### PR TITLE
tools: add trace_replay binary

### DIFF
--- a/docs/design-docs/trace-replay.md
+++ b/docs/design-docs/trace-replay.md
@@ -1,0 +1,310 @@
+# trace_replay Design Document
+
+## Overview
+
+`trace_replay` is a small Linux/Android/macOS test tool that takes an existing
+Perfetto trace and **replays its producer-side traffic against a real `traced`
+daemon** (system or tracebox-spawned). The goal is *not* to produce a
+byte-identical copy of the input trace, but to drive `traced` with realistic
+write patterns so its CPU, memory, and stability can be measured.
+
+Source: `src/tools/trace_replay/`. Binary: `out/<cfg>/trace_replay`.
+
+The headline use case is regression testing the `TraceBufferV2` rewrite — the
+tool exposes `--use-trace-buffer-v2` to flip every buffer to the new
+implementation on a single command line.
+
+## High-level flow
+
+```
+ ┌─────────────┐    ┌────────────┐    ┌──────────────────┐
+ │   Analyze   │ →  │  Forge cfg │ →  │ Spawn N producer │
+ │   input     │    │  + per-pid │    │  subprocesses    │
+ │   .trace    │    │ replay-bin │    │  (this binary)   │
+ └─────────────┘    └────────────┘    └──────────────────┘
+                                              │
+                                              ▼
+                                       ┌──────────────┐
+                                       │ traced (sys  │
+                                       │ or tracebox) │
+                                       └──────────────┘
+                                              ▲
+                                              │
+                                       ┌──────────────┐
+                                       │  perfetto    │
+                                       │  cmdline     │
+                                       │  consumer    │
+                                       └──────────────┘
+```
+
+Inside, the orchestrator process runs in three phases:
+
+1. **Analyze** the input trace, lifting out the original `TraceConfig`, the
+   per-sequence buffer mapping, and a per-pid list of replayable packets.
+2. **Forge** a fresh `TraceConfig` (buffers preserved, all original data
+   sources replaced with `replay.bufN`) and write one binary replay file per
+   producer pid.
+3. **Replay** — start `traced`, fork producer subprocesses that connect via
+   the SDK, then launch `perfetto -c forged.cfg.pb -o out.trace`. Once all
+   producers exit, send SIGINT to perfetto and tear down.
+
+Step 3 can be repeated `--iterations N` times back-to-back for benchmarking.
+
+## Phase 1: trace analysis
+
+`src/tools/trace_replay/trace_analyzer.{h,cc}`.
+
+The input is mmap'd and walked at the `Trace.packet` level using
+`protos::pbzero::Trace::Decoder`. Any `compressed_packets` payload is inflated
+in-process via `trace_processor::util::GzipDecompressor::DecompressFully`
+(self-contained, only depends on zlib) and the inflated bytes are recursively
+re-fed into the same iterator.
+
+For each `TracePacket` we capture:
+
+* `trusted_pid` — the producer process this packet came from. Packets without
+  `trusted_pid` are skipped.
+* `trusted_packet_sequence_id` — the SDK TraceWriter id. `seq_id == 1`
+  (`kServicePacketSequenceID`) is skipped because that's traced itself.
+* `timestamp` and the *effective clock id* (see below).
+* The raw inner bytes of the packet, **with reserved top-level fields
+  stripped** (see [Reserved field stripping](#reserved-field-stripping)).
+* The first `TraceConfig` packet — kept as `original_config`.
+* `trace_stats.writer_stats` entries — used to recover the
+  `sequence_id → buffer_index` map.
+
+### Buffer mapping recovery
+
+Ground truth is `trace_stats.writer_stats`, but in practice that packet is
+often missing or incomplete (e.g. mid-stream snapshots, traces stopped before
+final stats). The tool falls back, per sequence:
+
+1. **By `writer_stats`** if available.
+2. **By content**: inspect the payload field present in any packet on the
+   sequence (`ftrace_events`, `process_stats`, `track_event`,
+   `gpu_counter_event`, etc.) and map that to the corresponding data source
+   name in the original `TraceConfig`, then to its `target_buffer`.
+3. **Default to buffer 0** with a warning.
+
+Strict mode (`--ignore-orphan-writers` *not* set) hard-fails if some sequences
+can't be mapped at all.
+
+### Clock handling — mini clock tracker
+
+The tool resolves only what it can resolve cheaply: it captures the **first**
+`ClockSnapshot` packet and indexes every clock id it contains, computing
+`offset[clock_id] = ref_ts − this_clock_ts` against the trace's primary clock
+(BOOTTIME unless overridden by
+`TraceConfig.builtin_data_sources.primary_trace_clock` or
+`ClockSnapshot.primary_trace_clock`).
+
+For each packet, the **effective clock id** is resolved as:
+
+```
+per-packet timestamp_clock_id  >  TracePacketDefaults.timestamp_clock_id  >  trace default
+```
+
+Then:
+
+* clock in offset map → translate to ref-clock ns, used for ordering and pacing.
+* clock not in offset map (typically `clock_id = 64`, track_event's
+  sequence-local incremental clock) → packet **fires immediately** with no
+  warning. Per-sequence "last good timestamp" fallback handles ts-unset
+  packets (they inherit the previous packet's translated time).
+
+No further snapshots are consulted; suspended time / drift is ignored. This
+is intentional — a tracker capable of doing more would have to pull in
+`trace_processor:lib` (huge), and the tool's purpose doesn't require
+sub-microsecond accuracy.
+
+`--zero-delay` overrides everything and forces `rel_ts_ns = 0` on every
+record (used for max-throughput stress tests).
+
+### Reserved field stripping
+
+`src/tracing/service/packet_stream_validator.cc` rejects any TracePacket
+whose top-level fields include the service-injected ones: `trusted_pid`,
+`trusted_packet_sequence_id`, `trusted_uid`, `trace_config`, `trace_stats`,
+`synchronization_marker`, `compressed_packets`, `machine_id`, `service_event`,
+`trace_provenance`, `protovms`. The original input trace has all of these
+stamped onto every packet, so before persisting bytes for replay the analyzer
+walks each packet with `protozero::ProtoDecoder`, drops the reserved fields,
+and re-encodes the rest. Without this, every replayed packet would be
+silently dropped by traced.
+
+## Phase 2: config forging
+
+`src/tools/trace_replay/config_forger.{h,cc}`.
+
+`ForgeReplayConfig` builds a fresh `TraceConfig` rather than copy-then-clear
+(cppgen `.gen.h` only generates `clear_<field>()` for repeated fields).
+
+* **Kept verbatim**: `buffers` (size, fill policy). Pacing knobs that don't
+  change semantics: `flush_period_ms`, `data_source_stop_timeout_ms`,
+  `write_into_file`, `file_write_period_ms`, `max_file_size_bytes`,
+  `compression_type`, `notify_traceur`, `allow_user_build_tracing`,
+  `prefer_suspend_clock_for_duration`, `incremental_state_config`.
+* **Dropped**: `data_sources`, `trigger_config`, `statsd_metadata`,
+  `statsd_logging`, `android_report_config`, `enable_extra_guardrails`.
+* **Replaced**: one new data source per *used* buffer index N, with
+  `name = "replay.bufN"` and `target_buffer = N`.
+* **`duration_ms`**: copied from `trigger_config.trigger_timeout_ms` if the
+  original had a trigger config, else from `original.duration_ms`, else
+  `max_rel_ts_ms + 5000` as a hard safety cap.
+* **`--use-trace-buffer-v2`**: when set, every kept buffer gets
+  `experimental_mode = TRACE_BUFFER_V2`.
+
+The forged config is serialized to `<out_dir>/forged.cfg.pb`.
+
+## Phase 3: replay file format
+
+`src/tools/trace_replay/replay_file.{h,cc}`.
+
+Per-pid binary file `replay-pid<PID>.bin`:
+
+```
+header  : "PREPLAY1" | uint32 num_records | uint32 num_buffers
+record* : uint64 rel_ts_ns | uint32 orig_seq_id | uint32 buffer_idx |
+          uint32 payload_size | bytes payload
+```
+
+Records are sorted by `rel_ts_ns` ascending. `payload` is the *inner*
+TracePacket body with reserved fields removed.
+
+## Phase 4: orchestration & producer subprocesses
+
+`src/tools/trace_replay/orchestrator.cc` (parent) and
+`src/tools/trace_replay/producer_worker.cc` (child).
+
+### Backend selection
+
+* **System traced** (default if reachable): probe the producer socket, and if
+  `connect()` succeeds, find traced's PID by scanning `/proc/*/comm`.
+* **tracebox** (`--use-tracebox`, or auto-fallback): spawn `tracebox traced`
+  with `PERFETTO_PRODUCER_SOCK_NAME` and `PERFETTO_CONSUMER_SOCK_NAME` pointed
+  at per-run paths under `<out_dir>/socks/`. Wait up to 5 s for the producer
+  socket to appear.
+
+The backend (specifically the tracebox subprocess, if any) is set up **once**
+per `trace_replay` invocation and shared across iterations.
+
+### Producer worker model
+
+Each producer pid in the original trace gets its own subprocess. The parent
+spawns each child by re-exec'ing itself with
+`--replay-worker <replay-file> --ready-fd N` and a pipe.
+
+Inside the worker (`producer_worker.cc`):
+
+* `Tracing::Initialize({kSystemBackend, shmem_size_hint_kb=8192,
+  shmem_page_size_hint_kb=32})`. Big SMB to absorb large ftrace bundles
+  without stalling on every chunk; `kStall` exhausted policy so packets are
+  never silently dropped.
+* For each `buffer_idx` referenced in its replay file, register
+  `ReplayDS<N>` — a template instantiation per buffer index.
+  `ReplayDS<0..31>` static members are defined at the end of the .cc file
+  (32 is a compile-time cap; runs that exceed it refuse to start).
+* Once registered, write `'R'` to the parent's ready pipe.
+* `OnStart` for each instance: capture process-wide `t0` (once via
+  `std::call_once`); for every original `sequence_id` targeting this buffer,
+  spawn one `std::thread`. That thread:
+  1. Sleeps until `t0 + rel_ts_ns` (capped at 50 ms per sleep to stay
+     responsive to OnStop).
+  2. Calls `ReplayDS<N>::Trace([](auto ctx){
+     ctx.NewTracePacket()->AppendRawProtoBytes(payload, size); })`. The
+     SDK's TLS gives each thread its own TraceWriter, so the original
+     fan-out of distinct writers is preserved.
+  3. Final `ctx.Flush()` on its sequence when the records are exhausted.
+* Worker exits once every thread has drained.
+
+### Orchestration loop
+
+```
+for iter in 1..N:
+    sample traced /proc/<pid>/stat            (CPU baseline)
+    spawn producers, wait for 'R' on each ready pipe
+    start ProcMonitor (per-iter monitor.csv, tracks peak RSS)
+    optionally start `perf record -F 99 -g -p <traced_pid>` (--perf)
+    spawn `perfetto -c forged.cfg.pb -o iter-K/out.trace`
+    loop {
+        poll producers; every 10 s emit a progress line
+            (elapsed / total ms, ETA, alive count, traced RSS)
+        break when all producers terminated
+    }
+    sample traced /proc/<pid>/stat            (CPU delta)
+    SIGINT perfetto; bounded 30 s wait
+    SIGINT perf if running
+    stop ProcMonitor; record peak_rss_kb
+SIGTERM tracebox if we spawned it
+```
+
+`base::Subprocess` from `include/perfetto/ext/base/subprocess.h` handles all
+process spawning, ready-pipe `preserve_fds`, and `PR_SET_PDEATHSIG`-based
+cleanup.
+
+## Per-iteration metrics & benchmark output
+
+For each iteration we capture:
+
+* `wall_ms` — time from perfetto launch to last producer exit.
+* `traced_cpu_user_ms` / `traced_cpu_sys_ms` — delta of utime/stime from
+  `/proc/<traced_pid>/stat`, scaled by `_SC_CLK_TCK`.
+* `traced_rss_peak_kb` — atomic peak observed by `ProcMonitor` during the
+  iteration.
+* `out_trace_bytes`.
+
+With `--iterations N > 1`, a Google-Benchmark-style table is printed at
+the end with mean / median / sample stddev / min / max for every metric.
+Single-iteration runs get a compact one-shot summary.
+
+## Output layout
+
+```
+<out_dir>/                          (default: a fresh /tmp/replay.XXXXXX)
+├── forged.cfg.pb                   serialized TraceConfig
+├── replay-pid<PID>.bin             one per producer pid
+├── socks/                          only with --use-tracebox
+│   ├── producer
+│   └── consumer
+└── iter-K/                         per-iteration (single-iter runs write
+    ├── out.trace                    directly under <out_dir>)
+    ├── monitor.csv
+    └── perf.data                   only with --perf
+```
+
+## CLI
+
+```
+trace_replay [options] <input.trace>
+
+  --out-dir DIR              Default: /tmp/replay.XXXXXX (mkdtemp)
+  --iterations N             Default 1; >1 prints a benchmark table
+  --use-tracebox             Spawn our own traced via tracebox
+  --use-trace-buffer-v2      Set experimental_mode=TRACE_BUFFER_V2 on every
+                             buffer in the forged config
+  --perf                     `perf record -F 99 -g` on traced per iteration
+  --monitor-interval-ms N    /proc poll interval (default 250)
+  --ignore-orphan-writers    Drop packets whose seq_id can't be mapped
+  --max-buffers N            Refuse traces with >N buffers (cap 32)
+  --analyze-only             Stop after analysis + config forging
+  --zero-delay               Force rel_ts_ns=0 on every record
+
+Internal:
+  --replay-worker FILE --ready-fd N
+                             Child-process entry point. Not for human use.
+```
+
+## Known caveats
+
+* **32-buffer compile-time cap** (`ReplayDS<0..31>`). A trace with more
+  buffers is refused.
+* **Real-time pacing**: a 957 s original trace takes ~957 s to replay
+  (use `--zero-delay` to blast it as fast as possible).
+* The output trace is *not* byte-identical to the input. `trusted_*` fields
+  are re-stamped by traced, sequence ids are re-assigned by the SDK, and
+  packets in clocks absent from the first ClockSnapshot fire immediately
+  rather than at their original times. The traffic *shape* (per-buffer
+  pressure, packet sizes, per-sequence fan-out) is what we preserve.
+* The clock tracker uses only the first snapshot; if BOOTTIME and MONOTONIC
+  drift later in the trace (e.g. across a suspend), replayed timestamps will
+  diverge slightly from the original. Out of scope for this tool.

--- a/src/tools/BUILD.gn
+++ b/src/tools/BUILD.gn
@@ -38,6 +38,7 @@ group("tools") {
       "cpu_utilization",
       "dump_ftrace_stats",
       "skippy",
+      "trace_replay",
     ]
   }
 }

--- a/src/tools/trace_replay/BUILD.gn
+++ b/src/tools/trace_replay/BUILD.gn
@@ -1,0 +1,45 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+executable("trace_replay") {
+  testonly = true
+  deps = [
+    "../../../gn:default_deps",
+    "../../../include/perfetto/tracing",
+    "../../../protos/perfetto/common:cpp",
+    "../../../protos/perfetto/common:zero",
+    "../../../protos/perfetto/config:cpp",
+    "../../../protos/perfetto/config:zero",
+    "../../../protos/perfetto/trace:zero",
+    "../../base",
+    "../../trace_processor/util:gzip",
+    "../../tracing:client_api",
+    "../../tracing:platform_impl",
+  ]
+  sources = [
+    "config_forger.cc",
+    "config_forger.h",
+    "main.cc",
+    "orchestrator.cc",
+    "orchestrator.h",
+    "proc_monitor.cc",
+    "proc_monitor.h",
+    "producer_worker.cc",
+    "producer_worker.h",
+    "replay_file.cc",
+    "replay_file.h",
+    "trace_analyzer.cc",
+    "trace_analyzer.h",
+  ]
+}

--- a/src/tools/trace_replay/config_forger.cc
+++ b/src/tools/trace_replay/config_forger.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/tools/trace_replay/config_forger.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "protos/perfetto/config/data_source_config.gen.h"
+
+namespace perfetto {
+namespace trace_replay {
+
+protos::gen::TraceConfig ForgeReplayConfig(
+    const protos::gen::TraceConfig& original,
+    const std::set<uint32_t>& used_buffers,
+    uint64_t max_rel_ts_ns,
+    const ForgeOptions& fopts) {
+  // Build the forged config from scratch: the cppgen `.gen.h` plugin only
+  // emits `clear_<field>()` for repeated fields, so we can't "deep-copy then
+  // drop" optionals. Instead we copy only the fields we want to preserve.
+  protos::gen::TraceConfig cfg;
+
+  // Buffers are copied verbatim — size, fill policy, etc. stay the same.
+  // Optionally force every buffer to use TRACE_BUFFER_V2.
+  for (const auto& buf : original.buffers()) {
+    auto* nb = cfg.add_buffers();
+    *nb = buf;
+    if (fopts.use_trace_buffer_v2) {
+      nb->set_experimental_mode(
+          protos::gen::TraceConfig_BufferConfig::TRACE_BUFFER_V2);
+    }
+  }
+
+  // Pass-through pacing knobs and write-into-file behaviour so the replay
+  // session pressures traced the same way the original did.
+  if (original.has_flush_period_ms())
+    cfg.set_flush_period_ms(original.flush_period_ms());
+  if (original.has_data_source_stop_timeout_ms())
+    cfg.set_data_source_stop_timeout_ms(original.data_source_stop_timeout_ms());
+  if (original.has_write_into_file())
+    cfg.set_write_into_file(original.write_into_file());
+  if (original.has_file_write_period_ms())
+    cfg.set_file_write_period_ms(original.file_write_period_ms());
+  if (original.has_max_file_size_bytes())
+    cfg.set_max_file_size_bytes(original.max_file_size_bytes());
+  if (original.has_compression_type())
+    cfg.set_compression_type(original.compression_type());
+  if (original.has_notify_traceur())
+    cfg.set_notify_traceur(original.notify_traceur());
+  if (original.has_allow_user_build_tracing())
+    cfg.set_allow_user_build_tracing(original.allow_user_build_tracing());
+  if (original.has_prefer_suspend_clock_for_duration())
+    cfg.set_prefer_suspend_clock_for_duration(
+        original.prefer_suspend_clock_for_duration());
+  if (original.has_incremental_state_config())
+    *cfg.mutable_incremental_state_config() =
+        original.incremental_state_config();
+
+  // duration_ms policy.
+  uint32_t duration_ms = 0;
+  if (original.has_trigger_config() &&
+      original.trigger_config().trigger_timeout_ms() > 0) {
+    duration_ms = original.trigger_config().trigger_timeout_ms();
+  } else if (original.has_duration_ms() && original.duration_ms() > 0) {
+    duration_ms = original.duration_ms();
+  } else {
+    uint64_t safety = max_rel_ts_ns / 1000000ull + 5000ull;
+    if (safety > std::numeric_limits<uint32_t>::max())
+      safety = std::numeric_limits<uint32_t>::max();
+    duration_ms = static_cast<uint32_t>(safety);
+  }
+  cfg.set_duration_ms(duration_ms);
+
+  // Inject one data source per used buffer.
+  std::vector<uint32_t> sorted(used_buffers.begin(), used_buffers.end());
+  std::sort(sorted.begin(), sorted.end());
+  for (uint32_t buf : sorted) {
+    auto* ds = cfg.add_data_sources();
+    auto* dc = ds->mutable_config();
+    dc->set_name("replay.buf" + std::to_string(buf));
+    dc->set_target_buffer(buf);
+  }
+
+  return cfg;
+}
+
+}  // namespace trace_replay
+}  // namespace perfetto

--- a/src/tools/trace_replay/config_forger.h
+++ b/src/tools/trace_replay/config_forger.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TOOLS_TRACE_REPLAY_CONFIG_FORGER_H_
+#define SRC_TOOLS_TRACE_REPLAY_CONFIG_FORGER_H_
+
+#include <cstdint>
+#include <set>
+
+#include "protos/perfetto/config/trace_config.gen.h"
+
+namespace perfetto {
+namespace trace_replay {
+
+// Builds a replay TraceConfig from the original config:
+//  - Keeps buffers verbatim.
+//  - Drops data_sources, trigger_config, statsd_*, android_report_config,
+//    enable_extra_guardrails.
+//  - Adds one data source per buffer index in `used_buffers`, named
+//    "replay.buf<N>", with target_buffer = N.
+//  - duration_ms: copied from original.trigger_config.trigger_timeout_ms if
+//    present, else original.duration_ms if >0, else
+//    max_rel_ts_ns/1e6 + 5000 (safety cap).
+struct ForgeOptions {
+  bool use_trace_buffer_v2 = false;
+};
+
+protos::gen::TraceConfig ForgeReplayConfig(
+    const protos::gen::TraceConfig& original,
+    const std::set<uint32_t>& used_buffers,
+    uint64_t max_rel_ts_ns,
+    const ForgeOptions& fopts = {});
+
+}  // namespace trace_replay
+}  // namespace perfetto
+
+#endif  // SRC_TOOLS_TRACE_REPLAY_CONFIG_FORGER_H_

--- a/src/tools/trace_replay/main.cc
+++ b/src/tools/trace_replay/main.cc
@@ -49,7 +49,10 @@ void PrintUsage(const char* argv0) {
       "                            TRACE_BUFFER_V2.\n"
       "  --use-tracebox            Spawn our own traced via tracebox\n"
       "                            instead of using the system one.\n"
-      "  --perf                    Run `perf record` on traced.\n"
+      "  --perf                    Run `perf record -g` on traced (callstack\n"
+      "                            sampling).\n"
+      "  --perf-stat               Run `perf stat` on traced (counters only,\n"
+      "                            no callstacks). Cheaper than --perf.\n"
       "  --monitor-interval-ms N   /proc poll interval (default 250).\n"
       "  --ignore-orphan-writers   Drop packets whose sequence_id is\n"
       "                            missing from trace_stats.writer_stats.\n"
@@ -91,6 +94,7 @@ int main(int argc, char** argv) {
       {"zero-delay", no_argument, nullptr, 1008},
       {"iterations", required_argument, nullptr, 1009},
       {"use-trace-buffer-v2", no_argument, nullptr, 1010},
+      {"perf-stat", no_argument, nullptr, 1011},
       {"replay-worker", required_argument, nullptr, 1100},
       {"ready-fd", required_argument, nullptr, 1101},
       {"help", no_argument, nullptr, 'h'},
@@ -137,6 +141,9 @@ int main(int argc, char** argv) {
         break;
       case 1010:
         oo.use_trace_buffer_v2 = true;
+        break;
+      case 1011:
+        oo.capture_perf_stat = true;
         break;
       case 1100:
         is_worker = true;

--- a/src/tools/trace_replay/main.cc
+++ b/src/tools/trace_replay/main.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "perfetto/base/build_config.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/getopt.h"
+#include "perfetto/ext/base/string_utils.h"
+
+#include "src/tools/trace_replay/orchestrator.h"
+#include "src/tools/trace_replay/producer_worker.h"
+
+namespace perfetto {
+namespace trace_replay {
+namespace {
+
+void PrintUsage(const char* argv0) {
+  fprintf(
+      stderr,
+      "Usage: %s [options] <input.trace>\n"
+      "\n"
+      "Replay a Perfetto trace against the running traced (or tracebox)\n"
+      "in order to assess service-side performance.\n"
+      "\n"
+      "Options:\n"
+      "  --out-dir DIR             Output directory (artifacts go here).\n"
+      "                            Default: a fresh /tmp/replay.XXXXXX.\n"
+      "  --iterations N            Run the replay N times (default 1) and\n"
+      "                            print a benchmark-style summary.\n"
+      "  --use-trace-buffer-v2     Force every buffer in the forged config\n"
+      "                            to BufferConfig.experimental_mode =\n"
+      "                            TRACE_BUFFER_V2.\n"
+      "  --use-tracebox            Spawn our own traced via tracebox\n"
+      "                            instead of using the system one.\n"
+      "  --perf                    Run `perf record` on traced.\n"
+      "  --monitor-interval-ms N   /proc poll interval (default 250).\n"
+      "  --ignore-orphan-writers   Drop packets whose sequence_id is\n"
+      "                            missing from trace_stats.writer_stats.\n"
+      "  --max-buffers N           Refuse traces with more buffers than\n"
+      "                            this (default 32, hard cap 32).\n"
+      "  --analyze-only            Run analysis + config forge, no replay.\n"
+      "  --zero-delay              Skip real-time pacing entirely; fire\n"
+      "                            every packet ASAP. Required when the\n"
+      "                            trace contains non-default clocks.\n"
+      "\n"
+      "Internal:\n"
+      "  --replay-worker FILE --ready-fd N\n"
+      "                            Invoked by the orchestrator in child\n"
+      "                            processes; not for human use.\n",
+      argv0);
+}
+
+}  // namespace
+}  // namespace trace_replay
+}  // namespace perfetto
+
+int main(int argc, char** argv) {
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) &&   \
+    !PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID) && \
+    !PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE)
+  fprintf(stderr, "trace_replay is supported only on Linux/Android/macOS.\n");
+  return 1;
+#else
+  using namespace perfetto::trace_replay;
+
+  static const struct option kLongOpts[] = {
+      {"out-dir", required_argument, nullptr, 1001},
+      {"use-tracebox", no_argument, nullptr, 1002},
+      {"perf", no_argument, nullptr, 1003},
+      {"monitor-interval-ms", required_argument, nullptr, 1004},
+      {"ignore-orphan-writers", no_argument, nullptr, 1005},
+      {"max-buffers", required_argument, nullptr, 1006},
+      {"analyze-only", no_argument, nullptr, 1007},
+      {"zero-delay", no_argument, nullptr, 1008},
+      {"iterations", required_argument, nullptr, 1009},
+      {"use-trace-buffer-v2", no_argument, nullptr, 1010},
+      {"replay-worker", required_argument, nullptr, 1100},
+      {"ready-fd", required_argument, nullptr, 1101},
+      {"help", no_argument, nullptr, 'h'},
+      {nullptr, 0, nullptr, 0},
+  };
+
+  OrchestratorOptions oo;
+  ProducerWorkerOptions pw;
+  bool is_worker = false;
+
+  for (;;) {
+    int c = getopt_long(argc, argv, "h", kLongOpts, nullptr);
+    if (c == -1)
+      break;
+    switch (c) {
+      case 1001:
+        oo.out_dir = optarg;
+        break;
+      case 1002:
+        oo.use_tracebox = true;
+        break;
+      case 1003:
+        oo.capture_perf = true;
+        break;
+      case 1004:
+        oo.monitor_interval_ms = static_cast<uint32_t>(atoi(optarg));
+        break;
+      case 1005:
+        oo.ignore_orphan_writers = true;
+        break;
+      case 1006:
+        oo.max_buffers = static_cast<uint32_t>(atoi(optarg));
+        break;
+      case 1007:
+        oo.analyze_only = true;
+        break;
+      case 1008:
+        oo.zero_delay = true;
+        break;
+      case 1009:
+        oo.iterations = static_cast<uint32_t>(atoi(optarg));
+        if (oo.iterations == 0)
+          oo.iterations = 1;
+        break;
+      case 1010:
+        oo.use_trace_buffer_v2 = true;
+        break;
+      case 1100:
+        is_worker = true;
+        pw.replay_file = optarg;
+        break;
+      case 1101:
+        pw.ready_fd = atoi(optarg);
+        break;
+      case 'h':
+      default:
+        PrintUsage(argv[0]);
+        return c == 'h' ? 0 : 1;
+    }
+  }
+
+  if (is_worker) {
+    if (pw.replay_file.empty()) {
+      fprintf(stderr, "--replay-worker requires a file argument.\n");
+      return 1;
+    }
+    return RunProducerWorker(pw);
+  }
+
+  if (optind >= argc) {
+    PrintUsage(argv[0]);
+    return 1;
+  }
+  oo.input_trace_path = argv[optind];
+
+  return RunOrchestrator(oo);
+#endif
+}

--- a/src/tools/trace_replay/orchestrator.cc
+++ b/src/tools/trace_replay/orchestrator.cc
@@ -569,14 +569,31 @@ int RunOrchestrator(const OrchestratorOptions& opts) {
                                     opts.monitor_interval_ms));
       monitor->Start();
     }
