### PR TITLE
ai/skills: add GPU timeline occupancy workflow

### DIFF
--- a/ai/skills/perfetto/SKILL-template.md
+++ b/ai/skills/perfetto/SKILL-template.md
@@ -45,7 +45,17 @@ retention, or optimize heap usage:
     across a process, read
     [heap_dump_cluster.md](workflows/android_memory/heap_dump_cluster.md).
 
-## 3. Are you trying to do ad-hoc trace analysis?
+## 3. Are you trying to analyze GPU/accelerator performance?
+
+If you have a resolved trace with GPU activity and want to know whether the
+workload is GPU-bound or host-bound:
+
+*   **GPU timeline occupancy:** To decompose the GPU timeline into device-busy
+    vs idle time, get per-GPU busy percentages, and find the largest idle gaps
+    with host-side attribution, read
+    [timeline_occupancy.md](workflows/gpu/timeline_occupancy.md).
+
+## 4. Are you trying to do ad-hoc trace analysis?
 
 If you want to load a trace and write custom PerfettoSQL queries:
 

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_idle_gaps.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_idle_gaps.sql
@@ -1,0 +1,30 @@
+-- Largest idle gaps on the GPU timeline.
+--
+-- After merging all GPU activity intervals into a single busy timeline, the
+-- gaps between consecutive busy intervals are the windows where the device had
+-- no work resident. These gaps are where you look UPSTREAM for the cause:
+-- submission/launch latency, host-side synchronization or waits, device memory
+-- allocation, host-device copies, or host-side work starving the device.
+--
+-- No parameters; operates on the whole trace. Returns the top idle gaps as
+-- (gap_start_rel_ns, gap_dur_ns), where gap_start_rel_ns is relative to
+-- trace_start(). To attribute a gap to host work, take a gap's
+-- [gap_start, gap_start + gap_dur] window and run the host-attribution query
+-- in timeline_occupancy.md.
+--
+-- NOTE: this merges across all GPUs into one timeline. For a multi-GPU trace,
+-- scope to one device by adding a ugpu filter (see timeline_occupancy.md).
+
+INCLUDE PERFETTO MODULE intervals.overlap;
+
+CREATE PERFETTO TABLE _gpu_busy AS
+SELECT ts, dur, ts + dur AS te
+FROM interval_merge_overlapping!((SELECT ts, dur FROM gpu_slice WHERE dur > 0), 0);
+
+SELECT ts - trace_start() AS gap_start_rel_ns, next_ts - ts AS gap_dur_ns
+FROM (SELECT te AS ts, LEAD(ts) OVER (ORDER BY ts) AS next_ts FROM _gpu_busy)
+WHERE
+  next_ts - ts > 0
+ORDER BY
+  gap_dur_ns DESC
+LIMIT 10;

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_timeline_decomposition.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_timeline_decomposition.sql
@@ -1,0 +1,58 @@
+-- GPU timeline wall-clock decomposition: device-busy vs idle.
+--
+-- For each GPU, reports how much of wall-clock time had work resident on the
+-- device versus sitting idle. This is the trace-level answer that a coarse
+-- device "utilization percent" gauge cannot give: such gauges report only that
+-- something is resident, not how the timeline decomposes or where the idle is.
+--
+-- "Busy" is the UNION of GPU activity intervals (work running concurrently on
+-- multiple hardware queues is merged, not summed, so concurrency is never
+-- double-counted). Covers all GPU render-stage activity, not just one category.
+--
+-- No parameters; operates on the whole trace. One row per GPU.
+--   busy_pct_of_active : busy / (first .. last activity) span -> packing.
+--   busy_pct_of_trace  : busy / whole-trace wall clock        -> idle outside
+--                        the active span (setup, I/O, teardown) shows up here.
+
+INCLUDE PERFETTO MODULE intervals.overlap;
+
+CREATE PERFETTO TABLE _gpu_work AS
+SELECT
+  s.ts,
+  s.dur,
+  IFNULL(EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu'), 0) AS ugpu
+FROM gpu_slice AS s
+JOIN gpu_track AS t ON s.track_id = t.id
+WHERE
+  s.dur > 0;
+
+CREATE PERFETTO TABLE _gpu_busy AS
+SELECT ugpu, ts, dur
+FROM interval_merge_overlapping_partitioned!((
+    SELECT ts, dur, ugpu FROM _gpu_work
+  ), (ugpu));
+
+SELECT
+  k.ugpu AS gpu,
+  IFNULL(g.name, 'GPU ' || k.ugpu) AS gpu_name,
+  COUNT(*) AS activities,
+  trace_end() - trace_start() AS trace_wall_ns,
+  MAX(k.ts + k.dur) - MIN(k.ts) AS active_span_ns,
+  (SELECT SUM(b.dur) FROM _gpu_busy AS b WHERE b.ugpu = k.ugpu) AS gpu_busy_ns,
+  ROUND(
+    100.0 * (SELECT SUM(b.dur) FROM _gpu_busy AS b WHERE b.ugpu = k.ugpu)
+    / (MAX(k.ts + k.dur) - MIN(k.ts)),
+    1
+  ) AS busy_pct_of_active,
+  ROUND(
+    100.0 * (SELECT SUM(b.dur) FROM _gpu_busy AS b WHERE b.ugpu = k.ugpu)
+    / (trace_end() - trace_start()),
+    1
+  ) AS busy_pct_of_trace
+FROM _gpu_work AS k
+LEFT JOIN gpu AS g ON g.ugpu = k.ugpu
+GROUP BY
+  k.ugpu,
+  gpu_name
+ORDER BY
+  k.ugpu;

--- a/ai/skills/perfetto/workflows/gpu/timeline_occupancy.md
+++ b/ai/skills/perfetto/workflows/gpu/timeline_occupancy.md
@@ -1,0 +1,143 @@
+# GPU timeline occupancy — is the GPU actually working?
+
+This workflow decomposes the GPU timeline into **device-busy** vs **idle** time,
+so you can tell whether a workload is GPU-bound (optimize the device work) or
+host-bound (the device is starved and you must look upstream). It works on any
+trace that contains GPU render-stage activity, for any GPU/accelerator vendor.
+
+Why this and not a device "utilization percent" gauge: a coarse utilization
+number tells you only that something is *resident* on the device, not how the
+wall clock decomposes or where the idle is. The trace-level view — the union of
+GPU activity intervals measured against the timeline (or a window of interest) —
+is what tells you whether you have a GPU problem or a host problem. The gaps
+point you upstream: submission/launch latency, host-side synchronization,
+allocation, host-device copies, or host work starving the device.
+
+If the user has not yet loaded a trace into `trace_processor`, follow
+`../../infra-references/querying.md` first, then come back here.
+
+---
+
+## Phase 1: Mandatory first-pass triage
+
+Run this before any open-ended exploration. It produces the headline verdict.
+
+1.  Run the decomposition script. It takes the trace file as its argument and
+    returns one row per GPU as CSV.
+
+    ```bash
+    trace_processor query --query-file scripts/gpu_timeline_decomposition.sql TRACE_FILE
+    ```
+
+    Columns: `gpu`, `gpu_name`, `activities`, `trace_wall_ns`, `active_span_ns`,
+    `gpu_busy_ns`, `busy_pct_of_active`, `busy_pct_of_trace`.
+
+2.  Interpret:
+
+    - **`busy_pct_of_active` is high (≳ 90%)** — within the window where the GPU
+      is doing work, activity is packed back-to-back. This is **GPU-bound**: the
+      lever is the device work itself, not the host. Stop here unless the user
+      wants deeper device-side analysis.
+    - **`busy_pct_of_active` is low** — there are meaningful idle gaps *between*
+      activities even while the workload is "running." This is **host-bound** /
+      stalled. Proceed to Phase 2 to find and attribute the gaps.
+    - **`busy_pct_of_trace` ≪ `busy_pct_of_active`** — the GPU is well-packed
+      while active, but a large fraction of wall-clock has no GPU work at all
+      (setup, I/O, teardown). Whether that matters depends on the window the
+      user cares about; confirm with them.
+
+3.  If the workload repeats a phase (e.g. an iteration marked by a named slice),
+    decompose per window — this is usually the number that matters. Pick the
+    boundary slice name for the workload and substitute it:
+
+    ```sql
+    INCLUDE PERFETTO MODULE intervals.overlap;
+    INCLUDE PERFETTO MODULE intervals.intersect;
+
+    CREATE PERFETTO TABLE windows AS
+      SELECT ROW_NUMBER() OVER (ORDER BY ts) AS id, name, ts, dur
+      FROM slice WHERE name GLOB 'YOUR_BOUNDARY_SLICE*' AND dur > 0;
+
+    CREATE PERFETTO TABLE busy AS
+      SELECT ROW_NUMBER() OVER (ORDER BY ts) AS id, ts, dur
+      FROM interval_merge_overlapping!((
+        SELECT ts, dur FROM gpu_slice WHERE dur > 0), 0);
+
+    SELECT
+      w.name AS window,
+      w.dur AS window_ns,
+      IFNULL(SUM(ii.dur), 0) AS gpu_busy_ns,
+      ROUND(100.0 * IFNULL(SUM(ii.dur), 0) / w.dur, 1) AS gpu_busy_pct
+    FROM windows w
+    LEFT JOIN _interval_intersect!((windows, busy), ()) ii ON ii.id_0 = w.id
+    GROUP BY w.id, w.name, w.dur
+    ORDER BY w.ts;
+    ```
+
+---
+
+## Phase 2: Find and attribute the idle gaps
+
+> Run this when Phase 1 shows the GPU is idle for a window that matters.
+
+1.  List the largest idle gaps on the GPU timeline:
+
+    ```bash
+    trace_processor query --query-file scripts/gpu_idle_gaps.sql TRACE_FILE
+    ```
+
+    Returns `gap_start_rel_ns` (relative to trace start) and `gap_dur_ns`,
+    biggest first.
+
+2.  Attribute the biggest gap to host-side work. Take the gap's absolute window
+    `[$gap_start, $gap_end]` (`$gap_start = trace_start() + gap_start_rel_ns`,
+    `$gap_end = $gap_start + gap_dur_ns`) and substitute the numeric values —
+    `trace_processor` does not interpret `$` variables:
+
+    ```sql
+    INCLUDE PERFETTO MODULE slices.with_context;
+
+    SELECT
+      s.name,
+      s.thread_name,
+      COUNT(*) AS n,
+      SUM(MIN(s.ts + s.dur, $gap_end) - MAX(s.ts, $gap_start)) AS overlap_ns
+    FROM thread_or_process_slice s
+    WHERE s.dur > 0 AND s.depth = 0
+      AND s.ts < $gap_end AND s.ts + s.dur > $gap_start
+    GROUP BY s.name, s.thread_name
+    ORDER BY overlap_ns DESC
+    LIMIT 10;
+    ```
+
+    The top rows name what the host was doing while the GPU sat idle. Common
+    causes: device memory allocation/free, host-device copies, host-side
+    synchronization or waits, submission/launch overhead dominating, or
+    host-side compute (input preparation) starving the device.
+
+3.  For multi-GPU traces, the scripts above merge all GPUs into one timeline.
+    To analyze one device, add `AND EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu')
+    = N` to the activity selection (joining `gpu_track t`).
+
+---
+
+## Phase 3: Reporting
+
+A good summary states:
+
+1.  **The verdict** — GPU-bound or host-bound, with the numbers
+    (`busy_pct_of_active`, and per-window % if available).
+2.  **Where the idle is** — the largest gaps and the host work that overlaps
+    them, named concretely (slice name, thread).
+3.  **The lever** — device-side optimization (GPU-bound) vs. removing the
+    upstream stall (host-bound: hide allocation, overlap copies, batch
+    submissions, fix the host pipeline).
+
+Keep the SQL and the gap timestamps available so the user can audit.
+
+## Reference
+
+- GPU data sources: <https://perfetto.dev/docs/data-sources/gpu>
+- Interval helpers: stdlib `intervals.overlap`, `intervals.intersect`
+- PerfettoSQL tour:
+  <https://perfetto.dev/docs/analysis/perfetto-sql-getting-started>


### PR DESCRIPTION
Adds a vendor-agnostic GPU workflow that decomposes the GPU timeline into device-busy vs idle (interval union, not sum), reports per-GPU busy % of active span and of the whole trace, and surfaces the largest idle gaps with host-side attribution to distinguish GPU-bound from host-bound workloads. Includes two parameter-free triage scripts and a router entry.