### PR TITLE
tp: add Transaction + parameterized Execute to PerfettoSqlConnection

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
@@ -490,18 +490,15 @@ PerfettoSqlConnection::PrepareSqliteStatement(SqlSource sql_source) {
 void PerfettoSqlConnection::Initialize(Initializer init) {
   // Wrap the ~100 static-table CREATEs in one transaction; otherwise SQLite
   // implicitly commits after each statement.
-  auto exec_or_die = [&](const char* sql) {
-    auto s = Execute(SqlSource::FromTraceProcessorImplementation(sql));
-    PERFETTO_CHECK(s.ok());
-  };
-  exec_or_die("BEGIN TRANSACTION");
-  for (const auto& info : init.static_tables) {
-    RegisterStaticTable(info.dataframe, info.name);
+  {
+    Transaction txn(this);
+    for (const auto& info : init.static_tables) {
+      RegisterStaticTable(info.dataframe, info.name);
+    }
+    for (auto& info : init.static_table_functions) {
+      RegisterStaticTableFunction(std::move(info));
+    }
   }
-  for (auto& info : init.static_table_functions) {
-    RegisterStaticTableFunction(std::move(info));
-  }
-  exec_or_die("COMMIT");
   for (const auto& mod : init.sqlite_modules) {
     if (mod.is_state_manager) {
       virtual_module_state_managers_.push_back(
@@ -598,6 +595,48 @@ PerfettoSqlConnection::Execute(SqlSource sql) {
   }
   RETURN_IF_ERROR(res->stmt.status());
   return res->stats;
+}
+
+base::Status PerfettoSqlConnection::Execute(
+    SqlSource sql,
+    std::initializer_list<std::string_view> binds) {
+  // Bypass the PerfettoSQL frontend: this overload is for hot internal loops
+  // running plain SQLite, where the parser/frame setup would dominate.
+  sqlite3* db = connection_->db();
+  sqlite3_stmt* stmt = nullptr;
+  int rc = sqlite3_prepare_v2(db, sql.sql().c_str(),
+                              static_cast<int>(sql.sql().size()), &stmt,
+                              /*pzTail=*/nullptr);
+  if (rc != SQLITE_OK) {
+    return base::ErrStatus("Prepare failed: %s", sqlite3_errmsg(db));
+  }
+  int idx = 1;
+  for (const auto& b : binds) {
+    // |b.data()| must outlive the step+finalize below; SQLITE_STATIC (passed
+    // as nullptr destructor) tells SQLite not to copy.
+    sqlite3_bind_text(stmt, idx++, b.data(), static_cast<int>(b.size()),
+                      /*destructor=*/nullptr);
+  }
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+  }
+  sqlite3_finalize(stmt);
+  if (rc != SQLITE_DONE) {
+    return base::ErrStatus("Step failed: %s", sqlite3_errmsg(db));
+  }
+  return base::OkStatus();
+}
+
+PerfettoSqlConnection::Transaction::Transaction(PerfettoSqlConnection* conn)
+    : conn_(conn) {
+  auto s = conn_->Execute(
+      SqlSource::FromTraceProcessorImplementation("BEGIN TRANSACTION"));
+  PERFETTO_CHECK(s.ok());
+}
+
+PerfettoSqlConnection::Transaction::~Transaction() {
+  auto s =
+      conn_->Execute(SqlSource::FromTraceProcessorImplementation("COMMIT"));
+  PERFETTO_CHECK(s.ok());
 }
 
 base::StatusOr<PerfettoSqlConnection::ExecutionResult>

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include <memory>
 #include <optional>
 #include <string>
@@ -114,6 +115,32 @@ class PerfettoSqlConnection {
   // Returns an error if the execution of any statement failed or if there was
   // no valid SQL to run.
   base::StatusOr<ExecutionStats> Execute(SqlSource sql);
+
+  // Executes a single-statement parameterized SQL, binding |binds| to its
+  // |?| placeholders in order. Strings in |binds| must outlive the call.
+  // Bypasses the PerfettoSQL frontend: the SQL must be plain SQLite.
+  //
+  // Intended for hot internal loops where the same INSERT/UPDATE shape is
+  // run many times with different values. Each call still prepares and
+  // finalizes a fresh sqlite3_stmt (lookaside makes that cheap); wrap the
+  // loop in a |Transaction| to avoid per-call commits.
+  base::Status Execute(SqlSource sql,
+                       std::initializer_list<std::string_view> binds);
+
+  // RAII transaction. Issues BEGIN on construction and COMMIT on
+  // destruction. Use to batch a sequence of Execute() calls so SQLite does
+  // not implicitly commit after each statement.
+  class [[nodiscard]] Transaction {
+   public:
+    explicit Transaction(PerfettoSqlConnection*);
+    ~Transaction();
+
+    Transaction(const Transaction&) = delete;
+    Transaction& operator=(const Transaction&) = delete;
+
+   private:
+    PerfettoSqlConnection* conn_;
+  };
 
   // Executes all the statements in |sql| fully until the final statement and
   // returns a |ExecutionResult| object containing a |ScopedStmt| for the final

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -214,22 +214,22 @@ base::Status RegisterAllProtoBuilderFunctions(
   return base::OkStatus();
 }
 
-void BuildBoundsTable(sqlite3* db, std::pair<int64_t, int64_t> bounds) {
-  char* error = nullptr;
-  sqlite3_exec(db, "DELETE FROM _trace_bounds", nullptr, nullptr, &error);
-  if (error) {
-    PERFETTO_ELOG("Error deleting from bounds table: %s", error);
-    sqlite3_free(error);
+void BuildBoundsTable(PerfettoSqlConnection* engine,
+                      std::pair<int64_t, int64_t> bounds) {
+  auto del = engine->Execute(
+      SqlSource::FromTraceProcessorImplementation("DELETE FROM _trace_bounds"));
+  if (!del.ok()) {
+    PERFETTO_ELOG("Error deleting from bounds table: %s",
+                  del.status().c_message());
     return;
   }
-
   base::StackString<1024> sql("INSERT INTO _trace_bounds VALUES(%" PRId64
                               ", %" PRId64 ")",
                               bounds.first, bounds.second);
-  sqlite3_exec(db, sql.c_str(), nullptr, nullptr, &error);
-  if (error) {
-    PERFETTO_ELOG("Error inserting bounds table: %s", error);
-    sqlite3_free(error);
+  auto ins = engine->Execute(
+      SqlSource::FromTraceProcessorImplementation(sql.ToStdString()));
+  if (!ins.ok()) {
+    PERFETTO_ELOG("Error inserting bounds table: %s", ins.status().c_message());
   }
 }
 
@@ -264,15 +264,13 @@ std::vector<std::string> SanitizeMetricMountPaths(
   return sanitized;
 }
 
-void InsertIntoTraceMetricsTable(sqlite3* db, const std::string& metric_name) {
-  char* insert_sql = sqlite3_mprintf(
-      "INSERT INTO _trace_metrics(name) VALUES('%q')", metric_name.c_str());
-  char* insert_error = nullptr;
-  sqlite3_exec(db, insert_sql, nullptr, nullptr, &insert_error);
-  sqlite3_free(insert_sql);
-  if (insert_error) {
-    PERFETTO_ELOG("Error registering table: %s", insert_error);
-    sqlite3_free(insert_error);
+void InsertIntoTraceMetricsTable(PerfettoSqlConnection* engine,
+                                 const std::string& metric_name) {
+  auto s = engine->Execute(SqlSource::FromTraceProcessorImplementation(
+                               "INSERT INTO _trace_metrics(name) VALUES(?)"),
+                           {metric_name});
+  if (!s.ok()) {
+    PERFETTO_ELOG("Error registering table: %s", s.c_message());
   }
 }
 
@@ -526,11 +524,14 @@ TraceProcessorImpl::TraceProcessorImpl(const Config& cfg)
                                 config_.skip_builtin_metric_paths.end(),
                                 "") != config_.skip_builtin_metric_paths.end();
   if (!skip_all_sql) {
+    // Wrap the per-metric INSERTs in one transaction; otherwise SQLite
+    // implicitly commits after each statement.
+    PerfettoSqlConnection::Transaction txn(engine_.get());
     for (const auto& file_to_sql :
          SqlBundle(sql_metrics::kAmalgamatedSqlMetrics)) {
       if (base::StartsWithAny(file_to_sql.path, sanitized_extension_paths))
         continue;
-      RegisterMetric(file_to_sql.path, std::string(file_to_sql.sql_view()));
+      RegisterMetricImpl(file_to_sql.path, std::string(file_to_sql.sql_view()));
     }
   }
 }
@@ -619,7 +620,7 @@ void TraceProcessorImpl::CacheBoundsAndBuildTable() {
   }
   bounds_tables_mutations_ = mutations;
   cached_trace_bounds_ = AggregatePluginTimestampBounds(plugins_);
-  BuildBoundsTable(engine_->sqlite_connection()->db(), cached_trace_bounds_);
+  BuildBoundsTable(engine_.get(), cached_trace_bounds_);
 }
 
 // =================================================================
@@ -838,13 +839,18 @@ size_t TraceProcessorImpl::RestoreInitialTables() {
 
 base::Status TraceProcessorImpl::RegisterMetric(const std::string& path,
                                                 const std::string& sql) {
+  return RegisterMetricImpl(path, sql);
+}
+
+base::Status TraceProcessorImpl::RegisterMetricImpl(std::string path,
+                                                    std::string sql) {
   // Check if the metric with the given path already exists and if it does,
   // just update the SQL associated with it.
   auto it = std::find_if(
       sql_metrics_.begin(), sql_metrics_.end(),
       [&path](const metrics::SqlMetricFile& m) { return m.path == path; });
   if (it != sql_metrics_.end()) {
-    it->sql = sql;
+    it->sql = std::move(sql);
     return base::OkStatus();
   }
 
@@ -859,13 +865,13 @@ base::Status TraceProcessorImpl::RegisterMetric(const std::string& path,
   auto no_ext_name = basename.substr(0, sql_idx);
 
   metrics::SqlMetricFile metric;
-  metric.path = path;
-  metric.sql = sql;
 
   if (IsRootMetricField(no_ext_name)) {
     metric.proto_field_name = no_ext_name;
     metric.output_table_name = no_ext_name + "_output";
 
+    // proto_field_to_sql_metric_path_ stores |path| by value: this is the
+    // one unavoidable copy on the root-metric path.
     auto field_it_and_inserted =
         proto_field_to_sql_metric_path_.emplace(*metric.proto_field_name, path);
     if (!field_it_and_inserted.second) {
@@ -882,13 +888,11 @@ base::Status TraceProcessorImpl::RegisterMetric(const std::string& path,
           "and %s are both trying to output the proto field %s",
           prev_path.c_str(), path.c_str(), metric.proto_field_name->c_str());
     }
+    InsertIntoTraceMetricsTable(engine_.get(), *metric.proto_field_name);
   }
-
-  if (metric.proto_field_name) {
-    InsertIntoTraceMetricsTable(engine_->sqlite_connection()->db(),
-                                *metric.proto_field_name);
-  }
-  sql_metrics_.emplace_back(metric);
+  metric.path = std::move(path);
+  metric.sql = std::move(sql);
+  sql_metrics_.emplace_back(std::move(metric));
   return base::OkStatus();
 }
 
@@ -1072,13 +1076,17 @@ TraceProcessorImpl::InitPerfettoSqlConnection(
     IncludeAfterEofPrelude(connection.get());
   }
 
-  sqlite3* db = connection->sqlite_connection()->db();
-  for (const auto& metric : sql_metrics) {
-    if (metric.proto_field_name) {
-      InsertIntoTraceMetricsTable(db, *metric.proto_field_name);
+  // Same batching as the constructor: wrap the per-metric INSERTs in one
+  // transaction.
+  {
+    PerfettoSqlConnection::Transaction txn(connection.get());
+    for (const auto& metric : sql_metrics) {
+      if (metric.proto_field_name) {
+        InsertIntoTraceMetricsTable(connection.get(), *metric.proto_field_name);
+      }
     }
   }
-  BuildBoundsTable(db, cached_trace_bounds);
+  BuildBoundsTable(connection.get(), cached_trace_bounds);
   return connection;
 }
 

--- a/src/trace_processor/trace_processor_impl.h
+++ b/src/trace_processor/trace_processor_impl.h
@@ -140,6 +140,12 @@ class TraceProcessorImpl : public TraceProcessor,
   // Needed for iterators to be able to access the context.
   friend class IteratorImpl;
 
+  // By-value RegisterMetric body. External callers go through the
+  // |RegisterMetric| override (which copies its const-ref args into our
+  // parameters); the constructor's amalgamated-metrics loop calls this
+  // directly so it can move the temporaries through without extra copies.
+  base::Status RegisterMetricImpl(std::string path, std::string sql);
+
   bool IsRootMetricField(const std::string& metric_name);
 
   void CacheBoundsAndBuildTable();


### PR DESCRIPTION
Introduce two helpers on PerfettoSqlConnection:

 - A Transaction RAII type that issues BEGIN/COMMIT, for batching a
   sequence of Execute() calls so SQLite does not implicitly commit
   after each statement.

 - A parameterized Execute() overload that prepares/binds/steps a
   single plain-SQLite statement directly, bypassing the PerfettoSQL
   frontend. Intended for hot internal loops running the same
   INSERT/UPDATE shape with varying values.

Use both in TraceProcessorImpl: wrap the per-metric INSERTs into the
_trace_metrics table in a single transaction (both at startup and in
InitPerfettoSqlConnection), and switch InsertIntoTraceMetricsTable to
the parameterized overload. Also pass path/sql by value into a private
RegisterMetricImpl so the constructor's amalgamated-metrics loop can
move them through.
