### PR TITLE
ui: Import scss files via typescript module imports

### DIFF
--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -9,3 +9,4 @@ build.js
 eslint.config.js
 **/*.grammar.js
 **/*.grammar.terms.js
+**/vite.d.ts

--- a/ui/build.mjs
+++ b/ui/build.mjs
@@ -130,10 +130,6 @@ const RULES = [
   {r: /ui\/src\/assets\/(data_explorer\/node_info\/(.*)[.]md)/, f: copyAssets},
   {r: /buildtools\/typefaces\/(.+[.]woff2)/, f: copyAssets},
   {r: /buildtools\/catapult_trace_viewer\/(.+(js|html))/, f: copyAssets},
-  {
-    r: /ui\/src\/assets\/.+[.]scss|ui\/src\/(?:plugins|core_plugins)\/.+[.]scss/,
-    f: compileScss,
-  },
   {r: /ui\/src\/chrome_extension\/.*/, f: copyExtensionAssets},
   {r: /.*\/dist\/.+\/(?!manifest\.json).*/, f: genServiceWorkerManifestJson},
   {r: /.*\/dist\/.*[.](js|html|css|wasm)$/, f: notifyLiveServer},
@@ -386,8 +382,6 @@ Env-var overrides:
     generateImports('ui/src/core_plugins', 'all_core_plugins');
     generateImports('ui/src/plugins', 'all_plugins');
     scanDir('ui/src/assets');
-    scanDir('ui/src/plugins', /[.]scss$/);
-    scanDir('ui/src/core_plugins', /[.]scss$/);
     scanDir('ui/src/chrome_extension');
     scanDir('buildtools/typefaces');
     scanDir('buildtools/catapult_trace_viewer');
@@ -534,28 +528,6 @@ function copyAssets(src, dst) {
 
 function copyUiTestArtifactsAssets(src, dst) {
   addTask(cp, [src, pjoin(cfg.outUiTestArtifactsDir, dst)]);
-}
-
-function compileScss() {
-  const src = pjoin(ROOT_DIR, 'ui/src/assets/perfetto.scss');
-  const dst = pjoin(cfg.outDistDir, 'perfetto.css');
-  // In watch mode, don't exit(1) if scss fails. It can easily happen by
-  // having a typo in the css. It will still print an error.
-  const noErrCheck = !!cfg.watch;
-  const args = [src, dst];
-  if (!cfg.verbose) {
-    args.unshift('--quiet');
-  }
-  addTask(execModule, ['sass', args, {noErrCheck}]);
-  if (cfg.bigtrace) {
-    const srcBt = pjoin(ROOT_DIR, 'ui/src/assets/bigtrace.scss');
-    const dstBt = pjoin(cfg.outBigtraceDistDir, 'bigtrace.css');
-    const argsBt = [srcBt, dstBt];
-    if (!cfg.verbose) {
-      argsBt.unshift('--quiet');
-    }
-    addTask(execModule, ['sass', argsBt, {noErrCheck}]);
-  }
 }
 
 function compileProtos() {
@@ -998,7 +970,7 @@ function isDistComplete() {
     'frontend_bundle.js',
     'engine_bundle.js',
     'traceconv_bundle.js',
-    'perfetto.css',
+    'frontend.css',
     ...cfg.wasmModules.map((wasmMod) => `${wasmMod}.wasm`),
   ];
   const relPaths = new Set();

--- a/ui/src/assets/bigtrace.scss
+++ b/ui/src/assets/bigtrace.scss
@@ -27,9 +27,7 @@
 // Widgets
 @import "widgets.scss";
 
-// Auto generated imports
-@import "../gen/all_plugins";
-@import "../gen/all_core_plugins";
+// Plugin styles are imported by each plugin's index.ts via Vite's CSS pipeline.
 
 // BigTrace-specific styles. Classes use the .pf-bt- prefix to avoid
 // collisions with existing Perfetto UI classes.

--- a/ui/src/assets/index.html
+++ b/ui/src/assets/index.html
@@ -122,7 +122,7 @@ Technical Information:
       // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload.
       const fontAttrs = {crossOrigin: '', as: 'font', type: 'font/woff2'}
       const assetsPreload = {
-        '/perfetto.css': {as: 'style'},
+        '/frontend.css': {as: 'style'},
         '/assets/MaterialSymbolsOutlined.woff2': fontAttrs,
         '/assets/Roboto.woff2': fontAttrs,
       };

--- a/ui/src/assets/perfetto.scss
+++ b/ui/src/assets/perfetto.scss
@@ -35,7 +35,3 @@
 
 // Widgets
 @import "widgets.scss";
-
-// Auto generated imports
-@import "../gen/all_plugins";
-@import "../gen/all_core_plugins";

--- a/ui/src/bigtrace/index.ts
+++ b/ui/src/bigtrace/index.ts
@@ -14,6 +14,7 @@
 
 // Keep this import first.
 import '../base/static_initializers';
+import '../assets/bigtrace.scss';
 import m from 'mithril';
 import {defer} from '../base/deferred';
 import {reportError, addErrorHandler, type ErrorDetails} from '../base/logging';

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {AppImpl} from '../../core/app_impl';
 import type {PerfettoPlugin} from '../../public/plugin';

--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {AppImpl} from '../../core/app_impl';
 import type {PerfettoPlugin} from '../../public/plugin';

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {App} from '../../public/app';
 import {showMultiTraceModal} from './multi_trace_modal';

--- a/ui/src/core_plugins/dev.perfetto.SearchUtils/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.SearchUtils/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';

--- a/ui/src/core_plugins/dev.perfetto.SettingsPage/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.SettingsPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {App} from '../../public/app';
 import type {PerfettoPlugin} from '../../public/plugin';

--- a/ui/src/core_plugins/dev.perfetto.Timeline/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import z from 'zod';
 import {DisposableStack} from '../../base/disposable_stack';

--- a/ui/src/core_plugins/dev.perfetto.Timeline/timeline_page.scss
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/timeline_page.scss
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@import "../../assets/theme";
+
 .pf-timeline-header {
   position: relative;
 }

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 // Keep this import first.
-import z from 'zod';
 import '../base/disposable_polyfill';
 import '../base/static_initializers';
+import '../assets/perfetto.scss';
+import z from 'zod';
 import NON_CORE_PLUGINS from '../gen/all_plugins';
 import CORE_PLUGINS from '../gen/all_core_plugins';
 import m from 'mithril';
@@ -302,7 +303,7 @@ function main() {
   const cssLoadPromise = defer<void>();
   const css = document.createElement('link');
   css.rel = 'stylesheet';
-  css.href = assetSrc('perfetto.css');
+  css.href = assetSrc('frontend.css');
   css.onload = () => cssLoadPromise.resolve();
   css.onerror = (err) => cssLoadPromise.reject(err);
   const favicon = document.head.querySelector('#favicon');

--- a/ui/src/plugins/com.android.AndroidLockContention/index.ts
+++ b/ui/src/plugins/com.android.AndroidLockContention/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import {QuerySlot, SerialTaskQueue} from '../../base/query_slot';
 import {LockOwnerDetailsPanel} from './lock_owner_details_panel';
 import {LOCK_CONTENTION_SQL} from './lock_contention_sql';

--- a/ui/src/plugins/com.android.AndroidLog/index.ts
+++ b/ui/src/plugins/com.android.AndroidLog/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import {createAggregationTab} from '../../components/aggregation_adapter';
 import {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import {z} from 'zod';
 import type {PerfettoPlugin} from '../../public/plugin';

--- a/ui/src/plugins/com.google.PerfettoMcp/index.ts
+++ b/ui/src/plugins/com.google.PerfettoMcp/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import type {Trace} from '../../public/trace';
 import type {App} from '../../public/app';
 import type {PerfettoPlugin} from '../../public/plugin';

--- a/ui/src/plugins/com.meta.GpuCompute/index.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';

--- a/ui/src/plugins/dev.perfetto.AggregateProfiles/index.ts
+++ b/ui/src/plugins/dev.perfetto.AggregateProfiles/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 
 import type {QueryFlamegraphMetric} from '../../components/query_flamegraph';

--- a/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';

--- a/ui/src/plugins/dev.perfetto.Ftrace/index.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 
 import type {PerfettoPlugin} from '../../public/plugin';

--- a/ui/src/plugins/dev.perfetto.Memscope/index.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {App} from '../../public/app';
 import type {PerfettoPlugin} from '../../public/plugin';

--- a/ui/src/plugins/dev.perfetto.MetricsPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.MetricsPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';

--- a/ui/src/plugins/dev.perfetto.QueryLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.QueryLog/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';

--- a/ui/src/plugins/dev.perfetto.QueryPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import {z} from 'zod';
 import {runQueryForQueryTable} from '../../components/query_table/queries';

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/index.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import type {App} from '../../public/app';
 import type {PerfettoPlugin} from '../../public/plugin';
 import {AdbWebsocketTargetProvider} from './adb/websocket/adb_websocket_target_provider';

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import {removeFalsyValues} from '../../base/array_utils';
 import {Icons} from '../../base/semantic_icons';

--- a/ui/src/plugins/dev.perfetto.Screenshots/index.ts
+++ b/ui/src/plugins/dev.perfetto.Screenshots/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import {TrackNode} from '../../public/workspace';
 import {NUM} from '../../trace_processor/query_result';
 import type {Trace} from '../../public/trace';

--- a/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
+++ b/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {Trace} from '../../public/trace';
 import type {PerfettoPlugin} from '../../public/plugin';

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import m from 'mithril';
 import type {App} from '../../public/app';
 import type {PerfettoPlugin} from '../../public/plugin';

--- a/ui/src/plugins/org.chromium.V8/index.ts
+++ b/ui/src/plugins/org.chromium.V8/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {V8RuntimeCallStatsTab} from './v8_runtime_call_stats_tab';

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './styles.scss';
 import {addWattsonThreadTrack} from './wattson_thread_utils';
 import type {App} from '../../public/app';
 import {createAggregationTab} from '../../components/aggregation_adapter';

--- a/ui/src/types/vite.d.ts
+++ b/ui/src/types/vite.d.ts
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pulls in Vite's ambient type declarations so tsc accepts side-effect imports
+// of *.scss / *.css and asset paths (*.png, *.svg, ...) handled by Vite's
+// build pipeline, plus types for import.meta.env and import.meta.hot.
+//
+// We use a /// reference rather than tsconfig's "types" field because the
+// latter is exclusive: setting it would disable auto-inclusion of every other
+// @types/* package (node, jest, chrome, mithril, ...) and break the build.
+/// <reference types="vite/client" />

--- a/ui/vite.config.mjs
+++ b/ui/vite.config.mjs
@@ -199,6 +199,10 @@ export default defineConfig({
     },
     outDir: path.join(OUT_SYMLINK, bundleCfg.dir),
     emptyOutDir: false,           // build.mjs puts wasm/css/assets here too.
+    // Force a single CSS asset per bundle (named after the entry chunk, e.g.
+    // frontend.css). IIFE builds don't auto-inject <link> tags, so extraction
+    // needs to be explicit.
+    cssCodeSplit: false,
     sourcemap: !NO_SOURCE_MAPS,
     minify: MINIFY_JS ? 'terser' : false,
     terserOptions: MINIFY_JS === 'preserve_comments'
@@ -211,7 +215,14 @@ export default defineConfig({
         format: 'iife',
         name: BUNDLE,
         entryFileNames,
-        assetFileNames: '[name][extname]',
+        // With cssCodeSplit:false Vite emits the CSS as "style.css" by
+        // default. Rename it to <bundle>.css so that index.html's preload
+        // and the assetSrc('frontend.css') call match.
+        assetFileNames: (info) => {
+          const name = info.names?.[0] || info.name || '';
+          if (name.endsWith('.css')) return `${BUNDLE}.css`;
+          return '[name][extname]';
+        },
         inlineDynamicImports: true,
       },
       onwarn(warning, warn) {


### PR DESCRIPTION
Import scss files using ES6 imports like this:

```ts
import 'foo.scss';
```

This patch configures the build script and vite to process imported scss files and output them to one css file per bundle. This is the modern approach to css bundling and provides the opportunity to allow much tighter coupling between a component's typescript file and its css.

It also makes plugin importing a lot more straightforward as we simply need to include the various index.ts files from the plugins to also obtain their styles.

The resulting css file is still served, imported and hot-reloaded in exactly the same way as before.

In the interest of changing as little as possible, the scss files are mostly unchanged, frontend/index.ts simply imports perfetto.scss which in turn imports the rest of the tree. In the future we could and probably should make each logical component import its own stylesheet.