### PR TITLE
stdlib: Wattson: Explicit cast of rail's macro output

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/wattson/aggregation.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/aggregation.sql
@@ -17,8 +17,6 @@ INCLUDE PERFETTO MODULE intervals.intersect;
 
 INCLUDE PERFETTO MODULE wattson.cpu.idle;
 
-INCLUDE PERFETTO MODULE wattson.device_infos;
-
 INCLUDE PERFETTO MODULE wattson.estimates;
 
 INCLUDE PERFETTO MODULE wattson.tasks.attribution;
@@ -165,105 +163,6 @@ AS (
     $window_table,
     _wattson_cpus
   )
-);
-
--- ========================================================
--- MACRO: _wattson_base_components_avg_mw
---
--- Low-level macro to calculate base power components average mW.
---
--- Input:
---   window_table: A table with columns (ts, dur, period_id).
---
--- Output:
---   Wide table with CPU policy, average power per core, DSU, and GPU.
--- ========================================================
-CREATE PERFETTO MACRO _wattson_base_components_avg_mw(
-  window_table TableOrSubquery
-)
-RETURNS TableOrSubquery
-AS (
-  SELECT
-    (
-      SELECT
-        m.policy
-      FROM _dev_cpu_policy_map AS m
-      WHERE
-        m.cpu = 0
-    ) AS cpu0_poli,
-    (
-      SELECT
-        m.policy
-      FROM _dev_cpu_policy_map AS m
-      WHERE
-        m.cpu = 1
-    ) AS cpu1_poli,
-    (
-      SELECT
-        m.policy
-      FROM _dev_cpu_policy_map AS m
-      WHERE
-        m.cpu = 2
-    ) AS cpu2_poli,
-    (
-      SELECT
-        m.policy
-      FROM _dev_cpu_policy_map AS m
-      WHERE
-        m.cpu = 3
-    ) AS cpu3_poli,
-    (
-      SELECT
-        m.policy
-      FROM _dev_cpu_policy_map AS m
-      WHERE
-        m.cpu = 4
-    ) AS cpu4_poli,
-    (
-      SELECT
-        m.policy
-      FROM _dev_cpu_policy_map AS m
-      WHERE
-        m.cpu = 5
-    ) AS cpu5_poli,
-    (
-      SELECT
-        m.policy
-      FROM _dev_cpu_policy_map AS m
-      WHERE
-        m.cpu = 6
-    ) AS cpu6_poli,
-    (
-      SELECT
-        m.policy
-      FROM _dev_cpu_policy_map AS m
-      WHERE
-        m.cpu = 7
-    ) AS cpu7_poli,
-    sum(ii.dur * ss.cpu0_mw) / nullif(sum(ii.dur), 0) AS cpu0_mw,
-    sum(ii.dur * ss.cpu1_mw) / nullif(sum(ii.dur), 0) AS cpu1_mw,
-    sum(ii.dur * ss.cpu2_mw) / nullif(sum(ii.dur), 0) AS cpu2_mw,
-    sum(ii.dur * ss.cpu3_mw) / nullif(sum(ii.dur), 0) AS cpu3_mw,
-    sum(ii.dur * ss.cpu4_mw) / nullif(sum(ii.dur), 0) AS cpu4_mw,
-    sum(ii.dur * ss.cpu5_mw) / nullif(sum(ii.dur), 0) AS cpu5_mw,
-    sum(ii.dur * ss.cpu6_mw) / nullif(sum(ii.dur), 0) AS cpu6_mw,
-    sum(ii.dur * ss.cpu7_mw) / nullif(sum(ii.dur), 0) AS cpu7_mw,
-    sum(ii.dur * ss.dsu_scu_mw) / nullif(sum(ii.dur), 0) AS dsu_scu_mw,
-    sum(ii.dur * ss.gpu_mw) / nullif(sum(ii.dur), 0) AS gpu_mw,
-    sum(ii.dur * ss.tpu_mw) / nullif(sum(ii.dur), 0) AS tpu_mw,
-    sum(ii.dur) AS period_dur,
-    ii.id_0 AS period_id
-  FROM _interval_intersect!(
-    (
-      (SELECT period_id AS id, * FROM $window_table),
-      _ii_subquery!(_system_state_mw)
-    ),
-    ()
-  ) AS ii
-  JOIN _system_state_mw AS ss
-    ON ss._auto_id = id_1
-  GROUP BY
-    period_id
 );
 
 -- ========================================================

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/estimates.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/estimates.sql
@@ -19,6 +19,8 @@ INCLUDE PERFETTO MODULE intervals.intersect;
 
 INCLUDE PERFETTO MODULE wattson.cpu.estimates;
 
