### PR TITLE
tp: move gpu descriptor parsing to tokenization and prevent 0 ts packets

### DIFF
--- a/src/trace_processor/importers/proto/gpu_counter_sequence_state.h
+++ b/src/trace_processor/importers/proto/gpu_counter_sequence_state.h
@@ -21,23 +21,36 @@
 
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/storage/trace_storage.h"
 
 namespace perfetto::trace_processor {
 
 class TraceProcessorContext;
 
-// Per-incremental-state cache of which interned counter descriptors have
-// already had their custom counter groups inserted. Lives on
-// `IncrementalState` so it shares scope with the interned-data table that
-// the descriptors themselves are looked up from — keying by iid alone is
-// safe here because two distinct producers necessarily live on distinct
-// packet sequences (and therefore distinct IncrementalStates), so they each
-// get their own cache.
+// Per-incremental-state result of parsing interned GPU counter descriptors.
+// The descriptors are parsed once at tokenization time (tracks interned,
+// counter groups inserted) and the resulting `counter_id -> track` mapping is
+// cached here for the parse stage to look up.
+//
+// Lives on `IncrementalState` so it shares scope with the interned-data table
+// that the descriptors themselves are looked up from — keying by iid alone is
+// safe here because two distinct producers necessarily live on distinct packet
+// sequences (and therefore distinct IncrementalStates), so they each get their
+// own cache.
 struct GpuCounterSequenceState : PacketSequenceStateGeneration::CustomState {
   explicit GpuCounterSequenceState(TraceProcessorContext*);
   ~GpuCounterSequenceState() override;
 
-  base::FlatHashMap<uint64_t, bool> custom_groups_inserted;
+  struct CounterTrackInfo {
+    TrackId track_id;
+    bool forwards_looking;
+  };
+
+  // Key: counter_descriptor_iid. Value: per-descriptor map of counter_id ->
+  // track info. Presence of an iid key means the descriptor has already been
+  // parsed (tracks interned, groups inserted) at tokenization time.
+  base::FlatHashMap<uint64_t, base::FlatHashMap<uint32_t, CounterTrackInfo>>
+      descriptors;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/gpu_event_parser.cc
+++ b/src/trace_processor/importers/proto/gpu_event_parser.cc
@@ -167,8 +167,6 @@ GpuEventParser::GpuEventParser(TraceProcessorContext* context)
           context->storage->InternString("launch.workgroup_size.z")),
       description_id_(context->storage->InternString("description")),
       correlation_id_(context->storage->InternString("correlation_id")),
-      counter_id_key_id_(context->storage->InternString("counter_id")),
-      counter_name_key_id_(context->storage->InternString("counter_name")),
       tag_id_(context_->storage->InternString("tag")),
       log_message_id_(context->storage->InternString("message")),
       log_severity_ids_{{context_->storage->InternString("UNSPECIFIED"),
@@ -435,155 +433,38 @@ void GpuEventParser::PushGpuCounterValue(
   *last_id = id;
 }
 
-void GpuEventParser::ParseGpuCounterEvent(
+void GpuEventParser::PushGpuCounterValues(
     int64_t ts,
-    PacketSequenceStateGeneration* sequence_state,
-    ConstBytes blob) {
-  GpuCounterEvent::Decoder event(blob);
-
-  // Handle the new interned descriptor path.
-  if (event.has_counter_descriptor_iid()) {
-    auto* interned = sequence_state->LookupInternedMessage<
-        protos::pbzero::InternedData::kGpuCounterDescriptorsFieldNumber,
-        InternedGpuCounterDescriptor>(event.counter_descriptor_iid());
-    if (!interned || !interned->has_counter_descriptor()) {
-      context_->stats_tracker->IncrementStats(stats::gpu_counters_invalid_spec);
-      return;
-    }
-
-    GpuCounterDescriptor::Decoder desc(interned->counter_descriptor());
-    auto gpu_id = interned->gpu_id();
-    auto group_metadata = BuildGroupMetadata(desc);
-
-    for (auto it = event.counters(); it; ++it) {
-      GpuCounterEvent::GpuCounter::Decoder counter(*it);
-      if (!counter.has_counter_id() ||
-          !(counter.has_int_value() || counter.has_double_value())) {
-        continue;
-      }
-
-      // Find the matching spec in the descriptor.
-      bool found = false;
-      for (auto spec_it = desc.specs(); spec_it; ++spec_it) {
-        GpuCounterDescriptor::GpuCounterSpec::Decoder spec(*spec_it);
-        if (!spec.has_counter_id() ||
-            spec.counter_id() != counter.counter_id()) {
-          continue;
-        }
-        if (!spec.has_name()) {
-          context_->stats_tracker->IncrementStats(
-              stats::gpu_counters_invalid_spec);
-          break;
-        }
-        found = true;
-
-        auto track_id = InternGpuCounterTrack(gpu_id, spec);
-        auto [last_it, inserted] =
-            gpu_counter_last_id_.Insert(track_id, std::nullopt);
-        if (inserted) {
-          InsertCounterGroups(track_id, spec, group_metadata);
-        }
-
-        double counter_val = counter.has_int_value()
-                                 ? static_cast<double>(counter.int_value())
-                                 : counter.double_value();
-        bool forwards_looking = spec.value_direction() ==
-                                GpuCounterDescriptor::GpuCounterSpec::
-                                    VALUE_DIRECTION_FORWARDS_LOOKING;
-        PushGpuCounterValue(ts, counter_val, track_id, forwards_looking,
-                            &*last_it);
-        break;
-      }
-
-      if (!found) {
-        context_->stats_tracker->IncrementStats(
-            stats::gpu_counters_invalid_spec);
-      }
-    }
-
-    // Insert custom counter groups once per interned descriptor. The cache
-    // lives on the sequence's IncrementalState (alongside the interned-data
-    // table the descriptor was looked up from), so two producers picking the
-    // same iid on different sequences each get their own cache.
-    auto iid = event.counter_descriptor_iid();
-    auto* gpu_counter_state =
-        sequence_state->GetCustomState<GpuCounterSequenceState>();
-    if (!gpu_counter_state->custom_groups_inserted.Find(iid)) {
-      gpu_counter_state->custom_groups_inserted.Insert(iid, true);
-      base::FlatHashMap<uint32_t, TrackId> counter_id_to_track;
-      for (auto spec_it = desc.specs(); spec_it; ++spec_it) {
-        GpuCounterDescriptor::GpuCounterSpec::Decoder spec(*spec_it);
-        if (!spec.has_counter_id() || !spec.has_name()) {
-          continue;
-        }
-        auto track_id = InternGpuCounterTrack(gpu_id, spec);
-        counter_id_to_track.Insert(spec.counter_id(), track_id);
-      }
-      InsertCustomCounterGroups(desc, counter_id_to_track);
-    }
-    return;
-  }
-
-  // Legacy inline counter_descriptor path.
-  if (event.has_counter_descriptor()) {
-    GpuCounterDescriptor::Decoder descriptor(event.counter_descriptor());
-    auto group_metadata = BuildGroupMetadata(descriptor);
-    base::FlatHashMap<uint32_t, TrackId> counter_id_to_track;
-    for (auto it = descriptor.specs(); it; ++it) {
-      GpuCounterDescriptor::GpuCounterSpec::Decoder spec(*it);
-      if (!spec.has_counter_id()) {
-        context_->import_logs_tracker->RecordParserError(
-            stats::gpu_counters_invalid_spec, ts);
-        continue;
-      }
-      if (!spec.has_name()) {
-        context_->import_logs_tracker->RecordParserError(
-            stats::gpu_counters_invalid_spec, ts);
-        continue;
-      }
-
-      auto counter_id = spec.counter_id();
-      if (gpu_counter_state_.Find(counter_id)) {
-        context_->import_logs_tracker->RecordParserError(
-            stats::gpu_counters_invalid_spec, ts,
-            [this, counter_id, &spec](ArgsTracker::BoundInserter& inserter) {
-              inserter.AddArg(counter_id_key_id_,
-                              Variadic::UnsignedInteger(counter_id));
-              inserter.AddArg(counter_name_key_id_,
-                              Variadic::String(context_->storage->InternString(
-                                  spec.name())));
-            });
-        continue;
-      }
-
-      auto gpu_id = event.gpu_id();
-      auto track_id = InternGpuCounterTrack(gpu_id, spec);
-      InsertCounterGroups(track_id, spec, group_metadata);
-      bool forwards_looking = spec.value_direction() ==
-                              GpuCounterDescriptor::GpuCounterSpec::
-                                  VALUE_DIRECTION_FORWARDS_LOOKING;
-      gpu_counter_state_.Insert(
-          counter_id, GpuCounterState{track_id, {}, forwards_looking});
-      counter_id_to_track.Insert(counter_id, track_id);
-    }
-    InsertCustomCounterGroups(descriptor, counter_id_to_track);
-  }
-
+    const CounterTrackMap& counter_map,
+    bool report_missing,
+    const GpuCounterEvent::Decoder& event) {
+  // The descriptor (interned or inline) was parsed at tokenization time by
+  // GraphicsEventModule, which resolved the counter_id -> track mapping passed
+  // in `counter_map`. Here we just look up each sample and push its value.
   for (auto it = event.counters(); it; ++it) {
     GpuCounterEvent::GpuCounter::Decoder counter(*it);
     if (!counter.has_counter_id() ||
         !(counter.has_int_value() || counter.has_double_value())) {
       continue;
     }
-    auto* state = gpu_counter_state_.Find(counter.counter_id());
-    if (!state) {
+    const auto* info = counter_map.Find(counter.counter_id());
+    if (!info) {
+      // Unknown counter_id (no matching spec). For the interned path this is a
+      // genuine mismatch; for the legacy path it just means no descriptor has
+      // defined this counter yet.
+      if (report_missing) {
+        context_->stats_tracker->IncrementStats(
+            stats::gpu_counters_invalid_spec);
+      }
       continue;
     }
     double counter_val = counter.has_int_value()
                              ? static_cast<double>(counter.int_value())
                              : counter.double_value();
-    PushGpuCounterValue(ts, counter_val, state->track_id,
-                        state->forwards_looking, &state->last_id);
+    auto [last_it, inserted] =
+        gpu_counter_last_id_.Insert(info->track_id, std::nullopt);
+    PushGpuCounterValue(ts, counter_val, info->track_id, info->forwards_looking,
+                        &*last_it);
   }
 }
 

--- a/src/trace_processor/importers/proto/gpu_event_parser.h
+++ b/src/trace_processor/importers/proto/gpu_event_parser.h
@@ -29,8 +29,10 @@
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/protozero/field.h"
 #include "protos/perfetto/common/gpu_counter_descriptor.pbzero.h"
+#include "protos/perfetto/trace/gpu/gpu_counter_event.pbzero.h"
 #include "protos/perfetto/trace/gpu/gpu_render_stage_event.pbzero.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
+#include "src/trace_processor/importers/proto/gpu_counter_sequence_state.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/vulkan_memory_tracker.h"
 #include "src/trace_processor/storage/trace_storage.h"
@@ -64,9 +66,39 @@ class GpuEventParser {
       protos::pbzero::VulkanMemoryEvent::Operation;
   explicit GpuEventParser(TraceProcessorContext*);
 
-  void ParseGpuCounterEvent(int64_t ts,
-                            PacketSequenceStateGeneration* sequence_state,
-                            ConstBytes);
+  // GPU counter descriptor helpers, used at tokenization time by
+  // GraphicsEventModule to turn a GpuCounterDescriptor into tracks and counter
+  // groups.
+  struct GroupMetadata {
+    StringId name;
+    StringId description;
+  };
+  using GroupMetadataMap = base::FlatHashMap<int32_t, GroupMetadata>;
+  using CounterTrackMap =
+      base::FlatHashMap<uint32_t, GpuCounterSequenceState::CounterTrackInfo>;
+  TrackId InternGpuCounterTrack(
+      int32_t gpu_id,
+      const protos::pbzero::GpuCounterDescriptor::GpuCounterSpec::Decoder&
+          spec);
+  GroupMetadataMap BuildGroupMetadata(
+      const protos::pbzero::GpuCounterDescriptor::Decoder& desc);
+  void InsertCounterGroups(
+      TrackId track_id,
+      const protos::pbzero::GpuCounterDescriptor::GpuCounterSpec::Decoder& spec,
+      const GroupMetadataMap& group_metadata);
+  void InsertCustomCounterGroups(
+      const protos::pbzero::GpuCounterDescriptor::Decoder& desc,
+      const base::FlatHashMap<uint32_t, TrackId>& counter_id_to_track);
+
+  // Pushes the sample values of a GpuCounterEvent at parse time, using an
+  // already-resolved counter_id -> track mapping (built at tokenization time).
+  // If `report_missing` is set, counters with no matching entry in the map are
+  // counted as gpu_counters_invalid_spec (used by the interned path).
+  void PushGpuCounterValues(
+      int64_t ts,
+      const CounterTrackMap& counter_map,
+      bool report_missing,
+      const protos::pbzero::GpuCounterEvent::Decoder& event);
   void ParseGpuRenderStageEvent(int64_t ts,
                                 PacketSequenceStateGeneration*,
                                 ConstBytes);
@@ -100,24 +132,6 @@ class GpuEventParser {
   StringId FormatCounterUnit(
       const protos::pbzero::GpuCounterDescriptor::GpuCounterSpec::Decoder&
           spec);
-  TrackId InternGpuCounterTrack(
-      int32_t gpu_id,
-      const protos::pbzero::GpuCounterDescriptor::GpuCounterSpec::Decoder&
-          spec);
-  struct GroupMetadata {
-    StringId name;
-    StringId description;
-  };
-  using GroupMetadataMap = base::FlatHashMap<int32_t, GroupMetadata>;
-  GroupMetadataMap BuildGroupMetadata(
-      const protos::pbzero::GpuCounterDescriptor::Decoder& desc);
-  void InsertCounterGroups(
-      TrackId track_id,
-      const protos::pbzero::GpuCounterDescriptor::GpuCounterSpec::Decoder& spec,
-      const GroupMetadataMap& group_metadata);
-  void InsertCustomCounterGroups(
-      const protos::pbzero::GpuCounterDescriptor::Decoder& desc,
-      const base::FlatHashMap<uint32_t, TrackId>& counter_id_to_track);
   // Pushes a counter sample for a GPU counter, handling both the
   // backwards-looking and forwards-looking conventions (see
   // GpuCounterSpec.ValueDirection).
@@ -146,17 +160,8 @@ class GpuEventParser {
   const StringId pid_id_;
   const StringId tid_id_;
 
-  // For GpuCounterEvent (legacy inline counter_descriptor path).
-  // Key: counter_id (global scope, backward compatible).
-  struct GpuCounterState {
-    TrackId track_id;
-    std::optional<tables::CounterTable::Id> last_id;
-    bool forwards_looking;
-  };
-  base::FlatHashMap<uint32_t, GpuCounterState> gpu_counter_state_;
-
-  // Track-level last_id for the interned counter_descriptor_iid path.
-  // Key: TrackId.
+  // Track-level last_id for GPU counters. Used by both the interned and the
+  // legacy inline descriptor paths when pushing samples. Key: TrackId.
   base::FlatHashMap<TrackId, std::optional<tables::CounterTable::Id>>
       gpu_counter_last_id_;
 
@@ -177,8 +182,6 @@ class GpuEventParser {
   const StringId workgroup_z_id_;
   const StringId description_id_;
   const StringId correlation_id_;
-  const StringId counter_id_key_id_;
-  const StringId counter_name_key_id_;
   std::vector<std::optional<HwQueueInfo>> gpu_hw_queue_ids_;
   base::FlatHashMap<uint64_t, bool> gpu_hw_queue_ids_name_to_set_;
 

--- a/src/trace_processor/importers/proto/graphics_event_module.cc
+++ b/src/trace_processor/importers/proto/graphics_event_module.cc
@@ -17,24 +17,42 @@
 #include "src/trace_processor/importers/proto/graphics_event_module.h"
 
 #include <cstdint>
+#include <utility>
 
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "src/trace_processor/importers/common/args_tracker.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
+#include "src/trace_processor/importers/common/stats_tracker.h"
+#include "src/trace_processor/importers/proto/gpu_counter_sequence_state.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/storage/stats.h"
+#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
+#include "protos/perfetto/common/gpu_counter_descriptor.pbzero.h"
+#include "protos/perfetto/trace/gpu/gpu_counter_event.pbzero.h"
+#include "protos/perfetto/trace/interned_data/interned_data.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
 namespace perfetto::trace_processor {
 
+using perfetto::protos::pbzero::GpuCounterDescriptor;
+using perfetto::protos::pbzero::GpuCounterEvent;
+using perfetto::protos::pbzero::InternedData;
+using perfetto::protos::pbzero::InternedGpuCounterDescriptor;
 using perfetto::protos::pbzero::TracePacket;
 
 GraphicsEventModule::GraphicsEventModule(
     ProtoImporterModuleContext* module_context,
     TraceProcessorContext* context)
     : ProtoImporterModule(module_context),
+      context_(context),
       parser_(context),
       frame_parser_(context),
-      frame_timeline_parser_(context) {
+      frame_timeline_parser_(context),
+      counter_id_key_id_(context->storage->InternString("counter_id")),
+      counter_name_key_id_(context->storage->InternString("counter_name")) {
   RegisterForField(TracePacket::kFrameTimelineEventFieldNumber);
   RegisterForField(TracePacket::kGpuCounterEventFieldNumber);
   RegisterForField(TracePacket::kGpuRenderStageEventFieldNumber);
@@ -47,6 +65,164 @@ GraphicsEventModule::GraphicsEventModule(
 
 GraphicsEventModule::~GraphicsEventModule() = default;
 
+ModuleResult GraphicsEventModule::TokenizePacket(
+    const TracePacket::Decoder& decoder,
+    TraceBlobView* packet,
+    int64_t /*packet_timestamp*/,
+    RefPtr<PacketSequenceStateGeneration> state,
+    uint32_t field_id) {
+  if (field_id != TracePacket::kGpuCounterEventFieldNumber) {
+    return ModuleResult::Ignored();
+  }
+
+  // A GpuCounterEvent has two independent sections that are handled in different
+  // stages:
+  //  - the descriptor section (counter_descriptor / counter_descriptor_iid) is
+  //    handled here at tokenization time (track + counter group setup);
+  //  - the event section (the counter samples) is handled at parse time.
+  // The descriptor section is processed unconditionally, even if the packet has
+  // no timestamp.
+  GpuCounterEvent::Decoder event(decoder.gpu_counter_event());
+  TokenizeGpuCounterEvent(state.get(), packet->offset(), event);
+
+  // Only the event section needs a timestamp (the samples have to be sorted). A
+  // descriptor-only packet legitimately has no samples and no timestamp, so only
+  // flag/drop the packet when it actually carries samples. Returning a
+  // non-Ignored result stops it from reaching the sorter.
+  if (event.counters() && !decoder.has_timestamp()) {
+    context_->import_logs_tracker->RecordTokenizationError(
+        stats::gpu_counters_missing_timestamp, packet->offset());
+    return ModuleResult::Handled();
+  }
+
+  // Let the packet flow through to the sorter so its samples are pushed at parse
+  // time.
+  return ModuleResult::Ignored();
+}
+
+void GraphicsEventModule::TokenizeGpuCounterEvent(
+    PacketSequenceStateGeneration* state,
+    size_t packet_offset,
+    const GpuCounterEvent::Decoder& event) {
+  auto* gpu_counter_state = state->GetCustomState<GpuCounterSequenceState>();
+
+  // Interned descriptor path: parse the descriptor once per iid, interning the
+  // tracks and inserting the counter groups. The resulting counter_id -> track
+  // mapping is cached on the sequence's IncrementalState (alongside the
+  // interned-data table the descriptor was looked up from), so two producers
+  // picking the same iid on different sequences each get their own cache.
+  if (event.has_counter_descriptor_iid()) {
+    auto iid = event.counter_descriptor_iid();
+    if (gpu_counter_state->descriptors.Find(iid)) {
+      return;
+    }
+
+    auto* interned = state->LookupInternedMessage<
+        InternedData::kGpuCounterDescriptorsFieldNumber,
+        InternedGpuCounterDescriptor>(iid);
+    if (!interned || !interned->has_counter_descriptor()) {
+      context_->stats_tracker->IncrementStats(stats::gpu_counters_invalid_spec);
+      return;
+    }
+
+    GpuCounterDescriptor::Decoder desc(interned->counter_descriptor());
+    auto gpu_id = interned->gpu_id();
+    auto group_metadata = parser_.BuildGroupMetadata(desc);
+
+    base::FlatHashMap<uint32_t, GpuCounterSequenceState::CounterTrackInfo>
+        counter_map;
+    base::FlatHashMap<uint32_t, TrackId> counter_id_to_track;
+    for (auto spec_it = desc.specs(); spec_it; ++spec_it) {
+      GpuCounterDescriptor::GpuCounterSpec::Decoder spec(*spec_it);
+      if (!spec.has_counter_id() || !spec.has_name()) {
+        continue;
+      }
+      auto track_id = parser_.InternGpuCounterTrack(gpu_id, spec);
+      if (counter_id_to_track.Insert(spec.counter_id(), track_id).second) {
+        parser_.InsertCounterGroups(track_id, spec, group_metadata);
+      }
+      bool forwards_looking = spec.value_direction() ==
+                              GpuCounterDescriptor::GpuCounterSpec::
+                                  VALUE_DIRECTION_FORWARDS_LOOKING;
+      counter_map.Insert(spec.counter_id(),
+                         GpuCounterSequenceState::CounterTrackInfo{
+                             track_id, forwards_looking});
+    }
+    parser_.InsertCustomCounterGroups(desc, counter_id_to_track);
+    gpu_counter_state->descriptors.Insert(iid, std::move(counter_map));
+    return;
+  }
+
+  // Legacy inline counter_descriptor path. counter_ids are global here, so the
+  // mapping is cached on the module-global `legacy_gpu_counters_`.
+  if (event.has_counter_descriptor()) {
+    GpuCounterDescriptor::Decoder descriptor(event.counter_descriptor());
+    auto group_metadata = parser_.BuildGroupMetadata(descriptor);
+    base::FlatHashMap<uint32_t, TrackId> counter_id_to_track;
+    for (auto it = descriptor.specs(); it; ++it) {
+      GpuCounterDescriptor::GpuCounterSpec::Decoder spec(*it);
+      if (!spec.has_counter_id()) {
+        context_->import_logs_tracker->RecordTokenizationError(
+            stats::gpu_counters_invalid_spec, packet_offset);
+        continue;
+      }
+      if (!spec.has_name()) {
+        context_->import_logs_tracker->RecordTokenizationError(
+            stats::gpu_counters_invalid_spec, packet_offset);
+        continue;
+      }
+
+      auto counter_id = spec.counter_id();
+      if (legacy_gpu_counters_.Find(counter_id)) {
+        context_->import_logs_tracker->RecordTokenizationError(
+            stats::gpu_counters_invalid_spec, packet_offset,
+            [this, counter_id, &spec](ArgsTracker::BoundInserter& inserter) {
+              inserter.AddArg(counter_id_key_id_,
+                              Variadic::UnsignedInteger(counter_id));
+              inserter.AddArg(counter_name_key_id_,
+                              Variadic::String(context_->storage->InternString(
+                                  spec.name())));
+            });
+        continue;
+      }
+
+      auto gpu_id = event.gpu_id();
+      auto track_id = parser_.InternGpuCounterTrack(gpu_id, spec);
+      parser_.InsertCounterGroups(track_id, spec, group_metadata);
+      bool forwards_looking = spec.value_direction() ==
+                              GpuCounterDescriptor::GpuCounterSpec::
+                                  VALUE_DIRECTION_FORWARDS_LOOKING;
+      legacy_gpu_counters_.Insert(
+          counter_id, GpuCounterSequenceState::CounterTrackInfo{
+                          track_id, forwards_looking});
+      counter_id_to_track.Insert(counter_id, track_id);
+    }
+    parser_.InsertCustomCounterGroups(descriptor, counter_id_to_track);
+  }
+}
+
+void GraphicsEventModule::ParseGpuCounterEvent(
+    int64_t ts,
+    PacketSequenceStateGeneration* state,
+    protozero::ConstBytes blob) {
+  GpuCounterEvent::Decoder event(blob);
+  if (event.has_counter_descriptor_iid()) {
+    auto* gpu_counter_state = state->GetCustomState<GpuCounterSequenceState>();
+    const auto* counter_map =
+        gpu_counter_state->descriptors.Find(event.counter_descriptor_iid());
+    if (!counter_map) {
+      // The descriptor was missing or invalid; already reported at
+      // tokenization time.
+      return;
+    }
+    parser_.PushGpuCounterValues(ts, *counter_map, /*report_missing=*/true,
+                                 event);
+    return;
+  }
+  parser_.PushGpuCounterValues(ts, legacy_gpu_counters_,
+                               /*report_missing=*/false, event);
+}
+
 void GraphicsEventModule::ParseTracePacketData(
     const TracePacket::Decoder& decoder,
     int64_t ts,
@@ -58,8 +234,8 @@ void GraphicsEventModule::ParseTracePacketData(
           ts, decoder.frame_timeline_event());
       return;
     case TracePacket::kGpuCounterEventFieldNumber:
-      parser_.ParseGpuCounterEvent(ts, data.sequence_state.get(),
-                                   decoder.gpu_counter_event());
+      ParseGpuCounterEvent(ts, data.sequence_state.get(),
+                           decoder.gpu_counter_event());
       return;
     case TracePacket::kGpuRenderStageEventFieldNumber:
       parser_.ParseGpuRenderStageEvent(ts, data.sequence_state.get(),

--- a/src/trace_processor/importers/proto/graphics_event_module.cc
+++ b/src/trace_processor/importers/proto/graphics_event_module.cc
@@ -75,8 +75,8 @@ ModuleResult GraphicsEventModule::TokenizePacket(
     return ModuleResult::Ignored();
   }
 
-  // A GpuCounterEvent has two independent sections that are handled in different
-  // stages:
+  // A GpuCounterEvent has two independent sections that are handled in
+  // different stages:
   //  - the descriptor section (counter_descriptor / counter_descriptor_iid) is
   //    handled here at tokenization time (track + counter group setup);
   //  - the event section (the counter samples) is handled at parse time.
@@ -86,8 +86,8 @@ ModuleResult GraphicsEventModule::TokenizePacket(
   TokenizeGpuCounterEvent(state.get(), packet->offset(), event);
 
   // Only the event section needs a timestamp (the samples have to be sorted). A
-  // descriptor-only packet legitimately has no samples and no timestamp, so only
-  // flag/drop the packet when it actually carries samples. Returning a
+  // descriptor-only packet legitimately has no samples and no timestamp, so
+  // only flag/drop the packet when it actually carries samples. Returning a
   // non-Ignored result stops it from reaching the sorter.
   if (event.counters() && !decoder.has_timestamp()) {
     context_->import_logs_tracker->RecordTokenizationError(
@@ -95,8 +95,8 @@ ModuleResult GraphicsEventModule::TokenizePacket(
     return ModuleResult::Handled();
   }
 
-  // Let the packet flow through to the sorter so its samples are pushed at parse
-  // time.
+  // Let the packet flow through to the sorter so its samples are pushed at
+  // parse time.
   return ModuleResult::Ignored();
 }
 
@@ -192,9 +192,9 @@ void GraphicsEventModule::TokenizeGpuCounterEvent(
       bool forwards_looking = spec.value_direction() ==
                               GpuCounterDescriptor::GpuCounterSpec::
                                   VALUE_DIRECTION_FORWARDS_LOOKING;
-      legacy_gpu_counters_.Insert(
-          counter_id, GpuCounterSequenceState::CounterTrackInfo{
-                          track_id, forwards_looking});
+      legacy_gpu_counters_.Insert(counter_id,
+                                  GpuCounterSequenceState::CounterTrackInfo{
+                                      track_id, forwards_looking});
       counter_id_to_track.Insert(counter_id, track_id);
     }
     parser_.InsertCustomCounterGroups(descriptor, counter_id_to_track);

--- a/src/trace_processor/importers/proto/graphics_event_module.h
+++ b/src/trace_processor/importers/proto/graphics_event_module.h
@@ -25,6 +25,7 @@
 #include "src/trace_processor/importers/proto/graphics_frame_event_parser.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
+#include "protos/perfetto/trace/gpu/gpu_counter_event.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
 namespace perfetto::trace_processor {
@@ -36,15 +37,48 @@ class GraphicsEventModule : public ProtoImporterModule {
 
   ~GraphicsEventModule() override;
 
+  ModuleResult TokenizePacket(const protos::pbzero::TracePacket::Decoder&,
+                              TraceBlobView* packet,
+                              int64_t packet_timestamp,
+                              RefPtr<PacketSequenceStateGeneration> state,
+                              uint32_t field_id) override;
+
   void ParseTracePacketData(const protos::pbzero::TracePacket::Decoder&,
                             int64_t ts,
                             const TracePacketData&,
                             uint32_t field_id) override;
 
  private:
+  // Parses the GpuCounterDescriptor portion of a GpuCounterEvent (if present)
+  // at tokenization time: interns the counter tracks and inserts the counter
+  // groups, caching the resulting counter_id -> track mapping (on the
+  // sequence's GpuCounterSequenceState for the interned path, or on the
+  // module-global `legacy_gpu_counters_` for the inline path) for the parse
+  // stage. `packet_offset` is the byte offset of the packet, used for error
+  // reporting.
+  void TokenizeGpuCounterEvent(
+      PacketSequenceStateGeneration* state,
+      size_t packet_offset,
+      const protos::pbzero::GpuCounterEvent::Decoder& event);
+
+  // Pushes the sample values of a GpuCounterEvent at parse time, resolving the
+  // counter_id -> track mapping built at tokenization time.
+  void ParseGpuCounterEvent(int64_t ts,
+                            PacketSequenceStateGeneration* state,
+                            protozero::ConstBytes);
+
+  TraceProcessorContext* const context_;
   GpuEventParser parser_;
   GraphicsFrameEventParser frame_parser_;
   FrameTimelineEventParser frame_timeline_parser_;
+
+  const StringId counter_id_key_id_;
+  const StringId counter_name_key_id_;
+
+  // counter_id -> track info for the legacy inline counter_descriptor path
+  // (mode 1). counter_ids are global in this mode, so the map is shared across
+  // all packet sequences (this module instance is per-trace).
+  GpuEventParser::CounterTrackMap legacy_gpu_counters_;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -108,6 +108,11 @@ namespace perfetto::trace_processor::stats {
        "Invalid order of generic task state events. Should never happen."),    \
   F(gpu_counters_invalid_spec,            kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
   F(gpu_counters_missing_spec,            kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
+  F(gpu_counters_missing_timestamp,       kSingle,  kError,    kTrace, Scope::kMachineAndTrace,           \
+      "A GpuCounterEvent packet was received without a timestamp on the "      \
+      "containing TracePacket. Without a timestamp the counter samples cannot "\
+      "be placed on the trace timeline, so the packet is dropped. This "       \
+      "indicates a bug in the trace producer."),                              \
   F(gpu_render_stage_parser_errors,       kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
   F(graphics_frame_event_parser_errors,   kSingle,  kInfo,     kAnalysis, Scope::kMachineAndTrace, ""), \
   F(guess_trace_type_duration_ns,         kSingle,  kInfo,     kAnalysis, Scope::kGlobal, ""), \

--- a/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
+++ b/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
@@ -579,6 +579,94 @@ class GraphicsGpuTrace(TestSuite):
           20,0.000000,"CounterB",1
         """))
 
+  def test_gpu_counter_missing_timestamp_dropped(self):
+    # A GpuCounterEvent packet without a timestamp on the containing TracePacket
+    # cannot be placed on the timeline, so it is dropped at tokenization time
+    # and counted in the gpu_counters_missing_timestamp stat.
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+          packet {
+            trusted_packet_sequence_id: 1
+            timestamp: 10
+            gpu_counter_event {
+              gpu_id: 0
+              counter_descriptor {
+                specs {
+                  counter_id: 1
+                  name: "CounterA"
+                  description: "desc A"
+                }
+              }
+              counters { counter_id: 1 int_value: 100 }
+            }
+          }
+          packet {
+            trusted_packet_sequence_id: 1
+            gpu_counter_event {
+              gpu_id: 0
+              counters { counter_id: 1 int_value: 200 }
+            }
+          }
+        """),
+        query="""
+          SELECT
+            (SELECT count(*) FROM counter
+             JOIN gpu_counter_track ON counter.track_id = gpu_counter_track.id)
+              AS sample_count,
+            (SELECT value FROM stats
+             WHERE name = 'gpu_counters_missing_timestamp') AS dropped;
+        """,
+        out=Csv("""
+          "sample_count","dropped"
+          1,1
+        """))
+
+  def test_gpu_counter_descriptor_parsed_without_timestamp(self):
+    # The descriptor section of a GpuCounterEvent is handled at tokenization
+    # time independently of the event section. Even though the descriptor packet
+    # has no timestamp (so it is dropped as a sample-bearing event), the track is
+    # still set up, so a later timestamped sample resolves to it.
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+          packet {
+            trusted_packet_sequence_id: 1
+            gpu_counter_event {
+              gpu_id: 0
+              counter_descriptor {
+                specs {
+                  counter_id: 1
+                  name: "CounterA"
+                  description: "desc A"
+                  # VALUE_DIRECTION_FORWARDS_LOOKING, so the sample value lands on
+                  # its own timestamp (avoids the backwards-looking placeholder).
+                  value_direction: 2
+                }
+              }
+            }
+          }
+          packet {
+            trusted_packet_sequence_id: 1
+            timestamp: 10
+            gpu_counter_event {
+              gpu_id: 0
+              counters { counter_id: 1 int_value: 100 }
+            }
+          }
+        """),
+        query="""
+          SELECT
+            (SELECT value FROM stats
+             WHERE name = 'gpu_counters_missing_timestamp') AS dropped,
+            ts, value, name, gpu_id
+          FROM counter
+          JOIN gpu_counter_track ON counter.track_id = gpu_counter_track.id
+          ORDER BY ts;
+        """,
+        out=Csv("""
+          "dropped","ts","value","name","gpu_id"
+          0,10,100.000000,"CounterA",0
+        """))
+
   def test_gpu_render_stages_flow(self):
     return DiffTestBlueprint(
         trace=Path('gpu_render_stages_flow.textproto'),


### PR DESCRIPTION
This CL moves descriptor parsing to happen at tokeniation time so that
the contract adhered by produces (emit your descriptor before your
event) also causes correct parsing behaviour.

The current behaviour could break that if there was some other producer
which which was emitting larger timestamps such that the descriptor
would be sorted *after* the event that contained it.

Also while I'm here, add an explicit error stat + import logs for the
case of dropping events due to having zero timestamps (post descriptor
parse) which is invalid.
