### PR TITLE
tp: improve handling of includes to prepare for multi-connection

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/engine/BUILD.gn
@@ -62,6 +62,7 @@ perfetto_unittest_source_set("unittests") {
     "../../../../gn:gtest_and_gmock",
     "../../../../gn:sqlite",
     "../../../base",
+    "../../../base:test_support",
     "../..//tables:tables_python",
     "../../containers",
     "../../perfetto_sql/intrinsics/table_functions:interface",

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
@@ -557,11 +557,21 @@ PerfettoSqlConnection::ExecuteUntilLastStatement(SqlSource sql_source) {
 
   auto result = ExecuteUntilLastStatementImpl(std::move(sql_source));
 
-  // Unwind the stack back to our entry point. For include frames,
-  // add their traceback info to any error that occurred.
+  // Unwind the stack back to our entry point. For include frames on the
+  // error path, decorate the result with traceback info AND mark the
+  // module poisoned so future INCLUDEs of the same key short-circuit
+  // with the same error rather than re-running the broken body. Poison
+  // walks up the stack naturally because every ancestor INCLUDE frame
+  // also hits this branch on its way out.
+  //
+  // Poison the module with the error context as it stands BEFORE we
+  // prepend this frame's own traceback. The stored reason therefore
+  // shows what failed inside this module (descendant tracebacks) but
+  // not where this module was called from (ancestor tracebacks).
   while (execution_stack_.size() > stack_base) {
     auto& frame = execution_stack_.back();
-    if (!result.ok() && frame.type == FrameType::kInclude) {
+    if (frame.type == FrameType::kInclude && !result.ok()) {
+      frame.include_claim.ReleasePoisoned(result.status().message());
       std::string traceback = frame.traceback_sql.AsTraceback(0);
       result = base::ErrStatus("%s%s", traceback.c_str(),
                                result.status().c_message());
@@ -576,34 +586,46 @@ PerfettoSqlConnection::ProcessFrame(size_t frame_idx) {
   // Handle wildcard frames specially - they just push include frames
   if (execution_stack_[frame_idx].type == FrameType::kWildcard) {
     auto& frame = execution_stack_[frame_idx];
-    // Find next module to include (skip already included ones)
     while (frame.wildcard_index < frame.wildcard_modules.size()) {
-      auto& module_pair = frame.wildcard_modules[frame.wildcard_index];
-      const std::string& key = module_pair.first;
-      auto* file_ptr = module_pair.second;
-      frame.wildcard_index++;
+      auto& slot = frame.wildcard_modules[frame.wildcard_index++];
+      std::string key = std::move(slot.first);
+      std::string sql = std::move(slot.second);
 
-      if (!file_ptr->included) {
-        PERFETTO_TP_TRACE(
-            metatrace::Category::QUERY_TIMELINE,
-            "Include (expanded from wildcard)",
-            [&key](metatrace::Record* r) { r->AddArg("Module", key); });
+      PERFETTO_TP_TRACE(
+          metatrace::Category::QUERY_TIMELINE,
+          "Include (expanded from wildcard)",
+          [&key](metatrace::Record* r) { r->AddArg("Module", key); });
 
-        // Copy traceback before push_back which may invalidate frame ref
-        SqlSource traceback = frame.wildcard_traceback_sql;
-
-        // Push include frame for this module
-        execution_stack_.push_back(
-            {FrameType::kInclude,
-             SqlSource::FromModuleInclude(file_ptr->sql, key),
-             /*parser=*/nullptr, /*accumulated_stats=*/{},
-             /*current_stmt=*/std::nullopt, key, file_ptr, std::move(traceback),
-             /*wildcard_modules=*/{},
-             /*wildcard_index=*/0,
-             /*wildcard_traceback_sql=*/
-             SqlSource::FromTraceProcessorImplementation("")});
-        return FrameResult::kContinue;
+      if (IsKeyOnIncludeStack(key)) {
+        std::string traceback = frame.wildcard_traceback_sql.AsTraceback(0);
+        return base::ErrStatus(
+            "%sINCLUDE: cycle detected — module '%s' is already mid-import "
+            "in this execution.",
+            traceback.c_str(), key.c_str());
       }
+      auto res = database_->TryClaimInclude(key);
+      if (res.already_included) {
+        continue;
+      }
+      if (res.poisoned) {
+        std::string traceback = frame.wildcard_traceback_sql.AsTraceback(0);
+        return base::ErrStatus(
+            "%sINCLUDE: module '%s' poisoned by earlier failure: %s",
+            traceback.c_str(), key.c_str(), res.poison_reason.c_str());
+      }
+
+      // Copy traceback before push_back which may invalidate frame ref.
+      SqlSource traceback = frame.wildcard_traceback_sql;
+      execution_stack_.push_back(
+          {FrameType::kInclude, SqlSource::FromModuleInclude(sql, key),
+           /*parser=*/nullptr, /*accumulated_stats=*/{},
+           /*current_stmt=*/std::nullopt, key, std::move(traceback),
+           /*include_claim=*/std::move(res.claim),
+           /*wildcard_modules=*/{},
+           /*wildcard_index=*/0,
+           /*wildcard_traceback_sql=*/
+           SqlSource::FromTraceProcessorImplementation("")});
+      return FrameResult::kContinue;
     }
     // No more modules to process
     return FrameResult::kFrameDone;
@@ -735,7 +757,7 @@ PerfettoSqlConnection::ProcessFrame(size_t frame_idx) {
   if (frame.accumulated_stats.statement_count_with_output > 0) {
     return base::ErrStatus("INCLUDE: Included module returning values.");
   }
-  frame.file_ptr->included = true;
+  frame.include_claim.ReleaseSuccess();
   return FrameResult::kFrameDone;
 }
 
@@ -768,8 +790,9 @@ PerfettoSqlConnection::ExecuteUntilLastStatementImpl(SqlSource sql_source) {
   execution_stack_.push_back(
       {FrameType::kRoot, std::move(sql_source), /*parser=*/nullptr,
        /*accumulated_stats=*/{}, /*current_stmt=*/std::nullopt,
-       /*include_key=*/{}, /*file_ptr=*/nullptr,
+       /*include_key=*/{},
        /*traceback_sql=*/SqlSource::FromTraceProcessorImplementation(""),
+       /*include_claim=*/{},
        /*wildcard_modules=*/{}, /*wildcard_index=*/0,
        /*wildcard_traceback_sql=*/
        SqlSource::FromTraceProcessorImplementation("")});
@@ -1091,62 +1114,81 @@ base::Status PerfettoSqlConnection::IncludePackageImpl(
     const std::string& include_key,
     const PerfettoSqlParser& parser) {
   if (!include_key.empty() && include_key.back() == '*') {
-    // If the key ends with a wildcard, collect all matching modules and
-    // push a wildcard frame that will process them one at a time.
+    // If the key ends with a wildcard, collect all matching (key, sql) pairs
+    // and push a wildcard frame that will process them one at a time. The
+    // expander goes through |TryClaimInclude| per module; already-included
+    // modules are skipped silently and poisoned modules surface their
+    // recorded reason.
     std::string prefix = include_key.substr(0, include_key.size() - 1);
-    std::vector<
-        std::pair<std::string, sql_modules::RegisteredPackage::ModuleFile*>>
-        matching_modules;
+    std::vector<std::pair<std::string, std::string>> matching_modules;
     for (auto module = package.modules.GetIterator(); module; ++module) {
       if (!base::StartsWith(module.key(), prefix))
         continue;
-      // Include both already-included and not-yet-included modules in the list
-      // The wildcard frame will skip already-included ones during iteration
-      matching_modules.emplace_back(module.key(), &module.value());
+      matching_modules.emplace_back(module.key(), module.value());
     }
 
     if (matching_modules.empty()) {
       return base::OkStatus();
     }
 
-    // Push a wildcard frame that will iterate through these modules
     execution_stack_.push_back(
         {FrameType::kWildcard,
          /*sql_source=*/SqlSource::FromTraceProcessorImplementation(""),
          /*parser=*/nullptr, /*accumulated_stats=*/{},
          /*current_stmt=*/std::nullopt,
-         /*include_key=*/{}, /*file_ptr=*/nullptr,
+         /*include_key=*/{},
          /*traceback_sql=*/SqlSource::FromTraceProcessorImplementation(""),
-         std::move(matching_modules), /*wildcard_index=*/0,
+         /*include_claim=*/{}, std::move(matching_modules),
+         /*wildcard_index=*/0,
          /*wildcard_traceback_sql=*/parser.statement_sql()});
     return base::OkStatus();
   }
-  auto* module_file = package.modules.Find(include_key);
-  if (!module_file) {
+  auto* module_sql = package.modules.Find(include_key);
+  if (!module_sql) {
     return base::ErrStatus("INCLUDE: unknown module '%s'", include_key.c_str());
   }
-  return IncludeModuleImpl(*module_file, include_key, parser);
+  return IncludeModuleImpl(include_key, *module_sql, parser);
+}
+
+bool PerfettoSqlConnection::IsKeyOnIncludeStack(const std::string& key) const {
+  for (const auto& f : execution_stack_) {
+    if (f.type == FrameType::kInclude && f.include_key == key) {
+      return true;
+    }
+  }
+  return false;
 }
 
 base::Status PerfettoSqlConnection::IncludeModuleImpl(
-    sql_modules::RegisteredPackage::ModuleFile& file,
     const std::string& key,
+    const std::string& sql,
     const PerfettoSqlParser& parser) {
-  // INCLUDE is noop for already included files.
-  if (file.included) {
+  if (IsKeyOnIncludeStack(key)) {
+    std::string traceback = parser.statement_sql().AsTraceback(0);
+    return base::ErrStatus(
+        "%sINCLUDE: cycle detected — module '%s' is already mid-import in "
+        "this execution.",
+        traceback.c_str(), key.c_str());
+  }
+  auto res = database_->TryClaimInclude(key);
+  if (res.already_included) {
     return base::OkStatus();
   }
-
-  // Push include frame onto execution stack. The main loop will process it.
+  if (res.poisoned) {
+    std::string traceback = parser.statement_sql().AsTraceback(0);
+    return base::ErrStatus(
+        "%sINCLUDE: module '%s' poisoned by earlier failure: %s",
+        traceback.c_str(), key.c_str(), res.poison_reason.c_str());
+  }
   execution_stack_.push_back({FrameType::kInclude,
-                              SqlSource::FromModuleInclude(file.sql, key),
+                              SqlSource::FromModuleInclude(sql, key),
                               /*parser=*/nullptr, /*accumulated_stats=*/{},
-                              /*current_stmt=*/std::nullopt, key, &file,
+                              /*current_stmt=*/std::nullopt, key,
                               /*traceback_sql=*/parser.statement_sql(),
+                              /*include_claim=*/std::move(res.claim),
                               /*wildcard_modules=*/{}, /*wildcard_index=*/0,
                               /*wildcard_traceback_sql=*/
                               SqlSource::FromTraceProcessorImplementation("")});
-
   return base::OkStatus();
 }
 

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
@@ -248,10 +248,15 @@ class PerfettoSqlConnection {
 
   SqliteConnection* sqlite_connection() { return connection_.get(); }
 
-  // Makes new SQL package available to include.
-  void RegisterPackage(const std::string& name,
-                       sql_modules::RegisteredPackage package) {
-    database_->RegisterPackage(name, std::move(package));
+  // Test-only accessor for the |PerfettoSqlDatabase| backing this connection.
+  PerfettoSqlDatabase* database_for_testing() { return database_.get(); }
+
+  // Makes new SQL package available to include. Fails if any module key in
+  // the new package has already been included or poisoned on the underlying
+  // database; see |PerfettoSqlDatabase::RegisterPackage|.
+  base::Status RegisterPackage(const std::string& name,
+                               sql_modules::RegisteredPackage package) {
+    return database_->RegisterPackage(name, std::move(package));
   }
 
   // Removes a SQL package.
@@ -334,15 +339,17 @@ class PerfettoSqlConnection {
     ExecutionStats accumulated_stats;
     std::optional<SqliteConnection::PreparedStatement> current_stmt;
 
-    // For include frames: metadata needed to complete the include
+    // For include frames: metadata needed to complete the include.
+    // |include_claim| owns the cross-connection in-flight slot for the
+    // module key; ReleaseSuccess is called on clean completion, and the
+    // unwind path on error calls ReleasePoisoned so subsequent attempts
+    // short-circuit with the recorded reason.
     std::string include_key;
-    sql_modules::RegisteredPackage::ModuleFile* file_ptr = nullptr;
     SqlSource traceback_sql;
+    PerfettoSqlDatabase::IncludeClaim include_claim;
 
-    // For wildcard frames: modules to include (processed in order)
-    std::vector<
-        std::pair<std::string, sql_modules::RegisteredPackage::ModuleFile*>>
-        wildcard_modules;
+    // For wildcard frames: (key, sql) pairs to expand one at a time.
+    std::vector<std::pair<std::string, std::string>> wildcard_modules;
     size_t wildcard_index = 0;
     SqlSource wildcard_traceback_sql;
   };
@@ -401,10 +408,17 @@ class PerfettoSqlConnection {
                                   const std::string& key,
                                   const PerfettoSqlParser&);
 
-  // Include a given module.
-  base::Status IncludeModuleImpl(sql_modules::RegisteredPackage::ModuleFile&,
-                                 const std::string& key,
+  // Include a given module body. Goes through |TryClaimInclude| on the
+  // database; returns OkStatus on already-included, an error on poisoned,
+  // or pushes an include frame on the execution stack on a fresh claim.
+  base::Status IncludeModuleImpl(const std::string& key,
+                                 const std::string& sql,
                                  const PerfettoSqlParser&);
+
+  // Returns true iff |key| is the |include_key| of an active |kInclude|
+  // frame on this connection's execution stack — i.e. a re-entry of |key|
+  // would form an include cycle.
+  bool IsKeyOnIncludeStack(const std::string& key) const;
 
   // Implementation of ExecuteUntilLastStatement. Separated to handle
   // re-entrant Execute() calls from statement handlers.

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_unittest.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_unittest.cc
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "src/base/test/status_matchers.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/sqlite/bindings/sqlite_result.h"
 #include "src/trace_processor/sqlite/sql_source.h"
@@ -29,6 +30,8 @@
 
 namespace perfetto::trace_processor {
 namespace {
+
+using base::gtest_matchers::IsError;
 
 class PerfettoSqlConnectionTest : public ::testing::Test {
  protected:
@@ -41,8 +44,7 @@ sql_modules::RegisteredPackage CreateTestPackage(
     const std::vector<std::pair<std::string, std::string>>& files) {
   sql_modules::RegisteredPackage result;
   for (const auto& file : files) {
-    result.modules[file.first] =
-        sql_modules::RegisteredPackage::ModuleFile{file.second, false};
+    result.modules[file.first] = file.second;
   }
   return result;
 }
@@ -302,8 +304,9 @@ TEST_F(PerfettoSqlConnectionTest, Include_All) {
   auto res_create = connection_->Execute(
       SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE *"));
   ASSERT_TRUE(res_create.ok()) << res_create.status().c_message();
-  ASSERT_TRUE(connection_->FindPackage("foo")->modules["foo.foo"].included);
-  ASSERT_TRUE(connection_->FindPackage("bar")->modules["bar.bar"].included);
+  auto* db = connection_->database_for_testing();
+  ASSERT_TRUE(db->IsModuleIncluded("foo.foo"));
+  ASSERT_TRUE(db->IsModuleIncluded("bar.bar"));
 }
 
 TEST_F(PerfettoSqlConnectionTest, Include_Module) {
@@ -320,9 +323,170 @@ TEST_F(PerfettoSqlConnectionTest, Include_Module) {
   auto res_create = connection_->Execute(
       SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.*"));
   ASSERT_TRUE(res_create.ok()) << res_create.status().c_message();
-  ASSERT_TRUE(connection_->FindPackage("foo")->modules["foo.foo1"].included);
-  ASSERT_TRUE(connection_->FindPackage("foo")->modules["foo.foo2"].included);
-  ASSERT_FALSE(connection_->FindPackage("bar")->modules["bar.bar"].included);
+  auto* db = connection_->database_for_testing();
+  ASSERT_TRUE(db->IsModuleIncluded("foo.foo1"));
+  ASSERT_TRUE(db->IsModuleIncluded("foo.foo2"));
+  ASSERT_FALSE(db->IsModuleIncluded("bar.bar"));
+}
+
+TEST_F(PerfettoSqlConnectionTest, Include_FailingModulePoisons) {
+  // A module with a syntactically broken body. The first INCLUDE fails;
+  // subsequent INCLUDEs of the same key short-circuit with a poison
+  // error rather than re-running the broken body.
+  connection_->RegisterPackage(
+      "foo", CreateTestPackage({{"foo.bad", "this is not valid sql"}}));
+
+  ASSERT_THAT(connection_->Execute(SqlSource::FromExecuteQuery(
+                  "INCLUDE PERFETTO MODULE foo.bad")),
+              IsError());
+  ASSERT_TRUE(connection_->database_for_testing()->IsModulePoisoned("foo.bad"));
+
+  auto second = connection_->Execute(
+      SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.bad"));
+  ASSERT_THAT(second, IsError());
+  EXPECT_THAT(second.status().c_message(),
+              testing::HasSubstr("poisoned by earlier failure"));
+}
+
+TEST_F(PerfettoSqlConnectionTest, Include_AlreadyIncludedShortCircuits) {
+  // A module body whose successful execution has a side-effect (CREATE
+  // TABLE). The second INCLUDE must NOT re-run the body — if it did,
+  // SQLite would return "table already exists" and the second INCLUDE
+  // would fail.
+  connection_->RegisterPackage(
+      "foo", CreateTestPackage(
+                 {{"foo.t", "CREATE PERFETTO TABLE foo AS SELECT 42 AS x"}}));
+
+  ASSERT_OK(connection_->Execute(
+      SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.t")));
+  ASSERT_OK(connection_->Execute(
+      SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.t")));
+}
+
+TEST_F(PerfettoSqlConnectionTest, Include_PoisonPropagatesUpStack) {
+  // foo.bad's body is broken; foo.good's body INCLUDEs foo.bad. Including
+  // foo.good fails, and BOTH foo.bad AND foo.good should be poisoned —
+  // poisoning walks up the stack as include frames are unwound on error.
+  connection_->RegisterPackage(
+      "foo",
+      CreateTestPackage({{"foo.bad", "this is not valid sql"},
+                         {"foo.good", "INCLUDE PERFETTO MODULE foo.bad"}}));
+
+  ASSERT_THAT(connection_->Execute(SqlSource::FromExecuteQuery(
+                  "INCLUDE PERFETTO MODULE foo.good")),
+              IsError());
+
+  auto* db = connection_->database_for_testing();
+  ASSERT_TRUE(db->IsModulePoisoned("foo.bad"));
+  ASSERT_TRUE(db->IsModulePoisoned("foo.good"));
+}
+
+TEST_F(PerfettoSqlConnectionTest,
+       Include_PoisonError_Direct_HasImmediateTraceback) {
+  // Re-including a poisoned module via a direct INCLUDE statement should
+  // surface the immediate INCLUDE line in the error traceback, matching the
+  // error format produced by the asynchronous failure path.
+  connection_->RegisterPackage(
+      "foo", CreateTestPackage({{"foo.bad", "this is not valid sql"}}));
+  ASSERT_THAT(connection_->Execute(SqlSource::FromExecuteQuery(
+                  "INCLUDE PERFETTO MODULE foo.bad")),
+              IsError());
+
+  auto retry = connection_->Execute(
+      SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.bad"));
+  ASSERT_THAT(retry, IsError());
+  EXPECT_THAT(retry.status().c_message(),
+              testing::HasSubstr("INCLUDE PERFETTO MODULE foo.bad"));
+  EXPECT_THAT(retry.status().c_message(),
+              testing::HasSubstr("poisoned by earlier failure"));
+}
+
+TEST_F(PerfettoSqlConnectionTest,
+       Include_PoisonError_Wildcard_HasImmediateTraceback) {
+  // Same as above but the retry happens via a wildcard expansion. The
+  // wildcard's own statement line should appear in the traceback.
+  connection_->RegisterPackage(
+      "foo", CreateTestPackage({{"foo.bad", "this is not valid sql"}}));
+  ASSERT_THAT(connection_->Execute(SqlSource::FromExecuteQuery(
+                  "INCLUDE PERFETTO MODULE foo.bad")),
+              IsError());
+
+  auto retry = connection_->Execute(
+      SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.*"));
+  ASSERT_THAT(retry, IsError());
+  EXPECT_THAT(retry.status().c_message(),
+              testing::HasSubstr("INCLUDE PERFETTO MODULE foo.*"));
+  EXPECT_THAT(retry.status().c_message(),
+              testing::HasSubstr("poisoned by earlier failure"));
+}
+
+TEST_F(PerfettoSqlConnectionTest, Include_PoisonReason_StableAcrossRetries) {
+  // Each retry of a poisoned include must produce an error message of the
+  // same length — the stored poison reason should not be padded with the
+  // retry's own traceback layers each time.
+  connection_->RegisterPackage(
+      "foo", CreateTestPackage({{"foo.bad", "this is not valid sql"}}));
+  ASSERT_THAT(connection_->Execute(SqlSource::FromExecuteQuery(
+                  "INCLUDE PERFETTO MODULE foo.bad")),
+              IsError());
+
+  auto a = connection_->Execute(
+      SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.bad"));
+  auto b = connection_->Execute(
+      SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.bad"));
+  ASSERT_THAT(a, IsError());
+  ASSERT_THAT(b, IsError());
+  EXPECT_EQ(a.status().message().size(), b.status().message().size());
+}
+
+TEST_F(PerfettoSqlConnectionTest, Include_CycleDetected) {
+  // foo.a includes foo.b, foo.b includes foo.a. Walking the connection's
+  // own execution stack catches the re-entry and surfaces a cycle error
+  // rather than re-entering |TryClaimInclude| (which would deadlock on its
+  // own claim).
+  connection_->RegisterPackage("foo",
+                               CreateTestPackage({
+                                   {"foo.a", "INCLUDE PERFETTO MODULE foo.b"},
+                                   {"foo.b", "INCLUDE PERFETTO MODULE foo.a"},
+                               }));
+
+  auto res = connection_->Execute(
+      SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.a"));
+  ASSERT_THAT(res, IsError());
+  EXPECT_THAT(res.status().c_message(), testing::HasSubstr("cycle detected"));
+}
+
+TEST_F(PerfettoSqlConnectionTest, RegisterPackage_FailsAfterModuleIncluded) {
+  // Re-registering a package whose module has already been imported is
+  // rejected: silently shadowing the imported body would surprise callers
+  // that have built on top of the original SQL.
+  ASSERT_OK(connection_->RegisterPackage(
+      "foo", CreateTestPackage(
+                 {{"foo.t", "CREATE PERFETTO TABLE foo AS SELECT 42 AS x"}})));
+  ASSERT_OK(connection_->Execute(
+      SqlSource::FromExecuteQuery("INCLUDE PERFETTO MODULE foo.t")));
+
+  auto status = connection_->RegisterPackage(
+      "foo", CreateTestPackage(
+                 {{"foo.t", "CREATE PERFETTO TABLE bar AS SELECT 1 AS x"}}));
+  ASSERT_THAT(status, IsError());
+  EXPECT_THAT(status.c_message(), testing::HasSubstr("foo.t"));
+  EXPECT_THAT(status.c_message(), testing::HasSubstr("already been included"));
+}
+
+TEST_F(PerfettoSqlConnectionTest, RegisterPackage_FailsAfterModulePoisoned) {
+  // Likewise for the poisoned case.
+  ASSERT_OK(connection_->RegisterPackage(
+      "foo", CreateTestPackage({{"foo.bad", "this is not valid sql"}})));
+  ASSERT_THAT(connection_->Execute(SqlSource::FromExecuteQuery(
+                  "INCLUDE PERFETTO MODULE foo.bad")),
+              IsError());
+
+  auto status = connection_->RegisterPackage(
+      "foo", CreateTestPackage({{"foo.bad", "SELECT 1"}}));
+  ASSERT_THAT(status, IsError());
+  EXPECT_THAT(status.c_message(), testing::HasSubstr("foo.bad"));
+  EXPECT_THAT(status.c_message(), testing::HasSubstr("poisoned"));
 }
 
 TEST_F(PerfettoSqlConnectionTest, DelegatingFunction_Error_TargetNotFound) {

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.cc
@@ -17,6 +17,7 @@
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_database.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -32,11 +33,30 @@ PerfettoSqlDatabase::PerfettoSqlDatabase(StringPool* pool)
 
 PerfettoSqlDatabase::~PerfettoSqlDatabase() = default;
 
-void PerfettoSqlDatabase::RegisterPackage(
+base::Status PerfettoSqlDatabase::RegisterPackage(
     const std::string& name,
     sql_modules::RegisteredPackage package) {
+  {
+    std::lock_guard<std::mutex> lock(include_mu_);
+    for (auto m = package.modules.GetIterator(); m; ++m) {
+      if (included_modules_.count(m.key()) != 0) {
+        return base::ErrStatus(
+            "Cannot register package '%s': module '%s' has already been "
+            "included on this database; re-registration would silently "
+            "shadow the imported body.",
+            name.c_str(), m.key().c_str());
+      }
+      if (poisoned_modules_.count(m.key()) != 0) {
+        return base::ErrStatus(
+            "Cannot register package '%s': module '%s' is poisoned by an "
+            "earlier failed include.",
+            name.c_str(), m.key().c_str());
+      }
+    }
+  }
   packages_.Erase(name);
   packages_.Insert(name, std::move(package));
+  return base::OkStatus();
 }
 
 void PerfettoSqlDatabase::ErasePackage(const std::string& name) {
@@ -74,6 +94,115 @@ PerfettoSqlDatabase::GetModules() const {
     }
   }
   return result;
+}
+
+// 'std::unique_lock' doesn't work well with thread annotations
+// (see https://github.com/llvm/llvm-project/issues/63239), so we suppress
+// thread safety static analysis for this method. The lock is held
+// throughout; analysis on every other method in the file is unaffected.
+PerfettoSqlDatabase::IncludeClaimResult PerfettoSqlDatabase::TryClaimInclude(
+    const std::string& key) PERFETTO_NO_THREAD_SAFETY_ANALYSIS {
+  std::unique_lock<std::mutex> lock(include_mu_);
+  // Wait until no peer connection is mid-import for the same key. Cycles
+  // (same connection re-entering for a key it already holds) are caught at
+  // the call site; reaching that case here would deadlock on ourselves.
+  include_cv_.wait(lock, [&]() PERFETTO_EXCLUSIVE_LOCKS_REQUIRED(include_mu_) {
+    return include_in_progress_.count(key) == 0;
+  });
+  IncludeClaimResult res;
+  if (included_modules_.count(key) != 0) {
+    res.already_included = true;
+    return res;
+  }
+  if (auto it = poisoned_modules_.find(key); it != poisoned_modules_.end()) {
+    res.poisoned = true;
+    res.poison_reason = it->second;
+    return res;
+  }
+  include_in_progress_.insert(key);
+  res.claim = IncludeClaim(this, key);
+  return res;
+}
+
+void PerfettoSqlDatabase::ReleaseClaimSuccess(const std::string& key) {
+  {
+    std::lock_guard<std::mutex> lock(include_mu_);
+    include_in_progress_.erase(key);
+    included_modules_.insert(key);
+  }
+  include_cv_.notify_all();
+}
+
+void PerfettoSqlDatabase::ReleaseClaimPoisoned(const std::string& key,
+                                               std::string reason) {
+  {
+    std::lock_guard<std::mutex> lock(include_mu_);
+    include_in_progress_.erase(key);
+    poisoned_modules_[key] = std::move(reason);
+  }
+  include_cv_.notify_all();
+}
+
+void PerfettoSqlDatabase::ReleaseClaimTransient(const std::string& key) {
+  {
+    std::lock_guard<std::mutex> lock(include_mu_);
+    include_in_progress_.erase(key);
+  }
+  include_cv_.notify_all();
+}
+
+bool PerfettoSqlDatabase::IsModuleIncluded(const std::string& key) const {
+  std::lock_guard<std::mutex> lock(include_mu_);
+  return included_modules_.count(key) != 0;
+}
+
+bool PerfettoSqlDatabase::IsModulePoisoned(const std::string& key) const {
+  std::lock_guard<std::mutex> lock(include_mu_);
+  return poisoned_modules_.count(key) != 0;
+}
+
+PerfettoSqlDatabase::IncludeClaim::IncludeClaim(IncludeClaim&& o) noexcept
+    : db_(std::exchange(o.db_, nullptr)), key_(std::move(o.key_)) {}
+
+PerfettoSqlDatabase::IncludeClaim& PerfettoSqlDatabase::IncludeClaim::operator=(
+    IncludeClaim&& o) noexcept {
+  if (this != &o) {
+    ResetTransient();
+    db_ = std::exchange(o.db_, nullptr);
+    key_ = std::move(o.key_);
+  }
+  return *this;
+}
+
+PerfettoSqlDatabase::IncludeClaim::~IncludeClaim() {
+  ResetTransient();
+}
+
+void PerfettoSqlDatabase::IncludeClaim::ReleaseSuccess() {
+  if (!db_) {
+    return;
+  }
+  db_->ReleaseClaimSuccess(key_);
+  db_ = nullptr;
+  key_.clear();
+}
+
+void PerfettoSqlDatabase::IncludeClaim::ReleasePoisoned(std::string reason) {
+  if (!db_) {
+    return;
+  }
+  db_->ReleaseClaimPoisoned(key_, std::move(reason));
+  db_ = nullptr;
+  key_.clear();
+}
+
+void PerfettoSqlDatabase::IncludeClaim::ResetTransient() {
+  if (!db_) {
+    return;
+  }
+  db_->ReleaseClaimTransient(key_);
+  db_ = nullptr;
+  key_.clear();
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.h
@@ -17,11 +17,17 @@
 #ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_ENGINE_PERFETTO_SQL_DATABASE_H_
 #define SRC_TRACE_PROCESSOR_PERFETTO_SQL_ENGINE_PERFETTO_SQL_DATABASE_H_
 
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "perfetto/base/status.h"
+#include "perfetto/base/thread_annotations.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
@@ -50,8 +56,13 @@ class PerfettoSqlDatabase {
     return sqlite_database_;
   }
 
-  void RegisterPackage(const std::string& name,
-                       sql_modules::RegisteredPackage package);
+  // Registers |package| under |name|. Fails if any module key in the new
+  // package has already been recorded as included or poisoned on this
+  // database, since re-registration would silently shadow a body the
+  // connection has already imported.
+  base::Status RegisterPackage(const std::string& name,
+                               sql_modules::RegisteredPackage package)
+      PERFETTO_LOCKS_EXCLUDED(include_mu_);
   void ErasePackage(const std::string& name);
   sql_modules::RegisteredPackage* FindPackage(const std::string& name);
   const sql_modules::RegisteredPackage* FindPackage(
@@ -81,7 +92,86 @@ class PerfettoSqlDatabase {
     return committed_static_table_functions_;
   }
 
+  // RAII guard for the in-flight slot of an INCLUDE PERFETTO MODULE.
+  //
+  // The caller owns the slot for the module key and disposes of it via
+  // exactly one of:
+  //   - |ReleaseSuccess()|         the body ran cleanly; future
+  //                                 |TryClaimInclude| calls for the same
+  //                                 key short-circuit with
+  //                                 |already_included = true|.
+  //   - |ReleasePoisoned(reason)|  the body errored in a non-retryable
+  //                                 way; the reason is recorded and replayed
+  //                                 to subsequent callers without ever
+  //                                 re-running the body.
+  //   - destructor with neither    the slot is freed without record. Used
+  //                                 when the claim was opened but no
+  //                                 user-visible work was attempted (e.g.
+  //                                 the caller bailed early).
+  class IncludeClaim {
+   public:
+    IncludeClaim() = default;
+    IncludeClaim(IncludeClaim&&) noexcept;
+    IncludeClaim& operator=(IncludeClaim&&) noexcept;
+    IncludeClaim(const IncludeClaim&) = delete;
+    IncludeClaim& operator=(const IncludeClaim&) = delete;
+    ~IncludeClaim();
+
+    void ReleaseSuccess();
+    void ReleasePoisoned(std::string reason);
+
+   private:
+    friend class PerfettoSqlDatabase;
+    IncludeClaim(PerfettoSqlDatabase* db, std::string key)
+        : db_(db), key_(std::move(key)) {}
+
+    void ResetTransient();
+
+    PerfettoSqlDatabase* db_ = nullptr;
+    std::string key_;
+  };
+
+  struct IncludeClaimResult {
+    // Owns the slot iff none of the flags below are set.
+    IncludeClaim claim;
+    bool already_included = false;
+    bool poisoned = false;
+    std::string poison_reason;
+  };
+
+  // Claims the include slot for |key|. Blocks until no peer connection is
+  // mid-import for the same key, then returns one of:
+  //   - |already_included = true|      a peer already finished a successful
+  //                                     import of this key; caller noops.
+  //   - |poisoned = true|              a previous attempt failed; caller
+  //                                     surfaces |poison_reason| without
+  //                                     re-running the body.
+  //   - claim populated                caller owns the slot and must
+  //                                     dispose of it via the claim.
+  // The caller must guarantee that |key| is not already mid-import on the
+  // calling connection; otherwise this call deadlocks waiting on its own
+  // claim. Connections detect that case (cycle) by walking their own
+  // execution stack before calling |TryClaimInclude|.
+  IncludeClaimResult TryClaimInclude(const std::string& key)
+      PERFETTO_LOCKS_EXCLUDED(include_mu_);
+
+  // True iff |key| has been recorded as successfully included. Test-only.
+  bool IsModuleIncluded(const std::string& key) const
+      PERFETTO_LOCKS_EXCLUDED(include_mu_);
+
+  // True iff |key| has been recorded as poisoned. Test-only.
+  bool IsModulePoisoned(const std::string& key) const
+      PERFETTO_LOCKS_EXCLUDED(include_mu_);
+
  private:
+  friend class IncludeClaim;
+  void ReleaseClaimSuccess(const std::string& key)
+      PERFETTO_LOCKS_EXCLUDED(include_mu_);
+  void ReleaseClaimPoisoned(const std::string& key, std::string reason)
+      PERFETTO_LOCKS_EXCLUDED(include_mu_);
+  void ReleaseClaimTransient(const std::string& key)
+      PERFETTO_LOCKS_EXCLUDED(include_mu_);
+
   StringPool* const pool_;
   std::shared_ptr<SqliteDatabase> sqlite_database_;
   base::FlatHashMap<std::string, sql_modules::RegisteredPackage> packages_;
@@ -90,6 +180,20 @@ class PerfettoSqlDatabase {
   sqlite::CommittedStateManager committed_dataframes_;
   sqlite::CommittedStateManager committed_runtime_table_functions_;
   sqlite::CommittedStateManager committed_static_table_functions_;
+
+  // Single mutex+condvar guards include_in_progress_, included_modules_ and
+  // poisoned_modules_. Waiters on |TryClaimInclude| block here while a peer
+  // connection holds the in-flight slot for the same key. Same-connection
+  // re-entry (cycles) is detected at the call site by walking the
+  // connection's execution stack — the database has no notion of cycles.
+  mutable std::mutex include_mu_;
+  std::condition_variable include_cv_;
+  std::unordered_set<std::string> include_in_progress_
+      PERFETTO_GUARDED_BY(include_mu_);
+  std::unordered_set<std::string> included_modules_
+      PERFETTO_GUARDED_BY(include_mu_);
+  std::unordered_map<std::string, std::string> poisoned_modules_
+      PERFETTO_GUARDED_BY(include_mu_);
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/stdlib_docs_table_function.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/stdlib_docs_table_function.cc
@@ -67,9 +67,9 @@ base::StatusOr<stdlib_doc::ParsedModule> ParseModule(
   if (!mod) {
     return base::ErrStatus("Module not found: %s", module_key.c_str());
   }
-  PERFETTO_DCHECK(mod->sql.size() <= std::numeric_limits<uint32_t>::max());
+  PERFETTO_DCHECK(mod->size() <= std::numeric_limits<uint32_t>::max());
   auto parsed = stdlib_doc::ParseStdlibModule(
-      mod->sql.c_str(), static_cast<uint32_t>(mod->sql.size()));
+      mod->c_str(), static_cast<uint32_t>(mod->size()));
   for (const auto& err : parsed.errors) {
     PERFETTO_DLOG("stdlib docs: parse error in '%s': %s", module_key.c_str(),
                   err.c_str());

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -277,8 +277,7 @@ base::StatusOr<sql_modules::RegisteredPackage> ToRegisteredPackage(
           "Module name '%s' must start with package name '%s.' as prefix.",
           module_name.c_str(), name.c_str());
     }
-    new_package.modules.Insert(module_name,
-                               {module_name_and_sql.second, false});
+    new_package.modules.Insert(module_name, module_name_and_sql.second);
   }
   return base::StatusOr<sql_modules::RegisteredPackage>(std::move(new_package));
 }
@@ -837,8 +836,7 @@ base::Status TraceProcessorImpl::RegisterSqlPackage(SqlPackage sql_package) {
   // Save the name before moving sql_package
   std::string pkg_name = name;
   registered_sql_packages_.emplace_back(std::move(sql_package));
-  engine_->RegisterPackage(pkg_name, std::move(new_package));
-  return base::OkStatus();
+  return engine_->RegisterPackage(pkg_name, std::move(new_package));
 }
 
 // =================================================================
@@ -1548,7 +1546,11 @@ TraceProcessorImpl::InitPerfettoSqlConnection(
     if (!new_package.ok()) {
       PERFETTO_FATAL("%s", new_package.status().c_message());
     }
-    connection->RegisterPackage(package.name, std::move(*new_package));
+    auto status =
+        connection->RegisterPackage(package.name, std::move(*new_package));
+    if (!status.ok()) {
+      PERFETTO_FATAL("%s", status.c_message());
+    }
   }
 
   // Import prelude package.

--- a/src/trace_processor/util/sql_modules.h
+++ b/src/trace_processor/util/sql_modules.h
@@ -32,14 +32,14 @@ using NameToPackage =
     base::FlatHashMap<std::string,
                       std::vector<std::pair<std::string, std::string>>>;
 
-// Map from include key to sql file. Include key is the string used in INCLUDE
-// function.
+// A package registered with |PerfettoSqlDatabase|. Each entry in |modules|
+// maps the include key (the string used in INCLUDE PERFETTO MODULE) to the
+// body SQL of that module. Whether a module has already been imported (or
+// previously poisoned an attempt) is tracked centrally on
+// |PerfettoSqlDatabase| so connections attached to the same database share a
+// consistent view.
 struct RegisteredPackage {
-  struct ModuleFile {
-    std::string sql;
-    bool included;
-  };
-  base::FlatHashMap<std::string, ModuleFile> modules;
+  base::FlatHashMap<std::string, std::string> modules;
 };
 
 inline std::string ReplaceSlashWithDot(std::string str) {


### PR DESCRIPTION
* add "claiming" system to allow for a single connection to "claim" the
  fact its including the module and have other connections which might
  also want to include at the smae time to wait for it.
* add cycle detection of includes on same thread
* change includes to "poison" on error: this allows removing mysterious
  errors on double includes or across-connections
