### PR TITLE
traced_probes: reduce noise in disconnect-trigger captures

### DIFF
--- a/src/traced/probes/probes_producer.cc
+++ b/src/traced/probes/probes_producer.cc
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -69,6 +70,13 @@ constexpr uint32_t kMaxConnectionBackoffMs = 30 * 1000;
 
 // Should be larger than FtraceController::kControllerFlushTimeoutMs.
 constexpr uint32_t kFlushTimeoutMs = 1000;
+
+// Floor for the kTraceDidntStop watchdog timeout. When the system is busy
+// (ftrace is loaded, draining takes time) the calculated timeout can be too
+// tight on short traces and trip the watchdog even though the producer can
+// recover. 5 minutes gives enough slack while still killing genuinely stuck
+// producers.
+constexpr uint32_t kMinTraceDidntStopTimeoutMs = 5 * 60 * 1000;
 
 constexpr size_t kTracingSharedMemSizeHintBytes = 2 * 1024 * 1024;
 constexpr size_t kTracingSharedMemPageSizeHintBytes = 32 * 1024;
@@ -555,9 +563,12 @@ void ProbesProducer::StartDataSource(DataSourceInstanceID instance_id,
     // might be < timeout measured in in wall time. But this is fine
     // because the resulting timeout will be conservative (it will be accurate
     // if the device never suspends, and will be more lax if it does).
-    uint32_t timeout =
+    // kMinTraceDidntStopTimeoutMs floors it so short traces don't trip the
+    // watchdog when the system is busy.
+    uint32_t timeout = std::max<uint32_t>(
         2 * (kDefaultFlushTimeoutMs + config.trace_duration_ms() +
-             config.stop_timeout_ms());
+             config.stop_timeout_ms()),
+        kMinTraceDidntStopTimeoutMs);
     watchdogs_.emplace(
         instance_id, base::Watchdog::GetInstance()->CreateFatalTimer(
                          timeout, base::WatchdogCrashReason::kTraceDidntStop));

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -462,10 +462,13 @@ void TracingServiceImpl::DisconnectProducer(ProducerID id) {
     }
 
     // Fire a disconnect trigger so pre-configured sessions can capture
-    // diagnostics when traced_probes crashes.
+    // diagnostics when the host traced_probes crashes. Skip producers
+    // relayed from another machine (e.g. a VM): they share the same
+    // producer name but their disconnects are expected on VM teardown.
     if constexpr (PERFETTO_FLAGS(
                       TRIGGER_PERFETTO_ON_TRACED_PROBES_DISCONNECT)) {
-      if (producer->name_ == "perfetto.traced_probes") {
+      if (producer->name_ == "perfetto.traced_probes" &&
+          producer->client_identity().machine_id() == kDefaultMachineID) {
         PERFETTO_ELOG("traced_probes disconnected, firing disconnect trigger");
         ActivateTriggers(id, {"perfetto.traced_probes.disconnect"});
       }


### PR DESCRIPTION
Two related changes to make perfetto.traced_probes.disconnect traces more useful for debugging real crashes:

1. probes_producer.cc: floor the kTraceDidntStop watchdog timeout at 5 min via the new kMinTraceDidntStopTimeoutMs constant. The previous 2 * (kDefaultFlushTimeoutMs + duration + stop_timeout) was too tight under heavy load: e.g. on a 30s/5s bounded session it works out to 80s, and on busy devices we saw the producer's main thread spend most of that in ftrace processing (multi-second per-DS read cycles), so the queued StopDataSource didn't get serviced in time. The floor prevents the spurious kill without weakening the guarantee that a genuinely stuck producer still gets killed.

2. tracing_service_impl.cc: skip the disconnect trigger for producers relayed from a non-default machine_id. VM-side (e.g. Microdroid pVM) traced_probes uses the same producer name "perfetto.traced_probes", so the existing check fired on every VM teardown, which is expected behaviour and not the host crash we want to capture.

Bug: b/496506220