### PR TITLE
protozero: make test_messages extensions import public to fix build

### DIFF
--- a/src/protozero/test/example_proto/test_messages.proto
+++ b/src/protozero/test/example_proto/test_messages.proto
@@ -18,7 +18,7 @@ syntax = "proto2";
 
 package protozero.test.protos;
 
-import "src/protozero/test/example_proto/extensions.proto";
+import public "src/protozero/test/example_proto/extensions.proto";
 import "src/protozero/test/example_proto/library.proto";
 import "src/protozero/test/example_proto/other_package/test_messages.proto";
 import "src/protozero/test/example_proto/subpackage/test_messages.proto";


### PR DESCRIPTION
src/protozero/test/example_proto/test_messages.proto imports extensions.proto so that extensions.proto is bundled into test_messages' descriptor set (the reflection-based protozero_to_text / text_to_proto tests build a DescriptorPool from it and need the extension definitions). 

The import is "unused" at the symbol level, so protoc emits an unused-import warning which breaks the perfetto->chromium autoroll.

Switch it to `import public`: protoc exempts public imports from the unused-import check, while still recording extensions.proto as a dependency, so the descriptor-based tests keep passing.