### PR TITLE
ui: Add details panel and process navigation to AndroidStartup plugin

### DIFF
--- a/ui/src/plugins/com.android.AndroidStartup/details_panel.ts
+++ b/ui/src/plugins/com.android.AndroidStartup/details_panel.ts
@@ -1,0 +1,165 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {TrackEventDetailsPanel} from '../../public/details_panel';
+import type {TrackEventSelection} from '../../public/selection';
+import type {Trace} from '../../public/trace';
+import {DetailsShell} from '../../widgets/details_shell';
+import {Section} from '../../widgets/section';
+import {Tree, TreeNode} from '../../widgets/tree';
+import {Anchor} from '../../widgets/anchor';
+import {Icons} from '../../base/semantic_icons';
+import {Timestamp} from '../../components/widgets/timestamp';
+import {DurationWidget} from '../../components/widgets/duration';
+import {exists} from '../../base/utils';
+import {NUM_NULL} from '../../trace_processor/query_result';
+import ProcessThreadGroupsPlugin from '../dev.perfetto.ProcessThreadGroups';
+import {findMainThreadTrackUri, scrollToTrackAndSelect} from './navigate';
+
+interface StartupInfo {
+  package: string;
+  startupType: string | null;
+  upid: number | null;
+  mainThreadTrackId: number | null;
+}
+
+export class StartupDetailsPanel implements TrackEventDetailsPanel {
+  private startup?: StartupInfo;
+  private selection?: TrackEventSelection;
+  private isLoading = true;
+
+  constructor(private readonly trace: Trace) {}
+
+  async load(sel: TrackEventSelection): Promise<void> {
+    this.isLoading = true;
+    this.selection = sel;
+
+    // The selection object is enriched with dataset columns by
+    // getSelectionDetails(). Extract the startup-specific fields.
+    const extra = sel as unknown as {
+      name: string;
+      startup_type: string | null;
+      upid: number | null;
+    };
+
+    // Query for the main thread track ID so we can navigate like the deeplink.
+    let mainThreadTrackId: number | null = null;
+    if (extra.upid != null) {
+      const result = await this.trace.engine.query(`
+        SELECT tt.id AS main_thread_track_id
+        FROM thread t
+        JOIN thread_track tt ON t.utid = tt.utid
+        WHERE t.upid = ${extra.upid} AND t.is_main_thread = 1
+        LIMIT 1
+      `);
+      const it = result.iter({main_thread_track_id: NUM_NULL});
+      if (it.valid()) {
+        mainThreadTrackId = it.main_thread_track_id;
+      }
+    }
+
+    this.startup = {
+      package: extra.name,
+      startupType: extra.startup_type,
+      upid: extra.upid,
+      mainThreadTrackId,
+    };
+
+    this.isLoading = false;
+  }
+
+  render(): m.Children {
+    if (this.isLoading || !this.startup || !this.selection) {
+      return m(DetailsShell, {
+        title: 'Android App Startup',
+        description: 'Loading...',
+      });
+    }
+
+    const {package: pkg, startupType, upid} = this.startup;
+    const sel = this.selection;
+
+    return m(
+      DetailsShell,
+      {title: 'Android App Startup'},
+      m(
+        Section,
+        {title: 'Details'},
+        m(
+          Tree,
+          m(TreeNode, {left: 'Package', right: pkg}),
+          exists(startupType) &&
+            m(TreeNode, {left: 'Startup Type', right: startupType}),
+          m(TreeNode, {
+            left: 'Start time',
+            right: m(Timestamp, {trace: this.trace, ts: sel.ts}),
+          }),
+          exists(sel.dur) &&
+            sel.dur > 0n &&
+            m(TreeNode, {
+              left: 'Duration',
+              right: m(DurationWidget, {trace: this.trace, dur: sel.dur}),
+            }),
+        ),
+      ),
+      upid != null &&
+        m(
+          Section,
+          {title: 'Actions'},
+          m(
+            Anchor,
+            {
+              icon: Icons.GoTo,
+              onclick: () => this.goToProcess(),
+              title: 'Go to process',
+            },
+            'Go to process',
+          ),
+        ),
+    );
+  }
+
+  private goToProcess() {
+    if (this.startup?.upid == null || !this.selection) return;
+
+    const processGroups = this.trace.plugins.getPlugin(
+      ProcessThreadGroupsPlugin,
+    ) as ProcessThreadGroupsPlugin;
+
+    const group = processGroups.getGroupForProcess(this.startup.upid);
+    if (!group?.uri) return;
+
+    group.expand();
+
+    const tracksToSelect: string[] = [];
+    if (this.startup.mainThreadTrackId != null) {
+      const mainThreadUri = findMainThreadTrackUri(
+        this.trace,
+        this.startup.mainThreadTrackId,
+      );
+      if (mainThreadUri) {
+        tracksToSelect.push(mainThreadUri);
+      }
+    }
+
+    scrollToTrackAndSelect(
+      this.trace,
+      group.uri,
+      tracksToSelect,
+      this.selection.ts,
+      this.selection.dur ?? 0n,
+    );
+  }
+}

