### PR TITLE
[DNS] tp: ui: fix reliable range computation for Chrome startup tracing

### DIFF
--- a/src/trace_processor/metrics/sql/chrome/chrome_reliable_range.sql
+++ b/src/trace_processor/metrics/sql/chrome/chrome_reliable_range.sql
@@ -158,24 +158,37 @@ DROP VIEW IF EXISTS chrome_reliable_range;
 CREATE PERFETTO VIEW chrome_reliable_range
 AS
 SELECT
-  -- If the trace has a cropping packet, we don't want to recompute the reliable
-  -- based on cropped track events - the result might be incorrect.
-  IFNULL(_extract_int_metadata('range_of_interest_start_us') * 1000,
-         MAX(thread_start, data_loss_free_start)) AS start,
-  IIF(_extract_int_metadata('range_of_interest_start_us') IS NOT NULL,
-      'Range of interest packet',
-      IIF(limiting_upid IN (SELECT upid FROM chrome_processes_with_missing_main),
-          'Missing main thread for upid=' || limiting_upid,
-          IIF(thread_start >= data_loss_free_start,
-              'First slice for utid=' || limiting_utid,
-               'Missing process data for upid=' || limiting_upid))) AS reason,
-  limiting_upid AS debug_limiting_upid,
-  limiting_utid AS debug_limiting_utid
-FROM
-  (SELECT
-    COALESCE(MAX(start), 0) AS thread_start,
-    utid AS limiting_utid,
-    COALESCE((SELECT start FROM chrome_processes_data_loss_free_period), 0) AS data_loss_free_start,
-    (SELECT limiting_upid FROM chrome_processes_data_loss_free_period) AS limiting_upid
-    FROM chrome_reliable_range_per_thread
-    WHERE has_first_packet_on_sequence = 0);
+  -- If the computed start would be at or past the end of the trace, the
+  -- "reliable range" is empty: no part of the trace is reliable. Return NULL
+  -- so consumers can distinguish "nothing reliable" from "reliable from time
+  -- T". `reason` is still populated to explain why.
+  IIF(raw_start >= COALESCE((SELECT MAX(ts + dur) FROM slice), raw_start + 1),
+      NULL, raw_start) AS start,
+  reason,
+  debug_limiting_upid,
+  debug_limiting_utid
+FROM (
+  SELECT
+    -- If the trace has a cropping packet, we don't want to recompute the
+    -- reliable range based on cropped track events - the result might be
+    -- incorrect.
+    IFNULL(_extract_int_metadata('range_of_interest_start_us') * 1000,
+           MAX(thread_start, data_loss_free_start)) AS raw_start,
+    IIF(_extract_int_metadata('range_of_interest_start_us') IS NOT NULL,
+        'Range of interest packet',
+        IIF(limiting_upid IN (SELECT upid FROM chrome_processes_with_missing_main),
+            'Missing main thread for upid=' || limiting_upid,
+            IIF(thread_start >= data_loss_free_start,
+                'First slice for utid=' || limiting_utid,
+                 'Missing process data for upid=' || limiting_upid))) AS reason,
+    limiting_upid AS debug_limiting_upid,
+    limiting_utid AS debug_limiting_utid
+  FROM
+    (SELECT
+      COALESCE(MAX(start), 0) AS thread_start,
+      utid AS limiting_utid,
+      COALESCE((SELECT start FROM chrome_processes_data_loss_free_period), 0) AS data_loss_free_start,
+      (SELECT limiting_upid FROM chrome_processes_data_loss_free_period) AS limiting_upid
+      FROM chrome_reliable_range_per_thread
+      WHERE has_first_packet_on_sequence = 0)
+);

--- a/test/trace_processor/diff_tests/metrics/chrome/tests.py
+++ b/test/trace_processor/diff_tests/metrics/chrome/tests.py
@@ -196,7 +196,7 @@ class ChromeMetrics(TestSuite):
         query=Path('chrome_reliable_range_test.sql'),
         out=Csv("""
         "start","reason","debug_limiting_upid","debug_limiting_utid"
-        1011,"Missing process data for upid=1",1,1
+        "[NULL]","Missing process data for upid=1",1,1
         """))
 
   def test_chrome_reliable_range_missing_browser_main(self):
@@ -205,7 +205,7 @@ class ChromeMetrics(TestSuite):
         query=Path('chrome_reliable_range_test.sql'),
         out=Csv("""
         "start","reason","debug_limiting_upid","debug_limiting_utid"
-        1011,"Missing main thread for upid=1",1,1
+        "[NULL]","Missing main thread for upid=1",1,1
         """))
 
   def test_chrome_reliable_range_missing_gpu_main(self):
@@ -214,7 +214,7 @@ class ChromeMetrics(TestSuite):
         query=Path('chrome_reliable_range_test.sql'),
         out=Csv("""
         "start","reason","debug_limiting_upid","debug_limiting_utid"
-        1011,"Missing main thread for upid=1",1,1
+        "[NULL]","Missing main thread for upid=1",1,1
         """))
 
   def test_chrome_reliable_range_missing_renderer_main(self):
@@ -223,7 +223,7 @@ class ChromeMetrics(TestSuite):
         query=Path('chrome_reliable_range_test.sql'),
         out=Csv("""
         "start","reason","debug_limiting_upid","debug_limiting_utid"
-        1011,"Missing main thread for upid=1",1,1
+        "[NULL]","Missing main thread for upid=1",1,1
         """))
 
   def test_chrome_reliable_range_non_chrome_process(self):

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -282,7 +282,7 @@ async function loadTraceIntoEngine(
   // traces.
   if (!hasJsonTrace && ENABLE_CHROME_RELIABLE_RANGE_ANNOTATION_FLAG.get()) {
     const reliableRangeStart = await computeTraceReliableRangeStart(engine);
-    if (reliableRangeStart > 0) {
+    if (reliableRangeStart !== null && reliableRangeStart > 0) {
       trace.notes.addNote({
         timestamp: reliableRangeStart,
         color: '#ff0000',
@@ -444,12 +444,14 @@ async function computeFtraceBounds(engine: Engine): Promise<TimeSpan | null> {
   return null;
 }
 
-async function computeTraceReliableRangeStart(engine: Engine): Promise<time> {
+async function computeTraceReliableRangeStart(
+  engine: Engine,
+): Promise<time | null> {
   const result =
     await engine.query(`SELECT RUN_METRIC('chrome/chrome_reliable_range.sql');
        SELECT start FROM chrome_reliable_range`);
-  const bounds = result.firstRow({start: LONG});
-  return Time.fromRaw(bounds.start);
+  const {start} = result.firstRow({start: LONG_NULL});
+  return start === null ? null : Time.fromRaw(start);
 }
 
 async function computeVisibleTime(
@@ -474,7 +476,9 @@ async function computeVisibleTime(
   // traces.
   if (!isJsonTrace && ENABLE_CHROME_RELIABLE_RANGE_ZOOM_FLAG.get()) {
     const reliableRangeStart = await computeTraceReliableRangeStart(engine);
-    visibleStart = Time.max(visibleStart, reliableRangeStart);
+    if (reliableRangeStart !== null) {
+      visibleStart = Time.max(visibleStart, reliableRangeStart);
+    }
   }
 
   // Move start of visible window to the first ftrace event


### PR DESCRIPTION
Reliable range doesn't really make sense for starutp tracing of Chrome.
