### PR TITLE
tp: bump SQLite per-connection lookaside slab

### DIFF
--- a/src/trace_processor/sqlite/sqlite_connection.cc
+++ b/src/trace_processor/sqlite/sqlite_connection.cc
@@ -125,14 +125,15 @@ SqliteConnection::SqliteConnection(std::shared_ptr<SqliteDatabase> database)
   EnsureSqliteInitialized();
   PERFETTO_CHECK(sqlite3_open_v2(database_->shared_filename().c_str(), &db,
                                  kSqliteOpenFlags, nullptr) == SQLITE_OK);
-  // Bump the per-connection lookaside slab well above the SQLite default
-  // (1200,40 ≈ 48 KB). At startup we measured ~10K lookaside hits and
-  // ~1.4K spillovers to malloc with the default; the spilled allocations
-  // all fit in a 1200-byte slot, so growing cnt (not sz) is what helps.
-  // 1.2 MB / connection trades RAM for ~1400 fewer mallocs per
-  // CreateInstance, and gives a bigger headroom for user queries.
+  // Bump the per-connection lookaside slab above the SQLite default of
+  // sz=1200 bytes, cnt=40 slots (~48 KB). At startup we measured ~10K
+  // lookaside hits and ~1.4K spillovers to malloc; the spilled
+  // allocations all fit in a 1200-byte slot, so growing cnt (not sz) is
+  // what helps. sz=1200, cnt=1000 (~1.2 MB / connection) trades RAM for
+  // ~1400 fewer mallocs per CreateInstance and leaves headroom for user
+  // queries.
   PERFETTO_CHECK(sqlite3_db_config(db, SQLITE_DBCONFIG_LOOKASIDE, nullptr,
-                                   1200, 1000) == SQLITE_OK);
+                                   /*sz=*/1200, /*cnt=*/1000) == SQLITE_OK);
   InitializeSqlite(db);
   db_.reset(db);
 }

--- a/src/trace_processor/sqlite/sqlite_connection.cc
+++ b/src/trace_processor/sqlite/sqlite_connection.cc
@@ -125,6 +125,14 @@ SqliteConnection::SqliteConnection(std::shared_ptr<SqliteDatabase> database)
   EnsureSqliteInitialized();
   PERFETTO_CHECK(sqlite3_open_v2(database_->shared_filename().c_str(), &db,
                                  kSqliteOpenFlags, nullptr) == SQLITE_OK);
+  // Bump the per-connection lookaside slab well above the SQLite default
+  // (1200,40 ≈ 48 KB). At startup we measured ~10K lookaside hits and
+  // ~1.4K spillovers to malloc with the default; the spilled allocations
+  // all fit in a 1200-byte slot, so growing cnt (not sz) is what helps.
+  // 1.2 MB / connection trades RAM for ~1400 fewer mallocs per
+  // CreateInstance, and gives a bigger headroom for user queries.
+  PERFETTO_CHECK(sqlite3_db_config(db, SQLITE_DBCONFIG_LOOKASIDE, nullptr,
+                                   1200, 1000) == SQLITE_OK);
   InitializeSqlite(db);
   db_.reset(db);
 }


### PR DESCRIPTION
Raise the lookaside slab from the SQLite default (1200,40 ~ 48 KB) to
1200x1000 (~1.2 MB) per connection. At startup we measured ~10K
lookaside hits and ~1.4K spillovers to malloc with the default; the
spilled allocations all fit in a 1200-byte slot, so growing the slot
count (not size) is what helps. Trades RAM for ~1400 fewer mallocs per
CreateInstance and gives more headroom for user queries.
