### PR TITLE
android_sdk: host stubs for perfetto_trace_lib_java host build

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20880,7 +20880,15 @@ java_defaults {
     libs: [
         "error_prone_annotations",
     ],
+    host_supported: true,
     sdk_version: "module_current",
+    target: {
+        host: {
+            libs: [
+                "perfetto_trace_lib_host_stubs",
+            ],
+        },
+    },
 }
 
 // GN: //protos/perfetto/trace:perfetto_trace_protos
@@ -24303,5 +24311,20 @@ filegroup {
     name: "ravenwood-perfetto-policies",
     srcs: [
         "src/android_sdk/jni/ravenwood-perfetto-policies.txt",
+    ],
+}
+
+// Host-only stubs for the small set of Android classes the perfetto Java
+// SDK references that are missing from Soong's host module_current
+// classpath (dalvik.annotation.optimization.{Critical,Fast}Native and
+// android.system.SystemCleaner; plus android.util.{ArraySet,Log} and
+// android.os.Process). Linked into the host variant of
+// perfetto_trace_lib_java_defaults as a libs: dep so the stubs are visible
+// to javac but not bundled into the jar; the Android variant continues
+// to use the real platform classes from module_current.
+java_library_host {
+    name: "perfetto_trace_lib_host_stubs",
+    srcs: [
+        "src/android_sdk/java/host_stubs/**/*.java",
     ],
 }

--- a/Android.bp.extras
+++ b/Android.bp.extras
@@ -339,3 +339,18 @@ filegroup {
         "src/android_sdk/jni/ravenwood-perfetto-policies.txt",
     ],
 }
+
+// Host-only stubs for the small set of Android classes the perfetto Java
+// SDK references that are missing from Soong's host module_current
+// classpath (dalvik.annotation.optimization.{Critical,Fast}Native and
+// android.system.SystemCleaner; plus android.util.{ArraySet,Log} and
+// android.os.Process). Linked into the host variant of
+// perfetto_trace_lib_java_defaults as a libs: dep so the stubs are visible
+// to javac but not bundled into the jar; the Android variant continues
+// to use the real platform classes from module_current.
+java_library_host {
+    name: "perfetto_trace_lib_host_stubs",
+    srcs: [
+        "src/android_sdk/java/host_stubs/**/*.java",
+    ],
+}

--- a/src/android_sdk/java/host_stubs/android/os/Process.java
+++ b/src/android_sdk/java/host_stubs/android/os/Process.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.os;
+
+/**
+ * Host-JVM stub of Android's {@code Process}. Only the surface needed by the
+ * perfetto SDK tests is implemented.
+ */
+public final class Process {
+  private Process() {}
+
+  /**
+   * Returns the current thread identifier. On a host JVM this is the JVM
+   * thread id (not the kernel tid); good enough for tests that only need
+   * a stable per-thread integer.
+   */
+  public static int myTid() {
+    return (int) Thread.currentThread().getId();
+  }
+}

--- a/src/android_sdk/java/host_stubs/android/system/SystemCleaner.java
+++ b/src/android_sdk/java/host_stubs/android/system/SystemCleaner.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.system;
+
+import java.lang.ref.Cleaner;
+
+/**
+ * Host-JVM stub of Android's process-wide cleaner. {@code java.lang.ref.Cleaner}
+ * is available on every JDK >= 9, so we simply hand out a per-process singleton.
+ */
+public final class SystemCleaner {
+  private static final Cleaner INSTANCE = Cleaner.create();
+
+  private SystemCleaner() {}
+
+  public static Cleaner cleaner() {
+    return INSTANCE;
+  }
+}

--- a/src/android_sdk/java/host_stubs/android/util/ArraySet.java
+++ b/src/android_sdk/java/host_stubs/android/util/ArraySet.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.util;
+
+import java.util.HashSet;
+
+/**
+ * Host-JVM stub of Android's memory-efficient {@code Set} implementation. The
+ * perfetto SDK tests only exercise the {@link java.util.Set} interface, so a
+ * {@link HashSet} subclass is sufficient on host.
+ */
+public class ArraySet<E> extends HashSet<E> {
+  public ArraySet() {
+    super();
+  }
+
+  public ArraySet(int capacity) {
+    super(capacity);
+  }
+}

