### PR TITLE
ui: Switch to es6 output for protobuf

### DIFF
--- a/ui/build.mjs
+++ b/ui/build.mjs
@@ -547,7 +547,7 @@ function compileProtos() {
     '-t',
     'static-module',
     '-w',
-    'commonjs',
+    'es6',
     '-p',
     ROOT_DIR,
     '-o',

--- a/ui/config/jest.unittest.config.js
+++ b/ui/config/jest.unittest.config.js
@@ -22,6 +22,16 @@ module.exports = {
         target: 'es2022',
       },
     }],
+    // pbjs now emits ES module .js files (e.g. out/.../gen/protos.js).
+    // Transpile those down to CJS so jest's Node runtime can require them.
+    // node_modules are still ignored by default.
+    '^.+\\.jsx?$': ['@swc/jest', {
+      jsc: {
+        parser: {syntax: 'ecmascript', jsx: false},
+        target: 'es2022',
+      },
+      module: {type: 'commonjs'},
+    }],
   },
   testRegex: '_(unittest|jsdomtest)[.]ts$',
   testEnvironment: __dirname + '/JestJsdomEnv.js',


### PR DESCRIPTION
Switch pbjs from commonjs mode to es6 mode - outputs generated files as es6 modules instead of commonjs.

Required for vite's dev server to work properly.

Should be a no-op.