+    // perf record (sampling + callstacks) or perf stat (counters only).
+    // We sample on `task-clock` rather than `cycles` so this works in
+    // environments without a hardware PMU (containers, VMs).
     std::unique_ptr<base::Subprocess> perf;
     if (opts.capture_perf && backend.traced_pid > 0) {
-      perf.reset(new base::Subprocess({"perf", "record", "-F", "99", "-g", "-p",
-                                       std::to_string(backend.traced_pid), "-o",
-                                       iter_dir + "/perf.data"}));
+      perf.reset(new base::Subprocess(
+          {"perf", "record", "-e", "task-clock", "-F", "4999", "-g", "-p",
+           std::to_string(backend.traced_pid), "-o",
+           iter_dir + "/perf.data"}));
       perf->args.stdout_mode = base::Subprocess::OutputMode::kInherit;
       perf->args.stderr_mode = base::Subprocess::OutputMode::kInherit;
       perf->Start();
+    }
+    std::unique_ptr<base::Subprocess> perf_stat;
+    if (opts.capture_perf_stat && backend.traced_pid > 0) {
+      perf_stat.reset(new base::Subprocess(
+          {"perf", "stat", "-e",
+           "task-clock,context-switches,cpu-migrations,page-faults,"
+           "minor-faults,major-faults,cycles,instructions,branch-misses,"
+           "cache-references,cache-misses",
+           "-p", std::to_string(backend.traced_pid), "-o",
+           iter_dir + "/perf.stat.txt"}));
+      perf_stat->args.stdout_mode = base::Subprocess::OutputMode::kInherit;
+      perf_stat->args.stderr_mode = base::Subprocess::OutputMode::kInherit;
+      perf_stat->Start();
     }
 
     // Launch perfetto consumer.
