### PR TITLE
watchdog: Support ro.hw_timeout_multiplier on Android

### DIFF
--- a/src/base/watchdog_posix.cc
+++ b/src/base/watchdog_posix.cc
@@ -67,7 +67,8 @@ base::CrashKey g_crash_key_actual_cpu("wdog_actual_cpu");
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
 // This system property is already used for all sorts of Android watchdogs.
-// Bringing the Perfetto watchdog behavior closer to that on Android reduces surprise.
+// Bringing the Perfetto watchdog behavior closer to that on Android reduces
+// surprise.
 uint32_t GetHwTimeoutMultiplier() {
   static uint32_t multiplier = []() {
     char prop_val[PROP_VALUE_MAX] = {0};

--- a/src/base/watchdog_posix.cc
+++ b/src/base/watchdog_posix.cc
@@ -66,6 +66,8 @@ base::CrashKey g_crash_key_actual_boot("wdog_actual_boot");
 base::CrashKey g_crash_key_actual_cpu("wdog_actual_cpu");
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+// This system property is already used for all sorts of Android watchdogs.
+// Bringing the Perfetto watchdog behavior closer to that on Android reduces surprise.
 uint32_t GetHwTimeoutMultiplier() {
   static uint32_t multiplier = []() {
     char prop_val[PROP_VALUE_MAX] = {0};

--- a/src/base/watchdog_posix.cc
+++ b/src/base/watchdog_posix.cc
@@ -30,12 +30,13 @@
 #include <unistd.h>
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
-#include <sys/system_properties.h>
+#include "perfetto/ext/base/android_utils.h"
 #endif
 
 #include <algorithm>
 #include <cinttypes>
 #include <fstream>
+#include <limits>
 #include <thread>
 
 #include "perfetto/base/build_config.h"
@@ -71,10 +72,12 @@ base::CrashKey g_crash_key_actual_cpu("wdog_actual_cpu");
 // surprise.
 uint32_t GetHwTimeoutMultiplier() {
   static uint32_t multiplier = []() {
-    char prop_val[PROP_VALUE_MAX] = {0};
-    if (__system_property_get("ro.hw_timeout_multiplier", prop_val) > 0) {
-      int val = atoi(prop_val);
-      return val > 1 ? static_cast<uint32_t>(val) : 1u;
+    std::string multiplier_prop = GetAndroidProp("ro.hw_timeout_multiplier");
+    if (!multiplier_prop.empty()) {
+      auto multiplier_opt = StringToUInt32(multiplier_prop);
+      if (multiplier_opt.has_value() && *multiplier_opt > 0) {
+        return *multiplier_opt;
+      }
     }
     return 1u;
   }();
@@ -156,7 +159,15 @@ Watchdog::Timer Watchdog::CreateFatalTimer(uint32_t ms,
     return Watchdog::Timer(this, 0, crash_reason);
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
-  ms *= GetHwTimeoutMultiplier();
+  uint32_t multiplier = GetHwTimeoutMultiplier();
+  if (ms > 0 && multiplier > 1) {
+    uint64_t scaled_ms = static_cast<uint64_t>(ms) * multiplier;
+    if (scaled_ms > std::numeric_limits<uint32_t>::max()) {
+      ms = std::numeric_limits<uint32_t>::max();
+    } else {
+      ms = static_cast<uint32_t>(scaled_ms);
+    }
+  }
 #endif
 
   return Watchdog::Timer(this, ms, crash_reason);

--- a/src/base/watchdog_posix.cc
+++ b/src/base/watchdog_posix.cc
@@ -29,6 +29,10 @@
 #include <sys/timerfd.h>
 #include <unistd.h>
 
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+#include <sys/system_properties.h>
+#endif
+
 #include <algorithm>
 #include <cinttypes>
 #include <fstream>
@@ -60,6 +64,20 @@ base::CrashKey g_crash_key_timeout("wdog_timeout");
 base::CrashKey g_crash_key_actual_mono("wdog_actual_mono");
 base::CrashKey g_crash_key_actual_boot("wdog_actual_boot");
 base::CrashKey g_crash_key_actual_cpu("wdog_actual_cpu");
+
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+uint32_t GetHwTimeoutMultiplier() {
+  static uint32_t multiplier = []() {
+    char prop_val[PROP_VALUE_MAX] = {0};
+    if (__system_property_get("ro.hw_timeout_multiplier", prop_val) > 0) {
+      int val = atoi(prop_val);
+      return val > 1 ? static_cast<uint32_t>(val) : 1u;
+    }
+    return 1u;
+  }();
+  return multiplier;
+}
+#endif
 
 bool IsMultipleOf(uint32_t number, uint32_t divisor) {
   return number >= divisor && number % divisor == 0;
@@ -133,6 +151,10 @@ Watchdog::Timer Watchdog::CreateFatalTimer(uint32_t ms,
                                            WatchdogCrashReason crash_reason) {
   if (!enabled_.load(std::memory_order_relaxed))
     return Watchdog::Timer(this, 0, crash_reason);
+
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+  ms *= GetHwTimeoutMultiplier();
+#endif
 
   return Watchdog::Timer(this, ms, crash_reason);
 }


### PR DESCRIPTION
Multiply fatal timer durations by the integer multiplier read from the system property `ro.hw_timeout_multiplier` when building for Android.

This keeps Perfetto thread and task-runner timeouts safe from triggering false-positive crashes (wdog_reason: 3) during prolonged suspend/resume cycles or on slow emulated environments.

I use direct `__system_property_get` to scale the interval `ms` inside `CreateFatalTimer`, ensuring that we avoid pulling heavy dependencies like libbase into Perfetto base. Non-Android platforms are unaffected.

Bug: 6122