### PR TITLE
heapprofd: add glob support to cmdline matching (only for running targets)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,12 @@ Unreleased:
       on only for the named producer sockets listed in
       `PERFETTO_PRODUCER_SOCK_NAME`. `--enable-relay-endpoint` retains its
       existing semantics for the common single-socket multi-machine setup.
+    * Allocation profiling (heapprofd): added partial wildcard matching support
+      to HeapprofdConfig.process_cmdline. The main limitation is that it is
+      incompatible with from-startup profiling on android, and therefore the
+      config should specify no_startup=true if any wildcard patterns are
+      included in process_cmdline. Otherwise the matching semantics are the same
+      as the perf profiling and java heap dump data sources.
   Trace Processor:
    *
   UI:

--- a/protos/perfetto/config/profiling/heapprofd_config.proto
+++ b/protos/perfetto/config/profiling/heapprofd_config.proto
@@ -59,13 +59,26 @@ message HeapprofdConfig {
   // this value.
   optional uint64 adaptive_sampling_max_sampling_interval_bytes = 25;
 
-  // E.g. surfaceflinger, com.android.phone
+  // Names of process cmdlines to profile. The semantics before perfetto v57 are
+  // as the following section (A), and on newer versions are both (A) and (B):
+  //
+  // (A) E.g. surfaceflinger, com.android.phone
   // This input is normalized in the following way: if it contains slashes,
   // everything up to the last slash is discarded. If it contains "@",
   // everything after the first @ is discared.
   // E.g. /system/bin/surfaceflinger@1.0 normalizes to surfaceflinger.
   // This transformation is also applied to the processes' command lines when
   // matching.
+  //
+  // (B) Perfetto v57+: a pattern may also contain a wildcard ('*'), in which
+  // case it is matched against running processes' command lines using glob
+  // semantics. If the pattern starts with '/' it is matched against the full
+  // argv0 (e.g. "/system/bin/*"), otherwise it is matched against the binary
+  // name part of argv0 (e.g. "system_*"). Wildcard patterns are *not*
+  // normalized as described above.
+  // Wildcard patterns are supported only for profiling already-running
+  // processes. A config must set no_startup=true if using wildcards, or it will
+  // be rejected.
   repeated string process_cmdline = 2;
 
   // For watermark based triggering or local debugging.

--- a/src/profiling/common/proc_utils.cc
+++ b/src/profiling/common/proc_utils.cc
@@ -145,25 +145,28 @@ ssize_t NormalizeCmdLine(char** cmdline_ptr, size_t size) {
   return first_arg - start;
 }
 
-std::optional<std::vector<std::string>> NormalizeCmdlines(
+std::optional<CmdlinePatterns> NormalizeCmdlines(
     const std::vector<std::string>& cmdlines) {
-  std::vector<std::string> normalized_cmdlines;
-  normalized_cmdlines.reserve(cmdlines.size());
-
-  for (size_t i = 0; i < cmdlines.size(); i++) {
-    std::string cmdline = cmdlines[i];  // mutable copy
+  CmdlinePatterns patterns;
+  for (const std::string& raw : cmdlines) {
+    if (raw.find('*') != std::string::npos) {
+      patterns.glob_patterns.push_back(raw);
+      continue;
+    }
+    std::string cmdline = raw;  // mutable copy
     // Add nullbyte to make sure it's a C string.
     cmdline.resize(cmdline.size() + 1, '\0');
     char* cmdline_cstr = &(cmdline[0]);
     ssize_t size = NormalizeCmdLine(&cmdline_cstr, cmdline.size());
     if (size == -1) {
       PERFETTO_PLOG("Failed to normalize cmdline %s. Stopping the parse.",
-                    cmdlines[i].c_str());
+                    raw.c_str());
       return std::nullopt;
     }
-    normalized_cmdlines.emplace_back(cmdline_cstr, static_cast<size_t>(size));
+    patterns.exact_patterns.emplace_back(cmdline_cstr,
+                                         static_cast<size_t>(size));
   }
-  return std::make_optional(normalized_cmdlines);
+  return std::make_optional(std::move(patterns));
 }
 
 // This is mostly the same as GetHeapprofdProgramProperty in
@@ -241,6 +244,21 @@ void FindPidsForCmdlines(const std::vector<std::string>& cmdlines,
 }
 
 namespace glob_aware {
+bool MatchCmdlineGlobPatterns(const std::string& cmdline,
+                              const std::vector<std::string>& patterns) {
+  if (patterns.empty())
+    return false;
+  const char* binname =
+      glob_aware::FindBinaryName(cmdline.c_str(), cmdline.size());
+  for (const std::string& pattern : patterns) {
+    if (glob_aware::MatchGlobPattern(pattern.c_str(), cmdline.c_str(),
+                                     binname)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void FindPidsForCmdlinePatterns(const std::vector<std::string>& patterns,
                                 std::set<pid_t>* pids) {
   ForEachPid([&patterns, pids](pid_t pid) {
@@ -249,15 +267,8 @@ void FindPidsForCmdlinePatterns(const std::vector<std::string>& patterns,
     std::string cmdline;
     if (!glob_aware::ReadProcCmdlineForPID(pid, &cmdline))
       return;
-    const char* binname =
-        glob_aware::FindBinaryName(cmdline.c_str(), cmdline.size());
-
-    for (const std::string& pattern : patterns) {
-      if (glob_aware::MatchGlobPattern(pattern.c_str(), cmdline.c_str(),
-                                       binname)) {
-        pids->insert(pid);
-      }
-    }
+    if (glob_aware::MatchCmdlineGlobPatterns(cmdline, patterns))
+      pids->insert(pid);
   });
 }
 }  // namespace glob_aware

--- a/src/profiling/common/proc_utils.h
+++ b/src/profiling/common/proc_utils.h
@@ -22,6 +22,7 @@
 #include <cinttypes>
 #include <optional>
 #include <set>
+#include <string>
 #include <vector>
 
 #include "perfetto/ext/base/scoped_file.h"
@@ -63,20 +64,27 @@ std::optional<Uids> GetUids(const std::string&);
 
 void FindAllProfilablePids(std::set<pid_t>* pids);
 
-// TODO(rsavitski): we're changing how the profilers treat proc cmdlines, the
-// newer semantics are implemented in proc_cmdline.h. Wrappers around those
-// implementations are placed in the "glob_aware" namespace here, until we
-// migrate to one implementation for all profilers.
+// Heapprofd requires tracking two types of cmdline patterns. The newer glob
+// matching is incompatible with startup-triggered profiling, so the patterns
+// are split based on whether they have a wildcard in them.
+struct CmdlinePatterns {
+  std::vector<std::string> exact_patterns;
+  std::vector<std::string> glob_patterns;
+};
+
 ssize_t NormalizeCmdLine(char** cmdline_ptr, size_t size);
-std::optional<std::vector<std::string>> NormalizeCmdlines(
+std::optional<CmdlinePatterns> NormalizeCmdlines(
     const std::vector<std::string>& cmdlines);
 void FindPidsForCmdlines(const std::vector<std::string>& cmdlines,
                          std::set<pid_t>* pids);
 bool GetCmdlineForPID(pid_t pid, std::string* name);
 
 namespace glob_aware {
-void FindPidsForCmdlinePatterns(const std::vector<std::string>& cmdlines,
+void FindPidsForCmdlinePatterns(const std::vector<std::string>& patterns,
                                 std::set<pid_t>* pids);
+
+bool MatchCmdlineGlobPatterns(const std::string& cmdline,
+                              const std::vector<std::string>& patterns);
 }  // namespace glob_aware
 
 }  // namespace profiling

--- a/src/profiling/common/proc_utils_unittest.cc
+++ b/src/profiling/common/proc_utils_unittest.cc
@@ -26,6 +26,8 @@ namespace profiling {
 namespace {
 
 using ::testing::Contains;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
 using ::testing::Not;
 
 std::string NormalizeToString(char* cmdline, size_t size) {
@@ -99,6 +101,32 @@ TEST(ProcUtilsTest, NormalizeNoNullTerminated) {
 TEST(ProcUtilsTest, NormalizeZeroLength) {
   char* cmdline = nullptr;
   EXPECT_EQ(NormalizeCmdLine(&cmdline, 0), -1);
+}
+
+TEST(ProcUtilsTest, NormalizeCmdlinesExactOnly) {
+  auto patterns = NormalizeCmdlines(
+      {"/system/bin/surfaceflinger@1.0", "com.android.phone"});
+  ASSERT_TRUE(patterns.has_value());
+  EXPECT_THAT(patterns->exact_patterns,
+              ElementsAre("surfaceflinger", "com.android.phone"));
+  EXPECT_THAT(patterns->glob_patterns, IsEmpty());
+}
+
+TEST(ProcUtilsTest, NormalizeCmdlinesSplitsExactAndGlob) {
+  auto patterns = NormalizeCmdlines(
+      {"/system/bin/surfaceflinger@1.0", "com.android.*", "system_server"});
+  ASSERT_TRUE(patterns.has_value());
+  EXPECT_THAT(patterns->exact_patterns,
+              ElementsAre("surfaceflinger", "system_server"));
+  // Glob patterns are kept verbatim (not normalized).
+  EXPECT_THAT(patterns->glob_patterns, ElementsAre("com.android.*"));
+}
+
+TEST(ProcUtilsTest, NormalizeCmdlinesGlobKeptVerbatim) {
+  auto patterns = NormalizeCmdlines({"/system/bin/*", "*@2.0"});
+  ASSERT_TRUE(patterns.has_value());
+  EXPECT_THAT(patterns->exact_patterns, IsEmpty());
+  EXPECT_THAT(patterns->glob_patterns, ElementsAre("/system/bin/*", "*@2.0"));
 }
 
 TEST(ProcUtilsTest, FindProfilablePids) {

--- a/src/profiling/memory/heapprofd_producer.cc
+++ b/src/profiling/memory/heapprofd_producer.cc
@@ -863,11 +863,11 @@ void HeapprofdProducer::SocketDelegate::OnNewIncomingConnection(
     std::unique_ptr<base::UnixSocket> new_connection) {
   Process peer_process;
   peer_process.pid = new_connection->peer_pid_linux();
-  if (!GetCmdlineForPID(peer_process.pid, &peer_process.cmdline)) {
-    PERFETTO_PLOG("Failed to get cmdline for %d", peer_process.pid);
-  }
-  if (!glob_aware::ReadProcCmdlineForPID(peer_process.pid,
-                                         &peer_process.raw_cmdline)) {
+  bool cmdline_ok = true;
+  cmdline_ok &= GetCmdlineForPID(peer_process.pid, &peer_process.cmdline);
+  cmdline_ok &= glob_aware::ReadProcCmdlineForPID(peer_process.pid,
+                                         &peer_process.raw_cmdline);
+  if (!cmdline_ok) {
     PERFETTO_PLOG("Failed to get cmdline for %d", peer_process.pid);
   }
   producer_->HandleClientConnection(std::move(new_connection), peer_process);

--- a/src/profiling/memory/heapprofd_producer.cc
+++ b/src/profiling/memory/heapprofd_producer.cc
@@ -42,6 +42,8 @@
 #include "perfetto/tracing/core/data_source_descriptor.h"
 #include "perfetto/tracing/core/forward_decls.h"
 #include "protos/perfetto/trace/profiling/profile_packet.pbzero.h"
+#include "src/profiling/common/proc_cmdline.h"
+#include "src/profiling/common/proc_utils.h"
 #include "src/profiling/common/producer_support.h"
 #include "src/profiling/common/profiler_guardrails.h"
 #include "src/profiling/memory/shared_ring_buffer.h"
@@ -83,7 +85,7 @@ std::vector<UnwindingWorker> MakeUnwindingWorkers(HeapprofdProducer* delegate,
 
 bool ConfigTargetsProcess(const HeapprofdConfig& cfg,
                           const Process& proc,
-                          const std::vector<std::string>& normalized_cmdlines) {
+                          const CmdlinePatterns& cmdline_patterns) {
   if (cfg.all())
     return true;
 
@@ -93,8 +95,12 @@ bool ConfigTargetsProcess(const HeapprofdConfig& cfg,
     return true;
   }
 
-  if (std::find(normalized_cmdlines.cbegin(), normalized_cmdlines.cend(),
-                proc.cmdline) != normalized_cmdlines.cend()) {
+  const auto& exact = cmdline_patterns.exact_patterns;
+  if (std::find(exact.cbegin(), exact.cend(), proc.cmdline) != exact.cend()) {
+    return true;
+  }
+  if (glob_aware::MatchCmdlineGlobPatterns(proc.raw_cmdline,
+                                           cmdline_patterns.glob_patterns)) {
     return true;
   }
   return false;
@@ -226,7 +232,8 @@ HeapprofdProducer::~HeapprofdProducer() = default;
 void HeapprofdProducer::SetTargetProcess(pid_t target_pid,
                                          std::string target_cmdline) {
   target_process_.pid = target_pid;
-  target_process_.cmdline = target_cmdline;
+  target_process_.cmdline = std::move(target_cmdline);
+  glob_aware::ReadProcCmdlineForPID(target_pid, &target_process_.raw_cmdline);
 }
 
 void HeapprofdProducer::SetDataSourceCallback(std::function<void()> fn) {
@@ -395,10 +402,25 @@ void HeapprofdProducer::SetupDataSource(DataSourceInstanceID id,
     return;
   }
 
-  std::optional<std::vector<std::string>> normalized_cmdlines =
+  std::optional<CmdlinePatterns> cmdline_patterns =
       NormalizeCmdlines(heapprofd_config.process_cmdline());
-  if (!normalized_cmdlines.has_value()) {
+  if (!cmdline_patterns.has_value()) {
     PERFETTO_ELOG("Rejecting data source due to invalid cmdline in config.");
+    return;
+  }
+
+  // Glob cmdline patterns are only supported for already-running processes, as
+  // the startup path relies on the self-triggering code to derive a single
+  // android sysprop to check (whereas with globs, it would need to check
+  // against all patterns).
+  // Reject configs that don't explicitly opt out of startup profiling to make
+  // this clear.
+  if (!cmdline_patterns->glob_patterns.empty() &&
+      (!heapprofd_config.no_startup() || heapprofd_config.no_running())) {
+    PERFETTO_ELOG(
+        "Rejecting data source: wildcard process_cmdline patterns cannot "
+        "profile processes from startup. Set no_startup=true, no_running=false "
+        "to use them.");
     return;
   }
 
@@ -406,7 +428,7 @@ void HeapprofdProducer::SetupDataSource(DataSourceInstanceID id,
   // already-connected process.
   if (mode_ == HeapprofdMode::kChild) {
     if (!ConfigTargetsProcess(heapprofd_config, target_process_,
-                              normalized_cmdlines.value())) {
+                              cmdline_patterns.value())) {
       PERFETTO_DLOG("Child mode skipping setup of unrelated data source.");
       return;
     }
@@ -440,7 +462,7 @@ void HeapprofdProducer::SetupDataSource(DataSourceInstanceID id,
     return;
   data_source.config = heapprofd_config;
   data_source.ds_config = ds_config;
-  data_source.normalized_cmdlines = std::move(normalized_cmdlines.value());
+  data_source.cmdline_patterns = std::move(cmdline_patterns.value());
   data_source.stop_timeout_ms = ds_config.stop_timeout_ms()
                                     ? ds_config.stop_timeout_ms()
                                     : 5000 /* kDataSourceStopTimeoutMs */;
@@ -474,9 +496,14 @@ void HeapprofdProducer::SetStartupProperties(DataSource* data_source) {
   if (heapprofd_config.all())
     data_source->properties.emplace_back(properties_.SetAll());
 
-  for (std::string cmdline : data_source->normalized_cmdlines)
-    data_source->properties.emplace_back(
-        properties_.SetProperty(std::move(cmdline)));
+  // Android: only non-glob patterns are compatible with startup properties (so
+  // that the startup codepaths can derive a single sysprop to check from its
+  // cmdline). SetupDataSource enforces that any configs with glob patterns have
+  // |no_startup| set, so we can ignore globs here.
+  for (const std::string& cmdline :
+       data_source->cmdline_patterns.exact_patterns) {
+    data_source->properties.emplace_back(properties_.SetProperty(cmdline));
+  }
 }
 
 void HeapprofdProducer::SignalRunningProcesses(DataSource* data_source) {
@@ -488,8 +515,14 @@ void HeapprofdProducer::SignalRunningProcesses(DataSource* data_source) {
   for (uint64_t pid : heapprofd_config.pid())
     pids.emplace(static_cast<pid_t>(pid));
 
-  if (!data_source->normalized_cmdlines.empty())
-    FindPidsForCmdlines(data_source->normalized_cmdlines, &pids);
+  const CmdlinePatterns& cmdline_patterns = data_source->cmdline_patterns;
+  if (!cmdline_patterns.exact_patterns.empty()) {
+    FindPidsForCmdlines(cmdline_patterns.exact_patterns, &pids);
+  }
+  if (!cmdline_patterns.glob_patterns.empty()) {
+    glob_aware::FindPidsForCmdlinePatterns(cmdline_patterns.glob_patterns,
+                                           &pids);
+  }
 
   if (heapprofd_config.min_anonymous_memory_kb() > 0)
     RemoveUnderAnonThreshold(heapprofd_config.min_anonymous_memory_kb(), &pids);
@@ -830,9 +863,13 @@ void HeapprofdProducer::SocketDelegate::OnNewIncomingConnection(
     std::unique_ptr<base::UnixSocket> new_connection) {
   Process peer_process;
   peer_process.pid = new_connection->peer_pid_linux();
-  if (!GetCmdlineForPID(peer_process.pid, &peer_process.cmdline))
+  if (!GetCmdlineForPID(peer_process.pid, &peer_process.cmdline)) {
     PERFETTO_PLOG("Failed to get cmdline for %d", peer_process.pid);
-
+  }
+  if (!glob_aware::ReadProcCmdlineForPID(peer_process.pid,
+                                         &peer_process.raw_cmdline)) {
+    PERFETTO_PLOG("Failed to get cmdline for %d", peer_process.pid);
+  }
   producer_->HandleClientConnection(std::move(new_connection), peer_process);
 }
 
@@ -923,7 +960,7 @@ HeapprofdProducer::DataSource* HeapprofdProducer::GetDataSourceForProcess(
     const Process& proc) {
   for (auto& ds_id_and_datasource : data_sources_) {
     DataSource& ds = ds_id_and_datasource.second;
-    if (ConfigTargetsProcess(ds.config, proc, ds.normalized_cmdlines))
+    if (ConfigTargetsProcess(ds.config, proc, ds.cmdline_patterns))
       return &ds;
   }
   return nullptr;
@@ -934,7 +971,7 @@ void HeapprofdProducer::RecordOtherSourcesAsRejected(DataSource* active_ds,
   for (auto& ds_id_and_datasource : data_sources_) {
     DataSource& ds = ds_id_and_datasource.second;
     if (&ds != active_ds &&
-        ConfigTargetsProcess(ds.config, proc, ds.normalized_cmdlines))
+        ConfigTargetsProcess(ds.config, proc, ds.cmdline_patterns))
       ds.rejected_pids.emplace(proc.pid);
   }
 }

--- a/src/profiling/memory/heapprofd_producer.cc
+++ b/src/profiling/memory/heapprofd_producer.cc
@@ -866,7 +866,7 @@ void HeapprofdProducer::SocketDelegate::OnNewIncomingConnection(
   bool cmdline_ok = true;
   cmdline_ok &= GetCmdlineForPID(peer_process.pid, &peer_process.cmdline);
   cmdline_ok &= glob_aware::ReadProcCmdlineForPID(peer_process.pid,
-                                         &peer_process.raw_cmdline);
+                                                  &peer_process.raw_cmdline);
   if (!cmdline_ok) {
     PERFETTO_PLOG("Failed to get cmdline for %d", peer_process.pid);
   }

--- a/src/profiling/memory/heapprofd_producer.h
+++ b/src/profiling/memory/heapprofd_producer.h
@@ -53,12 +53,14 @@ using HeapprofdConfig = protos::gen::HeapprofdConfig;
 
 struct Process {
   pid_t pid;
+  // Normalized cmdline (see process_cmdline in heapprofd_config.proto). Matched
+  // verbatim against CmdlinePatterns::exact_patterns.
   std::string cmdline;
+  // Full cmdline (capped to 511 chars). Used for glob matching against
+  // CmdlinePatterns::glob_patterns.
+  std::string raw_cmdline;
 };
 
-// TODO(rsavitski): central daemon can do less work if it knows that the global
-// operating mode is fork-based, as it then will not be interacting with the
-// clients. This can be implemented as an additional mode here.
 enum class HeapprofdMode { kCentral, kChild };
 
 bool HeapprofdConfigToClientConfiguration(
@@ -231,7 +233,7 @@ class HeapprofdProducer : public Producer, public UnwindingWorker::Delegate {
     std::set<pid_t> signaled_pids;
     std::set<pid_t> rejected_pids;
     std::map<pid_t, ProcessState> process_states;
-    std::vector<std::string> normalized_cmdlines;
+    CmdlinePatterns cmdline_patterns;
     InterningOutputTracker intern_state;
     bool shutting_down = false;
     bool started = false;
@@ -321,7 +323,7 @@ class HeapprofdProducer : public Producer, public UnwindingWorker::Delegate {
   std::map<DataSourceInstanceID, DataSource> data_sources_;
 
   // Specific to mode_ == kChild
-  Process target_process_{base::kInvalidPid, ""};
+  Process target_process_{base::kInvalidPid, "", ""};
   std::optional<std::function<void()>> data_source_callback_;
 
   SocketDelegate socket_delegate_;

--- a/src/profiling/memory/heapprofd_producer.h
+++ b/src/profiling/memory/heapprofd_producer.h
@@ -323,7 +323,8 @@ class HeapprofdProducer : public Producer, public UnwindingWorker::Delegate {
   std::map<DataSourceInstanceID, DataSource> data_sources_;
 
   // Specific to mode_ == kChild
-  Process target_process_{base::kInvalidPid, /*cmdline=*/"", /*raw_cmdline=*/""};
+  Process target_process_{base::kInvalidPid, /*cmdline=*/"",
+                          /*raw_cmdline=*/""};
   std::optional<std::function<void()>> data_source_callback_;
 
   SocketDelegate socket_delegate_;

--- a/src/profiling/memory/heapprofd_producer.h
+++ b/src/profiling/memory/heapprofd_producer.h
@@ -323,7 +323,7 @@ class HeapprofdProducer : public Producer, public UnwindingWorker::Delegate {
   std::map<DataSourceInstanceID, DataSource> data_sources_;
 
   // Specific to mode_ == kChild
-  Process target_process_{base::kInvalidPid, "", ""};
+  Process target_process_{base::kInvalidPid, /*cmdline=*/"", /*raw_cmdline=*/""};
   std::optional<std::function<void()>> data_source_callback_;
 
   SocketDelegate socket_delegate_;


### PR DESCRIPTION
Currently, heap profiling is the only data source that cannot be
configured with wildcard patterns for process names. This is because
"from startup" profiling on Android requires self-targeting code to
derive a unique sysprop name from the process cmdline, where the sysprop
value states whether to self-activate the profiling (and is set by
heapprofd). With wildcard matching, the startup case would need a
different scheme that can inspect all N patterns that are being
profiled.

This patch retrofits wildcard support into heapprofd, but makes it
explicitly incompatible with startup profiling to reduce surprise
factor. A config needs to explicitly state no_startup=true if its
|process_cmdline| includes wildcards.

The glob-aware matching codepath is identical to traced_perf and
java_hprof profilers.

Bug: 495877833