### PR TITLE
tp: fix proto to args parsing not correctly draining stack on error

### DIFF
--- a/src/trace_processor/util/proto_to_args_parser.cc
+++ b/src/trace_processor/util/proto_to_args_parser.cc
@@ -30,6 +30,7 @@
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/utils.h"
 #include "perfetto/protozero/field.h"
 #include "perfetto/protozero/proto_decoder.h"
 #include "perfetto/protozero/proto_utils.h"
@@ -218,6 +219,16 @@ base::Status ProtoToArgsParser::ParseMessage(
 }
 
 base::Status ProtoToArgsParser::RunWorkLoop(Delegate& delegate) {
+  // Drain scratch state on every exit path: work items hold raw pointers into
+  // descriptors and packet bytes that don't outlive this call. Pop in LIFO
+  // order so ScopedNestedKeyContext restores key_prefix_ correctly.
+  auto cleanup = base::OnScopeExit([this] {
+    while (!work_stack_.empty()) {
+      work_stack_.pop_back();
+    }
+    da_nested_storage_.clear();
+    nv_nested_storage_.clear();
+  });
   while (!work_stack_.empty()) {
     bool done = false;
     auto& top = work_stack_.back();

--- a/src/trace_processor/util/proto_to_args_parser_unittest.cc
+++ b/src/trace_processor/util/proto_to_args_parser_unittest.cc
@@ -1166,6 +1166,33 @@ TEST_F(DebugAnnotationParserTest, NestedValueDictMatchedKeysAndValues) {
               testing::ElementsAre("root.k1 root.k1 1", "root.k2 root.k2 2"));
 }
 
+// A failed parse must not leave stale work items behind for the next call to
+// resume (which would dereference dangling pointers).
+TEST_F(DebugAnnotationParserTest, ErrorClearsPersistentWorkState) {
+  protozero::HeapBuffered<protos::pbzero::DebugAnnotation> bad_msg;
+  bad_msg->set_name("bad_root");
+  auto* nested = bad_msg->set_nested_value();
+  nested->set_nested_type(protos::pbzero::DebugAnnotation::NestedValue::DICT);
+  nested->add_dict_keys("k1");
+  nested->add_dict_keys("k2");
+  auto* v1 = nested->add_dict_values();
+  v1->set_int_value(1);
+
+  DescriptorPool pool;
+  ProtoToArgsParser args_parser(pool);
+
+  base::Status status = ParseDebugAnnotation(args_parser, bad_msg, *this);
+  EXPECT_FALSE(status.ok());
+
+  protozero::HeapBuffered<protos::pbzero::DebugAnnotation> good_msg;
+  good_msg->set_name("good_root");
+  good_msg->set_int_value(42);
+
+  status = ParseDebugAnnotation(args_parser, good_msg, *this);
+  EXPECT_TRUE(status.ok()) << status.message();
+  EXPECT_THAT(args(), testing::ElementsAre("good_root good_root 42"));
+}
+
 TEST_F(DebugAnnotationParserTest, InternedString) {
   protozero::HeapBuffered<protos::pbzero::DebugAnnotation> msg;
   msg->set_name("root");


### PR DESCRIPTION
This could leak e.g. errors, descriptors etc between calls into the
parser.
