### PR TITLE
ui: Memory Overview Page

### DIFF
--- a/ui/src/base/bytes_format.ts
+++ b/ui/src/base/bytes_format.ts
@@ -1,0 +1,102 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Human-readable byte-size formatters.
+//
+// Two flavours, because the right base depends on what's being measured:
+//   - formatBytesIec: base-1024 with IEC units (KiB/MiB/GiB). Use for RAM,
+//     heap and other memory sizes — the kernel and allocators count in powers
+//     of two.
+//   - formatBytesSi: base-1000 with SI units (KB/MB/GB). Use for on-disk
+//     file sizes, network transfer and anything quoted decimally.
+//
+// Both keep the sign, render whole bytes without a decimal point ("512 B"),
+// and otherwise show two decimals ("1.50 MiB").
+//
+// By default the unit is auto-scaled to the largest that keeps the value >= 1.
+// Pass a `forceUnit` ('B' or one of the IEC/SI unit strings) to pin every value
+// to the same unit instead — useful for aligned/comparable table columns.
+
+const IEC_UNITS = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB'] as const;
+const SI_UNITS = ['KB', 'MB', 'GB', 'TB', 'PB'] as const;
+
+export type IecUnit = 'B' | (typeof IEC_UNITS)[number];
+export type SiUnit = 'B' | (typeof SI_UNITS)[number];
+
+export interface BytesFormatOptions {
+  forceUnit?: IecUnit | SiUnit;
+  fractionDigits?: number;
+}
+
+function formatScaled(
+  bytes: number,
+  base: number,
+  units: readonly string[],
+  forceUnit?: string,
+  fractionDigits = 1,
+): string {
+  const sign = bytes < 0 ? '-' : '';
+  const absBytes = Math.abs(bytes);
+
+  // Forced unit: skip auto-scaling and render every value in this unit.
+  if (forceUnit !== undefined) {
+    if (forceUnit === 'B') return `${sign}${absBytes} B`;
+    const i = units.indexOf(forceUnit);
+    const v = absBytes / Math.pow(base, i + 1);
+    return `${sign}${v.toLocaleString(undefined, {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    })} ${forceUnit}`;
+  }
+
+  if (absBytes < base) return `${sign}${absBytes} B`;
+  let v = absBytes / base;
+  let i = 0;
+  while (v >= base && i < units.length - 1) {
+    v /= base;
+    i++;
+  }
+  return `${sign}${v.toLocaleString(undefined, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })} ${units[i]}`;
+}
+
+// Base-1024 with IEC units: "512 B", "1.50 KiB", "2.00 MiB". Use for memory.
+export function formatBytesIec(
+  bytes: number,
+  options?: BytesFormatOptions,
+): string {
+  return formatScaled(
+    bytes,
+    1024,
+    IEC_UNITS,
+    options?.forceUnit,
+    options?.fractionDigits,
+  );
+}
+
+// Base-1000 with SI units: "512 B", "1.50 KB", "2.00 MB". Use for file sizes.
+export function formatBytesSi(
+  bytes: number,
+  options?: BytesFormatOptions,
+): string {
+  return formatScaled(
+    bytes,
+    1000,
+    SI_UNITS,
+    options?.forceUnit,
+    options?.fractionDigits,
+  );
+}

--- a/ui/src/base/time.ts
+++ b/ui/src/base/time.ts
@@ -318,8 +318,12 @@ export class Duration {
     return result.slice(0, -1);
   }
 
