### PR TITLE
ui: add opt-in engine startup benchmark

### DIFF
--- a/ui/build.mjs
+++ b/ui/build.mjs
@@ -87,6 +87,7 @@ const cfg = {
   verbose: false,
   debug: false,
   bigtrace: false,
+  engineBench: false,
   startHttpServer: false,
   httpServerListenHost: '127.0.0.1',
   httpServerListenPort: undefined,
@@ -123,6 +124,9 @@ const RULES = [
   {r: /ui\/src\/assets\/index.html/, f: copyIndexHtml},
   {r: /ui\/src\/assets\/bigtrace.html/, f: copyBigtraceHtml},
   {r: /ui\/src\/open_perfetto_trace\/index.html/, f: copyOpenPerfettoTraceHtml},
+  // engine_bench page; no-op without --enable-engine-bench.
+  {r: /ui\/src\/engine_bench\/bench\.html$/, f: copyEngineBenchHtml},
+  {r: /ui\/src\/engine_bench\/bench\.js$/, f: copyEngineBenchJs},
   {r: /ui\/src\/assets\/((.*)[.]png)/, f: copyAssets},
   {r: /ui\/src\/assets\/(data_explorer\/base-page\.json)/, f: copyAssets},
   {r: /ui\/src\/assets\/(data_explorer\/examples\/(.*)[.]json)/, f: copyAssets},
@@ -212,6 +216,11 @@ Env-var overrides:
   parser.add_argument('--run-unittests', '-t', {action: 'store_true'});
   parser.add_argument('--debug', '-d', {action: 'store_true'});
   parser.add_argument('--bigtrace', {action: 'store_true'});
+  parser.add_argument('--enable-engine-bench', {
+    action: 'store_true',
+    help: 'Build the engine startup benchmark page (engine_bench.html) and ' +
+          'its dedicated worker bundle. Off by default.',
+  });
   parser.add_argument('--open-perfetto-trace', {action: 'store_true'});
   parser.add_argument('--interactive', '-i', {action: 'store_true'});
   parser.add_argument('--rebaseline', '-r', {action: 'store_true'});
@@ -276,6 +285,7 @@ Env-var overrides:
   cfg.verbose = !!args.verbose;
   cfg.debug = !!args.debug;
   cfg.bigtrace = !!args.bigtrace;
+  cfg.engineBench = !!args.enable_engine_bench;
   cfg.openPerfettoTrace = !!args.open_perfetto_trace;
   cfg.startHttpServer = args.serve;
   cfg.noOverrideGnArgs = !!args.no_override_gn_args;
@@ -391,6 +401,9 @@ Env-var overrides:
     if (cfg.openPerfettoTrace) {
       scanDir('ui/src/open_perfetto_trace');
       tsProjects.push('ui/src/open_perfetto_trace');
+    }
+    if (cfg.engineBench) {
+      scanDir('ui/src/engine_bench');
     }
 
     if (cfg.check) {
@@ -514,6 +527,31 @@ function copyOpenPerfettoTraceHtml(src) {
   if (cfg.openPerfettoTrace) {
     addTask(cp, [src, pjoin(cfg.outOpenPerfettoTraceDistDir, 'index.html')]);
   }
+}
+
+function copyEngineBenchHtml(src) {
+  if (!cfg.engineBench) return;
+  // Goes next to engine_bench_bundle.js so its relative <script> resolves.
+  addTask(cp, [src, pjoin(cfg.outDistDir, 'engine_bench.html')]);
+  addTask(makeEngineBenchRedirect, []);
+}
+
+function makeEngineBenchRedirect() {
+  const target = `${cfg.version}/engine_bench.html`;
+  // Redirect via JS so the bench knob query string is preserved.
+  const html =
+    '<!DOCTYPE html><meta charset="utf-8">' +
+    '<title>Perfetto engine bench (redirect)</title>' +
+    `<script>location.replace(${JSON.stringify(target)} + location.search + ` +
+    'location.hash);</script>' +
+    `<noscript><meta http-equiv="refresh" content="0; url=${target}">` +
+    `<p>Redirecting to <a href="${target}">${target}</a>.</p></noscript>\n`;
+  fs.writeFileSync(pjoin(cfg.outDistRootDir, 'engine_bench.html'), html);
+}
+
+function copyEngineBenchJs(src) {
+  if (!cfg.engineBench) return;
+  addTask(cp, [src, pjoin(cfg.outDistDir, 'bench.js')]);
 }
 
 function copyAssets(src, dst) {
@@ -759,6 +797,7 @@ function runVite() {
     'chrome_extension',
   ];
   if (cfg.bigtrace) bundles.push('bigtrace');
+  if (cfg.engineBench) bundles.push('engine_bench');
   if (cfg.openPerfettoTrace) bundles.push('open_perfetto_trace');
   for (const bundle of bundles) {
     const args = [

--- a/ui/src/engine_bench/bench.html
+++ b/ui/src/engine_bench/bench.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<!--
+ Copyright (C) 2026 The Android Open Source Project
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+-->
+<!--
+ Engine startup benchmark page. Spawns N standalone bench workers
+ (engine_bench_bundle.js) sequentially and records per-phase startup
+ latencies. Only built when ui/build is run with --enable-engine-bench.
+
+ Query string:
+   n=<int>          number of iterations (default 10)
+   warmup=<int>     warmup iterations not included in stats (default 1)
+   cache=cold       append a cache-busting query string to the worker URL
+   auto=1           run immediately on load (Playwright sets this)
+   precompile=0     disable main-thread compileStreaming sharing
+
+ Results are exposed at window.__benchResults after the run completes.
+-->
+<html>
+<head>
+<meta charset="utf-8">
+<title>Perfetto engine startup benchmark</title>
+<style>
+  body { font-family: monospace; margin: 16px; }
+  h1 { font-size: 16px; }
+  button { font-family: monospace; padding: 4px 10px; }
+  table { border-collapse: collapse; margin-top: 12px; }
+  th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: right; }
+  th:first-child, td:first-child { text-align: left; }
+  .controls { margin-bottom: 12px; }
+  .controls label { margin-right: 12px; }
+  pre#log { background: #f4f4f4; padding: 8px; max-height: 200px; overflow: auto; }
+</style>
+</head>
+<body>
+<h1>Perfetto engine startup benchmark</h1>
+<div class="controls">
+  <label>Iterations: <input id="n" type="number" value="10" min="1" max="200"></label>
+  <label>Warmup: <input id="warmup" type="number" value="1" min="0" max="50"></label>
+  <label><input id="cold" type="checkbox"> Cache-bust each iter (cold-cache mode)</label>
+  <button id="run">Run</button>
+</div>
+<div id="status">Idle.</div>
+<table id="results" style="display:none">
+  <thead>
+    <tr><th>Phase</th><th>min</th><th>p50</th><th>p95</th><th>max</th><th>mean</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<h2 style="font-size:14px">Log</h2>
+<pre id="log"></pre>
+<script src="./bench.js"></script>
+</body>
+</html>

--- a/ui/src/engine_bench/bench.js
+++ b/ui/src/engine_bench/bench.js
@@ -1,0 +1,171 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Engine startup benchmark page — see bench.html.
+
+(function () {
+  'use strict';
+
+  const WORKER_URL = 'engine_bench_bundle.js';
+  // ?precompile=0 forces each worker to fetch + compile its own copy.
+  const PRECOMPILE =
+      new URLSearchParams(location.search).get('precompile') !== '0';
+  // The bench requires a memory64-capable browser (Chromium ≥ 133,
+  // Firefox ≥ 134). No fallback.
+  const WASM_URL = 'trace_processor_memory64.wasm';
+  const compiledModulePromise = PRECOMPILE
+    ? WebAssembly.compileStreaming(fetch(WASM_URL))
+    : Promise.resolve(undefined);
+
+  const $ = (id) => document.getElementById(id);
+  const params = new URLSearchParams(location.search);
+  const initialN = parseInt(params.get('n') || '', 10);
+  const initialWarmup = parseInt(params.get('warmup') || '', 10);
+  const initialCold = params.get('cache') === 'cold';
+  if (!isNaN(initialN)) $('n').value = String(initialN);
+  if (!isNaN(initialWarmup)) $('warmup').value = String(initialWarmup);
+  if (initialCold) $('cold').checked = true;
+
+  function log(msg) {
+    const el = $('log');
+    el.textContent += msg + '\n';
+    el.scrollTop = el.scrollHeight;
+    // eslint-disable-next-line no-console
+    console.log('[bench]', msg);
+  }
+
+  async function runOne(cacheBust) {
+    const url = cacheBust ? `${WORKER_URL}?cb=${cacheBust}` : WORKER_URL;
+    const t0 = performance.now();
+    const worker = new Worker(url);
+    const tAfterCtor = performance.now();
+    const wasmModule = await compiledModulePromise;
+    const bootstrap = {useMemory64: true};
+    if (wasmModule) bootstrap.wasmModule = wasmModule;
+    worker.postMessage(bootstrap);
+    try {
+      return await new Promise((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error('worker did not report bench-marks in 30s')),
+          30000,
+        );
+        worker.onerror = (e) => {
+          clearTimeout(timeout);
+          reject(new Error(`worker error: ${e.message || e.type}`));
+        };
+        worker.onmessage = (msg) => {
+          if (!msg.data) return;
+          if (msg.data.type === 'bench-error') {
+            clearTimeout(timeout);
+            reject(new Error(`worker reported error: ${msg.data.message}`));
+            return;
+          }
+          if (msg.data.type !== 'bench-marks') return;
+          clearTimeout(timeout);
+          const tReceived = performance.now();
+          resolve({
+            new_worker_sync_ms: tAfterCtor - t0,
+            e2e_main_thread_ms: tReceived - t0,
+            ...msg.data.phases,
+          });
+        };
+      });
+    } finally {
+      worker.terminate();
+    }
+  }
+
+  function percentile(sorted, p) {
+    if (sorted.length === 0) return NaN;
+    const idx = Math.min(
+      sorted.length - 1,
+      Math.max(0, Math.floor((p / 100) * sorted.length)),
+    );
+    return sorted[idx];
+  }
+
+  function summarise(samples) {
+    if (samples.length === 0) return {};
+    const keys = Object.keys(samples[0]);
+    const out = {};
+    for (const k of keys) {
+      const vals = samples.map((s) => s[k]).sort((a, b) => a - b);
+      out[k] = {
+        min: vals[0],
+        p50: percentile(vals, 50),
+        p95: percentile(vals, 95),
+        max: vals[vals.length - 1],
+        mean: vals.reduce((a, b) => a + b, 0) / vals.length,
+      };
+    }
+    return out;
+  }
+
+  function renderTable(summary) {
+    const tbody = $('results').querySelector('tbody');
+    tbody.innerHTML = '';
+    const order = [
+      'e2e_main_thread_ms',
+      'new_worker_sync_ms',
+      'bundle_eval_ms',
+      'bridge_ctor_ms',
+      'start_init_sync_ms',
+      'init_async_ms',
+      'total_worker_ms',
+    ];
+    const fmt = (v) => v.toFixed(1);
+    for (const k of order) {
+      if (!(k in summary)) continue;
+      const s = summary[k];
+      const tr = document.createElement('tr');
+      tr.innerHTML =
+        `<td>${k}</td><td>${fmt(s.min)}</td><td>${fmt(s.p50)}</td>` +
+        `<td>${fmt(s.p95)}</td><td>${fmt(s.max)}</td><td>${fmt(s.mean)}</td>`;
+      tbody.appendChild(tr);
+    }
+    $('results').style.display = '';
+  }
+
+  async function run() {
+    $('run').disabled = true;
+    const n = parseInt($('n').value, 10);
+    const warmup = parseInt($('warmup').value, 10);
+    const cold = $('cold').checked;
+    log(`Starting: n=${n}, warmup=${warmup}, cold=${cold}`);
+    const samples = [];
+    // Sequential: parallel spawns contend for the wasm code-cache slot.
+    for (let i = 0; i < warmup + n; i++) {
+      const cacheBust = cold ? `${Date.now()}-${i}` : '';
+      try {
+        const s = await runOne(cacheBust);
+        const tag = i < warmup ? 'warmup' : `iter ${i - warmup + 1}/${n}`;
+        log(`${tag}: e2e=${s.e2e_main_thread_ms.toFixed(1)}ms ` +
+            `start_init=${s.start_init_sync_ms.toFixed(1)}ms ` +
+            `init_async=${s.init_async_ms.toFixed(1)}ms`);
+        if (i >= warmup) samples.push(s);
+        $('status').textContent = `Running… ${i + 1}/${warmup + n}`;
+      } catch (e) {
+        log(`ERROR at iter ${i}: ${e.message}`);
+        $('status').textContent = `Aborted at iter ${i}: ${e.message}`;
+        $('run').disabled = false;
+        return;
+      }
+    }
+    const summary = summarise(samples);
+    renderTable(summary);
+    $('status').textContent = `Done. ${samples.length} samples.`;
+    window.__benchResults = {config: {n, warmup, cold}, samples, summary};
+    log('Results stored on window.__benchResults');
+    $('run').disabled = false;
+  }
+
+  $('run').addEventListener('click', run);
+  if (params.get('auto') === '1') {
+    setTimeout(run, 0);
+  }
+})();

--- a/ui/src/engine_bench/bench.test.ts
+++ b/ui/src/engine_bench/bench.test.ts
@@ -1,0 +1,88 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Engine startup benchmark — drives engine_bench.html, harvests the timings
+// it exposes on `window.__benchResults`, and prints a JSON summary.
+//
+// Disabled by default. Enable with `PERFETTO_BENCH=1`, and run only after
+// building the UI with `ui/build --enable-engine-bench` so the bench bundle
+// and page are present in dist.
+//
+// Tunables:
+//   PERFETTO_BENCH_N        iterations (default 20)
+//   PERFETTO_BENCH_WARMUP   warmup iterations excluded from stats (default 2)
+//   PERFETTO_BENCH_COLD     "1" to cache-bust each iteration
+
+import {test, expect} from '@playwright/test';
+
+interface PhaseStats {
+  readonly min: number;
+  readonly p50: number;
+  readonly p95: number;
+  readonly max: number;
+  readonly mean: number;
+}
+
+interface BenchResults {
+  readonly config: {n: number; warmup: number; cold: boolean};
+  readonly samples: ReadonlyArray<Record<string, number>>;
+  readonly summary: Record<string, PhaseStats>;
+}
+
+const enabled = process.env.PERFETTO_BENCH === '1';
+const N = Number(process.env.PERFETTO_BENCH_N ?? '20');
+const WARMUP = Number(process.env.PERFETTO_BENCH_WARMUP ?? '2');
+const COLD = process.env.PERFETTO_BENCH_COLD === '1';
+
+const describeFn = enabled ? test.describe : test.describe.skip;
+
+describeFn('engine startup benchmark', () => {
+  test.setTimeout(5 * 60_000);
+
+  test('measure cold/warm startup latencies', async ({browser}) => {
+    const page = await browser.newPage();
+    page.on('console', (msg) => {
+      if (msg.type() === 'warning' || msg.type() === 'error') {
+        // eslint-disable-next-line no-console
+        console.log(`[page ${msg.type()}] ${msg.text()}`);
+      }
+    });
+
+    const url =
+      `/engine_bench.html?auto=1&n=${N}&warmup=${WARMUP}` +
+      (COLD ? '&cache=cold' : '');
+    await page.goto(url);
+
+    await page.waitForFunction(
+      () =>
+        (window as unknown as {__benchResults?: BenchResults}).__benchResults
+          !== undefined,
+      undefined,
+      {timeout: 5 * 60_000},
+    );
+
+    const results = (await page.evaluate(
+      () => (window as unknown as {__benchResults: BenchResults}).__benchResults,
+    )) as BenchResults;
+
+    expect(results.samples.length).toBe(N);
+
+    // eslint-disable-next-line no-console
+    console.log('\n=== engine_startup_bench results ===');
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(results, null, 2));
+    // eslint-disable-next-line no-console
+    console.log('=== end engine_startup_bench results ===\n');
+  });
+});

--- a/ui/src/engine_bench/index.ts
+++ b/ui/src/engine_bench/index.ts
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Standalone worker entry for the engine startup benchmark. Drives the
+// production WasmBridge and reports per-phase timings.
+
+import {WasmBridge} from '../engine/wasm_bridge';
+
+const tWorkerStart = performance.now();
+const selfWorker = self as {} as Worker;
+
+selfWorker.onmessage = (msg: MessageEvent) => {
+  const data = msg.data as {
+    useMemory64: boolean;
+    wasmModule?: WebAssembly.Module;
+  };
+
+  const tBeforeBridge = performance.now();
+  const bridge = new WasmBridge();
+  const tAfterBridgeCtor = performance.now();
+
+  const tBeforeStartInit = performance.now();
+  bridge.startInit(data.useMemory64, data.wasmModule);
+  const tAfterStartInit = performance.now();
+  // We don't push RPCs through, so initialize() is intentionally skipped.
+
+  bridge.whenInitialized().then(
+    () => {
+      const tDone = performance.now();
+      selfWorker.postMessage({
+        type: 'bench-marks',
+        phases: {
+          bundle_eval_ms: tBeforeBridge - tWorkerStart,
+          bridge_ctor_ms: tAfterBridgeCtor - tBeforeBridge,
+          start_init_sync_ms: tAfterStartInit - tBeforeStartInit,
+          init_async_ms: tDone - tAfterStartInit,
+          total_worker_ms: tDone - tWorkerStart,
+        },
+      });
+    },
+    (err) => {
+      selfWorker.postMessage({
+        type: 'bench-error',
+        message: String((err && err.message) || err),
+      });
+    },
+  );
+};

--- a/ui/vite.config.mjs
+++ b/ui/vite.config.mjs
@@ -209,6 +209,7 @@ if (!BUNDLE) {
 const BUNDLE_CONFIGS = {
   frontend:            {dir: 'dist_version',                 entry: 'index.ts'},
   engine:              {dir: 'dist_version',                 entry: 'index.ts'},
+  engine_bench:        {dir: 'dist_version',                 entry: 'index.ts'},
   traceconv:           {dir: 'dist_version',                 entry: 'index.ts'},
   bigtrace:            {dir: 'dist_version/bigtrace',        entry: 'index.ts'},
   open_perfetto_trace: {dir: 'dist/open_perfetto_trace',     entry: 'index.ts'},


### PR DESCRIPTION
Standalone benchmark for trace_processor worker startup, all under
ui/src/engine_bench/. Built only when `ui/build --enable-engine-bench`
is passed — default builds emit no bench code or assets.

  - index.ts: standalone worker entry that drives WasmBridge with
    phase markers; bundled as engine_bench_bundle.js.
  - bench.html + bench.js: driver page that spawns N workers and
    exposes per-phase timings on window.__benchResults.
  - bench.test.ts: Playwright spec, additionally gated on
    PERFETTO_BENCH=1.
  - vite.config.mjs + build.mjs: new bundle entry, copy rules and
    scan-dir all no-op without the flag.
