### PR TITLE
ui: Add details panel and process navigation to AndroidAnr plugin

### DIFF
--- a/ui/src/plugins/com.android.AndroidAnr/details_panel.ts
+++ b/ui/src/plugins/com.android.AndroidAnr/details_panel.ts
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {TrackEventDetailsPanel} from '../../public/details_panel';
+import type {TrackEventSelection} from '../../public/selection';
+import type {Trace} from '../../public/trace';
+import {DetailsShell} from '../../widgets/details_shell';
+import {Section} from '../../widgets/section';
+import {Tree, TreeNode} from '../../widgets/tree';
+import {Anchor} from '../../widgets/anchor';
+import {Icons} from '../../base/semantic_icons';
+import {Timestamp} from '../../components/widgets/timestamp';
+import {DurationWidget} from '../../components/widgets/duration';
+import {exists} from '../../base/utils';
+import {NUM_NULL} from '../../trace_processor/query_result';
+import ProcessThreadGroupsPlugin from '../dev.perfetto.ProcessThreadGroups';
+import {findMainThreadTrackUri, scrollToTrackAndSelect} from './navigate';
+
+interface AnrInfo {
+  processName: string;
+  pid: number | null;
+  upid: number | null;
+  anrType: string;
+  subject: string | null;
+  mainThreadTrackId: number | null;
+}
+
+export class AnrDetailsPanel implements TrackEventDetailsPanel {
+  private anr?: AnrInfo;
+  private selection?: TrackEventSelection;
+  private isLoading = true;
+
+  constructor(private readonly trace: Trace) {}
+
+  async load(sel: TrackEventSelection): Promise<void> {
+    this.isLoading = true;
+    this.selection = sel;
+
+    // The selection object is enriched with dataset columns by
+    // getSelectionDetails(). Extract the ANR-specific fields.
+    const extra = sel as unknown as {
+      process_name: string;
+      pid: number | null;
+      upid: number | null;
+      anr_type: string;
+      subject: string | null;
+    };
+
+    // Query for the main thread track ID so we can navigate like the deeplink.
+    let mainThreadTrackId: number | null = null;
+    if (extra.upid != null) {
+      const result = await this.trace.engine.query(`
+        SELECT tt.id AS main_thread_track_id
+        FROM thread t
+        JOIN thread_track tt ON t.utid = tt.utid
+        WHERE t.upid = ${extra.upid} AND t.is_main_thread = 1
+        LIMIT 1
+      `);
+      const it = result.iter({main_thread_track_id: NUM_NULL});
+      if (it.valid()) {
+        mainThreadTrackId = it.main_thread_track_id;
+      }
+    }
+
+    this.anr = {
+      processName: extra.process_name,
+      pid: extra.pid,
+      upid: extra.upid,
+      anrType: extra.anr_type,
+      subject: extra.subject,
+      mainThreadTrackId,
+    };
+
+    this.isLoading = false;
+  }
+
+  render(): m.Children {
+    if (this.isLoading || !this.anr || !this.selection) {
+      return m(DetailsShell, {
+        title: 'Android ANR',
+        description: 'Loading...',
+      });
+    }
+
+    const {processName, pid, anrType, subject, upid} = this.anr;
+    const sel = this.selection;
+
+    return m(
+      DetailsShell,
+      {title: 'Android ANR'},
+      m(
+        Section,
+        {title: 'Details'},
+        m(
+          Tree,
+          m(TreeNode, {
+            left: 'Process',
+            right: pid != null ? `${processName} (${pid})` : processName,
+          }),
+          m(TreeNode, {left: 'ANR Type', right: anrType}),
+          exists(subject) && m(TreeNode, {left: 'Subject', right: subject}),
+          m(TreeNode, {
+            left: 'Start time',
+            right: m(Timestamp, {trace: this.trace, ts: sel.ts}),
+          }),
+          exists(sel.dur) &&
+            sel.dur > 0n &&
+            m(TreeNode, {
+              left: 'Duration',
+              right: m(DurationWidget, {trace: this.trace, dur: sel.dur}),
+            }),
+        ),
+      ),
+      upid != null &&
+        m(
+          Section,
+          {title: 'Actions'},
+          m(
+            Anchor,
+            {
+              icon: Icons.GoTo,
+              onclick: () => this.goToProcess(),
+              title: 'Go to process',
+            },
+            'Go to process',
+          ),
+        ),
+    );
+  }
+
+  private goToProcess() {
+    if (this.anr?.upid == null || !this.selection) return;
+
+    const processGroups = this.trace.plugins.getPlugin(
+      ProcessThreadGroupsPlugin,
+    ) as ProcessThreadGroupsPlugin;
+
+    const group = processGroups.getGroupForProcess(this.anr.upid);
+    if (!group?.uri) return;
+
+    group.expand();
+
+    // Find main thread track, falling back to the process group track.
+    const tracksToSelect: string[] = [];
+    let trackToScroll = group.uri;
+    if (this.anr.mainThreadTrackId != null) {
+      const uri = findMainThreadTrackUri(
+        this.trace,
+        this.anr.mainThreadTrackId,
+      );
+      if (uri) {
+        trackToScroll = uri;
+        tracksToSelect.push(uri);
+      }
+    }
+
+    scrollToTrackAndSelect(
+      this.trace,
+      trackToScroll,
+      tracksToSelect,
+      this.selection.ts,
+      this.selection.dur ?? 0n,
+    );
+  }
+}

