### PR TITLE
protovm: fix merge of repeated fields

### DIFF
--- a/src/protovm/node.h
+++ b/src/protovm/node.h
@@ -68,10 +68,6 @@ struct Node {
 
   struct IndexedRepeatedField {
     IntrusiveMap index_to_node;
-
-    // Flag needed to track the merge state of indexed repeated field
-    // (see implementation of Merge operation in RW proto)
-    bool has_been_merged;
   };
 
   struct Message {
@@ -98,6 +94,10 @@ struct Node {
                Message,
                Scalar>
       value;
+
+  // Flag needed to track the merge state of repeated fields
+  // (see implementation of Merge operation in RW proto)
+  bool has_been_merged = false;
 };
 
 Node& GetOuterNode(Node::MapNode& map_node);

--- a/src/protovm/rw_proto_cursor.cc
+++ b/src/protovm/rw_proto_cursor.cc
@@ -223,8 +223,8 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
     return StatusOr<void>::Ok();
   }
 
-  auto status_convertion = ConvertToMessageIfNeeded(node_);
-  PROTOVM_RETURN_IF_NOT_OK(status_convertion);
+  auto status_convert_to_message = ConvertToMessageIfNeeded(node_);
+  PROTOVM_RETURN_IF_NOT_OK(status_convert_to_message);
   auto* message = node_->GetIf<Node::Message>();
 
   protozero::ProtoDecoder decoder(data);
@@ -259,6 +259,7 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
       auto status_or_it = MapInsert(&message->field_id_to_node, field.id(),
                                     std::move(*status_or_map_value));
       PROTOVM_RETURN_IF_NOT_OK(status_or_it);
+      (*status_or_it)->value->has_been_merged = true;
       continue;
     }
 
@@ -269,15 +270,25 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
           field.id());
     }
 
+    // Promote field as repeated if needed:
+    // If this is the second time that the same field ID is being merged, then
+    // they are a repeated fields and they should live within an
+    // IndexedRepeatedField node.
+    if (it->value->has_been_merged) {
+      auto status_convert_to_indexed =
+          ConvertToIndexedRepeatedFieldIfNeeded(it->value.get());
+      PROTOVM_RETURN_IF_NOT_OK(status_convert_to_indexed);
+    }
+
     if (auto* indexed_fields = it->value->GetIf<Node::IndexedRepeatedField>()) {
       // Implements merge semantics for repeated fields: all existing fields are
       // removed and replaced with the newly received fields.
-      if (!indexed_fields->has_been_merged) {
+      if (!it->value->has_been_merged) {
         // Optimization opportunity: reuse the existing nodes to avoid N
         // allocation-deallocation pairs, where N is the number of newly
         // received repeated fields.
         allocator_->DeleteReferencedData(it->value.get());
-        indexed_fields->has_been_merged = true;
+        it->value->has_been_merged = true;
       }
       MapInsert(&indexed_fields->index_to_node,
                 indexed_fields->index_to_node.Size(),
@@ -289,14 +300,12 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
     // allocation-deallocation pair
     allocator_->Delete(it->value.release());
     it->value = std::move(*status_or_map_value);
+    it->value->has_been_merged = true;
   }
 
-  // Reset the merge state of repeated fields
+  // Reset the merge flags
   for (auto& field : message->field_id_to_node) {
-    if (auto* indexed_fields =
-            field.value->GetIf<Node::IndexedRepeatedField>()) {
-      indexed_fields->has_been_merged = false;
-    }
+    field.value->has_been_merged = false;
   }
 
   return StatusOr<void>::Ok();

--- a/src/protovm/test/rw_proto_unittest.cc
+++ b/src/protovm/test/rw_proto_unittest.cc
@@ -781,22 +781,10 @@ TEST_F(RwProtoTest, Merge_FieldsReplacement) {
 }
 
 TEST_F(RwProtoTest, Merge_RepeatedField) {
+  // initially empty
   auto cursor = data_empty_.GetRoot();
 
-  // initialize elements = [{id: 0, value: 1}]
-  {
-    protos::Element element;
-    element.set_id(0);
-    element.set_value(1);
-    auto bytes = element.SerializeAsString();
-
-    auto element0 = cursor;
-    element0.EnterRepeatedFieldAt(protos::TraceEntry::kElementsFieldNumber, 0);
-    element0.SetBytes(AsConstBytes(bytes));
-  }
-
   // merge with elements = [{id: 1, value: 10}, {id: 2, value: 20}]
-  // (fully replace original elements)
   {
     protos::TraceEntry entry;
 


### PR DESCRIPTION
In some cases, during a merge operation the ProtoVM was not able to detect
that a src field is repeated, so only the last field value was being retained and
previous values were being overwritten/discarded.
    
Now the ProtoVM detects when a certain field ID is encountered during merge
multiple times (i.e. it is repeated). In such cases the internal holding node is
promoted to IndexedRepeatedField and all the field values are stored in there.