### PR TITLE
tp: Downgrade android_aflags_errors to kInfo

### DIFF
--- a/docs/data-sources/android-aflags.md
+++ b/docs/data-sources/android-aflags.md
@@ -60,7 +60,7 @@ where name = 'android_aflags_errors'
 
 name | severity | source | value | description
 -----|----------|--------|-------|------------
-android_aflags_errors | error | trace | 1 | Errors occurred during the collection of Android aconfig flags by the android.aflags data source. This typically happens if the aflags tool fails or its output is malformed.
+android_aflags_errors | info | trace | 1 | Errors occurred during the collection of Android aconfig flags by the android.aflags data source. This typically happens if the aflags tool fails or its output is malformed.
 
 ### TraceConfig
 

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -24,7 +24,8 @@ namespace perfetto::trace_processor::stats {
 // Compile time list of parsing and processing stats.
 // clang-format off
 #define PERFETTO_TP_STATS(F)                                                   \
-  F(android_aflags_errors,               kSingle,  kError,    kTrace, Scope::kMachineAndTrace,          \
+  /* TODO(b/512786856): Restore severity to kError after flag rollout. */    \
+  F(android_aflags_errors,               kSingle,  kInfo,     kTrace, Scope::kMachineAndTrace,          \
        "Errors occurred during the collection of Android aconfig flags by the "\
        "android.aflags data source. This typically happens if the aflags tool "\
        "fails or its output is malformed."),                                   \

--- a/test/trace_processor/diff_tests/parser/android/tests_aflags.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_aflags.py
@@ -71,5 +71,5 @@ class AndroidAflags(TestSuite):
         """,
         out=Csv("""
         "ts","name","severity","display_value"
-        2000,"android_aflags_errors","error","Failed to read aflags"
+        2000,"android_aflags_errors","info","Failed to read aflags"
         """))


### PR DESCRIPTION
Since the aflags side feature is gated behind a flag to avoid "false" errors lower the severity to info.

We will update it back to kError once flag rollout is complete.

Bug: 512786856