### PR TITLE
perfetto: export trace protos from winscope_extensions for Bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9795,6 +9795,7 @@ perfetto_proto_library(
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_protos",
     ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
+        ":protos_perfetto_trace_non_minimal_protos",
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_protos",
     ],
 )

--- a/protos/third_party/android/frameworks/native/tracing/winscope/BUILD.gn
+++ b/protos/third_party/android/frameworks/native/tracing/winscope/BUILD.gn
@@ -99,6 +99,9 @@ perfetto_proto_library("winscope_extensions_@TYPE@") {
     "../../../base/proto/tracing/winscope/view/windowlayoutparams.proto",
     "../../../base/proto/tracing/winscope/windowmanager.proto",
   ]
-  public_deps = [ ":winscope_regular_@TYPE@" ]
+  public_deps = [
+    ":winscope_regular_@TYPE@",
+    "../../../../../../perfetto/trace:non_minimal_@TYPE@",
+  ]
   import_dirs = [ "${perfetto_protobuf_src_dir}" ]
 }


### PR DESCRIPTION
The winscope wiring files (frameworks_native_winscope.proto, frameworks_base_winscope.proto) use import public of trace_packet.proto, and Bazel requires the proto_library providing a public import to be listed directly in exports; getting it transitively via winscope_regular is not enough. Add trace:non_minimal to winscope_extensions' public_deps so the generated exports include it directly.