-  static formatSeconds(dur: duration): string {
-    return Duration.toSeconds(dur).toString() + ' s';
+  static formatSeconds(dur: duration, fixed?: number): string {
+    const duration = Duration.toSeconds(dur);
+    if (fixed !== undefined) {
+      return duration.toFixed(fixed) + ' s';
+    }
+    return duration.toString() + ' s';
   }
 
   static formatMilliseconds(dur: duration): string {

--- a/ui/src/components/widgets/charts/flamegraph_chart.ts
+++ b/ui/src/components/widgets/charts/flamegraph_chart.ts
@@ -17,6 +17,8 @@ import {PopupPosition} from '../../../widgets/popup';
 import {CursorTooltip} from '../../../widgets/cursor_tooltip';
 import './flamegraph_chart.scss';
 
+const TOOLTIP_OFFSET_PX = 12;
+
 export interface FlamegraphChartSegment {
   readonly name: string;
   readonly value: number;
@@ -212,7 +214,11 @@ export function FlamegraphChart(): m.Component<FlamegraphChartAttrs> {
         hoveredSeg !== undefined &&
           m(
             CursorTooltip,
-            {position: PopupPosition.BottomStart, offset: 12, skidding: 12},
+            {
+              position: PopupPosition.BottomStart,
+              offset: TOOLTIP_OFFSET_PX,
+              skidOffset: TOOLTIP_OFFSET_PX,
+            },
             m(
               '.pf-flamechart-tooltip',
               hoveredSeg.seg.tooltip ??

--- a/ui/src/components/widgets/charts_svg/chart_svg.scss
+++ b/ui/src/components/widgets/charts_svg/chart_svg.scss
@@ -64,8 +64,8 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 4px 12px;
-    padding: 4px 8px;
-    font-size: 10px;
+    padding: 4px 0;
+    font-size: var(--pf-font-size-s);
   }
 
   &.pf-chart-svg--legend-top .pf-chart-svg__legend,
@@ -109,6 +109,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    color: var(--pf-color-text-muted);
   }
 
   .pf-chart-svg__legend-value {

--- a/ui/src/components/widgets/charts_svg/legend.ts
+++ b/ui/src/components/widgets/charts_svg/legend.ts
@@ -80,13 +80,7 @@ export namespace ChartLegend {
           }),
         m('.pf-chart-svg__legend-name', name),
         value !== undefined &&
-          m(
-            '.pf-chart-svg__legend-value',
-            {
-              style: valueColor ? {color: valueColor} : undefined,
-            },
-            value,
-          ),
+          m('.pf-chart-svg__legend-value', {style: {color: valueColor}}, value),
       );
     },
   };

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -292,6 +292,11 @@ async function loadTraceIntoEngine(
   }
 
   // notify() will await that all listeners' promises have resolved.
+  //
+  // Annoyingly, since listeners are registered through an event interface we
+  // don't know which plugins we are calling so we cannot display the name of
+  // the plugin in the status bar or collect stats about a particular plugin.
+  updateStatus(app, `Notifying onTraceReady listeners`);
   await trace.onTraceReady.notify();
 
   if (serializedAppState !== undefined) {

--- a/ui/src/plugins/dev.perfetto.Memscope/components/billboard.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/billboard.scss
@@ -15,8 +15,35 @@
 .pf-memscope-billboard {
   padding: 14px 16px;
   border-radius: 8px;
-  border: 1px solid var(--pf-color-border-secondary);
-  background: var(--pf-color-background-secondary);
+  border: 0.5px solid var(--pf-col-border);
+  background: var(--pf-col-surface);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+// A card holding Billboard.Sections lays them out as equal-width columns.
+.pf-memscope-billboard:has(> .pf-memscope-billboard__section) {
+  display: flex;
+  gap: 24px;
+}
+
+.pf-memscope-billboard__section {
+  flex: 1 1 0;
+  min-width: 0;
+
+  // Thin divider between adjacent sections.
+  & + & {
+    border-left: 1px solid var(--pf-col-border);
+    padding-left: 24px;
+  }
+}
+
+// Muted caption beneath a section's value.
+.pf-memscope-billboard__sub {
+  font-size: var(--pf-font-size-s);
+  color: var(--pf-color-text-muted);
+  margin-top: 2px;
 }
 
 .pf-memscope-billboard__value {
@@ -58,5 +85,23 @@
   }
   &--down {
     color: var(--pf-color-success);
+  }
+}
+
+.pf-billboard-strip {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+
+  & > * {
+    flex-grow: 1;
+  }
+}
+
+// Style billboards inside a panel differently
+.pf-memscope-panel {
+  .pf-memscope-billboard {
+    background: var(--pf-col-inset);
+    box-shadow: none;
   }
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/components/billboard.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/billboard.ts
@@ -15,12 +15,19 @@
 import './billboard.scss';
 import m from 'mithril';
 
+// Billboard — a single "stat card" that surfaces one headline number (value +
+// unit) with a label, an optional description, and an optional delta badge that
+// colours itself green/red from the leading sign of `delta`. Use it to draw the
+// eye to the handful of figures that matter on a dashboard or summary panel
+// (e.g. total RSS, swap used, page-cache size). Lay several side by side with
+// BillboardStrip for an at-a-glance metrics row.
+
 export interface BillboardAttrs {
   // The primary value to display prominently. Accepts m.Children so callers
-  // can pass the output of billboardKb() which embeds a unit span.
+  // can pass the output of billboardBytes() which embeds a unit span.
   readonly value: m.Children;
   // Unit to display next to the value, e.g. "MB". Accepts m.Children for
-  // flexibility, but typically the output of billboardKb().
+  // flexibility, but typically the output of billboardBytes().
   readonly unit: m.Children;
   // Short label displayed below the value.
   readonly label: string;
@@ -33,8 +40,10 @@ export interface BillboardAttrs {
   readonly color?: string;
 }
 
-// A single stat card. Wrap multiple in billboards() for a row layout.
-export const Billboard: m.Component<BillboardAttrs> = {
+// A single stat card. Lay several side by side in a BillboardStrip for a
+// metrics row, or pack several Billboard.Sections into one card to pair related
+// stats in a single tile.
+export class Billboard implements m.ClassComponent<BillboardAttrs> {
   view({attrs}: m.Vnode<BillboardAttrs>) {
     const {value, unit, label, desc, delta, color} = attrs;
 
@@ -64,5 +73,38 @@ export const Billboard: m.Component<BillboardAttrs> = {
       m('.pf-memscope-billboard__label', label),
       desc !== undefined && m('.pf-memscope-billboard__desc', desc),
     ]);
+  }
+}
+
+export namespace Billboard {
+  export interface SectionAttrs {
+    // Heading shown above the value (rendered uppercase).
+    readonly label: m.Children;
+    // The headline figure for this segment.
+    readonly value: m.Children;
+    // Optional muted caption shown beneath the value.
+    readonly sub?: m.Children;
+  }
+
+  // One labelled segment within a Billboard card. Drop two or three directly
+  // inside a `.pf-memscope-billboard` element and they lay out side by side, so
+  // related figures share a single tile (uptime + OOM score, peak RSS + spike,
+  // memory Δ + trend …) instead of needing a card each.
+  export class Section implements m.ClassComponent<SectionAttrs> {
+    view({attrs}: m.Vnode<SectionAttrs>) {
+      return m('.pf-memscope-billboard__section', [
+        m('.pf-memscope-billboard__label', attrs.label),
+        m('.pf-memscope-billboard__value', attrs.value),
+        attrs.sub !== undefined && m('.pf-memscope-billboard__sub', attrs.sub),
+      ]);
+    }
+  }
+}
+
+// BillboardStrip — a horizontal flex row that lays out a set of Billboards with
+// equal growth, so a group of related stats reads as one cohesive metrics band.
+export const BillboardStrip: m.Component = {
+  view({children}: m.Vnode) {
+    return m('.pf-billboard-strip', children);
   },
 };

--- a/ui/src/plugins/dev.perfetto.Memscope/components/callout.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/callout.scss
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Callout strip: a leading icon plus a one-line message, tinted by intent.
+// Mirrors the colour treatment of the shared `widgets/callout` Callout
+// (pf-color-primary/success/warning/danger via the `pf-intent-*` classes), with
+// a Memscope-specific geometry — slightly larger padding/gap to match the
+// page's panel rhythm.
+
+.pf-memscope-callout {
+  @mixin color-theme($base-color) {
+    color: $base-color;
+    background: color-mix(in srgb, $base-color 15%, transparent);
+  }
+
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--pf-color-background-secondary);
+  border: solid 1px color-mix(in srgb, currentColor, transparent 50%);
+  border-radius: 8px;
+  font-size: var(--pf-font-size-s);
+
+  & > .pf-left-icon {
+    flex-shrink: 0;
+    align-self: center;
+  }
+
+  &__content {
+    flex: 1;
+  }
+
+  &.pf-intent-primary {
+    @include color-theme(var(--pf-color-primary));
+  }
+
+  &.pf-intent-danger {
+    @include color-theme(var(--pf-color-danger));
+  }
+
+  &.pf-intent-success {
+    @include color-theme(var(--pf-color-success));
+  }
+
+  &.pf-intent-warning {
+    @include color-theme(var(--pf-color-warning));
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/callout.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/callout.ts
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './callout.scss';
+import m from 'mithril';
+import {Button} from '../../../widgets/button';
+import {Icon} from '../../../widgets/icon';
+import {classNames} from '../../../base/classnames';
+import {classForIntent, type HTMLAttrs, Intent} from '../../../widgets/common';
+
+// Default leading icon per intent. The shared Callout widget renders an icon
+// only when one is explicitly supplied; this Memscope variant additionally
+// falls back to an intent-specific default so callers can omit `icon` and
+// still get a sensible glyph.
+const DEFAULT_ICONS: Record<Intent, string | undefined> = {
+  [Intent.None]: undefined,
+  [Intent.Primary]: 'lightbulb',
+  [Intent.Success]: 'check_circle',
+  [Intent.Warning]: 'info',
+  [Intent.Danger]: 'error',
+};
+
+interface CalloutAttrs extends HTMLAttrs {
+  // An icon to show to the left of the callout content. Falls back to a
+  // default glyph based on `intent` when omitted.
+  readonly icon?: string;
+
+  // Color the callout by specifying an intent. Uses the same palette as the
+  // shared `widgets/callout` (pf-color-primary/success/warning/danger).
+  readonly intent?: Intent;
+
+  // Adds a close button to the callout.
+  readonly dismissible?: boolean;
+
+  // A callback to be invoked when the callout's close button is clicked.
+  readonly onDismiss?: () => void;
+}
+
+// Callout — a compact strip pairing a leading icon with a one-line message,
+// tinted by intent. Use it to surface the single most relevant takeaway or
+// caveat next to a panel's figures (a hint, a success confirmation, a warning).
+// Mirrors the interface and colour treatment of the shared `widgets/callout`
+// Callout, with a Memscope-specific geometry and intent-based default icons.
+export class Callout implements m.ClassComponent<CalloutAttrs> {
+  view({attrs, children}: m.CVnode<CalloutAttrs>) {
+    const {
+      icon,
+      intent = Intent.None,
+      className,
+      dismissible = false,
+      onDismiss,
+      ...htmlAttrs
+    } = attrs;
+    const resolvedIcon = icon ?? DEFAULT_ICONS[intent];
+
+    return m(
+      '.pf-memscope-callout',
+      {
+        className: classNames(classForIntent(intent), className),
+        ...htmlAttrs,
+      },
+      resolvedIcon && m(Icon, {className: 'pf-left-icon', icon: resolvedIcon}),
+      m('span.pf-memscope-callout__content', children),
+      dismissible &&
+        m(Button, {
+          icon: 'close',
+          onclick: onDismiss,
+          compact: true,
+          title: 'Dismiss callout',
+        }),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/color_chip.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/color_chip.scss
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Colored category chip — shape only; colors injected via inline styles.
+// Colored category chip. The hue is injected per-instance via the
+// --pf-memscope-chip-color custom property (set inline); it gets softened
+// against the page background so the chip reads as a tint rather than a
+// saturated block.
 .pf-memscope-color-chip {
   display: inline-flex;
   align-items: center;
@@ -23,4 +26,13 @@
   border: 1px solid transparent;
   white-space: nowrap;
   line-height: 1.4;
+
+  --_mixed: color-mix(
+    in srgb,
+    var(--pf-memscope-chip-color, var(--pf-color-text)) 75%,
+    var(--pf-color-background)
+  );
+  color: var(--pf-chart-color-on);
+  background: var(--_mixed);
+  border-color: var(--_mixed);
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/components/color_chip.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/color_chip.ts
@@ -15,6 +15,13 @@
 import './color_chip.scss';
 import m from 'mithril';
 
+// ColorChip — a small rounded pill tinted with a caller-supplied colour, used
+// to tag a row or legend entry with the same hue as its data series (memory
+// category, process group, chart slice). The raw colour is softened against the
+// page background so the chip reads as a tint rather than a saturated block;
+// use chipColor() to compute that exact softened colour elsewhere (e.g. for a
+// matching chart series) so the chip and the thing it labels stay in sync.
+
 export interface ColorChipAttrs {
   // Hex color string - can be any valid CSS.
   readonly color?: string;

--- a/ui/src/plugins/dev.perfetto.Memscope/components/hero.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/hero.scss
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Hero connect / idle state.
+.pf-memscope-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 48px 24px;
+  border-radius: 8px;
+  border: 0.5px dashed var(--pf-col-border);
+  text-align: center;
+  // Subtle inset shadow for depth
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+.pf-memscope-hero__icon {
+  font-size: 48px;
+  color: var(--pf-color-text-muted);
+  opacity: 0.5;
+}
+
+.pf-memscope-hero__text {
+  font-size: var(--pf-font-size-m);
+  color: var(--pf-color-text-muted);
+  max-width: 420px;
+  line-height: 1.5;
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/hero.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/hero.ts
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import './hero.scss';
+import {Icon as RawIcon, type IconAttrs} from '../../../widgets/icon';
+
+// Hero — a prominent banner row that introduces a page or major section,
+// typically pairing a leading Hero.Icon with a block of Hero.Text (heading +
+// blurb). Use it at the top of a view to give the user immediate context for
+// what they're looking at. Compose via the namespaced slots:
+//
+//   m(Hero, m(Hero.Icon, {icon: 'memory'}), m(Hero.Text, 'Memory overview'))
+
+export function Hero(): m.Component {
+  return {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-hero', children);
+    },
+  };
+}
+
+export namespace Hero {
+  export const Icon: m.Component<IconAttrs> = {
+    view({attrs}: m.Vnode<IconAttrs>) {
+      return m(RawIcon, {...attrs, className: 'pf-memscope-hero__icon'});
+    },
+  };
+  export const Text: m.Component = {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-hero__text', children);
+    },
+  };
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/inset.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/inset.scss
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-memscope-inset {
+  padding: 12px 16px;
+  border: 0.5px solid var(--pf-col-border);
+  border-radius: 8px;
+  background: var(--pf-col-inset);
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/inset.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/inset.ts
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './inset.scss';
+import m from 'mithril';
+
+// A recessed well meant to sit inside a Panel (or other surface). Where a
+// Panel reads as a raised card against the page, an Inset reads as carved into
+// it — use it to group secondary content (ratios, nested billboards, callouts)
+// within a panel so it doesn't disappear surface-on-surface.
+export interface InsetAttrs {
+  readonly className?: string;
+}
+
+export class Inset implements m.ClassComponent<InsetAttrs> {
+  view({attrs, children}: m.CVnode<InsetAttrs>): m.Children {
+    return m('.pf-memscope-inset', {className: attrs.className}, children);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/page.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/page.scss
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-memscope-page {
+  --pf-border-width: 0.5px;
+  // Light-mode page chrome: a slightly cool-grey page so the white panels
+  // read as raised cards. Dark mode keeps the theme defaults (left unset).
+  --pf-col-base: #f6f6f6;
+  --pf-col-surface: #ffffff;
+  --pf-col-inset: #f1f1f1;
+  --pf-col-border: #e0e0e0;
+
+  .pf-theme-provider--dark & {
+    --pf-col-base: lch(4.52 0.3 272);
+    --pf-col-surface: lch(7.67 0.75 272);
+    --pf-col-inset: #242424;
+    --pf-col-border: #242424;
+  }
+
+  background: var(--pf-col-base);
+  height: 100%;
+  overflow-y: auto;
+
+  .pf-memscope-page__content {
+    max-width: 1400px;
+    margin-inline: auto; // Center the div
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .pf-memscope-page__title {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--pf-color-text-muted);
+  }
+
+  // Override some compoents from the base class
+  .pf-grid__header {
+    background: var(--pf-col-inset);
+    color: var(--pf-color-text-muted);
+    user-select: none;
+    text-transform: uppercase;
+  }
+
+  // Drop the panel body padding when it wraps a grid — the grid's own
+  // header/cell padding is enough.
+  .pf-memscope-panel__body:has(> .pf-grid) {
+    padding: 0;
+  }
+}
+
+.pf-memscope-subpage {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+// First-load entrance: each block fades in and rises a little into place.
+// Runs once when the element mounts (every section mounts at page open now,
+// showing its loading panel), so it plays on first load rather than on every
+// data swap. The 4-panel row cascades via nth-child.
+@keyframes pf-memscope-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+// Direct children of the page/subpage each fade up, cascading in document
+// order via nth-child.
+.pf-memscope-page__content > *,
+.pf-memscope-subpage > * {
+  animation: pf-memscope-enter 0.35s ease-out both;
+
+  @for $i from 1 through 8 {
+    &:nth-child(#{$i}) {
+      animation-delay: #{($i - 1) * 60}ms;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pf-memscope-page__content > *,
+  .pf-memscope-subpage > * {
+    animation: none;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/page.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/page.ts
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import './page.scss';
+
+// Page — the outermost shell for a Memscope view. It owns the scroll container,
+// the light/dark theme variables, and a centred, max-width content column, so
+// every Memscope page shares the same chrome and "raised cards on a cool-grey
+// canvas" look. Wrap a view's whole content in it and drop a Page.Title (and
+// optional Page.Subtitle) at the top. SubPage is a lighter wrapper for a nested
+// section that just needs the standard vertical gap + entrance animation
+// without re-establishing the full page chrome.
+
+export function Page(): m.Component {
+  return {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-page', m('.pf-memscope-page__content', children));
+    },
+  };
+}
+
+export namespace Page {
+  export const Title: m.Component = {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-page__title', children);
+    },
+  };
+
+  export const Subtitle: m.Component = {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-page__subtitle', children);
+    },
+  };
+}
+
+export function SubPage(): m.Component {
+  return {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-subpage', children);
+    },
+  };
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/panel.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/panel.scss
@@ -14,27 +14,26 @@
 
 .pf-memscope-panel {
   border-radius: 8px;
-  background: var(--pf-color-background-secondary);
-  border: 1px solid var(--pf-color-border-secondary);
+  background: var(--pf-col-surface);
+  border: 0.5px solid var(--pf-col-border);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
 .pf-memscope-panel__title-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-
-  h2 {
-    flex: 1;
-  }
+  gap: 6px;
 }
 
 .pf-memscope-panel__header {
   padding: 12px 16px;
-  border-bottom: 1px solid var(--pf-color-border);
+  border-bottom: 1px solid var(--pf-col-border);
 
   h2 {
     margin: 0;
-    font-size: 14px;
+    font-size: 18px;
     font-weight: 600;
     color: var(--pf-color-text);
   }
@@ -52,16 +51,40 @@
   gap: 8px;
   flex-wrap: wrap;
   flex-shrink: 0;
+  margin-left: auto;
 }
 
 .pf-memscope-panel__body {
   padding: 12px;
 }
 
+// Content fades in when it mounts. The body keeps its DOM node across the
+// loading→loaded swap, but its single child is replaced, so this animation
+// fires once at that moment (and once for the initial placeholder). The
+// panel's height still snaps to the new content; the fade is what masks it.
+@keyframes pf-memscope-body-fade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.pf-memscope-panel__body > * {
+  animation: pf-memscope-body-fade 0.3s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pf-memscope-panel__body > * {
+    animation: none;
+  }
+}
+
 .pf-memscope-placeholder {
   color: var(--pf-color-text-muted);
   font-size: var(--pf-font-size-s);
-  font-style: italic;
   padding: 32px 0;
   text-align: center;
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/components/panel.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/panel.ts
@@ -15,21 +15,77 @@
 import './panel.scss';
 import m from 'mithril';
 
+// Panel — the workhorse "card" of the Memscope UI: a bordered, raised surface
+// that groups a titled header with a body of content (a chart, a table, a strip
+// of Billboards). Nearly every block on a Memscope page is a Panel, which is
+// what gives the pages their consistent rhythm.
+//
+// Compose one from the two namespaced slots: a Panel.Header (a flat
+// {title, subtitle, controls} shape — every call site wants the same layout, so
+// it takes attrs rather than hand-assembled sub-slots) above a Panel.Body that
+// holds the payload. See the example at the bottom of this file.
+
 export interface PanelAttrs {
-  readonly title: string;
-  readonly subtitle?: string;
+  readonly className?: string;
 }
 
-export const Panel: m.Component<PanelAttrs> = {
-  view({attrs, children}) {
-    return m(
-      '.pf-memscope-panel',
-      m(
+export class Panel implements m.ClassComponent<PanelAttrs> {
+  view({attrs, children}: m.CVnode<PanelAttrs>): m.Children {
+    return m('.pf-memscope-panel', {className: attrs.className}, children);
+  }
+}
+
+export namespace Panel {
+  export interface HeaderAttrs {
+    readonly title: m.Children;
+    readonly subtitle?: m.Children;
+    readonly controls?: m.Children;
+  }
+
+  // The panel's header: a title row (title on the left, optional right-aligned
+  // controls) above an optional subtitle line.
+  export class Header implements m.ClassComponent<HeaderAttrs> {
+    view({attrs}: m.CVnode<HeaderAttrs>): m.Children {
+      return m(
         '.pf-memscope-panel__header',
-        m('h2', attrs.title),
-        attrs.subtitle !== undefined && m('p', attrs.subtitle),
-      ),
-      m('.pf-memscope-panel__body', children),
-    );
-  },
-};
+        m(
+          '.pf-memscope-panel__title-row',
+          m('h2.pf-memscope-panel__title', attrs.title),
+          attrs.controls !== undefined &&
+            m('.pf-memscope-panel__controls', attrs.controls),
+        ),
+        attrs.subtitle !== undefined &&
+          m('p.pf-memscope-panel__subtitle', attrs.subtitle),
+      );
+    }
+  }
+
+  export interface BodyAttrs {
+    readonly className?: string;
+  }
+
+  // The content area below the header. Holds the panel's actual payload
+  // (chart, table, billboards, free text).
+  export class Body implements m.ClassComponent<BodyAttrs> {
+    view({attrs, children}: m.CVnode<BodyAttrs>): m.Children {
+      return m(
+        '.pf-memscope-panel__body',
+        {className: attrs.className},
+        children,
+      );
+    }
+  }
+}
+
+// === Example usage ===
+//
+// import {Button} from '../../../../widgets/button';
+//
+// m(Panel,
+//   m(Panel.Header, {
+//     title: 'Memory Overview',
+//     subtitle: 'Heap usage across all processes',
+//     controls: m(Button, {label: 'Refresh', icon: 'refresh', onclick: reload}),
+//   }),
+//   m(Panel.Body, m(HeapChart, {data})),
+// );

--- a/ui/src/plugins/dev.perfetto.Memscope/components/progress_bar.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/progress_bar.ts
@@ -16,6 +16,12 @@ import './progress_bar.scss';
 import m from 'mithril';
 import {clamp} from '../../../base/math_utils';
 
+// ProgressBar — a horizontal "X of Y used" meter: an optional left label, a
+// filled track, and a right-aligned value (defaulting to "<pct>%") with an
+// optional muted suffix like " / 640 MB". Use it to show a bounded ratio at a
+// glance — memory or swap utilisation, cache fill, quota consumed. The pct is
+// clamped to 0..100 so out-of-range inputs can't overflow the track.
+
 export interface ProgressBarAttrs {
   // Percentage 0..100. Values outside the range are clamped.
   readonly pct: number;

--- a/ui/src/plugins/dev.perfetto.Memscope/components/table.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/table.scss
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-memscope-table {
+  border: solid 1px var(--pf-col-border);
+  border-radius: 8px;
+  overflow-x: auto;
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--pf-font-size-s);
+  }
+
+  th,
+  td {
+    padding: 8px 12px;
+    text-align: left;
+    vertical-align: baseline;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    font-size: var(--pf-font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pf-color-text-muted);
+    background: var(--pf-col-base);
+    border-bottom: 1px solid var(--pf-col-border);
+    white-space: nowrap;
+  }
+
+  tbody tr {
+    border-bottom: 1px solid var(--pf-col-border);
+
+    &:hover {
+      background: var(--pf-color-background-hover);
+    }
+  }
+
+  .pf-memscope-table__num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .pf-memscope-table__size {
+    font-weight: 600;
+  }
+
+  .pf-memscope-table__delta {
+    margin-top: 2px;
+    font-weight: 400;
+    font-size: var(--pf-font-size-xs);
+    color: var(--pf-color-text-muted);
+  }
+}
+
+.pf-memscope-table--flush {
+  margin-top: 0;
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/table.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/table.ts
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {HTMLAttrs} from '../../../widgets/common';
+import './table.scss';
+
+export class Table implements m.ClassComponent<HTMLAttrs> {
+  view({attrs, children}: m.CVnode<HTMLAttrs>): m.Children {
+    return m(
+      '.pf-memscope-table',
+      {className: attrs.className},
+      m('table', children),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/index.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/index.ts
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import './styles.scss';
 import m from 'mithril';
 import type {App} from '../../public/app';
 import type {PerfettoPlugin} from '../../public/plugin';
+import type {Trace} from '../../public/trace';
 import RecordPageV2 from '../dev.perfetto.RecordTraceV2';
+import {LiveSession} from './sessions/live_session';
+import './styles.scss';
 import {ConnectionPage} from './views/connection';
 import {Dashboard} from './views/dashboard';
-import {LiveSession} from './sessions/live_session';
+import {MemoryOverviewPage} from './views/landing_page/landing_page';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.Memscope';
@@ -60,5 +62,32 @@ export default class implements PerfettoPlugin {
         }
       },
     });
+  }
+
+  async onTraceLoad(ctx: Trace): Promise<void> {
+    const pageRoot = '/memoryoverview';
+
+    ctx.pages.registerPage({
+      route: pageRoot,
+      render: (subpage) =>
+        m(MemoryOverviewPage, {
+          trace: ctx,
+          subpage,
+          onSubpageChange: (subpage) => {
+            ctx.navigate(`#!${pageRoot}/${subpage}`);
+          },
+        }),
+    });
+
+    ctx.sidebar.addMenuItem({
+      section: 'current_trace',
+      sortOrder: 25,
+      text: 'Memory Overview',
+      href: `#!${pageRoot}`,
+      icon: 'memory',
+    });
+
+    // Make this page appear before the heap dump explorer page
+    ctx.initialPage.suggest(pageRoot, 500);
   }
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/landing_page_spec.md
+++ b/ui/src/plugins/dev.perfetto.Memscope/landing_page_spec.md
@@ -1,0 +1,454 @@
+# Memscope Landing Page Spec
+
+## Overview
+
+The memscope landing page is designed to show up first when opening a trace
+which is predominantly memory focused. It displays a general overview of memory
+in the trace, and is designed to be more approachable compared to dumping the
+user in the timeline. It will provide some high level overviews based on smaps,
+java heap dumps and native heap dumps, as well as providing links to the
+timeline and other memory views where available.
+
+## Design
+
+### Landing Page and Process Selector
+
+- Loads the processes that have one or more of the following:
+  - Smaps dumps (profiler_smaps)
+  - Java heap dumps (heap_graph_object)
+  - Native heap dumps (heap_profile_allocation)
+- Displays a select dropdown at the top of the page showing the name and pid of
+  each candidate process and the counters of the above.
+- The subpage is the upid of the selected process.
+- If no process is selected - we choose the 'best' process to show details about
+  (e.g. the one with the most snapshots).
+- When a process is selected (or auto), we show a little process card displaying
+  the process name, and some stats about the trace (time, num snapshots, etc).
+- Two tabs dispayed:
+  - Memory overview
+  - Smaps details
+
+### Memory Overview Tab
+
+#### Billboards
+
+##### Uptime
+
+Uptime requires that we enable record_process_age.
+
+```
+data_sources {
+  config {
+    name: "linux.process_stats"
+    process_stats_config {
+      record_process_age: true
+    }
+  }
+}
+```
+
+We can obtain this value from the process table via the `start_ts` field.
+
+```sql
+SELECT start_ts FROM process WHERE upid = ${upid}
+```
+
+##### OOM Score
+
+OOM score can be obtained via various methods - we obtain it via polling:
+
+```
+data_sources {
+  config {
+    name: "linux.process_stats"
+    process_stats_config {
+      proc_stats_poll_ms: 1000
+    }
+  }
+}
+```
+
+Read the final sample sample of the 'oom_score_adj' counter for the relevant
+process:
+
+```sql
+SELECT c.value AS oom_score_adj
+FROM counter c
+JOIN process_counter_track t ON c.track_id = t.id
+WHERE t.name = 'oom_score_adj' and t.upid = ${upid}
+ORDER BY c.ts desc
+LIMIT 1
+```
+
+##### Peak RSS anon+swap
+
+Smaps is required - right now we can only do this with an extra config passed to
+the java heap prof datasource:
+
+```
+{
+  config: {
+    name: 'android.java_hprof',
+    javaHprofConfig: {
+      pid: [pid],
+      continuousDumpConfig: {
+        dumpIntervalMs: DUMP_INTERVAL_MS, // Required for Java profiles.
+      },
+      smapsConfig: {},
+    },
+  },
+},
+```
+
+For each snapshot, sum anonymous_kb and swap_kb from each snapshot and find the
+max.
+
+```sql
+SELECT s.ts, CAST(ifnull(SUM(s.anonymous_kb + s.swap_kb), 0) * 1024 AS INT) AS total
+FROM profiler_smaps s
+WHERE s.upid = ${upid}
+GROUP BY s.ts
+ORDER BY s.ts ASC
+```
+
+##### RSS Spike
+
+This is designed to capture any spike in RSS missed in the periodic RSS polled
+counters. It's entirely counter based and
+
+To enable - configure process stats polling. The mem.rss.watermark and mem.rss
+counters should be present for each process. We then take the difference of the
+max watermark (or the last watermark, but choose max to be safe) from the max
+rss. This gives us the delta between the highest rss the kernel ever saw vs what
+we recorded.
+
+##### Memory Delta
+
+Derived entirely from smaps - same as the peak RSS ANON+SWAP card. It takese the
+rss anon + swap from the first snapshot in the trace and takes it away from the
+last snapshot in the trace to get the delta.
+
+##### Trend
+
+Same as above but normalized over time to give a value in MiB / hour.
+
+##### GC Churn & Java Churn
+
+Not available / implemented yet.
+
+#### Trace Overview
+
+Trace overview a stacked line chart showing the composition of smaps snapshots
+over time. Broken down by:
+
+- Native: [anon:scudo*], libc_malloc, jemalloc, GWP-ASan, [heap]
+- Java: _dalvik_, ashmem dalvik (the managed heap)
+- File-backed: any path starting / (.so, .oat, .apk, etc.)
+- Graphics: kgsl/mali/dri devices, dmabuf
+- Thread stacks: [stack], [anon:stack*]
+- Other: everything else
+
+For each section, the rss_kb + swap_kb (not anonymous_kb).
+
+It's used as a way to get a rough sense of how the memory was growing over the
+course of the trace, though it's rather coarse becuase it's based on smaps. It's
+also used as a navigation tool allowing the user to click on a snapshot to see
+more information about it in the folloiwng sections - or drag to select a region
+of snapshots and see the diffs as well.
+
+#### Where did all the memory go?
+
+A mini flamegraph showing in more (but still limited) detail the snapshot
+selected in the grpah above. The sizes of the flamegraph are always absolute (of
+the later snapshot if in diff mode). Hover the segments to get more details
+including:
+
+- Name
+- Size in MiB
+- Percentage of total
+- Delta since baseline snapshot (if in diff mode)
+- A brief explaination of the segment
+
+The tree looks like this:
+
+- File backed
+  - Native libs (.so)
+  - Other files
+- Anonymous
+  - Native
+    - Seen by profiler
+    - Allocator overhead (TODO what does this mean?)
+  - Java
+    - Reachable
+    - Unreachable
+  - Thread stacks
+  - Other anon
+- Other
+
+#### Java Memory
+
+Request java heap dumps
+
+```
+config: {
+  name: 'android.java_hprof',
+  targetBufferName: 'java_hprof',
+  javaHprofConfig: {
+    pid: [pid],
+    continuousDumpConfig: {
+      dumpIntervalMs: 10_000,
+    },
+  },
+}
+```
+
+For the selected snapshot from the line chart above - find the nearest java heap
+dump in the trace and display a breakdown of information.
+
+##### Total size
+
+Sum of the retained bytes from each of the objects in the heap dump.
+
+##### Live Objects
+
+Total count of all objects in the heap graph.
+
+##### Registered Native
+
+Sum of all the registered native memory in this snapshot - reachable only.
+
+##### Art overhead
+
+Derived from smaps - sums rss*kb from profiler_smaps for all mapping matching:
+*.art* / *.oat* / *.odex* / *.vdex* / \_dalvik-jit*
+
+##### Class breakdown tables
+
+Three tables break the heap down by class. They are the **same per-class dataset
+surfaced under three different sort orders** — identical columns, only the
+ranking (and the share denominator, which tracks the ranking) differs.
+
+**All three are reachable-only.** Unreachable objects (garbage awaiting GC) are
+excluded entirely, so every column describes live memory and the columns are
+comparable with each other — in particular `retained ≥ shallow` always holds.
+This matches what mature heap tools do (Eclipse MAT and DevTools strip or
+GC-away unreachable objects before reporting) and matches the in-tab
+flamegraphs, which are reachable-only by construction (BFS from GC roots /
+dominator tree). If we ever want to surface garbage / allocation churn, it
+belongs in its own column or section explicitly labelled as unreachable — never
+folded into these columns.
+
+Vocabulary (standard heap-analysis terms — do not overload them):
+
+- **Shallow**: an object's own bytes (`self_size`), Java heap only.
+- **Retained**: dominator-tree retained size — everything freed if the instances
+  went away (self + the subtree they _exclusively_ dominate + registered
+  native). Reachable by definition. This is the only thing called "retained";
+  the live self size is "shallow", not "retained".
+- **Instances**: count of live instances of the class.
+
+Common columns (every table, in this order):
+
+- **Class** — class name, with the `↳ via <class>` retainer annotation (below).
+- **Instances** — reachable instance count.
+- **Shallow** — reachable self size (Java only).
+- **Retained** — dominated size, Java + registered native. A class that owns big
+  native buffers (bitmaps, NIO) shows up as `retained ≫ shallow`, so native
+  doesn't need its own column.
+- **Share** — this class's share of the reachable total of the column the table
+  is ranked by, drawn as a tiny progress bar (retained-share for the retained
+  table, shallow-share for the shallow table, count-share for the count table).
+
+In diff mode every numeric column shows its delta vs the baseline dump.
+
+The three tables:
+
+- **Top classes by retained size** — ranked by retained (Java + native) desc.
+  "What holds the most memory alive — the biggest wins if collected." This is
+  the leak-hunting view.
+- **Top classes by shallow size** — ranked by shallow desc. "Whose own instances
+  occupy the most memory" — big arrays, bitmaps, buffers. A class can top this
+  without topping retained (a large `byte[]` that holds nothing else) and
+  vice-versa (a tiny map that dominates a huge subtree).
+- **Top classes by instance count** — ranked by instance count desc. Surfaces
+  churn from many small objects.
+
+For library classes (`java.*`, `android.*`, `kotlin.*`, arrays, etc.) the class
+cell shows a second `↳ via <class>` line - the nearest app-side class up the
+dominator tree that retains them, i.e. the code in your app most responsible for
+keeping them alive. When walking up finds no app-side owner before the GC roots,
+it shows `GC root` instead. This annotation appears across all three tables. If
+one of these sections is an aggregate of two different sets of instances which
+are owned by multiple roots - we just choose the largest retainer.
+
+> Note: because the columns are now identical and only the sort differs, these
+> three tables could collapse into a single table with sortable column headers.
+> Kept as three pre-sorted "top N" tables for now to suit the at-a-glance
+> landing-page style with no interaction required.
+
+#### Bitmaps
+
+Displays information about reachable `android.graphics.Bitmap` instances in the
+selected heap dump.
+
+- Total bitmaps: A count of the reachable bitmap instances in this snapshot.
+- Bitmap memory: Total bytes used by those bitmaps - Java self size + registered
+  native, plus an estimate (width × height × 4) of the pixel buffer for non-heap
+  (ashmem / hardware) backings, since those bytes aren't in self/native size.
+  The sub-line splits it into heap vs ashmem (est).
+- Largest group: The single dimension group (e.g. 1080×2400) consuming the most
+  bytes - shows its total size and instance count. Only shown when the dump
+  records bitmap dimensions (ART HPROF dumps; proto-format dumps don't).
+- Of java retained: The bitmaps' heap self + registered native bytes as a
+  percentage of the dump's total reachable Java heap + registered native.
+  Excludes the estimated ashmem pixel bytes, since those aren't part of the Java
+  retained total.
+
+The insight callout also names the nearest app-side class retaining the bitmaps
+(same dominator-walk as the `↳ via` annotation above), when resolvable.
+
+When in diff mode, count, size and share show diffs. If this group didnt exist
+in the baseline snap then show 'new'.
+
+TODO: How's best to show who owns these bitmaps - seeing as they're grouped by
+size.
+
+#### Native allocations
+
+Here we find the closest native allocations (not necesserily aligned to smaps /
+java heap dumps) and drill into some stats about it.
+
+##### Billboards
+
+- RSS anon + swap: Total native allocator footprint from smaps (anonymous_kb +
+  swap_kb of the native bucket - scudo/jemalloc/libc_malloc/GWP-ASan/[heap]) at
+  the selected snapshot. This is the denominator for profiler coverage.
+- Seen by profiler: Cumulative unreleased native bytes the profiler observed
+  (allocations minus frees) up to the selected snapshot. The value is bytes; the
+  sub-line shows it as a % coverage of the native RSS above, or the Δ vs
+  baseline when comparing.
+- Allocator overhead + unseen: RSS anon + swap − seen by profiler. The part of
+  the native footprint the profiler can't explain: allocator metadata,
+  fragmentation, and allocations made before tracing started.
+- Thread stacks: Resident stack memory (anon + swap of [stack] / [anon:stack*])
+  from smaps - resident, not the full reservation, since only touched pages
+  count. Sub-line shows the thread count.
+
+##### Profiler Coverage
+
+A proportion bar showing the seen by profiler and unseen from above visually.
+
+##### Table
+
+A breakdown of unreleased memory seen by the profiler:
+
+- Call-stack snippet: A mini callstack (regex based app only stack frames) back
+  up to the root. Only the top 5 callsites by unreleased bytes are shown.
+- Amount of unreleased memory from this callsite.
+- Number of allocations.
+- Share of profiled unreleased memory as a percentage.
+
+When in diff mode - we don't show diffs, we just rescope the unreleased
+calculation to run from the baseline to the selected snapshot (the column header
+becomes "Δ unreleased").
+
+### Smaps Detail Tab
+
+The raw `/proc/<pid>/smaps` dump for one snapshot of the selected process,
+folded into the same taxonomy as the composition chart. A dropdown picks which
+snapshot to view (labelled `#N · t=Xs · <RSS>`, defaulting to the latest); it's
+only shown when there's more than one. Unlike the overview tab this has its own
+snapshot selection - it does not follow the line-chart selection - and has no
+diff mode.
+
+#### Smaps Billboards
+
+Each is a sum over every mapping in the snapshot:
+
+- Total RSS: Total resident set (rss_kb). Sub-line shows the mapping count.
+- RSS anon + swap: Private anonymous + swapped (anonymous_kb + swap_kb).
+- Total PSS: Proportional set size (proportional_resident_kb) - shared pages
+  divided by the number of sharers, so the process's fair share.
+- Private dirty: Private dirty bytes (private_dirty_kb) - the unshareable cost
+  that can't be reclaimed without paging out.
+- Swap: Bytes swapped out (swap_kb, e.g. zram).
+
+#### Mapping Table
+
+Every mapping in the snapshot, aggregated by path. Two view modes:
+
+- Tree (default): mappings bucketed into a two-level taxonomy. Groups and
+  sub-groups are collapsible and show their summed columns; leaf paths are
+  listed under each sub-group (capped, with a "… N more" row).
+- Flat: individual mappings sorted by RSS (capped at 200).
+
+The taxonomy and the rule matching each sub-category (matched against the
+mapping path):
+
+- Anonymous (paths not starting with `/`)
+  - Native heap:
+    `^\[anon:(scudo|libc_malloc|jemalloc|GWP-ASan|partition_alloc|\.bss)` or
+    exactly `[heap]`
+  - Java heap: `^\[anon:dalvik-(main|large object|zygote|non moving|free list)`
+  - Java other / ART: `dalvik` or `\.art\]$`
+  - Thread stacks: `^\[stack\]` or `^\[anon:stack`
+  - Other anon: anything else (fallback)
+- File-backed (path starts with `/`)
+  - Native libs (.so): `\.so$`
+  - Java (.jar/.oat/.art): `\.(jar|dex|oat|odex|vdex|art)$`
+  - Resources / APK: `\.(apk|ttf|otf|dat)$` or path starts with `/fonts/`
+  - Other file-backed: fallback for any other `/…` path
+- Graphics / shared
+  - ashmem / dmabuf: `dmabuf` or `^/dev/ashmem`
+  - GPU / driver: `^/dev/(kgsl|mali|dri)`
+
+Classification is first-match in a fixed precedence - **graphics → file-backed →
+anonymous specifics → other anon** - which is not the display order. The
+graphics checks run first so `/dev/ashmem*` and `/dev/kgsl*` (which start with
+`/`) land under Graphics rather than File-backed, and the dalvik heap spaces are
+matched before the generic `dalvik` bucket.
+
+A regex filter narrows the paths (falls back to substring match if the regex is
+invalid), and an "All columns" toggle expands from the default RSS / Priv. dirty
+/ Swap to also show PSS, Anon+swap, Priv. clean, and Shared dirty/clean.
+
+## TODO List
+
+- [x] Use Megabytes everywhere
+- [x] What is shallow and retained?
+- [ ] Fix graph scale y axis
+- [ ] Think actionability - how to work out WHERE these allocations happens
+  - [ ] Why do we not have callstacks for bytes and bitmaps in the java heap
+        breakdown?
+- [x] Go to the actual java heap dump when clicking show in timeline - don't
+      just select the track.
+- [ ] Shaded flamegraph regions showing dirty/clean split for file backed.
+- [ ] Make it clearer when we're showing a diff.
+- [ ] Fix the flamechart fatness when we have very thin sections.
+- [x] How to switch between smaps snapshots in the smaps details tab.
+- [ ] Might be nice to show WHICH GC root.
+- [ ] Links to the flamegraph when clicking on a class in the java heap table.
+- [ ] Detect whether the trace is obfuscated.
+- [ ] Too bright red and green.
+- [ ] There's a difference between the datasource not being configured and the
+      data source not being there.
+- [ ] Understand the config
+- [ ] Little billboards - some clickable not availble or something.
+- [ ] Clickable little chip in the BL of the line chart goes white when hovered.
+- [ ] The top level trace overview - what to do if there are no snapshots.
+  - [ ] Move the trace overview bar chart in the composition over time (and also
+        show if we have more tha one snapshot) - and it should change depending
+        on the diff.
+- [ ] Remove the y axis for the line chart.
+- [ ] Fix the 700B in the retained panel.
+- [ ] If we click on java the flamegraph should we nav to other pages - on other
+      tabs / pages.
+- [ ] Degredation when SMAPs is not present.
+- [ ] Make Heap reachability smaller
+- [ ] Have unreachable heap as separate billboard along with reachable.
+- [ ] The 'via' we should have multiple 'via' if that's the case.
+- [ ] Should we have top down table as well?
+- [ ] bitmaps - make them clickable and navigate to HDE.
+- [ ] How does it look if we only have 1 snapshot - without smaps - without. -
+      add bug for this.
+- [ ] Link to heap dump explorer when clicking on class.

--- a/ui/src/plugins/dev.perfetto.Memscope/sessions/live_session.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/sessions/live_session.ts
@@ -23,6 +23,7 @@ import {createAdbTracingSession} from '../../dev.perfetto.RecordTraceV2/adb/adb_
 import type {TracingSession} from '../../dev.perfetto.RecordTraceV2/interfaces/tracing_session';
 import type {TracedWebsocketTarget} from '../../dev.perfetto.RecordTraceV2/traced_over_websocket/traced_websocket_target';
 import type {ConnectionResult} from '../views/connection';
+import {download} from '../../../base/download_utils';
 import {ProfileSession, type ProfileState} from './profile_session';
 
 export interface ProfileView {
@@ -207,6 +208,24 @@ export class LiveSession {
       this.app.openTraceFromBuffer({
         buffer: traceData,
         title: fileName,
+        fileName,
+      });
+    }
+  }
+
+  /** Stops the active profile and downloads the trace file. */
+  async stopAndDownloadProfile(): Promise<void> {
+    const profile = this.profileImpl?.session;
+    if (!profile) return;
+    const processName = profile.processName;
+    const pid = profile.pid;
+    await profile.stop();
+    const traceData = profile.getTraceData();
+    this.profileImpl = undefined;
+    if (traceData) {
+      const fileName = `heap-${processName}-${pid}.perfetto-trace`;
+      await download({
+        content: new Uint8Array(traceData),
         fileName,
       });
     }
@@ -429,7 +448,7 @@ function createMonitoringConfig(
               'task/task_newtask',
               'task/task_rename',
               'lowmemorykiller/lowmemory_kill',
-              'oom/oom_score_adj_update',
+              // 'oom/oom_score_adj_update',
             ],
             atraceApps: ['lmkd'],
             disableGenericEvents: true,

--- a/ui/src/plugins/dev.perfetto.Memscope/sessions/profile_session.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/sessions/profile_session.ts
@@ -19,10 +19,11 @@ import type {TracingSession} from '../../dev.perfetto.RecordTraceV2/interfaces/t
 import {TracedWebsocketTarget} from '../../dev.perfetto.RecordTraceV2/traced_over_websocket/traced_websocket_target';
 
 const DUMP_INTERVAL_MS = 10_000;
+const HEAPPROFD_DUMP_INTERVAL_MS = 5_000;
 const PROC_STATS_BUFFER_SIZE_KB = 4 * 1024;
-const HEAPPROFD_BUFFER_SIZE_KB = 128 * 1024;
-const JAVA_HPROF_BUFFER_SIZE_KB = 256 * 1024;
-const STATS_POLL_INTERVAL_MS = 3000;
+const HEAPPROFD_BUFFER_SIZE_KB = 512 * 1024;
+const JAVA_HPROF_BUFFER_SIZE_KB = 512 * 1024;
+const STATS_POLL_INTERVAL_MS = 3_000;
 
 export type ProfileState = 'recording' | 'stopping' | 'finished' | 'error';
 
@@ -50,7 +51,7 @@ export class ProfileSession {
     startX: number,
   ): Promise<ProfileSession> {
     const self = new ProfileSession(pid, processName, startX);
-    const config = buildProcessProfileConfig(pid);
+    const config = buildProcessProfileConfig(pid, processName);
     const result =
       targetOrDevice instanceof TracedWebsocketTarget
         ? await targetOrDevice.startTracing(config)
@@ -125,7 +126,10 @@ export class ProfileSession {
   }
 }
 
-function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
+function buildProcessProfileConfig(
+  pid: number,
+  processName: string,
+): protos.ITraceConfig {
   return {
     compressionType:
       protos.TraceConfig.CompressionType.COMPRESSION_TYPE_DEFLATE,
@@ -145,6 +149,11 @@ function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
         sizeKb: JAVA_HPROF_BUFFER_SIZE_KB,
         fillPolicy: protos.TraceConfig.BufferConfig.FillPolicy.RING_BUFFER,
       },
+      {
+        name: 'ftrace',
+        sizeKb: 4 * 1024,
+        fillPolicy: protos.TraceConfig.BufferConfig.FillPolicy.RING_BUFFER,
+      },
     ],
     dataSources: [
       {
@@ -153,6 +162,8 @@ function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
           targetBufferName: 'process_stats',
           processStatsConfig: {
             scanAllProcessesOnStart: true, // Necessary for track names.
+            procStatsPollMs: 1000,
+            recordProcessAge: true, // Necessary for process uptime.
           },
         },
       },
@@ -166,7 +177,7 @@ function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
             shmemSizeBytes: 16 * 1024 * 1024,
             blockClient: true, // Important for trace integrity.
             continuousDumpConfig: {
-              dumpIntervalMs: DUMP_INTERVAL_MS, // Important for getting regular heap snapshots to see how memory usage evolves over time.
+              dumpIntervalMs: HEAPPROFD_DUMP_INTERVAL_MS, // Important for getting regular heap snapshots to see how memory usage evolves over time.
             },
           },
         },
@@ -180,6 +191,18 @@ function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
             continuousDumpConfig: {
               dumpIntervalMs: DUMP_INTERVAL_MS, // Required for Java profiles.
             },
+            smapsConfig: {},
+          },
+        },
+      },
+      {
+        config: {
+          name: 'linux.ftrace',
+          targetBufferName: 'ftrace',
+          ftraceConfig: {
+            ftraceEvents: ['ftrace/print'],
+            atraceCategories: ['dalvik'],
+            atraceApps: [processName],
           },
         },
       },

--- a/ui/src/plugins/dev.perfetto.Memscope/styles.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/styles.scss
@@ -12,24 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.pf-memscope-page__container {
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  height: 100%;
-  background: var(--pf-color-background);
-}
-
-.pf-memscope-page {
-  width: 100%;
-  max-width: 1600px;
-  margin-inline: auto;
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
 // Page title bar.
 .pf-memscope-title-bar {
   display: flex;
@@ -89,86 +71,10 @@
   padding: 8px;
 }
 
-// Hero connect / idle state.
-.pf-memscope-hero {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  padding: 48px 24px;
-  border-radius: 8px;
-  border: 1px dashed var(--pf-color-border-secondary);
-  text-align: center;
-}
-
-.pf-memscope-hero__icon {
-  font-size: 48px;
-  color: var(--pf-color-text-muted);
-  opacity: 0.5;
-}
-
-.pf-memscope-hero__text {
-  font-size: var(--pf-font-size-m);
-  color: var(--pf-color-text-muted);
-  max-width: 420px;
-  line-height: 1.5;
-}
-
-.pf-memscope-hero__actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 .pf-memscope-device-list {
   display: flex;
   flex-direction: column;
   gap: 8px;
   width: 100%;
   max-width: 400px;
-}
-
-.pf-memscope-page {
-  .pf-memscope-profile-btn {
-    visibility: hidden;
-  }
-
-  .pf-grid__row:hover .pf-memscope-profile-btn {
-    visibility: visible;
-  }
-
-  .pf-grid__header {
-    background: var(--pf-color-background);
-    color: var(--pf-color-text-muted);
-    user-select: none;
-    text-transform: uppercase;
-  }
-
-  .pf-grid__body {
-    background: var(--pf-color-background-secondary);
-  }
-
-  // Zero-padding for the profile button cell in the process table.
-  .pf-grid-cell:has(.pf-memscope-profile-btn) {
-    --pf-cell-padding-block: 0;
-    --pf-cell-padding-inline: 2px;
-  }
-
-  // Drop the panel body padding when it wraps a grid — the grid's own
-  // header/cell padding is enough.
-  .pf-memscope-panel__body:has(> .pf-grid) {
-    padding: 0;
-  }
-}
-
-.pf-memscope-color-chip {
-  --_mixed: color-mix(
-    in srgb,
-    var(--pf-memscope-chip-color, var(--pf-color-text)) 75%,
-    var(--pf-color-background)
-  );
-  color: var(--pf-chart-color-on);
-  background: var(--_mixed);
-  border-color: var(--_mixed);
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/utils.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/utils.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {formatBytesIec} from '../../base/bytes_format';
 import type {TsValue} from './sessions/live_session';
 
 /** Maps counter samples to chart points with x in seconds since `t0` (ns). */
@@ -24,23 +25,22 @@ export function counterPoints(
 }
 
 /**
- * Returns a Y-axis tick interval (in KB) that produces clean KB/MB/GB labels.
- * Targets ~5 ticks by picking the smallest interval from the sequence
- * 1, 2, 5, 10, 20, 50, 100, 200, 500 × {KB, MB, GB} that keeps tick count ≤ 6.
- *
- * Uses SI units (1 MB = 1000 KB, 1 GB = 1000 MB) to match `formatKb`.
+ * Returns a Y-axis tick interval (in KB) that lands on power-of-2 (IEC)
+ * boundaries, so labels rendered with `formatBytesIec` read as clean
+ * KiB/MiB/GiB values. Targets ~5 ticks by picking the smallest interval from
+ * 1, 2, 4, 8 … 512 × {KiB, MiB, GiB} (1 MiB = 1024 KiB) that keeps ticks ≤ 6.
  */
 export function niceKbInterval(maxKb: number): number {
   if (maxKb <= 0) return 1;
   const rawInterval = maxKb / 5;
-  const steps = [1, 2, 5, 10, 20, 50, 100, 200, 500];
-  for (const unit of [1, 1000, 1000 * 1000]) {
+  const steps = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512];
+  for (const unit of [1, 1024, 1024 * 1024]) {
     for (const step of steps) {
       const candidate = unit * step;
       if (candidate >= rawInterval) return candidate;
     }
   }
-  return 1000 * 1000 * 500; // fallback: 500 GB
+  return 1024 * 1024 * 512; // fallback: 512 GiB
 }
 
 /** Returns the maximum y value across all series in a chart dataset. */
@@ -56,25 +56,8 @@ export function maxSeriesKb(
   return max;
 }
 
-export function formatKb(kb: number): string {
-  if (kb < 1000) return `${kb.toLocaleString()} KB`;
-  if (kb < 1000 * 1000) return `${(kb / 1000).toFixed(1)} MB`;
-  return `${(kb / (1000 * 1000)).toFixed(1)} GB`;
-}
-
-/** Renders a KB value for a billboard with the unit in a smaller span. */
-export function billboardKb(kb: number) {
-  let value: string;
-  let unit: string;
-  if (kb < 1000) {
-    value = kb.toLocaleString();
-    unit = 'KB';
-  } else if (kb < 1000 * 1000) {
-    value = (kb / 1000).toFixed(1);
-    unit = 'MB';
-  } else {
-    value = (kb / (1000 * 1000)).toFixed(1);
-    unit = 'GB';
-  }
+/** Renders a byte value for a billboard with the unit in a smaller span. */
+export function billboardBytes(bytes: number) {
+  const [value, unit] = formatBytesIec(bytes).split(' ');
   return {value, unit};
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/views/connection.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/connection.ts
@@ -18,7 +18,6 @@ import {showPopupWindow} from '../../../base/popup_window';
 import {exists} from '../../../base/utils';
 import {Button, ButtonVariant} from '../../../widgets/button';
 import {Intent} from '../../../widgets/common';
-import {Icon} from '../../../widgets/icon';
 import {TextInput} from '../../../widgets/text_input';
 import {RadioGroup} from '../../../widgets/radio_group';
 import type {AdbDevice} from '../../dev.perfetto.RecordTraceV2/adb/adb_device';
@@ -36,6 +35,8 @@ import {
 } from '../../dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_utils';
 import {TracedWebsocketTarget} from '../../dev.perfetto.RecordTraceV2/traced_over_websocket/traced_websocket_target';
 import {AsyncWebsocket} from '../../dev.perfetto.RecordTraceV2/websocket/async_websocket';
+import {Page} from '../components/page';
+import {Hero} from '../components/hero';
 
 export interface ConnectionResult {
   device?: AdbDevice;
@@ -85,44 +86,37 @@ export class ConnectionPage implements m.ClassComponent<ConnectionPageAttrs> {
 
   view({attrs}: m.CVnode<ConnectionPageAttrs>) {
     return m(
-      '.pf-memscope-page__container',
+      Page,
+      m(Page.Title, 'Memscope'),
       m(
-        '.pf-memscope-page',
-        m('.pf-memscope-title-bar', m('h1', 'Memscope')),
+        Hero,
+        m(Hero.Icon, {icon: 'memory'}),
         m(
-          '.pf-memscope-hero',
-          m(Icon, {icon: 'memory', className: 'pf-memscope-hero__icon'}),
-          m(
-            '.pf-memscope-hero__text',
-            'Connect to an Android device or Linux host to monitor ' +
-              'per-process memory usage in real time via traced.',
-          ),
-          m(
-            RadioGroup,
-            {
-              intent: Intent.Primary,
-              selectedValue: this.connectionMethod,
-              onValueChange: (value) => {
-                this.connectionMethod = value as ConnectionMethod;
-                this.error = undefined;
-              },
-            },
-            m(RadioGroup.Button, {value: 'usb', icon: 'usb'}, 'USB'),
-            m(
-              RadioGroup.Button,
-              {value: 'websocket', icon: 'lan'},
-              'WebSocket',
-            ),
-            m(
-              RadioGroup.Button,
-              {value: 'web_proxy', icon: 'corporate_fare'},
-              'Web Proxy',
-            ),
-            m(RadioGroup.Button, {value: 'linux', icon: 'computer'}, 'Linux'),
-          ),
-          this.renderConnectBox(attrs),
-          this.error && m('.pf-memscope-error', this.error),
+          Hero.Text,
+          'Connect to an Android device or Linux host to monitor ' +
+            'per-process memory usage in real time via traced.',
         ),
+        m(
+          RadioGroup,
+          {
+            intent: Intent.Primary,
+            selectedValue: this.connectionMethod,
+            onValueChange: (value) => {
+              this.connectionMethod = value as ConnectionMethod;
+              this.error = undefined;
+            },
+          },
+          m(RadioGroup.Button, {value: 'usb', icon: 'usb'}, 'USB'),
+          m(RadioGroup.Button, {value: 'websocket', icon: 'lan'}, 'WebSocket'),
+          m(
+            RadioGroup.Button,
+            {value: 'web_proxy', icon: 'corporate_fare'},
+            'Web Proxy',
+          ),
+          m(RadioGroup.Button, {value: 'linux', icon: 'computer'}, 'Linux'),
+        ),
+        this.renderConnectBox(attrs),
+        this.error && m('.pf-memscope-error', this.error),
       ),
     );
   }

--- a/ui/src/plugins/dev.perfetto.Memscope/views/dashboard.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/dashboard.scss
@@ -12,33 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.pf-memscope--muted {
-  color: var(--pf-color-text-muted);
-}
-
-// Title bar sub-layout (left group, separator, device badge, actions).
+// Title bar sub-layout (left group, actions).
 .pf-memscope-title-bar__left {
   display: flex;
   align-items: baseline;
   gap: 12px;
   flex-shrink: 0;
-}
-
-// Thin vertical rule that separates logical groups in the toolbar.
-.pf-memscope-title-bar__sep {
-  width: 1px;
-  height: 18px;
-  background: var(--pf-color-border);
-  flex-shrink: 0;
-}
-
-.pf-memscope-title-bar__device {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  font-size: var(--pf-font-size-m);
-  font-weight: 500;
-  color: var(--pf-color-text-muted);
 }
 
 // Right-side cluster: device identity + button group.
@@ -55,27 +34,6 @@
   font-size: var(--pf-font-size-m);
   font-weight: 500;
   color: var(--pf-color-text-hint);
-}
-
-.pf-memscope-session-pill__sep {
-  width: 1px;
-  height: 18px;
-  background: var(--pf-color-border);
-  flex-shrink: 0;
-}
-
-.pf-memscope-session-pill__snapshot {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 4px;
-  font-size: var(--pf-font-size-s);
-  font-variant-numeric: tabular-nums;
-  color: var(--pf-color-text-muted);
-  cursor: help;
-
-  .material-icons {
-    font-size: 16px;
-  }
 }
 
 // Snapshot info popup content.
@@ -111,7 +69,7 @@
   &.pf-memscope-snapshot-info__sum {
     margin-top: 6px;
     padding-top: 8px;
-    border-top: 1px solid var(--pf-color-border);
+    border-top: 1px solid var(--pf-col-border);
     font-weight: 600;
     font-size: var(--pf-font-size-m);
 

--- a/ui/src/plugins/dev.perfetto.Memscope/views/dashboard.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/dashboard.ts
@@ -12,30 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import './dashboard.scss';
 import m from 'mithril';
-import type {App} from '../../../public/app';
-import {Button, ButtonGroup, ButtonVariant} from '../../../widgets/button';
-import {Intent} from '../../../widgets/common';
-import {RadioGroup} from '../../../widgets/radio_group';
+import {GateDetector} from '../../../base/mithril_utils';
 import type {
   LineChartData,
   LineChartSeries,
 } from '../../../components/widgets/charts/line_chart';
-import {GateDetector} from '../../../base/mithril_utils';
+import type {App} from '../../../public/app';
+import {Button, ButtonGroup, ButtonVariant} from '../../../widgets/button';
+import {Chip} from '../../../widgets/chip';
+import {Intent} from '../../../widgets/common';
+import {MenuDivider, MenuItem, PopupMenu} from '../../../widgets/menu';
+import {PopupPosition} from '../../../widgets/popup';
+import {RadioGroup} from '../../../widgets/radio_group';
+import {Page} from '../components/page';
 import type {
   LiveSession,
   ProfileView,
   SnapshotData,
 } from '../sessions/live_session';
+import './dashboard.scss';
 import {ProfilePage} from './profile_page';
-import {ProcessesTab} from './tabs/processes';
-import {renderSystemTab} from './tabs/system';
 import {renderPageCacheTab} from './tabs/page_cache';
 import {renderPressureSwapTab} from './tabs/pressure_swap';
-import {Chip} from '../../../widgets/chip';
-import {PopupPosition} from '../../../widgets/popup';
-import {MenuDivider, MenuItem, PopupMenu} from '../../../widgets/menu';
+import {ProcessesTab} from './tabs/processes';
+import {renderSystemTab} from './tabs/system';
 
 type Tab = 'processes' | 'system' | 'file_cache' | 'pressure_swap';
 
@@ -120,18 +121,15 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
           visible ? session.resume() : session.pause(),
       },
       m(
-        '.pf-memscope-page__container',
-        m(
-          '.pf-memscope-page',
+        Page,
 
-          // Title bar with status and actions (always shown).
-          this.renderTitleBar(attrs),
+        // Title bar with status and actions (always shown).
+        this.renderTitleBar(attrs),
 
-          // Profile page or dashboard content.
-          session.profile !== undefined
-            ? this.renderProfilePage(attrs, session.profile)
-            : this.renderDashboard(attrs),
-        ),
+        // Profile page or dashboard content.
+        session.profile !== undefined
+          ? this.renderProfilePage(attrs, session.profile)
+          : this.renderDashboard(attrs),
       ),
     );
   }
@@ -359,6 +357,12 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
       baseline: this.profileBaseline,
       onStop: () => {
         session.stopAndOpenProfile().then(() => {
+          this.profileBaseline = undefined;
+          m.redraw();
+        });
+      },
+      onStopAndDownload: () => {
+        session.stopAndDownloadProfile().then(() => {
           this.profileBaseline = undefined;
           m.redraw();
         });

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
@@ -1,0 +1,574 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+$border-radius: 4px;
+
+// The page chrome (background, width-capped content column, title/subtitle)
+// now comes from the shared Page component; only the empty-state caption is
+// still rendered under this name.
+.pf-memscope-landing__empty {
+  margin-block: 48px;
+  color: var(--pf-color-text-muted);
+}
+
+// ---------------------------------------------------------------------------
+// Capture strip
+// ---------------------------------------------------------------------------
+
+// Layout only — the raised-card chrome (border, shadow, background) comes from
+// the Panel this class is applied to.
+.pf-memscope-capture {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 6px;
+  padding: 12px 16px;
+}
+
+.pf-memscope-capture__identity {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: var(--pf-font-size-s);
+  color: var(--pf-color-text-muted);
+
+  .pf-memscope-capture__process {
+    font-size: var(--pf-font-size-m);
+    font-weight: 600;
+    color: var(--pf-color-text);
+  }
+}
+
+.pf-memscope-capture__sources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+}
+
+.pf-memscope-capture__source {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: var(--pf-font-size-s);
+  color: var(--pf-color-text-muted);
+
+  &--empty {
+    opacity: 0.6;
+  }
+
+  .pf-memscope-capture__label {
+    font-weight: 600;
+    color: var(--pf-color-text);
+  }
+
+  .pf-memscope-capture__facts {
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.pf-memscope-capture__dot {
+  align-self: center;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+
+  // Per-source colours, matching the chart series.
+  &--smaps {
+    background: #4caf50;
+  }
+
+  &--dump {
+    background: #2196f3;
+  }
+
+  &--native {
+    background: #ff9800;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Process selector
+// ---------------------------------------------------------------------------
+
+.pf-memscope-process-select {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+
+  .pf-memscope-process-select__label {
+    font-weight: 600;
+    font-size: var(--pf-font-size-m);
+    color: var(--pf-color-text-muted);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Charts
+// ---------------------------------------------------------------------------
+
+.pf-memscope-charts {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+// ---------------------------------------------------------------------------
+// Billboards (headline stats row)
+// ---------------------------------------------------------------------------
+
+.pf-memscope-billboards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+
+  // Variant used inside section panels: tighter and flush with the
+  // surrounding flex gap.
+  &--section {
+    gap: 16px;
+    margin-bottom: 0;
+  }
+}
+
+.pf-memscope-oom-chip {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  background: rgb(52 168 83 / 15%);
+  color: #1e7e34;
+  font-size: var(--pf-font-size-xs);
+  font-weight: 600;
+}
+
+// ---------------------------------------------------------------------------
+// Tabs
+// ---------------------------------------------------------------------------
+
+.pf-memscope-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--pf-col-border);
+}
+
+.pf-memscope-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  font-size: var(--pf-font-size-m);
+  color: var(--pf-color-text-muted);
+  cursor: pointer;
+
+  .pf-icon {
+    font-size: 16px;
+  }
+
+  &:hover {
+    color: var(--pf-color-text);
+  }
+
+  &--active {
+    color: var(--pf-color-accent);
+    border-bottom-color: var(--pf-color-accent);
+    font-weight: 600;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section building blocks (callout, ratio bar, top tables, share bars)
+// ---------------------------------------------------------------------------
+
+// The ratio bar and the growth bar are the same "uppercase label · big figure ·
+// proportion bar" shape, both wrapped in an Inset for chrome. Their shared
+// typography lives here; the per-bar blocks below only add what's unique.
+.pf-memscope-ratio__label,
+.pf-memscope-growth__label {
+  font-size: var(--pf-font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--pf-color-text-muted);
+}
+
+.pf-memscope-ratio__headline,
+.pf-memscope-growth__headline {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+// The big headline figure (percentage / delta) and its muted caption.
+.pf-memscope-ratio__pct,
+.pf-memscope-growth__delta {
+  font-size: var(--pf-font-size-xl);
+  font-weight: 700;
+  color: var(--pf-color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.pf-memscope-ratio__text,
+.pf-memscope-growth__context {
+  font-size: var(--pf-font-size-s);
+  color: var(--pf-color-text-muted);
+}
+
+.pf-memscope-ratio {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  &__pct-delta {
+    margin-left: auto;
+    font-size: var(--pf-font-size-xs);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--pf-color-text-muted);
+  }
+
+  &__legend-change {
+    color: var(--pf-color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.pf-memscope-tables {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+  gap: 8px 32px;
+  align-items: start;
+}
+
+.pf-memscope-toptable {
+  min-width: 0;
+
+  .pf-memscope-toptable__title {
+    margin-bottom: 4px;
+    font-weight: 600;
+    color: var(--pf-color-text);
+  }
+
+  .pf-memscope-toptable__subtitle {
+    font-weight: 400;
+    font-size: var(--pf-font-size-s);
+    color: var(--pf-color-text-muted);
+  }
+}
+
+.pf-memscope-sharebar {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  .pf-memscope-sharebar__track {
+    width: 80px;
+    height: 8px;
+    border-radius: 4px;
+    background: var(--pf-col-border);
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
+  .pf-memscope-sharebar__fill {
+    height: 100%;
+    border-radius: 4px;
+    background: var(--pf-color-accent, #4285f4);
+  }
+
+  .pf-memscope-sharebar__pct {
+    min-width: 30px;
+    text-align: right;
+    font-size: var(--pf-font-size-xs);
+    color: var(--pf-color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.pf-memscope-classname {
+  font-family: var(--pf-font-family-mono, monospace);
+  font-size: var(--pf-font-size-xs);
+}
+
+a.pf-memscope-classname {
+  color: var(--pf-color-primary);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.pf-memscope-classcell {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+
+  &__via {
+    font-family: var(--pf-font-family-mono, monospace);
+    font-size: var(--pf-font-size-xs);
+    color: var(--pf-color-text-muted);
+  }
+
+  // The via owner is a link too, but it stays in the muted retainer color so the
+  // annotation reads as one line; only the hover underline signals the link.
+  &__vialink {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.pf-memscope-stack {
+  display: flex;
+  flex-direction: column;
+  font-family: var(--pf-font-family-mono, monospace);
+  font-size: var(--pf-font-size-xs);
+  line-height: 1.5;
+  word-break: break-all;
+
+  // Frames run leaf → root, top to bottom. Each caller is indented and
+  // prefixed with a connector so the chain reads vertically.
+  .pf-memscope-stack__frame {
+    &:first-child {
+      font-weight: 600;
+    }
+
+    &:not(:first-child) {
+      padding-left: 12px;
+      color: var(--pf-color-text-muted);
+
+      &::before {
+        content: "↳ ";
+        color: var(--pf-color-text-hint);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Smaps detail tab
+// ---------------------------------------------------------------------------
+
+.pf-memscope-smaps__controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  .pf-memscope-tab {
+    padding: 4px 12px;
+    border: 0.5px solid var(--pf-col-border);
+    border-radius: 12px;
+
+    &--active {
+      border-color: var(--pf-color-accent);
+    }
+  }
+}
+
+.pf-memscope-smaps__filter {
+  flex: 1;
+  max-width: 320px;
+  margin-inline: 8px;
+}
+
+.pf-memscope-smaps__path {
+  font-family: var(--pf-font-family-mono, monospace);
+  font-size: var(--pf-font-size-xs);
+  word-break: break-all;
+}
+
+.pf-memscope-smaps__lvl1 {
+  padding-left: 28px !important;
+}
+
+.pf-memscope-smaps__lvl2 {
+  padding-left: 56px !important;
+}
+
+.pf-memscope-smaps__group,
+.pf-memscope-smaps__subgroup {
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+
+  td:first-child {
+    white-space: nowrap;
+  }
+
+  .pf-memscope-growth__swatch {
+    display: inline-block;
+    vertical-align: baseline;
+    margin-right: 2px;
+  }
+
+  .pf-memscope-smaps__count {
+    font-weight: 400;
+    font-size: var(--pf-font-size-xs);
+    color: var(--pf-color-text-muted);
+  }
+}
+
+.pf-memscope-smaps__group {
+  background: var(--pf-col-surface);
+}
+
+.pf-memscope-smaps__chevron {
+  font-size: 16px;
+  vertical-align: middle;
+  margin-right: 2px;
+  color: var(--pf-color-text-muted);
+}
+
+.pf-memscope-smaps__counttext {
+  align-self: center;
+  margin-left: 8px;
+  font-size: var(--pf-font-size-s);
+  color: var(--pf-color-text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.pf-memscope-smaps__more {
+  font-style: italic;
+  color: var(--pf-color-text-muted);
+  font-size: var(--pf-font-size-xs);
+}
+
+// ---------------------------------------------------------------------------
+// Growth attribution ("Where the growth went")
+// ---------------------------------------------------------------------------
+
+// Layout only — the recessed chrome (padding, border, background) comes from
+// the Inset this class is applied to.
+.pf-memscope-growth {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  &__swatch {
+    align-self: center;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Memory map ("Where did all the memory go?")
+// ---------------------------------------------------------------------------
+
+.pf-memscope-memmap {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  &__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: var(--pf-font-size-s);
+    color: var(--pf-color-accent);
+    cursor: pointer;
+    white-space: nowrap;
+
+    .pf-icon {
+      font-size: 16px;
+    }
+  }
+
+  &__section-header {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 10px;
+
+    .pf-memscope-memmap__section-title {
+      font-weight: 600;
+      color: var(--pf-color-text);
+
+      &--diff {
+        color: var(--pf-color-primary);
+      }
+    }
+
+    .pf-memscope-memmap__section-hint {
+      font-size: var(--pf-font-size-s);
+      color: var(--pf-color-text-muted);
+    }
+  }
+
+  &__badge {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    margin-left: auto;
+    padding: 4px 10px;
+    border: 0.5px solid var(--pf-col-border);
+    border-radius: 6px;
+    background: var(--pf-col-base);
+    font-size: var(--pf-font-size-s);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--pf-color-text);
+
+    .pf-icon {
+      align-self: center;
+      font-size: 14px;
+      color: var(--pf-color-text-muted);
+    }
+  }
+
+  &__snaps {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  &__snap {
+    padding: 2px 8px;
+    border: 0.5px solid var(--pf-col-border);
+    border-radius: 10px;
+    background: var(--pf-col-base);
+    font-size: var(--pf-font-size-xs);
+    font-variant-numeric: tabular-nums;
+    color: var(--pf-color-text-muted);
+    cursor: pointer;
+
+    &:hover {
+      background: var(--pf-color-background-hover);
+    }
+
+    &--active {
+      background: var(--pf-color-accent);
+      border-color: var(--pf-color-accent);
+      color: white;
+      font-weight: 600;
+    }
+
+    &--base {
+      border-color: var(--pf-color-accent);
+      color: var(--pf-color-accent);
+      font-weight: 600;
+    }
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.ts
@@ -1,0 +1,180 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {assertIsInstance} from '../../../../base/assert';
+import {QuerySlot} from '../../../../base/query_slot';
+import type {Trace} from '../../../../public/trace';
+import type {Engine} from '../../../../trace_processor/engine';
+import {
+  materializeRows,
+  NUM,
+  STR,
+} from '../../../../trace_processor/query_result';
+import {Select} from '../../../../widgets/select';
+import './landing_page.scss';
+import {ProcessMemDetails} from './proc_mem_overview';
+import {EmptyState} from '../../../../widgets/empty_state';
+import {Page} from '../../components/page';
+
+// Per-process memory-capture counts, used to populate and score the process
+// picker on the overview page.
+interface ProcMemStat {
+  readonly upid: number;
+  readonly pid: number;
+  readonly procName: string;
+  readonly heapDumps: number;
+  readonly smapsSnapshots: number;
+  readonly nativeDumps: number;
+}
+
+export interface MemoryOverviewPageAttrs {
+  readonly trace: Trace;
+  readonly subpage: string | undefined;
+  readonly onSubpageChange: (subpage: string) => void;
+}
+
+type ProcWithMem = readonly ProcMemStat[];
+
+// Returns a list processes that have memory dumps/smaps/profiles in the trace.
+async function loadProcessMemoryStats(engine: Engine): Promise<ProcWithMem> {
+  const result = await engine.query(`
+    SELECT
+      p.upid,
+      p.pid,
+      COALESCE(p.cmdline, p.name, '<unknown>') AS procName,
+      (
+        SELECT count(DISTINCT graph_sample_ts)
+        FROM heap_graph_object o
+        WHERE o.upid = p.upid
+      ) AS heapDumps,
+      (
+        SELECT count(DISTINCT ts)
+        FROM profiler_smaps s
+        WHERE s.upid = p.upid
+      ) AS smapsSnapshots,
+      (
+        SELECT count(DISTINCT ts)
+        FROM heap_profile_allocation a
+        WHERE a.upid = p.upid
+      ) AS nativeDumps
+    FROM process p
+    WHERE heapDumps > 0 OR smapsSnapshots > 0 OR nativeDumps > 0
+    ORDER BY p.upid;
+  `);
+  return materializeRows(result, {
+    upid: NUM,
+    pid: NUM,
+    procName: STR,
+    heapDumps: NUM,
+    smapsSnapshots: NUM,
+    nativeDumps: NUM,
+  });
+}
+
+// Scores a process to determine how relevant it is for the landing page.
+// Higher score = more relevant. We weight by data type and count to pick
+// the process with the richest memory analysis data.
+function scoreProc(p: ProcMemStat): number {
+  // Heap dumps are the richest data source, followed by smaps, then profiles.
+  return p.heapDumps * 3 + p.smapsSnapshots * 2 + p.nativeDumps * 1;
+}
+
+function pickBestProc(procs: ProcWithMem) {
+  if (procs.length === 0) return undefined;
+  return procs.reduce((best, p) => (scoreProc(p) > scoreProc(best) ? p : best));
+}
+
+// The subpage might look like '/123' or even '/123/foo'
+function parseUpidFromSubpage(subpage: string): number {
+  const parts = subpage.split('/').filter((x) => x !== '');
+  if (parts.length === 0) return Number.NaN;
+  return parseInt(parts[0]);
+}
+
+export class MemoryOverviewPage
+  implements m.Component<MemoryOverviewPageAttrs>
+{
+  private readonly slot = new QuerySlot<ProcWithMem>();
+
+  view({attrs}: m.Vnode<MemoryOverviewPageAttrs>) {
+    const {trace, subpage, onSubpageChange} = attrs;
+
+    return m(
+      Page,
+      m(Page.Title, 'Memory Overview'),
+      m(
+        Page.Subtitle,
+        'Memory triage: smaps owns the total, the native and Java ' +
+          'profilers explain what is inside.',
+      ),
+      this.renderPageContent(trace, subpage, onSubpageChange),
+    );
+  }
+
+  private renderPageContent(
+    trace: Trace,
+    subpage: string | undefined,
+    onSubpageChange: (subpage: string) => void,
+  ) {
+    const procsWithMemResult = this.slot.use({
+      key: '',
+      queryFn: () => loadProcessMemoryStats(trace.engine),
+    });
+
+    const procs = procsWithMemResult.data;
+    if (!procs) {
+      return m(EmptyState, {icon: 'hourglass', title: 'Loading processes...'});
+    }
+
+    const bestProc = pickBestProc(procs);
+    if (!bestProc) {
+      return m(EmptyState, 'No processes with memory in this trace');
+    }
+
+    const selectedUpid = subpage
+      ? parseUpidFromSubpage(subpage)
+      : bestProc.upid;
+
+    return [
+      m('.pf-memscope-process-select', [
+        m('span.pf-memscope-process-select__label', 'Process'),
+        m(
+          Select,
+          {
+            value: selectedUpid?.toString(),
+            onchange: (e: Event) => {
+              assertIsInstance(e.target, HTMLSelectElement);
+              onSubpageChange(e.target.value);
+            },
+          },
+          procs.map((p) =>
+            m('option', {value: p.upid.toString()}, procOptionLabel(p)),
+          ),
+        ),
+      ]),
+      Number.isNaN(selectedUpid)
+        ? m('', `Unable to parse upid from subpage ${subpage}`)
+        : m(ProcessMemDetails, {trace, upid: selectedUpid}),
+    ];
+  }
+}
+
+function procOptionLabel(p: ProcMemStat): string {
+  const parts: string[] = [];
+  if (p.heapDumps > 0) parts.push(`${p.heapDumps} java_hprof`);
+  if (p.nativeDumps > 0) parts.push(`${p.nativeDumps} heapprofd`);
+  if (p.smapsSnapshots > 0) parts.push(`${p.smapsSnapshots} smaps`);
+  return parts.length > 0 ? `${p.procName} (${parts.join(', ')})` : p.procName;
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/mem_format.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/mem_format.ts
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Small formatting/widget helpers shared between the Memscope overview views
+// (the per-process overview page and the top-level trace overview cards).
+
+import m from 'mithril';
+import {
+  formatBytesIec,
+  type BytesFormatOptions,
+} from '../../../../base/bytes_format';
+import {Billboard} from '../../components/billboard';
+
+// Memory sizes are always shown in mebibytes (base-1024) for consistency across
+// the page, rather than auto-scaling to B/KiB/GiB. Pass an explicit forceUnit to
+// override for a specific call.
+const UNIT: BytesFormatOptions['forceUnit'] = 'MiB';
+
+export function formatBytes(
+  bytes: number,
+  options?: BytesFormatOptions,
+): string {
+  return formatBytesIec(bytes, {
+    ...options,
+    forceUnit: options?.forceUnit ?? UNIT,
+  });
+}
+
+// Formats a signed byte delta, e.g. "+1.20 MiB" / "-0.50 MiB" / "±0.00 MiB".
+// Pass {fractionDigits} to control decimal places (default 2). Uses the
+// current locale for grouping/decimals automatically.
+export function formatDelta(
+  bytes: number,
+  options?: BytesFormatOptions,
+): string {
+  if (bytes === 0) return `±${formatBytes(0, options)}`;
+  const sign = bytes > 0 ? '+' : '-';
+  const absBytes = Math.abs(bytes);
+  return `${sign}${formatBytes(absBytes, options)}`;
+}
+
+// Consistent delta coloring across the page: red when a value grew (up),
+// green when it shrank (down), neutral (default text color) at zero. Matches
+// the Billboard delta convention (--pf-color-danger / --pf-color-success).
+export function deltaColor(n: number): string | undefined {
+  if (n > 0) return 'var(--pf-color-danger)';
+  if (n < 0) return 'var(--pf-color-success)';
+  return undefined;
+}
+
+// Signed integer delta, e.g. "+1,024" / "-7".
+export function formatCountDelta(n: number): string {
+  return `${n > 0 ? '+' : ''}${n.toLocaleString()}`;
+}
+
+// A delta rendered as colored text (red up / green down). `text` defaults to
+// formatDelta(n); pass a custom string for rates, counts or "Δ … vs baseline".
+export function deltaText(n: number, text: string = formatDelta(n)): m.Child {
+  return m('span', {style: {color: deltaColor(n)}}, text);
+}
+
+// One score card holding 1–2 stat groups (label above, value, optional
+// sub-line). Used for the top billboard row and the per-section cards. Each
+// group is a Billboard.Section, so multiple groups lay out side by side.
+export function statCard(
+  stats: {label: string; value: m.Children; sub?: m.Children}[],
+): m.Child {
+  return m(
+    '.pf-memscope-billboard',
+    stats.map((s) => m(Billboard.Section, s)),
+  );
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
@@ -1,0 +1,423 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Gate} from '../../../../base/mithril_utils';
+import {QuerySlot} from '../../../../base/query_slot';
+import {Time, type time} from '../../../../base/time';
+import {ProportionBar} from '../../../../components/widgets/charts/proportion_bar';
+import type {Trace} from '../../../../public/trace';
+import {
+  LONG,
+  LONG_NULL,
+  NUM,
+  STR,
+} from '../../../../trace_processor/query_result';
+import {Icon} from '../../../../widgets/icon';
+import {BitmapsSection} from './summary/bitmaps_section';
+import {CompositionTimeline} from './summary/composition_timeline';
+import {JavaSection} from './summary/java_section';
+import {MemoryMap} from './summary/memory_map';
+import {NativeSection} from './summary/native_section';
+import {SmapsDetail} from './smaps_detail';
+import {deltaColor, formatDelta} from './mem_format';
+import {type MemSelection, nearestByTs} from './selection';
+import {SMAPS_CATEGORIES, SMAPS_CATEGORY_CASE_SQL} from './smaps_categories';
+import {TraceOverview} from './summary/trace_overview';
+import './landing_page.scss';
+import {SubPage} from '../../components/page';
+import {Inset} from '../../components/inset';
+import {Panel} from '../../components/panel';
+
+// Sample count and observed time span of one capture source (smaps / heapprofd)
+// for a process. spanS is undefined when there are fewer than two samples.
+interface SourceFacts {
+  readonly samples: number;
+  readonly spanS?: number;
+}
+
+// The terse facts the header capture strip shows for the selected process: its
+// name and a per-source summary. Each source is loaded with a cheap aggregate
+// query rather than pulling every row.
+interface CaptureInfo {
+  readonly processName: string;
+  readonly smaps: SourceFacts;
+  readonly dumps: number;
+  readonly native: SourceFacts;
+}
+
+// Runs a `(n, min_ts, max_ts)` aggregate and turns it into a SourceFacts: the
+// distinct-sample count and, when there's more than one, the wall-clock span
+// between the first and last sample.
+async function loadSourceFacts(
+  trace: Trace,
+  sql: string,
+): Promise<SourceFacts> {
+  const res = await trace.engine.query(sql);
+  const it = res.iter({n: NUM, min_ts: LONG_NULL, max_ts: LONG_NULL});
+  if (!it.valid() || it.n === 0) return {samples: 0};
+  const spanS =
+    it.n > 1 && it.min_ts !== null && it.max_ts !== null
+      ? Number(it.max_ts - it.min_ts) / 1e9
+      : undefined;
+  return {samples: it.n, spanS};
+}
+
+async function loadCaptureInfo(
+  trace: Trace,
+  upid: number,
+): Promise<CaptureInfo> {
+  const nameRes = await trace.engine.query(`
+    SELECT coalesce(name, '<unknown>') AS pname FROM process WHERE upid = ${upid}
+  `);
+  const nameIt = nameRes.iter({pname: STR});
+  const processName = nameIt.valid() ? nameIt.pname : '<unknown>';
+
+  const smaps = await loadSourceFacts(
+    trace,
+    `SELECT COUNT(DISTINCT ts) AS n, MIN(ts) AS min_ts, MAX(ts) AS max_ts
+     FROM profiler_smaps WHERE upid = ${upid}`,
+  );
+
+  const dumpRes = await trace.engine.query(`
+    SELECT COUNT(*) AS n FROM heap_profile_events
+    WHERE upid = ${upid} AND type = 'java_heap_graph'
+  `);
+  const dumpIt = dumpRes.iter({n: NUM});
+  const dumps = dumpIt.valid() ? dumpIt.n : 0;
+
+  const native = await loadSourceFacts(
+    trace,
+    `SELECT COUNT(DISTINCT ts) AS n, MIN(ts) AS min_ts, MAX(ts) AS max_ts
+     FROM heap_profile_allocation WHERE upid = ${upid}`,
+  );
+
+  return {processName, smaps, dumps, native};
+}
+
+// One smaps snapshot's resident+swap memory for one process, split by the full
+// smaps category taxonomy (SMAPS_CATEGORIES). Powers the "where the growth went"
+// bar, which spans the whole trace and is independent of the page's snapshot
+// selection. Uses the same rss+swap metric and category split as the
+// composition-over-time chart so the two read consistently.
+interface GrowthSnapshot {
+  ts: time;
+  total: number;
+  byCategory: ReadonlyMap<string, number>; // category key → rss+swap bytes
+}
+
+// Loads the per-snapshot rss+swap breakdown for one process across the whole
+// trace, for the growth bar. Uses the same path → category classification
+// (SMAPS_CATEGORY_CASE_SQL) as the composition chart.
+async function loadGrowthData(
+  trace: Trace,
+  upid: number,
+): Promise<GrowthSnapshot[]> {
+  const byTs = new Map<
+    bigint,
+    {ts: time; total: number; byCategory: Map<string, number>}
+  >();
+  const res = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      ${SMAPS_CATEGORY_CASE_SQL} AS category,
+      CAST(ifnull(SUM(s.rss_kb + s.swap_kb), 0) * 1024 AS INT) AS bytes
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+    GROUP BY s.ts, category
+    ORDER BY s.ts ASC
+  `);
+  for (
+    const it = res.iter({ts: LONG, category: STR, bytes: NUM});
+    it.valid();
+    it.next()
+  ) {
+    let snap = byTs.get(it.ts);
+    if (snap === undefined) {
+      snap = {ts: Time.fromRaw(it.ts), total: 0, byCategory: new Map()};
+      byTs.set(it.ts, snap);
+    }
+    snap.total += it.bytes;
+    snap.byCategory.set(
+      it.category,
+      (snap.byCategory.get(it.category) ?? 0) + it.bytes,
+    );
+  }
+  return Array.from(byTs.values());
+}
+
+export interface ProcessMemDetailsAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+}
+
+export class ProcessMemDetails
+  implements m.ClassComponent<ProcessMemDetailsAttrs>
+{
+  // Capture strip facts: process name + per-source sample counts. Its own slot
+  // so the (heavier) section components can load independently.
+  private readonly captureSlot = new QuerySlot<CaptureInfo>();
+  // Growth card data: per-snapshot rss+swap breakdown over the whole trace.
+  // Independent of the snapshot selection, so it lives in its own slot.
+  private readonly growthSlot = new QuerySlot<GrowthSnapshot[]>();
+  // Page-wide snapshot selection (by ts), driven by the composition timeline
+  // and consumed by the snapshot-relative sections. Undefined → each section
+  // shows its latest snapshot/dump.
+  private selection?: MemSelection;
+  // Active top-level tab.
+  private activeTab: 'summary' | 'smaps' = 'summary';
+
+  onremove() {
+    this.captureSlot.dispose();
+    this.growthSlot.dispose();
+  }
+
+  view({attrs}: m.Vnode<ProcessMemDetailsAttrs>) {
+    const {trace, upid} = attrs;
+    let capture: CaptureInfo | undefined;
+    let error: string | undefined;
+    try {
+      capture = this.captureSlot.use({
+        key: {traceId: trace.traceInfo.uuid, upid},
+        queryFn: () => loadCaptureInfo(trace, upid),
+      }).data;
+    } catch (e) {
+      error = String(e);
+    }
+
+    // The section components load their own data, so they render immediately;
+    // the capture strip is laid out right away too and fills in its per-process
+    // facts when the capture query resolves. Both tab bodies stay mounted and
+    // are toggled with a Gate (display:none when hidden) rather than
+    // conditionally rendered, so switching tabs doesn't remount the section
+    // components and re-run their data loads.
+    return [
+      error && m('p.pf-error', `Error: ${error}`),
+      !error && this.renderCaptureStrip(trace, capture),
+      !error && this.renderTabs(),
+      !error &&
+        m(
+          Gate,
+          {open: this.activeTab === 'summary'},
+          this.renderSections(trace, upid),
+        ),
+      !error &&
+        m(
+          Gate,
+          {open: this.activeTab === 'smaps'},
+          m(SubPage, m(SmapsDetail, {trace, upid})),
+        ),
+    ];
+  }
+
+  // Header capture strip: trace identity plus one colored dot + terse facts
+  // per source (smaps / java_hprof / heapprofd), for the selected process. The
+  // trace title/duration are known immediately; `info` is undefined while its
+  // query is in flight, in which case the per-process facts render as "…" so
+  // the strip is laid out from first paint rather than popping in.
+  private renderCaptureStrip(trace: Trace, info?: CaptureInfo): m.Children {
+    const durationS = Number(trace.traceInfo.end - trace.traceInfo.start) / 1e9;
+    const loading = info === undefined;
+
+    const sourceFacts = (f: SourceFacts): string | undefined =>
+      f.samples > 0
+        ? `${f.samples} samples` +
+          (f.spanS !== undefined ? ` over ${f.spanS.toFixed(1)}s` : '')
+        : undefined;
+
+    const sources: {key: string; label: string; facts?: string}[] = [
+      {key: 'smaps', label: 'smaps', facts: info && sourceFacts(info.smaps)},
+      {
+        key: 'dump',
+        label: 'java_hprof',
+        facts: info && (info.dumps > 0 ? `${info.dumps} dumps` : undefined),
+      },
+      {
+        key: 'native',
+        label: 'heapprofd',
+        facts: info && sourceFacts(info.native),
+      },
+    ];
+
+    return m(Panel, {className: 'pf-memscope-capture'}, [
+      m('.pf-memscope-capture__identity', [
+        m('span.pf-memscope-capture__process', info?.processName ?? '…'),
+        m('span', `${trace.traceInfo.traceTitle} · ${durationS.toFixed(1)}s`),
+      ]),
+      m(
+        '.pf-memscope-capture__sources',
+        sources.map((s) =>
+          m(
+            'span.pf-memscope-capture__source',
+            {
+              // Only dim a source once we know it has no data; while loading
+              // we don't yet know, so leave it at full strength.
+              className:
+                !loading && s.facts === undefined
+                  ? 'pf-memscope-capture__source--empty'
+                  : undefined,
+            },
+            [
+              m(
+                `span.pf-memscope-capture__dot.pf-memscope-capture__dot--${s.key}`,
+              ),
+              m('span.pf-memscope-capture__label', s.label),
+              m(
+                'span.pf-memscope-capture__facts',
+                loading ? '…' : s.facts ?? 'none',
+              ),
+            ],
+          ),
+        ),
+      ),
+    ]);
+  }
+
+  private renderTabs(): m.Children {
+    const tabs: {key: 'summary' | 'smaps'; label: string; icon: string}[] = [
+      {key: 'summary', label: 'Summary', icon: 'description'},
+      {key: 'smaps', label: 'Smaps Detail', icon: 'table_rows'},
+    ];
+    return m(
+      '.pf-memscope-tabs',
+      tabs.map((t) =>
+        m(
+          'button.pf-memscope-tab',
+          {
+            className:
+              this.activeTab === t.key ? 'pf-memscope-tab--active' : undefined,
+            onclick: () => (this.activeTab = t.key),
+          },
+          [m(Icon, {icon: t.icon}), t.label],
+        ),
+      ),
+    );
+  }
+
+  // The "where the growth went" bar: how rss+swap memory (from smaps) split
+  // across the smaps category taxonomy between two snapshots. Rendered inside
+  // the composition-over-time section, below the chart (same smaps source). It
+  // mirrors the page selection the same way the chart does: the endpoints are
+  // baseline → selected, falling back to first → selected, and finally to the
+  // whole trace (first → last) when nothing is selected. Undefined while loading
+  // or when there aren't two snapshots to diff (the composition panel covers the
+  // empty case).
+  private renderGrowthBar(
+    trace: Trace,
+    upid: number,
+    selTs?: time,
+    baseTs?: time,
+  ): m.Children {
+    const result = this.growthSlot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadGrowthData(trace, upid),
+    });
+    const snaps = result.data;
+    if (snaps === undefined || snaps.length < 2) return undefined;
+    const firstSnap = snaps[0];
+    const lastSnap = snaps[snaps.length - 1];
+    // Selected endpoint (nearest snapshot), or the latest when unselected.
+    const sel = selTs !== undefined ? nearestByTs(snaps, selTs)! : lastSnap;
+    // Baseline endpoint: an explicit baseline (when diffing), otherwise the
+    // first snapshot so a single selection reads as "growth up to here".
+    const resolvedBase =
+      baseTs !== undefined ? nearestByTs(snaps, baseTs) : undefined;
+    const base =
+      resolvedBase !== undefined && resolvedBase.ts !== sel.ts
+        ? resolvedBase
+        : firstSnap;
+    const diffing = resolvedBase !== undefined && resolvedBase.ts !== sel.ts;
+    const wholeTrace = base.ts === firstSnap.ts && sel.ts === lastSnap.ts;
+    const first = base;
+    const last = sel;
+    const total = last.total - first.total;
+    const categories = SMAPS_CATEGORIES.map((c) => ({
+      name: c.label,
+      color: c.color,
+      delta:
+        (last.byCategory.get(c.key) ?? 0) - (first.byCategory.get(c.key) ?? 0),
+    }));
+    const shrinking = total < 0;
+    // Growth rate, normalised to bytes/hour over the observed snapshot span.
+    const spanSeconds = Number(last.ts - first.ts) / 1e9;
+    const ratePerHour =
+      spanSeconds > 0 ? (total / spanSeconds) * 3600 : undefined;
+
+    return m(Inset, {className: 'pf-memscope-growth'}, [
+      m(
+        '.pf-memscope-growth__label',
+        shrinking ? 'Where the shrinkage went' : 'Where the growth went',
+      ),
+      m('.pf-memscope-growth__headline', [
+        m(
+          'span.pf-memscope-growth__delta',
+          {style: {color: deltaColor(total)}},
+          formatDelta(total),
+        ),
+        m(
+          'span.pf-memscope-growth__context',
+          `${shrinking ? 'removed' : 'added'} ` +
+            (diffing
+              ? 'vs baseline'
+              : wholeTrace
+                ? 'over the trace'
+                : 'up to selection'),
+        ),
+        ratePerHour !== undefined &&
+          m(
+            'span.pf-memscope-growth__context',
+            `· ${formatDelta(ratePerHour)}/hour`,
+          ),
+      ]),
+      m(ProportionBar, {
+        segments: categories.map((c) => ({
+          label: c.name,
+          // Only regions moving in the dominant direction size the bar; the
+          // rest get zero width but still appear in the legend.
+          weight: (shrinking ? c.delta < 0 : c.delta > 0)
+            ? Math.abs(c.delta)
+            : 0,
+          color: c.color,
+          value: formatDelta(c.delta),
+          valueColor: deltaColor(c.delta),
+        })),
+      }),
+    ]);
+  }
+
+  private renderSections(trace: Trace, upid: number): m.Children {
+    // All section panels share one wrapper so their entrance animation can
+    // cascade in document order (nth-child resets per parent).
+    const selection = this.selection;
+    const selTs = selection?.sel;
+    const baseTs = selection?.base;
+    return [
+      m(
+        SubPage,
+        m(TraceOverview, {trace, upid}),
+        m(CompositionTimeline, {
+          trace,
+          upid,
+          selection,
+          belowChart: this.renderGrowthBar(trace, upid, selTs, baseTs),
+          onSelect: (s: MemSelection) => (this.selection = s),
+        }),
+        m(MemoryMap, {trace, upid, selTs, baseTs}),
+        m(JavaSection, {trace, upid, selTs, baseTs}),
+        m(BitmapsSection, {trace, upid, selTs, baseTs}),
+        m(NativeSection, {trace, upid, selTs, baseTs}),
+      ),
+    ];
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/process_links.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/process_links.ts
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// "Show in timeline" deep-linking, shared by the Memscope overview panels.
+
+import m from 'mithril';
+import {Icons} from '../../../../base/semantic_icons';
+import type {Trace} from '../../../../public/trace';
+import {Anchor} from '../../../../widgets/anchor';
+
+// Finds the workspace track for `upid` whose kinds satisfy `kindMatch` (e.g.
+// the smaps, java-heap-graph or heapprofd track), or undefined if absent.
+export function findProcessTrack(
+  trace: Trace,
+  upid: number | undefined,
+  kindMatch: (kind: string) => boolean,
+) {
+  if (upid === undefined) return undefined;
+  return trace.defaultWorkspace.flatTracks.find((t) => {
+    if (t.uri === undefined) return false;
+    const track = trace.tracks.getTrack(t.uri);
+    if (track?.tags?.upid !== upid) return false;
+    return (track?.tags?.kinds ?? []).some(kindMatch);
+  });
+}
+
+// "Show in timeline" deep-link: selects `trackNode` and switches to the
+// timeline. Disabled (greyed out) when there's no matching track.
+export function showInTimelineLink(
+  trace: Trace,
+  uri: string | undefined,
+  eventId: number,
+): m.Child {
+  return m(
+    Anchor,
+    {
+      disabled: uri === undefined,
+      icon: Icons.UpdateSelection,
+      onclick: () => {
+        if (uri === undefined) return;
+        trace.selection.selectTrackEvent(uri, eventId, {
+          clearSearch: true,
+          scrollToSelection: true,
+        });
+        trace.navigate('#!/viewer');
+      },
+    },
+    'Show in timeline',
+  );
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
@@ -1,0 +1,261 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Presentational widgets shared by the Memscope per-section panels (Java,
+// bitmaps, native): the compact top-N table, class-name cells, the share bar,
+// the delta cell and the single-ratio bar.
+
+import m from 'mithril';
+import {ProportionBar} from '../../../../components/widgets/charts/proportion_bar';
+import {Panel} from '../../components/panel';
+import {Table} from '../../components/table';
+import {Inset} from '../../components/inset';
+import {deltaColor, formatBytes, formatDelta} from './mem_format';
+import {EmptyState} from '../../../../widgets/empty_state';
+import {Stack} from '../../../../widgets/stack';
+
+// A section panel shown when the trace has no data for it: keeps the panel's
+// title/subtitle (so the page reads consistently) and states what's missing
+// in the body, rather than rendering nothing.
+export function emptyPanel(opts: {
+  title: string;
+  subtitle?: string;
+  message: string;
+  detail?: m.Children;
+}): m.Child {
+  return m(
+    Panel,
+    m(Panel.Header, {title: opts.title, subtitle: opts.subtitle}),
+    m(
+      Panel.Body,
+      m(
+        Stack,
+        {spacing: 'large'},
+        m(
+          '.pf-memscope-landing__empty',
+          m(EmptyState, {title: opts.message}, opts.detail),
+        ),
+      ),
+    ),
+  );
+}
+
+// A section panel shown while its data is loading: the panel (title/subtitle)
+// is laid out immediately with a loading placeholder in the body, so the page
+// doesn't jump as sections resolve.
+export function loadingPanel(opts: {
+  title: string;
+  subtitle?: string;
+}): m.Child {
+  return m(
+    Panel,
+    m(Panel.Header, {title: opts.title, subtitle: opts.subtitle}),
+    m(
+      Panel.Body,
+      m(
+        Stack,
+        {spacing: 'large'},
+        m(
+          '.pf-memscope-placeholder',
+          m(EmptyState, {icon: 'hourglass', title: 'Loading...'}),
+        ),
+      ),
+    ),
+  );
+}
+
+// Trims a fully-qualified class name to its last segment(s) for legends, e.g.
+// 'java.util.HashMap$Node' -> 'HashMap$Node'. Arrays and 'Other' pass through.
+export function shortClassName(name: string): string {
+  if (name === 'Other') return name;
+  const arrayDepth = (name.match(/\[\]/g) ?? []).length;
+  const base = name.replace(/\[\]/g, '');
+  const last = base.slice(base.lastIndexOf('.') + 1);
+  return last + '[]'.repeat(arrayDepth);
+}
+
+// Compact titled table used by the Java / bitmaps / native sections.
+export function topTable(opts: {
+  title: string;
+  subtitle?: string;
+  cols: {label: string; num?: boolean}[];
+  rows: m.Children[][];
+}): m.Child {
+  return m('.pf-memscope-toptable', [
+    m('.pf-memscope-toptable__title', [
+      opts.title,
+      opts.subtitle !== undefined &&
+        m('span.pf-memscope-toptable__subtitle', ` · ${opts.subtitle}`),
+    ]),
+    m(
+      Table,
+      {className: 'pf-memscope-table--flush'},
+      m(
+        'thead',
+        m(
+          'tr',
+          opts.cols.map((c) =>
+            m(c.num ? 'th.pf-memscope-table__num' : 'th', c.label),
+          ),
+        ),
+      ),
+      m(
+        'tbody',
+        opts.rows.map((cells) =>
+          m(
+            'tr',
+            cells.map((cell, i) =>
+              m(opts.cols[i].num ? 'td.pf-memscope-table__num' : 'td', cell),
+            ),
+          ),
+        ),
+      ),
+    ),
+  ]);
+}
+
+// Link to the Heap Dump Explorer's object list, filtered to one class. The HDE
+// page (com.android.HeapDumpExplorer) parses `cls` out of the query string, so
+// the value is URI-encoded the same way the explorer's own links are.
+export function heapDumpClassHref(cls: string): string {
+  return `#!/heapdump/objects?cls=${encodeURIComponent(cls)}`;
+}
+
+// A class-name cell. The class name links to that class's instances in the Heap
+// Dump Explorer. When `retainers` are given, each one adds a `↳ via <owner>`
+// line naming an app-side class that dominates this (library) class's instances
+// up the dominator chain, with the bytes attributed to that owner; the owner
+// name links to the explorer too. A class held through several owners shows
+// several lines, so a single misleading "via" can't imply all the retained
+// bytes flow through one owner.
+export function classNameCell(
+  full: string,
+  retainers?: ReadonlyArray<{name: string; bytes: number}>,
+): m.Child {
+  const vias = (retainers ?? []).filter((r) => r.name !== full);
+  // With one owner the byte count just echoes the row's retained size, so omit
+  // it; with several, the split is the whole point, so show each owner's bytes.
+  const showBytes = vias.length > 1;
+  return m('.pf-memscope-classcell', [
+    m(
+      'a.pf-memscope-classname',
+      {href: heapDumpClassHref(full), title: full},
+      shortClassName(full),
+    ),
+    ...vias.map((r) =>
+      m(
+        'span.pf-memscope-classcell__via',
+        {title: `Retained via ${r.name}: ${formatBytes(r.bytes)}`},
+        [
+          '↳ via ',
+          m(
+            'a.pf-memscope-classcell__vialink',
+            {href: heapDumpClassHref(r.name)},
+            shortClassName(r.name),
+          ),
+          showBytes ? ` · ${formatBytes(r.bytes)}` : '',
+        ],
+      ),
+    ),
+  ]);
+}
+
+// Two-line table cell: value on top, signed Δ vs baseline below (colored
+// red up / green down, "new" when the row has no baseline). When not
+// comparing, just the value.
+export function deltaCell(
+  text: m.Children,
+  delta: number | undefined,
+  comparing: boolean,
+  fmt: (n: number) => string = formatDelta,
+): m.Children {
+  if (!comparing) return text;
+  return [
+    m('div', text),
+    m(
+      'div.pf-memscope-table__delta',
+      {style: {color: delta === undefined ? undefined : deltaColor(delta)}},
+      delta === undefined ? 'new' : fmt(delta),
+    ),
+  ];
+}
+
+// Tiny horizontal progress bar used for the "share %" table columns.
+export function shareBar(frac: number): m.Child {
+  const pct = Math.max(0, Math.min(100, frac * 100));
+  return m('.pf-memscope-sharebar', [
+    m(
+      '.pf-memscope-sharebar__track',
+      m('.pf-memscope-sharebar__fill', {style: {width: `${pct}%`}}),
+    ),
+    m('span.pf-memscope-sharebar__pct', `${Math.round(pct)}%`),
+  ]);
+}
+
+// Single-ratio bar (heap reachability, profiler coverage): an uppercase
+// label, a big percentage headline, a two-tone bar and a two-entry legend.
+export function ratioBar(opts: {
+  label: string;
+  tooltip: string;
+  pct: number;
+  headline: string;
+  color: string;
+  aLabel: string;
+  aBytes: number;
+  bLabel: string;
+  bBytes: number;
+  // When comparing, the change in each leg vs the baseline dump. Rendered as
+  // a muted "(±X)" beside the absolute value, and a "Δ … pts" on the headline.
+  aDelta?: number;
+  bDelta?: number;
+  pctDelta?: number;
+}): m.Child {
+  const pct = Math.max(0, Math.min(100, opts.pct));
+  const legDelta = (d?: number) =>
+    d !== undefined &&
+    m(
+      'span.pf-memscope-ratio__legend-change',
+      {style: {color: deltaColor(d)}},
+      ` (${formatDelta(d)})`,
+    );
+  return m(Inset, {className: 'pf-memscope-ratio'}, [
+    m('.pf-memscope-ratio__label', {title: opts.tooltip}, opts.label),
+    m('.pf-memscope-ratio__headline', [
+      m('span.pf-memscope-ratio__pct', `${Math.round(pct)}%`),
+      m('span.pf-memscope-ratio__text', opts.headline),
+      opts.pctDelta !== undefined &&
+        m(
+          'span.pf-memscope-ratio__pct-delta',
+          {style: {color: deltaColor(opts.pctDelta)}},
+          `Δ ${opts.pctDelta >= 0 ? '+' : ''}${Math.round(opts.pctDelta)} pts vs baseline`,
+        ),
+    ]),
+    m(ProportionBar, {
+      segments: [
+        {
+          label: opts.aLabel,
+          weight: pct,
+          color: opts.color,
+          value: [formatBytes(opts.aBytes), legDelta(opts.aDelta)],
+        },
+        {
+          label: opts.bLabel,
+          weight: 100 - pct,
+          color: '#c3c7cc',
+          value: [formatBytes(opts.bBytes), legDelta(opts.bDelta)],
+        },
+      ],
+    }),
+  ]);
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/selection.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/selection.ts
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The page-wide snapshot selection, shared between the composition timeline
+// (which drives it) and the sections below (which render relative to it).
+// Identified by absolute timestamp so each section — which loads its own
+// snapshots/dumps — can correlate by nearest ts.
+
+import type {time} from '../../../../base/time';
+
+export interface MemSelection {
+  // The inspected snapshot's timestamp.
+  readonly sel: time;
+  // When a range was brushed, the earlier baseline snapshot to diff against.
+  readonly base?: time;
+}
+
+// The row of a ts-ascending series nearest to `ts`. Falls back to the last row
+// when `ts` is undefined (no selection yet → sections show their latest data).
+export function nearestByTs<T extends {ts: time}>(
+  rows: readonly T[],
+  ts?: time,
+): T | undefined {
+  if (rows.length === 0) return undefined;
+  if (ts === undefined) return rows[rows.length - 1];
+  let best = rows[0];
+  let bestDist = ts > best.ts ? ts - best.ts : best.ts - ts;
+  for (const r of rows) {
+    const dist = ts > r.ts ? ts - r.ts : r.ts - ts;
+    if (dist < bestDist) {
+      best = r;
+      bestDist = dist;
+    }
+  }
+  return best;
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/smaps_categories.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/smaps_categories.ts
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shared smaps category taxonomy: the SQL path → category classifier and the
+// display metadata (labels / colors) for each category. Used by the
+// composition-over-time chart and the memory map.
+
+// Path → category classification. Keys match SMAPS_CATEGORIES. Expects the
+// profiler_smaps row to be aliased `s` in the query.
+export const SMAPS_CATEGORY_CASE_SQL = `
+  CASE
+    WHEN s.path GLOB '*dalvik*' OR s.path GLOB '/dev/ashmem/dalvik*'
+      THEN 'java'
+    WHEN s.path GLOB '[anon:scudo*' OR s.path GLOB '[anon:libc_malloc*'
+      OR s.path GLOB '[anon:jemalloc*' OR s.path GLOB '[anon:GWP-ASan*'
+      OR s.path = '[heap]'
+      THEN 'native'
+    WHEN s.path = '[stack]' OR s.path GLOB '[anon:stack*'
+      THEN 'stack'
+    WHEN s.path GLOB '/dev/kgsl*' OR s.path GLOB '/dev/mali*'
+      OR s.path GLOB '/dev/dri*' OR s.path GLOB '*dmabuf*'
+      THEN 'graphics'
+    WHEN s.path GLOB '/*'
+      THEN 'file'
+    ELSE 'other'
+  END
+`;
+
+// File-backed mapping → bucket classification, for breaking the File-backed
+// block down by path. Keys match FILE_BUCKETS. Expects the profiler_smaps row
+// to be aliased `s`.
+export const SMAPS_FILE_BUCKET_CASE_SQL = `
+  CASE
+    WHEN s.path GLOB '*.so' OR s.path GLOB '*.so.*' THEN 'so'
+    WHEN s.path GLOB '*.jar' OR s.path GLOB '*.oat'
+      OR s.path GLOB '*.odex' OR s.path GLOB '*.vdex'
+      OR s.path GLOB '*.art' OR s.path GLOB '*.dex' THEN 'java_code'
+    WHEN s.path GLOB '*.apk' OR s.path GLOB '*.ttf'
+      OR s.path GLOB '*.otf' OR s.path GLOB '*.dat' THEN 'resources'
+    ELSE 'other_file'
+  END
+`;
+
+// Display metadata for the smaps categories, in stack/legend order. The keys
+// match the `category` values produced by SMAPS_CATEGORY_CASE_SQL.
+export const SMAPS_CATEGORIES = [
+  {key: 'native', label: 'Native', color: '#4285f4'},
+  {key: 'java', label: 'Java', color: '#f4b400'},
+  {key: 'file', label: 'File-backed', color: '#34a853'},
+  {key: 'graphics', label: 'Graphics', color: '#a142f4'},
+  {key: 'stack', label: 'Thread stacks', color: '#26c6da'},
+  {key: 'other', label: 'Other', color: '#9aa0a6'},
+];
+
+export const MEMMAP_GREY = '#9aa0a6';
+
+// Color for a smaps category key, falling back to grey for unknown keys.
+export function smapsCategoryColor(key: string): string {
+  return SMAPS_CATEGORIES.find((c) => c.key === key)?.color ?? MEMMAP_GREY;
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/smaps_detail.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/smaps_detail.ts
@@ -1,0 +1,539 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// "Smaps detail" tab: every mapping of the selected snapshot (a dropdown picks
+// which; defaults to the latest), folded into the two-level taxonomy (or flat),
+// with regex filtering, optional extra columns and collapsible groups.
+// Self-contained: owns its query slots and loading.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../base/query_slot';
+import type {Trace} from '../../../../public/trace';
+import {LONG, NUM, STR} from '../../../../trace_processor/query_result';
+import {Button} from '../../../../widgets/button';
+import {Icon} from '../../../../widgets/icon';
+import {RadioGroup} from '../../../../widgets/radio_group';
+import {Select} from '../../../../widgets/select';
+import {TextInput} from '../../../../widgets/text_input';
+import {Panel} from '../../components/panel';
+import {formatBytes, statCard} from './mem_format';
+import {emptyPanel, loadingPanel} from './section_widgets';
+import {MEMMAP_GREY} from './smaps_categories';
+import {BillboardStrip} from '../../components/billboard';
+import {Table} from '../../components/table';
+import {Stack} from '../../../../widgets/stack';
+
+const TITLE = 'Every mapping, grouped';
+const SUBTITLE =
+  'The raw /proc/<pid>/smaps dump, folded into the same taxonomy as the ' +
+  'composition above. Filter by regex, or flatten to see individual mappings.';
+
+// One smaps path (VMA group) at the latest snapshot, with the full residency
+// split.
+interface SmapsPathRow {
+  path: string;
+  rss: number;
+  pss: number;
+  anon: number;
+  swap: number;
+  privateDirty: number;
+  privateClean: number;
+  sharedDirty: number;
+  sharedClean: number;
+}
+
+// Two-level taxonomy for the tree view: top-level groups and their
+// subcategories, in display order. classifyMapping() assigns each path.
+const SMAPS_TREE: {
+  key: string;
+  label: string;
+  color: string;
+  subs: {key: string; label: string; color: string}[];
+}[] = [
+  {
+    key: 'anon',
+    label: 'Anonymous',
+    color: '#4285f4',
+    subs: [
+      {key: 'native_heap', label: 'Native heap', color: '#4285f4'},
+      {key: 'java_heap', label: 'Java heap', color: '#f4b400'},
+      {key: 'java_other', label: 'Java other / ART', color: '#f4b400'},
+      {key: 'stacks', label: 'Thread stacks', color: '#26c6da'},
+      {key: 'other_anon', label: 'Other anon', color: MEMMAP_GREY},
+    ],
+  },
+  {
+    key: 'file',
+    label: 'File-backed',
+    color: '#34a853',
+    subs: [
+      {key: 'java_code', label: 'Java (.jar/.oat/.art)', color: '#34a853'},
+      {key: 'so_libs', label: 'Native libs (.so)', color: '#34a853'},
+      {key: 'resources', label: 'Resources / APK', color: '#34a853'},
+      {key: 'other_file', label: 'Other file-backed', color: '#34a853'},
+    ],
+  },
+  {
+    key: 'gfx',
+    label: 'Graphics / shared',
+    color: '#a142f4',
+    subs: [
+      {key: 'ashmem', label: 'ashmem / dmabuf', color: '#a142f4'},
+      {key: 'gpu', label: 'GPU / driver', color: '#a142f4'},
+    ],
+  },
+];
+
+// Classifies one smaps path into a (group, sub) of SMAPS_TREE. Order matters:
+// graphics devices before the generic file-backed '/' check, and the dalvik
+// heap spaces before the generic dalvik bucket.
+function classifyMapping(path: string): {group: string; sub: string} {
+  if (/dmabuf|^\/dev\/ashmem/.test(path)) {
+    return {group: 'gfx', sub: 'ashmem'};
+  }
+  if (/^\/dev\/(kgsl|mali|dri)/.test(path)) {
+    return {group: 'gfx', sub: 'gpu'};
+  }
+  if (path.startsWith('/')) {
+    if (/\.so$/.test(path)) return {group: 'file', sub: 'so_libs'};
+    if (/\.(jar|dex|oat|odex|vdex|art)$/.test(path)) {
+      return {group: 'file', sub: 'java_code'};
+    }
+    if (/\.(apk|ttf|otf|dat)$/.test(path) || path.startsWith('/fonts/')) {
+      return {group: 'file', sub: 'resources'};
+    }
+    return {group: 'file', sub: 'other_file'};
+  }
+  if (
+    /^\[anon:dalvik-(main|large object|zygote|non moving|free list)/.test(path)
+  ) {
+    return {group: 'anon', sub: 'java_heap'};
+  }
+  if (/dalvik|\.art\]$/.test(path)) return {group: 'anon', sub: 'java_other'};
+  if (/^\[stack\]|^\[anon:stack/.test(path)) {
+    return {group: 'anon', sub: 'stacks'};
+  }
+  if (
+    /^\[anon:(scudo|libc_malloc|jemalloc|GWP-ASan|partition_alloc|\.bss)/.test(
+      path,
+    ) ||
+    path === '[heap]'
+  ) {
+    return {group: 'anon', sub: 'native_heap'};
+  }
+  return {group: 'anon', sub: 'other_anon'};
+}
+
+// One smaps snapshot for the picker: its ts and total resident bytes.
+interface SmapsSnapshotInfo {
+  ts: bigint;
+  rss: number;
+}
+
+// All smaps snapshots for one process (ts-ascending) with their total RSS, to
+// populate the snapshot dropdown.
+async function loadSmapsSnapshots(
+  trace: Trace,
+  upid: number,
+): Promise<SmapsSnapshotInfo[]> {
+  const out: SmapsSnapshotInfo[] = [];
+  const res = await trace.engine.query(`
+    SELECT s.ts AS ts, CAST(ifnull(SUM(s.rss_kb), 0) * 1024 AS INT) AS rss
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+    GROUP BY s.ts
+    ORDER BY s.ts ASC
+  `);
+  for (const it = res.iter({ts: LONG, rss: NUM}); it.valid(); it.next()) {
+    out.push({ts: it.ts, rss: it.rss});
+  }
+  return out;
+}
+
+// Per-path residency at the given smaps snapshot of one process. When `ts` is
+// undefined, falls back to the latest snapshot.
+async function loadSmapsPaths(
+  trace: Trace,
+  upid: number,
+  ts: bigint | undefined,
+): Promise<SmapsPathRow[]> {
+  const tsFilter =
+    ts !== undefined
+      ? `s.ts = ${ts}`
+      : `s.ts = (SELECT MAX(ts) FROM profiler_smaps WHERE upid = ${upid})`;
+  const rows: SmapsPathRow[] = [];
+  const res = await trace.engine.query(`
+    SELECT
+      s.path AS path,
+      CAST(ifnull(SUM(s.rss_kb), 0) * 1024 AS INT) AS rss,
+      CAST(ifnull(SUM(s.proportional_resident_kb), 0) * 1024 AS INT) AS pss,
+      CAST(ifnull(SUM(s.anonymous_kb), 0) * 1024 AS INT) AS anon,
+      CAST(ifnull(SUM(s.swap_kb), 0) * 1024 AS INT) AS swap,
+      CAST(ifnull(SUM(s.private_dirty_kb), 0) * 1024 AS INT) AS private_dirty,
+      CAST(ifnull(SUM(s.private_clean_resident_kb), 0) * 1024 AS INT)
+        AS private_clean,
+      CAST(ifnull(SUM(s.shared_dirty_resident_kb), 0) * 1024 AS INT)
+        AS shared_dirty,
+      CAST(ifnull(SUM(s.shared_clean_resident_kb), 0) * 1024 AS INT)
+        AS shared_clean
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid} AND ${tsFilter}
+    GROUP BY s.path
+    ORDER BY rss DESC
+  `);
+  for (
+    const it = res.iter({
+      path: STR,
+      rss: NUM,
+      pss: NUM,
+      anon: NUM,
+      swap: NUM,
+      private_dirty: NUM,
+      private_clean: NUM,
+      shared_dirty: NUM,
+      shared_clean: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    rows.push({
+      path: it.path,
+      rss: it.rss,
+      pss: it.pss,
+      anon: it.anon,
+      swap: it.swap,
+      privateDirty: it.private_dirty,
+      privateClean: it.private_clean,
+      sharedDirty: it.shared_dirty,
+      sharedClean: it.shared_clean,
+    });
+  }
+  return rows;
+}
+
+export interface SmapsDetailAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+}
+
+export class SmapsDetail implements m.ClassComponent<SmapsDetailAttrs> {
+  private readonly slot = new QuerySlot<SmapsPathRow[]>();
+  private readonly snapshotsSlot = new QuerySlot<SmapsSnapshotInfo[]>();
+  // View state.
+  private smapsFlat = false;
+  private smapsAllCols = false;
+  private smapsFilter = '';
+  // The selected snapshot ts, or undefined to follow the latest snapshot.
+  private selectedTs?: bigint;
+  // Collapsed group/subgroup keys in the tree.
+  private readonly collapsed = new Set<string>();
+
+  onremove() {
+    this.slot.dispose();
+    this.snapshotsSlot.dispose();
+  }
+
+  view({attrs}: m.Vnode<SmapsDetailAttrs>): m.Children {
+    const {trace, upid} = attrs;
+    const snapshots =
+      this.snapshotsSlot.use({
+        key: {traceId: trace.traceInfo.uuid, upid},
+        queryFn: () => loadSmapsSnapshots(trace, upid),
+      }).data ?? [];
+    const rows = this.slot.use({
+      key: {
+        traceId: trace.traceInfo.uuid,
+        upid,
+        ts: this.selectedTs?.toString() ?? 'latest',
+      },
+      queryFn: () => loadSmapsPaths(trace, upid, this.selectedTs),
+    }).data;
+    if (rows === undefined) {
+      return m(
+        '.pf-memscope-charts',
+        loadingPanel({title: TITLE, subtitle: SUBTITLE}),
+      ); // Still loading.
+    }
+    if (rows.length === 0) {
+      return emptyPanel({
+        title: TITLE,
+        subtitle: SUBTITLE,
+        message: 'No smaps data in this trace for this process.',
+      });
+    }
+
+    const sum = (list: SmapsPathRow[], get: (r: SmapsPathRow) => number) =>
+      list.reduce((s, r) => s + get(r), 0);
+
+    let filtered = rows;
+    if (this.smapsFilter !== '') {
+      try {
+        const re = new RegExp(this.smapsFilter);
+        filtered = rows.filter((r) => re.test(r.path));
+      } catch {
+        filtered = rows.filter((r) => r.path.includes(this.smapsFilter));
+      }
+    }
+
+    const cols: {label: string; get: (r: SmapsPathRow) => number}[] = this
+      .smapsAllCols
+      ? [
+          {label: 'RSS', get: (r) => r.rss},
+          {label: 'PSS', get: (r) => r.pss},
+          {label: 'Anon+swap', get: (r) => r.anon + r.swap},
+          {label: 'Priv. dirty', get: (r) => r.privateDirty},
+          {label: 'Priv. clean', get: (r) => r.privateClean},
+          {label: 'Shared dirty', get: (r) => r.sharedDirty},
+          {label: 'Shared clean', get: (r) => r.sharedClean},
+          {label: 'Swap', get: (r) => r.swap},
+        ]
+      : [
+          {label: 'RSS', get: (r) => r.rss},
+          {label: 'Priv. dirty', get: (r) => r.privateDirty},
+          {label: 'Swap', get: (r) => r.swap},
+        ];
+
+    const fmtCell = (n: number) => (n > 0 ? formatBytes(n) : '—');
+    const numCells = (r: SmapsPathRow) =>
+      cols.map((c) => m('td.pf-memscope-table__num', fmtCell(c.get(r))));
+    const sumCells = (list: SmapsPathRow[]) =>
+      cols.map((c) =>
+        m(
+          'td.pf-memscope-table__num.pf-memscope-table__size',
+          fmtCell(sum(list, c.get)),
+        ),
+      );
+
+    const toggle = (key: string) => {
+      if (this.collapsed.has(key)) {
+        this.collapsed.delete(key);
+      } else {
+        this.collapsed.add(key);
+      }
+    };
+    const chevron = (key: string) =>
+      m(Icon, {
+        className: 'pf-memscope-smaps__chevron',
+        icon: this.collapsed.has(key) ? 'chevron_right' : 'expand_more',
+      });
+    const swatch = (color: string) =>
+      m('span.pf-memscope-growth__swatch', {style: {background: color}});
+
+    const MAX_CHILD_ROWS = 30;
+    const pathRow = (r: SmapsPathRow, indent: string) =>
+      m('tr', [m(`td.pf-memscope-smaps__path.${indent}`, r.path), numCells(r)]);
+    const moreRow = (n: number, indent: string) =>
+      m(
+        'tr.pf-memscope-smaps__more',
+        m(
+          `td.${indent}`,
+          {colspan: cols.length + 1},
+          `… ${n} more mappings (filter to narrow down)`,
+        ),
+      );
+
+    let body: m.Child[];
+    if (this.smapsFlat) {
+      body = filtered
+        .slice(0, 200)
+        .map((r) => pathRow(r, 'pf-memscope-smaps__lvl0'));
+      if (filtered.length > 200) {
+        body.push(moreRow(filtered.length - 200, 'pf-memscope-smaps__lvl0'));
+      }
+    } else {
+      // Bucket each mapping into its (group, sub) of the taxonomy.
+      const buckets = new Map<string, SmapsPathRow[]>();
+      for (const r of filtered) {
+        const {group, sub} = classifyMapping(r.path);
+        const key = `${group}/${sub}`;
+        const list = buckets.get(key) ?? [];
+        list.push(r);
+        buckets.set(key, list);
+      }
+
+      body = [];
+      for (const g of SMAPS_TREE) {
+        const subLists = g.subs
+          .map((s) => ({
+            meta: s,
+            rows: buckets.get(`${g.key}/${s.key}`) ?? [],
+          }))
+          .filter((s) => s.rows.length > 0)
+          .sort(
+            (a, b) => sum(b.rows, (r) => r.rss) - sum(a.rows, (r) => r.rss),
+          );
+        if (subLists.length === 0) continue;
+        const groupRows = subLists.flatMap((s) => s.rows);
+
+        body.push(
+          m('tr.pf-memscope-smaps__group', {onclick: () => toggle(g.key)}, [
+            m('td', [chevron(g.key), swatch(g.color), ` ${g.label}`]),
+            sumCells(groupRows),
+          ]),
+        );
+        if (this.collapsed.has(g.key)) continue;
+
+        for (const s of subLists) {
+          const subKey = `${g.key}/${s.meta.key}`;
+          body.push(
+            m(
+              'tr.pf-memscope-smaps__subgroup',
+              {onclick: () => toggle(subKey)},
+              [
+                m('td.pf-memscope-smaps__lvl1', [
+                  chevron(subKey),
+                  swatch(s.meta.color),
+                  ` ${s.meta.label} `,
+                  m('span.pf-memscope-smaps__count', `· ${s.rows.length} maps`),
+                ]),
+                sumCells(s.rows),
+              ],
+            ),
+          );
+          if (this.collapsed.has(subKey)) continue;
+          const sorted = s.rows.slice().sort((a, b) => b.rss - a.rss);
+          for (const r of sorted.slice(0, MAX_CHILD_ROWS)) {
+            body.push(pathRow(r, 'pf-memscope-smaps__lvl2'));
+          }
+          if (sorted.length > MAX_CHILD_ROWS) {
+            body.push(
+              moreRow(
+                sorted.length - MAX_CHILD_ROWS,
+                'pf-memscope-smaps__lvl2',
+              ),
+            );
+          }
+        }
+      }
+    }
+
+    return m(
+      Panel,
+      m(Panel.Header, {title: TITLE, subtitle: SUBTITLE}),
+      m(
+        Panel.Body,
+        m(Stack, {spacing: 'large'}, [
+          m(BillboardStrip, [
+            statCard([
+              {
+                label: 'Total RSS',
+                value: formatBytes(sum(rows, (r) => r.rss)),
+                sub: `${rows.length} mappings`,
+              },
+            ]),
+            statCard([
+              {
+                label: 'RSS anon + swap',
+                value: formatBytes(sum(rows, (r) => r.anon + r.swap)),
+                sub: 'private anon + swapped',
+              },
+            ]),
+            statCard([
+              {
+                label: 'Total PSS',
+                value: formatBytes(sum(rows, (r) => r.pss)),
+                sub: 'proportional set size',
+              },
+            ]),
+            statCard([
+              {
+                label: 'Private dirty',
+                value: formatBytes(sum(rows, (r) => r.privateDirty)),
+                sub: 'unshareable cost',
+              },
+            ]),
+            statCard([
+              {
+                label: 'Swap',
+                value: formatBytes(sum(rows, (r) => r.swap)),
+                sub: 'zram / swapped out',
+              },
+            ]),
+          ]),
+          m('.pf-memscope-smaps__controls', [
+            snapshots.length > 1 &&
+              m(
+                Select,
+                {
+                  // Default to the latest snapshot when nothing is picked.
+                  value: (
+                    this.selectedTs ?? snapshots[snapshots.length - 1].ts
+                  ).toString(),
+                  onchange: (e: Event) => {
+                    const v = (e.target as HTMLSelectElement).value;
+                    this.selectedTs = BigInt(v);
+                  },
+                },
+                snapshots.map((s, i) => {
+                  const secs = Number(s.ts - trace.traceInfo.start) / 1e9;
+                  return m(
+                    'option',
+                    {value: s.ts.toString()},
+                    `#${i + 1} · t=${secs.toFixed(0)}s · ${formatBytes(s.rss)}`,
+                  );
+                }),
+              ),
+            m(
+              RadioGroup,
+              {
+                selectedValue: this.smapsFlat ? 'flat' : 'tree',
+                onValueChange: (value: string) =>
+                  (this.smapsFlat = value === 'flat'),
+              },
+              m(
+                RadioGroup.Button,
+                {value: 'tree', icon: 'account_tree'},
+                'Tree',
+              ),
+              m(
+                RadioGroup.Button,
+                {value: 'flat', icon: 'format_list_bulleted'},
+                'Flat',
+              ),
+            ),
+            m(TextInput, {
+              className: 'pf-memscope-smaps__filter',
+              leftIcon: 'search',
+              placeholder: 'Filter by regex, e.g. \\.so$ or dalvik|scudo',
+              value: this.smapsFilter,
+              onInput: (value: string) => (this.smapsFilter = value),
+            }),
+            m(Button, {
+              icon: 'view_column',
+              label: 'All columns',
+              active: this.smapsAllCols,
+              onclick: () => (this.smapsAllCols = !this.smapsAllCols),
+            }),
+            m(
+              'span.pf-memscope-smaps__counttext',
+              `${filtered.length} / ${rows.length} mappings`,
+            ),
+          ]),
+          m(
+            Table,
+            {className: 'pf-memscope-table--flush'},
+            m(
+              'thead',
+              m('tr', [
+                m('th', 'Region / path'),
+                cols.map((c) => m('th.pf-memscope-table__num', c.label)),
+              ]),
+            ),
+            m('tbody', body),
+          ),
+        ]),
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
@@ -1,0 +1,503 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// "What about bitmaps?" — reachable android.graphics.Bitmap instances grouped
+// by dimensions and storage backing, from the latest heap dump of one process.
+// Self-contained: owns its query slot and loading logic.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import type {Trace} from '../../../../../public/trace';
+import {
+  LONG,
+  NUM,
+  NUM_NULL,
+  STR,
+  STR_NULL,
+} from '../../../../../trace_processor/query_result';
+import {Panel} from '../../../components/panel';
+import {Callout} from '../../../components/callout';
+import {Intent} from '../../../../../widgets/common';
+import {
+  deltaText,
+  formatBytes,
+  formatCountDelta,
+  formatDelta,
+  statCard,
+} from '../mem_format';
+import {nearestByTs} from '../selection';
+import {
+  deltaCell,
+  emptyPanel,
+  loadingPanel,
+  shareBar,
+  shortClassName,
+  topTable,
+} from '../section_widgets';
+import {Stack} from '../../../../../widgets/stack';
+import {BillboardStrip} from '../../../components/billboard';
+
+const TITLE = 'What about bitmaps?';
+const SUBTITLE =
+  'Usually the largest and most reducible cost on Android — pulled out on ' +
+  'their own.';
+
+// One reachable-bitmap group at the latest dump: (dimensions, storage backing)
+// with its count and sizes. width/height are undefined on proto-format heap
+// graphs (only ART HPROF dumps record field values).
+interface BitmapGroup {
+  width?: number;
+  height?: number;
+  storage?: string;
+  count: number;
+  selfSize: number;
+  nativeSize: number;
+}
+
+interface BitmapsData {
+  // All dumps with reachable bitmaps, ts-ascending (empty → none).
+  readonly dumps: {ts: time}[];
+  // Bitmap groups per dump, keyed by dump ts (raw bigint).
+  readonly groupsByTs: ReadonlyMap<bigint, BitmapGroup[]>;
+  // Reachable Java heap + registered native per dump (for the "share of Java
+  // retained" card), keyed by dump ts.
+  readonly javaRetainedByTs: ReadonlyMap<bigint, number>;
+  // Nearest non-library class retaining the bitmaps (last dump), if resolvable.
+  readonly bitmapRetainer?: string;
+}
+
+async function loadBitmapsData(
+  trace: Trace,
+  upid: number,
+): Promise<BitmapsData> {
+  await trace.engine.query(
+    'INCLUDE PERFETTO MODULE android.memory.heap_graph.bitmap;',
+  );
+  const groupsByTs = new Map<bigint, BitmapGroup[]>();
+  const res = await trace.engine.query(`
+    SELECT
+      b.graph_sample_ts AS ts,
+      b.width AS width,
+      b.height AS height,
+      b.bitmap_storage_type AS storage,
+      COUNT(*) AS cnt,
+      CAST(ifnull(SUM(b.self_size), 0) AS INT) AS self_size,
+      CAST(ifnull(SUM(b.native_size), 0) AS INT) AS native_size
+    FROM heap_graph_bitmaps b
+    WHERE b.upid = ${upid} AND b.reachable
+    GROUP BY b.graph_sample_ts, b.width, b.height, b.bitmap_storage_type
+    ORDER BY b.graph_sample_ts ASC
+  `);
+  for (
+    const it = res.iter({
+      ts: LONG,
+      width: NUM_NULL,
+      height: NUM_NULL,
+      storage: STR_NULL,
+      cnt: NUM,
+      self_size: NUM,
+      native_size: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    let list = groupsByTs.get(it.ts);
+    if (list === undefined) {
+      list = [];
+      groupsByTs.set(it.ts, list);
+    }
+    list.push({
+      width: it.width ?? undefined,
+      height: it.height ?? undefined,
+      storage: it.storage ?? undefined,
+      count: it.cnt,
+      selfSize: it.self_size,
+      nativeSize: it.native_size,
+    });
+  }
+  const dumps = Array.from(groupsByTs.keys())
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    .map((ts) => ({ts: Time.fromRaw(ts)}));
+
+  const javaRetainedByTs = new Map<bigint, number>();
+  try {
+    await trace.engine.query(
+      'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;',
+    );
+    const statsRes = await trace.engine.query(`
+      SELECT
+        s.graph_sample_ts AS ts,
+        CAST(s.reachable_heap_size + s.reachable_native_alloc_registry_size
+          AS INT) AS retained
+      FROM android_heap_graph_stats s
+      WHERE s.upid = ${upid}
+    `);
+    for (
+      const it = statsRes.iter({ts: LONG, retained: NUM});
+      it.valid();
+      it.next()
+    ) {
+      javaRetainedByTs.set(it.ts, Math.max(0, it.retained));
+    }
+  } catch {
+    // No heap-graph stats — leave the "of Java retained" card hidden.
+  }
+
+  const bitmapRetainer = await loadBitmapRetainer(trace, upid);
+
+  return {dumps, groupsByTs, javaRetainedByTs, bitmapRetainer};
+}
+
+// The nearest non-library class that dominates the reachable Bitmap instances
+// at the latest dump (the app-side owner up the dominator chain).
+async function loadBitmapRetainer(
+  trace: Trace,
+  upid: number,
+): Promise<string | undefined> {
+  try {
+    await trace.engine.query(
+      'INCLUDE PERFETTO MODULE android.memory.heap_graph.raw_dominator_tree;',
+    );
+    const res = await trace.engine.query(`
+      WITH RECURSIVE
+      last_ts AS (
+        SELECT MAX(graph_sample_ts) AS ts
+        FROM heap_graph_object WHERE upid = ${upid}
+      ),
+      ck AS (
+        SELECT c.id,
+          CASE WHEN c.name GLOB 'java.*' OR c.name GLOB 'javax.*'
+            OR c.name GLOB 'kotlin.*' OR c.name GLOB 'kotlinx.*'
+            OR c.name GLOB 'dalvik.*' OR c.name GLOB 'sun.*'
+            OR c.name GLOB 'libcore.*' OR c.name GLOB 'android.*'
+            OR c.name GLOB 'androidx.*' OR c.name GLOB 'com.android.*'
+            OR c.name GLOB 'com.google.android.*'
+            OR c.name LIKE '%[]%'
+            OR c.name NOT GLOB '*.*'
+            THEN 0 ELSE 1 END AS is_app,
+          c.name AS name
+        FROM heap_graph_class c
+      ),
+      obj AS (
+        SELECT o.id, ck.is_app, ck.name AS class_name,
+          o.self_size + o.native_size AS size
+        FROM heap_graph_object o
+        JOIN last_ts l ON o.graph_sample_ts = l.ts
+        JOIN ck ON ck.id = o.type_id
+        WHERE o.upid = ${upid} AND o.reachable
+      ),
+      walk(seed_size, cur_id, depth) AS (
+        SELECT ob.size, d.idom_id, 1
+        FROM obj ob
+        JOIN _raw_heap_graph_dominator_tree d ON d.id = ob.id
+        WHERE ob.class_name = 'android.graphics.Bitmap' AND d.idom_id IS NOT NULL
+        UNION ALL
+        SELECT w.seed_size, d.idom_id, w.depth + 1
+        FROM walk w
+        JOIN obj cur ON cur.id = w.cur_id
+        JOIN _raw_heap_graph_dominator_tree d ON d.id = w.cur_id
+        WHERE cur.is_app = 0 AND d.idom_id IS NOT NULL AND w.depth < 24
+      ),
+      hits AS (
+        SELECT cur.class_name AS retainer, w.seed_size,
+          ROW_NUMBER() OVER (PARTITION BY w.cur_id ORDER BY w.depth) AS rn
+        FROM walk w
+        JOIN obj cur ON cur.id = w.cur_id
+        WHERE cur.is_app = 1
+      )
+      SELECT retainer FROM hits WHERE rn = 1
+      GROUP BY retainer
+      ORDER BY SUM(seed_size) DESC
+      LIMIT 1
+    `);
+    const it = res.iter({retainer: STR});
+    if (it.valid()) return it.retainer;
+  } catch {
+    // No dominator tree — skip the retainer note.
+  }
+  return undefined;
+}
+
+// Pixel bytes for non-heap backings (ashmem / hardware) are not part of
+// self/native size — estimate them as w*h*4 when dimensions are known.
+function bytesOf(g: BitmapGroup): number {
+  const estPixels =
+    g.storage !== 'heap' && g.width !== undefined && g.height !== undefined
+      ? g.width * g.height * 4 * g.count
+      : 0;
+  return g.selfSize + g.nativeSize + estPixels;
+}
+
+// Group bitmaps by dimensions only (current dump's count + bytes per size).
+function groupByDims(
+  groups: BitmapGroup[],
+): Map<string, {count: number; bytes: number}> {
+  const byDims = new Map<string, {count: number; bytes: number}>();
+  for (const g of groups) {
+    const key =
+      g.width !== undefined && g.height !== undefined
+        ? `${g.width}×${g.height}`
+        : 'unknown';
+    const e = byDims.get(key) ?? {count: 0, bytes: 0};
+    e.count += g.count;
+    e.bytes += bytesOf(g);
+    byDims.set(key, e);
+  }
+  return byDims;
+}
+
+export interface BitmapsSectionAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  // The page-wide selection (by ts). Undefined → latest dump.
+  readonly selTs?: time;
+  readonly baseTs?: time;
+}
+
+export class BitmapsSection implements m.ClassComponent<BitmapsSectionAttrs> {
+  private readonly slot = new QuerySlot<BitmapsData>();
+
+  onremove() {
+    this.slot.dispose();
+  }
+
+  view({attrs}: m.Vnode<BitmapsSectionAttrs>): m.Children {
+    const {trace, upid, selTs, baseTs} = attrs;
+    const data = this.slot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadBitmapsData(trace, upid),
+      // Emulate an empty response
+      // queryFn: async () => ({
+      //   dumps: [],
+      //   groupsByTs: new Map<bigint, BitmapGroup[]>(),
+      //   javaRetainedByTs: new Map<bigint, number>(),
+      // }),
+    }).data;
+    if (data === undefined) {
+      return loadingPanel({title: TITLE, subtitle: SUBTITLE}); // Still loading.
+    }
+    if (data.dumps.length === 0) {
+      return emptyPanel({
+        title: TITLE,
+        subtitle: SUBTITLE,
+        message: 'No reachable bitmaps found',
+        detail:
+          'This trace has no Java heap graph, or the process allocated none.',
+      });
+    }
+
+    // Resolve the selection to dumps. No selection → latest.
+    const cur = nearestByTs(data.dumps, selTs)!;
+    const baseDump =
+      baseTs !== undefined ? nearestByTs(data.dumps, baseTs) : undefined;
+    const comparing = baseDump !== undefined && baseDump.ts !== cur.ts;
+    const groups = data.groupsByTs.get(cur.ts) ?? [];
+    const baseGroups = comparing ? data.groupsByTs.get(baseDump.ts) ?? [] : [];
+
+    const totalCount = groups.reduce((s, g) => s + g.count, 0);
+    const totalBytes = groups.reduce((s, g) => s + bytesOf(g), 0);
+    const baseCount = baseGroups.reduce((s, g) => s + g.count, 0);
+    const baseBytes = baseGroups.reduce((s, g) => s + bytesOf(g), 0);
+    const heapBytes = groups
+      .filter((g) => g.storage === 'heap')
+      .reduce((s, g) => s + g.selfSize + g.nativeSize, 0);
+    const ashmemBytes = groups
+      .filter((g) => g.storage === 'ashmem')
+      .reduce((s, g) => s + bytesOf(g), 0);
+
+    const byDims = groupByDims(groups);
+    const byDimsBase = comparing ? groupByDims(baseGroups) : undefined;
+    const dims = Array.from(byDims.entries()).map(([key, e]) => ({key, ...e}));
+    const bySize = dims.slice().sort((a, b) => b.bytes - a.bytes);
+    const byCount = dims.slice().sort((a, b) => b.count - a.count);
+    const hasDims = dims.some((d) => d.key !== 'unknown');
+    const largest = bySize[0];
+
+    const javaRetained = data.javaRetainedByTs.get(cur.ts) ?? 0;
+    // Bitmap heap-self + registered-native bytes (excludes the estimated ashmem
+    // pixels, which aren't part of the Java retained total) as a % of the
+    // dump's reachable heap + native, with the baseline equivalent for the diff.
+    const bitmapHeapNative = groups.reduce(
+      (s, g) => s + g.selfSize + g.nativeSize,
+      0,
+    );
+    const javaRetainedPct =
+      javaRetained > 0 ? (bitmapHeapNative / javaRetained) * 100 : 0;
+    const baseJavaRetained = comparing
+      ? data.javaRetainedByTs.get(baseDump.ts) ?? 0
+      : 0;
+    const baseBitmapHeapNative = baseGroups.reduce(
+      (s, g) => s + g.selfSize + g.nativeSize,
+      0,
+    );
+    const baseJavaRetainedPct =
+      baseJavaRetained > 0
+        ? (baseBitmapHeapNative / baseJavaRetained) * 100
+        : 0;
+    const javaRetainedPtsDelta = javaRetainedPct - baseJavaRetainedPct;
+    const retainerNote: m.Children =
+      data.bitmapRetainer !== undefined
+        ? [
+            ' Mostly retained by ',
+            m('b', shortClassName(data.bitmapRetainer)),
+            '.',
+          ]
+        : '';
+
+    const insight: m.Children = hasDims
+      ? [
+          m('b', largest.count.toLocaleString()),
+          ' bitmaps of ',
+          m('b', largest.key),
+          ' alone account for ',
+          m('b', formatBytes(largest.bytes)),
+          ashmemBytes > heapBytes
+            ? [
+                '. Most bitmap bytes live in ',
+                m('b', 'ashmem'),
+                ` (${formatBytes(ashmemBytes)}) rather than the Java heap ` +
+                  `(${formatBytes(heapBytes)}).`,
+              ]
+            : '.',
+          retainerNote,
+        ]
+      : [
+          'This trace format does not record bitmap dimensions — only ' +
+            'counts and sizes are available.',
+        ];
+
+    const dimRows = (list: {key: string; count: number; bytes: number}[]) =>
+      list.slice(0, 5).map((d) => {
+        const base = byDimsBase?.get(d.key);
+        const shareFrac = totalBytes > 0 ? d.bytes / totalBytes : 0;
+        const baseShareFrac =
+          base !== undefined && baseBytes > 0 ? base.bytes / baseBytes : 0;
+        return [
+          d.key,
+          deltaCell(
+            d.count.toLocaleString(),
+            base !== undefined ? d.count - base.count : undefined,
+            comparing,
+            formatCountDelta,
+          ),
+          deltaCell(
+            formatBytes(d.bytes),
+            base !== undefined ? d.bytes - base.bytes : undefined,
+            comparing,
+          ),
+          // Share of all bitmap bytes, with the change in share (percentage
+          // points, this snapshot's total vs the baseline's) below in diff mode.
+          deltaCell(
+            shareBar(shareFrac),
+            comparing ? (shareFrac - baseShareFrac) * 100 : undefined,
+            comparing,
+            (n) =>
+              n === 0 ? '±0 pts' : `${n > 0 ? '+' : ''}${n.toFixed(1)} pts`,
+          ),
+        ];
+      });
+
+    const tableSubtitle = comparing
+      ? 'grouped by dimensions · Δ vs baseline'
+      : 'grouped by dimensions';
+
+    return m(
+      Panel,
+      m(Panel.Header, {title: TITLE, subtitle: SUBTITLE}),
+      m(
+        Panel.Body,
+        m(Stack, {spacing: 'large'}, [
+          m(Callout, {intent: Intent.Primary}, insight),
+          m(BillboardStrip, [
+            statCard([
+              {
+                label: 'Total bitmaps',
+                value: totalCount.toLocaleString(),
+                sub: comparing
+                  ? deltaText(
+                      totalCount - baseCount,
+                      `Δ ${formatCountDelta(totalCount - baseCount)} vs baseline`,
+                    )
+                  : 'live android.graphics.Bitmap',
+              },
+            ]),
+            statCard([
+              {
+                label: 'Bitmap memory',
+                value: formatBytes(totalBytes),
+                sub: comparing
+                  ? deltaText(
+                      totalBytes - baseBytes,
+                      `Δ ${formatDelta(totalBytes - baseBytes)} vs baseline`,
+                    )
+                  : `${formatBytes(heapBytes)} heap · ${formatBytes(
+                      ashmemBytes,
+                    )} ashmem (est.)`,
+              },
+            ]),
+            hasDims &&
+              statCard([
+                {
+                  label: 'Largest group',
+                  value: formatBytes(largest.bytes),
+                  sub: `${largest.key} ×${largest.count}`,
+                },
+              ]),
+            javaRetained > 0 &&
+              statCard([
+                {
+                  label: 'Of Java retained',
+                  value: `${Math.round(javaRetainedPct)}%`,
+                  sub: comparing
+                    ? deltaText(
+                        javaRetainedPtsDelta,
+                        `Δ ${javaRetainedPtsDelta >= 0 ? '+' : ''}${Math.round(
+                          javaRetainedPtsDelta,
+                        )} pts vs baseline`,
+                      )
+                    : 'share of heap + native',
+                },
+              ]),
+          ]),
+          hasDims &&
+            m('.pf-memscope-tables', [
+              topTable({
+                title: 'Largest bitmaps',
+                subtitle: tableSubtitle,
+                cols: [
+                  {label: 'Dimensions'},
+                  {label: 'Count', num: true},
+                  {label: 'Size', num: true},
+                  {label: 'Share of all bitmap', num: true},
+                ],
+                rows: dimRows(bySize),
+              }),
+              topTable({
+                title: 'Most frequent bitmaps',
+                subtitle: tableSubtitle,
+                cols: [
+                  {label: 'Dimensions'},
+                  {label: 'Count', num: true},
+                  {label: 'Size', num: true},
+                  {label: 'Share of all bitmap', num: true},
+                ],
+                rows: dimRows(byCount),
+              }),
+            ]),
+        ]),
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/composition_timeline.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/composition_timeline.ts
@@ -1,0 +1,263 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The "Composition over time" line graph: resident memory by smaps category,
+// one stacked point per snapshot, for one process across the whole trace. Owns
+// its own query slot, loading logic and (currently internal) snapshot
+// selection.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import {
+  LineChartSvg,
+  type LineChartData,
+} from '../../../../../components/widgets/charts_svg/line_chart_svg';
+import type {Trace} from '../../../../../public/trace';
+import {LONG, NUM, STR} from '../../../../../trace_processor/query_result';
+import {Icon} from '../../../../../widgets/icon';
+import {Panel} from '../../../components/panel';
+import {niceKbInterval} from '../../../utils';
+import {deltaText, formatBytes} from '../mem_format';
+import {type MemSelection, nearestByTs} from '../selection';
+import {emptyPanel, loadingPanel} from '../section_widgets';
+import {SMAPS_CATEGORIES, SMAPS_CATEGORY_CASE_SQL} from '../smaps_categories';
+
+// One smaps snapshot (a single ts): per-category resident+swap bytes and the
+// total footprint. The x position (seconds from trace start) is precomputed.
+interface TimelineSnapshot {
+  readonly ts: time;
+  readonly x: number; // seconds from trace start
+  readonly total: number;
+  readonly byCategory: ReadonlyMap<string, number>; // category key → rss+swap
+}
+
+interface TimelineData {
+  readonly snapshots: TimelineSnapshot[];
+  readonly chart?: LineChartData;
+}
+
+async function loadTimelineData(
+  trace: Trace,
+  upid: number,
+): Promise<TimelineData> {
+  const byTs = new Map<bigint, Map<string, number>>();
+  const res = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      ${SMAPS_CATEGORY_CASE_SQL} AS category,
+      CAST(ifnull(SUM(s.rss_kb + s.swap_kb), 0) * 1024 AS INT) AS bytes
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+    GROUP BY s.ts, category
+    ORDER BY s.ts ASC
+  `);
+  for (
+    const it = res.iter({ts: LONG, category: STR, bytes: NUM});
+    it.valid();
+    it.next()
+  ) {
+    let cats = byTs.get(it.ts);
+    if (cats === undefined) {
+      cats = new Map();
+      byTs.set(it.ts, cats);
+    }
+    cats.set(it.category, (cats.get(it.category) ?? 0) + it.bytes);
+  }
+
+  const start = trace.traceInfo.start;
+  const snapshots: TimelineSnapshot[] = Array.from(byTs.entries()).map(
+    ([ts, byCategory]) => {
+      let total = 0;
+      for (const v of byCategory.values()) total += v;
+      return {
+        ts: Time.fromRaw(ts),
+        x: Number(ts - start) / 1e9,
+        total,
+        byCategory,
+      };
+    },
+  );
+
+  // Stacked composition chart: one series per category, dropping categories
+  // that are zero everywhere.
+  let chart: LineChartData | undefined;
+  if (snapshots.length > 0) {
+    const series = SMAPS_CATEGORIES.map((c) => ({
+      name: c.label,
+      color: c.color,
+      points: snapshots.map((s) => ({x: s.x, y: s.byCategory.get(c.key) ?? 0})),
+    })).filter((s) => s.points.some((p) => p.y > 0));
+    chart = {series};
+  }
+
+  return {snapshots, chart};
+}
+
+export interface CompositionTimelineAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  // The page-wide selection (by ts), or undefined when nothing is selected
+  // yet (the timeline then highlights the latest snapshot).
+  readonly selection?: MemSelection;
+  // Called when the user clicks a snapshot or brushes a range.
+  readonly onSelect: (selection: MemSelection) => void;
+  // Optional content rendered inside the panel, below the chart (e.g. the
+  // whole-trace "where the growth went" bar).
+  readonly belowChart?: m.Children;
+}
+
+export class CompositionTimeline
+  implements m.ClassComponent<CompositionTimelineAttrs>
+{
+  private readonly slot = new QuerySlot<TimelineData>();
+
+  onremove() {
+    this.slot.dispose();
+  }
+
+  view({attrs}: m.Vnode<CompositionTimelineAttrs>): m.Children {
+    const {trace, upid, selection, onSelect, belowChart} = attrs;
+    const data = this.slot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadTimelineData(trace, upid),
+    }).data;
+    if (data === undefined) {
+      return loadingPanel({title: 'Composition over time'}); // Still loading.
+    }
+
+    const snaps = data.snapshots;
+    if (snaps.length === 0 || data.chart === undefined) {
+      return emptyPanel({
+        title: 'Composition over time',
+        message: 'No smaps snapshots in this trace for this process.',
+      });
+    }
+
+    // Resolve the page selection (by ts) to snapshot indices for rendering.
+    // No selection → highlight the latest snapshot.
+    const lastIdx = snaps.length - 1;
+    const idxOfTs = (ts: time) => snaps.indexOf(nearestByTs(snaps, ts)!);
+    const selIdx = selection !== undefined ? idxOfTs(selection.sel) : lastIdx;
+    let baseIdx =
+      selection?.base !== undefined ? idxOfTs(selection.base) : undefined;
+    if (baseIdx === selIdx) baseIdx = undefined;
+    const snap = snaps[selIdx];
+    const base = baseIdx !== undefined ? snaps[baseIdx] : undefined;
+
+    // Index of the snapshot whose x is closest to a clicked/brushed time.
+    const nearestSnap = (x: number) => {
+      let bestIdx = 0;
+      for (let i = 1; i < snaps.length; i++) {
+        if (Math.abs(snaps[i].x - x) < Math.abs(snaps[bestIdx].x - x)) {
+          bestIdx = i;
+        }
+      }
+      return bestIdx;
+    };
+
+    return m(
+      Panel,
+      m(Panel.Header, {
+        title: 'Composition over time',
+        subtitle:
+          'Resident memory by region, one point per smaps snapshot. Click ' +
+          'a snapshot to inspect it, or drag to compare two.',
+        controls: m('span.pf-memscope-memmap__badge', [
+          m(Icon, {icon: 'photo_camera'}),
+          base !== undefined && baseIdx !== undefined
+            ? [
+                `Snapshot #${baseIdx + 1} → #${selIdx + 1} · `,
+                deltaText(snap.total - base.total),
+              ]
+            : `Snapshot #${selIdx + 1} · ${formatBytes(snap.total)}`,
+        ]),
+      }),
+      m(
+        Panel.Body,
+        m('.pf-memscope-memmap', [
+          m(LineChartSvg, {
+            data: data.chart,
+            height: 160,
+            stacked: true,
+            xAxisLabel: 'Time (s)',
+            yAxisLabel: 'Size',
+            showLegend: true,
+            showPoints: true,
+            gridLines: 'vertical',
+            formatXValue: (v: number) => `${v.toFixed(0)}s`,
+            formatYValue: (v: number) => formatBytes(v),
+            // Snap ticks to power-of-2 (MiB) boundaries so the IEC labels read as
+            // clean MiB/GiB values rather than fractional decimals.
+            // This axis is in bytes; niceKbInterval works in KB, so scale in
+            // and back out by 1024 to get a power-of-2-aligned byte interval.
+            yAxisMinInterval:
+              niceKbInterval(Math.max(0, ...snaps.map((s) => s.total)) / 1024) *
+              1024,
+            markers: [
+              // In compare mode, show the baseline snapshot as a muted marker so
+              // it's distinguishable from the (accent-coloured) selected one.
+              base !== undefined &&
+                baseIdx !== undefined && {
+                  x: base.x,
+                  label: `#${baseIdx + 1}`,
+                  color: 'var(--pf-color-text-muted)',
+                },
+              // Selected snapshot stays red (the marker default).
+              {x: snap.x, label: `#${selIdx + 1}`},
+            ].filter(Boolean) as ReadonlyArray<{
+              x: number;
+              label?: string;
+              color?: string;
+            }>,
+            selection:
+              base !== undefined ? {start: base.x, end: snap.x} : undefined,
+            onPointClick: (x: number) => {
+              onSelect({sel: snaps[nearestSnap(x)].ts});
+            },
+            onBrush: ({start, end}: {start: number; end: number}) => {
+              const a = nearestSnap(start);
+              const b = nearestSnap(end);
+              onSelect(
+                a === b
+                  ? {sel: snaps[a].ts}
+                  : {sel: snaps[b].ts, base: snaps[a].ts},
+              );
+            },
+          }),
+          belowChart,
+          m(
+            '.pf-memscope-memmap__snaps',
+            snaps.map((s, i) =>
+              m(
+                'button.pf-memscope-memmap__snap',
+                {
+                  className:
+                    i === selIdx
+                      ? 'pf-memscope-memmap__snap--active'
+                      : i === baseIdx
+                        ? 'pf-memscope-memmap__snap--base'
+                        : undefined,
+                  title: `t=${s.x.toFixed(1)}s · ${formatBytes(s.total)}`,
+                  onclick: () => onSelect({sel: s.ts}),
+                },
+                `#${i + 1}`,
+              ),
+            ),
+          ),
+        ]),
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/java_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/java_section.ts
@@ -1,0 +1,802 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// "How much Java memory did you use, and where did it go?" — from the full
+// heap graph: reachability, totals and the three top-classes tables, for the
+// latest heap dump of one process. Self-contained: owns its query slot and
+// loading logic.
+
+import m from 'mithril';
+import {Icons} from '../../../../../base/semantic_icons';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import type {Trace} from '../../../../../public/trace';
+import {LONG, NUM, STR} from '../../../../../trace_processor/query_result';
+import {Anchor} from '../../../../../widgets/anchor';
+import {Panel} from '../../../components/panel';
+import {Callout} from '../../../components/callout';
+import {Intent} from '../../../../../widgets/common';
+import {
+  deltaText,
+  formatBytes,
+  formatCountDelta,
+  formatDelta,
+  statCard,
+} from '../mem_format';
+import {findProcessTrack, showInTimelineLink} from '../process_links';
+import {nearestByTs} from '../selection';
+import {
+  classNameCell,
+  deltaCell,
+  emptyPanel,
+  loadingPanel,
+  ratioBar,
+  shareBar,
+  shortClassName,
+  topTable,
+} from '../section_widgets';
+import {Stack} from '../../../../../widgets/stack';
+import {BillboardStrip} from '../../../components/billboard';
+
+const TITLE = 'How much Java memory did you use, and where did it go?';
+const SUBTITLE =
+  'From the full heap graph — complete and exact, with retention but no ' +
+  'callstacks.';
+
+// Per-class aggregation row at a dump. All sizes/counts are reachable-only (see
+// landing_page_spec.md): unreachable garbage is excluded so the three tables'
+// columns are comparable and retained >= shallow always holds. rnRetained/
+// rnShallow/rnCount are the class's rank under each of the three orderings.
+interface ClassAggRow {
+  typeName: string;
+  // Reachable instance count of this class.
+  reachableObjCount: number;
+  // Shallow: sum of self_size over reachable instances (Java heap only).
+  reachableSizeBytes: number;
+  // Native self: registered native owned by this class's reachable instances.
+  reachableNativeSizeBytes: number;
+  // Retained = dominatedSizeBytes + dominatedNativeSizeBytes (Java + native).
+  dominatedSizeBytes: number;
+  dominatedNativeSizeBytes: number;
+  rnRetained: number; // by retained (dominated Java + native)
+  rnShallow: number; // by shallow (reachable self)
+  rnCount: number; // by reachable instance count
+}
+
+// Per-dump heap-graph stats.
+interface DumpStats {
+  readonly ts: time;
+  readonly totalHeapSize: number;
+  readonly totalObjCount: number;
+  readonly reachableHeapSize: number;
+  readonly reachableNativeSize: number;
+  readonly reachableObjCount: number;
+  // MIN(heap_graph_object.id) for this dump — the HeapProfile track event id
+  // used to select the dump on the timeline.
+  readonly eventId: number;
+}
+
+// One app-side owner of a (library) class's instances: the nearest app class up
+// the dominator chain, and the bytes of that class attributed to it.
+export interface ClassRetainer {
+  readonly name: string;
+  readonly bytes: number;
+}
+
+interface JavaData {
+  // All dumps for this process, ts-ascending (empty → no heap graph).
+  readonly dumps: DumpStats[];
+  // Top classes per dump, keyed by dump ts (raw bigint).
+  readonly classesByTs: ReadonlyMap<bigint, ClassAggRow[]>;
+  // App-side retainers per class (last dump): the distinct nearest app-side
+  // dominators of a library class's instances, each with the bytes attributed
+  // to it, largest first. A class held through several owners gets several
+  // entries instead of a single (misleading) "via".
+  readonly retainerOf: ReadonlyMap<string, ReadonlyArray<ClassRetainer>>;
+  // ART images + JIT cache resident bytes, one entry per smaps snapshot
+  // (ts-ascending). Lets the card align to the selected/baseline dump and diff.
+  readonly artByTs: readonly {ts: time; art: number}[];
+}
+
+async function loadJavaData(trace: Trace, upid: number): Promise<JavaData> {
+  await trace.engine.query(
+    'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;',
+  );
+  // MIN(object id) per dump — the HeapProfile track event id for that dump
+  // (mirrors how dev.perfetto.HeapProfile builds its timeline events).
+  const eventIdByTs = new Map<bigint, number>();
+  const eventRes = await trace.engine.query(`
+    SELECT graph_sample_ts AS ts, MIN(id) AS event_id
+    FROM heap_graph_object
+    WHERE upid = ${upid}
+    GROUP BY graph_sample_ts
+  `);
+  for (
+    const it = eventRes.iter({ts: LONG, event_id: NUM});
+    it.valid();
+    it.next()
+  ) {
+    eventIdByTs.set(it.ts, it.event_id);
+  }
+
+  const dumps: DumpStats[] = [];
+  const statsRes = await trace.engine.query(`
+    SELECT
+      s.graph_sample_ts AS ts,
+      s.total_heap_size AS total_heap_size,
+      s.total_obj_count AS total_obj_count,
+      s.reachable_heap_size AS reachable_heap_size,
+      s.reachable_native_alloc_registry_size AS reachable_native_size,
+      s.reachable_obj_count AS reachable_obj_count
+    FROM android_heap_graph_stats s
+    WHERE s.upid = ${upid}
+    ORDER BY s.graph_sample_ts ASC
+  `);
+  for (
+    const it = statsRes.iter({
+      ts: LONG,
+      total_heap_size: NUM,
+      total_obj_count: NUM,
+      reachable_heap_size: NUM,
+      reachable_native_size: NUM,
+      reachable_obj_count: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    dumps.push({
+      ts: Time.fromRaw(it.ts),
+      totalHeapSize: it.total_heap_size,
+      totalObjCount: it.total_obj_count,
+      reachableHeapSize: it.reachable_heap_size,
+      reachableNativeSize: it.reachable_native_size,
+      reachableObjCount: it.reachable_obj_count,
+      eventId: eventIdByTs.get(it.ts) ?? -1,
+    });
+  }
+  const classesByTs = new Map<bigint, ClassAggRow[]>();
+  if (dumps.length === 0) {
+    return {dumps, classesByTs, retainerOf: new Map(), artByTs: []};
+  }
+
+  // Top classes (per the three orderings) at every dump, so picking any
+  // snapshot (or diffing two) is in-memory.
+  await trace.engine.query(
+    'INCLUDE PERFETTO MODULE ' +
+      'android.memory.heap_graph.heap_graph_class_aggregation;',
+  );
+  const aggRes = await trace.engine.query(`
+    WITH ranked AS (
+      SELECT
+        a.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY a.graph_sample_ts
+          ORDER BY a.dominated_size_bytes + a.dominated_native_size_bytes DESC
+        ) AS rn_retained,
+        ROW_NUMBER() OVER (
+          PARTITION BY a.graph_sample_ts
+          ORDER BY a.reachable_size_bytes DESC
+        ) AS rn_shallow,
+        ROW_NUMBER() OVER (
+          PARTITION BY a.graph_sample_ts ORDER BY a.reachable_obj_count DESC
+        ) AS rn_count
+      FROM android_heap_graph_class_aggregation a
+      WHERE a.upid = ${upid}
+    )
+    SELECT
+      r.graph_sample_ts AS ts,
+      r.type_name AS type_name,
+      r.reachable_obj_count AS reachable_obj_count,
+      r.reachable_size_bytes AS reachable_size_bytes,
+      r.reachable_native_size_bytes AS reachable_native_size_bytes,
+      r.dominated_size_bytes AS dominated_size_bytes,
+      r.dominated_native_size_bytes AS dominated_native_size_bytes,
+      r.rn_retained AS rn_retained,
+      r.rn_shallow AS rn_shallow,
+      r.rn_count AS rn_count
+    FROM ranked r
+    WHERE r.rn_retained <= 8 OR r.rn_shallow <= 8 OR r.rn_count <= 8
+  `);
+  for (
+    const it = aggRes.iter({
+      ts: LONG,
+      type_name: STR,
+      reachable_obj_count: NUM,
+      reachable_size_bytes: NUM,
+      reachable_native_size_bytes: NUM,
+      dominated_size_bytes: NUM,
+      dominated_native_size_bytes: NUM,
+      rn_retained: NUM,
+      rn_shallow: NUM,
+      rn_count: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    let list = classesByTs.get(it.ts);
+    if (list === undefined) {
+      list = [];
+      classesByTs.set(it.ts, list);
+    }
+    list.push({
+      typeName: it.type_name,
+      reachableObjCount: it.reachable_obj_count,
+      reachableSizeBytes: it.reachable_size_bytes,
+      reachableNativeSizeBytes: it.reachable_native_size_bytes,
+      dominatedSizeBytes: it.dominated_size_bytes,
+      dominatedNativeSizeBytes: it.dominated_native_size_bytes,
+      rnRetained: it.rn_retained,
+      rnShallow: it.rn_shallow,
+      rnCount: it.rn_count,
+    });
+  }
+
+  const retainerOf = await loadRetainers(trace, upid);
+  const artByTs = await loadArtByTs(trace, upid);
+
+  return {dumps, classesByTs, retainerOf, artByTs};
+}
+
+// For each library class at the latest dump, the app-side classes that dominate
+// its instances, walking up the dominator tree to the nearest non-library
+// (app/third-party) ancestor of each object. Instances of one class can resolve
+// to different owners, so we report up to RETAINER_MAX_VIAS of them, each with
+// the bytes attributed to it (the shallow size of the library objects that
+// terminate at that owner — a clean partition, not the overlapping dominated
+// sizes shown in the table). When the chain reaches the super root without
+// passing through an app class — i.e. the object is held directly by the GC
+// root set — the retainer is reported as "GC root". Wrapped defensively: a heap
+// graph without a dominator tree yields an empty map.
+//
+// At most this many distinct owners are surfaced per class, ...
+const RETAINER_MAX_VIAS = 3;
+// ...and owners contributing less than this fraction of the class's largest
+// owner are dropped as noise.
+const RETAINER_MIN_SHARE = 0.1;
+async function loadRetainers(
+  trace: Trace,
+  upid: number,
+): Promise<ReadonlyMap<string, ReadonlyArray<ClassRetainer>>> {
+  const retainerOf = new Map<string, ClassRetainer[]>();
+  try {
+    await trace.engine.query(
+      'INCLUDE PERFETTO MODULE android.memory.heap_graph.raw_dominator_tree;',
+    );
+    const res = await trace.engine.query(`
+      WITH RECURSIVE
+      last_ts AS (
+        SELECT MAX(graph_sample_ts) AS ts
+        FROM heap_graph_object WHERE upid = ${upid}
+      ),
+      ck AS (
+        -- Classify by the *wrapped* name: a class object is named
+        -- "java.lang.Class<X>" and holds X's statics, so an app class's class
+        -- object must count as app (an app-side owner), not library. The
+        -- original name is kept for display/joins; only is_app uses the
+        -- unwrapped form.
+        SELECT id, name,
+          CASE WHEN cname GLOB 'java.*' OR cname GLOB 'javax.*'
+            OR cname GLOB 'kotlin.*' OR cname GLOB 'kotlinx.*'
+            OR cname GLOB 'dalvik.*' OR cname GLOB 'sun.*'
+            OR cname GLOB 'libcore.*' OR cname GLOB 'android.*'
+            OR cname GLOB 'androidx.*' OR cname GLOB 'com.android.*'
+            OR cname GLOB 'com.google.android.*'
+            OR cname LIKE '%[]%'
+            OR cname NOT GLOB '*.*'
+            THEN 0 ELSE 1 END AS is_app
+        FROM (
+          SELECT c.id, c.name AS name,
+            CASE WHEN c.name GLOB 'java.lang.Class<*>'
+              THEN substr(c.name, 17, length(c.name) - 17)
+              ELSE c.name END AS cname
+          FROM heap_graph_class c
+        )
+      ),
+      obj AS (
+        SELECT o.id, ck.is_app, ck.name AS class_name,
+          o.self_size + o.native_size AS size
+        FROM heap_graph_object o
+        JOIN last_ts l ON o.graph_sample_ts = l.ts
+        JOIN ck ON ck.id = o.type_id
+        WHERE o.upid = ${upid} AND o.reachable
+      ),
+      walk(seed_id, owned_class, seed_size, anc_id, depth) AS (
+        SELECT ob.id, ob.class_name, ob.size, d.idom_id, 1
+        FROM obj ob
+        JOIN _raw_heap_graph_dominator_tree d ON d.id = ob.id
+        WHERE ob.is_app = 0
+        UNION ALL
+        SELECT w.seed_id, w.owned_class, w.seed_size, d.idom_id, w.depth + 1
+        FROM walk w
+        JOIN obj cur ON cur.id = w.anc_id
+        JOIN _raw_heap_graph_dominator_tree d ON d.id = w.anc_id
+        WHERE cur.is_app = 0 AND w.depth < 24
+      ),
+      -- Each rung is a dominator-tree ancestor of the seed. A NULL anc_id is
+      -- the rung above the topmost node: the synthetic super root, i.e. the
+      -- object is retained directly by the GC root set. The search terminates
+      -- at the nearest app-side ancestor, or at that root if the whole chain
+      -- up to it is library/system.
+      classified AS (
+        SELECT w.seed_id, w.owned_class, w.seed_size, w.depth,
+          CASE
+            WHEN w.anc_id IS NULL THEN 'GC root'
+            WHEN a.class_name GLOB 'java.lang.Class<*>'
+              THEN substr(a.class_name, 17, length(a.class_name) - 17)
+            ELSE a.class_name
+          END AS retainer,
+          CASE WHEN w.anc_id IS NULL THEN 1 ELSE a.is_app END AS terminal
+        FROM walk w
+        LEFT JOIN obj a ON a.id = w.anc_id
+      ),
+      hits AS (
+        SELECT seed_id, owned_class, seed_size, retainer,
+          ROW_NUMBER() OVER (PARTITION BY seed_id ORDER BY depth) AS rn
+        FROM classified
+        WHERE terminal = 1
+      ),
+      -- Rank the distinct retainers of each class by attributed bytes, largest
+      -- first, so the UI can show the few dominant owners instead of just one.
+      -- "GC root" ranks last on ties so a real app owner wins an equal split.
+      agg AS (
+        SELECT owned_class, retainer, SUM(seed_size) AS bytes,
+          ROW_NUMBER() OVER (
+            PARTITION BY owned_class
+            ORDER BY SUM(seed_size) DESC, (retainer = 'GC root') ASC
+          ) AS rrn
+        FROM hits WHERE rn = 1
+        GROUP BY owned_class, retainer
+      )
+      SELECT a.owned_class AS type_name, a.retainer AS retainer_name,
+        a.bytes AS bytes
+      FROM agg a
+      WHERE a.rrn <= ${RETAINER_MAX_VIAS}
+      ORDER BY a.owned_class, a.rrn
+    `);
+    for (
+      const it = res.iter({type_name: STR, retainer_name: STR, bytes: NUM});
+      it.valid();
+      it.next()
+    ) {
+      let list = retainerOf.get(it.type_name);
+      if (list === undefined) {
+        list = [];
+        retainerOf.set(it.type_name, list);
+      }
+      list.push({name: it.retainer_name, bytes: it.bytes});
+    }
+    // Drop trailing owners that are tiny next to the class's biggest one; the
+    // SQL already ordered each list largest-first.
+    for (const [cls, list] of retainerOf) {
+      const cutoff = list[0].bytes * RETAINER_MIN_SHARE;
+      retainerOf.set(
+        cls,
+        list.filter((r) => r.bytes >= cutoff),
+      );
+    }
+  } catch {
+    // No dominator tree (e.g. non-Android heap graph) — skip the annotation.
+  }
+  return retainerOf;
+}
+
+// ART images + JIT cache resident bytes per smaps snapshot (ts-ascending), so
+// the card can align to the selected/baseline dump and diff between them.
+async function loadArtByTs(
+  trace: Trace,
+  upid: number,
+): Promise<{ts: time; art: number}[]> {
+  const res = await trace.engine.query(`
+    SELECT s.ts AS ts, CAST(ifnull(SUM(s.rss_kb), 0) * 1024 AS INT) AS art
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+      AND (s.path GLOB '*.art*' OR s.path GLOB '*.oat*'
+        OR s.path GLOB '*.odex*' OR s.path GLOB '*.vdex*'
+        OR s.path GLOB '*dalvik-jit*')
+    GROUP BY s.ts
+    ORDER BY s.ts ASC
+  `);
+  const out: {ts: time; art: number}[] = [];
+  for (const it = res.iter({ts: LONG, art: NUM}); it.valid(); it.next()) {
+    out.push({ts: Time.fromRaw(it.ts), art: it.art});
+  }
+  return out;
+}
+
+export interface JavaSectionAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  // The page-wide selection (by ts). Undefined → latest dump.
+  readonly selTs?: time;
+  readonly baseTs?: time;
+}
+
+export class JavaSection implements m.ClassComponent<JavaSectionAttrs> {
+  private readonly slot = new QuerySlot<JavaData>();
+
+  onremove() {
+    this.slot.dispose();
+  }
+
+  view({attrs}: m.Vnode<JavaSectionAttrs>): m.Children {
+    const {trace, upid, selTs, baseTs} = attrs;
+    const data = this.slot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadJavaData(trace, upid),
+      // Emulate no data available
+      // queryFn: async () => ({
+      //   dumps: [],
+      //   classesByTs: new Map<bigint, ClassAggRow[]>(),
+      //   retainerOf: new Map<string, string>(),
+      //   artByTs: [],
+      // }),
+    }).data;
+    if (data === undefined) {
+      return loadingPanel({title: TITLE, subtitle: SUBTITLE}); // Still loading.
+    }
+    if (data.dumps.length === 0) {
+      return emptyPanel({
+        title: TITLE,
+        subtitle: SUBTITLE,
+        message: 'No Java heap graph in this trace for this process',
+        detail: 'Capture a java_hprof dump to see the managed heap',
+      });
+    }
+
+    // Resolve the selection to dumps (nearest by ts). No selection → latest.
+    const cur = nearestByTs(data.dumps, selTs)!;
+    const baseDump =
+      baseTs !== undefined ? nearestByTs(data.dumps, baseTs) : undefined;
+    // Both endpoints can resolve to the same dump (dumps are sparser than
+    // smaps snapshots) — that's not a comparison.
+    const baseStats =
+      baseDump !== undefined && baseDump.ts !== cur.ts ? baseDump : undefined;
+    const comparing = baseStats !== undefined;
+    const selIdx = data.dumps.indexOf(cur);
+    const baseIdx =
+      baseStats !== undefined ? data.dumps.indexOf(baseStats) : undefined;
+
+    // ART overhead is smaps-sourced, so align to the smaps snapshot nearest
+    // each dump's ts (rather than always the latest) so it diffs alongside the
+    // heap-graph cards in compare mode.
+    const curArt = nearestByTs(data.artByTs, cur.ts)?.art;
+    const baseArt = comparing
+      ? nearestByTs(data.artByTs, baseStats.ts)?.art
+      : undefined;
+
+    const classes = data.classesByTs.get(cur.ts) ?? [];
+    const baseClassByName = new Map(
+      comparing
+        ? (data.classesByTs.get(baseStats.ts) ?? []).map(
+            (c) => [c.typeName, c] as const,
+          )
+        : [],
+    );
+    const withDelta = (
+      text: m.Children,
+      delta: number | undefined,
+      fmt: (n: number) => string = formatDelta,
+    ): m.Children => deltaCell(text, delta, comparing, fmt);
+
+    const tOf = (ts: time) =>
+      (Number(ts - trace.traceInfo.start) / 1e9).toFixed(1);
+
+    const reachableTotal = cur.reachableHeapSize + cur.reachableNativeSize;
+    const baseReachableTotal = comparing
+      ? baseStats.reachableHeapSize + baseStats.reachableNativeSize
+      : 0;
+
+    // A share-% cell that, in compare mode, shows the change in share below the
+    // bar as signed percentage points (cur share − baseline share).
+    const shareCell = (
+      value: number,
+      total: number,
+      baseValue: number | undefined,
+      baseTotal: number,
+    ): m.Children => {
+      const frac = total > 0 ? value / total : 0;
+      if (!comparing) return shareBar(frac);
+      const baseFrac =
+        baseValue !== undefined && baseTotal > 0 ? baseValue / baseTotal : 0;
+      return withDelta(shareBar(frac), (frac - baseFrac) * 100, (n) =>
+        n === 0 ? '±0 pts' : `${n > 0 ? '+' : ''}${n.toFixed(1)} pts`,
+      );
+    };
+    const unreachableHeap = cur.totalHeapSize - cur.reachableHeapSize;
+    const reachPct =
+      cur.totalHeapSize > 0
+        ? (cur.reachableHeapSize / cur.totalHeapSize) * 100
+        : 0;
+
+    // Insight: the class with the largest retained (dominated) size.
+    const topRetainer = classes
+      .slice()
+      .sort((a, b) => a.rnRetained - b.rnRetained)[0];
+    const insight: m.Children = [];
+    if (topRetainer !== undefined && reachableTotal > 0) {
+      const retained =
+        topRetainer.dominatedSizeBytes + topRetainer.dominatedNativeSizeBytes;
+      insight.push(
+        m('b', shortClassName(topRetainer.typeName)),
+        ' retains ',
+        m('b', formatBytes(retained)),
+        ' — ',
+        m(
+          'b',
+          `${Math.round((retained / reachableTotal) * 100)}% of the ` +
+            'Java heap',
+        ),
+        '.',
+      );
+    }
+    if (cur.totalHeapSize > 0) {
+      insight.push(
+        ' ',
+        m('b', `${Math.round(100 - reachPct)}%`),
+        ' of the heap is currently unreachable (awaiting GC).',
+      );
+    }
+
+    // All three class tables show the same five reachable-only columns
+    // (Class · Instances · Shallow · Retained · Share); only the ranking and
+    // the share denominator differ. `shareMetric` selects the value the share
+    // bar measures and `shareTotal`/`shareBaseTotal` its denominator.
+    const classCols = [
+      {label: 'Class'},
+      {label: 'Instances', num: true},
+      {label: 'Shallow', num: true},
+      {label: 'Native', num: true},
+      {label: 'Retained', num: true},
+      {label: 'Share', num: true},
+    ];
+    const classRow = (
+      c: ClassAggRow,
+      shareMetric: (r: ClassAggRow) => number,
+      shareTotal: number,
+      shareBaseTotal: number,
+    ): m.Children[] => {
+      const b = baseClassByName.get(c.typeName);
+      const retained = c.dominatedSizeBytes + c.dominatedNativeSizeBytes;
+      const baseRetained =
+        b !== undefined
+          ? b.dominatedSizeBytes + b.dominatedNativeSizeBytes
+          : undefined;
+      return [
+        classNameCell(c.typeName, data.retainerOf.get(c.typeName)),
+        withDelta(
+          c.reachableObjCount.toLocaleString(),
+          b !== undefined
+            ? c.reachableObjCount - b.reachableObjCount
+            : undefined,
+          formatCountDelta,
+        ),
+        withDelta(
+          formatBytes(c.reachableSizeBytes),
+          b !== undefined
+            ? c.reachableSizeBytes - b.reachableSizeBytes
+            : undefined,
+        ),
+        withDelta(
+          c.reachableNativeSizeBytes > 0
+            ? formatBytes(c.reachableNativeSizeBytes)
+            : '—',
+          b !== undefined
+            ? c.reachableNativeSizeBytes - b.reachableNativeSizeBytes
+            : undefined,
+        ),
+        withDelta(
+          formatBytes(retained),
+          baseRetained !== undefined ? retained - baseRetained : undefined,
+        ),
+        shareCell(
+          shareMetric(c),
+          shareTotal,
+          b !== undefined ? shareMetric(b) : undefined,
+          shareBaseTotal,
+        ),
+      ];
+    };
+
+    const retainedRows = classes
+      .filter((c) => c.rnRetained <= 5)
+      .sort((a, b) => a.rnRetained - b.rnRetained)
+      .map((c) =>
+        classRow(
+          c,
+          (r) => r.dominatedSizeBytes + r.dominatedNativeSizeBytes,
+          reachableTotal,
+          baseReachableTotal,
+        ),
+      );
+
+    const shallowRows = classes
+      .filter((c) => c.rnShallow <= 5)
+      .sort((a, b) => a.rnShallow - b.rnShallow)
+      .map((c) =>
+        classRow(
+          c,
+          (r) => r.reachableSizeBytes,
+          cur.reachableHeapSize,
+          comparing ? baseStats.reachableHeapSize : 0,
+        ),
+      );
+
+    const countRows = classes
+      .filter((c) => c.rnCount <= 5)
+      .sort((a, b) => a.rnCount - b.rnCount)
+      .map((c) =>
+        classRow(
+          c,
+          (r) => r.reachableObjCount,
+          cur.reachableObjCount,
+          comparing ? baseStats.reachableObjCount : 0,
+        ),
+      );
+
+    return m(
+      Panel,
+      m(Panel.Header, {
+        title: TITLE,
+        subtitle: SUBTITLE,
+        controls: [
+          showInTimelineLink(
+            trace,
+            findProcessTrack(trace, upid, (k) => k === 'java_heap_graph')?.uri,
+            cur.eventId,
+          ),
+          m(
+            Anchor,
+            {
+              disabled: true,
+              title:
+                'Direct linking to specific heap dumps in HDE is not yet ' +
+                'supported',
+              icon: Icons.ExternalLink,
+            },
+            'Show in Heap Dump Explorer',
+          ),
+        ],
+      }),
+      m(
+        Panel.Body,
+        m(Stack, {spacing: 'large'}, [
+          m('.pf-memscope-memmap__section-header', [
+            m(
+              'span.pf-memscope-memmap__section-title',
+              {
+                className: comparing
+                  ? 'pf-memscope-memmap__section-title--diff'
+                  : 'pf-memscope-memmap__section-title--straight',
+              },
+              comparing && baseStats !== undefined
+                ? `Dump @ t=${tOf(baseStats.ts)}s → t=${tOf(cur.ts)}s`
+                : `Dump @ t=${tOf(cur.ts)}s`,
+            ),
+            m(
+              'span.pf-memscope-memmap__section-hint',
+              comparing && baseIdx !== undefined
+                ? `dumps #${baseIdx + 1} → #${selIdx + 1} · Δ vs baseline`
+                : `dump #${selIdx + 1} of ${data.dumps.length}`,
+            ),
+          ]),
+          insight.length > 0 && m(Callout, {intent: Intent.Primary}, insight),
+          m(BillboardStrip, [
+            statCard([
+              {
+                label: 'Heap',
+                value: formatBytes(cur.totalHeapSize),
+                sub: comparing
+                  ? deltaText(
+                      cur.totalHeapSize - baseStats.totalHeapSize,
+                      `Δ ${formatDelta(cur.totalHeapSize - baseStats.totalHeapSize)} vs baseline`,
+                    )
+                  : 'reachable + unreachable',
+              },
+            ]),
+            statCard([
+              {
+                label: 'Live objects',
+                value: cur.totalObjCount.toLocaleString(),
+                sub: comparing
+                  ? deltaText(
+                      cur.totalObjCount - baseStats.totalObjCount,
+                      `Δ ${formatCountDelta(cur.totalObjCount - baseStats.totalObjCount)} vs baseline`,
+                    )
+                  : `${cur.reachableObjCount.toLocaleString()} reach · ` +
+                    `${(
+                      cur.totalObjCount - cur.reachableObjCount
+                    ).toLocaleString()} unreach`,
+              },
+            ]),
+            statCard([
+              {
+                label: 'Registered native',
+                value: formatBytes(cur.reachableNativeSize),
+                sub: comparing
+                  ? deltaText(
+                      cur.reachableNativeSize - baseStats.reachableNativeSize,
+                      `Δ ${formatDelta(cur.reachableNativeSize - baseStats.reachableNativeSize)} vs baseline`,
+                    )
+                  : 'owned by Java (bitmaps, NIO)',
+              },
+            ]),
+            curArt !== undefined &&
+              curArt > 0 &&
+              statCard([
+                {
+                  label: 'ART overhead',
+                  value: formatBytes(curArt),
+                  sub:
+                    comparing && baseArt !== undefined
+                      ? deltaText(
+                          curArt - baseArt,
+                          `Δ ${formatDelta(curArt - baseArt)} vs baseline`,
+                        )
+                      : '.art images + JIT cache',
+                },
+              ]),
+          ]),
+          ratioBar({
+            label: 'Heap reachability',
+            tooltip:
+              'Reachable = objects a GC root still references. Unreachable ' +
+              'objects are garbage awaiting collection.',
+            pct: reachPct,
+            headline: 'of the Java heap is reachable',
+            color: '#f4b400',
+            aLabel: 'Reachable',
+            aBytes: cur.reachableHeapSize,
+            bLabel: 'Unreachable',
+            bBytes: unreachableHeap,
+            ...(comparing
+              ? {
+                  aDelta: cur.reachableHeapSize - baseStats.reachableHeapSize,
+                  bDelta:
+                    unreachableHeap -
+                    (baseStats.totalHeapSize - baseStats.reachableHeapSize),
+                  pctDelta:
+                    reachPct -
+                    (baseStats.totalHeapSize > 0
+                      ? (baseStats.reachableHeapSize /
+                          baseStats.totalHeapSize) *
+                        100
+                      : 0),
+                }
+              : {}),
+          }),
+          m('.pf-memscope-tables', [
+            retainedRows.length > 0 &&
+              topTable({
+                title: 'Top classes by retained size',
+                cols: classCols,
+                rows: retainedRows,
+              }),
+            shallowRows.length > 0 &&
+              topTable({
+                title: 'Top classes by shallow size',
+                cols: classCols,
+                rows: shallowRows,
+              }),
+            countRows.length > 0 &&
+              topTable({
+                title: 'Top classes by instance count',
+                cols: classCols,
+                rows: countRows,
+              }),
+          ]),
+        ]),
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/memory_map.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/memory_map.ts
@@ -1,0 +1,597 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The "Where did all the memory go?" panel: a complete breakdown of resident
+// memory for one process, from smaps, rendered as a nested flame-chart. The
+// Native and Java blocks are optionally split a third level using cross-source
+// figures (heapprofd unreleased / heap-graph reachable). Self-contained: owns
+// its own query slot and loading logic and shows the latest smaps snapshot.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import {
+  FlamegraphChart,
+  type FlamegraphChartSegment,
+} from '../../../../../components/widgets/charts/flamegraph_chart';
+import type {Trace} from '../../../../../public/trace';
+import {SMAPS_TRACK_KIND} from '../../../../../public/track_kinds';
+import {LONG, NUM, STR} from '../../../../../trace_processor/query_result';
+import {Callout} from '../../../components/callout';
+import {Intent} from '../../../../../widgets/common';
+import {Panel} from '../../../components/panel';
+import {deltaText, formatBytes, formatDelta} from '../mem_format';
+import {findProcessTrack, showInTimelineLink} from '../process_links';
+import {nearestByTs} from '../selection';
+import {emptyPanel, loadingPanel} from '../section_widgets';
+import {
+  MEMMAP_GREY,
+  SMAPS_CATEGORIES,
+  SMAPS_CATEGORY_CASE_SQL,
+  SMAPS_FILE_BUCKET_CASE_SQL,
+  smapsCategoryColor,
+} from '../smaps_categories';
+
+// File-backed subcategories for the memory map's second level, in display
+// order. Keys match the buckets produced by SMAPS_FILE_BUCKET_CASE_SQL. All
+// share the file-backed colour; they're distinguished by label.
+const FILE_BUCKETS = [
+  {key: 'so', label: 'Native libs (.so)', color: '#34a853'},
+  {key: 'java_code', label: 'Java code (.jar/.oat)', color: '#2e7d46'},
+  {key: 'resources', label: 'Resources / APK', color: '#46b966'},
+  {key: 'other_file', label: 'Other files', color: '#7cc596'},
+];
+
+// Lightens a block colour for its "remainder" sub-block (the part we can't
+// attribute to a profiler/reachability figure).
+const MEMMAP_LIGHTEN: Record<string, string> = {
+  '#4285f4': '#a6c8fa', // native blue → light
+  '#f4b400': '#fad470', // java amber → light
+};
+
+// Plain-language explanation shown under the block breakdown while hovering
+// each block of the memory map.
+const MEMMAP_BLOCK_INFO: Record<string, string> = {
+  'File-backed':
+    'Memory backed by files on disk: code (.so/.oat), fonts and resources. ' +
+    'Mostly clean — the kernel can drop and re-read it under pressure.',
+  'Anonymous':
+    'Memory not backed by any file: heaps and runtime allocations. This is ' +
+    'what your process truly costs; it can only be reclaimed by swapping.',
+  'Graphics':
+    'GPU buffers and driver mappings (kgsl / mali / dri / dmabuf) mapped ' +
+    'into this process.',
+  'Other':
+    'Non-anonymous regions that do not fit the other buckets (devices, ' +
+    'shared memory files, …).',
+  'Native':
+    'Native allocator arenas (scudo / jemalloc / libc malloc / GWP-ASan) ' +
+    'and the legacy [heap]. What malloc() costs you in resident memory.',
+  'Java':
+    'Dalvik/ART managed heap and runtime spaces — everything the Java ' +
+    'garbage collector manages.',
+  'Thread stacks': 'Stack memory for every live thread in the process.',
+  'Other anon':
+    'Anonymous memory not attributable to a specific allocator: plain ' +
+    'mmap() regions, untagged buffers, IPC shared memory.',
+  'Native libs (.so)':
+    'Shared libraries (.so) mapped into the process — code and read-only ' +
+    'data, mostly clean and shared between processes.',
+  'Java code (.jar/.oat)':
+    'Compiled and bytecode Java artifacts (.jar/.oat/.odex/.vdex/.art) ' +
+    'backing the managed runtime.',
+  'Resources / APK':
+    'APK archives, fonts and asset files mapped by the app and framework.',
+  'Other files': 'File-backed mappings that do not fit the other buckets.',
+  'Seen by profiler':
+    'Native allocations the heapprofd profiler observed as still unreleased ' +
+    'at this snapshot. Allocations made before tracing started are invisible.',
+  'Allocator overhead':
+    'Native resident memory the profiler could not attribute: allocator ' +
+    'metadata, fragmentation and allocations that predate the trace.',
+  'Reachable':
+    'Java heap still reachable from GC roots at the nearest heap dump — live ' +
+    'objects the collector cannot free.',
+  'Unreachable / other':
+    'Managed heap not accounted for as reachable at the nearest dump: ' +
+    'garbage awaiting collection, runtime overhead and dump skew.',
+};
+
+// Per-category resident/swap/anon bytes at one snapshot.
+interface CategoryBytes {
+  rss: number;
+  swap: number;
+  anon: number;
+}
+
+// One smaps snapshot (a single ts): per-category bytes, the file-backed
+// breakdown by bucket and the total footprint. x is seconds from trace start.
+interface MemSnapshot {
+  readonly ts: time;
+  readonly x: number;
+  readonly total: number;
+  readonly byCategory: ReadonlyMap<string, CategoryBytes>;
+  readonly fileByBucket: ReadonlyMap<string, number>;
+  // MIN(profiler_smaps.id) for this snapshot — the Smaps track event id used to
+  // select it on the timeline (mirrors dev.perfetto.Smaps' _smaps_snapshots).
+  readonly eventId: number;
+}
+
+// Cross-source figures layered onto the memory map's third level.
+interface MemExtras {
+  readonly nativeSeen: number; // heapprofd unreleased bytes
+  readonly javaReachable: number; // reachable Java heap + native registry bytes
+}
+
+// The flame-tree for the selected snapshot, built in a slot keyed by the
+// selection so it's constructed once per snapshot change rather than on every
+// redraw — the chart's hover tooltip drives frequent redraws, and rebuilding
+// the whole tree (and its baseline diff) on each one is wasted work. In compare
+// mode each block carries its Δ vs the baseline snapshot's tree.
+interface MemTreeResult {
+  readonly tree: FlamegraphChartSegment;
+}
+
+interface MemoryMapData {
+  readonly snapshots: MemSnapshot[];
+}
+
+async function loadMemoryMapData(
+  trace: Trace,
+  upid: number,
+): Promise<MemoryMapData> {
+  // Per-(snapshot, category) resident/swap/anon.
+  const cats = new Map<bigint, Map<string, CategoryBytes>>();
+  const catRes = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      ${SMAPS_CATEGORY_CASE_SQL} AS category,
+      CAST(ifnull(SUM(s.rss_kb), 0) * 1024 AS INT) AS rss,
+      CAST(ifnull(SUM(s.swap_kb), 0) * 1024 AS INT) AS swap,
+      CAST(ifnull(SUM(s.anonymous_kb), 0) * 1024 AS INT) AS anon
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+    GROUP BY s.ts, category
+    ORDER BY s.ts ASC
+  `);
+  for (
+    const it = catRes.iter({
+      ts: LONG,
+      category: STR,
+      rss: NUM,
+      swap: NUM,
+      anon: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    let byCat = cats.get(it.ts);
+    if (byCat === undefined) {
+      byCat = new Map();
+      cats.set(it.ts, byCat);
+    }
+    byCat.set(it.category, {rss: it.rss, swap: it.swap, anon: it.anon});
+  }
+
+  // Per-(snapshot, file-bucket) resident+swap for file-backed mappings.
+  const files = new Map<bigint, Map<string, number>>();
+  const fileRes = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      ${SMAPS_FILE_BUCKET_CASE_SQL} AS bucket,
+      CAST(ifnull(SUM(s.rss_kb + s.swap_kb), 0) * 1024 AS INT) AS bytes
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid} AND s.path GLOB '/*'
+    GROUP BY s.ts, bucket
+    ORDER BY s.ts ASC
+  `);
+  for (
+    const it = fileRes.iter({ts: LONG, bucket: STR, bytes: NUM});
+    it.valid();
+    it.next()
+  ) {
+    let byBucket = files.get(it.ts);
+    if (byBucket === undefined) {
+      byBucket = new Map();
+      files.set(it.ts, byBucket);
+    }
+    byBucket.set(it.bucket, (byBucket.get(it.bucket) ?? 0) + it.bytes);
+  }
+
+  // MIN(object id) per snapshot — the Smaps track event id for that ts
+  // (mirrors how dev.perfetto.Smaps builds its _smaps_snapshots events).
+  const eventIdByTs = new Map<bigint, number>();
+  const eventRes = await trace.engine.query(`
+    SELECT ts, MIN(id) AS event_id
+    FROM profiler_smaps
+    WHERE upid = ${upid}
+    GROUP BY ts
+  `);
+  for (
+    const it = eventRes.iter({ts: LONG, event_id: NUM});
+    it.valid();
+    it.next()
+  ) {
+    eventIdByTs.set(it.ts, it.event_id);
+  }
+
+  const start = trace.traceInfo.start;
+  const snapshots: MemSnapshot[] = Array.from(cats.entries()).map(
+    ([ts, byCategory]) => {
+      let total = 0;
+      for (const r of byCategory.values()) total += r.rss + r.swap;
+      return {
+        ts: Time.fromRaw(ts),
+        x: Number(ts - start) / 1e9,
+        total,
+        byCategory,
+        fileByBucket: files.get(ts) ?? new Map(),
+        eventId: eventIdByTs.get(ts) ?? -1,
+      };
+    },
+  );
+
+  return {snapshots};
+}
+
+// Cross-source figures for the snapshot at `ts`. nativeSeen is the cumulative
+// heapprofd unreleased footprint up to ts (summed across heaps); javaReachable
+// is the reachable Java heap of the heap-graph dump nearest ts. Both are
+// best-effort — absent data yields 0 and the third-level split is skipped.
+async function loadExtras(
+  trace: Trace,
+  upid: number,
+  ts: time | undefined,
+): Promise<MemExtras> {
+  if (ts === undefined) return {nativeSeen: 0, javaReachable: 0};
+
+  let nativeSeen = 0;
+  const nativeRes = await trace.engine.query(`
+    SELECT CAST(ifnull(SUM(a.size), 0) AS INT) AS seen
+    FROM heap_profile_allocation a
+    WHERE a.upid = ${upid} AND a.ts <= ${ts}
+  `);
+  const nativeIt = nativeRes.firstRow({seen: NUM});
+  nativeSeen = Math.max(0, nativeIt.seen);
+
+  let javaReachable = 0;
+  try {
+    await trace.engine.query(
+      'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;',
+    );
+    const javaRes = await trace.engine.query(`
+      SELECT
+        CAST(s.reachable_heap_size + s.reachable_native_alloc_registry_size
+          AS INT) AS reachable
+      FROM android_heap_graph_stats s
+      WHERE s.upid = ${upid}
+      ORDER BY ABS(s.graph_sample_ts - ${ts}) ASC
+      LIMIT 1
+    `);
+    const javaIt = javaRes.iter({reachable: NUM});
+    if (javaIt.valid()) javaReachable = Math.max(0, javaIt.reachable);
+  } catch {
+    // No heap graph — leave javaReachable at 0.
+  }
+
+  return {nativeSeen, javaReachable};
+}
+
+// Builds the nested region tree for one snapshot, shaped for FlameChartSimple.
+// The root is the resident+swap total; each level splits proportionally:
+//   root        → File-backed / Anonymous / Graphics / Other
+//   File-backed → .so / .jar-.oat / resources / other
+//   Anonymous   → Native / Java / Thread stacks / Other anon
+//   Native      → Seen by profiler / Allocator overhead
+//   Java        → Reachable / Unreachable / other
+// `baseByLabel` (compare mode) adds a "Δ vs baseline" line to each tooltip.
+function buildMemTree(
+  snap: MemSnapshot,
+  extras: MemExtras,
+  baseByLabel?: Map<string, number>,
+): FlamegraphChartSegment {
+  const get = (key: string) => snap.byCategory.get(key);
+  const resSwap = (r?: CategoryBytes) => (r ? r.rss + r.swap : 0);
+
+  const file = get('file');
+  const graphics = get('graphics');
+  const other = get('other');
+  const native = get('native');
+  const java = get('java');
+  const stack = get('stack');
+  // The "other" category mixes anonymous and non-anonymous regions; its
+  // anonymous part (plus swap, which is always anonymous) belongs in the
+  // Anonymous block, the remainder in Other.
+  const otherAnon = other ? other.anon + other.swap : 0;
+  const otherNonAnon = other ? Math.max(0, other.rss - other.anon) : 0;
+  const fileBytes = resSwap(file);
+  const nativeBytes = resSwap(native);
+  const javaBytes = resSwap(java);
+  const stackBytes = resSwap(stack);
+  const graphicsBytes = resSwap(graphics);
+  const anonBytes = nativeBytes + javaBytes + stackBytes + otherAnon;
+  const total = fileBytes + anonBytes + graphicsBytes + otherNonAnon;
+
+  const nativeColor = smapsCategoryColor('native');
+  const javaColor = smapsCategoryColor('java');
+  // Clamp the cross-source figures to the smaps block size so a sub-block
+  // never overflows its parent.
+  const nativeSeen = Math.min(Math.max(0, extras.nativeSeen), nativeBytes);
+  const javaReachable = Math.min(Math.max(0, extras.javaReachable), javaBytes);
+
+  // One node, with a tooltip carrying the share and the plain-language
+  // explanation (when one is known for the label).
+  const seg = (
+    label: string,
+    bytes: number,
+    color: string,
+    children: FlamegraphChartSegment[] = [],
+  ): FlamegraphChartSegment => {
+    const share = total > 0 ? ((bytes / total) * 100).toFixed(1) : '0';
+    const tip: m.Children = [
+      m('.pf-flamechart-tooltip__name', label),
+      m('.pf-flamechart-tooltip__value', `${formatBytes(bytes)} · ${share}%`),
+    ];
+    const baseBytes = baseByLabel?.get(label);
+    if (baseBytes !== undefined) {
+      tip.push(
+        deltaText(bytes - baseBytes, `Δ ${formatDelta(bytes - baseBytes)}`),
+      );
+    }
+    const info = MEMMAP_BLOCK_INFO[label];
+    if (info !== undefined) {
+      tip.push(m('.pf-flamechart-tooltip__desc', info));
+    }
+    return {name: label, value: bytes, cssColor: color, children, tooltip: tip};
+  };
+
+  // File-backed second level: split into path buckets, scaled so they sum to
+  // exactly fileBytes (the bucket query and the category query round
+  // independently). If no bucket data, dump it all into "other files".
+  const bucketBytes = FILE_BUCKETS.map(
+    (b) => snap.fileByBucket.get(b.key) ?? 0,
+  );
+  const bucketTotal = bucketBytes.reduce((s, b) => s + b, 0);
+  const fileChildren = FILE_BUCKETS.map((b, i) =>
+    seg(
+      b.label,
+      bucketTotal > 0
+        ? (bucketBytes[i] / bucketTotal) * fileBytes
+        : b.key === 'other_file'
+          ? fileBytes
+          : 0,
+      b.color,
+    ),
+  ).filter((s) => s.value > 0);
+
+  const anonChildren = [
+    seg(
+      'Native',
+      nativeBytes,
+      nativeColor,
+      [
+        seg('Seen by profiler', nativeSeen, nativeColor),
+        seg(
+          'Allocator overhead',
+          nativeBytes - nativeSeen,
+          MEMMAP_LIGHTEN[nativeColor] ?? nativeColor,
+        ),
+      ].filter((s) => s.value > 0),
+    ),
+    seg(
+      'Java',
+      javaBytes,
+      javaColor,
+      [
+        seg('Reachable', javaReachable, javaColor),
+        seg(
+          'Unreachable / other',
+          javaBytes - javaReachable,
+          MEMMAP_LIGHTEN[javaColor] ?? javaColor,
+        ),
+      ].filter((s) => s.value > 0),
+    ),
+    seg('Thread stacks', stackBytes, smapsCategoryColor('stack')),
+    seg('Other anon', otherAnon, smapsCategoryColor('other')),
+  ].filter((s) => s.value > 0);
+
+  const children = [
+    seg('File-backed', fileBytes, smapsCategoryColor('file'), fileChildren),
+    seg('Anonymous', anonBytes, smapsCategoryColor('native'), anonChildren),
+    seg('Graphics', graphicsBytes, smapsCategoryColor('graphics')),
+    seg('Other', otherNonAnon, smapsCategoryColor('other')),
+  ].filter((s) => s.value > 0);
+
+  return seg('Resident + swap', total, MEMMAP_GREY, children);
+}
+
+// Flattens a region tree to a label → bytes map, for diffing one snapshot's
+// tree against another's (labels are unique across the tree).
+function flattenMemTree(
+  seg: FlamegraphChartSegment,
+  out: Map<string, number>,
+): Map<string, number> {
+  out.set(seg.name, seg.value);
+  for (const c of seg.children) flattenMemTree(c, out);
+  return out;
+}
+
+const TITLE = 'Where did all the memory go?';
+
+export interface MemoryMapAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  // The page-wide selection (by ts). Undefined → latest snapshot.
+  readonly selTs?: time;
+  readonly baseTs?: time;
+}
+
+export class MemoryMap implements m.ClassComponent<MemoryMapAttrs> {
+  // Per-snapshot tree inputs (keyed by upid; the selection doesn't reload it).
+  private readonly slot = new QuerySlot<MemoryMapData>();
+  // The flame-tree for the selected/baseline snapshot, keyed by selection so it
+  // is only (re)built when the snapshot changes, not on every redraw.
+  private readonly treeSlot = new QuerySlot<MemTreeResult>();
+
+  onremove() {
+    this.slot.dispose();
+    this.treeSlot.dispose();
+  }
+
+  view({attrs}: m.Vnode<MemoryMapAttrs>): m.Children {
+    const {trace, upid, selTs, baseTs} = attrs;
+    const subtitle =
+      'A complete breakdown of resident memory, from smaps, for the ' +
+      'selected snapshot.';
+    const data = this.slot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadMemoryMapData(trace, upid),
+    }).data;
+    if (data === undefined) {
+      return loadingPanel({title: TITLE, subtitle}); // Still loading.
+    }
+
+    const snaps = data.snapshots;
+    if (snaps.length === 0) {
+      return emptyPanel({
+        title: TITLE,
+        subtitle,
+        message: 'No smaps data in this trace for this process.',
+      });
+    }
+
+    // Resolve the selection to snapshots. No selection → latest.
+    const snap = nearestByTs(snaps, selTs)!;
+    const selIdx = snaps.indexOf(snap);
+    const baseSnap =
+      baseTs !== undefined ? nearestByTs(snaps, baseTs) : undefined;
+    const base =
+      baseSnap !== undefined && baseSnap.ts !== snap.ts ? baseSnap : undefined;
+    const baseIdx = base !== undefined ? snaps.indexOf(base) : undefined;
+    const comparing = base !== undefined;
+
+    // The flame-tree for the resolved snapshot, built (with its baseline diff)
+    // in a slot keyed by the selection so it's only constructed when the
+    // snapshot changes, not on every (hover-driven) redraw.
+    const tree = this.treeSlot.use({
+      key: {
+        traceId: trace.traceInfo.uuid,
+        upid,
+        sel: snap.ts.toString(),
+        base: base !== undefined ? base.ts.toString() : null,
+      },
+      queryFn: async () => {
+        // In compare mode, annotate each block with its Δ vs the baseline tree.
+        const baseByLabel =
+          base !== undefined
+            ? flattenMemTree(
+                buildMemTree(base, await loadExtras(trace, upid, base.ts)),
+                new Map(),
+              )
+            : undefined;
+        const selExtras = await loadExtras(trace, upid, snap.ts);
+        return {tree: buildMemTree(snap, selExtras, baseByLabel)};
+      },
+    }).data?.tree;
+
+    const first = snaps[0];
+    const last = snaps[snaps.length - 1];
+    // Insight: biggest slice of the latest snapshot + fastest-growing slice.
+    const catVal = (s: MemSnapshot, key: string) => {
+      const r = s.byCategory.get(key);
+      return r ? r.rss + r.swap : 0;
+    };
+    const stats = SMAPS_CATEGORIES.map((c) => ({
+      ...c,
+      last: catVal(last, c.key),
+      delta: catVal(last, c.key) - catVal(first, c.key),
+    }));
+    const biggest = stats.reduce((a, b) => (b.last > a.last ? b : a));
+    const fastest = stats.reduce((a, b) => (b.delta > a.delta ? b : a));
+    const pct =
+      last.total > 0 ? Math.round((biggest.last / last.total) * 100) : 0;
+    const insight: m.Children = [
+      m('b', `${biggest.label} memory`),
+      ' is ',
+      m('b', `${pct}% of the footprint`),
+    ];
+    if (snaps.length > 1 && fastest.delta > 0) {
+      if (fastest.key === biggest.key) {
+        insight.push(
+          ' and the fastest-growing slice (',
+          m('b', formatDelta(fastest.delta)),
+          ').',
+        );
+      } else {
+        insight.push(
+          '; ',
+          m('b', fastest.label),
+          ' is the fastest-growing slice (',
+          m('b', formatDelta(fastest.delta)),
+          ').',
+        );
+      }
+    } else {
+      insight.push('.');
+    }
+
+    const smapsTrackNode = findProcessTrack(
+      trace,
+      upid,
+      (k) => k === SMAPS_TRACK_KIND,
+    );
+
+    return m(
+      Panel,
+      m(Panel.Header, {
+        title: TITLE,
+        subtitle,
+        controls: showInTimelineLink(trace, smapsTrackNode?.uri, snap.eventId),
+      }),
+      m(
+        Panel.Body,
+        m('.pf-memscope-memmap', [
+          m(Callout, {intent: Intent.Primary}, insight),
+          m('.pf-memscope-memmap__section-header', [
+            m(
+              'span.pf-memscope-memmap__section-title',
+              {
+                className:
+                  comparing && baseIdx !== undefined
+                    ? 'pf-memscope-memmap__section-title--diff'
+                    : 'pf-memscope-memmap__section-title--straight',
+              },
+              comparing && baseIdx !== undefined
+                ? `Diffing snapshot #${baseIdx + 1} → #${selIdx + 1}`
+                : `Snapshot #${selIdx + 1} — t=${snap.x.toFixed(0)}s`,
+            ),
+            m(
+              'span.pf-memscope-memmap__section-hint',
+              comparing
+                ? 'block widths from the later snapshot · hover for Δ vs baseline'
+                : 'absolute resident memory · hover a block for details',
+            ),
+          ]),
+          tree !== undefined
+            ? m(FlamegraphChart, {
+                data: tree,
+                formatValue: formatBytes,
+                hideRoot: true,
+              })
+            : m('.pf-memscope-placeholder', 'Building memory map…'),
+        ]),
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/native_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/native_section.ts
@@ -1,0 +1,483 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// "How much native memory did you use, and where did it go?" — heapprofd
+// coverage vs the smaps native total, plus the top unreleased call-stacks over
+// the whole trace, for one process. Self-contained: owns its query slot and
+// loading logic.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../../base/query_slot';
+import type {time} from '../../../../../base/time';
+import type {Trace} from '../../../../../public/trace';
+import {
+  LONG_NULL,
+  NUM,
+  NUM_NULL,
+  STR,
+  STR_NULL,
+} from '../../../../../trace_processor/query_result';
+import {Panel} from '../../../components/panel';
+import {Callout} from '../../../components/callout';
+import {Intent} from '../../../../../widgets/common';
+import {deltaText, formatBytes, formatDelta, statCard} from '../mem_format';
+import {findProcessTrack, showInTimelineLink} from '../process_links';
+import {
+  emptyPanel,
+  loadingPanel,
+  ratioBar,
+  shareBar,
+  topTable,
+} from '../section_widgets';
+import {SMAPS_CATEGORY_CASE_SQL} from '../smaps_categories';
+import {Stack} from '../../../../../widgets/stack';
+import {BillboardStrip} from '../../../components/billboard';
+
+const TITLE = 'How much native memory did you use, and where did it go?';
+const SUBTITLE =
+  "Aggregated by allocation callstack — the clearest signal when it's " +
+  'available.';
+
+// One top-unreleased heapprofd callsite with its app-only frame chain
+// (leaf → root).
+interface NativeStack {
+  unreleased: number;
+  allocs: number;
+  frames: string[];
+}
+
+interface NativeData {
+  readonly hasProfile: boolean;
+  // Top app-attributed callsites by unreleased bytes in the selected window.
+  readonly stacks: NativeStack[];
+  // Total positive-net unreleased bytes in the window (share-bar denominator).
+  readonly profileTotal: number;
+  // Cumulative unreleased bytes the profiler observed up to the selected
+  // snapshot.
+  readonly seen: number;
+  // In compare mode, the cumulative unreleased up to the baseline snapshot.
+  readonly baseSeen?: number;
+  // Native allocator footprint (rss+swap) at the selected smaps snapshot.
+  readonly nativeRss: number;
+  // Thread-stack footprint (rss+swap) at the selected smaps snapshot.
+  readonly stackBytes: number;
+  readonly threads?: number;
+  // HeapProfile track event id (MIN object id) at the heapprofd dump nearest
+  // the selection — the target for "show in timeline". -1 when no profile.
+  readonly eventId: number;
+}
+
+// heapprofd data is incremental (per-dump deltas), so a window sum is "what
+// was allocated and still unreleased in that window":
+//   - single snapshot → window (start, selTs] → cumulative unreleased up to it.
+//   - range brushed → window (baseTs, selTs] → net unreleased between the two.
+async function loadNativeData(
+  trace: Trace,
+  upid: number,
+  selTs: time | undefined,
+  baseTs: time | undefined,
+): Promise<NativeData> {
+  const countRes = await trace.engine.query(`
+    SELECT COUNT(*) AS n FROM heap_profile_allocation WHERE upid = ${upid}
+  `);
+  const hasProfile = countRes.firstRow({n: NUM}).n > 0;
+  if (!hasProfile) {
+    return {
+      hasProfile: false,
+      stacks: [],
+      profileTotal: 0,
+      seen: 0,
+      nativeRss: 0,
+      stackBytes: 0,
+      eventId: -1,
+    };
+  }
+
+  // The smaps snapshot to read the native/stack footprint from: the selected
+  // one, or the latest when nothing is selected.
+  const tsRes = await trace.engine.query(
+    `SELECT MAX(ts) AS ts FROM profiler_smaps WHERE upid = ${upid}`,
+  );
+  const lastSmapsTs = tsRes.firstRow({ts: LONG_NULL}).ts;
+  const snapTs: bigint | null = selTs ?? lastSmapsTs;
+  let nativeRss = 0;
+  let stackBytes = 0;
+  if (snapTs !== null) {
+    const catRes = await trace.engine.query(`
+      SELECT
+        ${SMAPS_CATEGORY_CASE_SQL} AS category,
+        CAST(ifnull(SUM(s.anonymous_kb + s.swap_kb), 0) * 1024 AS INT) AS bytes
+      FROM profiler_smaps s
+      WHERE s.upid = ${upid} AND s.ts = ${snapTs}
+      GROUP BY category
+    `);
+    for (
+      const it = catRes.iter({category: STR, bytes: NUM});
+      it.valid();
+      it.next()
+    ) {
+      if (it.category === 'native') nativeRss = it.bytes;
+      else if (it.category === 'stack') stackBytes = it.bytes;
+    }
+  }
+
+  // Cumulative unreleased up to the selected snapshot (and the baseline, for
+  // the compare delta).
+  const seen = await cumulativeUnreleased(trace, upid, snapTs);
+  const baseSeen =
+    baseTs !== undefined
+      ? await cumulativeUnreleased(trace, upid, baseTs)
+      : undefined;
+
+  const threadsRes = await trace.engine.query(
+    `SELECT COUNT(*) AS n FROM thread WHERE upid = ${upid}`,
+  );
+  const threads = threadsRes.firstRow({n: NUM}).n;
+
+  // HeapProfile track event id (MIN object id) at the heapprofd dump nearest
+  // the selection, so "show in timeline" jumps to the right point on the
+  // heapprofd track. heapprofd is continuous (not snapshot-based), so this is
+  // the closest dump to the selected window end rather than an exact match.
+  const eventRes = await trace.engine.query(`
+    SELECT MIN(a.id) AS event_id
+    FROM heap_profile_allocation a
+    WHERE a.upid = ${upid}
+      AND a.ts = (
+        SELECT ts FROM heap_profile_allocation
+        WHERE upid = ${upid}
+        ORDER BY ${snapTs !== null ? `ABS(ts - ${snapTs})` : 'ts'}
+        LIMIT 1
+      )
+  `);
+  const eventId = eventRes.firstRow({event_id: NUM_NULL}).event_id ?? -1;
+
+  // Call-stacks over the window (baseTs, selTs].
+  const {stacks, profileTotal} = await loadNativeStacks(
+    trace,
+    upid,
+    baseTs,
+    snapTs,
+  );
+
+  return {
+    hasProfile: true,
+    stacks,
+    profileTotal,
+    seen,
+    baseSeen,
+    nativeRss,
+    stackBytes,
+    threads: threads > 0 ? threads : undefined,
+    eventId,
+  };
+}
+
+// Cumulative positive+negative unreleased bytes for the process up to `toTs`
+// (the whole trace when null).
+async function cumulativeUnreleased(
+  trace: Trace,
+  upid: number,
+  toTs: bigint | null,
+): Promise<number> {
+  const res = await trace.engine.query(`
+    SELECT CAST(ifnull(SUM(a.size), 0) AS INT) AS seen
+    FROM heap_profile_allocation a
+    WHERE a.upid = ${upid}${toTs !== null ? ` AND a.ts <= ${toTs}` : ''}
+  `);
+  return Math.max(0, res.firstRow({seen: NUM}).seen);
+}
+
+// Loads the top native allocation call-stacks for one process over the window
+// (fromTs, toTs]. Frame chains are filtered to app frames.
+async function loadNativeStacks(
+  trace: Trace,
+  upid: number,
+  fromTs: time | undefined,
+  toTs: bigint | null,
+): Promise<{stacks: NativeStack[]; profileTotal: number}> {
+  const window =
+    (fromTs !== undefined ? ` AND a.ts > ${fromTs}` : '') +
+    (toTs !== null ? ` AND a.ts <= ${toTs}` : '');
+  const unrelCte = `
+    unrel AS (
+      SELECT
+        a.callsite_id AS callsite_id,
+        SUM(a.size) AS unreleased,
+        SUM(CASE WHEN a.count > 0 THEN a.count ELSE 0 END) AS allocs
+      FROM heap_profile_allocation a
+      WHERE a.upid = ${upid}${window}
+      GROUP BY a.callsite_id
+      HAVING SUM(a.size) > 0
+    )`;
+
+  const stacks: NativeStack[] = [];
+  const stackRes = await trace.engine.query(`
+    WITH
+    ${unrelCte},
+    top_sites AS (
+      SELECT * FROM (
+        SELECT u.*, ROW_NUMBER() OVER (
+          ORDER BY u.unreleased DESC
+        ) AS rn
+        FROM unrel u
+      ) WHERE rn <= 5
+    ),
+    chain(top_id, unreleased, allocs, callsite_id, depth) AS (
+      SELECT callsite_id, unreleased, allocs, callsite_id, 0
+      FROM top_sites
+      UNION ALL
+      SELECT c.top_id, c.unreleased, c.allocs, sc.parent_id, c.depth + 1
+      FROM chain c
+      JOIN stack_profile_callsite sc ON sc.id = c.callsite_id
+      WHERE sc.parent_id IS NOT NULL AND c.depth < 128
+    )
+    SELECT
+      c.top_id AS top_id,
+      CAST(c.unreleased AS INT) AS unreleased,
+      CAST(c.allocs AS INT) AS allocs,
+      c.depth AS depth,
+      coalesce(f.deobfuscated_name, f.name, '<unknown>') AS frame_name,
+      mp.name AS mapping_name
+    FROM chain c
+    JOIN stack_profile_callsite sc ON sc.id = c.callsite_id
+    JOIN stack_profile_frame f ON sc.frame_id = f.id
+    LEFT JOIN stack_profile_mapping mp ON f.mapping = mp.id
+    ORDER BY c.top_id, c.depth ASC
+  `);
+  let cur: (NativeStack & {topId: number}) | undefined;
+  for (
+    const it = stackRes.iter({
+      top_id: NUM,
+      unreleased: NUM,
+      allocs: NUM,
+      depth: NUM,
+      frame_name: STR,
+      mapping_name: STR_NULL,
+    });
+    it.valid();
+    it.next()
+  ) {
+    if (cur === undefined || cur.topId !== it.top_id) {
+      cur = {
+        topId: it.top_id,
+        unreleased: it.unreleased,
+        allocs: it.allocs,
+        frames: [],
+      };
+      stacks.push(cur);
+    }
+    // Keep only frames from the app under test; drop system/runtime libraries.
+    if (isAppMapping(it.mapping_name ?? undefined)) {
+      cur.frames.push(it.frame_name);
+    }
+  }
+  stacks.sort((a, b) => b.unreleased - a.unreleased);
+
+  const totRes = await trace.engine.query(`
+    WITH ${unrelCte}
+    SELECT CAST(ifnull(SUM(unreleased), 0) AS INT) AS total FROM unrel
+  `);
+  const profileTotal = totRes.firstRow({total: NUM}).total;
+
+  return {stacks, profileTotal};
+}
+
+// True when a frame's mapping belongs to the app under test rather than a
+// system/runtime library. App code is installed under /data/app or /data/data.
+function isAppMapping(mapping?: string): boolean {
+  if (mapping === undefined) return false;
+  return /^\/data\/(app|data)\//.test(mapping);
+}
+
+// Shrinks an (already app-only) frame chain (leaf → root) to a short snippet.
+function stackSnippet(frames: string[]): string[] {
+  if (frames.length === 0) return ['(no app frames)'];
+  if (frames.length <= 7) return frames;
+  const leaf = frames[0];
+  const middle = frames.slice(1, -2).slice(0, 4);
+  const root = frames.slice(-2);
+  return [leaf, ...middle, '…', ...root];
+}
+
+export interface NativeSectionAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  // The page-wide selection (by ts). Undefined → whole trace / latest.
+  readonly selTs?: time;
+  readonly baseTs?: time;
+}
+
+export class NativeSection implements m.ClassComponent<NativeSectionAttrs> {
+  private readonly slot = new QuerySlot<NativeData>();
+
+  onremove() {
+    this.slot.dispose();
+  }
+
+  view({attrs}: m.Vnode<NativeSectionAttrs>): m.Children {
+    const {trace, upid, selTs, baseTs} = attrs;
+    const data = this.slot.use({
+      key: {
+        traceId: trace.traceInfo.uuid,
+        upid,
+        sel: selTs !== undefined ? selTs.toString() : null,
+        base: baseTs !== undefined ? baseTs.toString() : null,
+      },
+      queryFn: () => loadNativeData(trace, upid, selTs, baseTs),
+      // Keep the previous window's data while the new one loads, so the panel
+      // doesn't flash empty on every snapshot change.
+      retainOn: ['sel', 'base'],
+    }).data;
+    if (data === undefined) {
+      return loadingPanel({title: TITLE, subtitle: SUBTITLE}); // Still loading.
+    }
+
+    if (!data.hasProfile) {
+      return emptyPanel({
+        title: TITLE,
+        subtitle: SUBTITLE,
+        message:
+          'No native heap profile (heapprofd) data in this trace for this ' +
+          'process.',
+      });
+    }
+
+    const {seen, baseSeen, nativeRss, stackBytes, threads, profileTotal} = data;
+    const comparing = baseTs !== undefined && baseSeen !== undefined;
+    const coveragePct = nativeRss > 0 ? (seen / nativeRss) * 100 : undefined;
+    const overhead = nativeRss > seen ? nativeRss - seen : 0;
+
+    const stackRows = data.stacks.slice(0, 5).map((s) => [
+      m(
+        '.pf-memscope-stack',
+        stackSnippet(s.frames).map((f) =>
+          m(
+            '.pf-memscope-stack__frame',
+            {title: f},
+            f.length > 60 ? `${f.slice(0, 58)}…` : f,
+          ),
+        ),
+      ),
+      formatBytes(s.unreleased),
+      s.allocs.toLocaleString(),
+      shareBar(profileTotal > 0 ? s.unreleased / profileTotal : 0),
+    ]);
+
+    return m(
+      Panel,
+      m(Panel.Header, {
+        title: TITLE,
+        subtitle: SUBTITLE,
+        controls: showInTimelineLink(
+          trace,
+          findProcessTrack(trace, upid, (k) => k.startsWith('heap_profile:'))
+            ?.uri,
+          data.eventId,
+        ),
+      }),
+      m(
+        Panel.Body,
+        m(Stack, {spacing: 'large'}, [
+          m(
+            Callout,
+            {intent: Intent.Warning},
+            'The native profiler only sees allocations made ',
+            m('b', 'after'),
+            " tracing started — it can't explain the past. Leaks present " +
+              'before t=0 are invisible here; trust the composition totals ' +
+              'above for the full resident picture.',
+          ),
+          m(BillboardStrip, [
+            nativeRss > 0 &&
+              statCard([
+                {
+                  label: 'RSS anon + swap',
+                  value: formatBytes(nativeRss),
+                  sub: 'total native private footprint',
+                },
+              ]),
+            statCard([
+              {
+                label: 'Seen by profiler',
+                value: formatBytes(seen),
+                sub:
+                  comparing && baseSeen !== undefined
+                    ? deltaText(
+                        seen - baseSeen,
+                        `Δ ${formatDelta(seen - baseSeen)} vs baseline`,
+                      )
+                    : coveragePct !== undefined
+                      ? `${Math.round(coveragePct)}% coverage`
+                      : 'unreleased over the whole trace',
+              },
+            ]),
+            overhead > 0 &&
+              statCard([
+                {
+                  label: 'Allocator overhead + unseen',
+                  value: formatBytes(overhead),
+                  sub: 'metadata, fragmentation, pre-trace',
+                },
+              ]),
+            stackBytes > 0 &&
+              statCard([
+                {
+                  label: 'Thread stacks',
+                  value: formatBytes(stackBytes),
+                  sub: threads !== undefined ? `${threads} threads` : undefined,
+                },
+              ]),
+          ]),
+          coveragePct !== undefined &&
+            ratioBar({
+              label: 'Profiler coverage',
+              tooltip:
+                'Unreleased bytes the profiler observed vs the native ' +
+                'allocator footprint from smaps. The rest predates the trace.',
+              pct: coveragePct,
+              headline: 'of native RSS explained by the profiler',
+              color: '#4285f4',
+              aLabel: 'Seen by profiler',
+              aBytes: seen,
+              bLabel: 'Unseen (pre-trace)',
+              bBytes: overhead,
+            }),
+          stackRows.length > 0
+            ? topTable({
+                title: 'Top allocation call-stacks',
+                subtitle: comparing
+                  ? 'unreleased between baseline and selected snapshot · ' +
+                    'app frames only'
+                  : selTs !== undefined
+                    ? 'unreleased up to the selected snapshot · app frames only'
+                    : 'unreleased over the whole trace · app frames only',
+                cols: [
+                  {label: 'Call-stack snippet'},
+                  {label: comparing ? 'Δ unreleased' : 'Unreleased', num: true},
+                  {label: 'Allocs', num: true},
+                  {label: 'Share of profiled', num: true},
+                ],
+                rows: stackRows,
+              })
+            : m(
+                '.pf-memscope-placeholder',
+                comparing
+                  ? 'No app allocations captured between these snapshots.'
+                  : 'No app allocations captured by the profiler here.',
+              ),
+        ]),
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/trace_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/trace_overview.ts
@@ -1,0 +1,286 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The top-level "trace overview" billboard: a row of headline stat cards for
+// one process (uptime / OOM score, peak RSS + spike, memory Δ + trend). Each
+// underlying query has its own slot so they load independently, and every card
+// is always rendered: missing facts show "N/A" rather than dropping the card.
+// Spans the whole trace, independent of the page's snapshot selection.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import type {Trace} from '../../../../../public/trace';
+import {
+  LONG,
+  NUM,
+  NUM_NULL,
+  STR,
+} from '../../../../../trace_processor/query_result';
+import {deltaText, formatBytes, formatDelta, statCard} from '../mem_format';
+import {BillboardStrip} from '../../../components/billboard';
+
+// Uptime + OOM score, from the process's last heap-graph dump.
+interface StatsData {
+  readonly uptime?: number; // ns, at the last heap dump
+  readonly oomScoreAdj?: number; // at the last heap dump
+}
+
+// RSS counter maxima over the whole trace.
+interface CounterData {
+  readonly rssWatermark?: number; // max of mem.rss.watermark
+  readonly rssMax?: number; // max of mem.rss
+}
+
+// Per-snapshot total anon+swap (smaps), ts-sorted across the whole trace.
+type AnonSwapSeries = readonly {ts: time; total: number}[];
+
+async function loadStats(trace: Trace, upid: number): Promise<StatsData> {
+  await trace.engine.query(
+    'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;',
+  );
+  const res = await trace.engine.query(`
+    SELECT
+      s.process_uptime AS uptime,
+      s.oom_score_adj AS oom_score_adj
+    FROM android_heap_graph_stats s
+    WHERE s.upid = ${upid}
+    ORDER BY s.graph_sample_ts DESC
+    LIMIT 1
+  `);
+  const it = res.iter({uptime: NUM_NULL, oom_score_adj: NUM_NULL});
+  if (!it.valid()) return {};
+  return {
+    uptime: it.uptime ?? undefined,
+    oomScoreAdj: it.oom_score_adj ?? undefined,
+  };
+}
+
+async function loadCounters(trace: Trace, upid: number): Promise<CounterData> {
+  let rssWatermark: number | undefined;
+  let rssMax: number | undefined;
+  const res = await trace.engine.query(`
+    SELECT t.name AS counter_name, MAX(c.value) AS max_value
+    FROM counter c
+    JOIN process_counter_track t ON c.track_id = t.id
+    WHERE t.upid = ${upid}
+      AND t.name IN ('mem.rss.watermark', 'mem.rss')
+    GROUP BY t.name
+  `);
+  for (
+    const it = res.iter({counter_name: STR, max_value: NUM});
+    it.valid();
+    it.next()
+  ) {
+    if (it.counter_name === 'mem.rss.watermark') rssWatermark = it.max_value;
+    else if (it.counter_name === 'mem.rss') rssMax = it.max_value;
+  }
+  return {rssWatermark, rssMax};
+}
+
+async function loadAnonSwap(
+  trace: Trace,
+  upid: number,
+): Promise<AnonSwapSeries> {
+  const anonSwap: {ts: time; total: number}[] = [];
+  const res = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      CAST(ifnull(SUM(s.anonymous_kb + s.swap_kb), 0) * 1024 AS INT) AS total
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+    GROUP BY s.ts
+    ORDER BY s.ts ASC
+  `);
+  for (const it = res.iter({ts: LONG, total: NUM}); it.valid(); it.next()) {
+    anonSwap.push({ts: Time.fromRaw(it.ts), total: it.total});
+  }
+  return anonSwap;
+}
+
+// "4h 12m" / "5m 3s" / "37s" from a duration in nanoseconds.
+function formatDurationShort(ns: number): string {
+  const secs = ns / 1e9;
+  if (secs < 60) return `${secs.toFixed(0)}s`;
+  const mins = secs / 60;
+  if (mins < 60) return `${Math.floor(mins)}m ${Math.round(secs % 60)}s`;
+  return `${Math.floor(mins / 60)}h ${Math.round(mins % 60)}m`;
+}
+
+// Coarse human label for an oom_score_adj value.
+function oomScoreLabel(adj: number): string {
+  if (adj <= 0) return 'foreground';
+  if (adj <= 200) return 'perceptible';
+  if (adj <= 600) return 'service';
+  return 'cached';
+}
+
+// One stat slot: the value when known, `undefined` once loaded but absent
+// (→ "N/A"), and a `loading` flag while the underlying query is in flight
+// (→ "…"). `sub` is an optional caption shown under an available value.
+interface Cell {
+  readonly label: string;
+  readonly loading: boolean;
+  readonly value?: m.Children;
+  readonly sub?: m.Children;
+}
+
+// Renders a cell into the {label, value, sub} shape statCard expects, mapping
+// the loading/absent states to "…" / "N/A — not available".
+function renderCell(c: Cell): {
+  label: string;
+  value: m.Children;
+  sub?: m.Children;
+} {
+  if (c.loading) return {label: c.label, value: '…'};
+  if (c.value === undefined) {
+    return {label: c.label, value: '-', sub: 'not available'};
+  }
+  return {label: c.label, value: c.value, sub: c.sub};
+}
+
+// A card whose stats are all Cells — always rendered, so missing facts surface
+// as "N/A" rather than dropping the whole card.
+function cellCard(cells: Cell[]): m.Child {
+  return statCard(cells.map(renderCell));
+}
+
+export interface TraceOverviewAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+}
+
+export class TraceOverview implements m.ClassComponent<TraceOverviewAttrs> {
+  // One slot per query, so the three load and redraw independently.
+  private readonly statsSlot = new QuerySlot<StatsData>();
+  private readonly counterSlot = new QuerySlot<CounterData>();
+  private readonly smapsSlot = new QuerySlot<AnonSwapSeries>();
+
+  onremove() {
+    this.statsSlot.dispose();
+    this.counterSlot.dispose();
+    this.smapsSlot.dispose();
+  }
+
+  view({attrs}: m.Vnode<TraceOverviewAttrs>): m.Children {
+    const {trace, upid} = attrs;
+    const key = {traceId: trace.traceInfo.uuid, upid};
+    const stats = this.statsSlot.use({
+      key,
+      queryFn: () => loadStats(trace, upid),
+    }).data;
+    const counters = this.counterSlot.use({
+      key,
+      queryFn: () => loadCounters(trace, upid),
+    }).data;
+    const snaps = this.smapsSlot.use({
+      key,
+      queryFn: () => loadAnonSwap(trace, upid),
+    }).data;
+
+    const statsLoading = stats === undefined;
+    const countersLoading = counters === undefined;
+    const snapsLoading = snaps === undefined;
+
+    // Card 1: uptime + OOM score (heap-graph dump).
+    const uptimeCard = cellCard([
+      {
+        label: 'Uptime',
+        loading: statsLoading,
+        value:
+          stats?.uptime !== undefined
+            ? formatDurationShort(stats.uptime)
+            : undefined,
+      },
+      {
+        label: 'OOM score',
+        loading: statsLoading,
+        value:
+          stats?.oomScoreAdj !== undefined ? `${stats.oomScoreAdj}` : undefined,
+        sub:
+          stats?.oomScoreAdj !== undefined
+            ? m('span.pf-memscope-oom-chip', oomScoreLabel(stats.oomScoreAdj))
+            : undefined,
+      },
+    ]);
+
+    // Card 2: peak RSS (smaps) + RSS spike (counters).
+    const peak =
+      snaps !== undefined && snaps.length > 0
+        ? Math.max(...snaps.map((r) => r.total))
+        : undefined;
+    const wm = counters?.rssWatermark;
+    const rssMax = counters?.rssMax;
+    // Spike is the watermark's overshoot above the best-sampled RSS. When the
+    // poll caught the peak (wm == rssMax) that's a real "no spike" → 0, not
+    // missing data; only an absent counter leaves it undefined.
+    const spike =
+      wm !== undefined && rssMax !== undefined
+        ? Math.max(0, wm - rssMax)
+        : undefined;
+    const rssCard = cellCard([
+      {
+        label: 'Peak RSS',
+        loading: snapsLoading,
+        value: peak !== undefined ? formatBytes(peak) : undefined,
+        sub: 'rss anon + swap',
+      },
+      {
+        label: 'RSS spike',
+        loading: countersLoading,
+        value: spike !== undefined ? deltaText(spike) : undefined,
+        sub: 'hi-watermark − max',
+      },
+    ]);
+
+    // Card 3: memory Δ + trend (smaps, first → last snapshot).
+    const haveDelta = snaps !== undefined && snaps.length > 1;
+    const first = haveDelta ? snaps[0] : undefined;
+    const last = haveDelta ? snaps[snaps.length - 1] : undefined;
+    const total =
+      first !== undefined && last !== undefined
+        ? last.total - first.total
+        : undefined;
+    const spanSeconds =
+      first !== undefined && last !== undefined
+        ? Number(last.ts - first.ts) / 1e9
+        : 0;
+    const deltaCard = cellCard([
+      {
+        label: 'Memory Δ',
+        loading: snapsLoading,
+        value: total !== undefined ? deltaText(total) : undefined,
+        sub: 'first → last',
+      },
+      {
+        label: 'Trend',
+        loading: snapsLoading,
+        value:
+          total !== undefined && spanSeconds > 0
+            ? deltaText(total, `${formatDelta((total / spanSeconds) * 3600)}/h`)
+            : undefined,
+      },
+    ]);
+
+    // GC / Java allocation churn: not yet wired to a data source (needs ART GC
+    // events + allocation-rate sampling), so both cells report "not available"
+    // rather than placeholder numbers.
+    const churnCard = cellCard([
+      {label: 'GC churn', loading: false, value: undefined},
+      {label: 'Java churn', loading: false, value: undefined},
+    ]);
+
+    return m(BillboardStrip, [uptimeCard, rssCard, deltaCard, churnCard]);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/profile_page.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/profile_page.scss
@@ -18,7 +18,7 @@
   align-items: stretch;
   border-radius: 8px;
   background: var(--pf-color-background-secondary);
-  border: 1px solid var(--pf-color-danger);
+  border: 0.5px solid var(--pf-color-danger);
   overflow: hidden;
   box-shadow: 0 0 0 3px
     color-mix(in srgb, var(--pf-color-danger) 25%, transparent);
@@ -43,7 +43,7 @@
   min-width: 0;
 
   & + & {
-    border-left: 1px solid var(--pf-color-border-secondary);
+    border-left: 1px solid var(--pf-col-border);
   }
 }
 
@@ -121,7 +121,7 @@
   font-weight: 600;
   color: var(--pf-color-text);
   background: var(--pf-color-background);
-  border: 1px solid var(--pf-color-border-secondary);
+  border: 0.5px solid var(--pf-col-border);
   border-radius: 4px;
   padding: 2px 8px;
   white-space: nowrap;

--- a/ui/src/plugins/dev.perfetto.Memscope/views/profile_page.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/profile_page.ts
@@ -23,7 +23,8 @@ import {Intent} from '../../../widgets/common';
 import {Icon} from '../../../widgets/icon';
 import {Billboard} from '../components/billboard';
 import {ProgressBar} from '../components/progress_bar';
-import {billboardKb, formatKb, maxSeriesKb, niceKbInterval} from '../utils';
+import {billboardBytes, maxSeriesKb, niceKbInterval} from '../utils';
+import {formatBytesIec} from '../../../base/bytes_format';
 import {Icons} from '../../../base/semantic_icons';
 import {Stack} from '../../../widgets/stack';
 
@@ -36,6 +37,7 @@ export interface ProfilePageAttrs {
   readonly chartData?: LineChartData;
   readonly baseline?: {anonSwap: number; file: number; dmabuf: number};
   readonly onStop: () => void;
+  readonly onStopAndDownload: () => void;
   readonly onCancel: () => void;
 }
 
@@ -122,6 +124,13 @@ export class ProfilePage implements m.ClassComponent<ProfilePageAttrs> {
                 onclick: () => attrs.onCancel(),
               }),
               m(Button, {
+                label: 'Stop & Download',
+                icon: 'download',
+                variant: ButtonVariant.Filled,
+                intent: Intent.Primary,
+                onclick: () => attrs.onStopAndDownload(),
+              }),
+              m(Button, {
                 label: 'Stop & Open Trace',
                 icon: Icons.ExternalLink,
                 variant: ButtonVariant.Filled,
@@ -162,10 +171,10 @@ function renderBillboards(
     const delta = baselineVal !== undefined ? current - baselineVal : undefined;
     const deltaStr =
       delta !== undefined
-        ? `${delta >= 0 ? '+' : ''}${formatKb(delta)}`
+        ? `${delta >= 0 ? '+' : ''}${formatBytesIec(delta * 1024)}`
         : undefined;
     return m(Billboard, {
-      ...billboardKb(current),
+      ...billboardBytes(current * 1024),
       label,
       desc,
       delta: deltaStr,
@@ -217,7 +226,7 @@ function renderBreakdownChart(attrs: ProfilePageAttrs): m.Children {
           xAxisMin: xMin,
           xAxisMax: xMax,
           formatXValue: (v: number) => `${v.toFixed(0)}s`,
-          formatYValue: (v: number) => formatKb(v),
+          formatYValue: (v: number) => formatBytesIec(v * 1024),
           yAxisMinInterval: niceKbInterval(maxSeriesKb(chartData.series)),
         });
       })()

--- a/ui/src/plugins/dev.perfetto.Memscope/views/tabs/page_cache.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/tabs/page_cache.ts
@@ -20,15 +20,14 @@ import {
 } from '../../../../components/widgets/charts_svg/line_chart_svg';
 import type {LiveSession, SnapshotData} from '../../sessions/live_session';
 import {
-  billboardKb,
+  billboardBytes,
   counterPoints,
-  formatKb,
   maxSeriesKb,
   niceKbInterval,
 } from '../../utils';
-import {Billboard} from '../../components/billboard';
+import {formatBytesIec} from '../../../../base/bytes_format';
+import {Billboard, BillboardStrip} from '../../components/billboard';
 import {Panel} from '../../components/panel';
-import {Stack} from '../../../../widgets/stack';
 
 function buildPageCacheTimeSeries(
   data: SnapshotData,
@@ -222,23 +221,22 @@ export function renderPageCacheTab(session: LiveSession): m.Children {
   const fileCacheActivityData = buildFileCacheActivityTimeSeries(data, t0);
   const bb = getPageCacheBillboards(fileCacheBreakdownData);
 
-  return m(Stack, {spacing: 'large'}, [
+  return m.fragment({}, [
     bb !== undefined &&
       m(
-        Stack,
-        {orientation: 'horizontal', spacing: 'large'},
+        BillboardStrip,
         m(Billboard, {
-          ...billboardKb(bb.total),
+          ...billboardBytes(bb.total * 1024),
           label: 'Total Page Cache',
           desc: 'Derived: Active(file) + Inactive(file) from /proc/meminfo',
         }),
         m(Billboard, {
-          ...billboardKb(bb.dirty),
+          ...billboardBytes(bb.dirty * 1024),
           label: 'Dirty',
           desc: 'Source: Dirty from /proc/meminfo',
         }),
         m(Billboard, {
-          ...billboardKb(bb.mapped),
+          ...billboardBytes(bb.mapped * 1024),
           label: 'Mapped',
           desc: 'Source: Mapped from /proc/meminfo',
         }),
@@ -246,58 +244,64 @@ export function renderPageCacheTab(session: LiveSession): m.Children {
 
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'Page Cache',
         subtitle:
           'Source: /proc/meminfo counters Active(file), Inactive(file), Shmem. ' +
           'Stacked: Active(file) + Inactive(file) + Shmem \u2248 Cached.',
-      },
-      pageCacheChartData
-        ? m(LineChartSvg, {
-            data: pageCacheChartData,
-            height: 250,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Cache',
-            showLegend: true,
-            showPoints: false,
-            stacked: true,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => formatKb(v),
-            yAxisMinInterval: niceKbInterval(
-              maxSeriesKb(pageCacheChartData.series),
-            ),
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        pageCacheChartData
+          ? m(LineChartSvg, {
+              data: pageCacheChartData,
+              height: 250,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Cache',
+              showLegend: true,
+              showPoints: false,
+              stacked: true,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => formatBytesIec(v * 1024),
+              yAxisMinInterval: niceKbInterval(
+                maxSeriesKb(pageCacheChartData.series),
+              ),
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
 
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'Page Cache Activity',
         subtitle:
           'Source: /proc/vmstat counters, shown as rates (delta/s). ' +
           'Refaults = workingset_refault_file (evicted pages needed again). ' +
           'Stolen = pgsteal_file (pages reclaimed). ' +
           'Scanned = pgscan_file (pages considered for reclaim).',
-      },
-      fileCacheActivityData
-        ? m(LineChartSvg, {
-            data: fileCacheActivityData,
-            height: 200,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Pages/s',
-            showLegend: true,
-            showPoints: false,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => v.toLocaleString(),
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        fileCacheActivityData
+          ? m(LineChartSvg, {
+              data: fileCacheActivityData,
+              height: 200,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Pages/s',
+              showLegend: true,
+              showPoints: false,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => v.toLocaleString(),
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
   ]);
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/views/tabs/pressure_swap.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/tabs/pressure_swap.ts
@@ -19,12 +19,8 @@ import {
   type LineChartSeries,
 } from '../../../../components/widgets/charts_svg/line_chart_svg';
 import type {LiveSession, SnapshotData} from '../../sessions/live_session';
-import {
-  counterPoints,
-  formatKb,
-  maxSeriesKb,
-  niceKbInterval,
-} from '../../utils';
+import {counterPoints, maxSeriesKb, niceKbInterval} from '../../utils';
+import {formatBytesIec} from '../../../../base/bytes_format';
 import {Panel} from '../../components/panel';
 import {Grid, GridCell, GridHeaderCell} from '../../../../widgets/grid';
 
@@ -162,32 +158,39 @@ function renderLmkPanel(
 ): m.Children {
   return m(
     Panel,
-    {
+    m(Panel.Header, {
       title: `LMK Kills (${events.length})`,
       subtitle:
         'Low Memory Killer events recorded during this session. ' +
         'Source: lmkd atrace / lowmemorykiller ftrace.',
-    },
-    events.length > 0 &&
-      m(Grid, {
-        columns: [
-          {key: 'time', header: m(GridHeaderCell, 'Time')},
-          {key: 'pid', header: m(GridHeaderCell, 'PID')},
-          {
-            key: 'process',
-            header: m(GridHeaderCell, 'Process'),
-            maxInitialWidthPx: 400,
-          },
-          {key: 'oom', header: m(GridHeaderCell, 'OOM Adj')},
-        ],
-        rowData: events.map((ev) => [
-          m(GridCell, {align: 'right'}, `${((ev.ts - t0) / 1e9).toFixed(1)}s`),
-          m(GridCell, {align: 'right'}, String(ev.pid)),
-          m(GridCell, ev.processName || '(unknown)'),
-          m(GridCell, {align: 'right'}, String(ev.oomScoreAdj)),
-        ]),
-        fillHeight: false,
-      }),
+    }),
+    m(
+      Panel.Body,
+      events.length > 0 &&
+        m(Grid, {
+          columns: [
+            {key: 'time', header: m(GridHeaderCell, 'Time')},
+            {key: 'pid', header: m(GridHeaderCell, 'PID')},
+            {
+              key: 'process',
+              header: m(GridHeaderCell, 'Process'),
+              maxInitialWidthPx: 400,
+            },
+            {key: 'oom', header: m(GridHeaderCell, 'OOM Adj')},
+          ],
+          rowData: events.map((ev) => [
+            m(
+              GridCell,
+              {align: 'right'},
+              `${((ev.ts - t0) / 1e9).toFixed(1)}s`,
+            ),
+            m(GridCell, {align: 'right'}, String(ev.pid)),
+            m(GridCell, ev.processName || '(unknown)'),
+            m(GridCell, {align: 'right'}, String(ev.oomScoreAdj)),
+          ]),
+          fillHeight: false,
+        }),
+    ),
   );
 }
 
@@ -204,109 +207,121 @@ export function renderPressureSwapTab(session: LiveSession): m.Children {
   return [
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'Memory Pressure (PSI)',
         subtitle:
           'Source: /proc/pressure/memory (psi.mem.some, psi.mem.full). ' +
           'Derived: cumulative \u00b5s converted to ms/s rate. ' +
           '"some" = at least one task stalled, "full" = all tasks stalled.',
-      },
-      psiChartData
-        ? m(LineChartSvg, {
-            data: psiChartData,
-            height: 200,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Stall (ms/s)',
-            showLegend: true,
-            showPoints: false,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => `${v.toFixed(1)} ms/s`,
-            // TODO(stevegolton): Add markers back in when we support them in LineChartSvg.
-            //   x: (ev.ts - t0) / 1e9,
-            // })),
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        psiChartData
+          ? m(LineChartSvg, {
+              data: psiChartData,
+              height: 200,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Stall (ms/s)',
+              showLegend: true,
+              showPoints: false,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => `${v.toFixed(1)} ms/s`,
+              // TODO(stevegolton): Add markers back in when we support them in LineChartSvg.
+              //   x: (ev.ts - t0) / 1e9,
+              // })),
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
 
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'Page Faults',
         subtitle:
           'Source: /proc/vmstat counters pgfault, pgmajfault. ' +
           'Derived: cumulative counts converted to faults/s rate. ' +
           'Minor (pgfault) = page in RAM but not in TLB. Major (pgmajfault) = page must be read from disk.',
-      },
-      pageFaultChartData
-        ? m(LineChartSvg, {
-            data: pageFaultChartData,
-            height: 200,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Faults/s',
-            showLegend: true,
-            showPoints: false,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => `${v.toFixed(0)} f/s`,
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        pageFaultChartData
+          ? m(LineChartSvg, {
+              data: pageFaultChartData,
+              height: 200,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Faults/s',
+              showLegend: true,
+              showPoints: false,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => `${v.toFixed(0)} f/s`,
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
 
     swapChartData &&
       m(
         Panel,
-        {
+        m(Panel.Header, {
           title: 'Swap Usage',
           subtitle:
             'Source: /proc/meminfo counters SwapTotal, SwapFree, SwapCached. ' +
             'Derived: Swap dirty = (SwapTotal \u2212 SwapFree) \u2212 SwapCached.',
-        },
-        m(LineChartSvg, {
-          data: swapChartData,
-          height: 200,
-          xAxisMin: data.xMin,
-          xAxisMax: data.xMax,
-          xAxisLabel: 'Time (s)',
-          yAxisLabel: 'Swap',
-          showLegend: true,
-          showPoints: false,
-          stacked: true,
-          gridLines: 'both',
-          formatXValue: (v: number) => `${v.toFixed(0)}s`,
-          formatYValue: (v: number) => formatKb(v),
-          yAxisMinInterval: niceKbInterval(
-            maxSeriesKb(swapChartData?.series ?? []),
-          ),
         }),
+        m(
+          Panel.Body,
+          m(LineChartSvg, {
+            data: swapChartData,
+            height: 200,
+            xAxisMin: data.xMin,
+            xAxisMax: data.xMax,
+            xAxisLabel: 'Time (s)',
+            yAxisLabel: 'Swap',
+            showLegend: true,
+            showPoints: false,
+            stacked: true,
+            gridLines: 'both',
+            formatXValue: (v: number) => `${v.toFixed(0)}s`,
+            formatYValue: (v: number) => formatBytesIec(v * 1024),
+            yAxisMinInterval: niceKbInterval(
+              maxSeriesKb(swapChartData?.series ?? []),
+            ),
+          }),
+        ),
       ),
 
     vmstatChartData &&
       m(
         Panel,
-        {
+        m(Panel.Header, {
           title: 'Swap I/O (pswpin / pswpout)',
           subtitle:
             'Source: /proc/vmstat counters pswpin, pswpout. ' +
             'Derived: cumulative page counts converted to pages/s rate.',
-        },
-        m(LineChartSvg, {
-          data: vmstatChartData,
-          xAxisMin: data.xMin,
-          xAxisMax: data.xMax,
-          height: 200,
-          xAxisLabel: 'Time (s)',
-          yAxisLabel: 'Pages/s',
-          showLegend: true,
-          showPoints: false,
-          gridLines: 'both',
-          formatXValue: (v: number) => `${v.toFixed(0)}s`,
-          formatYValue: (v: number) => `${v.toFixed(0)} pg/s`,
         }),
+        m(
+          Panel.Body,
+          m(LineChartSvg, {
+            data: vmstatChartData,
+            xAxisMin: data.xMin,
+            xAxisMax: data.xMax,
+            height: 200,
+            xAxisLabel: 'Time (s)',
+            yAxisLabel: 'Pages/s',
+            showLegend: true,
+            showPoints: false,
+            gridLines: 'both',
+            formatXValue: (v: number) => `${v.toFixed(0)}s`,
+            formatYValue: (v: number) => `${v.toFixed(0)} pg/s`,
+          }),
+        ),
       ),
 
     renderLmkPanel(data.lmkEvents, t0),

--- a/ui/src/plugins/dev.perfetto.Memscope/views/tabs/processes.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/tabs/processes.ts
@@ -42,9 +42,10 @@ import {
   CATEGORIES,
   type CategoryId,
 } from '../../process_categories';
-import {Billboard} from '../../components/billboard';
+import {Billboard, BillboardStrip} from '../../components/billboard';
 import {ColorChip, chipColor} from '../../components/color_chip';
-import {billboardKb, formatKb, maxSeriesKb, niceKbInterval} from '../../utils';
+import {billboardBytes, maxSeriesKb, niceKbInterval} from '../../utils';
+import {formatBytesIec} from '../../../../base/bytes_format';
 import {
   type ProcessGrouping,
   type ProcessMetric,
@@ -52,7 +53,6 @@ import {
   PROCESS_METRIC_OPTIONS,
   OOM_SCORE_BUCKETS,
 } from '../../process_data';
-import {Stack} from '../../../../widgets/stack';
 
 export type {ProcessGrouping, ProcessMetric, ProcessMemoryRow};
 export {PROCESS_METRIC_OPTIONS, OOM_SCORE_BUCKETS};
@@ -511,23 +511,22 @@ export class ProcessesTab implements m.ClassComponent<ProcessesTabAttrs> {
     const totalFileKb = latestProcesses.reduce((s, p) => s + p.fileKb, 0);
     const totalDmabufKb = latestProcesses.reduce((s, p) => s + p.dmabufKb, 0);
 
-    return m(Stack, {spacing: 'large'}, [
+    return m.fragment({}, [
       latestProcesses.length > 0 &&
         m(
-          Stack,
-          {orientation: 'horizontal', spacing: 'large'},
+          BillboardStrip,
           m(Billboard, {
-            ...billboardKb(totalAnonSwapKb),
+            ...billboardBytes(totalAnonSwapKb * 1024),
             label: 'RSS Anon + Swap',
             desc: 'Sum of anonymous RSS + swap across all processes',
           }),
           m(Billboard, {
-            ...billboardKb(totalFileKb),
+            ...billboardBytes(totalFileKb * 1024),
             label: 'File',
             desc: 'Sum of file-backed RSS across all processes',
           }),
           m(Billboard, {
-            ...billboardKb(totalDmabufKb),
+            ...billboardBytes(totalDmabufKb * 1024),
             label: 'DMA-BUF',
             desc: 'Sum of DMA-BUF heap RSS across all processes',
           }),
@@ -607,7 +606,7 @@ export class ProcessesTab implements m.ClassComponent<ProcessesTabAttrs> {
                 xAxisMin: chartXMin,
                 xAxisMax: chartXMax,
                 formatXValue: (v: number) => `${v.toFixed(0)}s`,
-                formatYValue: (v: number) => formatKb(v),
+                formatYValue: (v: number) => formatBytesIec(v * 1024),
                 yAxisMinInterval: niceKbInterval(maxSeriesKb(chartData.series)),
                 onSeriesClick: isDrilledDown
                   ? undefined
@@ -818,22 +817,28 @@ class ProcessTable implements m.ClassComponent<ProcessTableAttrs> {
             : oomLabel,
         ),
         m(GridCell, {align: 'right', style: mutedStyle}, ageStr),
-        m(GridCell, {align: 'right', style: mutedStyle}, formatKb(p.rssKb)),
+        m(
+          GridCell,
+          {align: 'right', style: mutedStyle},
+          formatBytesIec(p.rssKb * 1024),
+        ),
         m(GridCell, {style: mutedStyle}, sparkline(p.rssTrendKb)),
         m(
           GridCell,
           {align: 'right', style: mutedStyle},
-          p.anonKb + p.swapKb > 0 ? formatKb(p.anonKb + p.swapKb) : '-',
+          p.anonKb + p.swapKb > 0
+            ? formatBytesIec((p.anonKb + p.swapKb) * 1024)
+            : '-',
         ),
         m(
           GridCell,
           {align: 'right', style: mutedStyle},
-          p.fileKb > 0 ? formatKb(p.fileKb) : '-',
+          p.fileKb > 0 ? formatBytesIec(p.fileKb * 1024) : '-',
         ),
         m(
           GridCell,
           {align: 'right', style: mutedStyle},
-          p.shmemKb > 0 ? formatKb(p.shmemKb) : '-',
+          p.shmemKb > 0 ? formatBytesIec(p.shmemKb * 1024) : '-',
         ),
       ];
     });
@@ -850,6 +855,14 @@ class ProcessTable implements m.ClassComponent<ProcessTableAttrs> {
             ? `Stopping and reading trace for ${profile.processName}\u2026`
             : `Recording heap profile for ${profile.processName} (PID ${profile.pid})`,
           !isStopping && [
+            m(Button, {
+              label: 'Stop & Download',
+              icon: 'download',
+              minimal: true,
+              intent: Intent.Danger,
+              onclick: () =>
+                session.stopAndDownloadProfile().then(() => m.redraw()),
+            }),
             m(Button, {
               label: 'Stop & Open',
               icon: 'stop',

--- a/ui/src/plugins/dev.perfetto.Memscope/views/tabs/system.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/tabs/system.ts
@@ -19,10 +19,10 @@ import {
   type LineChartSeries,
 } from '../../../../components/widgets/charts_svg/line_chart_svg';
 import type {LiveSession, SnapshotData} from '../../sessions/live_session';
-import {billboardKb, formatKb, maxSeriesKb, niceKbInterval} from '../../utils';
-import {Billboard} from '../../components/billboard';
+import {billboardBytes, maxSeriesKb, niceKbInterval} from '../../utils';
+import {formatBytesIec} from '../../../../base/bytes_format';
+import {Billboard, BillboardStrip} from '../../components/billboard';
 import {Panel} from '../../components/panel';
-import {Stack} from '../../../../widgets/stack';
 
 /** System memory breakdown from /proc/meminfo, partitioning MemTotal. */
 function buildSystemTimeSeries(
@@ -195,31 +195,31 @@ export function renderSystemTab(session: LiveSession): m.Children {
   const bb = buildSystemBillboards(data);
   const chartData = buildSystemTimeSeries(data, t0);
 
-  return m(Stack, {spacing: 'large'}, [
+  return m.fragment({}, [
     bb !== undefined &&
-      m(Stack, {orientation: 'horizontal', spacing: 'large'}, [
+      m(BillboardStrip, [
         m(Billboard, {
-          ...billboardKb(bb.totalKb),
+          ...billboardBytes(bb.totalKb * 1024),
           label: 'MemTotal',
           desc: 'Total physical RAM',
         }),
         m(Billboard, {
-          ...billboardKb(bb.availableKb),
+          ...billboardBytes(bb.availableKb * 1024),
           label: 'MemAvailable',
           desc: 'Available without swapping',
         }),
         m(Billboard, {
-          ...billboardKb(bb.anonKb),
+          ...billboardBytes(bb.anonKb * 1024),
           label: 'Anon',
           desc: 'Active(anon) + Inactive(anon)',
         }),
         m(Billboard, {
-          ...billboardKb(bb.fileCacheKb),
+          ...billboardBytes(bb.fileCacheKb * 1024),
           label: 'Page Cache',
           desc: 'File LRU \u2212 Shmem',
         }),
         m(Billboard, {
-          ...billboardKb(bb.freeKb),
+          ...billboardBytes(bb.freeKb * 1024),
           label: 'MemFree',
           desc: 'Completely unused RAM',
         }),
@@ -227,30 +227,33 @@ export function renderSystemTab(session: LiveSession): m.Children {
 
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'System Memory',
         subtitle:
           'Stacked areas partition MemTotal. Source: /proc/meminfo. ' +
           'Anon = Active(anon) + Inactive(anon). Page cache = Active(file) + Inactive(file) \u2212 Shmem. ' +
           'Unaccounted = MemTotal \u2212 sum of all other categories.',
-      },
-      chartData
-        ? m(LineChartSvg, {
-            data: chartData,
-            height: 400,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Memory',
-            showLegend: true,
-            showPoints: false,
-            stacked: true,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => formatKb(v),
-            yAxisMinInterval: niceKbInterval(maxSeriesKb(chartData.series)),
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        chartData
+          ? m(LineChartSvg, {
+              data: chartData,
+              height: 400,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Memory',
+              showLegend: true,
+              showPoints: false,
+              stacked: true,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => formatBytesIec(v * 1024),
+              yAxisMinInterval: niceKbInterval(maxSeriesKb(chartData.series)),
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
   ]);
 }

--- a/ui/src/plugins/dev.perfetto.Smaps/index.ts
+++ b/ui/src/plugins/dev.perfetto.Smaps/index.ts
@@ -16,6 +16,7 @@ import {Time} from '../../base/time';
 import {materialColorScheme} from '../../components/colorizer';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import type {PerfettoPlugin} from '../../public/plugin';
+import {SMAPS_TRACK_KIND} from '../../public/track_kinds';
 import type {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
 import {SourceDataset} from '../../trace_processor/dataset';
@@ -86,7 +87,11 @@ export default class implements PerfettoPlugin {
             getInitialColumns,
           ),
       });
-      trace.tracks.registerTrack({uri, renderer, tags: {upid}});
+      trace.tracks.registerTrack({
+        uri,
+        renderer,
+        tags: {kinds: [SMAPS_TRACK_KIND], upid},
+      });
 
       group.addChildInOrder(
         new TrackNode({

--- a/ui/src/public/track_kinds.ts
+++ b/ui/src/public/track_kinds.ts
@@ -20,3 +20,4 @@ export const THREAD_STATE_TRACK_KIND = 'ThreadStateTrack';
 export const SLICE_TRACK_KIND = 'SliceTrack';
 export const COUNTER_TRACK_KIND = 'CounterTrack';
 export const ANDROID_LOGS_TRACK_KIND = 'AndroidLogTrack';
+export const SMAPS_TRACK_KIND = 'SmapsTrack';

--- a/ui/src/trace_processor/query_result.ts
+++ b/ui/src/trace_processor/query_result.ts
@@ -400,6 +400,24 @@ export interface QueryResult {
   elapsedTimeMs(): number;
 }
 
+// Drains a QueryResult into an array of typed rows described by `spec`. This is
+// the array-materializing counterpart to iter(): use it when you want every row
+// up front rather than streaming through them.
+// Example: const rows = materializeRows(result, {id: NUM, name: STR});
+export function materializeRows<T extends Row>(
+  result: QueryResult,
+  spec: T,
+): T[] {
+  const rows: T[] = [];
+  const cols = Object.keys(spec);
+  for (const it = result.iter(spec); it.valid(); it.next()) {
+    const row: Record<string, SqlValue> = {};
+    for (const col of cols) row[col] = it.get(col);
+    rows.push(row as T);
+  }
+  return rows;
+}
+
 // Interface exposed to engine.ts to pump in the data as new row batches arrive.
 export interface WritableQueryResult {
   // |resBytes| is a proto-encoded trace_processor.QueryResult message.

--- a/ui/src/widgets/anchor.scss
+++ b/ui/src/widgets/anchor.scss
@@ -39,4 +39,16 @@
   &:focus-visible {
     @include focus;
   }
+
+  &--disabled {
+    color: var(--pf-color-text-disabled);
+    text-decoration-color: var(--pf-color-text-disabled);
+    cursor: not-allowed;
+
+    &:hover {
+      // Cancel the hover affordances while disabled.
+      background: transparent;
+      text-decoration-thickness: 1px;
+    }
+  }
 }

--- a/ui/src/widgets/anchor.ts
+++ b/ui/src/widgets/anchor.ts
@@ -23,15 +23,34 @@ interface AnchorAttrs extends HTMLAnchorAttrs {
 
   // Optional icon to show at the start of the content.
   readonly startIcon?: string;
+
+  // When true, the anchor is greyed out and non-interactive (no href, no
+  // click handlers).
+  readonly disabled?: boolean;
 }
 
 export class Anchor implements m.ClassComponent<AnchorAttrs> {
   view({attrs, children}: m.CVnode<AnchorAttrs>) {
-    const {icon, startIcon, ...htmlAttrs} = attrs;
+    const {icon, startIcon, disabled, ...htmlAttrs} = attrs;
+
+    let selector = 'a.pf-anchor';
+    let anchorAttrs: m.Attributes = htmlAttrs;
+    if (disabled) {
+      // Strip the interactive attributes so the anchor can't be navigated or
+      // clicked while disabled.
+      const {
+        href: _href,
+        onclick: _onclick,
+        target: _target,
+        ...rest
+      } = htmlAttrs;
+      selector = 'a.pf-anchor.pf-anchor--disabled';
+      anchorAttrs = {...rest, 'aria-disabled': 'true'};
+    }
 
     return m(
-      'a.pf-anchor',
-      htmlAttrs,
+      selector,
+      anchorAttrs,
       startIcon &&
         m(Icon, {icon: startIcon, className: 'pf-anchor__icon--start'}),
       children,

--- a/ui/src/widgets/cursor_tooltip.ts
+++ b/ui/src/widgets/cursor_tooltip.ts
@@ -32,8 +32,15 @@ import type {ExtendedModifiers} from './popper_utils';
 export interface CursorTooltipAttrs extends HTMLAttrs {
   // Which side of the cursor to place the tooltip. Defaults to Right.
   readonly position?: PopupPosition;
-  // Distance in px between the tooltip and the cursor. Default = 8.
+  // Gap in px between the tooltip and the cursor, measured along the placement
+  // axis — i.e. how far out in the `position` direction (e.g. how far to the
+  // right for the default Right placement). Default = 8.
   readonly offset?: number;
+  // Shift in px along the cross axis (perpendicular to `position`), sliding the
+  // tooltip sideways past the cursor without changing its distance. Positive
+  // values move toward the end of that axis — e.g. downward for the default
+  // Right placement. Default = 0.
+  readonly skidOffset?: number;
 }
 
 class VElement implements VirtualElement {
@@ -132,7 +139,7 @@ export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
   }
 
   private createOrUpdatePopper(attrs: CursorTooltipAttrs) {
-    const {position = PopupPosition.Right, offset = 8} = attrs;
+    const {position = PopupPosition.Right, offset = 8, skidOffset = 0} = attrs;
 
     // Custom modifier to hide the tooltip when our canary - and hence the
     // tooltip's parent - is not visible. This can be due to the canary or one
@@ -161,7 +168,7 @@ export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
         {
           name: 'offset',
           options: {
-            offset: [0, offset], // Shift away from cursor
+            offset: [skidOffset, offset],
           },
         },
         hideOnInvisible,


### PR DESCRIPTION
# Memory Overview Page · Spec

What the memory overview page shows when a recorded trace is opened, where every
number comes from, and the smells it surfaces.

> memory overview page · v2 · overview screen · web app · companion: Explainer
> doc

**Job of the memory overview page → Triage, not diagnosis.** Orient someone who
just opened a trace: how much memory, growing or steady, which way to dig
(managed vs native), and where to click. smaps owns the totals (OS truth); the
two profilers explain what's inside. Every element traces to a real measurement
or an honest "unknown."

## Summary

For a single selected process, the page shows three things:

1. **Charts**, one per data source, plotted over time:
   1. **smaps footprint** — anon+swap only, split into Java heap (dalvik),
      Native heap (malloc allocator arenas) and Other.
   2. **Native heap (heapprofd)** — cumulative allocated, freed, and unreleased
      (net) over time.
   3. **Java heap (java_hprof)** — total reachable bytes by class (top 6 +
      Other) + unreachable (aggregated).
2. **Insights** — a small set of automatic observations, each flagged only when
   active and always showing the numbers behind it:
   1. Process footprint growing (anon+swap, smaps).
   2. Unreleased native memory growing (heapprofd).
   3. Java heap growing across dumps.
3. **Snapshot table** — every dump, smaps sample, and native profile listed in
   time order, with links to the timeline and (for dumps) the Heap Dump
   Explorer.

When a source is missing for the selected process, its insight is shown as a
neutral placeholder ("this process has no …") rather than hidden.

What it deliberately does **not** do:

1. **Combine or correlate sources.** Each datasource is represented on its own
   chart; nothing is overlaid on a shared graph and no attempt is made to tie
   one datasource type to another. However, smaps provides a robust overview
   chart.
2. **Detect problems reliably.** The insight rules are intentionally simple
   first-vs-last-sample comparisons. They produce false positives — memory can
   be legitimately higher at the end of a trace — but they're easy to understand
   and act as a starting point we can interate on.
3. **Cover non-malloc native allocators.** We don't distingush the art allocator
   if also collected by heapprofd. We assume all heap profile dumps are native.
4. **Present the most useful breakdowns in the top level charts** The axis for
   breaking down the various data sources is somewhat arbitrary:
   1. Smaps: java/native/other seems sensible, but we could go further.
   2. heapprofd: allocated/released/unreleased seems sensible - we could break
      down by other metrics e.g. top X callsites?
   3. Java Heap Dumps: by top X classes + reachable seems sensible - could also
      breakdown by JNI root perhaps.
5. There's a lot more interesting things we could do with smaps dumps that I'm
   currently not doing. E.g. clean/dirty, file RSS, various breakdowns by
   different categories of paths.

Known issues:

- Page performance is bad.
- Page generally lacks polish.
- Gives no guidance on which tracing options to enable when a datasource is
  absent.
- Smaps are reported using a different upid to the parent process they're
  recording so some smaps snapshots are associated with process `<unknown>` or
  `init`. Fixed by
  https://googleplex-android-review.git.corp.google.com/c/platform/art/+/40226332.
- For smaps you'll need to be running >ZP1A.260602.001

# Screenshots

## Overview charts
<img width="894" height="1169" alt="image" src="https://github.com/user-attachments/assets/962e9ebd-f51a-41a1-ba81-df3eaf3f2d6f" />

## Insights
<img width="900" height="286" alt="image" src="https://github.com/user-attachments/assets/1dc79cf8-b0a3-414f-b955-ca1d7b7b8d20" />

## Details
<img width="1101" height="769" alt="image" src="https://github.com/user-attachments/assets/e7841333-3c69-475a-bd1b-1d3377c61116" />
