### PR TITLE
android_sdk: Increase default track event cache size

### DIFF
--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
@@ -36,7 +36,7 @@ import dev.perfetto.sdk.PerfettoTrackEventExtra.Proto;
 
 /** Builder for Perfetto track event extras. */
 public final class PerfettoTrackEventBuilder {
-  private static final int DEFAULT_EXTRA_CACHE_SIZE = 5;
+  private static final int DEFAULT_EXTRA_CACHE_SIZE = 16;
   private static final int DEFAULT_PENDING_POINTERS_LIST_SIZE = 16;
 
   private PerfettoTrackEventExtra mExtra;


### PR DESCRIPTION
In the oom adjuster there are some track events with 12 fields. This spilled the default extras cache size of 5. Bump to 16 to fix: b/518590599.

Longer term, we can serialize protos in Java which will remove the need to maintain this caches that can cause cliff performance regressions.

Test: Manually tested and verified 6x improvement for oom adjuster trace points.
