### PR TITLE
[DNS] ui: SurfaceFlinger layers viewer (com.android.SurfaceFlinger)

### DIFF
--- a/src/trace_processor/plugins/winscope_importer/winscope_importer.cc
+++ b/src/trace_processor/plugins/winscope_importer/winscope_importer.cc
@@ -16,12 +16,17 @@
 
 #include "src/trace_processor/plugins/winscope_importer/winscope_importer.h"
 
+#include <cstdint>
+#include <limits>
 #include <memory>
+#include <utility>
 
 #include "perfetto/base/compiler.h"
 #include "src/trace_processor/core/plugin/plugin.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/plugins/winscope_importer/winscope_module.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
 
 namespace perfetto::trace_processor::winscope_importer {
 
@@ -34,6 +39,50 @@ class WinscopeImporter : public Plugin<WinscopeImporter> {
       TraceProcessorContext* trace_context) override {
     module_context->modules.emplace_back(
         new WinscopeModule(module_context, trace_context));
+  }
+
+  // The winscope snapshot tables are the only events in a trace captured with
+  // just the winscope data sources, so this plugin contributes their extent to
+  // the trace bounds (otherwise such a trace has empty bounds and the UI treats
+  // it as empty). GetBoundsMutationCount must enumerate the same tables.
+  uint64_t GetBoundsMutationCount() override {
+    if (trace_context_ == nullptr) {
+      return 0;
+    }
+    const auto& s = *trace_context_->storage;
+    return s.surfaceflinger_layers_snapshot_table().mutations() +
+           s.surfaceflinger_transactions_table().mutations() +
+           s.windowmanager_table().mutations() +
+           s.window_manager_shell_transitions_table().mutations() +
+           s.inputmethod_clients_table().mutations() +
+           s.inputmethod_manager_service_table().mutations() +
+           s.inputmethod_service_table().mutations() +
+           s.viewcapture_table().mutations() + s.protolog_table().mutations();
+  }
+
+  std::pair<int64_t, int64_t> GetTimestampBounds() override {
+    int64_t start_ns = std::numeric_limits<int64_t>::max();
+    int64_t end_ns = 0;
+    if (trace_context_ == nullptr) {
+      return {start_ns, end_ns};
+    }
+    const auto& s = *trace_context_->storage;
+    const auto include = [&](auto it) {
+      for (; it; ++it) {
+        start_ns = std::min(it.ts(), start_ns);
+        end_ns = std::max(it.ts(), end_ns);
+      }
+    };
+    include(s.surfaceflinger_layers_snapshot_table().IterateRows());
+    include(s.surfaceflinger_transactions_table().IterateRows());
+    include(s.windowmanager_table().IterateRows());
+    include(s.window_manager_shell_transitions_table().IterateRows());
+    include(s.inputmethod_clients_table().IterateRows());
+    include(s.inputmethod_manager_service_table().IterateRows());
+    include(s.inputmethod_service_table().IterateRows());
+    include(s.viewcapture_table().IterateRows());
+    include(s.protolog_table().IterateRows());
+    return {start_ns, end_ns};
   }
 };
 

