### PR TITLE
feat(trace_processor): parse legacy_sort_index for thread/process ordering

### DIFF
--- a/src/trace_processor/importers/proto/track_event_parser.cc
+++ b/src/trace_processor/importers/proto/track_event_parser.cc
@@ -228,6 +228,10 @@ TrackEventParser::TrackEventParser(TraceProcessorContext* context,
       callsite_id_key_id_(context_->storage->InternString("callsite_id")),
       end_callsite_id_key_id_(
           context_->storage->InternString("end_callsite_id")),
+      thread_sort_index_hint_id_(
+          context_->storage->InternString("thread_sort_index_hint")),
+      process_sort_index_hint_id_(
+          context_->storage->InternString("process_sort_index_hint")),
       chrome_string_lookup_(context->storage.get()),
       active_chrome_processes_tracker_(context) {
   // Opt into DebugAnnotation handling: ParseMessage routes DebugAnnotation
@@ -346,6 +350,15 @@ UniquePid TrackEventParser::ParseProcessDescriptor(
     context_->process_tracker->SetStartTsIfUnset(upid,
                                                  decoder.start_timestamp_ns());
   }
+
+  // Parse legacy_sort_index and store it as process_sort_index_hint for UI
+  // ordering. This allows SDK users to control process display order in the UI.
+  if (decoder.has_legacy_sort_index()) {
+    context_->process_tracker->AddArgsToProcess(upid).AddArg(
+        process_sort_index_hint_id_,
+        Variadic::Integer(decoder.legacy_sort_index()));
+  }
+
   // TODO(skyostil): Remove parsing for legacy chrome_process_type field.
   // TODO(lalitm): this maze of priorities around Chrome process labels is
   // because of us trying to fix process naming without breaking backcompat.
@@ -424,6 +437,14 @@ UniqueTid TrackEventParser::ParseThreadDescriptor(
   }
   context_->process_tracker->UpdateThreadName(
       utid, name_id, ThreadNamePriority::kTrackDescriptor);
+
+  // Parse legacy_sort_index and store it as thread_sort_index_hint for UI
+  // ordering. This allows SDK users to control thread display order in the UI.
+  if (decoder.has_legacy_sort_index()) {
+    context_->process_tracker->AddArgsToThread(utid).AddArg(
+        thread_sort_index_hint_id_,
+        Variadic::Integer(decoder.legacy_sort_index()));
+  }
   return utid;
 }
 

--- a/src/trace_processor/importers/proto/track_event_parser.h
+++ b/src/trace_processor/importers/proto/track_event_parser.h
@@ -128,6 +128,10 @@ class TrackEventParser {
   const StringId callsite_id_key_id_;
   const StringId end_callsite_id_key_id_;
 
+  // String IDs for sort index hints (used for thread/process ordering in UI)
+  const StringId thread_sort_index_hint_id_;
+  const StringId process_sort_index_hint_id_;
+
   ChromeStringLookup chrome_string_lookup_;
   std::vector<uint32_t> reflect_fields_;
   ActiveChromeProcessesTracker active_chrome_processes_tracker_;

--- a/test/trace_processor/diff_tests/parser/parsing/process_sort_index.textproto
+++ b/test/trace_processor/diff_tests/parser/parsing/process_sort_index.textproto
@@ -1,0 +1,46 @@
+# Process with legacy_sort_index
+packet {
+  track_descriptor {
+    uuid: 100
+    process {
+      pid: 100
+      process_name: "HighPriorityProcess"
+      legacy_sort_index: 100
+    }
+  }
+  timestamp: 1000
+  track_event {
+    type: TYPE_INSTANT
+  }
+}
+
+# Process without legacy_sort_index (should have default NULL)
+packet {
+  track_descriptor {
+    uuid: 200
+    process {
+      pid: 200
+      process_name: "NormalProcess"
+    }
+  }
+  timestamp: 1000
+  track_event {
+    type: TYPE_INSTANT
+  }
+}
+
+# Process with lower sort_index
+packet {
+  track_descriptor {
+    uuid: 300
+    process {
+      pid: 300
+      process_name: "LowPriorityProcess"
+      legacy_sort_index: 10
+    }
+  }
+  timestamp: 1000
+  track_event {
+    type: TYPE_INSTANT
+  }
+}

--- a/test/trace_processor/diff_tests/parser/parsing/process_sort_index_test.out
+++ b/test/trace_processor/diff_tests/parser/parsing/process_sort_index_test.out
@@ -1,0 +1,4 @@
+pid	name	sort_index_hint
+100	HighPriorityProcess	100
+200	NormalProcess	NULL
+300	LowPriorityProcess	10

--- a/test/trace_processor/diff_tests/parser/parsing/process_sort_index_test.sql
+++ b/test/trace_processor/diff_tests/parser/parsing/process_sort_index_test.sql
@@ -1,0 +1,9 @@
+-- Verify that legacy_sort_index from ProcessDescriptor is parsed and stored as process_sort_index_hint
+
+-- Check that processes have the correct sort index hints
+SELECT
+  pid,
+  name,
+  extract_arg(arg_set_id, 'process_sort_index_hint') AS sort_index_hint
+FROM process
+ORDER BY pid;

--- a/test/trace_processor/diff_tests/parser/parsing/thread_sort_index.textproto
+++ b/test/trace_processor/diff_tests/parser/parsing/thread_sort_index.textproto
@@ -1,0 +1,49 @@
+# Thread with legacy_sort_index
+packet {
+  track_descriptor {
+    uuid: 1
+    thread {
+      pid: 1234
+      tid: 1234
+      thread_name: "MainThread"
+      legacy_sort_index: 10
+    }
+  }
+  timestamp: 1000
+  track_event {
+    type: TYPE_INSTANT
+  }
+}
+
+# Thread without legacy_sort_index (should have default 0)
+packet {
+  track_descriptor {
+    uuid: 2
+    thread {
+      pid: 1234
+      tid: 5678
+      thread_name: "WorkerThread"
+    }
+  }
+  timestamp: 1000
+  track_event {
+    type: TYPE_INSTANT
+  }
+}
+
+# Thread with higher sort_index (should appear first)
+packet {
+  track_descriptor {
+    uuid: 3
+    thread {
+      pid: 1234
+      tid: 9999
+      thread_name: "HighPriorityThread"
+      legacy_sort_index: 100
+    }
+  }
+  timestamp: 1000
+  track_event {
+    type: TYPE_INSTANT
+  }
+}

--- a/test/trace_processor/diff_tests/parser/parsing/thread_sort_index_test.out
+++ b/test/trace_processor/diff_tests/parser/parsing/thread_sort_index_test.out
@@ -1,0 +1,4 @@
+tid	name	sort_index_hint
+1234	MainThread	10
+5678	WorkerThread	NULL
+9999	HighPriorityThread	100

--- a/test/trace_processor/diff_tests/parser/parsing/thread_sort_index_test.sql
+++ b/test/trace_processor/diff_tests/parser/parsing/thread_sort_index_test.sql
@@ -1,0 +1,9 @@
+-- Verify that legacy_sort_index from ThreadDescriptor is parsed and stored as thread_sort_index_hint
+
+-- Check that threads have the correct sort index hints
+SELECT
+  tid,
+  name,
+  extract_arg(arg_set_id, 'thread_sort_index_hint') AS sort_index_hint
+FROM thread
+ORDER BY tid;


### PR DESCRIPTION
  ## Summary
  Add support for parsing `legacy_sort_index` from `ThreadDescriptor` and `ProcessDescriptor` protobuf messages.

  ## Problem
  The `legacy_sort_index` field exists in the protobuf definitions but was not being parsed by the trace processor. This meant that SDK users setting `legacy_sort_index` on their TrackDescriptors would not see threads/processes ordered correctly in the UI.

  ## Solution
  Parse the `legacy_sort_index` field and store it as `thread_sort_index_hint` / `process_sort_index_hint` args, which the UI already uses for ordering (supports JSON format via `thread_sort_index` metadata).

  ## Testing
  Added diff tests for both thread and process `legacy_sort_index` parsing.

  ## Usage
  SDK users can now control thread display order:
  ```cpp
  auto desc = perfetto::ThreadTrack::Current().Serialize();
  desc.mutable_thread()->set_thread_name("MainThread");
  desc.mutable_thread()->set_legacy_sort_index(10);
  perfetto::TrackEvent::SetTrackDescriptor(perfetto::ThreadTrack::Current(), desc);
```
  Note: The UI sorts by thread_sort_index_hint in ascending order (lower values appear first).