### PR TITLE
tp: fix clash with "DEBUG" on MacOS toolchain

### DIFF
--- a/src/trace_processor/plugins/winscope_importer/BUILD.gn
+++ b/src/trace_processor/plugins/winscope_importer/BUILD.gn
@@ -116,6 +116,7 @@ perfetto_unittest_source_set("unittests") {
     "../../../../protos/perfetto/trace/android:winscope_regular_cpp",
     "../../../../src/protozero",
     "../../importers/common",
+    "../../storage",
   ]
   sources = [
     "surfaceflinger_layers_extractor_unittest.cc",

--- a/src/trace_processor/plugins/winscope_importer/protolog_message_decoder.cc
+++ b/src/trace_processor/plugins/winscope_importer/protolog_message_decoder.cc
@@ -22,7 +22,7 @@
 
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/string_utils.h"
-#include "perfetto/ext/base/string_view.h"
+#include "src/trace_processor/importers/common/stats_tracker.h"
 
 namespace perfetto::trace_processor::winscope {
 
@@ -385,8 +385,9 @@ std::optional<DecodedMessage> ProtoLogMessageDecoder::DecodeCollidingMessageIds(
       }
       collision_message += ">";
     }
-    return DecodedMessage{ProtoLogLevel::WARN, std::string(kCollisionGroupTag),
-                          collision_message, std::nullopt};
+    return DecodedMessage{ProtoLogLevel::PROTOLOG_LEVEL_WARN,
+                          std::string(kCollisionGroupTag), collision_message,
+                          std::nullopt};
   }
 }
 

--- a/src/trace_processor/plugins/winscope_importer/protolog_message_decoder.h
+++ b/src/trace_processor/plugins/winscope_importer/protolog_message_decoder.h
@@ -23,9 +23,6 @@
 #include <vector>
 
 #include "perfetto/ext/base/flat_hash_map.h"
