### PR TITLE
Add support for a PARTITION BY clause to generateSqlWithInternalLayout()

### DIFF
--- a/test/trace_processor/diff_tests/stdlib/prelude/window_functions_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/prelude/window_functions_tests.py
@@ -218,3 +218,51 @@ class PreludeWindowFunctions(TestSuite):
         4,3
         5,3
         """))
+
+  def test_layout_with_partition_by(self):
+    #   1 2 3 4 5 6 7 8 9 10
+    # Partition A:
+    #   |-----| |-------|
+    #     |---------|
+    # Partition B:
+    #       |-------------|
+    #             |---|
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        """),
+        query="""
+        CREATE TABLE TEST(start INTEGER, end INTEGER, partition_id TEXT);
+
+        INSERT INTO TEST
+        VALUES
+        (1, 4, 'A'),
+        (2, 7, 'A'),
+        (3, 10, 'B'),
+        (5, 9, 'A'),
+        (6, 8, 'B');
+
+        WITH custom_slices as (
+          SELECT
+            start as ts,
+            end - start as dur,
+            partition_id
+          FROM test
+        )
+        SELECT
+          ts,
+          INTERNAL_LAYOUT(ts, dur) OVER (
+            PARTITION BY partition_id
+            ORDER BY ts
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          ) as depth
+        FROM custom_slices
+        ORDER BY ts ASC
+        """,
+        out=Csv("""
+        "ts","depth"
+        1,0
+        2,1
+        3,0
+        5,0
+        6,1
+        """))

--- a/ui/src/components/sql_utils/layout.ts
+++ b/ui/src/components/sql_utils/layout.ts
@@ -14,21 +14,27 @@
 
 // Object to facilitate generation of SELECT statement using
 // generateSqlWithInternalLayout.
-//
-// Fields:
-// @columns: a string array list of the columns to be selected from the table.
-// required by the internal_layout function.
-// @source: the table or select statement in the FROM clause.
-// @whereClause: the WHERE clause to filter data from the source table.
-// @orderByClause: the ORDER BY clause for the query data.
-// TODO(stevegolton): Move these comments inline.
 interface GenerateSqlArgs {
+  // A string array list of the columns to be selected from the table.
   columns: string[];
+
+  // The table or select statement in the FROM clause.
   source: string;
+
+  // The expression returning the timestamp of a slice in the source table.
   ts: string;
+
+  // The expression returning the duration of a slice in the source table.
   dur: string;
+
+  // The WHERE clause to filter data from the source table (optional).
   whereClause?: string;
+
+  // The ORDER BY clause for the results (optional).
   orderByClause?: string;
+
+  // The PARTITION BY clause for the internal_layout window function (optional).
+  partitionByClause?: string;
 }
 
 // Function to generate a SELECT statement utilizing the internal_layout
@@ -36,10 +42,15 @@ interface GenerateSqlArgs {
 export function generateSqlWithInternalLayout(
   sqlArgs: GenerateSqlArgs,
 ): string {
+  const maybePartitionBy =
+    sqlArgs.partitionByClause === undefined
+      ? ''
+      : `PARTITION BY ${sqlArgs.partitionByClause} `;
   let sql =
     `SELECT ` +
     sqlArgs.columns.toString() +
-    `, internal_layout(${sqlArgs.ts}, ${sqlArgs.dur}) OVER (ORDER BY ${sqlArgs.ts}` +
+    `, internal_layout(${sqlArgs.ts}, ${sqlArgs.dur}) OVER (` +
+    `${maybePartitionBy}ORDER BY ${sqlArgs.ts}` +
     ' ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS depth' +
     ` FROM (${sqlArgs.source})`;
   if (sqlArgs.whereClause !== undefined) {


### PR DESCRIPTION
This allows plugin to create nested layouts, where the plugin first lays out top-level slices (a single `generateSqlWithInternalLayout()` call _without_ a `PARTITION BY` clause) and then lays out their descendants (a second `generateSqlWithInternalLayout()` call _with_ a `PARTITION BY` clause).

Issue: #5841