### PR TITLE
ui: Add custom SVG-based line chart component

### DIFF
--- a/ui/src/assets/widgets.scss
+++ b/ui/src/assets/widgets.scss
@@ -36,6 +36,7 @@
 @import "widgets/hotkey_context";
 @import "widgets/hotkey";
 @import "widgets/icon";
+@import "widgets/line_chart_svg";
 @import "widgets/linear_progress";
 @import "widgets/menu";
 @import "widgets/middle_ellipsis";
@@ -57,8 +58,8 @@
 @import "widgets/stack";
 @import "widgets/tab_strip";
 @import "widgets/tabs";
-@import "widgets/task_status";
 @import "widgets/tag_input";
+@import "widgets/task_status";
 @import "widgets/text_input";
 @import "widgets/text_paragraph";
 @import "widgets/timestamp";

--- a/ui/src/assets/widgets/line_chart_svg.scss
+++ b/ui/src/assets/widgets/line_chart_svg.scss
@@ -1,0 +1,158 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-line-chart-svg {
+  display: flex;
+  min-height: 0;
+  min-width: 0;
+
+  &.pf-chart-svg--fill-parent {
+    height: 100%;
+    width: 100%;
+  }
+
+  &.pf-chart-svg--legend-top {
+    flex-direction: column-reverse;
+  }
+
+  &.pf-chart-svg--legend-bottom {
+    flex-direction: column;
+  }
+
+  &.pf-chart-svg--legend-right {
+    flex-direction: row;
+  }
+
+  .pf-chart-svg__container {
+    flex: 1 1 0;
+    min-height: 0;
+    min-width: 0;
+  }
+
+  .pf-chart-svg__svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .pf-chart-svg__loading,
+  .pf-chart-svg__empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: var(--pf-color-text-muted);
+    font-size: var(--pf-font-size-s);
+  }
+
+  .pf-chart-svg__legend {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px 12px;
+    padding: 4px 8px;
+    font-size: 10px;
+  }
+
+  &.pf-chart-svg--legend-top .pf-chart-svg__legend,
+  &.pf-chart-svg--legend-bottom .pf-chart-svg__legend {
+    justify-content: center;
+  }
+
+  &.pf-chart-svg--legend-right .pf-chart-svg__legend {
+    flex-direction: column;
+    align-items: flex-start;
+    flex: 0 0 auto;
+    width: 140px;
+    overflow: hidden;
+  }
+
+  .pf-chart-svg__legend-entry {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    user-select: none;
+  }
+
+  .pf-chart-svg__legend-entry--hidden {
+    opacity: 0.4;
+
+    .pf-chart-svg__legend-name,
+    .pf-chart-svg__legend-value {
+      text-decoration: line-through;
+    }
+  }
+
+  .pf-chart-svg__legend-swatch {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+    flex: 0 0 auto;
+  }
+
+  .pf-chart-svg__legend-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .pf-chart-svg__legend-value {
+    font-weight: bold;
+    margin-left: 2px;
+  }
+}
+
+.pf-chart-svg__tooltip-content {
+  font-size: var(--pf-font-size-s);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pf-chart-svg__tooltip-header {
+  font-weight: bold;
+  margin-bottom: 2px;
+}
+
+.pf-chart-svg__tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pf-chart-svg__tooltip-row--hovered {
+  font-weight: bold;
+}
+
+.pf-chart-svg__tooltip-row--muted {
+  color: var(--pf-color-text-muted);
+}
+
+.pf-chart-svg__tooltip-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex: 0 0 auto;
+}
+
+.pf-chart-svg__tooltip-name {
+  flex: 1 1 auto;
+  margin-right: 8px;
+}
+
+.pf-chart-svg__tooltip-value {
+  font-weight: bold;
+}

--- a/ui/src/base/array_utils.ts
+++ b/ui/src/base/array_utils.ts
@@ -86,14 +86,28 @@ export function intersperse<T, S>(arr: T[], separator: S): (T | S)[] {
   );
 }
 
