### PR TITLE
tools: update android health aidl version to match internal tree

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -809,7 +809,7 @@ cc_library_shared {
     ],
     shared_libs: [
         "android.hardware.atrace@1.0",
-        "android.hardware.health-V2-ndk",
+        "android.hardware.health-V5-ndk",
         "android.hardware.health@2.0",
         "android.hardware.power.stats-V1-cpp",
         "android.hardware.power.stats@1.0",
@@ -24464,8 +24464,8 @@ phony {
             required: [
                 "system_tracing_protos_descriptor",
             ],
-        }
-    }
+        },
+    },
 }
 
 filegroup {

--- a/Android.bp
+++ b/Android.bp
@@ -24464,8 +24464,8 @@ phony {
             required: [
                 "system_tracing_protos_descriptor",
             ],
-        },
-    },
+        }
+    }
 }
 
 filegroup {

--- a/src/android_internal/BUILD.gn
+++ b/src/android_internal/BUILD.gn
@@ -40,7 +40,7 @@ if (perfetto_build_with_android) {
     ]
     libs = [
       "android.hardware.health@2.0",
-      "android.hardware.health-V2-ndk",
+      "android.hardware.health-V5-ndk",
       "android.hardware.power.stats@1.0",
       "android.hardware.power.stats-V1-cpp",
       "android.hardware.atrace@1.0",

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -202,7 +202,7 @@ shared_library_allowlist = [
     'android',
     'android.hardware.atrace@1.0',
     'android.hardware.health@2.0',
-    'android.hardware.health-V2-ndk',
+    'android.hardware.health-V5-ndk',
     'android.hardware.power.stats@1.0',
     'android.hardware.power.stats-V1-cpp',
     'android.system.suspend.control.internal-cpp',


### PR DESCRIPTION
Resolves a downstream-only patch.

git cherry-pick -x b9d38cae53f5456ad8220026b00116ace5d50789

---

Update redundant AIDL instances to preferred versions

Replaced older AIDL instances V2 with the newer V5 version in order to reduce the redundant AIDL footprint.

Bug: 220392885
Test: TH
Flag: EXEMPT BUGFIX
Change-Id: Ifcb3ddf88377074b983c38d08183c0f6d1149648
(cherry picked from commit b9d38cae53f5456ad8220026b00116ace5d50789)
