### PR TITLE
protovm: fix UAF in protovm::ParseSelect

### DIFF
--- a/src/protovm/error_handling.h
+++ b/src/protovm/error_handling.h
@@ -92,6 +92,18 @@ void LogStacktraceMessage(Stacktrace& stacktrace,
     }                                                                   \
   } while (0)
 
+#define PROTOVM_INTERNAL_CONCAT_IMPL(x, y) x##y
+#define PROTOVM_INTERNAL_MACRO_CONCAT(x, y) PROTOVM_INTERNAL_CONCAT_IMPL(x, y)
+
+// Evaluates |rhs| which should return a StatusOr<T> and assigns this
+// to |lhs|. If the status is an error status, returns the status from the
+// current function.
+#define PROTOVM_ASSIGN_OR_RETURN(lhs, rhs)                       \
+  PROTOVM_INTERNAL_MACRO_CONCAT(auto status_or, __LINE__) = rhs; \
+  PROTOVM_RETURN_IF_NOT_OK(                                      \
+      PROTOVM_INTERNAL_MACRO_CONCAT(status_or, __LINE__));       \
+  lhs = std::move(PROTOVM_INTERNAL_MACRO_CONCAT(status_or, __LINE__).value())
+
 enum class Status : uint8_t {
   kOk,
   kError,

--- a/src/protovm/executor.h
+++ b/src/protovm/executor.h
@@ -36,6 +36,10 @@ struct Cursors {
   RwProto::Cursor dst;
   CursorEnum selected{CursorEnum::VM_CURSOR_UNSPECIFIED};
   bool create_if_not_exist{false};
+
+  // Used internally by Parser to detect illegal "del" operations.
+  // See detailed explanation in the Parser implementation.
+  const RwProto::Cursor* innermost_saved_dst{nullptr};
 };
 
 // Executor's methods are virtual to be overridden in tests

--- a/src/protovm/parser.cc
+++ b/src/protovm/parser.cc
@@ -27,7 +27,7 @@ Parser::Parser(protozero::ConstBytes program, Executor* executor)
 StatusOr<void> Parser::Run(RoCursor src, RwProto::Cursor dst) {
   cursors_.src = src;
   cursors_.dst = dst;
-  innermost_saved_dst_node_ = nullptr;
+  cursors_.innermost_saved_dst = nullptr;
   return ParseInstructions(program_.instructions());
 }
 
@@ -76,12 +76,16 @@ StatusOr<void> Parser::ParseInstruction(
     auto status = ParseRegLoad(instruction);
     PROTOVM_RETURN_IF_NOT_OK(status, "reg_load");
   } else if (instruction.has_del()) {
-    // Refuse to delete a non-root node whose address matches the snapshot
-    // of an enclosing select: restoring that snapshot would otherwise
-    // install a stale pointer.
-    const Node* deleting = cursors_.dst.GetNode();
-    if (deleting != nullptr && !cursors_.dst.IsAtRoot() &&
-        deleting == innermost_saved_dst_node_) {
+    PROTOVM_ASSIGN_OR_RETURN(bool is_root, cursors_.dst.IsRoot());
+    if (cursors_.innermost_saved_dst != nullptr &&
+        cursors_.dst == *cursors_.innermost_saved_dst && !is_root) {
+      // Illegal operation
+      // For each "select" operation we effectively save a snapshot of the
+      // cursors on the stack, so that they can be restored when a frame is
+      // exited. This "del" operation is attempting to delete a "dst" cursor
+      // that is currently aliased in the parent stack frame. This would result
+      // in a dangling pointer when the current frame is exited and the aliased
+      // "dst" is restored.
       PROTOVM_ABORT(
           "del would invalidate a cursor saved by an enclosing select");
     }
@@ -134,8 +138,7 @@ StatusOr<void> Parser::ParseRegLoad(
 StatusOr<void> Parser::ParseSelect(
     const protos::pbzero::VmInstruction::Decoder& instruction) {
   auto saved_cursors = cursors_;
-  const Node* prev_innermost_saved_dst_node = innermost_saved_dst_node_;
-  innermost_saved_dst_node_ = saved_cursors.dst.GetNode();
+  cursors_.innermost_saved_dst = &saved_cursors.dst;
 
   protos::pbzero::VmOpSelect::Decoder select(instruction.select());
   cursors_.selected = !select.has_cursor()
@@ -150,7 +153,6 @@ StatusOr<void> Parser::ParseSelect(
   }
 
   auto status = ParseSelectRec(instruction, select.relative_path());
-  innermost_saved_dst_node_ = prev_innermost_saved_dst_node;
   cursors_ = saved_cursors;
 
   return status;

--- a/src/protovm/parser.cc
+++ b/src/protovm/parser.cc
@@ -27,6 +27,7 @@ Parser::Parser(protozero::ConstBytes program, Executor* executor)
 StatusOr<void> Parser::Run(RoCursor src, RwProto::Cursor dst) {
   cursors_.src = src;
   cursors_.dst = dst;
+  innermost_saved_dst_node_ = nullptr;
   return ParseInstructions(program_.instructions());
 }
 
@@ -75,6 +76,15 @@ StatusOr<void> Parser::ParseInstruction(
     auto status = ParseRegLoad(instruction);
     PROTOVM_RETURN_IF_NOT_OK(status, "reg_load");
   } else if (instruction.has_del()) {
+    // Refuse to delete a non-root node whose address matches the snapshot
+    // of an enclosing select: restoring that snapshot would otherwise
+    // install a stale pointer.
+    const Node* deleting = cursors_.dst.GetNode();
+    if (deleting != nullptr && !cursors_.dst.IsAtRoot() &&
+        deleting == innermost_saved_dst_node_) {
+      PROTOVM_ABORT(
+          "del would invalidate a cursor saved by an enclosing select");
+    }
     auto status = executor_->Delete(&cursors_.dst);
     PROTOVM_RETURN_IF_NOT_OK(status, "del");
   } else if (instruction.has_merge()) {
@@ -124,6 +134,8 @@ StatusOr<void> Parser::ParseRegLoad(
 StatusOr<void> Parser::ParseSelect(
     const protos::pbzero::VmInstruction::Decoder& instruction) {
   auto saved_cursors = cursors_;
+  const Node* prev_innermost_saved_dst_node = innermost_saved_dst_node_;
+  innermost_saved_dst_node_ = saved_cursors.dst.GetNode();
 
   protos::pbzero::VmOpSelect::Decoder select(instruction.select());
   cursors_.selected = !select.has_cursor()
@@ -138,6 +150,7 @@ StatusOr<void> Parser::ParseSelect(
   }
 
   auto status = ParseSelectRec(instruction, select.relative_path());
+  innermost_saved_dst_node_ = prev_innermost_saved_dst_node;
   cursors_ = saved_cursors;
 
   return status;

--- a/src/protovm/parser.h
+++ b/src/protovm/parser.h
@@ -22,7 +22,6 @@
 
 #include "src/protovm/error_handling.h"
 #include "src/protovm/executor.h"
-#include "src/protovm/node.h"
 #include "src/protovm/ro_cursor.h"
 #include "src/protovm/rw_proto.h"
 
@@ -53,12 +52,6 @@ class Parser {
   protos::pbzero::VmProgram::Decoder program_;
   Cursors cursors_;
   Executor* executor_;
-
-  // dst.GetNode() captured by the innermost in-flight ParseSelect frame, or
-  // nullptr when no select is active. Saved positions form a non-strict
-  // descending chain, so any deletion target that matches an outer saved
-  // cursor also matches this one.
-  const Node* innermost_saved_dst_node_ = nullptr;
 };
 
 }  // namespace protovm

--- a/src/protovm/parser.h
+++ b/src/protovm/parser.h
@@ -22,6 +22,7 @@
 
 #include "src/protovm/error_handling.h"
 #include "src/protovm/executor.h"
+#include "src/protovm/node.h"
 #include "src/protovm/ro_cursor.h"
 #include "src/protovm/rw_proto.h"
 
@@ -52,6 +53,12 @@ class Parser {
   protos::pbzero::VmProgram::Decoder program_;
   Cursors cursors_;
   Executor* executor_;
+
+  // dst.GetNode() captured by the innermost in-flight ParseSelect frame, or
+  // nullptr when no select is active. Saved positions form a non-strict
+  // descending chain, so any deletion target that matches an outer saved
+  // cursor also matches this one.
+  const Node* innermost_saved_dst_node_ = nullptr;
 };
 
 }  // namespace protovm

--- a/src/protovm/rw_proto_cursor.cc
+++ b/src/protovm/rw_proto_cursor.cc
@@ -48,6 +48,17 @@ RwProtoCursor::RwProtoCursor() = default;
 RwProtoCursor::RwProtoCursor(Node* node, Allocator* allocator)
     : node_{node}, allocator_{allocator} {}
 
+bool RwProtoCursor::operator==(const RwProtoCursor& other) const {
+  return node_ == other.node_;
+}
+bool RwProtoCursor::operator!=(const RwProtoCursor& other) const {
+  return !(*this == other);
+}
+
+StatusOr<bool> RwProtoCursor::IsRoot() const {
+  return parent_link_.node == nullptr;
+}
+
 StatusOr<bool> RwProtoCursor::HasField(uint32_t field_id) {
   PERFETTO_DCHECK(node_);
 
@@ -305,20 +316,21 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
 StatusOr<void> RwProtoCursor::Delete() {
   PERFETTO_DCHECK(node_);
 
-  bool is_root_node = !parent_link_.node;
-  if (is_root_node) {
+  PROTOVM_ASSIGN_OR_RETURN(bool is_root, IsRoot());
+  if (is_root) {
     node_->value = Node::Empty{};
     return StatusOr<void>::Ok();
   }
 
-  PERFETTO_DCHECK(parent_link_.node);
   PERFETTO_DCHECK(parent_link_.map);
   PERFETTO_DCHECK(parent_link_.map_node);
 
   parent_link_.map->Remove(*parent_link_.map_node);
   allocator_->Delete(&GetOuterNode(*parent_link_.map_node));
 
-  node_ = nullptr;  // Delete operation invalidates cursor
+  // Delete operation invalidates cursor
+  node_ = nullptr;
+  parent_link_ = {};
 
   return StatusOr<void>::Ok();
 }

--- a/src/protovm/rw_proto_cursor.cc
+++ b/src/protovm/rw_proto_cursor.cc
@@ -17,6 +17,7 @@
 #include "src/protovm/rw_proto_cursor.h"
 
 #include "perfetto/protozero/proto_decoder.h"
+#include "src/protovm/error_handling.h"
 
 namespace perfetto {
 namespace protovm {
@@ -56,11 +57,12 @@ bool RwProtoCursor::operator!=(const RwProtoCursor& other) const {
 }
 
 StatusOr<bool> RwProtoCursor::IsRoot() const {
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
   return parent_link_.node == nullptr;
 }
 
 StatusOr<bool> RwProtoCursor::HasField(uint32_t field_id) {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   // Eagerly decompose bytes because the field being tested will be entered
   // later anyways. See Executor::EnterField().
@@ -72,7 +74,7 @@ StatusOr<bool> RwProtoCursor::HasField(uint32_t field_id) {
 }
 
 StatusOr<void> RwProtoCursor::EnterField(uint32_t field_id) {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   auto status_or_it = FindOrCreateMessageField(node_, field_id);
   PROTOVM_RETURN_IF_NOT_OK(status_or_it);
@@ -100,7 +102,7 @@ StatusOr<void> RwProtoCursor::EnterField(uint32_t field_id) {
 
 StatusOr<void> RwProtoCursor::EnterRepeatedFieldAt(uint32_t field_id,
                                                    uint32_t index) {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   auto status_or_message_field = FindOrCreateMessageField(node_, field_id);
   PROTOVM_RETURN_IF_NOT_OK(status_or_message_field);
@@ -125,7 +127,7 @@ StatusOr<void> RwProtoCursor::EnterRepeatedFieldAt(uint32_t field_id,
 
 StatusOr<RwProtoCursor::RepeatedFieldIterator>
 RwProtoCursor::IterateRepeatedField(uint32_t field_id) {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   auto status_convertion_to_message = ConvertToMessageIfNeeded(node_);
   PROTOVM_RETURN_IF_NOT_OK(status_convertion_to_message);
@@ -150,7 +152,7 @@ RwProtoCursor::IterateRepeatedField(uint32_t field_id) {
 StatusOr<void> RwProtoCursor::EnterRepeatedFieldByKey(uint32_t field_id,
                                                       uint32_t map_key_field_id,
                                                       uint64_t key) {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   auto status_or_message_field = FindOrCreateMessageField(node_, field_id);
   PROTOVM_RETURN_IF_NOT_OK(status_or_message_field);
@@ -174,7 +176,7 @@ StatusOr<void> RwProtoCursor::EnterRepeatedFieldByKey(uint32_t field_id,
 }
 
 StatusOr<Scalar> RwProtoCursor::GetScalar() const {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   auto* scalar = node_->GetIf<Scalar>();
   if (!scalar) {
@@ -185,7 +187,7 @@ StatusOr<Scalar> RwProtoCursor::GetScalar() const {
 }
 
 StatusOr<void> RwProtoCursor::SetBytes(protozero::ConstBytes data) {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   if (bool is_compatible = node_->GetIf<Node::Empty>() ||
                            node_->GetIf<Node::Bytes>() ||
@@ -205,7 +207,7 @@ StatusOr<void> RwProtoCursor::SetBytes(protozero::ConstBytes data) {
 }
 
 StatusOr<void> RwProtoCursor::SetScalar(Scalar scalar) {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   if (bool is_compatible =
           node_->GetIf<Node::Empty>() || node_->GetIf<Scalar>();
@@ -220,7 +222,7 @@ StatusOr<void> RwProtoCursor::SetScalar(Scalar scalar) {
 
 StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
                                     uint32_t flags) {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   if (bool is_compatible = node_->GetIf<Node::Empty>() ||
                            node_->GetIf<Node::Message>() ||
@@ -314,7 +316,7 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
 }
 
 StatusOr<void> RwProtoCursor::Delete() {
-  PERFETTO_DCHECK(node_);
+  PROTOVM_RETURN_IF_NOT_OK(CheckIsValid());
 
   PROTOVM_ASSIGN_OR_RETURN(bool is_root, IsRoot());
   if (is_root) {
@@ -681,6 +683,13 @@ StatusOr<uint64_t> RwProtoCursor::ReadScalarField(const Node& node,
   PROTOVM_ABORT(
       "Attempted to read scalar field (id=%u) but parent node has type %s",
       field_id, node.GetTypeName());
+}
+
+StatusOr<void> RwProtoCursor::CheckIsValid() const {
+  if (!node_) {
+    PROTOVM_ABORT("Attempted to access invalid cursor");
+  }
+  return StatusOr<void>::Ok();
 }
 
 }  // namespace protovm

--- a/src/protovm/rw_proto_cursor.h
+++ b/src/protovm/rw_proto_cursor.h
@@ -50,9 +50,10 @@ class RwProtoCursor {
   RwProtoCursor();
   explicit RwProtoCursor(Node* node, Allocator* allocator);
 
-  const Node* GetNode() const { return node_; }
-  bool IsAtRoot() const { return parent_link_.node == nullptr; }
+  bool operator==(const RwProtoCursor& other) const;
+  bool operator!=(const RwProtoCursor& other) const;
 
+  StatusOr<bool> IsRoot() const;
   StatusOr<bool> HasField(uint32_t field_id);
   StatusOr<void> EnterField(uint32_t field_id);
   StatusOr<void> EnterRepeatedFieldAt(uint32_t field_id, uint32_t index);

--- a/src/protovm/rw_proto_cursor.h
+++ b/src/protovm/rw_proto_cursor.h
@@ -132,6 +132,8 @@ class RwProtoCursor {
                                              OwnedPtr<Node> map_value);
   StatusOr<uint64_t> ReadScalarField(const Node& node, uint32_t field_id);
 
+  StatusOr<void> CheckIsValid() const;
+
   Node* node_ = nullptr;
   ParentLink parent_link_ = {};
   Allocator* allocator_ = nullptr;

--- a/src/protovm/rw_proto_cursor.h
+++ b/src/protovm/rw_proto_cursor.h
@@ -49,6 +49,10 @@ class RwProtoCursor {
 
   RwProtoCursor();
   explicit RwProtoCursor(Node* node, Allocator* allocator);
+
+  const Node* GetNode() const { return node_; }
+  bool IsAtRoot() const { return parent_link_.node == nullptr; }
+
   StatusOr<bool> HasField(uint32_t field_id);
   StatusOr<void> EnterField(uint32_t field_id);
   StatusOr<void> EnterRepeatedFieldAt(uint32_t field_id, uint32_t index);

--- a/src/protovm/test/parser_unittest.cc
+++ b/src/protovm/test/parser_unittest.cc
@@ -66,12 +66,16 @@ TEST_F(ParserTest, RegLoad) {
 }
 
 TEST_F(ParserTest, Del) {
+  Allocator allocator_{10 * 1024 * 1024};
+  RwProto rw_proto{&allocator_};
+  auto rw_cursor = rw_proto.GetRoot();
+
   EXPECT_CALL(executor_, Delete(testing::_))
       .WillOnce(testing::Return(testing::ByMove(StatusOr<void>::Ok())));
 
   auto program = SamplePrograms::Delete().SerializeAsString();
   Parser parser(AsConstBytes(program), &executor_);
-  ASSERT_TRUE(parser.Run(RoCursor{}, RwProto::Cursor{}).IsOk());
+  ASSERT_TRUE(parser.Run(RoCursor{}, rw_cursor).IsOk());
 }
 
 TEST_F(ParserTest, Merge) {

--- a/src/protovm/test/rw_proto_unittest.cc
+++ b/src/protovm/test/rw_proto_unittest.cc
@@ -1072,6 +1072,24 @@ TEST_F(RwProtoTest, SerializeAsString) {
       SerializeAsString(data_trace_entry_with_two_elements_));
 }
 
+TEST_F(RwProtoTest, AccessNonRootFieldAfterDeleteAborts) {
+  auto cursor = data_empty_.GetRoot();
+  ASSERT_TRUE(cursor.EnterField(1).IsOk());
+  ASSERT_TRUE(cursor.Delete().IsOk());
+
+  ASSERT_TRUE(cursor.IsRoot().IsAbort());
+  ASSERT_TRUE(cursor.HasField(1).IsAbort());
+  ASSERT_TRUE(cursor.EnterField(1).IsAbort());
+  ASSERT_TRUE(cursor.EnterRepeatedFieldAt(1, 0).IsAbort());
+  ASSERT_TRUE(cursor.IterateRepeatedField(1).IsAbort());
+  ASSERT_TRUE(cursor.EnterRepeatedFieldByKey(1, 1, 0).IsAbort());
+  ASSERT_TRUE(cursor.GetScalar().IsAbort());
+  ASSERT_TRUE(cursor.SetBytes(protozero::ConstBytes{}).IsAbort());
+  ASSERT_TRUE(cursor.SetScalar(Scalar::Fixed32(0)).IsAbort());
+  ASSERT_TRUE(cursor.Merge(protozero::ConstBytes{}, 0).IsAbort());
+  ASSERT_TRUE(cursor.Delete().IsAbort());
+}
+
 }  // namespace test
 }  // namespace protovm
 }  // namespace perfetto

--- a/src/protovm/test/sample_programs.h
+++ b/src/protovm/test/sample_programs.h
@@ -403,6 +403,75 @@ class SamplePrograms {
 
     return program;
   }
+
+  static perfetto::protos::VmProgram DelAliasedRoot() {
+    perfetto::protos::VmProgram program;
+    auto* outer = program.add_instructions();
+    auto* outer_select = outer->mutable_select();
+    outer_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
+    outer->add_nested_instructions()->mutable_del();
+    return program;
+  }
+
+  static perfetto::protos::VmProgram DelAliasedDstInsideSrcSelect() {
+    // The outer select walks dst to a non-root child. The inner select uses
+    // cursor=SRC with a non-empty relative_path, so dst remains pinned at
+    // the outer's child while src walks elsewhere. A nested `del` targets
+    // that pinned dst node. The parser must abort rather than restore a
+    // stale dst pointer.
+    perfetto::protos::VmProgram program;
+    auto* outer = program.add_instructions();
+    auto* outer_select = outer->mutable_select();
+    outer_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
+    outer_select->set_create_if_not_exist(true);
+    outer_select->add_relative_path()->set_field_id(1);
+
+    auto* inner = outer->add_nested_instructions();
+    auto* inner_select = inner->mutable_select();
+    inner_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_SRC);
+    inner_select->add_relative_path()->set_field_id(
+        protos::Patch::kElementsToSetFieldNumber);
+    inner->add_nested_instructions()->mutable_del();
+    return program;
+  }
+
+  static perfetto::protos::VmProgram DelAliasedDstInsideEmptyPathDstSelect() {
+    // The outer select walks dst to a non-root child; the inner select has
+    // an empty relative_path so its snapshot aliases that same child; a
+    // nested `del` then targets the child. The parser must abort rather
+    // than restore a stale dst pointer.
+    perfetto::protos::VmProgram program;
+    auto* outer = program.add_instructions();
+    auto* outer_select = outer->mutable_select();
+    outer_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
+    outer_select->set_create_if_not_exist(true);
+    outer_select->add_relative_path()->set_field_id(1);
+
+    auto* inner = outer->add_nested_instructions();
+    auto* inner_select = inner->mutable_select();
+    inner_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
+    inner->add_nested_instructions()->mutable_del();
+
+    outer->add_nested_instructions()->mutable_del();
+    return program;
+  }
+
+  static perfetto::protos::VmProgram DelAndNestedDel() {
+    perfetto::protos::VmProgram program;
+    auto* outer = program.add_instructions();
+    auto* select = outer->mutable_select();
+    select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
+    select->set_create_if_not_exist(true);
+    select->add_relative_path()->set_field_id(1);
+
+    auto* outer_del = outer->add_nested_instructions();
+    outer_del->mutable_del();
+
+    auto* inner_del = outer_del->add_nested_instructions();
+    inner_del->mutable_del();
+
+    return program;
+  }
 };
 
 }  // namespace test

--- a/src/protovm/test/vm_unittest.cc
+++ b/src/protovm/test/vm_unittest.cc
@@ -201,6 +201,71 @@ TEST_F(VmTest, CloneReadOnly) {
   ASSERT_EQ(cloned_state.elements(1).value(), 11);
 }
 
+TEST_F(VmTest, ApplyPatch_DelInsideSrcSelectAbortsOnAliasedDst) {
+  // The outer select walks dst to a non-root child. The inner select uses
+  // cursor=SRC with a non-empty relative_path, so dst remains pinned at
+  // the outer's child while src walks elsewhere. A nested `del` targets
+  // that pinned dst node. The parser must abort rather than restore a
+  // stale dst pointer.
+  perfetto::protos::VmProgram program;
+  auto* outer = program.add_instructions();
+  auto* outer_select = outer->mutable_select();
+  outer_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
+  outer_select->set_create_if_not_exist(true);
+  outer_select->add_relative_path()->set_field_id(1);
+
+  auto* inner = outer->add_nested_instructions();
+  auto* inner_select = inner->mutable_select();
+  inner_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_SRC);
+  inner_select->add_relative_path()->set_field_id(
+      protos::Patch::kElementsToSetFieldNumber);
+  inner->add_nested_instructions()->mutable_del();
+
+  auto serialized = program.SerializeAsString();
+  Vm vm{AsConstBytes(serialized), MEMORY_LIMIT_BYTES};
+
+  auto patch = SamplePackets::PatchWithInitialState().SerializeAsString();
+  auto status = vm.ApplyPatch(AsConstBytes(patch));
+  ASSERT_TRUE(status.IsAbort());
+  ASSERT_FALSE(status.stacktrace().empty());
+  ASSERT_NE(status.stacktrace().front().find(
+                "del would invalidate a cursor saved by an enclosing select"),
+            std::string::npos);
+}
+
+TEST_F(VmTest, ApplyPatch_DelInsideEmptyPathSelectAborts) {
+  // The outer select walks dst to a non-root child; the inner select has
+  // an empty relative_path so its snapshot aliases that same child; a
+  // nested `del` then targets the child. The parser must abort rather
+  // than restore a stale dst pointer.
+  perfetto::protos::VmProgram program;
+  auto* outer = program.add_instructions();
+  auto* outer_select = outer->mutable_select();
+  outer_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
+  outer_select->set_create_if_not_exist(true);
+  outer_select->add_relative_path()->set_field_id(1);
+
+  auto* inner = outer->add_nested_instructions();
+  auto* inner_select = inner->mutable_select();
+  inner_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
+  inner->add_nested_instructions()->mutable_del();
+
+  // A second `del` that, in the buggy version, would operate on the dangling
+  // cursor restored by the inner select and trigger a double-free.
+  outer->add_nested_instructions()->mutable_del();
+
+  auto serialized = program.SerializeAsString();
+  Vm vm{AsConstBytes(serialized), MEMORY_LIMIT_BYTES};
+
+  auto patch = SamplePackets::PatchWithInitialState().SerializeAsString();
+  auto status = vm.ApplyPatch(AsConstBytes(patch));
+  ASSERT_TRUE(status.IsAbort());
+  ASSERT_FALSE(status.stacktrace().empty());
+  ASSERT_NE(status.stacktrace().front().find(
+                "del would invalidate a cursor saved by an enclosing select"),
+            std::string::npos);
+}
+
 TEST_F(VmTest, GetMemoryUsage) {
   auto program =
       SamplePrograms::IncrementalTraceInstructions().SerializeAsString();

--- a/src/protovm/test/vm_unittest.cc
+++ b/src/protovm/test/vm_unittest.cc
@@ -201,69 +201,42 @@ TEST_F(VmTest, CloneReadOnly) {
   ASSERT_EQ(cloned_state.elements(1).value(), 11);
 }
 
-TEST_F(VmTest, ApplyPatch_DelInsideSrcSelectAbortsOnAliasedDst) {
-  // The outer select walks dst to a non-root child. The inner select uses
-  // cursor=SRC with a non-empty relative_path, so dst remains pinned at
-  // the outer's child while src walks elsewhere. A nested `del` targets
-  // that pinned dst node. The parser must abort rather than restore a
-  // stale dst pointer.
-  perfetto::protos::VmProgram program;
-  auto* outer = program.add_instructions();
-  auto* outer_select = outer->mutable_select();
-  outer_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
-  outer_select->set_create_if_not_exist(true);
-  outer_select->add_relative_path()->set_field_id(1);
-
-  auto* inner = outer->add_nested_instructions();
-  auto* inner_select = inner->mutable_select();
-  inner_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_SRC);
-  inner_select->add_relative_path()->set_field_id(
-      protos::Patch::kElementsToSetFieldNumber);
-  inner->add_nested_instructions()->mutable_del();
-
-  auto serialized = program.SerializeAsString();
-  Vm vm{AsConstBytes(serialized), MEMORY_LIMIT_BYTES};
+TEST_F(VmTest, ApplyPatch_DelAliasedRoot) {
+  auto program = SamplePrograms::DelAliasedRoot().SerializeAsString();
+  Vm vm{AsConstBytes(program), MEMORY_LIMIT_BYTES};
 
   auto patch = SamplePackets::PatchWithInitialState().SerializeAsString();
   auto status = vm.ApplyPatch(AsConstBytes(patch));
-  ASSERT_TRUE(status.IsAbort());
-  ASSERT_FALSE(status.stacktrace().empty());
-  ASSERT_NE(status.stacktrace().front().find(
-                "del would invalidate a cursor saved by an enclosing select"),
-            std::string::npos);
+  ASSERT_TRUE(status.IsOk());
 }
 
-TEST_F(VmTest, ApplyPatch_DelInsideEmptyPathSelectAborts) {
-  // The outer select walks dst to a non-root child; the inner select has
-  // an empty relative_path so its snapshot aliases that same child; a
-  // nested `del` then targets the child. The parser must abort rather
-  // than restore a stale dst pointer.
-  perfetto::protos::VmProgram program;
-  auto* outer = program.add_instructions();
-  auto* outer_select = outer->mutable_select();
-  outer_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
-  outer_select->set_create_if_not_exist(true);
-  outer_select->add_relative_path()->set_field_id(1);
-
-  auto* inner = outer->add_nested_instructions();
-  auto* inner_select = inner->mutable_select();
-  inner_select->set_cursor(perfetto::protos::VmCursorEnum::VM_CURSOR_DST);
-  inner->add_nested_instructions()->mutable_del();
-
-  // A second `del` that, in the buggy version, would operate on the dangling
-  // cursor restored by the inner select and trigger a double-free.
-  outer->add_nested_instructions()->mutable_del();
-
-  auto serialized = program.SerializeAsString();
-  Vm vm{AsConstBytes(serialized), MEMORY_LIMIT_BYTES};
+TEST_F(VmTest, ApplyPatch_DelAliasedDstAborts1) {
+  auto program =
+      SamplePrograms::DelAliasedDstInsideSrcSelect().SerializeAsString();
+  Vm vm{AsConstBytes(program), MEMORY_LIMIT_BYTES};
 
   auto patch = SamplePackets::PatchWithInitialState().SerializeAsString();
   auto status = vm.ApplyPatch(AsConstBytes(patch));
   ASSERT_TRUE(status.IsAbort());
-  ASSERT_FALSE(status.stacktrace().empty());
-  ASSERT_NE(status.stacktrace().front().find(
-                "del would invalidate a cursor saved by an enclosing select"),
-            std::string::npos);
+}
+
+TEST_F(VmTest, ApplyPatch_DelAliasedDstAborts2) {
+  auto program = SamplePrograms::DelAliasedDstInsideEmptyPathDstSelect()
+                     .SerializeAsString();
+  Vm vm{AsConstBytes(program), MEMORY_LIMIT_BYTES};
+
+  auto patch = SamplePackets::PatchWithInitialState().SerializeAsString();
+  auto status = vm.ApplyPatch(AsConstBytes(patch));
+  ASSERT_TRUE(status.IsAbort());
+}
+
+TEST_F(VmTest, ApplyPatch_AccessDeletedDstAborts) {
+  auto program = SamplePrograms::DelAndNestedDel().SerializeAsString();
+  Vm vm{AsConstBytes(program), MEMORY_LIMIT_BYTES};
+
+  auto patch = SamplePackets::PatchWithInitialState().SerializeAsString();
+  auto status = vm.ApplyPatch(AsConstBytes(patch));
+  ASSERT_TRUE(status.IsAbort());
 }
 
 TEST_F(VmTest, GetMemoryUsage) {

--- a/src/tracing/service/packet_stream_validator.cc
+++ b/src/tracing/service/packet_stream_validator.cc
@@ -42,6 +42,8 @@ const uint32_t kReservedFieldIds[] = {
     protos::pbzero::TracePacket::kTrustedPidFieldNumber,
     protos::pbzero::TracePacket::kMachineIdFieldNumber,
     protos::pbzero::TracePacket::kServiceEventFieldNumber,
+    protos::pbzero::TracePacket::kTraceProvenanceFieldNumber,
+    protos::pbzero::TracePacket::kProtovmsFieldNumber,
 };
 
 // This translation unit is quite subtle and perf-sensitive. Remember to check

--- a/src/tracing/service/packet_stream_validator_unittest.cc
+++ b/src/tracing/service/packet_stream_validator_unittest.cc
@@ -21,6 +21,7 @@
 #include "protos/perfetto/trace/ftrace/ftrace_event.gen.h"
 #include "protos/perfetto/trace/ftrace/ftrace_event_bundle.gen.h"
 #include "protos/perfetto/trace/ftrace/sched.gen.h"
+#include "protos/perfetto/trace/perfetto/trace_provenance.gen.h"
 #include "protos/perfetto/trace/perfetto/tracing_service_event.gen.h"
 #include "protos/perfetto/trace/test_event.gen.h"
 #include "protos/perfetto/trace/trace_packet.gen.h"
@@ -205,6 +206,26 @@ TEST(PacketStreamValidatorTest, SimplePacketWithZeroMachineID) {
 TEST(PacketStreamValidatorTest, SimplePacketWithServiceEvent) {
   protos::gen::TracePacket proto;
   proto.mutable_service_event()->set_flush_started(true);
+  std::string ser_buf = proto.SerializeAsString();
+
+  Slices seq;
+  seq.emplace_back(&ser_buf[0], ser_buf.size());
+  EXPECT_FALSE(PacketStreamValidator::Validate(seq));
+}
+
+TEST(PacketStreamValidatorTest, SimplePacketWithTraceProvenance) {
+  protos::gen::TracePacket proto;
+  proto.mutable_trace_provenance()->add_buffers();
+  std::string ser_buf = proto.SerializeAsString();
+
+  Slices seq;
+  seq.emplace_back(&ser_buf[0], ser_buf.size());
+  EXPECT_FALSE(PacketStreamValidator::Validate(seq));
+}
+
+TEST(PacketStreamValidatorTest, SimplePacketWithProtoVms) {
+  protos::gen::TracePacket proto;
+  proto.mutable_protovms()->add_instance();
   std::string ser_buf = proto.SerializeAsString();
 
   Slices seq;


### PR DESCRIPTION
ParseSelect snapshots `cursors_` (which holds raw Node* pointers in
RwProtoCursor::node_ and parent_link_.map_node) before running nested
instructions and unconditionally restores it afterwards. A nested `del`
that frees the same node aliased by the snapshot would leave a dangling
pointer on restore; a subsequent `del` would then double-free the node
and corrupt the SlabAllocator freelist.

Track one extra Node* in the parser: the dst.GetNode() of the innermost
in-flight ParseSelect frame. When `del` is asked to free a non-root
node whose address matches that snapshot, abort the program instead of
producing a stale cursor on restore. Snapshots form a non-strict
descending chain (each new ParseSelect either keeps dst at the same
node or moves it deeper), so checking only the innermost is sufficient:
if any outer snapshot aliases the deletion target, this one does too.
Auxiliary space is O(1).

Legitimate `del` patterns continue to work: top-level del; del under a
select that walks dst to the target via path components; iterate-and-
delete on a repeated field. Only `del` wrapped in a select that does
not move dst is rejected, and those forms are always expressible by
hoisting the del out of the wrapper:

  select(cursor=DST, path=[]) { del }       -> del
  select(cursor=SRC, path=[X]) { del }      -> select(SRC,X){...}; del
  select(path=[X]) { select(path=[]){del} } -> select(path=[X]){del}

As defense in depth, also reserve TracePacket.trace_provenance (124)
and TracePacket.protovms (125) in the SMB packet validator. Both
fields are emitted only by TracingServiceImpl and have no legitimate
producer-side use, so dropping them on the producer-incoming path
prevents a compromised producer from injecting protovm programs or
spoofing sequence provenance.

Regression tests added in vm_unittest.cc for both the empty-path and
SRC-cursor-with-non-empty-path variants of the UAF, and in
packet_stream_validator_unittest.cc for the two newly reserved fields.
