### PR TITLE
 tbV2: fix data loss when re-admitting a scraped chunk evicted by wrap

### DIFF
--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -232,14 +232,18 @@ TBChunk* ChunkSeqIterator::NextChunkInSequence() {
   return next_chunk;
 }
 
-void ChunkSeqIterator::EraseCurrentChunk() {
+void ChunkSeqIterator::EraseCurrentChunk(
+    uint16_t bytes_overwritten_by_this_pass) {
   size_t chunk_off = buf_->OffsetOf(chunk_);
   TRACE_BUFFER_V2_DLOG("EraseChunk() id=%u off=%zu", chunk_->chunk_id,
                        chunk_off);
   const uint32_t chunk_size = chunk_->size;
   const bool was_incomplete = chunk_->flags & kChunkIncomplete;
+  PERFETTO_DCHECK(bytes_overwritten_by_this_pass <= chunk_->payload_size);
+  const uint16_t payload_read =
+      chunk_->payload_size - bytes_overwritten_by_this_pass;
   seq_->last_chunk_consumed = SequenceState::ConsumedChunkInfo{
-      chunk_->chunk_id, chunk_->payload_size, was_incomplete};
+      chunk_->chunk_id, payload_read, was_incomplete};
 
   auto& chunk_list = seq_->chunks;
 
@@ -339,7 +343,7 @@ bool ChunkSeqReader::ReadNextPacketInSeqOrder(TracePacket* out_packet) {
         end_reached = true;
       } else {
         // We read all the fragments for the current chunk. Erase it.
-        seq_iter_.EraseCurrentChunk();
+        seq_iter_.EraseCurrentChunk(bytes_overwritten_in_chunk_);
       }
       if (end_reached)
         return false;  // We reached our target chunk (or an incomplete chunk).
@@ -348,6 +352,7 @@ bool ChunkSeqReader::ReadNextPacketInSeqOrder(TracePacket* out_packet) {
         return false;  // There are no more chunks in the sequence.
       iter_ = next_chunk;
       frag_iter_ = FragIterator(next_chunk);
+      bytes_overwritten_in_chunk_ = 0;
       continue;
     }
 
@@ -451,6 +456,11 @@ void ChunkSeqReader::ConsumeFragment(TBChunk* chunk, Frag* frag) {
 
   PERFETTO_DCHECK(chunk->payload_avail >= frag->size_with_header());
   chunk->payload_avail -= frag->size_with_header();
+
+  // In kEraseMode the bytes we just consumed were overwritten, not read
+  // out. Track them so EraseCurrentChunk records the right payload_read.
+  if (mode_ == kEraseMode)
+    bytes_overwritten_in_chunk_ += frag->size_with_header();
 
   if (chunk->payload_avail == 0) {
     TRACE_BUFFER_V2_DLOG("  Fully consumed chunk @ %zu", buf_->OffsetOf(chunk));
@@ -767,18 +777,27 @@ void TraceBufferV2::CopyChunkUntrusted(
 
   // Don't allow re-commit of chunks that have been consumed already, unless
   // the chunk was evicted while incomplete (scraped) and the new commit has
-  // strictly more payload. In that case we re-admit it so the previously-
-  // dropped fragments can be recovered. Keep this acceptance condition in
-  // sync with the re-admit branch of the gap check in ChunkSeqReader's ctor.
+  // strictly more payload than the consumer had already read before the
+  // eviction. In that case we re-admit it so the previously-evicted suffix
+  // (including any bytes that were overwritten without being read) is
+  // recovered. Keep this acceptance condition in sync with the re-admit
+  // branch of the gap check in ChunkSeqReader's ctor.
   //
-  // When re-admitting, |previously_consumed_payload| records how many payload
-  // bytes were already consumed before eviction, so we can skip them below.
+  // When re-admitting, |previously_consumed_payload| records how many
+  // payload bytes were already read before the eviction; we skip exactly
+  // that many on the re-admitted chunk so the unread suffix is replayed
+  // from the producer's resubmission.
   uint16_t previously_consumed_payload = 0;
   if (seq.last_chunk_consumed.has_value()) {
     int cmp = ChunkIdCompare(chunk_id, seq.last_chunk_consumed->chunk_id);
     if (cmp == 0 && seq.last_chunk_consumed->was_incomplete &&
-        seq.last_chunk_consumed->payload_size < all_frags_size) {
-      previously_consumed_payload = seq.last_chunk_consumed->payload_size;
+        seq.last_chunk_consumed->payload_read < all_frags_size) {
+      previously_consumed_payload = seq.last_chunk_consumed->payload_read;
+      // The eviction's data_loss signal (set by DeleteNextChunksFor on the
+      // overwritten suffix) is now stale: those bytes are about to be
+      // replayed from the resubmission. A later eviction on this sequence
+      // re-sets data_loss if real data is lost.
+      seq.data_loss = false;
       TRACE_BUFFER_V2_DLOG("  Re-admitting chunk %u (prev_payload=%u)",
                            chunk_id, previously_consumed_payload);
     } else if (cmp <= 0) {

--- a/src/tracing/service/trace_buffer_v2.h
+++ b/src/tracing/service/trace_buffer_v2.h
@@ -184,11 +184,15 @@ struct SequenceState {
   // Snapshot of the last chunk that was erased (consumed or evicted) in this
   // sequence. Used to detect gaps between consecutive chunks and to decide
   // whether a re-committed chunk should be accepted or discarded.
-  // |payload_size| and |was_incomplete| capture the chunk's state at the time
-  // of consumption; see CopyChunkUntrusted() for how they are used.
+  // |payload_read| is the count of payload bytes that were read out of the
+  // chunk via ReadNextTracePacket before it left the buffer. It equals
+  // payload_size for a chunk drained by reads, and the prefix-read amount
+  // for a chunk evicted with unread bytes (the overwritten suffix is NOT
+  // counted). The re-admit path in CopyChunkUntrusted() skips this many
+  // bytes on the resubmitted chunk so the unread suffix is replayed.
   struct ConsumedChunkInfo {
     ChunkID chunk_id = 0;
-    uint16_t payload_size = 0;
+    uint16_t payload_read = 0;
     bool was_incomplete = false;
   };
   std::optional<ConsumedChunkInfo> last_chunk_consumed;
@@ -297,7 +301,11 @@ class ChunkSeqIterator {
   ChunkSeqIterator& operator=(const ChunkSeqIterator&) = default;
 
   TBChunk* NextChunkInSequence();
-  void EraseCurrentChunk();
+  // |bytes_overwritten_by_this_pass| is the count of payload bytes this
+  // pass overwrote in kEraseMode for the current chunk (zero in kReadMode).
+  // Used to derive payload_read = payload_size - bytes_overwritten_by_this_pass
+  // on the SequenceState's last_chunk_consumed entry.
+  void EraseCurrentChunk(uint16_t bytes_overwritten_by_this_pass);
   TBChunk* chunk() const { return chunk_; }
   bool sequence_gap_detected() const { return sequence_gap_detected_; }
   bool valid() const { return !!seq_ && !!chunk_; }
@@ -375,6 +383,12 @@ class ChunkSeqReader {
   TBChunk* iter_ = nullptr;
 
   FragIterator frag_iter_;
+
+  // Bytes of iter_'s payload that this pass has overwritten. Incremented
+  // by ConsumeFragment when mode_ == kEraseMode; stays 0 in kReadMode and
+  // is reset to 0 on every chunk transition. Passed to EraseCurrentChunk to
+  // derive payload_read = payload_size - bytes_overwritten_in_chunk_.
+  uint16_t bytes_overwritten_in_chunk_ = 0;
 };
 
 }  // namespace internal

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -2488,17 +2488,18 @@ TEST_F(TraceBufferV2Test, RescrapeAfterEviction_FullyRead) {
 // payload is "consumed" by kEraseMode), and the producer later commits the
 // chunk with more data taking the re-admit branch.
 //
-// Currently THIS TEST FAILS on TraceBufferV2 because EraseCurrentChunk
-// stores payload_size = total at eviction regardless of whether the bytes
-// had been delivered to the consumer; the re-admit then skips a+b on the
-// new chunk even though *none* of them had been read. 'a' and 'b' are
-// silently dropped and previous_packet_dropped fires on 'c'. This matches
-// the field fingerprint write_wrap_count=1, chunks_overwritten=1,
+// Pre-fix bug: EraseCurrentChunk stored payload_size = total at eviction
+// regardless of whether the bytes had been delivered to the consumer, so
+// the re-admit skipped a+b on the new chunk even though *none* of them
+// had been read. 'a' and 'b' were silently dropped and
+// previous_packet_dropped fired on 'c'. This matched the field
+// fingerprint write_wrap_count=1, chunks_overwritten=1,
 // bytes_overwritten=4096, sequence_packet_loss=1.
 //
-// The assertions encode the expected post-fix behaviour: a+b+c+d are all
-// recovered in order with no previous_packet_dropped flag. A follow-up
-// commit fixes the buffer so the test passes.
+// Post-fix: last_chunk_consumed records bytes-actually-delivered-by-reads
+// (0 here, since no reads ran), the re-admit replays a+b+c+d in full,
+// and the data_loss flag set during eviction is cleared because the bytes
+// that tripped it have been recovered.
 TEST_F(TraceBufferV2Test, RescrapeAfterEviction_NoReadsBeforeWrap) {
   ResetBuffer(4096);
   SuppressClientDchecksForTesting();

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -2482,6 +2482,98 @@ TEST_F(TraceBufferV2Test, RescrapeAfterEviction_FullyRead) {
       << "Packet 'c' should still be dropped (chunk incomplete)";
 }
 
+// Scrape → evict (no reads in between) → complete commit. This is the
+// realistic write_into_file scenario when buffer pressure beats the reader:
+// chunk-0 is scraped, never drained, the buffer wraps around it (its full
+// payload is "consumed" by kEraseMode), and the producer later commits the
+// chunk with more data taking the re-admit branch.
+//
+// Currently THIS TEST FAILS on TraceBufferV2 because EraseCurrentChunk
+// stores payload_size = total at eviction regardless of whether the bytes
+// had been delivered to the consumer; the re-admit then skips a+b on the
+// new chunk even though *none* of them had been read. 'a' and 'b' are
+// silently dropped and previous_packet_dropped fires on 'c'. This matches
+// the field fingerprint write_wrap_count=1, chunks_overwritten=1,
+// bytes_overwritten=4096, sequence_packet_loss=1.
+//
+// The assertions encode the expected post-fix behaviour: a+b+c+d are all
+// recovered in order with no previous_packet_dropped flag. A follow-up
+// commit fixes the buffer so the test passes.
+TEST_F(TraceBufferV2Test, RescrapeAfterEviction_NoReadsBeforeWrap) {
+  ResetBuffer(4096);
+  SuppressClientDchecksForTesting();
+
+  // Scrape chunk 0 (incomplete) with [a, b, c]. Scraping drops 'c' (the
+  // last fragment), leaving payload_size = payload_avail = a + b.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(20, 'a')
+      .AddPacket(30, 'b')
+      .AddPacket(40, 'c')
+      .PadTo(512)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/false);
+
+  // Fill the rest of the buffer (no reads in between).
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(1))
+      .AddPacket(3568, 'x')
+      .CopyIntoTraceBuffer();
+
+  // A small follow-up write forces a wrap that evicts chunk 0 while every
+  // payload byte is still unread.
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(2))
+      .AddPacket(20, 'y')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(1u, trace_buffer()->stats().write_wrap_count());
+  // chunks_overwritten / bytes_overwritten reflect buffer pressure and
+  // remain set even with the fix; they are not consumer-visible drops.
+  EXPECT_EQ(1u, trace_buffer()->stats().chunks_overwritten());
+  EXPECT_EQ(512u, trace_buffer()->stats().bytes_overwritten());
+
+  // Producer commits chunk 0 with the full payload [a, b, c, d]. Re-admit
+  // path: was_incomplete=true and consumed_by_reads=0 < all_frags_size, so
+  // the new chunk is admitted with payload_avail covering all four packets.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(20, 'a')
+      .AddPacket(30, 'b')
+      .AddPacket(40, 'c')
+      .AddPacket(50, 'd')
+      .PadTo(512)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/true);
+
+  // Drain and verify: a, b, c, d all recovered in order with no spurious
+  // previous_packet_dropped. Track the dropped flag for 'a' specifically
+  // since that's the one a regression would flip.
+  trace_buffer()->BeginRead();
+  std::vector<std::vector<FakePacketFragment>> packets;
+  bool a_dropped = false;
+  for (;;) {
+    bool dropped = false;
+    auto p = ReadPacket(/*sequence_properties=*/nullptr, &dropped);
+    if (p.empty())
+      break;
+    if (p.size() == 1 && p[0] == FakePacketFragment(20, 'a'))
+      a_dropped = dropped;
+    packets.push_back(std::move(p));
+  }
+
+  bool found_a = false, found_b = false, found_c = false, found_d = false;
+  for (const auto& pkt : packets) {
+    if (pkt.size() == 1 && pkt[0] == FakePacketFragment(20, 'a'))
+      found_a = true;
+    if (pkt.size() == 1 && pkt[0] == FakePacketFragment(30, 'b'))
+      found_b = true;
+    if (pkt.size() == 1 && pkt[0] == FakePacketFragment(40, 'c'))
+      found_c = true;
+    if (pkt.size() == 1 && pkt[0] == FakePacketFragment(50, 'd'))
+      found_d = true;
+  }
+  EXPECT_TRUE(found_a) << "Packet 'a' not found after re-admission";
+  EXPECT_TRUE(found_b) << "Packet 'b' not found after re-admission";
+  EXPECT_TRUE(found_c) << "Packet 'c' not found after re-admission";
+  EXPECT_TRUE(found_d) << "Packet 'd' not found after re-admission";
+  EXPECT_FALSE(a_dropped) << "Recovered 'a' falsely flagged as dropped — "
+                             "data_loss not cleared on successful re-admit.";
+}
+
 // Scrape → read → evict → producer completes chunk. The complete commit has
 // strictly more payload and must be re-admitted, recovering the previously-
 // dropped fragment and allowing cross-chunk reassembly.


### PR DESCRIPTION
  On RING_BUFFER buffers with a slow consumer (e.g. write_into_file with a
  multi-minute file_write_period_ms), a scraped chunk can be evicted by the
  wrap before any reader has touched it. When the producer later commits the
  same chunk_id with chunk_complete=true and more data, CopyChunkUntrusted
  takes the re-admit branch.

  The re-admit was using last_chunk_consumed.payload_size as the "bytes the
  consumer already saw" cursor and skipping them on the resubmitted chunk.
  But EraseCurrentChunk wrote that field to the chunk's total payload
  regardless of how the chunk left the buffer, so any bytes that were
  overwritten without ever being read got skipped on re-admit too. The
  producer resubmitted them and the buffer threw them away anyway.

  Fix:
  - ChunkSeqReader tracks bytes_overwritten_in_chunk_, reset on every chunk
    transition and incremented in ConsumeFragment when mode_ == kEraseMode.
  - EraseCurrentChunk records payload_read = payload_size - bytes_overwritten
    on last_chunk_consumed. The field was previously called payload_size; it
    is now payload_read to match what it actually stores.
  - CopyChunkUntrusted's re-admit branch uses payload_read for both the
    acceptance check and the skip count, and clears seq.data_loss since the
    bytes that tripped it are about to be replayed.