### PR TITLE
tbV2: fix data loss when re-admitting scraped chunks

### DIFF
--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -232,14 +232,17 @@ TBChunk* ChunkSeqIterator::NextChunkInSequence() {
   return next_chunk;
 }
 
-void ChunkSeqIterator::EraseCurrentChunk() {
+void ChunkSeqIterator::EraseCurrentChunk(uint16_t bytes_overwritten_in_chunk) {
   size_t chunk_off = buf_->OffsetOf(chunk_);
   TRACE_BUFFER_V2_DLOG("EraseChunk() id=%u off=%zu", chunk_->chunk_id,
                        chunk_off);
   const uint32_t chunk_size = chunk_->size;
   const bool was_incomplete = chunk_->flags & kChunkIncomplete;
+  PERFETTO_DCHECK(bytes_overwritten_in_chunk <= chunk_->payload_size);
+  const uint16_t payload_read =
+      chunk_->payload_size - bytes_overwritten_in_chunk;
   seq_->last_chunk_consumed = SequenceState::ConsumedChunkInfo{
-      chunk_->chunk_id, chunk_->payload_size, was_incomplete};
+      chunk_->chunk_id, payload_read, was_incomplete};
 
   auto& chunk_list = seq_->chunks;
 
@@ -291,14 +294,20 @@ ChunkSeqReader::ChunkSeqReader(TraceBufferV2* buf,
 
   if (seq_->last_chunk_consumed.has_value()) {
     const auto& last = *seq_->last_chunk_consumed;
-    // Re-admit: an incomplete chunk that was evicted has been re-committed
-    // with strictly more payload. The chunk_id is unchanged, so the +1
-    // successor check below would fire spuriously even though the re-admit
-    // recovered the deferred fragments without losing data. Keep this
-    // predicate in sync with the re-admit acceptance check in
+    // Re-admit: the same incomplete chunk_id was evicted and then re-committed
+    // with more payload. The producer is replaying the bytes we overwrote, so
+    // this is a recovery, not a loss, and the checks below must skip it. Keep
+    // this predicate in sync with the re-admit acceptance check in
     // TraceBufferV2::CopyChunkUntrusted.
     bool readmit = last.was_incomplete && iter_->chunk_id == last.chunk_id;
-    if (!readmit && iter_->chunk_id != last.chunk_id + 1) {
+    // Otherwise, report a data loss in two cases:
+    // 1) a chunk_id discontinuity: one or more chunks in between were dropped.
+    // 2) the chunk_ids are contiguous, but the previous chunk was overwritten
+    //    with packets still unread. The chunk_id arithmetic alone cannot see
+    //    this, because eviction advances last_chunk_consumed.chunk_id, making
+    //    the successor look contiguous.
+    if (!readmit &&
+        (iter_->chunk_id != last.chunk_id + 1 || last.had_unread_on_evict)) {
       seq_->data_loss = true;
     }
   }
@@ -339,7 +348,7 @@ bool ChunkSeqReader::ReadNextPacketInSeqOrder(TracePacket* out_packet) {
         end_reached = true;
       } else {
         // We read all the fragments for the current chunk. Erase it.
-        seq_iter_.EraseCurrentChunk();
+        seq_iter_.EraseCurrentChunk(bytes_overwritten_in_chunk_);
       }
       if (end_reached)
         return false;  // We reached our target chunk (or an incomplete chunk).
@@ -348,6 +357,7 @@ bool ChunkSeqReader::ReadNextPacketInSeqOrder(TracePacket* out_packet) {
         return false;  // There are no more chunks in the sequence.
       iter_ = next_chunk;
       frag_iter_ = FragIterator(next_chunk);
+      bytes_overwritten_in_chunk_ = 0;
       continue;
     }
 
@@ -451,6 +461,14 @@ void ChunkSeqReader::ConsumeFragment(TBChunk* chunk, Frag* frag) {
 
   PERFETTO_DCHECK(chunk->payload_avail >= frag->size_with_header());
   chunk->payload_avail -= frag->size_with_header();
+
+  // In kEraseMode the bytes we just consumed were overwritten, not read
+  // out. Track them so EraseCurrentChunk records the right payload_read.
+  // Only count fragments of iter_, the chunk we are about to erase: fragment
+  // reassembly also consumes continuation fragments from later chunks, and
+  // those bytes don't belong to iter_'s payload.
+  bytes_overwritten_in_chunk_ +=
+      (mode_ == kEraseMode && chunk == iter_) ? frag->size_with_header() : 0;
 
   if (chunk->payload_avail == 0) {
     TRACE_BUFFER_V2_DLOG("  Fully consumed chunk @ %zu", buf_->OffsetOf(chunk));
@@ -767,18 +785,22 @@ void TraceBufferV2::CopyChunkUntrusted(
 
   // Don't allow re-commit of chunks that have been consumed already, unless
   // the chunk was evicted while incomplete (scraped) and the new commit has
-  // strictly more payload. In that case we re-admit it so the previously-
-  // dropped fragments can be recovered. Keep this acceptance condition in
-  // sync with the re-admit branch of the gap check in ChunkSeqReader's ctor.
+  // strictly more payload than the consumer had already read before the
+  // eviction. In that case we re-admit it so the previously-evicted suffix
+  // (including any bytes that were overwritten without being read) is
+  // recovered. Keep this acceptance condition in sync with the re-admit
+  // branch of the gap check in ChunkSeqReader's ctor.
   //
-  // When re-admitting, |previously_consumed_payload| records how many payload
-  // bytes were already consumed before eviction, so we can skip them below.
+  // When re-admitting, |previously_consumed_payload| records how many
+  // payload bytes were already read before the eviction; we skip exactly
+  // that many on the re-admitted chunk so the unread suffix is replayed
+  // from the producer's resubmission.
   uint16_t previously_consumed_payload = 0;
   if (seq.last_chunk_consumed.has_value()) {
     int cmp = ChunkIdCompare(chunk_id, seq.last_chunk_consumed->chunk_id);
     if (cmp == 0 && seq.last_chunk_consumed->was_incomplete &&
-        seq.last_chunk_consumed->payload_size < all_frags_size) {
-      previously_consumed_payload = seq.last_chunk_consumed->payload_size;
+        seq.last_chunk_consumed->payload_read < all_frags_size) {
+      previously_consumed_payload = seq.last_chunk_consumed->payload_read;
       TRACE_BUFFER_V2_DLOG("  Re-admitting chunk %u (prev_payload=%u)",
                            chunk_id, previously_consumed_payload);
     } else if (cmp <= 0) {
@@ -1006,10 +1028,14 @@ void TraceBufferV2::DeleteNextChunksFor(size_t bytes_to_clear) {
       has_cleared_unconsumed_fragments = true;
     }
 
-    // In future this branch should become "&& !protovm_has_consumed_packet"
-    // We shouldn't report a data loss if ProtoVM merged the outgoing packet.
-    if (has_cleared_unconsumed_fragments) {
-      csr.seq()->data_loss = true;
+    // We overwrote a chunk that still held undelivered packets. Mark it on
+    // the just-erased chunk; ChunkSeqReader's ctor turns this into a data
+    // loss unless the chunk is re-admitted with the same chunk_id.
+    // In future this condition should become "&& !protovm_has_consumed_packet"
+    // as we shouldn't report a loss if ProtoVM merged the outgoing packet.
+    if (has_cleared_unconsumed_fragments &&
+        csr.seq()->last_chunk_consumed.has_value()) {
+      csr.seq()->last_chunk_consumed->had_unread_on_evict = true;
     }
 
     // ChunkSeqReader(kEraseMode) must delete the chunk once

--- a/src/tracing/service/trace_buffer_v2.h
+++ b/src/tracing/service/trace_buffer_v2.h
@@ -184,12 +184,22 @@ struct SequenceState {
   // Snapshot of the last chunk that was erased (consumed or evicted) in this
   // sequence. Used to detect gaps between consecutive chunks and to decide
   // whether a re-committed chunk should be accepted or discarded.
-  // |payload_size| and |was_incomplete| capture the chunk's state at the time
-  // of consumption; see CopyChunkUntrusted() for how they are used.
+  // |payload_read| is the count of payload bytes that were read out of the
+  // chunk via ReadNextTracePacket before it left the buffer (see
+  // EraseCurrentChunk() for how it is computed). It equals payload_size for a
+  // chunk drained by reads, and the prefix-read amount for a chunk evicted
+  // with unread bytes (the overwritten suffix is NOT counted). The re-admit
+  // path in CopyChunkUntrusted() skips this many bytes on the resubmitted
+  // chunk so the unread suffix is replayed.
+  // |had_unread_on_evict| is set when the chunk was overwritten while it
+  // still had undelivered packets. Whether that is an actual data loss is
+  // decided when the next chunk is read (ChunkSeqReader's ctor): if the same
+  // chunk_id is re-admitted the bytes come back, otherwise they are lost.
   struct ConsumedChunkInfo {
     ChunkID chunk_id = 0;
-    uint16_t payload_size = 0;
+    uint16_t payload_read = 0;
     bool was_incomplete = false;
+    bool had_unread_on_evict = false;
   };
   std::optional<ConsumedChunkInfo> last_chunk_consumed;
 
@@ -297,7 +307,11 @@ class ChunkSeqIterator {
   ChunkSeqIterator& operator=(const ChunkSeqIterator&) = default;
 
   TBChunk* NextChunkInSequence();
-  void EraseCurrentChunk();
+  // |bytes_overwritten_in_chunk| is the count of the current chunk's payload
+  // bytes this pass overwrote in kEraseMode (zero in kReadMode). It is recorded
+  // on the SequenceState's last_chunk_consumed entry as payload_read; see
+  // ChunkSeqReader::bytes_overwritten_in_chunk_.
+  void EraseCurrentChunk(uint16_t bytes_overwritten_in_chunk);
   TBChunk* chunk() const { return chunk_; }
   bool sequence_gap_detected() const { return sequence_gap_detected_; }
   bool valid() const { return !!seq_ && !!chunk_; }
@@ -375,6 +389,12 @@ class ChunkSeqReader {
   TBChunk* iter_ = nullptr;
 
   FragIterator frag_iter_;
+
+  // Bytes of iter_'s payload that this pass has overwritten. Incremented
+  // by ConsumeFragment when mode_ == kEraseMode; stays 0 in kReadMode and
+  // is reset to 0 on every chunk transition. Passed to EraseCurrentChunk
+  // which records payload_read = payload_size - bytes_overwritten_in_chunk_.
+  uint16_t bytes_overwritten_in_chunk_ = 0;
 };
 
 }  // namespace internal

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -1720,6 +1720,45 @@ TEST_F(TraceBufferV2Test, PacketDropOnOverwrite) {
   ASSERT_TRUE(previous_packet_dropped);
 }
 
+// A chunk is overwritten while it still has unread packets, and the next
+// chunk that survives has the immediately following chunk_id. Because the
+// chunk_ids are consecutive, the gap between them looks like no gap at all,
+// so the drop can only be reported from the flag recorded when the chunk was
+// overwritten. We read chunk 0 fully first so that the overwritten chunk is
+// the one the next read compares against.
+TEST_F(TraceBufferV2Test, PacketDropOnOverwrite_ContiguousChunkId) {
+  ResetBuffer(4096);
+  SuppressClientDchecksForTesting();
+
+  // chunk 0: read it to completion so last_chunk_consumed = {id:0}.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(10, 'a')
+      .CopyIntoTraceBuffer();
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(10, 'a')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());  // erases chunk 0 -> last = {0}.
+
+  // chunk 1: large, never read.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(2000, 'b')
+      .CopyIntoTraceBuffer();
+
+  // chunk 2: large enough to wrap and overwrite chunk 1 while it's unread.
+  // After this, last_chunk_consumed = {id:1, had_unread_on_evict:true}.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(2))
+      .AddPacket(3000, 'c')
+      .CopyIntoTraceBuffer();
+
+  // Reading chunk 2: chunk_id 2 == last(1)+1, so the id-gap check is silent.
+  // The drop is reported only via had_unread_on_evict.
+  bool previous_packet_dropped = false;
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(nullptr, &previous_packet_dropped),
+              ElementsAre(FakePacketFragment(3000, 'c')));
+  EXPECT_TRUE(previous_packet_dropped)
+      << "overwrite of contiguous-id chunk 1 not reported as a drop";
+}
+
 TEST_F(TraceBufferV2Test, Clone_NoFragments) {
   ResetBuffer(4096);
   const char kNumWriters = 3;
@@ -2480,6 +2519,124 @@ TEST_F(TraceBufferV2Test, RescrapeAfterEviction_FullyRead) {
   EXPECT_FALSE(found_a) << "Packet 'a' duplicated after rescrape re-admission";
   EXPECT_FALSE(found_c)
       << "Packet 'c' should still be dropped (chunk incomplete)";
+}
+
+// Scrape → evict (no reads) → complete commit. When buffer pressure wraps
+// over a scraped chunk before the consumer drains it, the chunk's whole
+// payload is overwritten unread. A later complete commit of the same
+// chunk_id must be re-admitted in full, recovering every packet. Since the
+// consumer never saw any of the evicted bytes, no drop is reported.
+TEST_F(TraceBufferV2Test, RescrapeAfterEviction_NoReadsBeforeWrap) {
+  ResetBuffer(4096);
+  SuppressClientDchecksForTesting();
+
+  // Scrape chunk 0 (incomplete) with [a, b, c]. Scraping drops 'c' (the
+  // last fragment), leaving payload_size = payload_avail = a + b.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(20, 'a')
+      .AddPacket(30, 'b')
+      .AddPacket(40, 'c')
+      .PadTo(512)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/false);
+
+  // Fill the rest of the buffer (no reads in between).
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(1))
+      .AddPacket(3568, 'x')
+      .CopyIntoTraceBuffer();
+
+  // A small follow-up write forces a wrap that evicts chunk 0 while every
+  // payload byte is still unread.
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(2))
+      .AddPacket(20, 'y')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(1u, trace_buffer()->stats().write_wrap_count());
+  // chunks_overwritten / bytes_overwritten track buffer pressure, not
+  // consumer-visible drops, so they are expected to be set here.
+  EXPECT_EQ(1u, trace_buffer()->stats().chunks_overwritten());
+  EXPECT_EQ(512u, trace_buffer()->stats().bytes_overwritten());
+
+  // Producer commits chunk 0 with the full payload [a, b, c, d]. The chunk
+  // was evicted while incomplete with nothing read, so it is re-admitted
+  // with all four packets available.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(20, 'a')
+      .AddPacket(30, 'b')
+      .AddPacket(40, 'c')
+      .AddPacket(50, 'd')
+      .PadTo(512)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/true);
+
+  // Drain and verify: a, b, c, d all recovered, none flagged as dropped.
+  trace_buffer()->BeginRead();
+  bool found_a = false, found_b = false, found_c = false, found_d = false;
+  bool a_dropped = false;
+  for (;;) {
+    bool dropped = false;
+    auto p = ReadPacket(/*sequence_properties=*/nullptr, &dropped);
+    if (p.empty())
+      break;
+    if (p.size() != 1)
+      continue;
+    if (p[0] == FakePacketFragment(20, 'a')) {
+      found_a = true;
+      a_dropped = dropped;
+    } else if (p[0] == FakePacketFragment(30, 'b')) {
+      found_b = true;
+    } else if (p[0] == FakePacketFragment(40, 'c')) {
+      found_c = true;
+    } else if (p[0] == FakePacketFragment(50, 'd')) {
+      found_d = true;
+    }
+  }
+  EXPECT_TRUE(found_a) << "Packet 'a' not found after re-admission";
+  EXPECT_TRUE(found_b) << "Packet 'b' not found after re-admission";
+  EXPECT_TRUE(found_c) << "Packet 'c' not found after re-admission";
+  EXPECT_TRUE(found_d) << "Packet 'd' not found after re-admission";
+  EXPECT_FALSE(a_dropped)
+      << "recovered 'a' should not be flagged as a dropped packet";
+}
+
+// A chunk holding the BEGIN of a fragmented packet is overwritten while the
+// chunk holding the continuation (END) survives. During the eviction pass the
+// reader reassembles the packet across both chunks, consuming the continuation
+// fragment that lives in the later chunk. The byte accounting that backs
+// payload_read must charge the evicted chunk only for its own payload, not for
+// the continuation bytes of the surviving chunk.
+TEST_F(TraceBufferV2Test,
+       PacketDropOnOverwrite_FragmentedAcrossSurvivingChunk) {
+  ResetBuffer(4096);
+  SuppressClientDchecksForTesting();
+
+  // chunk 0: 'a' whole + 'b' begin (continues into chunk 1). Unread.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(20, 'a')
+      .AddPacket(100, 'b', kContOnNextChunk)
+      .CopyIntoTraceBuffer();
+
+  // chunk 1: 'b' end (continuation). Unread, and survives the wrap below.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(100, 'b', kContFromPrevChunk)
+      .CopyIntoTraceBuffer();
+
+  // Filler on a different sequence, sized so the next write wraps and evicts
+  // chunk 0 (whose packet 'b' continues into the still-present chunk 1).
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(0))
+      .AddPacket(3790, 'x')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(1))
+      .AddPacket(20, 'y')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(1u, trace_buffer()->stats().write_wrap_count());
+
+  // The eviction of chunk 0 reassembled 'b' across chunks 0 and 1. We should
+  // be able to drain the buffer without tripping any internal accounting
+  // check, and the surviving data must read back cleanly.
+  trace_buffer()->BeginRead();
+  for (;;) {
+    auto p = ReadPacket();
+    if (p.empty())
+      break;
+  }
 }
 
 // Scrape → read → evict → producer completes chunk. The complete commit has


### PR DESCRIPTION
Setup: a RING_BUFFER with a slow consumer (e.g. write_into_file on a long
file_write_period_ms). A chunk gets scraped, then the buffer wraps and
overwrites it before anyone reads it. Later the producer commits that same
chunk again, with more data. We try to re-admit it to recover the lost
packets.

The bug: on re-admit we skip the bytes the consumer "already saw" so we
don't deliver them twice. But we were tracking that as the chunk's *total*
payload, not the bytes actually read. So bytes that were overwritten
without ever being read got skipped too — the producer re-sent them and we
dropped them a second time.

The fix has three parts:

1. Track what was really read. EraseCurrentChunk now records payload_read
  (= payload_size minus the bytes overwritten unread) instead of the full
  payload_size, and re-admit skips only that. The field was renamed from
  payload_size to payload_read to match.

2. Catch silent overwrites. Eviction bumps last_chunk_consumed.chunk_id, so
  a chunk overwritten with unread packets looks like a normal next chunk
  and no gap is reported. We now flag it (had_unread_on_evict) and report
  the loss on the next read — unless the same chunk is re-admitted.

3. Don't miscount fragmented packets. A packet can span two chunks. When we
  erase the first one, reassembly also touches the fragment in the second;
  those bytes belong to the second chunk, not the one being erased. We now
  only count a fragment's bytes against the chunk it lives in. 