### PR TITLE
[DNS] ui: make datagrid filter chips editable

### DIFF
--- a/ui/src/components/widgets/datagrid/column_filter_menu.ts
+++ b/ui/src/components/widgets/datagrid/column_filter_menu.ts
@@ -50,8 +50,6 @@ interface DistinctValuesSubmenuAttrs {
   readonly field: string;
   readonly excludeNull?: boolean;
   readonly valueFormatter: (value: SqlValue) => string;
-  // Pre-checked at mount; read once in oninit so parent re-renders
-  // don't clobber in-flight edits.
   readonly initialSelectedValues?: ReadonlyArray<SqlValue>;
   readonly onApply: (selectedValues: Set<SqlValue>) => void;
 }
@@ -60,8 +58,7 @@ export class DistinctValuesSubmenu
   implements m.ClassComponent<DistinctValuesSubmenuAttrs>
 {
   private selectedValues = new Set<SqlValue>();
-  // Initial selection captured at oninit; pinned to top of the idle
-  // layout so toggles don't shift items.
+  // Initial selection captured at oninit; pinned to top of the idle layout.
   private pinned = new Set<SqlValue>();
   private searchQuery = '';
   private static readonly MAX_VISIBLE_ITEMS = 100;
@@ -233,10 +230,7 @@ export class DistinctValuesSubmenu
 interface TextFilterSubmenuAttrs {
   readonly placeholder?: string;
   readonly inputType: 'text' | 'number';
-  // Pre-fills input on mount; read once in oninit so re-renders don't
-  // clobber typing.
   readonly initialValue?: string;
-  // Submit-button label; defaults to 'Add Filter' (edit-mode uses 'Save').
   readonly submitLabel?: string;
   readonly onApply: (value: string | number) => void;
 }
@@ -644,8 +638,7 @@ export interface EditFilterMenuAttrs {
   readonly onFilterReplace: (filter: FilterOpAndValue) => void;
 }
 
-// Uneditable: null-arity ops, or value-bearing ops with value=null
-// (legal per type but SQL `col = NULL` never matches).
+// Uneditable: null-arity ops.
 export function isEditableFilter(filter: FilterOpAndValue): boolean {
   switch (filter.op) {
     case 'is null':
@@ -670,8 +663,6 @@ export class EditFilterMenu implements m.ClassComponent<EditFilterMenuAttrs> {
       onFilterReplace,
     } = attrs;
 
-    // Defense-in-depth: DataGrid also skips wiring onEdit for these
-    // filters so the popup normally never opens with one.
     if (!isEditableFilter(initialFilter)) {
       return null;
     }
@@ -681,8 +672,7 @@ export class EditFilterMenu implements m.ClassComponent<EditFilterMenuAttrs> {
       return m(DistinctValuesSubmenu, {
         datasource,
         field,
-        // Match add-mode: `in`/`not in` doesn't match NULL, use the null
-        // op instead.
+        // Match add-mode: `in`/`not in` doesn't match NULL.
         excludeNull: true,
         valueFormatter,
         initialSelectedValues: initialFilter.value,
@@ -759,7 +749,6 @@ export class EditFilterMenu implements m.ClassComponent<EditFilterMenuAttrs> {
       });
     }
 
-    // Exhaustiveness fall-through; FilterOpAndValue should be covered.
     return null;
   }
 }

--- a/ui/src/components/widgets/datagrid/column_filter_menu.ts
+++ b/ui/src/components/widgets/datagrid/column_filter_menu.ts
@@ -50,6 +50,9 @@ interface DistinctValuesSubmenuAttrs {
   readonly field: string;
   readonly excludeNull?: boolean;
   readonly valueFormatter: (value: SqlValue) => string;
+  // Pre-checked at mount; read once in oninit so parent re-renders
+  // don't clobber in-flight edits.
+  readonly initialSelectedValues?: ReadonlyArray<SqlValue>;
   readonly onApply: (selectedValues: Set<SqlValue>) => void;
 }
 
@@ -57,8 +60,20 @@ export class DistinctValuesSubmenu
   implements m.ClassComponent<DistinctValuesSubmenuAttrs>
 {
   private selectedValues = new Set<SqlValue>();
+  // Initial selection captured at oninit; pinned to top of the idle
+  // layout so toggles don't shift items.
+  private pinned = new Set<SqlValue>();
   private searchQuery = '';
   private static readonly MAX_VISIBLE_ITEMS = 100;
+
+  oninit({attrs}: m.Vnode<DistinctValuesSubmenuAttrs>) {
+    if (attrs.initialSelectedValues !== undefined) {
+      for (const v of attrs.initialSelectedValues) {
+        this.selectedValues.add(v);
+        this.pinned.add(v);
+      }
+    }
+  }
 
   view({attrs}: m.Vnode<DistinctValuesSubmenuAttrs>) {
     const {datasource, field, excludeNull, valueFormatter, onApply} = attrs;
@@ -76,7 +91,7 @@ export class DistinctValuesSubmenu
     const distinctValues = excludeNull ? data.filter((v) => v !== null) : data;
 
     // Use fuzzy search to filter and get highlighted segments
-    const fuzzyResults = (() => {
+    const baseResults = (() => {
       if (this.searchQuery === '') {
         // No search - show all values without highlighting
         return distinctValues.map((value) => ({
@@ -93,6 +108,22 @@ export class DistinctValuesSubmenu
           segments: result.segments,
         }));
       }
+    })();
+
+    // Pin initial selection at top of idle layout; skip during search
+    // so fuzzy relevance wins.
+    const fuzzyResults = (() => {
+      if (this.searchQuery !== '') return baseResults;
+      const pinnedItems: typeof baseResults = [];
+      const rest: typeof baseResults = [];
+      for (const r of baseResults) {
+        if (this.pinned.has(r.value)) {
+          pinnedItems.push(r);
+        } else {
+          rest.push(r);
+        }
+      }
+      return [...pinnedItems, ...rest];
     })();
 
     // Limit the number of items rendered
@@ -202,6 +233,11 @@ export class DistinctValuesSubmenu
 interface TextFilterSubmenuAttrs {
   readonly placeholder?: string;
   readonly inputType: 'text' | 'number';
+  // Pre-fills input on mount; read once in oninit so re-renders don't
+  // clobber typing.
+  readonly initialValue?: string;
+  // Submit-button label; defaults to 'Add Filter' (edit-mode uses 'Save').
+  readonly submitLabel?: string;
   readonly onApply: (value: string | number) => void;
 }
 
@@ -210,8 +246,19 @@ export class TextFilterSubmenu
 {
   private inputValue = '';
 
+  oninit({attrs}: m.Vnode<TextFilterSubmenuAttrs>) {
+    if (attrs.initialValue !== undefined) {
+      this.inputValue = attrs.initialValue;
+    }
+  }
+
   view({attrs}: m.Vnode<TextFilterSubmenuAttrs>) {
-    const {placeholder = 'Enter value...', inputType, onApply} = attrs;
+    const {
+      placeholder = 'Enter value...',
+      inputType,
+      submitLabel = 'Add Filter',
+      onApply,
+    } = attrs;
 
     const applyFilter = () => {
       if (this.inputValue.trim().length > 0) {
@@ -233,7 +280,7 @@ export class TextFilterSubmenu
       Form,
       {
         className: 'pf-data-grid__text-filter-form',
-        submitLabel: 'Add Filter',
+        submitLabel,
         submitIcon: 'check',
         onSubmit: (e: Event) => {
           e.preventDefault();
@@ -579,5 +626,140 @@ function renderFilterMenuItems(config: FilterMenuAttrs): m.ChildArray {
     default:
       // When columnType is undefined, show all filters
       return renderUnknownTypeFilterMenuItems(config);
+  }
+}
+
+// Edit-mode counterpart of FilterMenu: renders submenu content directly
+// (so callers mount it inside a Popup) for changing an existing filter's
+// value. Op is locked, except for `=`/`!=` → `in`/`not in` promotion on
+// the multiselect path (matches add-mode's wire shape).
+
+export interface EditFilterMenuAttrs {
+  readonly datasource: DataSource;
+  readonly field: string;
+  readonly columnType: ColumnType | undefined;
+  readonly valueFormatter: (value: SqlValue) => string;
+  readonly initialFilter: FilterOpAndValue;
+  // Caller-side replace: this component doesn't know its index.
+  readonly onFilterReplace: (filter: FilterOpAndValue) => void;
+}
+
+// Uneditable: null-arity ops, or value-bearing ops with value=null
+// (legal per type but SQL `col = NULL` never matches).
+export function isEditableFilter(filter: FilterOpAndValue): boolean {
+  switch (filter.op) {
+    case 'is null':
+    case 'is not null':
+      return false;
+    case 'in':
+    case 'not in':
+      return true;
+    default:
+      return filter.value !== null;
+  }
+}
+
+export class EditFilterMenu implements m.ClassComponent<EditFilterMenuAttrs> {
+  view({attrs}: m.Vnode<EditFilterMenuAttrs>): m.Children {
+    const {
+      datasource,
+      field,
+      columnType,
+      valueFormatter,
+      initialFilter,
+      onFilterReplace,
+    } = attrs;
+
+    // Defense-in-depth: DataGrid also skips wiring onEdit for these
+    // filters so the popup normally never opens with one.
+    if (!isEditableFilter(initialFilter)) {
+      return null;
+    }
+
+    if (initialFilter.op === 'in' || initialFilter.op === 'not in') {
+      const op = initialFilter.op;
+      return m(DistinctValuesSubmenu, {
+        datasource,
+        field,
+        // Match add-mode: `in`/`not in` doesn't match NULL, use the null
+        // op instead.
+        excludeNull: true,
+        valueFormatter,
+        initialSelectedValues: initialFilter.value,
+        onApply: (selectedValues) => {
+          onFilterReplace({op, value: Array.from(selectedValues)});
+        },
+      });
+    }
+
+    // `=` / `!=` on text/identifier/unknown columns promote to
+    // `in` / `not in` on save — matches add-mode's wire shape.
+    if (initialFilter.op === '=' || initialFilter.op === '!=') {
+      const usesDistinctValues =
+        columnType === 'text' ||
+        columnType === 'identifier' ||
+        columnType === undefined;
+      if (usesDistinctValues) {
+        const promotedOp: 'in' | 'not in' =
+          initialFilter.op === '=' ? 'in' : 'not in';
+        return m(DistinctValuesSubmenu, {
+          datasource,
+          field,
+          excludeNull: true,
+          valueFormatter,
+          initialSelectedValues: [initialFilter.value],
+          onApply: (selectedValues) => {
+            onFilterReplace({
+              op: promotedOp,
+              value: Array.from(selectedValues),
+            });
+          },
+        });
+      }
+      const op = initialFilter.op;
+      return m(TextFilterSubmenu, {
+        placeholder: 'Enter value...',
+        inputType: 'number',
+        initialValue: String(initialFilter.value),
+        submitLabel: 'Save',
+        onApply: (value) => {
+          onFilterReplace({op, value});
+        },
+      });
+    }
+
+    if (
+      initialFilter.op === '<' ||
+      initialFilter.op === '<=' ||
+      initialFilter.op === '>' ||
+      initialFilter.op === '>='
+    ) {
+      const op = initialFilter.op;
+      return m(TextFilterSubmenu, {
+        placeholder: 'Enter number...',
+        inputType: 'number',
+        initialValue: String(initialFilter.value),
+        submitLabel: 'Save',
+        onApply: (value) => {
+          onFilterReplace({op, value});
+        },
+      });
+    }
+
+    if (initialFilter.op === 'glob' || initialFilter.op === 'not glob') {
+      const op = initialFilter.op;
+      return m(TextFilterSubmenu, {
+        placeholder: 'Enter glob pattern...',
+        inputType: 'text',
+        initialValue: String(initialFilter.value),
+        submitLabel: 'Save',
+        onApply: (value) => {
+          onFilterReplace({op, value});
+        },
+      });
+    }
+
+    // Exhaustiveness fall-through; FilterOpAndValue should be covered.
+    return null;
   }
 }

--- a/ui/src/components/widgets/datagrid/column_filter_menu_unittest.ts
+++ b/ui/src/components/widgets/datagrid/column_filter_menu_unittest.ts
@@ -1,0 +1,292 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {SqlValue} from '../../../trace_processor/query_result';
+import {
+  DistinctValuesSubmenu,
+  EditFilterMenu,
+  type EditFilterMenuAttrs,
+  TextFilterSubmenu,
+} from './column_filter_menu';
+import type {DataSource} from './data_source';
+import type {ColumnType} from './datagrid_schema';
+import type {FilterOpAndValue} from './model';
+
+// DataSource stub: only useDistinctValues is wired; everything else
+// throws so tests fail loudly on unexpected use.
+function makeStubDataSource(distinctData?: readonly SqlValue[]): DataSource {
+  return {
+    useDistinctValues: () => ({
+      data: distinctData,
+      isPending: distinctData === undefined,
+      isFresh: true,
+    }),
+  } as unknown as DataSource;
+}
+
+// Test-local union of attrs across both submenu types — saves
+// exporting their private interfaces. onApply: unknown so both Set
+// and primitive callers pass without `any`.
+interface InspectableSubmenuAttrs {
+  readonly initialSelectedValues?: ReadonlyArray<SqlValue>;
+  readonly excludeNull?: boolean;
+  readonly inputType?: 'text' | 'number';
+  readonly initialValue?: string;
+  readonly submitLabel?: string;
+  readonly onApply: (value: unknown) => void;
+}
+
+// Helper: render EditFilterMenu's view() and return the resulting
+// vnode (or null). Tests inspect tag + attrs to assert dispatch.
+function editView(
+  initialFilter: FilterOpAndValue,
+  columnType: ColumnType | undefined,
+  overrides: Partial<EditFilterMenuAttrs> = {},
+): m.Children {
+  const inst = new EditFilterMenu();
+  return inst.view({
+    attrs: {
+      datasource: makeStubDataSource(['a', 'b', 'c']),
+      field: 'col',
+      columnType,
+      valueFormatter: (v: SqlValue) => String(v),
+      initialFilter,
+      onFilterReplace: vi.fn(),
+      ...overrides,
+    },
+  } as unknown as m.Vnode<EditFilterMenuAttrs>);
+}
+
+// Narrow m.Children to a single Vnode for tag/attrs assertions; cast
+// targets the test-local union since the concrete type varies.
+function asVnode(c: m.Children): m.Vnode<InspectableSubmenuAttrs> {
+  return c as unknown as m.Vnode<InspectableSubmenuAttrs>;
+}
+
+describe('EditFilterMenu — dispatch by op', () => {
+  test.each(['in', 'not in'] as const)(
+    '%s → DistinctValuesSubmenu with array seed',
+    (op) => {
+      const v = asVnode(editView({op, value: ['x', 'y']}, 'text'));
+      expect(v.tag).toBe(DistinctValuesSubmenu);
+      expect(v.attrs.initialSelectedValues).toEqual(['x', 'y']);
+      expect(v.attrs.excludeNull).toBe(true);
+    },
+  );
+
+  test.each(['text', 'identifier', undefined] as const)(
+    '= on %s column → DistinctValuesSubmenu with single-element seed',
+    (columnType) => {
+      const v = asVnode(editView({op: '=', value: 'foo'}, columnType));
+      expect(v.tag).toBe(DistinctValuesSubmenu);
+      expect(v.attrs.initialSelectedValues).toEqual(['foo']);
+    },
+  );
+
+  test('= on quantitative → TextFilterSubmenu(number)', () => {
+    const v = asVnode(editView({op: '=', value: 100}, 'quantitative'));
+    expect(v.tag).toBe(TextFilterSubmenu);
+    expect(v.attrs.inputType).toBe('number');
+    expect(v.attrs.initialValue).toBe('100');
+    expect(v.attrs.submitLabel).toBe('Save');
+  });
+
+  test('!= on text → DistinctValuesSubmenu', () => {
+    const v = asVnode(editView({op: '!=', value: 'foo'}, 'text'));
+    expect(v.tag).toBe(DistinctValuesSubmenu);
+  });
+
+  test('!= on quantitative → TextFilterSubmenu(number)', () => {
+    const v = asVnode(editView({op: '!=', value: 1}, 'quantitative'));
+    expect(v.tag).toBe(TextFilterSubmenu);
+    expect(v.attrs.inputType).toBe('number');
+  });
+
+  test.each(['<', '<=', '>', '>='] as const)(
+    '%s → TextFilterSubmenu(number)',
+    (op) => {
+      const v = asVnode(editView({op, value: 100}, 'quantitative'));
+      expect(v.tag).toBe(TextFilterSubmenu);
+      expect(v.attrs.inputType).toBe('number');
+      expect(v.attrs.initialValue).toBe('100');
+      expect(v.attrs.submitLabel).toBe('Save');
+    },
+  );
+
+  test.each(['glob', 'not glob'] as const)(
+    '%s → TextFilterSubmenu(text)',
+    (op) => {
+      const v = asVnode(editView({op, value: '*hello*'}, 'text'));
+      expect(v.tag).toBe(TextFilterSubmenu);
+      expect(v.attrs.inputType).toBe('text');
+      expect(v.attrs.initialValue).toBe('*hello*');
+    },
+  );
+
+  test('is null → null (no editor)', () => {
+    expect(editView({op: 'is null'}, 'text')).toBeNull();
+  });
+
+  test('is not null → null (no editor)', () => {
+    expect(editView({op: 'is not null'}, 'quantitative')).toBeNull();
+  });
+
+  test('malformed {op: "=", value: null} → null (refuse to edit)', () => {
+    // Legal per the type but never produced by add-mode (multi-select
+    // emits arrays); refuse rather than render an empty editor.
+    expect(editView({op: '=', value: null}, 'quantitative')).toBeNull();
+    expect(editView({op: '!=', value: null}, 'text')).toBeNull();
+    expect(editView({op: '>', value: null}, 'quantitative')).toBeNull();
+    expect(editView({op: 'glob', value: null}, 'text')).toBeNull();
+  });
+});
+
+describe('EditFilterMenu — op promotion on save', () => {
+  test.each([
+    ['=', 'in'],
+    ['!=', 'not in'],
+  ] as const)(
+    '%s on text + apply emits {op: "%s", value: [...]}',
+    (op, promoted) => {
+      const onFilterReplace = vi.fn();
+      const v = asVnode(
+        editView({op, value: 'foo'}, 'text', {onFilterReplace}),
+      );
+      v.attrs.onApply(new Set(['foo', 'bar']));
+      expect(onFilterReplace).toHaveBeenCalledWith({
+        op: promoted,
+        value: ['foo', 'bar'],
+      });
+    },
+  );
+
+  test('= on quantitative + apply preserves op', () => {
+    const onFilterReplace = vi.fn();
+    const v = asVnode(
+      editView({op: '=', value: 100}, 'quantitative', {onFilterReplace}),
+    );
+    v.attrs.onApply(200);
+    expect(onFilterReplace).toHaveBeenCalledWith({op: '=', value: 200});
+  });
+
+  test('in + apply preserves op', () => {
+    const onFilterReplace = vi.fn();
+    const v = asVnode(
+      editView({op: 'in', value: ['a']}, 'text', {onFilterReplace}),
+    );
+    v.attrs.onApply(new Set(['a', 'b', 'c']));
+    expect(onFilterReplace).toHaveBeenCalledWith({
+      op: 'in',
+      value: ['a', 'b', 'c'],
+    });
+  });
+
+  test('> + apply preserves op', () => {
+    const onFilterReplace = vi.fn();
+    const v = asVnode(
+      editView({op: '>', value: 100}, 'quantitative', {onFilterReplace}),
+    );
+    v.attrs.onApply(500);
+    expect(onFilterReplace).toHaveBeenCalledWith({op: '>', value: 500});
+  });
+
+  test('glob + apply preserves op', () => {
+    const onFilterReplace = vi.fn();
+    const v = asVnode(
+      editView({op: 'glob', value: '*x*'}, 'text', {onFilterReplace}),
+    );
+    v.attrs.onApply('*y*');
+    expect(onFilterReplace).toHaveBeenCalledWith({op: 'glob', value: '*y*'});
+  });
+});
+
+describe('DistinctValuesSubmenu — initial state', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  // Locate Apply via its label element (the icon glyph pollutes the
+  // button's textContent).
+  function findApplyButton(root: HTMLElement): HTMLButtonElement | undefined {
+    const labels = Array.from(
+      root.querySelectorAll('.pf-menu-item__label'),
+    ) as HTMLElement[];
+    const applyLabel = labels.find(
+      (el) => (el.textContent ?? '').trim() === 'Apply',
+    );
+    return (
+      (applyLabel?.closest(
+        'button.pf-menu-item',
+      ) as HTMLButtonElement | null) ?? undefined
+    );
+  }
+
+  test('Apply button is enabled iff initialSelectedValues is non-empty', () => {
+    const renderWithSeed = (
+      initialSelectedValues?: ReadonlyArray<SqlValue>,
+    ): HTMLButtonElement => {
+      const root = document.createElement('div');
+      document.body.appendChild(root);
+      m.render(
+        root,
+        m(DistinctValuesSubmenu, {
+          datasource: makeStubDataSource(['a', 'b', 'c']),
+          field: 'col',
+          valueFormatter: (v) => String(v),
+          initialSelectedValues,
+          onApply: vi.fn(),
+        }),
+      );
+      const applyButton = findApplyButton(root);
+      expect(applyButton).toBeDefined();
+      return applyButton!;
+    };
+    expect(renderWithSeed(['a']).disabled).toBe(false);
+    expect(renderWithSeed(undefined).disabled).toBe(true);
+  });
+
+  // Return the visible distinct-value labels in DOM order (excludes
+  // Apply / Clear footer items, which live in a sibling __footer).
+  function listLabels(root: HTMLElement): string[] {
+    const items = Array.from(
+      root.querySelectorAll('.pf-distinct-values-menu__list .pf-menu-item'),
+    ) as HTMLElement[];
+    return items.map((el) => {
+      const label = el.querySelector('.pf-menu-item__label');
+      return (label?.textContent ?? '').trim();
+    });
+  }
+
+  test('pinned: initial selection renders at the top in original order', () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.render(
+      root,
+      m(DistinctValuesSubmenu, {
+        datasource: makeStubDataSource(['alpha', 'beta', 'gamma', 'delta']),
+        field: 'col',
+        valueFormatter: (v) => String(v),
+        // gamma comes after alpha+beta in the source list but pinning
+        // bumps both pinned items to the top, preserving the source
+        // order WITHIN the pinned group.
+        initialSelectedValues: ['gamma', 'alpha'],
+        onApply: vi.fn(),
+      }),
+    );
+    // Pinned items first (in source order: alpha before gamma),
+    // then the unpinned rest (in source order: beta, delta).
+    expect(listLabels(root)).toEqual(['alpha', 'gamma', 'beta', 'delta']);
+  });
+});

--- a/ui/src/components/widgets/datagrid/column_filter_menu_unittest.ts
+++ b/ui/src/components/widgets/datagrid/column_filter_menu_unittest.ts
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import m from 'mithril';
+import type m from 'mithril';
 import type {SqlValue} from '../../../trace_processor/query_result';
-import {
-  DistinctValuesSubmenu,
-  EditFilterMenu,
-  type EditFilterMenuAttrs,
-  TextFilterSubmenu,
-} from './column_filter_menu';
+import {EditFilterMenu, type EditFilterMenuAttrs} from './column_filter_menu';
 import type {DataSource} from './data_source';
 import type {ColumnType} from './datagrid_schema';
 import type {FilterOpAndValue} from './model';
@@ -36,20 +31,12 @@ function makeStubDataSource(distinctData?: readonly SqlValue[]): DataSource {
   } as unknown as DataSource;
 }
 
-// Test-local union of attrs across both submenu types — saves
-// exporting their private interfaces. onApply: unknown so both Set
-// and primitive callers pass without `any`.
+// Test-local view of the submenu attrs we care about — onApply is the
+// hook op-promotion goes through.
 interface InspectableSubmenuAttrs {
-  readonly initialSelectedValues?: ReadonlyArray<SqlValue>;
-  readonly excludeNull?: boolean;
-  readonly inputType?: 'text' | 'number';
-  readonly initialValue?: string;
-  readonly submitLabel?: string;
   readonly onApply: (value: unknown) => void;
 }
 
-// Helper: render EditFilterMenu's view() and return the resulting
-// vnode (or null). Tests inspect tag + attrs to assert dispatch.
 function editView(
   initialFilter: FilterOpAndValue,
   columnType: ColumnType | undefined,
@@ -69,90 +56,13 @@ function editView(
   } as unknown as m.Vnode<EditFilterMenuAttrs>);
 }
 
-// Narrow m.Children to a single Vnode for tag/attrs assertions; cast
-// targets the test-local union since the concrete type varies.
 function asVnode(c: m.Children): m.Vnode<InspectableSubmenuAttrs> {
   return c as unknown as m.Vnode<InspectableSubmenuAttrs>;
 }
 
-describe('EditFilterMenu — dispatch by op', () => {
-  test.each(['in', 'not in'] as const)(
-    '%s → DistinctValuesSubmenu with array seed',
-    (op) => {
-      const v = asVnode(editView({op, value: ['x', 'y']}, 'text'));
-      expect(v.tag).toBe(DistinctValuesSubmenu);
-      expect(v.attrs.initialSelectedValues).toEqual(['x', 'y']);
-      expect(v.attrs.excludeNull).toBe(true);
-    },
-  );
-
-  test.each(['text', 'identifier', undefined] as const)(
-    '= on %s column → DistinctValuesSubmenu with single-element seed',
-    (columnType) => {
-      const v = asVnode(editView({op: '=', value: 'foo'}, columnType));
-      expect(v.tag).toBe(DistinctValuesSubmenu);
-      expect(v.attrs.initialSelectedValues).toEqual(['foo']);
-    },
-  );
-
-  test('= on quantitative → TextFilterSubmenu(number)', () => {
-    const v = asVnode(editView({op: '=', value: 100}, 'quantitative'));
-    expect(v.tag).toBe(TextFilterSubmenu);
-    expect(v.attrs.inputType).toBe('number');
-    expect(v.attrs.initialValue).toBe('100');
-    expect(v.attrs.submitLabel).toBe('Save');
-  });
-
-  test('!= on text → DistinctValuesSubmenu', () => {
-    const v = asVnode(editView({op: '!=', value: 'foo'}, 'text'));
-    expect(v.tag).toBe(DistinctValuesSubmenu);
-  });
-
-  test('!= on quantitative → TextFilterSubmenu(number)', () => {
-    const v = asVnode(editView({op: '!=', value: 1}, 'quantitative'));
-    expect(v.tag).toBe(TextFilterSubmenu);
-    expect(v.attrs.inputType).toBe('number');
-  });
-
-  test.each(['<', '<=', '>', '>='] as const)(
-    '%s → TextFilterSubmenu(number)',
-    (op) => {
-      const v = asVnode(editView({op, value: 100}, 'quantitative'));
-      expect(v.tag).toBe(TextFilterSubmenu);
-      expect(v.attrs.inputType).toBe('number');
-      expect(v.attrs.initialValue).toBe('100');
-      expect(v.attrs.submitLabel).toBe('Save');
-    },
-  );
-
-  test.each(['glob', 'not glob'] as const)(
-    '%s → TextFilterSubmenu(text)',
-    (op) => {
-      const v = asVnode(editView({op, value: '*hello*'}, 'text'));
-      expect(v.tag).toBe(TextFilterSubmenu);
-      expect(v.attrs.inputType).toBe('text');
-      expect(v.attrs.initialValue).toBe('*hello*');
-    },
-  );
-
-  test('is null → null (no editor)', () => {
-    expect(editView({op: 'is null'}, 'text')).toBeNull();
-  });
-
-  test('is not null → null (no editor)', () => {
-    expect(editView({op: 'is not null'}, 'quantitative')).toBeNull();
-  });
-
-  test('malformed {op: "=", value: null} → null (refuse to edit)', () => {
-    // Legal per the type but never produced by add-mode (multi-select
-    // emits arrays); refuse rather than render an empty editor.
-    expect(editView({op: '=', value: null}, 'quantitative')).toBeNull();
-    expect(editView({op: '!=', value: null}, 'text')).toBeNull();
-    expect(editView({op: '>', value: null}, 'quantitative')).toBeNull();
-    expect(editView({op: 'glob', value: null}, 'text')).toBeNull();
-  });
-});
-
+// On text columns, `=` / `!=` editing promotes to `in` / `not in` on
+// save (the editor is a multi-select, so the apply payload is a Set).
+// On quantitative columns and on already-set ops, no promotion.
 describe('EditFilterMenu — op promotion on save', () => {
   test.each([
     ['=', 'in'],
@@ -209,84 +119,5 @@ describe('EditFilterMenu — op promotion on save', () => {
     );
     v.attrs.onApply('*y*');
     expect(onFilterReplace).toHaveBeenCalledWith({op: 'glob', value: '*y*'});
-  });
-});
-
-describe('DistinctValuesSubmenu — initial state', () => {
-  afterEach(() => {
-    document.body.innerHTML = '';
-  });
-
-  // Locate Apply via its label element (the icon glyph pollutes the
-  // button's textContent).
-  function findApplyButton(root: HTMLElement): HTMLButtonElement | undefined {
-    const labels = Array.from(
-      root.querySelectorAll('.pf-menu-item__label'),
-    ) as HTMLElement[];
-    const applyLabel = labels.find(
-      (el) => (el.textContent ?? '').trim() === 'Apply',
-    );
-    return (
-      (applyLabel?.closest(
-        'button.pf-menu-item',
-      ) as HTMLButtonElement | null) ?? undefined
-    );
-  }
-
-  test('Apply button is enabled iff initialSelectedValues is non-empty', () => {
-    const renderWithSeed = (
-      initialSelectedValues?: ReadonlyArray<SqlValue>,
-    ): HTMLButtonElement => {
-      const root = document.createElement('div');
-      document.body.appendChild(root);
-      m.render(
-        root,
-        m(DistinctValuesSubmenu, {
-          datasource: makeStubDataSource(['a', 'b', 'c']),
-          field: 'col',
-          valueFormatter: (v) => String(v),
-          initialSelectedValues,
-          onApply: vi.fn(),
-        }),
-      );
-      const applyButton = findApplyButton(root);
-      expect(applyButton).toBeDefined();
-      return applyButton!;
-    };
-    expect(renderWithSeed(['a']).disabled).toBe(false);
-    expect(renderWithSeed(undefined).disabled).toBe(true);
-  });
-
-  // Return the visible distinct-value labels in DOM order (excludes
-  // Apply / Clear footer items, which live in a sibling __footer).
-  function listLabels(root: HTMLElement): string[] {
-    const items = Array.from(
-      root.querySelectorAll('.pf-distinct-values-menu__list .pf-menu-item'),
-    ) as HTMLElement[];
-    return items.map((el) => {
-      const label = el.querySelector('.pf-menu-item__label');
-      return (label?.textContent ?? '').trim();
-    });
-  }
-
-  test('pinned: initial selection renders at the top in original order', () => {
-    const root = document.createElement('div');
-    document.body.appendChild(root);
-    m.render(
-      root,
-      m(DistinctValuesSubmenu, {
-        datasource: makeStubDataSource(['alpha', 'beta', 'gamma', 'delta']),
-        field: 'col',
-        valueFormatter: (v) => String(v),
-        // gamma comes after alpha+beta in the source list but pinning
-        // bumps both pinned items to the top, preserving the source
-        // order WITHIN the pinned group.
-        initialSelectedValues: ['gamma', 'alpha'],
-        onApply: vi.fn(),
-      }),
-    );
-    // Pinned items first (in source order: alpha before gamma),
-    // then the unpinned rest (in source order: beta, delta).
-    expect(listLabels(root)).toEqual(['alpha', 'gamma', 'beta', 'delta']);
   });
 });

--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -617,8 +617,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
             }),
         ],
         filterChips: this.filters.map((filter, index) => {
-          // Filters that carry no editable value (null-arity ops, or
-          // malformed value-bearing ops with value=null) render as
+          // Filters that carry no editable value render as
           // remove-only chips with no edit popup.
           const editable = isEditableFilter(filter);
           const colInfo = getColumnInfo(schema, rootSchema, filter.field);

--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -42,8 +42,13 @@ import {
   ColumnMenu,
   getAggregateFunctionsForColumnType,
 } from './add_column_menu';
+import {Popup, PopupPosition} from '../../../widgets/popup';
 import {CellFilterMenu} from './cell_filter_menu';
-import {FilterMenu} from './column_filter_menu';
+import {
+  EditFilterMenu,
+  FilterMenu,
+  isEditableFilter,
+} from './column_filter_menu';
 import {ColumnInfoMenu} from './column_info_menu';
 import type {
   DataSource,
@@ -420,6 +425,11 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
   private paginationOffset: number = 0;
   private paginationLimit: number = 100;
 
+  // Which filter chip's edit-popup is currently open. Undefined =
+  // no popup. Toggled by clicks on the chip body; cleared on apply
+  // or outside-click.
+  private editingFilterIndex: number | undefined;
+
   // The grid API instance for column autosizing etc
   private gridApi?: GridApi;
 
@@ -606,14 +616,59 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
                 ),
             }),
         ],
-        filterChips: this.filters.map((filter, index) =>
-          m(GridFilterChip, {
+        filterChips: this.filters.map((filter, index) => {
+          // Filters that carry no editable value (null-arity ops, or
+          // malformed value-bearing ops with value=null) render as
+          // remove-only chips with no edit popup.
+          const editable = isEditableFilter(filter);
+          const colInfo = getColumnInfo(schema, rootSchema, filter.field);
+          const chip = m(GridFilterChip, {
             content: this.formatFilter(filter, schema, rootSchema),
             onRemove: filtersAreMutable
               ? () => this.removeFilter(index, attrs)
               : undefined,
-          }),
-        ),
+            onEdit:
+              filtersAreMutable && editable
+                ? () => {
+                    this.editingFilterIndex =
+                      this.editingFilterIndex === index ? undefined : index;
+                  }
+                : undefined,
+          });
+          if (!filtersAreMutable || !editable) return chip;
+          // Controlled-mode Popup: trigger keeps its own onclick (the
+          // chip's onEdit toggles editingFilterIndex); Popup just
+          // renders the body when that index matches. BottomStart
+          // anchors the popup to the chip's left edge so it grows
+          // rightward with the reading direction.
+          return m(
+            Popup,
+            {
+              trigger: chip,
+              isOpen: this.editingFilterIndex === index,
+              onChange: (open) => {
+                this.editingFilterIndex = open ? index : undefined;
+              },
+              position: PopupPosition.BottomStart,
+            },
+            m(EditFilterMenu, {
+              datasource,
+              field: filter.field,
+              columnType: colInfo?.columnType,
+              valueFormatter: (v) =>
+                colInfo?.cellFormatter?.(v, {}) ?? String(v),
+              initialFilter: filter,
+              onFilterReplace: (newFilter) => {
+                this.editingFilterIndex = undefined;
+                this.replaceFilter(
+                  index,
+                  {field: filter.field, ...newFilter},
+                  attrs,
+                );
+              },
+            }),
+          );
+        }),
         drillDownFields:
           this.pivot?.drillDown &&
           this.pivot.drillDown.map(({field, value}) => {
@@ -815,12 +870,28 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
   }
 
   private clearFilters(attrs: DataGridAttrs): void {
+    // Editing index points into a now-empty array — drop it.
+    this.editingFilterIndex = undefined;
     this.filters = [];
     attrs.onFiltersChanged?.([]);
   }
 
   private removeFilter(index: number, attrs: DataGridAttrs): void {
+    this.editingFilterIndex = undefined;
     const newFilters = this.filters.filter((_, i) => i !== index);
+    this.filters = newFilters;
+    attrs.onFiltersChanged?.(newFilters);
+  }
+
+  private replaceFilter(
+    index: number,
+    newFilter: Filter,
+    attrs: DataGridAttrs,
+  ): void {
+    if (index < 0 || index >= this.filters.length) return;
+    const newFilters = this.filters.map((f, i) =>
+      i === index ? newFilter : f,
+    );
     this.filters = newFilters;
     attrs.onFiltersChanged?.(newFilters);
   }

--- a/ui/src/components/widgets/datagrid/datagrid_toolbar.ts
+++ b/ui/src/components/widgets/datagrid/datagrid_toolbar.ts
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 import m from 'mithril';
+import {classNames} from '../../../base/classnames';
 import {Box} from '../../../widgets/box';
 import {Button, ButtonVariant} from '../../../widgets/button';
 import {Chip} from '../../../widgets/chip';
+import type {HTMLAttrs} from '../../../widgets/common';
 import {Stack, StackAuto} from '../../../widgets/stack';
 import {isEmptyVnodes} from '../../../base/mithril_utils';
 
@@ -25,19 +27,44 @@ export class GridFilterBar implements m.ClassComponent {
   }
 }
 
-export interface GridFilterChipAttrs {
+export interface GridFilterChipAttrs extends HTMLAttrs {
   readonly content: m.Children;
   readonly onRemove?: () => void;
+  // Called when the chip BODY is clicked (the × button is excluded
+  // via a propagation guard). Lets callers open a popup that edits
+  // the filter the chip represents.
+  readonly onEdit?: () => void;
 }
 
 export class GridFilterChip implements m.ClassComponent<GridFilterChipAttrs> {
   view({attrs}: m.Vnode<GridFilterChipAttrs>): m.Children {
+    // Pass through any HTML attrs (notably `ref` and `active`, which
+    // the Popup widget injects when this chip is used as a Popup
+    // trigger) to the underlying Chip widget. Without this, the
+    // class-component boundary swallows those attrs and Popup's
+    // findRef-by-ref fails on mount.
+    const {content, onRemove, onEdit, className, onclick, ...rest} = attrs;
     return m(Chip, {
-      className: 'pf-grid-filter',
-      label: attrs.content,
-      removable: attrs.onRemove !== undefined,
-      onRemove: attrs.onRemove,
+      ...rest,
+      className: classNames(
+        'pf-grid-filter',
+        onEdit && 'pf-grid-filter--editable',
+        className,
+      ),
+      label: content,
+      removable: onRemove !== undefined,
+      onRemove,
       removeButtonTitle: 'Remove filter',
+      // The × close button is rendered as a Button inside the chip
+      // root and doesn't stopPropagation. Skip onEdit if the click
+      // originated from inside a .pf-button so removing a chip
+      // doesn't also open its editor.
+      onclick: onEdit
+        ? (e: PointerEvent) => {
+            if ((e.target as Element | null)?.closest('.pf-button')) return;
+            onEdit();
+          }
+        : onclick,
     });
   }
 }

--- a/ui/src/widgets/grid.scss
+++ b/ui/src/widgets/grid.scss
@@ -316,3 +316,7 @@ $indent-guide-offset: 12px;
     max-width: 300px;
   }
 }
+
+.pf-grid-filter--editable {
+  cursor: pointer;
+}


### PR DESCRIPTION
  Allow users to edit existing data grid filters by clicking on the filter chip. This opens a popup with the appropriate editor (multiselect or text input) pre-filled with the current filter value, rather than forcing users to delete and recreate the filter from scratch.

  Implementation details:
   - Adds an onEdit callback to GridFilterChip, guarding against clicks on the remove button.
   - Introduces EditFilterMenu which smartly reuses the existing TextFilterSubmenu and DistinctValuesSubmenu based on the filter type.
   - Promotes `=` to `in` and `!=` to `not in` when editing text/identifier columns to seamlessly match the add-mode multiselect wire shape.
   - Pins initially selected items to the top of the multiselect menu so they remain visible and stable during the edit.

Screenshots (trace: AndroidExample)
- `in` filter chip
<img width="1238" height="1040" alt="image" src="https://github.com/user-attachments/assets/a015eb0b-17f6-4804-b8bc-c66ab7a5ea19" />

- `>=` filter chip
<img width="1398" height="336" alt="image" src="https://github.com/user-attachments/assets/640ee73e-20ce-4548-95f7-9b3fbe76d068" />

- `glob` filter chip
<img width="1646" height="378" alt="image" src="https://github.com/user-attachments/assets/0590e9bb-13c4-47a9-af7d-dba84767567a" />
