### PR TITLE
ui: Fix Wattson estimate aggregator registration for GPU/TPU only traces

### DIFF
--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -80,7 +80,14 @@ export default class Wattson implements PerfettoPlugin {
       : [];
 
     // Short circuit if Wattson is not supported for this Perfetto trace
-    if (!(markersSupported || cpuSupported || gpuSupported)) return;
+    if (!(markersSupported || cpuSupported || gpuSupported || tpuSupported)) {
+      return;
+    }
+
+    // Register selection aggregators that are common to all subsystems.
+    ctx.selection.registerAreaSelectionTab(
+      createAggregationTab(ctx, new WattsonEstimateSelectionAggregator()),
+    );
 
     const group = new TrackNode({name: 'Wattson', isSummary: true});
     ctx.defaultWorkspace.addChildInOrder(group);
@@ -307,11 +314,8 @@ async function addWattsonCpuElements(
   group.addChildInOrder(new TrackNode({uri, name: `DSU/SCU${estimateSuffix}`}));
 
   // Register selection aggregators.
-  // NOTE: the registration order matters because the laste two aggregators
-  // depend on views created by the first two.
-  ctx.selection.registerAreaSelectionTab(
-    createAggregationTab(ctx, new WattsonEstimateSelectionAggregator()),
-  );
+  // NOTE: The registration order matters because subsequent aggregators
+  // (Process, Package) depend on views created by Thread aggregator
   ctx.selection.registerAreaSelectionTab(
     createAggregationTab(ctx, new WattsonThreadSelectionAggregator(ctx)),
   );


### PR DESCRIPTION
Problem is, Wattson Estimation UI Tab won't show GPU/TPU info if CPU wattson is not enabled. This is not expected because CPU GPU TPU are independent of each other.

<img width="1622" height="435" alt="image" src="https://github.com/user-attachments/assets/b16d9504-8cb8-4bdf-8875-d54cb385fb34" />


This PR registers WattsonEstimateSelectionAggregator globally during trace load instead of limiting it to CPU elements initialization. This ensures the "Wattson estimates" tab is available and works on traces that only have GPU or TPU power estimates but no CPU estimates.

Also update the trace load short-circuit check to include tpuSupported to prevent early exit on TPU-only traces.

Bug: 515498287
Test: UI test