### PR TITLE
tp: add new tool for computing lineage of sql modules

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3013,6 +3013,7 @@ cc_test {
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":perfetto_src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
         ":perfetto_src_trace_processor_perfetto_sql_parser_parser",
         ":perfetto_src_trace_processor_perfetto_sql_preprocessor_grammar",
         ":perfetto_src_trace_processor_perfetto_sql_preprocessor_preprocessor",
@@ -16967,12 +16968,19 @@ filegroup {
     name: "perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",
 }
 
+// GN: //src/trace_processor/perfetto_sql/parser:intrinsic_macro_expansion
+filegroup {
+    name: "perfetto_src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
+    srcs: [
+        "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.cc",
+    ],
+}
+
 // GN: //src/trace_processor/perfetto_sql/parser:parser
 filegroup {
     name: "perfetto_src_trace_processor_perfetto_sql_parser_parser",
     srcs: [
         "src/trace_processor/perfetto_sql/parser/function_util.cc",
-        "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.cc",
         "src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.cc",
     ],
 }
@@ -17965,6 +17973,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":perfetto_src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
         ":perfetto_src_trace_processor_perfetto_sql_parser_parser",
         ":perfetto_src_trace_processor_perfetto_sql_preprocessor_grammar",
         ":perfetto_src_trace_processor_perfetto_sql_preprocessor_preprocessor",
@@ -20484,6 +20493,7 @@ cc_test {
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_unittests",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":perfetto_src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
         ":perfetto_src_trace_processor_perfetto_sql_parser_parser",
         ":perfetto_src_trace_processor_perfetto_sql_parser_test_utils",
         ":perfetto_src_trace_processor_perfetto_sql_parser_unittests",
@@ -21433,6 +21443,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":perfetto_src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
         ":perfetto_src_trace_processor_perfetto_sql_parser_parser",
         ":perfetto_src_trace_processor_perfetto_sql_preprocessor_grammar",
         ":perfetto_src_trace_processor_perfetto_sql_preprocessor_preprocessor",
@@ -21997,6 +22008,7 @@ cc_binary_host {
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":perfetto_src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
         ":perfetto_src_trace_processor_perfetto_sql_parser_parser",
         ":perfetto_src_trace_processor_perfetto_sql_preprocessor_grammar",
         ":perfetto_src_trace_processor_perfetto_sql_preprocessor_preprocessor",

--- a/BUILD
+++ b/BUILD
@@ -351,6 +351,28 @@ perfetto_cc_binary(
     ] + PERFETTO_CONFIG.deps.protobuf_full,
 )
 
+# GN target: //src/trace_processor/perfetto_sql/pfsql:pfsql
+perfetto_cc_binary(
+    name = "pfsql",
+    srcs = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_public_abi_base",
+        ":include_perfetto_public_base",
+        ":src_trace_processor_perfetto_sql_lineage_resolver_lineage_resolver",
+        ":src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
+        ":src_trace_processor_perfetto_sql_syntaqlite_syntaqlite",
+        ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_json_serializer",
+        ":src_trace_processor_util_json_value",
+        ":src_trace_processor_util_simple_json_serializer",
+        "src/trace_processor/perfetto_sql/pfsql/main.cc",
+    ],
+    deps = [
+        ":src_base_base",
+    ],
+)
+
 # GN target: //src/trace_processor/rpc:trace_processor_rpc
 perfetto_cc_library(
     name = "trace_processor_rpc",
@@ -424,6 +446,7 @@ perfetto_cc_library(
         ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
         ":src_trace_processor_perfetto_sql_intrinsics_table_functions_tables",
         ":src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
         ":src_trace_processor_perfetto_sql_parser_parser",
         ":src_trace_processor_perfetto_sql_preprocessor_grammar",
         ":src_trace_processor_perfetto_sql_preprocessor_preprocessor",
@@ -651,6 +674,7 @@ perfetto_cc_library(
         ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
         ":src_trace_processor_perfetto_sql_intrinsics_table_functions_tables",
         ":src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
         ":src_trace_processor_perfetto_sql_parser_parser",
         ":src_trace_processor_perfetto_sql_preprocessor_grammar",
         ":src_trace_processor_perfetto_sql_preprocessor_preprocessor",
@@ -3683,14 +3707,30 @@ perfetto_filegroup(
     ],
 )
 
+# GN target: //src/trace_processor/perfetto_sql/lineage_resolver:lineage_resolver
+perfetto_filegroup(
+    name = "src_trace_processor_perfetto_sql_lineage_resolver_lineage_resolver",
+    srcs = [
+        "src/trace_processor/perfetto_sql/lineage_resolver/lineage_resolver.cc",
+        "src/trace_processor/perfetto_sql/lineage_resolver/lineage_resolver.h",
+    ],
+)
+
+# GN target: //src/trace_processor/perfetto_sql/parser:intrinsic_macro_expansion
+perfetto_filegroup(
+    name = "src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
+    srcs = [
+        "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.cc",
+        "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.h",
+    ],
+)
+
 # GN target: //src/trace_processor/perfetto_sql/parser:parser
 perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_parser_parser",
     srcs = [
         "src/trace_processor/perfetto_sql/parser/function_util.cc",
         "src/trace_processor/perfetto_sql/parser/function_util.h",
-        "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.cc",
-        "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.h",
         "src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.cc",
         "src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.h",
     ],
@@ -9364,6 +9404,7 @@ perfetto_cc_library(
         ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
         ":src_trace_processor_perfetto_sql_intrinsics_table_functions_tables",
         ":src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
         ":src_trace_processor_perfetto_sql_parser_parser",
         ":src_trace_processor_perfetto_sql_preprocessor_grammar",
         ":src_trace_processor_perfetto_sql_preprocessor_preprocessor",
@@ -9621,6 +9662,7 @@ perfetto_cc_binary(
         ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
         ":src_trace_processor_perfetto_sql_intrinsics_table_functions_tables",
         ":src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":src_trace_processor_perfetto_sql_parser_intrinsic_macro_expansion",
         ":src_trace_processor_perfetto_sql_parser_parser",
         ":src_trace_processor_perfetto_sql_preprocessor_grammar",
         ":src_trace_processor_perfetto_sql_preprocessor_preprocessor",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -50,6 +50,9 @@ if (enable_perfetto_trace_processor && enable_perfetto_trace_processor_sqlite) {
     all_targets += [ "src/bigtrace/worker:worker_main" ]
   }
   all_targets += [ "src/trace_processor:trace_processor_shell" ]
+  if (perfetto_build_standalone) {
+    all_targets += [ "src/trace_processor/perfetto_sql/pfsql" ]
+  }
 }
 
 if (enable_perfetto_trace_processor) {

--- a/src/trace_processor/perfetto_sql/lineage_resolver/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/lineage_resolver/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/perfetto.gni")
+
+assert(enable_perfetto_trace_processor_sqlite)
+
+# Library: resolves cross-module lineage for PerfettoSQL `.sql` trees. Public
+# API in lineage_resolver.h. Consumed by trace_processor_shell's `analyze
+# lineage` subcommand and available for any other in-tree caller.
+source_set("lineage_resolver") {
+  sources = [
+    "lineage_resolver.cc",
+    "lineage_resolver.h",
+  ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../base",
+    "../parser:intrinsic_macro_expansion",
+    "../syntaqlite",
+  ]
+}

--- a/src/trace_processor/perfetto_sql/lineage_resolver/lineage_resolver.cc
+++ b/src/trace_processor/perfetto_sql/lineage_resolver/lineage_resolver.cc
@@ -1,0 +1,591 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/perfetto_sql/lineage_resolver/lineage_resolver.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.h"
+#include "src/trace_processor/perfetto_sql/syntaqlite/syntaqlite_perfetto.h"
+#include "src/trace_processor/perfetto_sql/syntaqlite/utils.h"
+
+namespace perfetto::trace_processor::lineage_resolver {
+namespace {
+
+using NameSet = std::unordered_set<std::string>;
+
+constexpr std::string_view kPreludePrefix = "prelude.";
+
+bool IsPreludeModule(const std::string& m) {
+  return m.size() >= kPreludePrefix.size() &&
+         std::string_view(m).substr(0, kPreludePrefix.size()) == kPreludePrefix;
+}
+
+// "slices/with_context.sql" → "slices.with_context".
+std::string ModuleNameFromRelPath(const std::string& rel) {
+  std::string r = rel;
+  constexpr std::string_view kSuffix = ".sql";
+  if (r.size() >= kSuffix.size() &&
+      std::string_view(r).substr(r.size() - kSuffix.size()) == kSuffix) {
+    r.resize(r.size() - kSuffix.size());
+  }
+  for (char& c : r) {
+    if (c == '/')
+      c = '.';
+  }
+  return r;
+}
+
+// Raw (unresolved) refs collected from a single CREATE PERFETTO * statement's
+// AST. Materialised into
+// DefinedSymbol::uses/implicit_uses/intrinsics_or_external once the global
+// symbol index is built.
+struct RawRefs {
+  NameSet relation_refs;
+  NameSet function_refs;
+  NameSet macro_invocations;
+};
+
+// A defined symbol as seen during parsing, before resolution.
+struct ScratchSymbol {
+  std::string name;
+  std::string kind;
+  RawRefs refs;
+};
+
+struct ScratchModule {
+  std::string module;
+  std::string path;
+  std::string tree_root;
+  std::vector<ScratchSymbol> symbols;
+  std::vector<std::string> includes;
+  std::vector<std::string> errors;
+};
+
+struct SymbolIndex {
+  struct Origin {
+    std::string module;
+    std::string kind;
+  };
+  base::FlatHashMap<std::string, Origin> by_name;
+};
+
+struct DiscoveredFile {
+  std::string module;
+  std::string tree_root;
+  std::string rel_path;
+};
+
+struct MacroDef {
+  std::string body;
+  std::vector<std::string> param_names;
+  std::vector<const char*> param_name_ptrs;
+  std::vector<SyntaqliteLength> param_name_lens;
+};
+
+class MacroRegistry {
+ public:
+  void Add(std::string name, MacroDef def) {
+    def.param_name_ptrs.clear();
+    def.param_name_lens.clear();
+    def.param_name_ptrs.reserve(def.param_names.size());
+    def.param_name_lens.reserve(def.param_names.size());
+    for (const auto& p : def.param_names) {
+      def.param_name_ptrs.push_back(p.data());
+      def.param_name_lens.push_back(static_cast<SyntaqliteLength>(p.size()));
+    }
+    defs_.Insert(std::move(name), std::move(def));
+  }
+  const MacroDef* Lookup(std::string_view name) const {
+    return defs_.Find(std::string(name));
+  }
+  perfetto_sql::IntrinsicMacroExpander& intrinsics() { return intrinsics_; }
+
+ private:
+  base::FlatHashMap<std::string, MacroDef> defs_;
+  perfetto_sql::IntrinsicMacroExpander intrinsics_;
+};
+
+int MacroLookupCb(void* user_data,
+                  SyntaqliteParser* parser,
+                  const char* name,
+                  SyntaqliteLength name_len,
+                  const SyntaqliteToken* args,
+                  uint32_t arg_count) {
+  auto* reg = static_cast<MacroRegistry*>(user_data);
+  std::string_view nm(name, name_len);
+
+  // 1) Try the real C++-implemented intrinsic macros first — same expander
+  // the runtime preprocessor uses, so expansions are byte-exact.
+  switch (reg->intrinsics().TryExpand(nm, args, arg_count)) {
+    case perfetto_sql::ExpandStatus::kExpanded: {
+      std::string_view body = reg->intrinsics().body();
+      syntaqlite_macro_expansion_set_result(
+          parser, body.data(), static_cast<SyntaqliteLength>(body.size()), 0,
+          0);
+      return SYNTAQLITE_MACRO_LOOKUP_OK;
+    }
+    case perfetto_sql::ExpandStatus::kExpansionFailed:
+      return SYNTAQLITE_MACRO_LOOKUP_ERROR;
+    case perfetto_sql::ExpandStatus::kNotIntrinsic:
+      break;
+  }
+
+  // 2) Fall through to the user macro registry built from `.sql` sources.
+  if (const MacroDef* def = reg->Lookup(nm)) {
+    int rc = syntaqlite_macro_expansion_expand_and_set_result(
+        parser, def->body.data(),
+        static_cast<SyntaqliteLength>(def->body.size()),
+        def->param_name_ptrs.empty() ? nullptr : def->param_name_ptrs.data(),
+        def->param_name_lens.empty() ? nullptr : def->param_name_lens.data(),
+        static_cast<uint32_t>(def->param_names.size()),
+        // Some macros embed runtime `$table` placeholders (resolved at execute
+        // time by the table-pointer scan machinery, not by syntaqlite) — let
+        // them pass through verbatim instead of failing the expansion.
+        SYNTAQLITE_EXPAND_PASSTHROUGH_UNKNOWN);
+    return rc < 0 ? SYNTAQLITE_MACRO_LOOKUP_ERROR : SYNTAQLITE_MACRO_LOOKUP_OK;
+  }
+  return SYNTAQLITE_MACRO_LOOKUP_NOT_FOUND;
+}
+
+struct ParserDeleter {
+  void operator()(SyntaqliteParser* p) const { syntaqlite_parser_destroy(p); }
+};
+using ScopedParser = std::unique_ptr<SyntaqliteParser, ParserDeleter>;
+
+std::string SpanString(SyntaqliteParser* p, SyntaqliteTextSpan span) {
+  // Macro-arg drill-through can hand us spans with surrounding whitespace
+  // (authored arg text is verbatim). Trim so identifiers compare cleanly.
+  return std::string(base::TrimWhitespace(SyntaqliteSpanText(p, span)));
+}
+
+ScopedParser MakeParser(MacroRegistry* registry_for_lookup) {
+  ScopedParser p(syntaqlite_parser_create_with_dialect(
+      nullptr, syntaqlite_perfetto_dialect()));
+  PERFETTO_CHECK(p != nullptr);
+  syntaqlite_parser_set_macro_fallback(p.get(), 1);
+  if (registry_for_lookup) {
+    syntaqlite_parser_set_macro_lookup(p.get(), &MacroLookupCb,
+                                       registry_for_lookup);
+  }
+  return p;
+}
+
+void ExtractMacroParamNames(SyntaqliteParser* p,
+                            uint32_t arg_list_id,
+                            std::vector<std::string>& out) {
+  if (!syntaqlite_node_is_present(arg_list_id))
+    return;
+  const auto* list = static_cast<const SyntaqlitePerfettoMacroArgList*>(
+      syntaqlite_parser_node(p, arg_list_id));
+  uint32_t count = syntaqlite_list_count(list);
+  out.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    uint32_t id = syntaqlite_list_child_id(list, i);
+    if (!syntaqlite_node_is_present(id))
+      continue;
+    const auto* item = static_cast<const SyntaqlitePerfettoMacroArg*>(
+        syntaqlite_parser_node(p, id));
+    if (!item)
+      continue;
+    out.emplace_back(SpanString(p, item->arg_name));
+  }
+}
+
+// Walk every node in the current statement's arena and harvest references
+// into `out`. CTE-local names are filtered out via a scratch set.
+void CollectStatementRefs(SyntaqliteParser* p, RawRefs& out) {
+  NameSet cte_locals;
+  uint32_t n = syntaqlite_parser_node_count(p);
+  for (uint32_t id = 1; id < n; ++id) {
+    if (!syntaqlite_node_is_present(id))
+      continue;
+    const auto* node =
+        static_cast<const SyntaqliteNode*>(syntaqlite_parser_node(p, id));
+    if (node && node->tag == SYNTAQLITE_NODE_CTE_DEFINITION) {
+      cte_locals.insert(SpanString(p, node->cte_definition.cte_name));
+    }
+  }
+  for (uint32_t id = 1; id < n; ++id) {
+    if (!syntaqlite_node_is_present(id))
+      continue;
+    const auto* node =
+        static_cast<const SyntaqliteNode*>(syntaqlite_parser_node(p, id));
+    if (!node)
+      continue;
+    switch (static_cast<int>(node->tag)) {
+      case SYNTAQLITE_NODE_TABLE_REF: {
+        std::string name = SpanString(p, node->table_ref.table_name);
+        auto bang = name.find('!');
+        if (bang != std::string::npos) {
+          out.macro_invocations.insert(name.substr(0, bang));
+          break;
+        }
+        if (name.empty() || cte_locals.count(name))
+          break;
+        out.relation_refs.insert(std::move(name));
+        break;
+      }
+      case SYNTAQLITE_NODE_FUNCTION_CALL:
+      case SYNTAQLITE_NODE_AGGREGATE_FUNCTION_CALL:
+      case SYNTAQLITE_NODE_ORDERED_SET_FUNCTION_CALL: {
+        SyntaqliteTextSpan span =
+            node->tag == SYNTAQLITE_NODE_FUNCTION_CALL
+                ? node->function_call.func_name
+                : (node->tag == SYNTAQLITE_NODE_AGGREGATE_FUNCTION_CALL
+                       ? node->aggregate_function_call.func_name
+                       : node->ordered_set_function_call.func_name);
+        std::string name = SpanString(p, span);
+        if (name.empty())
+          break;
+        auto bang = name.find('!');
+        if (bang != std::string::npos) {
+          out.macro_invocations.insert(name.substr(0, bang));
+          break;
+        }
+        out.function_refs.insert(std::move(name));
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  uint32_t rw_count = syntaqlite_result_macro_count(p);
+  for (uint32_t i = 0; i < rw_count; ++i) {
+    SyntaqliteMacroRewrite rw = syntaqlite_result_macro_rewrite_at(p, i);
+    if (rw.name && rw.name_len > 0)
+      out.macro_invocations.emplace(rw.name, rw.name_len);
+  }
+}
+
+base::Status DiscoverTree(const std::string& root,
+                          std::vector<DiscoveredFile>& out) {
+  std::string trimmed = root;
+  while (!trimmed.empty() && trimmed.back() == '/')
+    trimmed.pop_back();
+  std::vector<std::string> all;
+  if (auto st = base::ListFilesRecursive(trimmed, all); !st.ok())
+    return st;
+  for (auto& rel : all) {
+    if (rel.size() < 4 || rel.compare(rel.size() - 4, 4, ".sql") != 0)
+      continue;
+    out.push_back({ModuleNameFromRelPath(rel), trimmed, std::move(rel)});
+  }
+  return base::OkStatus();
+}
+
+// Pass A: walk every file once to collect macro bodies (for the expansion
+// registry) and all top-level defined-symbol names (for the global symbol
+// index). We do NOT call CollectStatementRefs here — refs are gathered in
+// pass B once macros can be expanded.
+void PassA(const DiscoveredFile& f, ScratchModule& m, MacroRegistry& registry) {
+  m.module = f.module;
+  m.path = f.rel_path;
+  m.tree_root = f.tree_root;
+
+  std::string sql;
+  if (!base::ReadFile(f.tree_root + "/" + f.rel_path, &sql)) {
+    m.errors.push_back("failed to read file");
+    return;
+  }
+  ScopedParser owned = MakeParser(/*registry_for_lookup=*/nullptr);
+  SyntaqliteParser* p = owned.get();
+  syntaqlite_parser_reset(p, sql.data(), static_cast<uint32_t>(sql.size()));
+
+  for (;;) {
+    int32_t rc = syntaqlite_parser_next(p);
+    if (rc == SYNTAQLITE_PARSE_DONE)
+      break;
+    if (rc == SYNTAQLITE_PARSE_ERROR) {
+      const char* msg = syntaqlite_result_error_msg(p);
+      m.errors.push_back(msg ? std::string("passA: ") + msg
+                             : std::string("passA: unknown parse error"));
+      continue;
+    }
+    uint32_t root = syntaqlite_result_root(p);
+    if (!syntaqlite_node_is_present(root))
+      continue;
+    const auto* node =
+        static_cast<const SyntaqliteNode*>(syntaqlite_parser_node(p, root));
+    if (!node)
+      continue;
+    auto push_symbol = [&](std::string name, const char* kind) {
+      ScratchSymbol s;
+      s.name = std::move(name);
+      s.kind = kind;
+      m.symbols.push_back(std::move(s));
+    };
+    switch (static_cast<int>(node->tag)) {
+      case SYNTAQLITE_NODE_INCLUDE_PERFETTO_MODULE_STMT:
+        m.includes.push_back(
+            SpanString(p, node->include_perfetto_module_stmt.module_name));
+        break;
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_TABLE_STMT:
+        push_symbol(SpanString(p, node->create_perfetto_table_stmt.table_name),
+                    "table");
+        break;
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_VIEW_STMT:
+        push_symbol(SpanString(p, node->create_perfetto_view_stmt.view_name),
+                    "view");
+        break;
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_FUNCTION_STMT:
+        push_symbol(
+            SpanString(p, node->create_perfetto_function_stmt.function_name),
+            "function");
+        break;
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_DELEGATING_FUNCTION_STMT:
+        push_symbol(
+            SpanString(
+                p,
+                node->create_perfetto_delegating_function_stmt.function_name),
+            "function");
+        break;
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_MACRO_STMT: {
+        const auto& n = node->create_perfetto_macro_stmt;
+        std::string name = SpanString(p, n.macro_name);
+        push_symbol(name, "macro");
+        MacroDef def;
+        def.body = SpanString(p, n.body);
+        ExtractMacroParamNames(p, n.args, def.param_names);
+        registry.Add(std::move(name), std::move(def));
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}
+
+// Pass B: re-parse with the macro lookup callback so invocations expand and
+// references inside macro bodies flow into the AST. For each defining
+// statement, attach its arena's refs to the matching ScratchSymbol (matched
+// by source-order index).
+void PassB(const DiscoveredFile& f, MacroRegistry& registry, ScratchModule& m) {
+  std::string sql;
+  if (!base::ReadFile(f.tree_root + "/" + f.rel_path, &sql)) {
+    m.errors.push_back("failed to read file (passB)");
+    return;
+  }
+  ScopedParser owned = MakeParser(&registry);
+  SyntaqliteParser* p = owned.get();
+  syntaqlite_parser_reset(p, sql.data(), static_cast<uint32_t>(sql.size()));
+
+  size_t sym_idx = 0;
+  for (;;) {
+    int32_t rc = syntaqlite_parser_next(p);
+    if (rc == SYNTAQLITE_PARSE_DONE)
+      break;
+    if (rc == SYNTAQLITE_PARSE_ERROR) {
+      const char* msg = syntaqlite_result_error_msg(p);
+      m.errors.push_back(msg ? std::string("passB: ") + msg
+                             : std::string("passB: unknown parse error"));
+      continue;
+    }
+    uint32_t root = syntaqlite_result_root(p);
+    if (!syntaqlite_node_is_present(root))
+      continue;
+    const auto* node =
+        static_cast<const SyntaqliteNode*>(syntaqlite_parser_node(p, root));
+    if (!node)
+      continue;
+    switch (static_cast<int>(node->tag)) {
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_TABLE_STMT:
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_VIEW_STMT:
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_FUNCTION_STMT:
+        // The bodies of these have refs we care about. Match by source-order
+        // index against the symbols we collected in pass A.
+        if (sym_idx < m.symbols.size())
+          CollectStatementRefs(p, m.symbols[sym_idx].refs);
+        ++sym_idx;
+        break;
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_DELEGATING_FUNCTION_STMT:
+      case SYNTAQLITE_NODE_CREATE_PERFETTO_MACRO_STMT:
+        // No body refs to collect; still advance the symbol cursor so later
+        // entries stay aligned with pass A's order.
+        ++sym_idx;
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+DefinedSymbol Materialise(const ScratchSymbol& scratch,
+                          const std::string& self_module,
+                          const SymbolIndex& idx,
+                          NameSet& touched_non_prelude_modules) {
+  DefinedSymbol out;
+  out.name = scratch.name;
+  out.kind = scratch.kind;
+
+  auto resolve = [&](const std::string& name) {
+    auto* o = idx.by_name.Find(name);
+    if (!o) {
+      out.intrinsics_or_external.insert(name);
+      return;
+    }
+    if (o->module == self_module)
+      return;  // Self-reference; ignore.
+    SymbolRefsByModule& bucket_map =
+        IsPreludeModule(o->module) ? out.implicit_uses : out.uses;
+    auto* bucket = bucket_map.Find(o->module);
+    if (!bucket) {
+      bucket_map.Insert(o->module, std::vector<SymbolRef>{});
+      bucket = bucket_map.Find(o->module);
+    }
+    bucket->push_back({name, o->kind});
+    if (!IsPreludeModule(o->module))
+      touched_non_prelude_modules.insert(o->module);
+  };
+  for (const auto& n : scratch.refs.relation_refs)
+    resolve(n);
+  for (const auto& n : scratch.refs.function_refs)
+    resolve(n);
+  for (const auto& n : scratch.refs.macro_invocations)
+    resolve(n);
+  return out;
+}
+
+// Two modules defining the same name is a bug — the runtime engine would
+// reject it. Surface it loudly by appending an error to every involved
+// module's errors list. Resolution itself uses first-defined-wins (which
+// is deterministic given the sorted file order), but any collision entry
+// here means the source needs fixing.
+void FlagSymbolCollisions(std::vector<ScratchModule>& modules) {
+  // name → indices into |modules| that define it.
+  base::FlatHashMap<std::string, std::vector<size_t>> definers_by_name;
+  for (size_t i = 0; i < modules.size(); ++i) {
+    for (const auto& s : modules[i].symbols) {
+      auto* v = definers_by_name.Find(s.name);
+      if (!v) {
+        definers_by_name.Insert(s.name, std::vector<size_t>{});
+        v = definers_by_name.Find(s.name);
+      }
+      v->push_back(i);
+    }
+  }
+  for (auto it = definers_by_name.GetIterator(); it; ++it) {
+    const auto& defining_indices = it.value();
+    if (defining_indices.size() < 2)
+      continue;
+    for (size_t i : defining_indices) {
+      std::string msg =
+          "symbol collision: '" + it.key() + "' is also defined in";
+      bool first = true;
+      for (size_t j : defining_indices) {
+        if (j == i)
+          continue;
+        msg += first ? " " : ", ";
+        msg += modules[j].module;
+        first = false;
+      }
+      modules[i].errors.push_back(std::move(msg));
+    }
+  }
+}
+
+ResolvedModule MaterialiseModule(const ScratchModule& m,
+                                 const SymbolIndex& idx) {
+  ResolvedModule out;
+  out.module = m.module;
+  out.path = m.path;
+  out.tree_root = m.tree_root;
+  out.declared_includes = m.includes;
+  out.errors = m.errors;
+
+  NameSet touched_non_prelude_modules;
+  out.symbols.reserve(m.symbols.size());
+  for (const auto& s : m.symbols) {
+    out.symbols.push_back(
+        Materialise(s, m.module, idx, touched_non_prelude_modules));
+  }
+
+  NameSet declared(m.includes.begin(), m.includes.end());
+  for (const auto& mod : touched_non_prelude_modules) {
+    if (!declared.count(mod))
+      out.missing_includes.push_back(mod);
+  }
+  std::sort(out.missing_includes.begin(), out.missing_includes.end());
+  return out;
+}
+
+}  // namespace
+
+void Resolver::AddTreeRoot(std::string absolute_root) {
+  tree_roots_.push_back(std::move(absolute_root));
+}
+
+std::vector<ResolvedModule> Resolver::Resolve() {
+  std::vector<DiscoveredFile> files;
+  for (const auto& root : tree_roots_) {
+    auto st = DiscoverTree(root, files);
+    PERFETTO_DCHECK(st.ok());
+    (void)st;
+  }
+  std::sort(files.begin(), files.end(),
+            [](const DiscoveredFile& a, const DiscoveredFile& b) {
+              return a.module < b.module;
+            });
+  {
+    std::vector<DiscoveredFile> deduped;
+    NameSet seen;
+    for (auto& f : files) {
+      if (seen.insert(f.module).second)
+        deduped.push_back(std::move(f));
+    }
+    files = std::move(deduped);
+  }
+
+  MacroRegistry registry;
+  std::vector<ScratchModule> scratch(files.size());
+  for (size_t i = 0; i < files.size(); ++i)
+    PassA(files[i], scratch[i], registry);
+
+  // Global symbol index — first-defined wins (deterministic given the sorted
+  // file order). Collisions are flagged separately as errors on every
+  // involved module.
+  SymbolIndex idx;
+  for (const auto& m : scratch) {
+    for (const auto& s : m.symbols) {
+      if (!idx.by_name.Find(s.name))
+        idx.by_name.Insert(s.name, SymbolIndex::Origin{m.module, s.kind});
+    }
+  }
+  FlagSymbolCollisions(scratch);
+
+  for (size_t i = 0; i < files.size(); ++i)
+    PassB(files[i], registry, scratch[i]);
+
+  std::vector<ResolvedModule> out;
+  out.reserve(scratch.size());
+  for (const auto& m : scratch)
+    out.push_back(MaterialiseModule(m, idx));
+  return out;
+}
+
+}  // namespace perfetto::trace_processor::lineage_resolver

--- a/src/trace_processor/perfetto_sql/lineage_resolver/lineage_resolver.h
+++ b/src/trace_processor/perfetto_sql/lineage_resolver/lineage_resolver.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_LINEAGE_RESOLVER_LINEAGE_RESOLVER_H_
+#define SRC_TRACE_PROCESSOR_PERFETTO_SQL_LINEAGE_RESOLVER_LINEAGE_RESOLVER_H_
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "perfetto/ext/base/flat_hash_map.h"
+
+namespace perfetto::trace_processor::lineage_resolver {
+
+// A reference to a symbol defined by another module.
+struct SymbolRef {
+  std::string name;
+  std::string kind;  // "table" | "view" | "function" | "macro"
+};
+
+// Cross-module references bucketed by the dotted module name that defines
+// them, e.g. { "slices.with_context": [{name:"thread_slice", kind:"view"}] }.
+using SymbolRefsByModule =
+    base::FlatHashMap<std::string, std::vector<SymbolRef>>;
+
+// One CREATE PERFETTO {TABLE,VIEW,FUNCTION,MACRO} in a module, with its
+// own resolved dependencies. Macro invocations are recorded under `uses`
+// alongside table/view/function refs; through macro expansion, references
+// from inside macro bodies appear here too (attributed to the symbol that
+// invoked the macro).
+struct DefinedSymbol {
+  std::string name;
+  std::string kind;  // "table" | "view" | "function" | "macro"
+
+  // Resolved cross-module references, grouped by defining module.
+  SymbolRefsByModule uses;
+  // Same shape but for modules under prelude.* (auto-loaded by the runtime).
+  SymbolRefsByModule implicit_uses;
+  // Names referenced but not defined by any module in the configured trees —
+  // typically C++ tables/functions, SQLite builtins, etc.
+  std::unordered_set<std::string> intrinsics_or_external;
+};
+
+// All the lineage info for a single .sql module.
+struct ResolvedModule {
+  // Dotted module name (e.g. "slices.with_context").
+  std::string module;
+  // Path relative to the owning tree (e.g. "slices/with_context.sql").
+  std::string path;
+  // Absolute root of the tree this module came from.
+  std::string tree_root;
+
+  // One entry per CREATE PERFETTO {TABLE,VIEW,FUNCTION,MACRO} in the file,
+  // in source order.
+  std::vector<DefinedSymbol> symbols;
+
+  // INCLUDE PERFETTO MODULE statements as authored.
+  std::vector<std::string> declared_includes;
+  // Non-prelude modules used by any symbol but not in declared_includes.
+  std::vector<std::string> missing_includes;
+
+  // Per-statement parse errors. Empty on success.
+  std::vector<std::string> errors;
+};
+
+// Resolves cross-module lineage for one or more trees of PerfettoSQL files.
+//
+// Treats `prelude.*` modules as implicitly available (the runtime engine
+// auto-loads them, so callers needn't `INCLUDE` them). Expands `__intrinsic_*`
+// macros using the same C++ expander the engine uses at runtime; expands user
+// macros from the configured trees recursively, so references inside macro
+// bodies appear in the resolved record of whoever invoked the macro.
+//
+// Usage:
+//   Resolver r;
+//   r.AddTreeRoot("/path/to/stdlib");
+//   r.AddTreeRoot("/path/to/other");
+//   for (const ResolvedModule& m : r.Resolve()) { ... }
+class Resolver {
+ public:
+  // Adds an absolute tree root to discover .sql files in. The path within
+  // the tree determines the module name (`/` → `.`, `.sql` stripped). All
+  // trees share one module namespace; first-added-wins on name collisions.
+  void AddTreeRoot(std::string absolute_root);
+
+  // Discovers files, parses, resolves. Returns one record per module sorted
+  // by module name.
+  std::vector<ResolvedModule> Resolve();
+
+ private:
+  std::vector<std::string> tree_roots_;
+};
+
+}  // namespace perfetto::trace_processor::lineage_resolver
+
+#endif  // SRC_TRACE_PROCESSOR_PERFETTO_SQL_LINEAGE_RESOLVER_LINEAGE_RESOLVER_H_

--- a/src/trace_processor/perfetto_sql/parser/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/parser/BUILD.gn
@@ -16,16 +16,27 @@ import("../../../../gn/test.gni")
 
 assert(enable_perfetto_trace_processor_sqlite)
 
+source_set("intrinsic_macro_expansion") {
+  sources = [
+    "intrinsic_macro_expansion.cc",
+    "intrinsic_macro_expansion.h",
+  ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../base",
+    "../syntaqlite",
+  ]
+}
+
 source_set("parser") {
   sources = [
     "function_util.cc",
     "function_util.h",
-    "intrinsic_macro_expansion.cc",
-    "intrinsic_macro_expansion.h",
     "perfetto_sql_parser.cc",
     "perfetto_sql_parser.h",
   ]
   deps = [
+    ":intrinsic_macro_expansion",
     "../..:metatrace",
     "../../../../gn:default_deps",
     "../../../../gn:sqlite",

--- a/src/trace_processor/perfetto_sql/pfsql/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/pfsql/BUILD.gn
@@ -1,0 +1,31 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/perfetto.gni")
+import("../../../../gn/perfetto_host_executable.gni")
+
+assert(enable_perfetto_trace_processor_sqlite)
+
+# pfsql: standalone offline CLI for working with PerfettoSQL source files.
+# Not part of trace_processor_shell — pfsql does not load traces.
+perfetto_host_executable("pfsql") {
+  sources = [ "main.cc" ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../base",
+    "../../util:json_value",
+    "../../util:simple_json_serializer",
+    "../lineage_resolver",
+  ]
+}

--- a/src/trace_processor/perfetto_sql/pfsql/main.cc
+++ b/src/trace_processor/perfetto_sql/pfsql/main.cc
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// pfsql: offline tool for working with PerfettoSQL source files. Does not
+// load a trace. Each subcommand defines its own input shape.
+//
+// Subcommands:
+//   lineage   Cross-module dependency graph over `.sql` trees.
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/getopt.h"
+#include "src/trace_processor/perfetto_sql/lineage_resolver/lineage_resolver.h"
+#include "src/trace_processor/util/json_value.h"
+#include "src/trace_processor/util/simple_json_serializer.h"
+
+namespace perfetto::trace_processor::pfsql {
+namespace {
+
+// ---------- lineage subcommand ----------
+
+std::string DirOf(const std::string& path) {
+  auto slash = path.find_last_of('/');
+  return slash == std::string::npos ? std::string(".") : path.substr(0, slash);
+}
+
+std::string ResolvePath(const std::string& base_dir, const std::string& p) {
+  return (!p.empty() && p[0] == '/') ? p : base_dir + "/" + p;
+}
+
+base::Status LoadConfig(const std::string& config_path,
+                        lineage_resolver::Resolver& resolver) {
+  std::string text;
+  if (!base::ReadFile(config_path, &text))
+    return base::ErrStatus("failed to read config %s", config_path.c_str());
+  auto parsed = json::Parse(text);
+  if (!parsed.ok())
+    return base::ErrStatus("invalid JSON in %s: %s", config_path.c_str(),
+                           parsed.status().c_message());
+  const json::Dom& doc = *parsed;
+  if (!doc.IsObject() || !doc.HasMember("trees") || !doc["trees"].IsArray())
+    return base::ErrStatus("config must be { \"trees\": [ ... ] }");
+  const std::string base_dir = DirOf(config_path);
+  bool empty = true;
+  for (const auto& t : doc["trees"]) {
+    std::string root;
+    if (t.IsString()) {
+      root = t.AsString();
+    } else if (t.IsObject() && t.HasMember("root") && t["root"].IsString()) {
+      root = t["root"].AsString();
+    } else {
+      return base::ErrStatus(
+          "each tree must be a string or { \"root\": \"...\" }");
+    }
+    resolver.AddTreeRoot(ResolvePath(base_dir, root));
+    empty = false;
+  }
+  return empty ? base::ErrStatus("config has no trees") : base::OkStatus();
+}
+
+// Snapshot a SymbolRefsByModule into a sorted vector so JSON output is stable.
+using SortedUseEntry =
+    std::pair<std::string, const std::vector<lineage_resolver::SymbolRef>*>;
+std::vector<SortedUseEntry> SortedUses(
+    const lineage_resolver::SymbolRefsByModule& by_mod) {
+  std::vector<SortedUseEntry> out;
+  for (auto it = by_mod.GetIterator(); it; ++it)
+    out.emplace_back(it.key(), &it.value());
+  std::sort(out.begin(), out.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
+  return out;
+}
+
+std::vector<std::string> SortedStrings(
+    const std::unordered_set<std::string>& set) {
+  std::vector<std::string> out(set.begin(), set.end());
+  std::sort(out.begin(), out.end());
+  return out;
+}
+
+std::string EmitLineageJson(
+    const std::vector<lineage_resolver::ResolvedModule>& ms) {
+  auto write_strings = [](const auto& items) {
+    return [&items](json::JsonArraySerializer& a) {
+      for (const auto& s : items)
+        a.AppendString(s);
+    };
+  };
+  auto write_use_map = [](const lineage_resolver::SymbolRefsByModule& by_mod) {
+    auto sorted = SortedUses(by_mod);
+    return [sorted = std::move(sorted)](json::JsonDictSerializer& d) {
+      for (const auto& kv : sorted) {
+        d.AddArray(kv.first, [&kv](json::JsonArraySerializer& a) {
+          for (const auto& u : *kv.second) {
+            a.AppendDict([&u](json::JsonDictSerializer& e) {
+              e.AddString("name", u.name);
+              e.AddString("kind", u.kind);
+            });
+          }
+        });
+      }
+    };
+  };
+
+  std::string out = json::SerializeJson([&](json::JsonValueSerializer&& w) {
+    std::move(w).WriteDict([&](json::JsonDictSerializer& root) {
+      root.AddArray("modules", [&](json::JsonArraySerializer& arr) {
+        for (const auto& m : ms) {
+          arr.AppendDict([&](json::JsonDictSerializer& mod) {
+            mod.AddString("module", m.module);
+            mod.AddString("path", m.path);
+            mod.AddArray("declared_includes",
+                         write_strings(m.declared_includes));
+            mod.AddArray("symbols", [&](json::JsonArraySerializer& syms) {
+              for (const auto& s : m.symbols) {
+                syms.AppendDict([&](json::JsonDictSerializer& sd) {
+                  sd.AddString("name", s.name);
+                  sd.AddString("kind", s.kind);
+                  sd.AddDict("uses", write_use_map(s.uses));
+                  sd.AddDict("implicit_uses", write_use_map(s.implicit_uses));
+                  sd.AddArray(
+                      "intrinsics_or_external",
+                      write_strings(SortedStrings(s.intrinsics_or_external)));
+                });
+              }
+            });
+            mod.AddArray("missing_includes", write_strings(m.missing_includes));
+            mod.AddArray("errors", write_strings(m.errors));
+          });
+        }
+      });
+    });
+  });
+  out.push_back('\n');
+  return out;
+}
+
+const char* kLineageHelp = R"(Usage:
+  pfsql lineage <tree_path>...
+  pfsql lineage --config <file.json>
+
+Cross-module dependency graph over PerfettoSQL `.sql` trees. Input is given
+EITHER as positional tree paths (resolved against the CWD) OR as a JSON
+config (not both). The JSON shape is:
+  { "trees": [ "path/to/stdlib",
+               { "root": "path/to/other" } ] }
+Paths inside the JSON are resolved against the config's dir.
+
+All trees share one module namespace; the path within each tree determines
+the dotted module name (`slices/with_context.sql` -> `slices.with_context`).
+First-tree-wins on name collisions.
+
+Anything under `prelude.*` is treated as auto-included (the runtime engine
+auto-loads it). Macros are expanded recursively — references inside macro
+bodies surface in the resolved record of the invoking symbol.
+
+Output: a single JSON object on stdout with a `modules` array, one entry per
+module:
+  - module / path
+  - declared_includes:  authored INCLUDE PERFETTO MODULE stmts
+  - symbols:            one entry per CREATE PERFETTO
+                        TABLE/VIEW/FUNCTION/MACRO, in source order. Each
+                        carries its OWN:
+                          - name / kind
+                          - uses:           cross-module refs by defining
+                                            module
+                          - implicit_uses:  refs into prelude.*
+                          - intrinsics_or_external:
+                                            bare names not defined anywhere
+  - missing_includes:   non-prelude modules used by any symbol but not
+                        declared
+  - errors:             parse errors or symbol-name collisions
+)";
+
+int RunLineage(int argc, char** argv) {
+  std::string config_path;
+  static const option long_opts[] = {
+      {"config", required_argument, nullptr, 'c'},
+      {"help", no_argument, nullptr, 'h'},
+      {nullptr, 0, nullptr, 0}};
+  optind = 1;  // restart getopt
+  for (;;) {
+    int c = getopt_long(argc, argv, "c:h", long_opts, nullptr);
+    if (c < 0)
+      break;
+    if (c == 'c') {
+      config_path = optarg;
+    } else if (c == 'h') {
+      fputs(kLineageHelp, stdout);
+      return 0;
+    } else {
+      fputs(kLineageHelp, stderr);
+      return 1;
+    }
+  }
+  std::vector<std::string> tree_paths;
+  for (int i = optind; i < argc; ++i)
+    tree_paths.emplace_back(argv[i]);
+
+  const bool have_config = !config_path.empty();
+  const bool have_paths = !tree_paths.empty();
+  if (have_config && have_paths) {
+    fprintf(stderr,
+            "pfsql lineage: pass either positional tree paths or --config, "
+            "not both\n");
+    return 1;
+  }
+  if (!have_config && !have_paths) {
+    fprintf(stderr,
+            "pfsql lineage: expected one or more tree paths, or --config "
+            "FILE\n");
+    return 1;
+  }
+
+  lineage_resolver::Resolver resolver;
+  if (have_config) {
+    if (auto st = LoadConfig(config_path, resolver); !st.ok()) {
+      fprintf(stderr, "%s\n", st.c_message());
+      return 1;
+    }
+  } else {
+    for (const auto& p : tree_paths)
+      resolver.AddTreeRoot(p);
+  }
+  std::string s = EmitLineageJson(resolver.Resolve());
+  fwrite(s.data(), 1, s.size(), stdout);
+  return 0;
+}
+
+// ---------- top-level dispatcher ----------
+
+const char* kTopLevelHelp =
+    R"(pfsql: offline tool for working with PerfettoSQL.
+
+Usage: pfsql <subcommand> [args]
+
+Subcommands:
+  lineage   Cross-module dependency graph over `.sql` trees.
+
+Run 'pfsql <subcommand> --help' for subcommand details.
+)";
+
+int Main(int argc, char** argv) {
+  if (argc < 2) {
+    fputs(kTopLevelHelp, stderr);
+    return 1;
+  }
+  std::string_view sub(argv[1]);
+  if (sub == "-h" || sub == "--help" || sub == "help") {
+    fputs(kTopLevelHelp, stdout);
+    return 0;
+  }
+  if (sub == "lineage") {
+    // Shift argv so getopt sees `pfsql lineage [args]` as `lineage [args]`.
+    return RunLineage(argc - 1, argv + 1);
+  }
+  fprintf(stderr, "pfsql: unknown subcommand '%.*s'\n\n",
+          static_cast<int>(sub.size()), sub.data());
+  fputs(kTopLevelHelp, stderr);
+  return 1;
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::pfsql
+
+int main(int argc, char** argv) {
+  return perfetto::trace_processor::pfsql::Main(argc, argv);
+}

--- a/src/trace_processor/perfetto_sql/syntaqlite/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/syntaqlite/BUILD.gn
@@ -28,6 +28,7 @@ source_set("syntaqlite") {
   deps = [ "../../../../gn:default_deps" ]
   visibility = [
     "../../util:sql_module_doc_parser",
+    "../lineage_resolver:lineage_resolver",
     "../parser:*",
     "../tokenizer",
   ]
@@ -41,12 +42,10 @@ if (perfetto_build_standalone) {
   shared_library("perfetto_fmt_dialect") {
     sources = _syntaqlite_sources
     deps = [ "../../../../gn:default_deps" ]
-
-    # `SYNTAQLITE_SHARED` makes `SYNTAQLITE_API` expand to
-    # `visibility("default")`, exporting the public C API (including the
-    # `syntaqlite_perfetto_dialect_template` entry point the CLI dlsyms)
-    # while the `visibility_hidden` config keeps everything else hidden.
-    defines = [ "SYNTAQLITE_SHARED" ]
+    defines = [
+      "SYNTAQLITE_SHARED",
+      "SYNTAQLITE_OMIT_RUNTIME",
+    ]
     if (is_mac) {
       ldflags = [ "-Wl,-undefined,dynamic_lookup" ]
     }

--- a/tools/gen_bazel
+++ b/tools/gen_bazel
@@ -118,6 +118,7 @@ default_targets = [
     '//src/tools/proto_filter:proto_filter',
     '//src/tools/proto_merger:proto_merger',
     '//src/trace_processor:trace_processor_shell_lib',
+    '//src/trace_processor/perfetto_sql/pfsql:pfsql',
     '//src/trace_processor/rpc:trace_processor_rpc',
     '//test:client_api_example',
 ] + public_targets + allowlist_public_targets


### PR DESCRIPTION
Allows for fetching the depednency graph to do analysis of private/public
depdenencies etc allowing for better architected modules.

This tool is a temporary thing and might well disappear and be replaced
with the syntaqlite CLI directly. I want to evolve this first and then
see if it is better placed upstream or here. I think it will go upstream
but I can iterate faster if it lives here.
