### PR TITLE
[SDK] Avoid DCHECK Track::FromPointer in uninitialized perfetto

### DIFF
--- a/include/perfetto/tracing/track.h
+++ b/include/perfetto/tracing/track.h
@@ -117,7 +117,8 @@ struct PERFETTO_EXPORT_COMPONENT Track {
     // per-proccess and the same pointer value can be used in different
     // processes. If you hit this check but are providing no |parent| track,
     // verify that Tracing::Initialize() was called for the current process.
-    PERFETTO_DCHECK(parent.uuid != Track().uuid);
+    PERFETTO_DCHECK(parent.uuid != Track().uuid ||
+                    MakeProcessTrack().uuid == 0);
 
     return Track(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr)),
                  parent);
@@ -226,7 +227,8 @@ class PERFETTO_EXPORT_COMPONENT NamedTrack : public Track {
     // per-proccess and the same pointer value can be used in different
     // processes. If you hit this check but are providing no |parent| track,
     // verify that Tracing::Initialize() was called for the current process.
-    PERFETTO_DCHECK(parent.uuid != Track().uuid);
+    PERFETTO_DCHECK(parent.uuid != Track().uuid ||
+                    MakeProcessTrack().uuid == 0);
 
     return NamedTrack(std::forward<TrackEventName>(name),
                       static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr)),

--- a/src/tracing/track.cc
+++ b/src/tracing/track.cc
@@ -34,7 +34,7 @@
 namespace perfetto {
 
 // static
-uint64_t Track::process_uuid;
+uint64_t Track::process_uuid = 0;
 
 protos::gen::TrackDescriptor Track::Serialize() const {
   protos::gen::TrackDescriptor desc;


### PR DESCRIPTION
It's common for perfetto to not be initialized by the test harness in Chrome.
This prevents (Named)Track::FromPointer from being used outside of TRACE_EVENT macro.

This is a common pattern:
```
auto track = perfetto::Track::FromPointer(this);
TRACE_EVENT_BEGIN(..., track);
TRACE_EVENT_END(..., track);
```
To allow doing this without extra hoops (e.g. guarding behind perfetto::Tracing::IsInitialized()), this PR avoids triggering the
DCHECK when perfetto is not initialized (process_uuid = 0).

Some thoughts: this poses a risk of *not* triggering the check if the track is created before perfetto is initialized. However: (1) this wasn't the purpose of this check anyway and it's possible to do so with other Tack api and (2) in chrome, perfetto is initialized early enough that it'd be hard to achieve.

