### PR TITLE
base: avoid strerror text in sched boost tests

### DIFF
--- a/src/base/scoped_sched_boost_unittest.cc
+++ b/src/base/scoped_sched_boost_unittest.cc
@@ -29,8 +29,10 @@
 #include "test/status_matchers.h"
 
 using testing::_;
+using testing::AllOf;
 using testing::ElementsAre;
 using testing::Eq;
+using testing::HasSubstr;
 using testing::NiceMock;
 using testing::Return;
 
@@ -270,9 +272,9 @@ TEST_F(ScopedSchedBoostLinuxIntegrationTest, WrongConfig) {
   // range. So we test error reporting only for the 'Policy::kSchedFifo'
   auto boost = ScopedSchedBoost::Boost(
       SchedPolicyAndPrio{SchedPolicyAndPrio::Policy::kSchedFifo, 101});
-  ASSERT_STREQ(
-      boost.status().c_message(),
-      "sched_setscheduler(1, 101) failed (errno: 22, Invalid argument)");
+  ASSERT_THAT(boost.status().c_message(),
+              AllOf(HasSubstr("sched_setscheduler(1, 101) failed"),
+                    HasSubstr("errno: 22")));
 }
 
 TEST_F(ScopedSchedBoostLinuxIntegrationTest, ReturnNoPermission) {
@@ -281,9 +283,9 @@ TEST_F(ScopedSchedBoostLinuxIntegrationTest, ReturnNoPermission) {
   }
   auto boost = ScopedSchedBoost::Boost(
       SchedPolicyAndPrio{SchedPolicyAndPrio::Policy::kSchedFifo, 42});
-  ASSERT_STREQ(
-      boost.status().c_message(),
-      "sched_setscheduler(1, 42) failed (errno: 1, Operation not permitted)");
+  ASSERT_THAT(boost.status().c_message(),
+              AllOf(HasSubstr("sched_setscheduler(1, 42) failed"),
+                    HasSubstr("errno: 1")));
 }
 
 }  // namespace


### PR DESCRIPTION
Avoid matching the localized strerror text in the ScopedSchedBoost Linux integration tests.

The tests still check that the expected sched_setscheduler call failed and that the stable errno value is present.

Tested:
- /data1/ent_145/src/buildtools/linux64-format/clang-format --dry-run --Werror src/base/scoped_sched_boost_unittest.cc
- git diff --check