### PR TITLE
gn: Stop passing -Werror in non-hermetic builds

### DIFF
--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -267,8 +267,8 @@ config("default") {
     ]
   }
 
-  # Treat warnings as errors, but give up on fuzzer builds.
-  if (!is_fuzzer) {
+  # Treat warnings as errors, but give up on fuzzer and non-hermetic builds.
+  if (!is_fuzzer && is_hermetic_clang) {
     if (is_win) {
       cflags += [ "/WX" ]
     } else {


### PR DESCRIPTION
Passing -Werror when the compiler version is not
controlled is considered a bad practice. See e.g.
https://blog.schmorp.de/2016-02-27-tidbits-for-the-love-of-god-dont-use-werror.html

Therefore, stop doing so in non-hermetic builds.