+INCLUDE PERFETTO MODULE wattson.device_infos;
+
 INCLUDE PERFETTO MODULE wattson.gpu.estimates;
 
 INCLUDE PERFETTO MODULE wattson.tpu.estimates;
@@ -34,34 +36,101 @@ CREATE VIRTUAL TABLE _cpu_gpu_tpu_system_state_mw USING SPAN_OUTER_JOIN(_cpu_gpu
 CREATE PERFETTO TABLE _system_state_mw AS
 SELECT * FROM _cpu_gpu_tpu_system_state_mw;
 
--- API to get power from each system state in an arbitrary time window
-CREATE PERFETTO FUNCTION _windowed_system_state_mw(ts TIMESTAMP, dur LONG)
-RETURNS TABLE(
-  cpu0_mw DOUBLE,
-  cpu1_mw DOUBLE,
-  cpu2_mw DOUBLE,
-  cpu3_mw DOUBLE,
-  cpu4_mw DOUBLE,
-  cpu5_mw DOUBLE,
-  cpu6_mw DOUBLE,
-  cpu7_mw DOUBLE,
-  dsu_scu_mw DOUBLE,
-  gpu_mw DOUBLE,
-  tpu_mw DOUBLE
+-- ========================================================
+-- MACRO: _wattson_base_components_avg_mw
+--
+-- Low-level macro to calculate base power components average mW.
+--
+-- Input:
+--   window_table: A table with columns (ts, dur, period_id).
+--
+-- Output:
+--   Wide table with CPU policy, average power per core, DSU, and GPU.
+-- ========================================================
+CREATE PERFETTO MACRO _wattson_base_components_avg_mw(
+  window_table TableOrSubquery
 )
-AS
-SELECT
-  sum(ss.cpu0_mw * ii.dur) / sum(ii.dur) AS cpu0_mw,
-  sum(ss.cpu1_mw * ii.dur) / sum(ii.dur) AS cpu1_mw,
-  sum(ss.cpu2_mw * ii.dur) / sum(ii.dur) AS cpu2_mw,
-  sum(ss.cpu3_mw * ii.dur) / sum(ii.dur) AS cpu3_mw,
-  sum(ss.cpu4_mw * ii.dur) / sum(ii.dur) AS cpu4_mw,
-  sum(ss.cpu5_mw * ii.dur) / sum(ii.dur) AS cpu5_mw,
-  sum(ss.cpu6_mw * ii.dur) / sum(ii.dur) AS cpu6_mw,
-  sum(ss.cpu7_mw * ii.dur) / sum(ii.dur) AS cpu7_mw,
-  sum(ss.dsu_scu_mw * ii.dur) / sum(ii.dur) AS dsu_scu_mw,
-  sum(ss.gpu_mw * ii.dur) / sum(ii.dur) AS gpu_mw,
-  sum(ss.tpu_mw * ii.dur) / sum(ii.dur) AS tpu_mw
-FROM _interval_intersect_single!($ts, $dur, _ii_subquery!(_system_state_mw)) AS ii
-JOIN _system_state_mw AS ss
-  ON ss._auto_id = id;
+RETURNS TableOrSubquery
+AS (
+  SELECT
+    (
+      SELECT
+        m.policy
+      FROM _dev_cpu_policy_map AS m
+      WHERE
+        m.cpu = 0
+    ) AS cpu0_poli,
+    (
+      SELECT
+        m.policy
+      FROM _dev_cpu_policy_map AS m
+      WHERE
+        m.cpu = 1
+    ) AS cpu1_poli,
+    (
+      SELECT
+        m.policy
+      FROM _dev_cpu_policy_map AS m
+      WHERE
+        m.cpu = 2
+    ) AS cpu2_poli,
+    (
+      SELECT
+        m.policy
+      FROM _dev_cpu_policy_map AS m
+      WHERE
+        m.cpu = 3
+    ) AS cpu3_poli,
+    (
+      SELECT
+        m.policy
+      FROM _dev_cpu_policy_map AS m
+      WHERE
+        m.cpu = 4
+    ) AS cpu4_poli,
+    (
+      SELECT
+        m.policy
+      FROM _dev_cpu_policy_map AS m
+      WHERE
+        m.cpu = 5
+    ) AS cpu5_poli,
+    (
+      SELECT
+        m.policy
+      FROM _dev_cpu_policy_map AS m
+      WHERE
+        m.cpu = 6
+    ) AS cpu6_poli,
+    (
+      SELECT
+        m.policy
+      FROM _dev_cpu_policy_map AS m
+      WHERE
+        m.cpu = 7
+    ) AS cpu7_poli,
+    cast_double!(sum(ii.dur * ss.cpu0_mw) / nullif(sum(ii.dur), 0)) AS cpu0_mw,
+    cast_double!(sum(ii.dur * ss.cpu1_mw) / nullif(sum(ii.dur), 0)) AS cpu1_mw,
+    cast_double!(sum(ii.dur * ss.cpu2_mw) / nullif(sum(ii.dur), 0)) AS cpu2_mw,
+    cast_double!(sum(ii.dur * ss.cpu3_mw) / nullif(sum(ii.dur), 0)) AS cpu3_mw,
+    cast_double!(sum(ii.dur * ss.cpu4_mw) / nullif(sum(ii.dur), 0)) AS cpu4_mw,
+    cast_double!(sum(ii.dur * ss.cpu5_mw) / nullif(sum(ii.dur), 0)) AS cpu5_mw,
+    cast_double!(sum(ii.dur * ss.cpu6_mw) / nullif(sum(ii.dur), 0)) AS cpu6_mw,
+    cast_double!(sum(ii.dur * ss.cpu7_mw) / nullif(sum(ii.dur), 0)) AS cpu7_mw,
+    cast_double!(sum(ii.dur * ss.dsu_scu_mw) / nullif(sum(ii.dur), 0)) AS dsu_scu_mw,
+    cast_double!(sum(ii.dur * ss.gpu_mw) / nullif(sum(ii.dur), 0)) AS gpu_mw,
+    cast_double!(sum(ii.dur * ss.tpu_mw) / nullif(sum(ii.dur), 0)) AS tpu_mw,
+    sum(ii.dur) AS period_dur,
+    ii.id_0 AS period_id
+  FROM _interval_intersect!(
+    (
+      (SELECT period_id AS id, * FROM $window_table),
+      _ii_subquery!(_system_state_mw)
+    ),
+    ()
+  ) AS ii
+  JOIN _system_state_mw AS ss
+    ON ss._auto_id = id_1
+  GROUP BY
+    period_id
+);

--- a/test/trace_processor/diff_tests/stdlib/wattson/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/wattson/tests.py
@@ -247,7 +247,9 @@ class WattsonStdlib(TestSuite):
           cpu6_mw,
           cpu7_mw,
           dsu_scu_mw
-        FROM _windowed_system_state_mw(362426061658, 5067704349)
+        FROM _wattson_base_components_avg_mw!(
+          (SELECT 362426061658 AS ts, 5067704349 AS dur, 0 AS period_id)
+        )
         """,
         out=Csv("""
             "cpu0_mw","cpu1_mw","cpu2_mw","cpu3_mw","cpu4_mw","cpu5_mw","cpu6_mw","cpu7_mw","dsu_scu_mw"

--- a/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
@@ -70,7 +70,9 @@ export class WattsonEstimateSelectionAggregator implements Aggregator {
 
       CREATE PERFETTO VIEW ${this.id} AS
       WITH window_stats AS (
-        SELECT * FROM _windowed_system_state_mw(${area.start}, ${duration})
+        SELECT * FROM _wattson_base_components_avg_mw!(
+          (SELECT ${area.start} AS ts, ${duration} AS dur, 0 AS period_id)
+        )
       )
     `;
 


### PR DESCRIPTION
Cast output of estimated_mws to double, since that is the canonical output format for all consumers of Wattson estimates (metrics, UI).

Additionally, cleanup redundant macros/functions, since _wattson_base_components_avg_mw() and _windowed_system_state_mw() were providing the same functionality. Delete _windowed_system_state_mw(), and move _wattson_base_components_avg_mw() from aggregation module to estimates module.

Test: Manual test for output type
Bug: 505427990
Bug: 511902307
