### PR TITLE
base: fix SDK compile by adding default constructor to circularqueue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,12 @@ Unreleased:
   SDK:
    *
 
+v56.1 - 2026-06-04:
+  SDK:
+    * Fixed C++ SDK build failure on aarch64 with recent libstdc++ versions
+      (e.g. 12.5.0) caused by `CircularQueue::Iterator` not being default
+      constructible.
+
 v56.0 - 2026-05-21:
   Tracing service and probes:
     * Added `machine_id` and `machine_name` fields to `TracingServiceState`,

--- a/include/perfetto/ext/base/circular_queue.h
+++ b/include/perfetto/ext/base/circular_queue.h
@@ -71,6 +71,9 @@ class CircularQueue {
       ignore_result(generation);
     }
 
+    // Needed so std::reverse_iterator<Iterator> is default constructible, which
+    // some libstdc++ versions require. Never used default-constructed.
+    Iterator() noexcept = default;
     Iterator(const Iterator&) noexcept = default;
     Iterator& operator=(const Iterator&) noexcept = default;
     Iterator(Iterator&&) noexcept = default;
@@ -168,11 +171,11 @@ class CircularQueue {
       PERFETTO_DCHECK(pos_ <= queue_->end_);
     }
 
-    CircularQueue* queue_;
-    uint64_t pos_;
+    CircularQueue* queue_ = nullptr;
+    uint64_t pos_ = 0;
 
 #if PERFETTO_DCHECK_IS_ON()
-    uint32_t generation_;
+    uint32_t generation_ = 0;
 #endif
   };
 


### PR DESCRIPTION
Fixes: https://github.com/google/perfetto/issues/6139
