### PR TITLE
ui: Improve QueryLog tab UX

### DIFF
--- a/ui/src/plugins/dev.perfetto.QueryLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.QueryLog/index.ts
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import './styles.scss';
 import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
-
-function formatMillis(millis: number) {
-  return millis.toFixed(1);
-}
+import {QueryTab} from './query_log';
+import './styles.scss';
 
 export default class QueryLogPlugin implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.QueryLog';
@@ -42,41 +39,7 @@ export default class QueryLogPlugin implements PerfettoPlugin {
           return 'Query Log';
         },
         render() {
-          // Show the logs in reverse order
-          const queryLog = Array.from(trace.engine.queryLog).reverse();
-          return m(
-            'table.pf-query-log-table',
-            m(
-              'tr',
-              m('th', 'Query'),
-              m('th', 'Tag'),
-              m('th', 'Status'),
-              m('th', 'Start time (ms)'),
-              m('th', 'Duration (ms)'),
-            ),
-            queryLog.map((ql) =>
-              m(
-                'tr',
-                m('td', m('pre', ql.query.trim())),
-                m('td', ql.tag),
-                m(
-                  'td',
-                  ql.success === undefined
-                    ? 'Running...'
-                    : ql.success
-                      ? 'Completed'
-                      : 'Failed',
-                ),
-                m('td', formatMillis(ql.startTime)),
-                m(
-                  'td',
-                  ql.elapsedTimeMs === undefined
-                    ? '...'
-                    : formatMillis(ql.elapsedTimeMs),
-                ),
-              ),
-            ),
-          );
+          return m(QueryTab, {trace});
         },
       },
     });

