### PR TITLE
ui: Add bitmap metadata to the HeapDumpExplorer page

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
@@ -225,6 +225,23 @@ export const COL_INFO = {
     'Native size of every object reachable from this one (BFS tree). ' +
     'Includes objects also reachable via other paths.',
   reachableCount: 'Count of objects reachable from this one (BFS tree).',
+  bitmapStorage:
+    'Pixel-storage backing decoded from Bitmap.mId. ' +
+    "'heap' = malloc'd in this process — each duplicate is real RAM cost. " +
+    "'ashmem' = shared kernel memory — duplicates with the same source_id " +
+    'are kernel-shared (PSS-attributed), no real RAM cost. ' +
+    "'hardware' = AHardwareBuffer — duplicates may share GPU memory if " +
+    'they wrap the same buffer handle.',
+  bitmapId:
+    'Encoded Bitmap.mId — process-monotonic instance counter (' +
+    'pid·10⁷ + storage_type·10⁶ + counter). Stable identifier within one ' +
+    "process; it's never a dedup key (every Bitmap allocation gets a " +
+    'fresh value).',
+  bitmapSource:
+    'Parcel sender derived from Bitmap.mSourceId. Blank when this Bitmap ' +
+    "was allocated locally. When present, it's the sender's process name " +
+    'and pid at writeToParcel time. Multiple Bitmaps with the same ' +
+    'source_id and same content_hash are kernel-shared, NOT duplicated.',
 } as const;
 
 // Label + info icon for DataGrid column titles.

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -1793,6 +1793,10 @@ export async function getBitmapList(
 ): Promise<BitmapListRow[]> {
   await requireDominatorTree(engine);
   const dumpData = await loadBitmapDumpData(engine, activeDump);
+
+  await engine.query(
+    `INCLUDE PERFETTO MODULE android.memory.heap_graph.bitmap;`,
+  );
   const res = await engine.query(`
     SELECT
       o.id,
@@ -1807,15 +1811,22 @@ export async function getBitmapList(
       d.dominated_obj_count,
       od.value_string,
       c.kind AS class_kind,
-      MAX(CASE WHEN f.field_name GLOB '*mWidth' THEN f.int_value END) AS width,
-      MAX(CASE WHEN f.field_name GLOB '*mHeight' THEN f.int_value END) AS height,
-      MAX(CASE WHEN f.field_name GLOB '*mDensity' THEN f.int_value END) AS density,
-      MAX(CASE WHEN f.field_name GLOB '*mNativePtr' THEN f.long_value END) AS native_ptr
+      cast_int!(b.width) AS width,
+      cast_int!(b.height) AS height,
+      cast_int!(b.density) AS density,
+      MAX(CASE WHEN f.field_name GLOB '*mNativePtr' THEN f.long_value END) AS native_ptr,
+      b.bitmap_id,
+      b.bitmap_storage_type,
+      b.source_id,
+      cast_int!(b.source_pid) AS source_pid,
+      b.source_storage_type,
+      b.source_process_name
     FROM heap_graph_object o
     JOIN heap_graph_class c ON o.type_id = c.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     LEFT JOIN heap_graph_primitive f ON f.field_set_id = od.field_set_id
+    LEFT JOIN heap_graph_bitmaps b ON b.object_id = o.id
     WHERE o.reachable != 0
       AND ${dumpFilterSql(activeDump, 'o')}
       AND (c.name = 'android.graphics.Bitmap'
@@ -1833,6 +1844,12 @@ export async function getBitmapList(
     hasPixelData: boolean;
     density: number;
     nativePtr: bigint | null;
+    bitmapId: bigint | null;
+    storageType: string | null;
+    sourceId: bigint | null;
+    sourcePid: number | null;
+    sourceStorageType: string | null;
+    sourceProcessName: string | null;
   }> = [];
   const hashInputs: Array<{objectId: number; nativePtr: bigint}> = [];
   for (
@@ -1853,6 +1870,12 @@ export async function getBitmapList(
       height: NUM_NULL,
       density: NUM_NULL,
       native_ptr: LONG_NULL,
+      bitmap_id: LONG_NULL,
+      bitmap_storage_type: STR_NULL,
+      source_id: LONG_NULL,
+      source_pid: NUM_NULL,
+      source_storage_type: STR_NULL,
+      source_process_name: STR_NULL,
     });
     it.valid();
     it.next()
@@ -1873,6 +1896,12 @@ export async function getBitmapList(
       hasPixelData,
       density: it.density ?? 0,
       nativePtr: it.native_ptr,
+      bitmapId: it.bitmap_id,
+      storageType: it.bitmap_storage_type,
+      sourceId: it.source_id,
+      sourcePid: it.source_pid,
+      sourceStorageType: it.source_storage_type,
+      sourceProcessName: it.source_process_name,
     });
   }
 
@@ -1890,6 +1919,12 @@ export async function getBitmapList(
     hasPixelData: r.hasPixelData,
     density: r.density,
     bufferHash: hashes.get(r.row.id) ?? null,
+    storageType: r.storageType,
+    bitmapId: r.bitmapId,
+    sourceId: r.sourceId,
+    sourcePid: r.sourcePid,
+    sourceStorageType: r.sourceStorageType,
+    sourceProcessName: r.sourceProcessName,
   }));
   return rows;
 }

--- a/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
@@ -147,6 +147,32 @@ export interface BitmapListRow {
   density: number;
   /** Content hash of the compressed pixel buffer, null when unavailable. */
   bufferHash: string | null;
+  /**
+   * Pixel-storage backing decoded from `Bitmap.mId` via the
+   * `android.memory.heap_graph.bitmap` stdlib module. One of
+   * 'heap' | 'ashmem' | 'hardware' | 'wrapped_pixel_ref'.
+   * 'heap' = malloc'd in this process (real RAM cost per copy);
+   * 'ashmem' = shared kernel memory (PSS-shared across processes);
+   * 'hardware' = AHardwareBuffer (GPU memory).
+   */
+  storageType: string | null;
+  /** Encoded `Bitmap.mId`. */
+  bitmapId: bigint | null;
+  /**
+   * Encoded `Bitmap.mSourceId` for parcel-received Bitmaps; null when the
+   * Bitmap was locally allocated (raw -1 sentinel canonicalised).
+   */
+  sourceId: bigint | null;
+  /** Sender pid decoded from sourceId. Null when sourceId is null. */
+  sourcePid: number | null;
+  /** Sender's pixel storage type at writeToParcel time. */
+  sourceStorageType: string | null;
+  /**
+   * Sender's process name resolved against `process` at the heap dump's
+   * timestamp. Requires the trace to include process info (e.g. captured
+   * via `linux.process_stats` alongside the HPROF dump). Null otherwise.
+   */
+  sourceProcessName: string | null;
 }
 
 export interface StringListRow {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
@@ -31,6 +31,8 @@ import {
   shortClassName,
   BitmapImage,
   renderPath,
+  colHeader,
+  COL_INFO,
 } from '../components';
 import type {PathEntry} from '../types';
 import * as queries from '../queries';
@@ -65,6 +67,12 @@ function bitmapRowToRow(r: BitmapListRow): Row {
     reachable_count: r.row.reachableCount,
     heap: r.row.heap,
     buffer_hash: r.bufferHash,
+    storage: r.storageType,
+    bitmap_id: r.bitmapId === null ? null : r.bitmapId.toString(),
+    source_id: r.sourceId === null ? null : r.sourceId.toString(),
+    source_process_name: r.sourceProcessName,
+    source_pid: r.sourcePid,
+    source_storage: r.sourceStorageType,
   };
 }
 
@@ -149,6 +157,42 @@ function makeBitmapListSchema(navigate: NavFn): SchemaRegistry {
       pixel_count: {
         title: 'Pixels',
         columnType: 'quantitative',
+      },
+      storage: {
+        title: colHeader('Storage', COL_INFO.bitmapStorage),
+        columnType: 'text',
+        cellRenderer: (value: SqlValue) =>
+          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+      },
+      bitmap_id: {
+        title: colHeader('Bitmap ID', COL_INFO.bitmapId),
+        columnType: 'text',
+        cellRenderer: (value: SqlValue) =>
+          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+      },
+      source_id: {
+        title: colHeader('Source ID', COL_INFO.bitmapSource),
+        columnType: 'text',
+        cellRenderer: (value: SqlValue) =>
+          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+      },
+      source_process_name: {
+        title: colHeader('Source Process', COL_INFO.bitmapSource),
+        columnType: 'text',
+        cellRenderer: (value: SqlValue) =>
+          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+      },
+      source_pid: {
+        title: colHeader('Source PID', COL_INFO.bitmapSource),
+        columnType: 'quantitative',
+        cellRenderer: (value: SqlValue) =>
+          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+      },
+      source_storage: {
+        title: colHeader('Source Storage', COL_INFO.bitmapSource),
+        columnType: 'text',
+        cellRenderer: (value: SqlValue) =>
+          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
       },
     },
   };
@@ -274,6 +318,20 @@ function BitmapCard(): m.Component<BitmapCardAttrs> {
               {class: 'pf-hde-bitmap-card__secondary'},
               fmtSize(row.row.retainedTotal),
             ),
+            row.storageType !== null
+              ? m(
+                  'span',
+                  {class: 'pf-hde-bitmap-card__secondary'},
+                  row.storageType,
+                )
+              : null,
+            row.sourceId !== null
+              ? m(
+                  'span',
+                  {class: 'pf-hde-bitmap-card__secondary'},
+                  `from ${row.sourceProcessName ?? '?'} (${row.sourcePid ?? '?'})`,
+                )
+              : null,
           ),
           m(
             'button',
@@ -425,6 +483,10 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
         {id: 'id', field: 'id'},
         {id: 'cls', field: 'cls'},
         {id: 'dimensions', field: 'dimensions'},
+        {id: 'storage', field: 'storage'},
+        {id: 'source_process_name', field: 'source_process_name'},
+        {id: 'source_pid', field: 'source_pid'},
+        {id: 'source_storage', field: 'source_storage'},
         {id: 'self_size', field: 'self_size'},
         {id: 'native_size', field: 'native_size'},
         {id: 'retained', field: 'retained'},
@@ -433,6 +495,8 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
         {id: 'reachable_size', field: 'reachable_size'},
         {id: 'reachable_native', field: 'reachable_native'},
         {id: 'reachable_count', field: 'reachable_count'},
+        {id: 'bitmap_id', field: 'bitmap_id'},
+        {id: 'source_id', field: 'source_id'},
         {id: 'buffer_hash', field: 'buffer_hash'},
       ];
       const onFiltersChanged = (f: readonly Filter[]) => {


### PR DESCRIPTION
Bitmaps pack useful info in the mId and mSourceId field.

We now have a stdlib module that exposes those, lets expose the details in the bitmap tab.