### PR TITLE
perfetto: honor PERFETTO_REGEX_FORCE_STD in regex backend headers

### DIFF
--- a/src/base/regex/regex_pcre2.h
+++ b/src/base/regex/regex_pcre2.h
@@ -19,8 +19,10 @@
 
 #include "perfetto/base/build_config.h"
 
-// See note in regex_re2.h.
-#if PERFETTO_BUILDFLAG(PERFETTO_PCRE2)
+// See note in regex_re2.h. Also honor PERFETTO_REGEX_FORCE_STD: targets that
+// define it (e.g. libperfetto_client_experimental) opt out of the optional
+// backends and must not pull in <pcre2.h>, even when PERFETTO_PCRE2 is set.
+#if PERFETTO_BUILDFLAG(PERFETTO_PCRE2) && !defined(PERFETTO_REGEX_FORCE_STD)
 
 #include <limits>
 #include <memory>
@@ -198,6 +200,7 @@ class RegexPcre2 {
 }  // namespace base
 }  // namespace perfetto
 
-#endif  // PERFETTO_BUILDFLAG(PERFETTO_PCRE2)
+#endif  // PERFETTO_BUILDFLAG(PERFETTO_PCRE2) &&
+        // !defined(PERFETTO_REGEX_FORCE_STD)
 
 #endif  // SRC_BASE_REGEX_REGEX_PCRE2_H_

--- a/src/base/regex/regex_re2.h
+++ b/src/base/regex/regex_re2.h
@@ -20,8 +20,10 @@
 #include "perfetto/base/build_config.h"
 
 // Guarded because gen_amalgamated inlines the body even when the include
-// site in regex.cc is preprocessed out.
-#if PERFETTO_BUILDFLAG(PERFETTO_RE2)
+// site in regex.cc is preprocessed out. Also honor PERFETTO_REGEX_FORCE_STD:
+// targets that define it opt out of the optional backends and must not pull in
+// <re2/re2.h>, even when PERFETTO_RE2 is set.
+#if PERFETTO_BUILDFLAG(PERFETTO_RE2) && !defined(PERFETTO_REGEX_FORCE_STD)
 
 #include <memory>
 #include <string>
@@ -124,6 +126,7 @@ class RegexRe2 {
 }  // namespace base
 }  // namespace perfetto
 
-#endif  // PERFETTO_BUILDFLAG(PERFETTO_RE2)
+#endif  // PERFETTO_BUILDFLAG(PERFETTO_RE2) &&
+        // !defined(PERFETTO_REGEX_FORCE_STD)
 
 #endif  // SRC_BASE_REGEX_REGEX_RE2_H_

--- a/src/shared_lib/test/protos/test_messages.pzc.h
+++ b/src/shared_lib/test/protos/test_messages.pzc.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include "perfetto/public/pb_macros.h"
+#include "src/shared_lib/test/protos/extensions.pzc.h"
 #include "src/shared_lib/test/protos/library.pzc.h"
 #include "src/shared_lib/test/protos/other_package/test_messages.pzc.h"
 #include "src/shared_lib/test/protos/subpackage/test_messages.pzc.h"


### PR DESCRIPTION
#6034 made regex.cc include all backend headers unconditionally so gen_amalgamated can see through them, relying on each header to self-guard. regex_pcre2.h / regex_re2.h guarded only on PERFETTO_BUILDFLAG(PERFETTO_PCRE2/RE2), ignoring PERFETTO_REGEX_FORCE_STD.

In the android_tree build config PERFETTO_PCRE2 is defined to 1 globally, so the unconditional include pulled <pcre2.h> into every target, including libperfetto_client_experimental, which sets -DPERFETTO_REGEX_FORCE_STD precisely to avoid pulling in libpcre2 (see gn/perfetto.gni). This broke the Android auto-roll with "'pcre2.h' file not found".

Make the header self-guards also honor PERFETTO_REGEX_FORCE_STD, matching the backend-selection priority in regex.cc where FORCE_STD wins over PCRE2/RE2. Fix both headers as the opt-out contract applies symmetrically.