### PR TITLE
tp: PerfettoSqlParser supports Reset() + faster parse path

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4249,6 +4249,7 @@ perfetto_cpp_blob_header(
 perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_syntaqlite_syntaqlite",
     srcs = [
+        "src/trace_processor/perfetto_sql/syntaqlite/inline_dispatch.h",
         "src/trace_processor/perfetto_sql/syntaqlite/syntaqlite_perfetto.c",
         "src/trace_processor/perfetto_sql/syntaqlite/syntaqlite_perfetto.h",
         "src/trace_processor/perfetto_sql/syntaqlite/utils.h",

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
@@ -469,7 +469,8 @@ PerfettoSqlConnection::PerfettoSqlConnection(
 
 base::StatusOr<SqliteConnection::PreparedStatement>
 PerfettoSqlConnection::PrepareSqliteStatement(SqlSource sql_source) {
-  PerfettoSqlParser parser(std::move(sql_source), database_->macros());
+  PerfettoSqlParser parser(database_->macros());
+  parser.Reset(std::move(sql_source));
   if (!parser.Next()) {
     return base::ErrStatus("No statement found to prepare");
   }
@@ -673,8 +674,10 @@ PerfettoSqlConnection::ProcessFrame(size_t frame_idx) {
 
   // Initialize parser on first access to this frame
   if (!execution_stack_[frame_idx].parser) {
-    execution_stack_[frame_idx].parser = std::make_unique<PerfettoSqlParser>(
-        std::move(execution_stack_[frame_idx].sql_source), database_->macros());
+    execution_stack_[frame_idx].parser =
+        std::make_unique<PerfettoSqlParser>(database_->macros());
+    execution_stack_[frame_idx].parser->Reset(
+        std::move(execution_stack_[frame_idx].sql_source));
   }
 
   // Try to get next statement from this frame

--- a/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.cc
+++ b/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.cc
@@ -135,6 +135,7 @@ class MacroRewriteBuilder {
                       const base::FlatHashMap<std::string, Macro>& macros)
       : p_(p), stmt_(stmt), stmt_doc_offset_(stmt_doc_offset), macros_(macros) {
     uint32_t total = syntaqlite_result_macro_count(p_);
+    no_macros_ = (total == 0);
     children_.resize(total);
     for (uint32_t i = 0; i < total; i++) {
       auto r = syntaqlite_result_macro_rewrite_at(p_, i);
@@ -155,6 +156,9 @@ class MacroRewriteBuilder {
     if (syntaqlite_parser_node_text(p_, node_id, &len, &stmt_off) == nullptr)
       return std::nullopt;
     SqlSource base = stmt_.Substr(stmt_off + stmt_doc_offset_, len);
+    // No-macros parses can skip the per-node macro-free check.
+    if (no_macros_)
+      return base;
     if (syntaqlite_node_is_macro_free(p_, node_id))
       return base;
     return ApplyChildrenInRange(std::move(base), source_rooted_, stmt_off, len);
@@ -320,6 +324,8 @@ class MacroRewriteBuilder {
   const SqlSource& stmt_;
   uint32_t stmt_doc_offset_;
   const base::FlatHashMap<std::string, Macro>& macros_;
+  // Zero macros in the whole parse — lets NodeSource fast-path.
+  bool no_macros_ = true;
   // children_[parent_idx] = rewrite indices whose `parent_idx` equals that.
   std::vector<std::vector<uint32_t>> children_;
   // Rewrites whose parent is SYNTAQLITE_MACRO_PARENT_SOURCE.
@@ -535,13 +541,19 @@ base::StatusOr<Statement> ParseStatement(SyntaqliteParser* p,
 // (preprocessor-compat shims) and the engine-owned user macro registry.
 
 struct PerfettoSqlParser::Impl {
-  Impl(SqlSource src, const base::FlatHashMap<std::string, Macro>& m)
-      : source(std::move(src)), macros(m) {
+  explicit Impl(const base::FlatHashMap<std::string, Macro>& m)
+      : source(SqlSource::FromTraceProcessorImplementation("")), macros(m) {
     synq = syntaqlite_parser_create_with_dialect(nullptr,
                                                  syntaqlite_perfetto_dialect());
     PERFETTO_CHECK(synq != nullptr);
     PERFETTO_CHECK(syntaqlite_parser_set_collect_node_extents(synq, 1) == 0);
     syntaqlite_parser_set_macro_lookup(synq, &Impl::LookupMacro, this);
+  }
+
+  void Bind(SqlSource src) {
+    source = std::move(src);
+    current_statement.reset();
+    status = base::OkStatus();
     syntaqlite_parser_reset(synq, source.sql().data(),
                             static_cast<uint32_t>(source.sql().size()));
   }
@@ -668,9 +680,13 @@ bool PerfettoSqlParser::Impl::Next(
 }
 
 PerfettoSqlParser::PerfettoSqlParser(
-    SqlSource source,
     const base::FlatHashMap<std::string, Macro>& macros)
-    : impl_(std::make_unique<Impl>(std::move(source), macros)) {}
+    : impl_(std::make_unique<Impl>(macros)) {}
+
+void PerfettoSqlParser::Reset(SqlSource source) {
+  statement_sql_.reset();
+  impl_->Bind(std::move(source));
+}
 
 PerfettoSqlParser::~PerfettoSqlParser() = default;
 

--- a/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.h
+++ b/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.h
@@ -133,10 +133,13 @@ class PerfettoSqlParser {
                                  Include,
                                  SqliteSql>;
 
-  // Creates a new SQL parser with the a block of PerfettoSQL statements.
-  // Concretely, the passed string can contain >1 statement.
-  explicit PerfettoSqlParser(SqlSource,
-                             const base::FlatHashMap<std::string, Macro>&);
+  // Reset(SqlSource) must be called before iterating. The underlying
+  // syntaqlite parser is created once and reused across Reset() calls.
+  explicit PerfettoSqlParser(
+      const base::FlatHashMap<std::string, Macro>& macros);
+
+  // Rebinds to a fresh source; keeps the syntaqlite parser instance.
+  void Reset(SqlSource);
 
   ~PerfettoSqlParser();
 
@@ -164,6 +167,16 @@ class PerfettoSqlParser {
   const SqlSource& statement_sql() const {
     PERFETTO_CHECK(statement_sql_);
     return *statement_sql_;
+  }
+
+  // Like |statement_sql()| but moves the SqlSource out, leaving the parser
+  // with no current statement_sql. Callers must not call statement_sql()
+  // after this until the next successful Next() call.
+  SqlSource TakeStatementSql() {
+    PERFETTO_CHECK(statement_sql_);
+    SqlSource result = std::move(*statement_sql_);
+    statement_sql_.reset();
+    return result;
   }
 
   // Returns the error status for the parser. This will be |base::OkStatus()|

--- a/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser_unittest.cc
+++ b/src/trace_processor/perfetto_sql/parser/perfetto_sql_parser_unittest.cc
@@ -50,7 +50,8 @@ class PerfettoSqlParserTest : public ::testing::Test {
  protected:
   base::StatusOr<std::vector<PerfettoSqlParser::Statement>> Parse(
       SqlSource sql) {
-    PerfettoSqlParser parser(std::move(sql), macros_);
+    PerfettoSqlParser parser(macros_);
+    parser.Reset(std::move(sql));
     std::vector<PerfettoSqlParser::Statement> results;
     while (parser.Next()) {
       results.push_back(parser.statement());
@@ -79,7 +80,8 @@ class PerfettoSqlParserTest : public ::testing::Test {
   // The caller is responsible for asserting `sql` is syntactically well-formed
   // and produces exactly one statement; failures abort the test.
   SqlSource ParseOne(SqlSource sql) {
-    PerfettoSqlParser parser(std::move(sql), macros_);
+    PerfettoSqlParser parser(macros_);
+    parser.Reset(std::move(sql));
     PERFETTO_CHECK(parser.Next());
     PERFETTO_CHECK(parser.status().ok());
     SqlSource out = parser.statement_sql();
@@ -96,7 +98,8 @@ TEST_F(PerfettoSqlParserTest, Empty) {
 
 TEST_F(PerfettoSqlParserTest, SemiColonTerminatedStatement) {
   SqlSource res = SqlSource::FromExecuteQuery("SELECT * FROM slice;");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(), Statement{SqliteSql{}});
   ASSERT_EQ(parser.statement_sql(), FindSubstr(res, "SELECT * FROM slice"));
@@ -105,7 +108,8 @@ TEST_F(PerfettoSqlParserTest, SemiColonTerminatedStatement) {
 TEST_F(PerfettoSqlParserTest, MultipleStmts) {
   auto res =
       SqlSource::FromExecuteQuery("SELECT * FROM slice; SELECT * FROM s");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(), Statement{SqliteSql{}});
   ASSERT_EQ(parser.statement_sql().sql(),
@@ -118,7 +122,8 @@ TEST_F(PerfettoSqlParserTest, MultipleStmts) {
 
 TEST_F(PerfettoSqlParserTest, IgnoreOnlySpace) {
   auto res = SqlSource::FromExecuteQuery(" ; SELECT * FROM s; ; ;");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(), Statement{SqliteSql{}});
   ASSERT_EQ(parser.statement_sql().sql(),
@@ -220,7 +225,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoFunctionScalarError) {
 TEST_F(PerfettoSqlParserTest, CreatePerfettoFunctionAndOther) {
   auto res = SqlSource::FromExecuteQuery(
       "create perfetto function foo() returns INT as select 1; select foo()");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   CreateFn fn{
       false,
@@ -369,7 +375,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoMacro) {
   auto res = SqlSource::FromExecuteQuery(
       "create perfetto macro foo(a1 Expr, b1 TableOrSubquery,c3_d "
       "TableOrSubquery2 ) returns TableOrSubquery3 as random sql snippet");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(
       parser.statement(),
@@ -389,7 +396,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoMacro) {
 TEST_F(PerfettoSqlParserTest, CreateOrReplacePerfettoMacro) {
   auto res = SqlSource::FromExecuteQuery(
       "create or replace perfetto macro foo() returns Expr as 1");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(), Statement(CreateMacro{true,
                                                       FindSubstr(res, "foo"),
@@ -403,7 +411,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoMacroAndOther) {
   auto res = SqlSource::FromExecuteQuery(
       "create perfetto macro foo() returns sql1 as random sql snippet; "
       "select 1");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(), Statement(CreateMacro{
                                     false,
@@ -421,7 +430,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoMacroAndOther) {
 TEST_F(PerfettoSqlParserTest, CreatePerfettoTable) {
   auto res = SqlSource::FromExecuteQuery(
       "CREATE PERFETTO TABLE foo AS SELECT 42 AS bar");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(), Statement(CreateTable{
                                     false,
@@ -435,7 +445,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoTable) {
 TEST_F(PerfettoSqlParserTest, CreateOrReplacePerfettoTable) {
   auto res = SqlSource::FromExecuteQuery(
       "CREATE OR REPLACE PERFETTO TABLE foo AS SELECT 42 AS bar");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(), Statement(CreateTable{
                                     true,
@@ -449,7 +460,8 @@ TEST_F(PerfettoSqlParserTest, CreateOrReplacePerfettoTable) {
 TEST_F(PerfettoSqlParserTest, CreatePerfettoTableWithSchema) {
   auto res = SqlSource::FromExecuteQuery(
       "CREATE PERFETTO TABLE foo(bar INT) AS SELECT 42 AS bar");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(), Statement(CreateTable{
                                     false,
@@ -463,7 +475,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoTableWithSchema) {
 TEST_F(PerfettoSqlParserTest, CreatePerfettoTableAndOther) {
   auto res = SqlSource::FromExecuteQuery(
       "CREATE PERFETTO TABLE foo AS SELECT 42 AS bar; select 1");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(),
             Statement(CreateTable{
@@ -477,7 +490,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoTableAndOther) {
 TEST_F(PerfettoSqlParserTest, CreatePerfettoTableWithDataframe) {
   auto res = SqlSource::FromExecuteQuery(
       "CREATE PERFETTO TABLE foo USING DATAFRAME AS SELECT 42 AS bar");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(),
             Statement(CreateTable{
@@ -488,7 +502,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoTableWithDataframe) {
 TEST_F(PerfettoSqlParserTest, CreatePerfettoView) {
   auto res = SqlSource::FromExecuteQuery(
       "CREATE PERFETTO VIEW foo AS SELECT 42 AS bar");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(
       parser.statement(),
@@ -505,7 +520,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoView) {
 TEST_F(PerfettoSqlParserTest, CreateOrReplacePerfettoView) {
   auto res = SqlSource::FromExecuteQuery(
       "CREATE OR REPLACE PERFETTO VIEW foo AS SELECT 42 AS bar");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(
       parser.statement(),
@@ -522,7 +538,8 @@ TEST_F(PerfettoSqlParserTest, CreateOrReplacePerfettoView) {
 TEST_F(PerfettoSqlParserTest, CreatePerfettoViewAndOther) {
   auto res = SqlSource::FromExecuteQuery(
       "CREATE PERFETTO VIEW foo AS SELECT 42 AS bar; select 1");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(
       parser.statement(),
@@ -543,7 +560,8 @@ TEST_F(PerfettoSqlParserTest, CreatePerfettoViewWithSchema) {
   auto res = SqlSource::FromExecuteQuery(
       "CREATE PERFETTO VIEW foo(foo STRING, bar INT) AS SELECT 'a' as foo, 42 "
       "AS bar");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(),
             Statement(CreateView{
@@ -565,7 +583,8 @@ TEST_F(PerfettoSqlParserTest, ParseComplexArgumentType) {
       "CREATE PERFETTO VIEW foo(foo JOINID(foo.bar), bar LONG) AS SELECT "
       "'a' as foo, 42 "
       "AS bar");
-  PerfettoSqlParser parser(res, macros_);
+  PerfettoSqlParser parser(macros_);
+  parser.Reset(res);
   ASSERT_TRUE(parser.Next());
   ASSERT_EQ(parser.statement(),
             Statement(CreateView{

--- a/src/trace_processor/perfetto_sql/syntaqlite/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/syntaqlite/BUILD.gn
@@ -24,7 +24,14 @@ _syntaqlite_sources = [
 ]
 
 source_set("syntaqlite") {
-  sources = _syntaqlite_sources + [ "utils.h" ]
+  sources = _syntaqlite_sources + [
+              "inline_dispatch.h",
+              "utils.h",
+            ]
+
+  # Inline the dialect dispatch macros instead of going through dialect
+  # function pointers. Drops call_indirect on the parser hot path.
+  defines = [ "SYNTAQLITE_INLINE_DIALECT_DISPATCH=\"src/trace_processor/perfetto_sql/syntaqlite/inline_dispatch.h\"" ]
   deps = [ "../../../../gn:default_deps" ]
   visibility = [
     "../../util:sql_module_doc_parser",

--- a/src/trace_processor/perfetto_sql/syntaqlite/inline_dispatch.h
+++ b/src/trace_processor/perfetto_sql/syntaqlite/inline_dispatch.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_SYNTAQLITE_INLINE_DISPATCH_H_
+#define SRC_TRACE_PROCESSOR_PERFETTO_SQL_SYNTAQLITE_INLINE_DISPATCH_H_
+
+/* Inline dialect dispatch for syntaqlite_perfetto.c — replaces the dialect
+ * function-pointer indirection with direct calls. Enabled via
+ * -DSYNTAQLITE_INLINE_DIALECT_DISPATCH=\"...\". */
+
+#define SYNQ_PARSER_ALLOC(d, m, c) SynqPerfettoParseAlloc(m, c)
+#define SYNQ_PARSER_INIT(d, p, c) SynqPerfettoParseInit(p, c)
+#define SYNQ_PARSER_FINALIZE(d, p) SynqPerfettoParseFinalize(p)
+#define SYNQ_PARSER_FREE(d, p, f) SynqPerfettoParseFree(p, f)
+#define SYNQ_PARSER_FEED(d, p, t, m) SynqPerfettoParse(p, t, m)
+/* SynqPerfettoParseTrace is only declared under !NDEBUG (Lemon trace hook). */
+#ifndef NDEBUG
+#define SYNQ_PARSER_TRACE(d, f, s) \
+  do {                             \
+    SynqPerfettoParseTrace(f, s);  \
+  } while (0)
+#else
+#define SYNQ_PARSER_TRACE(d, f, s) ((void)(d), (void)(f), (void)(s))
+#endif
+#define SYNQ_GET_TOKEN(env, z, t) SynqPerfettoGetToken(env, z, t)
+
+#endif  // SRC_TRACE_PROCESSOR_PERFETTO_SQL_SYNTAQLITE_INLINE_DISPATCH_H_


### PR DESCRIPTION
Splits PerfettoSqlParser construction from source binding so a single
parser instance can be reused across Execute() calls via Reset(). Adds
TakeStatementSql() so callers can move the SqlSource out of the parser
without an extra copy. Adds a no_macros_ fast path in MacroRewriteBuilder
that skips the per-node macro-free check when the parse contains no
macros at all.

Inlines the syntaqlite dialect dispatch via a new inline_dispatch.h that
replaces dialect function-pointer indirection with direct calls; the
header is wired in through SYNTAQLITE_INLINE_DIALECT_DISPATCH.

Parser unit tests adjusted mechanically for the new Reset() API.
