### PR TITLE
Revert: host_supported on perfetto_trace_lib_java_defaults

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20880,7 +20880,6 @@ java_defaults {
     libs: [
         "error_prone_annotations",
     ],
-    host_supported: true,
     sdk_version: "module_current",
 }
 

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -385,8 +385,6 @@ additional_args = {
     ],
     'perfetto_trace_lib_java': [
         ('sdk_version', 'module_current'),
-        # Propagates to perfetto_trace_lib_framework_java via shared defaults.
-        ('host_supported', True),
         # Framework should use 'perfetto_trace_lib_framework_java' instead.
         ('visibility', {':__subpackages__'}),
     ],


### PR DESCRIPTION
Partial revert of ca68af800e. The Java side flip broke the AOSP downstream merge: the host variant of perfetto_trace_lib_framework_java fails to compile because module_current's host classpath doesn't expose dalvik.annotation.optimization.{Critical,Fast}Native or android.system.SystemCleaner.

C++ side (libperfetto_framework_jni host_supported + liblog Android-shared / host-static) is unaffected and stays.

Fix-forward (host stub library) is coming as a follow-up; reverting now to unblock the AOSP merge.