### PR TITLE
ui: Rename HeapDumpExplorer CSS classes from ah- to pf-hde-

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
@@ -45,7 +45,7 @@ export function InstanceLink(): m.Component<InstanceLinkAttrs> {
     view(vnode) {
       const {row, navigate} = vnode.attrs;
       if (!row || row.id === 0) {
-        return m('span', {class: 'ah-badge-referent'}, 'ROOT');
+        return m('span', {class: 'pf-hde-badge-referent'}, 'ROOT');
       }
       const full = 'className' in row ? (row as InstanceRow) : null;
       return m(
@@ -53,13 +53,17 @@ export function InstanceLink(): m.Component<InstanceLinkAttrs> {
         full &&
           full.reachabilityName !== 'unreachable' &&
           full.reachabilityName !== 'strong'
-          ? m('span', {class: 'ah-badge-reachability'}, full.reachabilityName)
+          ? m(
+              'span',
+              {class: 'pf-hde-badge-reachability'},
+              full.reachabilityName,
+            )
           : null,
-        full?.isRoot ? m('span', {class: 'ah-badge-root'}, 'root') : null,
+        full?.isRoot ? m('span', {class: 'pf-hde-badge-root'}, 'root') : null,
         m(
           'button',
           {
-            class: 'ah-link',
+            class: 'pf-hde-link',
             onclick: () => navigate('object', {id: row.id, label: row.display}),
           },
           row.display,
@@ -68,7 +72,7 @@ export function InstanceLink(): m.Component<InstanceLinkAttrs> {
           ? m(
               'span',
               {
-                class: 'ah-badge-string',
+                class: 'pf-hde-badge-string',
                 title: row.str.length > 80 ? row.str : undefined,
               },
               '"' +
@@ -81,7 +85,7 @@ export function InstanceLink(): m.Component<InstanceLinkAttrs> {
         full?.referent
           ? m(
               'span',
-              {class: 'ah-badge-referent'},
+              {class: 'pf-hde-badge-referent'},
               ' for ',
               m(InstanceLink, {
                 row: full.referent,
@@ -110,24 +114,24 @@ export function Section(): m.Component<SectionAttrs> {
     view(vnode) {
       return m(
         'div',
-        {class: 'ah-section'},
+        {class: 'pf-hde-section'},
         m(
           'div',
-          {class: 'ah-section__header'},
+          {class: 'pf-hde-section__header'},
           m(
             'button',
             {
-              'class': 'ah-section__toggle',
+              'class': 'pf-hde-section__toggle',
               'onclick': () => {
                 open = !open;
               },
               'aria-expanded': open,
             },
-            m('span', {class: 'ah-section__title'}, vnode.attrs.title),
+            m('span', {class: 'pf-hde-section__title'}, vnode.attrs.title),
             m(
               'svg',
               {
-                class: `ah-section__chevron${open ? ' ah-section__chevron--open' : ''}`,
+                class: `pf-hde-section__chevron${open ? ' pf-hde-section__chevron--open' : ''}`,
                 viewBox: '0 0 20 20',
                 fill: 'currentColor',
               },
@@ -142,14 +146,14 @@ export function Section(): m.Component<SectionAttrs> {
             ? m(
                 'div',
                 {
-                  class: 'ah-section__actions',
+                  class: 'pf-hde-section__actions',
                   onclick: (e: Event) => e.stopPropagation(),
                 },
                 vnode.attrs.actions,
               )
             : null,
         ),
-        open ? m('div', {class: 'ah-section__body'}, vnode.children) : null,
+        open ? m('div', {class: 'pf-hde-section__body'}, vnode.children) : null,
       );
     },
   };
@@ -158,7 +162,7 @@ export function Section(): m.Component<SectionAttrs> {
 /** Renders a size value as a right-aligned formatted byte string. */
 export function sizeRenderer(value: SqlValue): CellRenderResult {
   return {
-    content: m('span', {class: 'ah-mono'}, fmtSize(Number(value ?? 0))),
+    content: m('span', {class: 'pf-hde-mono'}, fmtSize(Number(value ?? 0))),
     align: 'right',
   };
 }
@@ -166,7 +170,11 @@ export function sizeRenderer(value: SqlValue): CellRenderResult {
 /** Renders a numeric count value as a right-aligned locale string. */
 export function countRenderer(value: SqlValue): CellRenderResult {
   return {
-    content: m('span', {class: 'ah-mono'}, Number(value ?? 0).toLocaleString()),
+    content: m(
+      'span',
+      {class: 'pf-hde-mono'},
+      Number(value ?? 0).toLocaleString(),
+    ),
     align: 'right',
   };
 }
@@ -223,11 +231,11 @@ export const COL_INFO = {
 export function colHeader(label: string, info: m.Children): m.Children {
   return m(
     'span',
-    {class: 'ah-col-header'},
+    {class: 'pf-hde-col-header'},
     label,
     m(
       Tooltip,
-      {trigger: m(Icon, {className: 'ah-col-header__info', icon: 'info'})},
+      {trigger: m(Icon, {className: 'pf-hde-col-header__info', icon: 'info'})},
       info,
     ),
   );
@@ -326,7 +334,7 @@ export function PrimOrRefCell(): m.Component<PrimOrRefCellAttrs> {
           navigate,
         });
       }
-      return m('span', {class: 'ah-mono'}, v.v);
+      return m('span', {class: 'pf-hde-mono'}, v.v);
     },
   };
 }
@@ -377,11 +385,11 @@ export function BitmapImage(): m.Component<BitmapImageAttrs> {
     view(vnode) {
       const {format} = vnode.attrs;
       if (format === 'rgba') {
-        return m('canvas', {class: 'ah-bitmap-image'});
+        return m('canvas', {class: 'pf-hde-bitmap-image'});
       }
       // Always render the img element so oncreate fires and creates the blob URL.
       // Before the blob URL is ready, src is empty (blank image).
-      return m('img', {src: blobUrl ?? '', class: 'ah-bitmap-image'});
+      return m('img', {src: blobUrl ?? '', class: 'pf-hde-bitmap-image'});
     },
   };
 }
@@ -390,19 +398,19 @@ export function BitmapImage(): m.Component<BitmapImageAttrs> {
 export function renderPath(path: PathEntry[], navigate: NavFn): m.Children {
   return m(
     'div',
-    {class: 'ah-view-stack--tight'},
+    {class: 'pf-hde-view-stack--tight'},
     path.map((pe, i) =>
       m(
         'div',
         {
           key: i,
-          class: `ah-path-entry${pe.isDominator ? ' ah-semibold' : ''}`,
-          style: {'--ah-depth': String(i)},
+          class: `pf-hde-path-entry${pe.isDominator ? ' pf-hde-semibold' : ''}`,
+          style: {'--pf-hde-depth': String(i)},
         },
         [
-          m('span', {class: 'ah-path-arrow'}, i === 0 ? '' : '\u2192'),
+          m('span', {class: 'pf-hde-path-arrow'}, i === 0 ? '' : '\u2192'),
           m(InstanceLink, {row: pe.row, navigate}),
-          pe.field ? m('span', {class: 'ah-path-field'}, pe.field) : null,
+          pe.field ? m('span', {class: 'pf-hde-path-field'}, pe.field) : null,
         ],
       ),
     ),

--- a/ui/src/plugins/com.android.HeapDumpExplorer/format.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/format.ts
@@ -28,14 +28,14 @@ export function deltaBgClass(deltaKb: number): string {
   if (deltaKb === 0) return '';
   const abs = Math.abs(deltaKb);
   if (deltaKb > 0) {
-    if (abs >= 50_000) return 'ah-delta-bg-pos-heavy';
-    if (abs >= 10_000) return 'ah-delta-bg-pos-medium';
-    if (abs >= 1_000) return 'ah-delta-bg-pos-light';
+    if (abs >= 50_000) return 'pf-hde-delta-bg-pos-heavy';
+    if (abs >= 10_000) return 'pf-hde-delta-bg-pos-medium';
+    if (abs >= 1_000) return 'pf-hde-delta-bg-pos-light';
     return '';
   }
-  if (abs >= 50_000) return 'ah-delta-bg-neg-heavy';
-  if (abs >= 10_000) return 'ah-delta-bg-neg-medium';
-  if (abs >= 1_000) return 'ah-delta-bg-neg-light';
+  if (abs >= 50_000) return 'pf-hde-delta-bg-neg-heavy';
+  if (abs >= 10_000) return 'pf-hde-delta-bg-neg-medium';
+  if (abs >= 1_000) return 'pf-hde-delta-bg-neg-light';
   return '';
 }
 

--- a/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
@@ -266,8 +266,8 @@ function renderDumpSelector(session: HeapDumpExplorerSession): m.Children {
 
   return m(
     'div',
-    {class: 'ah-dump-selector'},
-    m('span', {class: 'ah-dump-selector__label'}, 'Heap dump:'),
+    {class: 'pf-hde-dump-selector'},
+    m('span', {class: 'pf-hde-dump-selector__label'}, 'Heap dump:'),
     m(
       PopupMenu,
       {
@@ -316,9 +316,9 @@ export class HeapDumpPage implements m.ClassComponent<HeapDumpPageAttrs> {
     if (active === null || overview === null) {
       return m(
         'div',
-        {class: 'ah-page'},
+        {class: 'pf-hde-page'},
         renderDumpSelector(session),
-        m('div', {class: 'ah-loading'}, m(Spinner, {easing: true})),
+        m('div', {class: 'pf-hde-loading'}, m(Spinner, {easing: true})),
       );
     }
 
@@ -328,11 +328,11 @@ export class HeapDumpPage implements m.ClassComponent<HeapDumpPageAttrs> {
 
     return m(
       'div',
-      {class: 'ah-page'},
+      {class: 'pf-hde-page'},
       renderDumpSelector(session),
       m(
         'main',
-        {class: 'ah-main'},
+        {class: 'pf-hde-main'},
         m(Tabs, {
           key: tabsKey,
           tabs: buildTabs(session, active, session.nav, overview),

--- a/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
@@ -15,16 +15,16 @@
 // Styles for the Heapdump Explorer plugin.
 // The CSS reset is provided by Perfetto's global styles.
 
-.ah-page {
+.pf-hde-page {
   // Domain-specific badge tokens — no --pf-* equivalent.
-  --ah-badge-reachability: #d97706;
-  --ah-badge-root: #f43f5e;
-  --ah-badge-string: #047857;
+  --pf-hde-badge-reachability: #d97706;
+  --pf-hde-badge-root: #f43f5e;
+  --pf-hde-badge-string: #047857;
 
   .pf-theme-provider--dark & {
-    --ah-badge-reachability: #fbbf24;
-    --ah-badge-root: #fb7185;
-    --ah-badge-string: #34d399;
+    --pf-hde-badge-reachability: #fbbf24;
+    --pf-hde-badge-root: #fb7185;
+    --pf-hde-badge-string: #34d399;
   }
 
   height: 100%;
@@ -35,7 +35,7 @@
   overflow: hidden;
 }
 
-.ah-main {
+.pf-hde-main {
   flex: 1;
   min-height: 0;
   display: flex;
@@ -49,28 +49,28 @@
   line-height: 1.25rem;
 
   // The Tabs widget's content area must be a flex column so that DataGrid
-  // views (which use flex: 1 on .ah-view-content) fill the available height.
+  // views (which use flex: 1 on .pf-hde-view-content) fill the available height.
   .pf-tabs__content {
     display: flex;
     flex-direction: column;
   }
 }
 
-.ah-heading-row {
+.pf-hde-heading-row {
   display: flex;
   align-items: baseline;
   gap: 0.75rem;
   margin-bottom: 0.75rem;
 
   // Remove the heading's own bottom margin when inside a heading row.
-  .ah-view-heading {
+  .pf-hde-view-heading {
     margin-bottom: 0;
   }
 }
 
 // Inline label+control (e.g. "Path: <select>") sitting at the right edge
-// of an .ah-heading-row.
-.ah-heading-control {
+// of an .pf-hde-heading-row.
+.pf-hde-heading-control {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
@@ -83,7 +83,7 @@
 }
 
 // Flex-growing wrapper for view content with a DataGrid that fills height.
-.ah-view-content {
+.pf-hde-view-content {
   flex: 1;
   min-height: 0;
   display: flex;
@@ -93,11 +93,11 @@
 // Empty state for scroll views (bitmaps, etc.) where fillHeight cannot resolve
 // against a fixed parent. Uses viewport-relative height minus the page shell
 // (tab bar + padding) to vertically center the icon.
-.ah-empty-fill {
+.pf-hde-empty-fill {
   height: calc(100vh - 200px);
 }
 
-.ah-loading {
+.pf-hde-loading {
   color: var(--pf-color-text-hint);
   padding: 1rem;
   display: flex;
@@ -106,7 +106,7 @@
   flex: 1;
 }
 
-.ah-dump-selector {
+.pf-hde-dump-selector {
   flex: none;
   display: flex;
   align-items: center;
@@ -117,16 +117,16 @@
   font-size: 0.875rem;
 }
 
-.ah-dump-selector__label {
+.pf-hde-dump-selector__label {
   color: var(--pf-color-text-hint);
 }
 
-.ah-error-text {
+.pf-hde-error-text {
   color: var(--pf-color-danger);
   padding: 1rem;
 }
 
-.ah-view-heading {
+.pf-hde-view-heading {
   font-size: 1.125rem;
   line-height: 1.75rem;
   font-weight: 600;
@@ -134,7 +134,7 @@
   color: var(--pf-color-text);
 }
 
-.ah-default-changed-callout {
+.pf-hde-default-changed-callout {
   margin-bottom: 1rem;
   align-items: center;
   gap: 0.75rem;
@@ -149,13 +149,13 @@
   }
 }
 
-.ah-muted-heading {
+.pf-hde-muted-heading {
   font-size: 0.875rem;
   color: var(--pf-color-text-hint);
   margin-bottom: 0.5rem;
 }
 
-.ah-sub-heading {
+.pf-hde-sub-heading {
   font-size: 0.8125rem;
   line-height: 1.25rem;
   font-weight: 600;
@@ -165,32 +165,32 @@
   margin-bottom: 0.5rem;
 }
 
-.ah-card {
+.pf-hde-card {
   background: var(--pf-color-background);
   border: 1px solid var(--pf-color-border);
   padding: 1rem;
 }
 
-.ah-card--compact {
-  @extend .ah-card;
+.pf-hde-card--compact {
+  @extend .pf-hde-card;
   padding: 0.75rem;
 }
 
-.ah-bitmap-image {
+.pf-hde-bitmap-image {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
   image-rendering: pixelated;
 }
 
-.ah-bitmap-card {
+.pf-hde-bitmap-card {
   border: 1px solid var(--pf-color-border);
   border-radius: 3px;
   overflow: hidden;
   margin-bottom: 1rem;
 }
 
-.ah-bitmap-card__image {
+.pf-hde-bitmap-card__image {
   margin: 0 auto;
   display: flex;
   align-items: center;
@@ -198,7 +198,7 @@
   padding: 0.5rem;
 }
 
-.ah-bitmap-card__info {
+.pf-hde-bitmap-card__info {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -207,43 +207,43 @@
   font-size: 0.875rem;
 }
 
-.ah-bitmap-card__secondary {
+.pf-hde-bitmap-card__secondary {
   margin-left: 0.75rem;
   color: var(--pf-color-text-hint);
 }
 
-.ah-bitmap-card__path {
+.pf-hde-bitmap-card__path {
   padding: 0.5rem 0.75rem;
   border-top: 1px solid var(--pf-color-border-secondary);
   font-size: 0.8125rem;
 }
 
-.ah-info-grid {
+.pf-hde-info-grid {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.375rem 1rem;
 }
 
-.ah-info-grid--compact {
-  @extend .ah-info-grid;
+.pf-hde-info-grid--compact {
+  @extend .pf-hde-info-grid;
   gap: 0.25rem 1rem;
 }
 
-.ah-info-grid__label {
+.pf-hde-info-grid__label {
   color: var(--pf-color-text-muted);
 }
 
-.ah-section {
+.pf-hde-section {
   background: var(--pf-color-background);
   border: 1px solid var(--pf-color-border);
 }
 
-.ah-section__header {
+.pf-hde-section__header {
   display: flex;
   align-items: stretch;
 }
 
-.ah-section__toggle {
+.pf-hde-section__toggle {
   flex: 1;
   padding: 0.5rem 1rem;
   display: flex;
@@ -255,7 +255,7 @@
   }
 }
 
-.ah-section__actions {
+.pf-hde-section__actions {
   display: flex;
   align-items: center;
   padding: 0 1rem;
@@ -263,25 +263,25 @@
   border-left: 1px solid var(--pf-color-border-secondary);
 }
 
-.ah-section__title {
+.pf-hde-section__title {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 600;
   color: var(--pf-color-text-muted);
 }
 
-.ah-section__chevron {
+.pf-hde-section__chevron {
   width: 0.75rem;
   height: 0.75rem;
   color: var(--pf-color-text-hint);
   transition: transform 0.15s;
 }
 
-.ah-section__chevron--open {
+.pf-hde-section__chevron--open {
   transform: rotate(90deg);
 }
 
-.ah-section__body {
+.pf-hde-section__body {
   padding: 0.75rem 1rem;
   border-top: 1px solid var(--pf-color-border-secondary);
   overflow-x: auto;
@@ -296,7 +296,7 @@
   }
 }
 
-.ah-link {
+.pf-hde-link {
   color: var(--pf-color-primary);
   text-decoration: underline;
   &:hover {
@@ -304,38 +304,38 @@
   }
 }
 
-.ah-link--alt {
+.pf-hde-link--alt {
   color: var(--pf-color-primary);
   &:hover {
     text-decoration: underline;
   }
 }
 
-.ah-badge-reachability {
-  color: var(--ah-badge-reachability);
+.pf-hde-badge-reachability {
+  color: var(--pf-hde-badge-reachability);
   font-size: 0.8125rem;
   line-height: 1.25rem;
   margin-right: 0.25rem;
 }
 
-.ah-badge-root {
-  color: var(--ah-badge-root);
+.pf-hde-badge-root {
+  color: var(--pf-hde-badge-root);
   font-size: 0.8125rem;
   line-height: 1.25rem;
   margin-right: 0.25rem;
 }
 
-.ah-badge-string {
-  color: var(--ah-badge-string);
+.pf-hde-badge-string {
+  color: var(--pf-hde-badge-string);
   margin-left: 0.25rem;
 }
 
-.ah-badge-referent {
+.pf-hde-badge-referent {
   color: var(--pf-color-text-hint);
   margin-left: 0.25rem;
 }
 
-.ah-download-link {
+.pf-hde-download-link {
   font-size: 0.875rem;
   line-height: 1.25rem;
   color: var(--pf-color-primary);
@@ -345,111 +345,111 @@
   }
 }
 
-.ah-path-arrow {
+.pf-hde-path-arrow {
   color: var(--pf-color-text-hint);
 }
 
-.ah-path-field {
+.pf-hde-path-field {
   color: var(--pf-color-text-muted);
 }
 
-.ah-view-stack > * + * {
+.pf-hde-view-stack > * + * {
   margin-top: 0.75rem;
 }
 
-.ah-view-stack--tight > * + * {
+.pf-hde-view-stack--tight > * + * {
   margin-top: 0.125rem;
 }
 
-.ah-mono {
+.pf-hde-mono {
   font-family: var(--pf-font-monospace);
 }
-.ah-semibold {
+.pf-hde-semibold {
   font-weight: 600;
 }
-.ah-break-all {
+.pf-hde-break-all {
   word-break: break-all;
 }
-.ah-opacity-60 {
+.pf-hde-opacity-60 {
   opacity: 0.6;
 }
 
-.ah-view-heading--tight {
+.pf-hde-view-heading--tight {
   margin-bottom: 0.25rem;
 }
 
-.ah-action-row {
+.pf-hde-action-row {
   display: flex;
   align-items: center;
   gap: 0.75rem;
 }
 
-.ah-bitmap-meta {
+.pf-hde-bitmap-meta {
   display: flex;
   align-items: center;
   gap: 0.75rem;
   color: var(--pf-color-text-muted);
 }
 
-.ah-path-entry {
+.pf-hde-path-entry {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding-left: calc(min(var(--ah-depth, 0), 20) * 0.75rem);
+  padding-left: calc(min(var(--pf-hde-depth, 0), 20) * 0.75rem);
 }
 
-.ah-dup-grid-container {
+.pf-hde-dup-grid-container {
   height: 400px;
 }
 
-.ah-desc {
+.pf-hde-desc {
   font-size: 0.875rem;
   line-height: 1.25rem;
   color: var(--pf-color-text-muted);
   margin-bottom: 0.5rem;
 }
 
-.ah-str-color {
-  color: var(--ah-badge-string);
+.pf-hde-str-color {
+  color: var(--pf-hde-badge-string);
 }
 
-.ah-str-badge {
-  color: var(--ah-badge-string);
+.pf-hde-str-badge {
+  color: var(--pf-hde-badge-string);
   margin-left: 0.25rem;
 }
 
-.ah-muted {
+.pf-hde-muted {
   color: var(--pf-color-text-muted);
 }
 
-.ah-flex-none {
+.pf-hde-flex-none {
   flex-shrink: 0;
 }
 
 // Spacing (minimal set)
-.ah-mt-1 {
+.pf-hde-mt-1 {
   margin-top: 0.25rem;
 }
-.ah-mb-2 {
+.pf-hde-mb-2 {
   margin-bottom: 0.5rem;
 }
-.ah-mb-3 {
+.pf-hde-mb-3 {
   margin-bottom: 0.75rem;
 }
-.ah-mb-4 {
+.pf-hde-mb-4 {
   margin-bottom: 1rem;
 }
-.ah-mt-4 {
+.pf-hde-mt-4 {
   margin-top: 1rem;
 }
 
-.ah-col-header {
+.pf-hde-col-header {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
 }
 
-.ah-col-header__info {
+.pf-hde-col-header__info {
   color: var(--pf-color-fg-muted, #888);
   font-size: 14px;
   cursor: help;
@@ -457,10 +457,10 @@
   transition: opacity 0.15s ease;
 }
 
-.ah-col-header:hover .ah-col-header__info {
+.pf-hde-col-header:hover .pf-hde-col-header__info {
   opacity: 1;
 }
 
-.ah-col-header__info:hover {
+.pf-hde-col-header__info:hover {
   color: var(--pf-color-fg, #333);
 }

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
@@ -85,7 +85,7 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
             m(
               'button',
               {
-                class: 'ah-link',
+                class: 'pf-hde-link',
                 onclick: () =>
                   navigate('object', {id, label: str ? `"${str}"` : display}),
               },
@@ -94,7 +94,7 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
             str
               ? m(
                   'span',
-                  {class: 'ah-str-badge'},
+                  {class: 'pf-hde-str-badge'},
                   ` "${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`,
                 )
               : null,
@@ -201,8 +201,8 @@ function AllObjectsView(): m.Component<AllObjectsViewAttrs> {
 
       if (!dataSource) return null;
 
-      return m('div', {class: 'ah-view-content'}, [
-        m('h2', {class: 'ah-view-heading'}, counter.heading('Objects')),
+      return m('div', {class: 'pf-hde-view-content'}, [
+        m('h2', {class: 'pf-hde-view-heading'}, counter.heading('Objects')),
         m(DataGrid, {
           schema: makeUiSchema(navigate),
           rootSchema: 'query',

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
@@ -65,7 +65,7 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
           return m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () => navigate('object', {id, label: display}),
             },
             display,
@@ -156,8 +156,8 @@ function ArraysView(): m.Component<ArraysViewAttrs> {
 
       if (!dataSource) return null;
 
-      return m('div', {class: 'ah-view-content'}, [
-        m('h2', {class: 'ah-view-heading'}, counter.heading('Arrays')),
+      return m('div', {class: 'pf-hde-view-content'}, [
+        m('h2', {class: 'pf-hde-view-heading'}, counter.heading('Arrays')),
         m(DataGrid, {
           schema: makeUiSchema(navigate),
           rootSchema: 'query',

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
@@ -81,7 +81,7 @@ function makeBitmapListSchema(navigate: NavFn): SchemaRegistry {
           return m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () =>
                 navigate('object', {
                   id,
@@ -96,7 +96,7 @@ function makeBitmapListSchema(navigate: NavFn): SchemaRegistry {
         title: 'Dimensions',
         columnType: 'text',
         cellRenderer: (value: SqlValue) =>
-          m('span', {class: 'ah-mono'}, String(value ?? '')),
+          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
       },
       self_size: {
         title: 'Shallow',
@@ -226,24 +226,24 @@ function BitmapCard(): m.Component<BitmapCardAttrs> {
               data: bitmap.data,
             })
           : bitmap === 'loading'
-            ? m('span', {class: 'ah-bitmap-card__secondary'}, '\u2026')
+            ? m('span', {class: 'pf-hde-bitmap-card__secondary'}, '\u2026')
             : bitmap === 'error'
-              ? m('span', {class: 'ah-bitmap-card__secondary'}, 'no data')
+              ? m('span', {class: 'pf-hde-bitmap-card__secondary'}, 'no data')
               : !row.hasPixelData
                 ? m(
                     'span',
-                    {class: 'ah-bitmap-card__secondary'},
+                    {class: 'pf-hde-bitmap-card__secondary'},
                     'no pixel data',
                   )
                 : null;
 
       return m(
         'div',
-        {class: 'ah-bitmap-card'},
+        {class: 'pf-hde-bitmap-card'},
         m(
           'div',
           {
-            class: 'ah-bitmap-card__image',
+            class: 'pf-hde-bitmap-card__image',
             style: {
               maxWidth: `${dpW}px`,
               maxHeight: '45vh',
@@ -254,27 +254,31 @@ function BitmapCard(): m.Component<BitmapCardAttrs> {
         ),
         m(
           'div',
-          {class: 'ah-bitmap-card__info'},
+          {class: 'pf-hde-bitmap-card__info'},
           m(
             'div',
             null,
-            m('span', {class: 'ah-mono'}, `${row.width}\u00d7${row.height} px`),
             m(
               'span',
-              {class: 'ah-bitmap-card__secondary'},
+              {class: 'pf-hde-mono'},
+              `${row.width}\u00d7${row.height} px`,
+            ),
+            m(
+              'span',
+              {class: 'pf-hde-bitmap-card__secondary'},
               `${dpW}\u00d7${dpH} dp`,
             ),
-            m('span', {class: 'ah-bitmap-card__secondary'}, `@${dpi}dpi`),
+            m('span', {class: 'pf-hde-bitmap-card__secondary'}, `@${dpi}dpi`),
             m(
               'span',
-              {class: 'ah-bitmap-card__secondary'},
+              {class: 'pf-hde-bitmap-card__secondary'},
               fmtSize(row.row.retainedTotal),
             ),
           ),
           m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () =>
                 navigate('object', {
                   id: row.row.id,
@@ -289,15 +293,15 @@ function BitmapCard(): m.Component<BitmapCardAttrs> {
           vnode.attrs.pathData !== null
           ? m(
               'div',
-              {class: 'ah-bitmap-card__path'},
+              {class: 'pf-hde-bitmap-card__path'},
               m(
                 'div',
-                {class: 'ah-muted-heading'},
+                {class: 'pf-hde-muted-heading'},
                 PATH_HEADING[vnode.attrs.pathMode],
               ),
               vnode.attrs.pathData.length > 0
                 ? renderPath(vnode.attrs.pathData, navigate)
-                : m('span', {class: 'ah-muted'}, 'No path to GC root.'),
+                : m('span', {class: 'pf-hde-muted'}, 'No path to GC root.'),
             )
           : null,
       );
@@ -395,7 +399,7 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
       const {engine, activeDump, navigate} = vnode.attrs;
 
       if (!rows) {
-        return m('div', {class: 'ah-loading'}, m(Spinner, {easing: true}));
+        return m('div', {class: 'pf-hde-loading'}, m(Spinner, {easing: true}));
       }
 
       const totalRetained = rows.reduce(
@@ -412,7 +416,7 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
             vnode.attrs.hasFieldValues === false
               ? 'Bitmap data requires an ART heap dump (.hprof)'
               : 'No bitmap data available',
-          className: 'ah-empty-fill',
+          className: 'pf-hde-empty-fill',
         });
       }
 
@@ -435,17 +439,17 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
         filters = [...f];
       };
 
-      return m('div', {class: 'ah-view-scroll'}, [
-        m('div', {class: 'ah-heading-row'}, [
+      return m('div', {class: 'pf-hde-view-scroll'}, [
+        m('div', {class: 'pf-hde-heading-row'}, [
           m(
             'h2',
-            {class: 'ah-view-heading'},
+            {class: 'pf-hde-view-heading'},
             `Bitmaps (${rows.length.toLocaleString()})`,
           ),
           m(
             'label',
-            {class: 'ah-heading-control'},
-            m('span', {class: 'ah-heading-control__label'}, 'Path'),
+            {class: 'pf-hde-heading-control'},
+            m('span', {class: 'pf-hde-heading-control__label'}, 'Path'),
             m(
               Select,
               {
@@ -478,7 +482,7 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
             ),
           ),
         ]),
-        m('div', {class: 'ah-card ah-mb-4'}, [
+        m('div', {class: 'pf-hde-card pf-hde-mb-4'}, [
           m(DataGrid, {
             schema: SUMMARY_SCHEMA,
             rootSchema: 'query',
@@ -503,7 +507,7 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
         withPixels.length > 0
           ? m(
               'div',
-              {class: 'ah-mb-4'},
+              {class: 'pf-hde-mb-4'},
               withPixels.map((r) =>
                 m(BitmapCard, {
                   key: r.row.id,
@@ -521,10 +525,10 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
             )
           : null,
         withPixels.length > 0
-          ? m('div', {class: 'ah-mb-4'}, [
+          ? m('div', {class: 'pf-hde-mb-4'}, [
               m(
                 'h3',
-                {class: 'ah-muted-heading'},
+                {class: 'pf-hde-muted-heading'},
                 `${withPixels.length} bitmap${withPixels.length > 1 ? 's' : ''} with pixel data`,
               ),
               m(DataGrid, {
@@ -539,10 +543,10 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
             ])
           : null,
         withoutPixels.length > 0
-          ? m('div', {class: 'ah-mb-4'}, [
+          ? m('div', {class: 'pf-hde-mb-4'}, [
               m(
                 'h3',
-                {class: 'ah-muted-heading ah-mt-4'},
+                {class: 'pf-hde-muted-heading pf-hde-mt-4'},
                 `${withoutPixels.length} bitmap${withoutPixels.length > 1 ? 's' : ''} without pixel data`,
               ),
               m(DataGrid, {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
@@ -67,7 +67,7 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
           m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () => navigate('objects', {cls: String(value)}),
             },
             String(value),
@@ -167,8 +167,8 @@ function ClassesView(): m.Component<ClassesViewAttrs> {
 
       if (!dataSource) return null;
 
-      return m('div', {class: 'ah-view-content'}, [
-        m('h2', {class: 'ah-view-heading'}, counter.heading('Classes')),
+      return m('div', {class: 'pf-hde-view-content'}, [
+        m('h2', {class: 'pf-hde-view-heading'}, counter.heading('Classes')),
         m(DataGrid, {
           schema: makeUiSchema(navigate),
           rootSchema: 'query',

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
@@ -75,7 +75,7 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
           return m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () => navigate('object', {id, label: display}),
             },
             display,
@@ -167,8 +167,8 @@ function DominatorsView(): m.Component<DominatorsViewAttrs> {
 
       if (!dataSource) return null;
 
-      return m('div', {class: 'ah-view-content'}, [
-        m('h2', {class: 'ah-view-heading'}, counter.heading('Dominators')),
+      return m('div', {class: 'pf-hde-view-content'}, [
+        m('h2', {class: 'pf-hde-view-heading'}, counter.heading('Dominators')),
         m(DataGrid, {
           schema: makeUiSchema(navigate),
           rootSchema: 'query',

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_objects_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_objects_view.ts
@@ -91,7 +91,7 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
             m(
               'button',
               {
-                class: 'ah-link',
+                class: 'pf-hde-link',
                 onclick: () =>
                   navigate('object', {id, label: str ? `"${str}"` : display}),
               },
@@ -100,7 +100,7 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
             str
               ? m(
                   'span',
-                  {class: 'ah-str-badge'},
+                  {class: 'pf-hde-str-badge'},
                   ` "${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`,
                 )
               : null,
@@ -218,14 +218,14 @@ function FlamegraphObjectsView(): m.Component<FlamegraphObjectsViewAttrs> {
           nodeName
             ? m(
                 'h2',
-                {class: 'ah-view-heading'},
+                {class: 'pf-hde-view-heading'},
                 'Flamegraph: ',
-                m('span', {class: 'ah-mono'}, nodeName),
+                m('span', {class: 'pf-hde-mono'}, nodeName),
               )
             : null,
           m(
             'div',
-            {class: 'ah-card ah-mb-3'},
+            {class: 'pf-hde-card pf-hde-mb-3'},
             m(
               'p',
               'No flamegraph selection found. Select a node in the ',
@@ -235,11 +235,11 @@ function FlamegraphObjectsView(): m.Component<FlamegraphObjectsViewAttrs> {
         ]);
       }
 
-      return m('div', {class: 'ah-view-content'}, [
-        m('div', {class: 'ah-heading-row'}, [
+      return m('div', {class: 'pf-hde-view-content'}, [
+        m('div', {class: 'pf-hde-heading-row'}, [
           m(
             'h2',
-            {class: 'ah-view-heading'},
+            {class: 'pf-hde-view-heading'},
             counter.heading(
               nodeName ? `Flamegraph: ${nodeName}` : 'Flamegraph Objects',
             ),
@@ -247,7 +247,7 @@ function FlamegraphObjectsView(): m.Component<FlamegraphObjectsViewAttrs> {
           onBackToTimeline
             ? m(
                 'button',
-                {class: 'ah-download-link', onclick: onBackToTimeline},
+                {class: 'pf-hde-download-link', onclick: onBackToTimeline},
                 'Back to Timeline',
               )
             : null,

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
@@ -190,7 +190,7 @@ const FlamegraphView: m.ClosureComponent<FlamegraphViewAttrs> = () => {
 
       return m(
         'div',
-        {class: 'ah-view-content ah-flamegraph-view'},
+        {class: 'pf-hde-view-content pf-hde-flamegraph-view'},
         m(FlamegraphPanel, {
           trace: attrs.trace,
           metrics,

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
@@ -175,12 +175,12 @@ function arrayElemToRow(e: ArrayElemRow, elemTypeName: string): Row {
 function nullableSizeRenderer(value: SqlValue): CellRenderResult {
   if (value === null) {
     return {
-      content: m('span', {class: 'ah-mono ah-opacity-60'}, '\u2026'),
+      content: m('span', {class: 'pf-hde-mono pf-hde-opacity-60'}, '\u2026'),
       align: 'right',
     };
   }
   return {
-    content: m('span', {class: 'ah-mono'}, fmtSize(Number(value ?? 0))),
+    content: m('span', {class: 'pf-hde-mono'}, fmtSize(Number(value ?? 0))),
     align: 'right',
   };
 }
@@ -224,14 +224,18 @@ const SIZE_SCHEMA: SchemaRegistry = {
       cellRenderer: (value: SqlValue): CellRenderResult => {
         if (value === null) {
           return {
-            content: m('span', {class: 'ah-mono ah-opacity-60'}, '\u2026'),
+            content: m(
+              'span',
+              {class: 'pf-hde-mono pf-hde-opacity-60'},
+              '\u2026',
+            ),
             align: 'right',
           };
         }
         return {
           content: m(
             'span',
-            {class: 'ah-mono'},
+            {class: 'pf-hde-mono'},
             Number(value).toLocaleString(),
           ),
           align: 'right',
@@ -256,7 +260,7 @@ function makeInstanceSchema(navigate: NavFn): SchemaRegistry {
             m(
               'button',
               {
-                class: 'ah-link',
+                class: 'pf-hde-link',
                 onclick: () =>
                   navigate('object', {id, label: str ? `"${str}"` : display}),
               },
@@ -265,7 +269,7 @@ function makeInstanceSchema(navigate: NavFn): SchemaRegistry {
             str
               ? m(
                   'span',
-                  {class: 'ah-str-badge'},
+                  {class: 'pf-hde-str-badge'},
                   ` "${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`,
                 )
               : null,
@@ -347,7 +351,7 @@ function makeFieldSchema(navigate: NavFn): SchemaRegistry {
             return m(
               'button',
               {
-                class: 'ah-link',
+                class: 'pf-hde-link',
                 onclick: () =>
                   navigate('object', {
                     id: Number(row.ref_id),
@@ -379,7 +383,7 @@ function makeFieldSchema(navigate: NavFn): SchemaRegistry {
               navigate,
             });
           }
-          return m('span', {class: 'ah-mono'}, String(value ?? ''));
+          return m('span', {class: 'pf-hde-mono'}, String(value ?? ''));
         },
       },
       shallow: {
@@ -450,7 +454,7 @@ function makeArraySchema(
         title: 'Index',
         columnType: 'quantitative',
         cellRenderer: (value: SqlValue): CellRenderResult => ({
-          content: m('span', {class: 'ah-mono'}, String(value ?? 0)),
+          content: m('span', {class: 'pf-hde-mono'}, String(value ?? 0)),
           align: 'right',
         }),
       },
@@ -469,7 +473,7 @@ function makeArraySchema(
               navigate,
             });
           }
-          return m('span', {class: 'ah-mono'}, String(value ?? ''));
+          return m('span', {class: 'pf-hde-mono'}, String(value ?? ''));
         },
       },
       shallow: {
@@ -597,12 +601,12 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
       const {navigate, params} = vnode.attrs;
 
       if (detail === 'loading') {
-        return m('div', {class: 'ah-loading'}, m(Spinner, {easing: true}));
+        return m('div', {class: 'pf-hde-loading'}, m(Spinner, {easing: true}));
       }
       if (!detail) {
         return m(
           'div',
-          {class: 'ah-error-text'},
+          {class: 'pf-hde-error-text'},
           'No object with id ' + fmtHex(params.id),
         );
       }
@@ -614,7 +618,7 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
           ? m(
               'button',
               {
-                class: 'ah-link',
+                class: 'pf-hde-link',
                 title: isDominator
                   ? 'Open in Flamegraph pivoted on this dominator path'
                   : 'Open in Flamegraph pivoted on this shortest path',
@@ -631,14 +635,14 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
             )
           : null;
 
-      return m('div', {class: 'ah-view-scroll ah-view-stack'}, [
+      return m('div', {class: 'pf-hde-view-scroll pf-hde-view-stack'}, [
         m('div', [
           m(
             'h2',
-            {class: 'ah-view-heading ah-view-heading--tight'},
+            {class: 'pf-hde-view-heading pf-hde-view-heading--tight'},
             'Object ' + fmtHex(row.id),
           ),
-          m('div', {class: 'ah-action-row'}, [
+          m('div', {class: 'pf-hde-action-row'}, [
             m(InstanceLink, {row, navigate}),
           ]),
         ]),
@@ -651,7 +655,7 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
                 format: detail.bitmap.format,
                 data: detail.bitmap.data,
               }),
-              m('div', {class: 'ah-bitmap-meta ah-mt-1'}, [
+              m('div', {class: 'pf-hde-bitmap-meta pf-hde-mt-1'}, [
                 m(
                   'span',
                   detail.bitmap.width +
@@ -664,7 +668,7 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
                 m(
                   'button',
                   {
-                    class: 'ah-download-link',
+                    class: 'pf-hde-download-link',
                     onclick: () => {
                       if (
                         detail === null ||
@@ -695,30 +699,30 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
           detail.shortestPath
             ? m(
                 'div',
-                {class: 'ah-view-stack--tight'},
+                {class: 'pf-hde-view-stack--tight'},
                 detail.shortestPath.map((pe, i) =>
                   m(
                     'div',
                     {
                       key: i,
-                      class: 'ah-path-entry',
-                      style: {'--ah-depth': String(i)},
+                      class: 'pf-hde-path-entry',
+                      style: {'--pf-hde-depth': String(i)},
                     },
                     [
                       m(
                         'span',
-                        {class: 'ah-path-arrow'},
+                        {class: 'pf-hde-path-arrow'},
                         i === 0 ? '' : '\u2192',
                       ),
                       m(InstanceLink, {row: pe.row, navigate}),
                       pe.field
-                        ? m('span', {class: 'ah-path-field'}, pe.field)
+                        ? m('span', {class: 'pf-hde-path-field'}, pe.field)
                         : null,
                     ],
                   ),
                 ),
               )
-            : m('p', {class: 'ah-muted'}, 'No path to GC root.'),
+            : m('p', {class: 'pf-hde-muted'}, 'No path to GC root.'),
         ),
 
         m(
@@ -730,35 +734,35 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
           detail.dominatorPath
             ? m(
                 'div',
-                {class: 'ah-view-stack--tight'},
+                {class: 'pf-hde-view-stack--tight'},
                 detail.dominatorPath.map((pe, i) =>
                   m(
                     'div',
                     {
                       key: i,
-                      class: `ah-path-entry${pe.isDominator ? ' ah-semibold' : ''}`,
-                      style: {'--ah-depth': String(i)},
+                      class: `pf-hde-path-entry${pe.isDominator ? ' pf-hde-semibold' : ''}`,
+                      style: {'--pf-hde-depth': String(i)},
                     },
                     [
                       m(
                         'span',
-                        {class: 'ah-path-arrow'},
+                        {class: 'pf-hde-path-arrow'},
                         i === 0 ? '' : '\u2192',
                       ),
                       m(InstanceLink, {row: pe.row, navigate}),
                       pe.field
-                        ? m('span', {class: 'ah-path-field'}, pe.field)
+                        ? m('span', {class: 'pf-hde-path-field'}, pe.field)
                         : null,
                     ],
                   ),
                 ),
               )
-            : m('p', {class: 'ah-muted'}, 'No path to GC root.'),
+            : m('p', {class: 'pf-hde-muted'}, 'No path to GC root.'),
         ),
 
         m(Section, {title: 'Object Info'}, [
-          m('div', {class: 'ah-info-grid'}, [
-            m('span', {class: 'ah-info-grid__label'}, 'Class:'),
+          m('div', {class: 'pf-hde-info-grid'}, [
+            m('span', {class: 'pf-hde-info-grid__label'}, 'Class:'),
             m(
               'span',
               detail.classObjRow
@@ -768,11 +772,11 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
                   })
                 : '???',
             ),
-            m('span', {class: 'ah-info-grid__label'}, 'Heap:'),
+            m('span', {class: 'pf-hde-info-grid__label'}, 'Heap:'),
             m('span', row.heap),
             ...(row.isRoot
               ? [
-                  m('span', {class: 'ah-info-grid__label'}, 'Root Types:'),
+                  m('span', {class: 'pf-hde-info-grid__label'}, 'Root Types:'),
                   m('span', row.rootTypeNames?.join(', ')),
                 ]
               : []),
@@ -825,9 +829,9 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
 
         detail.isClassObj
           ? m(Section, {title: 'Class Info'}, [
-              m('div', {class: 'ah-info-grid ah-mb-3'}, [
-                m('span', {class: 'ah-info-grid__label'}, 'Instance Size:'),
-                m('span', {class: 'ah-mono'}, String(detail.instanceSize)),
+              m('div', {class: 'pf-hde-info-grid pf-hde-mb-3'}, [
+                m('span', {class: 'pf-hde-info-grid__label'}, 'Instance Size:'),
+                m('span', {class: 'pf-hde-mono'}, String(detail.instanceSize)),
               ]),
             ])
           : null,
@@ -854,7 +858,7 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
               {title: 'Fields'},
               detail.instanceFields.length > 0
                 ? renderFieldsGrid(detail.instanceFields, navigate)
-                : m('p', {class: 'ah-muted'}, 'No instance fields.'),
+                : m('p', {class: 'pf-hde-muted'}, 'No instance fields.'),
             )
           : null,
 
@@ -915,7 +919,7 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
                 ],
                 showExportButton: true,
               })
-            : m('p', {class: 'ah-muted'}, 'No references to this object.'),
+            : m('p', {class: 'pf-hde-muted'}, 'No references to this object.'),
         ),
 
         m(
@@ -949,7 +953,11 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
                 ],
                 showExportButton: true,
               })
-            : m('p', {class: 'ah-muted'}, 'No immediately dominated objects.'),
+            : m(
+                'p',
+                {class: 'pf-hde-muted'},
+                'No immediately dominated objects.',
+              ),
         ),
       ]);
     },
@@ -958,7 +966,7 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
 
 function renderFieldsGrid(fields: FieldRow[], navigate: NavFn): m.Children {
   if (fields.length === 0) {
-    return m('div', {class: 'ah-info-grid__label'}, 'No fields');
+    return m('div', {class: 'pf-hde-info-grid__label'}, 'No fields');
   }
   return m(DataGrid, {
     schema: makeFieldSchema(navigate),
@@ -1002,18 +1010,18 @@ function renderArrayGrid(
 
   return m('div', [
     onDownloadBytes || elems.length > 0
-      ? m('div', {class: 'ah-action-row ah-mb-2'}, [
+      ? m('div', {class: 'pf-hde-action-row pf-hde-mb-2'}, [
           onDownloadBytes
             ? m(
                 'button',
-                {class: 'ah-download-link', onclick: onDownloadBytes},
+                {class: 'pf-hde-download-link', onclick: onDownloadBytes},
                 'Download bytes',
               )
             : null,
           elems.length > 0
             ? m(
                 'button',
-                {class: 'ah-download-link', onclick: copyTsv},
+                {class: 'pf-hde-download-link', onclick: copyTsv},
                 'Copy as TSV',
               )
             : null,
@@ -1083,7 +1091,7 @@ function classFilterLink(className: string, navigate: NavFn): m.Child {
   return m(
     'button',
     {
-      class: 'ah-link',
+      class: 'pf-hde-link',
       title: 'Open subclasses of this class',
       onclick: () =>
         navigate('classes', {rootClass: subclassFilterTarget(className)}),
@@ -1099,17 +1107,17 @@ function renderClassHierarchy(
   const topDown = hierarchy.slice().reverse();
   return m(
     'div',
-    {class: 'ah-view-stack--tight'},
+    {class: 'pf-hde-view-stack--tight'},
     topDown.map((className, i) =>
       m(
         'div',
         {
           key: className,
-          class: `ah-path-entry${i === topDown.length - 1 ? ' ah-semibold' : ''}`,
-          style: {'--ah-depth': String(i)},
+          class: `pf-hde-path-entry${i === topDown.length - 1 ? ' pf-hde-semibold' : ''}`,
+          style: {'--pf-hde-depth': String(i)},
         },
         [
-          m('span', {class: 'ah-path-arrow'}, i === 0 ? '' : '→'),
+          m('span', {class: 'pf-hde-path-arrow'}, i === 0 ? '' : '→'),
           classFilterLink(className, navigate),
         ],
       ),

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/overview_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/overview_view.ts
@@ -75,7 +75,7 @@ function makeDuplicateBitmapSchema(navigate: NavFn): SchemaRegistry {
           m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () =>
                 navigate('bitmaps', {
                   filterKey: String(row.groupKey ?? ''),
@@ -108,7 +108,7 @@ function makeDuplicateArraySchema(navigate: NavFn): SchemaRegistry {
           m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () => navigate('objects', {cls: String(value ?? '')}),
             },
             String(value ?? ''),
@@ -125,7 +125,7 @@ function makeDuplicateArraySchema(navigate: NavFn): SchemaRegistry {
           m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () =>
                 navigate('arrays', {
                   arrayHash: String(row.arrayHash ?? ''),
@@ -158,7 +158,8 @@ function makeDuplicateStringSchema(navigate: NavFn): SchemaRegistry {
           m(
             'button',
             {
-              class: 'ah-link ah-mono ah-break-all ah-str-color',
+              class:
+                'pf-hde-link pf-hde-mono pf-hde-break-all pf-hde-str-color',
               onclick: () =>
                 navigate('strings', {
                   q: String(value ?? ''),
@@ -178,7 +179,7 @@ function makeDuplicateStringSchema(navigate: NavFn): SchemaRegistry {
           m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () => navigate('strings', {q: String(row.value ?? '')}),
             },
             String(value),
@@ -209,25 +210,25 @@ function renderDuplicateSection(
   data: Row[],
   columns: Array<{id: string; field: string}>,
 ): m.Children {
-  return m('div', {class: 'ah-card ah-mt-4'}, [
-    m('h3', {class: 'ah-sub-heading'}, title),
-    m('p', {class: 'ah-desc'}, [
+  return m('div', {class: 'pf-hde-card pf-hde-mt-4'}, [
+    m('h3', {class: 'pf-hde-sub-heading'}, title),
+    m('p', {class: 'pf-hde-desc'}, [
       groupCount +
         ' group' +
         (groupCount > 1 ? 's' : '') +
         ' detected, wasting ',
-      m('span', {class: 'ah-mono ah-semibold'}, fmtSize(totalWasted)),
+      m('span', {class: 'pf-hde-mono pf-hde-semibold'}, fmtSize(totalWasted)),
       '. ',
       m(
         'button',
         {
-          class: 'ah-link--alt',
+          class: 'pf-hde-link--alt',
           onclick: () => navigate(targetView as NavState['view']),
         },
         linkLabel,
       ),
     ]),
-    m('div', {class: 'ah-dup-grid-container'}, [
+    m('div', {class: 'pf-hde-dup-grid-container'}, [
       m(DataGrid, {
         schema,
         rootSchema: 'query',
@@ -301,13 +302,13 @@ function OverviewView(): m.Component<OverviewViewAttrs> {
         },
       ];
 
-      return m('div', {class: 'ah-view-scroll'}, [
-        m('h2', {class: 'ah-view-heading'}, 'Overview'),
+      return m('div', {class: 'pf-hde-view-scroll'}, [
+        m('h2', {class: 'pf-hde-view-heading'}, 'Overview'),
         showHint
           ? m(
               Callout,
               {
-                className: 'ah-default-changed-callout',
+                className: 'pf-hde-default-changed-callout',
                 icon: 'info',
                 dismissible: true,
                 onDismiss: onDismissDefaultChangedHint,
@@ -328,8 +329,8 @@ function OverviewView(): m.Component<OverviewViewAttrs> {
             )
           : null,
 
-        m('div', {class: 'ah-card ah-mb-4'}, [
-          m('h3', {class: 'ah-sub-heading'}, 'General Information'),
+        m('div', {class: 'pf-hde-card pf-hde-mb-4'}, [
+          m('h3', {class: 'pf-hde-sub-heading'}, 'General Information'),
           m(DataGrid, {
             schema: INFO_SCHEMA,
             rootSchema: 'query',
@@ -340,8 +341,8 @@ function OverviewView(): m.Component<OverviewViewAttrs> {
             ],
           }),
         ]),
-        m('div', {class: 'ah-card'}, [
-          m('h3', {class: 'ah-sub-heading'}, 'Bytes Retained by Heap'),
+        m('div', {class: 'pf-hde-card'}, [
+          m('h3', {class: 'pf-hde-sub-heading'}, 'Bytes Retained by Heap'),
           m(DataGrid, {
             schema: HEAP_SCHEMA,
             rootSchema: 'query',
@@ -381,8 +382,8 @@ function OverviewView(): m.Component<OverviewViewAttrs> {
           : overview.hasFieldValues
             ? m(
                 'div',
-                {class: 'ah-card ah-mt-4 ah-mb-4'},
-                m('p', {class: 'ah-muted'}, 'No duplicate bitmaps found.'),
+                {class: 'pf-hde-card pf-hde-mt-4 pf-hde-mb-4'},
+                m('p', {class: 'pf-hde-muted'}, 'No duplicate bitmaps found.'),
               )
             : null,
         overview.duplicateStrings && overview.duplicateStrings.length > 0
@@ -410,8 +411,8 @@ function OverviewView(): m.Component<OverviewViewAttrs> {
           : overview.hasFieldValues
             ? m(
                 'div',
-                {class: 'ah-card ah-mb-4'},
-                m('p', {class: 'ah-muted'}, 'No duplicate strings found.'),
+                {class: 'pf-hde-card pf-hde-mb-4'},
+                m('p', {class: 'pf-hde-muted'}, 'No duplicate strings found.'),
               )
             : null,
         overview.duplicateArrays && overview.duplicateArrays.length > 0

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
@@ -78,7 +78,7 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
           return m(
             'button',
             {
-              class: 'ah-link',
+              class: 'pf-hde-link',
               onclick: () =>
                 navigate('object', {
                   id,
@@ -90,7 +90,7 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
             m(
               'span',
               {
-                class: 'ah-mono ah-break-all ah-str-color',
+                class: 'pf-hde-mono pf-hde-break-all pf-hde-str-color',
               },
               str
                 ? '"' +
@@ -214,7 +214,7 @@ function StringsView(): m.Component<StringsViewAttrs> {
       const {navigate} = vnode.attrs;
 
       if (!allRows) {
-        return m('div', {class: 'ah-loading'}, m(Spinner, {easing: true}));
+        return m('div', {class: 'pf-hde-loading'}, m(Spinner, {easing: true}));
       }
 
       if (allRows.length === 0) {
@@ -241,10 +241,10 @@ function StringsView(): m.Component<StringsViewAttrs> {
         {property: 'Total retained', value: fmtSize(totalRetained)},
       ];
 
-      return m('div', {class: 'ah-view-content'}, [
-        m('h2', {class: 'ah-view-heading'}, counter.heading('Strings')),
+      return m('div', {class: 'pf-hde-view-content'}, [
+        m('h2', {class: 'pf-hde-view-heading'}, counter.heading('Strings')),
 
-        m('div', {class: 'ah-card ah-mb-4 ah-flex-none'}, [
+        m('div', {class: 'pf-hde-card pf-hde-mb-4 pf-hde-flex-none'}, [
           m(DataGrid, {
             schema: SUMMARY_SCHEMA,
             rootSchema: 'query',


### PR DESCRIPTION
The HeapDump Explorer plugin is now in line with the repo-wide pf- CSS namespace convention documented in docs/AGENTS-ui.md

Pure rename of every "ah-" / "--ah-" token to "pf-hde-" / "--pf-hde-" across styles.scss and all .ts class strings (no behavioural change).