@@ -663,6 +680,10 @@ int RunOrchestrator(const OrchestratorOptions& opts) {
     if (perf) {
       perf->Kill(SIGINT);
       perf->Wait(10000);
+    }
+    if (perf_stat) {
+      perf_stat->Kill(SIGINT);
+      perf_stat->Wait(10000);
     }
     if (monitor)
       monitor->Stop();

--- a/src/tools/trace_replay/orchestrator.cc
+++ b/src/tools/trace_replay/orchestrator.cc
@@ -1,0 +1,690 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/tools/trace_replay/orchestrator.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+#include <memory>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/time.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/pipe.h"
+#include "perfetto/ext/base/scoped_file.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/subprocess.h"
+#include "perfetto/ext/base/watchdog_posix.h"
+
+#include "src/tools/trace_replay/config_forger.h"
+#include "src/tools/trace_replay/proc_monitor.h"
+#include "src/tools/trace_replay/replay_file.h"
+#include "src/tools/trace_replay/trace_analyzer.h"
+
+namespace perfetto {
+namespace trace_replay {
+
+namespace {
+
+std::string DefaultOutDir() {
+  char tmpl[] = "/tmp/replay.XXXXXX";
+  char* p = mkdtemp(tmpl);
+  if (!p) {
+    char fb[64];
+    snprintf(fb, sizeof(fb), "/tmp/replay.%d", static_cast<int>(getpid()));
+    return fb;
+  }
+  return std::string(p);
+}
+
+// Reads /proc/<pid>/stat into `out`. Returns false if the process is gone.
+bool ReadTracedStats(int pid, base::ProcStat* out) {
+  if (pid <= 0)
+    return false;
+  char path[64];
+  snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+  base::ScopedFile fd(base::OpenFile(path, O_RDONLY));
+  if (!fd)
+    return false;
+  return base::ReadProcStat(fd.get(), out);
+}
+
+long ReadTracedRssKb(int pid) {
+  if (pid <= 0)
+    return -1;
+  char path[64];
+  snprintf(path, sizeof(path), "/proc/%d/statm", pid);
+  std::string s;
+  if (!base::ReadFile(path, &s))
+    return -1;
+  long sz = 0, rss = 0;
+  if (sscanf(s.c_str(), "%ld %ld", &sz, &rss) != 2)
+    return -1;
+  return rss * (sysconf(_SC_PAGESIZE) / 1024);
+}
+
+bool MakeDirP(const std::string& path) {
+  if (mkdir(path.c_str(), 0755) == 0)
+    return true;
+  if (errno == EEXIST) {
+    struct stat st{};
+    return stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+  }
+  PERFETTO_ELOG("mkdir(%s) failed: %s", path.c_str(), strerror(errno));
+  return false;
+}
+
+bool WriteWholeFile(const std::string& path, const void* data, size_t size) {
+  base::ScopedFile fd(base::OpenFile(path, O_WRONLY | O_CREAT | O_TRUNC, 0644));
+  if (!fd) {
+    PERFETTO_ELOG("Cannot open %s: %s", path.c_str(), strerror(errno));
+    return false;
+  }
+  return base::WriteAll(fd.get(), data, size) == static_cast<ssize_t>(size);
+}
+
+// Returns the absolute path to argv[0], resolving "./" etc. so we can spawn
+// ourselves as a producer worker.
+std::string ResolveSelfExe() {
+  char buf[PATH_MAX];
+  ssize_t n = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+  if (n > 0) {
+    buf[n] = '\0';
+    return std::string(buf);
+  }
+  return std::string("trace_replay");
+}
+
+// Returns the dir component of `path`, or "." if there's no slash.
+std::string DirName(const std::string& path) {
+  auto slash = path.find_last_of('/');
+  return slash == std::string::npos ? std::string(".") : path.substr(0, slash);
+}
+
+// Tries to connect() to the given UNIX socket path. Returns true on success.
+bool CanConnectToUnixSocket(const std::string& path) {
+  int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0)
+    return false;
+  struct sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  if (path.size() >= sizeof(addr.sun_path)) {
+    close(fd);
+    return false;
+  }
+  memcpy(addr.sun_path, path.c_str(), path.size() + 1);
+  bool ok =
+      connect(fd, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) == 0;
+  close(fd);
+  return ok;
+}
+
+// Reads /proc/PID/comm for every PID dir; returns the first PID whose comm
+// matches `comm`. -1 if not found.
+int FindProcessByComm(const std::string& comm) {
+  DIR* d = opendir("/proc");
+  if (!d)
+    return -1;
+  int found = -1;
+  while (struct dirent* ent = readdir(d)) {
+    if (ent->d_type != DT_DIR)
+      continue;
+    int pid = atoi(ent->d_name);
+    if (pid <= 0)
+      continue;
+    std::string p = std::string("/proc/") + ent->d_name + "/comm";
+    std::string content;
+    if (!base::ReadFile(p, &content))
+      continue;
+    // /proc/<pid>/comm has a trailing newline.
+    while (!content.empty() && (content.back() == '\n' || content.back() == 0))
+      content.pop_back();
+    if (content == comm) {
+      found = pid;
+      break;
+    }
+  }
+  closedir(d);
+  return found;
+}
+
+struct BackendInfo {
+  std::string producer_sock;
+  std::string consumer_sock;
+  int traced_pid = -1;
+  std::unique_ptr<base::Subprocess> tracebox;  // if we spawned it
+};
+
+struct IterationMetrics {
+  std::string iter_dir;
+  double wall_ms = 0;
+  double traced_cpu_user_ms = 0;
+  double traced_cpu_sys_ms = 0;
+  long traced_rss_peak_kb = 0;
+  size_t out_trace_bytes = 0;
+};
+
+void PrintSingleRunSummary(const IterationMetrics& m) {
+  fprintf(stderr,
+          "\n------------- trace_replay summary -------------\n"
+          "  wall                 : %10.1f ms\n"
+          "  traced cpu (user)    : %10.1f ms\n"
+          "  traced cpu (sys)     : %10.1f ms\n"
+          "  traced cpu (total)   : %10.1f ms\n"
+          "  traced rss peak      : %10ld kB\n"
+          "  output trace size    : %10zu B\n"
+          "------------------------------------------------\n",
+          m.wall_ms, m.traced_cpu_user_ms, m.traced_cpu_sys_ms,
+          m.traced_cpu_user_ms + m.traced_cpu_sys_ms, m.traced_rss_peak_kb,
+          m.out_trace_bytes);
+}
+
+struct Stats {
+  double mean = 0, median = 0, stddev = 0, min = 0, max = 0;
+};
+
+template <typename Getter>
+Stats ComputeStats(const std::vector<IterationMetrics>& xs, Getter g) {
+  std::vector<double> vs;
+  vs.reserve(xs.size());
+  for (const auto& x : xs)
+    vs.push_back(g(x));
+  std::sort(vs.begin(), vs.end());
+  Stats s;
+  if (vs.empty())
+    return s;
+  s.min = vs.front();
+  s.max = vs.back();
+  s.median = vs[vs.size() / 2];
+  double sum = 0;
+  for (double v : vs)
+    sum += v;
+  s.mean = sum / static_cast<double>(vs.size());
+  if (vs.size() > 1) {
+    double sq = 0;
+    for (double v : vs) {
+      double d = v - s.mean;
+      sq += d * d;
+    }
+    s.stddev =
+        std::sqrt(sq / static_cast<double>(vs.size() - 1));  // sample stddev
+  }
+  return s;
+}
+
+void PrintBenchmarkSummary(const std::vector<IterationMetrics>& ms) {
+  const Stats wall =
+      ComputeStats(ms, [](const IterationMetrics& m) { return m.wall_ms; });
+  const Stats cpu = ComputeStats(ms, [](const IterationMetrics& m) {
+    return m.traced_cpu_user_ms + m.traced_cpu_sys_ms;
+  });
+  const Stats rss = ComputeStats(ms, [](const IterationMetrics& m) {
+    return static_cast<double>(m.traced_rss_peak_kb);
+  });
+  const Stats out_sz = ComputeStats(ms, [](const IterationMetrics& m) {
+    return static_cast<double>(m.out_trace_bytes);
+  });
+
+  fprintf(stderr,
+          "\n========================= trace_replay benchmark "
+          "=========================\n");
+  fprintf(stderr, "Iterations: %zu\n\n", ms.size());
+  fprintf(stderr, "%-22s %12s %12s %12s %12s %12s\n", "Metric", "mean",
+          "median", "stddev", "min", "max");
+  fprintf(stderr,
+          "------------------------------------------------------------------"
+          "----------\n");
+  fprintf(stderr, "%-22s %12.1f %12.1f %12.1f %12.1f %12.1f\n", "wall (ms)",
+          wall.mean, wall.median, wall.stddev, wall.min, wall.max);
+  fprintf(stderr, "%-22s %12.1f %12.1f %12.1f %12.1f %12.1f\n",
+          "traced cpu (ms)", cpu.mean, cpu.median, cpu.stddev, cpu.min,
+          cpu.max);
+  fprintf(stderr, "%-22s %12.0f %12.0f %12.1f %12.0f %12.0f\n",
+          "traced rss peak (kB)", rss.mean, rss.median, rss.stddev, rss.min,
+          rss.max);
+  fprintf(stderr, "%-22s %12.0f %12.0f %12.1f %12.0f %12.0f\n",
+          "output trace (bytes)", out_sz.mean, out_sz.median, out_sz.stddev,
+          out_sz.min, out_sz.max);
+  fprintf(stderr,
+          "==================================================================="
+          "=========\n\n");
+}
+
+bool SetupBackend(const OrchestratorOptions& opts,
+                  const std::string& out_dir,
+                  BackendInfo* info) {
+  if (!opts.use_tracebox) {
+    // Try system traced first.
+    const char* def_prod = getenv("PERFETTO_PRODUCER_SOCK_NAME");
+    if (!def_prod)
+      def_prod =
+#if defined(__ANDROID__)
+          "/dev/socket/traced_producer";
+#else
+          "/tmp/perfetto-producer";
+#endif
+    if (CanConnectToUnixSocket(def_prod)) {
+      info->producer_sock = def_prod;
+      const char* def_cons = getenv("PERFETTO_CONSUMER_SOCK_NAME");
+      if (!def_cons)
+        def_cons =
+#if defined(__ANDROID__)
+            "/dev/socket/traced_consumer";
+#else
+            "/tmp/perfetto-consumer";
+#endif
+      info->consumer_sock = def_cons;
+      info->traced_pid = FindProcessByComm("traced");
+      if (info->traced_pid < 0) {
+        PERFETTO_ELOG(
+            "Connected to system producer socket but could not find a "
+            "process named 'traced' in /proc. Monitoring will be skipped.");
+      }
+      PERFETTO_LOG("Using system traced (pid=%d, sock=%s)", info->traced_pid,
+                   def_prod);
+      return true;
+    }
+    PERFETTO_LOG(
+        "System producer socket %s unreachable; falling back to tracebox.",
+        def_prod);
+  }
+
+  // tracebox path.
+  std::string sock_dir = out_dir + "/socks";
+  if (!MakeDirP(sock_dir))
+    return false;
+  info->producer_sock = sock_dir + "/producer";
+  info->consumer_sock = sock_dir + "/consumer";
+
+  std::string self = ResolveSelfExe();
+  std::string outbin = DirName(self);
+  std::string tracebox_path = outbin + "/tracebox";
+  struct stat st{};
+  if (stat(tracebox_path.c_str(), &st) != 0) {
+    PERFETTO_ELOG(
+        "tracebox not found next to %s (expected %s). Build it with "
+        "`tools/ninja -C %s tracebox`.",
+        self.c_str(), tracebox_path.c_str(), outbin.c_str());
+    return false;
+  }
+
+  info->tracebox.reset(new base::Subprocess({tracebox_path, "traced"}));
+  info->tracebox->args.env = {
+      "PERFETTO_PRODUCER_SOCK_NAME=" + info->producer_sock,
+      "PERFETTO_CONSUMER_SOCK_NAME=" + info->consumer_sock,
+  };
+  info->tracebox->args.stdout_mode = base::Subprocess::OutputMode::kInherit;
+  info->tracebox->args.stderr_mode = base::Subprocess::OutputMode::kInherit;
+  info->tracebox->Start();
+  info->traced_pid = info->tracebox->pid();
+  PERFETTO_LOG("Spawned tracebox traced (pid=%d, prod=%s, cons=%s)",
+               info->traced_pid, info->producer_sock.c_str(),
+               info->consumer_sock.c_str());
+
+  // Wait until producer socket becomes reachable (up to 5s).
+  for (int i = 0; i < 50; i++) {
+    if (CanConnectToUnixSocket(info->producer_sock))
+      return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  PERFETTO_ELOG("tracebox traced did not come up within 5s");
+  return false;
+}
+
+}  // namespace
+
+int RunOrchestrator(const OrchestratorOptions& opts) {
+  if (opts.input_trace_path.empty()) {
+    PERFETTO_ELOG("No input trace path");
+    return 1;
+  }
+
+  std::string out_dir = opts.out_dir.empty() ? DefaultOutDir() : opts.out_dir;
+  if (!MakeDirP(out_dir))
+    return 1;
+
+  PERFETTO_LOG("Analyzing %s ...", opts.input_trace_path.c_str());
+  TraceAnalysis ana;
+  AnalyzeOptions ao;
+  ao.ignore_orphan_writers = opts.ignore_orphan_writers;
+  ao.zero_delay = opts.zero_delay;
+  auto status = AnalyzeTraceFile(opts.input_trace_path, ao, &ana);
+  if (!status.ok()) {
+    PERFETTO_ELOG("Analysis failed: %s", status.c_message());
+    return 1;
+  }
+
+  std::set<uint32_t> used_buffers;
+  for (const auto& kv : ana.records_by_pid) {
+    for (const auto& r : kv.second)
+      used_buffers.insert(r.buffer_idx);
+  }
+
+  if (used_buffers.empty()) {
+    PERFETTO_ELOG("No replayable packets found in the input trace");
+    return 1;
+  }
+
+  uint32_t max_buf_idx = *used_buffers.rbegin();
+  if (max_buf_idx + 1 > opts.max_buffers) {
+    PERFETTO_ELOG("Input trace uses buffer index %u, exceeds --max-buffers=%u",
+                  max_buf_idx, opts.max_buffers);
+    return 1;
+  }
+  if (max_buf_idx + 1 > 32) {
+    PERFETTO_ELOG(
+        "Replay supports at most 32 buffers (compile-time ReplayDS<0..31>). "
+        "Trace uses buf=%u.",
+        max_buf_idx);
+    return 1;
+  }
+
+  uint32_t num_buffers =
+      static_cast<uint32_t>(ana.original_config.buffers().size());
+
+  PERFETTO_LOG("Trace summary: pids=%zu  total_packets=%" PRIu64
+               "  buffers_used=%zu  "
+               "(of %u in cfg)  min_ts=%" PRIu64 "  max_rel_ts_ms=%" PRIu64
+               "  skipped_service=%" PRIu64 "  skipped_no_pid=%" PRIu64,
+               ana.records_by_pid.size(), ana.total_packets,
+               used_buffers.size(), num_buffers, ana.min_ts_ns,
+               ana.max_rel_ts_ns / 1000000, ana.skipped_service_packets,
+               ana.skipped_no_pid_packets);
+  PERFETTO_LOG("Packet mapping: by_stats=%" PRIu64 "  by_content=%" PRIu64
+               "  defaulted_to_buf0=%" PRIu64 "  dropped_orphan=%" PRIu64,
+               ana.mapping_stats.packets_resolved_by_stats,
+               ana.mapping_stats.packets_resolved_by_content,
+               ana.mapping_stats.packets_defaulted_to_buf0,
+               ana.mapping_stats.packets_dropped_orphan);
+  for (const auto& kv : ana.records_by_pid) {
+    std::set<uint32_t> seqs, bufs;
+    for (const auto& r : kv.second) {
+      seqs.insert(r.orig_seq_id);
+      bufs.insert(r.buffer_idx);
+    }
+    PERFETTO_LOG("  pid=%d  packets=%zu  seqs=%zu  bufs=%zu", kv.first,
+                 kv.second.size(), seqs.size(), bufs.size());
+  }
+
+  // Forge config.
+  ForgeOptions fopts;
+  fopts.use_trace_buffer_v2 = opts.use_trace_buffer_v2;
+  protos::gen::TraceConfig forged = ForgeReplayConfig(
+      ana.original_config, used_buffers, ana.max_rel_ts_ns, fopts);
+  std::string forged_pb = forged.SerializeAsString();
+  std::string forged_pb_path = out_dir + "/forged.cfg.pb";
+  if (!WriteWholeFile(forged_pb_path, forged_pb.data(), forged_pb.size())) {
+    PERFETTO_ELOG("Failed to write %s", forged_pb_path.c_str());
+    return 1;
+  }
+  PERFETTO_LOG("Forged TraceConfig: %s (%zu bytes, duration_ms=%u, %d ds)",
+               forged_pb_path.c_str(), forged_pb.size(), forged.duration_ms(),
+               static_cast<int>(forged.data_sources().size()));
+
+  // Write one replay file per pid.
+  struct PidReplay {
+    int32_t pid;
+    std::string path;
+    size_t records;
+  };
+  std::vector<PidReplay> pid_replays;
+  for (auto& kv : ana.records_by_pid) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s/replay-pid%d.bin", out_dir.c_str(),
+             kv.first);
+    auto st = WriteReplayFile(path, num_buffers, kv.second);
+    if (!st.ok()) {
+      PERFETTO_ELOG("Failed to write %s: %s", path, st.c_message());
+      return 1;
+    }
+    PERFETTO_LOG("Wrote %s (records=%zu)", path, kv.second.size());
+    pid_replays.push_back({kv.first, path, kv.second.size()});
+  }
+
+  if (opts.analyze_only) {
+    PERFETTO_LOG("Analyze-only mode requested; stopping after analysis.");
+    return 0;
+  }
+
+  // -------- live replay --------
+
+  BackendInfo backend;
+  if (!SetupBackend(opts, out_dir, &backend))
+    return 1;
+
+  std::string self = ResolveSelfExe();
+  std::string outbin = DirName(self);
+  std::string perfetto_bin = outbin + "/perfetto";
+  {
+    struct stat st{};
+    if (stat(perfetto_bin.c_str(), &st) != 0) {
+      PERFETTO_LOG("%s not found; assuming `perfetto` is on PATH.",
+                   perfetto_bin.c_str());
+      perfetto_bin = "perfetto";
+    }
+  }
+
+  std::vector<IterationMetrics> metrics;
+  metrics.reserve(opts.iterations);
+  int rc = 0;
+
+  const long ticks_per_sec = sysconf(_SC_CLK_TCK);
+
+  for (uint32_t iter = 0; iter < opts.iterations; iter++) {
+    std::string iter_dir = out_dir;
+    if (opts.iterations > 1) {
+      char sub[64];
+      snprintf(sub, sizeof(sub), "/iter-%u", iter);
+      iter_dir += sub;
+      if (!MakeDirP(iter_dir)) {
+        rc = 1;
+        break;
+      }
+      PERFETTO_LOG("=== iteration %u/%u in %s ===", iter + 1, opts.iterations,
+                   iter_dir.c_str());
+    }
+
+    IterationMetrics m;
+    m.iter_dir = iter_dir;
+
+    // Sample traced's CPU counters at the start of this iteration.
+    base::ProcStat ps_start{};
+    bool have_ps_start = ReadTracedStats(backend.traced_pid, &ps_start);
+
+    // Spawn producer subprocesses, each with a ready pipe.
+    std::vector<std::unique_ptr<base::Subprocess>> producers;
+    std::vector<base::Pipe> ready_pipes;
+    producers.reserve(pid_replays.size());
+    ready_pipes.reserve(pid_replays.size());
+    for (const auto& pr : pid_replays) {
+      base::Pipe pipe = base::Pipe::Create();
+      int write_fd = pipe.wr.get();
+      auto sub = std::make_unique<base::Subprocess>();
+      sub->args.exec_cmd = {self, "--replay-worker", pr.path, "--ready-fd",
+                            std::to_string(write_fd)};
+      sub->args.env = {
+          "PERFETTO_PRODUCER_SOCK_NAME=" + backend.producer_sock,
+          "PERFETTO_CONSUMER_SOCK_NAME=" + backend.consumer_sock,
+      };
+      sub->args.preserve_fds.push_back(write_fd);
+      sub->args.stdout_mode = base::Subprocess::OutputMode::kInherit;
+      sub->args.stderr_mode = base::Subprocess::OutputMode::kInherit;
+      sub->Start();
+      pipe.wr.reset();
+      producers.push_back(std::move(sub));
+      ready_pipes.push_back(std::move(pipe));
+    }
+
+    for (size_t i = 0; i < ready_pipes.size(); i++) {
+      char ch = 0;
+      ssize_t n = read(ready_pipes[i].rd.get(), &ch, 1);
+      if (n != 1 || ch != 'R') {
+        PERFETTO_ELOG("Producer pid=%d did not signal ready (read=%zd)",
+                      producers[i]->pid(), n);
+        rc = 1;
+        break;
+      }
+    }
+    if (rc != 0)
+      break;
+    PERFETTO_LOG("All %zu producers ready.", producers.size());
+
+    // Per-iteration monitor and perf.
+    std::unique_ptr<ProcMonitor> monitor;
+    if (backend.traced_pid > 0) {
+      monitor.reset(new ProcMonitor(backend.traced_pid,
+                                    iter_dir + "/monitor.csv",
+                                    opts.monitor_interval_ms));
+      monitor->Start();
+    }
+    std::unique_ptr<base::Subprocess> perf;
+    if (opts.capture_perf && backend.traced_pid > 0) {
+      perf.reset(new base::Subprocess({"perf", "record", "-F", "99", "-g", "-p",
+                                       std::to_string(backend.traced_pid), "-o",
+                                       iter_dir + "/perf.data"}));
+      perf->args.stdout_mode = base::Subprocess::OutputMode::kInherit;
+      perf->args.stderr_mode = base::Subprocess::OutputMode::kInherit;
+      perf->Start();
+    }
+
+    // Launch perfetto consumer.
+    std::string out_trace = iter_dir + "/out.trace";
+    base::Subprocess perfetto_proc(
+        {perfetto_bin, "-c", forged_pb_path, "-o", out_trace});
+    perfetto_proc.args.env = {
+        "PERFETTO_PRODUCER_SOCK_NAME=" + backend.producer_sock,
+        "PERFETTO_CONSUMER_SOCK_NAME=" + backend.consumer_sock,
+    };
+    perfetto_proc.args.stdout_mode = base::Subprocess::OutputMode::kInherit;
+    perfetto_proc.args.stderr_mode = base::Subprocess::OutputMode::kInherit;
+    perfetto_proc.Start();
+    PERFETTO_LOG("Launched perfetto cmdline (pid=%d, out=%s)",
+                 perfetto_proc.pid(), out_trace.c_str());
+
+    const int64_t t_start_ms = base::GetWallTimeMs().count();
+    const int64_t total_ms =
+        static_cast<int64_t>(ana.max_rel_ts_ns / 1000000ull);
+    int64_t last_progress_ms = t_start_ms;
+
+    for (;;) {
+      size_t alive = 0;
+      for (auto& sub : producers) {
+        if (sub->Poll() != base::Subprocess::kTerminated)
+          alive++;
+      }
+      int64_t now_ms = base::GetWallTimeMs().count();
+      if (now_ms - last_progress_ms >= 10000 || alive == 0) {
+        int64_t elapsed_ms = now_ms - t_start_ms;
+        int64_t remaining_ms =
+            total_ms > elapsed_ms ? total_ms - elapsed_ms : 0;
+        long rss_kb = ReadTracedRssKb(backend.traced_pid);
+        char rss_str[32];
+        if (rss_kb >= 0)
+          snprintf(rss_str, sizeof(rss_str), "%ld kB", rss_kb);
+        else
+          snprintf(rss_str, sizeof(rss_str), "n/a");
+        if (total_ms > 0) {
+          double pct = std::min(100.0, 100.0 * static_cast<double>(elapsed_ms) /
+                                           static_cast<double>(total_ms));
+          PERFETTO_LOG("replay progress: %.1f%% (%" PRId64 " / %" PRId64
+                       " ms)  ETA %" PRId64
+                       "s  producers_alive=%zu/%zu  traced_rss=%s",
+                       pct, elapsed_ms, total_ms, remaining_ms / 1000, alive,
+                       producers.size(), rss_str);
+        } else {
+          PERFETTO_LOG("replay progress: elapsed=%" PRId64
+                       " ms  producers_alive=%zu/%zu  traced_rss=%s",
+                       elapsed_ms, alive, producers.size(), rss_str);
+        }
+        last_progress_ms = now_ms;
+      }
+      if (alive == 0)
+        break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
+
+    // Producers done. Sample traced CPU now, before SIGINT'ing perfetto
+    // (we want to attribute the replay work itself, not the buffer drain).
+    base::ProcStat ps_end{};
+    bool have_ps_end = ReadTracedStats(backend.traced_pid, &ps_end);
+
+    m.wall_ms = static_cast<double>(base::GetWallTimeMs().count() - t_start_ms);
+    if (have_ps_start && have_ps_end && ticks_per_sec > 0) {
+      double utime = static_cast<double>(ps_end.utime - ps_start.utime);
+      double stime = static_cast<double>(ps_end.stime - ps_start.stime);
+      m.traced_cpu_user_ms =
+          utime * 1000.0 / static_cast<double>(ticks_per_sec);
+      m.traced_cpu_sys_ms = stime * 1000.0 / static_cast<double>(ticks_per_sec);
+    }
+    m.traced_rss_peak_kb = monitor ? monitor->peak_rss_kb() : 0;
+
+    PERFETTO_LOG(
+        "iter %u done: wall=%.0f ms  traced_cpu=%.0f ms (user=%.0f + sys=%.0f)"
+        "  traced_rss_peak=%ld kB",
+        iter + 1, m.wall_ms, m.traced_cpu_user_ms + m.traced_cpu_sys_ms,
+        m.traced_cpu_user_ms, m.traced_cpu_sys_ms, m.traced_rss_peak_kb);
+
+    // Stop the consumer and ancillary processes.
+    perfetto_proc.Kill(SIGINT);
+    if (!perfetto_proc.Wait(30000))
+      perfetto_proc.KillAndWaitForTermination(SIGTERM);
+    if (perf) {
+      perf->Kill(SIGINT);
+      perf->Wait(10000);
+    }
+    if (monitor)
+      monitor->Stop();
+
+    struct stat ot{};
+    if (stat(out_trace.c_str(), &ot) == 0)
+      m.out_trace_bytes = static_cast<size_t>(ot.st_size);
+    metrics.push_back(m);
+  }
+
+  if (backend.tracebox)
+    backend.tracebox->KillAndWaitForTermination(SIGTERM);
+
+  // ----- benchmark summary -----
+  if (!metrics.empty() && opts.iterations > 1)
+    PrintBenchmarkSummary(metrics);
+  else if (!metrics.empty())
+    PrintSingleRunSummary(metrics.front());
+
+  PERFETTO_LOG("Done. Artifacts in %s", out_dir.c_str());
+  return rc;
+}
+
+}  // namespace trace_replay
+}  // namespace perfetto

