### PR TITLE
Reapply "tp: route PerfettoSqlParser through syntaqlite macro expansion"

### DIFF
--- a/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.h
+++ b/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.h
@@ -50,7 +50,7 @@ class PerfettoSqlParser {
   // syntaqlite, false if it uses the handwritten PerfettoSqlPreprocessor.
   // Exposed so tests can gate path-specific assertions; will be removed
   // along with the legacy implementation when the cutover completes.
-  static constexpr bool kUsesSyntaqliteMacros = false;
+  static constexpr bool kUsesSyntaqliteMacros = true;
 
   // A CREATE PERFETTO MACRO definition. Aliased to the preprocessor type so
   // engine code can spell `PerfettoSqlParser::Macro` instead of reaching into


### PR DESCRIPTION
With syntaqlite bump, this should now be fixed. Attempt a reland.

This reverts commit 8a4e689feda6813649e4109ef805c6a473971aac.
