### PR TITLE
ui: avoid negative-duration visible window from reliable-range zoom

### DIFF
--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -474,7 +474,13 @@ async function computeVisibleTime(
   // traces.
   if (!isJsonTrace && ENABLE_CHROME_RELIABLE_RANGE_ZOOM_FLAG.get()) {
     const reliableRangeStart = await computeTraceReliableRangeStart(engine);
-    visibleStart = Time.max(visibleStart, reliableRangeStart);
+    // If the reliable range starts at or past the current visible end,
+    // applying it would produce a span with negative duration. Skip the
+    // adjustment in that case (e.g. traces where the reliable-range query
+    // returns trace_end because some process data is missing).
+    if (reliableRangeStart < visibleEnd) {
+      visibleStart = Time.max(visibleStart, reliableRangeStart);
+    }
   }
 
   // Move start of visible window to the first ftrace event


### PR DESCRIPTION
When the "Enable Chrome reliable range zoom" experimental flag is on,
computeVisibleTime() moved visibleStart forward to the Chrome reliable
range start without checking that it stays <= visibleEnd. On traces
where chrome_reliable_range reports a start at (or past) the visible
window end - e.g. because a process is missing data and the metric
returns trace_end - the resulting TimeSpan asserted with:

Bug: b/515070419