### PR TITLE
bt-ui: bigtrace add SQL formatting to the query editor

### DIFF
--- a/ui/build.mjs
+++ b/ui/build.mjs
@@ -703,8 +703,22 @@ function copySyntaqliteRuntime() {
     'syntaqlite-sqlite.wasm',
   ]) {
     addTask(cp, [pjoin(srcDir, fname), pjoin(dstDir, fname)]);
+    // The bigtrace bundle resolves assets against its own serving root.
+    if (cfg.bigtrace) {
+      addTask(cp, [
+        pjoin(srcDir, fname),
+        pjoin(cfg.outBigtraceDistDir, 'assets', fname),
+      ]);
+    }
   }
   addTask(buildSyntaqlitePerfettoDialect, []);
+  if (cfg.bigtrace) {
+    // Tasks run in queue order, so this copies the freshly-built dialect.
+    addTask(cp, [
+      pjoin(cfg.outDistDir, 'assets', 'syntaqlite-perfetto.wasm'),
+      pjoin(cfg.outBigtraceDistDir, 'assets', 'syntaqlite-perfetto.wasm'),
+    ]);
+  }
 }
 
 function getBuildToolsBinDir() {

--- a/ui/src/bigtrace/help_modal.ts
+++ b/ui/src/bigtrace/help_modal.ts
@@ -47,6 +47,11 @@ class BigTraceHelpContent implements m.ClassComponent {
           m('td', keycap('Ctrl'), ' + ', keycap('Enter')),
           m('td', 'Execute selected text (when text is selected)'),
         ),
+        m(
+          'tr',
+          m('td', keycap('Alt'), ' + ', keycap('Shift'), ' + ', keycap('F')),
+          m('td', 'Format query'),
+        ),
       ),
       m('h2', 'Running commands'),
       m(

--- a/ui/src/bigtrace/index.ts
+++ b/ui/src/bigtrace/index.ts
@@ -56,7 +56,9 @@ function setupContentSecurityPolicy() {
   // Note: self and sha-xxx must be quoted, urls data: and blob: must not.
   const policy = {
     'default-src': [`'self'`],
-    'script-src': [`'self'`],
+    // wasm-unsafe-eval: the SQL formatter runs as WebAssembly; this allows
+    // Wasm compilation without enabling JS eval().
+    'script-src': [`'self'`, `'wasm-unsafe-eval'`],
     'object-src': ['none'],
     'connect-src': [
       `'self'`,

--- a/ui/src/bigtrace/pages/editor_tab_view.ts
+++ b/ui/src/bigtrace/pages/editor_tab_view.ts
@@ -27,6 +27,7 @@ import {InMemoryDataSource} from '../../components/widgets/datagrid/in_memory_da
 import {getBigtraceEndpoint} from '../settings/endpoint_storage';
 import {BigtraceAsyncDataSource} from '../query/bigtrace_async_data_source';
 import {setHistoryActiveTab} from '../query/query_history';
+import {formatPerfettoSql} from '../query/sql_formatter';
 import {BigtraceQueryClient} from '../query/bigtrace_query_client';
 import type {QueryRunner} from '../query/query_runner';
 import {
@@ -140,6 +141,20 @@ function buildTabBindings(
   };
 }
 
+// Format a tab's query in place; no-op when formatting fails (the error is
+// logged) or the text is already clean. Bound to Alt+Shift+F in the editor.
+async function formatTabQuery(
+  tab: BigTraceEditorTab,
+  tabsState: QueryTabsState,
+  text: string,
+): Promise<void> {
+  const formatted = await formatPerfettoSql(text);
+  if (formatted === undefined || formatted === tab.editorText) return;
+  tab.editorText = formatted;
+  tabsState.markDirty();
+  m.redraw();
+}
+
 // ---------------------------------------------------------------------------
 // Editor panel: toolbar (Run/Cancel + limit + Persistent) and the editor.
 // ---------------------------------------------------------------------------
@@ -180,7 +195,15 @@ function renderEditorPanel(
           m(HotkeyGlyphs, {hotkey: 'Mod+Enter'}),
         ),
         m(StackAuto),
+        // Icon-only to keep the toolbar lean; the editor binds the same chord.
+        m(Button, {
+          icon: 'format_align_left',
+          title: 'Format query (Alt+Shift+F)',
+          disabled: deriveTitleFromQuery(tab.editorText) === undefined,
+          onclick: () => void formatTabQuery(tab, tabsState, tab.editorText),
+        }),
         useBigtraceBackend && [
+          m('span.pf-bt-toolbar-divider', {'aria-hidden': 'true'}),
           m(Switch, {
             label: 'Persistent',
             title:
@@ -224,6 +247,8 @@ function renderEditorPanel(
       language: 'perfetto-sql',
       autofocus: true,
       onSave: () => {},
+      // Alt+Shift+F (option+shift+F on Mac); listed in the help modal.
+      onFormat: (text: string) => formatTabQuery(tab, tabsState, text),
       onUpdate: (text: string) => {
         tab.editorText = text;
         tabsState.markDirty();

--- a/ui/src/bigtrace/query/sql_formatter.ts
+++ b/ui/src/bigtrace/query/sql_formatter.ts
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Engine} from 'syntaqlite';
+import {assetSrc} from '../../base/assets';
+
+// Lazy module singleton — the wasm assets are only fetched on first use.
+let enginePromise: Promise<Engine> | undefined;
+
+function getFormatterEngine(): Promise<Engine> {
+  if (enginePromise === undefined) {
+    const engine = new Engine({
+      runtimeJsPath: assetSrc('assets/syntaqlite-runtime.js'),
+      runtimeWasmPath: assetSrc('assets/syntaqlite-runtime.wasm'),
+    });
+    enginePromise = (async () => {
+      await engine.load();
+      const binding = await engine.loadDialectFromUrl(
+        assetSrc('assets/syntaqlite-perfetto.wasm'),
+        'syntaqlite_perfetto_dialect_template',
+      );
+      engine.setDialectPointer(binding.ptr);
+      return engine;
+    })();
+  }
+  return enginePromise;
+}
+
+// Format PerfettoSQL with the same options the main Query page uses.
+// Returns undefined (and leaves the caller's text untouched) on failure.
+export async function formatPerfettoSql(
+  text: string,
+): Promise<string | undefined> {
+  try {
+    const engine = await getFormatterEngine();
+    const result = engine.runFmt(text, {
+      lineWidth: 80,
+      indentWidth: 2,
+      keywordCase: 1,
+      semicolons: true,
+    });
+    if (result.ok) return result.text;
+    console.error('SQL formatting failed', result.text);
+  } catch (e) {
+    console.error('SQL formatting failed', e);
+  }
+  return undefined;
+}


### PR DESCRIPTION
Format the editor tab's SQL with the same syntaqlite formatter the Query page uses: Alt+Shift+F in the editor (the option key on Mac) plus an icon-only toolbar button. The shortcut is documented in the help modal. No command — the chord can't be expressed in the command hotkey grammar, whose key matching breaks on option-composed characters on Mac; the editor binding matches by key code and works everywhere.

The engine init mirrors the Query page plugin's (it is private to the plugin and cannot be imported across bundles). The syntaqlite assets are now also copied into the bigtrace dist, which resolves assets against its own serving root, and bigtrace's CSP gains 'wasm-unsafe-eval' — Wasm compilation without JS eval().
