### PR TITLE
fix(python): bound Windows TraceProcessor close wait

### DIFF
--- a/python/perfetto/trace_processor/api.py
+++ b/python/perfetto/trace_processor/api.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import signal
+import subprocess
 import dataclasses as dc
 from urllib.parse import urlparse
 from typing import Any, Dict, List, Optional, Union
@@ -40,6 +41,8 @@ TraceReference = registry.TraceReference
 # Custom exception raised if any trace_processor functions return a
 # response with an error defined
 TraceProcessorException = PerfettoException
+
+_TP_CLOSE_TIMEOUT_SECONDS = 5
 
 
 @dc.dataclass
@@ -337,13 +340,21 @@ class TraceProcessor:
 
   def close(self):
     if hasattr(self, 'subprocess') and self.subprocess:
+      wait_timeout = None
       # On Windows, we need to send a break signal to terminate the whole process group.
       # On other platforms, killing the parent process is sufficient.
       if sys.platform == 'win32':
         self.subprocess.send_signal(signal.CTRL_BREAK_EVENT)
+        wait_timeout = _TP_CLOSE_TIMEOUT_SECONDS
       else:
         self.subprocess.kill()
-      self.subprocess.wait()
+
+      try:
+        self.subprocess.wait(timeout=wait_timeout)
+      except subprocess.TimeoutExpired:
+        self.subprocess.kill()
+        self.subprocess.wait(timeout=wait_timeout)
+
       # Set to None so __del__ doesn't call this again.
       self.subprocess = None
       if hasattr(self, '_tp_stdout') and self._tp_stdout:


### PR DESCRIPTION
## Problem

`TraceProcessor.close()` can block indefinitely on Windows when shutting down a locally spawned `trace_processor_shell` process.

When the Python API owns the local trace processor process, `close()` is the public cleanup path used by context managers, `finally` blocks, test cleanup, and `BatchTraceProcessor.close()`. On Windows, the current close path sends `CTRL_BREAK_EVENT` to the process group and then calls `Popen.wait()` with no timeout.

`CTRL_BREAK_EVENT` is a Windows console-control shutdown request. It is not the same as forcibly terminating the process. If the event is not delivered, or if `trace_processor_shell.exe` does not exit after receiving it, the following unbounded `wait()` leaves the caller stuck in cleanup.

This can affect Python-library embedders that do not run under a normal interactive console, such as `pythonw.exe`, PyInstaller `--windowed` applications, Windows services, scheduled tasks, and CI agents.

## Root Cause

A previous Windows orphan-process fix created a new process group and sent `CTRL_BREAK_EVENT`, avoiding the case where killing only the launcher could leave the real trace processor worker running.

The remaining bug is the assumption that this graceful process-group shutdown always makes the subprocess exit. The code waits forever after that request, so a cleanup API can hang even though it is only trying to release an owned subprocess.

## Change

Keep the existing Windows process-group shutdown behavior, but bound the wait after `CTRL_BREAK_EVENT`.

- On Windows, wait up to a small timeout after sending `CTRL_BREAK_EVENT`.
- If the wait times out, fall back to `kill()` and wait with the same bound.
- Leave the non-Windows `kill(); wait()` path unchanged.

This is intentionally a narrow bugfix. It does not add a public config option, change process-tree management, or replace the existing Windows process-group behavior.