### PR TITLE
protozero: speed up TypedProtoDecoder

### DIFF
--- a/include/perfetto/protozero/proto_decoder.h
+++ b/include/perfetto/protozero/proto_decoder.h
@@ -334,14 +334,22 @@ class PERFETTO_EXPORT_COMPONENT TypedProtoDecoderBase : public ProtoDecoder {
   // If the field |id| is known at compile time, prefer the templated
   // specialization at<kFieldNumber>().
   const Field& Get(uint32_t id) const {
-    if (PERFETTO_LIKELY(id < num_fields_ && id < size_))
+    // Presence is tracked by |presence_| (see HasField()), so the field storage
+    // is left uninitialized and reads are gated on the bitmap. HasField(id)
+    // implies the slot was written (and the storage expanded to cover it), so
+    // fields_[id] is safe to dereference. Out-of-range or never-seen ids
+    // resolve to a static invalid field.
+    if (PERFETTO_LIKELY(id < num_fields_) && HasField(id))
       return fields_[id];
-    // If id >= num_fields_, the field id is invalid (was not known in the
-    // .proto) and we return the 0th field, which is always !valid().
-    // If id >= size_ and <= num_fields, the id is valid but the field has not
-    // been seen while decoding (hence the stack storage has not been expanded)
-    // so we return the 0th invalid field.
-    return fields_[0];
+    return kInvalidField;
+  }
+
+  // True if the field with the given id was seen while decoding. Presence is
+  // tracked by a bitmap (1 bit per field id, sized to num_fields_) instead of
+  // zero-initializing the whole field storage: this replaces the unconditional
+  // 1.6KB memset with a clear of num_fields_/8 bytes.
+  bool HasField(uint32_t id) const {
+    return (presence_[id >> 6] >> (id & 63)) & 1u;
   }
 
   // Like Get(), but also resolves "extension" fields whose id exceeds the
@@ -464,29 +472,41 @@ class PERFETTO_EXPORT_COMPONENT TypedProtoDecoderBase : public ProtoDecoder {
 
  protected:
   TypedProtoDecoderBase(Field* storage,
+                        uint64_t* presence,
                         uint32_t num_fields,
                         uint32_t capacity,
                         const uint8_t* buffer,
                         size_t length)
       : ProtoDecoder(buffer, length),
         fields_(storage),
+        presence_(presence),
         num_fields_(num_fields),
         // The reason for "capacity -1" is to avoid hitting the expansion path
         // in TypedProtoDecoderBase::ParseAllFields() when we are just setting
         // fields < INITIAL_STACK_CAPACITY (which is the most common case).
         size_(std::min(num_fields, capacity - 1)),
         capacity_(capacity) {
-    // The reason why Field needs to be trivially de/constructible is to avoid
-    // implicit initializers on all the ~1000 entries. We need it to initialize
-    // only on the first |max_field_id| fields, the remaining capacity doesn't
-    // require initialization.
+    // Field storage is left uninitialized: presence is tracked by |presence_|
+    // and reads are gated on HasField(), so we only clear the presence bitmap
+    // (num_fields_/8 bytes) instead of the whole field storage. Field must stay
+    // trivially de/constructible for leaving it uninitialized to be well
+    // defined.
     static_assert(std::is_trivially_constructible<Field>::value &&
                       std::is_trivially_destructible<Field>::value &&
                       std::is_trivial<Field>::value,
                   "Field must be a trivial aggregate type");
-    memset(fields_, 0, sizeof(Field) * capacity_);
+    memset(presence_, 0, sizeof(uint64_t) * ((num_fields_ + 63) / 64));
     PERFETTO_DCHECK(capacity > 0);
   }
+
+  // Marks the field with the given id as present. See HasField().
+  void SetField(uint32_t id) {
+    presence_[id >> 6] |= uint64_t(1) << (id & 63);
+  }
+
+  // Returned by Get()/at() for fields that were not seen while decoding. Always
+  // !valid() (id == 0). Replaces the reliance on a zeroed fields_[0].
+  static const Field kInvalidField;
 
   void ParseAllFields();
 
@@ -502,6 +522,10 @@ class PERFETTO_EXPORT_COMPONENT TypedProtoDecoderBase : public ProtoDecoder {
   // specialization) or |heap_storage_| after ExpandHeapStorage() is called, in
   // case of a large number of repeated fields.
   Field* fields_;
+
+  // Presence bitmap, 1 bit per field id, sized to cover [0, num_fields_).
+  // Provided by the template specialization (always on-stack). See HasField().
+  uint64_t* presence_;
 
   // Number of known fields, without accounting repeated storage. This is equal
   // to MAX_FIELD_ID + 1 (to account for the invalid 0th field). It never
@@ -545,6 +569,7 @@ class TypedProtoDecoder : public TypedProtoDecoderBase {
  public:
   TypedProtoDecoder(const uint8_t* buffer, size_t length)
       : TypedProtoDecoderBase(on_stack_storage_,
+                              presence_storage_,
                               /*num_fields=*/MAX_FIELD_ID + 1,
                               PROTOZERO_DECODER_INITIAL_STACK_CAPACITY,
                               buffer,
@@ -555,12 +580,12 @@ class TypedProtoDecoder : public TypedProtoDecoderBase {
   template <uint32_t FIELD_ID>
   const Field& at() const {
     static_assert(FIELD_ID <= MAX_FIELD_ID, "FIELD_ID > MAX_FIELD_ID");
-    // If the field id is < the on-stack capacity, it's safe to always
-    // dereference |fields_|, whether it's still using the stack or it fell
-    // back on the heap. Because both terms of the if () are known at compile
-    // time, the compiler elides the branch for ids < INITIAL_STACK_CAPACITY.
+    // For ids < the on-stack capacity, fields_[FIELD_ID] always exists (the
+    // on-stack array covers it, and a heap fallback only grows the storage), so
+    // we just gate the read on the presence bit. The branch on FIELD_ID is
+    // resolved at compile time.
     if (FIELD_ID < PROTOZERO_DECODER_INITIAL_STACK_CAPACITY) {
-      return fields_[FIELD_ID];
+      return HasField(FIELD_ID) ? fields_[FIELD_ID] : kInvalidField;
     } else {
       // Otherwise use the slowpath Get() which will do a runtime check.
       return Get(FIELD_ID);
@@ -610,9 +635,14 @@ class TypedProtoDecoder : public TypedProtoDecoderBase {
       memcpy(on_stack_storage_, other.on_stack_storage_,
              sizeof(on_stack_storage_));
     }
+    // The presence bitmap is always on-stack; repoint and copy it.
+    presence_ = presence_storage_;
+    memcpy(presence_storage_, other.presence_storage_,
+           sizeof(presence_storage_));
   }
 
   Field on_stack_storage_[PROTOZERO_DECODER_INITIAL_STACK_CAPACITY];
+  uint64_t presence_storage_[(MAX_FIELD_ID + 1 + 63) / 64];
 };
 
 }  // namespace protozero

--- a/include/perfetto/protozero/proto_utils.h
+++ b/include/perfetto/protozero/proto_utils.h
@@ -23,6 +23,7 @@
 #include <type_traits>
 
 #include "perfetto/base/logging.h"
+#include "perfetto/public/compiler.h"
 #include "perfetto/public/pb_utils.h"
 
 // Helper macro for the constexpr functions containing
@@ -307,6 +308,52 @@ inline const uint8_t* ParseVarInt(const uint8_t* start,
                                   const uint8_t* end,
                                   uint64_t* out_value) {
   return PerfettoPbParseVarInt(start, end, out_value);
+}
+
+// Unrolled multi-byte varint decode. Avoids the per-byte bounds-check + loop
+// branch of ParseVarInt, which matters for long varints (e.g. ftrace
+// timestamps are 8-10 bytes). The caller must guarantee at least 10 readable
+// bytes at |p| and that p[0] has the continuation bit set. Returns nullptr on
+// an overlong (> 10 byte) varint. The 10th byte contributes only its low bit
+// (matching ParseVarInt).
+PERFETTO_ALWAYS_INLINE inline const uint8_t* ParseVarIntUnrolled(
+    const uint8_t* p,
+    uint64_t* out) {
+  uint64_t value = p[0] & 0x7Fu;
+#define PERFETTO_PZ_VARINT_STEP(i)                           \
+  value |= static_cast<uint64_t>(p[i] & 0x7Fu) << (7 * (i)); \
+  if (PERFETTO_LIKELY(!(p[i] & 0x80))) {                     \
+    *out = value;                                            \
+    return p + (i) + 1;                                      \
+  }
+  PERFETTO_PZ_VARINT_STEP(1)
+  PERFETTO_PZ_VARINT_STEP(2)
+  PERFETTO_PZ_VARINT_STEP(3)
+  PERFETTO_PZ_VARINT_STEP(4)
+  PERFETTO_PZ_VARINT_STEP(5)
+  PERFETTO_PZ_VARINT_STEP(6)
+  PERFETTO_PZ_VARINT_STEP(7)
+  PERFETTO_PZ_VARINT_STEP(8)
+  PERFETTO_PZ_VARINT_STEP(9)
+#undef PERFETTO_PZ_VARINT_STEP
+  return nullptr;
+}
+
+// Decodes a varint at |pos|: single-byte fastpath, then the unrolled decode
+// when there is enough headroom, then the bounded byte-loop near the end of the
+// buffer. Returns nullptr on a truncated/overlong varint (note: unlike
+// ParseVarInt, which returns |pos| on failure).
+PERFETTO_ALWAYS_INLINE inline const uint8_t* ParseVarIntFast(const uint8_t* pos,
+                                                             const uint8_t* end,
+                                                             uint64_t* out) {
+  if (PERFETTO_LIKELY(pos < end && *pos < 0x80)) {
+    *out = *pos;
+    return pos + 1;
+  }
+  if (PERFETTO_LIKELY(end - pos >= 10))
+    return ParseVarIntUnrolled(pos, out);
+  const uint8_t* next = ParseVarInt(pos, end, out);
+  return next == pos ? nullptr : next;
 }
 
 enum class RepetitionType {

--- a/src/protozero/BUILD.gn
+++ b/src/protozero/BUILD.gn
@@ -154,10 +154,14 @@ if (enable_perfetto_benchmarks) {
       ":testing_messages_zero",
       "../../gn:benchmark",
       "../../gn:default_deps",
+      "../../protos/perfetto/trace:zero",
+      "../../protos/perfetto/trace/ftrace:zero",
+      "../../protos/perfetto/trace/track_event:zero",
       "../base",
       "../base:test_support",
     ]
     sources = [
+      "test/proto_decoder_benchmark.cc",
       "test/proto_ring_buffer_benchmark.cc",
       "test/protozero_benchmark.cc",
     ]

--- a/src/protozero/proto_decoder.cc
+++ b/src/protozero/proto_decoder.cc
@@ -35,6 +35,8 @@ using namespace proto_utils;
 #error Unimplemented for big endian archs.
 #endif
 
+const Field TypedProtoDecoderBase::kInvalidField{};
+
 namespace {
 
 struct ParseFieldResult {
@@ -77,56 +79,49 @@ ParseFieldResult ParseOneField(const uint8_t* const buffer,
   uint64_t int_value = 0;
   uint64_t size = 0;
 
-  switch (field_type) {
-    case static_cast<uint8_t>(ProtoWireType::kVarInt): {
-      new_pos = ParseVarInt(pos, end, &int_value);
+  // An if-chain ordered by frequency beats a switch jump table here: the
+  // wire-type sequence within one message type is near-constant, so these
+  // branches predict almost perfectly, whereas the jump table compiles to a
+  // hard-to-predict indirect jump.
+  if (PERFETTO_LIKELY(field_type ==
+                      static_cast<uint8_t>(ProtoWireType::kVarInt))) {
+    new_pos = ParseVarInt(pos, end, &int_value);
 
-      // new_pos not being greater than pos means ParseVarInt could not fully
-      // parse the number. This is because we are out of space in the buffer.
-      // Set the id to zero and return but don't update the offset so a future
-      // read can read this field.
-      if (PERFETTO_UNLIKELY(new_pos == pos))
-        return res;
-
-      break;
-    }
-
-    case static_cast<uint8_t>(ProtoWireType::kLengthDelimited): {
-      uint64_t payload_length;
-      new_pos = ParseVarInt(pos, end, &payload_length);
-      if (PERFETTO_UNLIKELY(new_pos == pos))
-        return res;
-
-      // ParseVarInt guarantees that |new_pos| <= |end| when it succeeds;
-      if (payload_length > static_cast<uint64_t>(end - new_pos))
-        return res;
-
-      const uintptr_t payload_start = reinterpret_cast<uintptr_t>(new_pos);
-      int_value = payload_start;
-      size = payload_length;
-      new_pos += payload_length;
-      break;
-    }
-
-    case static_cast<uint8_t>(ProtoWireType::kFixed64): {
-      new_pos = pos + sizeof(uint64_t);
-      if (PERFETTO_UNLIKELY(new_pos > end))
-        return res;
-      memcpy(&int_value, pos, sizeof(uint64_t));
-      break;
-    }
-
-    case static_cast<uint8_t>(ProtoWireType::kFixed32): {
-      new_pos = pos + sizeof(uint32_t);
-      if (PERFETTO_UNLIKELY(new_pos > end))
-        return res;
-      memcpy(&int_value, pos, sizeof(uint32_t));
-      break;
-    }
-
-    default:
-      PERFETTO_DLOG("Invalid proto field type: %u", field_type);
+    // new_pos not being greater than pos means ParseVarInt could not fully
+    // parse the number. This is because we are out of space in the buffer.
+    // Set the id to zero and return but don't update the offset so a future
+    // read can read this field.
+    if (PERFETTO_UNLIKELY(new_pos == pos))
       return res;
+  } else if (PERFETTO_LIKELY(
+                 field_type ==
+                 static_cast<uint8_t>(ProtoWireType::kLengthDelimited))) {
+    uint64_t payload_length;
+    new_pos = ParseVarInt(pos, end, &payload_length);
+    if (PERFETTO_UNLIKELY(new_pos == pos))
+      return res;
+
+    // ParseVarInt guarantees that |new_pos| <= |end| when it succeeds;
+    if (payload_length > static_cast<uint64_t>(end - new_pos))
+      return res;
+
+    const uintptr_t payload_start = reinterpret_cast<uintptr_t>(new_pos);
+    int_value = payload_start;
+    size = payload_length;
+    new_pos += payload_length;
+  } else if (field_type == static_cast<uint8_t>(ProtoWireType::kFixed64)) {
+    new_pos = pos + sizeof(uint64_t);
+    if (PERFETTO_UNLIKELY(new_pos > end))
+      return res;
+    memcpy(&int_value, pos, sizeof(uint64_t));
+  } else if (field_type == static_cast<uint8_t>(ProtoWireType::kFixed32)) {
+    new_pos = pos + sizeof(uint32_t);
+    if (PERFETTO_UNLIKELY(new_pos > end))
+      return res;
+    memcpy(&int_value, pos, sizeof(uint32_t));
+  } else {
+    PERFETTO_DLOG("Invalid proto field type: %u", field_type);
+    return res;
   }
 
   res.next = new_pos;
@@ -178,66 +173,122 @@ Field ProtoDecoder::ReadField() {
 }
 
 void TypedProtoDecoderBase::ParseAllFields() {
-  const uint8_t* cur = begin_;
-  ParseFieldResult res;
-  for (;;) {
-    res = ParseOneField(cur, end_);
-    PERFETTO_DCHECK(res.parse_res != ParseFieldResult::kOk || res.next != cur);
-    cur = res.next;
-    if (PERFETTO_UNLIKELY(res.parse_res == ParseFieldResult::kSkip))
-      continue;
-    if (PERFETTO_UNLIKELY(res.parse_res == ParseFieldResult::kAbort))
-      break;
+  // Self-contained decode loop: unlike ReadField()/ParseOneField() (which
+  // return a 32-byte ParseFieldResult per field), this inlines the tag+value
+  // decode and writes the Field straight into its storage slot. The storage
+  // model (direct field-id indexing, presence bitmap, heap expansion, FIFO
+  // overflow for repeated and extension fields) is unchanged.
+  const uint8_t* pos = begin_;
+  const uint8_t* const end = end_;
+  while (pos < end) {
+    const uint8_t* const field_start = pos;
 
-    PERFETTO_DCHECK(res.parse_res == ParseFieldResult::kOk);
-    PERFETTO_DCHECK(res.field.valid());
-    auto field_id = res.field.id();
-    // Fields with an id beyond the highest field id known in-tree at compile
-    // time are out-of-tree "extension" fields (e.g. carved out of TracePacket's
-    // `extensions 1000 to 1999` range). They are intentionally not stored here
-    // because fields_ is indexed directly by field id, and extension ids are
-    // sparse and potentially very high. Callers that need them must use
-    // TypedProtoDecoderBase::GetExtensionSlowly().
-    // TODO: store extensions in a sparse, object-pooled side table so they stay
-    // accessible without a buffer re-scan. See GetExtensionSlowly() for the
-    // proposed design.
+    // --- Tag. Single-byte fastpath for field ids < 16. ---
+    uint64_t preamble = *pos;
+    if (PERFETTO_LIKELY(preamble < 0x80)) {
+      pos++;
+    } else {
+      const uint8_t* next = ParseVarIntFast(pos, end, &preamble);
+      if (PERFETTO_UNLIKELY(!next))
+        break;  // Truncated tag.
+      pos = next;
+    }
+    const uint32_t field_id = static_cast<uint32_t>(preamble >> 3);
+    if (PERFETTO_UNLIKELY(field_id == 0)) {
+      pos = field_start;
+      break;
+    }
+    const uint8_t wire_type = static_cast<uint8_t>(preamble & 7u);
+
+    // --- Value. If-chain ordered by frequency: the wire-type sequence within
+    // a message type is near-constant, so these branches predict near-perfectly
+    // (a switch jump table compiles to a hard-to-predict indirect jump). ---
+    uint64_t int_value = 0;
+    uint32_t size = 0;
+    if (PERFETTO_LIKELY(wire_type ==
+                        static_cast<uint8_t>(ProtoWireType::kVarInt))) {
+      const uint8_t* next = ParseVarIntFast(pos, end, &int_value);
+      if (PERFETTO_UNLIKELY(!next)) {
+        pos = field_start;
+        break;
+      }
+      pos = next;
+    } else if (PERFETTO_LIKELY(
+                   wire_type ==
+                   static_cast<uint8_t>(ProtoWireType::kLengthDelimited))) {
+      uint64_t payload_length;
+      const uint8_t* next = ParseVarIntFast(pos, end, &payload_length);
+      if (PERFETTO_UNLIKELY(!next)) {
+        pos = field_start;
+        break;
+      }
+      pos = next;
+      if (PERFETTO_UNLIKELY(payload_length >
+                            static_cast<uint64_t>(end - pos))) {
+        pos = field_start;
+        break;
+      }
+      int_value = reinterpret_cast<uintptr_t>(pos);
+      pos += payload_length;
+      if (PERFETTO_UNLIKELY(payload_length > kMaxMessageLength))
+        continue;  // Skip the oversized field but keep parsing, like v1.
+      size = static_cast<uint32_t>(payload_length);
+    } else if (wire_type == static_cast<uint8_t>(ProtoWireType::kFixed64)) {
+      if (PERFETTO_UNLIKELY(end - pos <
+                            static_cast<ptrdiff_t>(sizeof(uint64_t)))) {
+        pos = field_start;
+        break;
+      }
+      memcpy(&int_value, pos, sizeof(uint64_t));
+      pos += sizeof(uint64_t);
+    } else if (wire_type == static_cast<uint8_t>(ProtoWireType::kFixed32)) {
+      if (PERFETTO_UNLIKELY(end - pos <
+                            static_cast<ptrdiff_t>(sizeof(uint32_t)))) {
+        pos = field_start;
+        break;
+      }
+      uint32_t v32;
+      memcpy(&v32, pos, sizeof(uint32_t));
+      int_value = v32;
+      pos += sizeof(uint32_t);
+    } else {
+      pos = field_start;
+      break;  // Invalid wire type.
+    }
+
+    // --- Store. Fields with an id beyond the in-tree range are out-of-tree
+    // extension fields; like v1 they are not stored here (callers resolve them
+    // via GetExtensionSlowly(), which re-scans the buffer).
     if (PERFETTO_UNLIKELY(field_id >= num_fields_))
       continue;
 
-    // There are two reasons why we might want to expand the heap capacity:
-    // 1. We are writing a non-repeated field, which has an id >
-    //    INITIAL_STACK_CAPACITY. In this case ExpandHeapStorage() ensures to
-    //    allocate at least (num_fields_ + 1) slots.
-    // 2. We are writing a repeated field but ran out of capacity.
+    // Expand if the id is beyond the current stack extent, or the overflow
+    // region is full.
     if (PERFETTO_UNLIKELY(field_id >= size_ || size_ >= capacity_))
       ExpandHeapStorage();
 
-    PERFETTO_DCHECK(field_id < size_);
-    Field* fld = &fields_[field_id];
-    if (PERFETTO_LIKELY(!fld->valid())) {
-      // This is the first time we see this field.
-      *fld = std::move(res.field);
+    if (PERFETTO_LIKELY(!HasField(field_id))) {
+      // First time we see this field; presence is the bitmap, not validity.
+      SetField(field_id);
+      fields_[field_id].initialize(field_id, wire_type, int_value, size);
     } else {
-      // Repeated field case.
-      // In this case we need to:
-      // 1. Append the last value of the field to end of the repeated field
-      //    storage.
-      // 2. Replace the default instance at offset |field_id| with the current
-      //    value. This is because in case of repeated field a call to Get(X) is
-      //    supposed to return the last value of X, not the first one.
-      // This is so that the RepeatedFieldIterator will iterate in the right
-      // order, see comments on RepeatedFieldIterator.
-      if (num_fields_ > size_) {
+      // Repeated field: push the previous value to the overflow region (so
+      // RepeatedFieldIterator yields FIFO) and keep the last value in the slot.
+      if (PERFETTO_UNLIKELY(num_fields_ > size_))
         ExpandHeapStorage();
-        fld = &fields_[field_id];
-      }
-
-      PERFETTO_DCHECK(size_ < capacity_);
-      fields_[size_++] = *fld;
-      *fld = std::move(res.field);
+      fields_[size_++] = fields_[field_id];
+      fields_[field_id].initialize(field_id, wire_type, int_value, size);
     }
   }
-  read_ptr_ = res.next;
+  // Some call sites dereference an *exhausted* RepeatedFieldIterator, which
+  // points at fields_[size_], and rely on reading a zeroed/invalid field there.
+  // v1 historically guaranteed this by zero-initializing all storage; since we
+  // no longer memset it, write a single zeroed sentinel to preserve the
+  // contract. size_ < capacity_ always holds here (the ctor reserves a spare
+  // via "capacity - 1" and ExpandHeapStorage keeps one).
+  if (PERFETTO_LIKELY(size_ < capacity_))
+    fields_[size_] = Field{};
+  read_ptr_ = pos;
 }
 
 void TypedProtoDecoderBase::ExpandHeapStorage() {
@@ -256,13 +307,12 @@ void TypedProtoDecoderBase::ExpandHeapStorage() {
   static_assert(std::is_trivially_copyable<Field>::value,
                 "Field must be trivially copyable");
 
-  // Zero-initialize the slots for known field IDs slots, as they can be
-  // randomly accessed. Instead, there is no need to initialize the repeated
-  // slots, because they are written linearly with no gaps and are always
-  // initialized before incrementing |size_|.
+  // The newly-exposed known-field slots [size_, new_size) are left
+  // uninitialized: reads are gated on the presence bitmap (HasField()), which
+  // already covers all of [0, num_fields_) and is unaffected by the heap
+  // expansion. The repeated slots are written linearly with no gaps and are
+  // always initialized before incrementing |size_|.
   const uint32_t new_size = std::max(size_, num_fields_);
-  memset(&new_storage[size_], 0, sizeof(Field) * (new_size - size_));
-
   memcpy(&new_storage[0], fields_, sizeof(Field) * size_);
 
   heap_storage_ = std::move(new_storage);

--- a/src/protozero/test/proto_decoder_benchmark.cc
+++ b/src/protozero/test/proto_decoder_benchmark.cc
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Microbenchmarks for TypedProtoDecoder on real traces from test/data,
+// replaying the access patterns of trace_processor's hot proto import paths
+// (TracePacket scan, ftrace bundle/event decode, TrackEvent decode) using the
+// real pbzero-generated decoders.
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/protozero/proto_decoder.h"
+#include "src/base/test/utils.h"
+
+#include "protos/perfetto/trace/ftrace/ftrace_event.pbzero.h"
+#include "protos/perfetto/trace/ftrace/ftrace_event_bundle.pbzero.h"
+#include "protos/perfetto/trace/ftrace/sched.pbzero.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "protos/perfetto/trace/track_event/track_event.pbzero.h"
+
+namespace {
+
+using protozero::ConstBytes;
+using protozero::ProtoDecoder;
+
+namespace pbzero = perfetto::protos::pbzero;
+
+// Packets / ftrace bundles / track events are pre-tokenized outside the timed
+// region (with the schema-less ProtoDecoder) so the benchmarks measure the
+// typed decoder cost only.
+struct LoadedTrace {
+  std::string blob;
+  std::vector<ConstBytes> packets;
+  std::vector<ConstBytes> ftrace_bundles;
+  std::vector<ConstBytes> track_events;
+  size_t num_ftrace_events = 0;
+  int64_t packets_bytes = 0;
+  int64_t ftrace_bundles_bytes = 0;
+  int64_t track_events_bytes = 0;
+};
+
+const LoadedTrace& GetTrace(const char* name) {
+  static auto* cache = new std::unordered_map<std::string, LoadedTrace>();
+  auto it = cache->find(name);
+  if (it != cache->end())
+    return it->second;
+
+  LoadedTrace& trace = (*cache)[name];
+  std::string path =
+      perfetto::base::GetTestDataPath(std::string("test/data/") + name);
+  PERFETTO_CHECK(perfetto::base::ReadFile(path, &trace.blob));
+
+  ProtoDecoder outer(trace.blob.data(), trace.blob.size());
+  for (auto f = outer.ReadField(); f.valid(); f = outer.ReadField()) {
+    if (f.id() != 1)
+      continue;
+    trace.packets.push_back(f.as_bytes());
+    trace.packets_bytes += static_cast<int64_t>(f.size());
+
+    ProtoDecoder packet(f.as_bytes());
+    for (auto pf = packet.ReadField(); pf.valid(); pf = packet.ReadField()) {
+      if (pf.id() == pbzero::TracePacket::kFtraceEventsFieldNumber) {
+        trace.ftrace_bundles.push_back(pf.as_bytes());
+        trace.ftrace_bundles_bytes += static_cast<int64_t>(pf.size());
+        ProtoDecoder bundle(pf.as_bytes());
+        for (auto bf = bundle.ReadField(); bf.valid(); bf = bundle.ReadField()) {
+          if (bf.id() == pbzero::FtraceEventBundle::kEventFieldNumber)
+            trace.num_ftrace_events++;
+        }
+      } else if (pf.id() == pbzero::TracePacket::kTrackEventFieldNumber) {
+        trace.track_events.push_back(pf.as_bytes());
+        trace.track_events_bytes += static_cast<int64_t>(pf.size());
+      }
+    }
+  }
+  PERFETTO_CHECK(!trace.packets.empty());
+  return trace;
+}
+
+// Mirrors ProtoTraceReader::ParsePacket(): decode every TracePacket and inspect
+// a handful of header fields + "which data field is set".
+uint64_t ScanPackets(const LoadedTrace& trace) {
+  uint64_t acc = 0;
+  for (const ConstBytes& p : trace.packets) {
+    pbzero::TracePacket::Decoder d(p.data, p.size);
+    if (d.has_timestamp())
+      acc += d.timestamp();
+    acc += d.trusted_packet_sequence_id();
+    acc += d.sequence_flags();
+    acc += d.has_ftrace_events();
+    acc += d.has_track_event();
+    acc += d.has_interned_data();
+  }
+  return acc;
+}
+
+// Mirrors the ftrace tokenization path: decode each bundle, walk |event|,
+// decode every FtraceEvent and the sched events within.
+uint64_t ScanFtraceEvents(const LoadedTrace& trace) {
+  uint64_t acc = 0;
+  for (const ConstBytes& b : trace.ftrace_bundles) {
+    pbzero::FtraceEventBundle::Decoder bundle(b.data, b.size);
+    acc += bundle.cpu();
+    for (auto it = bundle.event(); it; ++it) {
+      pbzero::FtraceEvent::Decoder event(*it);
+      // Order-sensitive mix so repeated |event| iteration order is exercised.
+      acc = acc * 31 + event.timestamp();
+      acc += event.pid();
+      if (event.has_sched_switch()) {
+        pbzero::SchedSwitchFtraceEvent::Decoder ss(event.sched_switch());
+        acc += static_cast<uint64_t>(ss.next_pid());
+        acc += static_cast<uint64_t>(ss.prev_state());
+      } else if (event.has_sched_waking()) {
+        pbzero::SchedWakingFtraceEvent::Decoder sw(event.sched_waking());
+        acc += static_cast<uint64_t>(sw.pid());
+      }
+    }
+  }
+  return acc;
+}
+
+// Mirrors TrackEventParser: decode each TrackEvent, read the hot fields.
+uint64_t ScanTrackEvents(const LoadedTrace& trace) {
+  uint64_t acc = 0;
+  for (const ConstBytes& te : trace.track_events) {
+    pbzero::TrackEvent::Decoder d(te.data, te.size);
+    acc += static_cast<uint64_t>(d.type());
+    acc += d.track_uuid();
+    acc += d.name_iid();
+    for (auto it = d.category_iids(); it; ++it)
+      acc += *it;
+    acc += d.has_extra_counter_values();
+  }
+  return acc;
+}
+
+void BM_TracePacketScan(benchmark::State& state, const char* trace_name) {
+  const LoadedTrace& trace = GetTrace(trace_name);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(ScanPackets(trace));
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) *
+                          trace.packets_bytes);
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(trace.packets.size()));
+}
+
+void BM_FtraceEventScan(benchmark::State& state, const char* trace_name) {
+  const LoadedTrace& trace = GetTrace(trace_name);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(ScanFtraceEvents(trace));
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) *
+                          trace.ftrace_bundles_bytes);
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(trace.num_ftrace_events));
+}
+
+void BM_TrackEventScan(benchmark::State& state, const char* trace_name) {
+  const LoadedTrace& trace = GetTrace(trace_name);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(ScanTrackEvents(trace));
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) *
+                          trace.track_events_bytes);
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(trace.track_events.size()));
+}
+
+BENCHMARK_CAPTURE(BM_TracePacketScan, android_30s, "example_android_trace_30s.pb");
+BENCHMARK_CAPTURE(BM_TracePacketScan,
+                  chrome_rendering,
+                  "chrome_rendering_desktop.pftrace");
+BENCHMARK_CAPTURE(BM_TracePacketScan,
+                  android_postboot,
+                  "android_postboot_unlock.pftrace");
+
+BENCHMARK_CAPTURE(BM_FtraceEventScan, android_30s, "example_android_trace_30s.pb");
+BENCHMARK_CAPTURE(BM_FtraceEventScan, sched_and_ps, "android_sched_and_ps.pb");
+BENCHMARK_CAPTURE(BM_FtraceEventScan, android_boot, "android_boot.pftrace");
+
+BENCHMARK_CAPTURE(BM_TrackEventScan,
+                  chrome_rendering,
+                  "chrome_rendering_desktop.pftrace");
+BENCHMARK_CAPTURE(BM_TrackEventScan,
+                  chrome_scroll,
+                  "chrome_touch_gesture_scroll.pftrace");
+
+}  // namespace


### PR DESCRIPTION
Replace the unconditional 1.6KB per-decode memset with a presence bitmap
(field storage left uninitialized, reads gated by a per-id bit), inline the
parse loop so each field is written straight into its slot (no
ParseFieldResult round-trip), order wire-type dispatch as a frequency
if-chain, and decode varints with an unrolled fast path. Adds a decode
microbenchmark over real traces.

Decode microbenchmark, linux_clang_release, per iter (wall = median ns,
counters via perf stat slope method), before -> after:

  FtraceEventScan/sched_and_ps      wall 17.24ms -> 11.64ms (1.48x)  instr 387.2M -> 259.4M (1.49x)
  TrackEventScan/chrome_rendering   wall  4.35ms ->  2.84ms (1.53x)  instr 181.5M -> 101.5M (1.79x)
  TracePacketScan/chrome_rendering  wall  5.16ms ->  3.38ms (1.53x)  instr 249.3M -> 140.7M (1.77x)

Per-optimization breakdown, FtraceEventScan/sched_and_ps, each added on top
of the previous, pinned to one core (instructions deterministic; cycles are
the frequency-independent proxy, min of 3; wall omitted as this host is a VM
with no clock control):
  baseline                       387.2M instr  69.1M cyc
  + presence bitmap (no memset)  357.9M instr  60.0M cyc
  + inlined parse loop           320.4M instr  56.0M cyc
  + if-chain wire dispatch       301.7M instr  54.7M cyc
  + unrolled varint              259.4M instr  48.6M cyc

End-to-end trace_processor_shell parse (perf stat -r 3), before -> after:
  example_android_trace_30s.pb      instr 3.50G -> 3.32G (-5.1%)  cpu 325.6ms -> 329.1ms
  android_sched_and_ps.pb           instr 2.50G -> 2.36G (-5.5%)  cpu 212.3ms -> 205.1ms
  chrome_rendering_desktop.pftrace  instr 3.22G -> 2.93G (-9.2%)  cpu 247.7ms -> 230.5ms
