### PR TITLE
trace_processor: Parse adreno_cmdbatch_retired/sync events

### DIFF
--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -542,6 +542,7 @@ FtraceParser::FtraceParser(TraceProcessorContext* context,
       gpu_power_state_off_id_(context->storage->InternString("OFF")),
       gpu_power_state_pg_id_(context->storage->InternString("PG")),
       gpu_power_state_on_id_(context->storage->InternString("ON")),
+      gpu_cmdbatch_slice_name_id_(context->storage->InternString("GPU")),
       ddic_underrun_id_(context_->storage->InternString("ddic_underrun")),
       panel_settings_full_id_(
           context_->storage->InternString("panel_settings_full")),
@@ -947,6 +948,14 @@ base::Status FtraceParser::ParseFtraceEvent(uint32_t cpu,
       }
       case FtraceEvent::kKgslGpuFrequencyFieldNumber: {
         ParseKgslGpuFreq(ts, fld_bytes);
+        break;
+      }
+      case FtraceEvent::kKgslAdrenoCmdbatchQueuedFieldNumber: {
+        ParseKgslAdrenoCmdbatchQueued(pid, fld_bytes);
+        break;
+      }
+      case FtraceEvent::kKgslAdrenoCmdbatchRetiredFieldNumber: {
+        ParseKgslAdrenoCmdbatchRetired(ts, fld_bytes);
         break;
       }
       case FtraceEvent::kCpuIdleFieldNumber: {
@@ -1947,6 +1956,72 @@ void FtraceParser::ParseKgslGpuFreq(int64_t timestamp, ConstBytes blob) {
       tracks::kGpuFrequencyBlueprint,
       tracks::Dimensions(ugpu.value, freq.gpu_id()));
   context_->event_tracker->PushCounter(timestamp, new_freq, track);
+}
+
+void FtraceParser::ParseKgslAdrenoCmdbatchQueued(uint32_t pid,
+                                                 protozero::ConstBytes data) {
+  protos::pbzero::KgslAdrenoCmdbatchQueuedFtraceEvent::Decoder evt(data);
+  adreno_cmdbatch_ctx_tids_.Insert(evt.id(), pid);
+}
+
+void FtraceParser::ParseKgslAdrenoCmdbatchRetired(int64_t ts,
+                                                  protozero::ConstBytes data) {
+  protos::pbzero::KgslAdrenoCmdbatchRetiredFtraceEvent::Decoder evt(data);
+
+  static constexpr auto kBlueprint = TrackCompressor::SliceBlueprint(
+      "adreno_gpu_cmdbatch",
+      tracks::DimensionBlueprints(tracks::UintDimensionBlueprint("context_id"),
+                                  tracks::UintDimensionBlueprint("prio")),
+      tracks::DynamicNameBlueprint());
+
+  if (evt.retire() < evt.start()) {
+    return;
+  }
+
+  constexpr int64_t kAdrenoXoFreqHz = 19200000;
+  const int64_t duration = static_cast<int64_t>(evt.retire() - evt.start()) *
+                           1000000000 / kAdrenoXoFreqHz;
+
+  const uint32_t context_id = evt.id();
+  const uint32_t prio = static_cast<uint32_t>(evt.prio());
+
+  // Resolve process name from queued event's tid.
+  std::optional<base::StringView> pname;
+  auto* queued_tid = adreno_cmdbatch_ctx_tids_.Find(context_id);
+  if (queued_tid) {
+    UniqueTid utid = context_->process_tracker->GetOrCreateThread(*queued_tid);
+    auto upid = context_->storage->thread_table()[utid].upid();
+    if (upid.has_value()) {
+      auto name_id = context_->storage->process_table()[*upid].name();
+      if (name_id.has_value())
+        pname = context_->storage->GetString(*name_id);
+    }
+  }
+
+  StringId track_name;
+  if (pname.has_value()) {
+    base::StackString<256> name("GPU %.*s (Ctx=%u, Prio=%u)",
+                                static_cast<int>(pname->size()), pname->data(),
+                                context_id, prio);
+    track_name = context_->storage->InternString(name.string_view());
+  } else {
+    base::StackString<64> name("GPU (Ctx=%u, Prio=%u)", context_id, prio);
+    track_name = context_->storage->InternString(name.string_view());
+  }
+
+  TrackId track_id = context_->track_compressor->InternScoped(
+      kBlueprint, tracks::Dimensions(context_id, prio), ts, duration,
+      tracks::DynamicName(track_name));
+
+  // Update the track name in case the track was previously created with the
+  // fallback name (no process name available at that time).
+  if (pname.has_value()) {
+    auto rr = (*context_->storage->mutable_track_table())[track_id];
+    rr.set_name(track_name);
+  }
+
+  context_->slice_tracker->Scoped(ts, track_id, kNullStringId,
+                                  gpu_cmdbatch_slice_name_id_, duration);
 }
 
 void FtraceParser::ParseCpuIdle(int64_t timestamp, ConstBytes blob) {

--- a/src/trace_processor/importers/ftrace/ftrace_parser.h
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.h
@@ -95,6 +95,8 @@ class FtraceParser {
   void ParseCpuFreqThrottle(int64_t timestamp, protozero::ConstBytes);
   void ParseGpuFreq(int64_t timestamp, protozero::ConstBytes);
   void ParseKgslGpuFreq(int64_t timestamp, protozero::ConstBytes);
+  void ParseKgslAdrenoCmdbatchQueued(uint32_t pid, protozero::ConstBytes);
+  void ParseKgslAdrenoCmdbatchRetired(int64_t ts, protozero::ConstBytes);
   void ParseCpuIdle(int64_t timestamp, protozero::ConstBytes);
   void ParsePrint(int64_t timestamp, uint32_t pid, protozero::ConstBytes);
   void ParseZero(int64_t timestamp, uint32_t pid, protozero::ConstBytes);
@@ -465,6 +467,10 @@ class FtraceParser {
   const StringId gpu_power_state_off_id_;
   const StringId gpu_power_state_pg_id_;
   const StringId gpu_power_state_on_id_;
+
+  base::FlatHashMap<uint32_t, uint32_t> adreno_cmdbatch_ctx_tids_;
+  const StringId gpu_cmdbatch_slice_name_id_;
+
   const StringId ddic_underrun_id_;
   const StringId panel_settings_full_id_;
   const StringId panel_settings_lite_id_;

--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
@@ -52,6 +52,7 @@
 #include "protos/perfetto/trace/ftrace/ftrace_event.pbzero.h"
 #include "protos/perfetto/trace/ftrace/ftrace_event_bundle.pbzero.h"
 #include "protos/perfetto/trace/ftrace/fwtp_ftrace.pbzero.h"
+#include "protos/perfetto/trace/ftrace/kgsl.pbzero.h"
 #include "protos/perfetto/trace/ftrace/power.pbzero.h"
 #include "protos/perfetto/trace/ftrace/thermal_exynos.pbzero.h"
 #include "src/trace_processor/util/clock_synchronizer.h"
@@ -318,6 +319,20 @@ void FtraceTokenizer::TokenizeFtraceEvent(
           protos::pbzero::FtraceEvent::kFwtpPerfettoSliceFieldNumber)) {
     TokenizeFtraceFwtpPerfettoSlice(cpu, raw_ts, std::move(event),
                                     std::move(state));
+    return;
+  }
+  if (PERFETTO_UNLIKELY(
+          event_id ==
+          protos::pbzero::FtraceEvent::kKgslAdrenoCmdbatchSyncFieldNumber)) {
+    TokenizeFtraceAdrenoCmdbatchSync(cpu, raw_ts, std::move(event),
+                                     std::move(state));
+    return;
+  }
+  if (PERFETTO_UNLIKELY(
+          event_id ==
+          protos::pbzero::FtraceEvent::kKgslAdrenoCmdbatchRetiredFieldNumber)) {
+    TokenizeFtraceAdrenoCmdbatchRetired(cpu, raw_ts, std::move(event),
+                                        std::move(state));
     return;
   }
 
@@ -677,6 +692,88 @@ void FtraceTokenizer::TokenizeFtraceFwtpPerfettoSlice(
       cpu, timestamp,
       FtraceData{std::move(event), std::move(state), raw_ts,
                  /*insert_ftrace_event=*/false, /*parse_event=*/true});
+}
+
+void FtraceTokenizer::TokenizeFtraceAdrenoCmdbatchSync(
+    uint32_t cpu,
+    int64_t raw_ts,
+    TraceBlobView event,
+    RefPtr<PacketSequenceStateGeneration> state) {
+  auto field = GetFtraceEventField(
+      protos::pbzero::FtraceEvent::kKgslAdrenoCmdbatchSyncFieldNumber, event);
+  if (!field.has_value())
+    return;
+  protos::pbzero::KgslAdrenoCmdbatchSyncFtraceEvent::Decoder evt(
+      field.value().data(), field.value().size());
+  AdrenoCmdbatchSyncPoint sync{raw_ts, evt.ticks()};
+  adreno_cmdbatch_sync_points_.Insert(evt.timestamp(), sync);
+
+  // Process any retired event that arrived before this sync event.
+  auto* pending = pending_adreno_cmdbatch_retired_.Find(evt.timestamp());
+  if (pending) {
+    constexpr int64_t kAdrenoXoFreqHz = 19200000;
+    int64_t gpu_start_ts =
+        sync.trace_ts + static_cast<int64_t>(pending->start - sync.gpu_ticks) *
+                            1000000000 / kAdrenoXoFreqHz;
+    module_context_->PushFtraceEvent(
+        pending->cpu, pending->raw_ts,
+        FtraceData{pending->event.copy(), pending->state,
+                   FtraceData::kRawTsUnset,
+                   /*insert_ftrace_event=*/true, /*parse_event=*/false});
+    module_context_->PushFtraceEvent(
+        pending->cpu, gpu_start_ts,
+        FtraceData{std::move(pending->event), std::move(pending->state),
+                   pending->raw_ts,
+                   /*insert_ftrace_event=*/false, /*parse_event=*/true});
+    pending_adreno_cmdbatch_retired_.Erase(evt.timestamp());
+    adreno_cmdbatch_sync_points_.Erase(evt.timestamp());
+  }
+
+  module_context_->PushFtraceEvent(
+      cpu, raw_ts, FtraceData{std::move(event), std::move(state)});
+}
+
+void FtraceTokenizer::TokenizeFtraceAdrenoCmdbatchRetired(
+    uint32_t cpu,
+    int64_t raw_ts,
+    TraceBlobView event,
+    RefPtr<PacketSequenceStateGeneration> state) {
+  auto field = GetFtraceEventField(
+      protos::pbzero::FtraceEvent::kKgslAdrenoCmdbatchRetiredFieldNumber,
+      event);
+  if (!field.has_value())
+    return;
+  protos::pbzero::KgslAdrenoCmdbatchRetiredFtraceEvent::Decoder evt(
+      field.value().data(), field.value().size());
+
+  auto* sync = adreno_cmdbatch_sync_points_.Find(evt.timestamp());
+  if (sync) {
+    constexpr int64_t kAdrenoXoFreqHz = 19200000;
+    int64_t gpu_start_ts =
+        sync->trace_ts + static_cast<int64_t>(evt.start() - sync->gpu_ticks) *
+                             1000000000 / kAdrenoXoFreqHz;
+    adreno_cmdbatch_sync_points_.Erase(evt.timestamp());
+    module_context_->PushFtraceEvent(
+        cpu, raw_ts,
+        FtraceData{event.copy(), state, FtraceData::kRawTsUnset,
+                   /*insert_ftrace_event=*/true, /*parse_event=*/false});
+    module_context_->PushFtraceEvent(
+        cpu, gpu_start_ts,
+        FtraceData{std::move(event), std::move(state), raw_ts,
+                   /*insert_ftrace_event=*/false, /*parse_event=*/true});
+    return;
+  }
+
+  // Sync hasn't arrived yet: push raw copy for ftrace_event table now,
+  // buffer the event for the parsing push when sync arrives.
+  module_context_->PushFtraceEvent(
+      cpu, raw_ts,
+      FtraceData{event.copy(), state, FtraceData::kRawTsUnset,
+                 /*insert_ftrace_event=*/true, /*parse_event=*/false});
+  pending_adreno_cmdbatch_retired_.Insert(
+      evt.timestamp(),
+      PendingAdrenoCmdbatchRetired{cpu, raw_ts, evt.start(), std::move(event),
+                                   std::move(state)});
 }
 
 std::optional<protozero::Field> FtraceTokenizer::GetFtraceEventField(

--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
@@ -25,6 +25,7 @@
 #include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/protozero/field.h"
 #include "perfetto/trace_processor/ref_counted.h"
@@ -99,6 +100,16 @@ class FtraceTokenizer {
       int64_t raw_ts,
       TraceBlobView event,
       RefPtr<PacketSequenceStateGeneration> state);
+  void TokenizeFtraceAdrenoCmdbatchSync(
+      uint32_t cpu,
+      int64_t raw_ts,
+      TraceBlobView event,
+      RefPtr<PacketSequenceStateGeneration> state);
+  void TokenizeFtraceAdrenoCmdbatchRetired(
+      uint32_t cpu,
+      int64_t raw_ts,
+      TraceBlobView event,
+      RefPtr<PacketSequenceStateGeneration> state);
   std::optional<protozero::Field> GetFtraceEventField(
       uint32_t event_id,
       const TraceBlobView& event);
@@ -112,6 +123,28 @@ class FtraceTokenizer {
   TraceProcessorContext* context_;
   ProtoImporterModuleContext* module_context_;
   GenericFtraceTracker* generic_tracker_;
+
+  // Stashed sync point for computing gpu_start_ts.
+  struct AdrenoCmdbatchSyncPoint {
+    int64_t trace_ts;
+    uint64_t gpu_ticks;
+  };
+  base::FlatHashMap<uint32_t, AdrenoCmdbatchSyncPoint>
+      adreno_cmdbatch_sync_points_;
+
+  // Buffer retired event when its matching sync hasn't been seen yet, so
+  // gpu_start_ts can be computed when sync arrives. Sync and retired for the
+  // same cmdbatch can land on different CPUs, and bundles are processed one
+  // CPU at a time, so retired may be seen before sync.
+  struct PendingAdrenoCmdbatchRetired {
+    uint32_t cpu;
+    int64_t raw_ts;
+    uint64_t start;
+    TraceBlobView event;
+    RefPtr<PacketSequenceStateGeneration> state;
+  };
+  base::FlatHashMap<uint32_t, PendingAdrenoCmdbatchRetired>
+      pending_adreno_cmdbatch_retired_;
 
   int64_t latest_ftrace_clock_snapshot_ts_ = 0;
   std::vector<bool> per_cpu_seen_first_bundle_;

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -75,6 +75,7 @@ from diff_tests.parser.cros.tests import Cros
 from diff_tests.parser.etm.tests import Etm
 from diff_tests.parser.etw.tests import Etw
 from diff_tests.parser.fs.tests import Fs
+from diff_tests.parser.ftrace.adreno_cmdbatch_tests import AdrenoCmdbatch
 from diff_tests.parser.ftrace.block_io_tests import BlockIo
 from diff_tests.parser.ftrace.ftrace_crop_tests import FtraceCrop
 from diff_tests.parser.ftrace.kprobes_tests import Kprobes
@@ -270,6 +271,7 @@ def fetch_all_diff_tests(
       ParsingRssStats,
       ParsingSysStats,
       ParsingMemoryCounters,
+      AdrenoCmdbatch,
       BlockIo,
       FtraceCrop,
       Kprobes,

--- a/test/trace_processor/diff_tests/parser/ftrace/adreno_cmdbatch_tests.py
+++ b/test/trace_processor/diff_tests/parser/ftrace/adreno_cmdbatch_tests.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import Csv, TextProto
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class AdrenoCmdbatch(TestSuite):
+
+  def test_adreno_cmdbatch_retired_slice(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          process_tree {
+            processes { pid: 100 cmdline: "com.example.app" }
+            threads { tid: 100 tgid: 100 }
+          }
+        }
+        packet { trusted_packet_sequence_id: 1 ftrace_events {
+          cpu: 0
+          event {
+            timestamp: 900000000
+            pid: 100
+            kgsl_adreno_cmdbatch_queued {
+              id: 1
+              timestamp: 42
+              prio: 0
+            }
+          }
+          event {
+            timestamp: 1000000000
+            pid: 100
+            kgsl_adreno_cmdbatch_sync {
+              id: 1
+              timestamp: 42
+              ticks: 19200000
+              prio: 0
+            }
+          }
+          event {
+            timestamp: 3100000000
+            pid: 100
+            kgsl_adreno_cmdbatch_retired {
+              id: 1
+              timestamp: 42
+              start: 38400000
+              retire: 57600000
+              prio: 0
+            }
+          }
+        }}
+        """),
+        query="""
+        SELECT
+          slice.name as name,
+          slice.ts as ts,
+          slice.dur as dur,
+          track.name as track_name
+        FROM slice
+        JOIN track ON slice.track_id = track.id
+        WHERE track.type = 'adreno_gpu_cmdbatch'
+        """,
+        out=Csv("""
+        "name","ts","dur","track_name"
+        "GPU",2000000000,1000000000,"GPU com.example.app (Ctx=1, Prio=0)"
+        """))
+
+  def test_adreno_cmdbatch_cross_cpu(self):
+    """Retired event on a different CPU bundle that arrives before sync."""
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          process_tree {
+            processes { pid: 100 cmdline: "com.example.app" }
+            threads { tid: 100 tgid: 100 }
+          }
+        }
+        packet { trusted_packet_sequence_id: 1 ftrace_events {
+          cpu: 0
+          event {
+            timestamp: 900000000
+            pid: 100
+            kgsl_adreno_cmdbatch_queued {
+              id: 1
+              timestamp: 42
+              prio: 0
+            }
+          }
+        }}
+        packet { trusted_packet_sequence_id: 1 ftrace_events {
+          cpu: 3
+          event {
+            timestamp: 3100000000
+            pid: 100
+            kgsl_adreno_cmdbatch_retired {
+              id: 1
+              timestamp: 42
+              start: 38400000
+              retire: 57600000
+              prio: 0
+            }
+          }
+        }}
+        packet { trusted_packet_sequence_id: 1 ftrace_events {
+          cpu: 0
+          event {
+            timestamp: 1000000000
+            pid: 100
+            kgsl_adreno_cmdbatch_sync {
+              id: 1
+              timestamp: 42
+              ticks: 19200000
+              prio: 0
+            }
+          }
+        }}
+        """),
+        query="""
+        SELECT
+          slice.name as name,
+          slice.ts as ts,
+          slice.dur as dur,
+          track.name as track_name
+        FROM slice
+        JOIN track ON slice.track_id = track.id
+        WHERE track.type = 'adreno_gpu_cmdbatch'
+        """,
+        out=Csv("""
+        "name","ts","dur","track_name"
+        "GPU",2000000000,1000000000,"GPU com.example.app (Ctx=1, Prio=0)"
+        """))

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_tracks.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_tracks.ts
@@ -269,6 +269,11 @@ export const SLICE_TRACK_SCHEMAS: ReadonlyArray<SliceTrackTypeSchema> = [
     group: undefined,
   },
   {
+    type: 'adreno_gpu_cmdbatch',
+    topLevelGroup: 'GPU',
+    group: 'Adreno Cmdbatch',
+  },
+  {
     type: 'triggers',
     topLevelGroup: 'SYSTEM',
     group: undefined,


### PR DESCRIPTION
Add custom parsing for kgsl adreno_cmdbatch_sync and adreno_cmdbatch_retired ftrace events to produce GPU timeline slices in the trace processor.
<img width="1202" height="421" alt="image" src="https://github.com/user-attachments/assets/b99952e1-9c10-4ffa-a068-f6ccf1efecc9" />

This is a rework of #5519 (reverted in #5793) which fixes the GPU event drift in the timeline by using per-cmdbatch sync points instead of a single global clock snapshot. 
Confirmed this PR fixes all drift issues that @batesj has observed on his end.

Test run result:

```
$ tools/ninja -C out/host
[16/16] stamp obj/default.stamp

$ .venv/bin/python3 tools/diff_test_trace_processor.py out/host/trace_processor_shell --name-filter '.*adreno.*'
[==========] Running 1 tests.
[ RUN      ] AdrenoCmdbatch:adreno_cmdbatch_retired_slice
[       OK ] AdrenoCmdbatch:adreno_cmdbatch_retired_slice (ingest: 738.62 ms query: 0.44 ms)
[==========] Name filter selected 1 tests out of 1357.
[==========] 1 tests ran out of 1 total. (1115 ms total)
[  PASSED  ] 1 tests.
```