### PR TITLE
tp: make all functions keyed by lowercase in hashmap

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
@@ -1371,7 +1371,7 @@ base::Status PerfettoSqlConnection::RegisterDelegatingFunction(
 
   // Look up the target function in our registry
   IntrinsicFunctionInfo* info_ptr =
-      intrinsic_function_registry_.Find(target_function_name);
+      intrinsic_function_registry_.Find(base::ToLower(target_function_name));
   if (info_ptr == nullptr) {
     return base::ErrStatus(
         "Target function '%s' not found in registry. "
@@ -1432,7 +1432,7 @@ base::Status PerfettoSqlConnection::RegisterFunctionAndAddToRegistry(
   info.argc = argc;
   info.ctx = ctx;
   info.deterministic = deterministic;
-  intrinsic_function_registry_[name] = info;
+  intrinsic_function_registry_[base::ToLower(name)] = info;
 
   return base::OkStatus();
 }

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
@@ -470,8 +470,9 @@ class PerfettoSqlConnection {
   StaticTableFunctionModule::Context* static_table_fn_context_ = nullptr;
   DataframeModule::Context* dataframe_context_ = nullptr;
 
-  // Registry of intrinsic functions that can be aliased
-  // Maps intrinsic_name -> (function_ptr, argc, ctx, deterministic)
+  // Registry of intrinsic functions that can be aliased.
+  // Maps lowercased name -> (function_ptr, argc, ctx, deterministic). Keys are
+  // lowercased to match SQLite's case-insensitive function namespace.
   struct IntrinsicFunctionInfo {
     SqliteConnection::Fn* func;
     int argc;

--- a/src/trace_processor/sqlite/sqlite_connection.cc
+++ b/src/trace_processor/sqlite/sqlite_connection.cc
@@ -25,6 +25,7 @@
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/sqlite/scoped_db.h"
 #include "src/trace_processor/sqlite/sql_source.h"
@@ -186,7 +187,7 @@ base::Status SqliteConnection::RegisterFunction(const char* name,
         "Unable to register function with name %s: %s (SQLite error code: %d)",
         name, sqlite3_errmsg(db_.get()), ret);
   }
-  *fn_ctx_.Insert(std::make_pair(name, argc), ctx).first = ctx;
+  *fn_ctx_.Insert(std::make_pair(base::ToLower(name), argc), ctx).first = ctx;
   return base::OkStatus();
 }
 
@@ -244,7 +245,7 @@ base::Status SqliteConnection::UnregisterFunction(const char* name, int argc) {
         "%d)",
         name, sqlite3_errmsg(db_.get()), ret);
   }
-  fn_ctx_.Erase({name, argc});
+  fn_ctx_.Erase({base::ToLower(name), argc});
   return base::OkStatus();
 }
 
@@ -259,7 +260,7 @@ void SqliteConnection::RegisterVirtualTableModule(
 }
 
 void* SqliteConnection::GetFunctionContext(const std::string& name, int argc) {
-  auto* res = fn_ctx_.Find(std::make_pair(name, argc));
+  auto* res = fn_ctx_.Find(std::make_pair(base::ToLower(name), argc));
   return res ? *res : nullptr;
 }
 

--- a/src/trace_processor/sqlite/sqlite_connection.h
+++ b/src/trace_processor/sqlite/sqlite_connection.h
@@ -172,6 +172,9 @@ class SqliteConnection {
  private:
   std::optional<uint32_t> GetErrorOffset() const;
 
+  // Keys are stored lowercased to match SQLite's case-insensitive function
+  // namespace; otherwise a case-variant registration could free the SQLite
+  // context while we kept a dangling pointer here.
   base::FlatHashMap<std::pair<std::string, int>,
                     void*,
                     base::MurmurHash<std::pair<std::string, int>>>


### PR DESCRIPTION
Prevents UAF when there is inconsistency between lower/upper case
use when doing create/create or replace etc.
