### PR TITLE
Handle invalid utids in export_json.cc

### DIFF
--- a/src/trace_processor/export_json.cc
+++ b/src/trace_processor/export_json.cc
@@ -1585,7 +1585,9 @@ class JsonExporter {
 
   std::pair<int64_t, int64_t> UtidToPidAndTid(UniqueTid utid) {
     auto pid_and_tid_it = utids_to_exported_pids_and_tids_.find(utid);
-    PERFETTO_DCHECK(pid_and_tid_it != utids_to_exported_pids_and_tids_.end());
+    if (pid_and_tid_it == utids_to_exported_pids_and_tids_.end()) {
+      return {0, 0};
+    }
     return pid_and_tid_it->second;
   }
 

--- a/src/trace_processor/export_json.cc
+++ b/src/trace_processor/export_json.cc
@@ -626,6 +626,10 @@ class JsonExporter {
         if (args.HasMember("debug")) {
           Dom debug = std::move(args["debug"]);
           args.RemoveMember("debug");
+          // Prevent spoofing legacy event args from trace data.
+          if (debug.HasMember(kLegacyEventArgsKey)) {
+            debug.RemoveMember(kLegacyEventArgsKey);
+          }
           for (const auto& member : debug.GetMemberNames()) {
             args[member] = debug[member].Copy();
           }
@@ -1585,11 +1589,7 @@ class JsonExporter {
 
   std::pair<int64_t, int64_t> UtidToPidAndTid(UniqueTid utid) {
     auto pid_and_tid_it = utids_to_exported_pids_and_tids_.find(utid);
-    // Trace data can make its way into the translated utids here, thus we
-    // might observe invalid ones.
-    if (pid_and_tid_it == utids_to_exported_pids_and_tids_.end()) {
-      return {0, 0};
-    }
+    PERFETTO_DCHECK(pid_and_tid_it != utids_to_exported_pids_and_tids_.end());
     return pid_and_tid_it->second;
   }
 

--- a/src/trace_processor/export_json.cc
+++ b/src/trace_processor/export_json.cc
@@ -1585,6 +1585,8 @@ class JsonExporter {
 
   std::pair<int64_t, int64_t> UtidToPidAndTid(UniqueTid utid) {
     auto pid_and_tid_it = utids_to_exported_pids_and_tids_.find(utid);
+    // Trace data can make its way into the translated utids here, thus we
+    // might observe invalid ones.
     if (pid_and_tid_it == utids_to_exported_pids_and_tids_.end()) {
       return {0, 0};
     }


### PR DESCRIPTION
Theoretically, trace data can override the `passthrough_utid` param in args, which is later used to lookup a tid/pid. Work around invalid values by returning invalid tid/pids when an invalid utid is supplied.

See also http://crbug.com/513155149.
