### PR TITLE
ui: fix extension server shared link behavior

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal.ts
@@ -81,6 +81,9 @@ export class AddExtensionServerModal {
   private confirmLoad(): void {
     const modules = this.deferredInitialModules;
     this.deferredInitialModules = undefined;
+    // Clicking "Load modules" is the only thing that may contact a server
+    // configured from an untrusted prefill. Clear the gate before scheduling.
+    this.awaitingConfirmation = false;
     this.scheduleManifestFetch(modules);
   }
 
@@ -528,7 +531,13 @@ export class AddExtensionServerModal {
   private scheduleManifestFetch(
     preserveEnabledModules?: ReadonlyArray<string>,
   ): void {
-    this.awaitingConfirmation = false;
+    // Never contact the server while waiting for the user to confirm an
+    // untrusted prefilled configuration (from a shared link). Edits to the
+    // form (which trigger debouncedFetch) and server-type switches must not
+    // bypass the consent gate; only confirmLoad() clears it.
+    if (this.awaitingConfirmation) {
+      return;
+    }
     this.loadedState = undefined;
     this.fetchLimiter.schedule(() => this.loadManifest(preserveEnabledModules));
   }

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal_unittest.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal_unittest.ts
@@ -88,4 +88,19 @@ describe('AddExtensionServerModal', () => {
     await flushAsync();
     expect(mockFetch).toHaveBeenCalled();
   });
+
+  test('editing the form does not bypass the confirmation gate', async () => {
+    const modal = new AddExtensionServerModal(undefined, PREFILL);
+    await flushAsync();
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    // Simulate an edit to an input field: onInput handlers route through
+    // debouncedFetch -> scheduleManifestFetch. While awaiting confirmation
+    // this must not contact the server.
+    (
+      modal as unknown as {scheduleManifestFetch(): void}
+    ).scheduleManifestFetch();
+    await flushAsync();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Prevent autofill edits from causing manifest fetches without explicit
confirm.
