### PR TITLE
perfetto: keep zlib out of libperfetto_client_experimental

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1058,6 +1058,7 @@ cc_library {
         "perfetto_defaults",
     ],
     cflags: [
+        "-DPERFETTO_FORCE_DISABLE_ZLIB",
         "-DPERFETTO_REGEX_FORCE_STD",
         "-DPERFETTO_SHLIB_SDK_IMPLEMENTATION",
         "-DZLIB_IMPLEMENTATION",
@@ -1067,7 +1068,6 @@ cc_library {
         android: {
             shared_libs: [
                 "liblog",
-                "libz",
             ],
             static_libs: [
                 "perfetto_flags_c_lib",
@@ -1076,7 +1076,6 @@ cc_library {
         host: {
             static_libs: [
                 "liblog",
-                "libz",
             ],
         },
         windows: {
@@ -1362,6 +1361,7 @@ cc_library_static {
         "perfetto_defaults",
     ],
     cflags: [
+        "-DPERFETTO_FORCE_DISABLE_ZLIB",
         "-DPERFETTO_REGEX_FORCE_STD",
         "-DZLIB_IMPLEMENTATION",
     ],
@@ -1372,16 +1372,8 @@ cc_library_static {
     min_sdk_version: "30",
     target: {
         android: {
-            shared_libs: [
-                "libz",
-            ],
             static_libs: [
                 "perfetto_flags_c_lib",
-            ],
-        },
-        host: {
-            static_libs: [
-                "libz",
             ],
         },
     },
@@ -2224,16 +2216,8 @@ cc_library_static {
     ],
     target: {
         android: {
-            shared_libs: [
-                "libz",
-            ],
             static_libs: [
                 "perfetto_flags_c_lib",
-            ],
-        },
-        host: {
-            static_libs: [
-                "libz",
             ],
         },
     },
@@ -3495,16 +3479,8 @@ cc_test {
     test_config: "PerfettoIntegrationTests.xml",
     target: {
         android: {
-            shared_libs: [
-                "libz",
-            ],
             static_libs: [
                 "perfetto_flags_c_lib",
-            ],
-        },
-        host: {
-            static_libs: [
-                "libz",
             ],
         },
     },

--- a/include/perfetto/base/build_config.h
+++ b/include/perfetto/base/build_config.h
@@ -238,13 +238,6 @@
 #endif
 #endif
 
-#undef PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ZLIB
-#if defined(PERFETTO_SDK_ENABLE_ZLIB) && (PERFETTO_SDK_ENABLE_ZLIB == 1)
-#define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ZLIB() 1
-#else
-#define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ZLIB() 0
-#endif
-
 #undef PERFETTO_BUILDFLAG_DEFINE_PERFETTO_RE2
 #if defined(PERFETTO_SDK_ENABLE_RE2) && (PERFETTO_SDK_ENABLE_RE2 == 1)
 #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_RE2() 1
@@ -252,6 +245,23 @@
 #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_RE2() 0
 #endif
 
+#undef PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ZLIB
+#if defined(PERFETTO_SDK_ENABLE_ZLIB) && (PERFETTO_SDK_ENABLE_ZLIB == 1)
+#define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ZLIB() 1
+#else
+#define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ZLIB() 0
+#endif
+
 #endif  // PERFETTO_BUILDFLAG(PERFETTO_AMALGAMATED_SDK)
+
+// Unlike PERFETTO_SDK_ENABLE_ZLIB above (amalgamated SDK opt-in), this is a
+// file-scope opt-out that applies to every build. Define it to compile out the
+// optional zlib compressor. Static libs like libperfetto_client_experimental
+// get linked into many binaries, so keeping the compressor out means those
+// binaries don't have to link libz. See tools/gen_android_bp.
+#if defined(PERFETTO_FORCE_DISABLE_ZLIB)
+#undef PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ZLIB
+#define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ZLIB() 0
+#endif
 
 #endif  // INCLUDE_PERFETTO_BASE_BUILD_CONFIG_H_

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -363,7 +363,11 @@ additional_args = {
         # lib to pay the libpcre2 code-size cost. Regex usage in the client
         # SDK is minimal, so std::regex is an acceptable tradeoff.
         # See b/498785154 for the binary-size regression that motivated this.
-        ('cflags', {'-DPERFETTO_REGEX_FORCE_STD'}),
+        #
+        # Same idea for zlib: the compressor would otherwise pull in libz, and
+        # consumers that don't link it fail with undefined deflate* symbols.
+        ('cflags',
+         {'-DPERFETTO_REGEX_FORCE_STD', '-DPERFETTO_FORCE_DISABLE_ZLIB'}),
     ],
     'libperfetto_c': [
         ('min_sdk_version', '30'),
@@ -383,7 +387,11 @@ additional_args = {
         # lib to pay the libpcre2 code-size cost. Regex usage in the client
         # SDK is minimal, so std::regex is an acceptable tradeoff.
         # See b/498785154 for the binary-size regression that motivated this.
-        ('cflags', {'-DPERFETTO_REGEX_FORCE_STD'}),
+        #
+        # Same idea for zlib: the compressor would otherwise pull in libz, and
+        # consumers that don't link it fail with undefined deflate* symbols.
+        ('cflags',
+         {'-DPERFETTO_REGEX_FORCE_STD', '-DPERFETTO_FORCE_DISABLE_ZLIB'}),
     ],
     'perfetto_trace_protos': [
         ('apex_available', {
@@ -516,6 +524,10 @@ def enable_sqlite(module):
 
 
 def enable_zlib(module):
+  # Modules built with PERFETTO_FORCE_DISABLE_ZLIB compile out the compressor
+  # and don't reference any zlib symbols, so skip the libz dep for them.
+  if '-DPERFETTO_FORCE_DISABLE_ZLIB' in module.cflags:
+    return
   if module.type == 'cc_binary_host':
     module.static_libs.add('libz')
   elif module.host_supported:


### PR DESCRIPTION
#6034  wired service:zlib_compressor into in_process_backend (part of libperfetto_client_experimental / libperfetto_c) whenever enable_perfetto_zlib is on. In the android_tree build config PERFETTO_ZLIB is hard-defined to 1, so zlib_compressor.o (which calls deflate*) is compiled into the client SDK static library. 

Downstream binaries that link the .a but do not link libz then fail with undefined deflate / deflateInit_ / deflateEnd, breaking the Android auto-roll.

Fix: build_config.h forces PERFETTO_ZLIB off when PERFETTO_FORCE_DISABLE_ZLIB is defined, gen_android_bp defines it for the two SDK static libs, and enable_zlib() suppresses the libz dep for them (mirroring enable_pcre2). The zlib compressor then compiles to nothing, so no libz dependency is imposed on consumers.

The amalgamated SDK (opt-in via PERFETTO_SDK_ENABLE_ZLIB) and standalone builds are unaffected.
