### PR TITLE
perfetto: package perfetto.prebuilts in Android python_library

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -25662,6 +25662,8 @@ filegroup {
     name: "perfetto-trace-processor-python-srcs",
     srcs: [
         "python/perfetto/common/*.py",
+        "python/perfetto/prebuilts/*.py",
+        "python/perfetto/prebuilts/manifests/*.py",
         "python/perfetto/trace_processor/*.py",
     ],
     path: "python",

--- a/Android.bp.extras
+++ b/Android.bp.extras
@@ -153,6 +153,8 @@ filegroup {
     name: "perfetto-trace-processor-python-srcs",
     srcs: [
         "python/perfetto/common/*.py",
+        "python/perfetto/prebuilts/*.py",
+        "python/perfetto/prebuilts/manifests/*.py",
         "python/perfetto/trace_processor/*.py",
     ],
     path: "python",


### PR DESCRIPTION
#6133  added an import-time dependency on the perfetto.prebuilts package in python/perfetto/trace_processor/platform.py. 

The perfetto-trace-processor-python-srcs filegroup only globbed common/*.py and trace_processor/*.py, so perfetto/prebuilts/** was never included in the perfetto-trace-processor-python library. Downstream Android tests (e.g. metrics_v2_test) that import perfetto.trace_processor now fail at import time with:

    ModuleNotFoundError: No module named 'perfetto.prebuilts'

Add the prebuilts globs to the filegroup in Android.bp.extras (the source of truth) and mirror the change in the generated Android.bp.
