### PR TITLE
ai/skills: add GPU frequency residency workflow

### DIFF
--- a/ai/skills/perfetto/workflows/gpu/frequency_residency.md
+++ b/ai/skills/perfetto/workflows/gpu/frequency_residency.md
@@ -1,0 +1,252 @@
+# GPU frequency residency — the GPU is busy, but at what clock?
+
+This workflow looks at the GPU's clock while it is doing work. Whether the GPU
+is **busy** or **idle** is a separate question; this one assumes you already
+have busy time to explain and asks, *during that busy time*, whether the device
+ran at its peak frequency or was held back. A GPU that is busy 100% of the time
+but pinned at half its clock is leaving half its throughput on the table — and a
+busy/idle view, or a steady-state frequency average, cannot see that.
+
+It works on any trace that has a canonical GPU **frequency** track — the
+`gpufreq` counter track (one per GPU) that the Perfetto UI renders as the
+per-GPU *Frequency* track. It catches the two classic, workload-agnostic
+clock pathologies:
+
+- **Slow DVFS ramp** after an idle→busy transition: the clock starts at a floor
+  state and takes time to ramp up, so the work that woke the GPU runs slow.
+  Bursty workloads (UI rendering, inference serving) pay this repeatedly and it
+  is invisible in pure occupancy.
+- **Sustained throttling**: the clock held below peak *while busy*, usually
+  because of a physical limit — correlated here against temperature and power.
+
+If the user has not yet loaded a trace into `trace_processor`, follow
+`../../infra-references/querying.md` first, then come back here.
+
+> If `gpu_frequency_residency.sql` returns no rows, the trace has no `gpufreq`
+> track and this workflow does not apply.
+
+---
+
+## Phase 1: Mandatory first-pass triage
+
+Run this before any open-ended exploration. It produces the headline verdict.
+
+1.  Run the residency script. It takes the trace file as its argument and
+    returns one row per GPU (that has a frequency track) as CSV.
+
+    ```bash
+    trace_processor query --query-file scripts/gpu_frequency_residency.sql TRACE_FILE
+    ```
+
+    Columns: `gpu`, `gpu_name`, `active_span_ns`, `gpu_busy_ns`,
+    `busy_pct_of_active`, `fmax_mhz`, `mean_busy_mhz`, `eff_occupancy_pct`,
+    `freq_coverage_pct`.
+
+2.  Interpret. The headline is `eff_occupancy_pct` vs `busy_pct_of_active`:
+
+    - **`eff_occupancy_pct` ≈ `busy_pct_of_active`** — when the GPU is busy it
+      runs at (near) peak clock. The clock is healthy; the lever is elsewhere —
+      the device work itself, or the idle between work, not the clock. Stop here.
+    - **`eff_occupancy_pct` ≪ `busy_pct_of_active`** — the GPU is busy but
+      underclocked. The clock *is* the problem. Proceed to Phase 2 (ramp) and
+      Phase 3 (throttling) to find out why.
+    - **`fmax_mhz` is the max OBSERVED frequency**, not necessarily the hardware
+      ceiling. If the workload never demanded peak, `fmax` understates the true
+      maximum and `eff_occupancy_pct` is optimistic. Confirm the expected peak
+      with the user if it matters.
+    - **`freq_coverage_pct` well below 100** — some busy time had no frequency
+      sample; the figures are partial. Say so.
+
+3.  For the breakdown behind `mean_busy_mhz`, list the time spent at each clock
+    while busy (the residency histogram):
+
+    ```sql
+    INCLUDE PERFETTO MODULE counters.intervals;
+    INCLUDE PERFETTO MODULE intervals.overlap;
+    INCLUDE PERFETTO MODULE intervals.intersect;
+
+    CREATE PERFETTO TABLE _gpu_freq AS
+      SELECT f.id, f.ts, f.dur, f.value AS freq_khz, gct.ugpu
+      FROM counter_leading_intervals!((
+        SELECT c.id, c.ts, c.track_id, c.value
+        FROM counter AS c
+        JOIN gpu_counter_track AS gct ON gct.id = c.track_id
+        WHERE gct.name = 'gpufreq')) AS f
+      JOIN gpu_counter_track AS gct ON gct.id = f.track_id;
+
+    CREATE PERFETTO TABLE _gpu_busy AS
+      SELECT ROW_NUMBER() OVER (ORDER BY ugpu, ts) AS id, ugpu, ts, dur
+      FROM interval_merge_overlapping_partitioned!((
+        SELECT s.ts, s.dur,
+               IFNULL(EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu'), 0) AS ugpu
+        FROM gpu_slice AS s JOIN gpu_track AS t ON s.track_id = t.id
+        WHERE s.dur > 0), (ugpu));
+
+    SELECT b.ugpu AS gpu, f.freq_khz / 1000 AS freq_mhz,
+           SUM(ii.dur) AS busy_at_freq_ns,
+           ROUND(100.0 * SUM(ii.dur)
+                 / SUM(SUM(ii.dur)) OVER (PARTITION BY b.ugpu), 1) AS pct_of_busy
+    FROM _interval_intersect!((_gpu_busy, _gpu_freq), (ugpu)) AS ii
+    JOIN _gpu_busy AS b ON b.id = ii.id_0
+    JOIN _gpu_freq AS f ON f.id = ii.id_1
+    GROUP BY b.ugpu, f.freq_khz
+    ORDER BY b.ugpu, f.freq_khz;
+    ```
+
+4.  If the workload repeats a phase (e.g. an iteration marked by a named slice),
+    compute `eff_occupancy_pct` per window — usually the number that matters.
+    Substitute the boundary slice name; append this after the `_gpu_freq` /
+    `_gpu_busy` tables from step 3:
+
+    ```sql
+    CREATE PERFETTO TABLE windows AS
+      SELECT ROW_NUMBER() OVER (ORDER BY ts) AS id, name, ts, dur
+      FROM slice WHERE name GLOB 'YOUR_BOUNDARY_SLICE*' AND dur > 0;
+
+    CREATE PERFETTO TABLE _baf_iv AS
+      SELECT ROW_NUMBER() OVER (ORDER BY ii.ts) AS id, ii.ts, ii.dur,
+             f.freq_khz, b.ugpu
+      FROM _interval_intersect!((_gpu_busy, _gpu_freq), (ugpu)) AS ii
+      JOIN _gpu_busy AS b ON b.id = ii.id_0
+      JOIN _gpu_freq AS f ON f.id = ii.id_1;
+
+    SELECT w.name AS window, b.ugpu AS gpu, w.dur AS window_ns,
+           ROUND(100.0 * SUM(b.freq_khz * ii.dur)
+                 / (w.dur * (SELECT MAX(freq_khz) FROM _gpu_freq
+                             WHERE ugpu = b.ugpu)), 1) AS eff_occupancy_pct
+    FROM _interval_intersect!((windows, _baf_iv), ()) AS ii
+    JOIN windows AS w ON w.id = ii.id_0
+    JOIN _baf_iv AS b ON b.id = ii.id_1
+    GROUP BY w.id, w.name, b.ugpu, w.dur
+    ORDER BY w.ts;
+    ```
+
+---
+
+## Phase 2: Slow DVFS ramp
+
+> Run this when Phase 1 shows the GPU is busy but underclocked.
+
+1.  List the ramp events — idle→busy edges where the clock had to climb to reach
+    a healthy state:
+
+    ```bash
+    trace_processor query --query-file scripts/gpu_dvfs_ramp.sql TRACE_FILE
+    ```
+
+    Returns, worst first: `gpu`, `gpu_name`, `edge_rel_ns`, `idle_gap_ns`,
+    `freq_at_edge_mhz`, `target_mhz` (90% of `fmax`), `ramp_ns`, `completed`.
+    `idle_gap_ns` is NULL for the first burst (cold start). `completed = 0`
+    means the burst ended while still ramping, so `ramp_ns` is a lower bound.
+
+2.  Interpret:
+
+    - **Many edges with large `ramp_ns`** — the workload keeps letting the GPU
+      go idle and pays the wake-up cost each time. The lever is upstream: shrink
+      the idle gaps (batch work to amortize wake-ups, keep the device warm, or
+      tune the governor). Note that each such idle gap costs twice: the idle
+      itself, plus this ramp tax once work resumes.
+    - **`completed = 0` ramps** — bursts so short the clock never even reaches
+      peak before the work is done; the workload is paying ramp cost for almost
+      no peak-clock time.
+
+3.  For the aggregate tax — how much wall-clock is spent ramping — run the
+    summary:
+
+    ```sql
+    INCLUDE PERFETTO MODULE counters.intervals;
+    INCLUDE PERFETTO MODULE intervals.overlap;
+
+    CREATE PERFETTO TABLE _gpu_freq AS
+      SELECT f.id, f.ts, f.dur, f.value AS freq_khz, gct.ugpu
+      FROM counter_leading_intervals!((
+        SELECT c.id, c.ts, c.track_id, c.value
+        FROM counter AS c
+        JOIN gpu_counter_track AS gct ON gct.id = c.track_id
+        WHERE gct.name = 'gpufreq')) AS f
+      JOIN gpu_counter_track AS gct ON gct.id = f.track_id;
+
+    CREATE PERFETTO TABLE _gpu_busy AS
+      SELECT ugpu, ts, ts + dur AS te
+      FROM interval_merge_overlapping_partitioned!((
+        SELECT s.ts, s.dur,
+               IFNULL(EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu'), 0) AS ugpu
+        FROM gpu_slice AS s JOIN gpu_track AS t ON s.track_id = t.id
+        WHERE s.dur > 0), (ugpu));
+
+    CREATE PERFETTO TABLE _fmax AS
+      SELECT ugpu, MAX(freq_khz) AS fmax_khz FROM _gpu_freq GROUP BY ugpu;
+
+    CREATE PERFETTO TABLE _ramps AS
+      SELECT b.ugpu,
+        IFNULL((SELECT MIN(f.ts) FROM _gpu_freq AS f
+                WHERE f.ugpu = b.ugpu
+                  AND f.freq_khz >= 0.9 * (SELECT fmax_khz FROM _fmax WHERE ugpu = b.ugpu)
+                  AND f.ts >= b.ts AND f.ts < b.te), b.te) - b.ts AS ramp_ns
+      FROM _gpu_busy AS b
+      WHERE (SELECT f.freq_khz FROM _gpu_freq AS f
+             WHERE f.ugpu = b.ugpu AND f.ts <= b.ts AND f.ts + f.dur > b.ts)
+            < 0.9 * (SELECT fmax_khz FROM _fmax WHERE ugpu = b.ugpu);
+
+    SELECT ugpu AS gpu, COUNT(*) AS n_ramps, SUM(ramp_ns) AS total_ramp_ns,
+           CAST(AVG(ramp_ns) AS INT) AS mean_ramp_ns, MAX(ramp_ns) AS max_ramp_ns
+    FROM _ramps GROUP BY ugpu;
+    ```
+
+---
+
+## Phase 3: Sustained throttling
+
+> Run this when Phase 1 shows underclocking that Phase 2 does not fully explain
+> (i.e. the clock is low even outside the post-wake ramp).
+
+1.  List sustained throttle intervals — the clock held below target *after* it
+    had already reached target in the same burst — with thermal/power context:
+
+    ```bash
+    trace_processor query --query-file scripts/gpu_sustained_throttle.sql TRACE_FILE
+    ```
+
+    Returns, longest first: `gpu`, `gpu_name`, `start_rel_ns`, `dur_ns`,
+    `freq_mhz`, `target_mhz`, `temp_c`, `power_w`.
+
+2.  Interpret the correlation:
+
+    - **High `temp_c` + capped clock** — thermal throttling. The lever is
+      cooling / thermal headroom, not the code.
+    - **High `power_w` + capped clock** — power-limited. The lever is the power
+      budget / cap.
+    - **Neither elevated (or both NULL)** — the cap is policy or governor
+      behaviour, not a physical limit; or the trace lacks `Temperature` / `Power`
+      tracks for that GPU (NULL). Note which.
+    - **No rows** — no sustained throttling; the underclock from Phase 1 is the
+      ramp (Phase 2), not throttling.
+
+---
+
+## Phase 4: Reporting
+
+A good summary states:
+
+1.  **The verdict** — clock-healthy, ramp-bound, or throttle-bound, with the
+    numbers (`eff_occupancy_pct` vs `busy_pct_of_active`, and per-window if
+    available).
+2.  **Where the clock loss is** — the worst ramps (with idle gaps) and/or the
+    throttle intervals (with the temperature/power that explains them), named
+    concretely.
+3.  **The lever** — ramp: shrink idle gaps, batch work to amortize wake-ups,
+    keep the device warm, tune the governor. Throttle: cooling / power headroom.
+    Clock-healthy: the lever is elsewhere — the device work or the idle between
+    work, not the clock.
+
+Keep the SQL and timestamps available so the user can audit. For multi-GPU
+traces, every script is per-GPU; a GPU with activity but no `gpufreq` track is
+simply absent from Phase 1 — say so rather than implying it ran at peak.
+
+## Reference
+
+- GPU data sources: <https://perfetto.dev/docs/data-sources/gpu>
+- Canonical frequency track: `gpu_counter_track` where `name = 'gpufreq'`
+  (type `gpu_frequency`, kHz); stdlib analog `android.gpu.frequency`.
+- Interval helpers: stdlib `counters.intervals`, `intervals.overlap`,
+  `intervals.intersect`.

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_dvfs_ramp.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_dvfs_ramp.sql
@@ -1,0 +1,121 @@
+-- DVFS ramp latency after idle->busy transitions.
+--
+-- When a GPU wakes from idle, its clock is at a low (floor) state and the DVFS
+-- governor must ramp it up. Until it reaches a healthy clock, the work that
+-- triggered the wake runs slow. This tax is invisible to a busy/idle view and
+-- to a steady-state frequency average -- it only shows up right after each
+-- idle->busy edge. Bursty workloads (UI rendering, inference serving) pay it
+-- repeatedly.
+--
+-- For every idle->busy edge (the start of a merged busy interval) where the
+-- clock is below target, this reports how long until the clock first reaches
+-- the target. Edges already at/above target are skipped (no ramp needed).
+--
+-- target = 90% of the per-GPU max OBSERVED frequency. To change it, edit the
+-- 0.9 factor below.
+--
+-- Columns (worst ramps first):
+--   edge_rel_ns       : edge timestamp, relative to trace start.
+--   idle_gap_ns       : idle gap immediately before the edge; NULL for the
+--                       first burst (cold start / trace boundary). A larger gap
+--                       means the clock had more time to drop.
+--   freq_at_edge_mhz  : clock at the moment work resumed.
+--   target_mhz        : 90% of fmax.
+--   ramp_ns           : time from the edge until the clock first reaches target.
+--   completed         : 1 if target was reached before the burst ended; 0 if the
+--                       burst ended still ramping (ramp_ns is then a lower bound:
+--                       edge..burst end).
+
+INCLUDE PERFETTO MODULE counters.intervals;
+
+INCLUDE PERFETTO MODULE intervals.overlap;
+
+CREATE PERFETTO TABLE _gpu_freq AS
+SELECT f.id, f.ts, f.dur, f.value AS freq_khz, gct.ugpu
+FROM counter_leading_intervals!((
+    SELECT c.id, c.ts, c.track_id, c.value
+    FROM counter AS c
+    JOIN gpu_counter_track AS gct ON gct.id = c.track_id
+    WHERE gct.name = 'gpufreq'
+  )) AS f
+JOIN gpu_counter_track AS gct
+  ON gct.id = f.track_id;
+
+CREATE PERFETTO TABLE _gpu_busy AS
+SELECT
+  ROW_NUMBER() OVER (ORDER BY ugpu, ts) AS id,
+  ugpu,
+  ts,
+  dur,
+  ts + dur AS te
+FROM interval_merge_overlapping_partitioned!((
+    SELECT
+      s.ts,
+      s.dur,
+      IFNULL(EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu'), 0) AS ugpu
+    FROM gpu_slice AS s
+    JOIN gpu_track AS t ON s.track_id = t.id
+    WHERE
+      s.dur > 0
+  ), (ugpu));
+
+CREATE PERFETTO TABLE _fmax AS
+SELECT ugpu, MAX(freq_khz) AS fmax_khz FROM _gpu_freq GROUP BY ugpu;
+
+-- One row per idle->busy edge, with the clock at the edge and the preceding gap.
+CREATE PERFETTO TABLE _edges AS
+SELECT
+  b.ugpu,
+  b.ts AS edge_ts,
+  b.te AS busy_end,
+  b.ts - LAG(b.te) OVER (PARTITION BY b.ugpu ORDER BY b.ts) AS idle_gap_ns,
+  (
+    SELECT f.freq_khz
+    FROM _gpu_freq AS f
+    WHERE
+      f.ugpu = b.ugpu
+      AND f.ts <= b.ts
+      AND f.ts + f.dur > b.ts
+  ) AS freq_at_edge_khz,
+  (SELECT fmax_khz FROM _fmax WHERE ugpu = b.ugpu) AS fmax_khz
+FROM _gpu_busy AS b;
+
+SELECT
+  e.ugpu AS gpu,
+  IFNULL(g.name, 'GPU ' || e.ugpu) AS gpu_name,
+  e.edge_ts - trace_start() AS edge_rel_ns,
+  e.idle_gap_ns,
+  e.freq_at_edge_khz / 1000 AS freq_at_edge_mhz,
+  CAST(0.9 * e.fmax_khz AS INT) / 1000 AS target_mhz,
+  IFNULL(
+    (
+      SELECT MIN(f.ts)
+      FROM _gpu_freq AS f
+      WHERE
+        f.ugpu = e.ugpu
+        AND f.freq_khz >= 0.9 * e.fmax_khz
+        AND f.ts >= e.edge_ts
+        AND f.ts < e.busy_end
+    ),
+    e.busy_end
+  )
+  - e.edge_ts AS ramp_ns,
+  CASE
+    WHEN (
+      SELECT MIN(f.ts)
+      FROM _gpu_freq AS f
+      WHERE
+        f.ugpu = e.ugpu
+        AND f.freq_khz >= 0.9 * e.fmax_khz
+        AND f.ts >= e.edge_ts
+        AND f.ts < e.busy_end
+    ) IS NOT NULL THEN 1
+    ELSE 0
+  END AS completed
+FROM _edges AS e
+LEFT JOIN gpu AS g ON g.ugpu = e.ugpu
+WHERE
+  e.freq_at_edge_khz < 0.9 * e.fmax_khz
+ORDER BY
+  ramp_ns DESC
+LIMIT 20;

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_frequency_residency.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_frequency_residency.sql
@@ -1,0 +1,108 @@
+-- GPU frequency residency during busy time + effective occupancy.
+--
+-- Skill "timeline occupancy" answers "is the GPU busy?". This answers the next
+-- question: "the GPU is busy, but at what clock?". A device that is busy 100% of
+-- the time but pinned at half its peak frequency is leaving half its throughput
+-- on the table, and a pure busy/idle decomposition cannot see that.
+--
+-- It composes with the busy timeline: "busy" is the UNION of GPU activity
+-- intervals (concurrency on multiple hardware queues is merged, not summed), and
+-- each slice of busy time is attributed to the GPU frequency in effect during
+-- it. The frequency source is the canonical per-GPU "gpufreq" counter track
+-- (type gpu_frequency, kHz) -- the same track the Perfetto UI renders as the
+-- per-GPU "Frequency" track -- expanded into gapless intervals.
+--
+-- No parameters; operates over each GPU's active span (first..last activity).
+-- One row per GPU that has a gpufreq track. Columns:
+--   busy_pct_of_active : busy / active span                 -> packing.
+--   fmax_mhz           : max OBSERVED frequency (peak seen in this trace, not
+--                        necessarily the hardware ceiling).
+--   mean_busy_mhz      : time-weighted mean clock while busy.
+--   eff_occupancy_pct  : busy_pct_of_active * (mean_busy / fmax). The single
+--                        "useful work" figure: how much of peak the GPU
+--                        actually delivered over the active span. eff well below
+--                        busy_pct_of_active means the clock, not idle, is the
+--                        lever (see gpu_dvfs_ramp.sql / gpu_sustained_throttle.sql).
+--   freq_coverage_pct  : fraction of busy time that had a frequency sample. If
+--                        low, the numbers above are partial -- treat with care.
+
+INCLUDE PERFETTO MODULE counters.intervals;
+
+INCLUDE PERFETTO MODULE intervals.overlap;
+
+INCLUDE PERFETTO MODULE intervals.intersect;
+
+-- Canonical per-GPU frequency timeline (gpufreq), gapless, keyed by ugpu.
+CREATE PERFETTO TABLE _gpu_freq AS
+SELECT f.id, f.ts, f.dur, f.value AS freq_khz, gct.ugpu
+FROM counter_leading_intervals!((
+    SELECT c.id, c.ts, c.track_id, c.value
+    FROM counter AS c
+    JOIN gpu_counter_track AS gct ON gct.id = c.track_id
+    WHERE gct.name = 'gpufreq'
+  )) AS f
+JOIN gpu_counter_track AS gct
+  ON gct.id = f.track_id;
+
+-- Device-busy timeline per GPU (union of GPU activity).
+CREATE PERFETTO TABLE _gpu_busy AS
+SELECT ROW_NUMBER() OVER (ORDER BY ugpu, ts) AS id, ugpu, ts, dur
+FROM interval_merge_overlapping_partitioned!((
+    SELECT
+      s.ts,
+      s.dur,
+      IFNULL(EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu'), 0) AS ugpu
+    FROM gpu_slice AS s
+    JOIN gpu_track AS t ON s.track_id = t.id
+    WHERE
+      s.dur > 0
+  ), (ugpu));
+
+-- Busy time attributed to the frequency in effect (busy intersect freq).
+CREATE PERFETTO TABLE _busy_at_freq AS
+SELECT b.ugpu, f.freq_khz, ii.dur
+FROM _interval_intersect!((_gpu_busy, _gpu_freq), (ugpu)) AS ii
+JOIN _gpu_busy AS b
+  ON b.id = ii.id_0
+JOIN _gpu_freq AS f
+  ON f.id = ii.id_1;
+
+CREATE PERFETTO TABLE _span AS
+SELECT
+  ugpu,
+  MIN(ts) AS span_start,
+  MAX(ts + dur) AS span_end,
+  SUM(dur) AS busy_ns
+FROM _gpu_busy
+GROUP BY
+  ugpu;
+
+SELECT
+  s.ugpu AS gpu,
+  IFNULL(g.name, 'GPU ' || s.ugpu) AS gpu_name,
+  s.span_end - s.span_start AS active_span_ns,
+  s.busy_ns AS gpu_busy_ns,
+  ROUND(100.0 * s.busy_ns / (s.span_end - s.span_start), 1) AS busy_pct_of_active,
+  (SELECT MAX(freq_khz) FROM _gpu_freq WHERE ugpu = s.ugpu) / 1000 AS fmax_mhz,
+  ROUND(
+    (SELECT SUM(dur * freq_khz) FROM _busy_at_freq WHERE ugpu = s.ugpu) * 1.0
+    / (SELECT SUM(dur) FROM _busy_at_freq WHERE ugpu = s.ugpu)
+    / 1000,
+    0
+  ) AS mean_busy_mhz,
+  ROUND(
+    100.0 * (SELECT SUM(dur * freq_khz) FROM _busy_at_freq WHERE ugpu = s.ugpu)
+    / ((s.span_end - s.span_start)
+    * (SELECT MAX(freq_khz) FROM _gpu_freq WHERE ugpu = s.ugpu)),
+    1
+  ) AS eff_occupancy_pct,
+  ROUND(
+    100.0 * (SELECT SUM(dur) FROM _busy_at_freq WHERE ugpu = s.ugpu) / s.busy_ns,
+    1
+  ) AS freq_coverage_pct
+FROM _span AS s
+LEFT JOIN gpu AS g ON g.ugpu = s.ugpu
+WHERE
+  EXISTS (SELECT 1 FROM _gpu_freq WHERE ugpu = s.ugpu)
+ORDER BY
+  s.ugpu;

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_sustained_throttle.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_sustained_throttle.sql
@@ -1,0 +1,139 @@
+-- Sustained GPU throttling: clock held below target while busy, after it had
+-- already ramped up -- correlated with temperature and power.
+--
+-- This is distinct from DVFS ramp (gpu_dvfs_ramp.sql). A ramp is the transient
+-- low-clock period right after waking from idle. Throttling is the clock falling
+-- back below target *after* it had reached target within the same burst -- i.e.
+-- the governor pulling the clock down while there is still work to do. That
+-- usually means a physical limit: thermal or power.
+--
+-- An interval counts as throttling when, while the GPU is busy:
+--   1. freq < target (90% of the per-GPU max OBSERVED frequency), AND
+--   2. it starts at/after the moment the clock first reached target following
+--      the most recent idle->busy edge (so the initial ramp is excluded), AND
+--   3. it lasts at least min_sustained_ns.
+-- To change the thresholds, edit the 0.9 factor and the `>= 1000` floor below.
+-- The 1000 ns floor only drops sub-microsecond noise; raise it (e.g. to 1e6 for
+-- 1 ms) to focus on genuinely sustained throttling.
+--
+-- Temperature (C) and Power (W) are read from the canonical per-GPU counter
+-- tracks if present and averaged over each throttle interval; NULL means no
+-- such track, or no sample landed inside a short interval. High temp + capped
+-- clock => thermal; high power + capped clock => power-limited.
+--
+-- Columns (longest throttle intervals first):
+--   start_rel_ns : interval start, relative to trace start.
+--   dur_ns       : how long the clock was held below target.
+--   freq_mhz     : the (reduced) clock during the interval.
+--   target_mhz   : 90% of fmax.
+--   temp_c       : mean GPU temperature over the interval (NULL if unavailable).
+--   power_w      : mean GPU power over the interval (NULL if unavailable).
+
+INCLUDE PERFETTO MODULE counters.intervals;
+
+INCLUDE PERFETTO MODULE intervals.overlap;
+
+INCLUDE PERFETTO MODULE intervals.intersect;
+
+CREATE PERFETTO TABLE _gpu_freq AS
+SELECT f.id, f.ts, f.dur, f.value AS freq_khz, gct.ugpu
+FROM counter_leading_intervals!((
+    SELECT c.id, c.ts, c.track_id, c.value
+    FROM counter AS c
+    JOIN gpu_counter_track AS gct ON gct.id = c.track_id
+    WHERE gct.name = 'gpufreq'
+  )) AS f
+JOIN gpu_counter_track AS gct
+  ON gct.id = f.track_id;
+
+CREATE PERFETTO TABLE _gpu_busy AS
+SELECT
+  ROW_NUMBER() OVER (ORDER BY ugpu, ts) AS id,
+  ugpu,
+  ts,
+  dur,
+  ts + dur AS te
+FROM interval_merge_overlapping_partitioned!((
+    SELECT
+      s.ts,
+      s.dur,
+      IFNULL(EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu'), 0) AS ugpu
+    FROM gpu_slice AS s
+    JOIN gpu_track AS t ON s.track_id = t.id
+    WHERE
+      s.dur > 0
+  ), (ugpu));
+
+CREATE PERFETTO TABLE _fmax AS
+SELECT ugpu, MAX(freq_khz) AS fmax_khz FROM _gpu_freq GROUP BY ugpu;
+
+-- For each busy edge, the instant the clock first reached target after it.
+CREATE PERFETTO TABLE _edges AS
+SELECT
+  b.ugpu,
+  b.ts AS edge_ts,
+  (
+    SELECT MIN(f.ts)
+    FROM _gpu_freq AS f
+    WHERE
+      f.ugpu = b.ugpu
+      AND f.freq_khz >= 0.9 * (SELECT fmax_khz FROM _fmax WHERE ugpu = b.ugpu)
+      AND f.ts >= b.ts
+      AND f.ts < b.te
+  ) AS ramp_reach_ts
+FROM _gpu_busy AS b;
+
+-- Busy time spent below target (busy intersect low-frequency intervals).
+CREATE PERFETTO TABLE _low_busy AS
+SELECT ii.ts, ii.dur, f.freq_khz, b.ugpu
+FROM _interval_intersect!((_gpu_busy, _gpu_freq), (ugpu)) AS ii
+JOIN _gpu_busy AS b
+  ON b.id = ii.id_0
+JOIN _gpu_freq AS f
+  ON f.id = ii.id_1
+WHERE
+  f.freq_khz < 0.9 * (SELECT fmax_khz FROM _fmax WHERE ugpu = b.ugpu);
+
+SELECT
+  l.ugpu AS gpu,
+  IFNULL(g.name, 'GPU ' || l.ugpu) AS gpu_name,
+  l.ts - trace_start() AS start_rel_ns,
+  l.dur AS dur_ns,
+  l.freq_khz / 1000 AS freq_mhz,
+  CAST(0.9 * (SELECT fmax_khz FROM _fmax WHERE ugpu = l.ugpu) AS INT) / 1000 AS target_mhz,
+  (
+    SELECT ROUND(AVG(c.value), 1)
+    FROM counter AS c
+    JOIN gpu_counter_track AS t ON t.id = c.track_id
+    WHERE
+      t.name = 'Temperature'
+      AND t.ugpu = l.ugpu
+      AND c.ts >= l.ts
+      AND c.ts < l.ts + l.dur
+  ) AS temp_c,
+  (
+    SELECT ROUND(AVG(c.value), 1)
+    FROM counter AS c
+    JOIN gpu_counter_track AS t ON t.id = c.track_id
+    WHERE
+      t.name = 'Power'
+      AND t.ugpu = l.ugpu
+      AND c.ts >= l.ts
+      AND c.ts < l.ts + l.dur
+  ) AS power_w
+FROM _low_busy AS l
+LEFT JOIN gpu AS g ON g.ugpu = l.ugpu
+WHERE
+  l.dur >= 1000
+  AND l.ts
+  >= (
+    SELECT MAX(e.ramp_reach_ts)
+    FROM _edges AS e
+    WHERE
+      e.ugpu = l.ugpu
+      AND e.edge_ts <= l.ts
+      AND e.ramp_reach_ts IS NOT NULL
+  )
+ORDER BY
+  l.dur DESC
+LIMIT 20;

--- a/ai/skills/perfetto/workflows/gpu/timeline_occupancy.md
+++ b/ai/skills/perfetto/workflows/gpu/timeline_occupancy.md
@@ -36,8 +36,11 @@ Run this before any open-ended exploration. It produces the headline verdict.
 
     - **`busy_pct_of_active` is high (≳ 90%)** — within the window where the GPU
       is doing work, activity is packed back-to-back. This is **GPU-bound**: the
-      lever is the device work itself, not the host. Stop here unless the user
-      wants deeper device-side analysis.
+      lever is the device work itself, not the host. The first deeper
+      device-side question is *at what clock* the GPU ran while busy — a device
+      packed at half its peak frequency looks GPU-bound but is really
+      clock-limited. To check, read
+      [frequency_residency.md](frequency_residency.md).
     - **`busy_pct_of_active` is low** — there are meaningful idle gaps *between*
       activities even while the workload is "running." This is **host-bound** /
       stalled. Proceed to Phase 2 to find and attribute the gaps.


### PR DESCRIPTION
Adds a GPU workflow that, given device-busy time, answers at what clock the GPU actually ran: per-GPU effective occupancy (busy % of active span x mean-busy-clock / observed peak), a frequency residency histogram, slow DVFS ramp after idle->busy transitions, and sustained throttling correlated with temperature and power. It composes on the timeline occupancy busy timeline and uses the canonical per-GPU gpufreq track. Includes three parameter-free triage scripts; reached from the timeline occupancy workflow's GPU-bound branch rather than the top-level router.