### PR TITLE
tp: drop ftrace based on raw timestamps not forged ones

### DIFF
--- a/src/trace_processor/importers/common/parser_types.h
+++ b/src/trace_processor/importers/common/parser_types.h
@@ -138,6 +138,24 @@ struct alignas(8) TracePacketData {
 };
 static_assert(sizeof(TracePacketData) % 8 == 0);
 
+// Used by the ftrace push path. Carries the original event timestamp (in trace
+// time) alongside the sorter-visible ts.
+//
+// For events whose tokenizer synthesises a custom ts (e.g. retiming a kgsl
+// cmdbatch_retired to its GPU start), `raw_ts` preserves the original event
+// time so drop-window checks in the parser see when the event actually
+// happened, not where it was placed. For all other events the field is left as
+// the kUnset sentinel and consumes no extra storage in the token buffer (the
+// descriptor records its presence in a single bit).
+struct alignas(8) FtraceData {
+  static constexpr int64_t kRawTsUnset = std::numeric_limits<int64_t>::max();
+
+  TraceBlobView packet;
+  RefPtr<PacketSequenceStateGeneration> sequence_state;
+  int64_t raw_ts = kRawTsUnset;
+};
+static_assert(sizeof(FtraceData) % 8 == 0);
+
 struct alignas(8) TrackEventData {
   TrackEventData(TraceBlobView pv,
                  RefPtr<PacketSequenceStateGeneration> generation)

--- a/src/trace_processor/importers/ftrace/ftrace_module.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_module.cc
@@ -28,7 +28,7 @@ FtraceModule::FtraceModule(ProtoImporterModuleContext* module_context)
 
 void FtraceModule::ParseFtraceEventData(uint32_t /*cpu*/,
                                         int64_t /*ts*/,
-                                        const TracePacketData&) {}
+                                        const FtraceData&) {}
 
 void FtraceModule::ParseInlineSchedSwitch(uint32_t /*cpu*/,
                                           int64_t /*ts*/,

--- a/src/trace_processor/importers/ftrace/ftrace_module.h
+++ b/src/trace_processor/importers/ftrace/ftrace_module.h
@@ -30,7 +30,7 @@ class FtraceModule : public ProtoImporterModule {
 
   virtual void ParseFtraceEventData(uint32_t cpu,
                                     int64_t ts,
-                                    const TracePacketData& data);
+                                    const FtraceData& data);
 
   virtual void ParseInlineSchedSwitch(uint32_t cpu,
                                       int64_t ts,

--- a/src/trace_processor/importers/ftrace/ftrace_module_impl.h
+++ b/src/trace_processor/importers/ftrace/ftrace_module_impl.h
@@ -50,7 +50,7 @@ class FtraceModuleImpl : public FtraceModule {
 
   void ParseFtraceEventData(uint32_t cpu,
                             int64_t ts,
-                            const TracePacketData& data) override {
+                            const FtraceData& data) override {
     base::Status res = parser_.ParseFtraceEvent(cpu, ts, data);
     if (!res.ok()) {
       PERFETTO_ELOG("%s", res.message().c_str());

--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -847,9 +847,16 @@ base::Status FtraceParser::ParseFtraceStats(ConstBytes blob,
 
 base::Status FtraceParser::ParseFtraceEvent(uint32_t cpu,
                                             int64_t ts,
-                                            const TracePacketData& data) {
+                                            const FtraceData& data) {
   MaybeOnFirstFtraceEvent();
-  if (PERFETTO_UNLIKELY(ts < drop_ftrace_data_before_ts_)) {
+  // Drop-window checks compare against the original event time. For events
+  // whose tokenizer synthesised a custom ts (e.g. retiming a kgsl
+  // cmdbatch_retired to its GPU start), `data.raw_ts` carries the original
+  // event time so we don't drop in-trace events that were merely placed
+  // earlier on the timeline.
+  const int64_t raw_ts =
+      data.raw_ts == FtraceData::kRawTsUnset ? ts : data.raw_ts;
+  if (PERFETTO_UNLIKELY(raw_ts < drop_ftrace_data_before_ts_)) {
     context_->stats_tracker->IncrementStats(
         stats::ftrace_packet_before_tracing_start);
     return base::OkStatus();
@@ -895,7 +902,7 @@ base::Status FtraceParser::ParseFtraceEvent(uint32_t cpu,
     // this event signifies a beginning of an operation that can end on a
     // different cpu, we could conclude that the operation never ends.
     // See b/192586066.
-    if (PERFETTO_UNLIKELY(ts < soft_drop_ftrace_data_before_ts_)) {
+    if (PERFETTO_UNLIKELY(raw_ts < soft_drop_ftrace_data_before_ts_)) {
       return base::OkStatus();
     }
 

--- a/src/trace_processor/importers/ftrace/ftrace_parser.h
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.h
@@ -63,7 +63,7 @@ class FtraceParser {
 
   base::Status ParseFtraceEvent(uint32_t cpu,
                                 int64_t ts,
-                                const TracePacketData& data);
+                                const FtraceData& data);
   base::Status ParseInlineSchedSwitch(uint32_t cpu,
                                       int64_t ts,
                                       const InlineSchedSwitch& data);

--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
@@ -273,46 +273,58 @@ void FtraceTokenizer::TokenizeFtraceEvent(
     }
   }
 
+  // Convert the bundle's event timestamp once. Custom tokenizers receive this
+  // as `raw_ts` and use it as FtraceData::raw_ts so the parser's drop-window
+  // checks compare against the original event time (not any synthetic placement
+  // time). The generic path also reuses it as the queue ts.
+  std::optional<int64_t> raw_ts_opt = context_->clock_tracker->ToTraceTime(
+      clock_id, static_cast<int64_t>(raw_timestamp));
+  // ClockTracker will increment some error stats if it failed to convert the
+  // timestamp so just return.
+  if (!raw_ts_opt.has_value()) {
+    return;
+  }
+  int64_t raw_ts = *raw_ts_opt;
+
   if (PERFETTO_UNLIKELY(
           event_id == protos::pbzero::FtraceEvent::kGpuWorkPeriodFieldNumber)) {
-    TokenizeFtraceGpuWorkPeriod(cpu, std::move(event), std::move(state));
+    TokenizeFtraceGpuWorkPeriod(cpu, raw_ts, std::move(event),
+                                std::move(state));
     return;
   }
   if (PERFETTO_UNLIKELY(
           event_id ==
           protos::pbzero::FtraceEvent::kThermalExynosAcpmBulkFieldNumber)) {
-    TokenizeFtraceThermalExynosAcpmBulk(cpu, std::move(event),
+    TokenizeFtraceThermalExynosAcpmBulk(cpu, raw_ts, std::move(event),
                                         std::move(state));
     return;
   }
   if (PERFETTO_UNLIKELY(
           event_id ==
           protos::pbzero::FtraceEvent::kParamSetValueCpmFieldNumber)) {
-    TokenizeFtraceParamSetValueCpm(cpu, std::move(event), std::move(state));
+    TokenizeFtraceParamSetValueCpm(cpu, raw_ts, std::move(event),
+                                   std::move(state));
     return;
   }
   if (PERFETTO_UNLIKELY(
           event_id ==
           protos::pbzero::FtraceEvent::kFwtpPerfettoCounterFieldNumber)) {
-    TokenizeFtraceFwtpPerfettoCounter(cpu, std::move(event), std::move(state));
+    TokenizeFtraceFwtpPerfettoCounter(cpu, raw_ts, std::move(event),
+                                      std::move(state));
     return;
   }
   if (PERFETTO_UNLIKELY(
           event_id ==
           protos::pbzero::FtraceEvent::kFwtpPerfettoSliceFieldNumber)) {
-    TokenizeFtraceFwtpPerfettoSlice(cpu, std::move(event), std::move(state));
+    TokenizeFtraceFwtpPerfettoSlice(cpu, raw_ts, std::move(event),
+                                    std::move(state));
     return;
   }
 
-  std::optional<int64_t> timestamp = context_->clock_tracker->ToTraceTime(
-      clock_id, static_cast<int64_t>(raw_timestamp));
-  // ClockTracker will increment some error stats if it failed to convert the
-  // timestamp so just return.
-  if (!timestamp.has_value()) {
-    return;
-  }
+  // Generic path: queue ts equals raw_ts, so leave FtraceData::raw_ts as the
+  // kRawTsUnset sentinel (compressed away in the token buffer).
   module_context_->PushFtraceEvent(
-      cpu, *timestamp, TracePacketData{std::move(event), std::move(state)});
+      cpu, raw_ts, FtraceData{std::move(event), std::move(state)});
 }
 
 PERFETTO_ALWAYS_INLINE
@@ -500,6 +512,7 @@ FtraceTokenizer::HandleFtraceClockSnapshot(
 
 void FtraceTokenizer::TokenizeFtraceGpuWorkPeriod(
     uint32_t cpu,
+    int64_t raw_ts,
     TraceBlobView event,
     RefPtr<PacketSequenceStateGeneration> state) {
   // Special handling of valid gpu_work_period tracepoint events which contain
@@ -530,11 +543,12 @@ void FtraceTokenizer::TokenizeFtraceGpuWorkPeriod(
     return;
   }
   module_context_->PushFtraceEvent(
-      cpu, *timestamp, TracePacketData{std::move(event), std::move(state)});
+      cpu, *timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
 }
 
 void FtraceTokenizer::TokenizeFtraceThermalExynosAcpmBulk(
     uint32_t cpu,
+    int64_t raw_ts,
     TraceBlobView event,
     RefPtr<PacketSequenceStateGeneration> state) {
   // Special handling of valid thermal_exynos_acpm_bulk tracepoint events which
@@ -555,11 +569,12 @@ void FtraceTokenizer::TokenizeFtraceThermalExynosAcpmBulk(
   auto timestamp =
       static_cast<int64_t>(thermal_exynos_acpm_bulk_event.timestamp());
   module_context_->PushFtraceEvent(
-      cpu, timestamp, TracePacketData{std::move(event), std::move(state)});
+      cpu, timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
 }
 
 void FtraceTokenizer::TokenizeFtraceParamSetValueCpm(
     uint32_t cpu,
+    int64_t raw_ts,
     TraceBlobView event,
     RefPtr<PacketSequenceStateGeneration> state) {
   // Special handling of valid param_set_value_cpm tracepoint events which
@@ -579,11 +594,12 @@ void FtraceTokenizer::TokenizeFtraceParamSetValueCpm(
   }
   int64_t timestamp = param_set_value_cpm_event.timestamp();
   module_context_->PushFtraceEvent(
-      cpu, timestamp, TracePacketData{std::move(event), std::move(state)});
+      cpu, timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
 }
 
 void FtraceTokenizer::TokenizeFtraceFwtpPerfettoCounter(
     uint32_t cpu,
+    int64_t raw_ts,
     TraceBlobView event,
     RefPtr<PacketSequenceStateGeneration> state) {
   // Special handling of valid fwtp_perfetto_counter tracepoint events which
@@ -604,11 +620,12 @@ void FtraceTokenizer::TokenizeFtraceFwtpPerfettoCounter(
   int64_t timestamp =
       static_cast<int64_t>(fwtp_perfetto_counter_event.timestamp());
   module_context_->PushFtraceEvent(
-      cpu, timestamp, TracePacketData{std::move(event), std::move(state)});
+      cpu, timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
 }
 
 void FtraceTokenizer::TokenizeFtraceFwtpPerfettoSlice(
     uint32_t cpu,
+    int64_t raw_ts,
     TraceBlobView event,
     RefPtr<PacketSequenceStateGeneration> state) {
   // Special handling of valid fwtp_perfetto_slice tracepoint events which
@@ -629,7 +646,7 @@ void FtraceTokenizer::TokenizeFtraceFwtpPerfettoSlice(
   int64_t timestamp =
       static_cast<int64_t>(fwtp_perfetto_slice_event.timestamp());
   module_context_->PushFtraceEvent(
-      cpu, timestamp, TracePacketData{std::move(event), std::move(state)});
+      cpu, timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
 }
 
 std::optional<protozero::Field> FtraceTokenizer::GetFtraceEventField(

--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
@@ -76,22 +76,27 @@ class FtraceTokenizer {
       protos::pbzero::FtraceEventBundle::Decoder& decoder,
       uint32_t packet_sequence_id);
   void TokenizeFtraceGpuWorkPeriod(uint32_t cpu,
+                                   int64_t raw_ts,
                                    TraceBlobView event,
                                    RefPtr<PacketSequenceStateGeneration> state);
   void TokenizeFtraceThermalExynosAcpmBulk(
       uint32_t cpu,
+      int64_t raw_ts,
       TraceBlobView event,
       RefPtr<PacketSequenceStateGeneration> state);
   void TokenizeFtraceParamSetValueCpm(
       uint32_t cpu,
+      int64_t raw_ts,
       TraceBlobView event,
       RefPtr<PacketSequenceStateGeneration> state);
   void TokenizeFtraceFwtpPerfettoCounter(
       uint32_t cpu,
+      int64_t raw_ts,
       TraceBlobView event,
       RefPtr<PacketSequenceStateGeneration> state);
   void TokenizeFtraceFwtpPerfettoSlice(
       uint32_t cpu,
+      int64_t raw_ts,
       TraceBlobView event,
       RefPtr<PacketSequenceStateGeneration> state);
   std::optional<protozero::Field> GetFtraceEventField(

--- a/src/trace_processor/importers/proto/proto_importer_module.cc
+++ b/src/trace_processor/importers/proto/proto_importer_module.cc
@@ -81,7 +81,7 @@ void ProtoImporterModule::RegisterForField(uint32_t field_id) {
 
 void ProtoImporterModuleContext::PushFtraceEvent(uint32_t cpu,
                                                  int64_t ts,
-                                                 TracePacketData data) {
+                                                 FtraceData data) {
   PushToStream(cpu, ts, data, ftrace_event_streams, ftrace_stream_factory);
 }
 

--- a/src/trace_processor/importers/proto/proto_importer_module.h
+++ b/src/trace_processor/importers/proto/proto_importer_module.h
@@ -167,7 +167,7 @@ class ProtoImporterModule {
 //
 // Used to store per-trace state in a place where everyone can access it.
 struct ProtoImporterModuleContext {
-  void PushFtraceEvent(uint32_t cpu, int64_t ts, TracePacketData data);
+  void PushFtraceEvent(uint32_t cpu, int64_t ts, FtraceData data);
   void PushEtwEvent(uint32_t cpu, int64_t ts, TracePacketData data);
   void PushInlineSchedSwitch(uint32_t cpu, int64_t ts, InlineSchedSwitch data);
   void PushInlineSchedWaking(uint32_t cpu, int64_t ts, InlineSchedWaking data);
@@ -184,10 +184,9 @@ struct ProtoImporterModuleContext {
   std::unique_ptr<TraceSorter::Stream<TrackEventData>> track_event_stream;
 
   using FtraceStreamFactory =
-      std::function<std::unique_ptr<TraceSorter::Stream<TracePacketData>>(
-          uint32_t)>;
+      std::function<std::unique_ptr<TraceSorter::Stream<FtraceData>>(uint32_t)>;
   FtraceStreamFactory ftrace_stream_factory;
-  std::vector<std::unique_ptr<TraceSorter::Stream<TracePacketData>>>
+  std::vector<std::unique_ptr<TraceSorter::Stream<FtraceData>>>
       ftrace_event_streams;
 
   using EtwStreamFactory =

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
@@ -121,7 +121,7 @@ void ProtoTraceParserImpl::ParseEtwEvent(uint32_t cpu,
 
 void ProtoTraceParserImpl::ParseFtraceEvent(uint32_t cpu,
                                             int64_t ts,
-                                            TracePacketData data) {
+                                            FtraceData data) {
   PERFETTO_DCHECK(module_context_->ftrace_module);
   module_context_->ftrace_module->ParseFtraceEventData(cpu, ts, data);
 }

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl.h
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl.h
@@ -45,7 +45,7 @@ class ProtoTraceParserImpl {
   void ParseTrackEvent(int64_t ts, TrackEventData data);
   void ParseTracePacket(int64_t ts, TracePacketData data);
   void ParseEtwEvent(uint32_t cpu, int64_t /*ts*/, TracePacketData data);
-  void ParseFtraceEvent(uint32_t cpu, int64_t /*ts*/, TracePacketData data);
+  void ParseFtraceEvent(uint32_t cpu, int64_t /*ts*/, FtraceData data);
   void ParseInlineSchedSwitch(uint32_t cpu,
                               int64_t /*ts*/,
                               InlineSchedSwitch data);

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -100,12 +100,11 @@ class TrackEventSink
  private:
   ProtoTraceParserImpl* parser_;
 };
-class FtraceEventSink
-    : public TraceSorter::Sink<TracePacketData, FtraceEventSink> {
+class FtraceEventSink : public TraceSorter::Sink<FtraceData, FtraceEventSink> {
  public:
   FtraceEventSink(ProtoTraceParserImpl* parser, uint32_t cpu)
       : parser_(parser), cpu_(cpu) {}
-  void Parse(int64_t ts, TracePacketData data) {
+  void Parse(int64_t ts, FtraceData data) {
     parser_->ParseFtraceEvent(cpu_, ts, std::move(data));
   }
 

--- a/src/trace_processor/sorter/trace_token_buffer.cc
+++ b/src/trace_processor/sorter/trace_token_buffer.cc
@@ -59,6 +59,41 @@ static_assert(sizeof(TrackEventDataDescriptor) == 8,
 static_assert(alignof(TrackEventDataDescriptor) == 8,
               "CompressedTracePacketData must be 8-aligned");
 
+struct alignas(8) TracePacketDataDescriptor {
+  static constexpr uint8_t kMaxOffsetFromInternedBlobBits = 25;
+  static constexpr uint32_t kMaxOffsetFromInternedBlob =
+      (1Ul << kMaxOffsetFromInternedBlobBits) - 1;
+
+  uint16_t intern_blob_index;
+  uint16_t intern_seq_index;
+  uint32_t intern_blob_offset : kMaxOffsetFromInternedBlobBits;
+};
+static_assert(sizeof(TracePacketDataDescriptor) == 8,
+              "TracePacketDataDescriptor must be small");
+static_assert(alignof(TracePacketDataDescriptor) == 8,
+              "TracePacketDataDescriptor must be 8-aligned");
+
+struct alignas(8) FtraceDataDescriptor {
+  static constexpr uint8_t kMaxOffsetFromInternedBlobBits = 25;
+  static constexpr uint32_t kMaxOffsetFromInternedBlob =
+      (1Ul << kMaxOffsetFromInternedBlobBits) - 1;
+
+  uint16_t intern_blob_index;
+  uint16_t intern_seq_index;
+  uint32_t intern_blob_offset : kMaxOffsetFromInternedBlobBits;
+  uint32_t has_raw_ts : 1;
+};
+static_assert(sizeof(FtraceDataDescriptor) == 8,
+              "FtraceDataDescriptor must be small");
+static_assert(alignof(FtraceDataDescriptor) == 8,
+              "FtraceDataDescriptor must be 8-aligned");
+static_assert(FtraceDataDescriptor::kMaxOffsetFromInternedBlob ==
+                  TrackEventDataDescriptor::kMaxOffsetFromInternedBlob,
+              "Descriptors must agree on max blob offset");
+static_assert(TracePacketDataDescriptor::kMaxOffsetFromInternedBlob ==
+                  TrackEventDataDescriptor::kMaxOffsetFromInternedBlob,
+              "Descriptors must agree on max blob offset");
+
 template <typename T>
 T ExtractFromPtr(uint8_t** ptr) {
   T* typed_ptr = reinterpret_cast<T*>(*ptr);
@@ -84,7 +119,59 @@ uint32_t GetAllocSize(const TrackEventDataDescriptor& desc) {
   return alloc_size;
 }
 
+uint32_t GetAllocSize(const FtraceDataDescriptor& desc) {
+  uint32_t alloc_size = sizeof(FtraceDataDescriptor);
+  alloc_size += sizeof(uint64_t);
+  alloc_size += desc.has_raw_ts * sizeof(int64_t);
+  return alloc_size;
+}
+
+uint32_t GetAllocSize(const TracePacketDataDescriptor&) {
+  return sizeof(TracePacketDataDescriptor) + sizeof(uint64_t);
+}
+
 }  // namespace
+
+template <typename Desc>
+std::pair<BumpAllocator::AllocId, uint8_t*> TraceTokenBuffer::AppendCommon(
+    Desc& desc,
+    const TraceBlobView& packet,
+    RefPtr<PacketSequenceStateGeneration> sequence_state) {
+  BumpAllocator::AllocId alloc_id =
+      AllocAndResizeInternedVectors(GetAllocSize(desc));
+  InternedIndex interned_index = GetInternedIndex(alloc_id);
+
+  desc.intern_blob_offset = InternTraceBlob(interned_index, packet);
+  desc.intern_blob_index =
+      static_cast<uint16_t>(interned_blobs_.at(interned_index).size() - 1);
+  desc.intern_seq_index =
+      InternSeqState(interned_index, std::move(sequence_state));
+
+  uint8_t* ptr = static_cast<uint8_t*>(allocator_.GetPointer(alloc_id));
+  ptr = AppendToPtr(ptr, desc);
+  uint64_t packet_size = static_cast<uint64_t>(packet.size());
+  ptr = AppendToPtr(ptr, packet_size);
+  return {alloc_id, ptr};
+}
+
+template <typename Desc>
+std::pair<TracePacketData, uint8_t*> TraceTokenBuffer::ExtractCommon(
+    Id id,
+    Desc* out_desc) {
+  uint8_t* ptr = static_cast<uint8_t*>(allocator_.GetPointer(id.alloc_id));
+  *out_desc = ExtractFromPtr<Desc>(&ptr);
+  uint64_t packet_size = ExtractFromPtr<uint64_t>(&ptr);
+
+  InternedIndex interned_index = GetInternedIndex(id.alloc_id);
+  BlobWithOffset& bwo =
+      interned_blobs_.at(interned_index)[out_desc->intern_blob_index];
+  TraceBlobView tbv(RefPtr<TraceBlob>::FromReleasedUnsafe(bwo.blob),
+                    bwo.offset_in_blob + out_desc->intern_blob_offset,
+                    static_cast<uint32_t>(packet_size));
+  auto seq = RefPtr<PacketSequenceStateGeneration>::FromReleasedUnsafe(
+      interned_seqs_.at(interned_index)[out_desc->intern_seq_index]);
+  return {TracePacketData{std::move(tbv), std::move(seq)}, ptr};
+}
 
 TraceTokenBuffer::Id TraceTokenBuffer::Append(TrackEventData ted) {
   // TrackEventData (and TracePacketData) are two big contributors to the size
@@ -104,30 +191,10 @@ TraceTokenBuffer::Id TraceTokenBuffer::Append(TrackEventData ted) {
   desc.has_counter_value = std::not_equal_to<double>()(ted.counter_value, 0);
   desc.extra_counter_count = ted.CountExtraCounterValues();
 
-  // Allocate enough memory using the BumpAllocator to store the data in |ted|.
-  // Also figure out the interned index.
-  BumpAllocator::AllocId alloc_id =
-      AllocAndResizeInternedVectors(GetAllocSize(desc));
-  InternedIndex interned_index = GetInternedIndex(alloc_id);
-
-  // Compute the interning information for the TrackBlob and the SequenceState.
   TracePacketData& tpd = ted.trace_packet_data;
-  desc.intern_blob_offset = InternTraceBlob(interned_index, tpd.packet);
-  desc.intern_blob_index =
-      static_cast<uint16_t>(interned_blobs_.at(interned_index).size() - 1);
-  desc.intern_seq_index =
-      InternSeqState(interned_index, std::move(tpd.sequence_state));
+  auto [alloc_id, ptr] =
+      AppendCommon(desc, tpd.packet, std::move(tpd.sequence_state));
 
-  // Store the descriptor
-  uint8_t* ptr = static_cast<uint8_t*>(allocator_.GetPointer(alloc_id));
-  ptr = AppendToPtr(ptr, desc);
-
-  // Store the packet sizes.
-  uint64_t packet_size = static_cast<uint64_t>(tpd.packet.size());
-  ptr = AppendToPtr(ptr, packet_size);
-
-  // Add the "optional" fields of TrackEventData based on whether or not they
-  // are non-null.
   if (desc.has_thread_instruction_count) {
     ptr = AppendToPtr(ptr, ted.thread_instruction_count.value());
   }
@@ -143,23 +210,54 @@ TraceTokenBuffer::Id TraceTokenBuffer::Append(TrackEventData ted) {
   return Id{alloc_id};
 }
 
+TraceTokenBuffer::Id TraceTokenBuffer::Append(TracePacketData data) {
+  TracePacketDataDescriptor desc;
+  auto [alloc_id, ptr] =
+      AppendCommon(desc, data.packet, std::move(data.sequence_state));
+  base::ignore_result(ptr);
+  return Id{alloc_id};
+}
+
+TraceTokenBuffer::Id TraceTokenBuffer::Append(FtraceData data) {
+  FtraceDataDescriptor desc;
+  desc.has_raw_ts = data.raw_ts != FtraceData::kRawTsUnset;
+
+  auto [alloc_id, ptr] =
+      AppendCommon(desc, data.packet, std::move(data.sequence_state));
+
+  if (desc.has_raw_ts) {
+    ptr = AppendToPtr(ptr, data.raw_ts);
+  }
+  return Id{alloc_id};
+}
+
+template <>
+TracePacketData TraceTokenBuffer::Extract<TracePacketData>(Id id) {
+  TracePacketDataDescriptor desc;
+  auto [data, ptr] = ExtractCommon(id, &desc);
+  base::ignore_result(ptr);
+  allocator_.Free(id.alloc_id);
+  return std::move(data);
+}
+
+template <>
+FtraceData TraceTokenBuffer::Extract<FtraceData>(Id id) {
+  FtraceDataDescriptor desc;
+  auto [tpd, ptr] = ExtractCommon(id, &desc);
+  FtraceData data{std::move(tpd.packet), std::move(tpd.sequence_state),
+                  FtraceData::kRawTsUnset};
+  if (desc.has_raw_ts) {
+    data.raw_ts = ExtractFromPtr<int64_t>(&ptr);
+  }
+  allocator_.Free(id.alloc_id);
+  return data;
+}
+
 template <>
 TrackEventData TraceTokenBuffer::Extract<TrackEventData>(Id id) {
-  uint8_t* ptr = static_cast<uint8_t*>(allocator_.GetPointer(id.alloc_id));
-  TrackEventDataDescriptor desc =
-      ExtractFromPtr<TrackEventDataDescriptor>(&ptr);
-  uint64_t packet_size = ExtractFromPtr<uint64_t>(&ptr);
-
-  InternedIndex interned_index = GetInternedIndex(id.alloc_id);
-  BlobWithOffset& bwo =
-      interned_blobs_.at(interned_index)[desc.intern_blob_index];
-  TraceBlobView tbv(RefPtr<TraceBlob>::FromReleasedUnsafe(bwo.blob),
-                    bwo.offset_in_blob + desc.intern_blob_offset,
-                    static_cast<uint32_t>(packet_size));
-  auto seq = RefPtr<PacketSequenceStateGeneration>::FromReleasedUnsafe(
-      interned_seqs_.at(interned_index)[desc.intern_seq_index]);
-
-  TrackEventData ted{std::move(tbv), std::move(seq)};
+  TrackEventDataDescriptor desc;
+  auto [tpd, ptr] = ExtractCommon(id, &desc);
+  TrackEventData ted{std::move(tpd.packet), std::move(tpd.sequence_state)};
   if (desc.has_thread_instruction_count) {
     ted.thread_instruction_count = ExtractFromPtr<int64_t>(&ptr);
   }
@@ -209,7 +307,7 @@ uint32_t TraceTokenBuffer::InternTraceBlob(InternedIndex interned_index,
   // of this TraceBlob one higher than the number of RefPtrs pointing to it.
   // This allows avoid storing the same RefPtr n times.
   //
-  // Calls to this function are paired to Extract<TrackEventData> which picks
+  // Calls to this function are paired to the matching Extract<T> which picks
   // up this "leaked" pointer.
   TraceBlob* leaked = tbv.blob().ReleaseUnsafe();
   base::ignore_result(leaked);

--- a/src/trace_processor/sorter/trace_token_buffer.h
+++ b/src/trace_processor/sorter/trace_token_buffer.h
@@ -18,14 +18,11 @@
 #define SRC_TRACE_PROCESSOR_SORTER_TRACE_TOKEN_BUFFER_H_
 
 #include <cstdint>
-#include <limits>
-#include <optional>
 #include <utility>
 #include <vector>
 
 #include "perfetto/base/compiler.h"
 #include "perfetto/ext/base/circular_queue.h"
-#include "perfetto/ext/base/utils.h"
 #include "perfetto/trace_processor/trace_blob.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/common/parser_types.h"
@@ -64,13 +61,8 @@ class TraceTokenBuffer {
     return Id{id};
   }
   PERFETTO_WARN_UNUSED_RESULT Id Append(TrackEventData);
-  PERFETTO_WARN_UNUSED_RESULT Id Append(TracePacketData data) {
-    // While in theory we could add a special case for TracePacketData, the
-    // judgment call we make is that the code complexity does not justify the
-    // micro-performance gain you might hope to see by avoiding the few if
-    // conditions in the |TracePacketData| path.
-    return Append(TrackEventData(std::move(data)));
-  }
+  PERFETTO_WARN_UNUSED_RESULT Id Append(FtraceData);
+  PERFETTO_WARN_UNUSED_RESULT Id Append(TracePacketData);
 
   // Gets a pointer an object of type |T| from the token buffer using an id
   // previously returned by |Append|. This type *must* match the type added
@@ -121,6 +113,26 @@ class TraceTokenBuffer {
   uint16_t InternSeqState(InternedIndex, RefPtr<PacketSequenceStateGeneration>);
   uint32_t AddTraceBlob(InternedIndex, const TraceBlobView&);
 
+  // Common prologue shared between Append(TrackEventData|TracePacketData|
+  // FtraceData): allocates storage sized for |desc|, fills its intern_* fields,
+  // writes |desc| and the packet size to the buffer, and returns the alloc id
+  // plus a pointer positioned after the packet size (where any per-type
+  // optional fields can be appended).
+  template <typename Desc>
+  std::pair<BumpAllocator::AllocId, uint8_t*> AppendCommon(
+      Desc& desc,
+      const TraceBlobView& packet,
+      RefPtr<PacketSequenceStateGeneration> sequence_state);
+
+  // Common prologue shared between Extract<TrackEventData|TracePacketData|
+  // FtraceData>: reads |*out_desc| and the packet size out of the buffer,
+  // materialises the TraceBlobView and sequence state, and returns them as a
+  // TracePacketData together with a pointer positioned after the packet size
+  // (where any per-type optional fields live). The caller is responsible for
+  // freeing the allocation.
+  template <typename Desc>
+  std::pair<TracePacketData, uint8_t*> ExtractCommon(Id id, Desc* out_desc);
+
   BumpAllocator::AllocId AllocAndResizeInternedVectors(uint32_t size);
   InternedIndex GetInternedIndex(BumpAllocator::AllocId);
 
@@ -135,11 +147,11 @@ template <>
 PERFETTO_WARN_UNUSED_RESULT TrackEventData
     TraceTokenBuffer::Extract<TrackEventData>(Id);
 template <>
-PERFETTO_WARN_UNUSED_RESULT inline TracePacketData
-TraceTokenBuffer::Extract<TracePacketData>(Id id) {
-  // See the comment in Append(TracePacketData) for why we do this.
-  return Extract<TrackEventData>(id).trace_packet_data;
-}
+PERFETTO_WARN_UNUSED_RESULT FtraceData
+    TraceTokenBuffer::Extract<FtraceData>(Id);
+template <>
+PERFETTO_WARN_UNUSED_RESULT TracePacketData
+    TraceTokenBuffer::Extract<TracePacketData>(Id);
 
 }  // namespace trace_processor
 }  // namespace perfetto

--- a/src/trace_processor/sorter/trace_token_buffer_unittest.cc
+++ b/src/trace_processor/sorter/trace_token_buffer_unittest.cc
@@ -166,6 +166,59 @@ TEST_F(TraceTokenBufferUnittest, TrackEventDataInOut) {
   ASSERT_EQ(extracted.extra_counter_values, counter_array);
 }
 
+TEST_F(TraceTokenBufferUnittest, FtraceDataInOutWithoutRawTs) {
+  TraceBlobView tbv(TraceBlob::Allocate(1024));
+  FtraceData data{tbv.copy(), state, FtraceData::kRawTsUnset};
+
+  TraceTokenBuffer::Id id = store.Append(std::move(data));
+  FtraceData extracted = store.Extract<FtraceData>(id);
+  ASSERT_EQ(extracted.packet, tbv);
+  ASSERT_EQ(extracted.sequence_state, state);
+  ASSERT_EQ(extracted.raw_ts, FtraceData::kRawTsUnset);
+}
+
+TEST_F(TraceTokenBufferUnittest, FtraceDataInOutWithRawTs) {
+  TraceBlobView tbv(TraceBlob::Allocate(1024));
+  constexpr int64_t kRawTs = 1234567890123;
+  FtraceData data{tbv.copy(), state, kRawTs};
+
+  TraceTokenBuffer::Id id = store.Append(std::move(data));
+  FtraceData extracted = store.Extract<FtraceData>(id);
+  ASSERT_EQ(extracted.packet, tbv);
+  ASSERT_EQ(extracted.sequence_state, state);
+  ASSERT_EQ(extracted.raw_ts, kRawTs);
+}
+
+TEST_F(TraceTokenBufferUnittest, FtraceDataMixedRawTsPresence) {
+  // Interleave entries with and without raw_ts to ensure the variable-length
+  // encoding doesn't desync between adjacent allocations.
+  TraceBlobView root(TraceBlob::Allocate(2048));
+  TraceBlobView tbv_1 = root.slice_off(0, 512);
+  TraceBlobView tbv_2 = root.slice_off(512, 512);
+  TraceBlobView tbv_3 = root.slice_off(1024, 512);
+  constexpr int64_t kRawTs1 = 100;
+  constexpr int64_t kRawTs3 = 300;
+
+  TraceTokenBuffer::Id id_1 =
+      store.Append(FtraceData{tbv_1.copy(), state, kRawTs1});
+  TraceTokenBuffer::Id id_2 =
+      store.Append(FtraceData{tbv_2.copy(), state, FtraceData::kRawTsUnset});
+  TraceTokenBuffer::Id id_3 =
+      store.Append(FtraceData{tbv_3.copy(), state, kRawTs3});
+
+  FtraceData out_1 = store.Extract<FtraceData>(id_1);
+  ASSERT_EQ(out_1.packet, tbv_1);
+  ASSERT_EQ(out_1.raw_ts, kRawTs1);
+
+  FtraceData out_2 = store.Extract<FtraceData>(id_2);
+  ASSERT_EQ(out_2.packet, tbv_2);
+  ASSERT_EQ(out_2.raw_ts, FtraceData::kRawTsUnset);
+
+  FtraceData out_3 = store.Extract<FtraceData>(id_3);
+  ASSERT_EQ(out_3.packet, tbv_3);
+  ASSERT_EQ(out_3.raw_ts, kRawTs3);
+}
+
 TEST_F(TraceTokenBufferUnittest, ExtractOrAppendAfterFreeMemory) {
   auto unused_res = store.Extract<TraceBlobView>(
       store.Append(TraceBlobView(TraceBlob::Allocate(1234))));


### PR DESCRIPTION
We allow some events to change their timestamp value at tokenization
time. This should however not be used to decide to drop the ftrace
event or not, which should always use the raw ts. Properly plumb
that through to prevent incorrect drops

Moreover, improve performance of TracePacketData passing through the
sorter queues by adding dedicated code instead of the same codepath
as TrackEventData.
