### PR TITLE
proto_merger: keep oneof fields and enum values deleted upstream

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -355,15 +355,8 @@ perfetto_cc_binary(
     name = "proto_merger",
     srcs = [
         ":src_protozero_multifile_error_collector",
-        "src/tools/proto_merger/allowlist.cc",
-        "src/tools/proto_merger/allowlist.h",
+        ":src_tools_proto_merger_lib",
         "src/tools/proto_merger/main.cc",
-        "src/tools/proto_merger/proto_file.cc",
-        "src/tools/proto_merger/proto_file.h",
-        "src/tools/proto_merger/proto_file_serializer.cc",
-        "src/tools/proto_merger/proto_file_serializer.h",
-        "src/tools/proto_merger/proto_merger.cc",
-        "src/tools/proto_merger/proto_merger.h",
     ],
     deps = [
         ":src_base_base",
@@ -2334,6 +2327,21 @@ perfetto_filegroup(
         "src/shared_lib/stream_writer.h",
         "src/shared_lib/thread_utils.cc",
         "src/shared_lib/tracing_session.cc",
+    ],
+)
+
+# GN target: //src/tools/proto_merger:lib
+perfetto_filegroup(
+    name = "src_tools_proto_merger_lib",
+    srcs = [
+        "src/tools/proto_merger/allowlist.cc",
+        "src/tools/proto_merger/allowlist.h",
+        "src/tools/proto_merger/proto_file.cc",
+        "src/tools/proto_merger/proto_file.h",
+        "src/tools/proto_merger/proto_file_serializer.cc",
+        "src/tools/proto_merger/proto_file_serializer.h",
+        "src/tools/proto_merger/proto_merger.cc",
+        "src/tools/proto_merger/proto_merger.h",
     ],
 )
 

--- a/src/tools/BUILD.gn
+++ b/src/tools/BUILD.gn
@@ -117,7 +117,10 @@ group("unittests") {
   deps = [ ":tracing_proto_extensions_unittests" ]
 
   if (current_toolchain == host_toolchain) {
-    deps += [ "ftrace_proto_gen:unittests" ]
+    deps += [
+      "ftrace_proto_gen:unittests",
+      "proto_merger:unittests",
+    ]
   }
 }
 

--- a/src/tools/proto_merger/BUILD.gn
+++ b/src/tools/proto_merger/BUILD.gn
@@ -13,20 +13,31 @@
 # limitations under the License.
 
 import("../../../gn/perfetto_host_executable.gni")
+import("../../../gn/test.gni")
 
 perfetto_host_executable("proto_merger") {
   testonly = true
   deps = [
+    ":lib",
     "../../../gn:default_deps",
     "../../../gn:protobuf_full",
     "../../base",
     "../../base:version",
     "../../protozero:multifile_error_collector",
   ]
+  sources = [ "main.cc" ]
+}
+
+source_set("lib") {
+  testonly = true
+  deps = [
+    "../../../gn:default_deps",
+    "../../../gn:protobuf_full",
+    "../../base",
+  ]
   sources = [
     "allowlist.cc",
     "allowlist.h",
-    "main.cc",
     "proto_file.cc",
     "proto_file.h",
     "proto_file_serializer.cc",
@@ -34,4 +45,16 @@ perfetto_host_executable("proto_merger") {
     "proto_merger.cc",
     "proto_merger.h",
   ]
+}
+
+perfetto_unittest_source_set("unittests") {
+  testonly = true
+  deps = [
+    ":lib",
+    "../../../gn:default_deps",
+    "../../../gn:gtest_and_gmock",
+    "../../../gn:protobuf_full",
+    "../../base",
+  ]
+  sources = [ "proto_file_serializer_unittest.cc" ]
 }

--- a/src/tools/proto_merger/proto_file_serializer.cc
+++ b/src/tools/proto_merger/proto_file_serializer.cc
@@ -106,6 +106,12 @@ std::string SerializeEnum(size_t indent, const ProtoFile::Enum& en) {
   for (const auto& value : en.values) {
     output += SerializeEnumValue(indent, value);
   }
+  if (!en.deleted_values.empty()) {
+    output += DeletedComment(prefix);
+    for (const auto& value : en.deleted_values) {
+      output += SerializeEnumValue(indent, value);
+    }
+  }
   output += prefix + "}\n";
 
   output += SerializeTrailingComments(prefix, en);
@@ -143,6 +149,12 @@ std::string SerializeOneof(size_t indent, const ProtoFile::Oneof& oneof) {
   output += prefix + "oneof " + oneof.name + " {\n";
   for (const auto& field : oneof.fields) {
     output += SerializeField(indent, field, false);
+  }
+  if (!oneof.deleted_fields.empty()) {
+    output += DeletedComment(prefix);
+    for (const auto& field : oneof.deleted_fields) {
+      output += SerializeField(indent, field, false);
+    }
   }
   output += prefix + "}\n";
 

--- a/src/tools/proto_merger/proto_file_serializer_unittest.cc
+++ b/src/tools/proto_merger/proto_file_serializer_unittest.cc
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/tools/proto_merger/proto_file_serializer.h"
+
+#include "src/tools/proto_merger/allowlist.h"
+#include "src/tools/proto_merger/proto_merger.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto {
+namespace proto_merger {
+namespace {
+
+using testing::HasSubstr;
+using testing::Not;
+
+ProtoFile::Field MakeField(const std::string& type,
+                           const std::string& name,
+                           int number) {
+  ProtoFile::Field field{};
+  field.packageless_type = type;
+  field.type = type;
+  field.name = name;
+  field.number = number;
+  return field;
+}
+
+ProtoFile::Enum::Value MakeEnumValue(const std::string& name, int number) {
+  ProtoFile::Enum::Value value{};
+  value.name = name;
+  value.number = number;
+  return value;
+}
+
+TEST(ProtoFileSerializerTest, DeletedMessageFieldIsPreserved) {
+  ProtoFile file;
+  ProtoFile::Message message{};
+  message.name = "Container";
+  message.fields.push_back(MakeField("int32", "keep_me", 1));
+  message.deleted_fields.push_back(MakeField("string", "deleted_upstream", 2));
+  file.messages.push_back(message);
+
+  std::string out = ProtoFileToDotProto(file);
+  EXPECT_THAT(out, HasSubstr("int32 keep_me = 1;"));
+  EXPECT_THAT(out, HasSubstr("string deleted_upstream = 2;"));
+  EXPECT_THAT(out, HasSubstr("not present upstream"));
+}
+
+TEST(ProtoFileSerializerTest, DeletedOneofFieldIsPreserved) {
+  ProtoFile file;
+  ProtoFile::Message message{};
+  message.name = "Container";
+
+  ProtoFile::Oneof oneof{};
+  oneof.name = "data";
+  oneof.fields.push_back(MakeField("int32", "keep_me", 1));
+  oneof.deleted_fields.push_back(MakeField("string", "deleted_upstream", 2));
+  message.oneofs.push_back(oneof);
+  file.messages.push_back(message);
+
+  std::string out = ProtoFileToDotProto(file);
+  EXPECT_THAT(out, HasSubstr("int32 keep_me = 1;"));
+  EXPECT_THAT(out, HasSubstr("string deleted_upstream = 2;"));
+  EXPECT_THAT(out, HasSubstr("not present upstream"));
+}
+
+TEST(ProtoFileSerializerTest, DeletedEnumValueIsPreserved) {
+  ProtoFile file;
+  ProtoFile::Enum en{};
+  en.name = "Status";
+  en.values.push_back(MakeEnumValue("OK", 0));
+  en.deleted_values.push_back(MakeEnumValue("LEGACY_STATUS", 1));
+  file.enums.push_back(en);
+
+  std::string out = ProtoFileToDotProto(file);
+  EXPECT_THAT(out, HasSubstr("OK = 0;"));
+  EXPECT_THAT(out, HasSubstr("LEGACY_STATUS = 1;"));
+  EXPECT_THAT(out, HasSubstr("not present upstream"));
+}
+
+// End-to-end regression test: a field deleted upstream inside a oneof (and a
+// value deleted from an enum) must survive a merge + serialize round trip.
+TEST(ProtoFileSerializerTest, MergeKeepsFieldsDeletedUpstream) {
+  ProtoFile input;
+  {
+    ProtoFile::Message message{};
+    message.name = "Container";
+
+    ProtoFile::Enum en{};
+    en.name = "Status";
+    en.values.push_back(MakeEnumValue("OK", 0));
+    en.values.push_back(MakeEnumValue("LEGACY_STATUS", 1));
+    message.enums.push_back(en);
+
+    ProtoFile::Oneof oneof{};
+    oneof.name = "data";
+    oneof.fields.push_back(MakeField("int32", "keep_me", 1));
+    oneof.fields.push_back(MakeField("string", "deleted_upstream", 2));
+    message.oneofs.push_back(oneof);
+
+    message.fields.push_back(MakeField("int32", "plain_deleted", 3));
+    input.messages.push_back(message);
+  }
+
+  // Upstream removed the "deleted_upstream" oneof field, the "LEGACY_STATUS"
+  // enum value and the "plain_deleted" message field.
+  ProtoFile upstream;
+  {
+    ProtoFile::Message message{};
+    message.name = "Container";
+
+    ProtoFile::Enum en{};
+    en.name = "Status";
+    en.values.push_back(MakeEnumValue("OK", 0));
+    message.enums.push_back(en);
+
+    ProtoFile::Oneof oneof{};
+    oneof.name = "data";
+    oneof.fields.push_back(MakeField("int32", "keep_me", 1));
+    message.oneofs.push_back(oneof);
+
+    upstream.messages.push_back(message);
+  }
+
+  ProtoFile merged;
+  ASSERT_TRUE(MergeProtoFiles(input, upstream, Allowlist{}, merged).ok());
+
+  std::string out = ProtoFileToDotProto(merged);
+  EXPECT_THAT(out, HasSubstr("int32 keep_me = 1;"));
+  EXPECT_THAT(out, HasSubstr("string deleted_upstream = 2;"));
+  EXPECT_THAT(out, HasSubstr("LEGACY_STATUS = 1;"));
+  EXPECT_THAT(out, HasSubstr("int32 plain_deleted = 3;"));
+}
+
+// Fields which exist only upstream and are not allowlisted should still be
+// dropped from the merged output.
+TEST(ProtoFileSerializerTest, MergeDropsNonAllowlistedUpstreamFields) {
+  ProtoFile input;
+  {
+    ProtoFile::Message message{};
+    message.name = "Container";
+    message.fields.push_back(MakeField("int32", "keep_me", 1));
+    input.messages.push_back(message);
+  }
+
+  ProtoFile upstream;
+  {
+    ProtoFile::Message message{};
+    message.name = "Container";
+    message.fields.push_back(MakeField("int32", "keep_me", 1));
+    message.fields.push_back(MakeField("string", "new_upstream", 2));
+    upstream.messages.push_back(message);
+  }
+
+  ProtoFile merged;
+  ASSERT_TRUE(MergeProtoFiles(input, upstream, Allowlist{}, merged).ok());
+
+  std::string out = ProtoFileToDotProto(merged);
+  EXPECT_THAT(out, HasSubstr("int32 keep_me = 1;"));
+  EXPECT_THAT(out, Not(HasSubstr("new_upstream")));
+}
+
+}  // namespace
+}  // namespace proto_merger
+}  // namespace perfetto


### PR DESCRIPTION
When a field still exists in our local proto but was removed upstream, proto_merger is supposed to keep it under a "not present upstream" comment. That worked for plain message fields, but fields inside a oneof and enum values were dropped from the output: the merge step tracked them as deleted, the serializer just never wrote them back.

- Write back deleted oneof fields and enum values, under the same comment used for the other deleted items.
- Split the sources into a lib target so tests can link against them.
- Add tests for the serializer and a merge round trip, hooked into perfetto_unittests.