### PR TITLE
Revert "tp: route PerfettoSqlParser through syntaqlite macro expansion (#5616)"

### DIFF
--- a/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.h
+++ b/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.h
@@ -50,7 +50,7 @@ class PerfettoSqlParser {
   // syntaqlite, false if it uses the handwritten PerfettoSqlPreprocessor.
   // Exposed so tests can gate path-specific assertions; will be removed
   // along with the legacy implementation when the cutover completes.
-  static constexpr bool kUsesSyntaqliteMacros = true;
+  static constexpr bool kUsesSyntaqliteMacros = false;
 
   // A CREATE PERFETTO MACRO definition. Aliased to the preprocessor type so
   // engine code can spell `PerfettoSqlParser::Macro` instead of reaching into


### PR DESCRIPTION
This reverts commit 8998ceef5ef241b5b9de7a9bc5d49d38c1847253.

Reason: causing subtle macro expansion failures in G3