### PR TITLE
perfetto: fix --set-socket-permissions failing in traced_relay

### DIFF
--- a/src/traced_relay/relay_service.cc
+++ b/src/traced_relay/relay_service.cc
@@ -589,7 +589,12 @@ int PERFETTO_EXPORT_ENTRYPOINT RelayServiceMain(int argc, char** argv) {
   } else {
     auto listen_socket = GetProducerSocket();
     remove(listen_socket);
-    if (!listen_socket_group.empty()) {
+    svc->Start(listen_socket, GetRelaySocket());
+
+    // Start() creates the socket file, so permissions must be set after it.
+    // Only unix sockets have a file to chmod.
+    if (!listen_socket_group.empty() &&
+        base::GetSockFamily(listen_socket) == base::SockFamily::kUnix) {
       auto status = base::SetFilePermissions(listen_socket, listen_socket_group,
                                              listen_socket_mode_bits);
       if (!status.ok()) {
@@ -598,8 +603,6 @@ int PERFETTO_EXPORT_ENTRYPOINT RelayServiceMain(int argc, char** argv) {
         return 1;
       }
     }
-
-    svc->Start(listen_socket, GetRelaySocket());
   }
 
   // If the TRACED_RELAY_NOTIFY_FD env var is set, write 1 and close the FD.


### PR DESCRIPTION
SetFilePermissions() was called on the producer socket path right after remove()-ing it, but the socket file is only created later by RelayService::Start() when it binds the listening socket. The chown therefore always failed with ENOENT and traced_relay exited at startup whenever --set-socket-permissions was passed.

Move the SetFilePermissions() call after Start(), mirroring what traced does in src/traced/service/service.cc, and skip it for non-unix (TCP/vsock) sockets where file permissions do not apply, again matching traced.

Fixes #6145.