### PR TITLE
perfetto: fix proto compilation with sandboxed protoc

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1839,6 +1839,9 @@ java_library {
     proto: {
         type: "lite",
         canonical_path_from_root: false,
+        local_include_dirs: [
+            ".",
+        ],
     },
 }
 
@@ -22266,6 +22269,9 @@ java_library {
     proto: {
         type: "lite",
         canonical_path_from_root: false,
+        local_include_dirs: [
+            ".",
+        ],
     },
 }
 
@@ -25507,6 +25513,7 @@ java_library_host {
     name: "perfetto_config-full",
     proto: {
         type: "full",
+        local_include_dirs: ["."],
     },
     srcs: [
         "protos/perfetto/config/perfetto_config.proto",
@@ -25517,6 +25524,7 @@ java_library {
     name: "perfetto_config-lite",
     proto: {
         type: "lite",
+        local_include_dirs: ["."],
     },
     srcs: [
         "protos/perfetto/config/perfetto_config.proto",
@@ -25528,6 +25536,7 @@ java_library_host {
     proto: {
         type: "full",
         canonical_path_from_root: false,
+        local_include_dirs: ["."],
     },
     static_libs: [
         "libprotobuf-java-full",
@@ -25543,6 +25552,7 @@ java_library_host {
     name: "perfetto_trace-full",
     proto: {
         type: "full",
+        local_include_dirs: ["."],
     },
     srcs: [
         "protos/perfetto/trace/perfetto_trace.proto",
@@ -25555,6 +25565,7 @@ java_library_host {
     name: "perfetto_metrics-full",
     proto: {
         type: "full",
+        local_include_dirs: ["."],
     },
     srcs: [
         "protos/perfetto/metrics/perfetto_merged_metrics.proto",
@@ -25748,6 +25759,7 @@ java_library {
         type: "lite",
         include_dirs: ["external/protobuf/src"],
         canonical_path_from_root: false,
+        local_include_dirs: ["."],
     },
     srcs: [
         ":libprotobuf-internal-descriptor-proto",
@@ -25771,6 +25783,7 @@ java_library {
     proto: {
         type: "lite",
         canonical_path_from_root: false,
+        local_include_dirs: ["."],
     },
     sdk_version: "system_server_current",
     min_sdk_version: "35",
@@ -25832,8 +25845,8 @@ phony {
             required: [
                 "system_tracing_protos_descriptor",
             ],
-        }
-    }
+        },
+    },
 }
 
 filegroup {

--- a/Android.bp.extras
+++ b/Android.bp.extras
@@ -4,6 +4,7 @@ java_library_host {
     name: "perfetto_config-full",
     proto: {
         type: "full",
+        local_include_dirs: ["."],
     },
     srcs: [
         "protos/perfetto/config/perfetto_config.proto",
@@ -14,6 +15,7 @@ java_library {
     name: "perfetto_config-lite",
     proto: {
         type: "lite",
+        local_include_dirs: ["."],
     },
     srcs: [
         "protos/perfetto/config/perfetto_config.proto",
@@ -25,6 +27,7 @@ java_library_host {
     proto: {
         type: "full",
         canonical_path_from_root: false,
+        local_include_dirs: ["."],
     },
     static_libs: [
         "libprotobuf-java-full",
@@ -40,6 +43,7 @@ java_library_host {
     name: "perfetto_trace-full",
     proto: {
         type: "full",
+        local_include_dirs: ["."],
     },
     srcs: [
         "protos/perfetto/trace/perfetto_trace.proto",
@@ -52,6 +56,7 @@ java_library_host {
     name: "perfetto_metrics-full",
     proto: {
         type: "full",
+        local_include_dirs: ["."],
     },
     srcs: [
         "protos/perfetto/metrics/perfetto_merged_metrics.proto",
@@ -245,6 +250,7 @@ java_library {
         type: "lite",
         include_dirs: ["external/protobuf/src"],
         canonical_path_from_root: false,
+        local_include_dirs: ["."],
     },
     srcs: [
         ":libprotobuf-internal-descriptor-proto",
@@ -268,6 +274,7 @@ java_library {
     proto: {
         type: "lite",
         canonical_path_from_root: false,
+        local_include_dirs: ["."],
     },
     sdk_version: "system_server_current",
     min_sdk_version: "35",
@@ -329,8 +336,8 @@ phony {
             required: [
                 "system_tracing_protos_descriptor",
             ],
-        }
-    }
+        },
+    },
 }
 
 filegroup {

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -1266,7 +1266,13 @@ def create_proto_group_modules(blueprint, gn: GnParser, module_name: str,
       name = label_to_module_name(module_name) + '_java_protos'
       module = Module('java_library', name, name)
       module.comment = f'''GN: [{', '.join(target_names)}]'''
-      module.proto = {'type': 'lite', 'canonical_path_from_root': False}
+      # local_include_dirs is required to resolve imports when protoc
+      # sandboxing is enabled. See b/498317670 for more details.
+      module.proto = {
+          'type': 'lite',
+          'canonical_path_from_root': False,
+          'local_include_dirs': ['.'],
+      }
       module.srcs = module_sources
       module.host_supported = True
       module.sdk_version = 'current'


### PR DESCRIPTION
When protoc sandboxing is enabled, Soong shards proto compilation, which requires explicitly declaring include directories for imports to resolve correctly within the sandbox.

Add local_include_dirs: ["."] to the java proto modules so imports resolve relative to the repository root. The hand-written modules are updated in Android.bp.extras; gen_android_bp now emits the same for the autogenerated perfetto_{trace,config}_java_protos modules.

Porting ag/40227792 upstream
Bug: 498317670