### PR TITLE
tp: fix crash in experimental_flat_slice and switch how STF work

### DIFF
--- a/python/generators/trace_processor_table/public.py
+++ b/python/generators/trace_processor_table/public.py
@@ -165,6 +165,22 @@ class WrappingSqlView:
   view_name: str
 
 
+class Purpose(Enum):
+  """
+  Describes how a table is consumed, which can affect how it is generated.
+  """
+  # The table is used as a regular table: read from SQL via the normal
+  # query-plan cursor.
+  DEFAULT = auto()
+
+  # The table is the output of a StaticTableFunction. The SQLite module for
+  # such functions reads every output cell via random access
+  # (Dataframe::GetCell), so all nullable columns are forced to a
+  # random-access-capable null layout (DenseNull) regardless of cpp_access.
+  # The scan-only SparseNull default would abort at read time.
+  STATIC_TABLE_FUNCTION = auto()
+
+
 @dataclass(frozen=True)
 class Table:
   """
@@ -184,6 +200,7 @@ class Table:
     parent: The parent table for this table. All columns are inherited from the
     specified table.
     wrapping_sql_view: See |WrappingSqlView|.
+    purpose: How the table is consumed. See |Purpose|.
   """
   python_module: str
   class_name: str
@@ -193,6 +210,7 @@ class Table:
   add_implicit_column: bool = True
   tabledoc: Optional[TableDoc] = None
   wrapping_sql_view: Optional[WrappingSqlView] = None
+  purpose: Purpose = Purpose.DEFAULT
   # TODO(lalitm): remove once migration sticks.
   use_legacy_table_backend: bool = False
 

--- a/python/generators/trace_processor_table/serialize.py
+++ b/python/generators/trace_processor_table/serialize.py
@@ -19,6 +19,7 @@ from python.generators.trace_processor_table.public import Alias
 from python.generators.trace_processor_table.public import ColumnFlag
 from python.generators.trace_processor_table.public import CppAccess
 from python.generators.trace_processor_table.public import CppAccessDuration
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import SqlAccess
 from python.generators.trace_processor_table.util import ParsedTable
 from python.generators.trace_processor_table.util import ParsedColumn
@@ -44,6 +45,7 @@ class ColumnSerializer:
     self.is_no_transform_id = parsed_type.is_no_transform_id()
 
     self.is_implicit_id = self.parsed_col.is_implicit_id
+    self.table_purpose = table.table.purpose
 
   def row_field(self) -> Optional[str]:
     if self.is_implicit_id:
@@ -246,6 +248,11 @@ class ColumnSerializer:
 
   def _get_nullability_tag(self) -> str:
     if self.is_optional or self.is_string:
+      # StaticTableFunction outputs are read by random access (GetCell), which
+      # the scan-only SparseNull layout does not support. Force DenseNull for
+      # all nullable columns regardless of cpp_access.
+      if self.table_purpose == Purpose.STATIC_TABLE_FUNCTION:
+        return 'dataframe::DenseNull'
       if self.col.sql_access == SqlAccess.HIGH_PERF:
         return 'dataframe::DenseNull'
       if self.col.cpp_access == CppAccess.NONE:

--- a/src/trace_processor/perfetto_sql/engine/static_table_function_module.cc
+++ b/src/trace_processor/perfetto_sql/engine/static_table_function_module.cc
@@ -56,10 +56,25 @@ std::string ToSqliteCreateTableType(dataframe::StorageType type) {
   }
 }
 
