### PR TITLE
OOME proto: add exception message string

### DIFF
--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -17310,6 +17310,8 @@ message ArtProcessMetadata {
   optional uint64 oom_free_bytes_until_oom = 7;
   // Stacktrace for the thread doing the failing allocation
   optional JavaStack oom_thread_java_stack = 8;
+  // Full OOME exception message
+  optional string oom_error_msg = 9;
 }
 
 // End of protos/perfetto/trace/profiling/art_process_metadata.proto

--- a/protos/perfetto/trace/profiling/art_process_metadata.proto
+++ b/protos/perfetto/trace/profiling/art_process_metadata.proto
@@ -45,4 +45,6 @@ message ArtProcessMetadata {
   optional uint64 oom_free_bytes_until_oom = 7;
   // Stacktrace for the thread doing the failing allocation
   optional JavaStack oom_thread_java_stack = 8;
+  // Full OOME exception message
+  optional string oom_error_msg = 9;
 }


### PR DESCRIPTION
Addressing the review comments; it is not trivial or future-proof to try to have a structured form for all variations that the OOME exception message can take.

Bug: 502598449
