### PR TITLE
ui: Avoid using screenshots to assert omnibox behavior

### DIFF
--- a/ui/src/test/omnibox.test.ts
+++ b/ui/src/test/omnibox.test.ts
@@ -14,33 +14,28 @@
 
 import {test} from '@playwright/test';
 import {PerfettoTestHelper} from './perfetto_ui_test_helper';
+import {expect} from '@playwright/test';
 
 test('command palette keyboard navigation', async ({browser}) => {
   const page = await browser.newPage();
   const pth = new PerfettoTestHelper(page);
   await pth.openTraceFile('api34_startup_cold.perfetto-trace');
 
+  // Open the command palette
   const omnibox = page.locator('input[ref=omnibox]');
   await omnibox.focus();
   await omnibox.fill('>');
 
-  await pth.waitForIdleAndScreenshot('command_palette_pos_0.png');
-  await omnibox.press('ArrowDown');
-  await pth.waitForIdleAndScreenshot('command_palette_pos_1.png');
+  const commands = page.locator('.pf-omnibox-options-container');
+
+  // Initially the first command should be highlighted.
+  expect(commands.first()).toHaveClass('pf-highlighted');
+
+  // Pressing up should highlight the last command.
   await omnibox.press('ArrowUp');
-  await pth.waitForIdleAndScreenshot('command_palette_pos_0.png');
+  expect(commands.last()).toHaveClass('pf-highlighted');
 
-  // Wrap around to the end of the list.
-  await omnibox.press('ArrowUp');
-
-  await pth.waitForIdleAndScreenshot('command_palette_pos_end-1.png');
-  await omnibox.press('ArrowUp');
-  await pth.waitForIdleAndScreenshot('command_palette_pos_end-2.png');
+  // Pressing down should highlight the first command again.
   await omnibox.press('ArrowDown');
-  await pth.waitForIdleAndScreenshot('command_palette_pos_end-1.png');
-
-  // Wrap around to the start of the list.
-  await omnibox.press('ArrowDown');
-
-  await pth.waitForIdleAndScreenshot('command_palette_pos_0.png');
+  expect(commands.first()).toHaveClass('pf-highlighted');
 });


### PR DESCRIPTION
The omnibox test is currently based on screenshots and is fragile because the screenshots can change any time a new command is introduced.

For instance - take this test failure in a PR that doesn't even tough the omnibox - simply adds a new command: https://storage.googleapis.com/perfetto-ci-artifacts/gh-26835408928-2-ui/ui-test-artifacts/index.html
https://github.com/google/perfetto/pull/5798

This patch modifies the test to assert correctness by asserting the state of the DOM instead of taking screenshots, which:
a) Asserts correct behavior directly (rather than purely comparing against a 'golden' screenshot, which itself could become wrong through careless rebases).
b) Is much less subject to false positives as the test surfaces is significantly smaller and more targeted.