-#include "src/trace_processor/importers/common/stats_tracker.h"
-#include "src/trace_processor/storage/trace_storage.h"
-#include "src/trace_processor/tables/winscope_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
 namespace perfetto::trace_processor::winscope {
@@ -34,12 +31,12 @@ inline constexpr std::string_view kCollisionGroupTag = "COLLISION_GROUP";
 inline constexpr std::string_view kUnknownGroupTag = "UNKNOWN_GROUP";
 
 enum ProtoLogLevel : int32_t {
-  DEBUG = 1,
-  VERBOSE = 2,
-  INFO = 3,
-  WARN = 4,
-  ERROR = 5,
-  WTF = 6,
+  PROTOLOG_LEVEL_DEBUG = 1,
+  PROTOLOG_LEVEL_VERBOSE = 2,
+  PROTOLOG_LEVEL_INFO = 3,
+  PROTOLOG_LEVEL_WARN = 4,
+  PROTOLOG_LEVEL_ERROR = 5,
+  PROTOLOG_LEVEL_WTF = 6,
 };
 
 struct DecodedMessage {

--- a/src/trace_processor/plugins/winscope_importer/protolog_parser.cc
+++ b/src/trace_processor/plugins/winscope_importer/protolog_parser.cc
@@ -189,22 +189,22 @@ void ProtoLogParser::PopulateReservedRowWithMessage(
 
   StringPool::Id level = log_level_unknown_string_id_;
   switch (log_level) {
-    case ProtoLogLevel::DEBUG:
+    case ProtoLogLevel::PROTOLOG_LEVEL_DEBUG:
       level = log_level_debug_string_id_;
       break;
-    case ProtoLogLevel::VERBOSE:
+    case ProtoLogLevel::PROTOLOG_LEVEL_VERBOSE:
       level = log_level_verbose_string_id_;
       break;
-    case ProtoLogLevel::INFO:
+    case ProtoLogLevel::PROTOLOG_LEVEL_INFO:
       level = log_level_info_string_id_;
       break;
-    case ProtoLogLevel::WARN:
+    case ProtoLogLevel::PROTOLOG_LEVEL_WARN:
       level = log_level_warn_string_id_;
       break;
-    case ProtoLogLevel::ERROR:
+    case ProtoLogLevel::PROTOLOG_LEVEL_ERROR:
       level = log_level_error_string_id_;
       break;
-    case ProtoLogLevel::WTF:
+    case ProtoLogLevel::PROTOLOG_LEVEL_WTF:
       level = log_level_wtf_string_id_;
       break;
   }

--- a/src/trace_processor/plugins/winscope_importer/test/protolog_message_decoder_unittest.cc
+++ b/src/trace_processor/plugins/winscope_importer/test/protolog_message_decoder_unittest.cc
@@ -15,8 +15,11 @@
  */
 
 #include "src/trace_processor/plugins/winscope_importer/protolog_message_decoder.h"
+
 #include "src/trace_processor/importers/common/global_stats_tracker.h"
 #include "src/trace_processor/importers/common/machine_tracker.h"
+#include "src/trace_processor/importers/common/stats_tracker.h"
+#include "src/trace_processor/storage/stats.h"
 
 #include "test/gtest_and_gmock.h"
 
@@ -48,12 +51,12 @@ class ProtologMessageDecoderTest : public ::testing::Test {
 
 TEST_F(ProtologMessageDecoderTest, DecodeSingleMessage) {
   uint64_t msg_id = 100;
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::INFO, default_group_id,
-                         "Test %d %s", "Some Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_INFO,
+                         default_group_id, "Test %d %s", "Some Location");
 
   auto decoded = decoder_->Decode(msg_id, {42}, {}, {}, {"hello"});
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->log_level, ProtoLogLevel::INFO);
+  EXPECT_EQ(decoded->log_level, ProtoLogLevel::PROTOLOG_LEVEL_INFO);
   EXPECT_EQ(decoded->group_tag, default_tag);
   EXPECT_EQ(decoded->message, "Test 42 hello");
   EXPECT_EQ(decoded->location, "Some Location");
@@ -68,14 +71,14 @@ TEST_F(ProtologMessageDecoderTest, DecodeSingleMessage) {
 TEST_F(ProtologMessageDecoderTest,
        DecodeCollidingMessagesWithDifferentParameters) {
   uint64_t msg_id = 100;
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::INFO, default_group_id,
-                         "Value: %d", "Some Location");
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::WARN, default_group_id,
-                         "Name: %s", "Other Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_INFO,
+                         default_group_id, "Value: %d", "Some Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_WARN,
+                         default_group_id, "Name: %s", "Other Location");
 
   auto decoded = decoder_->Decode(msg_id, {123}, {}, {}, {});
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->log_level, ProtoLogLevel::INFO);
+  EXPECT_EQ(decoded->log_level, ProtoLogLevel::PROTOLOG_LEVEL_INFO);
   EXPECT_EQ(decoded->group_tag, default_tag);
   EXPECT_THAT(decoded->message, "Value: 123");
   EXPECT_EQ(decoded->location, "Some Location");
@@ -89,14 +92,14 @@ TEST_F(ProtologMessageDecoderTest,
 
 TEST_F(ProtologMessageDecoderTest, DecodeCollidingMessagesWithSameParameters) {
   uint64_t msg_id = 100;
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::INFO, default_group_id,
-                         "Value: %d", "Some Location");
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::WARN, default_group_id,
-                         "Other Value: %d", "Other Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_INFO,
+                         default_group_id, "Value: %d", "Some Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_WARN,
+                         default_group_id, "Other Value: %d", "Other Location");
 
   auto decoded = decoder_->Decode(msg_id, {123}, {}, {}, {});
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->log_level, ProtoLogLevel::WARN);
+  EXPECT_EQ(decoded->log_level, ProtoLogLevel::PROTOLOG_LEVEL_WARN);
   EXPECT_EQ(decoded->group_tag, kCollisionGroupTag);
   EXPECT_THAT(decoded->message,
               testing::HasSubstr("<PROTOLOG COLLISION (id=0x"));
@@ -115,14 +118,14 @@ TEST_F(ProtologMessageDecoderTest, DecodeCollidingMessagesWithSameParameters) {
 
 TEST_F(ProtologMessageDecoderTest, DecodeCollidingMessagesWithNoMatch) {
   uint64_t msg_id = 100;
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::INFO, default_group_id,
-                         "Value: %d", "Some Location");
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::WARN, default_group_id,
-                         "Other Value: %d", "Other Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_INFO,
+                         default_group_id, "Value: %d", "Some Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_WARN,
+                         default_group_id, "Other Value: %d", "Other Location");
 
   auto decoded = decoder_->Decode(msg_id, {}, {}, {true}, {});
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->log_level, ProtoLogLevel::WARN);
+  EXPECT_EQ(decoded->log_level, ProtoLogLevel::PROTOLOG_LEVEL_WARN);
   EXPECT_EQ(decoded->group_tag, kCollisionGroupTag);
   EXPECT_THAT(decoded->message,
               testing::HasSubstr("<PROTOLOG COLLISION (id=0x"));
