### PR TITLE
[SDK] Add missing TrackEventSessionObserver::OnFlush

### DIFF
--- a/include/perfetto/tracing/internal/track_event_data_source.h
+++ b/include/perfetto/tracing/internal/track_event_data_source.h
@@ -279,6 +279,8 @@ class PERFETTO_EXPORT_COMPONENT TrackEventDataSource
       std::move(inner_stop_args.async_stop_closure)();
   }
 
+  void OnFlush(const DataSourceBase::FlushArgs& args) override;
+
   void WillClearIncrementalState(
       const DataSourceBase::ClearIncrementalStateArgs& args) override {
     TrackEventInternal::WillClearIncrementalState(args);

--- a/include/perfetto/tracing/internal/track_event_internal.h
+++ b/include/perfetto/tracing/internal/track_event_internal.h
@@ -95,6 +95,7 @@ class PERFETTO_EXPORT_COMPONENT TrackEventSessionObserver {
   // to emit track events from this callback.
   virtual void OnStop(const DataSourceBase::StopArgs&);
   // Called when the tracing service requests a Flush.
+  // FlushArgs::HandleFlushAsynchronously is not supported.
   virtual void OnFlush(const DataSourceBase::FlushArgs&);
   // Called when tracing muxer requests to clear incremental state.
   virtual void WillClearIncrementalState(

--- a/include/perfetto/tracing/internal/track_event_internal.h
+++ b/include/perfetto/tracing/internal/track_event_internal.h
@@ -94,6 +94,8 @@ class PERFETTO_EXPORT_COMPONENT TrackEventSessionObserver {
   // Called when a track event tracing session is stopped. It is still possible
   // to emit track events from this callback.
   virtual void OnStop(const DataSourceBase::StopArgs&);
+  // Called when the tracing service requests a Flush.
+  virtual void OnFlush(const DataSourceBase::FlushArgs&);
   // Called when tracing muxer requests to clear incremental state.
   virtual void WillClearIncrementalState(
       const DataSourceBase::ClearIncrementalStateArgs&);
@@ -239,6 +241,7 @@ class PERFETTO_EXPORT_COMPONENT TrackEventInternal {
                              uint32_t internal_instance_index);
   static void OnStart(const DataSourceBase::StartArgs&);
   static void OnStop(const DataSourceBase::StopArgs&);
+  static void OnFlush(const DataSourceBase::FlushArgs&);
   static void WillClearIncrementalState(
       const DataSourceBase::ClearIncrementalStateArgs&);
 

--- a/src/tracing/internal/track_event_internal.cc
+++ b/src/tracing/internal/track_event_internal.cc
@@ -44,6 +44,7 @@ TrackEventSessionObserver::~TrackEventSessionObserver() = default;
 void TrackEventSessionObserver::OnSetup(const DataSourceBase::SetupArgs&) {}
 void TrackEventSessionObserver::OnStart(const DataSourceBase::StartArgs&) {}
 void TrackEventSessionObserver::OnStop(const DataSourceBase::StopArgs&) {}
+void TrackEventSessionObserver::OnFlush(const DataSourceBase::FlushArgs&) {}
 void TrackEventSessionObserver::WillClearIncrementalState(
     const DataSourceBase::ClearIncrementalStateArgs&) {}
 
@@ -144,6 +145,20 @@ bool NameMatchesPatternList(const std::vector<std::string>& patterns,
   }
   return false;
 }
+
+class FlushArgsImpl : public DataSourceBase::FlushArgs {
+ public:
+  FlushArgsImpl(const DataSourceBase::FlushArgs& base) {
+    internal_instance_index = base.internal_instance_index;
+    flush_flags = base.flush_flags;
+  }
+  ~FlushArgsImpl() override = default;
+
+  std::function<void()> HandleFlushAsynchronously() const override {
+    // HandleFlushAsynchronously not supported.
+    PERFETTO_IMMEDIATE_CRASH();
+  }
+};
 
 }  // namespace
 
@@ -298,6 +313,14 @@ void TrackEventInternal::OnStop(const DataSourceBase::StopArgs& args) {
       ->ForEachObserverForRegistries(
           GetInstance().GetRegistries(),
           [&](TrackEventSessionObserver* o) { o->OnStop(args); });
+}
+
+// static
+void TrackEventInternal::OnFlush(const DataSourceBase::FlushArgs& args) {
+  TrackEventSessionObserverRegistry::GetInstance()
+      ->ForEachObserverForRegistries(
+          GetInstance().GetRegistries(),
+          [&](TrackEventSessionObserver* o) { o->OnFlush(args); });
 }
 
 // static
@@ -650,6 +673,11 @@ protos::pbzero::DebugAnnotation* TrackEventInternal::AddDebugAnnotation(
 
 void TrackEventDataSource::OnStart(const DataSourceBase::StartArgs& args) {
   TrackEventInternal::OnStart(args);
+}
+
+void TrackEventDataSource::OnFlush(const DataSourceBase::FlushArgs& args) {
+  FlushArgsImpl inner_flush_args{args};
+  TrackEventInternal::OnFlush(inner_flush_args);
 }
 
 }  // namespace internal


### PR DESCRIPTION
This PR exposes TrackEventSessionObserver::OnFlush similar to other TrackEventSessionObserver methods,
matching DataSource::OnFlush.

FlushArgs::HandleFlushAsynchronously is not supported (PERFETTO_IMMEDIATE_CRASH)
because having multiple observers each calling it would require non trivial chaining.

Some thoughts: StopArgs::HandleStopAsynchronously exists but it's broken; it doesn't actually implement
chaining, and will only work for the first observer that tries to use it. IMO there's no good case for it and it's not worth trying to support.
