### PR TITLE
ui: Attempt to fix playwright flakes

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -20,12 +20,12 @@ const outDir = process.env.OUT_DIR ?? '../out/ui';
 const isRebaseline = process.argv.includes('--update-snapshots');
 
 export default defineConfig({
-  timeout: 30_000,
+  timeout: 60_000,
   testDir: './src',
   snapshotDir: '../test/data/ui-screenshots',
   snapshotPathTemplate: '{snapshotDir}/{testFileName}/{testName}/{arg}{ext}',
   outputDir: `${outDir}/ui-test-results`,
-  fullyParallel: true,
+  fullyParallel: false,
   retries: isCi ? 2 : 0, // Retry only in CI
   reporter: [
     [

--- a/ui/src/test/funcgraph_trace.test.ts
+++ b/ui/src/test/funcgraph_trace.test.ts
@@ -22,7 +22,7 @@ let page: Page;
 
 test.beforeAll(async ({browser}, _testInfo) => {
   // This trace is quite large, bump the timeout up a little
-  test.setTimeout(120_000);
+  test.slow();
   page = await browser.newPage();
   pth = new PerfettoTestHelper(page);
   await pth.openTraceFile('ui-funcgraph.pftrace');

--- a/ui/src/test/table_viewer.test.ts
+++ b/ui/src/test/table_viewer.test.ts
@@ -228,7 +228,7 @@ test('Go to thread_state', async () => {
 
 test('Go to sched', async () => {
   // This test can take a little longer
-  test.setTimeout(60_000);
+  test.slow();
 
   // Open Android trace with kernel scheduling data.
   await pth.openTraceFile('api34_startup_cold.perfetto-trace');


### PR DESCRIPTION
- Set `fullyParallel: false` - runs each test in each file sequentially.
- Bump default timeouts from 30s->60s
- Use `test.slow()` instead of manually specifying timeouts in certain tests, which simply triples the default timeout.