### PR TITLE
tp: stream stdlib into engine without copies

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
@@ -1236,7 +1236,7 @@ bool PerfettoSqlConnection::IsKeyOnIncludeStack(const std::string& key) const {
 
 base::Status PerfettoSqlConnection::IncludeModuleImpl(
     const std::string& key,
-    const std::string& sql,
+    std::string_view sql,
     const PerfettoSqlParser& parser) {
   if (IsKeyOnIncludeStack(key)) {
     std::string traceback = parser.statement_sql().AsTraceback(0);
@@ -1255,15 +1255,15 @@ base::Status PerfettoSqlConnection::IncludeModuleImpl(
         "%sINCLUDE: module '%s' poisoned by earlier failure: %s",
         traceback.c_str(), key.c_str(), res.poison_reason.c_str());
   }
-  execution_stack_.push_back({FrameType::kInclude,
-                              SqlSource::FromModuleInclude(sql, key),
-                              /*parser=*/nullptr, /*accumulated_stats=*/{},
-                              /*current_stmt=*/std::nullopt, key,
-                              /*traceback_sql=*/parser.statement_sql(),
-                              /*include_claim=*/std::move(res.claim),
-                              /*wildcard_modules=*/{}, /*wildcard_index=*/0,
-                              /*wildcard_traceback_sql=*/
-                              SqlSource::FromTraceProcessorImplementation("")});
+  execution_stack_.push_back(
+      {FrameType::kInclude, SqlSource::FromModuleInclude(std::string(sql), key),
+       /*parser=*/nullptr, /*accumulated_stats=*/{},
+       /*current_stmt=*/std::nullopt, key,
+       /*traceback_sql=*/parser.statement_sql(),
+       /*include_claim=*/std::move(res.claim),
+       /*wildcard_modules=*/{}, /*wildcard_index=*/0,
+       /*wildcard_traceback_sql=*/
+       SqlSource::FromTraceProcessorImplementation("")});
   return base::OkStatus();
 }
 

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -437,7 +438,7 @@ class PerfettoSqlConnection {
   // database; returns OkStatus on already-included, an error on poisoned,
   // or pushes an include frame on the execution stack on a fresh claim.
   base::Status IncludeModuleImpl(const std::string& key,
-                                 const std::string& sql,
+                                 std::string_view sql,
                                  const PerfettoSqlParser&);
 
   // Returns true iff |key| is the |include_key| of an active |kInclude|

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_unittest.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_unittest.cc
@@ -40,11 +40,13 @@ class PerfettoSqlConnectionTest : public ::testing::Test {
       PerfettoSqlConnection::CreateConnectionToNewDatabase(&pool_, true);
 };
 
+// Takes const char* literals (static storage) — RegisteredPackage stores
+// string_views, so the bodies must outlive every connection that holds it.
 sql_modules::RegisteredPackage CreateTestPackage(
-    const std::vector<std::pair<std::string, std::string>>& files) {
+    std::initializer_list<std::pair<const char*, const char*>> files) {
   sql_modules::RegisteredPackage result;
   for (const auto& file : files) {
-    result.modules[file.first] = file.second;
+    result.modules.Insert(file.first, std::string_view(file.second));
   }
   return result;
 }

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.cc
@@ -54,7 +54,20 @@ base::Status PerfettoSqlDatabase::RegisterPackage(
       }
     }
   }
+  // Same-name re-registrations replace silently; the caller decides whether
+  // to allow that. Prefix overlaps with *different* package names are always
+  // rejected because |FindPackageForModule| assumes at most one package can
+  // match any given key.
   packages_.Erase(name);
+  for (auto pkg = packages_.GetIterator(); pkg; ++pkg) {
+    if (sql_modules::IsPackagePrefixOf(name, pkg.key()) ||
+        sql_modules::IsPackagePrefixOf(pkg.key(), name)) {
+      return base::ErrStatus(
+          "Package '%s' clashes with existing package '%s'. Package names "
+          "cannot be prefixes of each other.",
+          name.c_str(), pkg.key().c_str());
+    }
+  }
   packages_.Insert(name, std::move(package));
   return base::OkStatus();
 }

