### PR TITLE
ui: Add new side panel extension point

### DIFF
--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -40,6 +40,7 @@ import {PluginManagerImpl} from './plugin_manager';
 import {raf} from './raf_scheduler';
 import {Router} from './router';
 import type {SettingsManagerImpl} from './settings_manager';
+import {SidePanelManagerImpl} from './side_panel_manager';
 import {SidebarManagerImpl} from './sidebar_manager';
 import type {SerializedAppState} from './state_serialization_schema';
 import type {TraceImpl} from './trace_impl';
@@ -80,6 +81,7 @@ export class AppImpl implements App {
   readonly pages: PageManagerImpl;
   readonly sidebar: SidebarManagerImpl;
   readonly plugins: PluginManagerImpl;
+  readonly sidePanel = new SidePanelManagerImpl();
   readonly perfDebugging = new PerfManager();
   readonly analytics: AnalyticsInternal;
   readonly serviceWorkerController = new ServiceWorkerController();

--- a/ui/src/core/side_panel_manager.ts
+++ b/ui/src/core/side_panel_manager.ts
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+  SidePanelManager,
+  SidePanelTabDescriptor,
+} from '../public/side_panel';
+
+export class SidePanelManagerImpl implements SidePanelManager {
+  // The registry of tabs.
+  private _registry = new Map<string, SidePanelTabDescriptor>();
+
+  // The URI of the current tab we're looking at.
+  private _currentTabUri: string | undefined;
+
+  // Whether the entire side panel is visible or not.
+  private _visible = false;
+
+  registerTab(desc: SidePanelTabDescriptor): Disposable {
+    this._registry.set(desc.uri, desc);
+    return {
+      [Symbol.dispose]: () => {
+        this._registry.delete(desc.uri);
+        if (this._currentTabUri === desc.uri) {
+          this._currentTabUri = undefined;
+        }
+      },
+    };
+  }
+
+  showTab(uri: string): void {
+    if (!this._registry.has(uri)) {
+      console.warn(
+        `Trying to show side panel tab with URI ${uri} that is not registered`,
+      );
+      return;
+    }
+    this._currentTabUri = uri;
+    this._visible = true;
+  }
+
+  get visible(): boolean {
+    return this._visible;
+  }
+
+  set visible(v: boolean) {
+    this._visible = v;
+  }
+
+  get currentTabUri(): string | undefined {
+    return this._currentTabUri;
+  }
+
+  resolveTab(uri: string): SidePanelTabDescriptor | undefined {
+    return this._registry.get(uri);
+  }
+
+  get registeredTabs(): ReadonlyArray<SidePanelTabDescriptor> {
+    return Array.from(this._registry.values());
+  }
+}

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -54,6 +54,8 @@ import {MinimapManagerImpl} from './minimap_manager';
 import {InitialPageManagerImpl} from './initial_page_manager';
 import type {TraceStream} from '../public/stream';
 import type {OmniboxModeDescriptor} from '../public/omnibox';