@@ -140,12 +143,12 @@ TEST_F(ProtologMessageDecoderTest, GroupTagCollision) {
   uint64_t msg_id = 100;
   std::string_view other_group_tag = "OTHER_GROUP";
   decoder_->TrackGroup(default_group_id, other_group_tag);
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::INFO, default_group_id,
-                         "Test %d %s", "Some Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_INFO,
+                         default_group_id, "Test %d %s", "Some Location");
 
   auto decoded = decoder_->Decode(msg_id, {42}, {}, {}, {"hello"});
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->log_level, ProtoLogLevel::INFO);
+  EXPECT_EQ(decoded->log_level, ProtoLogLevel::PROTOLOG_LEVEL_INFO);
   EXPECT_EQ(decoded->group_tag, kCollisionGroupTag);
   EXPECT_EQ(decoded->message, "Test 42 hello");
   EXPECT_EQ(decoded->location, "Some Location");
@@ -157,12 +160,12 @@ TEST_F(ProtologMessageDecoderTest, GroupTagCollision) {
 TEST_F(ProtologMessageDecoderTest, GroupTagMissing) {
   uint64_t msg_id = 100;
   uint32_t other_group_id = 2;
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::INFO, other_group_id,
-                         "Test %d %s", "Some Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_INFO,
+                         other_group_id, "Test %d %s", "Some Location");
 
   auto decoded = decoder_->Decode(msg_id, {42}, {}, {}, {"hello"});
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->log_level, ProtoLogLevel::INFO);
+  EXPECT_EQ(decoded->log_level, ProtoLogLevel::PROTOLOG_LEVEL_INFO);
   EXPECT_EQ(decoded->group_tag, kUnknownGroupTag);
   EXPECT_EQ(decoded->message, "Test 42 hello");
   EXPECT_EQ(decoded->location, "Some Location");
@@ -173,12 +176,12 @@ TEST_F(ProtologMessageDecoderTest, GroupTagMissing) {
 
 TEST_F(ProtologMessageDecoderTest, MessageParameterMismatch) {
   uint64_t msg_id = 100;
-  decoder_->TrackMessage(msg_id, ProtoLogLevel::INFO, default_group_id,
-                         "Value: %d", "Some Location");
+  decoder_->TrackMessage(msg_id, ProtoLogLevel::PROTOLOG_LEVEL_INFO,
+                         default_group_id, "Value: %d", "Some Location");
 
   auto decoded = decoder_->Decode(msg_id, {}, {}, {}, {});
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->log_level, ProtoLogLevel::INFO);
+  EXPECT_EQ(decoded->log_level, ProtoLogLevel::PROTOLOG_LEVEL_INFO);
   EXPECT_EQ(decoded->group_tag, default_tag);
   EXPECT_THAT(decoded->message, "Value: [MISSING_PARAM]");
   EXPECT_EQ(decoded->location, "Some Location");


### PR DESCRIPTION
DEBUG is a common cflag on MacOS debug builds causing all sorts of
compile problems in these situations. Fix it by renaming the plain
DEBUG symbol by adding a prefix.
