### PR TITLE
Migrate battery modules to _intervals_fill_gaps.

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/battery/charging_states.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/battery/charging_states.sql
@@ -15,10 +15,11 @@
 
 INCLUDE PERFETTO MODULE counters.intervals;
 
+INCLUDE PERFETTO MODULE intervals.fill_gaps;
+
 -- Device charging states.
 CREATE PERFETTO TABLE android_charging_states(
-  -- Alias of counter.id if a slice with charging state exists otherwise
-  -- there will be a single row where id = 1.
+  -- A unique id for each row.
   id LONG,
   -- Timestamp at which the device charging state began.
   ts TIMESTAMP,
@@ -42,36 +43,38 @@ WITH
       ON counter_track.id = counter.track_id
     WHERE
       counter_track.name = 'BatteryStatus'
+  ),
+  _intervals AS (
+    SELECT
+      id,
+      ts,
+      dur,
+      CASE value
+        WHEN 2 THEN 'charging'
+        WHEN 3 THEN 'discharging'
+        WHEN 4 THEN 'not_charging'
+        WHEN 5 THEN 'full'
+      END AS short_charging_state,
+      CASE value
+        -- 0 and 1 are both 'Unknown'
+        WHEN 2 THEN 'Charging'
+        WHEN 3 THEN 'Discharging'
+        -- special case when charger is present but battery isn't charging
+        WHEN 4 THEN 'Not charging'
+        WHEN 5 THEN 'Full'
+      END AS charging_state
+    FROM counter_leading_intervals!(_counter)
+    WHERE
+      dur > 0
   )
+-- When the trace does not have a slice in the charging state track or when
+-- the charging state value is not a valid enum value, assume the charging
+-- state for the entire trace is unknown. The use of _intervals_fill_gaps
+-- ensures we still have data for the entirety of the trace.
 SELECT
-  id,
+  ROW_NUMBER() OVER () AS id,
   ts,
   dur,
-  CASE value
-    WHEN 2 THEN 'charging'
-    WHEN 3 THEN 'discharging'
-    WHEN 4 THEN 'not_charging'
-    WHEN 5 THEN 'full'
-    ELSE 'unknown'
-  END AS short_charging_state,
-  CASE value
-    -- 0 and 1 are both 'Unknown'
-    WHEN 2 THEN 'Charging'
-    WHEN 3 THEN 'Discharging'
-    -- special case when charger is present but battery isn't charging
-    WHEN 4 THEN 'Not charging'
-    WHEN 5 THEN 'Full'
-    ELSE 'Unknown'
-  END AS charging_state
-FROM counter_leading_intervals!(_counter)
-WHERE
-  dur > 0
-UNION
--- When the trace does not have a slice in the charging state track then
--- we will assume that the charging state for the entire trace is Unknown.
--- This ensures that we still have job data even if the charging state is
--- not known. The following statement will only ever return a single row.
-SELECT 1, trace_start(), trace_dur(), 'unknown', 'Unknown'
-WHERE
-  NOT EXISTS (SELECT * FROM _counter)
-  AND trace_dur() > 0;
+  COALESCE(short_charging_state, 'unknown') AS short_charging_state,
+  COALESCE(charging_state, 'Unknown') AS charging_state
+FROM _intervals_fill_gaps!((NULL), (short_charging_state, charging_state), _intervals);

--- a/src/trace_processor/perfetto_sql/stdlib/android/screen_state.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/screen_state.sql
@@ -14,6 +14,8 @@
 
 INCLUDE PERFETTO MODULE counters.intervals;
 
+INCLUDE PERFETTO MODULE intervals.fill_gaps;
+
 -- Table of the screen state - on, off or doze (always on display).
 CREATE PERFETTO TABLE android_screen_state(
   -- ID.
@@ -40,82 +42,66 @@ WITH
         WHERE
           name = 'ScreenState'
       ))
