### PR TITLE
ui: Surface SQL errors properly in DataGrid

### DIFF
--- a/ui/src/components/widgets/datagrid/data_source.ts
+++ b/ui/src/components/widgets/datagrid/data_source.ts
@@ -143,4 +143,7 @@ export interface DataSourceRows {
 
   // Whether the data is currently being fetched
   readonly isPending: boolean;
+
+  // If set, the query failed and this contains the error message.
+  readonly error?: string;
 }

--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -23,6 +23,8 @@ import {exists, isNumeric, maybeUndefined} from '../../../base/utils';
 import type {Row, SqlValue} from '../../../trace_processor/query_result';
 import {Anchor} from '../../../widgets/anchor';
 import {Button, ButtonGroup, ButtonVariant} from '../../../widgets/button';
+import {Callout} from '../../../widgets/callout';
+import {Intent} from '../../../widgets/common';
 import {EmptyState} from '../../../widgets/empty_state';
 import {
   Grid,
@@ -492,6 +494,20 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
 
     // Fetch data using the slot-like API
     const rowsResult = datasource.useRows(model);
+
+    if (rowsResult.error) {
+      return m(
+        '.pf-data-grid',
+        {
+          className: classNames(
+            fillHeight && 'pf-data-grid--fill-height',
+            className,
+          ),
+        },
+        m(Callout, {icon: 'error', intent: Intent.Danger}, rowsResult.error),
+      );
+    }
+
     const aggregateSummariesResult = datasource.useAggregateSummaries(model);
 
     // Expose the API

--- a/ui/src/components/widgets/datagrid/sql_data_source.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source.ts
@@ -103,23 +103,28 @@ export class SQLDataSource implements DataSource {
    * Fetch rows for the current model state.
    */
   useRows(model: DataSourceModel): DataSourceRows {
-    const {isPending: preamblePending} = this.usePreamble();
+    try {
+      const {isPending: preamblePending} = this.usePreamble();
 
-    // Don't trigger any other queries until the preamble has completed
-    if (preamblePending) {
-      return {isPending: true};
-    }
+      // Don't trigger any other queries until the preamble has completed
+      if (preamblePending) {
+        return {isPending: true};
+      }
 
-    const mode = model.mode;
-    switch (mode) {
-      case 'flat':
-        return this.flatEngine.getRows(model);
-      case 'pivot':
-        return this.pivotEngine.getRows(model);
-      case 'tree':
-        return this.treeEngine.getRows(model);
-      default:
-        assertUnreachable(mode);
+      const mode = model.mode;
+      switch (mode) {
+        case 'flat':
+          return this.flatEngine.getRows(model);
+        case 'pivot':
+          return this.pivotEngine.getRows(model);
+        case 'tree':
+          return this.treeEngine.getRows(model);
+        default:
+          assertUnreachable(mode);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return {isPending: false, error: msg};
     }
   }
 

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
@@ -15,15 +15,70 @@
 import m from 'mithril';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
-import type {Row} from '../../../trace_processor/query_result';
+import type {Row, SqlValue} from '../../../trace_processor/query_result';
+import {InMemoryDataSource} from '../../../components/widgets/datagrid/in_memory_data_source';
+import type {
+  DataSource,
+  DataSourceModel,
+  DataSourceRows,
+} from '../../../components/widgets/datagrid/data_source';
+import type {QueryResult} from '../../../base/query_slot';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
 import type {SQLSchemaRegistry} from '../../../components/widgets/datagrid/sql_schema';
 import {renderDocSection, renderWidgetShowcase} from '../widgets_page_utils';
 import type {App} from '../../../public/app';
 import {Anchor} from '../../../widgets/anchor';
 
+// Data source wrapper that can be flipped into an error state, for
+// demoing how the DataGrid surfaces datasource failures.
+class ErrorEmulatingDataSource implements DataSource {
+  failing = false;
+  private readonly inner: DataSource;
+  private readonly errorMessage: string;
+
+  constructor(inner: DataSource, errorMessage: string) {
+    this.inner = inner;
+    this.errorMessage = errorMessage;
+  }
+
+  useRows(model: DataSourceModel): DataSourceRows {
+    if (this.failing) {
+      return {isPending: false, error: this.errorMessage};
+    }
+    return this.inner.useRows(model);
+  }
+
+  useAggregateSummaries(model: DataSourceModel): QueryResult<Row> {
+    if (this.failing) {
+      return {data: undefined, isPending: false, isFresh: true};
+    }
+    return this.inner.useAggregateSummaries(model);
+  }
+
+  useDistinctValues(
+    column: string | undefined,
+  ): QueryResult<readonly SqlValue[]> {
+    return this.inner.useDistinctValues(column);
+  }
+
+  useParameterKeys(prefix: string | undefined): QueryResult<readonly string[]> {
+    return this.inner.useParameterKeys(prefix);
+  }
+
+  async exportData(model: DataSourceModel): Promise<readonly Row[]> {
+    if (this.failing) {
+      throw new Error(this.errorMessage);
+    }
+    return this.inner.exportData(model);
+  }
+}
+
 // Cache for the SQL data source - created once when page is first opened with a trace
 let cachedSliceDataSource: SQLDataSource | undefined;
+
+// Cached error-emulating wrapper around the in-memory employee data source so
+// the "emulateError" toggle persists across renders.
+let employeeErrorDataSource: ErrorEmulatingDataSource | undefined;
 
 // SQL schema for slice table with track join
 const SLICE_SQL_SCHEMA: SQLSchemaRegistry = {
@@ -182,19 +237,27 @@ export function renderDataGrid(app: App): m.Children {
     ),
 
     renderWidgetShowcase({
-      renderWidget: ({...rest}) => {
+      renderWidget: ({emulateError, ...rest}) => {
+        if (!employeeErrorDataSource) {
+          employeeErrorDataSource = new ErrorEmulatingDataSource(
+            new InMemoryDataSource(EMPLOYEE_DATA),
+            'Emulated datasource error: failed to fetch rows',
+          );
+        }
+        employeeErrorDataSource.failing = emulateError;
         return m(DataGrid, {
           ...rest,
           fillHeight: true,
           schema: EMPLOYEE_SCHEMA,
           rootSchema: 'employee',
-          data: EMPLOYEE_DATA,
+          data: employeeErrorDataSource,
         });
       },
       initialOpts: {
         showExportButton: false,
         structuredQueryCompatMode: false,
         enablePivotControls: true,
+        emulateError: false,
       },
       noPadding: true,
     }),


### PR DESCRIPTION
Display SQL errors live on the DataGrid when operating in SQLDataSource mode instead of just crashing the UI.

Note: This doesn't apply to the query page, as this already surfaces its own errors using a separate mechanism for technical reasons.