### PR TITLE
open_trace_in_ui: Fix `--origin` having a path component

### DIFF
--- a/tools/open_trace_in_ui
+++ b/tools/open_trace_in_ui
@@ -19,6 +19,7 @@ import os
 import socketserver
 import sys
 import webbrowser
+import urllib
 
 
 class ANSI:
@@ -71,7 +72,14 @@ def open_trace(path, open_browser, origin):
 
     httpd.expected_fname = fname
     httpd.fname_get_completed = None
-    httpd.allow_origin = origin
+
+    # In case the user's `--origin` has a path component, strip it out
+    def strip_url_path(url):
+      url_parsed = urllib.parse.urlparse(url)
+      return urllib.parse.urlunparse(
+          url_parsed._replace(path='', query='', fragment='', params=''))
+
+    httpd.allow_origin = strip_url_path(origin)
     while httpd.fname_get_completed is None:
       httpd.handle_request()
 


### PR DESCRIPTION
If a perfetto WebUI build is hosted on a URL with a path component (e.g. `http://internal-host/perfetto`) this allows `open_trace_in_ui` to properly extract the `origin` component while still redirecting to the proper page where the WebUI is hosted.  Note that the HTTP header this is being fed into, `Access-Control-Allow-Origin` does not support paths at all.