--- a/src/tools/trace_replay/orchestrator.h
+++ b/src/tools/trace_replay/orchestrator.h
@@ -30,6 +30,8 @@ struct OrchestratorOptions {
   bool use_tracebox = false;
   bool capture_perf = false;
   uint32_t monitor_interval_ms = 250;
+  // perf stat (counters only, no sampling) attached to traced per iteration.
+  bool capture_perf_stat = false;
   bool ignore_orphan_writers = false;
   uint32_t max_buffers = 32;
 

--- a/src/tools/trace_replay/orchestrator.h
+++ b/src/tools/trace_replay/orchestrator.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TOOLS_TRACE_REPLAY_ORCHESTRATOR_H_
+#define SRC_TOOLS_TRACE_REPLAY_ORCHESTRATOR_H_
+
+#include <cstdint>
+#include <string>
+
+namespace perfetto {
+namespace trace_replay {
+
+struct OrchestratorOptions {
+  std::string input_trace_path;
+  std::string out_dir;
+  bool analyze_only = false;
+  bool use_tracebox = false;
+  bool capture_perf = false;
+  uint32_t monitor_interval_ms = 250;
+  bool ignore_orphan_writers = false;
+  uint32_t max_buffers = 32;
+
+  // Skip real-time pacing entirely: every packet fires back-to-back as fast
+  // as the producer can push.
+  bool zero_delay = false;
+
+  // How many times to run the replay back-to-back. >1 enables a small
+  // benchmark-style summary at the end.
+  uint32_t iterations = 1;
+
+  // If true, force every buffer in the forged TraceConfig to use the
+  // experimental TRACE_BUFFER_V2 implementation
+  // (BufferConfig.experimental_mode = TRACE_BUFFER_V2).
+  bool use_trace_buffer_v2 = false;
+};
+
+int RunOrchestrator(const OrchestratorOptions& opts);
+
+}  // namespace trace_replay
+}  // namespace perfetto
+
+#endif  // SRC_TOOLS_TRACE_REPLAY_ORCHESTRATOR_H_

--- a/src/tools/trace_replay/proc_monitor.cc
+++ b/src/tools/trace_replay/proc_monitor.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/tools/trace_replay/proc_monitor.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/time.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/scoped_file.h"
+#include "perfetto/ext/base/watchdog_posix.h"
+
+namespace perfetto {
+namespace trace_replay {
+
+namespace {
+
+// /proc/PID/statm is space-separated: size resident shared text lib data dt
+// (all in pages).
+bool ReadStatmRssPages(int pid, long* rss_pages, long* vm_pages) {
+  char path[64];
+  snprintf(path, sizeof(path), "/proc/%d/statm", pid);
+  std::string buf;
+  if (!base::ReadFile(path, &buf))
+    return false;
+  long sz = 0, rss = 0;
+  if (sscanf(buf.c_str(), "%ld %ld", &sz, &rss) != 2)
+    return false;
+  *vm_pages = sz;
+  *rss_pages = rss;
+  return true;
+}
+
+}  // namespace
+
+ProcMonitor::ProcMonitor(int pid, std::string csv_path, uint32_t interval_ms)
+    : pid_(pid),
+      csv_path_(std::move(csv_path)),
+      interval_ms_(interval_ms ? interval_ms : 250) {}
+
+ProcMonitor::~ProcMonitor() {
+  Stop();
+}
+
+void ProcMonitor::Start() {
+  stop_.store(false);
+  thread_ = std::thread(&ProcMonitor::Run, this);
+}
+
+void ProcMonitor::Stop() {
+  if (!thread_.joinable())
+    return;
+  stop_.store(true);
+  thread_.join();
+}
+
+void ProcMonitor::Run() {
+  base::ScopedFile out_fd(
+      base::OpenFile(csv_path_, O_WRONLY | O_CREAT | O_TRUNC, 0644));
+  if (!out_fd) {
+    PERFETTO_ELOG("proc_monitor: cannot open %s: %s", csv_path_.c_str(),
+                  strerror(errno));
+    return;
+  }
+  const char* hdr = "t_ms,utime_ticks,stime_ticks,rss_kb,vm_kb\n";
+  if (base::WriteAll(out_fd.get(), hdr, strlen(hdr)) < 0) {
+    PERFETTO_ELOG("proc_monitor: write hdr failed");
+    return;
+  }
+
+  const long page_kb = sysconf(_SC_PAGESIZE) / 1024;
+  const auto t_start = std::chrono::steady_clock::now();
+  while (!stop_.load(std::memory_order_relaxed)) {
+    int64_t t_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - t_start)
+                       .count();
+
+    char stat_path[64];
+    snprintf(stat_path, sizeof(stat_path), "/proc/%d/stat", pid_);
+    base::ScopedFile stat_fd(base::OpenFile(stat_path, O_RDONLY));
+    if (!stat_fd) {
+      // traced gone — stop polling.
+      break;
+    }
+    base::ProcStat ps;
+    if (!base::ReadProcStat(stat_fd.get(), &ps))
+      break;
+
+    long rss_pages = 0, vm_pages = 0;
+    ReadStatmRssPages(pid_, &rss_pages, &vm_pages);
+    long rss_kb = rss_pages * page_kb;
+    long vm_kb = vm_pages * page_kb;
+    long prev_peak = peak_rss_kb_.load(std::memory_order_relaxed);
+    while (rss_kb > prev_peak &&
+           !peak_rss_kb_.compare_exchange_weak(prev_peak, rss_kb,
+                                               std::memory_order_relaxed)) {
+    }
+
+    char line[128];
+    int n = snprintf(line, sizeof(line), "%" PRId64 ",%lu,%lu,%ld,%ld\n", t_ms,
+                     ps.utime, ps.stime, rss_kb, vm_kb);
+    if (n > 0 &&
+        base::WriteAll(out_fd.get(), line, static_cast<size_t>(n)) < 0) {
+      break;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms_));
+  }
+}
+
+}  // namespace trace_replay
+}  // namespace perfetto

