### PR TITLE
bt-ui: Bigtrace UI fixes and polish

### DIFF
--- a/ui/src/assets/bigtrace.scss
+++ b/ui/src/assets/bigtrace.scss
@@ -555,6 +555,25 @@ pre.pf-bt-history-item-query--standalone {
   white-space: pre-wrap;
 }
 
+// A fetch_results failure shown in place of the results grid: a short heading
+// plus the selectable, scrollable error body (reusing .pf-bt-error-content).
+.pf-bt-results-error {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+
+  &__title {
+    padding: 12px 12px 0;
+    font-weight: 500;
+    color: var(--pf-color-danger);
+  }
+
+  .pf-bt-error-content {
+    flex: 1;
+  }
+}
+
 // min-height:0 chain lets DataGrid fillHeight work; only the body scrolls.
 .pf-bt-results-panel {
   display: flex;

--- a/ui/src/assets/bigtrace.scss
+++ b/ui/src/assets/bigtrace.scss
@@ -343,6 +343,8 @@
 // Status-colored left bar, meta card only (clashes with the pre's border).
 .pf-bt-history-item-meta {
   border-left: 3px solid transparent;
+  // The band opens the query on click (same as the Open button).
+  cursor: pointer;
 }
 
 .pf-query-history__item:has(.pf-bt-status-success) .pf-bt-history-item-meta {

--- a/ui/src/assets/bigtrace.scss
+++ b/ui/src/assets/bigtrace.scss
@@ -808,6 +808,15 @@ pre.pf-bt-history-item-query--standalone {
   &__chips {
     flex: 1 1 auto;
     min-width: 0;
+
+    // A chip with a long value (e.g. a trace-path filter) must ellipsize, not
+    // grow the editor panel past the split and scroll the whole page. The
+    // shared chip pins min-width: max-content, so cap and let it shrink here;
+    // its label already has text-overflow: ellipsis.
+    .pf-chip {
+      min-width: 0;
+      max-width: 100%;
+    }
   }
 
   // Only the "Edit settings" chip is clickable — give it the pointer cursor.

--- a/ui/src/bigtrace/pages/query_page.ts
+++ b/ui/src/bigtrace/pages/query_page.ts
@@ -18,7 +18,10 @@ import {EmptyState} from '../../widgets/empty_state';
 import {SplitPanel} from '../../widgets/split_panel';
 import {Spinner} from '../../widgets/spinner';
 import {Tabs, type TabsTab} from '../../widgets/tabs';
-import {QueryHistoryComponent} from '../query/query_history';
+import {
+  QueryHistoryComponent,
+  setHistoryActiveTab,
+} from '../query/query_history';
 import {QueryRunner} from '../query/query_runner';
 import {bigTraceSettingsStorage} from '../settings/bigtrace_settings_storage';
 import {sqlTablesLoader} from '../query/sql_tables';
@@ -56,6 +59,12 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
     };
     if (this.useBigtraceBackend) {
       bigTraceSettingsStorage.loadSettings();
+    }
+    // Open History on the sub-tab matching the active tab's Persistent mode;
+    // its default ('standard') otherwise wins on every mount.
+    const activeTab = this.tabsState.getActiveTab();
+    if (activeTab) {
+      setHistoryActiveTab(activeTab.materialize);
     }
     sqlTablesLoader.load();
   }

--- a/ui/src/bigtrace/pages/results_grid.ts
+++ b/ui/src/bigtrace/pages/results_grid.ts
@@ -157,9 +157,10 @@ function renderDataGrid(
   }
   const schema: SchemaRegistry = {data: columnSchema};
 
-  // Per-tab visible subset (empty/unset → all); shipped as the
+  // Per-tab visible subset (empty/unset → defaults); shipped as the
   // `:fetch_results` `columns` projection.
   const visible = resolveResultColumns(tab.resultColumns, allColumns);
+  const defaultVisible = resolveResultColumns(null, allColumns);
   const isAsync = dataSource instanceof BigtraceAsyncDataSource;
   const sortState = resultsSortByTab.get(tab);
 
@@ -197,7 +198,7 @@ function renderDataGrid(
     fillHeight: true,
     showExportButton: true,
     emptyStateMessage:
-      isAsync && allColumns.length === visible.length
+      isAsync && visible.length >= defaultVisible.length
         ? 'Query returned no rows'
         : 'No rows match the visible columns',
     toolbarItemsLeft: [

--- a/ui/src/bigtrace/pages/results_grid.ts
+++ b/ui/src/bigtrace/pages/results_grid.ts
@@ -81,17 +81,23 @@ export function renderResultsGrid(
 
   if (dataSource instanceof BigtraceAsyncDataSource) {
     const error = dataSource.getError();
-    if (
+    // A 400 before the query reaches a terminal state usually means the results
+    // aren't ready yet, not a real failure — keep the loading state until the
+    // run finishes. A 400 after completion (e.g. a bad filter) or any non-400
+    // error is a real error worth surfacing.
+    const isRealError =
       error !== null &&
       error !== '' &&
-      (isTerminal || error.includes('status: 400') === false)
-    ) {
+      (isTerminal || dataSource.getErrorStatus() !== 400);
+    if (isRealError) {
+      // Render in a selectable <pre> (not an EmptyState, whose text is
+      // truncated and user-select:none) so the full message is readable and
+      // copyable.
       tableContent.push(
-        m(EmptyState, {
-          title: `Failed to load schema: ${error}`,
-          icon: 'error',
-          fillHeight: true,
-        }),
+        m('.pf-bt-results-error', [
+          m('.pf-bt-results-error__title', 'Failed to load results'),
+          m('pre.pf-bt-error-content', error),
+        ]),
       );
       return tableContent;
     }

--- a/ui/src/bigtrace/pages/settings_page.ts
+++ b/ui/src/bigtrace/pages/settings_page.ts
@@ -65,6 +65,7 @@ import {
   type TracesSchemaResponse,
 } from '../query/bigtrace_query_client';
 import {BigtraceTraceListDataSource} from '../query/bigtrace_trace_list_data_source';
+import {formatCompact} from '../query/query_store';
 import {
   traceFilterState as traceFiltersState,
   traceOrderByState,
@@ -636,16 +637,22 @@ export class SettingsPage implements m.ClassComponent<SettingsPageAttrs> {
     // show it without re-fetching. No-op on /settings (no onTraceMatchCount).
     this.bindings?.onTraceMatchCount?.(n);
     const hasFilter = this.traceFilterss.length > 0;
+    // Compact count (1.2K) like the history sidebar's row counts; the exact
+    // number lives in the hover title.
     const text =
       n === undefined
         ? 'Counting traces…'
         : hasFilter
-          ? `${n.toLocaleString()} trace${n === 1 ? '' : 's'} match`
-          : `${n.toLocaleString()} trace${n === 1 ? '' : 's'}`;
+          ? `${formatCompact(n)} trace${n === 1 ? '' : 's'} match`
+          : `${formatCompact(n)} trace${n === 1 ? '' : 's'}`;
     // Filled label that reads as a status, not a clickable chip.
     return m(
       'span.pf-bt-trace-match-count',
       {
+        title:
+          n === undefined
+            ? undefined
+            : `${n.toLocaleString()} trace${n === 1 ? '' : 's'}`,
         style: {
           display: 'inline-flex',
           alignItems: 'center',

--- a/ui/src/bigtrace/query/bigtrace_async_data_source.ts
+++ b/ui/src/bigtrace/query/bigtrace_async_data_source.ts
@@ -22,6 +22,7 @@ import type {Row, SqlValue} from '../../trace_processor/query_result';
 import type {QueryResult} from '../../base/query_slot';
 import {
   type BigtraceQueryClient,
+  BigtraceHttpError,
   QueryCancelledError,
 } from './bigtrace_query_client';
 import {encodeFilters} from './filter_encoding';
@@ -37,6 +38,10 @@ export class BigtraceAsyncDataSource implements DataSource {
   private isFetching = false;
   private columns: string[] = [];
   private error: string | null = null;
+  // HTTP status of the last error, when it was an HTTP error (undefined
+  // otherwise). Lets the results view tell a not-ready-yet 400 from a real
+  // failure without parsing the message string.
+  private errorStatus: number | undefined;
   private hasInitialFetchCompleted = false;
   // Window in `loadedRows`, for range-change detection.
   private loadedOffset = 0;
@@ -173,6 +178,7 @@ export class BigtraceAsyncDataSource implements DataSource {
   private async fetchMoreRows(offset: number, limit: number) {
     if (this.signal?.aborted) return;
     this.error = null;
+    this.errorStatus = undefined;
     this.isFetching = true;
     m.redraw();
     try {
@@ -199,7 +205,14 @@ export class BigtraceAsyncDataSource implements DataSource {
       // Abort is expected when the owning tab closes; don't surface it.
       if (e instanceof QueryCancelledError) return;
       console.error('[bigtrace] fetch_results failed:', e);
-      this.error = e instanceof Error ? e.message : String(e);
+      if (e instanceof BigtraceHttpError) {
+        // Surface the backend's detail (not the wrapped message) and keep the
+        // status for the results view's not-ready-yet check.
+        this.error = e.detail;
+        this.errorStatus = e.status;
+      } else {
+        this.error = e instanceof Error ? e.message : String(e);
+      }
     } finally {
       this.isFetching = false;
       m.redraw();
@@ -214,6 +227,12 @@ export class BigtraceAsyncDataSource implements DataSource {
 
   getError(): string | null {
     return this.error;
+  }
+
+  // HTTP status of the last fetch error, if it was an HTTP error (undefined
+  // otherwise).
+  getErrorStatus(): number | undefined {
+    return this.errorStatus;
   }
 
   getColumns(): string[] {

--- a/ui/src/bigtrace/query/bigtrace_async_data_source_unittest.ts
+++ b/ui/src/bigtrace/query/bigtrace_async_data_source_unittest.ts
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, expect, test, vi} from 'vitest';
+import {BigtraceAsyncDataSource} from './bigtrace_async_data_source';
+import {
+  type BigtraceQueryClient,
+  BigtraceHttpError,
+  QueryCancelledError,
+} from './bigtrace_query_client';
+
+// A client whose fetchResults always rejects with `err`.
+function rejectingClient(err: Error): BigtraceQueryClient {
+  return {
+    fetchResults: vi.fn().mockRejectedValue(err),
+  } as unknown as BigtraceQueryClient;
+}
+
+describe('BigtraceAsyncDataSource error handling', () => {
+  test('an HTTP error surfaces the backend detail and status', async () => {
+    const client = rejectingClient(
+      new BigtraceHttpError(400, "unknown column 'foo'"),
+    );
+    const ds = new BigtraceAsyncDataSource('uid', client, () => 0);
+    await ds.ensureResultsLoaded();
+    // The view shows the detail, not the wrapped `HTTP 400: ...` message.
+    expect(ds.getError()).toBe("unknown column 'foo'");
+    expect(ds.getErrorStatus()).toBe(400);
+  });
+
+  test('a non-HTTP error surfaces its message with no status', async () => {
+    const client = rejectingClient(new Error('network down'));
+    const ds = new BigtraceAsyncDataSource('uid', client, () => 0);
+    await ds.ensureResultsLoaded();
+    expect(ds.getError()).toBe('network down');
+    expect(ds.getErrorStatus()).toBeUndefined();
+  });
+
+  test('a cancelled fetch is swallowed (no error surfaced)', async () => {
+    const client = rejectingClient(new QueryCancelledError());
+    const ds = new BigtraceAsyncDataSource('uid', client, () => 0);
+    await ds.ensureResultsLoaded();
+    expect(ds.getError()).toBeNull();
+    expect(ds.getErrorStatus()).toBeUndefined();
+  });
+});

--- a/ui/src/bigtrace/query/bigtrace_query_client.ts
+++ b/ui/src/bigtrace/query/bigtrace_query_client.ts
@@ -88,6 +88,21 @@ export class QueryNotFoundError extends Error {
   }
 }
 
+// Backend returned a non-OK HTTP status (other than 404, which maps to
+// QueryNotFoundError). `detail` is the human-readable `detail` from the error
+// body (or the raw body when it isn't JSON); `status` is the HTTP status, so
+// callers can render the detail and branch on the status instead of scraping
+// the message string.
+export class BigtraceHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly detail: string,
+  ) {
+    super(`HTTP ${status}: ${detail}`);
+    this.name = 'BigtraceHttpError';
+  }
+}
+
 // Single funnel for the BigTrace HTTP API.
 export class BigtraceQueryClient {
   constructor(private readonly endpoint: string) {}
@@ -357,15 +372,15 @@ export class BigtraceQueryClient {
         throw new QueryNotFoundError(m ? m[1] : path);
       }
       if (response.status === 403) {
-        throw new Error(
-          `HTTP error! status: ${response.status}, message: ${detail}. ` +
-            `This might be an authentication issue. Please ensure you ` +
-            `are logged in with the correct credentials.`,
+        // Most 403s here are an unauthenticated session; fold the hint into
+        // the detail so it reaches the user with the rest of the message.
+        throw new BigtraceHttpError(
+          403,
+          `${detail} (this may be an authentication issue — make sure you ` +
+            `are logged in with the correct credentials)`,
         );
       }
-      throw new Error(
-        `HTTP error! status: ${response.status}, message: ${detail}`,
-      );
+      throw new BigtraceHttpError(response.status, detail);
     }
     return response;
   }

--- a/ui/src/bigtrace/query/bigtrace_query_client_unittest.ts
+++ b/ui/src/bigtrace/query/bigtrace_query_client_unittest.ts
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 import {afterEach, describe, expect, test, vi} from 'vitest';
-import {BigtraceQueryClient, parseQueryResponse} from './bigtrace_query_client';
+import {
+  BigtraceHttpError,
+  BigtraceQueryClient,
+  parseQueryResponse,
+  QueryNotFoundError,
+} from './bigtrace_query_client';
 import {coerceFiltersForWire, encodeFilters} from './filter_encoding';
 import type {Filter} from '../../components/widgets/datagrid/model';
 import type {SettingFilter} from '../settings/settings_types';
@@ -409,6 +414,50 @@ describe('BigtraceQueryClient.fetchResults', () => {
       'android_id',
     ]);
     expect(urlFrom(fetchMock)).toContain(':fetch_results');
+  });
+});
+
+describe('BigtraceQueryClient error responses', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  function failWith(status: number, body: string): void {
+    const fakeResp = {
+      ok: false,
+      status,
+      text: () => Promise.resolve(body),
+      json: () => Promise.reject(new Error('not called on error path')),
+    };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(fakeResp) as unknown as typeof fetch;
+  }
+
+  test('a 400 throws BigtraceHttpError carrying the backend detail and status', async () => {
+    failWith(400, JSON.stringify({detail: "unknown column 'foo'"}));
+    const client = new BigtraceQueryClient('http://example/');
+    const err = await client.fetchResults('uid', 10, 0).catch((e) => e);
+    expect(err).toBeInstanceOf(BigtraceHttpError);
+    expect(err.status).toBe(400);
+    expect(err.detail).toBe("unknown column 'foo'");
+  });
+
+  test('a non-JSON error body becomes the detail verbatim', async () => {
+    failWith(500, 'upstream exploded');
+    const client = new BigtraceQueryClient('http://example/');
+    const err = await client.fetchResults('uid', 10, 0).catch((e) => e);
+    expect(err).toBeInstanceOf(BigtraceHttpError);
+    expect(err.status).toBe(500);
+    expect(err.detail).toBe('upstream exploded');
+  });
+
+  test('a 404 throws QueryNotFoundError, not BigtraceHttpError', async () => {
+    failWith(404, JSON.stringify({detail: 'gone'}));
+    const client = new BigtraceQueryClient('http://example/');
+    const err = await client.fetchResults('uid', 10, 0).catch((e) => e);
+    expect(err).toBeInstanceOf(QueryNotFoundError);
   });
 });
 

--- a/ui/src/bigtrace/query/query_history_item.ts
+++ b/ui/src/bigtrace/query/query_history_item.ts
@@ -131,6 +131,12 @@ export function renderHistoryItem(
       ? formatDate(new Date(startTime), {printTimezone: false})
       : 'N/A';
 
+  const openThis = () => {
+    if (openQuery && uuid) {
+      openQuery(queryText, uuid, isMaterialized, false, entry.limit, startTime);
+    }
+  };
+
   const buttonsRow = m(
     Stack,
     {
@@ -139,18 +145,7 @@ export function renderHistoryItem(
     },
     [
       m(Button, {
-        onclick: () => {
-          if (openQuery && uuid) {
-            openQuery(
-              queryText,
-              uuid,
-              isMaterialized,
-              false,
-              entry.limit,
-              startTime,
-            );
-          }
-        },
+        onclick: openThis,
         icon: Icons.ChangeTab,
         title: 'Open',
       }),
@@ -201,23 +196,35 @@ export function renderHistoryItem(
   return m(
     '.pf-query-history__item',
     {key: `${uuid}-${index}`},
-    m('.pf-bt-history-item-meta', [
-      buttonsRow,
-      m('div.pf-bt-history-item-header', [
-        m(
-          'span.pf-bt-history-item-status',
-          {
-            class: `pf-bt-status-${entry.status.toLowerCase().replace(/_/g, '-')}`,
-          },
-          statusDisplayLabel(entry.status),
-        ),
-        m(
-          'span.pf-bt-history-item-date',
-          {title: `UTC: ${utcString}`},
-          localString,
-        ),
-      ]),
-    ]),
+    m(
+      '.pf-bt-history-item-meta',
+      {
+        // The whole status/date band opens the query, like the Open button.
+        // Skip clicks that originated on the overlaid buttons so Delete
+        // doesn't also open.
+        onclick: (e: MouseEvent) => {
+          if ((e.target as HTMLElement).closest('button')) return;
+          openThis();
+        },
+      },
+      [
+        buttonsRow,
+        m('div.pf-bt-history-item-header', [
+          m(
+            'span.pf-bt-history-item-status',
+            {
+              class: `pf-bt-status-${entry.status.toLowerCase().replace(/_/g, '-')}`,
+            },
+            statusDisplayLabel(entry.status),
+          ),
+          m(
+            'span.pf-bt-history-item-date',
+            {title: `UTC: ${utcString}`},
+            localString,
+          ),
+        ]),
+      ],
+    ),
     // Materialized only: a banded strip between the header and the SQL pre.
     isMaterialized &&
       m(

--- a/ui/src/bigtrace/settings/column_order.ts
+++ b/ui/src/bigtrace/settings/column_order.ts
@@ -16,6 +16,10 @@
 
 export const LINK_COLUMN = 'link';
 
+// Backend-internal row identifier present on every result; hidden unless the
+// user explicitly adds it via the column picker.
+export const ROW_ID_COLUMN = '_row_id';
+
 // Hoist `link` to the front (keyed by name); no-op if absent or already first.
 export function linkColumnFirst<T>(
   items: readonly T[],
@@ -39,15 +43,17 @@ export function groupResultColumns(names: readonly string[]): string[] {
 }
 
 // Resolve a results-grid column selection against the available columns, then
-// group. null = show all; a list is intersected (all-stale → show all).
+// group. null = show all but `_row_id`; a list is intersected (all-stale →
+// back to the default). `_row_id` stays addable via the picker.
 export function resolveResultColumns(
   chosen: readonly string[] | null,
   available: ReadonlyArray<string>,
 ): string[] {
+  const defaults = available.filter((c) => c !== ROW_ID_COLUMN);
   if (chosen === null) {
-    return groupResultColumns([...available]);
+    return groupResultColumns(defaults);
   }
   const known = new Set(available);
   const filtered = chosen.filter((c) => known.has(c));
-  return groupResultColumns(filtered.length === 0 ? [...available] : filtered);
+  return groupResultColumns(filtered.length === 0 ? defaults : filtered);
 }

--- a/ui/src/bigtrace/settings/trace_state_unittest.ts
+++ b/ui/src/bigtrace/settings/trace_state_unittest.ts
@@ -312,4 +312,22 @@ describe('resolveResultColumns', () => {
       resolveResultColumns(['_meta', 'name', 'dur'], ['name', 'dur', '_meta']),
     ).toEqual(['name', 'dur', '_meta']);
   });
+
+  test('hides _row_id by default', () => {
+    expect(
+      resolveResultColumns(null, ['_row_id', 'trace_id', 'name', 'dur']),
+    ).toEqual(['trace_id', 'name', 'dur']);
+  });
+
+  test('keeps _row_id when explicitly chosen', () => {
+    expect(
+      resolveResultColumns(['name', '_row_id'], ['_row_id', 'name', 'dur']),
+    ).toEqual(['name', '_row_id']);
+  });
+
+  test('the all-stale fallback also hides _row_id', () => {
+    expect(resolveResultColumns(['old_a'], ['_row_id', 'name', 'dur'])).toEqual(
+      ['name', 'dur'],
+    );
+  });
 });


### PR DESCRIPTION
This PR introduces a bundle of UX improvements and bug fixes to the Bigtrace UI, addressing layout issues, error visibility, and history navigation.

  Key Changes:
   * Query History Polish:
     * The history sidebar now correctly syncs its active sub-tab (Persistent vs Ephemeral) with the currently active query tab on page
       load.
     * Clicking the status/date header band of a history entry now opens the query directly, providing a much larger click target.
   * Results Grid:
     * Hides the backend-internal _row_id column from the grid by default (still available via the column picker).
     * Refactors how fetch_results errors are displayed: they now render in a selectable, wrapping <pre> block with their raw HTTP status
       and detail, replacing the uncopyable and heavily truncated EmptyState widget.
   * Settings & Layout Fixes:
     * Abbreviates large trace counts on the settings page to a compact format (e.g., ~3.4K traces) with the exact count available on
       hover.
     * Prevents horizontally scrolling the entire query page when a filter chip contains an extremely long value (like a trace path);
       chips now properly cap their width and ellipsize their labels.