### PR TITLE
Keep core protos out of the embedded extension descriptor

### DIFF
--- a/src/tools/BUILD.gn
+++ b/src/tools/BUILD.gn
@@ -105,6 +105,7 @@ perfetto_unittest_source_set("tracing_proto_extensions_unittests") {
     ":tracing_proto_extensions_lib",
     "../../gn:default_deps",
     "../../gn:gtest_and_gmock",
+    "../../protos/perfetto/common:zero",
     "../base",
     "../base:test_support",
   ]

--- a/src/tools/tracing_proto_extensions.cc
+++ b/src/tools/tracing_proto_extensions.cc
@@ -200,6 +200,30 @@ void ConvertFileDescriptor(const google::protobuf::FileDescriptorProto& src,
   }
 }
 
+// Emits |fd| and its transitive dependencies into |fds|, skipping files already
+// added and core Perfetto protos (those under protos/perfetto/). Core protos
+// already ship in TraceProcessor and resolve there -- including the extendee
+// (e.g. TracePacket) -- so the descriptor only needs to carry the extension
+// files and the types they define. |is_root| keeps the extension file itself
+// even when it lives under protos/perfetto/; the skip applies to its deps.
+void AddFileAndTransitiveDeps(const google::protobuf::FileDescriptor* fd,
+                              bool is_root,
+                              std::set<std::string>* added_files,
+                              pbzero::FileDescriptorSet* fds) {
+  std::string name(fd->name().data(), fd->name().size());
+  if (!is_root && base::StartsWith(name, "protos/perfetto/"))
+    return;
+  if (!added_files->insert(name).second)
+    return;
+  google::protobuf::FileDescriptorProto file_proto;
+  fd->CopyTo(&file_proto);
+  ConvertFileDescriptor(file_proto, fds->add_file());
+  for (int i = 0; i < fd->dependency_count(); ++i) {
+    AddFileAndTransitiveDeps(fd->dependency(i), /*is_root=*/false, added_files,
+                             fds);
+  }
+}
+
 // Validates that:
 // 1. At least one extension targeting |scope| exists in |file_desc|.
 // 2. All such extension fields have field numbers within the given |ranges|.
@@ -671,26 +695,9 @@ base::StatusOr<std::vector<uint8_t>> GenerateExtensionDescriptors(
     // Validate field numbers.
     RETURN_IF_ERROR(ValidateFieldNumbers(file_desc, entry.scope, entry.ranges));
 
-    // Convert to our descriptor format. We include the extension file itself
-    // and its transitive dependencies that are NOT core Perfetto protos
-    // (those are already built into TraceProcessor).
-    // For simplicity, we include all dependencies. TraceProcessor's
-    // DescriptorPool handles duplicates gracefully.
-    google::protobuf::FileDescriptorProto file_proto;
-    file_desc->CopyTo(&file_proto);
-
-    if (added_files.insert(file_proto.name()).second) {
-      ConvertFileDescriptor(file_proto, fds->add_file());
-    }
-
-    // Also add direct dependencies needed for type resolution.
-    for (int i = 0; i < file_desc->dependency_count(); ++i) {
-      google::protobuf::FileDescriptorProto dep_proto;
-      file_desc->dependency(i)->CopyTo(&dep_proto);
-      if (added_files.insert(dep_proto.name()).second) {
-        ConvertFileDescriptor(dep_proto, fds->add_file());
-      }
-    }
+    // Emit the extension file plus its non-core transitive dependencies.
+    AddFileAndTransitiveDeps(file_desc, /*is_root=*/true, &added_files,
+                             fds.get());
   }
 
   return fds.SerializeAsArray();

--- a/src/tools/tracing_proto_extensions_unittest.cc
+++ b/src/tools/tracing_proto_extensions_unittest.cc
@@ -17,6 +17,7 @@
 #include "src/tools/tracing_proto_extensions.h"
 
 #include "perfetto/base/status.h"
+#include "protos/perfetto/common/descriptor.pbzero.h"
 #include "src/base/test/tmp_dir_tree.h"
 #include "src/base/test/utils.h"
 #include "test/gtest_and_gmock.h"
