### PR TITLE
perfetto: add proto2 extension support to protozero and trace_processor

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16070,6 +16070,14 @@ filegroup {
     ],
 }
 
+// GN: //src/protozero/text_to_proto:unittests
+filegroup {
+    name: "perfetto_src_protozero_text_to_proto_unittests",
+    srcs: [
+        "src/protozero/text_to_proto/text_to_proto_unittest.cc",
+    ],
+}
+
 // GN: //src/protozero:unittests
 filegroup {
     name: "perfetto_src_protozero_unittests",
@@ -21911,6 +21919,7 @@ cc_test {
         ":perfetto_src_protozero_testing_messages_subpackage_zero_gen",
         ":perfetto_src_protozero_testing_messages_zero_gen",
         ":perfetto_src_protozero_text_to_proto_text_to_proto",
+        ":perfetto_src_protozero_text_to_proto_unittests",
         ":perfetto_src_protozero_unittests",
         ":perfetto_src_shared_lib_for_testing",
         ":perfetto_src_shared_lib_shared_lib",

--- a/include/perfetto/protozero/proto_decoder.h
+++ b/include/perfetto/protozero/proto_decoder.h
@@ -344,6 +344,43 @@ class PERFETTO_EXPORT_COMPONENT TypedProtoDecoderBase : public ProtoDecoder {
     return fields_[0];
   }
 
+  // Like Get(), but also resolves "extension" fields whose id exceeds the
+  // highest field id known in-tree at compile time (i.e. id >= num_fields_,
+  // which is MAX_FIELD_ID + 1). Such fields are NOT stored by ParseAllFields()
+  // -- e.g. fields carved out of TracePacket's `extensions 1000 to 1999`
+  // range. For in-tree ids this delegates to Get(); for extension ids it falls
+  // back to a linear re-scan of the buffer.
+  //
+  // NOTE: for *repeated* fields the slow path returns the FIRST occurrence
+  // (FindField semantics), whereas Get() returns the last. All current
+  // extension fields are singular submessages, so this is not observable today.
+  //
+  // TODO: make extension lookups fast without re-scanning the buffer. The
+  // blocker is that fields_ is indexed directly by field id (on_stack_storage_,
+  // or heap_storage_ after ExpandHeapStorage()), so it must be sized to the
+  // largest field id. That is fine for the densely-numbered in-tree fields, but
+  // extension ids are sparse and can be arbitrarily high (the OOT range starts
+  // at 1000), so indexing by id would waste / unbound memory. Proposed design:
+  //   - Replace the flat array with a two-level sparse map. Level 1 is a set of
+  //     id ranges built dynamically while decoding (these need not match the
+  //     static extensions.json allocations), e.g. tracked with a bitset. Level
+  //     2 maps an id within a matched range to a compact slot index.
+  //   - Back the slots with an object pool so repeated decodes reuse storage
+  //     and allocate ~zero: only a few decoders are live at any time, so the
+  //     pool stays small.
+  // This costs memory proportional to the extension fields actually present
+  // rather than to the max field id, and keeps the decode hot path
+  // allocation-free.
+  Field GetExtensionSlowly(uint32_t id) const {
+    if (PERFETTO_LIKELY(id < num_fields_))
+      return Get(id);
+    // Slow path: id is in the extension range; re-scan the original buffer.
+    // Use a throwaway ProtoDecoder so this method stays const (FindField
+    // mutates the read cursor).
+    return ProtoDecoder(begin_, static_cast<size_t>(end_ - begin_))
+        .FindField(id);
+  }
+
   // Returns an object that allows to iterate over all instances of a repeated
   // field given its id. Example usage:
   //   for (auto it = decoder.GetRepeated<int32_t>(N); it; ++it) { ... }
@@ -527,6 +564,27 @@ class TypedProtoDecoder : public TypedProtoDecoderBase {
     } else {
       // Otherwise use the slowpath Get() which will do a runtime check.
       return Get(FIELD_ID);
+    }
+  }
+
+  // Keep the runtime base-class overload visible: declaring the templated
+  // GetExtensionSlowly() below would otherwise hide it (C++ name hiding is
+  // per-name, not per-signature).
+  using TypedProtoDecoderBase::GetExtensionSlowly;
+
+  // Templated analog of TypedProtoDecoderBase::GetExtensionSlowly() for when
+  // the field id is known at compile time (the common case: extension field
+  // numbers come from generated kFooFieldNumber constants). Because
+  // MAX_FIELD_ID is known here, the in-tree vs extension decision is made at
+  // compile time: in-tree ids (<= MAX_FIELD_ID) take the at<>() fast path,
+  // while extension ids beyond the in-tree range fall back to the base
+  // class's buffer re-scan.
+  template <uint32_t FIELD_ID>
+  Field GetExtensionSlowly() const {
+    if constexpr (FIELD_ID <= MAX_FIELD_ID) {
+      return at<FIELD_ID>();
+    } else {
+      return TypedProtoDecoderBase::GetExtensionSlowly(FIELD_ID);
     }
   }
 

--- a/src/protozero/BUILD.gn
+++ b/src/protozero/BUILD.gn
@@ -86,6 +86,7 @@ perfetto_unittest_source_set("unittests") {
     "../base:test_support",
     "descriptor_diff:unittests",
     "filtering:unittests",
+    "text_to_proto:unittests",
   ]
   sources = [
     "copyable_ptr_unittest.cc",

--- a/src/protozero/proto_decoder.cc
+++ b/src/protozero/proto_decoder.cc
@@ -192,6 +192,15 @@ void TypedProtoDecoderBase::ParseAllFields() {
     PERFETTO_DCHECK(res.parse_res == ParseFieldResult::kOk);
     PERFETTO_DCHECK(res.field.valid());
     auto field_id = res.field.id();
+    // Fields with an id beyond the highest field id known in-tree at compile
+    // time are out-of-tree "extension" fields (e.g. carved out of TracePacket's
+    // `extensions 1000 to 1999` range). They are intentionally not stored here
+    // because fields_ is indexed directly by field id, and extension ids are
+    // sparse and potentially very high. Callers that need them must use
+    // TypedProtoDecoderBase::GetExtensionSlowly().
+    // TODO: store extensions in a sparse, object-pooled side table so they stay
+    // accessible without a buffer re-scan. See GetExtensionSlowly() for the
+    // proposed design.
     if (PERFETTO_UNLIKELY(field_id >= num_fields_))
       continue;
 

--- a/src/protozero/proto_decoder_unittest.cc
+++ b/src/protozero/proto_decoder_unittest.cc
@@ -616,6 +616,42 @@ TEST(ProtoDecoderTest, OneBigFieldIdOnly) {
   ASSERT_FALSE(field.valid());
 }
 
+// GetExtensionSlowly() resolves fields whose id is beyond MAX_FIELD_ID (i.e.
+// out-of-tree extensions), which ParseAllFields() does not store and Get()
+// therefore cannot see.
+TEST(ProtoDecoderTest, GetExtensionSlowly) {
+  HeapBuffered<Message> message;
+  message->AppendVarInt(/*field_id=*/1, 11);
+  message->AppendVarInt(/*field_id=*/2, 12);
+  // Beyond MAX_FIELD_ID below; an out-of-tree extension field.
+  message->AppendVarInt(/*field_id=*/65535, 99);
+  auto data = message.SerializeAsArray();
+
+  TypedProtoDecoder<3> tpd(data.data(), data.size());
+
+  // Fast path: for in-tree ids GetExtensionSlowly matches Get().
+  EXPECT_EQ(tpd.GetExtensionSlowly(1).as_int32(), 11);
+  EXPECT_EQ(tpd.GetExtensionSlowly(2).as_int32(), 12);
+
+  // Get() can't see the extension field (id > MAX_FIELD_ID)...
+  EXPECT_FALSE(tpd.Get(65535).valid());
+  // ...but GetExtensionSlowly() finds it via a buffer re-scan.
+  ASSERT_TRUE(tpd.GetExtensionSlowly(65535).valid());
+  EXPECT_EQ(tpd.GetExtensionSlowly(65535).as_int32(), 99);
+
+  // An absent extension field is reported invalid.
+  EXPECT_FALSE(tpd.GetExtensionSlowly(1234).valid());
+
+  // The templated TypedProtoDecoder::GetExtensionSlowly<>() decides the
+  // in-tree (<= MAX_FIELD_ID) vs extension split at compile time, but yields
+  // the same results as the runtime overload.
+  EXPECT_EQ(tpd.GetExtensionSlowly<1>().as_int32(), 11);
+  EXPECT_EQ(tpd.GetExtensionSlowly<2>().as_int32(), 12);
+  ASSERT_TRUE(tpd.GetExtensionSlowly<65535>().valid());
+  EXPECT_EQ(tpd.GetExtensionSlowly<65535>().as_int32(), 99);
+  EXPECT_FALSE(tpd.GetExtensionSlowly<1234>().valid());
+}
+
 // Check what happens when trying to parse packed repeated field and finding a
 // mismatching wire type instead. A compliant protobuf decoder should accept it,
 // but protozero doesn't handle that. At least it shouldn't crash.

--- a/src/protozero/test/example_proto/extensions.proto
+++ b/src/protozero/test/example_proto/extensions.proto
@@ -43,6 +43,20 @@ message BrowserExtension {
   }
 }
 
+// Scalar extensions (exercise non-message FindFieldByName paths).
+message ScalarBrowserExtension {
+  extend RealFakeEvent {
+    optional uint32 ext_uint = 12;
+    optional string ext_string = 13;
+    optional bool ext_bool = 14;
+  }
+}
+
+// File-scope extend (no enclosing wrapper).
+extend RealFakeEvent {
+  optional uint32 file_scope_ext = 15;
+}
+
 // "Legacy" message with the same format as BrowserExtension. Tests that if
 // LegacyFakeEvent is split into RealFakeEvent and BrowserExtension, the wire
 // format remains compatible.

--- a/src/protozero/test/example_proto/test_messages.proto
+++ b/src/protozero/test/example_proto/test_messages.proto
@@ -18,6 +18,7 @@ syntax = "proto2";
 
 package protozero.test.protos;
 
+import "src/protozero/test/example_proto/extensions.proto";
 import "src/protozero/test/example_proto/library.proto";
 import "src/protozero/test/example_proto/other_package/test_messages.proto";
 import "src/protozero/test/example_proto/subpackage/test_messages.proto";

--- a/src/protozero/text_to_proto/BUILD.gn
+++ b/src/protozero/text_to_proto/BUILD.gn
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("../../../gn/test.gni")
+
 source_set("text_to_proto") {
   sources = [
     "text_to_proto.cc",
@@ -22,5 +24,19 @@ source_set("text_to_proto") {
     "../../../gn:default_deps",
     "../../../protos/perfetto/common:cpp",
     "../../base",
+  ]
+}
+
+perfetto_unittest_source_set("unittests") {
+  testonly = true
+  sources = [ "text_to_proto_unittest.cc" ]
+  deps = [
+    ":text_to_proto",
+    "..:protozero",
+    "..:testing_messages_zero",
+    "../../../gn:default_deps",
+    "../../../gn:gtest_and_gmock",
+    "../../base",
+    "../../trace_processor:gen_cc_test_messages_descriptor",
   ]
 }

--- a/src/protozero/text_to_proto/text_to_proto.cc
+++ b/src/protozero/text_to_proto/text_to_proto.cc
@@ -129,6 +129,7 @@ std::string Format(const char* fmt,
 enum ParseState {
   kWaitingForKey,
   kReadingKey,
+  kReadingExtensionKey,
   kWaitingForValue,
   kReadingStringValue,
   kReadingStringEscape,
@@ -141,13 +142,21 @@ struct Token {
   size_t column;
   size_t row;
   perfetto::base::StringView txt;
+  bool is_extension = false;
 
   size_t size() const { return txt.size(); }
   std::string ToStdString() const { return txt.ToStdString(); }
 };
 
+struct RegisteredExtension {
+  std::string extendee_full_name;
+  const FieldDescriptorProto* field;
+};
+
 struct ParserDelegateContext {
   const DescriptorProto* descriptor;
+  // Leading-dot qualified form (".pkg.Msg"), to match extendee names.
+  std::string descriptor_full_name;
   protozero::Message* message;
   std::set<std::string> seen_fields;
 };
@@ -207,15 +216,18 @@ class ErrorReporter {
 class ParserDelegate {
  public:
   ParserDelegate(
+      const std::string& root_type,
       const DescriptorProto* descriptor,
       protozero::Message* message,
       ErrorReporter* reporter,
       std::map<std::string, const DescriptorProto*> name_to_descriptor,
-      std::map<std::string, const EnumDescriptorProto*> name_to_enum)
+      std::map<std::string, const EnumDescriptorProto*> name_to_enum,
+      std::map<std::string, RegisteredExtension> name_to_extension)
       : reporter_(reporter),
         name_to_descriptor_(std::move(name_to_descriptor)),
-        name_to_enum_(std::move(name_to_enum)) {
-    ctx_.push(ParserDelegateContext{descriptor, message, {}});
+        name_to_enum_(std::move(name_to_enum)),
+        name_to_extension_(std::move(name_to_extension)) {
+    ctx_.push(ParserDelegateContext{descriptor, root_type, message, {}});
   }
 
   void NumericField(const Token& key, const Token& value) {
@@ -452,7 +464,8 @@ class ParserDelegate {
     const DescriptorProto* nested_descriptor = name_to_descriptor_[type_name];
     PERFETTO_CHECK(nested_descriptor);
     auto* nested_msg = msg()->BeginNestedMessage<protozero::Message>(field_id);
-    ctx_.push(ParserDelegateContext{nested_descriptor, nested_msg, {}});
+    ctx_.push(
+        ParserDelegateContext{nested_descriptor, type_name, nested_msg, {}});
     return true;
   }
 
@@ -522,20 +535,43 @@ class ParserDelegate {
       const std::set<FieldDescriptorProto::Type>& valid_field_types) {
     const std::string field_name = key.ToStdString();
     const FieldDescriptorProto* field_descriptor = nullptr;
-    for (const auto& f : descriptor()->field()) {
-      if (f.name() == field_name) {
-        field_descriptor = &f;
-        break;
+    if (key.is_extension) {
+      auto it = name_to_extension_.find(field_name);
+      if (it == name_to_extension_.end()) {
+        AddError(key, "No extension named \"$n\" registered",
+                 {
+                     {"$n", field_name},
+                 });
+        return nullptr;
       }
-    }
+      const RegisteredExtension& ext = it->second;
+      if (ext.extendee_full_name != descriptor_full_name()) {
+        AddError(key,
+                 "Extension \"$n\" extends \"$e\", not the current message $p",
+                 {
+                     {"$n", field_name},
+                     {"$e", ext.extendee_full_name},
+                     {"$p", descriptor_full_name()},
+                 });
+        return nullptr;
+      }
+      field_descriptor = ext.field;
+    } else {
+      for (const auto& f : descriptor()->field()) {
+        if (f.name() == field_name) {
+          field_descriptor = &f;
+          break;
+        }
+      }
 
-    if (!field_descriptor) {
-      AddError(key, "No field named \"$n\" in proto $p",
-               {
-                   {"$n", field_name},
-                   {"$p", descriptor_name()},
-               });
-      return nullptr;
+      if (!field_descriptor) {
+        AddError(key, "No field named \"$n\" in proto $p",
+                 {
+                     {"$n", field_name},
+                     {"$p", descriptor_name()},
+                 });
+        return nullptr;
+      }
     }
 
     bool is_repeated =
@@ -571,6 +607,11 @@ class ParserDelegate {
 
   const std::string& descriptor_name() { return descriptor()->name(); }
 
+  const std::string& descriptor_full_name() {
+    PERFETTO_CHECK(!ctx_.empty());
+    return ctx_.top().descriptor_full_name;
+  }
+
   protozero::Message* msg() {
     PERFETTO_CHECK(!ctx_.empty());
     return ctx_.top().message;
@@ -580,6 +621,7 @@ class ParserDelegate {
   ErrorReporter* reporter_;
   std::map<std::string, const DescriptorProto*> name_to_descriptor_;
   std::map<std::string, const EnumDescriptorProto*> name_to_enum_;
+  std::map<std::string, RegisteredExtension> name_to_extension_;
 };
 
 void Parse(std::string_view input, ParserDelegate* delegate) {
@@ -635,6 +677,16 @@ void Parse(std::string_view input, ParserDelegate* delegate) {
           key.offset = i;
           key.row = row;
           key.column = column;
+          key.is_extension = false;
+          continue;
+        }
+        if (c == '[') {
+          saw_colon_for_this_key = false;
+          state = kReadingExtensionKey;
+          key.offset = i + 1;  // exclude '['
+          key.row = row;
+          key.column = column;
+          key.is_extension = true;
           continue;
         }
         break;
@@ -648,6 +700,21 @@ void Parse(std::string_view input, ParserDelegate* delegate) {
         if (c == '#')
           comment_till_eol = true;
         continue;
+
+      case kReadingExtensionKey:
+        if (IsIdentifierBody(c) || c == '.')
+          continue;
+        if (c == ']') {
+          if (i == key.offset) {
+            delegate->AddError(row, column, "Empty extension name", {});
+            return;
+          }
+          key.txt = perfetto::base::StringView(input.data() + key.offset,
+                                               i - key.offset);
+          state = kWaitingForValue;
+          continue;
+        }
+        break;
 
       case kWaitingForValue:
         if (isspace(c))
@@ -769,6 +836,35 @@ void AddNestedDescriptors(
   }
 }
 
+// `extendee` may come fully qualified (`.pkg.Msg`) or relative (`Msg`).
+std::string NormalizeExtendee(const std::string& extendee,
+                              const std::string& package) {
+  if (!extendee.empty() && extendee[0] == '.')
+    return extendee;
+  if (package.empty())
+    return "." + extendee;
+  return "." + package + "." + extendee;
+}
+
+void AddExtensions(
+    const std::string& enclosing_full_name,
+    const std::string& package,
+    const DescriptorProto* descriptor,
+    std::map<std::string, RegisteredExtension>* name_to_extension) {
+  const std::string scope = enclosing_full_name.empty()
+                                ? std::string()
+                                : enclosing_full_name.substr(1);
+  for (const FieldDescriptorProto& ext : descriptor->extension()) {
+    const std::string key = scope + "." + ext.name();
+    (*name_to_extension)[key] =
+        RegisteredExtension{NormalizeExtendee(ext.extendee(), package), &ext};
+  }
+  for (const DescriptorProto& nested : descriptor->nested_type()) {
+    AddExtensions(enclosing_full_name + "." + nested.name(), package, &nested,
+                  name_to_extension);
+  }
+}
+
 }  // namespace
 
 perfetto::base::StatusOr<std::vector<uint8_t>> TextToProto(
@@ -779,6 +875,7 @@ perfetto::base::StatusOr<std::vector<uint8_t>> TextToProto(
     std::string_view input) {
   std::map<std::string, const DescriptorProto*> name_to_descriptor;
   std::map<std::string, const EnumDescriptorProto*> name_to_enum;
+  std::map<std::string, RegisteredExtension> name_to_extension;
   FileDescriptorSet file_descriptor_set;
 
   {
@@ -795,6 +892,15 @@ perfetto::base::StatusOr<std::vector<uint8_t>> TextToProto(
         name_to_descriptor[name] = &descriptor;
         AddNestedDescriptors(name, &descriptor, &name_to_descriptor,
                              &name_to_enum);
+        AddExtensions(name, file_descriptor.package(), &descriptor,
+                      &name_to_extension);
+      }
+      const std::string& file_scope = file_descriptor.package();
+      for (const FieldDescriptorProto& ext : file_descriptor.extension()) {
+        const std::string key =
+            file_scope.empty() ? ext.name() : file_scope + "." + ext.name();
+        name_to_extension[key] = RegisteredExtension{
+            NormalizeExtendee(ext.extendee(), file_scope), &ext};
       }
     }
   }
@@ -804,9 +910,10 @@ perfetto::base::StatusOr<std::vector<uint8_t>> TextToProto(
 
   protozero::HeapBuffered<protozero::Message> message;
   ErrorReporter reporter(file_name, input);
-  ParserDelegate delegate(descriptor, message.get(), &reporter,
+  ParserDelegate delegate(root_type, descriptor, message.get(), &reporter,
                           std::move(name_to_descriptor),
-                          std::move(name_to_enum));
+                          std::move(name_to_enum),
+                          std::move(name_to_extension));
   Parse(input, &delegate);
   if (!reporter.success())
     return perfetto::base::ErrStatus("%s", reporter.error().c_str());

--- a/src/protozero/text_to_proto/text_to_proto_unittest.cc
+++ b/src/protozero/text_to_proto/text_to_proto_unittest.cc
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/protozero/text_to_proto/text_to_proto.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "perfetto/ext/base/status_or.h"
+#include "src/protozero/test/example_proto/extensions.pbzero.h"
+#include "src/protozero/test/example_proto/test_messages.pbzero.h"
+#include "src/trace_processor/test_messages.descriptor.h"
+#include "test/gtest_and_gmock.h"
+
+namespace protozero {
+namespace {
+
+using ::perfetto::kTestMessagesDescriptor;
+namespace pbtest = ::protozero::test::protos::pbzero;
+
+perfetto::base::StatusOr<std::vector<uint8_t>> Parse(
+    const std::string& root_type,
+    const std::string& input) {
+  return TextToProto(kTestMessagesDescriptor.data(),
+                     kTestMessagesDescriptor.size(), root_type, "test", input);
+}
+
+TEST(TextToProtoTest, RegularField) {
+  auto result = Parse(".protozero.test.protos.RealFakeEvent",
+                      R"(base_int: 7
+                         base_string: "hello")");
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  pbtest::RealFakeEvent::Decoder dec(result.value().data(),
+                                     result.value().size());
+  EXPECT_EQ(dec.base_int(), 7u);
+  EXPECT_EQ(dec.base_string().ToStdString(), "hello");
+}
+
+TEST(TextToProtoTest, ExtensionWrapperScoped) {
+  auto result = Parse(".protozero.test.protos.RealFakeEvent",
+                      R"(base_int: 7
+                         [protozero.test.protos.BrowserExtension.extension_a] {
+                           int_a: 42
+                           string_a: "x"
+                         })");
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  pbtest::RealFakeEvent::Decoder dec(result.value().data(),
+                                     result.value().size());
+  EXPECT_EQ(dec.base_int(), 7u);
+
+  protozero::Field ext_field =
+      dec.FindField(pbtest::BrowserExtension::kExtensionAFieldNumber);
+  ASSERT_TRUE(ext_field.valid());
+  pbtest::SystemA::Decoder ext_dec(ext_field.as_bytes());
+  EXPECT_EQ(ext_dec.int_a(), 42u);
+  EXPECT_EQ(ext_dec.string_a().ToStdString(), "x");
+}
+
+TEST(TextToProtoTest, ExtensionRepeated) {
+  auto result = Parse(".protozero.test.protos.RealFakeEvent",
+                      R"([protozero.test.protos.BrowserExtension.extension_a] {
+                           int_a: 1
+                         }
+                         [protozero.test.protos.BrowserExtension.extension_b] {
+                           int_b: 99
+                         })");
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  pbtest::RealFakeEvent::Decoder dec(result.value().data(),
+                                     result.value().size());
+  protozero::Field a =
+      dec.FindField(pbtest::BrowserExtension::kExtensionAFieldNumber);
+  ASSERT_TRUE(a.valid());
+  EXPECT_EQ(pbtest::SystemA::Decoder(a.as_bytes()).int_a(), 1u);
+
+  protozero::Field b =
+      dec.FindField(pbtest::BrowserExtension::kExtensionBFieldNumber);
+  ASSERT_TRUE(b.valid());
+  EXPECT_EQ(pbtest::SystemB::Decoder(b.as_bytes()).int_b(), 99u);
+}
+
+TEST(TextToProtoTest, ExtensionUnknownName) {
+  auto result = Parse(
+      ".protozero.test.protos.RealFakeEvent",
+      "[protozero.test.protos.BrowserExtension.does_not_exist] { int_a: 1 }");
+  ASSERT_FALSE(result.ok());
+  EXPECT_NE(result.status().message().find("No extension named"),
+            std::string::npos)
+      << result.status().message();
+}
+
+TEST(TextToProtoTest, ExtensionWrongExtendee) {
+  // BrowserExtension.extension_a extends RealFakeEvent, not EveryField.
+  auto result = Parse(
+      ".protozero.test.protos.EveryField",
+      "[protozero.test.protos.BrowserExtension.extension_a] { int_a: 1 }");
+  ASSERT_FALSE(result.ok());
+  EXPECT_NE(result.status().message().find("extends"), std::string::npos)
+      << result.status().message();
+}
+
+TEST(TextToProtoTest, ExtensionScalar) {
+  auto result =
+      Parse(".protozero.test.protos.RealFakeEvent",
+            R"([protozero.test.protos.ScalarBrowserExtension.ext_uint]: 17
+         [protozero.test.protos.ScalarBrowserExtension.ext_string]: "abc"
+         [protozero.test.protos.ScalarBrowserExtension.ext_bool]: true)");
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  protozero::ProtoDecoder dec(result.value().data(), result.value().size());
+  protozero::Field f_uint = dec.FindField(12);
+  ASSERT_TRUE(f_uint.valid());
+  EXPECT_EQ(f_uint.as_uint32(), 17u);
+
+  protozero::Field f_str = dec.FindField(13);
+  ASSERT_TRUE(f_str.valid());
+  EXPECT_EQ(f_str.as_std_string(), "abc");
+
+  protozero::Field f_bool = dec.FindField(14);
+  ASSERT_TRUE(f_bool.valid());
+  EXPECT_TRUE(f_bool.as_bool());
+}
+
+TEST(TextToProtoTest, ExtensionFileScope) {
+  auto result = Parse(".protozero.test.protos.RealFakeEvent",
+                      "[protozero.test.protos.file_scope_ext]: 123");
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  protozero::ProtoDecoder dec(result.value().data(), result.value().size());
+  protozero::Field f = dec.FindField(15);
+  ASSERT_TRUE(f.valid());
+  EXPECT_EQ(f.as_uint32(), 123u);
+}
+
+TEST(TextToProtoTest, ExtensionEmptyBrackets) {
+  auto result = Parse(".protozero.test.protos.RealFakeEvent", "[]: 1");
+  EXPECT_FALSE(result.ok());
+}
+
+}  // namespace
+}  // namespace protozero

--- a/src/shared_lib/test/protos/extensions.pzc.h
+++ b/src/shared_lib/test/protos/extensions.pzc.h
@@ -90,4 +90,22 @@ PERFETTO_PB_EXTENSION_FIELD(protozero_test_protos_BrowserExtension,
                             protozero_test_protos_SystemB,
                             extension_b,
                             11);
+PERFETTO_PB_EXTENSION_FIELD(protozero_test_protos_ScalarBrowserExtension,
+                            protozero_test_protos_RealFakeEvent,
+                            VARINT,
+                            uint32_t,
+                            ext_uint,
+                            12);
+PERFETTO_PB_EXTENSION_FIELD(protozero_test_protos_ScalarBrowserExtension,
+                            protozero_test_protos_RealFakeEvent,
+                            STRING,
+                            const char*,
+                            ext_string,
+                            13);
+PERFETTO_PB_EXTENSION_FIELD(protozero_test_protos_ScalarBrowserExtension,
+                            protozero_test_protos_RealFakeEvent,
+                            VARINT,
+                            bool,
+                            ext_bool,
+                            14);
 #endif  // SRC_SHARED_LIB_TEST_PROTOS_EXTENSIONS_PZC_H_

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -499,6 +499,12 @@ base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
   latest_timestamp_ = std::max(timestamp, latest_timestamp_);
 
   auto& modules = module_context_.modules_by_field;
+  // TODO: decoder.Get(field_id) here shares the num_fields_ gap
+  // described in TypedProtoDecoderBase::GetExtensionSlowly(): a module
+  // registered for a field id in the out-of-tree `extensions 1000 to 1999`
+  // range would not be dispatched, because Get() can't see fields beyond the
+  // highest in-tree field id. Switch this to GetExtensionSlowly() (or the
+  // object-pool approach) once such fields land.
   for (uint32_t field_id = 1; field_id < modules.size(); ++field_id) {
     if (!modules[field_id].empty() && decoder.Get(field_id).valid()) {
       for (ProtoImporterModule* module : modules[field_id]) {

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -908,10 +908,8 @@ class TrackEventEventImporter {
                                     /* close_flow = */ true);
       }
     }
-    constexpr uint32_t kGpuCorrelationFieldId =
-        protos::pbzero::GpuTrackEvent::kGpuCorrelationFieldNumber;
-    protozero::ProtoDecoder event_decoder(blob_);
-    auto gpu_field = event_decoder.FindField(kGpuCorrelationFieldId);
+    auto gpu_field = event_.GetExtensionSlowly<
+        protos::pbzero::GpuTrackEvent::kGpuCorrelationFieldNumber>();
     if (gpu_field.valid()) {
       protos::pbzero::GpuCorrelation::Decoder gpu(gpu_field.as_bytes());
       for (auto it = gpu.render_stage_submission_event_ids(); it; ++it) {

--- a/src/trace_processor/plugins/winscope_importer/winscope_module.cc
+++ b/src/trace_processor/plugins/winscope_importer/winscope_module.cc
@@ -35,9 +35,9 @@
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/plugins/winscope_importer/shell_transitions_tracker.h"
 #include "src/trace_processor/plugins/winscope_importer/winscope.descriptor.h"
+#include "src/trace_processor/plugins/winscope_importer/winscope_proto_mapping.h"
 #include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/tables/winscope_tables_py.h"
-#include "src/trace_processor/plugins/winscope_importer/winscope_proto_mapping.h"
 
 namespace perfetto::trace_processor {
 
@@ -122,31 +122,31 @@ void WinscopeModule::ParseWinscopeExtensionsData(protozero::ConstBytes blob,
                                                  int64_t timestamp,
                                                  const TracePacketData& data) {
   WinscopeExtensionsImpl::Decoder decoder(blob.data, blob.size);
-
-  if (auto field =
-          decoder.Get(WinscopeExtensionsImpl::kInputmethodClientsFieldNumber);
+  if (auto field = decoder.GetExtensionSlowly<
+                   WinscopeExtensionsImpl::kInputmethodClientsFieldNumber>();
       field.valid()) {
     ParseInputMethodClientsData(timestamp, field.as_bytes());
-  } else if (field = decoder.Get(
-                 WinscopeExtensionsImpl::kInputmethodManagerServiceFieldNumber);
+  } else if (field = decoder.GetExtensionSlowly<
+                     WinscopeExtensionsImpl::
+                         kInputmethodManagerServiceFieldNumber>();
              field.valid()) {
     ParseInputMethodManagerServiceData(timestamp, field.as_bytes());
-  } else if (field = decoder.Get(
-                 WinscopeExtensionsImpl::kInputmethodServiceFieldNumber);
+  } else if (field = decoder.GetExtensionSlowly<
+                     WinscopeExtensionsImpl::kInputmethodServiceFieldNumber>();
              field.valid()) {
     ParseInputMethodServiceData(timestamp, field.as_bytes());
-  } else if (field =
-                 decoder.Get(WinscopeExtensionsImpl::kViewcaptureFieldNumber);
+  } else if (field = decoder.GetExtensionSlowly<
+                     WinscopeExtensionsImpl::kViewcaptureFieldNumber>();
              field.valid()) {
     viewcapture_parser_.Parse(timestamp, field.as_bytes(),
                               data.sequence_state.get());
-  } else if (field = decoder.Get(
-                 WinscopeExtensionsImpl::kAndroidInputEventFieldNumber);
+  } else if (field = decoder.GetExtensionSlowly<
+                     WinscopeExtensionsImpl::kAndroidInputEventFieldNumber>();
              field.valid()) {
     android_input_event_parser_.ParseAndroidInputEvent(timestamp,
                                                        field.as_bytes());
-  } else if (field =
-                 decoder.Get(WinscopeExtensionsImpl::kWindowmanagerFieldNumber);
+  } else if (field = decoder.GetExtensionSlowly<
+                     WinscopeExtensionsImpl::kWindowmanagerFieldNumber>();
              field.valid()) {
     windowmanager_parser_.Parse(timestamp, field.as_bytes());
   }

--- a/src/trace_processor/util/descriptors.cc
+++ b/src/trace_processor/util/descriptors.cc
@@ -21,6 +21,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -252,12 +253,22 @@ bool DescriptorPool::DescriptorsStructurallyEqual(
 }
 
 base::Status DescriptorPool::AddExtensionField(
-    const std::string& package_name,
-    protozero::ConstBytes field_desc_proto,
+    const ExtensionInfo& extension,
     std::vector<ExtensionTypeCheck>* extension_type_checks) {
   using FieldDescriptorProto = protos::pbzero::FieldDescriptorProto;
-  FieldDescriptorProto::Decoder f_decoder(field_desc_proto);
+  FieldDescriptorProto::Decoder f_decoder(extension.field_desc_proto);
   auto field = CreateFieldFromDecoder(f_decoder, true);
+
+  std::string_view scope = extension.parent_full_name.empty()
+                               ? extension.package_name
+                               : extension.parent_full_name;
+  PERFETTO_DCHECK(!scope.empty() && scope[0] == '.');
+  scope.remove_prefix(1);
+  std::string extension_full_name(scope);
+  if (!scope.empty())
+    extension_full_name.push_back('.');
+  extension_full_name.append(field.name());
+  field.set_extension_full_name(extension_full_name);
 
   std::string extendee_name = f_decoder.extendee().ToStdString();
   if (extendee_name.empty()) {
@@ -266,7 +277,7 @@ base::Status DescriptorPool::AddExtensionField(
 
   if (extendee_name[0] != '.') {
     // Only prepend if the extendee is not fully qualified
-    extendee_name = package_name + "." + extendee_name;
+    extendee_name = extension.package_name + "." + extendee_name;
   }
   std::optional<uint32_t> extendee = FindDescriptorIdx(extendee_name);
   if (!extendee.has_value()) {
@@ -332,7 +343,8 @@ base::Status DescriptorPool::AddNestedProtoDescriptors(
                                               merge_existing_messages));
   }
   for (auto ext_it = decoder.extension(); ext_it; ++ext_it) {
-    extensions->emplace_back(package_name, *ext_it);
+    extensions->push_back(
+        {package_name, proto_descriptor.full_name(), *ext_it});
   }
   return base::OkStatus();
 }
@@ -410,14 +422,13 @@ base::Status DescriptorPool::AddFromFileDescriptorSet(
           file_name, package, std::nullopt, *enum_it, merge_existing_messages));
     }
     for (auto ext_it = file.extension(); ext_it; ++ext_it) {
-      extensions.emplace_back(package, *ext_it);
+      extensions.push_back({package, /*parent_full_name=*/"", *ext_it});
     }
   }
 
   // Second pass: Add extension fields to the real protos.
   for (const auto& extension : extensions) {
-    RETURN_IF_ERROR(AddExtensionField(extension.first, extension.second,
-                                      &extension_type_checks));
+    RETURN_IF_ERROR(AddExtensionField(extension, &extension_type_checks));
   }
 
   // Third pass: resolve the types of all the fields.

--- a/src/trace_processor/util/descriptors.h
+++ b/src/trace_processor/util/descriptors.h
@@ -29,10 +29,7 @@
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
-
-namespace protozero {
-struct ConstBytes;
-}
+#include "perfetto/protozero/field.h"
 
 namespace perfetto::trace_processor {
 
@@ -56,6 +53,9 @@ class FieldDescriptor {
   bool is_repeated() const { return is_repeated_; }
   bool is_packed() const { return is_packed_; }
   bool is_extension() const { return is_extension_; }
+  const std::string& extension_full_name() const {
+    return extension_full_name_;
+  }
 
   const std::vector<uint8_t>& options() const { return options_; }
   std::vector<uint8_t>* mutable_options() { return &options_; }
@@ -65,6 +65,10 @@ class FieldDescriptor {
 
   void set_resolved_type_name(const std::string& resolved_type_name) {
     resolved_type_name_ = resolved_type_name;
+  }
+
+  void set_extension_full_name(const std::string& extension_full_name) {
+    extension_full_name_ = extension_full_name;
   }
 
  private:
@@ -78,6 +82,7 @@ class FieldDescriptor {
   bool is_repeated_;
   bool is_packed_;
   bool is_extension_;
+  std::string extension_full_name_;
 };
 
 class ProtoDescriptor {
@@ -171,7 +176,12 @@ class ProtoDescriptor {
   std::unordered_map<std::string, int32_t> enum_values_by_name_;
 };
 
-using ExtensionInfo = std::pair<std::string, protozero::ConstBytes>;
+struct ExtensionInfo {
+  std::string package_name;
+  // Enclosing message's full name. Empty for file-scope extends.
+  std::string parent_full_name;
+  protozero::ConstBytes field_desc_proto;
+};
 
 // Sometimes the same extension field number shows up twice with two
 // different type names (this happens during a package rename). We can't
@@ -244,8 +254,7 @@ class DescriptorPool {
                                        bool merge_existing_messages);
 
   base::Status AddExtensionField(
-      const std::string& package_name,
-      protozero::ConstBytes field_desc_proto,
+      const ExtensionInfo& extension,
       std::vector<ExtensionTypeCheck>* extension_type_checks);
 
   // Recursively searches for the given short type in all parent messages

--- a/src/trace_processor/util/protozero_to_json.cc
+++ b/src/trace_processor/util/protozero_to_json.cc
@@ -72,6 +72,9 @@ bool HasFieldOptions(const FieldDescriptor& field_desc) {
 
 std::string FulllyQualifiedFieldName(const ProtoDescriptor& desc,
                                      const FieldDescriptor& field_desc) {
+  if (field_desc.is_extension()) {
+    return field_desc.extension_full_name();
+  }
   return desc.package_name().substr(1) + "." + field_desc.name();
 }
 

--- a/src/trace_processor/util/protozero_to_text.cc
+++ b/src/trace_processor/util/protozero_to_text.cc
@@ -144,12 +144,7 @@ void PrintEnumField(const FieldDescriptor& fd,
 std::string FormattedFieldDescriptorName(
     const FieldDescriptor& field_descriptor) {
   if (field_descriptor.is_extension()) {
-    // Libprotobuf formatter always formats extension field names as fully
-    // qualified names.
-    // TODO(b/197625974): Assuming for now all our extensions will belong to the
-    // perfetto.protos package. Update this if we ever want to support extendees
-    // in different package.
-    return "[perfetto.protos." + field_descriptor.name() + "]";
+    return "[" + field_descriptor.extension_full_name() + "]";
   }
   return field_descriptor.name();
 }

--- a/src/trace_processor/util/protozero_to_text_unittests.cc
+++ b/src/trace_processor/util/protozero_to_text_unittests.cc
@@ -22,6 +22,7 @@
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/protozero/packed_repeated_fields.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
+#include "src/protozero/test/example_proto/extensions.pbzero.h"
 #include "src/protozero/test/example_proto/test_messages.pbzero.h"
 #include "src/trace_processor/importers/proto/track_event.descriptor.h"
 #include "src/trace_processor/test_messages.descriptor.h"
@@ -102,6 +103,31 @@ timestamp_delta_us: 3)",
       "timestamp_delta_us: 3",
       ProtozeroToText(pool, ".perfetto.protos.TrackEvent", binary_proto,
                       kSkipNewLines));
+}
+
+TEST(ProtozeroToTextTest, ExtensionWrapperScoped) {
+  using ::protozero::test::protos::pbzero::BrowserExtension;
+  using ::protozero::test::protos::pbzero::RealFakeEvent;
+  using ::protozero::test::protos::pbzero::SystemA;
+  protozero::HeapBuffered<RealFakeEvent> msg{kChunkSize, kChunkSize};
+  msg->set_base_int(7);
+  auto* ext = msg->BeginNestedMessage<SystemA>(
+      BrowserExtension::kExtensionAFieldNumber);
+  ext->set_int_a(42);
+  auto binary_proto = msg.SerializeAsArray();
+
+  DescriptorPool pool;
+  auto status = pool.AddFromFileDescriptorSet(kTestMessagesDescriptor.data(),
+                                              kTestMessagesDescriptor.size());
+  ASSERT_TRUE(status.ok());
+
+  EXPECT_EQ(
+      "base_int: 7\n"
+      "[protozero.test.protos.BrowserExtension.extension_a] {\n"
+      "  int_a: 42\n"
+      "}",
+      ProtozeroToText(pool, ".protozero.test.protos.RealFakeEvent",
+                      binary_proto, kIncludeNewLines));
 }
 
 // Sets up a descriptor pool with all the messages from


### PR DESCRIPTION
Adds the shared infrastructure needed to define and decode out-of-tree (OOT) proto extensions, independent of any specific extension:

- protozero TypedProtoDecoderBase::GetExtensionSlowly() for resolving extension fields whose ids exceed the highest in-tree field id.
- DescriptorPool / FieldDescriptor support for extension full names (ExtensionInfo carries the enclosing scope), with matching protozero_to_text / protozero_to_json formatting.
- text_to_proto extension support and the tracing_proto_extensions tool, including a --base-descriptor flag so leaf extension protos can be compiled against a prebuilt FileDescriptorSet instead of the full source closure.
- Refactor existing track_event and winscope extension decoding to use GetExtensionSlowly (behaviour-preserving for in-range fields).