--- a/src/trace_processor/plugins/stdlib_docs/stdlib_docs.cc
+++ b/src/trace_processor/plugins/stdlib_docs/stdlib_docs.cc
@@ -73,7 +73,7 @@ base::StatusOr<stdlib_doc::ParsedModule> ParseModule(
   }
   PERFETTO_DCHECK(mod->size() <= std::numeric_limits<uint32_t>::max());
   auto parsed = stdlib_doc::ParseStdlibModule(
-      mod->c_str(), static_cast<uint32_t>(mod->size()));
+      mod->data(), static_cast<uint32_t>(mod->size()));
   for (const auto& err : parsed.errors) {
     PERFETTO_DLOG("stdlib docs: parse error in '%s': %s", module_key.c_str(),
                   err.c_str());

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -233,20 +233,20 @@ void BuildBoundsTable(sqlite3* db, std::pair<int64_t, int64_t> bounds) {
   }
 }
 
+// Module bodies are string_views into |package|; the caller must keep
+// |package| alive for the lifetime of the result.
 base::StatusOr<sql_modules::RegisteredPackage> ToRegisteredPackage(
     const SqlPackage& package) {
   const std::string& name = package.name;
   sql_modules::RegisteredPackage new_package;
-  for (auto const& module_name_and_sql : package.modules) {
-    const std::string& module_name = module_name_and_sql.first;
-    // Module name must start with package name as prefix (and be longer)
+  for (const auto& [module_name, sql] : package.modules) {
     if (!sql_modules::IsPackagePrefixOf(name, module_name) ||
         name == module_name) {
       return base::ErrStatus(
           "Module name '%s' must start with package name '%s.' as prefix.",
           module_name.c_str(), name.c_str());
     }
-    new_package.modules.Insert(module_name, module_name_and_sql.second);
+    new_package.modules.Insert(module_name, std::string_view(sql));
   }
   return base::StatusOr<sql_modules::RegisteredPackage>(std::move(new_package));
 }
@@ -274,17 +274,6 @@ void InsertIntoTraceMetricsTable(sqlite3* db, const std::string& metric_name) {
     PERFETTO_ELOG("Error registering table: %s", insert_error);
     sqlite3_free(insert_error);
   }
-}
-
-sql_modules::NameToPackage GetStdlibPackages() {
-  sql_modules::NameToPackage packages;
-  for (const auto& file_to_sql : SqlBundle(stdlib::kStdlib)) {
-    std::string module_name = sql_modules::GetIncludeKey(file_to_sql.path);
-    std::string package_name = sql_modules::GetPackageName(module_name);
-    packages.Insert(package_name, {})
-        .first->emplace_back(module_name, file_to_sql.sql_view());
-  }
-  return packages;
 }
 
 // Aggregates GetBoundsMutationCount across all plugins.
@@ -513,16 +502,6 @@ TraceProcessorImpl::TraceProcessorImpl(const Config& cfg)
     PERFETTO_CHECK(status.ok());
   }
 
-  // Register stdlib packages.
-  auto packages = GetStdlibPackages();
-  for (auto package = packages.GetIterator(); package; ++package) {
-    registered_sql_packages_.emplace_back<SqlPackage>({
-        /*name=*/package.key(),
-        /*modules=*/package.value(),
-        /*allow_override=*/false,
-    });
-  }
-
   // Compute initial trace bounds before any tables are finalized.
   cached_trace_bounds_ = AggregatePluginTimestampBounds(plugins_);
 
