### PR TITLE
Reland: android_sdk: PERFETTO_JNI_HOST_PARAMS shim for non-ART JVMs

### DIFF
--- a/src/android_sdk/jni/dev_perfetto_sdk_PerfettoNativeMemoryCleaner.cc
+++ b/src/android_sdk/jni/dev_perfetto_sdk_PerfettoNativeMemoryCleaner.cc
@@ -28,7 +28,7 @@ typedef void (*FreeFunction)(void*);
 // Copied from
 // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/jni/platform/host/HostRuntime.cpp;l=56;drc=9a629e24776b648be56188aa3364e7d3953dae11
 static void dev_perfetto_sdk_PerfettoTrackEventExtra_applyNativeFunction(
-    jlong freeFunction,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong freeFunction,
     jlong ptr) {
   void* nativePtr = reinterpret_cast<void*>(static_cast<uintptr_t>(ptr));
   FreeFunction nativeFreeFunction =

--- a/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrace.cc
+++ b/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrace.cc
@@ -38,11 +38,13 @@ inline static jlong toJLong(T* ptr) {
   return static_cast<jlong>(reinterpret_cast<uintptr_t>(ptr));
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrace_get_process_track_uuid() {
+static jlong dev_perfetto_sdk_PerfettoTrace_get_process_track_uuid(
+    PERFETTO_JNI_HOST_PARAMS) {
   return sdk_for_jni::get_process_track_uuid();
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrace_get_thread_track_uuid(jlong tid) {
+static jlong dev_perfetto_sdk_PerfettoTrace_get_thread_track_uuid(
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong tid) {
   return sdk_for_jni::get_thread_track_uuid(tid);
 }
 
@@ -75,21 +77,25 @@ static jlong dev_perfetto_sdk_PerfettoTraceCategory_init(JNIEnv* env,
   return toJLong(new sdk_for_jni::Category(name_c_str, tags_c_strs));
 }
 
-static jlong dev_perfetto_sdk_PerfettoTraceCategory_delete() {
+static jlong dev_perfetto_sdk_PerfettoTraceCategory_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::Category::delete_category);
 }
 
-static void dev_perfetto_sdk_PerfettoTraceCategory_register(jlong ptr) {
+static void dev_perfetto_sdk_PerfettoTraceCategory_register(
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   auto* category = toPointer<sdk_for_jni::Category>(ptr);
   category->register_category();
 }
 
-static void dev_perfetto_sdk_PerfettoTraceCategory_unregister(jlong ptr) {
+static void dev_perfetto_sdk_PerfettoTraceCategory_unregister(
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   auto* category = toPointer<sdk_for_jni::Category>(ptr);
   category->unregister_category();
 }
 
-static jboolean dev_perfetto_sdk_PerfettoTraceCategory_is_enabled(jlong ptr) {
+static jboolean dev_perfetto_sdk_PerfettoTraceCategory_is_enabled(
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   auto* category = toPointer<sdk_for_jni::Category>(ptr);
   return category->is_category_enabled();
 }

--- a/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrackEventExtra.cc
+++ b/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrackEventExtra.cc
@@ -173,18 +173,19 @@ static jlong dev_perfetto_sdk_PerfettoTrackEventExtraArg_init(JNIEnv* env,
       StringBuffer::utf16_to_ascii(env, name).data()));
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraArg_delete() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraArg_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::DebugArg::delete_arg);
 }
 
 static jlong dev_perfetto_sdk_PerfettoTrackEventExtraArg_get_extra_ptr(
-    jlong ptr) {
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::DebugArg* arg = toPointer<sdk_for_jni::DebugArg>(ptr);
   return toJLong(arg->get());
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraArg_set_value_int64(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jlong val) {
   sdk_for_jni::DebugArg* arg = toPointer<sdk_for_jni::DebugArg>(ptr);
   auto& arg_int64 = arg->get()->arg_int64;
@@ -194,7 +195,7 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtraArg_set_value_int64(
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraArg_set_value_bool(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jboolean val) {
   sdk_for_jni::DebugArg* arg = toPointer<sdk_for_jni::DebugArg>(ptr);
   auto& arg_bool = arg->get()->arg_bool;
@@ -204,7 +205,7 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtraArg_set_value_bool(
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraArg_set_value_double(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jdouble val) {
   sdk_for_jni::DebugArg* arg = toPointer<sdk_for_jni::DebugArg>(ptr);
   auto& arg_double = arg->get()->arg_double;
@@ -225,37 +226,41 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtraArg_set_value_string(
   arg_string.value = StringBuffer::utf16_to_ascii(env, val).data();
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraField_init() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraField_init(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(new sdk_for_jni::ProtoField());
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFieldNested_init() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFieldNested_init(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(new sdk_for_jni::ProtoFieldNested());
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraField_delete() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraField_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::ProtoField::delete_field);
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFieldNested_delete() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFieldNested_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::ProtoFieldNested::delete_field);
 }
 
 static jlong dev_perfetto_sdk_PerfettoTrackEventExtraField_get_extra_ptr(
-    jlong ptr) {
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::ProtoField* field = toPointer<sdk_for_jni::ProtoField>(ptr);
   return toJLong(field->get());
 }
 
 static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFieldNested_get_extra_ptr(
-    jlong ptr) {
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::ProtoFieldNested* field =
       toPointer<sdk_for_jni::ProtoFieldNested>(ptr);
   return toJLong(field->get());
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraField_set_value_int64(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jlong id,
     jlong val) {
   sdk_for_jni::ProtoField* field = toPointer<sdk_for_jni::ProtoField>(ptr);
@@ -266,7 +271,7 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtraField_set_value_int64(
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraField_set_value_double(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jlong id,
     jdouble val) {
   sdk_for_jni::ProtoField* field = toPointer<sdk_for_jni::ProtoField>(ptr);
@@ -306,7 +311,7 @@ dev_perfetto_sdk_PerfettoTrackEventExtraField_set_value_with_interning(
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraFieldNested_add_field(
-    jlong field_ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong field_ptr,
     jlong arg_ptr) {
   sdk_for_jni::ProtoFieldNested* field =
       toPointer<sdk_for_jni::ProtoFieldNested>(field_ptr);
@@ -314,19 +319,20 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtraFieldNested_add_field(
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraFieldNested_set_id(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jlong id) {
   sdk_for_jni::ProtoFieldNested* field =
       toPointer<sdk_for_jni::ProtoFieldNested>(ptr);
   field->set_id(id);
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFlow_init() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFlow_init(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(new sdk_for_jni::Flow());
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraFlow_set_process_flow(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jlong id) {
   sdk_for_jni::Flow* flow = toPointer<sdk_for_jni::Flow>(ptr);
   flow->set_process_flow(id);
@@ -334,18 +340,19 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtraFlow_set_process_flow(
 
 static void
 dev_perfetto_sdk_PerfettoTrackEventExtraFlow_set_process_terminating_flow(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jlong id) {
   sdk_for_jni::Flow* flow = toPointer<sdk_for_jni::Flow>(ptr);
   flow->set_process_terminating_flow(id);
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFlow_delete() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFlow_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::Flow::delete_flow);
 }
 
 static jlong dev_perfetto_sdk_PerfettoTrackEventExtraFlow_get_extra_ptr(
-    jlong ptr) {
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::Flow* flow = toPointer<sdk_for_jni::Flow>(ptr);
   return toJLong(flow->get());
 }
@@ -362,12 +369,13 @@ static jlong dev_perfetto_sdk_PerfettoTrackEventExtraNamedTrack_init(
       is_name_static));
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraNamedTrack_delete() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraNamedTrack_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::NamedTrack::delete_track);
 }
 
 static jlong dev_perfetto_sdk_PerfettoTrackEventExtraNamedTrack_get_extra_ptr(
-    jlong ptr) {
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::NamedTrack* track = toPointer<sdk_for_jni::NamedTrack>(ptr);
   return toJLong(track->get());
 }
@@ -383,33 +391,36 @@ static jlong dev_perfetto_sdk_PerfettoTrackEventExtraCounterTrack_init(
       is_name_static));
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraCounterTrack_delete() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraCounterTrack_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::RegisteredTrack::delete_track);
 }
 
 static jlong dev_perfetto_sdk_PerfettoTrackEventExtraCounterTrack_get_extra_ptr(
-    jlong ptr) {
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::RegisteredTrack* track =
       toPointer<sdk_for_jni::RegisteredTrack>(ptr);
   return toJLong(track->get());
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraCounter_init() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraCounter_init(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(new sdk_for_jni::Counter());
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraCounter_delete() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraCounter_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::Counter::delete_counter);
 }
 
 static jlong dev_perfetto_sdk_PerfettoTrackEventExtraCounter_get_extra_ptr(
-    jlong ptr) {
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::Counter* counter = toPointer<sdk_for_jni::Counter>(ptr);
   return toJLong(counter->get());
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraCounter_set_value_int64(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jlong val) {
   sdk_for_jni::Counter* counter = toPointer<sdk_for_jni::Counter>(ptr);
   auto& counter_int64 = counter->get()->counter_int64;
@@ -418,7 +429,7 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtraCounter_set_value_int64(
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraCounter_set_value_double(
-    jlong ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr,
     jdouble val) {
   sdk_for_jni::Counter* counter = toPointer<sdk_for_jni::Counter>(ptr);
   auto& counter_double = counter->get()->counter_double;
@@ -426,21 +437,25 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtraCounter_set_value_double(
   counter_double.value = val;
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtra_init() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtra_init(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(new sdk_for_jni::Extra());
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtra_delete() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtra_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::Extra::delete_extra);
 }
 
-static void dev_perfetto_sdk_PerfettoTrackEventExtra_add_arg(jlong extra_ptr,
-                                                             jlong arg_ptr) {
+static void dev_perfetto_sdk_PerfettoTrackEventExtra_add_arg(
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong extra_ptr,
+    jlong arg_ptr) {
   sdk_for_jni::Extra* extra = toPointer<sdk_for_jni::Extra>(extra_ptr);
   extra->push_extra(toPointer<PerfettoTeHlExtra>(arg_ptr));
 }
 
-static void dev_perfetto_sdk_PerfettoTrackEventExtra_clear_args(jlong ptr) {
+static void dev_perfetto_sdk_PerfettoTrackEventExtra_clear_args(
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::Extra* extra = toPointer<sdk_for_jni::Extra>(ptr);
   extra->clear_extras();
 }
@@ -458,29 +473,31 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtra_emit(JNIEnv* env,
   StringBuffer::reset();
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraProto_init() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraProto_init(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(new sdk_for_jni::Proto());
 }
 
-static jlong dev_perfetto_sdk_PerfettoTrackEventExtraProto_delete() {
+static jlong dev_perfetto_sdk_PerfettoTrackEventExtraProto_delete(
+    PERFETTO_JNI_HOST_PARAMS) {
   return toJLong(&sdk_for_jni::Proto::delete_proto);
 }
 
 static jlong dev_perfetto_sdk_PerfettoTrackEventExtraProto_get_extra_ptr(
-    jlong ptr) {
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::Proto* proto = toPointer<sdk_for_jni::Proto>(ptr);
   return toJLong(proto->get());
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraProto_add_field(
-    long proto_ptr,
+    PERFETTO_JNI_HOST_PARAMS_COMMA long proto_ptr,
     jlong arg_ptr) {
   sdk_for_jni::Proto* proto = toPointer<sdk_for_jni::Proto>(proto_ptr);
   proto->add_field(toPointer<PerfettoTeHlProtoField>(arg_ptr));
 }
 
 static void dev_perfetto_sdk_PerfettoTrackEventExtraProto_clear_fields(
-    jlong ptr) {
+    PERFETTO_JNI_HOST_PARAMS_COMMA jlong ptr) {
   sdk_for_jni::Proto* proto = toPointer<sdk_for_jni::Proto>(ptr);
   proto->clear_fields();
 }

--- a/src/android_sdk/jni/macros.h
+++ b/src/android_sdk/jni/macros.h
@@ -16,7 +16,30 @@
 
 #ifndef SRC_ANDROID_SDK_JNI_MACROS_H_
 #define SRC_ANDROID_SDK_JNI_MACROS_H_
+#include <jni.h>
 #include <string_view>
+
+// JNI parameter shim for natives declared @CriticalNative on the Java
+// side. On Android device, ART recognises the annotation and calls the
+// function with no JNIEnv*/jclass prefix. On host VMs (notably Ravenwood,
+// where the perfetto SDK also runs) the annotation is invisible and the
+// standard JNI ABI is used; the host build is paired with a Java-source
+// preprocessor that strips @CriticalNative entirely, so every method
+// binds as a plain native and this macro adds the env+clazz prefix to
+// keep the C signatures matching.
+//
+//   static jlong foo(PERFETTO_JNI_HOST_PARAMS) { ... }
+//   static void  bar(PERFETTO_JNI_HOST_PARAMS_COMMA jlong x) { ... }
+//
+// Expands to nothing on device (so the on-wire binary is unchanged) and
+// to JNIEnv*,jclass[,] everywhere else.
+#if defined(__ANDROID__)
+#define PERFETTO_JNI_HOST_PARAMS
+#define PERFETTO_JNI_HOST_PARAMS_COMMA
+#else
+#define PERFETTO_JNI_HOST_PARAMS JNIEnv*, jclass
+#define PERFETTO_JNI_HOST_PARAMS_COMMA JNIEnv*, jclass,
+#endif
 
 // This is a very basic check to make sure we get the
 // 'PERFETTO_JNI_JARJAR_PREFIX' in the form of 'com/android/internal/'.

--- a/src/android_sdk/jni/macros.h
+++ b/src/android_sdk/jni/macros.h
@@ -33,6 +33,9 @@
 //
 // Expands to nothing on device (so the on-wire binary is unchanged) and
 // to JNIEnv*,jclass[,] everywhere else.
+//
+// Use __ANDROID__ directly rather than PERFETTO_BUILDFLAG so this
+// leaf JNI header doesn't pull in perfetto/base/build_config.h.
 #if defined(__ANDROID__)
 #define PERFETTO_JNI_HOST_PARAMS
 #define PERFETTO_JNI_HOST_PARAMS_COMMA


### PR DESCRIPTION
Relands commit 1dfd43ec215aaac663107c3321d97b935d8d47b8 (reverted in feccb3b180). Check __ANDROID__ instead of PERFETTO_BUILDFLAG so macros.h doesn't pull in perfetto/base/build_config.h.

Original body, unchanged:

  @CriticalNative natives skip JNIEnv*/jclass on ART but not on host
  VMs. Add a PERFETTO_JNI_HOST_PARAMS[_COMMA] shim that expands to
  empty on Android and to JNIEnv*, jclass[,] elsewhere, and apply it
  to every @CriticalNative C entry point. No change in behavior.

  Unblocks Ravenwood: host VMs can now bind these natives directly,
  which lets us drop the Ravenwood native-method allowlist as a
  follow-up. Also enables adding a host build of the Perfetto Java SDK.