### PR TITLE
tp: fix android input end-to-end latency app frame matching

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/input.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/input.sql
@@ -127,6 +127,7 @@ SELECT
   s.ts,
   s.dur,
   cast_int!(t.utid) AS utid,
+  cast_int!(t.upid) AS upid,
   t.process_name,
   str_split(s.name, '=', 3) AS extracted_input_event_id,
   str_split(str_split(parent.name, '_', 1), ' ', 0) AS event_action,
@@ -203,6 +204,7 @@ SELECT
   dev.consume_time,
   dev.finish_time,
   dev.utid,
+  dev.upid,
   dev.process_name,
   af.frame_id,
   af.ts AS frame_ts,
@@ -241,6 +243,8 @@ SELECT
     FROM _app_frame_to_surface_flinger_frame AS sf_frames
     WHERE
       sf_frames.app_ts >= _input_event_id_to_android_frame.frame_ts
+      -- App frame should belong to the process the input is delivered to.
+      AND sf_frames.upid = _input_event_id_to_android_frame.upid
     LIMIT 1
   ) AS present_time,
   (
@@ -248,6 +252,8 @@ SELECT
     FROM _app_frame_to_surface_flinger_frame AS sf_frames
     WHERE
       sf_frames.app_ts >= _input_event_id_to_android_frame.frame_ts
+      -- App frame should belong to the process the input is delivered to.
+      AND sf_frames.upid = _input_event_id_to_android_frame.upid
     LIMIT 1
   ) AS frame_id,
   event_seq,


### PR DESCRIPTION
This revision fixes the implementation of end_to_end_latency_dur in android_input_events: the first non-dropped frame of the input event needs to match the upid of the input event receiver. This fixes a bug that input event delivered to app A matches the first non-dropped frame of app B in calculating the end_to_end input latency.

Bug: b/515625953
Change-Id: Id159357c123226fb58d05b4ec62763161eea3705