--- a/ui/src/plugins/com.android.AndroidAnr/index.ts
+++ b/ui/src/plugins/com.android.AndroidAnr/index.ts
@@ -18,6 +18,7 @@ import {
   NUM,
   NUM_NULL,
   STR,
+  STR_NULL,
 } from '../../trace_processor/query_result';
 import type {Trace} from '../../public/trace';
 import type {PerfettoPlugin} from '../../public/plugin';
@@ -28,6 +29,8 @@ import {Time} from '../../base/time';
 import type {App} from '../../public/app';
 import type {RouteArgs} from '../../public/route_schema';
 import ProcessThreadGroupsPlugin from '../dev.perfetto.ProcessThreadGroups';
+import {AnrDetailsPanel} from './details_panel';
+import {findMainThreadTrackUri, scrollToTrackAndSelect} from './navigate';
 
 const ANR_TRACK_URI = '/android_anrs';
 
@@ -102,15 +105,26 @@ export default class AndroidAnr implements PerfettoPlugin {
             ts: LONG,
             dur: LONG_NULL,
             name: STR,
+            upid: NUM_NULL,
+            process_name: STR,
+            pid: NUM_NULL,
+            anr_type: STR,
+            subject: STR_NULL,
           },
           src: `
             SELECT
               ts - coalesce(anr_dur_ms, default_anr_dur_ms, 0) * 1000000 AS ts,
               coalesce(anr_dur_ms, default_anr_dur_ms, 0) * 1000000 AS dur,
-              process_name || ' ' || pid || ' : ' || anr_type AS name
+              process_name || ' ' || pid || ' : ' || anr_type AS name,
+              upid,
+              process_name,
+              pid,
+              anr_type,
+              subject
             FROM android_anrs
           `,
         }),
+        detailsPanel: () => new AnrDetailsPanel(ctx),
       }),
     });
 
