### PR TITLE
protovm: optimize node memory footprint

### DIFF
--- a/src/protovm/allocator.cc
+++ b/src/protovm/allocator.cc
@@ -22,6 +22,18 @@ namespace protovm {
 Allocator::Allocator(size_t memory_limit_bytes)
     : memory_limit_bytes_{memory_limit_bytes}, used_memory_bytes_{0} {}
 
+StatusOr<OwnedPtr<MapNode>> Allocator::CreateMapNode(uint64_t key,
+                                                     OwnedPtr<Node> value) {
+  PERFETTO_DCHECK(value);
+  auto p = Allocate();
+  if (!p.IsOk()) {
+    Delete(value.release());
+    PROTOVM_RETURN(p);
+  }
+  new (*p) MapNode{key, std::move(value)};
+  return OwnedPtr<MapNode>(static_cast<MapNode*>(*p));
+}
+
 StatusOr<Node::Bytes> Allocator::AllocateAndCopyBytes(
     protozero::ConstBytes data) {
   if (used_memory_bytes_ + data.size > memory_limit_bytes_) {
@@ -49,7 +61,14 @@ void Allocator::Delete(Node* node) {
   DeleteReferencedData(node);
   node->~Node();
   slab_allocator_.Free(node);
-  used_memory_bytes_ -= sizeof(Node);
+  used_memory_bytes_ -= kNodeSize;
+}
+
+void Allocator::Delete(MapNode* node) {
+  Delete(node->value.release());
+  node->~MapNode();
+  slab_allocator_.Free(node);
+  used_memory_bytes_ -= kNodeSize;
 }
 
 void Allocator::DeleteReferencedData(Node* node) {
@@ -59,16 +78,14 @@ void Allocator::DeleteReferencedData(Node* node) {
     for (auto it = indexed_fields->index_to_node.begin(); it;) {
       auto& map_node = *it;
       it = indexed_fields->index_to_node.Remove(it);
-      Delete(&GetOuterNode(map_node));
+      Delete(&map_node);
     }
   } else if (auto* mapped_fields = node->GetIf<Node::MappedRepeatedField>()) {
     for (auto it = mapped_fields->key_to_node.begin(); it;) {
       auto& map_node = *it;
       it = mapped_fields->key_to_node.Remove(it);
-      Delete(&GetOuterNode(map_node));
+      Delete(&map_node);
     }
-  } else if (auto* map_node = node->GetIf<Node::MapNode>()) {
-    Delete(map_node->value.release());
   } else if (auto* bytes = node->GetIf<Node::Bytes>()) {
     DeleteReferencedData(bytes);
   }
@@ -78,7 +95,7 @@ void Allocator::DeleteReferencedData(Node::Message* message) {
   for (auto it = message->field_id_to_node.begin(); it;) {
     auto& map_node = *it;
     it = message->field_id_to_node.Remove(it);
-    Delete(&GetOuterNode(map_node));
+    Delete(&map_node);
   }
 }
 
@@ -89,6 +106,22 @@ void Allocator::DeleteReferencedData(Node::Bytes* bytes) {
 void Allocator::DeallocateBytes(OwnedPtr<void> p, size_t size) {
   free(p.release());
   used_memory_bytes_ -= size;
+}
+
+StatusOr<void*> Allocator::Allocate() {
+  if (used_memory_bytes_ + kNodeSize > memory_limit_bytes_) {
+    PROTOVM_ABORT(
+        "Failed to allocate element (%zu bytes). Memory limit: %zu [bytes]. "
+        "Used: %zu "
+        "[bytes].)",
+        kNodeSize, memory_limit_bytes_, used_memory_bytes_);
+  }
+  auto* p = slab_allocator_.Allocate();
+  if (!p) {
+    PROTOVM_ABORT("Failed to allocate node");
+  }
+  used_memory_bytes_ += kNodeSize;
+  return p;
 }
 
 }  // namespace protovm

--- a/src/protovm/allocator.h
+++ b/src/protovm/allocator.h
@@ -17,6 +17,7 @@
 #ifndef SRC_PROTOVM_ALLOCATOR_H_
 #define SRC_PROTOVM_ALLOCATOR_H_
 
+#include <algorithm>
 #include <cstdlib>
 
 #include "perfetto/protozero/field.h"
@@ -33,13 +34,34 @@ namespace protovm {
 // the overall proto VM's memory footprint.
 class Allocator {
  public:
+  static constexpr size_t kNodeSize = std::max(sizeof(Node), sizeof(MapNode));
+  static constexpr size_t kNodeAlign =
+      std::max(alignof(Node), alignof(MapNode));
+
   explicit Allocator(size_t memory_limit_bytes);
+
+  template <class T, class... Args>
+  StatusOr<OwnedPtr<Node>> CreateNode(Args&&... args) {
+    auto p = Allocate();
+    PROTOVM_RETURN_IF_NOT_OK(p);
+
+    // 1. Construct node's inner value T passing args (struct aggregate
+    // initialization)
+    // 2. Construct node passing T (struct aggregate initialization)
+    new (*p) Node{T{std::forward<Args>(args)...}};
+
+    return OwnedPtr<Node>(static_cast<Node*>(*p));
+  }
+
+  StatusOr<OwnedPtr<MapNode>> CreateMapNode(uint64_t key, OwnedPtr<Node> value);
+
   StatusOr<Node::Bytes> AllocateAndCopyBytes(protozero::ConstBytes data);
 
   // Deeply delete a node and all the referenced data. E.g. if the node holds a
   // Node::Message, recursively delete the message fields and finally delete the
   // node.
   void Delete(Node* node);
+  void Delete(MapNode* node);
 
   // Deeply delete a node's referenced data, but do not delete the node itself.
   // E.g. if the node holds a Node::Message, recursively delete the message
@@ -54,39 +76,15 @@ class Allocator {
   // struct itself.
   void DeleteReferencedData(Node::Bytes* bytes);
 
-  template <class T, class... Args>
-  StatusOr<OwnedPtr<Node>> CreateNode(Args&&... args) {
-    if (used_memory_bytes_ + sizeof(Node) > memory_limit_bytes_) {
-      PROTOVM_ABORT(
-          "Failed to allocate node (%zu bytes). Memory limit: %zu [bytes]. "
-          "Used: %zu "
-          "[bytes].)",
-          sizeof(Node), memory_limit_bytes_, used_memory_bytes_);
-    }
-
-    auto* p = slab_allocator_.Allocate();
-    if (!p) {
-      PROTOVM_ABORT("Failed to allocate node");
-    }
-
-    used_memory_bytes_ += sizeof(Node);
-
-    // 1. Construct node's inner value T passing args (struct aggregate
-    // initialization)
-    // 2. Construct node passing T (struct aggregate initialization)
-    new (p) Node{T{std::forward<Args>(args)...}};
-
-    return OwnedPtr<Node>(static_cast<Node*>(p));
-  }
-
   size_t GetMemoryUsageBytes() const { return used_memory_bytes_; }
 
  private:
   void DeallocateBytes(OwnedPtr<void> p, size_t size);
+  StatusOr<void*> Allocate();
 
   size_t memory_limit_bytes_{0};
   size_t used_memory_bytes_{0};
-  SlabAllocator<sizeof(Node), alignof(Node)> slab_allocator_;
+  SlabAllocator<kNodeSize, kNodeAlign> slab_allocator_;
 };
 
 }  // namespace protovm

--- a/src/protovm/node.cc
+++ b/src/protovm/node.cc
@@ -29,8 +29,6 @@ const char* Node::GetTypeName() const {
           return "Empty";
         } else if constexpr (std::is_same_v<T, Node::IndexedRepeatedField>) {
           return "IndexedRepeatedField";
-        } else if constexpr (std::is_same_v<T, Node::MapNode>) {
-          return "MapEntry";
         } else if constexpr (std::is_same_v<T, Node::MappedRepeatedField>) {
           return "MappedRepeatedField";
         } else if constexpr (std::is_same_v<T, Node::Message>) {
@@ -42,20 +40,6 @@ const char* Node::GetTypeName() const {
         }
       },
       value);
-}
-
-Node& GetOuterNode(Node::MapNode& map_node) {
-  // Hackish solution to obtain offsetof(Node, MapNode). Alas, there isn't
-  // anything like the standard offsetof that works with std::variant. Note that
-  // the calculation can't be constexpr, however the compiler optimizes it out.
-  const Node tmp{Node::MapNode{0, nullptr}};
-  const auto* tmp_map_node = std::get_if<Node::MapNode>(&tmp.value);
-  const auto kOffset = reinterpret_cast<const char*>(tmp_map_node) -
-                       reinterpret_cast<const char*>(&tmp);
-
-  auto* node = reinterpret_cast<char*>(&map_node);
-  node -= kOffset;
-  return *reinterpret_cast<Node*>(node);
 }
 
 }  // namespace protovm

--- a/src/protovm/node.h
+++ b/src/protovm/node.h
@@ -29,7 +29,6 @@ namespace protovm {
 
 struct Node;
 
-namespace internal {
 struct MapNode {
   struct Traits {
     using KeyType = uint64_t;
@@ -47,14 +46,9 @@ struct MapNode {
   OwnedPtr<Node> value;
 };
 
-}  // namespace internal
-
-using IntrusiveMap =
-    base::IntrusiveTree<internal::MapNode, internal::MapNode::Traits>;
+using IntrusiveMap = base::IntrusiveTree<MapNode, MapNode::Traits>;
 
 struct Node {
-  using MapNode = internal::MapNode;
-
   struct Bytes {
     OwnedPtr<void> data;
     size_t size;
@@ -89,7 +83,6 @@ struct Node {
   std::variant<Bytes,
                Empty,
                IndexedRepeatedField,
-               MapNode,
                MappedRepeatedField,
                Message,
                Scalar>
@@ -99,8 +92,6 @@ struct Node {
   // (see implementation of Merge operation in RW proto)
   bool has_been_merged = false;
 };
-
-Node& GetOuterNode(Node::MapNode& map_node);
 
 }  // namespace protovm
 }  // namespace perfetto

--- a/src/protovm/rw_proto_cursor.cc
+++ b/src/protovm/rw_proto_cursor.cc
@@ -261,7 +261,7 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
       // Implements remove submessage semantics: empty src field means delete
       // the dst field
       message->field_id_to_node.Remove(*it);
-      allocator_->Delete(&GetOuterNode(*it));
+      allocator_->Delete(&*it);
       continue;
     }
 
@@ -337,7 +337,7 @@ StatusOr<void> RwProtoCursor::Delete() {
   PERFETTO_DCHECK(parent_link_.map_node);
 
   parent_link_.map->Remove(*parent_link_.map_node);
-  allocator_->Delete(&GetOuterNode(*parent_link_.map_node));
+  allocator_->Delete(parent_link_.map_node);
 
   // Delete operation invalidates cursor
   node_ = nullptr;
@@ -626,22 +626,18 @@ StatusOr<IntrusiveMap::Iterator> RwProtoCursor::MapInsert(
     uint64_t key,
     OwnedPtr<Node> map_value) {
   auto status_or_map_node =
-      allocator_->CreateNode<Node::MapNode>(key, std::move(map_value));
-  if (!status_or_map_node.IsOk()) {
-    allocator_->Delete(map_value.release());
-    PROTOVM_RETURN(status_or_map_node, "Failed to allocate node");
-  }
+      allocator_->CreateMapNode(key, std::move(map_value));
+  PROTOVM_RETURN_IF_NOT_OK(status_or_map_node, "Failed to allocate node");
 
-  auto [it, inserted] =
-      map->Insert(*status_or_map_node->release()->GetIf<Node::MapNode>());
+  auto [it, inserted] = map->Insert(*status_or_map_node->get());
   if (!inserted) {
-    allocator_->Delete(map_value.release());
     allocator_->Delete(status_or_map_node->release());
     PROTOVM_ABORT(
         "Failed to insert intrusive map entry (key = %d). Duplicated key?",
         static_cast<int>(key));
   }
 
+  status_or_map_node->release();
   return it;
 }
 

--- a/src/protovm/rw_proto_cursor.h
+++ b/src/protovm/rw_proto_cursor.h
@@ -110,7 +110,7 @@ class RwProtoCursor {
   struct ParentLink {
     Node* node;
     IntrusiveMap* map;
-    Node::MapNode* map_node;
+    MapNode* map_node;
   };
 
   StatusOr<void> ConvertToMessageIfNeeded(Node* node);

--- a/src/protovm/test/allocator_unittest.cc
+++ b/src/protovm/test/allocator_unittest.cc
@@ -15,6 +15,7 @@
  */
 
 #include "perfetto/protozero/field.h"
+#include "src/protovm/owned_ptr.h"
 #include "test/gtest_and_gmock.h"
 
 #include "src/protovm/allocator.h"
@@ -26,63 +27,87 @@ namespace test {
 
 class AllocatorTest : public ::testing::Test {
  protected:
-  static constexpr size_t kCapacity = 10;
-  static constexpr size_t kMemoryLimitBytes = kCapacity * sizeof(Node);
-  Allocator allocator_{kMemoryLimitBytes};
+  static constexpr size_t kAllocatorCapacityNodes = 10;
+  static constexpr size_t kAllocatorCapacityBytes =
+      kAllocatorCapacityNodes * Allocator::kNodeSize;
+  Allocator allocator_{kAllocatorCapacityBytes};
+
+  template <typename NodeType>
+  void TestAllocationRespectsMemoryLimit(
+      const std::function<StatusOr<OwnedPtr<NodeType>>()>& do_allocation,
+      size_t expected_allocations) {
+    ASSERT_EQ(allocator_.GetMemoryUsageBytes(), 0u);
+
+    // Allocate N nodes
+    auto nodes = std::vector<OwnedPtr<NodeType>>{};
+    for (size_t i = 0; i < expected_allocations; ++i) {
+      auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
+      auto node = do_allocation();
+      ASSERT_TRUE(node.IsOk());
+      ASSERT_GT(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
+      nodes.push_back(std::move(*node));
+    }
+
+    // Failed node allocation (memory limit reached)
+    {
+      auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
+      auto node_fail = do_allocation();
+      ASSERT_FALSE(node_fail.IsOk());
+      ASSERT_EQ(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
+    }
+
+    // Delete one node
+    {
+      auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
+      allocator_.Delete(nodes.back().release());
+      nodes.pop_back();
+      ASSERT_LT(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
+    }
+
+    // Successfull node allocation (verify that previous deletion actually freed
+    // memory for one node)
+    {
+      auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
+      auto node_success = do_allocation();
+      ASSERT_TRUE(node_success.IsOk());
+      ASSERT_GT(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
+      nodes.push_back(node_success->release());
+    }
+
+    // Delete all nodes
+    for (auto& n : nodes) {
+      auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
+      allocator_.Delete(n.release());
+      ASSERT_LT(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
+    }
+
+    ASSERT_EQ(allocator_.GetMemoryUsageBytes(), 0u);
+  }
 };
 
 TEST_F(AllocatorTest, NodeAllocationRespectsMemoryLimit) {
-  ASSERT_EQ(allocator_.GetMemoryUsageBytes(), 0u);
+  auto do_allocation = [this]() {
+    return allocator_.CreateNode<Node::Empty>();
+  };
+  auto expected_allocations = kAllocatorCapacityNodes;
+  TestAllocationRespectsMemoryLimit<Node>(do_allocation, expected_allocations);
+}
 
-  // Allocate N nodes
-  auto nodes = std::vector<OwnedPtr<Node>>{};
-  for (size_t i = 0; i < kCapacity; ++i) {
-    auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
+TEST_F(AllocatorTest, MapNodeAllocationRespectsMemoryLimit) {
+  auto do_allocation = [this]() -> StatusOr<OwnedPtr<MapNode>> {
     auto node = allocator_.CreateNode<Node::Empty>();
-    ASSERT_TRUE(node.IsOk());
-    ASSERT_GT(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
-    nodes.push_back(std::move(*node));
-  }
-
-  // Failed node allocation (memory limit reached)
-  {
-    auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
-    auto node_fail = allocator_.CreateNode<Node::Empty>();
-    ASSERT_FALSE(node_fail.IsOk());
-    ASSERT_EQ(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
-  }
-
-  // Delete one node
-  {
-    auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
-    allocator_.Delete(nodes.back().release());
-    nodes.pop_back();
-    ASSERT_LT(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
-  }
-
-  // Successfull node allocation (verify that previous deletion actually freed
-  // memory for one node)
-  {
-    auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
-    auto node_success = allocator_.CreateNode<Node::Empty>();
-    ASSERT_TRUE(node_success.IsOk());
-    ASSERT_GT(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
-    nodes.push_back(node_success->release());
-  }
-
-  // Delete all nodes
-  for (auto& n : nodes) {
-    auto prev_memory_usage = allocator_.GetMemoryUsageBytes();
-    allocator_.Delete(n.release());
-    ASSERT_LT(allocator_.GetMemoryUsageBytes(), prev_memory_usage);
-  }
-
-  ASSERT_EQ(allocator_.GetMemoryUsageBytes(), 0u);
+    PROTOVM_RETURN_IF_NOT_OK(node);
+    return allocator_.CreateMapNode(0, node->release());
+  };
+  auto expected_allocations = kAllocatorCapacityNodes / 2;
+  TestAllocationRespectsMemoryLimit<MapNode>(do_allocation,
+                                             expected_allocations);
 }
 
 TEST_F(AllocatorTest, BytesAllocationRespectsMemoryLimit) {
-  auto bytes0 = std::vector<std::uint8_t>(kMemoryLimitBytes / 2);
-  auto bytes1 = std::vector<std::uint8_t>(kMemoryLimitBytes - bytes0.size());
+  auto bytes0 = std::vector<std::uint8_t>(kAllocatorCapacityBytes / 2);
+  auto bytes1 =
+      std::vector<std::uint8_t>(kAllocatorCapacityBytes - bytes0.size());
 
   // Successfully allocate copy0 and copy1 (reach memory limit)
   auto copy0 = allocator_.AllocateAndCopyBytes(


### PR DESCRIPTION
Decouple MapNode and Node types, so that for MapNode we don't pay the
extra memory cost of Node (std::variant internal state, bool is_being_merged).

This reduces a MapNode's memory footprint from 64 to 48 bytes on Linux x64.