### PR TITLE
perfetto: declare empty permissions for pr-branch-check workflow

### DIFF
--- a/.github/workflows/pr-branch-check.yml
+++ b/.github/workflows/pr-branch-check.yml
@@ -24,6 +24,8 @@ on:
     branches:
       - dev/**/*
 
+permissions: {}
+
 jobs:
   pr-branch-check:
     if: startsWith(github.base_ref, 'dev/')


### PR DESCRIPTION
The single job in `pr-branch-check.yml` only inspects `github.base_ref` and exits 1 if a PR targets a `dev/` branch. No checkout, no API calls, no writes. `permissions: {}` matches the pattern that `cut-canary.yml` and `promote-stable.yml` already use in this repo.

YAML parses.