### PR TITLE
ui: Add dev.perfetto.JournaldLog plugin and update AndroidLog (3/3)

### DIFF
--- a/ui/src/core/embedder/default_plugins.ts
+++ b/ui/src/core/embedder/default_plugins.ts
@@ -70,6 +70,7 @@ export const defaultPlugins = [
   'dev.perfetto.Ftrace',
   'dev.perfetto.GlobalGroups',
   'dev.perfetto.Gpu',
+  'dev.perfetto.JournaldLog',
   'dev.perfetto.HeapProfile',
   'dev.perfetto.InstrumentsSamplesProfile',
   'dev.perfetto.KernelTrackEvent',

--- a/ui/src/plugins/dev.perfetto.JournaldLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.JournaldLog/index.ts
@@ -1,0 +1,158 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {
+  type JournaldLogFilteringCriteria,
+  JournaldLogPanel,
+} from './logs_panel';
+import type {Trace} from '../../public/trace';
+import type {PerfettoPlugin} from '../../public/plugin';
+import {NUM, STR_NULL} from '../../trace_processor/query_result';
+import {createJournaldLogTrack} from './logs_track';
+import {TrackNode} from '../../public/workspace';
+import {escapeSearchQuery} from '../../trace_processor/query_utils';
+import {exists} from '../../base/utils';
+
+const VERSION = 1;
+const JOURNALD_LOGS_TRACK_KIND = 'JournaldLogTrack';
+
+const DEFAULT_STATE: JournaldLogPluginState = {
+  version: VERSION,
+  filter: {
+    // Show all levels by default (7 = DEBUG, the least severe).
+    minimumLevel: 7,
+    tags: [],
+    isTagRegex: false,
+    textEntry: '',
+    hideNonMatching: true,
+  },
+};
+
+interface JournaldLogPluginState {
+  version: number;
+  filter: JournaldLogFilteringCriteria;
+}
+
+function isJournaldLogFilteringCriteria(
+  value: unknown,
+): value is JournaldLogFilteringCriteria {
+  if (!exists(value) || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.minimumLevel === 'number' &&
+    Array.isArray(candidate.tags) &&
+    candidate.tags.every((tag) => typeof tag === 'string') &&
+    typeof candidate.textEntry === 'string' &&
+    typeof candidate.hideNonMatching === 'boolean' &&
+    (candidate.isTagRegex === undefined ||
+      typeof candidate.isTagRegex === 'boolean')
+  );
+}
+
+function migrateJournaldPluginState(init: unknown): JournaldLogPluginState {
+  if (!exists(init) || typeof init !== 'object') {
+    return DEFAULT_STATE;
+  }
+  const candidate = init as Record<string, unknown>;
+  if (
+    candidate.version === VERSION &&
+    isJournaldLogFilteringCriteria(candidate.filter)
+  ) {
+    return {
+      version: VERSION,
+      filter: candidate.filter,
+    };
+  }
+  return DEFAULT_STATE;
+}
+
+function migrateJournaldFilter(value: unknown): JournaldLogFilteringCriteria {
+  return isJournaldLogFilteringCriteria(value) ? value : DEFAULT_STATE.filter;
+}
+
+export default class implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.JournaldLog';
+  async onTraceLoad(ctx: Trace): Promise<void> {
+    const store = ctx.mountStore<JournaldLogPluginState>(
+      'dev.perfetto.JournaldLogFilterState',
+      migrateJournaldPluginState,
+    );
+
+    const result = await ctx.engine.query(`
+      INCLUDE PERFETTO MODULE linux.systemd_journald;
+      select count(1) as cnt from linux_systemd_journald_logs;
+    `);
+    const logCount = result.firstRow({cnt: NUM}).cnt;
+    const uri = 'perfetto.JournaldLog';
+    if (logCount > 0) {
+      ctx.tracks.registerTrack({
+        uri,
+        tags: {kinds: [JOURNALD_LOGS_TRACK_KIND]},
+        renderer: createJournaldLogTrack(ctx, uri),
+      });
+      const track = new TrackNode({
+        name: 'Journald logs',
+        uri,
+      });
+      ctx.defaultWorkspace.addChildInOrder(track);
+    }
+
+    const journaldLogsTabUri = 'perfetto.JournaldLog#tab';
+
+    const filterStore = store.createSubStore(['filter'], migrateJournaldFilter);
+
+    ctx.tabs.registerTab({
+      isEphemeral: false,
+      uri: journaldLogsTabUri,
+      content: {
+        render: () => m(JournaldLogPanel, {filterStore, trace: ctx}),
+        getTitle: () => 'Journald Logs',
+      },
+    });
+
+    if (logCount > 0) {
+      ctx.tabs.addDefaultTab(journaldLogsTabUri);
+    }
+
+    ctx.commands.registerCommand({
+      id: 'dev.perfetto.ShowJournaldLogsTab',
+      name: 'Show journald logs tab',
+      callback: () => {
+        ctx.tabs.showTab(journaldLogsTabUri);
+      },
+    });
+
+    ctx.search.registerSearchProvider({
+      name: 'Journald logs',
+      selectTracks(tracks) {
+        return tracks
+          .filter((track) =>
+            track.tags?.kinds?.includes(JOURNALD_LOGS_TRACK_KIND),
+          )
+          .filter((t) =>
+            t.renderer.getDataset?.()?.implements({msg: STR_NULL}),
+          );
+      },
+      async getSearchFilter(searchTerm) {
+        return {
+          where: `msg GLOB ${escapeSearchQuery(searchTerm)}`,
+          columns: {msg: STR_NULL},
+        };
+      },
+    });
+  }
+}

