### PR TITLE
ui: Add option to make settings headless

### DIFF
--- a/ui/src/core/settings_manager.ts
+++ b/ui/src/core/settings_manager.ts
@@ -47,6 +47,7 @@ export class SettingImpl<T> implements Setting<T> {
     public readonly schema: z.ZodType<T>,
     public readonly requiresReload: boolean = false,
     public readonly render?: SettingRenderer<T>,
+    public readonly headless: boolean = false,
   ) {
     this.bootRawValue = this.manager.getStore()[this.id];
   }
@@ -117,6 +118,7 @@ export class SettingsManagerImpl implements SettingsManager {
       setting.schema,
       setting.requiresReload,
       setting.render,
+      setting.headless,
     );
 
     this.registry.set(setting.id, settingImpl as SettingImpl<unknown>);

--- a/ui/src/core_plugins/dev.perfetto.SettingsPage/settings_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.SettingsPage/settings_page.ts
@@ -183,6 +183,7 @@ export class SettingsPage implements m.ClassComponent<SettingsPageAttrs> {
     >();
     for (const result of settings) {
       const setting = result.item;
+      if (setting.headless) continue; // Don't display headless settings
       const isCore =
         setting.pluginId === undefined ||
         app.plugins.isCorePlugin(setting.pluginId);

--- a/ui/src/plugins/com.example.Settings/index.ts
+++ b/ui/src/plugins/com.example.Settings/index.ts
@@ -91,6 +91,21 @@ export default class implements PerfettoPlugin {
       },
     });
 
+    // Set the headless flag to true to register a setting that does not appear
+    // on the settings page. This is useful for persisting internal state that
+    // the user shouldn't configure directly (e.g. remembering the last used
+    // value of some control), while still benefiting from the settings
+    // persistence machinery.
+    const headlessSetting = app.settings.register({
+      id: 'com.example.Settings#headlessSetting',
+      name: 'Headless Setting',
+      description: 'A setting that is not shown on the settings page.',
+      schema: z.boolean(),
+      defaultValue: false,
+      headless: true,
+    });
+    console.log(`Headless setting value: ${headlessSetting.get()}`);
+
     // Set the requiresReload flag to true to indicate that the user should be
     // prompted to reload the app after changing this setting.
     app.settings.register({

--- a/ui/src/plugins/dev.perfetto.QueryPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/index.ts
@@ -129,6 +129,7 @@ export default class QueryPagePlugin implements PerfettoPlugin {
       description: 'Show the History/Tables sidebar on the Query page.',
       schema: z.boolean(),
       defaultValue: true,
+      headless: true,
     });
   }
 

--- a/ui/src/public/settings.ts
+++ b/ui/src/public/settings.ts
@@ -54,6 +54,12 @@ export interface SettingDescriptor<T> {
   // settings page. Required for settings that are move complex than a primitive
   // type, such as objects or arrays.
   readonly render?: SettingRenderer<T>;
+  // If true, the setting is hidden from the settings page and can only be
+  // changed programmatically. Use this for internal UI state that's persisted
+  // through the settings machinery but isn't meant for users to edit directly,
+  // such as panel positions or sidebar visibility, to avoid cluttering the
+  // settings page.
+  readonly headless?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add a new option when registering a setting to make it headless, which means it doesn't appear in the settings page and is only configurable programmatically. Useful for ephemeral settings such as panel positions or other state which is controllable elsewhere in the UI, which would otherwise clutter the settings page.
