### PR TITLE
cherry-pick->canary: Fix query formatting on prod (#6024)

### DIFF
--- a/ui/build.mjs
+++ b/ui/build.mjs
@@ -688,7 +688,7 @@ function buildWasm(skipWasmBuild) {
 
 function copySyntaqliteRuntime() {
   const srcDir = pjoin(ROOT_DIR, 'ui/node_modules/syntaqlite/wasm');
-  const dstDir = pjoin(cfg.outDistRootDir, 'assets');
+  const dstDir = pjoin(cfg.outDistDir, 'assets');
   for (const fname of [
     'syntaqlite-runtime.js',
     'syntaqlite-runtime.wasm',
@@ -721,7 +721,7 @@ function buildSyntaqlitePerfettoDialect() {
     ROOT_DIR,
     'src/trace_processor/perfetto_sql/syntaqlite/syntaqlite_perfetto.c',
   );
-  const dst = pjoin(cfg.outDistRootDir, 'assets', 'syntaqlite-perfetto.wasm');
+  const dst = pjoin(cfg.outDistDir, 'assets', 'syntaqlite-perfetto.wasm');
   try {
     const srcMtime = fs.statSync(src).mtimeMs;
     const dstMtime = fs.statSync(dst).mtimeMs;

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -14,6 +14,7 @@
 
 import m from 'mithril';
 import {Engine} from 'syntaqlite';
+import {assetSrc} from '../../base/assets';
 import {Icons} from '../../base/semantic_icons';
 import type {QueryResponse} from '../../components/query_table/queries';
 import {InMemoryDataSource} from '../../components/widgets/datagrid/in_memory_data_source';
@@ -98,13 +99,13 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
   private getFormatterEngine(): Promise<Engine> {
     if (this.formatterEnginePromise === undefined) {
       const engine = new Engine({
-        runtimeJsPath: 'assets/syntaqlite-runtime.js',
-        runtimeWasmPath: 'assets/syntaqlite-runtime.wasm',
+        runtimeJsPath: assetSrc('assets/syntaqlite-runtime.js'),
+        runtimeWasmPath: assetSrc('assets/syntaqlite-runtime.wasm'),
       });
       this.formatterEnginePromise = (async () => {
         await engine.load();
         const binding = await engine.loadDialectFromUrl(
-          'assets/syntaqlite-perfetto.wasm',
+          assetSrc('assets/syntaqlite-perfetto.wasm'),
           'syntaqlite_perfetto_dialect_template',
         );
         engine.setDialectPointer(binding.ptr);


### PR DESCRIPTION
Query formatting on the query page is broken on prod. This patch fixes it.

The syntaqlite wasm blobs were being placed in `dist/`, not `dist/<version>` so were never uploaded to GCS. Fix in build script and adjust URL path to match.