### PR TITLE
ui: Allow editing custom textproto record configs

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
@@ -40,7 +40,11 @@ import {Icons} from '../../../base/semantic_icons';
 import {shareRecordConfig} from '../config/config_sharing';
 import {Card} from '../../../widgets/card';
 import {showModal} from '../../../widgets/modal';
-import {traceConfigToPb} from '../../../base/proto_utils_wasm';
+import {
+  traceConfigToPb,
+  traceConfigToTxt,
+} from '../../../base/proto_utils_wasm';
+import {base64Decode} from '../../../base/string_utils';
 import protos from '../../../protos';
 import {ImportConfigDialog} from '../views/import_config';
 
@@ -290,6 +294,16 @@ class RecordConfigSelector implements m.ClassComponent<RecMgrAttrs> {
                     }
                   },
                 }),
+              isCustom &&
+                m(Button, {
+                  icon: 'edit',
+                  compact: true,
+                  title: 'Edit textproto',
+                  onclick: (e: Event) => {
+                    e.stopPropagation();
+                    this.editSavedConfig(recMgr, saved);
+                  },
+                }),
               m(Button, {
                 icon: 'share',
                 compact: true,
@@ -346,6 +360,19 @@ class RecordConfigSelector implements m.ClassComponent<RecMgrAttrs> {
                 : 'Custom',
             ),
             m('.pf-preset-card__subtitle', 'Click to save'),
+            hasUnsavedCustomConfig &&
+              m(
+                '.pf-preset-card__actions',
+                m(Button, {
+                  icon: 'edit',
+                  compact: true,
+                  title: 'Edit textproto',
+                  onclick: (e: Event) => {
+                    e.stopPropagation();
+                    this.editActiveCustomConfig(recMgr);
+                  },
+                }),
+              ),
           ),
         this.renderImportCard(recMgr),
       ]),
@@ -372,6 +399,78 @@ class RecordConfigSelector implements m.ClassComponent<RecMgrAttrs> {
       m('.pf-preset-card__title', 'Import'),
       m('.pf-preset-card__subtitle', 'Load textproto'),
     );
+  }
+
+  // Edit a saved custom config: round-trips the stored binary back to textproto,
+  // and on save overwrites the saved entry (keeping its name) and reloads it.
+  private async editSavedConfig(
+    recMgr: RecordingManager,
+    saved: SavedSessionSchema,
+  ) {
+    if (saved.config.kind !== 'custom') return;
+    const fileName = saved.config.customConfigFileName ?? 'textproto';
+    const bytes = base64Decode(saved.config.customTraceConfigBase64);
+    const initialText = await traceConfigToTxt(bytes);
+    this.openEditDialog(
+      recMgr,
+      `Edit config "${saved.name}"`,
+      initialText,
+      (parsed) => {
+        recMgr.setCustomTraceConfig(parsed, fileName);
+        const updated = recMgr.saveConfig(saved.name);
+        this.loadSavedConfig(recMgr, updated);
+      },
+    );
+  }
+
+  // Edit the active (unsaved) custom config: pre-fills from the live config and
+  // on save replaces it in place, leaving it unsaved.
+  private async editActiveCustomConfig(recMgr: RecordingManager) {
+    if (!recMgr.hasCustomTraceConfig) return;
+    const fileName = recMgr.customConfigFileName ?? 'textproto';
+    const initialText = await traceConfigToTxt(recMgr.genTraceConfig());
+    this.openEditDialog(recMgr, 'Edit config', initialText, (parsed) => {
+      recMgr.setCustomTraceConfig(parsed, fileName);
+    });
+  }
+
+  // Shared edit dialog: shows the textproto editor pre-filled with `initialText`
+  // and, on save, parses it and hands the decoded TraceConfig to `onSave`.
+  private openEditDialog(
+    recMgr: RecordingManager,
+    title: string,
+    initialText: string,
+    onSave: (parsed: protos.TraceConfig) => void,
+  ) {
+    let config = initialText;
+    showModal({
+      title,
+      content: () =>
+        m(ImportConfigDialog, {
+          config,
+          onUpdate: (x) => {
+            config = x;
+          },
+        }),
+      buttons: [
+        {
+          text: 'Save',
+          primary: true,
+          action: async () => {
+            const res = await traceConfigToPb(config);
+            if (!res.ok) {
+              showModal({
+                title: 'Import error',
+                content: `Failed to parse config: ${res.error}`,
+              });
+              return;
+            }
+            onSave(protos.TraceConfig.decode(res.value));
+            recMgr.app.raf.scheduleFullRedraw();
+          },
+        },
+      ],
+    });
   }
 
   private openRawTextProtoModal(recMgr: RecordingManager) {


### PR DESCRIPTION
Add an "edit" button to re-open the textproto editor for custom configs, both saved and the active-but-unsaved one. Saving a saved config overwrites it in place; saving the active one replaces it without creating a saved entry.

Shortcomings: edits round-trip through the binary TraceConfig, so comments and formatting aren't preserved. On a parse error the dialog closes and discards your edits before showing the error (pre-existing modal behaviour, shared with the import flow). This is due to a short coming with the way modals work. Modifying this is out of scope of this patch.

<img width="481" height="206" alt="image" src="https://github.com/user-attachments/assets/dd7f69ab-7d04-4dee-a079-067989527519" />

# Testing
### Modify an ephemeral config
- Open record page, create a new 'custom' recording config.
- Click the edit button to edit it. Make changes and press OK to save.
- Check the proto in "Command line instructions" reflects the modified proto.

### Modify a saved config
- Save the config
- Press edit and modify it again
- Ensure the config has chaneged on the "Command line instructions" page.

### UI reload
- Reload the UI
- Ensure the modified config has persisted the reload.