--- a/src/tools/trace_replay/proc_monitor.h
+++ b/src/tools/trace_replay/proc_monitor.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TOOLS_TRACE_REPLAY_PROC_MONITOR_H_
+#define SRC_TOOLS_TRACE_REPLAY_PROC_MONITOR_H_
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <thread>
+
+namespace perfetto {
+namespace trace_replay {
+
+class ProcMonitor {
+ public:
+  ProcMonitor(int pid, std::string csv_path, uint32_t interval_ms);
+  ~ProcMonitor();
+  void Start();
+  void Stop();
+  long peak_rss_kb() const {
+    return peak_rss_kb_.load(std::memory_order_relaxed);
+  }
+
+ private:
+  void Run();
+  int pid_;
+  std::string csv_path_;
+  uint32_t interval_ms_;
+  std::atomic<bool> stop_{false};
+  std::atomic<long> peak_rss_kb_{0};
+  std::thread thread_;
+};
+
+}  // namespace trace_replay
+}  // namespace perfetto
+
+#endif  // SRC_TOOLS_TRACE_REPLAY_PROC_MONITOR_H_

--- a/src/tools/trace_replay/producer_worker.cc
+++ b/src/tools/trace_replay/producer_worker.cc
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/tools/trace_replay/producer_worker.h"
+
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/time.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/tracing.h"
+
+#include "src/tools/trace_replay/replay_file.h"
+
+namespace perfetto {
+namespace trace_replay {
+
+namespace {
+
+// Cap. The producer worker pre-instantiates ReplayDS<0..kMaxBufs-1> at compile
+// time; if the trace forwards a buffer index >= kMaxBufs we refuse to run.
+constexpr int kMaxBufs = 32;
+
+// State shared between the OnStart callbacks of each ReplayDS instance and the
+// main thread of the producer worker.
+struct WorkerState {
+  // Per-buffer slice of records, grouped by original sequence_id.
+  // [buffer_idx][seq_id] = vector<rec>
+  std::map<uint32_t, std::map<uint32_t, std::vector<ReplayRecord>>>
+      records_by_buf;
+
+  // Set of buffers actually used by this process — exposed on stdout so the
+  // worker's main() can register only what it needs.
+  std::set<uint32_t> used_buffers;
+
+  // Anchor time for the replay: captured on the first OnStart of any ds.
+  std::atomic<int64_t> t0_ns{0};
+  std::once_flag t0_once;
+
+  // Worker thread bookkeeping.
+  std::mutex mtx;
+  std::condition_variable cv;
+  std::vector<std::thread> threads;
+  int active_workers = 0;  // protected by mtx
+  int total_started = 0;   // protected by mtx (monotonic)
+
+  bool stop_requested = false;  // set by OnStop()
+};
+
+WorkerState* g_state = nullptr;
+
+// One DataSource<T> per buffer index. The SDK keys static state by T, so we
+// need distinct types — hence the template parameter.
+template <int BufIdx>
+class ReplayDS : public DataSource<ReplayDS<BufIdx>> {
+ public:
+  // Replay packets can be large (e.g. ftrace bundles), and the SDK's TLS
+  // TraceWriter would otherwise silently drop chunks when the SHM fills up.
+  // Stall instead — we want to faithfully push every recorded byte and
+  // measure traced's response.
+  static constexpr BufferExhaustedPolicy kBufferExhaustedPolicy =
+      BufferExhaustedPolicy::kStall;
+
+  void OnSetup(const DataSourceBase::SetupArgs&) override {}
+  void OnStart(const DataSourceBase::StartArgs&) override {
+    if (!g_state)
+      return;
+    // Anchor t0 once per process.
+    std::call_once(g_state->t0_once, [] {
+      g_state->t0_ns.store(base::GetWallTimeNs().count(),
+                           std::memory_order_relaxed);
+    });
+
+    auto bit = g_state->records_by_buf.find(static_cast<uint32_t>(BufIdx));
+    if (bit == g_state->records_by_buf.end())
+      return;
+
+    // Spawn one thread per original sequence_id targeting this buffer.
+    for (auto& kv : bit->second) {
+      uint32_t orig_seq_id = kv.first;
+      // Move the records into the thread; we don't need them anymore in
+      // g_state once the thread owns them.
+      auto records = std::move(kv.second);
+      {
+        std::lock_guard<std::mutex> lk(g_state->mtx);
+        g_state->active_workers++;
+        g_state->total_started++;
+      }
+      g_state->threads.emplace_back([orig_seq_id,
+                                     records = std::move(records)]() mutable {
+        (void)orig_seq_id;  // SDK assigns its own sequence_id.
+        const int64_t t0 = g_state->t0_ns.load(std::memory_order_relaxed);
+        for (const auto& r : records) {
+          // Sleep until t0 + rel_ts_ns (boot time).
+          int64_t deadline_ns = t0 + static_cast<int64_t>(r.rel_ts_ns);
+          for (;;) {
+            int64_t now = base::GetWallTimeNs().count();
+            int64_t delta = deadline_ns - now;
+            if (delta <= 0)
+              break;
+            // Bail out promptly if the consumer asked us to stop.
+            {
+              std::lock_guard<std::mutex> lk(g_state->mtx);
+              if (g_state->stop_requested)
+                break;
+            }
+            // Cap the sleep at 50ms to remain responsive to stop.
+            int64_t cap_ns = 50 * 1000 * 1000;
+            std::this_thread::sleep_for(
+                std::chrono::nanoseconds(delta > cap_ns ? cap_ns : delta));
+          }
+          {
+            std::lock_guard<std::mutex> lk(g_state->mtx);
+            if (g_state->stop_requested)
+              break;
+          }
+          // Emit the recorded TracePacket body via AppendRawProtoBytes.
+          ReplayDS<BufIdx>::Trace(
+              [&r](typename ReplayDS<BufIdx>::TraceContext ctx) {
+                auto packet = ctx.NewTracePacket();
+                packet->AppendRawProtoBytes(r.bytes.data(), r.bytes.size());
+              });
+        }
+        // Final flush of this thread's writer.
+        ReplayDS<BufIdx>::Trace(
+            [](typename ReplayDS<BufIdx>::TraceContext ctx) { ctx.Flush(); });
+        {
+          std::lock_guard<std::mutex> lk(g_state->mtx);
+          if (--g_state->active_workers == 0)
+            g_state->cv.notify_all();
+        }
+      });
+    }
+    // Free the now-empty inner map.
+    g_state->records_by_buf.erase(bit);
+  }
+  void OnStop(const DataSourceBase::StopArgs&) override {
+    if (!g_state)
+      return;
+    std::lock_guard<std::mutex> lk(g_state->mtx);
+    g_state->stop_requested = true;
+    g_state->cv.notify_all();
+  }
+};
+
+template <int N>
+void RegisterAll(const std::set<uint32_t>& used) {
+  if (used.count(static_cast<uint32_t>(N))) {
+    DataSourceDescriptor dsd;
+    dsd.set_name("replay.buf" + std::to_string(N));
+    ReplayDS<N>::Register(dsd);
+  }
+  if constexpr (N + 1 < kMaxBufs)
+    RegisterAll<N + 1>(used);
+}
+
+}  // namespace
+
+int RunProducerWorker(const ProducerWorkerOptions& opts) {
+  WorkerState state;
+  g_state = &state;
+
+  uint32_t num_buffers = 0;
+  std::vector<ReplayRecord> all_records;
+  auto st = ReadReplayFile(opts.replay_file, &num_buffers, &all_records);
+  if (!st.ok()) {
+    PERFETTO_ELOG("ReadReplayFile failed: %s", st.c_message());
+    return 1;
+  }
+  for (auto& r : all_records) {
+    if (r.buffer_idx >= kMaxBufs) {
+      PERFETTO_ELOG("Record references buffer %u, exceeds kMaxBufs=%d",
+                    r.buffer_idx, kMaxBufs);
+      return 1;
+    }
+    state.used_buffers.insert(r.buffer_idx);
+    uint32_t b = r.buffer_idx;
+    uint32_t s = r.orig_seq_id;
+    state.records_by_buf[b][s].push_back(std::move(r));
+  }
+
+  PERFETTO_LOG("Worker: records=%zu  buffers_used=%zu  pid=%d",
+               all_records.size(), state.used_buffers.size(),
+               static_cast<int>(getpid()));
+
+  TracingInitArgs args;
+  args.backends = kSystemBackend;
+  // Big SMB so we can buffer bursts of large replayed packets without
+  // stalling on every chunk.
+  args.shmem_size_hint_kb = 8 * 1024;  // 8 MB
+  args.shmem_page_size_hint_kb = 32;   // 32 KB pages
+  Tracing::Initialize(args);
+
+  RegisterAll<0>(state.used_buffers);
+
+  // Signal the parent that we have registered.
+  if (opts.ready_fd >= 0) {
+    const char ch = 'R';
+    ssize_t r = write(opts.ready_fd, &ch, 1);
+    (void)r;
+    close(opts.ready_fd);
+  }
+
+  // Wait until either OnStop fired, or every worker we ever spawned has
+  // exited. The total_started>0 guard avoids returning before OnStart had a
+  // chance to spawn any worker thread at all.
+  {
+    std::unique_lock<std::mutex> lk(state.mtx);
+    state.cv.wait(lk, [&] {
+      return state.stop_requested ||
+             (state.total_started > 0 && state.active_workers == 0);
+    });
+  }
+
+  for (auto& t : state.threads) {
+    if (t.joinable())
+      t.join();
+  }
+
+  PERFETTO_LOG("Worker pid=%d done", static_cast<int>(getpid()));
+  return 0;
+}
+
+}  // namespace trace_replay
+}  // namespace perfetto
+
+// Allocate static storage for ReplayDS<0..31>.
+#define DEF_REPLAY_DS(N)                      \
+  PERFETTO_DEFINE_DATA_SOURCE_STATIC_MEMBERS( \
+      perfetto::trace_replay::ReplayDS<N>)
+DEF_REPLAY_DS(0);
+DEF_REPLAY_DS(1);
+DEF_REPLAY_DS(2);
+DEF_REPLAY_DS(3);
+DEF_REPLAY_DS(4);
+DEF_REPLAY_DS(5);
+DEF_REPLAY_DS(6);
+DEF_REPLAY_DS(7);
+DEF_REPLAY_DS(8);
+DEF_REPLAY_DS(9);
+DEF_REPLAY_DS(10);
+DEF_REPLAY_DS(11);
+DEF_REPLAY_DS(12);
+DEF_REPLAY_DS(13);
+DEF_REPLAY_DS(14);
+DEF_REPLAY_DS(15);
+DEF_REPLAY_DS(16);
+DEF_REPLAY_DS(17);
+DEF_REPLAY_DS(18);
+DEF_REPLAY_DS(19);
+DEF_REPLAY_DS(20);
+DEF_REPLAY_DS(21);
+DEF_REPLAY_DS(22);
+DEF_REPLAY_DS(23);
+DEF_REPLAY_DS(24);
+DEF_REPLAY_DS(25);
+DEF_REPLAY_DS(26);
+DEF_REPLAY_DS(27);
+DEF_REPLAY_DS(28);
+DEF_REPLAY_DS(29);
+DEF_REPLAY_DS(30);
+DEF_REPLAY_DS(31);
+#undef DEF_REPLAY_DS

