### PR TITLE
ui: Allow external hosts in Vite dev server

### DIFF
--- a/ui/build.mjs
+++ b/ui/build.mjs
@@ -826,6 +826,7 @@ async function startViteDevServer() {
     configFile: pjoin(ROOT_DIR, 'ui/vite.config.mjs'),
     server: {
       host: cfg.httpServerListenHost,
+      allowedHosts: cfg.httpServerListenHost ? true : undefined,
       port,
       strictPort: false,
       headers,


### PR DESCRIPTION

  When a custom httpServerListenHost is provided, via `ui/run-dev-server --serve-host my.host`, disable Vite's strict Host header checks by setting allowedHosts to true. This
  allows accessing the dev server, preventing Vite from blocking the requests due to DNS rebinding
  protections.