--- a/ui/src/plugins/com.android.AndroidStartup/index.ts
+++ b/ui/src/plugins/com.android.AndroidStartup/index.ts
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {LONG, LONG_NULL, NUM, STR} from '../../trace_processor/query_result';
+import {
+  LONG,
+  LONG_NULL,
+  NUM,
+  NUM_NULL,
+  STR,
+  STR_NULL,
+} from '../../trace_processor/query_result';
 import type {Trace} from '../../public/trace';
 import type {PerfettoPlugin} from '../../public/plugin';
 import {SliceTrack} from '../../components/tracks/slice_track';
@@ -22,6 +29,9 @@ import {optimizationsTrack} from './optimizations';
 import {Time} from '../../base/time';
 import type {App} from '../../public/app';
 import type {RouteArgs} from '../../public/route_schema';
+import ProcessThreadGroupsPlugin from '../dev.perfetto.ProcessThreadGroups';
+import {StartupDetailsPanel} from './details_panel';
+import {findMainThreadTrackUri, scrollToTrackAndSelect} from './navigate';
 
 const STARTUP_TRACK_URI = '/android_startups';
 const BREAKDOWN_TRACK_URI = '/android_startups_breakdown';
@@ -65,6 +75,7 @@ let startupArgs: StartupArgs;
 
 export default class AndroidStartup implements PerfettoPlugin {
   static readonly id = 'com.android.AndroidStartup';
+  static readonly dependencies = [ProcessThreadGroupsPlugin];
 
   static onActivate(app: App): void {
     const args: RouteArgs = app.initialRouteArgs;
@@ -97,16 +108,26 @@ export default class AndroidStartup implements PerfettoPlugin {
             ts: LONG,
             dur: LONG_NULL,
             name: STR,
+            startup_type: STR_NULL,
+            upid: NUM_NULL,
           },
           src: `
             SELECT
-              startup_id AS id,
-              ts,
-              dur,
-              package AS name
-            FROM android_startups
+              s.startup_id AS id,
+              s.ts,
+              s.dur,
+              s.package AS name,
+              s.startup_type,
+              (
+                SELECT p.upid
+                FROM android_startup_processes p
+                WHERE p.startup_id = s.startup_id
+                LIMIT 1
+              ) AS upid
+            FROM android_startups s
           `,
         }),
+        detailsPanel: () => new StartupDetailsPanel(ctx),
       }),
     });
 