-std::string CreateTableStmt(uint32_t args_count,
+std::string CreateTableStmt(const char* table_name,
+                            uint32_t args_count,
                             const dataframe::DataframeSpec& spec) {
   std::string create_stmt = "CREATE TABLE x(";
   for (uint32_t i = 0; i < spec.column_specs.size(); ++i) {
+    // The columns of a static table function are read by random access
+    // (Dataframe::GetCell), which the scan-only SparseNull layout does not
+    // support. Catch such a column here with a clear error rather than
+    // aborting deep inside a query. Backing tables defined via the Python
+    // generator should be marked with Purpose.STATIC_TABLE_FUNCTION, which
+    // forces nullable columns to DenseNull.
+    if (spec.column_specs[i].nullability.Is<dataframe::SparseNull>()) {
+      PERFETTO_FATAL(
+          "static table function '%s' column '%s' uses the SparseNull layout, "
+          "which does not support random access; use a DenseNull (or popcount) "
+          "layout, e.g. by marking the backing table with "
+          "Purpose.STATIC_TABLE_FUNCTION",
+          table_name, spec.column_names[i].c_str());
+    }
     create_stmt += spec.column_names[i] + " " +
                    ToSqliteCreateTableType(spec.column_specs[i].type);
     create_stmt += ", ";
@@ -88,7 +103,7 @@ int StaticTableFunctionModule::Create(sqlite3* db,
 
   uint32_t args_count = state->function->GetArgumentCount();
   auto spec = state->function->CreateSpec();
-  std::string create_stmt = CreateTableStmt(args_count, spec);
+  std::string create_stmt = CreateTableStmt(argv[2], args_count, spec);
   if (int r = sqlite3_declare_vtab(db, create_stmt.c_str()); r != SQLITE_OK) {
     *err = sqlite3_mprintf("failed to declare vtab %s", create_stmt.c_str());
     return r;
@@ -128,7 +143,7 @@ int StaticTableFunctionModule::Connect(sqlite3* db,
       vtab_state);
   uint32_t args_count = state->function->GetArgumentCount();
   auto spec = state->function->CreateSpec();
-  std::string create_stmt = CreateTableStmt(args_count, spec);
+  std::string create_stmt = CreateTableStmt(argv[2], args_count, spec);
   if (int r = sqlite3_declare_vtab(db, create_stmt.c_str()); r != SQLITE_OK) {
     return r;
   }

--- a/src/trace_processor/plugins/ancestor/tables.py
+++ b/src/trace_processor/plugins/ancestor/tables.py
@@ -14,12 +14,12 @@
 
 from python.generators.trace_processor_table.public import Column as C
 from python.generators.trace_processor_table.public import ColumnFlag
-from python.generators.trace_processor_table.public import CppAccess
 from python.generators.trace_processor_table.public import CppInt64
 from python.generators.trace_processor_table.public import CppOptional
 from python.generators.trace_processor_table.public import CppString
 from python.generators.trace_processor_table.public import CppTableId
 from python.generators.trace_processor_table.public import CppUint32
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 from src.trace_processor.tables.profiler_tables import STACK_PROFILE_CALLSITE_TABLE
@@ -30,37 +30,22 @@ from src.trace_processor.tables.track_tables import TRACK_TABLE
 SLICE_SUBSET_TABLE = Table(
     python_module=__file__,
     class_name="SliceSubsetTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="not_exposed_to_sql",
     columns=[
         C('id', CppTableId(SLICE_TABLE), flags=ColumnFlag.SORTED),
         C('ts', CppInt64(), flags=ColumnFlag.SORTED),
         C('dur', CppInt64()),
         C('track_id', CppTableId(TRACK_TABLE)),
-        C('category',
-          CppOptional(CppString()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C('name',
-          CppOptional(CppString()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C('category', CppOptional(CppString())),
+        C('name', CppOptional(CppString())),
         C('depth', CppUint32()),
-        C('parent_id',
-          CppOptional(CppTableId(SLICE_TABLE)),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C('arg_set_id',
-          CppOptional(CppUint32()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C('thread_ts',
-          CppOptional(CppInt64()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C('thread_dur',
-          CppOptional(CppInt64()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C('thread_instruction_count',
-          CppOptional(CppInt64()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C('thread_instruction_delta',
-          CppOptional(CppInt64()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C('parent_id', CppOptional(CppTableId(SLICE_TABLE))),
+        C('arg_set_id', CppOptional(CppUint32())),
+        C('thread_ts', CppOptional(CppInt64())),
+        C('thread_dur', CppOptional(CppInt64())),
+        C('thread_instruction_count', CppOptional(CppInt64())),
+        C('thread_instruction_delta', CppOptional(CppInt64())),
     ],
     add_implicit_column=False,
 )
@@ -68,6 +53,7 @@ SLICE_SUBSET_TABLE = Table(
 ANCESTOR_STACK_PROFILE_CALLSITE_TABLE = Table(
     python_module=__file__,
     class_name="AncestorStackProfileCallsiteTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="not_exposed_to_sql",
     columns=[
         C(
@@ -76,9 +62,7 @@ ANCESTOR_STACK_PROFILE_CALLSITE_TABLE = Table(
             flags=ColumnFlag.SORTED,
         ),
         C('depth', CppUint32()),
-        C('parent_id',
-          CppOptional(CppTableId(STACK_PROFILE_CALLSITE_TABLE)),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C('parent_id', CppOptional(CppTableId(STACK_PROFILE_CALLSITE_TABLE))),
         C('frame_id', CppTableId(STACK_PROFILE_FRAME_TABLE)),
     ],
     add_implicit_column=False,

--- a/src/trace_processor/plugins/connected_flow/tables.py
+++ b/src/trace_processor/plugins/connected_flow/tables.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from python.generators.trace_processor_table.public import Column as C
-from python.generators.trace_processor_table.public import CppAccess
 from python.generators.trace_processor_table.public import CppInt64
 from python.generators.trace_processor_table.public import CppOptional
 from python.generators.trace_processor_table.public import CppTableId
 from python.generators.trace_processor_table.public import CppUint32
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 from src.trace_processor.tables.slice_tables import SLICE_TABLE
@@ -25,16 +25,13 @@ from src.trace_processor.tables.slice_tables import SLICE_TABLE
 CONNECTED_FLOW_TABLE = Table(
     python_module=__file__,
     class_name="ConnectedFlowTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="not_exposed_to_sql",
     columns=[
         C('slice_out', CppTableId(SLICE_TABLE)),
         C('slice_in', CppTableId(SLICE_TABLE)),
-        C('trace_id',
-          CppOptional(CppInt64()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C('arg_set_id',
-          CppOptional(CppUint32()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C('trace_id', CppOptional(CppInt64())),
+        C('arg_set_id', CppOptional(CppUint32())),
     ],
 )
 

--- a/src/trace_processor/plugins/developer_functions/tables.py
+++ b/src/trace_processor/plugins/developer_functions/tables.py
@@ -14,22 +14,18 @@
 
 from python.generators.trace_processor_table.public import Column as C
 from python.generators.trace_processor_table.public import ColumnFlag
-from python.generators.trace_processor_table.public import CppAccess
 from python.generators.trace_processor_table.public import CppString
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 DATAFRAME_QUERY_PLAN_DECODER_TABLE_TABLE = Table(
     python_module=__file__,
     class_name="DataframeQueryPlanDecoderTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="not_exposed_to_sql",
     columns=[
-        C("bytecode_str",
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("serialized_bc",
-          CppString(),
-          flags=ColumnFlag.HIDDEN,
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C("bytecode_str", CppString()),
+        C("serialized_bc", CppString(), flags=ColumnFlag.HIDDEN),
     ],
 )
 

--- a/src/trace_processor/plugins/dfs_weight_bounded/tables.py
+++ b/src/trace_processor/plugins/dfs_weight_bounded/tables.py
@@ -13,21 +13,20 @@
 # limitations under the License.
 
 from python.generators.trace_processor_table.public import Column as C
-from python.generators.trace_processor_table.public import CppAccess
 from python.generators.trace_processor_table.public import CppOptional
 from python.generators.trace_processor_table.public import CppUint32
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 DFS_WEIGHT_BOUNDED_TABLE = Table(
     python_module=__file__,
     class_name="DfsWeightBoundedTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="__intrinsic_dfs_weight_bounded",
     columns=[
         C("root_node_id", CppUint32()),
         C("node_id", CppUint32()),
-        C("parent_node_id",
-          CppOptional(CppUint32()),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C("parent_node_id", CppOptional(CppUint32())),
     ],
 )
 

--- a/src/trace_processor/plugins/experimental_annotated_stack/tables.py
+++ b/src/trace_processor/plugins/experimental_annotated_stack/tables.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from python.generators.trace_processor_table.public import Column as C
-from python.generators.trace_processor_table.public import CppAccess
 from python.generators.trace_processor_table.public import CppOptional
 from python.generators.trace_processor_table.public import CppString
 from python.generators.trace_processor_table.public import CppTableId
 from python.generators.trace_processor_table.public import CppUint32
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 from src.trace_processor.tables.profiler_tables import STACK_PROFILE_CALLSITE_TABLE
@@ -26,17 +26,14 @@ from src.trace_processor.tables.profiler_tables import STACK_PROFILE_FRAME_TABLE
 EXPERIMENTAL_ANNOTATED_CALLSTACK_TABLE = Table(
     python_module=__file__,
     class_name="ExperimentalAnnotatedCallstackTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="experimental_annotated_callstack",
     columns=[
         C('id', CppTableId(STACK_PROFILE_CALLSITE_TABLE)),
         C('depth', CppUint32()),
-        C('parent_id',
-          CppOptional(CppTableId(STACK_PROFILE_CALLSITE_TABLE)),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C('parent_id', CppOptional(CppTableId(STACK_PROFILE_CALLSITE_TABLE))),
         C('frame_id', CppTableId(STACK_PROFILE_FRAME_TABLE)),
-        C("annotation",
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C("annotation", CppString()),
     ],
     add_implicit_column=False,
 )

--- a/src/trace_processor/plugins/experimental_flat_slice/tables.py
+++ b/src/trace_processor/plugins/experimental_flat_slice/tables.py
@@ -21,6 +21,7 @@ from python.generators.trace_processor_table.public import CppOptional
 from python.generators.trace_processor_table.public import CppString
 from python.generators.trace_processor_table.public import CppTableId
 from python.generators.trace_processor_table.public import CppUint32
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 from python.generators.trace_processor_table.public import TableDoc
 
@@ -29,6 +30,7 @@ from src.trace_processor.tables.track_tables import TRACK_TABLE
 
 EXPERIMENTAL_FLAT_SLICE_TABLE = Table(
     python_module=__file__,
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     class_name='ExperimentalFlatSliceTable',
     sql_name='experimental_flat_slice',
     columns=[

--- a/src/trace_processor/plugins/experimental_slice_layout/tables.py
+++ b/src/trace_processor/plugins/experimental_slice_layout/tables.py
@@ -15,6 +15,7 @@
 from python.generators.trace_processor_table.public import Column as C
 from python.generators.trace_processor_table.public import CppTableId
 from python.generators.trace_processor_table.public import CppUint32
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 from src.trace_processor.tables.slice_tables import SLICE_TABLE
@@ -22,6 +23,7 @@ from src.trace_processor.tables.slice_tables import SLICE_TABLE
 EXPERIMENTAL_SLICE_LAYOUT_TABLE = Table(
     python_module=__file__,
     class_name="ExperimentalSliceLayoutTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="experimental_slice_layout",
     columns=[
         C('id', CppTableId(SLICE_TABLE)),

--- a/src/trace_processor/plugins/stdlib_docs/tables.py
+++ b/src/trace_processor/plugins/stdlib_docs/tables.py
@@ -13,78 +13,65 @@
 # limitations under the License.
 
 from python.generators.trace_processor_table.public import Column as C
-from python.generators.trace_processor_table.public import CppAccess
 from python.generators.trace_processor_table.public import CppInt64
 from python.generators.trace_processor_table.public import CppString
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 STDLIB_DOCS_MODULES_TABLE = Table(
     python_module=__file__,
     class_name="StdlibDocsModulesTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="__intrinsic_stdlib_modules",
     columns=[
-        C("module", CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("package", CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C("module", CppString()),
+        C("package", CppString()),
     ],
 )
 
 STDLIB_DOCS_TABLES_TABLE = Table(
     python_module=__file__,
     class_name="StdlibDocsTablesTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="not_exposed_to_sql",
     columns=[
-        C("name", CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("type", CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("description",
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("exposed", CppInt64(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("cols", CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C("name", CppString()),
+        C("type", CppString()),
+        C("description", CppString()),
+        C("exposed", CppInt64()),
+        C("cols", CppString()),
     ],
 )
 
 STDLIB_DOCS_FUNCTIONS_TABLE = Table(
     python_module=__file__,
     class_name="StdlibDocsFunctionsTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="not_exposed_to_sql",
     columns=[
-        C("name", CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("description",
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("exposed", CppInt64(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("is_table_function",
-          CppInt64(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("return_type",
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("return_description",
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("args", CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("cols", CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C("name", CppString()),
+        C("description", CppString()),
+        C("exposed", CppInt64()),
+        C("is_table_function", CppInt64()),
+        C("return_type", CppString()),
+        C("return_description", CppString()),
+        C("args", CppString()),
+        C("cols", CppString()),
     ],
 )
 
 STDLIB_DOCS_MACROS_TABLE = Table(
     python_module=__file__,
     class_name="StdlibDocsMacrosTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="not_exposed_to_sql",
     columns=[
-        C("name", CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("description",
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("exposed", CppInt64(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("return_type",
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("return_description",
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C("args", CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C("name", CppString()),
+        C("description", CppString()),
+        C("exposed", CppInt64()),
+        C("return_type", CppString()),
+        C("return_description", CppString()),
+        C("args", CppString()),
     ],
 )
 

--- a/src/trace_processor/plugins/table_info/tables.py
+++ b/src/trace_processor/plugins/table_info/tables.py
@@ -14,24 +14,20 @@
 
 from python.generators.trace_processor_table.public import Column as C
 from python.generators.trace_processor_table.public import ColumnFlag
-from python.generators.trace_processor_table.public import CppAccess
 from python.generators.trace_processor_table.public import CppInt64
 from python.generators.trace_processor_table.public import CppString
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 TABLE_INFO_TABLE = Table(
     python_module=__file__,
     class_name="PerfettoTableInfoTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="perfetto_table_info",
     columns=[
-        C("table_name",
-          CppString(),
-          flags=ColumnFlag.HIDDEN,
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C('name', CppString(), cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
-        C('col_type',
-          CppString(),
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C("table_name", CppString(), flags=ColumnFlag.HIDDEN),
+        C('name', CppString()),
+        C('col_type', CppString()),
         C('nullable', CppInt64()),
         C('sorted', CppInt64()),
     ])

--- a/src/trace_processor/plugins/winscope_proto_to_args_with_defaults/tables.py
+++ b/src/trace_processor/plugins/winscope_proto_to_args_with_defaults/tables.py
@@ -20,17 +20,19 @@ from python.generators.trace_processor_table.public import CppInt64
 from python.generators.trace_processor_table.public import CppOptional
 from python.generators.trace_processor_table.public import CppString
 from python.generators.trace_processor_table.public import CppUint32
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 ARGS_WITH_DEFAULTS_TABLE = Table(
     python_module=__file__,
     class_name='WinscopeArgsWithDefaultsTable',
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name='__intrinsic_winscope_proto_to_args_with_defaults',
     columns=[
         C("table_name",
           CppString(),
           flags=ColumnFlag.HIDDEN,
-          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+          cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE),
         C(
             'base64_proto_id',
             CppUint32(),
@@ -39,12 +41,12 @@ ARGS_WITH_DEFAULTS_TABLE = Table(
         C(
             'flat_key',
             CppString(),
-            cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE,
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
         ),
         C(
             'key',
             CppString(),
-            cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE,
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
         ),
         C(
             'int_value',
@@ -54,7 +56,7 @@ ARGS_WITH_DEFAULTS_TABLE = Table(
         C(
             'string_value',
             CppOptional(CppString()),
-            cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE,
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
         ),
         C(
             'real_value',
@@ -64,7 +66,7 @@ ARGS_WITH_DEFAULTS_TABLE = Table(
         C(
             'value_type',
             CppString(),
-            cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE,
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
         ),
     ],
 )

--- a/src/trace_processor/plugins/winscope_surfaceflinger_hierarchy_paths/tables.py
+++ b/src/trace_processor/plugins/winscope_surfaceflinger_hierarchy_paths/tables.py
@@ -14,11 +14,13 @@
 
 from python.generators.trace_processor_table.public import Column as C
 from python.generators.trace_processor_table.public import CppUint32
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
 SURFACE_FLINGER_HIERARCHY_PATH_TABLE = Table(
     python_module=__file__,
     class_name="WinscopeSurfaceFlingerHierarchyPathTable",
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name="__intrinsic_winscope_surfaceflinger_hierarchy_path",
     columns=[
         C('snapshot_id', CppUint32()),

--- a/src/trace_processor/tables/profiler_tables.py
+++ b/src/trace_processor/tables/profiler_tables.py
@@ -27,6 +27,7 @@ from python.generators.trace_processor_table.public import CppUint32
 from python.generators.trace_processor_table.public import CppUint32 as CppBool
 from python.generators.trace_processor_table.public import CppDouble
 from python.generators.trace_processor_table.public import SqlAccess
+from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 from python.generators.trace_processor_table.public import TableDoc
 from python.generators.trace_processor_table.public import WrappingSqlView
@@ -1301,6 +1302,7 @@ GpuRenderStageEvent packets.''',
 EXPERIMENTAL_FLAMEGRAPH_TABLE = Table(
     python_module=__file__,
     class_name='ExperimentalFlamegraphTable',
+    purpose=Purpose.STATIC_TABLE_FUNCTION,
     sql_name='experimental_flamegraph',
     columns=[
         C(


### PR DESCRIPTION
Because of how the sqlite module for static table functions
is implemented, sparse null columns were a bit of a ticking problem
waiting to happen.

Instead make the fact we will use for a static table function a
property of the table rather than column and annotate all tables.