--- a/src/android_sdk/java/host_stubs/android/util/Log.java
+++ b/src/android_sdk/java/host_stubs/android/util/Log.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.util;
+
+/**
+ * Host-JVM stub of Android's logger. Routes to {@code System.err} so test
+ * output is captured in the JUnit runner.
+ */
+public final class Log {
+  private Log() {}
+
+  public static int v(String tag, String msg) { return println("V", tag, msg, null); }
+  public static int d(String tag, String msg) { return println("D", tag, msg, null); }
+  public static int i(String tag, String msg) { return println("I", tag, msg, null); }
+  public static int w(String tag, String msg) { return println("W", tag, msg, null); }
+  public static int w(String tag, String msg, Throwable tr) { return println("W", tag, msg, tr); }
+  public static int e(String tag, String msg) { return println("E", tag, msg, null); }
+  public static int e(String tag, String msg, Throwable tr) { return println("E", tag, msg, tr); }
+
+  private static int println(String level, String tag, String msg, Throwable tr) {
+    System.err.println(level + "/" + tag + ": " + msg);
+    if (tr != null) tr.printStackTrace(System.err);
+    return 0;
+  }
+}

--- a/src/android_sdk/java/host_stubs/dalvik/annotation/optimization/CriticalNative.java
+++ b/src/android_sdk/java/host_stubs/dalvik/annotation/optimization/CriticalNative.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dalvik.annotation.optimization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Host-JVM stub of ART's {@code @CriticalNative}. ART recognises this
+ * annotation and elides the JNIEnv pointer and jclass arguments on the C
+ * side; non-ART JVMs have no equivalent and ignore it. The C JNI uses
+ * {@code PERFETTO_JNI_HOST_PARAMS} to compile with the standard JNI
+ * signature when targeting non-ART JVMs, so this stub exists purely to
+ * satisfy javac when the perfetto SDK is built for host.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface CriticalNative {}

--- a/src/android_sdk/java/host_stubs/dalvik/annotation/optimization/FastNative.java
+++ b/src/android_sdk/java/host_stubs/dalvik/annotation/optimization/FastNative.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dalvik.annotation.optimization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Host-JVM stub of ART's @FastNative. See {@link CriticalNative} for the
+ * rationale.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface FastNative {}

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -385,6 +385,14 @@ additional_args = {
     ],
     'perfetto_trace_lib_java': [
         ('sdk_version', 'module_current'),
+        # Propagates to perfetto_trace_lib_framework_java via shared defaults.
+        ('host_supported', True),
+        # On host the module_current classpath doesn't expose
+        # dalvik.annotation.optimization or android.system.SystemCleaner;
+        # the stubs library defined in Android.bp.extras provides them.
+        ('host', {
+            'libs': {'perfetto_trace_lib_host_stubs'}
+        }),
         # Framework should use 'perfetto_trace_lib_framework_java' instead.
         ('visibility', {':__subpackages__'}),
     ],
@@ -625,6 +633,7 @@ class Target(object):
 
   def __init__(self, name):
     self.name = name
+    self.libs = set()
     self.shared_libs = set()
     self.static_libs = set()
     self.whole_static_libs = set()
@@ -638,6 +647,7 @@ class Target(object):
   def to_string(self, output):
     nested_out = []
     self._output_field(nested_out, 'enabled')
+    self._output_field(nested_out, 'libs')
     self._output_field(nested_out, 'shared_libs')
     self._output_field(nested_out, 'static_libs')
     self._output_field(nested_out, 'whole_static_libs')


### PR DESCRIPTION
Fix-forward for the host_supported flip on perfetto_trace_lib_java_defaults (landed as ca68af800e, reverted shortly after because the host build broke).

The host variant of perfetto_trace_lib_framework_java fails javac with "cannot find symbol" for dalvik.annotation.optimization.CriticalNative, @FastNative, and android.system.SystemCleaner. Those classes live on the device platform classpath but aren't surfaced by Soong's host module_current. Provide a small host-only stubs library that supplies just the surface the SDK references; reference it via target.host.libs on perfetto_trace_lib_java_defaults so it's visible to javac on host but inert (and unbundled) on Android.

Stub surface:
* dalvik.annotation.optimization.{Critical,Fast}Native: no-op annotations; ART's specialised ABI is already handled C-side by PERFETTO_JNI_HOST_PARAMS.
* android.system.SystemCleaner: delegates to java.lang.ref.Cleaner.
* android.util.ArraySet: extends java.util.HashSet.
* android.util.Log: routes to System.err.
* android.os.Process: minimal surface the SDK references.

Generator changes are limited to teaching Target about a Java-side libs field and emitting it in to_string; existing cc consumers are unaffected. The stubs library is hand-defined in Android.bp.extras as a java_library_host so it only builds on host and never lands on the Android side.

With this in place, host_supported on perfetto_trace_lib_java_defaults compiles cleanly on AOSP.

Tested with m out/soong/.intermediates/external/perfetto/perfetto_trace_lib_framework_java/linux_glibc_common/javac/perfetto_trace_lib_framework_java.jar
