### PR TITLE
tp: fix potential UAF in tree operations code

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3088,6 +3088,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_json_parser",
         ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_value",
+        ":perfetto_src_trace_processor_util_owned_sql_value",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",
         ":perfetto_src_trace_processor_util_proto_profiler",
@@ -18908,6 +18909,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_json_parser",
         ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_value",
+        ":perfetto_src_trace_processor_util_owned_sql_value",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",
         ":perfetto_src_trace_processor_util_proto_profiler",
@@ -19345,6 +19347,11 @@ filegroup {
     srcs: [
         "src/trace_processor/util/json_value.cc",
     ],
+}
+
+// GN: //src/trace_processor/util:owned_sql_value
+filegroup {
+    name: "perfetto_src_trace_processor_util_owned_sql_value",
 }
 
 // GN: //src/trace_processor/util:profile_builder
@@ -21466,6 +21473,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_json_parser",
         ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_value",
+        ":perfetto_src_trace_processor_util_owned_sql_value",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",
         ":perfetto_src_trace_processor_util_proto_profiler",
@@ -22481,6 +22489,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_json_parser",
         ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_value",
+        ":perfetto_src_trace_processor_util_owned_sql_value",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",
         ":perfetto_src_trace_processor_util_proto_profiler",
@@ -23116,6 +23125,7 @@ cc_binary_host {
         ":perfetto_src_trace_processor_util_json_parser",
         ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_value",
+        ":perfetto_src_trace_processor_util_owned_sql_value",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",
         ":perfetto_src_trace_processor_util_proto_profiler",

--- a/BUILD
+++ b/BUILD
@@ -534,6 +534,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_json_parser",
         ":src_trace_processor_util_json_serializer",
         ":src_trace_processor_util_json_value",
+        ":src_trace_processor_util_owned_sql_value",
         ":src_trace_processor_util_profile_builder",
         ":src_trace_processor_util_profiler_util",
         ":src_trace_processor_util_proto_profiler",
@@ -822,6 +823,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_json_parser",
         ":src_trace_processor_util_json_serializer",
         ":src_trace_processor_util_json_value",
+        ":src_trace_processor_util_owned_sql_value",
         ":src_trace_processor_util_profile_builder",
         ":src_trace_processor_util_profiler_util",
         ":src_trace_processor_util_proto_profiler",
@@ -5673,6 +5675,14 @@ perfetto_filegroup(
     ],
 )
 
+# GN target: //src/trace_processor/util:owned_sql_value
+perfetto_filegroup(
+    name = "src_trace_processor_util_owned_sql_value",
+    srcs = [
+        "src/trace_processor/util/owned_sql_value.h",
+    ],
+)
+
 # GN target: //src/trace_processor/util:profile_builder
 perfetto_filegroup(
     name = "src_trace_processor_util_profile_builder",
@@ -10100,6 +10110,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_json_parser",
         ":src_trace_processor_util_json_serializer",
         ":src_trace_processor_util_json_value",
+        ":src_trace_processor_util_owned_sql_value",
         ":src_trace_processor_util_profile_builder",
         ":src_trace_processor_util_profiler_util",
         ":src_trace_processor_util_proto_profiler",
@@ -10414,6 +10425,7 @@ perfetto_cc_binary(
         ":src_trace_processor_util_json_parser",
         ":src_trace_processor_util_json_serializer",
         ":src_trace_processor_util_json_value",
+        ":src_trace_processor_util_owned_sql_value",
         ":src_trace_processor_util_profile_builder",
         ":src_trace_processor_util_profiler_util",
         ":src_trace_processor_util_proto_profiler",

--- a/src/trace_processor/core/tree/BUILD.gn
+++ b/src/trace_processor/core/tree/BUILD.gn
@@ -33,5 +33,6 @@ source_set("tree") {
     "../dataframe",
     "../interpreter",
     "../util",
+    "../../util:owned_sql_value",
   ]
 }

--- a/src/trace_processor/core/tree/BUILD.gn
+++ b/src/trace_processor/core/tree/BUILD.gn
@@ -29,10 +29,10 @@ source_set("tree") {
     "../../../../include/perfetto/trace_processor:basic_types",
     "../../../base",
     "../../containers",
+    "../../util:owned_sql_value",
     "../common",
     "../dataframe",
     "../interpreter",
     "../util",
-    "../../util:owned_sql_value",
   ]
 }