@@ -184,6 +205,7 @@ export default class AndroidStartup implements PerfettoPlugin {
       SELECT
         s.ts,
         s.dur,
+        p.upid,
         tt.id AS main_thread_track_id
       FROM
         android_startups s
@@ -202,6 +224,7 @@ export default class AndroidStartup implements PerfettoPlugin {
     const it = result.iter({
       ts: LONG,
       dur: LONG_NULL,
+      upid: NUM,
       main_thread_track_id: NUM,
     });
     if (!it.valid()) {
@@ -210,67 +233,44 @@ export default class AndroidStartup implements PerfettoPlugin {
 
     const startupInfo = {
       ts: it.ts,
-      dur: it.dur ?? 0n, // Default duration to 0 if null
+      dur: it.dur ?? 0n,
+      upid: it.upid,
       mainThreadTrackId: it.main_thread_track_id,
     };
 
-    // 1. Pin the Android Startups track first.
+    // Pin the Android Startups track first.
     const trackNode = ctx.currentWorkspace.getTrackByUri(STARTUP_TRACK_URI);
     if (trackNode) {
       trackNode.pin();
     }
 
     const startTime = Time.fromRaw(BigInt(startupInfo.ts));
-    const endTime = Time.fromRaw(BigInt(startupInfo.ts + startupInfo.dur));
 
     ctx.onTraceReady.addListener(async () => {
-      // Find the main thread track by its track ID via the track tags.
-      const mainThreadTrackNode = ctx.currentWorkspace.flatTracks.find(
-        (track) => {
-          if (!track.uri) {
-            return false;
-          }
-          const trackDesc = ctx.tracks.getTrack(track.uri);
-          return trackDesc?.tags?.trackIds?.includes(
-            startupInfo.mainThreadTrackId,
-          );
-        },
+      const group = (
+        ctx.plugins.getPlugin(
+          ProcessThreadGroupsPlugin,
+        ) as ProcessThreadGroupsPlugin
+      ).getGroupForProcess(startupInfo.upid);
+
+      if (!group?.uri) return;
+      group.expand();
+
+      const tracksToSelect: string[] = [];
+      const mainThreadTrackUri = findMainThreadTrackUri(
+        ctx,
+        startupInfo.mainThreadTrackId,
       );
-
-      if (!mainThreadTrackNode?.uri) {
-        return;
+      if (mainThreadTrackUri) {
+        tracksToSelect.push(mainThreadTrackUri);
       }
-      const mainThreadTrackUri = mainThreadTrackNode.uri;
 
-      // 2. Scroll to the main thread track and focus into view
-      ctx.scrollTo({
-        track: {
-          uri: mainThreadTrackUri,
-          expandGroup: true,
-        },
-        time:
-          startupInfo.dur > 0n
-            ? {
-                start: startTime,
-                end: endTime,
-                behavior: {viewPercentage: 0.8},
-              }
-            : {
-                start: startTime,
-                behavior: 'focus',
-              },
-      });
-
-      // 3. Select the area on the main thread track
-      ctx.selection.selectArea(
-        {
-          start: startTime,
-          end: endTime,
-          trackUris: [mainThreadTrackUri],
-        },
-        {
-          switchToCurrentSelectionTab: true,
-        },
+      scrollToTrackAndSelect(
+        ctx,
+        group.uri,
+        tracksToSelect,
+        startTime,
+        startupInfo.dur,
       );
     });
   }

--- a/ui/src/plugins/com.android.AndroidStartup/navigate.ts
+++ b/ui/src/plugins/com.android.AndroidStartup/navigate.ts
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {type time, Time} from '../../base/time';
+import type {Trace} from '../../public/trace';
+
+// Finds the URI of a main thread track by its track ID, searching
+// through the workspace's track tags.
+export function findMainThreadTrackUri(
+  trace: Trace,
+  mainThreadTrackId: number,
+): string | undefined {
+  const node = trace.currentWorkspace.flatTracks.find((track) => {
+    if (!track.uri) return false;
+    const desc = trace.tracks.getTrack(track.uri);
+    return desc?.tags?.trackIds?.includes(mainThreadTrackId);
+  });
+  return node?.uri;
+}
+
+// Scrolls to a track at a specific time region and selects the area on
+// the given tracks.
+export function scrollToTrackAndSelect(
+  trace: Trace,
+  trackToScroll: string,
+  tracksToSelect: string[],
+  startTime: time,
+  dur: bigint,
+): void {
+  const endTime = Time.fromRaw(startTime + dur);
+
+  trace.scrollTo({
+    track: {
+      uri: trackToScroll,
+      expandGroup: true,
+    },
+    time:
+      dur > 0n
+        ? {
+            start: startTime,
+            end: endTime,
+            behavior: {viewPercentage: 0.8},
+          }
+        : {
+            start: startTime,
+            behavior: 'focus',
+          },
+  });
+
+  trace.selection.selectArea(
+    {
+      start: startTime,
+      end: endTime,
+      trackUris: tracksToSelect,
+    },
+    {
+      switchToCurrentSelectionTab: true,
+    },
+  );
+}


### PR DESCRIPTION
Clicking an app-startup slice now opens a details panel showing package name, startup type (cold/warm/hot), timestamp and duration. A 'Go to process' anchor scrolls to and expands the process track group on the main thread, matching the existing deeplink behavior.

The startup deeplink path is also realigned to expand the process group and select on the main thread track, matching the ANR pattern. Shared findMainThreadTrackUri and scrollToTrackAndSelect helpers live alongside the panel in navigate.ts .