@@ -524,6 +525,78 @@ TEST(GenProtoExtensionsTest, GenerateExtensionDescriptorsWithUnifiedRegistry) {
   ASSERT_TRUE(result.ok()) << result.status().message();
   // The output should be a non-empty FileDescriptorSet.
   EXPECT_GT(result->size(), 0u);
+}
+
+TEST(GenProtoExtensionsTest, GenerateExtensionDescriptorsExcludesCoreProtos) {
+  // The output carries the extension files and the types they define, but not
+  // the core Perfetto protos (the extendee and what it imports). Here a core
+  // extendee references a leaf type in a separate core file; both core files
+  // must be excluded from the output.
+  base::TmpDirTree tmp;
+  tmp.AddDir("protos");
+  tmp.AddDir("protos/perfetto");
+  tmp.AddDir("protos/perfetto/trace");
+  tmp.AddDir("protos/perfetto/trace/track_event");
+  tmp.AddDir("ext");
+  // A leaf type in its own core file.
+  tmp.AddFile("protos/perfetto/trace/track_event/leaf.proto", R"(
+    syntax = "proto2";
+    package perfetto.protos;
+    message CoreLeaf { optional int32 x = 1; }
+  )");
+  // A core extendee that references the leaf from the separate file.
+  tmp.AddFile("protos/perfetto/trace/track_event/track_event.proto", R"(
+    syntax = "proto2";
+    package perfetto.protos;
+    import "protos/perfetto/trace/track_event/leaf.proto";
+    message TrackEvent {
+      extensions 9900 to 9999;
+      optional CoreLeaf core_leaf = 1;
+    }
+  )");
+  // Out-of-tree extension: its own payload, extending the core TrackEvent.
+  tmp.AddFile("ext/my_ext.proto", R"(
+    syntax = "proto2";
+    package com.android.internal;
+    import "protos/perfetto/trace/track_event/track_event.proto";
+    message MyPayload { optional int32 y = 1; }
+    message MyExt {
+      extend perfetto.protos.TrackEvent {
+        optional MyPayload my_payload = 9900;
+      }
+    }
+  )");
+  tmp.AddFile("registry.json", R"({
+    "extensions": [
+      {
+        "scope": "perfetto.protos.TrackEvent",
+        "range": [9900, 9999],
+        "allocations": [
+          {"name": "ext", "range": [9900, 9999], "proto": "ext/my_ext.proto"}
+        ]
+      }
+    ]
+  })");
+
+  auto result = GenerateExtensionDescriptors(tmp.AbsolutePath("registry.json"),
+                                             {tmp.path()}, tmp.path());
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  std::vector<std::string> files;
+  protos::pbzero::FileDescriptorSet::Decoder fds(result->data(),
+                                                 result->size());
+  for (auto it = fds.file(); it; ++it) {
+    protos::pbzero::FileDescriptorProto::Decoder f(*it);
+    files.push_back(f.name().ToStdString());
+  }
+
+  // Extension file is present; the core extendee and core leaf are not.
+  EXPECT_THAT(files, testing::Contains("ext/my_ext.proto"));
+  EXPECT_THAT(files,
+              testing::Not(testing::Contains(
+                  "protos/perfetto/trace/track_event/track_event.proto")));
+  EXPECT_THAT(files, testing::Not(testing::Contains(
+                         "protos/perfetto/trace/track_event/leaf.proto")));
 }
 
 }  // namespace


### PR DESCRIPTION
tracing_proto_extensions builds the schema dictionary that ships on-device as /etc/tracing_descriptors.gz and gets embedded in traces to describe the out-of-tree extension fields.

Problem
- It emitted each extension file plus its direct imports — which pulled in the core extendee trace_packet.proto.
- That dragged a reference to the newest core types (e.g. SystemdJournaldEvent) into the dictionary without their definitions.
- Result: any trace_processor older than those types rejected the whole trace as corrupt, instead of just skipping unknown fields.

Fix
- Emit the extension file and its transitive deps, but skip core Perfetto protos (those under protos/perfetto/).
- trace_processor already has the core protos built in, and the extendee resolves against that — so they never need embedding.
- Matches the existing protozero_descriptor_diff design; shrinks the embedded descriptor (34 KB → <1 KB for the frameworks_base case).

Testing
- Verified an old trace_processor (v55.3) that failed to open such a trace opens it once the descriptor is rebuilt this way.
- Added a regression test asserting core protos are excluded from the output.