### PR TITLE
perfetto: fix typos in design, contributing, and analysis docs

### DIFF
--- a/docs/AGENTS-ui.md
+++ b/docs/AGENTS-ui.md
@@ -42,7 +42,7 @@ To build and serve the UI for development:
 ```sh
 # From the repository root
 ui/build    # Builds the UI.
-ui/build --typecheck # Run tsc --noEmit, does't bundle (faster).
+ui/build --typecheck # Run tsc --noEmit, doesn't bundle (faster).
 ui/run-dev-server    # Starts the development server with live reload.
 ```
 
@@ -228,7 +228,7 @@ async onTraceLoad(trace: Trace): Promise<void> {
 
 ## Track creation
 
-Rarely you need to create a new Track from scrach.
+Rarely you need to create a new Track from scratch.
 In most cases you can use higher level components in ui/src/components/tracks/, especially DatasetSliceTrack (examples in /docs/contributing/ui-plugins.md).
 Look at those examples first and keep creating a track via trace.tracks.registerTrack as a last-resort.
 

--- a/docs/analysis/perfetto-sql-syntax.md
+++ b/docs/analysis/perfetto-sql-syntax.md
@@ -13,7 +13,7 @@ tooling e.g. it cannot be used to create efficient analytic tables, import
 modules from the PerfettoSQL standard library etc.
 
 For this reason, PerfettoSQL adds new pieces of syntax which make the experience
-of writing SQL queries better. All such additons include the keyword `PERFETTO`
+of writing SQL queries better. All such additions include the keyword `PERFETTO`
 to make it clear that they are PerfettoSQL-only.
 
 <!-- TODO(b/290185551): we should really talk about our "recommendations" (e.g.
@@ -71,7 +71,7 @@ schemas, function arguments and return types:
 | `ARGSETID` | An identifier for a set of arguments. This set can be obtained by joining with an `args` table on `arg_set_id` column. |
 | `ID` | An ID column for this table. Each table can have only one ID column, whose values should be unique and fit into `uint32`. |
 | `JOINID(table.column)` | A foreign key reference into a given table. `table` should exist, should have column named `column` of type `ID`. |
-| `ID(table.column)` | A variant of the `ID` type, which is both primary key for this table and simultaneusly is a foreign key reference into another table. Useful when a given table is based on a subset of rows from another table (e.g. `slice`). |
+| `ID(table.column)` | A variant of the `ID` type, which is both primary key for this table and simultaneously is a foreign key reference into another table. Useful when a given table is based on a subset of rows from another table (e.g. `slice`). |
 
 ## Defining functions
 `CREATE PEFETTO FUNCTION` allows functions to be defined in SQL, which can be
@@ -186,7 +186,7 @@ CREATE OR REPLACE PERFETTO INDEX foo_track_and_name ON foo(track_id, name);
 
 The performance of those two queries should be very different now:
 ```sql
--- This doesn't have an index so it will have to linearily scan whole column.
+-- This doesn't have an index so it will have to linearly scan whole column.
 SELECT * FROM slice WHERE track_id = 10 AND name > "b";
 
 -- This has an index and can use binary search.
@@ -238,7 +238,7 @@ performance-sensitive query, a macro can be more efficient as it avoids the
 potential overhead of function calls in a large number.
 
 NOTE: Macros are expanded with a pre-processing step *before* any execution
-happens. Expansion is a purely syntatic operation involves replacing the macro
+happens. Expansion is a purely syntactic operation involves replacing the macro
 invocation with the SQL tokens in the macro definition.
 
 As macros are syntactic, the types of arguments and return types in macros are

--- a/docs/analysis/trace-processor-python.md
+++ b/docs/analysis/trace-processor-python.md
@@ -1,6 +1,6 @@
 # Trace Processor (Python)
 
-The trace processor Python API is built on the trace procesor
+The trace processor Python API is built on the trace processor
 [C++ library](/docs/analysis/trace-processor.md). By integrating with Python,
 the library allows using Python's rich data analysis ecosystem to process
 traces.

--- a/docs/contributing/build-instructions.md
+++ b/docs/contributing/build-instructions.md
@@ -188,7 +188,7 @@ You need all of these both for MSVC and clang-cl:
 - [Python 3](https://www.python.org/downloads/windows/)
 
 The [`win_find_msvc.py`](/gn/standalone/toolchain/win_find_msvc.py) script will
-locate the higest version numbers available from
+locate the highest version numbers available from
 `C:\Program Files (x86)\Windows Kits\10` and
 `C:\Program Files (x86)\Microsoft Visual Studio\2019`.
 
@@ -251,7 +251,7 @@ target_sysroot = "/path/to/sysroot"
 target_triplet = "aarch64-linux-gnu"  # Or any other supported triplet.
 ```
 
-For more details see the [Using cutom toolchains](#custom-toolchain) section
+For more details see the [Using custom toolchains](#custom-toolchain) section
 below.
 
 ## Build configurations

--- a/docs/contributing/common-tasks.md
+++ b/docs/contributing/common-tasks.md
@@ -129,7 +129,7 @@ native `trace_processor` instance to be used with the UI.
 A common case is when the UI is more recent than `trace_processor`
 and depends on a new table definition. With older versions of
 `trace_processor` in HTTP RPC mode the UI crashes attempting to query
-a non-existant table. To avoid this we use a version number. If the
+a non-existent table. To avoid this we use a version number. If the
 version number `trace_processor` reports is older than the one the UI
 was built with we prompt the user to update.
 

--- a/docs/contributing/developer-tools.md
+++ b/docs/contributing/developer-tools.md
@@ -1,8 +1,8 @@
 # Perfetto Developer Tools
 
 The Perfetto team have created several scripts/tools which navigating and
-working with the Perfetto codebase. This page is mainly targetted towards
-frequent contributors to Perfetto (e.g. team members or external contribtors
+working with the Perfetto codebase. This page is mainly targeted towards
+frequent contributors to Perfetto (e.g. team members or external contributors
 sending a lot of PRs).
 
 These tools have a bit of a learning curve to them but can significantly
@@ -90,7 +90,7 @@ All of these tools work by adding an entry to the repo's gitconfig called
 `branch.{branch_name}.parent` which keeps track of the parent branch. This is
 then used to figure out what a "stack" is and then perform operations on it.
 
-A normal workflow using these tools might look like ths:
+A normal workflow using these tools might look like this:
 
 ```
 # Create a branch for the feature.

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -112,7 +112,7 @@ You might want to contribute to the UI, Trace Processor, SDK or various data imp
 - If you want to add a new functionality to the UI, most likely the next step is the [UI getting started](ui-getting-started).
 - If you want to edit the core functionality of the UI: it's a much bigger change which would require in depth understanding of Perfetto UI. Most requests/bugs now are related to various plugins, not the core.
 - If you want to add a new ftrace event take a look at [common tasks page](common-tasks).
-- If you want to add a new table/view/function to Perfetto SQL standard library you need to first undestand [the Perfetto SQL syntax](/docs/analysis/perfetto-sql-syntax.md), and then read the details of updating the standard library at [common tasks page](common-tasks).
+- If you want to add a new table/view/function to Perfetto SQL standard library you need to first understand [the Perfetto SQL syntax](/docs/analysis/perfetto-sql-syntax.md), and then read the details of updating the standard library at [common tasks page](common-tasks).
 - If you want to add a support of a new file type into Perfetto, you need to add a new `importer` to Trace Processor C++ code.
 
 ## {#community} Communication

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -35,7 +35,7 @@ sudo chown  -R $USER /sys/kernel/debug/tracing
 ### On Android
 
 1.  Connect a device through `adb`
-2.  Start the build-in emulator (supported on Linux and MacOS):
+2.  Start the built-in emulator (supported on Linux and MacOS):
 
 ```bash
 tools/install-build-deps --android
@@ -206,7 +206,7 @@ googlers have access to, googlers can install gcloud
 [here](https://g3doc.corp.google.com/cloud/sdk/g3doc/index.md#installing-and-using-the-cloud-sdk)).
 
 The tests are run in a docker container by default, unless -`-no-docker` is
-passed. It's recommended to use the container for a stable and reproducable
+passed. It's recommended to use the container for a stable and reproducible
 testing environment, especially for rebaselining, otherwise it's very likely the
 screenshots will not match when run on the CI.
 

--- a/docs/contributing/ui-getting-started.md
+++ b/docs/contributing/ui-getting-started.md
@@ -83,7 +83,7 @@ running both prettier and eslint on the changed files:
 
 ```bash
 # By default it formats only files that changed from the upstream Git branch
-# (typicaly origin/main).
+# (typically origin/main).
 # Pass --all for formatting all files under ui/src
 ui/format-sources
 ```
@@ -112,7 +112,7 @@ is stored in the `State` class definition, and should be modified via
 implementing a new action in `src/common/actions.ts`. A new field added to
 `State` should be initialized in `src/common/empty_state.ts`.
 
-There are restrictions on whan can be used in the global state: plain JS objects
+There are restrictions on what can be used in the global state: plain JS objects
 are OK, but class instances are not (this limitation is due to state
 serialization: the state should be a valid JSON object). If storing class
 instances (like `Map` and `Set` data structures) is necessary, these can be

--- a/docs/design-docs/batch-trace-processor.md
+++ b/docs/design-docs/batch-trace-processor.md
@@ -119,7 +119,7 @@ machines is explored further in the "Future plans" section.
 The naive way to return the result of querying n traces is a list
 of n elements, with each element being result for a single trace. However,
 after performing several case-study performance investigations using BTP, it
-became obvious that this obvious answer was not the most convienent for the end
+became obvious that this obvious answer was not the most convenient for the end
 user.
 
 Instead, a pattern which proved very useful was to "flatten" the results into
@@ -146,7 +146,7 @@ default, open source ones.
 The first point is the formalization of the idea "platform" code. Even since the
 beginning of the Python API, there was always a need for code internally to be
 run slightly different to open source code. For example, Google internal Python
-distrubution does not use Pip, instead packaging dependencies into a single
+distribution does not use Pip, instead packaging dependencies into a single
 binary. The notion of a "platform" loosely existed to abstract this sort of
 differences but this was very ad-hoc. As part of batch trace processor
 implementation, this has been retroactively formalized.
@@ -171,7 +171,7 @@ A way around this would be to build a "no trace limit" mode. The idea here
 is that you would develop queries like usual with batch trace processor
 operating on a O(1000) traces with O(s) performance. Once the queries are
 relatively finalized, we could then "switch" the mode of batch trace processor
-to opeate closer to a "MapReduce" style pipeline which operates over O(10000)+
+to operate closer to a "MapReduce" style pipeline which operates over O(10000)+
 traces loading O(n cpus) traces at any one time.
 
 This allows us to retain both the quick iteration speed while developing queries
@@ -181,7 +181,7 @@ cause of the problem which is that we are restricted to a single machine.
 
 The "ideal" solution here is to, as mentioned above, shard batch trace processor
 across >1 machine. When querying traces, each trace is entirely independent of
-any other so paralleising across multiple machines yields very close to perfect
+any other so parallelising across multiple machines yields very close to perfect
 gains in performance at little cost.
 
 This is would be however quite a complex undertaking. We would need to design

--- a/docs/design-docs/protozero.md
+++ b/docs/design-docs/protozero.md
@@ -85,7 +85,7 @@ In order to generate ProtoZero stubs from proto you need to:
 
 ## Proto serialization
 
-The quickest way to undestand ProtoZero design principles is to start from a
+The quickest way to understand ProtoZero design principles is to start from a
 small example and compare the generated code between libprotobuf and ProtoZero.
 
 ```protobuf


### PR DESCRIPTION
Pure docs cleanup across 11 markdown files in `docs/`. All caught by codespell, all in user-facing prose (no code, identifiers, or API names).

| Area | Files | Notable fixes |
|---|---|---|
| `docs/design-docs/` | batch-trace-processor.md, protozero.md | `convienent` → `convenient`, `distrubution` → `distribution`, `opeate` → `operate`, `paralleising` → `parallelising`, `undestand` → `understand` |
| `docs/analysis/` | perfetto-sql-syntax.md, trace-processor-python.md | `additons` → `additions`, `simultaneusly` → `simultaneously`, `linearily` → `linearly`, `syntatic` → `syntactic`, `procesor` → `processor` |
| `docs/contributing/` | build-instructions, common-tasks, developer-tools, getting-started, testing, ui-getting-started | `higest` → `highest`, `cutom` → `custom`, `non-existant` → `non-existent`, `targetted` → `targeted`, `contribtors` → `contributors`, `ths` → `this`, `undestand` → `understand`, `build-in` → `built-in`, `reproducable` → `reproducible`, `typicaly` → `typically`, `whan` → `what` |
| `docs/AGENTS-ui.md` | | `does't` → `doesn't`, `scrach` → `scratch` |

Per `perfetto: ...` commit-prefix convention from this repo`s `CLAUDE.md`.

Codespell also flagged these in `docs/`, but I deliberately did NOT fix them — they aren't typos:
- `inout` — C++ argument-passing term used in `docs/AGENTS.md` coding-style notes.
- `CrOS` — Chrome OS abbreviation (proper noun).
- `te` — appears in URL fragments matching sepolicy `.te` files.
- `pre-empted` — both `pre-empted` and `preempted` are accepted spellings.
- `optionA` — appears to be a camelCase identifier name in `ui-plugins.md` rather than a misspelled word.