+  ),
+  mapped_names AS (
+    SELECT
+      id,
+      ts,
+      dur,
+      -- Should be kept in sync with the enums in Display.java
+      CASE value
+        -- Display.STATE_OFF
+        WHEN 1 THEN 'off'
+        -- Display.STATE_ON
+        WHEN 2 THEN 'on'
+        -- Display.STATE_DOZE
+        WHEN 3 THEN 'doze'
+        -- Display.STATE_DOZE_SUSPEND
+        WHEN 4 THEN 'doze'
+        -- Display.STATE_VR
+        WHEN 5 THEN 'on'
+        -- Display.STATE_ON_SUSPEND
+        WHEN 6 THEN 'on'
+      END AS simple_screen_state,
+      CASE value
+        -- Display.STATE_OFF
+        WHEN 1 THEN 'off'
+        -- Display.STATE_ON
+        WHEN 2 THEN 'on'
+        -- Display.STATE_DOZE
+        WHEN 3 THEN 'doze'
+        -- Display.STATE_DOZE_SUSPEND
+        WHEN 4 THEN 'doze-suspend'
+        -- Display.STATE_VR
+        WHEN 5 THEN 'on-vr'
+        -- Display.STATE_ON_SUSPEND
+        WHEN 6 THEN 'on-suspend'
+      END AS short_screen_state,
+      CASE value
+        -- Display.STATE_OFF
+        WHEN 1 THEN 'Screen off'
+        -- Display.STATE_ON
+        WHEN 2 THEN 'Screen on'
+        -- Display.STATE_DOZE
+        WHEN 3 THEN 'Always-on display (doze)'
+        -- Display.STATE_DOZE_SUSPEND
+        WHEN 4 THEN 'Always-on display (doze-suspend)'
+        -- Display.STATE_VR
+        WHEN 5 THEN 'Screen on (VR)'
+        -- Display.STATE_ON_SUSPEND
+        WHEN 6 THEN 'Screen on (suspend)'
+      END AS screen_state
+    FROM screen_state_span
+    WHERE
+      dur > 0
   )
--- Case when we have data.
 SELECT
-  id,
+  ROW_NUMBER() OVER () AS id,
   ts,
   dur,
-  -- Should be kept in sync with the enums in Display.java
-  CASE value
-    -- Display.STATE_OFF
-    WHEN 1 THEN 'off'
-    -- Display.STATE_ON
-    WHEN 2 THEN 'on'
-    -- Display.STATE_DOZE
-    WHEN 3 THEN 'doze'
-    -- Display.STATE_DOZE_SUSPEND
-    WHEN 4 THEN 'doze'
-    -- Display.STATE_VR
-    WHEN 5 THEN 'on'
-    -- Display.STATE_ON_SUSPEND
-    WHEN 6 THEN 'on'
-    ELSE 'unknown'
-  END AS simple_screen_state,
-  CASE value
-    -- Display.STATE_OFF
-    WHEN 1 THEN 'off'
-    -- Display.STATE_ON
-    WHEN 2 THEN 'on'
-    -- Display.STATE_DOZE
-    WHEN 3 THEN 'doze'
-    -- Display.STATE_DOZE_SUSPEND
-    WHEN 4 THEN 'doze-suspend'
-    -- Display.STATE_VR
-    WHEN 5 THEN 'on-vr'
-    -- Display.STATE_ON_SUSPEND
-    WHEN 6 THEN 'on-suspend'
-    ELSE 'unknown'
-  END AS short_screen_state,
-  CASE value
-    -- Display.STATE_OFF
-    WHEN 1 THEN 'Screen off'
-    -- Display.STATE_ON
-    WHEN 2 THEN 'Screen on'
-    -- Display.STATE_DOZE
-    WHEN 3 THEN 'Always-on display (doze)'
-    -- Display.STATE_DOZE_SUSPEND
-    WHEN 4 THEN 'Always-on display (doze-suspend)'
-    -- Display.STATE_VR
-    WHEN 5 THEN 'Screen on (VR)'
-    -- Display.STATE_ON_SUSPEND
-    WHEN 6 THEN 'Screen on (suspend)'
-    ELSE 'Unknown'
-  END AS screen_state
-FROM screen_state_span
-WHERE
-  dur > 0
-UNION
--- Unknown period until the first counter.
-SELECT
-  (SELECT max(id) + 1 FROM screen_state_span) AS id,
-  trace_start() AS ts,
-  (SELECT min(ts) FROM screen_state_span) - trace_start() AS dur,
-  'unknown' AS simple_screen_state,
-  'unknown' AS short_screen_state,
-  'Unknown' AS screen_state
-WHERE
-  trace_start() < (SELECT min(ts) FROM screen_state_span)
-  AND EXISTS (SELECT * FROM screen_state_span)
-UNION
--- Case when we do not have data.
-SELECT
-  1,
-  trace_start() AS ts,
-  trace_dur() AS dur,
-  'unknown' AS simple_screen_state,
-  'unknown' AS short_screen_state,
-  'Unknown' AS screen_state
-WHERE
-  NOT EXISTS (SELECT * FROM screen_state_span)
-  AND trace_dur() > 0;
+  COALESCE(simple_screen_state, 'unknown') AS simple_screen_state,
+  COALESCE(short_screen_state, 'unknown') AS short_screen_state,
+  COALESCE(screen_state, 'Unknown') AS screen_state
+FROM _intervals_fill_gaps!((NULL), (simple_screen_state,
+  short_screen_state,
+  screen_state), mapped_names);

