### PR TITLE
tp: refuse PERFETTO FUNCTION redefinition of C++ intrinsics to fix UAF

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
@@ -400,7 +400,21 @@ std::unique_ptr<PerfettoSqlConnection> PerfettoSqlConnection::Fork() {
       new PerfettoSqlConnection(database_, enable_extra_checks_));
 }
 
-PerfettoSqlConnection::~PerfettoSqlConnection() = default;
+PerfettoSqlConnection::~PerfettoSqlConnection() {
+  // Scalar function contexts can hold prepared statements (e.g.
+  // CreatedFunction::State::stmts_) that must be finalized before the
+  // underlying sqlite3* is closed. Explicitly unregister every entry now so
+  // SQLite invokes each function's FnCtxDestructor while the database is
+  // still alive; |connection_| is destroyed below.
+  for (auto it = fn_registry_.GetIterator(); it; ++it) {
+    base::Status s = connection_->UnregisterFunction(it.key().first.c_str(),
+                                                     it.key().second);
+    if (PERFETTO_UNLIKELY(!s.ok())) {
+      PERFETTO_FATAL("Failed to drop function: '%s'", it.key().first.c_str());
+    }
+  }
+  fn_registry_.Clear();
+}
 
 PerfettoSqlConnection::PerfettoSqlConnection(
     std::shared_ptr<PerfettoSqlDatabase> database,
@@ -861,9 +875,22 @@ base::Status PerfettoSqlConnection::RegisterLegacyRuntimeFunction(
     sql_argument::Type return_type,
     SqlSource sql) {
   int created_argc = static_cast<int>(prototype.arguments.size());
+  // Refuse to clobber a C++ intrinsic. The reused-ctx fast path below ends in
+  // CreatedFunction::Reset(), which destroys and placement-news a
+  // CreatedFunction::State over the existing object; if the existing function
+  // were an intrinsic (e.g. import, which registers a raw
+  // PerfettoSqlConnection*), the destructor call would dereference a
+  // non-existent vtable and the placement-new would corrupt the intrinsic's
+  // state -- type-confusion bug previously exploitable via
+  // CREATE OR REPLACE PERFETTO FUNCTION import(...).
+  if (IsIntrinsicFunction(prototype.function_name, created_argc)) {
+    return base::ErrStatus(
+        "CREATE PERFETTO FUNCTION[prototype=%s]: cannot redefine built-in "
+        "function with the same name and argument count",
+        prototype.ToString().c_str());
+  }
   auto* ctx = static_cast<CreatedFunction::UserData*>(
-      sqlite_connection()->GetFunctionContext(prototype.function_name,
-                                              created_argc));
+      GetFunctionContextOrNull(prototype.function_name, created_argc));
   if (ctx) {
     if (CreatedFunction::IsValid(ctx) && !replace) {
       return base::ErrStatus(
@@ -878,10 +905,11 @@ base::Status PerfettoSqlConnection::RegisterLegacyRuntimeFunction(
     std::unique_ptr<CreatedFunction::UserData> created_fn_ctx =
         CreatedFunction::MakeContext(this);
     ctx = created_fn_ctx.get();
-    RETURN_IF_ERROR(RegisterFunction<CreatedFunction>(
-        std::move(created_fn_ctx),
-        RegisterFunctionArgs(prototype.function_name.c_str(), true,
-                             static_cast<int>(prototype.arguments.size()))));
+    RegisterFunctionArgs args(prototype.function_name.c_str(), true,
+                              static_cast<int>(prototype.arguments.size()));
+    args.is_intrinsic = false;
+    RETURN_IF_ERROR(
+        RegisterFunction<CreatedFunction>(std::move(created_fn_ctx), args));
   }
   return CreatedFunction::Prepare(ctx, prototype, return_type, std::move(sql));
 }
@@ -1007,9 +1035,18 @@ base::Status PerfettoSqlConnection::ExecuteCreateView(
 
 base::Status PerfettoSqlConnection::EnableSqlFunctionMemoization(
     const std::string& name) {
-  constexpr size_t kSupportedArgCount = 1;
+  constexpr int kSupportedArgCount = 1;
+  // Refuse EXPERIMENTAL_MEMOIZE on intrinsics: their ctx is opaque and casting
+  // it to CreatedFunction::UserData* would walk a non-existent vtable inside
+  // EnableMemoization.
+  if (IsIntrinsicFunction(name, kSupportedArgCount)) {
+    return base::ErrStatus(
+        "EXPERIMENTAL_MEMOIZE: '%s' is a built-in function and cannot be "
+        "memoized",
+        name.c_str());
+  }
   auto* ctx = static_cast<CreatedFunction::UserData*>(
-      sqlite_connection()->GetFunctionContext(name, kSupportedArgCount));
+      GetFunctionContextOrNull(name, kSupportedArgCount));
   if (!ctx) {
     return base::ErrStatus(
         "EXPERIMENTAL_MEMOIZE: Function '%s'(INT) does not exist",
@@ -1394,7 +1431,7 @@ base::Status PerfettoSqlConnection::RegisterDelegatingFunction(
   PERFETTO_CHECK(argc == info.argc);
 
   // Check if function already exists and handle replace logic
-  auto* existing_ctx = sqlite_connection()->GetFunctionContext(new_name, argc);
+  auto* existing_ctx = GetFunctionContextOrNull(new_name, argc);
   if (existing_ctx) {
     if (!cf.replace) {
       return base::ErrStatus(
@@ -1421,10 +1458,22 @@ base::Status PerfettoSqlConnection::RegisterFunctionAndAddToRegistry(
     SqliteConnection::Fn* func,
     void* ctx,
     SqliteConnection::FnCtxDestructor* ctx_destructor,
-    bool deterministic) {
+    bool deterministic,
+    bool is_intrinsic) {
   // Register with SQLite
   RETURN_IF_ERROR(connection_->RegisterFunction(name, argc, func, ctx,
                                                 ctx_destructor, deterministic));
+
+  // Track ownership / kind. This is the only place that records whether a
+  // function's context is opaque (intrinsic) or a typed Destructible-derived
+  // state; the security-sensitive paths in |RegisterLegacyRuntimeFunction| and
+  // |EnableSqlFunctionMemoization| consult |IsIntrinsicFunction| before
+  // downcasting. Keys are lowercased to match SQLite's case-insensitive
+  // function namespace; otherwise CREATE OR REPLACE PERFETTO FUNCTION
+  // IMPORT(...) (mixed-case) could bypass the intrinsic check.
+  FunctionEntry entry{ctx, is_intrinsic};
+  *fn_registry_.Insert(std::make_pair(base::ToLower(name), argc), entry).first =
+      entry;
 
   // Also add to intrinsic registry for potential aliasing
   IntrinsicFunctionInfo info;
@@ -1435,6 +1484,20 @@ base::Status PerfettoSqlConnection::RegisterFunctionAndAddToRegistry(
   intrinsic_function_registry_[base::ToLower(name)] = info;
 
   return base::OkStatus();
+}
+
+void* PerfettoSqlConnection::GetFunctionContextOrNull(const std::string& name,
+                                                      int argc) const {
+  const auto* entry =
+      fn_registry_.Find(std::make_pair(base::ToLower(name), argc));
+  return entry ? entry->ctx : nullptr;
+}
+
+bool PerfettoSqlConnection::IsIntrinsicFunction(const std::string& name,
+                                                int argc) const {
+  const auto* entry =
+      fn_registry_.Find(std::make_pair(base::ToLower(name), argc));
+  return entry && entry->is_intrinsic;
 }
 
 base::Status PerfettoSqlConnection::ExecuteCreateMacro(

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
@@ -28,6 +28,8 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/hash.h"
+#include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/containers/string_pool.h"
@@ -195,6 +197,14 @@ class PerfettoSqlConnection {
     bool deterministic = true;
     std::optional<int> argc =
         std::nullopt;  // If nullopt, uses Function::kArgCount
+    // True for built-in C++ functions registered at initialization time, where
+    // |ctx| is an opaque pointer whose layout is known only to the registrant.
+    // False for functions managed by PerfettoSQL (currently CreatedFunction),
+    // where |ctx| is a Destructible-derived state object that
+    // |RegisterLegacyRuntimeFunction| may recover via a typed downcast. Default
+    // true so that new registrants never accidentally advertise type-safety
+    // they cannot deliver.
+    bool is_intrinsic = true;
   };
 
   template <typename Function>
@@ -367,7 +377,23 @@ class PerfettoSqlConnection {
       SqliteConnection::Fn* func,
       void* ctx,
       SqliteConnection::FnCtxDestructor* ctx_destructor,
-      bool deterministic);
+      bool deterministic,
+      bool is_intrinsic = true);
+
+  // Looks up |ctx| for the function with the given name/argc, or nullptr if no
+  // such function is registered with this connection. Membership in
+  // |fn_registry_| is also the only safe signal that a SQLite function context
+  // belongs to a typed Destructible-derived state (use |IsIntrinsicFunction|
+  // to distinguish): SqliteConnection itself does not track this.
+  void* GetFunctionContextOrNull(const std::string& name, int argc) const;
+
+  // Returns true if a function with the given name/argc is registered with
+  // this connection AND was registered as an intrinsic. Returns false either
+  // when the function is not registered or when it was registered as a
+  // managed-context PerfettoSQL function (currently only CreatedFunction).
+  // Callers MUST consult this before downcasting the result of
+  // |GetFunctionContextOrNull| to a typed Destructible-derived object.
+  bool IsIntrinsicFunction(const std::string& name, int argc) const;
 
   base::Status ExecuteInclude(const PerfettoSqlParser::Include&,
                               const PerfettoSqlParser& parser);
@@ -482,6 +508,31 @@ class PerfettoSqlConnection {
   base::FlatHashMap<std::string, IntrinsicFunctionInfo>
       intrinsic_function_registry_;
 
+  // Tracks every scalar function registered with |connection_| via
+  // |RegisterFunctionAndAddToRegistry|, keyed by (name, argc). Used for two
+  // things:
+  //
+  // 1) Discrimination: |is_intrinsic| tells us whether |ctx| is opaque (raw
+  //    C++ intrinsic, e.g. import's PerfettoSqlConnection*) or a typed
+  //    Destructible-derived state (CreatedFunction). Looking at SQLite alone
+  //    can't tell the difference, which is what historically allowed
+  //    CREATE OR REPLACE PERFETTO FUNCTION import(...) to type-confuse the
+  //    intrinsic's context with a CreatedFunction::State.
+  //
+  // 2) Teardown: scalar function contexts can hold prepared statements
+  //    (CreatedFunction::State::stmts_); those must be finalized before the
+  //    underlying sqlite3* is closed. The destructor walks this map and
+  //    explicitly unregisters every entry, which triggers SQLite to invoke
+  //    each entry's |FnCtxDestructor| in turn.
+  struct FunctionEntry {
+    void* ctx;
+    bool is_intrinsic;
+  };
+  base::FlatHashMap<std::pair<std::string, int>,
+                    FunctionEntry,
+                    base::MurmurHash<std::pair<std::string, int>>>
+      fn_registry_;
+
   std::unique_ptr<SqliteConnection> connection_;
 };
 
@@ -497,7 +548,8 @@ base::Status PerfettoSqlConnection::RegisterFunction(
   const char* name = args.name ? args.name : Function::kName;
   int argc = args.argc.has_value() ? args.argc.value() : Function::kArgCount;
   return RegisterFunctionAndAddToRegistry(name, argc, Function::Step, ctx,
-                                          nullptr, args.deterministic);
+                                          nullptr, args.deterministic,
+                                          args.is_intrinsic);
 }
 
 template <typename Function>
@@ -513,7 +565,7 @@ base::Status PerfettoSqlConnection::RegisterFunction(
         std::unique_ptr<typename Function::UserData>(
             static_cast<typename Function::UserData*>(ptr));
       },
-      args.deterministic);
+      args.deterministic, args.is_intrinsic);
 }
 
 template <typename Function>

--- a/src/trace_processor/sqlite/sqlite_connection.cc
+++ b/src/trace_processor/sqlite/sqlite_connection.cc
@@ -25,7 +25,6 @@
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
-#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/sqlite/scoped_db.h"
 #include "src/trace_processor/sqlite/sql_source.h"
@@ -134,20 +133,7 @@ std::unique_ptr<SqliteConnection> SqliteConnection::Fork() {
   return std::make_unique<SqliteConnection>(database_);
 }
 
-SqliteConnection::~SqliteConnection() {
-  // It is important to unregister any functions that have been registered with
-  // the database before destroying it. This is because functions can hold onto
-  // prepared statements, which must be finalized before database destruction.
-  for (auto it = fn_ctx_.GetIterator(); it; ++it) {
-    int ret = sqlite3_create_function_v2(db_.get(), it.key().first.c_str(),
-                                         it.key().second, SQLITE_UTF8, nullptr,
-                                         nullptr, nullptr, nullptr, nullptr);
-    if (PERFETTO_UNLIKELY(ret != SQLITE_OK)) {
-      PERFETTO_FATAL("Failed to drop function: '%s'", it.key().first.c_str());
-    }
-  }
-  fn_ctx_.Clear();
-}
+SqliteConnection::~SqliteConnection() = default;
 
 SqliteConnection::PreparedStatement SqliteConnection::PrepareStatement(
     SqlSource sql) {
@@ -187,7 +173,6 @@ base::Status SqliteConnection::RegisterFunction(const char* name,
         "Unable to register function with name %s: %s (SQLite error code: %d)",
         name, sqlite3_errmsg(db_.get()), ret);
   }
-  *fn_ctx_.Insert(std::make_pair(base::ToLower(name), argc), ctx).first = ctx;
   return base::OkStatus();
 }
 
@@ -245,7 +230,6 @@ base::Status SqliteConnection::UnregisterFunction(const char* name, int argc) {
         "%d)",
         name, sqlite3_errmsg(db_.get()), ret);
   }
-  fn_ctx_.Erase({base::ToLower(name), argc});
   return base::OkStatus();
 }
 
@@ -257,11 +241,6 @@ void SqliteConnection::RegisterVirtualTableModule(
   int res = sqlite3_create_module_v2(db_.get(), module_name.c_str(), module,
                                      ctx, destructor);
   PERFETTO_CHECK(res == SQLITE_OK);
-}
-
-void* SqliteConnection::GetFunctionContext(const std::string& name, int argc) {
-  auto* res = fn_ctx_.Find(std::make_pair(base::ToLower(name), argc));
-  return res ? *res : nullptr;
 }
 
 std::optional<uint32_t> SqliteConnection::GetErrorOffset() const {

--- a/src/trace_processor/sqlite/sqlite_connection.h
+++ b/src/trace_processor/sqlite/sqlite_connection.h
@@ -23,12 +23,8 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <utility>
 
 #include "perfetto/base/status.h"
-#include "perfetto/ext/base/flat_hash_map.h"
-#include "perfetto/ext/base/hash.h"
-#include "perfetto/ext/base/murmur_hash.h"
 #include "src/trace_processor/sqlite/scoped_db.h"
 #include "src/trace_processor/sqlite/sql_source.h"
 
@@ -146,9 +142,6 @@ class SqliteConnection {
                                   void* ctx,
                                   ModuleContextDestructor destructor);
 
-  // Gets the context for a registered SQL function.
-  void* GetFunctionContext(const std::string& name, int argc);
-
   // Sets a callback to be called when a transaction is committed.
   //
   // Returns the prior context object passed to a previous invocation of this
@@ -172,13 +165,6 @@ class SqliteConnection {
  private:
   std::optional<uint32_t> GetErrorOffset() const;
 
-  // Keys are stored lowercased to match SQLite's case-insensitive function
-  // namespace; otherwise a case-variant registration could free the SQLite
-  // context while we kept a dangling pointer here.
-  base::FlatHashMap<std::pair<std::string, int>,
-                    void*,
-                    base::MurmurHash<std::pair<std::string, int>>>
-      fn_ctx_;
   std::shared_ptr<SqliteDatabase> database_;
   ScopedDb db_;
 };


### PR DESCRIPTION
Move function registration out of SqliteConnection to PerfettoSqlConnection
wher eit belongs and make it impossible to redefine C++ intrinsic funcitons.
This prevents an unsafe cast of an arbitrary context object to CreatedFunction::Context,
and a delete of it causing a user after free as the intrinisic would still refer
to it.
