### PR TITLE
ui: Hide out-of-tree Tooltip/CursorTooltip portals when their in-tree elements are not visible

### DIFF
--- a/ui/src/widgets/cursor_tooltip.ts
+++ b/ui/src/widgets/cursor_tooltip.ts
@@ -20,11 +20,14 @@ import type {HTMLAttrs} from './common';
 import {
   createPopper,
   type Instance as PopperInstance,
+  type Modifier,
+  type OptionsGeneric,
   type VirtualElement,
 } from '@popperjs/core';
 import {classNames} from '../base/classnames';
 import {type Point2D, Vector2D} from '../base/geom';
 import {PopupPosition} from './popup';
+import type {ExtendedModifiers} from './popper_utils';
 
 export interface CursorTooltipAttrs extends HTMLAttrs {
   // Which side of the cursor to place the tooltip. Defaults to Right.
@@ -61,47 +64,54 @@ document.addEventListener('mousemove', (e) => {
 export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
   private readonly trash = new DisposableStack();
   private readonly virtualElement = new VElement();
+  private tooltipElement?: HTMLElement;
+  // An empty element rendered inline in the component tree (as opposed to the
+  // tooltip content, which is portalled elsewhere). Its visibility tracks that
+  // of the tooltip's parent, so we can hide the tooltip when the parent goes
+  // away (e.g. an ancestor gets display:none).
+  private canaryElement?: HTMLElement;
   private popper?: PopperInstance;
 
   view({children, attrs}: m.Vnode<CursorTooltipAttrs>) {
-    const {
-      className,
-      offset = 8,
-      position = PopupPosition.Right,
-      ...rest
-    } = attrs;
-    return m(
-      Portal,
-      {
-        ...rest,
-        className: classNames('pf-cursor-tooltip', className),
-        onBeforeContentMount: (dom: Element): MountOptions => {
-          const closestModal = dom.closest('.pf-overlay-container');
-          if (closestModal) {
-            return {container: closestModal};
-          }
-          return {container: undefined};
+    const {className, ...rest} = attrs;
+    return [
+      m('.pf-cursor-tooltip-canary', {
+        // Take up no space and don't affect layout, but keep a layout box so
+        // checkVisibility() reflects our ancestors' visibility.
+        style: {position: 'absolute', width: '0', height: '0'},
+        oncreate: (v: m.VnodeDOM) => {
+          this.canaryElement = v.dom as HTMLElement;
         },
-        onContentMount: (portal) => {
-          this.virtualElement.setPosition(globalMousePos);
-          this.popper = createPopper(this.virtualElement, portal, {
-            placement: position,
-            modifiers: [
-              {
-                name: 'offset',
-                options: {
-                  offset: [0, offset], // Shift away from cursor
-                },
-              },
-            ],
-          });
+        onremove: () => {
+          this.canaryElement = undefined;
         },
-        onContentUnmount: () => {
-          this.popper?.destroy();
+      }),
+      m(
+        Portal,
+        {
+          ...rest,
+          className: classNames('pf-cursor-tooltip', className),
+          onBeforeContentMount: (dom: Element): MountOptions => {
+            const closestModal = dom.closest('.pf-overlay-container');
+            if (closestModal) {
+              return {container: closestModal};
+            }
+            return {container: undefined};
+          },
+          onContentMount: (portal) => {
+            this.tooltipElement = portal;
+            this.virtualElement.setPosition(globalMousePos);
+            this.createOrUpdatePopper(attrs);
+          },
+          onContentUnmount: () => {
+            this.popper?.destroy();
+            this.popper = undefined;
+            this.tooltipElement = undefined;
+          },
         },
-      },
-      children,
-    );
+        children,
+      ),
+    ];
   }
 
   oncreate(_: m.VnodeDOM<CursorTooltipAttrs>) {
@@ -113,7 +123,59 @@ export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
     );
   }
 
+  onupdate({attrs}: m.VnodeDOM<CursorTooltipAttrs, this>) {
+    this.createOrUpdatePopper(attrs);
+  }
+
   onremove(_: m.VnodeDOM<CursorTooltipAttrs, this>) {
     this.trash.dispose();
+  }
+
+  private createOrUpdatePopper(attrs: CursorTooltipAttrs) {
+    const {position = PopupPosition.Right, offset = 8} = attrs;
+
+    // Custom modifier to hide the tooltip when our canary - and hence the
+    // tooltip's parent - is not visible. This can be due to the canary or one
+    // of its ancestors having display:none.
+    const hideOnInvisible: Modifier<'hideOnInvisible', {}> = {
+      name: 'hideOnInvisible',
+      enabled: true,
+      phase: 'main',
+      fn: ({state}) => {
+        const el = this.canaryElement;
+        if (el === undefined) {
+          return;
+        }
+        const isVisible =
+          typeof el.checkVisibility === 'function'
+            ? el.checkVisibility()
+            : window.getComputedStyle(el).display !== 'none' &&
+              window.getComputedStyle(el).visibility !== 'hidden';
+        state.elements.popper.style.display = isVisible ? '' : 'none';
+      },
+    };
+
+    const options: Partial<OptionsGeneric<ExtendedModifiers>> = {
+      placement: position,
+      modifiers: [
+        {
+          name: 'offset',
+          options: {
+            offset: [0, offset], // Shift away from cursor
+          },
+        },
+        hideOnInvisible,
+      ],
+    };
+
+    if (this.popper) {
+      this.popper.setOptions(options);
+    } else if (this.tooltipElement) {
+      this.popper = createPopper<ExtendedModifiers>(
+        this.virtualElement,
+        this.tooltipElement,
+        options,
+      );
+    }
   }
 }

--- a/ui/src/widgets/tooltip.ts
+++ b/ui/src/widgets/tooltip.ts
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 import './tooltip.scss';
-import {createPopper, type Instance, type OptionsGeneric} from '@popperjs/core';
+import {
+  createPopper,
+  type Modifier,
+  type Instance,
+  type OptionsGeneric,
+} from '@popperjs/core';
 import m from 'mithril';
 import {type MountOptions, Portal, type PortalAttrs} from './portal';
 import {classNames} from '../base/classnames';
@@ -182,6 +187,48 @@ export class Tooltip implements m.ClassComponent<TooltipAttrs> {
       edgeOffset = 0,
     } = attrs;
 
+    // Custom modifier to hide popup when trigger is not visible. This can be
+    // due to the trigger or one of its ancestors having display:none.
+    const hideOnInvisible: Modifier<'hideOnInvisible', {}> = {
+      name: 'hideOnInvisible',
+      enabled: true,
+      phase: 'main',
+      fn({state}) {
+        const reference = state.elements.reference;
+        if (!(reference instanceof HTMLElement)) {
+          return;
+        }
+
+        // Check if checkVisibility is supported
+        if (typeof reference.checkVisibility === 'function') {
+          const isVisible = reference.checkVisibility();
+
+          if (!isVisible) {
+            // Hide the popper by setting display to none
+            state.elements.popper.style.display = 'none';
+          } else {
+            // Show the popper
+            state.elements.popper.style.display = '';
+          }
+        } else {
+          // Fallback for browsers that don't support checkVisibility()
+          // Use intersection observer or other visibility checks
+          const rect = reference.getBoundingClientRect();
+          const isVisible =
+            rect.top >= 0 &&
+            rect.left >= 0 &&
+            rect.bottom <=
+              (window.innerHeight || document.documentElement.clientHeight) &&
+            rect.right <=
+              (window.innerWidth || document.documentElement.clientWidth) &&
+            window.getComputedStyle(reference).visibility !== 'hidden' &&
+            window.getComputedStyle(reference).display !== 'none';
+
+          state.elements.popper.style.display = isVisible ? '' : 'none';
+        }
+      },
+    };
+
     const options: Partial<OptionsGeneric<ExtendedModifiers>> = {
       placement: position,
       modifiers: [
@@ -201,6 +248,7 @@ export class Tooltip implements m.ClassComponent<TooltipAttrs> {
         },
         {name: 'preventOverflow', options: {padding: 8}},
         {name: 'arrow', options: {padding: 2}},
+        hideOnInvisible,
       ],
     };
 


### PR DESCRIPTION
This fixes a bug where switching pages while a CursorTooltip or Tooltip component is visible would remain on screen after e.g. switching pages.

This was previously fixed for Popup elements so this patch simply applies the same fix for CursorTooltip and Tooltip components too.