--- a/src/trace_processor/perfetto_sql/stdlib/android/suspend.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/suspend.sql
@@ -14,6 +14,8 @@
 -- limitations under the License.
 --
 
+INCLUDE PERFETTO MODULE intervals.fill_gaps;
+
 -- Table of suspended and awake slices.
 --
 -- Selects either the minimal or full ftrace source depending on what's
@@ -82,55 +84,25 @@ WITH
   suspend_slice AS (
     -- Filter out all the slices that overlapped with the following slices.
     -- This happens with data loss where we lose start and end slices for suspends.
-    SELECT ts, dur, machine_id
+    SELECT ts, dur, machine_id, 'suspended' AS power_state
     FROM suspend_slice_pre_filter
     WHERE
       duration_gap >= 0
-  ),
-  awake_slice AS (
-    -- For machines without any suspend slices, use the trace bounds.
-    SELECT trace_start() AS ts, trace_dur() AS dur, m.id AS machine_id
-    FROM machine AS m
-    WHERE
-      trace_dur() > 0
-      AND NOT EXISTS (
-        SELECT 1 FROM suspend_slice AS s WHERE s.machine_id = m.id
-      )
-      -- Only use the trace_bounds state for the primary machine: this is
-      -- because we know from the trace starting and ending at all that
-      -- the device was awake. However, for other machines, we don't actually
-      -- know the suspend state as it's very possible they were just asleep
-      -- throughout the trace.
-      AND m.id = 0
     UNION ALL
-    -- For machines with suspend slices, create one slice from the trace start
-    -- to the first suspend.
-    SELECT
-      trace_start() AS ts,
-      (
-        SELECT min(s2.ts)
-        FROM suspend_slice AS s2
-        WHERE
-          s2.machine_id = s.machine_id
-      )
-      - trace_start() AS dur,
-      s.machine_id
-    FROM (SELECT DISTINCT machine_id FROM suspend_slice) AS s
-    UNION ALL
-    -- And then one slice for each suspend, from the end of the suspend to the
-    -- start of the next one (or the end of the trace if there is no next one).
-    SELECT
-      ts + dur AS ts,
-      coalesce(lead(ts) OVER (PARTITION BY machine_id ORDER BY ts), trace_end())
-      - ts
-      - dur AS dur,
-      machine_id
-    FROM suspend_slice
+    -- This guarantees that if machine 0 has no suspend slices in the trace,
+    -- that _intervals_fill_gaps will add an awake slice for the trace bounds.
+    -- This only works for the primary machine because we know from the trace
+    -- starting and ending at all that the device was awake. However, for other
+    -- machines, we don't actually know the suspend state as it's very possible
+    -- they were just asleep throughout the trace.
+    SELECT NULL, NULL, 0, NULL
   )
