### PR TITLE
traced_perf: Include kernel return addresses in stack traces

### DIFF
--- a/src/profiling/perf/unwinding.cc
+++ b/src/profiling/perf/unwinding.cc
@@ -526,6 +526,7 @@ std::vector<unwindstack::FrameData> Unwinder::SymbolizeKernelCallchain(
     unwindstack::FrameData& frame = ret.emplace_back();
     frame.function_name = kernel_map->Lookup(ip);
     frame.map_info = kernel_map_info.ref();
+    frame.rel_pc = ip;
   }
   return ret;
 }


### PR DESCRIPTION
These are sometimes useful for identifying the call site (e.g. in case of an indirect call or multiple calls to the same function).