### PR TITLE
sdk: honor TraceConfig.compression_type on the in-process backend

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -954,6 +954,7 @@ cc_library {
         ":perfetto_src_tracing_ipc_producer_producer",
         ":perfetto_src_tracing_ipc_service_service",
         ":perfetto_src_tracing_service_service",
+        ":perfetto_src_tracing_service_zlib_compressor",
         ":perfetto_src_tracing_system_backend",
     ],
     host_supported: true,
@@ -1033,15 +1034,22 @@ cc_library {
     cflags: [
         "-DPERFETTO_REGEX_FORCE_STD",
         "-DPERFETTO_SHLIB_SDK_IMPLEMENTATION",
+        "-DZLIB_IMPLEMENTATION",
     ],
     min_sdk_version: "30",
     target: {
         android: {
             shared_libs: [
                 "liblog",
+                "libz",
             ],
             static_libs: [
                 "perfetto_flags_c_lib",
+            ],
+        },
+        host: {
+            static_libs: [
+                "libz",
             ],
         },
         windows: {
@@ -1168,6 +1176,7 @@ cc_library_static {
         ":perfetto_src_tracing_ipc_producer_producer",
         ":perfetto_src_tracing_ipc_service_service",
         ":perfetto_src_tracing_service_service",
+        ":perfetto_src_tracing_service_zlib_compressor",
         ":perfetto_src_tracing_system_backend",
     ],
     shared_libs: [
@@ -1317,6 +1326,7 @@ cc_library_static {
     ],
     cflags: [
         "-DPERFETTO_REGEX_FORCE_STD",
+        "-DZLIB_IMPLEMENTATION",
     ],
     apex_available: [
         "//apex_available:anyapex",
@@ -1325,8 +1335,16 @@ cc_library_static {
     min_sdk_version: "30",
     target: {
         android: {
+            shared_libs: [
+                "libz",
+            ],
             static_libs: [
                 "perfetto_flags_c_lib",
+            ],
+        },
+        host: {
+            static_libs: [
+                "libz",
             ],
         },
     },
@@ -2135,8 +2153,16 @@ cc_library_static {
     ],
     target: {
         android: {
+            shared_libs: [
+                "libz",
+            ],
             static_libs: [
                 "perfetto_flags_c_lib",
+            ],
+        },
+        host: {
+            static_libs: [
+                "libz",
             ],
         },
     },
@@ -3134,6 +3160,7 @@ cc_test {
         ":perfetto_src_tracing_ipc_producer_relay",
         ":perfetto_src_tracing_ipc_service_service",
         ":perfetto_src_tracing_service_service",
+        ":perfetto_src_tracing_service_zlib_compressor",
         ":perfetto_src_tracing_system_backend",
         ":perfetto_src_tracing_test_api_test_support",
         ":perfetto_src_tracing_test_client_api_integrationtests",
@@ -3348,8 +3375,16 @@ cc_test {
     test_config: "PerfettoIntegrationTests.xml",
     target: {
         android: {
+            shared_libs: [
+                "libz",
+            ],
             static_libs: [
                 "perfetto_flags_c_lib",
+            ],
+        },
+        host: {
+            static_libs: [
+                "libz",
             ],
         },
     },

--- a/BUILD
+++ b/BUILD
@@ -183,6 +183,7 @@ perfetto_cc_library(
         ":src_tracing_ipc_producer_producer",
         ":src_tracing_ipc_service_service",
         ":src_tracing_service_service",
+        ":src_tracing_service_zlib_compressor",
         ":src_tracing_system_backend",
     ],
     hdrs = [
@@ -276,7 +277,7 @@ perfetto_cc_library(
         ":src_base_regex_regex",
         ":src_base_version",
         ":src_protovm_protovm",
-    ],
+    ] + PERFETTO_CONFIG.deps.zlib,
     linkstatic = True,
 )
 
@@ -9505,6 +9506,7 @@ perfetto_cc_library(
         ":src_tracing_ipc_producer_producer",
         ":src_tracing_ipc_service_service",
         ":src_tracing_service_service",
+        ":src_tracing_service_zlib_compressor",
         ":src_tracing_system_backend",
     ],
     hdrs = [
@@ -9595,7 +9597,7 @@ perfetto_cc_library(
         ":src_base_regex_regex",
         ":src_base_version",
         ":src_protovm_protovm",
-    ],
+    ] + PERFETTO_CONFIG.deps.zlib,
     linkstatic = True,
 )
 

--- a/src/tracing/BUILD.gn
+++ b/src/tracing/BUILD.gn
@@ -205,6 +205,9 @@ source_set("in_process_backend") {
     "core",
     "service",
   ]
+  if (enable_perfetto_zlib) {
+    deps += [ "service:zlib_compressor" ]
+  }
   sources = [ "internal/in_process_tracing_backend.cc" ]
 }
 

--- a/src/tracing/internal/in_process_tracing_backend.cc
+++ b/src/tracing/internal/in_process_tracing_backend.cc
@@ -25,6 +25,10 @@
 
 #include "src/tracing/core/in_process_shared_memory.h"
 
+#if PERFETTO_BUILDFLAG(PERFETTO_ZLIB)
+#include "src/tracing/service/zlib_compressor.h"
+#endif
+
 // TODO(primiano): When the in-process backend is used, we should never end up
 // in a situation where the thread where the TracingService and Producer live
 // writes a packet and hence can get into the GetNewChunk() stall.
@@ -68,7 +72,16 @@ TracingService* InProcessTracingBackend::GetOrCreateService(
   if (!service_) {
     std::unique_ptr<InProcessSharedMemory::Factory> shm(
         new InProcessSharedMemory::Factory());
-    service_ = TracingService::CreateInstance(std::move(shm), task_runner);
+    TracingService::InitOpts init_opts = {};
+#if PERFETTO_BUILDFLAG(PERFETTO_ZLIB)
+    // Wire the zlib compressor so TraceConfig.compression_type =
+    // COMPRESSION_TYPE_DEFLATE takes effect on the in-process backend's
+    // service, mirroring what src/traced/service/service.cc does for the
+    // system backend.
+    init_opts.compressor_fn = &ZlibCompressFn;
+#endif
+    service_ =
+        TracingService::CreateInstance(std::move(shm), task_runner, init_opts);
     service_->SetSMBScrapingEnabled(true);
   }
   return service_.get();


### PR DESCRIPTION
Mirror what `src/traced/service/service.cc` does for the system backend: when the SDK is built with `enable_perfetto_zlib=true`, construct the in-process backend's TracingService with `init_opts.compressor_fn = &ZlibCompressFn` so that `TraceConfig.compression_type = COMPRESSION_TYPE_DEFLATE` actually takes effect. Without this, the in-process service is created with default `init_opts` (compressor_fn == nullptr) and the `compression_type` field on the TraceConfig is silently ignored — embedders writing a local `.pftrace` via `TracingSession::Setup(cfg, fd)` got an uncompressed file regardless of what they set in the config.

The compressor is wired only when PERFETTO_ZLIB is enabled, matching the existing pattern in `service.cc:136-139`. No new public API; the behavior is opt-in via the TraceConfig field that already exists.