### PR TITLE
Add missing standard library headers to smaps.cc

### DIFF
--- a/src/profiling/smaps/smaps.cc
+++ b/src/profiling/smaps/smaps.cc
@@ -17,9 +17,13 @@
 #include "perfetto/ext/profiling/smaps.h"
 
 #include <stdio.h>
+#include <cstdlib>
+#include <cstring>
 
 #include <deque>
+#include <string>
 #include <string_view>
+#include <vector>
 
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/utils.h"


### PR DESCRIPTION
This change adds missing includes for `<cstdlib>`, `<cstring>`, `<string>`,
and `<vector>`. These are required for std::strtoull, free(), strncmp,
std::string, and std::vector, respectively.

These missing headers caused compilation failures in the Chromium
autoroll.