### PR TITLE
frametimeline: add a new field for animationTime on SurfaceFrame

### DIFF
--- a/protos/perfetto/trace/android/frame_timeline_event.proto
+++ b/protos/perfetto/trace/android/frame_timeline_event.proto
@@ -155,6 +155,9 @@ message FrameTimelineEvent {
       LATCHED_DELAYED_LATCH_UNSIGNALED = 3;
     }
     optional LatchedFenceState latched_fence_state = 19;
+
+    // animation time (ms) used when drawing this frame.
+    optional float animation_time_millis = 20;
   };
 
   // Indicates the start of expected timeline slice for DisplayFrames.

--- a/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
+++ b/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
@@ -528,7 +528,8 @@ void FrameTimelineEventParser::ParseActualSurfaceFrameStart(int64_t timestamp,
   int64_t display_frame_token = event.display_frame_token();
   double jank_severity_score = static_cast<double>(event.jank_severity_score());
   double jank_debug_metadata = static_cast<double>(event.jank_debug_metadata());
-  double animation_time_millis = static_cast<double>(event.animation_time_millis()));
+  double animation_time_millis =
+      static_cast<double>(event.animation_time_millis());
   double present_delay_millis =
       static_cast<double>(event.present_delay_millis());
   double vsync_resynced_jitter_millis =
@@ -655,7 +656,7 @@ void FrameTimelineEventParser::ParseActualSurfaceFrameStart(int64_t timestamp,
         }
         if (event.has_animation_time_millis()) {
           inserter->AddArg(animation_time_millis_id_,
-                         Variadic::Real(animation_time_millis));
+                           Variadic::Real(animation_time_millis));
         }
       });
 

--- a/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
+++ b/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
@@ -211,6 +211,8 @@ FrameTimelineEventParser::FrameTimelineEventParser(
           context->storage->InternString("Surface frame token")),
       display_frame_token_id_(
           context->storage->InternString("Display frame token")),
+      animation_time_millis_id_(
+          context->storage->InternString("Animation Time (ms)")),
       present_delay_millis_id_(
           context->storage->InternString("Present Delay (ms)")),
       vsync_resynced_jitter_millis_id_(
@@ -526,6 +528,7 @@ void FrameTimelineEventParser::ParseActualSurfaceFrameStart(int64_t timestamp,
   int64_t display_frame_token = event.display_frame_token();
   double jank_severity_score = static_cast<double>(event.jank_severity_score());
   double jank_debug_metadata = static_cast<double>(event.jank_debug_metadata());
+  double animation_time_millis = static_cast<double>(event.animation_time_millis()));
   double present_delay_millis =
       static_cast<double>(event.present_delay_millis());
   double vsync_resynced_jitter_millis =
@@ -649,6 +652,10 @@ void FrameTimelineEventParser::ParseActualSurfaceFrameStart(int64_t timestamp,
               latched_fence_state_id_,
               Variadic::String(latched_fence_state_ids_[static_cast<size_t>(
                   event.latched_fence_state())]));
+        }
+        if (event.has_animation_time_millis()) {
+          inserter->AddArg(animation_time_millis_id_,
+                         Variadic::Real(animation_time_millis));
         }
       });
 

--- a/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
+++ b/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
@@ -621,6 +621,10 @@ void FrameTimelineEventParser::ParseActualSurfaceFrameStart(int64_t timestamp,
         inserter->AddArg(surface_frame_token_id_, Variadic::Integer(token));
         inserter->AddArg(display_frame_token_id_,
                          Variadic::Integer(display_frame_token));
+        if (event.has_animation_time_millis()) {
+          inserter->AddArg(animation_time_millis_id_,
+                           Variadic::Real(animation_time_millis));
+        }
         inserter->AddArg(present_delay_millis_id_,
                          Variadic::Real(present_delay_millis));
         inserter->AddArg(vsync_resynced_jitter_millis_id_,
@@ -653,10 +657,6 @@ void FrameTimelineEventParser::ParseActualSurfaceFrameStart(int64_t timestamp,
               latched_fence_state_id_,
               Variadic::String(latched_fence_state_ids_[static_cast<size_t>(
                   event.latched_fence_state())]));
-        }
-        if (event.has_animation_time_millis()) {
-          inserter->AddArg(animation_time_millis_id_,
-                           Variadic::Real(animation_time_millis));
         }
       });
 

--- a/src/trace_processor/importers/proto/frame_timeline_event_parser.h
+++ b/src/trace_processor/importers/proto/frame_timeline_event_parser.h
@@ -82,6 +82,7 @@ class FrameTimelineEventParser {
 
   const StringId surface_frame_token_id_;
   const StringId display_frame_token_id_;
+  const StringId animation_time_millis_id_;
   const StringId present_delay_millis_id_;
   const StringId vsync_resynced_jitter_millis_id_;
   const StringId present_type_id_;
@@ -93,7 +94,6 @@ class FrameTimelineEventParser {
   const StringId jank_severity_type_id_;
   const StringId jank_severity_score_id_;
   const StringId jank_debug_metadata_id_;
-  const StringId animation_time_millis_id_;
   const StringId layer_name_id_;
   const StringId prediction_type_id_;
   const StringId jank_tag_id_;

--- a/src/trace_processor/importers/proto/frame_timeline_event_parser.h
+++ b/src/trace_processor/importers/proto/frame_timeline_event_parser.h
@@ -93,6 +93,7 @@ class FrameTimelineEventParser {
   const StringId jank_severity_type_id_;
   const StringId jank_severity_score_id_;
   const StringId jank_debug_metadata_id_;
+  const StringId animation_time_millis_id_;
   const StringId layer_name_id_;
   const StringId prediction_type_id_;
   const StringId jank_tag_id_;


### PR DESCRIPTION
Add a new field for animationTime on SurfaceFrame.

Bug: 443090923