### PR TITLE
android_sdk: Host JVM test runner for PerfettoTraceTest

### DIFF
--- a/buildtools/.gitignore
+++ b/buildtools/.gitignore
@@ -21,6 +21,7 @@
 /expat/src/
 /googletest/
 /grpc/src/
+/java_sdk/
 /jsoncpp/
 /libbacktrace/
 /libbase/

--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -219,6 +219,14 @@ declare_args() {
   enable_perfetto_android_java_sdk =
       perfetto_build_with_android || (is_android && perfetto_build_standalone)
 
+  # Path to a host JDK include directory that contains jni.h. When set,
+  # the host-supported targets that build libperfetto_jni and its Java
+  # proto codegen use this and its platform-specific subdirectory as
+  # additional include paths. Empty (default) on Android / AOSP builds,
+  # where jni.h comes from the NDK / jni_headers; populated by
+  # tools/run_android_sdk_host_test from $JAVA_HOME.
+  jdk_include_path = ""
+
   enable_perfetto_benchmarks = perfetto_build_standalone && !is_win && !is_qnx
 
   enable_perfetto_fuzzers =

--- a/gn/standalone/run_java_protoc.py
+++ b/gn/standalone/run_java_protoc.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runs `protoc --java_out` over the transitive import closure of the roots.
+
+protoc only emits output for files passed on the command line, so this
+wrapper walks `import "...";` declarations to compute the closure and
+hands the full list to protoc. Touches a stamp file on success so the
+caller can declare a single GN action output.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+_IMPORT_RE = re.compile(r'^\s*import\s+"([^"]+)"\s*;')
+
+
+def transitive_imports(roots, proto_path):
+  visited = set()
+  stack = list(roots)
+  while stack:
+    rel = stack.pop()
+    if rel in visited:
+      continue
+    visited.add(rel)
+    abs_path = os.path.join(proto_path, rel)
+    if not os.path.exists(abs_path):
+      continue
+    with open(abs_path) as f:
+      for line in f:
+        m = _IMPORT_RE.match(line)
+        if m and m.group(1).startswith('protos/perfetto/'):
+          stack.append(m.group(1))
+  return sorted(visited)
+
+
+def main():
+  ap = argparse.ArgumentParser()
+  ap.add_argument('--protoc', required=True)
+  ap.add_argument('--proto-path', required=True)
+  ap.add_argument('--java-out', required=True)
+  ap.add_argument('--stamp', required=True)
+  ap.add_argument('roots', nargs='+')
+  args = ap.parse_args()
+
+  closure = transitive_imports(args.roots, args.proto_path)
+  os.makedirs(args.java_out, exist_ok=True)
+  subprocess.check_call([
+      args.protoc, '--proto_path=' + args.proto_path, '--java_out=' +
+      args.java_out
+  ] + closure)
+
+  with open(args.stamp, 'w'):
+    pass
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/src/android_sdk/java/host_stubs/androidx/test/ext/junit/runners/AndroidJUnit4.java
+++ b/src/android_sdk/java/host_stubs/androidx/test/ext/junit/runners/AndroidJUnit4.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.test.ext.junit.runners;
+
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * Host-JVM stub of androidx's runner. On Android this delegates to the
+ * Robolectric / instrumentation runner depending on context; on host JUnit 4
+ * is sufficient for the perfetto SDK tests.
+ */
+public class AndroidJUnit4 extends BlockJUnit4ClassRunner {
+  public AndroidJUnit4(Class<?> klass) throws InitializationError {
+    super(klass);
+  }
+}

--- a/src/android_sdk/java/test/BUILD.gn
+++ b/src/android_sdk/java/test/BUILD.gn
@@ -26,3 +26,45 @@ perfetto_android_instrumentation_test("perfetto_trace_instrumentation_test") {
   android_bp_test_config = "PerfettoAndroidSdkTest.xml"
   testonly = true
 }
+
+# Java sources for the perfetto protos PerfettoTraceTest imports.
+# protoc follows the transitive imports from these roots (~250 .proto
+# files under protos/perfetto/) at build time. Output is a stamp file
+# because Java codegen filenames vary per .proto; consumers glob the
+# output directory for *.java. Used by tools/run_android_sdk_host_test
+# on host; AOSP / device builds get the equivalent codegen from
+# perfetto_trace_java_protos via Soong/Bazel.
+action("perfetto_test_java_protos") {
+  testonly = true
+  _protoc_label = "../../../../gn:protoc($host_toolchain)"
+  _protoc = get_label_info(_protoc_label, "root_out_dir") + "/protoc"
+  _proto_path = rebase_path("../../../..", root_build_dir)
+  stamp_file = "$target_gen_dir/.$target_name.stamp"
+
+  script = "../../../../gn/standalone/run_java_protoc.py"
+  sources = [
+    "../../../../protos/perfetto/config/trace_config.proto",
+    "../../../../protos/perfetto/config/track_event/track_event_config.proto",
+    "../../../../protos/perfetto/trace/interned_data/interned_data.proto",
+    "../../../../protos/perfetto/trace/trace.proto",
+    "../../../../protos/perfetto/trace/trace_packet.proto",
+    "../../../../protos/perfetto/trace/track_event/chrome_latency_info.proto",
+    "../../../../protos/perfetto/trace/track_event/debug_annotation.proto",
+    "../../../../protos/perfetto/trace/track_event/source_location.proto",
+    "../../../../protos/perfetto/trace/track_event/track_descriptor.proto",
+    "../../../../protos/perfetto/trace/track_event/track_event.proto",
+  ]
+  inputs = [ _protoc ]
+  deps = [ _protoc_label ]
+  outputs = [ stamp_file ]
+  args = [
+           "--protoc",
+           "./" + rebase_path(_protoc, root_build_dir),
+           "--proto-path",
+           _proto_path,
+           "--java-out",
+           rebase_path(target_gen_dir, root_build_dir),
+           "--stamp",
+           rebase_path(stamp_file, root_build_dir),
+         ] + rebase_path(sources, "../../../..")
+}

--- a/src/android_sdk/jni/BUILD.gn
+++ b/src/android_sdk/jni/BUILD.gn
@@ -3,16 +3,6 @@ import("../../../gn/perfetto_android_sdk.gni")
 
 assert(enable_perfetto_android_java_sdk)
 
-declare_args() {
-  # Path to the host JDK include directory that contains jni.h. When set,
-  # libperfetto_jni's source set adds this and its platform-specific
-  # subdirectory to its include path so the .so can be built against a
-  # host JVM. tools/run_android_sdk_host_test sets it from $JAVA_HOME.
-  # Empty (default) on Android / AOSP builds, where jni.h comes from the
-  # NDK / jni_headers.
-  jdk_include_path = ""
-}
-
 SOURCE_SET_SOURCES = [
   "dev_perfetto_sdk_PerfettoNativeMemoryCleaner.cc",
   "dev_perfetto_sdk_PerfettoNativeMemoryCleaner.h",

--- a/src/android_sdk/jni/BUILD.gn
+++ b/src/android_sdk/jni/BUILD.gn
@@ -3,6 +3,16 @@ import("../../../gn/perfetto_android_sdk.gni")
 
 assert(enable_perfetto_android_java_sdk)
 
+declare_args() {
+  # Path to the host JDK include directory that contains jni.h. When set,
+  # libperfetto_jni's source set adds this and its platform-specific
+  # subdirectory to its include path so the .so can be built against a
+  # host JVM. tools/run_android_sdk_host_test sets it from $JAVA_HOME.
+  # Empty (default) on Android / AOSP builds, where jni.h comes from the
+  # NDK / jni_headers.
+  jdk_include_path = ""
+}
+
 SOURCE_SET_SOURCES = [
   "dev_perfetto_sdk_PerfettoNativeMemoryCleaner.cc",
   "dev_perfetto_sdk_PerfettoNativeMemoryCleaner.h",
@@ -19,15 +29,57 @@ SOURCE_SET_DEPS = [
   "../perfetto_sdk_for_jni:perfetto_sdk_for_jni",
 ]
 
+SOURCE_SET_INCLUDE_DIRS = []
+SOURCE_SET_HOST_CFLAGS = []
+if (jdk_include_path != "") {
+  SOURCE_SET_INCLUDE_DIRS += [
+    jdk_include_path,
+    "$jdk_include_path/linux",
+    "$jdk_include_path/darwin",
+
+    # Stub <android/log.h> mapping ANDROID_LOG_* + __android_log_print to
+    # stderr so the JNI sources compile cleanly without liblog on host.
+    "host_stubs",
+  ]
+
+  # The JNI sources are written against AOSP's warning profile; standalone
+  # host (-Weverything) trips a handful of pedantic warnings that AOSP
+  # doesn't. Scoped to this source set only; AOSP/device path is untouched.
+  # TODO: clean up the SDK sources and drop these suppressions.
+  SOURCE_SET_HOST_CFLAGS += [
+    "-Wno-old-style-cast",
+    "-Wno-writable-strings",
+    "-Wno-format-nonliteral",
+    "-Wno-extra-semi-stmt",
+    "-Wno-exit-time-destructors",
+    "-Wno-global-constructors",
+    "-Wno-sign-conversion",
+    "-Wno-shorten-64-to-32",
+    "-Wno-implicit-int-conversion",
+    "-Wno-cast-align",
+    "-Wno-missing-prototypes",
+    "-Wno-unused-parameter",
+    "-Wno-unused-but-set-variable",
+    "-Wno-zero-as-null-pointer-constant",
+    "-Wno-comma",
+    "-Wno-suggest-override",
+    "-Wno-suggest-destructor-override",
+  ]
+}
+
 source_set("libperfetto_jni_src") {
   sources = SOURCE_SET_SOURCES
   deps = SOURCE_SET_DEPS
+  include_dirs = SOURCE_SET_INCLUDE_DIRS
+  cflags = SOURCE_SET_HOST_CFLAGS
 }
 
 source_set("libperfetto_framework_jni_src") {
   sources = SOURCE_SET_SOURCES
   deps = SOURCE_SET_DEPS
-  cflags = [ "-DPERFETTO_JNI_JARJAR_PREFIX=com/android/internal/" ]
+  include_dirs = SOURCE_SET_INCLUDE_DIRS
+  cflags = SOURCE_SET_HOST_CFLAGS +
+           [ "-DPERFETTO_JNI_JARJAR_PREFIX=com/android/internal/" ]
 }
 
 perfetto_android_jni_library("libperfetto_jni") {

--- a/src/android_sdk/jni/host_stubs/android/log.h
+++ b/src/android_sdk/jni/host_stubs/android/log.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Host shim for liblog's <android/log.h>. Provides the small surface used by
+// JNIHelp.h and the perfetto SDK JNI sources, routed to stderr so it shows
+// up under the host JUnit runner. Only on the include path when
+// libperfetto_jni is built for host via tools/run_android_sdk_host_test.
+
+#ifndef SRC_ANDROID_SDK_JNI_HOST_STUBS_ANDROID_LOG_H_
+#define SRC_ANDROID_SDK_JNI_HOST_STUBS_ANDROID_LOG_H_
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum android_LogPriority {
+  ANDROID_LOG_UNKNOWN = 0,
+  ANDROID_LOG_DEFAULT,
+  ANDROID_LOG_VERBOSE,
+  ANDROID_LOG_DEBUG,
+  ANDROID_LOG_INFO,
+  ANDROID_LOG_WARN,
+  ANDROID_LOG_ERROR,
+  ANDROID_LOG_FATAL,
+  ANDROID_LOG_SILENT,
+} android_LogPriority;
+
+__attribute__((format(printf, 3, 4))) static inline int
+__android_log_print(int prio, const char* tag, const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  fprintf(stderr, "%d/%s: ", prio, tag ? tag : "");
+  int rc = vfprintf(stderr, fmt, ap);
+  fputc('\n', stderr);
+  va_end(ap);
+  if (prio == ANDROID_LOG_FATAL) {
+    abort();
+  }
+  return rc;
+}
+
+static inline int __android_log_write(int prio,
+                                      const char* tag,
+                                      const char* msg) {
+  fprintf(stderr, "%d/%s: %s\n", prio, tag ? tag : "", msg ? msg : "");
+  if (prio == ANDROID_LOG_FATAL) {
+    abort();
+  }
+  return 0;
+}
+
+__attribute__((noreturn, format(printf, 3, 4))) static inline void
+__android_log_assert(const char* cond, const char* tag, const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  fprintf(stderr, "F/%s: assertion `%s' failed: ", tag ? tag : "",
+          cond ? cond : "");
+  if (fmt) {
+    vfprintf(stderr, fmt, ap);
+  }
+  fputc('\n', stderr);
+  va_end(ap);
+  abort();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // SRC_ANDROID_SDK_JNI_HOST_STUBS_ANDROID_LOG_H_

--- a/tools/install-build-deps
+++ b/tools/install-build-deps
@@ -552,6 +552,42 @@ BUILD_DEPS_RUST = [
         'all', 'all'),
 ]
 
+# Maven jars used when building / testing the perfetto Java SDK on host.
+# Opt-in via --java-sdk; the standard build does not download or link
+# against any of these.
+JAVA_SDK_DEPS = [
+    Dependency(
+        'buildtools/java_sdk/junit-4.13.2.jar',
+        'https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar',
+        '8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3',
+        'all', 'all'),
+    Dependency(
+        'buildtools/java_sdk/hamcrest-2.2.jar',
+        'https://repo1.maven.org/maven2/org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar',
+        '5e62846a89f05cd78cd9c1a553f340d002458380c320455dd1f8fc5497a8a1c1',
+        'all', 'all'),
+    Dependency(
+        'buildtools/java_sdk/truth-1.4.4.jar',
+        'https://repo1.maven.org/maven2/com/google/truth/truth/1.4.4/truth-1.4.4.jar',
+        '52c86cddadc31bc8457c1e15689fc6b75e2e97ce2a83d8b54b795d556d489f8c',
+        'all', 'all'),
+    Dependency(
+        'buildtools/java_sdk/guava-33.4.0-jre.jar',
+        'https://repo1.maven.org/maven2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar',
+        'b918c98a7e44dbe94ebd9fe3e40cddaadb5a93e6a78eb6008b42df237241e538',
+        'all', 'all'),
+    Dependency(
+        'buildtools/java_sdk/protobuf-java-4.31.1.jar',
+        'https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/4.31.1/protobuf-java-4.31.1.jar',
+        'd60dfe7c68a0d38a248cca96924f289dc7e1966a887ee7cae397701af08575ae',
+        'all', 'all'),
+    Dependency(
+        'buildtools/java_sdk/error_prone_annotations-2.36.0.jar',
+        'https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.jar',
+        '77440e270b0bc9a249903c5a076c36a722c4886ca4f42675f2903a1c53ed61a5',
+        'all', 'all'),
+]
+
 # Sysroots required to cross-compile Linux targets (linux-arm{,64}).
 # These are taken from Chromium's build/linux/sysroot_scripts/sysroots.json.
 BUILD_DEPS_LINUX_CROSS_SYSROOTS = [
@@ -944,6 +980,10 @@ def Main():
       help='Override the autodetected build CPU architecture')
   parser.add_argument(
       '--rust', action='store_true', help='Rust toolchain to build Rust SDK')
+  parser.add_argument(
+      '--java-sdk',
+      action='store_true',
+      help='Maven jars used to build/test the perfetto Java SDK on host')
   args = parser.parse_args()
   if args.verify:
     CheckHashes()
@@ -977,6 +1017,8 @@ def Main():
     deps += BIGTRACE_DEPS
   if args.rust:
     deps += BUILD_DEPS_RUST
+  if args.java_sdk:
+    deps += JAVA_SDK_DEPS
   deps += SYNTAQLITE_DEPS
   deps_updated = False
   nodejs_updated = False

--- a/tools/run_android_sdk_host_test
+++ b/tools/run_android_sdk_host_test
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Runs the perfetto Java SDK test suite on a host JVM.
+
+Companion to tools/run_android_test (which runs the same test under ART on a
+device or emulator). Uses the JDK pointed to by $JAVA_HOME, the Maven jars
+landed by `tools/install-build-deps --java-sdk`, and the host stubs in
+src/android_sdk/java/host_stubs/ to compile the perfetto Java SDK and the
+PerfettoTraceTest suite for host. Links against the libperfetto_jni.so the
+gn+ninja pipeline produces and runs the JUnit suite.
+
+Prerequisites
+-------------
+  $JAVA_HOME points at a JDK >= 11 install root.
+  tools/install-build-deps              # standard C++ toolchain
+  tools/install-build-deps --java-sdk   # Maven jars (opt-in)
+"""
+
+import logging
+import os
+import re
+import subprocess
+import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+JAVA_DEPS_DIR = os.path.join(ROOT_DIR, 'buildtools/java_sdk')
+SDK_DIR = os.path.join(ROOT_DIR, 'src/android_sdk/java')
+OUT_DIR = os.path.join(ROOT_DIR, 'out/android_sdk_host_test')
+
+# Proto files referenced by PerfettoTraceTest. protoc generates one Java
+# class per .proto file passed; we walk imports from this set so the
+# codegen surface matches what the test actually uses. (The amalgamated
+# protos/perfetto/trace/perfetto_trace.proto would collapse 900+ messages
+# into a single nested Java class, which doesn't match the per-file
+# `perfetto.protos.<File>OuterClass` layout the test imports from and the
+# Soong/Bazel proto target produces on device.)
+TEST_PROTOS = [
+    'protos/perfetto/config/trace_config.proto',
+    'protos/perfetto/config/track_event/track_event_config.proto',
+    'protos/perfetto/trace/trace.proto',
+    'protos/perfetto/trace/trace_packet.proto',
+    'protos/perfetto/trace/interned_data/interned_data.proto',
+    'protos/perfetto/trace/track_event/chrome_latency_info.proto',
+    'protos/perfetto/trace/track_event/debug_annotation.proto',
+    'protos/perfetto/trace/track_event/source_location.proto',
+    'protos/perfetto/trace/track_event/track_descriptor.proto',
+    'protos/perfetto/trace/track_event/track_event.proto',
+]
+
+TEST_CLASS = 'dev.perfetto.sdk.test.PerfettoTraceTest'
+
+
+def Die(msg):
+  logging.error(msg)
+  sys.exit(1)
+
+
+def Run(cmd, **kwargs):
+  logging.debug('+ %s', ' '.join(cmd))
+  return subprocess.run(cmd, check=True, **kwargs)
+
+
+def JdkHome():
+  jh = os.environ.get('JAVA_HOME')
+  if not jh:
+    Die('JAVA_HOME not set. Install a JDK >= 11 and set JAVA_HOME.')
+  if not os.path.exists(os.path.join(jh, 'include/jni.h')):
+    Die('JAVA_HOME=%s does not look like a JDK install (no include/jni.h).' %
+        jh)
+  return jh
+
+
+def Glob(root, suffix):
+  for dirpath, _, files in os.walk(root):
+    for f in files:
+      if f.endswith(suffix):
+        yield os.path.join(dirpath, f)
+
+
+def MavenJars():
+  jars = sorted(Glob(JAVA_DEPS_DIR, '.jar'))
+  if not jars:
+    Die('No jars in %s. Run `tools/install-build-deps --java-sdk`.' %
+        JAVA_DEPS_DIR)
+  return jars
+
+
+def Classpath(*entries):
+  return os.pathsep.join(entries)
+
+
+def Gn(jdk_home):
+  os.makedirs(OUT_DIR, exist_ok=True)
+  Run([
+      os.path.join(ROOT_DIR, 'tools/gn'), 'gen', OUT_DIR, '--args=' + ' '.join([
+          'is_debug=false',
+          'enable_perfetto_android_java_sdk=true',
+          'jdk_include_path="%s"' % os.path.join(jdk_home, 'include'),
+      ])
+  ])
+
+
+def Ninja():
+  Run([
+      os.path.join(ROOT_DIR, 'tools/ninja'), '-C', OUT_DIR, 'libperfetto_jni',
+      'protoc'
+  ])
+
+
+_IMPORT_RE = re.compile(r'^\s*import\s+"([^"]+)"\s*;')
+
+
+def TransitiveImports(roots):
+  """Returns the closure of `roots` plus their transitive `import "…";`."""
+  visited = set()
+  stack = list(roots)
+  while stack:
+    rel = stack.pop()
+    if rel in visited:
+      continue
+    visited.add(rel)
+    with open(os.path.join(ROOT_DIR, rel)) as f:
+      for line in f:
+        m = _IMPORT_RE.match(line)
+        if m and m.group(1).startswith('protos/perfetto/'):
+          stack.append(m.group(1))
+  return sorted(visited)
+
+
+def GenJavaProtos():
+  out = os.path.join(OUT_DIR, 'java_protos')
+  os.makedirs(out, exist_ok=True)
+  Run([
+      os.path.join(OUT_DIR, 'protoc'), '--proto_path=' +
+      ROOT_DIR, '--java_out=' + out
+  ] + TransitiveImports(TEST_PROTOS))
+  return out
+
+
+def Javac(jdk_home, classes_dir, classpath, srcs):
+  Run([
+      os.path.join(jdk_home, 'bin/javac'), '-d', classes_dir, '-cp', classpath,
+      '-source', '11', '-target', '11'
+  ] + srcs)
+
+
+def Jar(jdk_home, jar_path, classes_dir):
+  Run([
+      os.path.join(jdk_home, 'bin/jar'), 'cf', jar_path, '-C', classes_dir, '.'
+  ])
+
+
+def CompileSdk(jdk_home, jars, java_proto_dir):
+  classes = os.path.join(OUT_DIR, 'sdk_classes')
+  os.makedirs(classes, exist_ok=True)
+  srcs = (
+      list(Glob(os.path.join(SDK_DIR, 'main'), '.java')) +
+      list(Glob(os.path.join(SDK_DIR, 'host_stubs'), '.java')) +
+      list(Glob(java_proto_dir, '.java')))
+  Javac(jdk_home, classes, Classpath(*jars), srcs)
+  jar = os.path.join(OUT_DIR, 'perfetto_sdk_host.jar')
+  Jar(jdk_home, jar, classes)
+  return jar
+
+
+def CompileTest(jdk_home, jars, sdk_jar):
+  classes = os.path.join(OUT_DIR, 'test_classes')
+  os.makedirs(classes, exist_ok=True)
+  srcs = list(Glob(os.path.join(SDK_DIR, 'test'), '.java'))
+  Javac(jdk_home, classes, Classpath(sdk_jar, *jars), srcs)
+  jar = os.path.join(OUT_DIR, 'perfetto_sdk_host_test.jar')
+  Jar(jdk_home, jar, classes)
+  return jar
+
+
+def RunTests(jdk_home, jars, sdk_jar, test_jar):
+  env = dict(os.environ, LD_LIBRARY_PATH=OUT_DIR)
+  Run([
+      os.path.join(jdk_home,
+                   'bin/java'), '-Djava.library.path=' + OUT_DIR, '-cp',
+      Classpath(sdk_jar, test_jar, *jars), 'org.junit.runner.JUnitCore',
+      TEST_CLASS
+  ],
+      env=env)
+
+
+def main():
+  logging.basicConfig(level=logging.INFO, format='%(message)s')
+  jdk_home = JdkHome()
+  jars = MavenJars()
+  Gn(jdk_home)
+  Ninja()
+  java_proto_dir = GenJavaProtos()
+  sdk_jar = CompileSdk(jdk_home, jars, java_proto_dir)
+  test_jar = CompileTest(jdk_home, jars, sdk_jar)
+  RunTests(jdk_home, jars, sdk_jar, test_jar)
+
+
+if __name__ == '__main__':
+  main()

--- a/tools/run_android_sdk_host_test
+++ b/tools/run_android_sdk_host_test
@@ -30,7 +30,6 @@ Prerequisites
 
 import logging
 import os
-import re
 import subprocess
 import sys
 
@@ -39,25 +38,8 @@ JAVA_DEPS_DIR = os.path.join(ROOT_DIR, 'buildtools/java_sdk')
 SDK_DIR = os.path.join(ROOT_DIR, 'src/android_sdk/java')
 OUT_DIR = os.path.join(ROOT_DIR, 'out/android_sdk_host_test')
 
-# Proto files referenced by PerfettoTraceTest. protoc generates one Java
-# class per .proto file passed; we walk imports from this set so the
-# codegen surface matches what the test actually uses. (The amalgamated
-# protos/perfetto/trace/perfetto_trace.proto would collapse 900+ messages
-# into a single nested Java class, which doesn't match the per-file
-# `perfetto.protos.<File>OuterClass` layout the test imports from and the
-# Soong/Bazel proto target produces on device.)
-TEST_PROTOS = [
-    'protos/perfetto/config/trace_config.proto',
-    'protos/perfetto/config/track_event/track_event_config.proto',
-    'protos/perfetto/trace/trace.proto',
-    'protos/perfetto/trace/trace_packet.proto',
-    'protos/perfetto/trace/interned_data/interned_data.proto',
-    'protos/perfetto/trace/track_event/chrome_latency_info.proto',
-    'protos/perfetto/trace/track_event/debug_annotation.proto',
-    'protos/perfetto/trace/track_event/source_location.proto',
-    'protos/perfetto/trace/track_event/track_descriptor.proto',
-    'protos/perfetto/trace/track_event/track_event.proto',
-]
+JAVA_PROTOS_TARGET = 'src/android_sdk/java/test:perfetto_test_java_protos'
+JAVA_PROTOS_DIR = 'gen/src/android_sdk/java/test'
 
 TEST_CLASS = 'dev.perfetto.sdk.test.PerfettoTraceTest'
 
@@ -114,39 +96,12 @@ def Gn(jdk_home):
 
 def Ninja():
   Run([
-      os.path.join(ROOT_DIR, 'tools/ninja'), '-C', OUT_DIR, 'libperfetto_jni',
-      'protoc'
+      os.path.join(ROOT_DIR, 'tools/ninja'),
+      '-C',
+      OUT_DIR,
+      'libperfetto_jni',
+      JAVA_PROTOS_TARGET,
   ])
-
-
-_IMPORT_RE = re.compile(r'^\s*import\s+"([^"]+)"\s*;')
-
-
-def TransitiveImports(roots):
-  """Returns the closure of `roots` plus their transitive `import "…";`."""
-  visited = set()
-  stack = list(roots)
-  while stack:
-    rel = stack.pop()
-    if rel in visited:
-      continue
-    visited.add(rel)
-    with open(os.path.join(ROOT_DIR, rel)) as f:
-      for line in f:
-        m = _IMPORT_RE.match(line)
-        if m and m.group(1).startswith('protos/perfetto/'):
-          stack.append(m.group(1))
-  return sorted(visited)
-
-
-def GenJavaProtos():
-  out = os.path.join(OUT_DIR, 'java_protos')
-  os.makedirs(out, exist_ok=True)
-  Run([
-      os.path.join(OUT_DIR, 'protoc'), '--proto_path=' +
-      ROOT_DIR, '--java_out=' + out
-  ] + TransitiveImports(TEST_PROTOS))
-  return out
 
 
 def Javac(jdk_home, classes_dir, classpath, srcs):
@@ -202,8 +157,8 @@ def main():
   jars = MavenJars()
   Gn(jdk_home)
   Ninja()
-  java_proto_dir = GenJavaProtos()
-  sdk_jar = CompileSdk(jdk_home, jars, java_proto_dir)
+  java_protos = os.path.join(OUT_DIR, JAVA_PROTOS_DIR)
+  sdk_jar = CompileSdk(jdk_home, jars, java_protos)
   test_jar = CompileTest(jdk_home, jars, sdk_jar)
   RunTests(jdk_home, jars, sdk_jar, test_jar)
 


### PR DESCRIPTION
Companion to tools/run_android_test (which runs the same test under ART on a device or emulator). tools/run_android_sdk_host_test uses $JAVA_HOME, the Maven jars fetched by `tools/install-build-deps --java-sdk`, and the host stubs landed in #5967 (plus a small AndroidJUnit4 stub added here for the test runner) to compile the perfetto Java SDK and the PerfettoTraceTest suite for host, links against libperfetto_jni.so from the gn+ninja pipeline, and runs the JUnit suite.

* src/android_sdk/jni/BUILD.gn: new jdk_include_path declare_arg + a conditional include_dirs / cflags block. Defaults empty so AOSP / device builds are untouched; the runner sets it from $JAVA_HOME/include.
* src/android_sdk/jni/host_stubs/android/log.h: stderr-mapping shim so the JNI sources can compile against the standard JNI ABI without liblog.
* src/android_sdk/java/host_stubs/androidx/test/ext/junit/runners/ AndroidJUnit4.java: stub for the test's @RunWith annotation; delegates to JUnit 4's BlockJUnit4ClassRunner.
* tools/install-build-deps --java-sdk: SHA256-pinned Maven jars (JUnit, Hamcrest, Truth, Guava, protobuf-java 4.31.1, error_prone_annotations) into buildtools/java_sdk/. Opt-in; standard build is unaffected.
* tools/run_android_sdk_host_test: runs gn gen with jdk_include_path, builds libperfetto_jni + protoc, generates Java protos for the closure of TEST_PROTOS, javac-compiles SDK + host_stubs + protos and the test, invokes JUnitCore. Picks jars by globbing buildtools/java_sdk/*.jar so version bumps live only in install-build-deps.

Usage:
  export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 tools/install-build-deps tools/install-build-deps --java-sdk tools/run_android_sdk_host_test # -> "OK (20 tests)" on host OpenJDK 21

 Follow-up: the 16-flag -Wno-* block in BUILD.gn suppresses standalone
 -Weverything warnings the upstream SDK sources trip. A separate CL will
 clean up the SDK sources and drop the suppression list.
