### PR TITLE
ui: Refresh query page columns on each query

### DIFF
--- a/ui/src/plugins/dev.perfetto.QueryPage/results_table.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/results_table.ts
@@ -211,6 +211,8 @@ export class ResultsTable implements m.Component<ResultsTableAttrs> {
     return [
       multiStatementWarning,
       m(DataGrid, {
+        enablePivotControls: false, // In-memory datasource does not support pivoting
+        columns: data.columns.map((col) => ({id: col, field: col})),
         schema: schema,
         rootSchema: 'root',
         data: data.dataSource,


### PR DESCRIPTION
The query page DataGrid was reusing the previous query's columns when a new query ran in the same editor tab, because the DataGrid only derived its column list from the schema in oninit. Pass columns explicitly from the current QueryResponse so each render reflects the latest result. Also disable pivot controls since the in-memory datasource doesn't support pivoting.

Fixes: https://buganizer.corp.google.com/issues/512990042