--- a/src/trace_processor/core/tree/tree_transformer.cc
+++ b/src/trace_processor/core/tree/tree_transformer.cc
@@ -62,18 +62,20 @@ struct TreeValueFetcher : core::ValueFetcher {
   static const Type kString = static_cast<Type>(SqlValue::Type::kString);
   static const Type kNull = static_cast<Type>(SqlValue::Type::kNull);
 
-  explicit TreeValueFetcher(const SqlValue* v) : values(v) {}
+  explicit TreeValueFetcher(const OwnedSqlValue* v) : values(v) {}
 
   Type GetValueType(uint32_t i) const {
-    return static_cast<Type>(values[i].type);
+    return static_cast<Type>(values[i].type());
   }
   int64_t GetInt64Value(uint32_t i) const { return values[i].AsLong(); }
   double GetDoubleValue(uint32_t i) const { return values[i].AsDouble(); }
-  const char* GetStringValue(uint32_t i) const { return values[i].AsString(); }
+  const char* GetStringValue(uint32_t i) const {
+    return values[i].AsString();
+  }
   static bool IteratorInit(uint32_t) { return false; }
   static bool IteratorNext(uint32_t) { return false; }
 
-  const SqlValue* values = nullptr;
+  const OwnedSqlValue* values = nullptr;
 };
 
 // Pushes one value from raw column data to the builder.