--- a/ui/src/plugins/dev.perfetto.JournaldLog/logs_panel.scss
+++ b/ui/src/plugins/dev.perfetto.JournaldLog/logs_panel.scss
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@function log-level-color($color, $mix) {
+  @return color-mix(in srgb, $color, var(--pf-color-text) $mix);
+}
+
+.pf-journald-logs-panel {
+  font-size: 11px;
+  font-family: var(--pf-font-monospace);
+
+  &__row {
+    &--emergency {
+      color: log-level-color(hsl(291, 100%, 50%), 20%);
+    }
+
+    &--alert {
+      color: log-level-color(hsl(291, 100%, 50%), 20%);
+    }
+
+    &--critical {
+      color: log-level-color(hsl(291, 100%, 50%), 20%);
+    }
+
+    &--error {
+      color: log-level-color(hsl(0, 86%, 60%), 20%);
+    }
+
+    &--warning {
+      color: log-level-color(hsl(38, 100%, 58%), 20%);
+    }
+
+    &--notice {
+      color: log-level-color(hsl(95, 52%, 45%), 30%);
+    }
+
+    &--info {
+      color: log-level-color(hsl(217, 100%, 60%), 30%);
+    }
+
+    &--debug {
+      color: log-level-color(hsl(0, 0%, 60%), 30%);
+    }
+
+    &--highlighted {
+      background: var(--pf-color-highlight);
+    }
+  }
+}

