### PR TITLE
tp: tolerate unresolvable type in OOT extension compatibility check

### DIFF
--- a/src/trace_processor/util/descriptors.cc
+++ b/src/trace_processor/util/descriptors.cc
@@ -461,6 +461,11 @@ base::Status DescriptorPool::AddFromFileDescriptorSet(
         ResolveShortType(check.extendee_full_name, check.existing_raw_type);
     std::optional<uint32_t> opt_new_idx =
         ResolveShortType(check.extendee_full_name, check.new_raw_type);
+    // Both types must resolve before we can compare; either can be absent.
+    //  - existing: TP's pool may reference a type whose definition wasn't
+    //  loaded.
+    //  - new: trace's descriptor may name a type without including its
+    //  definition.
     if (!opt_existing_idx.has_value() || !opt_new_idx.has_value()) {
       // A type isn't in the pool: normal for a trace recorded before an
       // out-of-tree migration renamed it. Can't compare structurally, but the

--- a/src/trace_processor/util/descriptors.cc
+++ b/src/trace_processor/util/descriptors.cc
@@ -462,11 +462,17 @@ base::Status DescriptorPool::AddFromFileDescriptorSet(
     std::optional<uint32_t> opt_new_idx =
         ResolveShortType(check.extendee_full_name, check.new_raw_type);
     if (!opt_existing_idx.has_value() || !opt_new_idx.has_value()) {
-      return base::ErrStatus(
-          "Field %s re-introduced as %s (was %s): cannot verify "
-          "compatibility because a type could not be resolved",
+      // A type isn't in the pool: normal for a trace recorded before an
+      // out-of-tree migration renamed it. Can't compare structurally, but the
+      // tag and wire type already matched and the existing definition is kept,
+      // so the field still decodes. Tolerate rather than reject the trace.
+      // TODO(b/524094370): harden this once OOT migrations stabilize.
+      PERFETTO_DLOG(
+          "Field %s re-introduced as %s (was %s): unresolved type, "
+          "skipping compatibility check",
           check.field_name.c_str(), check.new_raw_type.c_str(),
           check.existing_raw_type.c_str());
+      continue;
     }
     std::set<CanonicalDescriptorPair> comparisons_in_progress;
     if (!DescriptorsStructurallyEqual(opt_existing_idx.value(),


### PR DESCRIPTION
#5948  made the descriptor pool accept out-of-tree field renames (same tag, different type name) by comparing the two messages structurally instead of rejecting on the name mismatch. But that comparison needs both the old and new type present in the pool; when one can't be resolved it falls through to an error that aborts the whole trace as corrupt.

That unresolvable case is exactly what a trace recorded before a field's migration hits:

- #6060 (app_wakelock) made the on-device tool bundle a copy of core trace_packet.proto into every trace. That copy references field 56's type by name (perfetto.protos.HeapGraph) but not its definition.
- The field later moved to com.android.art.tracing.HeapGraph and the old type was dropped from the core protos.
- So current trace_processor sees the old name, has only the new one, can resolve neither the old definition (in the trace nor built in), and rejects the trace.
- #6098 stopped the bundling, but only for traces captured after it.

Tolerate the unresolvable case instead of aborting:

- CheckExtensionField already verified the tag and wire type match.
- AddField keeps the existing resolvable definition.
- The migration changed only the package name, not the wire format, so the field still decodes.
- The structural-mismatch and fundamental-type-mismatch checks are unchanged and still reject genuine conflicts.

Bug: 524094370