### PR TITLE
tp: add expected-error support to diff tests

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -140,7 +140,7 @@ Methods cannot take arguments and have to return a `DiffTestBlueprint`:
 class DiffTestBlueprint:
   trace: Union[Path, Json, Systrace, TextProto]
   query: Union[str, Path, Metric]
-  out: Union[Path, Json, Csv, TextProto]
+  out: Union[Path, Json, Csv, TextProto, ExpectedError]
 ```
 
 _Trace_ and _Out_: For every type apart from `Path`, contents of the object
@@ -149,6 +149,12 @@ will be treated as file contents so it has to follow the same rules.
 _Query_: For metric tests it is enough to provide the metric name. For query
 tests there can be a raw SQL statement, for example `"SELECT * FROM SLICE"`,
 or a path to an `.sql` file.
+
+_ExpectedError_: Setting `out=ExpectedError('error substring')` inverts the
+test: it passes if and only if loading the trace fails and the error message
+printed by `trace_processor_shell` contains the given substring. Use this to
+test strict parsing/import errors where the whole trace load is expected to
+fail. The query is still required but is never executed.
 
 NOTE: `trace_processor_shell` and the associated proto descriptors need to
 be built before running `tools/diff_test_trace_processor.py`. The easiest

--- a/python/generators/diff_tests/models.py
+++ b/python/generators/diff_tests/models.py
@@ -147,7 +147,12 @@ class TestResult:
     expected_content = self.expected.replace('\r\n', '\n')
 
     actual_content = self.actual.replace('\r\n', '\n')
-    self.passed = (expected_content == actual_content)
+    if test.blueprint.is_out_expected_error():
+      # The test expects the trace load to fail: pass iff trace_processor
+      # exited with an error and stderr contains the expected message.
+      self.passed = (self.exit_code != 0 and expected_content in self.stderr)
+    else:
+      self.passed = (expected_content == actual_content)
 
     if self.exit_code == 0:
       self.perf_result = PerfResult(self.test, perf_lines)

--- a/python/generators/diff_tests/runner.py
+++ b/python/generators/diff_tests/runner.py
@@ -131,7 +131,9 @@ class DiffTestsRunner:
 
         if not result or not result.passed:
           failures.append(test_name)
-        else:
+        elif result.perf_result:
+          # Passed expected-error tests have no perf result: trace_processor
+          # exits before the query runs.
           perf_results.append(result.perf_result)
     test_time_ms = int(
         (datetime.datetime.now() - test_run_start).total_seconds() * 1000)
@@ -229,7 +231,23 @@ class DiffTestsRunner:
 
     run_str = f"{colors.yellow('[ RUN      ]')} {result.test.name}\n"
     run_diagnostics = [f"trace_path: {trace_path}"] if print_trace_path else []
-    if result.exit_code != 0 or not result.passed:
+    if result.test.blueprint.is_out_expected_error():
+      # Expected-error tests pass when trace_processor fails: a non-zero exit
+      # code is part of the expectation, not a test harness failure.
+      if result.passed:
+        run_str += f"{colors.green('[       OK ]')} {result.test.name}"
+      else:
+        run_str += result.stderr
+        if result.exit_code == 0:
+          run_str += (f"Expected trace_processor to fail with an error "
+                      f"containing '{result.expected}' but it exited "
+                      f"successfully.\n")
+        else:
+          run_str += (f"trace_processor failed as expected but stderr did not "
+                      f"contain '{result.expected}'.\n")
+        run_str += write_cmdlines()
+        run_str += (f"{colors.red('[  FAILED  ]')} {result.test.name}")
+    elif result.exit_code != 0 or not result.passed:
       result.passed = False
       run_str += result.stderr
 

--- a/python/generators/diff_tests/test_loader.py
+++ b/python/generators/diff_tests/test_loader.py
@@ -19,7 +19,8 @@ import sys
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 
 from python.generators.diff_tests.testing import (BinaryProto, Csv, DataPath,
-                                                  DiffTestBlueprint, Json, Path,
+                                                  DiffTestBlueprint,
+                                                  ExpectedError, Json, Path,
                                                   Systrace, TextProto)
 from python.generators.diff_tests.models import DiscoveredTests, TestCase, TestType
 
@@ -162,6 +163,9 @@ class TestLoader:
       assert expected_path
       with open(expected_path, 'r') as expected_file:
         return expected_file.read()
+    if blueprint.is_out_expected_error():
+      assert isinstance(blueprint.out, ExpectedError)
+      return blueprint.out.contains
     assert isinstance(blueprint.out, (
         TextProto,
         Json,

--- a/python/generators/diff_tests/testing.py
+++ b/python/generators/diff_tests/testing.py
@@ -100,6 +100,17 @@ class BinaryProto:
 
 
 @dataclass
+class ExpectedError:
+  """Represents an expectation that loading the trace fails.
+
+  The test passes iff trace_processor exits with a non-zero exit code AND
+  its stderr contains the |contains| substring. Use this to test strict
+  parsing/import errors where the whole trace load is expected to fail.
+  """
+  contains: str
+
+
+@dataclass
 class SimpleperfProto:
   """Represents a simpleperf_proto binary file with inline generation."""
   records: List[str]  # List of textproto strings for Record messages
@@ -165,7 +176,7 @@ class DiffTestBlueprint:
   trace: Union[Path, DataPath, Json, Systrace, TextProto, RawText]
   query: Union[str, Path, DataPath, Metric, MetricV2SpecTextproto,
                StructuredQuery]
-  out: Union[Path, DataPath, Json, Csv, TextProto, BinaryProto]
+  out: Union[Path, DataPath, Json, Csv, TextProto, BinaryProto, ExpectedError]
   trace_modifier: Union[TraceInjector, None] = None
   register_files_dir: Optional[DataPath] = None
   # If set, this test will only be run if all of these module_dependencies are enabled.
@@ -217,6 +228,9 @@ class DiffTestBlueprint:
 
   def is_out_csv(self):
     return isinstance(self.out, Csv)
+
+  def is_out_expected_error(self):
+    return isinstance(self.out, ExpectedError)
 
 
 def removeprefix(s: str, prefix: str):

--- a/test/trace_processor/diff_tests/parser/parsing/tests.py
+++ b/test/trace_processor/diff_tests/parser/parsing/tests.py
@@ -16,6 +16,7 @@
 from python.generators.diff_tests.testing import Path, DataPath, Metric
 from python.generators.diff_tests.testing import Csv, Json, TextProto
 from python.generators.diff_tests.testing import DiffTestBlueprint, TraceInjector
+from python.generators.diff_tests.testing import ExpectedError, RawText
 from python.generators.diff_tests.testing import TestSuite
 
 
@@ -27,7 +28,17 @@ class Parsing(TestSuite):
   # http://perfetto/dev/docs/analysis/trace-processor#diff-tests for choosing
   # folder to add a new test to. TODO(lalitm): some tests here should be moved
   # of here and into the area folders; they are only here because they predate
-  # modularisation of diff tests. Sched
+  # modularisation of diff tests.
+
+  # Feeding trace_processor a file which is not a trace in any known format
+  # should fail the load with a clear error.
+  def test_unknown_trace_type_load_error(self):
+    return DiffTestBlueprint(
+        trace=RawText('this is garbage and not a trace in any known format'),
+        query='SELECT 1;',
+        out=ExpectedError('Unknown trace type provided (ERR:fmt)'))
+
+  # Sched
   def test_ts_desc_filter_android_sched_and_ps(self):
     return DiffTestBlueprint(
         trace=DataPath('android_sched_and_ps.pb'),


### PR DESCRIPTION
Add an ExpectedError out-type to the diff test framework. A test using
out=ExpectedError('substring') passes if and only if trace_processor
exits with a non-zero exit code AND its stderr contains the given
substring. This makes it possible to write diff tests for strict
parsing/import errors where the whole trace load is expected to fail;
previously the harness unconditionally failed any test whose
trace_processor invocation exited non-zero.

Add a demo test (garbage input -> 'Unknown trace type provided') and
document the new out-type in docs/contributing/testing.md.
