### PR TITLE
Optimize android_blocking_calls_cuj_per_frame_metric

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
@@ -165,7 +165,7 @@ WHERE
 
 -- Track all distinct frames that overlap with the CUJ slice. In this table two frames are considered
 -- distinct if they have different frame_id/vsync.
-CREATE PERFETTO VIEW _android_distinct_frames_in_cuj AS
+CREATE PERFETTO TABLE _android_distinct_frames_in_cuj AS
 -- Captures all frames in the CUJ boundary. In cases where there are multiple actual frames, there
 -- can be multiple rows with the same frame_id.
 SELECT

--- a/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
@@ -27,7 +27,7 @@ INCLUDE PERFETTO MODULE android.cujs.base;
 -- doFrame blocks are running without any visible changes on the screen - leading to
 -- no actual frames being drawn. When this happens there might be gaps in actual frame timeline,
 -- so then the next doFrame would be resolved as an earlier boundary for an extended frame.
-CREATE PERFETTO VIEW _extended_frame_boundary AS
+CREATE PERFETTO TABLE _extended_frame_boundary AS
 -- Get the start time of the NEXT frame in the sequence
 WITH
   _frames_with_next AS (
@@ -79,7 +79,7 @@ ORDER BY
   frame_id;
 
 -- Capture blocking call duration within frames within a CUJ.
-CREATE PERFETTO VIEW _blocking_calls_frame_cuj AS
+CREATE PERFETTO TABLE _blocking_calls_frame_cuj AS
 SELECT
   min(bc.dur, frame.ts_end - bc.ts, bc.ts_end - frame.ts) AS dur,
   max(frame.ts, bc.ts) AS ts,


### PR DESCRIPTION
Materialize intermediate views with window functions and groupings into Perfetto tables (_android_distinct_frames_in_cuj, _extended_frame_boundary, _blocking_calls_frame_cuj) to avoid quadratic view evaluation overhead during joins in SQLite.


Originally from gelanchezhian@