### PR TITLE
tp: improve experience of casting to id in SQL functions

### DIFF
--- a/python/generators/trace_processor_table/serialize.py
+++ b/python/generators/trace_processor_table/serialize.py
@@ -620,6 +620,16 @@ class {self.table_name} {{
     return RowReference(this, row);
   }}
 
+  // Returns an `Id` for `value` if it refers to a valid row in this table, or
+  // std::nullopt otherwise. Use this whenever turning an untrusted integer
+  // (e.g. from SQL or a decoded proto) into a typed `Id`.
+  std::optional<Id> TryCastId(int64_t value) const {{
+    if (value < 0 || value >= row_count()) {{
+      return std::nullopt;
+    }}
+    return Id{{static_cast<uint32_t>(value)}};
+  }}
+
   ConstCursor CreateCursor(
       std::vector<dataframe::FilterSpec> filters = {{}},
       std::vector<dataframe::SortSpec> sorts = {{}}) const {{

--- a/src/trace_processor/plugins/ancestor/ancestor.cc
+++ b/src/trace_processor/plugins/ancestor/ancestor.cc
@@ -47,8 +47,8 @@ bool GetAncestors(const T& table,
                   base::Status& out_status) {
   auto start_ref = table.FindById(starting_id);
   if (!start_ref) {
-    out_status = base::ErrStatus("no row with id %" PRIu32 "",
-                                 static_cast<uint32_t>(starting_id.value));
+    out_status =
+        base::ErrStatus("no row with id %" PRIu32 "", starting_id.value);
     return false;
   }
 
@@ -91,8 +91,12 @@ bool Ancestor::SliceCursor::Run(const std::vector<SqlValue>& arguments) {
   const auto& slice_table = storage_->slice_table();
   switch (type_) {
     case Type::kSlice: {
-      auto id = static_cast<uint32_t>(arguments[0].long_value);
-      if (!GetAncestors(slice_table, SliceId(id), ancestors_, status_)) {
+      auto id = slice_table.TryCastId(arguments[0].long_value);
+      if (!id) {
+        return OnFailure(base::ErrStatus("no row with id %" PRId64,
+                                         arguments[0].long_value));
+      }
+      if (!GetAncestors(slice_table, *id, ancestors_, status_)) {
         return false;
       }
       break;
@@ -139,8 +143,12 @@ bool Ancestor::StackProfileCursor::Run(const std::vector<SqlValue>& arguments) {
     return OnFailure(base::ErrStatus("start id should be an integer."));
   }
   const auto& callsite = storage_->stack_profile_callsite_table();
-  auto id = static_cast<uint32_t>(arguments[0].long_value);
-  if (!GetAncestors(callsite, CallsiteId(id), ancestors_, status_)) {
+  auto id = callsite.TryCastId(arguments[0].long_value);
+  if (!id) {
+    return OnFailure(
+        base::ErrStatus("no row with id %" PRId64, arguments[0].long_value));
+  }
+  if (!GetAncestors(callsite, *id, ancestors_, status_)) {
     return false;
   }
   for (const auto& ancestor_row : ancestors_) {

--- a/src/trace_processor/plugins/connected_flow/connected_flow.cc
+++ b/src/trace_processor/plugins/connected_flow/connected_flow.cc
@@ -16,6 +16,7 @@
 
 #include "src/trace_processor/plugins/connected_flow/connected_flow.h"
 
+#include <cinttypes>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -230,10 +231,12 @@ bool ConnectedFlow::Cursor::Run(const std::vector<SqlValue>& arguments) {
   if (arguments[0].type != SqlValue::Type::kLong) {
     return OnFailure(base::ErrStatus("start id should be an integer."));
   }
-  SliceId start_id{static_cast<uint32_t>(arguments[0].AsLong())};
-  if (!slice.FindById(start_id)) {
-    return OnFailure(base::ErrStatus("invalid slice id %u", start_id.value));
+  auto maybe_start_id = slice.TryCastId(arguments[0].AsLong());
+  if (!maybe_start_id) {
+    return OnFailure(
+        base::ErrStatus("invalid slice id %" PRId64, arguments[0].AsLong()));
   }
+  SliceId start_id = *maybe_start_id;
 
   // Use cached graph if available, otherwise build a new one.
   FlowGraph graph = cached_flow_graph_.has_value()
@@ -308,10 +311,9 @@ uint32_t ConnectedFlow::GetArgumentCount() const {
 namespace connected_flow {
 namespace {
 
-class ConnectedFlowPlugin
-    : public Plugin<ConnectedFlowPlugin,
-                    ancestor::AncestorPlugin,
-                    descendant::DescendantPlugin> {
+class ConnectedFlowPlugin : public Plugin<ConnectedFlowPlugin,
+                                          ancestor::AncestorPlugin,
+                                          descendant::DescendantPlugin> {
  public:
   ~ConnectedFlowPlugin() override;
 

--- a/src/trace_processor/plugins/experimental_annotated_stack/experimental_annotated_stack.cc
+++ b/src/trace_processor/plugins/experimental_annotated_stack/experimental_annotated_stack.cc
@@ -161,18 +161,18 @@ bool ExperimentalAnnotatedStack::Cursor::Run(
     return OnFailure(base::ErrStatus("invalid input callsite id"));
   }
 
-  CallsiteId start_id(static_cast<uint32_t>(arguments[0].AsLong()));
-  auto opt_start_ref = cs_table.FindById(start_id);
-  if (!opt_start_ref) {
-    return OnFailure(base::ErrStatus("callsite with id %" PRIu32 " not found",
-                                     start_id.value));
+  auto start_id = cs_table.TryCastId(arguments[0].AsLong());
+  if (!start_id) {
+    return OnFailure(base::ErrStatus("callsite with id %" PRId64 " not found",
+                                     arguments[0].AsLong()));
   }
+  auto start_ref = *cs_table.FindById(*start_id);
 
   // Iteratively walk the parent_id chain to construct the list of callstack
   // entries, each pointing at a frame.
   std::vector<CallsiteTable::RowNumber> cs_rows;
-  cs_rows.push_back(opt_start_ref->ToRowNumber());
-  std::optional<CallsiteId> maybe_parent_id = opt_start_ref->parent_id();
+  cs_rows.push_back(start_ref.ToRowNumber());
+  std::optional<CallsiteId> maybe_parent_id = start_ref.parent_id();
   while (maybe_parent_id) {
     auto parent_ref = *cs_table.FindById(*maybe_parent_id);
     cs_rows.push_back(parent_ref.ToRowNumber());

--- a/src/trace_processor/plugins/stack_functions/stack_functions.cc
+++ b/src/trace_processor/plugins/stack_functions/stack_functions.cc
@@ -135,19 +135,14 @@ struct StackFromStackProfileCallsiteFunction
             "STACK_FROM_STACK_PROFILE_CALLSITE: callsite_id must be integer");
     }
 
-    if (callsite_id_long > std::numeric_limits<uint32_t>::max() ||
-        callsite_id_long < 0 ||
-        !storage->stack_profile_callsite_table()
-             .FindById(tables::StackProfileCallsiteTable::Id(
-                 static_cast<uint32_t>(callsite_id_long)))
-             .has_value()) {
+    auto callsite_id =
+        storage->stack_profile_callsite_table().TryCastId(callsite_id_long);
+    if (!callsite_id) {
       return sqlite::utils::SetError(
           ctx, base::ErrStatus("STACK_FROM_STACK_PROFILE_CALLSITE: callsite_id "
                                "does not exist: %" PRId64,
                                callsite_id_long));
     }
-
-    uint32_t callsite_id = static_cast<uint32_t>(callsite_id_long);
 
     bool annotate = false;
     if (argc == 2) {
@@ -169,9 +164,9 @@ struct StackFromStackProfileCallsiteFunction
 
     protozero::HeapBuffered<Stack> stack;
     if (annotate) {
-      stack->add_entries()->set_annotated_callsite_id(callsite_id);
+      stack->add_entries()->set_annotated_callsite_id(callsite_id->value);
     } else {
-      stack->add_entries()->set_callsite_id(callsite_id);
+      stack->add_entries()->set_callsite_id(callsite_id->value);
     }
     return SetBytesResult(ctx, stack.SerializeAsArray());
   }
@@ -205,21 +200,17 @@ struct StackFromStackProfileFrameFunction
             ctx, "STACK_FROM_STACK_PROFILE_FRAME: frame_id must be integer");
     }
 
-    if (frame_id_long > std::numeric_limits<uint32_t>::max() ||
-        frame_id_long < 0 ||
-        !storage->stack_profile_frame_table()
-             .FindById(tables::StackProfileFrameTable::Id(
-                 static_cast<uint32_t>(frame_id_long)))
-             .has_value()) {
+    auto frame_id =
+        storage->stack_profile_frame_table().TryCastId(frame_id_long);
+    if (!frame_id) {
       return sqlite::utils::SetError(
           ctx, base::ErrStatus("STACK_FROM_STACK_PROFILE_FRAME: frame_id does "
                                "not exist: %" PRId64,
                                frame_id_long));
     }
 
-    uint32_t frame_id = static_cast<uint32_t>(frame_id_long);
     protozero::HeapBuffered<Stack> stack;
-    stack->add_entries()->set_frame_id(frame_id);
+    stack->add_entries()->set_frame_id(frame_id->value);
     return SetBytesResult(ctx, stack.SerializeAsArray());
   }
 };

--- a/src/trace_processor/util/profile_builder.cc
+++ b/src/trace_processor/util/profile_builder.cc
@@ -342,18 +342,23 @@ bool GProfileBuilder::AddSample(const Stack::Decoder& stack,
     return true;
   }
 
+  const auto& cs_table = context_.storage->stack_profile_callsite_table();
+  const auto& frame_table = context_.storage->stack_profile_frame_table();
+
   auto next = it;
   ++next;
   if (!next) {
     Stack::Entry::Decoder entry(it->as_bytes());
     if (entry.has_callsite_id() || entry.has_annotated_callsite_id()) {
       bool annotated = entry.has_annotated_callsite_id();
-      uint32_t callsite_id = entry.has_callsite_id()
-                                 ? entry.callsite_id()
-                                 : entry.annotated_callsite_id();
+      auto callsite_id = cs_table.TryCastId(
+          entry.has_callsite_id() ? entry.callsite_id()
+                                  : entry.annotated_callsite_id());
+      if (!callsite_id) {
+        return false;
+      }
       return samples_.AddSample(
-          GetLocationIdsForCallsite(CallsiteId(callsite_id), annotated),
-          values);
+          GetLocationIdsForCallsite(*callsite_id, annotated), values);
     }
   }
 
@@ -367,11 +372,14 @@ bool GProfileBuilder::AddSample(const Stack::Decoder& stack,
           WriteFakeLocationIfNeeded(entry.name().ToStdString()));
     } else if (entry.has_callsite_id() || entry.has_annotated_callsite_id()) {
       bool annotated = entry.has_annotated_callsite_id();
-      uint32_t callsite_id = entry.has_callsite_id()
-                                 ? entry.callsite_id()
-                                 : entry.annotated_callsite_id();
+      auto callsite_id = cs_table.TryCastId(
+          entry.has_callsite_id() ? entry.callsite_id()
+                                  : entry.annotated_callsite_id());
+      if (!callsite_id) {
+        return false;
+      }
       const protozero::PackedVarInt& ids =
-          GetLocationIdsForCallsite(CallsiteId(callsite_id), annotated);
+          GetLocationIdsForCallsite(*callsite_id, annotated);
       for (const uint8_t* p = ids.data(); p < ids.data() + ids.size();) {
         uint64_t location_id;
         p = protozero::proto_utils::ParseVarInt(p, ids.data() + ids.size(),
@@ -379,8 +387,12 @@ bool GProfileBuilder::AddSample(const Stack::Decoder& stack,
         location_ids.Append(location_id);
       }
     } else if (entry.has_frame_id()) {
-      location_ids.Append(WriteLocationIfNeeded(FrameId(entry.frame_id()),
-                                                CallsiteAnnotation::kNone));
+      auto frame_id = frame_table.TryCastId(entry.frame_id());
+      if (!frame_id) {
+        return false;
+      }
+      location_ids.Append(
+          WriteLocationIfNeeded(*frame_id, CallsiteAnnotation::kNone));
     }
   }
   return samples_.AddSample(location_ids, values);


### PR DESCRIPTION
Instead of blindly casting without bounds checking, just verify it's
in bounds of the table.