@@ -193,7 +195,7 @@ std::optional<uint32_t> TreeTransformer::ResolveColumn(
 
 base::Status TreeTransformer::FilterTree(
     std::vector<dataframe::FilterSpec> specs,
-    std::vector<SqlValue> values) {
+    std::vector<OwnedSqlValue> values) {
   if (cols_.row_count == 0 || specs.empty()) {
     return base::OkStatus();
   }

--- a/src/trace_processor/core/tree/tree_transformer.cc
+++ b/src/trace_processor/core/tree/tree_transformer.cc
@@ -69,9 +69,7 @@ struct TreeValueFetcher : core::ValueFetcher {
   }
   int64_t GetInt64Value(uint32_t i) const { return values[i].AsLong(); }
   double GetDoubleValue(uint32_t i) const { return values[i].AsDouble(); }
-  const char* GetStringValue(uint32_t i) const {
-    return values[i].AsString();
-  }
+  const char* GetStringValue(uint32_t i) const { return values[i].AsString(); }
   static bool IteratorInit(uint32_t) { return false; }
   static bool IteratorNext(uint32_t) { return false; }
 

--- a/src/trace_processor/core/tree/tree_transformer.h
+++ b/src/trace_processor/core/tree/tree_transformer.h
@@ -32,6 +32,7 @@
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/tree/propagate_spec.h"
 #include "src/trace_processor/core/tree/tree_columns.h"
+#include "src/trace_processor/util/owned_sql_value.h"
 
 namespace perfetto::trace_processor::core::interpreter {
 class BytecodeBuilder;
@@ -72,8 +73,12 @@ class TreeTransformer {
   // filtered-out nodes have their children reparented to the closest
   // surviving ancestor. Can be called multiple times; bytecodes are
   // emitted immediately.
+  //
+  // |values| must hold owning copies of any string/blob data because
+  // execution is deferred to ToDataframe(), which may run long after
+  // |values| was constructed.
   base::Status FilterTree(std::vector<dataframe::FilterSpec> specs,
-                          std::vector<SqlValue> values);
+                          std::vector<OwnedSqlValue> values);
 
   // Propagates column values from root toward leaves. For each spec, a new
   // output column is created and filled by copying the source column and
@@ -113,8 +118,10 @@ class TreeTransformer {
   // Register initialization info collected during FilterTree calls.
   std::vector<RegInit> reg_inits_;
 
-  // Filter values accumulated across FilterTree calls.
-  std::vector<SqlValue> filter_values_;
+  // Filter values accumulated across FilterTree calls. Stored as
+  // OwnedSqlValue so any string/blob payloads remain valid until
+  // ToDataframe() runs the interpreter.
+  std::vector<OwnedSqlValue> filter_values_;
   uint32_t filter_value_count_ = 0;
 
   // Propagation specs accumulated across PropagateDown calls.

--- a/src/trace_processor/perfetto_sql/engine/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/engine/BUILD.gn
@@ -41,6 +41,7 @@ source_set("engine") {
     "../../core/dataframe",
     "../../core/plugin",
     "../../types",
+    "../../util:owned_sql_value",
     "../../util:sql_argument",
     "../../util:stdlib",
     "../parser",

--- a/src/trace_processor/perfetto_sql/engine/created_function.cc
+++ b/src/trace_processor/perfetto_sql/engine/created_function.cc
@@ -24,7 +24,6 @@
 #include <stack>
 #include <string>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "perfetto/base/logging.h"
@@ -33,7 +32,6 @@
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/ext/base/string_view.h"
-#include "perfetto/ext/base/variant.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
 #include "src/trace_processor/perfetto_sql/parser/function_util.h"
@@ -44,6 +42,7 @@
 #include "src/trace_processor/sqlite/sqlite_connection.h"
 #include "src/trace_processor/sqlite/sqlite_utils.h"
 #include "src/trace_processor/tp_metatrace.h"
+#include "src/trace_processor/util/owned_sql_value.h"
 #include "src/trace_processor/util/sql_argument.h"
 
 namespace perfetto::trace_processor {
@@ -139,63 +138,6 @@ base::Status BindArguments(sqlite3_stmt* stmt,
   return base::OkStatus();
 }
 
-struct StoredSqlValue {
-  // unique_ptr to ensure that the pointers to these values are long-lived.
-  using OwnedString = std::unique_ptr<std::string>;
-  using OwnedBytes = std::unique_ptr<std::vector<uint8_t>>;
-  // variant is a pain to use, but it's the simplest way to ensure that
-  // the destructors run correctly for non-trivial members of the
-  // union.
-  using Data =
-      std::variant<int64_t, double, OwnedString, OwnedBytes, std::nullptr_t>;
-
-  explicit StoredSqlValue(SqlValue value) {
-    switch (value.type) {
-      case SqlValue::Type::kNull:
-        data = nullptr;
-        break;
-      case SqlValue::Type::kLong:
-        data = value.long_value;
-        break;
-      case SqlValue::Type::kDouble:
-        data = value.double_value;
-        break;
-      case SqlValue::Type::kString:
-        data = std::make_unique<std::string>(value.string_value);
-        break;
-      case SqlValue::Type::kBytes:
-        const auto* ptr = static_cast<const uint8_t*>(value.bytes_value);
-        data = std::make_unique<std::vector<uint8_t>>(ptr,
-                                                      ptr + value.bytes_count);
-        break;
-    }
-  }
-
-  SqlValue AsSqlValue() {
-    switch (data.index()) {
-      case base::variant_index<Data, std::nullptr_t>():
-        return {};
-      case base::variant_index<Data, int64_t>():
-        return SqlValue::Long(base::unchecked_get<int64_t>(data));
-      case base::variant_index<Data, double>():
-        return SqlValue::Double(base::unchecked_get<double>(data));
-      case base::variant_index<Data, OwnedString>(): {
-        const auto& str_ptr = base::unchecked_get<OwnedString>(data);
-        return SqlValue::String(str_ptr->c_str());
-      }
-      case base::variant_index<Data, OwnedBytes>(): {
-        const auto& bytes_ptr = base::unchecked_get<OwnedBytes>(data);
-        return SqlValue::Bytes(bytes_ptr->data(), bytes_ptr->size());
-      }
-    }
-    // GCC doesn't realize that the switch is exhaustive.
-    PERFETTO_CHECK(false);
-    return SqlValue();
-  }
-
-  Data data = nullptr;
-};
-
 class Memoizer {
  public:
   // Supported arguments. For now, only functions with a single int argument are
@@ -221,7 +163,7 @@ class Memoizer {
     if (!enabled_) {
       return std::nullopt;
     }
-    StoredSqlValue* value = memoized_values_.Find(args);
+    OwnedSqlValue* value = memoized_values_.Find(args);
     if (!value) {
       return std::nullopt;
     }
@@ -237,7 +179,7 @@ class Memoizer {
     if (!enabled_) {
       return;
     }
-    memoized_values_.Insert(args, StoredSqlValue(value));
+    memoized_values_.Insert(args, OwnedSqlValue(value));
   }
 
   // Checks that the function has a single int argument and returns it.
@@ -257,7 +199,7 @@ class Memoizer {
 
  private:
   bool enabled_ = false;
-  base::FlatHashMap<MemoizedArgs, StoredSqlValue> memoized_values_;
+  base::FlatHashMap<MemoizedArgs, OwnedSqlValue> memoized_values_;
 };
 
 // A helper to unroll recursive calls: to minimise the amount of stack space

--- a/src/trace_processor/plugins/tree_functions/BUILD.gn
+++ b/src/trace_processor/plugins/tree_functions/BUILD.gn
@@ -45,5 +45,6 @@ source_set("tree_functions") {
     "../../sqlite",
     "../../storage",
     "../../types",
+    "../../util:owned_sql_value",
   ]
 }

--- a/src/trace_processor/plugins/tree_functions/tree_filter.cc
+++ b/src/trace_processor/plugins/tree_functions/tree_filter.cc
@@ -31,6 +31,7 @@
 #include "src/trace_processor/sqlite/bindings/sqlite_type.h"
 #include "src/trace_processor/sqlite/bindings/sqlite_value.h"
 #include "src/trace_processor/sqlite/sqlite_utils.h"
+#include "src/trace_processor/util/owned_sql_value.h"
 
 namespace perfetto::trace_processor {
 
@@ -77,10 +78,15 @@ base::StatusOr<core::dataframe::Op> StringOperatorToOp(
 }
 
 // Represents a single filter constraint (column, operator, value).
+//
+// |value| is stored as OwnedSqlValue (rather than SqlValue) because
+// SQLite-provided string/blob memory is only valid for the duration of the
+// owning function call, and FilterConstraints are held across multiple
+// SQL function invocations via SQLite's pointer-passing API.
 struct FilterConstraint {
   std::string column_name;
   std::string op_str;
-  SqlValue value;
+  OwnedSqlValue value;
 };
 
 // Represents a list of filter constraints combined with a logical operator.
@@ -112,14 +118,16 @@ void TreeConstraint::Step(sqlite3_context* ctx,
       sqlite::utils::ExtractArgument(static_cast<uint32_t>(argc), argv, "op", 1,
                                      SqlValue::Type::kString));
 
-  // Extract value (any type).
+  // Extract value (any type). The SqlValue returned here borrows string/blob
+  // memory from SQLite which is only valid for the duration of this call,
+  // so deep-copy it into an OwnedSqlValue before storing it on the heap.
   auto value = sqlite::utils::SqliteValueToSqlValue(argv[2]);
 
   // Create and return a FilterConstraint pointer.
   auto constraint = std::make_unique<FilterConstraint>();
   constraint->column_name = column_name.AsString();
   constraint->op_str = op.AsString();
-  constraint->value = value;
+  constraint->value = OwnedSqlValue(value);
 
   return sqlite::result::UniquePointer(ctx, std::move(constraint),
                                        "FILTER_CONSTRAINT");
@@ -193,7 +201,7 @@ void TreeFilter::Step(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
   auto transformer = tree_ptr->Take();
 
   std::vector<core::dataframe::FilterSpec> specs;
-  std::vector<SqlValue> values;
+  std::vector<OwnedSqlValue> values;
   uint32_t idx = 0;
   for (const auto& c : constraints_ptr->constraints) {
     auto col = transformer.ResolveColumn(c.column_name);

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -252,6 +252,16 @@ source_set("sql_argument") {
   ]
 }
 
+source_set("owned_sql_value") {
+  sources = [ "owned_sql_value.h" ]
+  deps = [
+    "../../../gn:default_deps",
+    "../../../include/perfetto/base",
+    "../../../include/perfetto/ext/base",
+    "../../../include/perfetto/trace_processor:basic_types",
+  ]
+}
+
 source_set("args_utils") {
   sources = [
     "args_utils.cc",

--- a/src/trace_processor/util/owned_sql_value.h
+++ b/src/trace_processor/util/owned_sql_value.h
@@ -83,7 +83,7 @@ class OwnedSqlValue {
       case base::variant_index<Data, std::vector<uint8_t>>():
         return SqlValue::Type::kBytes;
     }
-    PERFETTO_FATAL("Unreachable");
+    PERFETTO_FATAL("For GCC");
   }
 
   int64_t AsLong() const { return base::unchecked_get<int64_t>(data_); }

--- a/src/trace_processor/util/owned_sql_value.h
+++ b/src/trace_processor/util/owned_sql_value.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_UTIL_OWNED_SQL_VALUE_H_
+#define SRC_TRACE_PROCESSOR_UTIL_OWNED_SQL_VALUE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/variant.h"
+#include "perfetto/trace_processor/basic_types.h"
+
+namespace perfetto::trace_processor {
+
+// An owning counterpart to SqlValue.
+//
+// SqlValue holds non-owning pointers to string/blob storage that must
+// outlive it (e.g. SQLite function argument memory which is only valid for
+// the duration of a single function call). OwnedSqlValue instead
+// deep-copies any string or blob payload into its own storage, so it can
+// be retained safely beyond the lifetime of the source.
+class OwnedSqlValue {
+ public:
+  // variant is a pain to use, but it's the simplest way to ensure
+  // destructors run correctly for non-trivial members of the union.
+  using Data = std::variant<std::nullptr_t,
+                            int64_t,
+                            double,
+                            std::string,
+                            std::vector<uint8_t>>;
+
+  OwnedSqlValue() = default;
+
+  explicit OwnedSqlValue(const SqlValue& value) {
+    switch (value.type) {
+      case SqlValue::Type::kNull:
+        data_ = nullptr;
+        break;
+      case SqlValue::Type::kLong:
+        data_ = value.long_value;
+        break;
+      case SqlValue::Type::kDouble:
+        data_ = value.double_value;
+        break;
+      case SqlValue::Type::kString:
+        data_ = std::string(value.string_value ? value.string_value : "");
+        break;
+      case SqlValue::Type::kBytes: {
+        const auto* ptr = static_cast<const uint8_t*>(value.bytes_value);
+        data_ = std::vector<uint8_t>(ptr, ptr + value.bytes_count);
+        break;
+      }
+    }
+  }
+
+  SqlValue::Type type() const {
+    switch (data_.index()) {
+      case base::variant_index<Data, std::nullptr_t>():
+        return SqlValue::Type::kNull;
+      case base::variant_index<Data, int64_t>():
+        return SqlValue::Type::kLong;
+      case base::variant_index<Data, double>():
+        return SqlValue::Type::kDouble;
+      case base::variant_index<Data, std::string>():
+        return SqlValue::Type::kString;
+      case base::variant_index<Data, std::vector<uint8_t>>():
+        return SqlValue::Type::kBytes;
+    }
+    PERFETTO_FATAL("Unreachable");
+  }
+
+  int64_t AsLong() const { return base::unchecked_get<int64_t>(data_); }
+  double AsDouble() const { return base::unchecked_get<double>(data_); }
+  const char* AsString() const {
+    return base::unchecked_get<std::string>(data_).c_str();
+  }
+  const void* AsBytes() const {
+    return base::unchecked_get<std::vector<uint8_t>>(data_).data();
+  }
+  size_t bytes_count() const {
+    return base::unchecked_get<std::vector<uint8_t>>(data_).size();
+  }
+
+  // Returns a non-owning SqlValue view backed by this object's storage. The
+  // pointers in the returned SqlValue are valid until this OwnedSqlValue is
+  // destroyed, reassigned, or moved.
+  SqlValue AsSqlValue() const {
+    switch (data_.index()) {
+      case base::variant_index<Data, std::nullptr_t>():
+        return {};
+      case base::variant_index<Data, int64_t>():
+        return SqlValue::Long(AsLong());
+      case base::variant_index<Data, double>():
+        return SqlValue::Double(AsDouble());
+      case base::variant_index<Data, std::string>():
+        return SqlValue::String(AsString());
+      case base::variant_index<Data, std::vector<uint8_t>>():
+        return SqlValue::Bytes(AsBytes(), bytes_count());
+    }
+    PERFETTO_FATAL("Unreachable");
+  }
+
+ private:
+  Data data_ = nullptr;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_UTIL_OWNED_SQL_VALUE_H_

--- a/test/trace_processor/diff_tests/stdlib/trees/tree_filter_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/trees/tree_filter_tests.py
@@ -372,3 +372,41 @@ class TreeFilter(TestSuite):
         2,0,7,"deep",60,4
         3,"[NULL]",8,"deep",70,4
         """))
+
+  def test_filter_constraint_value_outlives_sqlite_register(self):
+    """Constraint values built from expressions (e.g. printf) must be
+    deep-copied: SQLite is free to reuse the register backing them once
+    __intrinsic_tree_constraint returns, so the FilterConstraint cannot keep a
+    borrowed pointer. Regression test for a heap-use-after-free where the
+    constraint borrowed SQLite-owned string memory."""
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE std.trees.table_conversion;
+          INCLUDE PERFETTO MODULE std.trees.filter;
+
+          CREATE PERFETTO TABLE input_tree AS
+          SELECT 1 AS id, NULL AS parent_id, 'keep_1' AS name
+          UNION ALL SELECT 2, 1, 'remove_2'
+          UNION ALL SELECT 3, 1, 'keep_1'
+          UNION ALL SELECT 4, 2, 'keep_1';
+
+          SELECT _tree_id, _tree_parent_id, id, name
+          FROM _tree_to_table!(
+            _tree_filter(
+              _tree_from_table!((SELECT * FROM input_tree), (name)),
+              _tree_where(
+                _tree_constraint('name', '!=', printf('remove_%d', 2)),
+                _tree_constraint('name', '=', printf('keep_%d', 1))
+              )
+            ),
+            (name)
+          )
+          ORDER BY id;
+        """,
+        out=Csv("""
+        "_tree_id","_tree_parent_id","id","name"
+        0,"[NULL]",1,"keep_1"
+        1,0,3,"keep_1"
+        2,0,4,"keep_1"
+        """))


### PR DESCRIPTION
We were holding onto pointers from SQLite which could be invalidated
at any time and so we have to make a copy. We were not doing so however
leading to potential UAF situation (though I didn't see one in practice).

Refactor out the OwnedSqlValue struct which we were already using for
functions for use here as well.
