### PR TITLE
shared_lib: Expose shutdown

### DIFF
--- a/contrib/rust-sdk/perfetto-sys/src/bindings.rs
+++ b/contrib/rust-sdk/perfetto-sys/src/bindings.rs
@@ -394,6 +394,9 @@ unsafe extern "C" {
     pub fn PerfettoProducerInProcessInit(args: *const PerfettoProducerBackendInitArgs);
 }
 unsafe extern "C" {
+    pub fn PerfettoProducerShutdown();
+}
+unsafe extern "C" {
     pub fn PerfettoProducerActivateTriggers(
         trigger_names: *mut *const ::std::os::raw::c_char,
         ttl_ms: u32,

--- a/include/perfetto/public/abi/producer_abi.h
+++ b/include/perfetto/public/abi/producer_abi.h
@@ -66,6 +66,20 @@ PERFETTO_SDK_EXPORT void PerfettoProducerSystemInit(
 PERFETTO_SDK_EXPORT void PerfettoProducerInProcessInit(
     const struct PerfettoProducerBackendInitArgs* args);
 
+// Shutdown the global in-process perfetto producer releasing any allocated
+// OS resources (threads, files, sockets, etc.)
+//
+// Note that Perfetto cannot be reinitialized again in the same process [1].
+// Instead, this function is meant for shutting down all Perfetto-related
+// code so that it can be safely unloaded, e.g., with dlclose().
+//
+// It is only safe to call this function when all threads recording trace
+// events have been terminated or otherwise guaranteed to not make any further
+// calls into Perfetto.
+//
+// [1] Unless static data is also cleared through other means.
+PERFETTO_SDK_EXPORT void PerfettoProducerShutdown(void);
+
 // Informs the tracing services to activate any of these triggers if any tracing
 // session was waiting for them.
 //

--- a/src/shared_lib/producer.cc
+++ b/src/shared_lib/producer.cc
@@ -73,6 +73,10 @@ void PerfettoProducerSystemInit(
   perfetto::Tracing::Initialize(args);
 }
 
+void PerfettoProducerShutdown() {
+  perfetto::Tracing::Shutdown();
+}
+
 void PerfettoProducerActivateTriggers(const char* trigger_names[],
                                       uint32_t ttl_ms) {
   std::vector<std::string> triggers;


### PR DESCRIPTION
Example usage in https://ui.perfetto.dev/#!/?s=315a987bda469405966eb46797201e11b12d247c captured using https://github.com/google/android-cuttlefish/pull/2502.

The Cuttlefish launcher host tooling uses `fork()` ... a lot ... so we introduce a wrapper that handles shutting down tracing before `fork()`ing and re-initializing after `fork()`ing. With this, we need shutdown to be available via the c shared lib.

Bug: b/378560215