--- a/src/tools/trace_replay/producer_worker.cc
+++ b/src/tools/trace_replay/producer_worker.cc
@@ -34,7 +34,11 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/time.h"
 #include "perfetto/ext/base/file_utils.h"
-#include "perfetto/tracing.h"
+#include "perfetto/tracing/backend_type.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
+#include "perfetto/tracing/core/data_source_descriptor.h"
+#include "perfetto/tracing/data_source.h"
+#include "perfetto/tracing/tracing.h"
 
 #include "src/tools/trace_replay/replay_file.h"
 

--- a/src/tools/trace_replay/producer_worker.h
+++ b/src/tools/trace_replay/producer_worker.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TOOLS_TRACE_REPLAY_PRODUCER_WORKER_H_
+#define SRC_TOOLS_TRACE_REPLAY_PRODUCER_WORKER_H_
+
+#include <string>
+
+namespace perfetto {
+namespace trace_replay {
+
+struct ProducerWorkerOptions {
+  std::string replay_file;
+  int ready_fd = -1;
+};
+
+int RunProducerWorker(const ProducerWorkerOptions& opts);
+
+}  // namespace trace_replay
+}  // namespace perfetto
+
+#endif  // SRC_TOOLS_TRACE_REPLAY_PRODUCER_WORKER_H_

--- a/src/tools/trace_replay/replay_file.cc
+++ b/src/tools/trace_replay/replay_file.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/tools/trace_replay/replay_file.h"
+
+#include <fcntl.h>
+#include <string.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/scoped_file.h"
+
+namespace perfetto {
+namespace trace_replay {
+
+namespace {
+constexpr char kMagic[8] = {'P', 'R', 'E', 'P', 'L', 'A', 'Y', '1'};
+}  // namespace
+
+base::Status WriteReplayFile(const std::string& out_path,
+                             uint32_t num_buffers,
+                             const std::vector<ReplayRecord>& records_in) {
+  // Sort by rel_ts_ns ascending. Stable so equal timestamps keep input order.
+  std::vector<ReplayRecord> records = records_in;
+  std::stable_sort(records.begin(), records.end(),
+                   [](const ReplayRecord& a, const ReplayRecord& b) {
+                     return a.rel_ts_ns < b.rel_ts_ns;
+                   });
+
+  base::ScopedFile fd(
+      base::OpenFile(out_path, O_WRONLY | O_CREAT | O_TRUNC, 0644));
+  if (!fd)
+    return base::ErrStatus("Cannot open %s for writing", out_path.c_str());
+
+  ReplayFileHeader hdr{};
+  memcpy(hdr.magic, kMagic, sizeof(hdr.magic));
+  hdr.num_records = static_cast<uint32_t>(records.size());
+  hdr.num_buffers = num_buffers;
+
+  auto write_blob = [&](const void* data, size_t size) -> bool {
+    return base::WriteAll(fd.get(), data, size) == static_cast<ssize_t>(size);
+  };
+
+  if (!write_blob(&hdr, sizeof(hdr)))
+    return base::ErrStatus("Short write of header to %s", out_path.c_str());
+
+  for (const auto& r : records) {
+    uint64_t ts = r.rel_ts_ns;
+    uint32_t seq = r.orig_seq_id;
+    uint32_t buf = r.buffer_idx;
+    uint32_t sz = static_cast<uint32_t>(r.bytes.size());
+    if (!write_blob(&ts, sizeof(ts)) || !write_blob(&seq, sizeof(seq)) ||
+        !write_blob(&buf, sizeof(buf)) || !write_blob(&sz, sizeof(sz)) ||
+        (sz && !write_blob(r.bytes.data(), sz))) {
+      return base::ErrStatus("Short write to %s", out_path.c_str());
+    }
+  }
+  return base::OkStatus();
+}
+
+base::Status ReadReplayFile(const std::string& path,
+                            uint32_t* num_buffers,
+                            std::vector<ReplayRecord>* records) {
+  std::string blob;
+  if (!base::ReadFile(path, &blob))
+    return base::ErrStatus("Cannot read %s", path.c_str());
+
+  if (blob.size() < sizeof(ReplayFileHeader))
+    return base::ErrStatus("%s is shorter than the header", path.c_str());
+
+  ReplayFileHeader hdr{};
+  memcpy(&hdr, blob.data(), sizeof(hdr));
+  if (memcmp(hdr.magic, kMagic, 8) != 0)
+    return base::ErrStatus("%s: bad magic", path.c_str());
+
+  *num_buffers = hdr.num_buffers;
+  records->clear();
+  records->reserve(hdr.num_records);
+
+  size_t off = sizeof(hdr);
+  for (uint32_t i = 0; i < hdr.num_records; i++) {
+    constexpr size_t kRecHdr = sizeof(uint64_t) + sizeof(uint32_t) * 3;
+    if (off + kRecHdr > blob.size())
+      return base::ErrStatus("%s: truncated record header @%zu", path.c_str(),
+                             off);
+    uint64_t ts;
+    uint32_t seq, buf, sz;
+    memcpy(&ts, blob.data() + off, sizeof(ts));
+    off += sizeof(ts);
+    memcpy(&seq, blob.data() + off, sizeof(seq));
+    off += sizeof(seq);
+    memcpy(&buf, blob.data() + off, sizeof(buf));
+    off += sizeof(buf);
+    memcpy(&sz, blob.data() + off, sizeof(sz));
+    off += sizeof(sz);
+    if (off + sz > blob.size())
+      return base::ErrStatus("%s: truncated record payload @%zu", path.c_str(),
+                             off);
+    ReplayRecord r;
+    r.rel_ts_ns = ts;
+    r.orig_seq_id = seq;
+    r.buffer_idx = buf;
+    r.bytes.assign(reinterpret_cast<const uint8_t*>(blob.data() + off),
+                   reinterpret_cast<const uint8_t*>(blob.data() + off + sz));
+    off += sz;
+    records->push_back(std::move(r));
+  }
+  return base::OkStatus();
+}
+
+}  // namespace trace_replay
+}  // namespace perfetto

--- a/src/tools/trace_replay/replay_file.h
+++ b/src/tools/trace_replay/replay_file.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TOOLS_TRACE_REPLAY_REPLAY_FILE_H_
+#define SRC_TOOLS_TRACE_REPLAY_REPLAY_FILE_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+
+namespace perfetto {
+namespace trace_replay {
+
+// One TracePacket to be replayed. `bytes` is the *inner* serialized form of the
+// original TracePacket (i.e. the bytes that were the value of Trace.packet=1 in
+// the input trace). The producer writes them back via
+// TracePacket::AppendRawProtoBytes() inside a freshly opened packet.
+struct ReplayRecord {
+  uint64_t rel_ts_ns = 0;
+  uint32_t orig_seq_id = 0;
+  uint32_t buffer_idx = 0;
+  std::vector<uint8_t> bytes;
+};
+
+// A whole replay file is `Header` + N records as below. Little-endian, packed.
+//   magic[8]  = "PREPLAY1"
+//   num_recs  : uint32
+//   num_buffers : uint32   (the total buffer count of the forged config; this
+//                           tells the worker how many DSDs to register.)
+// Records (each):
+//   rel_ts_ns    : uint64
+//   orig_seq_id  : uint32
+//   buffer_idx   : uint32
+//   payload_size : uint32
+//   payload[]    : bytes
+struct ReplayFileHeader {
+  char magic[8];  // "PREPLAY1"
+  uint32_t num_records;
+  uint32_t num_buffers;
+};
+static_assert(sizeof(ReplayFileHeader) == 16, "ReplayFileHeader packed");
+
+// Writes the replay records sorted by rel_ts_ns ascending to `out_path`.
+base::Status WriteReplayFile(const std::string& out_path,
+                             uint32_t num_buffers,
+                             const std::vector<ReplayRecord>& records);
+
+// Reads a replay file in full into memory.
+base::Status ReadReplayFile(const std::string& path,
+                            uint32_t* num_buffers,
+                            std::vector<ReplayRecord>* records);
+
+}  // namespace trace_replay
+}  // namespace perfetto
+
+#endif  // SRC_TOOLS_TRACE_REPLAY_REPLAY_FILE_H_

