### PR TITLE
Android.bp.extras: Expose Wattson power curves in Android

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -24962,3 +24962,12 @@ java_library_host {
         "src/android_sdk/java/host_stubs/androidx/**/*.java",
     ],
 }
+
+filegroup {
+    name: "wattson_power_curves",
+    srcs: [
+        "src/trace_processor/plugins/wattson/data/**/*.csv",
+    ],
+    path: "src/trace_processor/plugins/wattson/data",
+    visibility: ["//visibility:public"],
+}

--- a/Android.bp.extras
+++ b/Android.bp.extras
@@ -364,3 +364,12 @@ java_library_host {
         "src/android_sdk/java/host_stubs/androidx/**/*.java",
     ],
 }
+
+filegroup {
+    name: "wattson_power_curves",
+    srcs: [
+        "src/trace_processor/plugins/wattson/data/**/*.csv",
+    ],
+    path: "src/trace_processor/plugins/wattson/data",
+    visibility: ["//visibility:public"],
+}


### PR DESCRIPTION
Add filegroup for Wattson power curves in Android.bp.extras, such that this data can be referenced by Android. This prevents having multiple copies of the same data across Perfetto/Android.

Bug: 456540614