--- a/src/trace_processor/tables/winscope_tables.py
+++ b/src/trace_processor/tables/winscope_tables.py
@@ -117,7 +117,7 @@ INPUTMETHOD_CLIENTS_TABLE = Table(
     class_name='InputMethodClientsTable',
     sql_name='__intrinsic_inputmethod_clients',
     columns=[
-        C('ts', CppInt64(), ColumnFlag.SORTED),
+        C('ts', CppInt64(), ColumnFlag.SORTED, cpp_access=CppAccess.READ),
         C(
             'arg_set_id',
             CppOptional(CppUint32()),
@@ -144,7 +144,7 @@ INPUTMETHOD_MANAGER_SERVICE_TABLE = Table(
     class_name='InputMethodManagerServiceTable',
     sql_name='__intrinsic_inputmethod_manager_service',
     columns=[
-        C('ts', CppInt64(), ColumnFlag.SORTED),
+        C('ts', CppInt64(), ColumnFlag.SORTED, cpp_access=CppAccess.READ),
         C(
             'arg_set_id',
             CppOptional(CppUint32()),
@@ -171,7 +171,7 @@ INPUTMETHOD_SERVICE_TABLE = Table(
     class_name='InputMethodServiceTable',
     sql_name='__intrinsic_inputmethod_service',
     columns=[
-        C('ts', CppInt64(), ColumnFlag.SORTED),
+        C('ts', CppInt64(), ColumnFlag.SORTED, cpp_access=CppAccess.READ),
         C(
             'arg_set_id',
             CppOptional(CppUint32()),
@@ -199,7 +199,7 @@ SURFACE_FLINGER_LAYERS_SNAPSHOT_TABLE = Table(
     sql_name='__intrinsic_surfaceflinger_layers_snapshot',
     wrapping_sql_view=WrappingSqlView('surfaceflinger_layers_snapshot'),
     columns=[
-        C('ts', CppInt64(), ColumnFlag.SORTED),
+        C('ts', CppInt64(), ColumnFlag.SORTED, cpp_access=CppAccess.READ),
         C(
             'arg_set_id',
             CppOptional(CppUint32()),
@@ -360,7 +360,7 @@ SURFACE_FLINGER_TRANSACTIONS_TABLE = Table(
     sql_name='__intrinsic_surfaceflinger_transactions',
     wrapping_sql_view=WrappingSqlView('surfaceflinger_transactions'),
     columns=[
-        C('ts', CppInt64(), ColumnFlag.SORTED),
+        C('ts', CppInt64(), ColumnFlag.SORTED, cpp_access=CppAccess.READ),
         C(
             'arg_set_id',
             CppOptional(CppUint32()),
@@ -459,7 +459,7 @@ VIEWCAPTURE_TABLE = Table(
     class_name='ViewCaptureTable',
     sql_name='__intrinsic_viewcapture',
     columns=[
-        C('ts', CppInt64(), ColumnFlag.SORTED),
+        C('ts', CppInt64(), ColumnFlag.SORTED, cpp_access=CppAccess.READ),
         C(
             'arg_set_id',
             CppOptional(CppUint32()),
@@ -804,7 +804,7 @@ WINDOW_MANAGER_TABLE = Table(
     class_name='WindowManagerTable',
     sql_name='__intrinsic_windowmanager',
     columns=[
-        C('ts', CppInt64(), ColumnFlag.SORTED),
+        C('ts', CppInt64(), ColumnFlag.SORTED, cpp_access=CppAccess.READ),
         C(
             'arg_set_id',
             CppOptional(CppUint32()),

--- a/ui/src/core/embedder/default_plugins.ts
+++ b/ui/src/core/embedder/default_plugins.ts
@@ -44,6 +44,7 @@ export const defaultPlugins = [
   'com.android.MemoryViz',
   'com.android.PinAndroidPerfMetrics',
   'com.android.PinSysUITracks',
+  'com.android.SurfaceFlinger',
   'com.android.SysUIWorkspace',
   'com.android.WearLongBatteryTracing',
   'com.google.PixelCpmTrace',

--- a/ui/src/plugins/com.android.SurfaceFlinger/index.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/index.ts
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {PerfettoPlugin} from '../../public/plugin';
+import type {Trace} from '../../public/trace';
+import {TrackNode} from '../../public/workspace';
+import {createSurfaceFlingerTrack} from './surfaceflinger_track';
+import {SurfaceFlingerPage} from './surfaceflinger_page';
+import {SURFACEFLINGER_ROUTE} from './surfaceflinger_route';
+import {SurfaceFlingerSession} from './surfaceflinger_session';
+
+// Viewer for SurfaceFlinger layer traces (the android.surfaceflinger.layers
+// data source). Surfaced two ways onto one shared session: a per-display
+// timeline track of layer snapshots, and a full-screen page (Surface/rects view
+// + layer hierarchy + curated & full proto properties) reached from the sidebar
+// or by opening a snapshot from the timeline.
+export default class implements PerfettoPlugin {
+  static readonly id = 'com.android.SurfaceFlinger';
+  static readonly description =
+    'SurfaceFlinger viewer: per-display layer snapshots on the timeline plus a ' +
+    'full-screen rects/hierarchy/properties page. Inspired by the Android ' +
+    'Winscope tool.';
+
+  async onTraceLoad(ctx: Trace): Promise<void> {
+    const session = new SurfaceFlingerSession(ctx);
+    await session.init();
+    if (session.displays.length === 0) return;
+
+    // Full-screen page + sidebar entry.
+    ctx.pages.registerPage({
+      route: SURFACEFLINGER_ROUTE,
+      render: (subpage) => m(SurfaceFlingerPage, {session, subpage}),
+    });
+    ctx.sidebar.addMenuItem({
+      section: 'current_trace',
+      sortOrder: 35,
+      text: 'SurfaceFlinger',
+      href: `#!${SURFACEFLINGER_ROUTE}`,
+      icon: 'layers',
+    });
+
+    // A nested "SurfaceFlinger" group with one track per display (real and
+    // virtual — virtual displays such as a video-encoder/screen-recorder target
+    // are part of what SurfaceFlinger actually composited, so they are shown).
+    // Each track is scoped to its display's composition; the same displays
+    // appear in the page's selector, so the timeline and page stay consistent.
+    const group = new TrackNode({
+      name: 'SurfaceFlinger',
+      isSummary: true,
+      sortOrder: -50,
+    });
+    for (const display of session.displays) {
+      const uri = `/surfaceflinger_track/${display.displayId}`;
+      ctx.tracks.registerTrack({
+        uri,
+        renderer: createSurfaceFlingerTrack(
+          ctx,
+          uri,
+          display.displayId,
+          session,
+        ),
+      });
+      const name = display.isVirtual
+        ? `${display.displayName} (virtual)`
+        : display.displayName;
+      group.addChildInOrder(new TrackNode({uri, name}));
+    }
+    ctx.defaultWorkspace.addChildInOrder(group);
+  }
+}

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger.scss
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger.scss
@@ -1,0 +1,227 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// All colours come from the Perfetto theme variables (--pf-color-*), which the
+// theme provider redefines for light and dark mode, so the viewer follows the
+// app theme automatically. The canvas (surfaceflinger_rects.ts) reads the same
+// variables via getComputedStyle since CSS variables don't reach a 2D context.
+
+.pf-sf-page {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-size: 13px;
+  color: var(--pf-color-text);
+  background: var(--pf-color-background);
+}
+
+.pf-sf-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--pf-color-border);
+  background: var(--pf-color-background-secondary);
+  flex: 0 0 auto;
+
+  &__pos {
+    font-variant-numeric: tabular-nums;
+    color: var(--pf-color-text-muted);
+  }
+  &__ts {
+    margin-left: auto;
+  }
+}
+
+.pf-sf-scrub {
+  flex: 1;
+  min-width: 120px;
+  accent-color: var(--pf-color-accent);
+}
+
+.pf-sf-main {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+// The 3-pane viewer; also used when embedded in the details drawer. The 1px gap
+// over a tinted background draws the dividers between panes.
+.pf-sf-viewer {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  min-height: 0;
+  gap: 1px;
+  background: var(--pf-color-border);
+}
+
+.pf-sf-pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  // Both axes scroll so long layer names / deep trees / wide values are
+  // reachable instead of being clipped.
+  overflow: auto;
+  background: var(--pf-color-background);
+
+  &--surface {
+    flex: 1.3 1 0;
+  }
+  &--hier {
+    flex: 1 1 0;
+  }
+  &--props {
+    flex: 1.1 1 0;
+  }
+}
+
+.pf-sf-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 8px;
+}
+
+.pf-sf-slider {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--pf-color-text-muted);
+
+  input[type="range"] {
+    accent-color: var(--pf-color-accent);
+  }
+}
+
+.pf-sf-rects {
+  padding: 6px 8px;
+  &__canvas {
+    width: 100%;
+    height: 380px;
+    display: block;
+    background: var(--pf-color-background-secondary);
+    border: 1px solid var(--pf-color-border);
+    border-radius: 3px;
+    cursor: crosshair;
+  }
+}
+
+.pf-sf-ts {
+  padding: 4px 8px;
+  color: var(--pf-color-text-muted);
+}
+
+.pf-sf-htree {
+  padding: 0 4px 8px;
+  // Grow to content so the enclosing pane scrolls horizontally rather than
+  // squashing or clipping nodes.
+  min-width: max-content;
+}
+
+.pf-sf-hnode {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  padding: 1px 4px;
+  border-radius: 3px;
+  color: var(--pf-color-text);
+
+  &--added {
+    background: color-mix(in srgb, var(--pf-color-success) 22%, transparent);
+  }
+  &--modified {
+    background: color-mix(in srgb, var(--pf-color-warning) 24%, transparent);
+  }
+  &--deleted {
+    background: color-mix(in srgb, var(--pf-color-danger) 20%, transparent);
+    text-decoration: line-through;
+    opacity: 0.7;
+  }
+  &--sel {
+    background: color-mix(in srgb, var(--pf-color-accent) 24%, transparent);
+  }
+  &__id {
+    color: var(--pf-color-text-muted);
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+  }
+  &__name {
+    white-space: nowrap;
+  }
+  // Hide/pin buttons: subtle until hover.
+  &__btn {
+    opacity: 0.3;
+    transform: scale(0.85);
+  }
+  &:hover &__btn {
+    opacity: 0.9;
+  }
+}
+
+.pf-sf-ref {
+  color: var(--pf-color-accent);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+// Header card at the top of the Properties pane: selected layer name + chips.
+.pf-sf-prophead {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--pf-color-border);
+  background: var(--pf-color-background-secondary);
+
+  &__name {
+    font-weight: 600;
+    word-break: break-all;
+  }
+  &__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+  }
+}
+
+.pf-sf-proto {
+  height: 340px;
+  display: flex;
+  flex-direction: column;
+  margin: 0 8px 8px;
+}
+
+// Curated-properties DataGrid (height is set inline from the row count).
+.pf-sf-curated {
+  display: flex;
+  flex-direction: column;
+  margin: 0 8px 8px;
+}
+
+// Section-title row inside the curated DataGrid.
+.pf-sf-cur-h {
+  font-weight: 600;
+  color: var(--pf-color-text);
+}
+
+.pf-sf-empty {
+  padding: 12px;
+  color: var(--pf-color-text-muted);
+}

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_controls.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_controls.ts
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The Surface-view controls (shading / only-visible / spacing / rotation),
+// shared by the full-screen page and the timeline details panel. Both bind to
+// the same SfViewOptions on the session, so the two views stay in sync.
+
+import m from 'mithril';
+import {Checkbox} from '../../widgets/checkbox';
+import {Select} from '../../widgets/select';
+import type {SfRectsOptions} from './surfaceflinger_rects';
+import type {SfViewOptions} from './surfaceflinger_session';
+
+export function rectsOptionsFrom(o: SfViewOptions): SfRectsOptions {
+  return {
+    showOnlyVisible: o.rectsOnlyVisible,
+    explode: o.explode,
+    rotation: o.rotation,
+    shading: o.shading,
+  };
+}
+
+export function renderSurfaceControls(o: SfViewOptions): m.Children {
+  return m('.pf-sf-toolbar', [
+    m(
+      Select,
+      {
+        title: 'Shading mode',
+        onchange: (e: Event) =>
+          (o.shading = (e.target as HTMLSelectElement).value as
+            | 'gradient'
+            | 'opacity'
+            | 'wireframe'),
+      },
+      ['gradient', 'opacity', 'wireframe'].map((v) =>
+        m('option', {value: v, selected: o.shading === v}, v),
+      ),
+    ),
+    m(Checkbox, {
+      label: 'Only visible',
+      checked: o.rectsOnlyVisible,
+      onchange: () => (o.rectsOnlyVisible = !o.rectsOnlyVisible),
+    }),
+    m('label.pf-sf-slider', [
+      'Spacing',
+      m('input[type=range]', {
+        min: 0,
+        max: 100,
+        title: 'Z separation between layers (visible when rotated)',
+        value: o.explode * 100,
+        oninput: (e: Event) =>
+          (o.explode = Number((e.target as HTMLInputElement).value) / 100),
+      }),
+    ]),
+    m('label.pf-sf-slider', [
+      'Rotation',
+      m('input[type=range]', {
+        min: 0,
+        max: 100,
+        title: 'Rotate the 3D layer stack',
+        value: o.rotation * 100,
+        oninput: (e: Event) =>
+          (o.rotation = Number((e.target as HTMLInputElement).value) / 100),
+      }),
+    ]),
+  ]);
+}

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_curated.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_curated.ts
@@ -1,0 +1,224 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Derives the "curated properties" summary for a selected layer from the
+// flattened proto args. Mirrors the field set the layer property groups +
+// surface_flinger_property_groups + visibility summary show, so users get the
+// same at-a-glance view.
+
+import {fmtNum, type SfArg, type SfLayer} from './surfaceflinger_data';
+
+export interface CuratedRow {
+  label: string;
+  value: string;
+  // Layer ids this row references (occludedBy/relativeParent), for click-to-go.
+  layerRefs?: number[];
+}
+
+export interface CuratedSection {
+  title: string;
+  rows: CuratedRow[];
+}
+
+export function buildArgMaps(args: SfArg[]): {
+  byKey: Map<string, SfArg>;
+  byFlat: Map<string, SfArg[]>;
+} {
+  const byKey = new Map<string, SfArg>();
+  const byFlat = new Map<string, SfArg[]>();
+  for (const a of args) {
+    byKey.set(a.key, a);
+    const list = byFlat.get(a.flatKey);
+    if (list) list.push(a);
+    else byFlat.set(a.flatKey, [a]);
+  }
+  return {byKey, byFlat};
+}
+
+function s(byKey: Map<string, SfArg>, key: string): string | undefined {
+  const a = byKey.get(key);
+  if (a === undefined) return undefined;
+  if (a.type === 'real') return fmtNum(a.value as number);
+  return String(a.value);
+}
+
+function rect(byKey: Map<string, SfArg>, p: string): string | undefined {
+  const l = byKey.get(`${p}.left`);
+  const t = byKey.get(`${p}.top`);
+  const r = byKey.get(`${p}.right`);
+  const b = byKey.get(`${p}.bottom`);
+  if (!l && !t && !r && !b) return undefined;
+  const f = (a?: SfArg) => (a ? fmtNum(Number(a.value)) : '?');
+  return `(${f(l)}, ${f(t)}) – (${f(r)}, ${f(b)})`;
+}
+
+function color(byKey: Map<string, SfArg>, p: string): string | undefined {
+  const r = byKey.get(`${p}.r`);
+  const g = byKey.get(`${p}.g`);
+  const bl = byKey.get(`${p}.b`);
+  const a = byKey.get(`${p}.a`);
+  if (!r && !g && !bl && !a) return undefined;
+  const f = (x?: SfArg) => (x ? fmtNum(Number(x.value)) : '?');
+  return `r:${f(r)} g:${f(g)} b:${f(bl)} α:${f(a)}`;
+}
+
+// Corner radii are shown as "(tl, tr, bl, br)", falling back to the scalar
+// corner_radius (replicated to all four) when the per-corner array is absent.
+function corners(
+  byKey: Map<string, SfArg>,
+  arrayPrefix: string,
+  scalarKey: string,
+): string | undefined {
+  const tl = byKey.get(`${arrayPrefix}.tl`);
+  const tr = byKey.get(`${arrayPrefix}.tr`);
+  const bl = byKey.get(`${arrayPrefix}.bl`);
+  const br = byKey.get(`${arrayPrefix}.br`);
+  const f = (x?: SfArg) => (x ? fmtNum(Number(x.value)) : '0');
+  if (tl || tr || bl || br) return `(${f(tl)}, ${f(tr)}, ${f(bl)}, ${f(br)})`;
+  const sc = byKey.get(scalarKey);
+  if (sc && Number(sc.value) !== 0) {
+    const v = fmtNum(Number(sc.value));
+    return `(${v}, ${v}, ${v}, ${v})`;
+  }
+  return undefined;
+}
+
+// Pixel-valued properties get a " px" suffix (shadow/blur radius).
+function px(byKey: Map<string, SfArg>, key: string): string | undefined {
+  const v = s(byKey, key);
+  return v === undefined ? undefined : `${v} px`;
+}
+
+function transform(byKey: Map<string, SfArg>, p: string): string | undefined {
+  const v = (k: string) => byKey.get(`${p}.${k}`);
+  if (!v('dsdx') && !v('dsdy') && !v('tx') && !v('ty')) return undefined;
+  const f = (x?: SfArg) => (x ? fmtNum(Number(x.value)) : '0');
+  return (
+    `[${f(v('dsdx'))} ${f(v('dtdx'))} ${f(v('tx'))}]  ` +
+    `[${f(v('dtdy'))} ${f(v('dsdy'))} ${f(v('ty'))}]`
+  );
+}
+
+function push(rows: CuratedRow[], label: string, value?: string) {
+  if (value !== undefined && value !== '') rows.push({label, value});
+}
+
+export function curatedProperties(
+  layer: SfLayer,
+  args: SfArg[],
+  layerName: (id: number) => string,
+): CuratedSection[] {
+  const {byKey, byFlat} = buildArgMaps(args);
+  const sections: CuratedSection[] = [];
+
+  // ----- Visibility -----
+  const vis: CuratedRow[] = [];
+  vis.push({label: 'Visible', value: layer.isVisible ? 'true' : 'false'});
+  const reasons = (byFlat.get('visibility_reason') ?? []).map((a) =>
+    String(a.value),
+  );
+  if (reasons.length) push(vis, 'Invisible due to', reasons.join(', '));
+  const refRow = (flat: string, label: string) => {
+    const ids = (byFlat.get(flat) ?? []).map((a) => Number(a.value));
+    if (ids.length) {
+      vis.push({
+        label,
+        value: ids.map((id) => `${layerName(id)} (#${id})`).join(', '),
+        layerRefs: ids,
+      });
+    }
+  };
+  refRow('occluded_by', 'Occluded by');
+  refRow('partially_occluded_by', 'Partially occluded by');
+  refRow('covered_by', 'Covered by');
+  push(vis, 'Flags', s(byKey, 'flags')); // flags shown in the visibility group
+  sections.push({title: 'Visibility', rows: vis});
+
+  // ----- Geometry -----
+  const geo: CuratedRow[] = [];
+  push(geo, 'Z', s(byKey, 'z'));
+  push(geo, 'Layer stack', s(byKey, 'layer_stack'));
+  if (layer.zOrderRelativeOf > 0) {
+    geo.push({
+      label: 'Z relative to',
+      value: `${layerName(layer.zOrderRelativeOf)} (#${layer.zOrderRelativeOf})`,
+      layerRefs: [layer.zOrderRelativeOf],
+    });
+  }
+  push(geo, 'Bounds', rect(byKey, 'bounds'));
+  push(geo, 'Screen bounds', rect(byKey, 'screen_bounds'));
+  push(geo, 'Crop', rect(byKey, 'crop'));
+  push(geo, 'Destination frame', rect(byKey, 'destination_frame'));
+  push(geo, 'Transform', transform(byKey, 'transform'));
+  push(geo, 'Requested transform', transform(byKey, 'requested_transform'));
+  sections.push({title: 'Geometry', rows: geo});
+
+  // ----- Buffer -----
+  const buf: CuratedRow[] = [];
+  const bw = s(byKey, 'active_buffer.width');
+  const bh = s(byKey, 'active_buffer.height');
+  if (bw || bh) {
+    const stride = s(byKey, 'active_buffer.stride');
+    const fmt = s(byKey, 'active_buffer.format');
+    buf.push({
+      label: 'Active buffer',
+      value: `${bw ?? '?'} × ${bh ?? '?'}  stride ${stride ?? '?'}  format ${fmt ?? '?'}`,
+    });
+  }
+  push(buf, 'Buffer transform', s(byKey, 'buffer_transform.type'));
+  push(buf, 'Dataspace', s(byKey, 'dataspace'));
+  push(buf, 'Frame number', s(byKey, 'curr_frame'));
+  push(
+    buf,
+    'HWC composition',
+    s(byKey, 'hwc_composition_type') ?? s(byKey, 'composition_type'),
+  );
+  if (buf.length) sections.push({title: 'Buffer', rows: buf});
+
+  // ----- Effects -----
+  const fx: CuratedRow[] = [];
+  push(fx, 'Color', color(byKey, 'color'));
+  push(fx, 'Requested color', color(byKey, 'requested_color'));
+  push(fx, 'Corner radii', corners(byKey, 'corner_radii', 'corner_radius'));
+  push(
+    fx,
+    'Requested corner radii',
+    corners(byKey, 'requested_corner_radii', 'requested_corner_radius'),
+  );
+  push(fx, 'Corner radius crop', rect(byKey, 'corner_radius_crop'));
+  push(fx, 'Shadow radius', px(byKey, 'shadow_radius'));
+  push(fx, 'Background blur', px(byKey, 'background_blur_radius'));
+  if (fx.length) sections.push({title: 'Color & effects', rows: fx});
+
+  // ----- Input -----
+  const inp: CuratedRow[] = [];
+  push(inp, 'Focusable', s(byKey, 'input_window_info.focusable'));
+  push(
+    inp,
+    'Touchable region',
+    rect(byKey, 'input_window_info.touchable_region.rect') ??
+      rect(byKey, 'input_window_info.frame'),
+  );
+  push(inp, 'Input transform', transform(byKey, 'input_window_info.transform'));
+  push(inp, 'Input config', s(byKey, 'input_window_info.input_config'));
+  push(inp, 'Crop layer (touch)', s(byKey, 'input_window_info.crop_layer_id'));
+  push(
+    inp,
+    'Replace touch with crop',
+    s(byKey, 'input_window_info.replace_touchable_region_with_crop'),
+  );
+  if (inp.length) sections.push({title: 'Input', rows: inp});
+
+  return sections.filter((sec) => sec.rows.length > 0);
+}

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_data.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_data.ts
@@ -1,0 +1,288 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Data layer for the SurfaceFlinger viewer: typed queries over the
+// trace_processor tables (snapshots, layers, rects, transforms, displays) plus
+// per-layer proto args, and the derivation of the "curated" property summary.
+
+import type {Engine} from '../../trace_processor/engine';
+import {
+  LONG,
+  LONG_NULL,
+  NUM,
+  NUM_NULL,
+  STR,
+  STR_NULL,
+} from '../../trace_processor/query_result';
+
+export interface SfDisplay {
+  displayId: string; // int64 as string (can exceed 2^53)
+  displayName: string;
+  isVirtual: boolean; // e.g. the video-encoder display created during recording
+  // Layer-stack/group id; layers with this group belong to this display.
+  // Undefined if the display has no trace rect (so it is not aliased onto the
+  // real group 0).
+  group: number | undefined;
+}
+
+export interface SfTransform {
+  dsdx: number;
+  dtdx: number;
+  tx: number;
+  dtdy: number;
+  dsdy: number;
+  ty: number;
+}
+
+// A display id is an int64 rendered as a base-10 string (it can exceed 2^53).
+// It comes from the trace, never user input, but validate before splicing into
+// SQL so a malformed value fails loudly instead of producing a syntax error.
+export function sqlInt(value: string): string {
+  if (!/^-?\d+$/.test(value)) {
+    throw new Error(`Expected an integer literal, got: ${value}`);
+  }
+  return value;
+}
+
+export interface SfLayer {
+  rowId: number; // __intrinsic_surfaceflinger_layer.id (for arg lookup)
+  layerId: number;
+  name: string;
+  isVisible: boolean;
+  parent: number; // parent layer id, -1 if none
+  zOrderRelativeOf: number; // -1 if none
+  isHiddenByPolicy: boolean;
+  isMissingZParent: boolean;
+  hwcCompositionType: number;
+  argSetId: number | undefined;
+  // String-pool id of the raw LayerProto. Identical protos share one id, so
+  // comparing it between snapshots is an exact "did anything change" diff.
+  base64ProtoId: number | undefined;
+  drawDepth: number | undefined; // painter order from the computed rect
+  opacity: number | undefined;
+  isSpy: boolean;
+  // Layer-stack/group id of this layer's rect — identifies which display it is
+  // composited on (matches SfDisplay.group). Undefined for layers without a rect.
+  groupId: number | undefined;
+  // Screen-space rect (already transformed bounds) if the layer has one.
+  rect?: {x: number; y: number; w: number; h: number};
+  transform: SfTransform;
+}
+
+// One per (display, snapshot): the timeline anchor for the track.
+export interface SfSnapshot {
+  snapshotId: number;
+  ts: bigint;
+}
+
+// Distinct displays present in the trace.
+export async function queryDisplays(engine: Engine): Promise<SfDisplay[]> {
+  const res = await engine.query(`
+    SELECT
+      d.display_id AS id,
+      COALESCE(MAX(d.display_name), 'Display') AS name,
+      MAX(IFNULL(d.is_virtual, 0)) AS virt,
+      MAX(tr.group_id) AS grp
+    FROM __intrinsic_surfaceflinger_display d
+    LEFT JOIN __intrinsic_winscope_trace_rect tr ON tr.id = d.trace_rect_id
+    GROUP BY d.display_id
+    ORDER BY d.display_id
+  `);
+  const out: SfDisplay[] = [];
+  const it = res.iter({id: LONG, name: STR, virt: NUM, grp: NUM_NULL});
+  for (; it.valid(); it.next()) {
+    out.push({
+      displayId: it.id.toString(),
+      displayName: it.name,
+      isVirtual: it.virt !== 0,
+      group: it.grp ?? undefined,
+    });
+  }
+  return out;
+}
+
+// Snapshots that contain the given display, in time order. Each snapshot is a
+// frame of layer state; the track shows one slice per snapshot.
+export async function querySnapshots(
+  engine: Engine,
+  displayId: string,
+): Promise<SfSnapshot[]> {
+  const res = await engine.query(`
+    SELECT s.id AS sid, s.ts AS ts
+    FROM __intrinsic_surfaceflinger_layers_snapshot s
+    WHERE s.id IN (
+      SELECT snapshot_id FROM __intrinsic_surfaceflinger_display
+      WHERE display_id = ${sqlInt(displayId)}
+    )
+    ORDER BY s.ts
+  `);
+  const out: SfSnapshot[] = [];
+  const it = res.iter({sid: NUM, ts: LONG});
+  for (; it.valid(); it.next()) out.push({snapshotId: it.sid, ts: it.ts});
+  return out;
+}
+
+// All layers of a snapshot, with their computed screen rect, transform and the
+// flags needed for the hierarchy chips.
+export async function queryLayers(
+  engine: Engine,
+  snapshotId: number,
+): Promise<SfLayer[]> {
+  const res = await engine.query(`
+    SELECT
+      l.id AS rowId,
+      IFNULL(l.layer_id, -1) AS layerId,
+      IFNULL(l.layer_name, '<no name>') AS name,
+      l.is_visible AS isVisible,
+      IFNULL(l.parent, -1) AS parent,
+      IFNULL(l.z_order_relative_of, -1) AS zrel,
+      l.is_hidden_by_policy AS hidden,
+      l.is_missing_z_parent AS missingZ,
+      IFNULL(l.hwc_composition_type, 0) AS hwc,
+      l.arg_set_id AS argSetId,
+      l.base64_proto_id AS base64,
+      tr.depth AS depth,
+      tr.opacity AS opacity,
+      tr.group_id AS grp,
+      IFNULL(tr.is_spy, 0) AS isSpy,
+      r.x AS x, r.y AS y, r.w AS w, r.h AS h,
+      t.dsdx AS dsdx, t.dtdx AS dtdx, t.tx AS tx,
+      t.dtdy AS dtdy, t.dsdy AS dsdy, t.ty AS ty
+    FROM __intrinsic_surfaceflinger_layer l
+    LEFT JOIN __intrinsic_winscope_trace_rect tr ON tr.id = l.layer_rect_id
+    LEFT JOIN __intrinsic_winscope_rect r ON r.id = tr.rect_id
+    LEFT JOIN __intrinsic_winscope_transform t ON t.id = tr.transform_id
+    WHERE l.snapshot_id = ${snapshotId}
+  `);
+  const out: SfLayer[] = [];
+  const it = res.iter({
+    rowId: NUM,
+    layerId: LONG,
+    name: STR,
+    isVisible: NUM,
+    parent: LONG,
+    zrel: LONG,
+    hidden: NUM,
+    missingZ: NUM,
+    hwc: LONG,
+    argSetId: NUM_NULL,
+    base64: NUM_NULL,
+    depth: NUM_NULL,
+    opacity: NUM_NULL,
+    grp: NUM_NULL,
+    isSpy: NUM,
+    x: NUM_NULL,
+    y: NUM_NULL,
+    w: NUM_NULL,
+    h: NUM_NULL,
+    dsdx: NUM_NULL,
+    dtdx: NUM_NULL,
+    tx: NUM_NULL,
+    dtdy: NUM_NULL,
+    dsdy: NUM_NULL,
+    ty: NUM_NULL,
+  });
+  for (; it.valid(); it.next()) {
+    const hasRect = it.w !== null && it.h !== null;
+    out.push({
+      rowId: it.rowId,
+      layerId: Number(it.layerId),
+      name: it.name,
+      isVisible: it.isVisible !== 0,
+      parent: Number(it.parent),
+      zOrderRelativeOf: Number(it.zrel),
+      isHiddenByPolicy: it.hidden !== 0,
+      isMissingZParent: it.missingZ !== 0,
+      hwcCompositionType: Number(it.hwc),
+      argSetId: it.argSetId ?? undefined,
+      base64ProtoId: it.base64 ?? undefined,
+      drawDepth: it.depth ?? undefined,
+      opacity: it.opacity ?? undefined,
+      groupId: it.grp ?? undefined,
+      isSpy: it.isSpy !== 0,
+      rect: hasRect
+        ? {x: it.x ?? 0, y: it.y ?? 0, w: it.w ?? 0, h: it.h ?? 0}
+        : undefined,
+      transform: {
+        dsdx: it.dsdx ?? 1,
+        dtdx: it.dtdx ?? 0,
+        tx: it.tx ?? 0,
+        dtdy: it.dtdy ?? 0,
+        dsdy: it.dsdy ?? 1,
+        ty: it.ty ?? 0,
+      },
+    });
+  }
+  return out;
+}
+
+// A flattened proto property: the arg `key` (with array indices) and its value.
+export interface SfArg {
+  key: string; // e.g. "color.a", "transform.dsdx", "occluded_by[0]"
+  flatKey: string; // without array indices
+  value: string | number | bigint;
+  type: 'int' | 'real' | 'string' | 'bool' | 'null';
+}
+
+// All proto args for a layer's arg_set_id (the full property set).
+export async function queryArgs(
+  engine: Engine,
+  argSetId: number,
+): Promise<SfArg[]> {
+  const res = await engine.query(`
+    SELECT key, flat_key AS flatKey, int_value AS i, string_value AS s,
+           real_value AS r, value_type AS vt
+    FROM args WHERE arg_set_id = ${argSetId}
+    ORDER BY key
+  `);
+  const out: SfArg[] = [];
+  const it = res.iter({
+    key: STR,
+    flatKey: STR,
+    i: LONG_NULL,
+    s: STR_NULL,
+    r: NUM_NULL,
+    vt: STR,
+  });
+  for (; it.valid(); it.next()) {
+    let value: string | number | bigint = '';
+    let type: SfArg['type'] = 'null';
+    if (it.vt === 'string' && it.s !== null) {
+      value = it.s;
+      type = 'string';
+    } else if (it.vt === 'bool') {
+      value = it.i !== null && it.i !== 0n ? 'true' : 'false';
+      type = 'bool';
+    } else if (it.vt === 'real' && it.r !== null) {
+      value = it.r;
+      type = 'real';
+    } else if (it.i !== null) {
+      value = it.i;
+      type = 'int';
+    } else if (it.s !== null) {
+      value = it.s;
+      type = 'string';
+    }
+    out.push({key: it.key, flatKey: it.flatKey, value, type});
+  }
+  return out;
+}
+
+// Formats a number compactly: integers as-is, reals to 3 dp without trailing
+// zeros, and non-finite values verbatim.
+export function fmtNum(n: number): string {
+  if (!isFinite(n)) return String(n);
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(3).replace(/\.?0+$/, '');
+}

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_page.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_page.ts
@@ -1,0 +1,126 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The full-screen SurfaceFlinger page: a toolbar (display selector,
+// snapshot time-slider, prev/next, timestamp) over the 3-pane viewer.
+
+import './surfaceflinger.scss';
+import m from 'mithril';
+import {Time} from '../../base/time';
+import {Timestamp} from '../../components/widgets/timestamp';
+import {Button} from '../../widgets/button';
+import {Select} from '../../widgets/select';
+import {SfViewer} from './surfaceflinger_viewer';
+import type {SurfaceFlingerSession} from './surfaceflinger_session';
+
+export interface SurfaceFlingerPageAttrs {
+  readonly session: SurfaceFlingerSession;
+  readonly subpage: string | undefined;
+}
+
+export class SurfaceFlingerPage
+  implements m.ClassComponent<SurfaceFlingerPageAttrs>
+{
+  view(vnode: m.Vnode<SurfaceFlingerPageAttrs>): m.Children {
+    const s = vnode.attrs.session;
+    if (s.displays.length === 0) {
+      return m(
+        '.pf-sf-page',
+        m(
+          '.pf-sf-empty',
+          'No SurfaceFlinger layers trace found. Record with the ' +
+            'android.surfaceflinger.layers data source.',
+        ),
+      );
+    }
+    const snap = s.currentSnapshot;
+    return m('.pf-sf-page', [
+      m('.pf-sf-bar', [
+        m(
+          Select,
+          {
+            onchange: (e: Event) =>
+              void s.setDisplay((e.target as HTMLSelectElement).value),
+          },
+          s.displays.map((d) =>
+            m(
+              'option',
+              {value: d.displayId, selected: d.displayId === s.displayId},
+              d.isVirtual ? `${d.displayName} (virtual)` : d.displayName,
+            ),
+          ),
+        ),
+        m(Button, {
+          icon: 'timeline',
+          label: 'Timeline',
+          title: 'Jump to this snapshot in the timeline',
+          onclick: () => {
+            const cur = s.currentSnapshot;
+            if (cur === undefined) return;
+            s.trace.navigate('#!/viewer');
+            // Select the snapshot slice on the current display's track (opens its
+            // details panel) and scroll the timeline to it.
+            s.trace.selection.selectTrackEvent(
+              `/surfaceflinger_track/${s.displayId}`,
+              cur.snapshotId,
+              {scrollToSelection: true},
+            );
+          },
+        }),
+        m(Button, {
+          icon: 'first_page',
+          title: 'First snapshot',
+          onclick: () => void s.setIndex(0),
+        }),
+        m(Button, {
+          icon: 'chevron_left',
+          title: 'Previous snapshot',
+          onclick: () => void s.setIndex(s.index - 1),
+        }),
+        m('input.pf-sf-scrub[type=range]', {
+          min: 0,
+          max: Math.max(0, s.snapshots.length - 1),
+          value: s.index,
+          oninput: (e: Event) =>
+            void s.setIndex(Number((e.target as HTMLInputElement).value)),
+        }),
+        m(Button, {
+          icon: 'chevron_right',
+          title: 'Next snapshot',
+          onclick: () => void s.setIndex(s.index + 1),
+        }),
+        m(Button, {
+          icon: 'last_page',
+          title: 'Last snapshot',
+          onclick: () => void s.setIndex(s.snapshots.length - 1),
+        }),
+        m(
+          'span.pf-sf-bar__pos',
+          `${s.snapshots.length === 0 ? 0 : s.index + 1} / ${s.snapshots.length}`,
+        ),
+        snap !== undefined
+          ? m('span.pf-sf-bar__ts', [
+              m(Timestamp, {trace: s.trace, ts: Time.fromRaw(snap.ts)}),
+            ])
+          : null,
+      ]),
+      m(
+        '.pf-sf-main',
+        s.snapshots.length === 0
+          ? m('.pf-sf-empty', 'No snapshots for this display.')
+          : m(SfViewer, {session: s}),
+      ),
+    ]);
+  }
+}

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_rects.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_rects.ts
@@ -1,0 +1,475 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The "Surface" view: a rotatable, stacked 3D view of the layer rectangles,
+// rendered with pure 2D-canvas projection (no WebGL/Three.js, so it works
+// headless).
+// Each layer's bounds (layer space + affine transform) become a quad; quads are
+// stacked along Z by draw depth, rotated (yaw + pitch) and orthographically
+// projected. Painter-ordered by projected depth, coloured by visibility, with
+// selection/pin highlight, labels, and click-to-select.
+
+import m from 'mithril';
+import {assertExists, assertIsInstance} from '../../base/assert';
+import type {SfLayer, SfTransform} from './surfaceflinger_data';
+
+interface Pt {
+  x: number;
+  y: number;
+}
+interface P3 {
+  x: number;
+  y: number;
+  d: number;
+}
+
+function apply(t: SfTransform, x: number, y: number): Pt {
+  return {x: t.dsdx * x + t.dtdx * y + t.tx, y: t.dtdy * x + t.dsdy * y + t.ty};
+}
+
+function quad(layer: SfLayer): Pt[] | undefined {
+  const r = layer.rect;
+  if (r === undefined || r.w <= 0 || r.h <= 0) return undefined;
+  const t = layer.transform;
+  return [
+    apply(t, r.x, r.y),
+    apply(t, r.x + r.w, r.y),
+    apply(t, r.x + r.w, r.y + r.h),
+    apply(t, r.x, r.y + r.h),
+  ];
+}
+
+function pointInPoly(p: Pt, q: Pt[]): boolean {
+  let inside = false;
+  for (let i = 0, j = q.length - 1; i < q.length; j = i++) {
+    const a = q[i];
+    const b = q[j];
+    if (
+      a.y > p.y !== b.y > p.y &&
+      p.x < ((b.x - a.x) * (p.y - a.y)) / (b.y - a.y) + a.x
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+export interface SfRectsOptions {
+  showOnlyVisible: boolean;
+  explode: number; // 0..1 Z separation (spacing)
+  rotation: number; // 0..1 yaw/pitch
+  shading: 'gradient' | 'opacity' | 'wireframe';
+}
+
+export interface SfRectsAttrs {
+  layers: SfLayer[];
+  selectedRowId?: number;
+  hiddenLayerIds: Set<number>;
+  pinnedLayerIds: Set<number>;
+  onSelect: (rowId: number) => void;
+  options: SfRectsOptions;
+}
+
+// Colours are read from the Perfetto theme variables at draw time (a 2D canvas
+// context can't use CSS variables), so the view follows light/dark mode.
+interface RectColors {
+  visibleFill: string;
+  invisibleFill: string;
+  selectedFill: string;
+  border: string;
+  selectedBorder: string;
+  pinnedBorder: string;
+  label: string;
+  halo: string;
+}
+
+function readColors(el: HTMLElement): RectColors {
+  const cs = getComputedStyle(el);
+  const v = (name: string, fallback: string) =>
+    cs.getPropertyValue(name).trim() || fallback;
+  return {
+    visibleFill: v('--pf-color-success', 'rgb(0,128,0)'),
+    invisibleFill: v('--pf-color-text-muted', 'rgb(150,150,150)'),
+    selectedFill: v('--pf-color-accent', 'rgb(38,103,231)'),
+    border: v('--pf-color-border', 'rgb(120,120,120)'),
+    selectedBorder: v('--pf-color-accent', 'rgb(38,103,231)'),
+    pinnedBorder: v('--pf-color-warning', 'rgb(232,158,0)'),
+    label: v('--pf-color-text', 'rgb(40,40,40)'),
+    halo: v('--pf-color-background', 'rgb(255,255,255)'),
+  };
+}
+
+export class SfRectsView implements m.ClassComponent<SfRectsAttrs> {
+  private canvas?: HTMLCanvasElement;
+  private attrs?: SfRectsAttrs;
+  private hit: Array<{rowId: number; q: Pt[]; order: number}> = [];
+  // Clickable region (in the gutter) for each rendered label.
+  private labelHit: Array<{rowId: number; x0: number; y0: number; y1: number}> =
+    [];
+
+  view(vnode: m.Vnode<SfRectsAttrs>) {
+    this.attrs = vnode.attrs;
+    return m('.pf-sf-rects', [
+      m('canvas.pf-sf-rects__canvas', {
+        onclick: (e: MouseEvent) => this.onClick(e),
+        oncreate: (v: m.VnodeDOM) => {
+          this.canvas = assertIsInstance(v.dom, HTMLCanvasElement);
+          this.draw();
+        },
+        onupdate: () => this.draw(),
+      }),
+    ]);
+  }
+
+  private onClick(e: MouseEvent) {
+    if (!this.canvas || !this.attrs) return;
+    const r = this.canvas.getBoundingClientRect();
+    const p = {x: e.clientX - r.left, y: e.clientY - r.top};
+    // Clicking a label (in the gutter) selects its rect. Mithril redraws after
+    // this handler, and selectLayer() redraws again once its args load.
+    for (const lh of this.labelHit) {
+      if (p.x >= lh.x0 && p.y >= lh.y0 && p.y <= lh.y1) {
+        this.attrs.onSelect(lh.rowId);
+        return;
+      }
+    }
+    let best: {rowId: number; order: number} | undefined;
+    for (const h of this.hit) {
+      if (pointInPoly(p, h.q) && (best === undefined || h.order > best.order)) {
+        best = {rowId: h.rowId, order: h.order};
+      }
+    }
+    if (best) {
+      this.attrs.onSelect(best.rowId);
+    }
+  }
+
+  private draw() {
+    const canvas = this.canvas;
+    const attrs = this.attrs;
+    if (!canvas || !attrs) return;
+    const cssW = canvas.clientWidth || 600;
+    const cssH = canvas.clientHeight || 420;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(cssW * dpr);
+    canvas.height = Math.floor(cssH * dpr);
+    const ctx = assertExists(canvas.getContext('2d'));
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+    const col = readColors(canvas);
+
+    const bounded = attrs.layers
+      .map((l) => ({l, q: quad(l)}))
+      .filter((d): d is {l: SfLayer; q: Pt[]} => d.q !== undefined)
+      .filter((d) => !attrs.hiddenLayerIds.has(d.l.layerId));
+    const items = bounded
+      .filter((d) => !attrs.options.showOnlyVisible || d.l.isVisible)
+      .sort((a, b) => (a.l.drawDepth ?? 0) - (b.l.drawDepth ?? 0)); // back->front
+
+    if (items.length === 0) {
+      // Distinguish "nothing here" from "everything here is hidden by the
+      // only-visible filter" (e.g. an encoder display whose only layer is an
+      // invisible mirror) so the empty state is actionable.
+      const hiddenByVis = attrs.options.showOnlyVisible
+        ? bounded.filter((d) => !d.l.isVisible).length
+        : 0;
+      const msg =
+        hiddenByVis > 0
+          ? `No visible layers — ${hiddenByVis} hidden. Uncheck “Only visible” to show.`
+          : 'No layers with bounds in this snapshot.';
+      ctx.fillStyle = col.label;
+      ctx.globalAlpha = 0.6;
+      ctx.font = '13px sans-serif';
+      ctx.fillText(msg, 12, 24);
+      ctx.globalAlpha = 1;
+      this.hit = [];
+      this.labelHit = [];
+      return;
+    }
+
+    // Reserve a right-hand gutter for the leader-line labels, so text lives
+    // beside the scene and never overlaps the rectangles.
+    const gutterW = Math.min(220, Math.max(132, Math.floor(cssW * 0.32)));
+    const sceneW = cssW - gutterW;
+
+    const n = items.length;
+    const zStep = attrs.options.explode * 160; // world Z per layer
+    // Pitch (angleX) ramps to 22.5° and yaw (angleY) is 1.5x pitch, both smooth
+    // from 0 so rotation=0 is a flat, straight-on 2D view.
+    const pitch = attrs.options.rotation * (Math.PI / 8);
+    const yaw = pitch * 1.5;
+    const cy = Math.cos(yaw);
+    const sy = Math.sin(yaw);
+    const cx = Math.cos(pitch);
+    const sx = Math.sin(pitch);
+
+    // Scene centre (2D centroid of all corners; mid Z).
+    let mx = 0;
+    let my = 0;
+    let cnt = 0;
+    for (const d of items) {
+      for (const p of d.q) {
+        mx += p.x;
+        my += p.y;
+        cnt++;
+      }
+    }
+    mx /= cnt;
+    my /= cnt;
+    const mz = ((n - 1) * zStep) / 2;
+
+    const project = (x: number, y: number, z: number): P3 => {
+      const X = x - mx;
+      const Y = y - my;
+      const Z = z - mz;
+      // yaw around Y, then pitch around X.
+      const X1 = X * cy + Z * sy;
+      const Z1 = -X * sy + Z * cy;
+      const Y2 = Y * cx - Z1 * sx;
+      const Z2 = Y * sx + Z1 * cx;
+      return {x: X1, y: Y2, d: Z2};
+    };
+
+    const proj = items.map((d, i) => {
+      const z = i * zStep;
+      const ps = d.q.map((p) => project(p.x, p.y, z));
+      const depth = ps.reduce((s, p) => s + p.d, 0) / ps.length;
+      return {l: d.l, ps, depth};
+    });
+
+    // Fit projected points into the canvas.
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const d of proj) {
+      for (const p of d.ps) {
+        minX = Math.min(minX, p.x);
+        minY = Math.min(minY, p.y);
+        maxX = Math.max(maxX, p.x);
+        maxY = Math.max(maxY, p.y);
+      }
+    }
+    // Fit the projected scene into the area left of the label gutter.
+    const margin = 18;
+    const sw = maxX - minX || 1;
+    const sh = maxY - minY || 1;
+    const scale = Math.min(
+      (sceneW - 2 * margin) / sw,
+      (cssH - 2 * margin) / sh,
+    );
+    const offX = margin + (sceneW - 2 * margin - sw * scale) / 2 - minX * scale;
+    const offY = margin + (cssH - 2 * margin - sh * scale) / 2 - minY * scale;
+    const toScreen = (p: P3): Pt => ({
+      x: offX + p.x * scale,
+      y: offY + p.y * scale,
+    });
+
+    // Painter order: far (small projected depth) first.
+    proj.sort((a, b) => a.depth - b.depth);
+
+    // Resolve the three fill colours to RGB once so gradient mode can darken by
+    // depth (solid) and opacity mode can apply the layer's own alpha.
+    const rgbVisible = parseRgb(ctx, col.visibleFill);
+    const rgbInvisible = parseRgb(ctx, col.invisibleFill);
+    const rgbSelected = parseRgb(ctx, col.selectedFill);
+    const mode = attrs.options.shading;
+
+    this.hit = [];
+    const drawn = proj.map((d, order) => {
+      const sq = d.ps.map(toScreen);
+      this.hit.push({rowId: d.l.rowId, q: sq, order});
+      return {
+        l: d.l,
+        sq,
+        order,
+        selected: d.l.rowId === attrs.selectedRowId,
+        pinned: attrs.pinnedLayerIds.has(d.l.layerId),
+      };
+    });
+
+    // Fills + borders.
+    for (const d of drawn) {
+      const rgb = d.selected
+        ? rgbSelected
+        : d.l.isVisible
+          ? rgbVisible
+          : rgbInvisible;
+      ctx.beginPath();
+      ctx.moveTo(d.sq[0].x, d.sq[0].y);
+      for (let i = 1; i < d.sq.length; i++) ctx.lineTo(d.sq[i].x, d.sq[i].y);
+      ctx.closePath();
+      if (mode === 'opacity') {
+        const op = d.l.opacity ?? (d.l.isVisible ? 0.72 : 0.28);
+        ctx.fillStyle = `rgba(${rgb.r},${rgb.g},${rgb.b},${op.toFixed(3)})`;
+        ctx.fill();
+      } else if (mode === 'gradient') {
+        // Front layers brighter, back layers darker (solid fill).
+        const k = 0.55 + 0.45 * (d.order / Math.max(1, n - 1));
+        ctx.fillStyle = `rgb(${Math.round(rgb.r * k)},${Math.round(
+          rgb.g * k,
+        )},${Math.round(rgb.b * k)})`;
+        ctx.fill();
+      } // wireframe: no fill, borders only.
+      ctx.lineWidth = d.pinned ? 3 : d.selected ? 2.5 : 1;
+      ctx.strokeStyle = d.pinned
+        ? col.pinnedBorder
+        : d.selected
+          ? col.selectedBorder
+          : col.border;
+      ctx.stroke();
+    }
+
+    this.drawLabels(ctx, col, drawn, sceneW, cssH, gutterW);
+  }
+
+  // Leader-line labels in the right gutter: every label sits in its own vertical
+  // slot (never overlapping another label or a rect) and a thin line connects it
+  // to the rect. Labels every rect when there are few; above a cap of 30, only
+  // the selected/pinned rects are labelled.
+  private drawLabels(
+    ctx: CanvasRenderingContext2D,
+    col: RectColors,
+    drawn: Array<{
+      l: SfLayer;
+      sq: Pt[];
+      order: number;
+      selected: boolean;
+      pinned: boolean;
+    }>,
+    sceneW: number,
+    cssH: number,
+    gutterW: number,
+  ) {
+    this.labelHit = [];
+    const labelAll = drawn.length <= 30;
+    let cands = drawn.filter((d) =>
+      labelAll
+        ? d.selected || d.pinned || d.l.isVisible
+        : d.selected || d.pinned,
+    );
+    // Priority: selected/pinned first, then front-most.
+    cands.sort((a, b) => {
+      const pa = a.selected || a.pinned ? 1 : 0;
+      const pb = b.selected || b.pinned ? 1 : 0;
+      return pa !== pb ? pb - pa : b.order - a.order;
+    });
+
+    const lineH = 16;
+    const pad = 8;
+    const maxLabels = Math.max(0, Math.floor((cssH - 2 * pad) / lineH));
+    cands = cands.slice(0, maxLabels);
+    if (cands.length === 0) return;
+
+    // Anchor each label to its rect's rightmost corner (closest to the gutter)
+    // to keep leader lines short, then stack labels top-to-bottom with at least
+    // lineH between them, always leaving room for the labels below.
+    const anchorOf = (sq: Pt[]) =>
+      sq.reduce((b, p) => (p.x > b.x ? p : b), sq[0]);
+    const placed = cands
+      .map((d) => {
+        const a = anchorOf(d.sq);
+        return {d, ax: a.x, ay: a.y, y: 0};
+      })
+      .sort((a, b) => a.ay - b.ay);
+    let nextMin = pad;
+    for (let i = 0; i < placed.length; i++) {
+      const remainingAfter = placed.length - 1 - i;
+      // Leave a few px of descender headroom so the bottom label isn't clipped.
+      const maxY = cssH - pad - 3 - remainingAfter * lineH;
+      let y = Math.max(placed[i].ay, nextMin);
+      if (y > maxY) y = maxY;
+      placed[i].y = y;
+      nextMin = y + lineH;
+    }
+
+    const labelX = sceneW + 10;
+    const maxTextW = gutterW - 18;
+    for (const it of placed) {
+      // The whole gutter row for this label is clickable (selects the rect).
+      this.labelHit.push({
+        rowId: it.d.l.rowId,
+        x0: sceneW,
+        y0: it.y - lineH + 3,
+        y1: it.y + 4,
+      });
+      const strong = it.d.selected || it.d.pinned;
+      const lineColor = it.d.pinned
+        ? col.pinnedBorder
+        : it.d.selected
+          ? col.selectedBorder
+          : col.border;
+      // Leader line.
+      ctx.strokeStyle = lineColor;
+      ctx.lineWidth = strong ? 1.5 : 1;
+      ctx.globalAlpha = strong ? 0.95 : 0.5;
+      ctx.beginPath();
+      ctx.moveTo(it.ax, it.ay);
+      ctx.lineTo(labelX - 4, it.y - 4);
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+      // Anchor dot.
+      ctx.beginPath();
+      ctx.arc(it.ax, it.ay, 2.5, 0, Math.PI * 2);
+      ctx.fillStyle = lineColor;
+      ctx.fill();
+      // Text with a halo so it stays legible over any leader line.
+      ctx.font = `${strong ? 'bold ' : ''}11px sans-serif`;
+      const text = fitText(ctx, it.d.l.name, maxTextW);
+      ctx.lineJoin = 'round';
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = col.halo;
+      ctx.strokeText(text, labelX, it.y);
+      ctx.fillStyle = strong ? lineColor : col.label;
+      ctx.fillText(text, labelX, it.y);
+    }
+  }
+}
+
+// Normalises any CSS colour string to RGB components by round-tripping it
+// through the canvas (which returns #rrggbb or rgba(...)).
+function parseRgb(
+  ctx: CanvasRenderingContext2D,
+  color: string,
+): {r: number; g: number; b: number} {
+  ctx.fillStyle = color;
+  const s = ctx.fillStyle as string;
+  if (s.startsWith('#')) {
+    return {
+      r: parseInt(s.slice(1, 3), 16),
+      g: parseInt(s.slice(3, 5), 16),
+      b: parseInt(s.slice(5, 7), 16),
+    };
+  }
+  const m = s.match(/rgba?\(([^)]+)\)/);
+  if (m) {
+    const [r, g, b] = m[1].split(',').map((x) => parseFloat(x));
+    return {r, g, b};
+  }
+  return {r: 128, g: 128, b: 128};
+}
+
+// Truncates text with an ellipsis to fit maxW px (font must already be set).
+function fitText(
+  ctx: CanvasRenderingContext2D,
+  name: string,
+  maxW: number,
+): string {
+  if (ctx.measureText(name).width <= maxW) return name;
+  let s = name;
+  while (s.length > 1 && ctx.measureText(s + '…').width > maxW) {
+    s = s.slice(0, -1);
+  }
+  return s + '…';
+}

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_route.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_route.ts
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Route for the full-screen SurfaceFlinger page.
+export const SURFACEFLINGER_ROUTE = '/surfaceflinger';

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_session.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_session.ts
@@ -1,0 +1,319 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shared state + data loading for the SurfaceFlinger viewer, owned by the
+// plugin and consumed by both the full-screen page and the timeline track's
+// "open in viewer" deep link. Holds the selected display, the current snapshot,
+// the loaded layers, the selected layer (+ its proto args), and the view
+// options so they persist as you scrub.
+
+import m from 'mithril';
+import type {Trace} from '../../public/trace';
+import {
+  queryArgs,
+  queryDisplays,
+  queryLayers,
+  querySnapshots,
+  type SfArg,
+  type SfDisplay,
+  type SfLayer,
+  type SfSnapshot,
+} from './surfaceflinger_data';
+
+export type ShadingMode = 'gradient' | 'opacity' | 'wireframe';
+
+export interface SfViewOptions {
+  rectsOnlyVisible: boolean;
+  explode: number;
+  rotation: number; // 0..1 yaw/pitch of the 3D rects view
+  shading: ShadingMode;
+  hierOnlyVisible: boolean;
+  hierFlat: boolean;
+  hierSimplify: boolean;
+  hierSearch: string;
+  propShowDefaults: boolean;
+  diff: boolean; // diff this snapshot against the previous one
+}
+
+export type DiffStatus = 'added' | 'deleted' | 'modified' | 'unchanged';
+
+export class SurfaceFlingerSession {
+  readonly trace: Trace;
+  displays: SfDisplay[] = [];
+  displayId?: string;
+  snapshots: SfSnapshot[] = [];
+  index = 0;
+
+  layers: SfLayer[] = [];
+  byRowId = new Map<number, SfLayer>();
+  byLayerId = new Map<number, SfLayer>();
+  selectedRowId?: number;
+  selectedArgs: SfArg[] = [];
+  // layerId of the current selection, so it persists across snapshots.
+  private keepLayerId?: number;
+
+  // Previous snapshot (for diff) and per-layerId signatures of it.
+  prevLayers: SfLayer[] = [];
+  prevByLayerId = new Map<number, SfLayer>();
+  // base64_proto_id of each previous-snapshot layer, for the exact diff.
+  private prevProtoByLayerId = new Map<number, number | undefined>();
+  // Property values of the selected layer in the previous snapshot, by arg key.
+  prevArgByKey = new Map<string, string>();
+
+  // Per-layerId so they persist as you scrub.
+  readonly hiddenLayerIds = new Set<number>();
+  readonly pinnedLayerIds = new Set<number>();
+  // Layers that other layers are Z-ordered relative to (for the RelZParent chip).
+  relZParentIds = new Set<number>();
+
+  loadingLayers = false;
+  // Monotonic tokens to discard superseded async work: loadToken guards a
+  // display/snapshot/layer load; argToken guards a selection's arg fetch. They
+  // are independent so selecting a layer never cancels an in-flight layer load.
+  private loadToken = 0;
+  private argToken = 0;
+
+  readonly options: SfViewOptions = {
+    rectsOnlyVisible: true,
+    explode: 0,
+    rotation: 0,
+    shading: 'gradient',
+    hierOnlyVisible: false,
+    hierFlat: false,
+    hierSimplify: true,
+    hierSearch: '',
+    propShowDefaults: false,
+    diff: false,
+  };
+
+  constructor(trace: Trace) {
+    this.trace = trace;
+  }
+
+  get displayName(): string {
+    return (
+      this.displays.find((d) => d.displayId === this.displayId)?.displayName ??
+      'Display'
+    );
+  }
+
+  // Layer-stack/group of the selected display.
+  get selectedDisplayGroup(): number | undefined {
+    return this.displays.find((d) => d.displayId === this.displayId)?.group;
+  }
+
+  // Layers composited on the selected display (by group). The surface view uses
+  // this so each display shows only its own composition; the hierarchy and
+  // properties use the full layer set (one cross-display tree).
+  displayLayers(): SfLayer[] {
+    const g = this.selectedDisplayGroup;
+    if (g === undefined) return this.layers;
+    return this.layers.filter((l) => l.groupId === g);
+  }
+
+  get currentSnapshot(): SfSnapshot | undefined {
+    return this.snapshots[this.index];
+  }
+
+  async init(): Promise<void> {
+    this.displays = await queryDisplays(this.trace.engine);
+    if (this.displays.length > 0) {
+      // Default to a real display, not a transient encoder/mirror (virtual) one.
+      const def = this.displays.find((d) => !d.isVirtual) ?? this.displays[0];
+      await this.setDisplay(def.displayId);
+    }
+  }
+
+  async setDisplay(displayId: string): Promise<void> {
+    const token = ++this.loadToken;
+    this.displayId = displayId;
+    const snapshots = await querySnapshots(this.trace.engine, displayId);
+    if (token !== this.loadToken) return; // superseded
+    this.snapshots = snapshots;
+    await this.loadIndex(0, token);
+  }
+
+  async setIndex(i: number): Promise<void> {
+    await this.loadIndex(i, ++this.loadToken);
+  }
+
+  // Jump to the snapshot whose timestamp is nearest ts (used by the timeline
+  // track's "open in viewer" deep link).
+  async setNearestTs(ts: bigint): Promise<void> {
+    if (this.snapshots.length === 0) return;
+    let best = 0;
+    let bestD = -1n;
+    for (let i = 0; i < this.snapshots.length; i++) {
+      const d =
+        this.snapshots[i].ts > ts
+          ? this.snapshots[i].ts - ts
+          : ts - this.snapshots[i].ts;
+      if (bestD < 0n || d < bestD) {
+        bestD = d;
+        best = i;
+      }
+    }
+    await this.loadIndex(best, ++this.loadToken);
+  }
+
+  // Loads the layers for snapshot `i`. `token` is the caller's loadToken; all
+  // state writes are gated on it still being current so a superseded load (a
+  // newer scrub / display change) never clobbers the winning one.
+  private async loadIndex(i: number, token: number): Promise<void> {
+    if (token !== this.loadToken) return;
+    if (this.snapshots.length === 0) {
+      this.index = 0;
+      this.layers = [];
+      this.loadingLayers = false;
+      m.redraw();
+      return;
+    }
+    this.index = Math.max(0, Math.min(i, this.snapshots.length - 1));
+    const snap = this.snapshots[this.index];
+    this.loadingLayers = true;
+    try {
+      const layers = await queryLayers(this.trace.engine, snap.snapshotId);
+      if (token !== this.loadToken) return;
+      this.layers = layers;
+      this.byRowId = new Map(layers.map((l) => [l.rowId, l]));
+      this.byLayerId = new Map(layers.map((l) => [l.layerId, l]));
+      this.relZParentIds = new Set(
+        layers
+          .filter((l) => l.zOrderRelativeOf > 0)
+          .map((l) => l.zOrderRelativeOf),
+      );
+      await this.loadPrev();
+      if (token !== this.loadToken) return;
+      // Keep the same layer (by layerId) selected across snapshots if present,
+      // else default to the front-most visible layer with a rect.
+      let def: SfLayer | undefined;
+      for (const l of layers) {
+        if (this.keepLayerId !== undefined && l.layerId === this.keepLayerId) {
+          def = l;
+          break;
+        }
+        if (
+          l.isVisible &&
+          l.rect &&
+          (def === undefined || (l.drawDepth ?? 0) > (def.drawDepth ?? 0))
+        ) {
+          def = l;
+        }
+      }
+      def ??= layers.at(0);
+      this.selectedRowId = undefined;
+      this.selectedArgs = [];
+      if (def !== undefined) await this.selectLayer(def.rowId);
+    } finally {
+      if (token === this.loadToken) this.loadingLayers = false;
+    }
+    m.redraw();
+  }
+
+  async selectLayer(rowId: number): Promise<void> {
+    const token = ++this.argToken;
+    this.selectedRowId = rowId;
+    const layer = this.byRowId.get(rowId);
+    this.keepLayerId = layer?.layerId;
+    const args =
+      layer?.argSetId !== undefined
+        ? await queryArgs(this.trace.engine, layer.argSetId)
+        : [];
+    if (token !== this.argToken) return; // superseded by a newer selection
+    this.selectedArgs = args;
+    // Previous-snapshot values of the same layer, for the property diff.
+    const prevArgByKey = new Map<string, string>();
+    if (this.options.diff && layer) {
+      const pl = this.prevByLayerId.get(layer.layerId);
+      if (pl?.argSetId !== undefined) {
+        const pa = await queryArgs(this.trace.engine, pl.argSetId);
+        if (token !== this.argToken) return;
+        for (const a of pa) prevArgByKey.set(a.key, String(a.value));
+      }
+    }
+    this.prevArgByKey = prevArgByKey;
+    m.redraw();
+  }
+
+  selectLayerByLayerId(layerId: number): void {
+    const t = this.byLayerId.get(layerId);
+    if (t) void this.selectLayer(t.rowId);
+  }
+
+  nameOf(layerId: number): string {
+    return this.byLayerId.get(layerId)?.name ?? `Layer ${layerId}`;
+  }
+
+  get selectedLayer(): SfLayer | undefined {
+    return this.selectedRowId !== undefined
+      ? this.byRowId.get(this.selectedRowId)
+      : undefined;
+  }
+
+  // ---- Diff ----
+  private async loadPrev(): Promise<void> {
+    if (!this.options.diff || this.index <= 0) {
+      this.prevLayers = [];
+      this.prevByLayerId = new Map();
+      this.prevProtoByLayerId = new Map();
+      return;
+    }
+    const prev = await queryLayers(
+      this.trace.engine,
+      this.snapshots[this.index - 1].snapshotId,
+    );
+    this.prevLayers = prev;
+    this.prevByLayerId = new Map(prev.map((l) => [l.layerId, l]));
+    this.prevProtoByLayerId = new Map(
+      prev.map((l) => [l.layerId, l.base64ProtoId]),
+    );
+  }
+
+  // Exact: identical LayerProtos share one base64_proto_id, so an id change
+  // means some property changed (an any-property diff).
+  diffStatusOf(l: SfLayer): DiffStatus {
+    if (!this.options.diff || this.index <= 0) return 'unchanged';
+    if (!this.prevProtoByLayerId.has(l.layerId)) return 'added';
+    const prevId = this.prevProtoByLayerId.get(l.layerId);
+    return prevId === l.base64ProtoId ? 'unchanged' : 'modified';
+  }
+
+  // Layers present in the previous snapshot but gone in this one.
+  deletedLayers(): SfLayer[] {
+    if (!this.options.diff || this.index <= 0) return [];
+    const cur = new Set(this.layers.map((l) => l.layerId));
+    return this.prevLayers.filter((l) => !cur.has(l.layerId));
+  }
+
+  async setDiff(on: boolean): Promise<void> {
+    this.options.diff = on;
+    await this.loadPrev();
+    if (this.selectedRowId !== undefined) {
+      await this.selectLayer(this.selectedRowId);
+    }
+    m.redraw();
+  }
+
+  // ---- Per-rect hide / pin (by layerId, persist across snapshots) ----
+  toggleHidden(layerId: number): void {
+    if (this.hiddenLayerIds.has(layerId)) this.hiddenLayerIds.delete(layerId);
+    else this.hiddenLayerIds.add(layerId);
+    m.redraw();
+  }
+  togglePinned(layerId: number): void {
+    if (this.pinnedLayerIds.has(layerId)) this.pinnedLayerIds.delete(layerId);
+    else this.pinnedLayerIds.add(layerId);
+    m.redraw();
+  }
+}

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_track.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_track.ts
@@ -1,0 +1,191 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-display timeline track of SurfaceFlinger layer snapshots (one incomplete
+// slice per snapshot, spanning to the next, like the Screenshots track). It
+// gives the viewer a timeline presence: selecting a snapshot shows a compact
+// summary and a link that opens the full SurfaceFlinger page at that moment.
+
+import m from 'mithril';
+import {Time} from '../../base/time';
+import {Timestamp} from '../../components/widgets/timestamp';
+import {materialColorScheme} from '../../components/colorizer';
+import {SliceTrack} from '../../components/tracks/slice_track';
+import type {TrackEventDetailsPanel} from '../../public/details_panel';
+import type {TrackEventSelection} from '../../public/selection';
+import type {Trace} from '../../public/trace';
+import {SourceDataset} from '../../trace_processor/dataset';
+import {LONG, NUM, STR} from '../../trace_processor/query_result';
+import {Button} from '../../widgets/button';
+import {Intent} from '../../widgets/common';
+import {DetailsShell} from '../../widgets/details_shell';
+import {GridLayout} from '../../widgets/grid_layout';
+import {Section} from '../../widgets/section';
+import {Tree, TreeNode} from '../../widgets/tree';
+import {rectsOptionsFrom} from './surfaceflinger_controls';
+import {type SfLayer, sqlInt} from './surfaceflinger_data';
+import {SfRectsView} from './surfaceflinger_rects';
+import {SURFACEFLINGER_ROUTE} from './surfaceflinger_route';
+import type {SurfaceFlingerSession} from './surfaceflinger_session';
+
+// Compact peek shown when a snapshot is selected on a display's timeline track:
+// the counts + top visible layers for that display plus a prominent button into
+// the full-screen viewer, kept in sync via load(). All the detail
+// (rects/hierarchy/properties) lives on the page.
+class SfSnapshotPanel implements TrackEventDetailsPanel {
+  private ts?: bigint;
+  private displayName = 'Display';
+  private index = 0; // snapshot index, to match the page's "N / total"
+  private total = 0;
+  private nLayers = 0;
+  private nVisible = 0;
+  private topLayers: string[] = [];
+  // This display's layers at this snapshot, captured at load() so the inline
+  // layout preview is stable even if the shared session later moves on.
+  private layers: SfLayer[] = [];
+
+  constructor(
+    private readonly session: SurfaceFlingerSession,
+    private readonly displayId: string,
+  ) {}
+
+  async load(sel: TrackEventSelection): Promise<void> {
+    this.ts = sel.ts;
+    // Sync the shared session to this track's display + snapshot, so the page
+    // opens here and the preview is scoped to this display.
+    if (this.session.displayId !== this.displayId) {
+      await this.session.setDisplay(this.displayId);
+    }
+    await this.session.setNearestTs(sel.ts);
+    this.displayName = this.session.displayName;
+    this.index = this.session.index;
+    this.total = this.session.snapshots.length;
+    const layers = this.session.displayLayers();
+    this.layers = layers;
+    this.nLayers = layers.length;
+    const visible = layers.filter((l) => l.isVisible);
+    this.nVisible = visible.length;
+    // Top-most visible layers (highest draw depth = front).
+    this.topLayers = visible
+      .filter((l) => l.rect)
+      .sort((a, b) => (b.drawDepth ?? 0) - (a.drawDepth ?? 0))
+      .slice(0, 6)
+      .map((l) => l.name.replace(/#\d+$/, '').trim());
+    m.redraw();
+  }
+
+  render(): m.Children {
+    return m(
+      DetailsShell,
+      {
+        title: 'SurfaceFlinger snapshot',
+        description: `${this.displayName} — ${this.nVisible}/${this.nLayers} layers visible`,
+        buttons: m(
+          'a',
+          {
+            href: `#!${SURFACEFLINGER_ROUTE}`,
+            title: 'Open the full viewer at this snapshot',
+          },
+          m(Button, {
+            label: 'Open in SurfaceFlinger viewer',
+            icon: 'open_in_full',
+            intent: Intent.Primary,
+          }),
+        ),
+      },
+      m(
+        GridLayout,
+        m(
+          Section,
+          {title: 'Snapshot'},
+          m(Tree, [
+            m(TreeNode, {
+              left: 'Snapshot',
+              right: `${this.index + 1} / ${this.total}`,
+            }),
+            this.ts !== undefined &&
+              m(TreeNode, {
+                left: 'Timestamp',
+                right: m(Timestamp, {
+                  trace: this.session.trace,
+                  ts: Time.fromRaw(this.ts),
+                }),
+              }),
+            m(TreeNode, {left: 'Layers', right: `${this.nLayers}`}),
+            m(TreeNode, {left: 'Visible', right: `${this.nVisible}`}),
+            m(
+              TreeNode,
+              {left: 'Top layers', right: `${this.topLayers.length}`},
+              this.topLayers.map((n) => m(TreeNode, {left: n})),
+            ),
+          ]),
+        ),
+        // Inline layout preview (like the VideoFrames panel shows the frame).
+        // No controls here — it respects the view options set on the page (shared
+        // session state) to keep the panel uncluttered. Clicking a rect or its
+        // label still selects the layer.
+        m(
+          Section,
+          {title: 'Layout'},
+          this.layers.length === 0
+            ? m('span', 'No layers.')
+            : m(SfRectsView, {
+                layers: this.layers,
+                selectedRowId: this.session.selectedRowId,
+                hiddenLayerIds: this.session.hiddenLayerIds,
+                pinnedLayerIds: this.session.pinnedLayerIds,
+                onSelect: (rowId) => void this.session.selectLayer(rowId),
+                options: rectsOptionsFrom(this.session.options),
+              }),
+        ),
+      ),
+    );
+  }
+}
+
+export function createSurfaceFlingerTrack(
+  trace: Trace,
+  uri: string,
+  displayId: string,
+  session: SurfaceFlingerSession,
+) {
+  // One track per display: show each snapshot that includes this display as an
+  // incomplete slice spanning to the next (dur = -1, like the Screenshots /
+  // VideoFrames tracks), labelled with its frame number within this display. The
+  // name doubles as the per-frame colorization seed.
+  const src = `
+    SELECT
+      id,
+      ts,
+      -1 AS dur,
+      0 AS depth,
+      'Frame ' || (ROW_NUMBER() OVER (ORDER BY ts)) AS name
+    FROM __intrinsic_surfaceflinger_layers_snapshot
+    WHERE id IN (
+      SELECT snapshot_id FROM __intrinsic_surfaceflinger_display
+      WHERE display_id = ${sqlInt(displayId)}
+    )
+  `;
+  const panel = new SfSnapshotPanel(session, displayId);
+  return SliceTrack.create({
+    trace,
+    uri,
+    dataset: new SourceDataset({
+      schema: {id: NUM, ts: LONG, dur: LONG, name: STR, depth: NUM},
+      src,
+    }),
+    colorizer: (row) => materialColorScheme(row.name),
+    detailsPanel: () => panel,
+  });
+}

--- a/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_viewer.ts
+++ b/ui/src/plugins/com.android.SurfaceFlinger/surfaceflinger_viewer.ts
@@ -1,0 +1,535 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The SurfaceFlinger 3-pane viewer (Surface rects | Hierarchy | Properties),
+// the layers viewer built from native Perfetto widgets
+// (Section, Tree, Chip, DataGrid). Reads/writes the shared SurfaceFlingerSession.
+
+import './surfaceflinger.scss';
+import m from 'mithril';
+import {DataGrid} from '../../components/widgets/datagrid/datagrid';
+import type {SchemaRegistry} from '../../components/widgets/datagrid/datagrid_schema';
+import {InMemoryDataSource} from '../../components/widgets/datagrid/in_memory_data_source';
+import type {Column} from '../../components/widgets/datagrid/model';
+import {Button} from '../../widgets/button';
+import {Checkbox} from '../../widgets/checkbox';
+import {Chip} from '../../widgets/chip';
+import {Intent} from '../../widgets/common';
+import {Section} from '../../widgets/section';
+import {TextInput} from '../../widgets/text_input';
+import {Tree, TreeNode} from '../../widgets/tree';
+import type {SqlValue} from '../../trace_processor/query_result';
+import {
+  rectsOptionsFrom,
+  renderSurfaceControls,
+} from './surfaceflinger_controls';
+import {curatedProperties} from './surfaceflinger_curated';
+import type {SfArg, SfLayer} from './surfaceflinger_data';
+import {SfRectsView} from './surfaceflinger_rects';
+import type {SurfaceFlingerSession} from './surfaceflinger_session';
+
+const PROTO_SCHEMA: SchemaRegistry = {
+  root: {
+    property: {title: 'Property', columnType: 'text'},
+    value: {title: 'Value', columnType: 'text'},
+    type: {title: 'Type', columnType: 'text'},
+  },
+};
+const PROTO_COLUMNS: readonly Column[] = [
+  {id: 'property', field: 'property'},
+  {id: 'value', field: 'value'},
+  {id: 'type', field: 'type'},
+];
+
+const CURATED_COLUMNS: readonly Column[] = [
+  {id: 'property', field: 'property'},
+  {id: 'value', field: 'value'},
+];
+
+// With diff on, an extra "Previous" column shows the prior snapshot's value for
+// any property that changed (blank if unchanged) — filter it to see only diffs.
+const PROTO_SCHEMA_DIFF: SchemaRegistry = {
+  root: {
+    property: {title: 'Property', columnType: 'text'},
+    value: {title: 'Value', columnType: 'text'},
+    previous: {title: 'Previous', columnType: 'text'},
+    type: {title: 'Type', columnType: 'text'},
+  },
+};
+const PROTO_COLUMNS_DIFF: readonly Column[] = [
+  {id: 'property', field: 'property'},
+  {id: 'value', field: 'value'},
+  {id: 'previous', field: 'previous'},
+  {id: 'type', field: 'type'},
+];
+
+// Curated grid sizing: it has no internal scroll, so its height is derived from
+// the row count (header rows + value rows), capped so a huge set still scrolls.
+const CURATED_ROW_PX = 27;
+const CURATED_PAD_PX = 40;
+const CURATED_MAX_PX = 460;
+
+function chipsFor(l: SfLayer, dup: boolean, relZParent: boolean): m.Children[] {
+  const out: m.Children[] = [];
+  const chip = (label: string, intent: Intent, title: string) =>
+    m(Chip, {label, intent, compact: true, rounded: true, title});
+  if (l.isVisible) out.push(chip('V', Intent.Success, 'Visible'));
+  if (l.hwcCompositionType === 1) {
+    out.push(chip('GPU', Intent.Warning, 'Client/GPU composition'));
+  } else if (l.hwcCompositionType >= 2) {
+    out.push(chip('HWC', Intent.Primary, 'Hardware composer composition'));
+  }
+  if (l.zOrderRelativeOf > 0) {
+    out.push(chip('RelZ', Intent.None, 'Z-ordered relative to another layer'));
+  }
+  if (relZParent) {
+    out.push(
+      chip(
+        'RelZParent',
+        Intent.None,
+        'Another layer is Z-ordered relative to this one',
+      ),
+    );
+  }
+  if (l.isHiddenByPolicy) {
+    out.push(chip('H', Intent.Danger, 'Hidden by policy'));
+  }
+  if (l.isMissingZParent) {
+    out.push(chip('MissingZ', Intent.Danger, 'Missing relative-Z parent'));
+  }
+  if (l.isSpy) out.push(chip('Spy', Intent.None, 'Input spy window'));
+  if (dup) out.push(chip('Dup', Intent.Warning, 'Duplicate layer id'));
+  return out;
+}
+
+interface TreeItem {
+  layer: SfLayer;
+  children: TreeItem[];
+  deleted?: boolean; // present in the previous snapshot only (diff)
+}
+
+// Whether a proto arg holds its (zero/empty/false) default, used to hide noise
+// when "Show defaults" is off. Only the empty string counts as a string default
+// (a literal "0" string is a real value).
+function isDefaultish(a: SfArg): boolean {
+  if (a.type === 'bool') return a.value === 'false';
+  if (a.type === 'string') return a.value === '';
+  return Number(a.value) === 0;
+}
+
+// "Simplify names": collapse a long dotted class name (a.b.c.d.z) to
+// "a.b.(...).z", leaving everything else (including any #id) intact.
+function simplify(name: string, on: boolean): string {
+  if (!on) return name;
+  const parts = name.split('.');
+  if (parts.length > 3) {
+    return `${parts[0]}.${parts[1]}.(…).${parts[parts.length - 1]}`;
+  }
+  return name;
+}
+
+export interface SfViewerAttrs {
+  session: SurfaceFlingerSession;
+}
+
+export class SfViewer implements m.ClassComponent<SfViewerAttrs> {
+  // Memoized DataGrid sources, rebuilt only when their inputs change (by
+  // reference), so the grids keep their internal filter/sort caches across the
+  // many redraws from hovering and scrubbing.
+  private curatedCache?: {
+    layer: SfLayer;
+    args: SfArg[];
+    ds: InMemoryDataSource;
+    schema: SchemaRegistry;
+    count: number;
+  };
+  private protoCache?: {
+    args: SfArg[];
+    showDefaults: boolean;
+    diff: boolean;
+    prev: Map<string, string>;
+    ds: InMemoryDataSource;
+    count: number;
+  };
+
+  view(vnode: m.Vnode<SfViewerAttrs>): m.Children {
+    const s = vnode.attrs.session;
+    return m('.pf-sf-viewer', [
+      this.renderSurface(s),
+      this.renderHierarchy(s),
+      this.renderProperties(s),
+    ]);
+  }
+
+  // ---- Surface (rects) ----
+  private renderSurface(s: SurfaceFlingerSession): m.Children {
+    const o = s.options;
+    return m('.pf-sf-pane.pf-sf-pane--surface', [
+      m(Section, {title: 'Surface'}, [
+        renderSurfaceControls(o),
+        // Shows the selected display's composition (its group). The rects view
+        // stays mounted across snapshot changes (keeping the previous frame
+        // until the next loads) so scrubbing doesn't flicker the canvas. The
+        // hierarchy and properties below use the full cross-display layer tree.
+        m(SfRectsView, {
+          layers: s.displayLayers(),
+          selectedRowId: s.selectedRowId,
+          hiddenLayerIds: s.hiddenLayerIds,
+          pinnedLayerIds: s.pinnedLayerIds,
+          onSelect: (rowId) => void s.selectLayer(rowId),
+          options: rectsOptionsFrom(o),
+        }),
+      ]),
+    ]);
+  }
+
+  // ---- Hierarchy ----
+  private buildTree(s: SurfaceFlingerSession): TreeItem[] {
+    const o = s.options;
+    let pool = s.layers;
+    if (o.hierOnlyVisible) pool = pool.filter((l) => l.isVisible);
+    if (o.hierSearch.trim()) {
+      const q = o.hierSearch.toLowerCase();
+      const keep = new Set<number>();
+      for (const l of s.layers) {
+        if (l.name.toLowerCase().includes(q) || String(l.layerId).includes(q)) {
+          let cur: SfLayer | undefined = l;
+          while (cur && !keep.has(cur.layerId)) {
+            keep.add(cur.layerId);
+            cur = cur.parent >= 0 ? s.byLayerId.get(cur.parent) : undefined;
+          }
+        }
+      }
+      pool = pool.filter((l) => keep.has(l.layerId));
+    }
+    const inPool = new Set(pool.map((l) => l.layerId));
+    const sortFn = (a: SfLayer, b: SfLayer) =>
+      (a.drawDepth ?? 1e9) - (b.drawDepth ?? 1e9);
+    const ghosts: TreeItem[] = o.diff
+      ? s.deletedLayers().map((layer) => ({layer, children: [], deleted: true}))
+      : [];
+    if (o.hierFlat) {
+      return [
+        ...[...pool].sort(sortFn).map((layer) => ({layer, children: []})),
+        ...ghosts,
+      ];
+    }
+    const childrenOf = new Map<number, SfLayer[]>();
+    const roots: SfLayer[] = [];
+    for (const l of pool) {
+      if (l.parent >= 0 && inPool.has(l.parent)) {
+        const arr = childrenOf.get(l.parent);
+        if (arr) arr.push(l);
+        else childrenOf.set(l.parent, [l]);
+      } else {
+        roots.push(l);
+      }
+    }
+    const build = (l: SfLayer): TreeItem => ({
+      layer: l,
+      children: (childrenOf.get(l.layerId) ?? []).sort(sortFn).map(build),
+    });
+    return [...roots.sort(sortFn).map(build), ...ghosts];
+  }
+
+  private renderNode(
+    s: SurfaceFlingerSession,
+    item: TreeItem,
+    dupIds: Set<number>,
+  ): m.Children {
+    const l = item.layer;
+    const selected = l.rowId === s.selectedRowId;
+    const status = item.deleted ? 'deleted' : s.diffStatusOf(l);
+    const cls = [
+      selected ? 'pf-sf-hnode--sel' : '',
+      status !== 'unchanged' ? `pf-sf-hnode--${status}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const hidden = s.hiddenLayerIds.has(l.layerId);
+    const pinned = s.pinnedLayerIds.has(l.layerId);
+    const label = m(
+      'span.pf-sf-hnode',
+      {
+        class: cls,
+        onclick: (e: Event) => {
+          e.stopPropagation();
+          if (!item.deleted) void s.selectLayer(l.rowId);
+        },
+      },
+      [
+        m('span.pf-sf-hnode__id', `${l.layerId}`),
+        m('span.pf-sf-hnode__name', simplify(l.name, s.options.hierSimplify)),
+        ...chipsFor(l, dupIds.has(l.layerId), s.relZParentIds.has(l.layerId)),
+        !item.deleted &&
+          m(Button, {
+            className: 'pf-sf-hnode__btn',
+            compact: true,
+            icon: hidden ? 'visibility_off' : 'visibility',
+            title: hidden ? 'Show rect' : 'Hide rect',
+            onclick: (e: Event) => {
+              e.stopPropagation();
+              s.toggleHidden(l.layerId);
+            },
+          }),
+        !item.deleted &&
+          m(Button, {
+            className: 'pf-sf-hnode__btn',
+            compact: true,
+            active: pinned,
+            icon: 'push_pin',
+            title: pinned ? 'Unpin rect' : 'Pin rect',
+            onclick: (e: Event) => {
+              e.stopPropagation();
+              s.togglePinned(l.layerId);
+            },
+          }),
+      ],
+    );
+    return m(
+      TreeNode,
+      {left: label, startsCollapsed: false},
+      item.children.map((c) => this.renderNode(s, c, dupIds)),
+    );
+  }
+
+  private renderHierarchy(s: SurfaceFlingerSession): m.Children {
+    const o = s.options;
+    const counts = new Map<number, number>();
+    for (const l of s.layers) {
+      counts.set(l.layerId, (counts.get(l.layerId) ?? 0) + 1);
+    }
+    const dupIds = new Set(
+      [...counts].filter(([, n]) => n > 1).map(([id]) => id),
+    );
+    return m('.pf-sf-pane.pf-sf-pane--hier', [
+      m(Section, {title: 'Hierarchy'}, [
+        m('.pf-sf-toolbar', [
+          m(Checkbox, {
+            label: 'Only visible',
+            checked: o.hierOnlyVisible,
+            onchange: () => (o.hierOnlyVisible = !o.hierOnlyVisible),
+          }),
+          m(Checkbox, {
+            label: 'Flat',
+            checked: o.hierFlat,
+            onchange: () => (o.hierFlat = !o.hierFlat),
+          }),
+          m(Checkbox, {
+            label: 'Simplify',
+            checked: o.hierSimplify,
+            onchange: () => (o.hierSimplify = !o.hierSimplify),
+          }),
+          m(Checkbox, {
+            label: 'Diff',
+            checked: o.diff,
+            onchange: () => void s.setDiff(!o.diff),
+          }),
+        ]),
+        m(TextInput, {
+          placeholder: 'Filter layers…',
+          value: o.hierSearch,
+          oninput: (e: Event) =>
+            (o.hierSearch = (e.target as HTMLInputElement).value),
+        }),
+        m(
+          Tree,
+          {className: 'pf-sf-htree'},
+          this.buildTree(s).map((item) => this.renderNode(s, item, dupIds)),
+        ),
+      ]),
+    ]);
+  }
+
+  // ---- Properties (curated + full proto) ----
+  // The curated summary as a DataGrid: section titles become header rows, and
+  // values that reference another layer (occluded-by, relative-Z parent) render
+  // as clickable links via a cell renderer.
+  private renderCurated(s: SurfaceFlingerSession): m.Children {
+    const layer = s.selectedLayer;
+    if (!layer) return m('.pf-sf-empty', 'Select a layer.');
+    const c =
+      this.curatedCache?.layer === layer &&
+      this.curatedCache.args === s.selectedArgs
+        ? this.curatedCache
+        : (this.curatedCache = this.buildCurated(s, layer));
+    if (c.count === 0) return m('.pf-sf-empty', 'No properties.');
+    const h = Math.min(
+      c.count * CURATED_ROW_PX + CURATED_PAD_PX,
+      CURATED_MAX_PX,
+    );
+    return m(
+      '.pf-sf-curated',
+      {style: {height: `${h}px`}},
+      m(DataGrid, {
+        schema: c.schema,
+        rootSchema: 'root',
+        data: c.ds,
+        columns: CURATED_COLUMNS,
+        fillHeight: true,
+        disableColumnControls: true,
+        disableFilterControls: true,
+        disablePivotControls: true,
+      }),
+    );
+  }
+
+  private buildCurated(
+    s: SurfaceFlingerSession,
+    layer: SfLayer,
+  ): NonNullable<SfViewer['curatedCache']> {
+    const sections = curatedProperties(layer, s.selectedArgs, (id) =>
+      s.nameOf(id),
+    );
+    // The DataGrid's in-memory source projects rows to the declared columns, so
+    // header-ness and layer references are derived from the two visible columns
+    // (the section titles and the per-row label) rather than carried as hidden
+    // fields.
+    const headerTitles = new Set<string>();
+    const refByLabel = new Map<string, number>();
+    const rows: Array<Record<string, SqlValue>> = [];
+    for (const sec of sections) {
+      headerTitles.add(sec.title);
+      rows.push({property: sec.title, value: ''});
+      for (const r of sec.rows) {
+        if (r.layerRefs && r.layerRefs.length > 0) {
+          refByLabel.set(r.label, r.layerRefs[0]);
+        }
+        rows.push({property: r.label, value: r.value});
+      }
+    }
+    const schema: SchemaRegistry = {
+      root: {
+        property: {
+          title: 'Property',
+          columnType: 'text',
+          cellRenderer: (v: SqlValue) =>
+            headerTitles.has(String(v))
+              ? m('span.pf-sf-cur-h', String(v))
+              : String(v ?? ''),
+        },
+        value: {
+          title: 'Value',
+          columnType: 'text',
+          cellRenderer: (v: SqlValue, row: Record<string, SqlValue>) => {
+            const ref = refByLabel.get(String(row.property));
+            if (ref !== undefined) {
+              return m(
+                'a.pf-sf-ref',
+                {onclick: () => s.selectLayerByLayerId(ref)},
+                String(v ?? ''),
+              );
+            }
+            return String(v ?? '');
+          },
+        },
+      },
+    };
+    return {
+      layer,
+      args: s.selectedArgs,
+      ds: new InMemoryDataSource(rows),
+      schema,
+      count: rows.length,
+    };
+  }
+
+  private renderPropHeader(
+    s: SurfaceFlingerSession,
+    layer: SfLayer,
+  ): m.Children {
+    const dup = s.layers.filter((l) => l.layerId === layer.layerId).length > 1;
+    return m('.pf-sf-prophead', [
+      m('.pf-sf-prophead__name', `${layer.name}  #${layer.layerId}`),
+      m(
+        '.pf-sf-prophead__chips',
+        chipsFor(layer, dup, s.relZParentIds.has(layer.layerId)),
+      ),
+    ]);
+  }
+
+  private renderProtoGrid(s: SurfaceFlingerSession): m.Children {
+    const diff = s.options.diff;
+    const showDefaults = s.options.propShowDefaults;
+    const c = this.protoCache;
+    const cached =
+      c !== undefined &&
+      c.args === s.selectedArgs &&
+      c.showDefaults === showDefaults &&
+      c.diff === diff &&
+      c.prev === s.prevArgByKey
+        ? c
+        : (this.protoCache = this.buildProto(s, diff, showDefaults));
+    if (cached.count === 0) return m('.pf-sf-empty', 'No properties.');
+    return m(
+      '.pf-sf-proto',
+      m(DataGrid, {
+        schema: diff ? PROTO_SCHEMA_DIFF : PROTO_SCHEMA,
+        rootSchema: 'root',
+        data: cached.ds,
+        columns: diff ? PROTO_COLUMNS_DIFF : PROTO_COLUMNS,
+        fillHeight: true,
+      }),
+    );
+  }
+
+  private buildProto(
+    s: SurfaceFlingerSession,
+    diff: boolean,
+    showDefaults: boolean,
+  ): NonNullable<SfViewer['protoCache']> {
+    const rows = s.selectedArgs
+      .filter((a) => showDefaults || !isDefaultish(a))
+      .map((a) => {
+        const value = String(a.value);
+        const row: Record<string, string> = {
+          property: a.key,
+          value,
+          type: a.type,
+        };
+        if (diff) {
+          const p = s.prevArgByKey.get(a.key);
+          row.previous = p !== undefined && p !== value ? p : '';
+        }
+        return row;
+      });
+    return {
+      args: s.selectedArgs,
+      showDefaults,
+      diff,
+      prev: s.prevArgByKey,
+      ds: new InMemoryDataSource(rows),
+      count: rows.length,
+    };
+  }
+
+  private renderProperties(s: SurfaceFlingerSession): m.Children {
+    const layer = s.selectedLayer;
+    return m('.pf-sf-pane.pf-sf-pane--props', [
+      layer ? this.renderPropHeader(s, layer) : null,
+      m(Section, {title: 'Properties'}, this.renderCurated(s)),
+      m(Section, {title: 'Proto dump'}, [
+        m('.pf-sf-toolbar', [
+          m(Checkbox, {
+            label: 'Show defaults',
+            checked: s.options.propShowDefaults,
+            onchange: () =>
+              (s.options.propShowDefaults = !s.options.propShowDefaults),
+          }),
+        ]),
+        this.renderProtoGrid(s),
+      ]),
+    ]);
+  }
+}


### PR DESCRIPTION
Adds a SurfaceFlinger layers viewer for the android.surfaceflinger.layers data source. Inspired by the Android Winscope tool.

trace_processor: the winscope importer plugin now reports the timestamp bounds of the winscope snapshot tables (SurfaceFlinger layers + transactions, WindowManager, shell transitions, IME, ViewCapture, ProtoLog). Previously a trace captured with only the winscope data sources had empty trace bounds and the UI treated it as empty; now it opens directly. Adds read access to those tables' `ts` column.

Surfaced two ways onto one shared session:
- A nested "SurfaceFlinger" timeline group with one track per display (real and virtual, e.g. a video-encoder/screen-recorder display, which are part of what SurfaceFlinger composited). Each track shows that display's snapshots as frame-numbered, colorized slices; selecting one shows a compact summary plus an inline layout preview and opens the page at that snapshot.
- A full-screen page (sidebar > SurfaceFlinger) with a display selector, snapshot time-slider, prev/next, and a jump-to-timeline button that selects the snapshot slice on that display's track. The snapshot index and timestamp are shown consistently in the page and the details panel.

Three panes:
- Surface: a rotatable, stacked 3D view of the selected display's layer rects, pure 2D-canvas projection (no WebGL). Camera angles follow the standalone tool's mapper3d (pitch = factor*PI/8, yaw = 1.5*pitch); gradient / opacity / wireframe shading; spacing slider; only-visible filter; per-rect hide + pin; click-to-select; and leader-line labels in a side gutter that never overlap and are themselves clickable.
- Hierarchy: the full cross-display layer tree with chips (visible / GPU / HWC / relative-Z / hidden / spy / duplicate), only-visible / flat / simplify-names / diff filters and search, and per-node hide + pin toggles.
- Properties: a header card (name + chips), a curated summary as a DataGrid (with clickable layer references) and the full proto dump as a filterable DataGrid; with diff on, layers are marked added/modified/deleted and the proto grid gains a Previous column.

A layer belongs to a display via its rect's group id, so the Surface scopes to the selected display's composition while the hierarchy/properties span all displays. Built from native widgets (Section, Tree, Chip, DataGrid, Checkbox, TextInput, Select) and themed with the --pf-color-* variables, so it follows the app's light and dark mode. Enabled by default.