+import type {SidePanelManagerImpl} from './side_panel_manager';
+import type {SidePanelTabDescriptor} from '../public/side_panel';
 
 /**
  * This implementation provides the plugin access to trace related resources,
@@ -185,6 +187,14 @@ export class TraceImpl implements Trace, Disposable {
         return disposable;
       },
     });
+
+    this.sidePanelProxy = createProxy(app.sidePanel, {
+      registerTab: (tab: SidePanelTabDescriptor) => {
+        const disposable = app.sidePanel.registerTab(tab);
+        this.trash.use(disposable);
+        return disposable;
+      },
+    });
   }
 
   // This method wires up changes to selection to side effects on search and
@@ -211,6 +221,7 @@ export class TraceImpl implements Trace, Disposable {
 
   private readonly commandMgrProxy: CommandManagerImpl;
   private readonly sidebarProxy: SidebarManagerImpl;
+  private readonly sidePanelProxy: SidePanelManagerImpl;
   private readonly pageMgrProxy: PageManagerImpl;
   private readonly settingsProxy: SettingsManagerImpl;
   private readonly omniboxProxy: OmniboxManagerImpl;
@@ -266,6 +277,10 @@ export class TraceImpl implements Trace, Disposable {
 
   get sidebar(): SidebarManagerImpl {
     return this.sidebarProxy;
+  }
+
+  get sidePanel(): SidePanelManagerImpl {
+    return this.sidePanelProxy;
   }
 
   get pages(): PageManager {

--- a/ui/src/frontend/side_panel.scss
+++ b/ui/src/frontend/side_panel.scss
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-side-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--pf-color-background);
+
+  .pf-side-panel__tabs {
+    height: 100%;
+
+    .pf-tabs__content {
+      overflow: auto;
+    }
+  }
+}

--- a/ui/src/frontend/side_panel.ts
+++ b/ui/src/frontend/side_panel.ts
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './side_panel.scss';
+import m from 'mithril';
+import type {SidePanelManagerImpl} from '../core/side_panel_manager';
+import {SplitPanel} from '../widgets/split_panel';
+import {Tabs, type TabsTab} from '../widgets/tabs';
+
+const DEFAULT_WIDTH_PX = 400;
+const MIN_WIDTH_PX = 200;
+
+interface SidePanelContainerAttrs {
+  readonly sidePanelMgr: SidePanelManagerImpl;
+  readonly pageContent: m.Children;
+}
+
+export function SidePanelContainer(): m.Component<SidePanelContainerAttrs> {
+  let widthPx = DEFAULT_WIDTH_PX;
+
+  return {
+    view(vnode) {
+      const {sidePanelMgr, pageContent} = vnode.attrs;
+      const openTabs = sidePanelMgr.registeredTabs;
+      const hasOpenTabs = openTabs.length > 0 && sidePanelMgr.visible;
+
+      if (!hasOpenTabs) {
+        return pageContent;
+      }
+
+      const tabs: TabsTab[] = [];
+      for (const panel of openTabs) {
+        tabs.push({
+          key: panel.uri,
+          title: panel.title,
+          content: panel.render(),
+          closeButton: false,
+          leftIcon: panel.icon,
+        });
+      }
+
+      const sidePanel = m(
+        '.pf-side-panel',
+        m(Tabs, {
+          tabs,
+          activeTabKey: sidePanelMgr.currentTabUri,
+          className: 'pf-side-panel__tabs',
+          onTabChange: (key) => sidePanelMgr.showTab(key),
+        }),
+      );
+
+      return m(SplitPanel, {
+        direction: 'horizontal',
+        controlledPanel: 'second',
+        split: {pixels: widthPx},
+        minSize: MIN_WIDTH_PX,
+        firstPanel: pageContent,
+        secondPanel: sidePanel,
+        onResize: (size: number) => {
+          widthPx = size;
+        },
+      });
+    },
+  };
+}

--- a/ui/src/frontend/topbar.scss
+++ b/ui/src/frontend/topbar.scss
@@ -32,9 +32,15 @@
     }
   }
 
-  &__error-box {
+  &__right {
     position: absolute;
     right: 10px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  &__error-box {
     display: flex;
     align-items: center;
     font-size: var(--pf-font-size-xxl);

--- a/ui/src/frontend/topbar.ts
+++ b/ui/src/frontend/topbar.ts
@@ -20,6 +20,7 @@ import {AppImpl} from '../core/app_impl';
 import {OmniboxMode} from '../core/omnibox_manager';
 import {Router} from '../core/router';
 import type {TraceImpl, TraceImplAttrs} from '../core/trace_impl';
+import type {SidePanelManagerImpl} from '../core/side_panel_manager';
 import {Button} from '../widgets/button';
 import {Intent} from '../widgets/common';
 import {Popup, PopupPosition} from '../widgets/popup';
@@ -75,18 +76,47 @@ export interface TopbarAttrs {
   readonly trace?: TraceImpl;
 }
 
+function renderSidePanelToggle(mgr: SidePanelManagerImpl): m.Children {
+  const hasTabs = mgr.registeredTabs.length > 0;
+  if (!hasTabs) return undefined;
+  return m(Button, {
+    icon: 'dock_to_left',
+    title: 'Toggle sidebar',
+    active: mgr.visible,
+    iconFilled: mgr.visible,
+    className: classNames('pf-topbar__side-panel-btn'),
+    onclick: () => {
+      if (mgr.visible) {
+        mgr.visible = false;
+      } else {
+        // If no tab is open, show the first registered one.
+        if (!mgr.currentTabUri && mgr.registeredTabs.length > 0) {
+          mgr.showTab(mgr.registeredTabs[0].uri);
+        } else {
+          mgr.visible = true;
+        }
+      }
+    },
+  });
+}
+
 export class Topbar implements m.ClassComponent<TopbarAttrs> {
   view({attrs}: m.Vnode<TopbarAttrs>) {
     const {trace} = attrs;
+    const app = AppImpl.instance;
     return m(
       '.pf-topbar',
       {
         className: classNames(
-          !AppImpl.instance.sidebar.visible && 'pf-topbar--hide-sidebar',
+          !app.sidebar.visible && 'pf-topbar--hide-sidebar',
         ),
       },
       m(Omnibox, {trace}),
-      trace && m(TraceErrorIcon, {trace}),
+      m(
+        '.pf-topbar__right',
+        trace && m(TraceErrorIcon, {trace}),
+        renderSidePanelToggle(app.sidePanel),
+      ),
     );
   }
 }

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -21,6 +21,7 @@ import {LinearProgress} from '../widgets/linear_progress';
 import {maybeRenderFullscreenModalDialog} from '../widgets/modal';
 import {initCssConstants} from './css_constants';
 import {Sidebar} from './views/sidebar';
+import {SidePanelContainer} from './side_panel';
 import {renderStatusBar} from './statusbar';
 import {taskTracker} from './task_tracker';
 import {Topbar} from './topbar';
@@ -67,7 +68,13 @@ export class UiMain implements m.ClassComponent {
         className: 'pf-ui-main__loading',
         state: isSomethingLoading ? 'indeterminate' : 'none',
       }),
-      m('.pf-ui-main__page-container', app.pages.renderPageForCurrentRoute()),
+      m(
+        '.pf-ui-main__page-container',
+        m(SidePanelContainer, {
+          sidePanelMgr: app.sidePanel,
+          pageContent: app.pages.renderPageForCurrentRoute(),
+        }),
+      ),
       m(CookieConsent),
       maybeRenderFullscreenModalDialog(),
       showStatusBarFlag.get() && renderStatusBar(app),

--- a/ui/src/plugins/com.example.SidePanel/index.ts
+++ b/ui/src/plugins/com.example.SidePanel/index.ts
@@ -1,0 +1,77 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {PerfettoPlugin} from '../../public/plugin';
+import type {Trace} from '../../public/trace';
+import {Button, ButtonVariant} from '../../widgets/button';
+import './side_panel_example.scss';
+
+export default class implements PerfettoPlugin {
+  static readonly id = 'com.example.SidePanel';
+  static readonly description =
+    'Example plugin showing how to register side panel tabs.';
+
+  async onTraceLoad(trace: Trace): Promise<void> {
+    trace.sidePanel.registerTab({
+      uri: 'com.example.SidePanel#Hello',
+      title: 'Example Side Panel',
+      icon: 'info',
+      render: () =>
+        m(
+          '.pf-side-panel-example',
+          m('h2', 'Hello from the example side panel!'),
+          m(
+            'p',
+            'This tab was contributed by the com.example.SidePanel plugin ',
+            'via trace.sidePanel.registerTab().',
+          ),
+        ),
+    });
+
+    let count = 0;
+    trace.sidePanel.registerTab({
+      uri: 'com.example.SidePanel#Counter',
+      title: 'Counter',
+      icon: 'add_circle',
+      render: () => {
+        return m(
+          '.pf-side-panel-example',
+          m('h2', 'Counter tab'),
+          m('p', `Count: ${count}`),
+          m(Button, {
+            variant: ButtonVariant.Filled,
+            onclick: () => count++,
+            label: 'Increment',
+          }),
+        );
+      },
+    });
+
+    trace.commands.registerCommand({
+      id: 'com.example.SidePanel#ShowHello',
+      name: 'Example: Show hello side panel',
+      callback: () => trace.sidePanel.showTab('com.example.SidePanel#Hello'),
+    });
+
+    trace.commands.registerCommand({
+      id: 'com.example.SidePanel#ShowCounter',
+      name: 'Example: Show counter side panel',
+      callback: () => trace.sidePanel.showTab('com.example.SidePanel#Counter'),
+    });
+
+    // Open the tab right away so the example is discoverable.
+    trace.sidePanel.showTab('com.example.SidePanel#Hello');
+  }
+}

--- a/ui/src/plugins/com.example.SidePanel/side_panel_example.scss
+++ b/ui/src/plugins/com.example.SidePanel/side_panel_example.scss
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-side-panel-example {
+  padding: 12px;
+}

--- a/ui/src/public/app.ts
+++ b/ui/src/public/app.ts
@@ -12,19 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type {RouteArgs} from './route_schema';
-import type {CommandManager} from './commands';
-import type {OmniboxManager} from './omnibox';
-import type {SidebarManager} from './sidebar';
 import type {Analytics} from './analytics';
-import type {PluginManager} from './plugin';
-import type {Trace} from './trace';
-import type {PageManager} from './page';
+import type {CommandManager} from './commands';
 import type {FeatureFlagManager} from './feature_flag';
+import type {OmniboxManager} from './omnibox';
+import type {PageManager} from './page';
+import type {PluginManager} from './plugin';
 import type {Raf} from './raf';
+import type {RouteArgs} from './route_schema';
 import type {SettingsManager} from './settings';
+import type {SidePanelManager} from './side_panel';
+import type {SidebarManager} from './sidebar';
 import type {TraceStream} from './stream';
 import type {TaskTracker} from './task_tracker';
+import type {Trace} from './trace';
 
 /**
  * The API endpoint to interact programmatically with the UI before a trace has
@@ -33,6 +34,7 @@ import type {TaskTracker} from './task_tracker';
 export interface App {
   readonly commands: CommandManager;
   readonly sidebar: SidebarManager;
+  readonly sidePanel: SidePanelManager;
   readonly omnibox: OmniboxManager;
   readonly analytics: Analytics;
   readonly plugins: PluginManager;

--- a/ui/src/public/app.ts
+++ b/ui/src/public/app.ts
@@ -34,7 +34,6 @@ import type {Trace} from './trace';
 export interface App {
   readonly commands: CommandManager;
   readonly sidebar: SidebarManager;
-  readonly sidePanel: SidePanelManager;
   readonly omnibox: OmniboxManager;
   readonly analytics: Analytics;
   readonly plugins: PluginManager;
@@ -63,6 +62,15 @@ export interface App {
    * Tracks async tasks for observability and idle detection.
    */
   readonly taskTracker: TaskTracker;
