### PR TITLE
ui: Colocate grammar.d.ts file rather than relying on an ambient declaration

### DIFF
--- a/ui/src/base/perfetto_sql_lang/perfetto_sql.grammar.d.ts
+++ b/ui/src/base/perfetto_sql_lang/perfetto_sql.grammar.d.ts
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// *.grammar files are compiled on import by Vite's @lezer/generator plugin.
+// The generated module exports a `parser` (and the .terms.* token IDs).
+import type {LRParser} from '@lezer/lr';
+export const parser: LRParser;

--- a/ui/src/types/virtual-modules.d.ts
+++ b/ui/src/types/virtual-modules.d.ts
@@ -34,10 +34,3 @@ declare module 'virtual:perfetto/all_core_plugins' {
   const plugins: PerfettoPluginStatic<PerfettoPlugin>[];
   export default plugins;
 }
-
-// *.grammar files are compiled on import by Vite's @lezer/generator plugin.
-// The generated module exports a `parser` (and the .terms.* token IDs).
-declare module '*.grammar' {
-  import type {LRParser} from '@lezer/lr';
-  export const parser: LRParser;
-}


### PR DESCRIPTION
Ambient global declarations are a bit mysterious, and require that each project (ui, bigtrace) include the correct ambient types file.

This patch moves the grammar.d.ts file next to the grammar file it corresponds to which is more explicit and any projects depending on the grammar file also pull in the types.