--- a/ui/src/plugins/dev.perfetto.JournaldLog/logs_panel.ts
+++ b/ui/src/plugins/dev.perfetto.JournaldLog/logs_panel.ts
@@ -1,0 +1,613 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './logs_panel.scss';
+import m from 'mithril';
+import {type time, Time, type TimeSpan} from '../../base/time';
+import {DetailsShell} from '../../widgets/details_shell';
+import {Timestamp} from '../../components/widgets/timestamp';
+import type {Engine} from '../../trace_processor/engine';
+import {
+  LONG,
+  LONG_NULL,
+  NUM,
+  NUM_NULL,
+  STR,
+} from '../../trace_processor/query_result';
+import {
+  escapeQuery,
+  escapeRegexQuery,
+  escapeSearchQuery,
+} from '../../trace_processor/query_utils';
+import {Select} from '../../widgets/select';
+import {Button} from '../../widgets/button';
+import {TextInput} from '../../widgets/text_input';
+import {
+  Grid,
+  type GridColumn,
+  type GridRow,
+  GridCell,
+  GridHeaderCell,
+} from '../../widgets/grid';
+import {classNames} from '../../base/classnames';
+import {TagInput} from '../../widgets/tag_input';
+import type {Store} from '../../base/store';
+import type {Trace} from '../../public/trace';
+import {Icons} from '../../base/semantic_icons';
+import {MenuItem} from '../../widgets/menu';
+import {SerialTaskQueue, QuerySlot} from '../../base/query_slot';
+import {Anchor} from '../../widgets/anchor';
+import {getThreadUriPrefix} from '../../public/utils';
+
+const ROW_H = 24;
+
+export interface JournaldLogFilteringCriteria {
+  readonly minimumLevel: number;
+  readonly tags: string[];
+  readonly isTagRegex?: boolean;
+  readonly textEntry: string;
+  readonly hideNonMatching: boolean;
+}
+
+export interface JournaldLogPanelAttrs {
+  readonly filterStore: Store<JournaldLogFilteringCriteria>;
+  readonly trace: Trace;
+}
+
+interface Pagination {
+  readonly offset: number;
+  readonly count: number;
+}
+
+interface LogEntries {
+  readonly offset: number;
+  readonly ids: number[];
+  readonly timestamps: time[];
+  readonly pids: (bigint | null)[];
+  readonly tids: (bigint | null)[];
+  readonly priorities: number[];
+  readonly upids: (number | null)[];
+  readonly utids: (number | null)[];
+  readonly tags: string[];
+  readonly units: string[];
+  readonly messages: string[];
+  readonly isHighlighted: boolean[];
+  readonly processName: string[];
+  readonly totalEvents: number;
+}
+
+export const JOURNALD_PRIORITIES = [
+  'Emergency',
+  'Alert',
+  'Critical',
+  'Error',
+  'Warning',
+  'Notice',
+  'Info',
+  'Debug',
+];
+
+export class JournaldLogPanel
+  implements m.ClassComponent<JournaldLogPanelAttrs>
+{
+  private readonly trace: Trace;
+  private readonly executor = new SerialTaskQueue();
+  private readonly viewQuery = new QuerySlot<AsyncDisposable>(this.executor);
+  private readonly entriesQuery = new QuerySlot<LogEntries>(this.executor);
+  private pagination: Pagination = {
+    offset: 0,
+    count: 0,
+  };
+
+  constructor({attrs}: m.CVnode<JournaldLogPanelAttrs>) {
+    this.trace = attrs.trace;
+  }
+
+  onremove() {
+    this.viewQuery.dispose();
+    this.entriesQuery.dispose();
+  }
+
+  view({attrs}: m.CVnode<JournaldLogPanelAttrs>) {
+    const visibleSpan = attrs.trace.timeline.visibleWindow.toTimeSpan();
+    const filters = attrs.filterStore.state;
+    const pagination = this.pagination;
+    const engine = attrs.trace.engine;
+
+    const viewResult = this.viewQuery.use({
+      key: {filters},
+      queryFn: () => updateLogView(engine, filters),
+    });
+
+    const entriesResult = this.entriesQuery.use({
+      key: {
+        filters,
+        viewport: {start: visibleSpan.start, end: visibleSpan.end},
+        pagination,
+      },
+      retainOn: ['pagination', 'viewport'],
+      queryFn: () => updateLogEntries(engine, visibleSpan, pagination),
+      enabled: !!viewResult.data,
+    });
+
+    const entries = entriesResult.data;
+    const totalEvents = entries?.totalEvents ?? 0;
+
+    return m(
+      DetailsShell,
+      {
+        title: 'Journald Logs',
+        description: `Total messages: ${totalEvents}`,
+        buttons: m(LogsFilters, {
+          store: attrs.filterStore,
+        }),
+      },
+      this.renderGrid(attrs.trace, entries),
+    );
+  }
+
+  private renderGrid(trace: Trace, entries: LogEntries | undefined) {
+    if (!entries) return null;
+
+    const hasProcessNames = entries.processName.some((name) => name);
+    const hasUnits = entries.units.some((u) => u);
+
+    const columns: GridColumn[] = [
+      {key: 'timestamp', header: m(GridHeaderCell, 'Timestamp')},
+      {key: 'pid', header: m(GridHeaderCell, 'PID')},
+      {key: 'tid', header: m(GridHeaderCell, 'TID')},
+      {key: 'level', header: m(GridHeaderCell, 'Level')},
+      ...(hasProcessNames
+        ? [{key: 'process', header: m(GridHeaderCell, 'Process')}]
+        : []),
+      {key: 'tag', header: m(GridHeaderCell, 'Tag')},
+      ...(hasUnits ? [{key: 'unit', header: m(GridHeaderCell, 'Unit')}] : []),
+      {
+        key: 'message',
+        maxInitialWidthPx: Infinity,
+        header: m(GridHeaderCell, 'Message'),
+      },
+    ];
+
+    return m(Grid, {
+      className: 'pf-journald-logs-panel',
+      columns,
+      rowData: {
+        data: this.renderRows(entries, hasProcessNames, hasUnits),
+        total: entries.totalEvents,
+        offset: entries.offset,
+        onLoadData: (offset, count) => {
+          this.pagination = {offset, count};
+          m.redraw();
+        },
+      },
+      virtualization: {
+        rowHeightPx: ROW_H,
+      },
+      fillHeight: true,
+      onRowHover: (rowIndex) => {
+        const actualIndex = rowIndex - entries.offset;
+        const timestamp = entries.timestamps[actualIndex];
+        if (timestamp !== undefined) {
+          trace.timeline.hoverCursorTimestamp = timestamp;
+        }
+      },
+      onRowOut: () => {
+        trace.timeline.hoverCursorTimestamp = undefined;
+      },
+    });
+  }
+
+  private renderRows(
+    entries: LogEntries,
+    hasProcessNames: boolean,
+    hasUnits: boolean,
+  ): ReadonlyArray<GridRow> {
+    const trace = this.trace;
+    const rows: GridRow[] = [];
+    for (let i = 0; i < entries.timestamps.length; i++) {
+      const priority = entries.priorities[i];
+      const priorityName = JOURNALD_PRIORITIES[priority] ?? '?';
+      const ts = entries.timestamps[i];
+      const eventId = entries.ids[i];
+      const priorityClass = classForPriority(priority);
+      const isHighlighted = entries.isHighlighted[i];
+      const className = classNames(
+        priorityClass && `pf-journald-logs-panel__row--${priorityClass}`,
+        isHighlighted && 'pf-journald-logs-panel__row--highlighted',
+      );
+
+      const row = [
+        m(
+          GridCell,
+          {
+            className,
+            menuItems: m(MenuItem, {
+              label: 'Go to event on timeline',
+              icon: Icons.UpdateSelection,
+              onclick: () => {
+                trace.selection.selectSqlEvent(
+                  'linux_systemd_journald_logs',
+                  eventId,
+                  {
+                    scrollToSelection: true,
+                    switchToCurrentSelectionTab: true,
+                  },
+                );
+              },
+            }),
+          },
+          m(Timestamp, {trace, ts}),
+        ),
+        m(
+          GridCell,
+          {className, align: 'right'},
+          entries.pids[i] !== null
+            ? m(
+                Anchor,
+                {
+                  onclick: () =>
+                    trace.scrollTo({
+                      track: {
+                        uri: `/process_${entries.upids[i]}`,
+                        expandGroup: true,
+                      },
+                    }),
+                },
+                String(entries.pids[i]),
+              )
+            : '',
+        ),
+        m(
+          GridCell,
+          {className, align: 'right'},
+          entries.utids[i] !== null
+            ? m(
+                Anchor,
+                {
+                  onclick: () => {
+                    const uri = `${getThreadUriPrefix(entries.upids[i], entries.utids[i]!)}_state`;
+                    trace.scrollTo({track: {uri, expandGroup: true}});
+                  },
+                },
+                String(entries.tids[i]),
+              )
+            : '',
+        ),
+        m(GridCell, {className}, priorityName),
+        hasProcessNames && m(GridCell, {className}, entries.processName[i]),
+        m(GridCell, {className}, entries.tags[i]),
+        hasUnits && m(GridCell, {className}, entries.units[i]),
+        m(GridCell, {className}, entries.messages[i]),
+      ].filter(Boolean);
+
+      rows.push(row);
+    }
+
+    return rows;
+  }
+}
+
+function classForPriority(priority: number): string | undefined {
+  switch (priority) {
+    case 0:
+      return 'emergency';
+    case 1:
+      return 'alert';
+    case 2:
+      return 'critical';
+    case 3:
+      return 'error';
+    case 4:
+      return 'warning';
+    case 5:
+      return 'notice';
+    case 6:
+      return 'info';
+    case 7:
+      return 'debug';
+    default:
+      return undefined;
+  }
+}
+
+interface LogPriorityWidgetAttrs {
+  readonly options: string[];
+  readonly selectedIndex: number;
+  readonly onSelect: (id: number) => void;
+}
+
+class LogPriorityWidget implements m.ClassComponent<LogPriorityWidgetAttrs> {
+  view(vnode: m.Vnode<LogPriorityWidgetAttrs>) {
+    const attrs = vnode.attrs;
+    const optionComponents = [];
+    for (let i = 0; i < attrs.options.length; i++) {
+      const selected = i === attrs.selectedIndex;
+      optionComponents.push(
+        m('option', {value: i, selected}, attrs.options[i]),
+      );
+    }
+    return m(
+      Select,
+      {
+        onchange: (e: Event) => {
+          const selectionValue = (e.target as HTMLSelectElement).value;
+          attrs.onSelect(Number(selectionValue));
+        },
+      },
+      optionComponents,
+    );
+  }
+}
+
+interface LogTextWidgetAttrs {
+  readonly onChange: (value: string) => void;
+}
+
+class LogTextWidget implements m.ClassComponent<LogTextWidgetAttrs> {
+  view({attrs}: m.CVnode<LogTextWidgetAttrs>) {
+    return m(TextInput, {
+      leftIcon: 'search',
+      placeholder: 'Search logs...',
+      onkeyup: (e: KeyboardEvent) => {
+        const htmlElement = e.target as HTMLInputElement;
+        attrs.onChange(htmlElement.value);
+      },
+    });
+  }
+}
+
+interface FilterByTextWidgetAttrs {
+  readonly hideNonMatching: boolean;
+  readonly onClick: () => void;
+}
+
+class FilterByTextWidget implements m.ClassComponent<FilterByTextWidgetAttrs> {
+  view({attrs}: m.Vnode<FilterByTextWidgetAttrs>) {
+    const icon = attrs.hideNonMatching ? Icons.Filter : Icons.FilterOff;
+    const tooltip = attrs.hideNonMatching
+      ? 'Show all logs and highlight matches'
+      : 'Show only matching logs';
+    return m(Button, {
+      icon,
+      tooltip,
+      onclick: attrs.onClick,
+    });
+  }
+}
+
+interface LogsFiltersAttrs {
+  readonly store: Store<JournaldLogFilteringCriteria>;
+}
+
+class LogsFilters implements m.ClassComponent<LogsFiltersAttrs> {
+  view({attrs}: m.CVnode<LogsFiltersAttrs>) {
+    return [
+      m('span', 'Log Level'),
+      m(LogPriorityWidget, {
+        options: JOURNALD_PRIORITIES,
+        selectedIndex: attrs.store.state.minimumLevel,
+        onSelect: (minimumLevel) => {
+          attrs.store.edit((draft) => {
+            draft.minimumLevel = minimumLevel;
+          });
+        },
+      }),
+      m(TagInput, {
+        leftIcon: 'label',
+        placeholder: 'Filter by tag...',
+        tags: attrs.store.state.tags,
+        onTagAdd: (tag) => {
+          attrs.store.edit((draft) => {
+            draft.tags.push(tag);
+          });
+        },
+        onTagRemove: (index) => {
+          attrs.store.edit((draft) => {
+            draft.tags.splice(index, 1);
+          });
+        },
+      }),
+      m(Button, {
+        icon: 'regular_expression',
+        tooltip: 'Use regex',
+        active: !!attrs.store.state.isTagRegex,
+        onclick: () => {
+          attrs.store.edit((draft) => {
+            draft.isTagRegex = !draft.isTagRegex;
+          });
+        },
+      }),
+      m(LogTextWidget, {
+        onChange: (text) => {
+          attrs.store.edit((draft) => {
+            draft.textEntry = text;
+          });
+        },
+      }),
+      m(FilterByTextWidget, {
+        hideNonMatching: attrs.store.state.hideNonMatching,
+        onClick: () => {
+          attrs.store.edit((draft) => {
+            draft.hideNonMatching = !draft.hideNonMatching;
+          });
+        },
+      }),
+    ];
+  }
+}
+
+async function updateLogEntries(
+  engine: Engine,
+  span: TimeSpan,
+  pagination: Pagination,
+): Promise<LogEntries> {
+  const rowsResult = await engine.query(`
+        select
+          id,
+          ts,
+          pid,
+          tid,
+          prio,
+          upid,
+          utid,
+          ifnull(tag, '[NULL]') as tag,
+          ifnull(msg, '[NULL]') as msg,
+          is_msg_highlighted as isMsgHighlighted,
+          is_process_highlighted as isProcessHighlighted,
+          ifnull(process_name, '') as processName,
+          ifnull(systemd_unit, '') as systemdUnit
+        from filtered_linux_systemd_journald_logs
+        where ts >= ${span.start} and ts <= ${span.end}
+        order by ts
+        limit ${pagination.offset}, ${pagination.count}
+    `);
+
+  const ids: number[] = [];
+  const timestamps: time[] = [];
+  const pids = [];
+  const tids = [];
+  const priorities: number[] = [];
+  const tags: string[] = [];
+  const units: string[] = [];
+  const messages: string[] = [];
+  const isHighlighted: boolean[] = [];
+  const processName: string[] = [];
+  const upids = [];
+  const utids = [];
+
+  const it = rowsResult.iter({
+    id: NUM,
+    ts: LONG,
+    pid: LONG_NULL,
+    tid: LONG_NULL,
+    prio: NUM,
+    upid: NUM_NULL,
+    utid: NUM_NULL,
+    tag: STR,
+    msg: STR,
+    isMsgHighlighted: NUM_NULL,
+    isProcessHighlighted: NUM,
+    processName: STR,
+    systemdUnit: STR,
+  });
+  for (; it.valid(); it.next()) {
+    ids.push(it.id);
+    timestamps.push(Time.fromRaw(it.ts));
+    pids.push(it.pid);
+    tids.push(it.tid);
+    priorities.push(it.prio);
+    upids.push(it.upid);
+    utids.push(it.utid);
+    tags.push(it.tag);
+    units.push(it.systemdUnit);
+    messages.push(it.msg);
+    isHighlighted.push(
+      it.isMsgHighlighted === 1 || it.isProcessHighlighted === 1,
+    );
+    processName.push(it.processName);
+  }
+
+  const queryRes = await engine.query(`
+    select
+      count(*) as totalEvents
+    from filtered_linux_systemd_journald_logs
+    where ts >= ${span.start} and ts <= ${span.end}
+  `);
+  const {totalEvents} = queryRes.firstRow({totalEvents: NUM});
+
+  return {
+    offset: pagination.offset,
+    ids,
+    timestamps,
+    pids,
+    tids,
+    priorities,
+    upids,
+    utids,
+    tags,
+    units,
+    messages,
+    isHighlighted,
+    processName,
+    totalEvents,
+  };
+}
+
+async function updateLogView(
+  engine: Engine,
+  filter: JournaldLogFilteringCriteria,
+): Promise<AsyncDisposable> {
+  const globMatch = composeGlobMatch(filter.hideNonMatching, filter.textEntry);
+  let selectedRows = `select linux_systemd_journald_logs.id, prio, ts, pid, tid, tag, msg,
+      process.name as process_name,
+      ifnull(linux_systemd_journald_logs.systemd_unit, '') as systemd_unit,
+      thread.upid as upid, thread.utid as utid,
+      ${globMatch}
+      from linux_systemd_journald_logs
+      left join thread using(utid)
+      left join process using(upid)
+      where prio <= ${filter.minimumLevel}`;
+  if (filter.tags.length) {
+    if (filter.isTagRegex) {
+      const tagGlobClauses = filter.tags.map(
+        (pattern) => `tag glob ${escapeRegexQuery(pattern)}`,
+      );
+      selectedRows += ` and (${tagGlobClauses.join(' OR ')})`;
+    } else {
+      selectedRows += ` and tag in (${serializeTags(filter.tags)})`;
+    }
+  }
+
+  await engine.query(
+    `create perfetto table filtered_linux_systemd_journald_logs as select *
+      from (${selectedRows})
+      where is_msg_chosen is 1 or is_process_chosen is 1`,
+  );
+
+  return {
+    async [Symbol.asyncDispose]() {
+      await engine.query('drop table filtered_linux_systemd_journald_logs');
+    },
+  };
+}
+
+function serializeTags(tags: string[]) {
+  return tags.map((tag) => escapeQuery(tag)).join();
+}
+
+function composeGlobMatch(isCollapsed: boolean, textEntry: string) {
+  if (isCollapsed) {
+    return `msg glob ${escapeSearchQuery(textEntry)} as is_msg_chosen,
+      (process.name is not null and process.name glob ${escapeSearchQuery(
+        textEntry,
+      )}) as is_process_chosen,
+      0 as is_msg_highlighted,
+      0 as is_process_highlighted`;
+  } else if (!textEntry) {
+    return `1 as is_msg_chosen,
+      1 as is_process_chosen,
+      0 as is_msg_highlighted,
+      0 as is_process_highlighted`;
+  } else {
+    return `1 as is_msg_chosen,
+      1 as is_process_chosen,
+      msg glob ${escapeSearchQuery(textEntry)} as is_msg_highlighted,
+      (process.name is not null and process.name glob ${escapeSearchQuery(
+        textEntry,
+      )}) as is_process_highlighted`;
+  }
+}
+
+export {JournaldLogPanel as LogPanel};

