### PR TITLE
ui: explicitly await user confirmation contacting opening add extension server URL

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal.ts
@@ -29,6 +29,7 @@ import {Icon} from '../../widgets/icon';
 import {Anchor} from '../../widgets/anchor';
 import {Popup} from '../../widgets/popup';
 import {EmptyState} from '../../widgets/empty_state';
+import {Intent} from '../../widgets/common';
 import {debounce} from '../../base/rate_limiters';
 
 type GithubUserInput = Extract<UserInput, {type: 'github'}>;
@@ -50,7 +51,8 @@ type LoadedState = OkLoadedState | ErrorLoadedState;
 const PAT_HELP_URL =
   'https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens';
 
-class AddExtensionServerModal {
+// Exported for unit testing only.
+export class AddExtensionServerModal {
   private readonly fetchLimiter = new AsyncLimiter();
   private readonly debouncedFetch = debounce(
     () => this.scheduleManifestFetch(),
@@ -59,13 +61,27 @@ class AddExtensionServerModal {
   private userInput: UserInput;
   private loadedState?: LoadedState;
   private readonly isEmbedderManaged: boolean;
+  private awaitingConfirmation = false;
+  private deferredInitialModules?: ReadonlyArray<string>;
 
   constructor(server?: ExtensionServer, prefill?: ExtensionServer) {
     this.userInput = createInitial(server ?? prefill);
     this.isEmbedderManaged = server?.origin === 'embedder_managed';
-    this.scheduleManifestFetch(
-      server?.enabledModules ?? prefill?.enabledModules,
-    );
+    const initialModules = server?.enabledModules ?? prefill?.enabledModules;
+    if (prefill !== undefined && server === undefined) {
+      // Prefill is untrusted: require an explicit click before contacting
+      // the server.
+      this.awaitingConfirmation = true;
+      this.deferredInitialModules = initialModules;
+    } else {
+      this.scheduleManifestFetch(initialModules);
+    }
+  }
+
+  private confirmLoad(): void {
+    const modules = this.deferredInitialModules;
+    this.deferredInitialModules = undefined;
+    this.scheduleManifestFetch(modules);
   }
 
   view() {
@@ -419,6 +435,7 @@ class AddExtensionServerModal {
 
   private renderModuleSection(): m.Children {
     const showRefresh =
+      !this.awaitingConfirmation &&
       !this.isEmptyInput() &&
       (this.loadedState?.type === 'ok' || this.loadedState?.type === 'error');
     return m(
@@ -438,6 +455,9 @@ class AddExtensionServerModal {
   }
 
   private renderModuleContent(): m.Children {
+    if (this.awaitingConfirmation) {
+      return this.renderLoadConfirmation();
+    }
     if (this.isEmptyInput()) {
       return m(EmptyState, {
         icon: 'extension',
@@ -481,9 +501,34 @@ class AddExtensionServerModal {
     });
   }
 
+  private renderLoadConfirmation(): m.Children {
+    return m(
+      '.pf-add-extension-server-modal__confirm',
+      m(Icon, {
+        icon: 'shield',
+        className: 'pf-add-extension-server-modal__confirm-icon',
+      }),
+      m(
+        '.pf-add-extension-server-modal__confirm-title',
+        'Confirm before contacting this server',
+      ),
+      m(
+        '.pf-add-extension-server-modal__confirm-body',
+        'This configuration was opened from a shared link. No request has been sent yet. Review the details above, then load the module list to continue.',
+      ),
+      m(Button, {
+        label: 'Load modules from this server',
+        icon: 'cloud_download',
+        intent: Intent.Primary,
+        onclick: () => this.confirmLoad(),
+      }),
+    );
+  }
+
   private scheduleManifestFetch(
     preserveEnabledModules?: ReadonlyArray<string>,
   ): void {
+    this.awaitingConfirmation = false;
     this.loadedState = undefined;
     this.fetchLimiter.schedule(() => this.loadManifest(preserveEnabledModules));
   }

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal_unittest.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal_unittest.ts
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AddExtensionServerModal} from './add_extension_server_modal';
+import type {ExtensionServer} from './types';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function mockJsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+    clone() {
+      return this;
+    },
+  } as unknown as Response);
+}
+
+// Flushes microtasks and any timers so AsyncLimiter-scheduled work can run.
+async function flushAsync() {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
+
+const PREFILL: ExtensionServer = {
+  type: 'https',
+  url: 'https://example.com/api',
+  enabledModules: [],
+  enabled: true,
+  auth: {type: 'https_sso'},
+  origin: 'user_added',
+};
+
+const EXISTING: ExtensionServer = {
+  type: 'https',
+  url: 'https://example.com',
+  enabledModules: ['default'],
+  enabled: true,
+  auth: {type: 'none'},
+  origin: 'user_added',
+};
+
+describe('AddExtensionServerModal', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+    mockFetch.mockImplementation(() =>
+      mockJsonResponse({
+        name: 'X',
+        namespace: 'x',
+        features: [],
+        modules: [],
+      }),
+    );
+  });
+
+  test('does not fetch when opened with prefill only', async () => {
+    new AddExtensionServerModal(undefined, PREFILL);
+    await flushAsync();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('fetches when opened with an existing server', async () => {
+    new AddExtensionServerModal(EXISTING);
+    await flushAsync();
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  test('confirmLoad triggers the deferred fetch', async () => {
+    const modal = new AddExtensionServerModal(undefined, PREFILL);
+    await flushAsync();
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    (modal as unknown as {confirmLoad(): void}).confirmLoad();
+    await flushAsync();
+    expect(mockFetch).toHaveBeenCalled();
+  });
+});

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal_unittest.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal_unittest.ts
@@ -15,7 +15,7 @@
 import {AddExtensionServerModal} from './add_extension_server_modal';
 import type {ExtensionServer} from './types';
 
-const mockFetch = jest.fn();
+const mockFetch = vi.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
 
 function mockJsonResponse(data: unknown, status = 200) {

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/styles.scss
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/styles.scss
@@ -99,6 +99,32 @@
     }
   }
 
+  &__confirm {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 16px;
+    text-align: center;
+    color: var(--pf-color-text-muted);
+  }
+
+  &__confirm-icon {
+    font-size: 4em;
+  }
+
+  &__confirm-title {
+    font-weight: 500;
+    color: var(--pf-color-text);
+  }
+
+  &__confirm-body {
+    max-width: 420px;
+    line-height: 1.4;
+  }
+
   .pf-multiselect-panel {
     flex: 1;
     min-height: 0;


### PR DESCRIPTION
THis ensures that we don't contact URL with credentials without the user first
approving it. It was possible to send a get request to an arbirrary URL just by letting
the user open a link otherwise.