@@ -200,6 +214,8 @@ export default class AndroidAnr implements PerfettoPlugin {
 
     this.pinAnrTrack(ctx);
 
+    const startTime = Time.fromRaw(BigInt(anrInfo.ts));
+
     ctx.onTraceReady.addListener(async () => {
       const group = (
         ctx.plugins.getPlugin(
@@ -212,72 +228,21 @@ export default class AndroidAnr implements PerfettoPlugin {
       }
       group.expand();
 
-      const processTrackUri = group.uri;
-      const tracksToSelect = [];
+      const tracksToSelect: string[] = [];
       if (anrInfo.mainThreadTrackId !== null) {
-        const mainThreadTrackNode = ctx.currentWorkspace.flatTracks.find(
-          (track) => {
-            if (!track.uri) {
-              return false;
-            }
-            const trackDesc = ctx.tracks.getTrack(track.uri);
-            return trackDesc?.tags?.trackIds?.includes(
-              anrInfo.mainThreadTrackId!,
-            );
-          },
-        );
-        if (mainThreadTrackNode?.uri) {
-          tracksToSelect.push(mainThreadTrackNode.uri);
+        const uri = findMainThreadTrackUri(ctx, anrInfo.mainThreadTrackId);
+        if (uri) {
+          tracksToSelect.push(uri);
         }
       }
 
-      this.scrollToAndSelect(
+      scrollToTrackAndSelect(
         ctx,
-        processTrackUri,
+        group.uri,
         tracksToSelect,
-        anrInfo.ts,
+        startTime,
         anrInfo.dur,
       );
     });
-  }
-
-  private scrollToAndSelect(
-    ctx: Trace,
-    trackToScroll: string,
-    tracksToSelect: string[],
-    ts: bigint,
-    dur: bigint,
-  ) {
-    const startTime = Time.fromRaw(BigInt(ts));
-    const endTime = Time.fromRaw(BigInt(ts + dur));
-
-    ctx.scrollTo({
-      track: {
-        uri: trackToScroll,
-        expandGroup: true,
-      },
-      time:
-        dur > 0n
-          ? {
-              start: startTime,
-              end: endTime,
-              behavior: {viewPercentage: 0.8},
-            }
-          : {
-              start: startTime,
-              behavior: 'focus',
-            },
-    });
-
-    ctx.selection.selectArea(
-      {
-        start: startTime,
-        end: endTime,
-        trackUris: tracksToSelect,
-      },
-      {
-        switchToCurrentSelectionTab: true,
-      },
-    );
   }
 }

--- a/ui/src/plugins/com.android.AndroidAnr/navigate.ts
+++ b/ui/src/plugins/com.android.AndroidAnr/navigate.ts
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {type time, Time} from '../../base/time';
+import type {Trace} from '../../public/trace';
+
+// Finds the URI of a main thread track by its track ID, searching
+// through the workspace's track tags.
+export function findMainThreadTrackUri(
+  trace: Trace,
+  mainThreadTrackId: number,
+): string | undefined {
+  const node = trace.currentWorkspace.flatTracks.find((track) => {
+    if (!track.uri) return false;
+    const desc = trace.tracks.getTrack(track.uri);
+    return desc?.tags?.trackIds?.includes(mainThreadTrackId);
+  });
+  return node?.uri;
+}
+
+// Scrolls to a track at a specific time region and selects the area on
+// the given tracks.
+export function scrollToTrackAndSelect(
+  trace: Trace,
+  trackToScroll: string,
+  tracksToSelect: string[],
+  startTime: time,
+  dur: bigint,
+): void {
+  const endTime = Time.fromRaw(startTime + dur);
+
+  trace.scrollTo({
+    track: {
+      uri: trackToScroll,
+      expandGroup: true,
+    },
+    time:
+      dur > 0n
+        ? {
+            start: startTime,
+            end: endTime,
+            behavior: {viewPercentage: 0.8},
+          }
+        : {
+            start: startTime,
+            behavior: 'focus',
+          },
+  });
+
+  trace.selection.selectArea(
+    {
+      start: startTime,
+      end: endTime,
+      trackUris: tracksToSelect,
+    },
+    {
+      switchToCurrentSelectionTab: true,
+    },
+  );
+}


### PR DESCRIPTION
Clicking an ANR slice now opens a details panel showing process info, ANR type, subject, timestamp and duration. A 'Go to process' anchor scrolls to and expands the process track group on the main thread, matching the existing deeplink behavior. Shared findMainThreadTrackUri and scrollToTrackAndSelect helpers live alongside the panel in navigate.ts.