--- a/src/tools/trace_replay/trace_analyzer.cc
+++ b/src/tools/trace_replay/trace_analyzer.cc
@@ -1,0 +1,566 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/tools/trace_replay/trace_analyzer.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <set>
+#include <tuple>
+#include <unordered_map>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/scoped_mmap.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/protozero/proto_decoder.h"
+#include "src/trace_processor/util/gzip_utils.h"
+
+#include "protos/perfetto/common/trace_stats.gen.h"
+#include "protos/perfetto/config/data_source_config.gen.h"
+#include "protos/perfetto/trace/clock_snapshot.pbzero.h"
+#include "protos/perfetto/trace/trace.pbzero.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "protos/perfetto/trace/trace_packet_defaults.pbzero.h"
+
+namespace perfetto {
+namespace trace_replay {
+
+namespace {
+
+// First pass over the raw bytes — visits every TracePacket, transparently
+// expanding any TracePacket that contains a `compressed_packets` field.
+//
+// A compressed_packets payload is a zlib-deflated stream of length-delimited
+// Trace.packet records (see src/tracing/service/zlib_compressor.cc), so once
+// inflated we can feed the bytes back through the same Trace::Decoder.
+template <typename Visit>
+bool IteratePackets(const uint8_t* data, size_t size, Visit&& visit) {
+  protos::pbzero::Trace::Decoder td(data, size);
+  for (auto p = td.packet(); p; ++p) {
+    auto bytes = p->as_bytes();
+    protos::pbzero::TracePacket::Decoder tp(bytes.data, bytes.size);
+    if (tp.has_compressed_packets()) {
+      auto blob = tp.compressed_packets();
+      auto inflated = trace_processor::util::GzipDecompressor::DecompressFully(
+          blob.data, blob.size);
+      if (inflated.empty()) {
+        PERFETTO_ELOG("Failed to inflate compressed_packets (%zu bytes in)",
+                      blob.size);
+        return false;
+      }
+      if (!IteratePackets(inflated.data(), inflated.size(), visit))
+        return false;
+    } else {
+      visit(bytes.data, bytes.size, tp);
+    }
+  }
+  return true;
+}
+
+// Field IDs that traced injects on the consumption path and that the
+// PacketStreamValidator rejects when present at top-level on the producer
+// side (see src/tracing/service/packet_stream_validator.cc). When we replay
+// the captured TracePacket bytes, we must strip these or the entire packet
+// gets dropped.
+bool IsReservedTopLevelField(uint32_t id) {
+  using TP = protos::pbzero::TracePacket;
+  return id == TP::kTrustedUidFieldNumber ||
+         id == TP::kTrustedPacketSequenceIdFieldNumber ||
+         id == TP::kTraceConfigFieldNumber ||
+         id == TP::kTraceStatsFieldNumber ||
+         id == TP::kCompressedPacketsFieldNumber ||
+         id == TP::kSynchronizationMarkerFieldNumber ||
+         id == TP::kTrustedPidFieldNumber || id == TP::kMachineIdFieldNumber ||
+         id == TP::kServiceEventFieldNumber ||
+         id == TP::kTraceProvenanceFieldNumber ||
+         id == TP::kProtovmsFieldNumber;
+}
+
+// Walks the inner TracePacket bytes and copies fields into `out`, skipping
+// reserved fields (which would cause traced to drop the replayed packet).
+// Returns the resulting byte vector.
+std::vector<uint8_t> StripReservedFields(const uint8_t* data, size_t size) {
+  std::vector<uint8_t> out;
+  out.reserve(size);
+  protozero::ProtoDecoder dec(data, size);
+  for (auto fld = dec.ReadField(); fld.valid(); fld = dec.ReadField()) {
+    if (IsReservedTopLevelField(fld.id()))
+      continue;
+    // Compute the byte range covered by this field (preamble + payload). The
+    // decoder advanced past it; the byte range starts at `data + start_off`
+    // and ends at `data + read_off`. We track `start_off` ourselves by
+    // sampling before the next ReadField — but ProtoDecoder doesn't expose a
+    // "field byte range" directly, so reconstruct from the Field handle.
+    //
+    // Re-encode the field: preamble (tag) + payload (with length for LEN).
+    using WT = protozero::proto_utils::ProtoWireType;
+    WT wt = fld.type();
+    uint8_t buf[16];
+    uint8_t* p = buf;
+    uint64_t tag =
+        (static_cast<uint64_t>(fld.id()) << 3) | static_cast<uint64_t>(wt);
+    p = protozero::proto_utils::WriteVarInt(tag, p);
+    if (wt == WT::kLengthDelimited) {
+      auto bytes = fld.as_bytes();
+      p = protozero::proto_utils::WriteVarInt(static_cast<uint64_t>(bytes.size),
+                                              p);
+      out.insert(out.end(), buf, p);
+      out.insert(out.end(), bytes.data, bytes.data + bytes.size);
+    } else if (wt == WT::kVarInt) {
+      // raw_int_value() preserves the encoded varint bytes.
+      uint64_t v = fld.raw_int_value();
+      p = protozero::proto_utils::WriteVarInt(v, p);
+      out.insert(out.end(), buf, p);
+    } else if (wt == WT::kFixed32) {
+      out.insert(out.end(), buf, p);
+      uint32_t v = fld.as_uint32();
+      const uint8_t* vp = reinterpret_cast<const uint8_t*>(&v);
+      out.insert(out.end(), vp, vp + 4);
+    } else if (wt == WT::kFixed64) {
+      out.insert(out.end(), buf, p);
+      uint64_t v = fld.as_uint64();
+      const uint8_t* vp = reinterpret_cast<const uint8_t*>(&v);
+      out.insert(out.end(), vp, vp + 8);
+    }
+    // Unknown / unsupported types: drop (shouldn't happen in well-formed
+    // input — ProtoDecoder would set ReadField()->valid() to false).
+  }
+  return out;
+}
+
+// Heuristic: identify the canonical data source name from the payload field
+// present in a TracePacket. Returns nullptr if the packet doesn't clearly
+// belong to a single recognizable data source.
+const char* GuessDataSourceName(
+    const protos::pbzero::TracePacket::Decoder& tp) {
+  if (tp.has_ftrace_events())
+    return "linux.ftrace";
+  if (tp.has_process_tree() || tp.has_process_stats())
+    return "linux.process_stats";
+  if (tp.has_sys_stats())
+    return "linux.sys_stats";
+  if (tp.has_system_info() || tp.has_cpu_info())
+    return "linux.system_info";
+  if (tp.has_track_event() || tp.has_track_descriptor() ||
+      tp.has_thread_descriptor() || tp.has_process_descriptor())
+    return "track_event";
+  if (tp.has_gpu_counter_event())
+    return "gpu.counters";
+  if (tp.has_gpu_render_stage_event())
+    return "gpu.renderstages";
+  if (tp.has_vulkan_memory_event())
+    return "android.gpu.memory";
+  if (tp.has_frame_timeline_event())
+    return "android.surfaceflinger.frametimeline";
+  if (tp.has_power_rails())
+    return "android.power";
+  if (tp.has_perf_sample())
+    return "linux.perf";
+  if (tp.has_chrome_events())
+    return "org.chromium.trace_event";
+  if (tp.has_profile_packet() || tp.has_streaming_profile_packet())
+    return "android.heapprofd";  // or linux.perf; default to heapprofd
+  if (tp.has_smaps_packet())
+    return "android.smaps";
+  if (tp.has_android_log())
+    return "android.log";
+  (void)tp;
+  return nullptr;
+}
+
+// From a TraceConfig, build a name -> target_buffer map. If a data source is
+// listed multiple times with the same name (possible with producer filters),
+// the lowest target_buffer wins (arbitrary; matches the lookup intent).
+std::unordered_map<std::string, uint32_t> BuildNameToBufferMap(
+    const protos::gen::TraceConfig& cfg) {
+  std::unordered_map<std::string, uint32_t> out;
+  for (const auto& ds : cfg.data_sources()) {
+    const std::string& name = ds.config().name();
+    uint32_t buf = ds.config().target_buffer();
+    auto it = out.find(name);
+    if (it == out.end() || buf < it->second)
+      out[name] = buf;
+  }
+  return out;
+}
+
+}  // namespace
+
+base::Status AnalyzeTraceFile(const std::string& path,
+                              const AnalyzeOptions& opts,
+                              TraceAnalysis* out) {
+  base::ScopedMmap mmap = base::ReadMmapWholeFile(path);
+  if (!mmap.IsValid())
+    return base::ErrStatus("Cannot mmap %s", path.c_str());
+
+  const auto* data = static_cast<const uint8_t*>(mmap.data());
+  const size_t size = mmap.length();
+
+  bool config_found = false;
+  bool have_trace_stats = false;
+  uint64_t min_ts = std::numeric_limits<uint64_t>::max();
+
+  constexpr uint32_t kClockBoot = 6;  // BUILTIN_CLOCK_BOOTTIME
+
+  // Trace-wide default clock. Defaults to BOOTTIME per builtin_clock.proto;
+  // can be overridden by the original config's primary_trace_clock or by the
+  // first ClockSnapshot.primary_trace_clock.
+  uint32_t default_clock_id = kClockBoot;
+
+  // Per-sequence clock override from TracePacketDefaults.timestamp_clock_id.
+  std::map<uint32_t, uint32_t> seq_default_clock;
+
+  // Mini clock tracker. Built from the FIRST ClockSnapshot packet only — we
+  // intentionally don't track subsequent snapshots or compensate for drift
+  // (suspended time, frequency adjustments). For each clock id seen in that
+  // snapshot, we record the offset to the reference (= default_clock_id)
+  // such that:  ref_ts_ns = local_ts_ns + clock_offset[id].
+  // Any clock id not in this map (most commonly clock_id=64, the
+  // sequence-local incremental clock used by track_event) is treated as
+  // "untranslatable" and its packets fire immediately (rel_ts_ns=0).
+  std::map<uint32_t, int64_t> clock_offset;
+  bool have_clock_snapshot = false;
+
+  // Per-packet captured data. `ts_set` distinguishes "timestamp 0 because the
+  // producer set it to 0" from "timestamp 0 because the field was absent" —
+  // the former participates in min_ts, the latter inherits the prior packet's
+  // timestamp on the same sequence. `clock_id` is the effective clock as
+  // determined by per-packet override / sequence default / trace default. It
+  // is used in a second pass to translate to BOOT-normalised ns once the
+  // MONO offset is known.
+  struct Raw {
+    int32_t pid;
+    uint32_t seq_id;
+    uint64_t ts;
+    bool ts_set;
+    uint32_t clock_id;
+    const uint8_t* p;
+    size_t len;
+    const char* inferred_ds_name;  // const-string literal, no ownership.
+  };
+  std::vector<Raw> records;
+  records.reserve(1u << 16);
+
+  if (!IteratePackets(
+          data, size,
+          [&](const uint8_t* pkt_data, size_t pkt_size,
+              protos::pbzero::TracePacket::Decoder& tp) {
+            if (tp.has_trace_config() && !config_found) {
+              auto cfg_bytes = tp.trace_config();
+              if (!out->original_config.ParseFromArray(cfg_bytes.data,
+                                                       cfg_bytes.size)) {
+                PERFETTO_ELOG("Failed to parse embedded TraceConfig");
+              } else {
+                config_found = true;
+                // Honour primary_trace_clock if the trace overrides BOOT.
+                if (out->original_config.builtin_data_sources()
+                        .has_primary_trace_clock()) {
+                  default_clock_id = static_cast<uint32_t>(
+                      out->original_config.builtin_data_sources()
+                          .primary_trace_clock());
+                }
+              }
+            }
+            if (tp.has_trace_stats()) {
+              protos::gen::TraceStats stats;
+              auto sbytes = tp.trace_stats();
+              if (stats.ParseFromArray(sbytes.data, sbytes.size)) {
+                for (const auto& ws : stats.writer_stats()) {
+                  out->seq_to_buf[ws.sequence_id()] = ws.buffer();
+                }
+                if (!stats.writer_stats().empty())
+                  have_trace_stats = true;
+              }
+            }
+
+            // Capture the first ClockSnapshot. We index every clock id it
+            // contains and compute its offset to the trace-default clock —
+            // no further drift compensation, no later snapshots consulted.
+            if (!have_clock_snapshot && tp.has_clock_snapshot()) {
+              auto cs_bytes = tp.clock_snapshot();
+              protos::pbzero::ClockSnapshot::Decoder cs(cs_bytes.data,
+                                                        cs_bytes.size);
+              // Honour ClockSnapshot.primary_trace_clock if set.
+              if (cs.has_primary_trace_clock()) {
+                default_clock_id =
+                    static_cast<uint32_t>(cs.primary_trace_clock());
+              }
+              std::map<uint32_t, uint64_t> snap_ts;
+              for (auto c = cs.clocks(); c; ++c) {
+                protos::pbzero::ClockSnapshot::Clock::Decoder ck(c->as_bytes());
+                snap_ts[ck.clock_id()] = ck.timestamp();
+              }
+              auto rit = snap_ts.find(default_clock_id);
+              if (rit != snap_ts.end()) {
+                const int64_t ref = static_cast<int64_t>(rit->second);
+                for (auto& kv : snap_ts) {
+                  clock_offset[kv.first] =
+                      ref - static_cast<int64_t>(kv.second);
+                }
+                have_clock_snapshot = true;
+              }
+            }
+
+            uint32_t seq_id = tp.trusted_packet_sequence_id();
+            if (seq_id == 0)
+              return;
+            if (seq_id == 1) {
+              out->skipped_service_packets++;
+              return;
+            }
+            if (!tp.has_trusted_pid()) {
+              out->skipped_no_pid_packets++;
+              return;
+            }
+            // Update per-sequence default from TracePacketDefaults (sent
+            // typically in the first packet of a sequence).
+            if (tp.has_trace_packet_defaults()) {
+              auto def_bytes = tp.trace_packet_defaults();
+              protos::pbzero::TracePacketDefaults::Decoder defs(def_bytes.data,
+                                                                def_bytes.size);
+              if (defs.has_timestamp_clock_id()) {
+                uint32_t ck = defs.timestamp_clock_id();
+                if (ck != 0)
+                  seq_default_clock[seq_id] = ck;
+              }
+            }
+
+            int32_t pid = tp.trusted_pid();
+            uint64_t ts = tp.timestamp();
+            bool ts_set = tp.has_timestamp() && ts != 0;
+
+            // Effective clock id: per-packet > sequence default > trace
+            // default. 0 means "unspecified" in the wire format.
+            uint32_t eff_clock = default_clock_id;
+            auto sit = seq_default_clock.find(seq_id);
+            if (sit != seq_default_clock.end())
+              eff_clock = sit->second;
+            if (tp.has_timestamp_clock_id() && tp.timestamp_clock_id() != 0) {
+              eff_clock = tp.timestamp_clock_id();
+            }
+
+            // min_ts is only meaningful for translatable timestamps; we
+            // compute it in the second pass once the clock tracker is built.
+
+            const char* name = GuessDataSourceName(tp);
+            records.push_back(
+                {pid, seq_id, ts, ts_set, eff_clock, pkt_data, pkt_size, name});
+          })) {
+    return base::ErrStatus("Failed to iterate packets in %s", path.c_str());
+  }
+
+  if (!config_found)
+    return base::ErrStatus(
+        "No TraceConfig packet in input trace; cannot derive replay config");
+
+  if (!have_trace_stats) {
+    PERFETTO_ELOG(
+        "Input trace has no usable trace_stats.writer_stats. The "
+        "sequence_id->buffer mapping will be inferred from packet content "
+        "(by data source name) using the original TraceConfig.");
+  }
+
+  // No strict-mode check anymore: packets in clocks not present in the
+  // first ClockSnapshot are silently treated as "fire immediately" in the
+  // second pass below.
+
+  // Build the content-based fallback map.
+  const auto name_to_buf = BuildNameToBufferMap(out->original_config);
+
+  // For each sequence_id without a writer_stats mapping, pick the most-popular
+  // inferred data-source name across its packets, then look up the buffer.
+  std::map<uint32_t, std::unordered_map<const char*, uint32_t>> seq_name_votes;
+  for (const auto& r : records) {
+    if (out->seq_to_buf.count(r.seq_id))
+      continue;
+    if (r.inferred_ds_name)
+      seq_name_votes[r.seq_id][r.inferred_ds_name]++;
+  }
+  // seq_id -> (buffer, source) where source is 'stats'|'content'|'default'.
+  enum class Source { kStats, kContent, kDefault };
+  std::map<uint32_t, std::pair<uint32_t, Source>> resolved;
+  for (const auto& kv : out->seq_to_buf)
+    resolved[static_cast<uint32_t>(kv.first)] = {kv.second, Source::kStats};
+
+  uint64_t seq_resolved_by_content = 0;
+  uint64_t seq_defaulted = 0;
+  std::set<uint32_t> orphan_unresolved;
+  for (auto& kv : seq_name_votes) {
+    if (kv.second.empty())
+      continue;
+    const char* best_name = nullptr;
+    uint32_t best_votes = 0;
+    for (auto& vk : kv.second) {
+      if (vk.second > best_votes) {
+        best_votes = vk.second;
+        best_name = vk.first;
+      }
+    }
+    auto it = name_to_buf.find(std::string(best_name));
+    if (it != name_to_buf.end()) {
+      resolved[kv.first] = {it->second, Source::kContent};
+      seq_resolved_by_content++;
+    }
+  }
+  // Any seq_id not in `resolved` after the above is still unmapped.
+  for (const auto& r : records) {
+    if (resolved.count(r.seq_id) == 0)
+      orphan_unresolved.insert(r.seq_id);
+  }
+
+  // Default-to-buf-0 fallback (unless ignore_orphan_writers and we drop).
+  if (!orphan_unresolved.empty()) {
+    if (opts.ignore_orphan_writers) {
+      PERFETTO_ELOG(
+          "%zu sequence_id(s) could not be mapped to a buffer (no stats, no "
+          "content match); dropping their packets as requested.",
+          orphan_unresolved.size());
+    } else {
+      PERFETTO_ELOG(
+          "%zu sequence_id(s) could not be mapped to a buffer (no stats, no "
+          "content match); defaulting them to buffer 0.",
+          orphan_unresolved.size());
+      for (uint32_t s : orphan_unresolved) {
+        resolved[s] = {0, Source::kDefault};
+        seq_defaulted++;
+      }
+    }
+  }
+
+  if (records.empty()) {
+    out->min_ts_ns = 0;
+    out->max_rel_ts_ns = 0;
+    return base::OkStatus();
+  }
+
+  // First pass: translate every (ts, clock) into reference-clock-equivalent
+  // nanoseconds using the offset map built from the first ClockSnapshot.
+  // Packets in clocks absent from the snapshot get boot_ts_set=false, which
+  // causes them to inherit the prior packet's timestamp on the same
+  // sequence (or rel_ts=0 if there is none yet) in the emission loop.
+  uint64_t min_boot_ts = std::numeric_limits<uint64_t>::max();
+  std::vector<uint64_t> boot_ts(records.size(), 0);
+  std::vector<bool> boot_ts_set(records.size(), false);
+  uint64_t untranslatable_packets = 0;
+  for (size_t i = 0; i < records.size(); i++) {
+    const Raw& r = records[i];
+    if (!r.ts_set)
+      continue;
+    int64_t off = 0;
+    if (r.clock_id == default_clock_id) {
+      off = 0;
+    } else {
+      auto oit = clock_offset.find(r.clock_id);
+      if (oit == clock_offset.end()) {
+        untranslatable_packets++;
+        continue;
+      }
+      off = oit->second;
+    }
+    int64_t v = static_cast<int64_t>(r.ts) + off;
+    if (v < 0)
+      v = 0;
+    uint64_t bts = static_cast<uint64_t>(v);
+    boot_ts[i] = bts;
+    boot_ts_set[i] = true;
+    min_boot_ts = std::min(min_boot_ts, bts);
+  }
+  out->min_ts_ns =
+      min_boot_ts == std::numeric_limits<uint64_t>::max() ? 0 : min_boot_ts;
+  (void)min_ts;  // Pre-translation min was only used for diagnostics.
+
+  // For each sequence_id, remember the last *translated-to-BOOT* timestamp
+  // so packets with no timestamp set (or with an unsupported clock) can
+  // inherit it (they emit right after the prior packet on the same writer).
+  // If a sequence's very first packets lack a usable timestamp, default to t0.
+  std::map<uint32_t, uint64_t> last_seq_ts;
+
+  for (size_t i = 0; i < records.size(); i++) {
+    const Raw& r = records[i];
+    auto it = resolved.find(r.seq_id);
+    if (it == resolved.end()) {
+      out->mapping_stats.packets_dropped_orphan++;
+      continue;
+    }
+    uint64_t ts;
+    if (boot_ts_set[i]) {
+      ts = boot_ts[i];
+      last_seq_ts[r.seq_id] = ts;
+    } else {
+      auto lt = last_seq_ts.find(r.seq_id);
+      ts = lt == last_seq_ts.end() ? out->min_ts_ns : lt->second;
+    }
+    uint64_t rel = ts >= out->min_ts_ns ? ts - out->min_ts_ns : 0;
+    if (opts.zero_delay)
+      rel = 0;  // Skip pacing — fire every packet ASAP.
+    ReplayRecord rec;
+    rec.rel_ts_ns = rel;
+    rec.orig_seq_id = r.seq_id;
+    rec.buffer_idx = it->second.first;
+    rec.bytes = StripReservedFields(r.p, r.len);
+    out->max_rel_ts_ns = std::max(out->max_rel_ts_ns, rel);
+    out->total_packets++;
+    switch (it->second.second) {
+      case Source::kStats:
+        out->mapping_stats.packets_resolved_by_stats++;
+        break;
+      case Source::kContent:
+        out->mapping_stats.packets_resolved_by_content++;
+        break;
+      case Source::kDefault:
+        out->mapping_stats.packets_defaulted_to_buf0++;
+        break;
+    }
+    out->records_by_pid[r.pid].push_back(std::move(rec));
+  }
+
+  for (auto& kv : out->records_by_pid) {
+    std::stable_sort(kv.second.begin(), kv.second.end(),
+                     [](const ReplayRecord& a, const ReplayRecord& b) {
+                       return a.rel_ts_ns < b.rel_ts_ns;
+                     });
+  }
+
+  PERFETTO_LOG("seq mapping: %zu by writer_stats, %" PRIu64
+               " by content, %" PRIu64
+               " defaulted to buf0 (totals are seq counts)",
+               out->seq_to_buf.size(), seq_resolved_by_content, seq_defaulted);
+  if (have_clock_snapshot) {
+    std::string parts;
+    for (auto& kv : clock_offset) {
+      if (!parts.empty())
+        parts += ", ";
+      parts += std::to_string(kv.first) + "->" + std::to_string(kv.second);
+    }
+    PERFETTO_LOG("clock tracker: ref=%u, offsets (ns): %s", default_clock_id,
+                 parts.c_str());
+  }
+  if (untranslatable_packets > 0) {
+    PERFETTO_LOG("clock tracker: %" PRIu64
+                 " packet(s) had timestamps in clocks not present in the first "
+                 "ClockSnapshot; they will fire immediately.",
+                 untranslatable_packets);
+  }
+
+  return base::OkStatus();
+}
+
+}  // namespace trace_replay
+}  // namespace perfetto