-SELECT ts, dur, 'awake' AS power_state, machine_id FROM awake_slice
-UNION ALL
-SELECT ts, dur, 'suspended' AS power_state, machine_id
-FROM suspend_slice
+SELECT
+  ts,
+  dur,
+  COALESCE(machine_id, 0) AS machine_id,
+  COALESCE(power_state, 'awake') AS power_state
+FROM _intervals_fill_gaps!((machine_id), (power_state), suspend_slice)
 ORDER BY
   ts;
 

--- a/src/trace_processor/perfetto_sql/stdlib/intervals/fill_gaps.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/fill_gaps.sql
@@ -89,13 +89,20 @@ AS (
       __intrinsic_token_apply!(__ifg_null, $data_cols)
     FROM Bounds
     UNION ALL
-    -- Part 4: the whole trace, if no valid slices are present.
+    -- Part 4.a: when there is no data for a group, return one row for the whole trace.
     SELECT
       trace_start(), trace_dur(),
       metasql_unparenthesize_exprlist!($group_cols),
       __intrinsic_token_apply!(__ifg_null, $data_cols)
     FROM Bounds
     WHERE min_ts IS NULL AND max_ts IS NULL
+    UNION ALL
+    -- Part 4.b: when there is no data at all, return null group_cols for the whole trace.
+    SELECT
+      trace_start(), trace_dur(),
+      __intrinsic_token_apply!(__ifg_null, $group_cols),
+      __intrinsic_token_apply!(__ifg_null, $data_cols)
+    WHERE NOT EXISTS(SELECT * FROM SourceData)
     UNION ALL
     -- Part 5: the time between slices (from when one ends, to next start).
     SELECT
@@ -107,4 +114,5 @@ AS (
   SELECT *
   FROM Parts
   WHERE IFNULL(dur, 0) > 0
+  ORDER BY ts
 );

--- a/test/trace_processor/diff_tests/stdlib/android/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/android/tests.py
@@ -1565,6 +1565,7 @@ class AndroidStdlib(TestSuite):
       """,
         out=Csv("""
         "ts","dur","charging_state"
+        368604000000,749651,"Unknown"
         368604749651,59806073237,"Charging"
       """))
 
@@ -1781,16 +1782,14 @@ class AndroidStdlib(TestSuite):
         """),
         query="""
         INCLUDE PERFETTO MODULE android.suspend;
-        SELECT ts, dur, power_state, machine_id FROM android_suspend_state ORDER BY ts;
+        SELECT ts, dur, power_state, machine_id FROM android_suspend_state ORDER BY machine_id, ts;
         """,
         out=Csv("""
         "ts","dur","power_state","machine_id"
-          100000000000,0,"awake",0
-          100000000000,6000000000,"awake",1
           100000000000,3000000000,"suspended",0
           103000000000,6000000000,"awake",0
+          100000000000,6000000000,"awake",1
           106000000000,3000000000,"suspended",1
-          109000000000,0,"awake",1
           """))
 
   def test_android_suspend_state_one_machine_no_events(self):
@@ -1840,9 +1839,7 @@ class AndroidStdlib(TestSuite):
         """,
         out=Csv("""
         "ts","dur","power_state","machine_id"
-        100000000000,0,"awake",0
         100000000000,3000000000,"suspended",0
-        103000000000,0,"awake",0
         """))
 
   def test_android_suspend_state_no_events(self):

--- a/test/trace_processor/diff_tests/stdlib/intervals/fill_gaps_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/intervals/fill_gaps_tests.py
@@ -115,6 +115,7 @@ class IntervalsFillGaps(TestSuite):
         """,
         out=Csv("""
         "ts","dur","grp","val"
+        100,900,"[NULL]","[NULL]"
         """))
 
   def test_fill_gaps_no_valid_slices(self):


### PR DESCRIPTION
This helper guarantees data from trace_start to trace_end which is important for state tables we join against.

In order to better support the common case, the macro was also updated to return a single row for the full trace when the input is totally empty.