--- a/ui/src/plugins/dev.perfetto.JournaldLog/logs_track.ts
+++ b/ui/src/plugins/dev.perfetto.JournaldLog/logs_track.ts
@@ -1,0 +1,142 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {makeColorScheme} from '../../components/colorizer';
+import {HSLColor} from '../../base/color';
+import type {Trace} from '../../public/trace';
+import {Time} from '../../base/time';
+import {
+  LONG,
+  NUM,
+  NUM_NULL,
+  STR,
+  STR_NULL,
+} from '../../trace_processor/query_result';
+import {SliceTrack} from '../../components/tracks/slice_track';
+import {SourceDataset} from '../../trace_processor/dataset';
+import {DetailsShell} from '../../widgets/details_shell';
+import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
+import {Section} from '../../widgets/section';
+import {Tree, TreeNode} from '../../widgets/tree';
+import {Timestamp} from '../../components/widgets/timestamp';
+import {Spinner} from '../../widgets/spinner';
+
+// Journald priority: 0=EMERG … 7=DEBUG (lower number = increased severity).
+const DEPTH_TO_COLOR = [
+  makeColorScheme(new HSLColor({h: 268, s: 100, l: 65})), // 0 EMERG - magenta
+  makeColorScheme(new HSLColor({h: 8, s: 89, l: 56})), // 1 ALERT
+  makeColorScheme(new HSLColor({h: 22, s: 88, l: 54})), // 2 CRIT
+  makeColorScheme(new HSLColor({h: 0, s: 86, l: 60})), // 3 ERROR - red
+  makeColorScheme(new HSLColor({h: 38, s: 100, l: 58})), // 4 WARNING - amber
+  makeColorScheme(new HSLColor({h: 95, s: 52, l: 45})), // 5 NOTICE - green
+  makeColorScheme(new HSLColor({h: 217, s: 100, l: 60})), // 6 INFO - blue
+  makeColorScheme(new HSLColor({h: 0, s: 0, l: 60})), // 7 DEBUG - grey
+];
+
+const EVT_PX = 6;
+
+const LOGS_SQL = `
+  select
+    id,
+    ts,
+    prio,
+    utid,
+    tag,
+    msg,
+    CASE
+      WHEN prio >= 0 AND prio <= 7 THEN prio
+      ELSE 7
+    END as depth
+  from linux_systemd_journald_logs
+  order by ts
+  -- linux_systemd_journald_logs aren't guaranteed to be ordered by ts, but this is a
+  -- requirement for SliceTrack's mipmap operator to work
+  -- correctly, so we must explicitly sort them above.
+`;
+
+const LOGS_SCHEMA = {
+  id: NUM,
+  ts: LONG,
+  prio: NUM,
+  utid: NUM_NULL,
+  depth: NUM,
+  tag: STR_NULL,
+  msg: STR_NULL,
+};
+
+export function createJournaldLogTrack(trace: Trace, uri: string) {
+  return SliceTrack.create({
+    trace,
+    uri,
+    rootTableName: 'linux_systemd_journald_logs',
+    dataset: new SourceDataset({
+      src: LOGS_SQL,
+      schema: LOGS_SCHEMA,
+    }),
+    initialMaxDepth: 7,
+    colorizer: (row) => DEPTH_TO_COLOR[row.depth],
+    tooltip: (slice) => [m('', m('b', slice.row.tag)), m('', slice.row.msg)],
+    instantStyle: {
+      width: EVT_PX,
+      render: (ctx, r) => ctx.fillRect(r.x, r.y, r.width, r.height),
+    },
+    sliceLayout: {padding: 2, sliceHeight: 7},
+    detailsPanel: (row) => {
+      let msg: string | undefined;
+
+      trace.engine
+        .query(
+          `select msg from linux_systemd_journald_logs where id = ${row.id}`,
+        )
+        .then((result) => {
+          msg = result.maybeFirstRow({msg: STR})?.msg;
+        });
+
+      return {
+        render() {
+          return m(
+            DetailsShell,
+            {title: 'Journald Log'},
+            m(
+              GridLayout,
+              m(
+                GridLayoutColumn,
+                m(
+                  Section,
+                  {title: 'Details'},
+                  m(
+                    Tree,
+                    m(TreeNode, {left: 'ID', right: row.id}),
+                    m(TreeNode, {
+                      left: 'Timestamp',
+                      right: m(Timestamp, {trace, ts: Time.fromRaw(row.ts)}),
+                    }),
+                    m(TreeNode, {left: 'Priority', right: row.prio}),
+                    m(TreeNode, {left: 'Tag', right: row.tag}),
+                    m(TreeNode, {left: 'Utid', right: row.utid}),
+                    m(TreeNode, {
+                      left: 'Message',
+                      right: msg ? msg : m(Spinner),
+                    }),
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      };
+    },
+  });
+}

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/index.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/index.ts
@@ -26,6 +26,7 @@ import {chromeRecordSection} from './pages/chrome';
 import {cpuRecordSection} from './pages/cpu';
 import {gpuRecordSection} from './pages/gpu';
 import {instructionsPage} from './pages/instructions_page';
+import {linuxRecordSection} from './pages/linux';
 import {memoryRecordSection} from './pages/memory';
 import {powerRecordSection} from './pages/power';
 import {RecordPageV2} from './pages/record_page';
@@ -119,6 +120,7 @@ export default class implements PerfettoPlugin {
         gpuRecordSection(),
         powerRecordSection(),
         memoryRecordSection(),
+        linuxRecordSection(),
         androidRecordSection(),
         perfettoSDKRecordSection(),
         stackSamplingRecordSection(),

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/linux.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/linux.ts
@@ -1,0 +1,89 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {RecordProbe, RecordSubpage} from '../config/config_interfaces';
+import type {TraceConfigBuilder} from '../config/trace_config_builder';
+import {Dropdown} from './widgets/dropdown';
+import {Textarea} from './widgets/textarea';
+
+const JOURNALD_DS = 'linux.systemd_journald';
+
+const MIN_PRIO_OPTIONS = [
+  {value: 0, label: 'Emergency'},
+  {value: 1, label: 'Alert'},
+  {value: 2, label: 'Critical'},
+  {value: 3, label: 'Error'},
+  {value: 4, label: 'Warning'},
+  {value: 5, label: 'Notice'},
+  {value: 6, label: 'Info'},
+  {value: 7, label: 'Debug'},
+] as const;
+
+export function linuxRecordSection(): RecordSubpage {
+  return {
+    kind: 'PROBES_PAGE',
+    id: 'linux',
+    title: 'Linux',
+    subtitle: 'Linux-specific data sources',
+    icon: 'dns',
+    probes: [journald()],
+  };
+}
+
+function journald(): RecordProbe {
+  const settings = {
+    minPrio: new Dropdown<number>({
+      title: 'Minimum syslog priority',
+      options: MIN_PRIO_OPTIONS,
+      defaultValue: 7,
+    }),
+    identifiers: new Textarea({
+      title: 'Process name (SYSLOG_IDENTIFIER) to record',
+      placeholder: 'One identifier per line\nsshd\nmy-service',
+    }),
+    units: new Textarea({
+      title: 'systemd units to record',
+      placeholder:
+        'One unit per line\nsystemd-journald.service\nuser@1000.service',
+    }),
+  };
+
+  return {
+    id: 'systemd_journald',
+    title: 'Journald log messages',
+    description: 'Records log messages from systemd-journald.',
+    supportedPlatforms: ['LINUX'],
+    settings,
+    genConfig(tc: TraceConfigBuilder) {
+      const ds = tc.addDataSource(JOURNALD_DS);
+      const journaldConfig = (ds.journaldConfig ??= {});
+      journaldConfig.minPrio = settings.minPrio.value;
+
+      const identifiers = settings.identifiers.text
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      if (identifiers.length > 0) {
+        journaldConfig.filterIdentifiers = identifiers;
+      }
+      const units = settings.units.text
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      if (units.length > 0) {
+        journaldConfig.filterUnits = units;
+      }
+    },
+  };
+}

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
@@ -158,6 +158,7 @@ export class RecordPageV2 implements m.ClassComponent<RecordPageAttrs> {
     memory: 40,
     android: 50,
     network: 60,
+    linux: 65,
     chrome: 70,
     stack_sampling: 80,
     perfetto_sdk: 90,

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/dropdown.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/dropdown.ts
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {assertTrue} from '../../../../base/assert';
+import type {ProbeSetting} from '../../config/config_interfaces';
+import {Select} from '../../../../widgets/select';
+
+export interface DropdownOption<T extends string | number> {
+  readonly value: T;
+  readonly label: string;
+}
+
+export interface DropdownAttrs<T extends string | number> {
+  readonly title: string;
+  readonly options: ReadonlyArray<DropdownOption<T>>;
+  readonly defaultValue?: T;
+}
+
+export class Dropdown<T extends string | number> implements ProbeSetting {
+  private _value: T;
+
+  constructor(readonly attrs: DropdownAttrs<T>) {
+    assertTrue(attrs.options.length > 0);
+    this._value = attrs.defaultValue ?? attrs.options[0].value;
+  }
+
+  serialize() {
+    return this._value;
+  }
+
+  deserialize(state: unknown): void {
+    if (typeof state !== 'string' && typeof state !== 'number') {
+      return;
+    }
+    const option = this.attrs.options.find(
+      (candidate) => candidate.value === state,
+    );
+    if (option) {
+      this._value = option.value;
+    }
+  }
+
+  get value(): T {
+    return this._value;
+  }
+
+  render() {
+    return m('.textarea-holder', [
+      m('header', this.attrs.title),
+      m(
+        Select,
+        {
+          value: String(this._value),
+          onchange: (e: Event) => {
+            const selectedValue = (e.target as HTMLSelectElement).value;
+            const option = this.attrs.options.find(
+              (candidate) => String(candidate.value) === selectedValue,
+            );
+            if (option) {
+              this._value = option.value;
+            }
+          },
+        },
+        this.attrs.options.map((option) =>
+          m('option', {value: String(option.value)}, option.label),
+        ),
+      ),
+    ]);
+  }
+}


### PR DESCRIPTION
Add a new JournaldLog plugin (dev.perfetto.JournaldLog) that displays
journald log entries from the linux.journald data source. The plugin
shares UI components with the existing AndroidLog plugin, extracted into:

- ui/src/components/tracks/log_track.ts: generic log track factory
- ui/src/components/widgets/log_panel/log_panel.ts: shared LogPanel
  component with filtering, search, and per-source extensibility

The AndroidLog plugin is refactored to use these shared components.
Register dev.perfetto.JournaldLog in default_plugins.ts.

This is part 3 of a split-up version of #5331 and will close #3288.

This PR was co-written by AI; while I iterated on it until the look and feel felt correct, there may be context or use cases that I am unaware of. I am open to all review comments, and will do my best to address them.