### PR TITLE
shared_lib: Expose header only library in Bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -280,6 +280,21 @@ perfetto_cc_library(
     linkstatic = True,
 )
 
+# GN target: //src/shared_lib:libperfetto_c_headers
+perfetto_cc_library(
+    name = "libperfetto_c_headers",
+    hdrs = [
+        ":include_perfetto_public_abi_base",
+        ":include_perfetto_public_abi_public",
+        ":include_perfetto_public_base",
+        ":include_perfetto_public_protos_protos",
+        ":include_perfetto_public_protozero",
+        ":include_perfetto_public_public",
+    ],
+    visibility = PERFETTO_CONFIG.public_visibility,
+    linkstatic = True,
+)
+
 # GN target: //src/tools/proto_filter:proto_filter
 perfetto_cc_binary(
     name = "proto_filter",

--- a/src/shared_lib/BUILD.gn
+++ b/src/shared_lib/BUILD.gn
@@ -61,3 +61,7 @@ shared_library("libperfetto_c") {
   ]
   public_deps = [ "../../include/perfetto/public" ]
 }
+
+static_library("libperfetto_c_headers") {
+  public_deps = [ "../../include/perfetto/public" ]
+}

--- a/tools/gen_bazel
+++ b/tools/gen_bazel
@@ -103,6 +103,7 @@ public_targets = [
 # These targets will be exported with visibility only to our allowlist.
 allowlist_public_targets = [
     '//src/shared_lib:libperfetto_c',
+    '//src/shared_lib:libperfetto_c_headers',
     '//src/traceconv:libpprofbuilder',
 ]
 


### PR DESCRIPTION
Bug: b/378560215

This would be useful for https://github.com/google/android-cuttlefish/pull/2502 where we could eliminate most of https://github.com/google/android-cuttlefish/pull/2502/changes#diff-d28a094890e585d0e9bec027b845e31c3c15ebd9c2262dd814dd6e7537ab2af8 when using the c library via `dlopen()` and we do not want to directly depend on the library itself.