### PR TITLE
py: ship pinned trace_processor with the package

### DIFF
--- a/docs/analysis/trace-processor-python.md
+++ b/docs/analysis/trace-processor-python.md
@@ -132,8 +132,14 @@ instance. The most important are:
   PerfettoSQL statements.
 - `verbose`: If `True`, `trace_processor` will print verbose output to stdout.
   This is useful for debugging and seeing more detailed error messages.
-- `bin_path`: Path to the `trace_processor` binary. If not given, the latest
-  prebuilt version will be downloaded.
+- `bin_path`: Path to the `trace_processor` binary. If not given, the
+  `trace_processor` version pinned to (and shipped with) the installed
+  `perfetto` package is downloaded and used. This keeps results reproducible:
+  upgrading the binary means upgrading the package.
+- `fetch_latest_trace_processor`: If `True` (and `bin_path` is not set), fetch
+  the latest available prebuilt from `get.perfetto.dev` instead of the version
+  pinned to the package. Use this to always run the newest build, at the cost of
+  reproducibility.
 
 ## API
 

--- a/docs/analysis/trace-processor-python.md
+++ b/docs/analysis/trace-processor-python.md
@@ -139,7 +139,9 @@ instance. The most important are:
 - `fetch_latest_trace_processor`: If `True` (and `bin_path` is not set), fetch
   the latest available prebuilt from `get.perfetto.dev` instead of the version
   pinned to the package. Use this to always run the newest build, at the cost of
-  reproducibility.
+  reproducibility. Note that this option is best-effort and may be ignored on
+  platforms which source the binary differently (e.g. inside Google3, where the
+  binary always comes from internal infra).
 
 ## API
 

--- a/python/perfetto/trace_processor/api.py
+++ b/python/perfetto/trace_processor/api.py
@@ -66,6 +66,12 @@ class TraceProcessorConfig:
   # trace_processor prebuilt from get.perfetto.dev instead of using the version
   # pinned to this package. This trades reproducibility for always being on the
   # newest build.
+  #
+  # Note: this option is best-effort and may be ignored on platforms which
+  # source the binary in a different way. In particular, inside Google3 the
+  # PlatformDelegate is swapped out (see PLATFORM_DELEGATE above) and the
+  # trace_processor binary always comes from internal infra, so this flag has
+  # no effect there.
   fetch_latest_trace_processor: bool = False
 
   # If True, the trace processor will use a unique port for each instance.

--- a/python/perfetto/trace_processor/api.py
+++ b/python/perfetto/trace_processor/api.py
@@ -58,9 +58,15 @@ class SqlPackage:
 @dc.dataclass
 class TraceProcessorConfig:
   # The path to the trace processor binary. If not specified, the trace
-  # processor will be automatically downloaded and run from the latest
-  # avaialble prebuilts.
+  # processor version pinned to (and shipped with) this package is downloaded
+  # and run. See `fetch_latest_trace_processor` to override this.
   bin_path: Optional[str] = None
+
+  # If True (and `bin_path` is not set), fetch the latest available
+  # trace_processor prebuilt from get.perfetto.dev instead of using the version
+  # pinned to this package. This trades reproducibility for always being on the
+  # newest build.
+  fetch_latest_trace_processor: bool = False
 
   # If True, the trace processor will use a unique port for each instance.
   unique_port: bool = True
@@ -107,6 +113,7 @@ class TraceProcessorConfig:
       load_timeout: int = 2,
       extra_flags: Optional[List[str]] = None,
       add_sql_packages: Optional[List[Union[str, SqlPackage]]] = None,
+      fetch_latest_trace_processor: bool = False,
   ):
     self.bin_path = bin_path
     self.unique_port = unique_port
@@ -117,6 +124,7 @@ class TraceProcessorConfig:
     self.load_timeout = load_timeout
     self.extra_flags = extra_flags
     self.add_sql_packages = add_sql_packages
+    self.fetch_latest_trace_processor = fetch_latest_trace_processor
 
 
 class TraceProcessor:
@@ -302,6 +310,7 @@ class TraceProcessor:
         self.config.load_timeout,
         self.config.extra_flags,
         self.config.add_sql_packages,
+        self.config.fetch_latest_trace_processor,
     )
     return TraceProcessorHttp(url, protos=self.protos)
 

--- a/python/perfetto/trace_processor/platform.py
+++ b/python/perfetto/trace_processor/platform.py
@@ -23,6 +23,8 @@ import tempfile
 from typing import Optional, Tuple
 from urllib import request
 
+from perfetto.prebuilts.manifests.trace_processor_shell import TRACE_PROCESSOR_SHELL_MANIFEST
+from perfetto.prebuilts.perfetto_prebuilts import get_perfetto_prebuilt
 from perfetto.trace_uri_resolver.path import PathUriResolver
 from perfetto.trace_uri_resolver.registry import ResolverRegistry
 
@@ -38,12 +40,21 @@ class PlatformDelegate:
     with open(os.path.join(ws, file), 'rb') as x:
       return x.read()
 
-  def get_shell_path(self, bin_path: Optional[str]) -> str:
+  def get_shell_path(self,
+                     bin_path: Optional[str],
+                     fetch_latest: bool = False) -> str:
     if bin_path is not None:
       if not os.path.isfile(bin_path):
         raise Exception(f'Path to binary is not valid ({bin_path}).')
       return bin_path
 
+    if not fetch_latest:
+      # Default: use the trace_processor version pinned to (and shipped with)
+      # this package. The actual binary is downloaded and verified against the
+      # pinned SHA-256 on first use, then cached under ~/.local/share/perfetto.
+      return get_perfetto_prebuilt(TRACE_PROCESSOR_SHELL_MANIFEST)
+
+    # Opt-in: fetch the latest trace_processor regardless of the pinned version.
     tp_path = os.path.join(tempfile.gettempdir(), 'trace_processor_python_api')
     if self._should_download_tp(tp_path):
       with contextlib.ExitStack() as stack:

--- a/python/perfetto/trace_processor/shell.py
+++ b/python/perfetto/trace_processor/shell.py
@@ -44,12 +44,14 @@ def load_shell(
     load_timeout: int = 2,
     extra_flags: Optional[List[str]] = None,
     add_sql_packages: Optional[List[Union[str, 'SqlPackage']]] = None,
+    fetch_latest_trace_processor: bool = False,
 ):
   addr, port = platform_delegate.get_bind_addr(
       port=0 if unique_port else TP_PORT)
   url = f'{addr}:{str(port)}'
 
-  shell_path = platform_delegate.get_shell_path(bin_path=bin_path)
+  shell_path = platform_delegate.get_shell_path(
+      bin_path=bin_path, fetch_latest=fetch_latest_trace_processor)
 
   # get Python interpreter path
   if not getattr(sys, 'frozen', False):

--- a/python/setup.py
+++ b/python/setup.py
@@ -37,6 +37,8 @@ setup(
         'perfetto',
         'perfetto.batch_trace_processor',
         'perfetto.common',
+        'perfetto.prebuilts',
+        'perfetto.prebuilts.manifests',
         'perfetto.protos.perfetto.trace',
         'perfetto.trace_builder',
         'perfetto.trace_processor',


### PR DESCRIPTION
By default the Python API now runs the trace_processor version pinned to
(and shipped with) the installed perfetto package, via the prebuilt
manifest, instead of always downloading the latest from get.perfetto.dev.

Fetching the latest build is still available as an opt-in via the new
TraceProcessorConfig.fetch_latest_trace_processor flag.
