### PR TITLE
protos: add trace_evdev_events bool for input tracing

### DIFF
--- a/protos/perfetto/config/android/android_input_event_config.proto
+++ b/protos/perfetto/config/android/android_input_event_config.proto
@@ -22,7 +22,7 @@ package perfetto.protos;
 //
 // NOTE: Input traces can only be taken on debuggable (userdebug/eng) builds!
 //
-// Next ID: 5
+// Next ID: 6
 message AndroidInputEventConfig {
   // Trace modes are tracing presets that are included in the system.
   enum TraceMode {
@@ -131,4 +131,8 @@ message AndroidInputEventConfig {
   // Trace details about which windows the system is sending each input event
   // to. All trace rules will apply.
   optional bool trace_dispatcher_window_dispatch = 4;
+
+  // Trace evdev events received from the kernel, including device additions and
+  // removals.
+  optional bool trace_evdev_events = 5;
 }

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -627,7 +627,7 @@ message AndroidGameInterventionListConfig {
 //
 // NOTE: Input traces can only be taken on debuggable (userdebug/eng) builds!
 //
-// Next ID: 5
+// Next ID: 6
 message AndroidInputEventConfig {
   // Trace modes are tracing presets that are included in the system.
   enum TraceMode {
@@ -736,6 +736,10 @@ message AndroidInputEventConfig {
   // Trace details about which windows the system is sending each input event
   // to. All trace rules will apply.
   optional bool trace_dispatcher_window_dispatch = 4;
+
+  // Trace evdev events received from the kernel, including device additions and
+  // removals.
+  optional bool trace_evdev_events = 5;
 }
 
 // End of protos/perfetto/config/android/android_input_event_config.proto

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -627,7 +627,7 @@ message AndroidGameInterventionListConfig {
 //
 // NOTE: Input traces can only be taken on debuggable (userdebug/eng) builds!
 //
-// Next ID: 5
+// Next ID: 6
 message AndroidInputEventConfig {
   // Trace modes are tracing presets that are included in the system.
   enum TraceMode {
@@ -736,6 +736,10 @@ message AndroidInputEventConfig {
   // Trace details about which windows the system is sending each input event
   // to. All trace rules will apply.
   optional bool trace_dispatcher_window_dispatch = 4;
+
+  // Trace evdev events received from the kernel, including device additions and
+  // removals.
+  optional bool trace_evdev_events = 5;
 }
 
 // End of protos/perfetto/config/android/android_input_event_config.proto


### PR DESCRIPTION
For trace size and privacy reasons, we don't want evdev events in every input trace, so add a bool to control whether they're enabled.

Bug: b/394861376