### PR TITLE
perfetto(python): fix the PyPI release flow

### DIFF
--- a/docs/contributing/python-releasing.md
+++ b/docs/contributing/python-releasing.md
@@ -2,46 +2,49 @@
 
 This guide shows how to make a new Perfetto Python library release to PyPI.
 
-The release process is split into two stages, both orchestrated by the
+The package version is derived automatically from the `CHANGELOG` (the top
+`vX.Y` entry maps to the PyPI version `0.X.Y`), so there is no separate
+version-bump step. Publishing is a single stage, driven by the
 `tools/release/release_python.py` script.
 
-## Stage 1: Bumping the version
+## Prerequisites
 
-The first stage creates a pull request to update the package version.
+- Run the script from the root of the repository.
+- A Python virtual environment must exist at `.venv` (the script uses
+  `.venv/bin/python`).
+- A clean git working directory (no uncommitted changes).
+- PyPI credentials: the username is `__token__`. For the password (API token),
+  find "Perfetto PyPi API Key" on http://go/valentine.
 
-1. Run the release script from the root of the repository.
+## Publishing
+
+1. Pick the release commit to publish from — normally the `vX.Y` tag commit.
+   For example:
 
 ```bash
-tools/release/release_python.py --bump-version
+COMMIT=$(git rev-parse v56.0^{commit})
 ```
 
-The script will guide you through the following steps:
-
-- **Versioning**: It will show you the current version from `python/setup.py` and prompt you for the new version.
-- **Branching**: It will prompt you for a new branch name and create it.
-- **Committing**: It will update the `version` in `python/setup.py` and create a commit.
-
-2. Once the script completes, push the new branch and create a pull request.
-
-3. After the pull request is reviewed and landed, proceed to Stage 2.
-
-## Stage 2: Publishing the release and updating the download URL
-
-The second stage publishes the package to PyPI and then creates a second pull request to update the source code with the correct download URL.
-
-1. Find the commit hash of the landed version bump CL from Stage 1.
-
-2. Run the release script again, providing the landed commit hash.
+2. Run the release script, passing that commit:
 
 ```bash
-tools/release/release_python.py --publish --commit <landed-commit-hash>
+tools/release/release_python.py --publish --commit "$COMMIT"
 ```
 
 The script will then perform the following steps:
 
 - **Checkout**: It will check out the specified commit.
-- **Build & Publish**: It will temporarily update the `download_url` in `python/setup.py`, build the package, and upload it to PyPI. You will be prompted for your PyPI credentials. For the username, use `__token__`. For the password (API token), find "Perfetto PyPi API Key" on http://go/valentine.
-- **Cleanup**: It will remove the temporary build artifacts.
-- **Final URL Update**: After publishing, the script will prompt you for a new branch name. It will then create a new commit on that branch that updates the `download_url` in `python/setup.py` to point to the commit from the `--commit` argument.
+- **Build & Publish**: It will temporarily update the `download_url` in
+  `python/setup.py` to that commit's source archive, build the package (the
+  version is read from the `CHANGELOG`), and, after you confirm, upload it to
+  PyPI. You will be prompted for your PyPI credentials.
+- **Cleanup**: It will remove the temporary build artifacts and restore
+  `python/setup.py`.
+- **Final URL Update**: After publishing, the script will prompt you for a new
+  branch name. It will then create a new commit on that branch that updates the
+  `download_url` in `python/setup.py` to point to the commit from the
+  `--commit` argument.
 
-3. Once the script completes, push the new branch for the `download_url` update and create a second pull request. After this final PR is landed, the release is complete.
+3. Once the script completes, push the new branch for the `download_url` update
+   and create a pull request. After this final PR is landed, the release is
+   complete.

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,22 +5,30 @@ from distutils.core import setup
 
 
 def _version_from_changelog():
-  """Derives the PyPI package version from the top entry of CHANGELOG.
+  """Derives the PyPI package version, e.g. '0.56.0'.
 
-  The CHANGELOG uses entries like 'vX.Y - YYYY-MM-DD:' for released versions
-  (and 'Unreleased:' at the top while a release is in flight). The first
-  matching 'vX.Y' line is mapped to the PyPI version '0.X.Y' — keeping the
-  package in the 0.x series while encoding the Perfetto release in the
-  minor/patch components.
+  Normally read from the top 'vX.Y' entry of the repo CHANGELOG, mapped to
+  '0.X.Y'. The CHANGELOG lives outside the package so it is not in the sdist;
+  when building from an sdist the CHANGELOG is absent, so fall back to the
+  version setuptools wrote into PKG-INFO when the sdist was created.
   """
-  changelog = os.path.join(
-      os.path.dirname(os.path.abspath(__file__)), os.pardir, 'CHANGELOG')
-  with open(changelog) as f:
-    for line in f:
-      m = re.match(r'^v(\d+)[.](\d+)\s', line)
-      if m:
-        return '0.%s.%s' % (m.group(1), m.group(2))
-  raise RuntimeError('No vX.Y entry found in %s' % changelog)
+  here = os.path.dirname(os.path.abspath(__file__))
+  changelog = os.path.join(here, os.pardir, 'CHANGELOG')
+  if os.path.exists(changelog):
+    with open(changelog) as f:
+      for line in f:
+        m = re.match(r'^v(\d+)[.](\d+)\s', line)
+        if m:
+          return '0.%s.%s' % (m.group(1), m.group(2))
+    raise RuntimeError('No vX.Y entry found in %s' % changelog)
+
+  pkg_info = os.path.join(here, 'PKG-INFO')
+  if os.path.exists(pkg_info):
+    with open(pkg_info) as f:
+      for line in f:
+        if line.startswith('Version:'):
+          return line.split(':', 1)[1].strip()
+  raise RuntimeError('Cannot determine version: no CHANGELOG or PKG-INFO')
 
 
 setup(

--- a/tools/release/release_python.py
+++ b/tools/release/release_python.py
@@ -30,6 +30,7 @@ NC = '\033[0m'  # No Color
 
 # Constants for paths. Assumes the script is run from the repository root.
 SETUP_PY_PATH = os.path.join('python', 'setup.py')
+CHANGELOG_PATH = 'CHANGELOG'
 VENV_PYTHON = (
     os.path.abspath(os.path.join('.venv', 'bin', 'python')) if sys.platform
     != 'win32' else os.path.join('.venv', 'Scripts', 'python.exe'))
@@ -90,41 +91,19 @@ def write_setup_py_content(content: str) -> None:
     f.write(content)
 
 
-def get_current_version(content: str) -> str:
-  """Extracts version from setup.py using a robust regex."""
-  match = re.search(r"version\s*=\s*'([^']*)'", content)
-  if not match:
-    error(f"Could not find version in {SETUP_PY_PATH}")
-    sys.exit(1)  # Unreachable, but satisfies type checker
-  return match.group(1)
+def version_from_changelog() -> str:
+  """Returns the PyPI version, e.g. '0.56.0'.
 
