### PR TITLE
ui: add docs on how to embed the UI in other tools

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -91,6 +91,7 @@
     - [Data Explorer](visualization/data-explorer.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Opening Large Traces](visualization/large-traces.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Embedding the UI](visualization/embedding-the-ui.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Debug Tracks](analysis/debug-tracks.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Heap Dump Explorer](visualization/heap-dump-explorer.md) {.tag-android}
 
@@ -150,6 +151,7 @@
     - [Synthetic Track Events](reference/synthetic-track-event.md) {.tag-perf}
     - [Kernel Track Events](reference/kernel-track-event.md) {.tag-android .tag-linux}
     - [Extension Server Protocol](visualization/extension-server-protocol.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Embedding API](visualization/embedding-api-reference.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Android Version Notes](reference/android-version-notes.md) {.tag-android}
 
   - [Advanced Topics](#)

--- a/docs/visualization/embedding-api-reference.md
+++ b/docs/visualization/embedding-api-reference.md
@@ -1,0 +1,168 @@
+# Perfetto UI embedding API reference
+
+This page is a reference for the `postMessage` and URL parameter surface used to
+embed the Perfetto UI (`ui.perfetto.dev`) inside an `<iframe>` on a host page.
+
+For a task-oriented walkthrough of the embedding flow, see
+[Embedding the Perfetto UI](/docs/visualization/embedding-the-ui.md). For the
+`window.open()` (new browser tab) variant and for sharing / `appStateHash`
+details, see [Deep linking to the Perfetto UI](/docs/visualization/deep-linking-to-perfetto-ui.md).
+
+NOTE: This is a reference, not a tutorial. Fields and message types not listed
+here are not part of the supported surface.
+
+## Message channel
+
+The host page communicates with the embedded UI via `window.postMessage`. The
+UI's message handler only acts on messages whose `event.source` is one of:
+
+| `event.source`            | When                                                              |
+| ------------------------- | ---------------------------------------------------------------- |
+| `window.parent`           | The UI runs inside the host's `<iframe>` (the embedding case).   |
+| `window.opener`           | The host launched the UI with `window.open()` (new-tab case).    |
+| A window this UI opened   | `event.source.opener === window`.                                |
+
+For iframe embedding, the UI's `window.parent` is the host page, so the host
+posts messages to `iframe.contentWindow` and the UI accepts them.
+
+Because the channel is not buffered, a handshake is required before posting a
+trace:
+
+1. The host repeatedly posts the string `'PING'` to the UI window.
+2. The UI replies with the string `'PONG'`. The reply is sent to `'*'` and is
+   sent only once the UI's message listener is registered **and**
+   `document.readyState === 'complete'`.
+3. The host listens for `'message'` events; on the first `data === 'PONG'` from
+   the UI window it stops pinging and posts the trace.
+
+A robust host pings on an interval (for example every 50-250ms) and clears the
+interval on the first `PONG`.
+
+A message with `{perfettoIgnore: true}` is ignored on purpose. This lets a host
+multiplex other traffic over the same channel.
+
+## Opening a trace
+
+To open a trace, post an object with a single `perfetto` key:
+
+```js
+iframe.contentWindow.postMessage({perfetto: {buffer, title}}, '*');
+```
+
+Fields of the `perfetto` object:
+
+| Field          | Type                                                      | Required | Default | Meaning                                                                                                                              |
+| -------------- | -------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `buffer`       | `ArrayBuffer`                                             | Yes      | -       | Raw trace bytes, e.g. from `fetch(...).then(r => r.arrayBuffer())`.                                                                  |
+| `title`        | `string`                                                 | Yes      | -       | Trace title shown in the UI.                                                                                                          |
+| `fileName`     | `string`                                                 | No       | -       | Suggested file name if the user downloads the trace.                                                                                 |
+| `url`          | `string`                                                 | No       | -       | Sharing URL. See sharing details in [Deep linking to the Perfetto UI](/docs/visualization/deep-linking-to-perfetto-ui.md).          |
+| `appStateHash` | `string`                                                 | No       | -       | 40-char hex hash; restores saved UI state from GCS. See [Deep linking to the Perfetto UI](/docs/visualization/deep-linking-to-perfetto-ui.md). |
+| `localOnly`    | `boolean`                                                | No       | `true`  | Defaults to `true` for posted traces, which disables download and share. Set `false` to enable them.                                |
+| `keepApiOpen`  | `boolean`                                                | No       | `false` | If `true`, the listener stays active so the host can post more traces later. If `false`/omitted, the handler removes its own message listener after the first trace (avoids duplicate posts, b/182502595). |
+| `pluginArgs`   | `{[pluginId: string]: {[key: string]: unknown}}`         | No       | -       | Passed to plugins' `onTraceLoad()`.                                                                                                  |
+
+### Bare ArrayBuffer shorthand
+
+A bare `ArrayBuffer` (`event.data instanceof ArrayBuffer`) is also accepted. It
+is treated as `{title: 'External trace', buffer}`.
+
+## Scroll to time range
+
+Post the following message after the trace is loaded to scroll/zoom the viewport
+to a time range:
+
+```js
+iframe.contentWindow.postMessage(
+    {perfetto: {timeStart, timeEnd, viewPercentage}}, '*');
+```
+
+| Field            | Type     | Required | Meaning                                          |
+| ---------------- | -------- | -------- | ------------------------------------------------ |
+| `timeStart`      | `number` | Yes      | Start of the range, in **seconds**.              |
+| `timeEnd`        | `number` | Yes      | End of the range, in **seconds**.                |
+| `viewPercentage` | `number` | No       | Fraction of the viewport the range should fill, in `(0.0, 1.0]`. Out-of-range values are ignored and replaced by `0.5`. |
+
+The handler retries internally (roughly 20 times at 200ms intervals) until the
+trace is ready, so this message can be posted shortly after the trace without
+waiting for an explicit "loaded" signal.
+
+## String commands
+
+The handler understands these string messages:
+
+| Message                 | Effect                                  |
+| ----------------------- | --------------------------------------- |
+| `'PING'`                | Replies with `'PONG'` (sent to `'*'`).  |
+| `'SHOW-HELP'`           | Opens the help dialog.                  |
+| `'RELOAD-CSS-CONSTANTS'`| Reloads CSS constants.                  |
+
+## URL parameters
+
+Set these on the iframe `src`. The route is hash-based:
+`https://ui.perfetto.dev/#!/?key=val&...`.
+
+| Parameter         | Value                          | Effect                                                                                                                              |
+| ----------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `mode`            | `embedded`                     | Enables embedded mode: the sidebar is **disabled entirely** (not just hidden) and the file-drop handler is not installed. Use this when embedding. |
+| `hideSidebar`     | `true`                         | Hides the sidebar visually without fully disabling it.                                                                             |
+| `url`             | `<https url>`                  | UI fetches a public trace itself (requires CORS allowing the UI origin). Alternative to `postMessage` for public traces.           |
+| `s`               | `<hash>`                       | Loads a permalink (saved state).                                                                                                   |
+| `visStart`        | `<ns>`                         | Initial viewport start, raw **nanosecond** timestamp (as in SQL tables). Pair with `visEnd`.                                       |
+| `visEnd`          | `<ns>`                         | Initial viewport end, raw **nanosecond** timestamp.                                                                               |
+| `ts`              | `<ns>`                         | Timestamp of the slice to select on load, in **nanoseconds**. Linking is by `ts`+`dur`, **not** by `id` (ids are unstable).        |
+| `dur`             | `<ns>`                         | Duration of the slice to select on load, in **nanoseconds**.                                                                       |
+| `pid`             | `<n>`                          | Process id used to disambiguate the slice selection.                                                                              |
+| `tid`             | `<n>`                          | Thread id used to disambiguate the slice selection.                                                                               |
+| `query`           | `<sql>`                        | Runs a SQL query on load (URL-encode the value).                                                                                  |
+| `startupCommands` | `<url-encoded JSON array>`     | Runs UI commands after load, e.g. `[{id:'dev.perfetto.PinTracksByRegex', args:['.*CPU [0-3].*']}]`.                                |
+| `enablePlugins`   | `<comma,list>`                 | Enables specific plugins by id.                                                                                                    |
+
+NOTE: `visStart`/`visEnd` and `ts`/`dur` are raw **nanoseconds**, whereas the
+`timeStart`/`timeEnd` `postMessage` fields are **seconds**.
+
+NOTE: Slice selection is by `ts`+`dur` (plus optional `pid`/`tid`), never by
+`id`, because ids are unstable across runs.
+
+## Origin trust
+
+If the posting origin is trusted, the trace opens immediately. The trusted set
+is:
+
+- Same-origin requests.
+- `localhost`, `127.0.0.1`, and `[::1]` (so local dev embedding works with no
+  prompt).
+- A few hardcoded Google origins.
+- Origins the user previously saved via "Always trust".
+
+If the origin is **not** trusted, the UI shows a modal:
+
+> `<origin>` is trying to open a trace file. Do you trust the origin?
+
+with the options **No**, **Yes**, and **Always trust**. "Always trust" persists
+the origin in `localStorage`.
+
+Embedding from a production domain therefore shows users a one-time consent
+prompt, unless you self-host the UI (same-origin => trusted).
+
+Strings in `title` and `url` are sanitized to the character set
+`[A-Za-z0-9.\-_#:/?=&;%+$ ]`.
+
+## Constraints
+
+- Does not work from `file://` URLs (browser security). Serve over `http(s)`.
+- The host page must **not** be served with
+  `Cross-Origin-Opener-Policy: same-origin`, which breaks the opener
+  relationship.
+- The UI is client-only. Posted traces stay in browser memory and are never
+  uploaded.
+- `ui.perfetto.dev` follows the latest release. If you need a fixed version,
+  self-host the UI build to pin it. Self-hosting also makes your origin
+  same-origin, so the consent modal is skipped.
+
+## Source
+
+The behavior above is defined in:
+
+- [/ui/src/frontend/post_message_handler.ts](/ui/src/frontend/post_message_handler.ts)
+- [/ui/src/public/route_schema.ts](/ui/src/public/route_schema.ts)

--- a/docs/visualization/embedding-api-reference.md
+++ b/docs/visualization/embedding-api-reference.md
@@ -79,8 +79,8 @@ iframe.contentWindow.postMessage(
 
 | Field            | Type     | Required | Meaning                                          |
 | ---------------- | -------- | -------- | ------------------------------------------------ |
-| `timeStart`      | `number` | Yes      | Start of the range, in **seconds**.              |
-| `timeEnd`        | `number` | Yes      | End of the range, in **seconds**.                |
+| `timeStart`      | `number` | Yes      | Range start, **absolute trace time in seconds** (not relative to trace start; clamped to trace bounds). |
+| `timeEnd`        | `number` | Yes      | Range end, **absolute trace time in seconds**.   |
 | `viewPercentage` | `number` | No       | Fraction of the viewport the range should fill, in `(0.0, 1.0]`. Out-of-range values are ignored and replaced by `0.5`. |
 
 The handler retries internally (roughly 20 times at 200ms intervals) until the

--- a/docs/visualization/embedding-the-ui.md
+++ b/docs/visualization/embedding-the-ui.md
@@ -1,0 +1,239 @@
+# Embedding the Perfetto UI
+
+This guide shows you how to embed the Perfetto trace viewer _inside_ your own
+tool or dashboard via an `<iframe>` and feed it traces programmatically. This is
+the right approach when you want the trace view to live within your app's
+chrome, as real tools like Dart DevTools and various profiler frontends do. If
+instead you just want to launch the full Perfetto UI in a new browser tab (the
+`window.open()` flow), see [Deep linking to the Perfetto UI](/docs/visualization/deep-linking-to-perfetto-ui.md);
+that page also covers sharing URLs and `appStateHash`, which this guide does not
+duplicate.
+
+## Before you begin
+
+- Serve your host page over `http(s)`, not `file://`. The embedding protocol
+  relies on `postMessage` between windows, which browsers disable for
+  `file://` origins.
+- Do NOT serve your host page with the
+  `Cross-Origin-Opener-Policy: same-origin` header. It breaks the
+  parent/iframe relationship the UI depends on.
+- During local development, serve from `localhost` / `127.0.0.1`. These origins
+  are trusted by the UI, so traces open with no consent prompt (see
+  [Trust prompts and going to production](#trust-prompts-and-going-to-production)).
+
+## Step 1: Add the iframe
+
+Embed the UI with `mode=embedded` in the URL. This fully disables the sidebar
+(not just hides it), which is what you want for an embedded view. The route is
+hash-based:
+
+```html
+<iframe
+  id="perfetto"
+  src="https://ui.perfetto.dev/#!/?mode=embedded"
+  width="100%"
+  height="600"
+></iframe>
+```
+
+In embedded mode the file-drop handler is also not installed, so the iframe only
+loads traces you post to it.
+
+## Step 2: Do the PING/PONG handshake
+
+The `postMessage` channel into the iframe is not buffered: if you post a trace
+before the UI has registered its message listener, the message is silently
+dropped. To avoid this race, repeatedly post the string `'PING'` until the UI
+replies with `'PONG'`. The UI only sends `'PONG'` once its listener is
+registered and `document.readyState === 'complete'`.
+
+```js
+const iframe = document.getElementById('perfetto');
+
+function waitForReady() {
+  return new Promise((resolve) => {
+    const interval = setInterval(() => {
+      iframe.contentWindow.postMessage('PING', '*');
+    }, 100);
+
+    window.addEventListener('message', function onMsg(evt) {
+      if (evt.source === iframe.contentWindow && evt.data === 'PONG') {
+        clearInterval(interval);
+        window.removeEventListener('message', onMsg);
+        resolve();
+      }
+    });
+  });
+}
+```
+
+## Step 3: Post the trace
+
+Once the handshake completes, post an object with a single `perfetto` key to the
+iframe's `contentWindow`. Only `buffer` (an `ArrayBuffer` of raw trace bytes) and
+`title` are required:
+
+```js
+async function openTrace() {
+  await waitForReady();
+
+  const resp = await fetch(
+    'https://storage.googleapis.com/perfetto-misc/example_android_trace_15s',
+  );
+  const buffer = await resp.arrayBuffer();
+
+  iframe.contentWindow.postMessage(
+    {
+      perfetto: {
+        buffer: buffer,
+        title: 'My embedded trace',
+      },
+    },
+    '*',
+  );
+}
+```
+
+The full set of fields on the `perfetto` object:
+
+- `buffer` (required): `ArrayBuffer` of raw trace bytes.
+- `title` (required): string shown as the trace title.
+- `fileName` (optional): suggested name if the user downloads the trace.
+- `url` (optional): sharing URL. See [Deep linking](/docs/visualization/deep-linking-to-perfetto-ui.md)
+  for how `url` and `appStateHash` enable sharing.
+- `appStateHash` (optional): 40-char hex hash restoring saved UI state.
+- `localOnly` (optional): defaults to `true` for posted traces, which disables
+  download/share. Set `false` to re-enable them.
+- `keepApiOpen` (optional): if `true`, the listener stays active so you can post
+  more traces later. If omitted, the handler removes its listener after the
+  first trace.
+- `pluginArgs` (optional): `{ [pluginId]: { [key]: unknown } }`, passed to
+  plugins' `onTraceLoad()`.
+
+NOTE: If you want to swap traces in the same iframe without reloading it, set
+`keepApiOpen: true` on the first post. Otherwise the UI stops listening after
+the first trace.
+
+TIP: A bare `ArrayBuffer` is also accepted (the UI treats it as a trace titled
+"External trace"), but posting the `{ perfetto: { buffer, title } }` object is
+preferred so you control the title.
+
+## Step 4 (optional): Drive the view
+
+You can steer the embedded view in two ways.
+
+To configure the UI as the trace opens, add `startupCommands` to the iframe
+`src` as a URL-encoded JSON array of commands. For example, to pin the CPU
+tracks:
+
+```js
+const commands = [
+  {id: 'dev.perfetto.PinTracksByRegex', args: ['.*CPU [0-3].*']},
+];
+const src =
+  'https://ui.perfetto.dev/#!/?mode=embedded&startupCommands=' +
+  encodeURIComponent(JSON.stringify(commands));
+```
+
+To scroll and zoom to a time range after the trace is loaded, post a second
+message. `timeStart` and `timeEnd` are in **seconds**. `viewPercentage` is
+optional and is a fraction in the range `(0, 1]` (e.g. `0.5` fills half the
+viewport); out-of-range values are ignored and fall back to `0.5`:
+
+```js
+iframe.contentWindow.postMessage(
+  {perfetto: {timeStart: 1.0, timeEnd: 1.5, viewPercentage: 0.5}},
+  '*',
+);
+```
+
+The UI retries this internally until the trace is ready, so you can post it
+shortly after the trace without your own wait loop.
+
+## Putting it together
+
+Paste this into a file (e.g. `index.html`), serve it over `http(s)` from
+`localhost`, and open it in a browser:
+
+```html
+<!doctype html>
+<html>
+  <body>
+    <iframe
+      id="perfetto"
+      src="https://ui.perfetto.dev/#!/?mode=embedded"
+      width="100%"
+      height="600"
+    ></iframe>
+
+    <script>
+      const iframe = document.getElementById('perfetto');
+      const SAMPLE =
+        'https://storage.googleapis.com/perfetto-misc/example_android_trace_15s';
+
+      function waitForReady() {
+        return new Promise((resolve) => {
+          const interval = setInterval(() => {
+            iframe.contentWindow.postMessage('PING', '*');
+          }, 100);
+          window.addEventListener('message', function onMsg(evt) {
+            if (evt.source === iframe.contentWindow && evt.data === 'PONG') {
+              clearInterval(interval);
+              window.removeEventListener('message', onMsg);
+              resolve();
+            }
+          });
+        });
+      }
+
+      (async () => {
+        await waitForReady();
+        const buffer = await (await fetch(SAMPLE)).arrayBuffer();
+        iframe.contentWindow.postMessage(
+          {perfetto: {buffer, title: 'My embedded trace'}},
+          '*',
+        );
+      })();
+    </script>
+  </body>
+</html>
+```
+
+## Trust prompts and going to production
+
+The UI guards which origins may push traces:
+
+- `localhost`, `127.0.0.1`, `[::1]`, same-origin, and a few hardcoded Google
+  origins are trusted. Traces from these open immediately with no prompt, so
+  local development just works.
+- From any other origin (e.g. your production domain), the UI shows a modal:
+  _"&lt;origin&gt; is trying to open a trace file. Do you trust the origin?"_
+  with **No / Yes / Always trust**. "Always trust" persists the origin in
+  `localStorage`, so each of your users sees the prompt at most once.
+
+To avoid the consent modal entirely in production, self-host the Perfetto UI
+build on your own domain. A same-origin host page is trusted, so no prompt
+appears.
+
+NOTE: `ui.perfetto.dev` follows the latest release, so the embedding protocol
+described here is stable, though UI details may change over time. If you need a
+fixed version, self-host the UI build to pin it. Self-hosting also gives the
+same-origin trust benefit described above.
+
+NOTE: The UI is client-only. Posted traces stay in browser memory and are never
+uploaded anywhere.
+
+## A complete example
+
+The companion [`perfetto-embed`](https://github.com/LalitMaganti/perfetto-embed)
+repository is a runnable end-to-end example: `npm start` serves a "devtool" host
+page whose control panel embeds the UI and drives it (load traces, zoom, pin
+tracks, run queries). It ships a small framework-agnostic `PerfettoEmbed`
+wrapper you can copy into your own tool, plus a React variant.
+
+## See also
+
+- [Deep linking to the Perfetto UI](/docs/visualization/deep-linking-to-perfetto-ui.md):
+  the `window.open()` (new tab) flow, plus sharing URLs and `appStateHash`.
+- [Embedding API reference](/docs/visualization/embedding-api-reference.md):
+  the full list of messages and URL parameters the UI accepts.

--- a/docs/visualization/embedding-the-ui.md
+++ b/docs/visualization/embedding-the-ui.md
@@ -136,13 +136,16 @@ const src =
 ```
 
 To scroll and zoom to a time range after the trace is loaded, post a second
-message. `timeStart` and `timeEnd` are in **seconds**. `viewPercentage` is
-optional and is a fraction in the range `(0, 1]` (e.g. `0.5` fills half the
-viewport); out-of-range values are ignored and fall back to `0.5`:
+message. `timeStart` and `timeEnd` are **absolute trace time in seconds**, not
+relative to the trace start (most traces do not start at 0); a range outside the
+trace is clamped to its bounds. `viewPercentage` is optional and is a fraction
+in the range `(0, 1]` (e.g. `0.5` fills half the viewport, `1` fills it exactly);
+out-of-range values are ignored and fall back to `0.5`:
 
 ```js
+// e.g. zoom to the first 2 seconds of a trace that starts at 261187s.
 iframe.contentWindow.postMessage(
-  {perfetto: {timeStart: 1.0, timeEnd: 1.5, viewPercentage: 0.5}},
+  {perfetto: {timeStart: 261187.0, timeEnd: 261189.0, viewPercentage: 1}},
   '*',
 );
 ```


### PR DESCRIPTION
This is already used by a bunch of other tools (e.g. Dart devtools,
Rust, Go hopefully soon) so it's worth formalizing this so it's
easier for future users.