+
+  /**
+   * Manage the side panel tabs - a global side panel that appears on the right
+   * of all pages, adding tabs and switching between them.
+   *
+   * @experimental - This is a new API and may change or be removed in the
+   * future. Use with caution and be prepared for breaking changes.
+   */
+  readonly sidePanel: SidePanelManager;
 
   // True if the current user is an 'internal' user. E.g. a Googler on
   // ui.perfetto.dev. Plugins might use this to determine whether to show

--- a/ui/src/public/side_panel.ts
+++ b/ui/src/public/side_panel.ts
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type m from 'mithril';
+
+export interface SidePanelTabDescriptor {
+  readonly uri: string;
+  readonly title: string;
+  readonly icon?: string;
+  render(): m.Children;
+}
+
+export interface SidePanelManager {
+  registerTab(tab: SidePanelTabDescriptor): Disposable;
+  showTab(uri: string): void;
+}

--- a/ui/src/public/side_panel.ts
+++ b/ui/src/public/side_panel.ts
@@ -22,6 +22,17 @@ export interface SidePanelTabDescriptor {
 }
 
 export interface SidePanelManager {
+  /**
+   * The title of the book.
+   * @experimental - This is a new API and may change or be removed in the
+   * future. Use with caution and be prepared for breaking changes.
+   */
   registerTab(tab: SidePanelTabDescriptor): Disposable;
+
+  /**
+   * Show a given tab in the side panel.
+   * @experimental - This is a new API and may change or be removed in the
+   * future. Use with caution and be prepared for breaking changes.
+   */
   showTab(uri: string): void;
 }


### PR DESCRIPTION
Gives plugins a place to surface their own UI alongside the main page. Plugins can register tabs against a new SidePanelManager (exposed on both App and Trace) and call showTab() open them; tabs registered via Trace are automatically torn down with the trace.

The panel itself lives to the right of the page content in a resizable split, with a tab strip across registered tabs so multiple plugins can coexist without fighting over the space.

Also add com.example.SidePanel example plugin which demonstrates using this panel extension point.

<img width="1106" height="682" alt="image" src="https://github.com/user-attachments/assets/99a5d40b-684e-4f73-8528-7dc1c0d60306" />