### PR TITLE
ui: Move distribution histogram to the left column in slice details

### DIFF
--- a/ui/src/components/details/thread_slice_details_tab.ts
+++ b/ui/src/components/details/thread_slice_details_tab.ts
@@ -326,8 +326,8 @@ export class ThreadSliceDetailsPanel implements TrackEventDetailsPanel {
         precFlows,
         followingFlows,
         args,
-        distribution,
         additionalSections,
+        distribution,
       );
     } else {
       return undefined;


### PR DESCRIPTION
Move the histogram/distribution panel to the bottom of right column, so that additional pieces of information like callstacks are rendered before histogram panels. 

Before:
<img width="1272" height="1247" alt="Screenshot 2026-05-13 at 9 23 59 AM" src="https://github.com/user-attachments/assets/a04cc9c7-fc9a-43c5-bc44-12be5f243855" />

Unless you made your details tab super high, you'd never notice that there is callstack.

After:
<img width="925" height="1317" alt="Screenshot 2026-05-13 at 2 59 39 PM" src="https://github.com/user-attachments/assets/eaea4e1b-d816-49ce-96cd-f20e6926b87a" />

