### PR TITLE
perfetto: make promote-stable skip the CHANGELOG Unreleased block

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -66,14 +66,13 @@ jobs:
       - name: Extract version from CHANGELOG
         id: version
         run: |
-          # First non-whitespace line must be a released version header.
-          # Anything else (e.g. still 'Unreleased:') means the release
-          # hasn't been marked ready. Update CHANGELOG on main, re-cut
-          # canary, and retry.
+          # The CHANGELOG keeps an 'Unreleased:' block at the top, so grab the
+          # first 'vX.Y' header instead of the first line. The release is ready
+          # once that header has a date.
           FIRST=$(git show "origin/canary:CHANGELOG" \
-                  | grep -m1 -E '^[^[:space:]]' || true)
+                  | grep -m1 -E '^v[0-9]+\.[0-9]+' || true)
           if ! [[ "$FIRST" =~ ^(v[0-9]+\.[0-9]+)[[:space:]]+-[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}: ]]; then
-            echo "::error::CHANGELOG top entry is not a released version header (got: '$FIRST'). Update CHANGELOG to 'vX.Y - YYYY-MM-DD:' on main, re-cut canary, and retry."
+            echo "::error::No dated release header found at the top of canary's CHANGELOG (got: '$FIRST'). Date the version header as 'vX.Y - YYYY-MM-DD:' on main, re-cut canary, and retry."
             exit 1
           fi
           VERSION="${BASH_REMATCH[1]}"


### PR DESCRIPTION
Match the first version header instead of the first non-whitespace line so promotion is consistent with tagging and the 'Unreleased:' convention. The dated-header check is retained, so an undated/draft header is still rejected, and the following tag-existence check still prevents re-promoting an already-released version.
