### PR TITLE
protovm: fix del_if_src_empty if skip_submessages is set

### DIFF
--- a/src/protovm/rw_proto_cursor.cc
+++ b/src/protovm/rw_proto_cursor.cc
@@ -246,13 +246,6 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
        field = decoder.ReadField()) {
     auto it = message->field_id_to_node.Find(field.id());
 
-    bool skip_submessages = (flags & kSkipSubmessages) != 0;
-    if (skip_submessages && it && it->value->GetIf<Node::Message>()) {
-      // Implements deep merge semantics: skip this message that was already
-      // merged by a previous operation
-      continue;
-    }
-
     bool del_if_src_empty = (flags & kDelIfSrcEmpty) != 0;
     if (it && del_if_src_empty &&
         field.type() ==
@@ -262,6 +255,13 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
       // the dst field
       message->field_id_to_node.Remove(*it);
       allocator_->Delete(&*it);
+      continue;
+    }
+
+    bool skip_submessages = (flags & kSkipSubmessages) != 0;
+    if (skip_submessages && it && it->value->GetIf<Node::Message>()) {
+      // Implements deep merge semantics: skip this message that was already
+      // merged by a previous operation
       continue;
     }
 

--- a/src/protovm/test/rw_proto_unittest.cc
+++ b/src/protovm/test/rw_proto_unittest.cc
@@ -928,6 +928,35 @@ TEST_F(RwProtoTest, Merge_DelIfSrcEmpty_RepeatedField) {
   ASSERT_EQ(entry.elements_size(), 0);
 }
 
+TEST_F(RwProtoTest, Merge_DelIfSrcEmptyAndSkipSubmessages) {
+  auto root = data_empty_.GetRoot();
+
+  // root = { single_element { id: 10 } }
+  {
+    auto cursor = root;
+    ASSERT_TRUE(cursor.EnterField(protos::TraceEntry::kSingleElementFieldNumber)
+                    .IsOk());
+    auto id_cursor = cursor;
+    ASSERT_TRUE(id_cursor.EnterField(protos::Element::kIdFieldNumber).IsOk());
+    ASSERT_TRUE(id_cursor.SetScalar(Scalar::VarInt(10)).IsOk());
+  }
+
+  // patch = { single_element {} }
+  protos::TraceEntry patch;
+  patch.mutable_single_element();
+
+  // Merge with both kDelIfSrcEmpty and kSkipSubmessages
+  ASSERT_TRUE(root.Merge(AsConstBytes(patch.SerializeAsString()),
+                         RwProto::Cursor::kDelIfSrcEmpty |
+                             RwProto::Cursor::kSkipSubmessages)
+                  .IsOk());
+
+  // Check root = {} (i.e. single_element is deleted, not skipped)
+  protos::TraceEntry entry;
+  entry.ParseFromString(SerializeAsString(data_empty_));
+  ASSERT_FALSE(entry.has_single_element());
+}
+
 TEST_F(RwProtoTest, SetBytes_IncompatibleWireType) {
   auto cursor = data_trace_entry_with_two_elements_.GetRoot();
   cursor.EnterRepeatedFieldAt(protos::TraceEntry::kElementsFieldNumber, 0);


### PR DESCRIPTION
reorders these two checks so a field set as field_x {} is properly deleted in the incremental state if del_if_src_emtpy is set.