--- a/src/tools/trace_replay/trace_analyzer.cc
+++ b/src/tools/trace_replay/trace_analyzer.cc
@@ -74,23 +74,45 @@ bool IteratePackets(const uint8_t* data, size_t size, Visit&& visit) {
   return true;
 }
 
-// Field IDs that traced injects on the consumption path and that the
-// PacketStreamValidator rejects when present at top-level on the producer
-// side (see src/tracing/service/packet_stream_validator.cc). When we replay
-// the captured TracePacket bytes, we must strip these or the entire packet
-// gets dropped.
+// Top-level TracePacket fields that the replay tool must NOT pass through.
+// Two reasons for the same answer:
+//
+//   1. Service-rejected on the producer side. The PacketStreamValidator
+//      (src/tracing/service/packet_stream_validator.cc) drops any TracePacket
+//      whose top-level fields contain a service-only one — every replayed
+//      packet carrying one of these would be dropped wholesale.
+//
+//   2. Re-written by traced anyway. tracing_service_impl.cc emits these
+//      fields itself (clock_snapshot, trace_uuid, system_info, etc.) at
+//      session setup/teardown and on every consumed packet. Re-emitting
+//      from the producer side is at best wasted bytes and at worst a
+//      duplicate that confuses downstream tools.
 bool IsReservedTopLevelField(uint32_t id) {
   using TP = protos::pbzero::TracePacket;
-  return id == TP::kTrustedUidFieldNumber ||
-         id == TP::kTrustedPacketSequenceIdFieldNumber ||
-         id == TP::kTraceConfigFieldNumber ||
-         id == TP::kTraceStatsFieldNumber ||
-         id == TP::kCompressedPacketsFieldNumber ||
-         id == TP::kSynchronizationMarkerFieldNumber ||
-         id == TP::kTrustedPidFieldNumber || id == TP::kMachineIdFieldNumber ||
-         id == TP::kServiceEventFieldNumber ||
-         id == TP::kTraceProvenanceFieldNumber ||
-         id == TP::kProtovmsFieldNumber;
+  // (1) PacketStreamValidator's kReservedFieldIds.
+  if (id == TP::kTrustedUidFieldNumber ||
+      id == TP::kTrustedPacketSequenceIdFieldNumber ||
+      id == TP::kTraceConfigFieldNumber ||
+      id == TP::kTraceStatsFieldNumber ||
+      id == TP::kCompressedPacketsFieldNumber ||
+      id == TP::kSynchronizationMarkerFieldNumber ||
+      id == TP::kTrustedPidFieldNumber || id == TP::kMachineIdFieldNumber ||
+      id == TP::kServiceEventFieldNumber ||
+      id == TP::kTraceProvenanceFieldNumber ||
+      id == TP::kProtovmsFieldNumber) {
+    return true;
+  }
+  // (2) Additional fields written by traced itself in tracing_service_impl.cc.
+  // `timestamp` is intentionally NOT here — producers legitimately set it
+  // on every packet. `buffer_index_for_stats` is in-memory only and not in
+  // the wire format, so nothing to strip.
+  return id == TP::kClockSnapshotFieldNumber ||
+         id == TP::kPreviousPacketDroppedFieldNumber ||
+         id == TP::kSystemInfoFieldNumber || id == TP::kTriggerFieldNumber ||
+         id == TP::kExtensionDescriptorFieldNumber ||
+         id == TP::kTraceUuidFieldNumber ||
+         id == TP::kRemoteClockSyncFieldNumber ||
+         id == TP::kCloneSnapshotTriggerFieldNumber;
 }
 
 // Walks the inner TracePacket bytes and copies fields into `out`, skipping

--- a/src/tools/trace_replay/trace_analyzer.h
+++ b/src/tools/trace_replay/trace_analyzer.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TOOLS_TRACE_REPLAY_TRACE_ANALYZER_H_
+#define SRC_TOOLS_TRACE_REPLAY_TRACE_ANALYZER_H_
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "protos/perfetto/config/trace_config.gen.h"
+
+#include "src/tools/trace_replay/replay_file.h"
+
+namespace perfetto {
+namespace trace_replay {
+
+// Stats about how the seq_id -> buffer mapping was recovered. Forward-declared
+// here so TraceAnalysis can use it (definition follows).
+struct MappingStats {
+  uint64_t packets_resolved_by_stats = 0;
+  uint64_t packets_resolved_by_content = 0;
+  uint64_t packets_defaulted_to_buf0 = 0;
+  uint64_t packets_dropped_orphan = 0;
+};
+
+struct TraceAnalysis {
+  // The first TraceConfig packet seen in the input trace.
+  protos::gen::TraceConfig original_config;
+
+  // sequence_id -> buffer index (from trace_stats.writer_stats).
+  std::map<uint64_t, uint32_t> seq_to_buf;
+
+  // pid -> sorted-by-rel-ts records.
+  std::map<int32_t, std::vector<ReplayRecord>> records_by_pid;
+
+  // The minimum TracePacket.timestamp observed (anchor for rel_ts_ns).
+  uint64_t min_ts_ns = 0;
+
+  // The maximum (rel_ts_ns) across all records.
+  uint64_t max_rel_ts_ns = 0;
+
+  // Total packet count emitted (excluding seq_id==1 and ones with no pid).
+  uint64_t total_packets = 0;
+
+  // Skipped: had no trusted_pid; sequence_id==1 (kServicePacketSequenceID).
+  uint64_t skipped_service_packets = 0;
+  uint64_t skipped_no_pid_packets = 0;
+
+  MappingStats mapping_stats;
+};
+
+struct AnalyzeOptions {
+  // When true, sequence_ids whose target buffer cannot be recovered (neither
+  // from trace_stats.writer_stats nor from content-based inference) are
+  // dropped silently instead of triggering an error.
+  bool ignore_orphan_writers = false;
+
+  // When true:
+  //  - sequences that emit packets in a non-default clock domain (i.e. set
+  //    `timestamp_clock_id` per-packet, or via `trace_packet_defaults`) are
+  //    still kept (their timestamps would be uninterpretable without a clock
+  //    converter, so the replay loses real-time pacing);
+  //  - every record's `rel_ts_ns` is forced to 0, so the producer emits the
+  //    entire replay as fast as it can.
+  // When false (default), the analyzer hard-fails on the first non-default
+  // clock packet seen, instructing the user to opt into --zero-delay.
+  bool zero_delay = false;
+};
+
+base::Status AnalyzeTraceFile(const std::string& path,
+                              const AnalyzeOptions& opts,
+                              TraceAnalysis* out);
+
+}  // namespace trace_replay
+}  // namespace perfetto
+
+#endif  // SRC_TOOLS_TRACE_REPLAY_TRACE_ANALYZER_H_


### PR DESCRIPTION
NOT FOR REVIEW YET.
I am not sure whether we should check this in. I fully vibe coded this to
be able to do perf tests based on real traces. Let's discuss.
I haven't looked into the code yet. If we decide to go there I can self-review
it first.

A new Linux/Android/macOS tool under src/tools/trace_replay that replays the
producer-side traffic of an existing Perfetto trace against a real `traced`
daemon, so its CPU, memory, and stability can be exercised under realistic
load — including under TraceBufferV2 via `--use-trace-buffer-v2`.

Pipeline:
 1. Analyze the input: iterate top-level packets (inflating any
    `compressed_packets` via the in-tree GzipDecompressor), recover the
    per-sequence target buffer from `trace_stats.writer_stats` plus a
    content-based fallback, and strip service-injected reserved fields from
    each packet so traced's PacketStreamValidator doesn't drop them. A mini
    clock tracker built from the first ClockSnapshot translates BOOT/MONO/
    REALTIME/etc. timestamps to the trace's primary clock; packets in clocks
    absent from the snapshot fire immediately.
 2. Forge a clean TraceConfig: keep buffers verbatim, drop data_sources/
    triggers/statsd/guardrails, inject one `replay.bufN` per used buffer,
    pick a sane `duration_ms`, and optionally flip every buffer to
    `experimental_mode = TRACE_BUFFER_V2`. Write one binary replay file per
    producer pid.
 3. Replay: spawn tracebox (or use system traced), re-exec ourselves once
    per pid as `--replay-worker` to act as SDK producers (one ReplayDS<N>
    per buffer, one std::thread per original sequence_id, kStall + 8MB SMB
    so large ftrace bundles don't drop), then `perfetto -c forged.cfg.pb`.
    A periodic `/proc/<traced>/{stat,statm}` monitor records peak RSS and
    a CPU delta; `--perf` adds `perf record` on traced.

`--iterations N` reuses the same forged config and tracebox across runs and
prints a Google-Benchmark-style mean/median/stddev/min/max table over wall
time, traced CPU, peak RSS, and output trace size. Default `--out-dir` is a
fresh `/tmp/replay.XXXXXX` from mkdtemp.

Design notes in docs/design-docs/trace-replay.md.