--- a/ui/src/plugins/dev.perfetto.QueryLog/query_log.ts
+++ b/ui/src/plugins/dev.perfetto.QueryLog/query_log.ts
@@ -1,0 +1,155 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {assertExists} from '../../base/assert';
+import type {Trace} from '../../public/trace';
+import type {QueryLog} from '../../trace_processor/engine';
+import {Button} from '../../widgets/button';
+import {Chip} from '../../widgets/chip';
+import {Intent} from '../../widgets/common';
+import {CopyToClipboardButton} from '../../widgets/copy_to_clipboard_button';
+import {DetailsShell} from '../../widgets/details_shell';
+
+function formatMillis(millis: number) {
+  return millis.toFixed(1);
+}
+
+interface QueryLogEntryAttrs {
+  readonly queryLog: QueryLog;
+}
+
+class QueryLogRow implements m.ClassComponent<QueryLogEntryAttrs> {
+  private isOpen = false;
+
+  view({attrs}: m.Vnode<QueryLogEntryAttrs>) {
+    const {queryLog: ql} = attrs;
+    assertExists(ql.query);
+    const fullQuery = ql.query.trim();
+    const isOpen = this.isOpen;
+    const toggle = () => {
+      this.isOpen = !this.isOpen;
+    };
+    const statusChip =
+      ql.success === undefined
+        ? m(Chip, {label: 'Running', intent: Intent.Warning, compact: true})
+        : ql.success
+          ? m(Chip, {label: 'Completed', intent: Intent.Success, compact: true})
+          : m(Chip, {label: 'Failed', intent: Intent.Danger, compact: true});
+    return m(
+      'tr.pf-query-log-row',
+      {class: isOpen ? 'pf-expanded' : ''},
+      m('td.pf-query-log-num', formatMillis(ql.startTime)),
+      m(
+        'td.pf-query-log-num',
+        ql.elapsedTimeMs === undefined ? '...' : formatMillis(ql.elapsedTimeMs),
+      ),
+      m('td', ql.tag),
+      m('td', statusChip),
+      m(
+        'td.pf-query-log-toggle',
+        m(Button, {
+          icon: isOpen ? 'expand_more' : 'chevron_right',
+          compact: true,
+          onclick: toggle,
+        }),
+      ),
+      m(
+        'td.pf-query-log-query',
+        {
+          title: isOpen ? undefined : fullQuery,
+          onclick: toggle,
+        },
+        isOpen
+          ? m(
+              '.pf-query-log-expanded-body',
+              m(
+                '.pf-query-log-expanded-toolbar',
+                {onclick: (e: Event) => e.stopPropagation()},
+                m(CopyToClipboardButton, {
+                  textToCopy: fullQuery,
+                  label: 'Copy',
+                  compact: true,
+                }),
+              ),
+              m('span.pf-query-log-full', fullQuery),
+            )
+          : m('span.pf-query-log-snippet', fullQuery.replace(/\s+/g, ' ')),
+      ),
+    );
+  }
+}
+
+export interface QueryTabAttrs {
+  readonly trace: Trace;
+}
+
+const PAGE_SIZE = 100;
+
+export class QueryTab implements m.ClassComponent<QueryTabAttrs> {
+  private visibleCount = PAGE_SIZE;
+
+  view({attrs}: m.Vnode<QueryTabAttrs>) {
+    const {trace} = attrs;
+    // Show the logs in reverse order
+    const queryLog = Array.from(trace.engine.queryLog).reverse();
+    const visible = queryLog.slice(0, this.visibleCount);
+    const remaining = queryLog.length - visible.length;
+    return m(
+      DetailsShell,
+      {
+        title: 'Query Log',
+        description: `${queryLog.length} ${queryLog.length === 1 ? 'entry' : 'entries'}`,
+        buttons: m(Button, {
+          label: 'Clear',
+          icon: 'delete',
+          disabled: queryLog.length === 0,
+          onclick: () => trace.engine.clearQueryLog(),
+        }),
+      },
+      m(
+        '.pf-query-log',
+        m(
+          'table.pf-query-log-table',
+          m(
+            'thead',
+            m(
+              'tr',
+              m('th.pf-query-log-num', 'Start (ms)'),
+              m('th.pf-query-log-num', 'Duration (ms)'),
+              m('th', 'Tag'),
+              m('th', 'Status'),
+              m('th'),
+              m('th', 'Query'),
+            ),
+          ),
+          m(
+            'tbody',
+            visible.map((ql) => m(QueryLogRow, {queryLog: ql})),
+          ),
+        ),
+        remaining > 0 &&
+          m(
+            '.pf-query-log-show-more',
+            m(Button, {
+              label: `Show ${Math.min(PAGE_SIZE, remaining)} more (${remaining} remaining)`,
+              onclick: () => {
+                this.visibleCount += PAGE_SIZE;
+              },
+            }),
+          ),
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.QueryLog/styles.scss
+++ b/ui/src/plugins/dev.perfetto.QueryLog/styles.scss
@@ -12,15 +12,118 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+.pf-query-log {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.pf-query-log-show-more {
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+}
+
+.pf-query-log-toolbar {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 8px;
+}
+
 .pf-query-log-table {
+  width: 100%;
+  max-width: 100%;
+  table-layout: auto;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 4px 8px;
+    text-align: left;
+    vertical-align: top;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
   tr:nth-child(even) {
-    border-collapse: collapse;
     background-color: var(--pf-color-background-secondary);
   }
 
-  td:first-child {
-    word-break: break-word;
-    overflow-wrap: break-word;
+  // Toggle column: tight.
+  th:nth-child(1),
+  td:nth-child(1) {
+    width: 32px;
+    padding: 2px 4px;
+  }
+
+  // Metadata columns (2-5): shrink to fit. With table-layout: auto and
+  // white-space: nowrap on td, width:1px collapses to the content width.
+  th:nth-child(2),
+  td:nth-child(2),
+  th:nth-child(3),
+  td:nth-child(3),
+  th:nth-child(4),
+  td:nth-child(4),
+  th:nth-child(5),
+  td:nth-child(5) {
+    width: 1px;
+  }
+
+  // Query column (col 6) absorbs all remaining space, snippet handles overflow.
+  th:nth-child(6),
+  td:nth-child(6) {
+    width: 100%;
+    min-width: 0;
+    max-width: 0; // forces snippet's overflow:hidden to win
     white-space: normal;
+  }
+
+  .pf-query-log-num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .pf-query-log-query {
+    cursor: pointer;
+  }
+
+  .pf-query-log-snippet {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+    font-family: var(--pf-font-mono, monospace);
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .pf-query-log-expanded > td {
+    padding: 0 8px 8px 40px;
+    background-color: var(--pf-color-background-secondary);
+  }
+
+  .pf-query-log-expanded-body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .pf-query-log-expanded-toolbar {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .pf-query-log-full {
+    display: block;
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--pf-font-mono, monospace);
+    font-size: 12px;
   }
 }

--- a/ui/src/trace_processor/engine.ts
+++ b/ui/src/trace_processor/engine.ts
@@ -48,9 +48,10 @@ export interface TraceProcessorConfig {
   forceFullSort: boolean;
 }
 
-const QUERY_LOG_BUFFER_SIZE = 100;
+const QUERY_LOG_BUFFER_SIZE = 1024;
 
-interface QueryLog {
+export interface QueryLog {
+  readonly id: number;
   readonly tag?: string;
   readonly query: string;
   readonly startTime: number;
@@ -67,6 +68,9 @@ export interface Engine {
    * times and success status (if completed).
    */
   readonly queryLog: ReadonlyArray<QueryLog>;
+
+  /** Clear the query log. In-flight queries are removed too. */
+  clearQueryLog(): void;
 
   /**
    * Execute a query against the database, returning a promise that resolves
@@ -172,9 +176,14 @@ export abstract class EngineBase implements Engine, Disposable {
   private _numRequestsPending = 0;
   private _failed: string | undefined = undefined;
   private _queryLog: Array<QueryLog> = [];
+  private _nextQueryLogId = 0;
 
   get queryLog(): ReadonlyArray<QueryLog> {
     return this._queryLog;
+  }
+
+  clearQueryLog(): void {
+    this._queryLog = [];
   }
 
   // TraceController sets this to raf.scheduleFullRedraw().
@@ -577,7 +586,12 @@ export abstract class EngineBase implements Engine, Disposable {
     success?: boolean;
   } {
     const startTime = performance.now();
-    const queryLog: QueryLog = {query, tag, startTime};
+    const queryLog: QueryLog = {
+      id: this._nextQueryLogId++,
+      query,
+      tag,
+      startTime,
+    };
     this._queryLog.push(queryLog);
     if (this._queryLog.length > QUERY_LOG_BUFFER_SIZE) {
       this._queryLog.shift();
@@ -786,6 +800,10 @@ export class EngineProxy implements Engine, Disposable {
 
   get queryLog() {
     return this.engine.queryLog;
+  }
+
+  clearQueryLog(): void {
+    this.engine.clearQueryLog();
   }
 
   constructor(engine: EngineBase, tag: string) {


### PR DESCRIPTION
The query log tab is a useful tool for debugging slow UI queries - it's a client side hosted live log of queries issues to the engine and how long each one is taking / has taken. The UX is terrible however.

This patch improves the UX.

- Consistent height rows for quick scanning.
- Status badges.
- Collapse/expand to show entire query.
- Copy query button.
- Larger buffer size.
- Clear button.

<img width="1821" height="522" alt="image" src="https://github.com/user-attachments/assets/36040f5c-3e56-4be5-92da-7a8770100bdc" />