### PR TITLE
tp: emit flags before positionals in classic->subcommand translation

### DIFF
--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -955,9 +955,15 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
   };
 
   // Determine which subcommand to dispatch to.
+  //
+  // For subcommands that themselves consume a positional mode argument
+  // (e.g. "server http", "server stdio", "export sqlite"), emit all flags
+  // *before* the mode positional. Our Windows getopt_compat implementation
+  // does not GNU-style permute argv, so any flag appearing after a positional
+  // would be left as a positional, which would then be misinterpreted as the
+  // trace file by the subcommand.
   if (options.enable_httpd) {
     args.emplace_back("server");
-    args.emplace_back("http");
     if (!options.port_number.empty()) {
       args.emplace_back("--port");
       args.emplace_back(options.port_number);
@@ -971,12 +977,13 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
       args.emplace_back(o);
     }
     add_global_flags();
+    args.emplace_back("http");
     if (!options.trace_file_path.empty())
       args.emplace_back(options.trace_file_path);
   } else if (options.enable_stdiod) {
     args.emplace_back("server");
-    args.emplace_back("stdio");
     add_global_flags();
+    args.emplace_back("stdio");
     if (!options.trace_file_path.empty())
       args.emplace_back(options.trace_file_path);
   } else if (options.summary) {
@@ -1040,10 +1047,10 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
           "Use the 'export' subcommand directly.");
     }
     args.emplace_back("export");
-    args.emplace_back("sqlite");
     args.emplace_back("-o");
     args.emplace_back(options.export_file_path);
     add_global_flags();
+    args.emplace_back("sqlite");
     if (!options.trace_file_path.empty())
       args.emplace_back(options.trace_file_path);
   } else if (!options.query_file_path.empty() ||


### PR DESCRIPTION
Our Windows getopt_compat implementation does not GNU-style permute argv,
so in trace_processor_shell's classic->subcommand translation, any flag
emitted after a positional sub-mode argument (e.g. "http" in
"server http --port 9001 trace.pb") was left as a positional by
getopt_long inside ParseFlags. The next subcommand then misinterpreted
"--port" as the trace file, producing:

  Could not read trace file (path: --port):
    Could not open trace file (path: --port)

Reorder the synthetic argv for the three classic translations that take
a positional sub-mode ("server http", "server stdio", "export sqlite")
so all flags are emitted before the mode positional. This keeps the fix
narrow and cherry-pickable; the broader getopt_compat permutation change
remains as a separate follow-up on main.