@@ -666,45 +645,29 @@ Iterator TraceProcessorImpl::ExecuteQuery(const std::string& sql) {
 base::Status TraceProcessorImpl::RegisterSqlPackage(SqlPackage sql_package) {
   const std::string& name = sql_package.name;
 
-  // Check for prefix clashes with existing packages
-  std::optional<size_t> same_package_idx;
-  for (size_t i = 0; i < registered_sql_packages_.size(); ++i) {
-    const std::string& existing_name = registered_sql_packages_[i].name;
-    bool is_same_package = (name == existing_name);
-    bool has_prefix_clash =
-        sql_modules::IsPackagePrefixOf(name, existing_name) ||
-        sql_modules::IsPackagePrefixOf(existing_name, name);
-
-    if (is_same_package) {
-      // Same package name: only allow if allow_override is set
-      if (!sql_package.allow_override) {
-        return base::ErrStatus(
-            "Package '%s' is already registered. Choose a different name.\n"
-            "If you want to replace the existing package using trace processor "
-            "shell, you need to pass the --dev flag and use "
-            "--override-sql-package to pass the module path.",
-            name.c_str());
-      }
-      same_package_idx = i;
-    } else if (has_prefix_clash) {
-      // Prefix clash with DIFFERENT package: always fail
-      return base::ErrStatus(
-          "Package '%s' clashes with existing package '%s'. "
-          "Package names cannot be prefixes of each other.",
-          name.c_str(), existing_name.c_str());
-    }
+  // Same-name gate. The engine holds both stdlib and previously-registered
+  // user packages, so a single lookup covers both.
+  if (engine_->FindPackage(name) != nullptr && !sql_package.allow_override) {
+    return base::ErrStatus(
+        "Package '%s' is already registered. Choose a different name.\n"
+        "If you want to replace the existing package using trace processor "
+        "shell, you need to pass the --dev flag and use "
+        "--override-sql-package to pass the module path.",
+        name.c_str());
   }
 
+  // Validate module names. The returned string_views point into |sql_package|
+  // and stay valid through the std::move below: std::vector's move ctor
+  // preserves element addresses.
   ASSIGN_OR_RETURN(auto new_package, ToRegisteredPackage(sql_package));
 
-  // If overriding same package, remove old one first
-  if (same_package_idx.has_value()) {
-    registered_sql_packages_.erase(registered_sql_packages_.begin() +
-                                   static_cast<ptrdiff_t>(*same_package_idx));
+  auto it = std::find_if(registered_sql_packages_.begin(),
+                         registered_sql_packages_.end(),
+                         [&](const SqlPackage& p) { return p.name == name; });
+  if (it != registered_sql_packages_.end()) {
+    registered_sql_packages_.erase(it);
     engine_->ErasePackage(name);
   }
-
-  // Save the name before moving sql_package
   std::string pkg_name = name;
   registered_sql_packages_.emplace_back(std::move(sql_package));
   return engine_->RegisterPackage(pkg_name, std::move(new_package));
@@ -1055,7 +1018,34 @@ TraceProcessorImpl::InitPerfettoSqlConnection(
     }
   }
 
-  // Reregister manually added stdlib packages.
+  // Stream stdlib straight from rodata into the connection. The bundle is
+  // sorted by path so package entries are contiguous: flush whenever the
+  // package name changes. Bodies stay as string_views into kStdlib.
+  {
+    auto flush = [&](const std::string& pkg,
+                     sql_modules::RegisteredPackage rp) {
+      auto status = connection->RegisterPackage(pkg, std::move(rp));
+      if (!status.ok()) {
+        PERFETTO_FATAL("%s", status.c_message());
+      }
+    };
+    std::string current_pkg;
+    sql_modules::RegisteredPackage rp;
+    for (const auto& f : SqlBundle(stdlib::kStdlib)) {
+      std::string include_key = sql_modules::GetIncludeKey(f.path);
+      std::string pkg = sql_modules::GetPackageName(include_key);
+      if (pkg != current_pkg) {
+        if (!current_pkg.empty())
+          flush(current_pkg, std::move(rp));
+        current_pkg = std::move(pkg);
+      }
+      rp.modules.Insert(std::move(include_key), f.sql_view());
+    }
+    if (!current_pkg.empty())
+      flush(current_pkg, std::move(rp));
+  }
+
+  // Re-register user-added packages.
   for (const auto& package : packages) {
     auto new_package = ToRegisteredPackage(package);
     if (!new_package.ok()) {

--- a/src/trace_processor/trace_processor_impl.h
+++ b/src/trace_processor/trace_processor_impl.h
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <list>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -147,7 +148,7 @@ class TraceProcessorImpl : public TraceProcessor,
     TraceProcessorContext* context;
     TraceStorage* storage;
     const Config& config;
-    const std::vector<SqlPackage>& packages;
+    const std::list<SqlPackage>& packages;
     std::vector<metrics::SqlMetricFile>& sql_metrics;
     const DescriptorPool* metrics_descriptor_pool;
     std::unordered_map<std::string, std::string>* proto_fn_name_to_path;
@@ -178,7 +179,9 @@ class TraceProcessorImpl : public TraceProcessor,
   DescriptorPool metrics_descriptor_pool_;
 
   std::vector<metrics::SqlMetricFile> sql_metrics_;
-  std::vector<SqlPackage> registered_sql_packages_;
+  // list (not vector) for stable element addresses: RegisteredPackage holds
+  // string_views into these std::strings.
+  std::list<SqlPackage> registered_sql_packages_;
 
   std::unordered_map<std::string, std::string> proto_field_to_sql_metric_path_;
   std::unordered_map<std::string, std::string> proto_fn_name_to_path_;

--- a/src/trace_processor/util/sql_modules.h
+++ b/src/trace_processor/util/sql_modules.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -38,8 +39,10 @@ using NameToPackage =
 // previously poisoned an attempt) is tracked centrally on
 // |PerfettoSqlDatabase| so connections attached to the same database share a
 // consistent view.
+//
+// The string_view bodies must outlive every connection holding this package.
 struct RegisteredPackage {
-  base::FlatHashMap<std::string, std::string> modules;
+  base::FlatHashMap<std::string, std::string_view> modules;
 };
 
 inline std::string ReplaceSlashWithDot(std::string str) {

--- a/tools/gen_amalgamated_sql.py
+++ b/tools/gen_amalgamated_sql.py
@@ -59,10 +59,16 @@ def expand_inputs(inputs):
 
 
 def pack_bundle(file_to_sql):
-  """Pack {relpath: sql_bytes} into the SqlBundle wire format."""
+  """Pack {relpath: sql_bytes} into the SqlBundle wire format.
+
+  Entries are sorted by path so that files belonging to the same top-level
+  directory (= PerfettoSQL package) end up contiguous in the bundle. The
+  consumer relies on this to detect package boundaries by a simple linear
+  scan rather than maintaining a hashmap.
+  """
   buf = bytearray()
   buf += struct.pack('<I', len(file_to_sql))
-  for path, sql in file_to_sql.items():
+  for path, sql in sorted(file_to_sql.items()):
     path_bytes = path.encode('utf-8')
     buf += struct.pack('<I', len(path_bytes))
     buf += path_bytes


### PR DESCRIPTION
Switches RegisteredPackage::modules to std::string_view so SQL bodies
can stay in rodata, sorts the gen_amalgamated_sql output by path so
entries belonging to the same package land contiguously, and streams
the bundled stdlib straight from the blob into the connection without
an intermediate SqlPackage copy.

To support string_view bodies, registered_sql_packages_ moves to
std::list for stable element addresses, and prefix-clash detection
moves into PerfettoSqlDatabase::RegisterPackage where it can see both
stdlib and user packages. The same-name override gate in
RegisterSqlPackage uses engine_->FindPackage to cover both stdlib and
user packages with a single lookup.
