### PR TITLE
ui: Add initial page plumbing

### DIFF
--- a/ui/src/core/initial_page_manager.ts
+++ b/ui/src/core/initial_page_manager.ts
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {InitialPageManager} from '../public/initial_page';
+
+interface Suggestion {
+  // Route to navigate to (e.g. '/heapdump').
+  readonly route: string;
+  // Higher wins.
+  readonly priority: number;
+  // Registration order, breaks ties at equal priority (earliest wins).
+  readonly seq: number;
+}
+
+export class InitialPageManagerImpl implements InitialPageManager {
+  private readonly suggestions = new Set<Suggestion>();
+  private seqCounter = 0;
+
+  suggest(route: string, priority: number): Disposable {
+    const s: Suggestion = {route, priority, seq: this.seqCounter++};
+    this.suggestions.add(s);
+    return {[Symbol.dispose]: () => this.suggestions.delete(s)};
+  }
+
+  // Returns the winning route, or undefined if none was suggested.
+  getWinner(): string | undefined {
+    let best: Suggestion | undefined;
+    for (const s of this.suggestions) {
+      if (
+        best === undefined ||
+        s.priority > best.priority ||
+        (s.priority === best.priority && s.seq < best.seq)
+      ) {
+        best = s;
+      }
+    }
+    return best?.route;
+  }
+}

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -254,7 +254,6 @@ async function loadTraceIntoEngine(
   trace.timeline.setVisibleWindow(newViewport);
 
   const cacheUuid = traceDetails.cached ? traceDetails.uuid : '';
-  Router.navigate(`#!/viewer?local_cache_key=${cacheUuid}`);
 
   // Make sure the helper views are available before we start adding tracks.
   await includeSummaryTables(trace);
@@ -268,6 +267,11 @@ async function loadTraceIntoEngine(
   await app.plugins.onTraceLoad(trace, (id) => {
     updateStatus(app, `Running plugin: ${id}`);
   });
+
+  // Plugins may call trace.initialPage.suggest(...) during onTraceLoad to
+  // request that the app navigate somewhere other than /viewer.
+  const initialRoute = trace.initialPage.getWinner() ?? '/viewer';
+  Router.navigate(`#!${initialRoute}?local_cache_key=${cacheUuid}`);
 
   decideTabs(trace);
 

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -51,6 +51,7 @@ import {StatusbarManagerImpl} from './statusbar_manager';
 import {SettingDescriptor} from '../public/settings';
 import {SettingsManagerImpl} from './settings_manager';
 import {MinimapManagerImpl} from './minimap_manager';
+import {InitialPageManagerImpl} from './initial_page_manager';
 import {TraceStream} from '../public/stream';
 import {OmniboxModeDescriptor} from '../public/omnibox';
 
@@ -77,6 +78,7 @@ export class TraceImpl implements Trace, Disposable {
   readonly onTraceReady = new EvtSource<void>();
   readonly statusbar = new StatusbarManagerImpl();
   readonly minimap = new MinimapManagerImpl();
+  readonly initialPage = new InitialPageManagerImpl();
   readonly loadingErrors: string[] = [];
   readonly app: AppImpl;
   readonly store = createStore<Record<string, unknown>>({});

--- a/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
@@ -54,6 +54,14 @@ export default class implements PerfettoPlugin {
       render: (subpage) => m(HeapDumpPage, {session, subpage}),
     });
 
+    if (
+      HeapProfilePlugin.openHeapDumpExplorerByDefaultFlag.get() &&
+      !(await traceHasTimelineData(ctx))
+    ) {
+      session.autoNavigated = true;
+      ctx.initialPage.suggest('/heapdump', 100);
+    }
+
     ctx.plugins
       .getPlugin(HeapProfilePlugin)
       .registerOnNodeSelectedListener(({pathHashes, isDominator, upid, ts}) =>
@@ -67,13 +75,5 @@ export default class implements PerfettoPlugin {
       href: '#!/heapdump',
       icon: 'memory',
     });
-
-    if (
-      HeapProfilePlugin.openHeapDumpExplorerByDefaultFlag.get() &&
-      !(await traceHasTimelineData(ctx))
-    ) {
-      session.autoNavigated = true;
-      ctx.onTraceReady.addListener(() => ctx.navigate('#!/heapdump'));
-    }
   }
 }

--- a/ui/src/public/initial_page.ts
+++ b/ui/src/public/initial_page.ts
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Lets plugins suggest, during onTraceLoad(), which page the app should
+ * navigate to once the trace finishes loading. Highest priority wins; ties
+ * resolve to first-registered. If no plugin suggests anything, the app falls
+ * back to '/viewer'.
+ *
+ * Trace-scoped: suggestions are cleared automatically when the trace unloads.
+ *
+ * Why this isn't part of PageManager: page registration is app-scoped (pages
+ * are registered both before any trace loads and from within onTraceLoad),
+ * but "which page should we land on for THIS trace" only makes sense in the
+ * context of a specific trace. Bolting it onto PageManager would either
+ * expose a method on `app.pages` that has no meaningful behaviour, or force
+ * PageManager to have a different shape on App vs. Trace. Keeping it as its
+ * own small manager hanging off Trace avoids both problems.
+ *
+ * Suggested priority ranges:
+ *   10  - generic alternative landing pages
+ *   100 - format-specific landing pages (e.g. a heap profile viewer for a
+ *         trace that contains only heap data)
+ */
+export interface InitialPageManager {
+  suggest(route: string, priority: number): Disposable;
+}

--- a/ui/src/public/trace.ts
+++ b/ui/src/public/trace.ts
@@ -28,6 +28,7 @@ import {Evt} from '../base/events';
 import {StatusbarManager} from './statusbar';
 import {MinimapManager} from './minimap';
 import {SearchManager} from './search';
+import {InitialPageManager} from './initial_page';
 
 // Lists all the possible event listeners using the key as the event name and
 // the type as the type of the callback.
@@ -57,6 +58,7 @@ export interface Trace extends App {
   readonly statusbar: StatusbarManager;
   readonly minimap: MinimapManager;
   readonly search: SearchManager;
+  readonly initialPage: InitialPageManager;
 
   // Events.
   onTraceReady: Evt<void>;


### PR DESCRIPTION
Allow plugins to suggest which page should be displayed by default after the trace loads - like `addDefaultTab()` but for pages.

Example usage:
```ts
ctx.initialPage.suggest('/heapdump', 100);
```