-export function min(xs: ReadonlyArray<number>): number {
+// Returns the smallest number in `xs`, or `undefined` if `xs` is empty.
+// Propagates NaN: if any element is NaN the result is NaN (matches
+// Math.min semantics).
+export function min(xs: ReadonlyArray<number>): number | undefined {
+  if (xs.length === 0) return undefined;
   let r = Infinity;
-  for (const x of xs) if (x < r) r = x;
-  return r === Infinity ? 0 : r;
+  for (const x of xs) {
+    if (Number.isNaN(x)) return NaN;
+    if (x < r) r = x;
+  }
+  return r;
 }
 
-export function max(xs: ReadonlyArray<number>): number {
+// Returns the largest number in `xs`, or `undefined` if `xs` is empty.
+// Propagates NaN: if any element is NaN the result is NaN (matches
+// Math.max semantics).
+export function max(xs: ReadonlyArray<number>): number | undefined {
+  if (xs.length === 0) return undefined;
   let r = -Infinity;
-  for (const x of xs) if (x > r) r = x;
-  return r === -Infinity ? 1 : r;
+  for (const x of xs) {
+    if (Number.isNaN(x)) return NaN;
+    if (x > r) r = x;
+  }
+  return r;
 }

--- a/ui/src/base/array_utils.ts
+++ b/ui/src/base/array_utils.ts
@@ -85,3 +85,15 @@ export function intersperse<T, S>(arr: T[], separator: S): (T | S)[] {
     i < arr.length - 1 ? [item, separator] : [item],
   );
 }
+
+export function min(xs: ReadonlyArray<number>): number {
+  let r = Infinity;
+  for (const x of xs) if (x < r) r = x;
+  return r === Infinity ? 0 : r;
+}
+
+export function max(xs: ReadonlyArray<number>): number {
+  let r = -Infinity;
+  for (const x of xs) if (x > r) r = x;
+  return r === -Infinity ? 1 : r;
+}

--- a/ui/src/base/array_utils_unittest.ts
+++ b/ui/src/base/array_utils_unittest.ts
@@ -18,6 +18,8 @@ import {
   removeFalsyValues,
   range,
   moveArrayItem,
+  min,
+  max,
 } from './array_utils';
 
 describe('range', () => {
@@ -96,4 +98,60 @@ test('moveArrayItem.moveBackward', () => {
   const input = range(3);
   moveArrayItem(input, 2, 0);
   expect(input).toEqual([2, 0, 1]);
+});
+
+describe('min', () => {
+  it('returns the smallest element', () => {
+    expect(min([3, 1, 4, 1, 5, 9, 2, 6])).toBe(1);
+  });
+
+  it('handles negative numbers', () => {
+    expect(min([-3, -1, -4, -1])).toBe(-4);
+  });
+
+  it('returns the only element for a singleton array', () => {
+    expect(min([42])).toBe(42);
+  });
+
+  it('returns undefined for an empty array', () => {
+    expect(min([])).toBeUndefined();
+  });
+
+  it('returns NaN if any element is NaN', () => {
+    expect(min([1, NaN, 3])).toBeNaN();
+    expect(min([NaN])).toBeNaN();
+  });
+
+  it('handles Infinity', () => {
+    expect(min([Infinity, 1, 2])).toBe(1);
+    expect(min([-Infinity, 1, 2])).toBe(-Infinity);
+  });
+});
+
+describe('max', () => {
+  it('returns the largest element', () => {
+    expect(max([3, 1, 4, 1, 5, 9, 2, 6])).toBe(9);
+  });
+
+  it('handles negative numbers', () => {
+    expect(max([-3, -1, -4, -1])).toBe(-1);
+  });
+
+  it('returns the only element for a singleton array', () => {
+    expect(max([42])).toBe(42);
+  });
+
+  it('returns undefined for an empty array', () => {
+    expect(max([])).toBeUndefined();
+  });
+
+  it('returns NaN if any element is NaN', () => {
+    expect(max([1, NaN, 3])).toBeNaN();
+    expect(max([NaN])).toBeNaN();
+  });
+
+  it('handles Infinity', () => {
+    expect(max([Infinity, 1, 2])).toBe(Infinity);
+    expect(max([-Infinity, 1, 2])).toBe(2);
+  });
 });

--- a/ui/src/components/widgets/charts_svg/common.ts
+++ b/ui/src/components/widgets/charts_svg/common.ts
@@ -23,7 +23,6 @@ export function chartColorVar(i: number): string {
 }
 
 export const TEXT_COLOR = 'var(--pf-color-text)';
-export const BG_COLOR = 'var(--pf-color-background)';
 export const BORDER_COLOR = 'var(--pf-color-border)';
 
 // Default approximate tick count used when picking nice axis steps.
@@ -51,13 +50,15 @@ export function round(v: number, step: number): number {
 }
 
 // Rough text width estimate at 10px monospace-ish font (~6px per char).
+// TODO(stevegolton): Replace this with proper text measurement - measureText()
+// or maybe https://github.com/chenglou/pretext.
 export function estimateLabelWidth(labels: ReadonlyArray<string>): number {
-  let m = 0;
-  for (const l of labels) {
-    const w = l.length * 6;
-    if (w > m) m = w;
+  let maxWidth = 0;
+  for (const label of labels) {
+    const width = label.length * 6;
+    if (width > maxWidth) maxWidth = width;
   }
-  return m;
+  return maxWidth;
 }
 
 // Axis range with exact bounds (no rounding to "nice" numbers). Tick
@@ -139,14 +140,13 @@ export function logRange(rawMin: number, rawMax: number): AxisRange {
   return {min: Math.pow(10, lo), max: Math.pow(10, hi), ticks};
 }
 
-// A point marker: a dot filled with the page background, ringed in the
-// series color.
+// A point marker: a white dot ringed in the series color.
 export function pointMarker(cx: number, cy: number, color: string, r: number) {
   return m('circle', {
     'cx': cx,
     'cy': cy,
     'r': r,
-    'fill': BG_COLOR,
+    'fill': '#fff',
     'stroke': color,
     'stroke-width': 2,
   });

--- a/ui/src/components/widgets/charts_svg/common.ts
+++ b/ui/src/components/widgets/charts_svg/common.ts
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+
+// Number of --pf-chart-color-N CSS variables defined by the theme.
+const CHART_COLOR_COUNT = 8;
+
+// Series colour for the i-th series, as a CSS variable reference.
+export function chartColorVar(i: number): string {
+  return `var(--pf-chart-color-${(i % CHART_COLOR_COUNT) + 1})`;
+}
+
+export const TEXT_COLOR = 'var(--pf-color-text)';
+export const BG_COLOR = 'var(--pf-color-background)';
+export const BORDER_COLOR = 'var(--pf-color-border)';
+
+// Default approximate tick count used when picking nice axis steps.
+const APPROX_TICK_COUNT = 5;
+
+export interface AxisRange {
+  readonly min: number;
+  readonly max: number;
+  readonly ticks: ReadonlyArray<number>;
+}
+
+// Default short-form numeric formatter for tick labels and tooltips.
+export function defaultFmt(v: number): string {
+  if (!isFinite(v)) return String(v);
+  if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+  if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + 'k';
+  if (Number.isInteger(v)) return v.toString();
+  return v.toFixed(2);
+}
+
+// Strip floating-point fuzz introduced by repeated addition.
+export function round(v: number, step: number): number {
+  const decimals = Math.max(0, -Math.floor(Math.log10(step)));
+  return Number(v.toFixed(decimals + 2));
+}
+
+// Rough text width estimate at 10px monospace-ish font (~6px per char).
+export function estimateLabelWidth(labels: ReadonlyArray<string>): number {
+  let m = 0;
+  for (const l of labels) {
+    const w = l.length * 6;
+    if (w > m) m = w;
+  }
+  return m;
+}
+
+// Axis range with exact bounds (no rounding to "nice" numbers). Tick
+// positions are picked at nice round values that fall within the supplied
+// bounds — including the bounds themselves at the ends.
+export function rangeWithFixedBounds(
+  boundMin: number,
+  boundMax: number,
+): AxisRange {
+  if (!isFinite(boundMin) || !isFinite(boundMax) || boundMin === boundMax) {
+    return {min: boundMin, max: boundMax, ticks: [boundMin, boundMax]};
+  }
+  const span = boundMax - boundMin;
+  const rough = span / APPROX_TICK_COUNT;
+  const mag = Math.pow(10, Math.floor(Math.log10(rough)));
+  const norm = rough / mag;
+  let step: number;
+  if (norm < 1.5) step = 1 * mag;
+  else if (norm < 3) step = 2 * mag;
+  else if (norm < 7) step = 5 * mag;
+  else step = 10 * mag;
+
+  const ticks: number[] = [boundMin];
+  const firstInner = Math.ceil(boundMin / step) * step;
+  for (let t = firstInner; t < boundMax - step / 2; t += step) {
+    if (t > boundMin + step / 4) ticks.push(round(t, step));
+  }
+  ticks.push(boundMax);
+  return {min: boundMin, max: boundMax, ticks};
+}
+
+// Generate a "nice" axis range with round-number ticks.
+// `integer` clamps the step to >= 1 and rounds tick values to integers.
+// `minInterval` clamps the step to be at least that value (e.g. pass 1024 so
+// ticks land on whole MB boundaries when data is in KB).
+export function niceRange(
+  rawMin: number,
+  rawMax: number,
+  opts: {integer?: boolean; minInterval?: number} = {},
+): AxisRange {
+  if (!isFinite(rawMin) || !isFinite(rawMax) || rawMin === rawMax) {
+    const v = isFinite(rawMin) ? rawMin : 0;
+    return {min: v - 1, max: v + 1, ticks: [v - 1, v, v + 1]};
+  }
+  const span = rawMax - rawMin;
+  const rough = span / APPROX_TICK_COUNT;
+  const mag = Math.pow(10, Math.floor(Math.log10(rough)));
+  const norm = rough / mag;
+  let step: number;
+  if (norm < 1.5) step = 1 * mag;
+  else if (norm < 3) step = 2 * mag;
+  else if (norm < 7) step = 5 * mag;
+  else step = 10 * mag;
+
+  if (opts.integer && step < 1) step = 1;
+  if (opts.minInterval !== undefined && step < opts.minInterval) {
+    step = opts.minInterval;
+  }
+
+  const niceMin = Math.floor(rawMin / step) * step;
+  const niceMax = Math.ceil(rawMax / step) * step;
+  const ticks: number[] = [];
+  for (let t = niceMin; t <= niceMax + step / 2; t += step) {
+    ticks.push(opts.integer ? Math.round(t) : round(t, step));
+  }
+  return {min: niceMin, max: niceMax, ticks};
+}
+
+// Log-scale axis range. Bounds are snapped to powers of 10; ticks land at
+// each power of 10 within the range. Caller must ensure both bounds > 0.
+export function logRange(rawMin: number, rawMax: number): AxisRange {
+  if (!isFinite(rawMin) || !isFinite(rawMax) || rawMin <= 0 || rawMax <= 0) {
+    return {min: 1, max: 10, ticks: [1, 10]};
+  }
+  const lo = Math.floor(Math.log10(rawMin));
+  const hi = Math.ceil(Math.log10(rawMax));
+  const ticks: number[] = [];
+  for (let p = lo; p <= hi; p++) ticks.push(Math.pow(10, p));
+  return {min: Math.pow(10, lo), max: Math.pow(10, hi), ticks};
+}
+
+// A point marker: a dot filled with the page background, ringed in the
+// series color.
+export function pointMarker(cx: number, cy: number, color: string, r: number) {
+  return m('circle', {
+    'cx': cx,
+    'cy': cy,
+    'r': r,
+    'fill': BG_COLOR,
+    'stroke': color,
+    'stroke-width': 2,
+  });
+}

--- a/ui/src/components/widgets/charts_svg/legend.ts
+++ b/ui/src/components/widgets/charts_svg/legend.ts
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {classNames} from '../../../base/classnames';
+import {chartColorVar} from './common';
+import {LineChartData} from './line_chart_svg';
+import m from 'mithril';
+
+export function renderLegend(
+  data: LineChartData,
+  fmtY: (v: number) => string,
+  hidden: ReadonlySet<string>,
+  onToggle: (name: string) => void,
+): m.Children {
+  return m(
+    '.pf-chart-svg__legend',
+    {key: 'legend'},
+    data.series.map((s, i) => {
+      const last =
+        s.points.length > 0 ? s.points[s.points.length - 1].y : undefined;
+      const color = s.color ?? chartColorVar(i);
+      const isHidden = hidden.has(s.name);
+      return m(
+        '.pf-chart-svg__legend-entry',
+        {
+          className: classNames(
+            isHidden && 'pf-chart-svg__legend-entry--hidden',
+          ),
+          style: {cursor: 'pointer'},
+          onclick: () => onToggle(s.name),
+        },
+        [
+          m('.pf-chart-svg__legend-swatch', {
+            style: {backgroundColor: color},
+          }),
+          m('.pf-chart-svg__legend-name', s.name),
+          last !== undefined
+            ? m('.pf-chart-svg__legend-value', fmtY(last))
+            : null,
+        ],
+      );
+    }),
+  );
+}

--- a/ui/src/components/widgets/charts_svg/line_chart_svg.ts
+++ b/ui/src/components/widgets/charts_svg/line_chart_svg.ts
@@ -38,6 +38,7 @@ import {
   pointMarker,
   rangeWithFixedBounds,
 } from './common';
+import {assertIsInstance} from '../../../base/assert';
 
 export type {
   LineChartAttrs,
@@ -115,10 +116,10 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
   onupdate({dom, attrs}: m.CVnodeDOM<LineChartAttrs>) {
     // Re-query: Mithril may have replaced the container node if siblings
     // changed (e.g. legend appeared/disappeared).
-    const container = dom.querySelector(
-      '.pf-chart-svg__container',
-    ) as HTMLElement | null;
-    if (!container) return;
+    const container = assertIsInstance(
+      dom.querySelector('.pf-chart-svg__container'),
+      HTMLElement,
+    );
     this.container = container;
     this.currentAttrs = attrs;
     const {width, height} = container.getBoundingClientRect();
@@ -171,9 +172,14 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
     } else if (isEmpty) {
       inner = m('.pf-chart-svg__empty', 'No data to display');
     } else {
-      inner = this.renderChart(attrs, data!, width, height);
+      inner = this.renderChart(attrs, data, width, height);
     }
 
+    // Mithril's render() function actually takes a hidden third parameter which
+    // is a function called whenever an event triggers a redraw from within the
+    // rendered vnodes. Here we can use this to hook up the events triggered
+    // from within the rendered SVG code to trigger a global redraw. This is the
+    // same technique used in raf.ts.
     const renderWithRedraw = m.render as (
       el: Element,
       vnodes: m.Children,
@@ -194,14 +200,14 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
     // measured dimensions on the very first paint and on every attrs change.
     // The legend is plain Mithril and lives outside the imperative subtree.
     const legend =
-      showLegend && data !== undefined
-        ? renderLegend(
-            data,
-            attrs.formatYValue ?? defaultFmt,
-            this.hiddenSeries,
-            (name: string) => this.toggleSeries(name),
-          )
-        : null;
+      showLegend &&
+      data !== undefined &&
+      renderLegend(
+        data,
+        attrs.formatYValue ?? defaultFmt,
+        this.hiddenSeries,
+        (name: string) => this.toggleSeries(name),
+      );
     const chart = m('.pf-chart-svg__container', {key: 'chart'});
 
     const seriesHover = data?.series
@@ -216,14 +222,14 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
       });
 
     const tooltip =
-      this.hover !== undefined && seriesHover !== undefined
-        ? renderTooltip(
-            attrs.stacked ? [...seriesHover].reverse() : seriesHover,
-            this.hover.index,
-            attrs.formatXValue ?? defaultFmt,
-            attrs.formatYValue ?? defaultFmt,
-          )
-        : null;
+      this.hover !== undefined &&
+      seriesHover !== undefined &&
+      renderTooltip(
+        attrs.stacked ? [...seriesHover].reverse() : seriesHover,
+        this.hover.index,
+        attrs.formatXValue ?? defaultFmt,
+        attrs.formatYValue ?? defaultFmt,
+      );
 
     return m(
       '.pf-line-chart-svg',
@@ -289,21 +295,22 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
       allY.push(0);
     }
 
+    const xMin = min(allX) ?? NaN;
+    const xMax = max(allX) ?? NaN;
+    const yMin = min(allY) ?? NaN;
+    const yMax = max(allY) ?? NaN;
     const xRange =
       attrs.xAxisMin !== undefined || attrs.xAxisMax !== undefined
-        ? rangeWithFixedBounds(
-            attrs.xAxisMin ?? min(allX),
-            attrs.xAxisMax ?? max(allX),
-          )
-        : niceRange(min(allX), max(allX), {integer: integerX});
+        ? rangeWithFixedBounds(attrs.xAxisMin ?? xMin, attrs.xAxisMax ?? xMax)
+        : niceRange(xMin, xMax, {integer: integerX});
     const yRange = logScale
       ? logRange(
           // Log scale needs strictly-positive bounds; clamp data to a small
           // floor.
-          Math.max(min(allY.filter((v) => v > 0)), 1e-9),
-          Math.max(max(allY), 1e-9),
+          Math.max(min(allY.filter((v) => v > 0)) ?? NaN, 1e-9),
+          Math.max(yMax, 1e-9),
         )
-      : niceRange(min(allY), max(allY), {
+      : niceRange(yMin, yMax, {
           integer: integerY,
           minInterval: yMinInterval,
         });
@@ -345,21 +352,22 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
         width: width,
         height: height,
         viewBox: `0 0 ${width} ${height}`,
-        style: attrs.onBrush ? {cursor: 'crosshair'} : undefined,
+        style: attrs.onBrush && {cursor: 'crosshair'},
         oncontextmenu: (e: Event) => {
           // Chrome has a bug where right click to bring up the context menu
           // breaks pointer capture - simply disable context menus for the
           // chart.
           e.preventDefault();
         },
-        onpointerdown: attrs.onBrush
-          ? (e: PointerEvent) => this.handleBrushDown(e, padLeft, plotW, xRange)
-          : undefined,
+        onpointerdown:
+          attrs.onBrush &&
+          ((e: PointerEvent) =>
+            this.handleBrushDown(e, padLeft, plotW, xRange)),
         onpointermove: (e: PointerEvent) =>
           this.handlePointerMove(e, seriesPlots, padLeft, plotW, xRange),
-        onpointerup: attrs.onBrush
-          ? (e: PointerEvent) => this.handleBrushUp(e, attrs.onBrush!)
-          : undefined,
+        onpointerup:
+          attrs.onBrush &&
+          ((e: PointerEvent) => this.handleBrushUp(e, attrs.onBrush!)),
         onpointerleave: () => {
           if (this.brushing) return; // capture keeps the drag alive.
           if (this.hover !== undefined) {
@@ -382,34 +390,32 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
         ),
       ),
       // Y axis name (rotated)
-      yName
-        ? m(
-            'text',
-            {
-              'x': AXIS_NAME_FONT_SIZE,
-              'y': padTop + plotH / 2,
-              'fill': TEXT_COLOR,
-              'font-size': AXIS_NAME_FONT_SIZE,
-              'text-anchor': 'middle',
-              'transform': `rotate(-90 ${AXIS_NAME_FONT_SIZE} ${padTop + plotH / 2})`,
-            },
-            yName,
-          )
-        : null,
+      yName &&
+        m(
+          'text',
+          {
+            'x': AXIS_NAME_FONT_SIZE,
+            'y': padTop + plotH / 2,
+            'fill': TEXT_COLOR,
+            'font-size': AXIS_NAME_FONT_SIZE,
+            'text-anchor': 'middle',
+            'transform': `rotate(-90 ${AXIS_NAME_FONT_SIZE} ${padTop + plotH / 2})`,
+          },
+          yName,
+        ),
       // X axis name
-      xName
-        ? m(
-            'text',
-            {
-              'x': padLeft + plotW / 2,
-              'y': height - 4,
-              'fill': TEXT_COLOR,
-              'font-size': AXIS_NAME_FONT_SIZE,
-              'text-anchor': 'middle',
-            },
-            xName,
-          )
-        : null,
+      xName &&
+        m(
+          'text',
+          {
+            'x': padLeft + plotW / 2,
+            'y': height - 4,
+            'fill': TEXT_COLOR,
+            'font-size': AXIS_NAME_FONT_SIZE,
+            'text-anchor': 'middle',
+          },
+          xName,
+        ),
       // Plot border + axes
       m('line', {
         x1: padLeft,
@@ -426,47 +432,44 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
         stroke: BORDER_COLOR,
       }),
       // Gridlines (drawn before series so they sit underneath).
-      showHGrid
-        ? yRange.ticks.map((t) =>
-            m('line', {
-              'x1': padLeft,
-              'y1': yToPx(t),
-              'x2': padLeft + plotW,
-              'y2': yToPx(t),
-              'stroke': BORDER_COLOR,
-              'stroke-opacity': 0.3,
-            }),
-          )
-        : null,
-      showVGrid
-        ? xRange.ticks.map((t) =>
-            m('line', {
-              'x1': xToPx(t),
-              'y1': padTop,
-              'x2': xToPx(t),
-              'y2': padTop + plotH,
-              'stroke': BORDER_COLOR,
-              'stroke-opacity': 0.3,
-            }),
-          )
-        : null,
+      showHGrid &&
+        yRange.ticks.map((t) =>
+          m('line', {
+            'x1': padLeft,
+            'y1': yToPx(t),
+            'x2': padLeft + plotW,
+            'y2': yToPx(t),
+            'stroke': BORDER_COLOR,
+            'stroke-opacity': 0.3,
+          }),
+        ),
+      showVGrid &&
+        xRange.ticks.map((t) =>
+          m('line', {
+            'x1': xToPx(t),
+            'y1': padTop,
+            'x2': xToPx(t),
+            'y2': padTop + plotH,
+            'stroke': BORDER_COLOR,
+            'stroke-opacity': 0.3,
+          }),
+        ),
       // Static selection overlay (driven by attrs.selection).
-      attrs.selection !== undefined
-        ? m('rect', {
-            'x': xToPx(clamp(attrs.selection.start, xRange.min, xRange.max)),
-            'y': padTop,
-            'width': Math.max(
-              0,
-              xToPx(clamp(attrs.selection.end, xRange.min, xRange.max)) -
-                xToPx(clamp(attrs.selection.start, xRange.min, xRange.max)),
-            ),
-            'height': plotH,
-            'fill': 'rgba(0, 120, 212, 0.08)',
-            'stroke': 'rgba(0, 120, 212, 0.3)',
-            'stroke-width': 1,
-            'pointer-events': 'none',
-          })
-        : null,
+      attrs.selection !== undefined &&
+        m('rect', {
+          'x': xToPx(clamp(attrs.selection.start, xRange.min, xRange.max)),
+          'y': padTop,
+          'width': Math.max(
+            0,
+            xToPx(clamp(attrs.selection.end, xRange.min, xRange.max)) -
+              xToPx(clamp(attrs.selection.start, xRange.min, xRange.max)),
+          ),
+          'height': plotH,
+          'fill': 'rgba(0, 120, 212, 0.08)',
+          'stroke': 'rgba(0, 120, 212, 0.3)',
+          'stroke-width': 1,
+          'pointer-events': 'none',
+        }),
       // Y ticks + labels
       yRange.ticks.map((t) =>
         m('g', [
@@ -521,24 +524,22 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
         // Series areas (stacked) — drawn back-to-front so the topmost
         // series sits on top. The area path is also the hit target for
         // hover emphasis.
-        stacked
-          ? seriesPlots.map((s, i) => {
-              const dim =
-                this.hoveredSeries !== undefined && this.hoveredSeries !== i;
-              return m('path', {
-                'd': areaPath(s, seriesPlots, i, xToPx, yToPx, padTop + plotH),
-                'fill': s.color,
-                'fill-opacity': dim ? 0.05 : 0.2,
-                'stroke': 'none',
-                'style': attrs.onSeriesClick ? {cursor: 'pointer'} : undefined,
-                'onmouseenter': () => this.setHoveredSeries(i),
-                'onmouseleave': () => this.clearHoveredSeries(i),
-                'onclick': attrs.onSeriesClick
-                  ? () => attrs.onSeriesClick!(s.name)
-                  : undefined,
-              });
-            })
-          : null,
+        stacked &&
+          seriesPlots.map((s, i) => {
+            const dim =
+              this.hoveredSeries !== undefined && this.hoveredSeries !== i;
+            return m('path', {
+              'd': areaPath(s, seriesPlots, i, xToPx, yToPx, padTop + plotH),
+              'fill': s.color,
+              'fill-opacity': dim ? 0.4 : 0.8,
+              'stroke': 'none',
+              'style': attrs.onSeriesClick && {cursor: 'pointer'},
+              'onmouseenter': () => this.setHoveredSeries(i),
+              'onmouseleave': () => this.clearHoveredSeries(i),
+              'onclick':
+                attrs.onSeriesClick && (() => attrs.onSeriesClick!(s.name)),
+            });
+          }),
         // Series lines (visible stroke).
         seriesPlots.map((s, i) => {
           const dim =
@@ -548,87 +549,83 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
             'fill': 'none',
             'stroke': s.color,
             'stroke-width': lineWidth,
-            'opacity': dim ? 0.2 : 1,
+            'opacity': dim ? 0.6 : 1,
             'pointer-events': 'none',
           });
         }),
         // Wider invisible hit target per series so hovering near a thin
         // line counts. Drawn after visible lines and before points so it
         // sits above for hit-testing without occluding visuals.
-        stacked
-          ? null
-          : seriesPlots.map((s, i) =>
-              m('path', {
-                'd': linePath(s, xToPx, yToPx),
-                'fill': 'none',
-                'stroke': 'transparent',
-                'stroke-width': 12,
-                'pointer-events': 'stroke',
-                'style': attrs.onSeriesClick ? {cursor: 'pointer'} : undefined,
-                'onmouseenter': () => this.setHoveredSeries(i),
-                'onmouseleave': () => this.clearHoveredSeries(i),
-                'onclick': attrs.onSeriesClick
-                  ? () => attrs.onSeriesClick!(s.name)
-                  : undefined,
-              }),
-            ),
+        !stacked &&
+          seriesPlots.map((s, i) =>
+            m('path', {
+              'd': linePath(s, xToPx, yToPx),
+              'fill': 'none',
+              'stroke': 'transparent',
+              'stroke-width': 12,
+              'pointer-events': 'stroke',
+              'style': attrs.onSeriesClick && {cursor: 'pointer'},
+              'onmouseenter': () => this.setHoveredSeries(i),
+              'onmouseleave': () => this.clearHoveredSeries(i),
+              'onclick':
+                attrs.onSeriesClick && (() => attrs.onSeriesClick!(s.name)),
+            }),
+          ),
         // Series points
-        showPoints
-          ? seriesPlots.map((s, i) => {
-              const dim =
-                this.hoveredSeries !== undefined && this.hoveredSeries !== i;
-              return m(
-                'g',
-                {
-                  'opacity': dim ? 0.2 : 1,
-                  'pointer-events': 'none',
-                },
-                s.points.map((p) =>
-                  pointMarker(xToPx(p.x), yToPx(p.y), s.color, 3),
-                ),
-              );
-            })
-          : null,
+        showPoints &&
+          seriesPlots.map((s, i) => {
+            const dim =
+              this.hoveredSeries !== undefined && this.hoveredSeries !== i;
+            return m(
+              'g',
+              {
+                'opacity': dim ? 0.2 : 1,
+                'pointer-events': 'none',
+              },
+              s.points.map((p) =>
+                pointMarker(xToPx(p.x), yToPx(p.y), s.color, 3),
+              ),
+            );
+          }),
         // Hover guide line + dots. pointer-events: none so they don't
         // steal mouseenter/leave from the per-series hit targets
         // underneath.
-        hoverIdx !== undefined && seriesPlots[0]?.points[hoverIdx] !== undefined
-          ? m('g', {'pointer-events': 'none'}, [
-              m('line', {
-                'x1': xToPx(seriesPlots[0].points[hoverIdx].x),
-                'y1': padTop,
-                'x2': xToPx(seriesPlots[0].points[hoverIdx].x),
-                'y2': padTop + plotH,
-                'stroke': TEXT_COLOR,
-                'stroke-dasharray': '3 3',
-              }),
-              ...seriesPlots.flatMap((s) => {
-                const p = s.points[hoverIdx];
-                if (p === undefined) return [];
-                return [pointMarker(xToPx(p.x), yToPx(p.y), s.color, 4)];
-              }),
-            ])
-          : null,
+        hoverIdx !== undefined &&
+          seriesPlots[0]?.points[hoverIdx] !== undefined &&
+          m('g', {'pointer-events': 'none'}, [
+            m('line', {
+              'x1': xToPx(seriesPlots[0].points[hoverIdx].x),
+              'y1': padTop,
+              'x2': xToPx(seriesPlots[0].points[hoverIdx].x),
+              'y2': padTop + plotH,
+              'stroke': TEXT_COLOR,
+              'stroke-dasharray': '3 3',
+            }),
+            ...seriesPlots.flatMap((s) => {
+              const p = s.points[hoverIdx];
+              if (p === undefined) return [];
+              return [pointMarker(xToPx(p.x), yToPx(p.y), s.color, 4)];
+            }),
+          ]),
       ]),
       // Active brush drag rect (drawn on top of everything else).
-      this.brushing
-        ? (() => {
-            const a = clamp(this.brushing.start, xRange.min, xRange.max);
-            const b = clamp(this.brushing.current, xRange.min, xRange.max);
-            const lo = Math.min(a, b);
-            const hi = Math.max(a, b);
-            return m('rect', {
-              'x': xToPx(lo),
-              'y': padTop,
-              'width': Math.max(0, xToPx(hi) - xToPx(lo)),
-              'height': plotH,
-              'fill': 'rgba(0, 120, 212, 0.15)',
-              'stroke': 'rgba(0, 120, 212, 0.5)',
-              'stroke-width': 1,
-              'pointer-events': 'none',
-            });
-          })()
-        : null,
+      this.brushing &&
+        (() => {
+          const a = clamp(this.brushing!.start, xRange.min, xRange.max);
+          const b = clamp(this.brushing!.current, xRange.min, xRange.max);
+          const lo = Math.min(a, b);
+          const hi = Math.max(a, b);
+          return m('rect', {
+            'x': xToPx(lo),
+            'y': padTop,
+            'width': Math.max(0, xToPx(hi) - xToPx(lo)),
+            'height': plotH,
+            'fill': 'rgba(0, 120, 212, 0.15)',
+            'stroke': 'rgba(0, 120, 212, 0.5)',
+            'stroke-width': 1,
+            'pointer-events': 'none',
+          });
+        })(),
       // Tooltip (HTML-overlaid via foreignObject would be cleaner, but a
       // sibling absolutely-positioned div is simpler and gets real CSS).
     );
@@ -734,17 +731,17 @@ function buildSeriesPlots(
   const cum = new Map<number, number>();
   for (let i = 0; i < series.length; i++) {
     const s = series[i];
-    const stacked: {x: number; y: number; raw: number}[] = [];
+    const stackedPoints: {x: number; y: number; raw: number}[] = [];
     for (const p of s.points) {
       const prev = cum.get(p.x) ?? 0;
       const next = prev + p.y;
       cum.set(p.x, next);
-      stacked.push({x: p.x, y: next, raw: p.y});
+      stackedPoints.push({x: p.x, y: next, raw: p.y});
     }
     result.push({
       name: s.name,
       color: s.color ?? chartColorVar(i),
-      points: stacked,
+      points: stackedPoints,
     });
   }
   return result;

--- a/ui/src/components/widgets/charts_svg/line_chart_svg.ts
+++ b/ui/src/components/widgets/charts_svg/line_chart_svg.ts
@@ -1,0 +1,794 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {SimpleResizeObserver} from '../../../base/resize_observer';
+import {classNames} from '../../../base/classnames';
+import {Spinner} from '../../../widgets/spinner';
+import type {
+  LineChartAttrs,
+  LineChartData,
+  LineChartSeries,
+} from '../charts/line_chart';
+import {clamp} from '../../../base/math_utils';
+import {max, min} from '../../../base/array_utils';
+import {renderLegend} from './legend';
+import {renderTooltip} from './tooltip';
+import {shortUuid} from '../../../base/uuid';
+import {
+  AxisRange,
+  BORDER_COLOR,
+  TEXT_COLOR,
+  chartColorVar,
+  defaultFmt,
+  estimateLabelWidth,
+  logRange,
+  niceRange,
+  pointMarker,
+  rangeWithFixedBounds,
+} from './common';
+
+export type {
+  LineChartAttrs,
+  LineChartData,
+  LineChartSeries,
+} from '../charts/line_chart';
+
+const DEFAULT_HEIGHT = 200;
+const AXIS_LABEL_FONT_SIZE = 10;
+const AXIS_NAME_FONT_SIZE = 11;
+const TICK_LENGTH = 4;
+const TICK_LABEL_GAP = 4;
+
+interface SeriesPlot {
+  readonly name: string;
+  readonly color: string;
+  readonly points: ReadonlyArray<{x: number; y: number; raw: number}>;
+}
+
+interface HoverState {
+  readonly clientX: number;
+  readonly clientY: number;
+  readonly index: number;
+  readonly xValue: number;
+}
+
+export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
+  private resizeObs?: Disposable;
+  private hover?: HoverState;
+  // Index of the currently-hovered series, if any. Used to dim other series.
+  private hoveredSeries?: number;
+  private container?: HTMLElement;
+  private currentAttrs?: LineChartAttrs;
+  private prevW = 0;
+  private prevH = 0;
+  // Active brush drag state, in *data* x-coordinates so a resize during the
+  // drag doesn't mangle the selection. Pointer capture keeps the drag bound
+  // to the SVG even when the cursor leaves it, so we don't need any
+  // window-level listeners.
+  private brushing?: {start: number; current: number; pointerId: number};
+  // Unique id for the plot-area clipPath. Multiple charts on the same page
+  // must not share an id.
+  private readonly clipId = `pf-chart-clip-${shortUuid()}`;
+  // Series the user has toggled off via legend click, keyed by series name.
+  private hiddenSeries = new Set<string>();
+
+  private toggleSeries(name: string) {
+    if (this.hiddenSeries.has(name)) {
+      this.hiddenSeries.delete(name);
+    } else {
+      this.hiddenSeries.add(name);
+    }
+  }
+
+  oncreate({dom, attrs}: m.CVnodeDOM<LineChartAttrs>) {
+    const container = dom.querySelector(
+      '.pf-chart-svg__container',
+    ) as HTMLElement;
+    this.container = container;
+    this.currentAttrs = attrs;
+    const {width, height} = container.getBoundingClientRect();
+    this.prevW = width;
+    this.prevH = height;
+    this.renderInner(container, attrs, width, height);
+    this.resizeObs = new SimpleResizeObserver(dom, () => {
+      if (!this.container || !this.currentAttrs) return;
+      const r = this.container.getBoundingClientRect();
+      if (r.width === this.prevW && r.height === this.prevH) return;
+      this.prevW = r.width;
+      this.prevH = r.height;
+      this.renderInner(this.container, this.currentAttrs, r.width, r.height);
+    });
+  }
+
+  onupdate({dom, attrs}: m.CVnodeDOM<LineChartAttrs>) {
+    // Re-query: Mithril may have replaced the container node if siblings
+    // changed (e.g. legend appeared/disappeared).
+    const container = dom.querySelector(
+      '.pf-chart-svg__container',
+    ) as HTMLElement | null;
+    if (!container) return;
+    this.container = container;
+    this.currentAttrs = attrs;
+    const {width, height} = container.getBoundingClientRect();
+    this.prevW = width;
+    this.prevH = height;
+    this.renderInner(container, attrs, width, height);
+  }
+
+  private setHoveredSeries(i: number) {
+    if (this.hoveredSeries !== i) {
+      this.hoveredSeries = i;
+    }
+  }
+
+  private clearHoveredSeries(i: number) {
+    if (this.hoveredSeries === i) {
+      this.hoveredSeries = undefined;
+    }
+  }
+
+  onremove() {
+    if (this.resizeObs) {
+      this.resizeObs[Symbol.dispose]();
+      this.resizeObs = undefined;
+    }
+    // Tear down the imperative inner tree so any descendant onremove hooks
+    // run.
+    if (this.container) {
+      m.render(this.container, []);
+    }
+  }
+
+  // Imperatively render the inner chart tree using measured dimensions.
+  private renderInner(
+    container: HTMLElement,
+    attrs: LineChartAttrs,
+    width: number,
+    height: number,
+  ) {
+    const {data} = attrs;
+    const isEmpty =
+      data !== undefined &&
+      (data.series.length === 0 ||
+        data.series.every((s) => s.points.length === 0));
+    const isLoading = data === undefined;
+
+    let inner: m.Children;
+    if (isLoading) {
+      inner = m('.pf-chart-svg__loading', m(Spinner));
+    } else if (isEmpty) {
+      inner = m('.pf-chart-svg__empty', 'No data to display');
+    } else {
+      inner = this.renderChart(attrs, data!, width, height);
+    }
+
+    const renderWithRedraw = m.render as (
+      el: Element,
+      vnodes: m.Children,
+      redraw?: () => void,
+    ) => void;
+
+    renderWithRedraw(container, inner, m.redraw);
+  }
+
+  view({attrs}: m.Vnode<LineChartAttrs>) {
+    const {height, fillParent, className, data} = attrs;
+    const legendPosition = attrs.legendPosition ?? 'top';
+    const showLegend =
+      attrs.showLegend ?? (data !== undefined && data.series.length > 1);
+
+    // The contents of .pf-chart-svg__container are managed imperatively
+    // via m.render() in onupdate/oncreate so that the chart is drawn using
+    // measured dimensions on the very first paint and on every attrs change.
+    // The legend is plain Mithril and lives outside the imperative subtree.
+    const legend =
+      showLegend && data !== undefined
+        ? renderLegend(
+            data,
+            attrs.formatYValue ?? defaultFmt,
+            this.hiddenSeries,
+            (name: string) => this.toggleSeries(name),
+          )
+        : null;
+    const chart = m('.pf-chart-svg__container', {key: 'chart'});
+
+    const seriesHover = data?.series
+      .filter((s) => !this.hiddenSeries.has(s.name))
+      .map((s, i) => {
+        const isHovered = this.hoveredSeries === i;
+        const isMuted = this.hoveredSeries !== undefined && !isHovered;
+        return {
+          series: s,
+          style: isHovered ? 'emphasis' : isMuted ? 'muted' : 'normal',
+        };
+      });
+
+    const tooltip =
+      this.hover !== undefined && seriesHover !== undefined
+        ? renderTooltip(
+            attrs.stacked ? [...seriesHover].reverse() : seriesHover,
+            this.hover.index,
+            attrs.formatXValue ?? defaultFmt,
+            attrs.formatYValue ?? defaultFmt,
+          )
+        : null;
+
+    return m(
+      '.pf-line-chart-svg',
+      {
+        className: classNames(
+          fillParent && 'pf-chart-svg--fill-parent',
+          `pf-chart-svg--legend-${legendPosition}`,
+          className,
+        ),
+        style: fillParent
+          ? undefined
+          : {height: `${height ?? DEFAULT_HEIGHT}px`},
+      },
+      // Removes falsy children - mithril doesn't like it when some children
+      // have keys while others are null.
+      [chart, legend, tooltip].filter(Boolean),
+    );
+  }
+
+  private renderChart(
+    attrs: LineChartAttrs,
+    data: LineChartData,
+    width: number,
+    height: number,
+  ) {
+    if (width === 0 || height === 0) {
+      return m('svg', {width: '100%', height: '100%'});
+    }
+
+    const stacked = attrs.stacked ?? false;
+    const showPoints = attrs.showPoints ?? true;
+    const lineWidth = attrs.lineWidth ?? 2;
+    const fmtX = attrs.formatXValue ?? defaultFmt;
+    const fmtY = attrs.formatYValue ?? defaultFmt;
+    const gridLines = attrs.gridLines;
+    const showHGrid = gridLines === 'horizontal' || gridLines === 'both';
+    const showVGrid = gridLines === 'vertical' || gridLines === 'both';
+    const logScale = attrs.logScale ?? false;
+    const scaleAxes = attrs.scaleAxes ?? false;
+    const integerX = attrs.integerX ?? false;
+    const integerY = attrs.integerY ?? false;
+    const yMinInterval = attrs.yAxisMinInterval;
+
+    // Compute series in chart-space (post-stacking if stacked). Series
+    // toggled off via the legend are excluded entirely.
+    const visibleSeries = data.series.filter(
+      (s) => !this.hiddenSeries.has(s.name),
+    );
+    const seriesPlots = buildSeriesPlots(visibleSeries, stacked);
+
+    // Compute axis ranges from the (post-stacking) values.
+    const allX: number[] = [];
+    const allY: number[] = [];
+    for (const s of seriesPlots) {
+      for (const p of s.points) {
+        allX.push(p.x);
+        allY.push(p.y);
+      }
+    }
+    // By default, force-include zero on the y-axis. `scaleAxes: true` opts
+    // out and computes the range from data min/max only.
+    if (!scaleAxes) {
+      allY.push(0);
+    }
+
+    const xRange =
+      attrs.xAxisMin !== undefined || attrs.xAxisMax !== undefined
+        ? rangeWithFixedBounds(
+            attrs.xAxisMin ?? min(allX),
+            attrs.xAxisMax ?? max(allX),
+          )
+        : niceRange(min(allX), max(allX), {integer: integerX});
+    const yRange = logScale
+      ? logRange(
+          // Log scale needs strictly-positive bounds; clamp data to a small
+          // floor.
+          Math.max(min(allY.filter((v) => v > 0)), 1e-9),
+          Math.max(max(allY), 1e-9),
+        )
+      : niceRange(min(allY), max(allY), {
+          integer: integerY,
+          minInterval: yMinInterval,
+        });
+
+    // Layout: axis names + tick labels eat into the canvas.
+    const xName = attrs.xAxisLabel;
+    const yName = attrs.yAxisLabel;
+    const yLabelWidth = estimateLabelWidth(yRange.ticks.map(fmtY));
+    const padLeft = (yName ? AXIS_NAME_FONT_SIZE + 6 : 0) + yLabelWidth + 8;
+    const padRight = 8;
+    const padTop = 8;
+    const padBottom =
+      (xName ? AXIS_NAME_FONT_SIZE + 6 : 0) + AXIS_LABEL_FONT_SIZE + 8;
+
+    const plotW = Math.max(0, width - padLeft - padRight);
+    const plotH = Math.max(0, height - padTop - padBottom);
+
+    const xToPx = (x: number) =>
+      padLeft + ((x - xRange.min) / (xRange.max - xRange.min || 1)) * plotW;
+    const yToPx = logScale
+      ? (y: number) => {
+          // Clamp to a tiny positive value so log() stays finite for zeros.
+          const v = y > 0 ? y : yRange.min;
+          const num = Math.log10(v) - Math.log10(yRange.min);
+          const den = Math.log10(yRange.max) - Math.log10(yRange.min) || 1;
+          return padTop + plotH - (num / den) * plotH;
+        }
+      : (y: number) =>
+          padTop +
+          plotH -
+          ((y - yRange.min) / (yRange.max - yRange.min || 1)) * plotH;
+
+    // Tooltip: snap to nearest x in the first series.
+    const hoverIdx = this.hover?.index;
+
+    return m(
+      'svg.pf-chart-svg__svg',
+      {
+        width: width,
+        height: height,
+        viewBox: `0 0 ${width} ${height}`,
+        style: attrs.onBrush ? {cursor: 'crosshair'} : undefined,
+        oncontextmenu: (e: Event) => {
+          // Chrome has a bug where right click to bring up the context menu
+          // breaks pointer capture - simply disable context menus for the
+          // chart.
+          e.preventDefault();
+        },
+        onpointerdown: attrs.onBrush
+          ? (e: PointerEvent) => this.handleBrushDown(e, padLeft, plotW, xRange)
+          : undefined,
+        onpointermove: (e: PointerEvent) =>
+          this.handlePointerMove(e, seriesPlots, padLeft, plotW, xRange),
+        onpointerup: attrs.onBrush
+          ? (e: PointerEvent) => this.handleBrushUp(e, attrs.onBrush!)
+          : undefined,
+        onpointerleave: () => {
+          if (this.brushing) return; // capture keeps the drag alive.
+          if (this.hover !== undefined) {
+            this.hover = undefined;
+          }
+        },
+        onlostpointercapture: () => {
+          // Pointer capture yanked (e.g. system gesture) — abandon the drag.
+          this.brushing = undefined;
+        },
+      },
+      // Clip data drawings to the plot area so lines/points can't extend
+      // past the axes when values fall outside the visible range.
+      m(
+        'defs',
+        m(
+          'clipPath',
+          {id: this.clipId},
+          m('rect', {x: padLeft, y: padTop, width: plotW, height: plotH}),
+        ),
+      ),
+      // Y axis name (rotated)
+      yName
+        ? m(
+            'text',
+            {
+              'x': AXIS_NAME_FONT_SIZE,
+              'y': padTop + plotH / 2,
+              'fill': TEXT_COLOR,
+              'font-size': AXIS_NAME_FONT_SIZE,
+              'text-anchor': 'middle',
+              'transform': `rotate(-90 ${AXIS_NAME_FONT_SIZE} ${padTop + plotH / 2})`,
+            },
+            yName,
+          )
+        : null,
+      // X axis name
+      xName
+        ? m(
+            'text',
+            {
+              'x': padLeft + plotW / 2,
+              'y': height - 4,
+              'fill': TEXT_COLOR,
+              'font-size': AXIS_NAME_FONT_SIZE,
+              'text-anchor': 'middle',
+            },
+            xName,
+          )
+        : null,
+      // Plot border + axes
+      m('line', {
+        x1: padLeft,
+        y1: padTop + plotH,
+        x2: padLeft + plotW,
+        y2: padTop + plotH,
+        stroke: BORDER_COLOR,
+      }),
+      m('line', {
+        x1: padLeft,
+        y1: padTop,
+        x2: padLeft,
+        y2: padTop + plotH,
+        stroke: BORDER_COLOR,
+      }),
+      // Gridlines (drawn before series so they sit underneath).
+      showHGrid
+        ? yRange.ticks.map((t) =>
+            m('line', {
+              'x1': padLeft,
+              'y1': yToPx(t),
+              'x2': padLeft + plotW,
+              'y2': yToPx(t),
+              'stroke': BORDER_COLOR,
+              'stroke-opacity': 0.3,
+            }),
+          )
+        : null,
+      showVGrid
+        ? xRange.ticks.map((t) =>
+            m('line', {
+              'x1': xToPx(t),
+              'y1': padTop,
+              'x2': xToPx(t),
+              'y2': padTop + plotH,
+              'stroke': BORDER_COLOR,
+              'stroke-opacity': 0.3,
+            }),
+          )
+        : null,
+      // Static selection overlay (driven by attrs.selection).
+      attrs.selection !== undefined
+        ? m('rect', {
+            'x': xToPx(clamp(attrs.selection.start, xRange.min, xRange.max)),
+            'y': padTop,
+            'width': Math.max(
+              0,
+              xToPx(clamp(attrs.selection.end, xRange.min, xRange.max)) -
+                xToPx(clamp(attrs.selection.start, xRange.min, xRange.max)),
+            ),
+            'height': plotH,
+            'fill': 'rgba(0, 120, 212, 0.08)',
+            'stroke': 'rgba(0, 120, 212, 0.3)',
+            'stroke-width': 1,
+            'pointer-events': 'none',
+          })
+        : null,
+      // Y ticks + labels
+      yRange.ticks.map((t) =>
+        m('g', [
+          m('line', {
+            x1: padLeft - TICK_LENGTH,
+            y1: yToPx(t),
+            x2: padLeft,
+            y2: yToPx(t),
+            stroke: BORDER_COLOR,
+          }),
+          m(
+            'text',
+            {
+              'x': padLeft - TICK_LENGTH - TICK_LABEL_GAP,
+              'y': yToPx(t),
+              'fill': TEXT_COLOR,
+              'font-size': AXIS_LABEL_FONT_SIZE,
+              'text-anchor': 'end',
+              'dominant-baseline': 'middle',
+            },
+            fmtY(t),
+          ),
+        ]),
+      ),
+      // X ticks + labels
+      xRange.ticks.map((t) =>
+        m('g', [
+          m('line', {
+            x1: xToPx(t),
+            y1: padTop + plotH,
+            x2: xToPx(t),
+            y2: padTop + plotH + TICK_LENGTH,
+            stroke: BORDER_COLOR,
+          }),
+          m(
+            'text',
+            {
+              'x': xToPx(t),
+              'y': padTop + plotH + TICK_LENGTH + TICK_LABEL_GAP,
+              'fill': TEXT_COLOR,
+              'font-size': AXIS_LABEL_FONT_SIZE,
+              'text-anchor': 'middle',
+              'dominant-baseline': 'hanging',
+            },
+            fmtX(t),
+          ),
+        ]),
+      ),
+      // Everything below renders in *data* coordinates and is clipped to
+      // the plot area so it can't bleed over the axes.
+      m('g', {'clip-path': `url(#${this.clipId})`}, [
+        // Series areas (stacked) — drawn back-to-front so the topmost
+        // series sits on top. The area path is also the hit target for
+        // hover emphasis.
+        stacked
+          ? seriesPlots.map((s, i) => {
+              const dim =
+                this.hoveredSeries !== undefined && this.hoveredSeries !== i;
+              return m('path', {
+                'd': areaPath(s, seriesPlots, i, xToPx, yToPx, padTop + plotH),
+                'fill': s.color,
+                'fill-opacity': dim ? 0.05 : 0.2,
+                'stroke': 'none',
+                'style': attrs.onSeriesClick ? {cursor: 'pointer'} : undefined,
+                'onmouseenter': () => this.setHoveredSeries(i),
+                'onmouseleave': () => this.clearHoveredSeries(i),
+                'onclick': attrs.onSeriesClick
+                  ? () => attrs.onSeriesClick!(s.name)
+                  : undefined,
+              });
+            })
+          : null,
+        // Series lines (visible stroke).
+        seriesPlots.map((s, i) => {
+          const dim =
+            this.hoveredSeries !== undefined && this.hoveredSeries !== i;
+          return m('path', {
+            'd': linePath(s, xToPx, yToPx),
+            'fill': 'none',
+            'stroke': s.color,
+            'stroke-width': lineWidth,
+            'opacity': dim ? 0.2 : 1,
+            'pointer-events': 'none',
+          });
+        }),
+        // Wider invisible hit target per series so hovering near a thin
+        // line counts. Drawn after visible lines and before points so it
+        // sits above for hit-testing without occluding visuals.
+        stacked
+          ? null
+          : seriesPlots.map((s, i) =>
+              m('path', {
+                'd': linePath(s, xToPx, yToPx),
+                'fill': 'none',
+                'stroke': 'transparent',
+                'stroke-width': 12,
+                'pointer-events': 'stroke',
+                'style': attrs.onSeriesClick ? {cursor: 'pointer'} : undefined,
+                'onmouseenter': () => this.setHoveredSeries(i),
+                'onmouseleave': () => this.clearHoveredSeries(i),
+                'onclick': attrs.onSeriesClick
+                  ? () => attrs.onSeriesClick!(s.name)
+                  : undefined,
+              }),
+            ),
+        // Series points
+        showPoints
+          ? seriesPlots.map((s, i) => {
+              const dim =
+                this.hoveredSeries !== undefined && this.hoveredSeries !== i;
+              return m(
+                'g',
+                {
+                  'opacity': dim ? 0.2 : 1,
+                  'pointer-events': 'none',
+                },
+                s.points.map((p) =>
+                  pointMarker(xToPx(p.x), yToPx(p.y), s.color, 3),
+                ),
+              );
+            })
+          : null,
+        // Hover guide line + dots. pointer-events: none so they don't
+        // steal mouseenter/leave from the per-series hit targets
+        // underneath.
+        hoverIdx !== undefined && seriesPlots[0]?.points[hoverIdx] !== undefined
+          ? m('g', {'pointer-events': 'none'}, [
+              m('line', {
+                'x1': xToPx(seriesPlots[0].points[hoverIdx].x),
+                'y1': padTop,
+                'x2': xToPx(seriesPlots[0].points[hoverIdx].x),
+                'y2': padTop + plotH,
+                'stroke': TEXT_COLOR,
+                'stroke-dasharray': '3 3',
+              }),
+              ...seriesPlots.flatMap((s) => {
+                const p = s.points[hoverIdx];
+                if (p === undefined) return [];
+                return [pointMarker(xToPx(p.x), yToPx(p.y), s.color, 4)];
+              }),
+            ])
+          : null,
+      ]),
+      // Active brush drag rect (drawn on top of everything else).
+      this.brushing
+        ? (() => {
+            const a = clamp(this.brushing.start, xRange.min, xRange.max);
+            const b = clamp(this.brushing.current, xRange.min, xRange.max);
+            const lo = Math.min(a, b);
+            const hi = Math.max(a, b);
+            return m('rect', {
+              'x': xToPx(lo),
+              'y': padTop,
+              'width': Math.max(0, xToPx(hi) - xToPx(lo)),
+              'height': plotH,
+              'fill': 'rgba(0, 120, 212, 0.15)',
+              'stroke': 'rgba(0, 120, 212, 0.5)',
+              'stroke-width': 1,
+              'pointer-events': 'none',
+            });
+          })()
+        : null,
+      // Tooltip (HTML-overlaid via foreignObject would be cleaner, but a
+      // sibling absolutely-positioned div is simpler and gets real CSS).
+    );
+  }
+
+  private handleBrushDown(
+    e: PointerEvent,
+    padLeft: number,
+    plotW: number,
+    xRange: AxisRange,
+  ) {
+    const svg = e.currentTarget as SVGSVGElement;
+    const rect = svg.getBoundingClientRect();
+    const px = clamp(e.clientX - rect.left, padLeft, padLeft + plotW);
+    const xVal =
+      xRange.min + ((px - padLeft) / (plotW || 1)) * (xRange.max - xRange.min);
+    // Capture the pointer so subsequent move/up events fire on the SVG even
+    // if the cursor leaves it. Capture is auto-released on pointerup.
+    svg.setPointerCapture(e.pointerId);
+    this.brushing = {start: xVal, current: xVal, pointerId: e.pointerId};
+    this.hover = undefined;
+    e.preventDefault();
+  }
+
+  private handleBrushUp(
+    e: PointerEvent,
+    onBrush: (range: {start: number; end: number}) => void,
+  ) {
+    if (!this.brushing || this.brushing.pointerId !== e.pointerId) return;
+    const {start, current} = this.brushing;
+    const lo = Math.min(start, current);
+    const hi = Math.max(start, current);
+    this.brushing = undefined;
+    if (hi > lo) onBrush({start: lo, end: hi});
+  }
+
+  private handlePointerMove(
+    e: PointerEvent,
+    seriesPlots: ReadonlyArray<SeriesPlot>,
+    padLeft: number,
+    plotW: number,
+    xRange: AxisRange,
+  ) {
+    const svg = e.currentTarget as SVGSVGElement;
+    const rect = svg.getBoundingClientRect();
+    // While brushing, track the drag end and suppress the cursor tooltip —
+    // it gets in the way of seeing what you're selecting.
+    if (this.brushing && this.brushing.pointerId === e.pointerId) {
+      const px = clamp(e.clientX - rect.left, padLeft, padLeft + plotW);
+      this.brushing = {
+        start: this.brushing.start,
+        current:
+          xRange.min +
+          ((px - padLeft) / (plotW || 1)) * (xRange.max - xRange.min),
+        pointerId: e.pointerId,
+      };
+      this.hover = undefined;
+      return;
+    }
+    if (seriesPlots.length === 0 || seriesPlots[0].points.length === 0) return;
+    const px = e.clientX - rect.left;
+    if (px < padLeft || px > padLeft + plotW) {
+      if (this.hover !== undefined) {
+        this.hover = undefined;
+      }
+      return;
+    }
+    const xVal =
+      xRange.min + ((px - padLeft) / (plotW || 1)) * (xRange.max - xRange.min);
+    // Nearest index in series 0 (assumes shared x; first series is reference).
+    const pts = seriesPlots[0].points;
+    let bestIdx = 0;
+    let bestDist = Infinity;
+    for (let i = 0; i < pts.length; i++) {
+      const d = Math.abs(pts[i].x - xVal);
+      if (d < bestDist) {
+        bestDist = d;
+        bestIdx = i;
+      }
+    }
+    this.hover = {
+      clientX: e.clientX,
+      clientY: e.clientY,
+      index: bestIdx,
+      xValue: pts[bestIdx].x,
+    };
+  }
+}
+
+function buildSeriesPlots(
+  series: ReadonlyArray<LineChartSeries>,
+  stacked: boolean,
+): ReadonlyArray<SeriesPlot> {
+  if (!stacked) {
+    return series.map((s, i) => ({
+      name: s.name,
+      color: s.color ?? chartColorVar(i),
+      points: s.points.map((p) => ({x: p.x, y: p.y, raw: p.y})),
+    }));
+  }
+  // Stacked: assume aligned x values across series; sum cumulatively.
+  const result: SeriesPlot[] = [];
+  const cum = new Map<number, number>();
+  for (let i = 0; i < series.length; i++) {
+    const s = series[i];
+    const stacked: {x: number; y: number; raw: number}[] = [];
+    for (const p of s.points) {
+      const prev = cum.get(p.x) ?? 0;
+      const next = prev + p.y;
+      cum.set(p.x, next);
+      stacked.push({x: p.x, y: next, raw: p.y});
+    }
+    result.push({
+      name: s.name,
+      color: s.color ?? chartColorVar(i),
+      points: stacked,
+    });
+  }
+  return result;
+}
+
+function linePath(
+  s: SeriesPlot,
+  xToPx: (x: number) => number,
+  yToPx: (y: number) => number,
+): string {
+  if (s.points.length === 0) return '';
+  let d = '';
+  for (let i = 0; i < s.points.length; i++) {
+    const p = s.points[i];
+    d += (i === 0 ? 'M' : 'L') + xToPx(p.x) + ',' + yToPx(p.y) + ' ';
+  }
+  return d.trim();
+}
+
+// For stacked areas, the bottom of series i is the top of series i-1
+// (in the same x order). For the bottom-most series, bottom = y0 baseline.
+function areaPath(
+  s: SeriesPlot,
+  all: ReadonlyArray<SeriesPlot>,
+  index: number,
+  xToPx: (x: number) => number,
+  yToPx: (y: number) => number,
+  baselinePx: number,
+): string {
+  if (s.points.length === 0) return '';
+  const top = s.points;
+  const bottom = index > 0 ? all[index - 1].points : undefined;
+  let d = '';
+  for (let i = 0; i < top.length; i++) {
+    d += (i === 0 ? 'M' : 'L') + xToPx(top[i].x) + ',' + yToPx(top[i].y) + ' ';
+  }
+  if (bottom !== undefined) {
+    for (let i = bottom.length - 1; i >= 0; i--) {
+      d += 'L' + xToPx(bottom[i].x) + ',' + yToPx(bottom[i].y) + ' ';
+    }
+  } else {
+    d += 'L' + xToPx(top[top.length - 1].x) + ',' + baselinePx + ' ';
+    d += 'L' + xToPx(top[0].x) + ',' + baselinePx + ' ';
+  }
+  d += 'Z';
+  return d;
+}

--- a/ui/src/components/widgets/charts_svg/tooltip.ts
+++ b/ui/src/components/widgets/charts_svg/tooltip.ts
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {classNames} from '../../../base/classnames';
+import {CursorTooltip} from '../../../widgets/cursor_tooltip';
+import {chartColorVar} from './common';
+import {LineChartSeries} from '../charts/line_chart';
+import m from 'mithril';
+import {PopupPosition} from '../../../widgets/popup';
+
+export function renderTooltip(
+  series: readonly {readonly style: string; readonly series: LineChartSeries}[],
+  index: number,
+  fmtX: (v: number) => string,
+  fmtY: (v: number) => string,
+): m.Children {
+  // X value comes from the first series with a point at `index`.
+  let xValue: number | undefined;
+  for (const s of series) {
+    if (s.series.points[index] !== undefined) {
+      xValue = s.series.points[index].x;
+      break;
+    }
+  }
+  return m(
+    CursorTooltip,
+    {
+      className: 'pf-chart-svg__tooltip',
+      key: 'tooltip',
+      position: PopupPosition.RightStart,
+      offset: 20,
+    },
+    m(
+      '.pf-chart-svg__tooltip-content',
+      xValue !== undefined
+        ? m('.pf-chart-svg__tooltip-header', fmtX(xValue))
+        : null,
+      series.map((s, i) => {
+        const p = s.series.points[index];
+        if (p === undefined) return null;
+        const color = s.series.color ?? chartColorVar(i);
+        const isHovered = s.style === 'emphasis';
+        const isMuted = s.style === 'muted';
+        return m(
+          '.pf-chart-svg__tooltip-row',
+          {
+            className: classNames(
+              isHovered && 'pf-chart-svg__tooltip-row--hovered',
+              isMuted && 'pf-chart-svg__tooltip-row--muted',
+            ),
+          },
+          [
+            m('.pf-chart-svg__tooltip-swatch', {
+              style: {backgroundColor: color},
+            }),
+            m('.pf-chart-svg__tooltip-name', s.series.name),
+            m('.pf-chart-svg__tooltip-value', fmtY(p.y)),
+          ],
+        );
+      }),
+    ),
+  );
+}

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
@@ -96,6 +96,7 @@ import {
 import {App} from '../../../public/app';
 import {EnumOption, renderWidgetShowcase} from '../widgets_page_utils';
 import {Trace} from '../../../public/trace';
+import {LineChartSvg} from '../../../components/widgets/charts_svg/line_chart_svg';
 
 // Generate sample data with normal distribution
 function generateNormalData(
@@ -169,6 +170,47 @@ export function renderCharts(app: App): m.Children {
           stacked: opts.stacked,
           gridLines: opts.gridLines,
           legendPosition: opts.legendPosition,
+        });
+      },
+      initialOpts: {
+        height: 250,
+        brushMode: new EnumOption('filter', [
+          'off',
+          'filter',
+          'select',
+        ] as const),
+        logScale: false,
+        showPoints: true,
+        multiSeries: false,
+        stacked: false,
+        gridLines: new EnumOption('none', [
+          'none',
+          'horizontal',
+          'vertical',
+          'both',
+        ] as const),
+        legendPosition: new EnumOption('top', [
+          'top',
+          'right',
+          'bottom',
+        ] as const),
+      },
+    }),
+
+    // LineChartSvg section
+    m('h2', {style: {marginTop: '32px'}}, 'LineChartSvg'),
+    renderWidgetShowcase({
+      renderWidget: (opts) => {
+        return m(LineChartDemo, {
+          height: opts.height,
+          brushMode: opts.brushMode,
+          logScale: opts.logScale,
+          showPoints: opts.showPoints,
+          multiSeries: opts.multiSeries,
+          stacked: opts.stacked,
+          gridLines: opts.gridLines,
+          legendPosition: opts.legendPosition,
+          useSvg: true,
         });
       },
       initialOpts: {
@@ -517,6 +559,38 @@ function renderSQLDemos(app: App): m.Children[] {
         ] as const),
       },
     }),
+    m('h3', {style: {marginTop: '32px'}}, 'SQLLineChartLoader (Svg)'),
+    renderWidgetShowcase({
+      renderWidget: (opts) => {
+        return m(SQLLineChartDemo, {
+          trace,
+          height: opts.height,
+          brushMode: opts.brushMode,
+          showPoints: opts.showPoints,
+          maxPoints: opts.maxPoints,
+          scaleAxes: opts.scaleAxes,
+          gridLines: opts.gridLines,
+          useSvg: true,
+        });
+      },
+      initialOpts: {
+        height: 250,
+        brushMode: new EnumOption('filter', [
+          'off',
+          'filter',
+          'select',
+        ] as const),
+        showPoints: true,
+        maxPoints: 200,
+        scaleAxes: true,
+        gridLines: new EnumOption('none', [
+          'none',
+          'horizontal',
+          'vertical',
+          'both',
+        ] as const),
+      },
+    }),
     m('h3', {style: {marginTop: '32px'}}, 'SQLPieChartLoader'),
     renderWidgetShowcase({
       renderWidget: (opts) => {
@@ -635,6 +709,34 @@ function renderSQLDemos(app: App): m.Children[] {
           maxPoints: opts.maxPoints,
           brushMode: opts.brushMode,
           gridLines: opts.gridLines,
+        });
+      },
+      initialOpts: {
+        height: 250,
+        maxPoints: 500,
+        brushMode: new EnumOption('filter', [
+          'off',
+          'filter',
+          'select',
+        ] as const),
+        gridLines: new EnumOption('none', [
+          'none',
+          'horizontal',
+          'vertical',
+          'both',
+        ] as const),
+      },
+    }),
+    m('h3', {style: {marginTop: '32px'}}, 'SQLCdfLoader (Svg)'),
+    renderWidgetShowcase({
+      renderWidget: (opts) => {
+        return m(SQLCdfDemo, {
+          trace,
+          height: opts.height,
+          maxPoints: opts.maxPoints,
+          brushMode: opts.brushMode,
+          gridLines: opts.gridLines,
+          useSvg: true,
         });
       },
       initialOpts: {
@@ -1146,6 +1248,7 @@ function SQLLineChartDemo(): m.Component<{
   maxPoints: number;
   scaleAxes: boolean;
   gridLines: string;
+  useSvg?: boolean;
 }> {
   let loader: SQLLineChartLoader | undefined;
   let brushedRange: {start: number; end: number} | undefined;
@@ -1171,23 +1274,25 @@ function SQLLineChartDemo(): m.Component<{
       };
       const {data, isPending} = loader.use(config);
 
+      const sqlLineChartProps = {
+        data,
+        height: attrs.height,
+        xAxisLabel: 'Timestamp',
+        yAxisLabel: 'Value',
+        showPoints: attrs.showPoints,
+        scaleAxes: attrs.scaleAxes,
+        gridLines: toGridLines(attrs.gridLines),
+        onBrush:
+          attrs.brushMode !== 'off'
+            ? (range: {start: number; end: number}) => {
+                brushedRange = range;
+              }
+            : undefined,
+        selection: attrs.brushMode === 'select' ? brushedRange : undefined,
+      };
+
       return m('div', [
-        m(LineChart, {
-          data,
-          height: attrs.height,
-          xAxisLabel: 'Timestamp',
-          yAxisLabel: 'Value',
-          showPoints: attrs.showPoints,
-          scaleAxes: attrs.scaleAxes,
-          gridLines: toGridLines(attrs.gridLines),
-          onBrush:
-            attrs.brushMode !== 'off'
-              ? (range) => {
-                  brushedRange = range;
-                }
-              : undefined,
-          selection: attrs.brushMode === 'select' ? brushedRange : undefined,
-        }),
+        m(attrs.useSvg ? LineChartSvg : LineChart, sqlLineChartProps),
         m(
           'pre',
           {
@@ -1336,61 +1441,9 @@ function LineChartDemo(): m.Component<{
   stacked: boolean;
   gridLines: string;
   legendPosition: LegendPosition;
+  useSvg?: boolean;
 }> {
   let brushRange: {start: number; end: number} | undefined;
-
-  // Helper to interpolate Y value between two points at a given X
-  function interpolateY(
-    p1: {x: number; y: number},
-    p2: {x: number; y: number},
-    x: number,
-  ): number {
-    if (p1.x === p2.x) return p1.y;
-    const t = (x - p1.x) / (p2.x - p1.x);
-    return p1.y + t * (p2.y - p1.y);
-  }
-
-  // Filter points to range, with interpolation at boundaries for continuity
-  function filterPointsWithInterpolation(
-    points: ReadonlyArray<{x: number; y: number}>,
-    start: number,
-    end: number,
-  ): Array<{x: number; y: number}> {
-    if (points.length === 0) return [];
-
-    // Sort points by X (should already be sorted, but just in case)
-    const sorted = [...points].sort((a, b) => a.x - b.x);
-
-    const result: Array<{x: number; y: number}> = [];
-
-    // Find points within range and interpolate at boundaries
-    for (let i = 0; i < sorted.length; i++) {
-      const curr = sorted[i];
-      const prev = i > 0 ? sorted[i - 1] : undefined;
-
-      // Add interpolated start point if we're crossing into the range
-      if (prev !== undefined && prev.x < start && curr.x >= start) {
-        if (curr.x > start) {
-          result.push({x: start, y: interpolateY(prev, curr, start)});
-        }
-      }
-
-      // Add current point if within range
-      if (curr.x >= start && curr.x <= end) {
-        result.push({x: curr.x, y: curr.y});
-      }
-
-      // Add interpolated end point if we're leaving the range
-      const next = i < sorted.length - 1 ? sorted[i + 1] : undefined;
-      if (next !== undefined && curr.x <= end && next.x > end) {
-        if (curr.x < end) {
-          result.push({x: end, y: interpolateY(curr, next, end)});
-        }
-      }
-    }
-
-    return result;
-  }
 
   return {
     view: ({attrs}) => {
@@ -1399,43 +1452,33 @@ function LineChartDemo(): m.Component<{
         ? LINE_CHART_MULTI_SERIES_DATA
         : LINE_CHART_SAMPLE_DATA;
 
-      // Filter data to the brushed X range (only in filter mode)
+      // Pass full data through; xAxisMin/xAxisMax handles the visible window.
       const range = brushRange;
-      const data: LineChartData =
-        isFilter && range !== undefined
-          ? {
-              series: fullData.series.map((s) => ({
-                ...s,
-                points: filterPointsWithInterpolation(
-                  s.points,
-                  range.start,
-                  range.end,
-                ),
-              })),
-            }
-          : fullData;
+      const data: LineChartData = fullData;
+
+      const lineChartProps = {
+        data,
+        height: attrs.height,
+        xAxisLabel: 'Time',
+        yAxisLabel: 'Value',
+        logScale: attrs.logScale,
+        showPoints: attrs.showPoints,
+        xAxisMin: isFilter ? range?.start : undefined,
+        xAxisMax: isFilter ? range?.end : undefined,
+        stacked: attrs.stacked,
+        gridLines: toGridLines(attrs.gridLines),
+        legendPosition: attrs.legendPosition,
+        onBrush:
+          attrs.brushMode !== 'off'
+            ? (newRange: {start: number; end: number}) => {
+                brushRange = newRange;
+              }
+            : undefined,
+        selection: attrs.brushMode === 'select' ? brushRange : undefined,
+      };
 
       return m('div', [
-        m(LineChart, {
-          data,
-          height: attrs.height,
-          xAxisLabel: 'Time',
-          yAxisLabel: 'Value',
-          logScale: attrs.logScale,
-          showPoints: attrs.showPoints,
-          xAxisMin: isFilter ? range?.start : undefined,
-          xAxisMax: isFilter ? range?.end : undefined,
-          stacked: attrs.stacked,
-          gridLines: toGridLines(attrs.gridLines),
-          legendPosition: attrs.legendPosition,
-          onBrush:
-            attrs.brushMode !== 'off'
-              ? (newRange) => {
-                  brushRange = newRange;
-                }
-              : undefined,
-          selection: attrs.brushMode === 'select' ? brushRange : undefined,
-        }),
+        m(attrs.useSvg ? LineChartSvg : LineChart, lineChartProps),
         m(
           'pre',
           {
@@ -2290,6 +2333,7 @@ function SQLCdfDemo(): m.Component<{
   maxPoints: number;
   brushMode: 'off' | 'filter' | 'select';
   gridLines: string;
+  useSvg?: boolean;
 }> {
   let loader: SQLCdfLoader | undefined;
   let brushedRange: {start: number; end: number} | undefined;
@@ -2314,23 +2358,25 @@ function SQLCdfDemo(): m.Component<{
       };
       const {data, isPending} = loader.use(config);
 
+      const cdfProps = {
+        data,
+        height: attrs.height,
+        xAxisLabel: 'Duration (ns)',
+        yAxisLabel: 'Cumulative %',
+        showPoints: false,
+        scaleAxes: true,
+        gridLines: toGridLines(attrs.gridLines),
+        onBrush:
+          attrs.brushMode !== 'off'
+            ? (range: {start: number; end: number}) => {
+                brushedRange = range;
+              }
+            : undefined,
+        selection: attrs.brushMode === 'select' ? brushedRange : undefined,
+      };
+
       return m('div', [
-        m(LineChart, {
-          data,
-          height: attrs.height,
-          xAxisLabel: 'Duration (ns)',
-          yAxisLabel: 'Cumulative %',
-          showPoints: false,
-          scaleAxes: true,
-          gridLines: toGridLines(attrs.gridLines),
-          onBrush:
-            attrs.brushMode !== 'off'
-              ? (range) => {
-                  brushedRange = range;
-                }
-              : undefined,
-          selection: attrs.brushMode === 'select' ? brushedRange : undefined,
-        }),
+        m(attrs.useSvg ? LineChartSvg : LineChart, cdfProps),
         m(
           'pre',
           {

--- a/ui/src/widgets/cursor_tooltip.ts
+++ b/ui/src/widgets/cursor_tooltip.ts
@@ -24,8 +24,14 @@ import {
 } from '@popperjs/core';
 import {classNames} from '../base/classnames';
 import {Point2D, Vector2D} from '../base/geom';
+import {PopupPosition} from './popup';
 
-export interface CursorTooltipAttrs extends HTMLAttrs {}
+export interface CursorTooltipAttrs extends HTMLAttrs {
+  // Which side of the cursor to place the tooltip. Defaults to Right.
+  readonly position?: PopupPosition;
+  // Distance in px between the tooltip and the cursor. Default = 8.
+  readonly offset?: number;
+}
 
 class VElement implements VirtualElement {
   private pos = new Vector2D({x: 0, y: 0});
@@ -58,7 +64,12 @@ export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
   private popper?: PopperInstance;
 
   view({children, attrs}: m.Vnode<CursorTooltipAttrs>) {
-    const {className, ...rest} = attrs;
+    const {
+      className,
+      offset = 8,
+      position = PopupPosition.Right,
+      ...rest
+    } = attrs;
     return m(
       Portal,
       {
@@ -74,12 +85,12 @@ export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
         onContentMount: (portal) => {
           this.virtualElement.setPosition(globalMousePos);
           this.popper = createPopper(this.virtualElement, portal, {
-            placement: 'right',
+            placement: position,
             modifiers: [
               {
                 name: 'offset',
                 options: {
-                  offset: [0, 8], // Shift away from cursor
+                  offset: [0, offset], // Shift away from cursor
                 },
               },
             ],


### PR DESCRIPTION
Adds LineChartSvg - a Mithril+SVG drop-in replacement for the ECharts backed LineChart.

Adds features such as series hover & tooltip emphasis, and handles updates much more cleanly without losing state compared to the echarts approach.

Also, add to the widget demo page, and add features to CursorTooltip (popup position and offset).