### PR TITLE
tp: use raw ftrace timestamp in ftrace_event table via dual-push

### DIFF
--- a/src/trace_processor/importers/common/parser_types.h
+++ b/src/trace_processor/importers/common/parser_types.h
@@ -153,6 +153,11 @@ struct alignas(8) FtraceData {
   TraceBlobView packet;
   RefPtr<PacketSequenceStateGeneration> sequence_state;
   int64_t raw_ts = kRawTsUnset;
+  // Custom tokenizers that forge a different sorter timestamp push each
+  // event twice: once at raw_ts for the ftrace_event table, and once at
+  // the forged timestamp for event-specific parsing.
+  bool insert_ftrace_event = true;
+  bool parse_event = true;
 };
 static_assert(sizeof(FtraceData) % 8 == 0);
 

--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -888,13 +888,19 @@ base::Status FtraceParser::ParseFtraceEvent(uint32_t cpu,
     }
 
     ConstBytes fld_bytes = fld.as_bytes();
-    if (fld.id() == FtraceEvent::kGenericFieldNumber) {
-      ParseLegacyGenericFtrace(ts, cpu, pid, fld_bytes);
-    } else if (GenericFtraceTracker::IsGenericFtraceEvent(fld.id())) {
-      ParseGenericFtrace(fld.id(), ts, cpu, pid, fld_bytes);
-    } else if (fld.id() != FtraceEvent::kSchedSwitchFieldNumber) {
-      // sched_switch parsing populates the raw table by itself
-      ParseTypedFtraceToRaw(fld.id(), ts, cpu, pid, fld_bytes, seq_state);
+
+    if (data.insert_ftrace_event) {
+      if (fld.id() == FtraceEvent::kGenericFieldNumber) {
+        ParseLegacyGenericFtrace(ts, cpu, pid, fld_bytes);
+      } else if (GenericFtraceTracker::IsGenericFtraceEvent(fld.id())) {
+        ParseGenericFtrace(fld.id(), ts, cpu, pid, fld_bytes);
+      } else if (fld.id() != FtraceEvent::kSchedSwitchFieldNumber) {
+        // sched_switch parsing populates the raw table by itself
+        ParseTypedFtraceToRaw(fld.id(), ts, cpu, pid, fld_bytes, seq_state);
+      }
+    }
+    if (!data.parse_event) {
+      return base::OkStatus();
     }
 
     // Skip everything besides the |raw| write if we're at the start of the

--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
@@ -543,7 +543,13 @@ void FtraceTokenizer::TokenizeFtraceGpuWorkPeriod(
     return;
   }
   module_context_->PushFtraceEvent(
-      cpu, *timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
+      cpu, raw_ts,
+      FtraceData{event.copy(), state, FtraceData::kRawTsUnset,
+                 /*insert_ftrace_event=*/true, /*parse_event=*/false});
+  module_context_->PushFtraceEvent(
+      cpu, *timestamp,
+      FtraceData{std::move(event), std::move(state), raw_ts,
+                 /*insert_ftrace_event=*/false, /*parse_event=*/true});
 }
 
 void FtraceTokenizer::TokenizeFtraceThermalExynosAcpmBulk(
@@ -569,7 +575,13 @@ void FtraceTokenizer::TokenizeFtraceThermalExynosAcpmBulk(
   auto timestamp =
       static_cast<int64_t>(thermal_exynos_acpm_bulk_event.timestamp());
   module_context_->PushFtraceEvent(
-      cpu, timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
+      cpu, raw_ts,
+      FtraceData{event.copy(), state, FtraceData::kRawTsUnset,
+                 /*insert_ftrace_event=*/true, /*parse_event=*/false});
+  module_context_->PushFtraceEvent(
+      cpu, timestamp,
+      FtraceData{std::move(event), std::move(state), raw_ts,
+                 /*insert_ftrace_event=*/false, /*parse_event=*/true});
 }
 
 void FtraceTokenizer::TokenizeFtraceParamSetValueCpm(
@@ -594,7 +606,13 @@ void FtraceTokenizer::TokenizeFtraceParamSetValueCpm(
   }
   int64_t timestamp = param_set_value_cpm_event.timestamp();
   module_context_->PushFtraceEvent(
-      cpu, timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
+      cpu, raw_ts,
+      FtraceData{event.copy(), state, FtraceData::kRawTsUnset,
+                 /*insert_ftrace_event=*/true, /*parse_event=*/false});
+  module_context_->PushFtraceEvent(
+      cpu, timestamp,
+      FtraceData{std::move(event), std::move(state), raw_ts,
+                 /*insert_ftrace_event=*/false, /*parse_event=*/true});
 }
 
 void FtraceTokenizer::TokenizeFtraceFwtpPerfettoCounter(
@@ -620,7 +638,13 @@ void FtraceTokenizer::TokenizeFtraceFwtpPerfettoCounter(
   int64_t timestamp =
       static_cast<int64_t>(fwtp_perfetto_counter_event.timestamp());
   module_context_->PushFtraceEvent(
-      cpu, timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
+      cpu, raw_ts,
+      FtraceData{event.copy(), state, FtraceData::kRawTsUnset,
+                 /*insert_ftrace_event=*/true, /*parse_event=*/false});
+  module_context_->PushFtraceEvent(
+      cpu, timestamp,
+      FtraceData{std::move(event), std::move(state), raw_ts,
+                 /*insert_ftrace_event=*/false, /*parse_event=*/true});
 }
 
 void FtraceTokenizer::TokenizeFtraceFwtpPerfettoSlice(
@@ -646,7 +670,13 @@ void FtraceTokenizer::TokenizeFtraceFwtpPerfettoSlice(
   int64_t timestamp =
       static_cast<int64_t>(fwtp_perfetto_slice_event.timestamp());
   module_context_->PushFtraceEvent(
-      cpu, timestamp, FtraceData{std::move(event), std::move(state), raw_ts});
+      cpu, raw_ts,
+      FtraceData{event.copy(), state, FtraceData::kRawTsUnset,
+                 /*insert_ftrace_event=*/true, /*parse_event=*/false});
+  module_context_->PushFtraceEvent(
+      cpu, timestamp,
+      FtraceData{std::move(event), std::move(state), raw_ts,
+                 /*insert_ftrace_event=*/false, /*parse_event=*/true});
 }
 
 std::optional<protozero::Field> FtraceTokenizer::GetFtraceEventField(

--- a/src/trace_processor/sorter/trace_token_buffer.cc
+++ b/src/trace_processor/sorter/trace_token_buffer.cc
@@ -82,6 +82,8 @@ struct alignas(8) FtraceDataDescriptor {
   uint16_t intern_seq_index;
   uint32_t intern_blob_offset : kMaxOffsetFromInternedBlobBits;
   uint32_t has_raw_ts : 1;
+  uint32_t insert_ftrace_event : 1;
+  uint32_t parse_event : 1;
 };
 static_assert(sizeof(FtraceDataDescriptor) == 8,
               "FtraceDataDescriptor must be small");
@@ -221,6 +223,8 @@ TraceTokenBuffer::Id TraceTokenBuffer::Append(TracePacketData data) {
 TraceTokenBuffer::Id TraceTokenBuffer::Append(FtraceData data) {
   FtraceDataDescriptor desc;
   desc.has_raw_ts = data.raw_ts != FtraceData::kRawTsUnset;
+  desc.insert_ftrace_event = data.insert_ftrace_event;
+  desc.parse_event = data.parse_event;
 
   auto [alloc_id, ptr] =
       AppendCommon(desc, data.packet, std::move(data.sequence_state));
@@ -249,6 +253,8 @@ FtraceData TraceTokenBuffer::Extract<FtraceData>(Id id) {
   if (desc.has_raw_ts) {
     data.raw_ts = ExtractFromPtr<int64_t>(&ptr);
   }
+  data.insert_ftrace_event = desc.insert_ftrace_event;
+  data.parse_event = desc.parse_event;
   allocator_.Free(id.alloc_id);
   return data;
 }

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -78,6 +78,7 @@ from diff_tests.parser.fs.tests import Fs
 from diff_tests.parser.ftrace.block_io_tests import BlockIo
 from diff_tests.parser.ftrace.ftrace_crop_tests import FtraceCrop
 from diff_tests.parser.ftrace.kprobes_tests import Kprobes
+from diff_tests.parser.ftrace.thermal_exynos_tests import ThermalExynos
 from diff_tests.parser.ftrace.generic_ftrace_tests import GenericFtrace
 from diff_tests.parser.ftrace.kernel_trackevent_tests import KernelTrackevent
 from diff_tests.parser.fuchsia.tests import Fuchsia
@@ -270,6 +271,7 @@ def fetch_all_diff_tests(
       BlockIo,
       FtraceCrop,
       Kprobes,
+      ThermalExynos,
       ParsingTracedStats,
       Zip,
       AndroidInputEvent,

--- a/test/trace_processor/diff_tests/parser/ftrace/thermal_exynos_tests.py
+++ b/test/trace_processor/diff_tests/parser/ftrace/thermal_exynos_tests.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import Csv, TextProto
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class ThermalExynos(TestSuite):
+
+  def test_thermal_exynos_ftrace_event_raw_ts(self):
+    """Custom tokenizers push each event twice: the ftrace_event table should
+    use the raw kernel timestamp (1000000000), while the counter table should
+    use the forged timestamp from the event data (5000000000)."""
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet { trusted_packet_sequence_id: 1 ftrace_events {
+          cpu: 0
+          event {
+            timestamp: 1000000000
+            pid: 42
+            thermal_exynos_acpm_bulk {
+              tz_id: 0
+              current_temp: 35
+              ctrl_temp: 40
+              timestamp: 5000000000
+            }
+          }
+        }}
+        """),
+        query="""
+        SELECT 'ftrace_event' as source, ts
+        FROM ftrace_event
+        WHERE name = 'thermal_exynos_acpm_bulk'
+        UNION ALL
+        SELECT 'counter' as source, ts
+        FROM counter
+        JOIN track ON counter.track_id = track.id
+        WHERE track.name = 'BIG Temperature'
+        """,
+        out=Csv("""
+        "source","ts"
+        "ftrace_event",1000000000
+        "counter",5000000000
+        """))


### PR DESCRIPTION
Custom tokenizers (gpu_work_period, thermal_exynos_acpm_bulk, param_set_value_cpm, fwtp_perfetto_counter, fwtp_perfetto_slice) forge a different sorter timestamp to reposition events on the timeline. This caused the ftrace_event table to show the forged timestamp instead of the original kernel time.

Fix this by having each custom tokenizer push the event through the sorter twice: once at the raw ftrace timestamp for the ftrace_event table, and once at the forged timestamp for event-specific parsing. Both ftrace_event.ts and slice.ts remain SORTED.

This builds on #5809 which introduced FtraceData::raw_ts for drop-window checks, and is a prerequisite for #5817 (adreno cmdbatch parsing) which needs to forge gpu_start_ts for correct slice ordering.

Bug: N/A