-
-def bump_version() -> None:
-  """Stage 1: Creates a commit with a bumped version number."""
-  info("--- Stage 1: Bumping version ---")
-  content = get_setup_py_content()
-  current_version = get_current_version(content)
-  info(f"Current version is {current_version}")
-
-  new_version = prompt("Enter the new version (e.g., X.Y.Z): ")
-  if not re.match(r'\d+\.\d+\.\d+', new_version):
-    error("Invalid version format. Please use 'X.Y.Z'.")
-
-  branch_name = prompt("Enter a name for the new release branch: ")
-  run_cmd('git', 'checkout', '-b', branch_name)
-
-  info(f"Updating version in {SETUP_PY_PATH} to {new_version}...")
-  new_content = re.sub(r"version\s*=\s*'[^']*'", f"version='{new_version}'",
-                       content)
-  write_setup_py_content(new_content)
-
-  run_cmd('git', 'add', SETUP_PY_PATH)
-  run_cmd('git', 'commit', '-m',
-          f'perfetto(python): Bump version to {new_version}')
-
-  info(f"Version bump commit created on branch '{branch_name}'.")
-  info("Please push this branch, create a pull request, and wait for it to "
-       "be landed.")
+  The version comes from the top 'vX.Y' entry of the CHANGELOG, same as
+  python/setup.py.
+  """
+  with open(CHANGELOG_PATH) as f:
+    for line in f:
+      m = re.match(r'^v(\d+)[.](\d+)\s', line)
+      if m:
+        return '0.%s.%s' % (m.group(1), m.group(2))
+  error(f"No vX.Y entry found in {CHANGELOG_PATH}")
+  sys.exit(1)  # Unreachable, but satisfies type checker
 
 
 def publish(commit: str) -> None:
@@ -135,9 +114,9 @@ def publish(commit: str) -> None:
   info(f"Checking out commit {commit}...")
   run_cmd('git', 'checkout', commit)
 
-  # Read the original content of setup.py at the release commit.
+  # setup.py content at the release commit, used below to rewrite download_url.
   content_at_commit = get_setup_py_content()
-  new_version = get_current_version(content_at_commit)
+  new_version = version_from_changelog()
   download_url = f"'https://github.com/google/perfetto/archive/{commit}.zip'"
 
   # Temporarily update download_url just for building the package.
@@ -199,19 +178,17 @@ def publish(commit: str) -> None:
 
 def main() -> None:
   parser = argparse.ArgumentParser(
-      description="Automates the Perfetto Python library release process.")
-  parser.add_argument(
-      '--bump-version',
-      action='store_true',
-      help="Stage 1: Bump version and create a release CL.")
+      description="Publishes the Perfetto Python library to PyPI. The version "
+      "comes from the CHANGELOG, so there is nothing to bump.")
   parser.add_argument(
       '--publish',
       action='store_true',
-      help="Stage 2: Publish the release to PyPI.")
+      help="Publish the release to PyPI and create the download_url CL.")
   parser.add_argument(
       '--commit',
       metavar='HASH',
-      help="The landed commit hash of the version bump CL (for --publish).")
+      help="The release commit to publish from, e.g. the vX.Y tag commit "
+      "(for --publish).")
 
   args = parser.parse_args()
 
@@ -226,11 +203,7 @@ def main() -> None:
 
   check_git_clean()
 
-  if args.bump_version:
-    if args.publish or args.commit:
-      parser.error("--bump-version cannot be used with --publish or --commit.")
-    bump_version()
-  elif args.publish:
+  if args.publish:
     if not args.commit:
       parser.error("--publish requires --commit.")
     publish(args.commit)


### PR DESCRIPTION
The package version is derived from the CHANGELOG. This makes the
release path work with that:

- release_python.py: read the version from the CHANGELOG instead of a
  'version=...' literal, and drop the version-bump stage since the
  version is now derived automatically.

- setup.py: when building from an sdist the CHANGELOG isn't present (it
  lives outside the package), so fall back to the version recorded in
  PKG-INFO. This unblocks building the wheel from the sdist.

Also update docs/contributing/python-releasing.md to match: publishing
is now a single step from the release commit.

Verified 'python -m build' produces both the sdist and the wheel (0.56.0).