### PR TITLE
tp: refactor IteratorImpl to be an abstract base for remote iterators

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17783,6 +17783,7 @@ filegroup {
         "src/trace_processor/iterator_impl.cc",
         "src/trace_processor/read_trace.cc",
         "src/trace_processor/read_trace_internal.cc",
+        "src/trace_processor/sqlite_iterator_impl.cc",
         "src/trace_processor/trace_processor.cc",
         "src/trace_processor/trace_processor_impl.cc",
     ],

--- a/BUILD
+++ b/BUILD
@@ -5956,6 +5956,8 @@ perfetto_filegroup(
         "src/trace_processor/read_trace.cc",
         "src/trace_processor/read_trace_internal.cc",
         "src/trace_processor/read_trace_internal.h",
+        "src/trace_processor/sqlite_iterator_impl.cc",
+        "src/trace_processor/sqlite_iterator_impl.h",
         "src/trace_processor/trace_processor.cc",
         "src/trace_processor/trace_processor_impl.cc",
         "src/trace_processor/trace_processor_impl.h",

--- a/include/perfetto/ext/trace_processor/rpc/query_result_serializer.h
+++ b/include/perfetto/ext/trace_processor/rpc/query_result_serializer.h
@@ -36,7 +36,7 @@ class QueryResult;
 namespace trace_processor {
 
 class Iterator;
-class IteratorImpl;
+class SqliteIteratorImpl;
 
 // This class serializes a TraceProcessor query result (i.e. an Iterator)
 // into batches of QueryResult (trace_processor.proto). This class
@@ -83,7 +83,7 @@ class QueryResultSerializer {
   void SerializeBatch(protos::pbzero::QueryResult*);
   void MaybeSerializeError(protos::pbzero::QueryResult*);
 
-  std::unique_ptr<IteratorImpl> iter_;
+  std::unique_ptr<SqliteIteratorImpl> iter_;
   const uint32_t num_cols_;
   const std::optional<base::TimeNanos> t_start_;
   bool did_write_metadata_ = false;

--- a/include/perfetto/trace_processor/iterator.h
+++ b/include/perfetto/trace_processor/iterator.h
@@ -108,8 +108,8 @@ class PERFETTO_EXPORT_COMPONENT Iterator {
   // other internal classes.
   std::unique_ptr<IteratorImpl> iterator_;
 
-  // Non-owning alias of |iterator_| set if (and only if) the backing impl is the
-  // local, sqlite-backed SqliteIteratorImpl (which is `final`). The methods
+  // Non-owning alias of |iterator_| set if (and only if) the backing impl is
+  // the local, sqlite-backed SqliteIteratorImpl (which is `final`). The methods
   // above call through this when set, so the local path stays a direct,
   // devirtualized call: making IteratorImpl abstract (to allow a remote
   // TraceProcessor to return a real Iterator) must not regress existing callers

--- a/include/perfetto/trace_processor/iterator.h
+++ b/include/perfetto/trace_processor/iterator.h
@@ -23,7 +23,6 @@
 
 #include "perfetto/base/export.h"
 #include "perfetto/trace_processor/basic_types.h"
-#include "perfetto/trace_processor/status.h"
 
 namespace perfetto {
 namespace trace_processor {
@@ -108,14 +107,11 @@ class PERFETTO_EXPORT_COMPONENT Iterator {
   // other internal classes.
   std::unique_ptr<IteratorImpl> iterator_;
 
-  // Non-owning alias of |iterator_| set if (and only if) the backing impl is
-  // the local, sqlite-backed SqliteIteratorImpl (which is `final`). The methods
-  // above call through this when set, so the local path stays a direct,
-  // devirtualized call: making IteratorImpl abstract (to allow a remote
-  // TraceProcessor to return a real Iterator) must not regress existing callers
-  // to virtual dispatch. Null for a remote iterator, which then dispatches
-  // through the virtual IteratorImpl* — a remote query is network-bound, so the
-  // indirect call there is irrelevant.
+  // Non-owning alias of |iterator_| set if backing impl is
+  // the local SqliteIteratorImpl. All methods should
+  // above call through this when set, so the the fast path is fast.
+  //
+  // Null for other iterator types.
   SqliteIteratorImpl* sqlite_fast_path_ = nullptr;
 };
 

--- a/include/perfetto/trace_processor/iterator.h
+++ b/include/perfetto/trace_processor/iterator.h
@@ -29,6 +29,7 @@ namespace perfetto {
 namespace trace_processor {
 
 class IteratorImpl;
+class SqliteIteratorImpl;
 
 // Iterator returning SQL rows satisfied by a query.
 //
@@ -94,15 +95,28 @@ class PERFETTO_EXPORT_COMPONENT Iterator {
   friend class QueryResultSerializer;
 
   // This is to allow QueryResultSerializer, which is very perf sensitive, to
-  // access direct the impl_ and avoid one extra function call for each cell.
+  // access the impl directly and avoid one extra function call for each cell.
+  // It downcasts to the concrete |T| (the serializer is only ever fed local
+  // SqliteIteratorImpl iterators) so the per-cell calls devirtualize.
   template <typename T = IteratorImpl>
   std::unique_ptr<T> take_impl() {
-    return std::move(iterator_);
+    sqlite_fast_path_ = nullptr;
+    return std::unique_ptr<T>(static_cast<T*>(iterator_.release()));
   }
 
   // A PIMPL pattern is used to avoid leaking the dependencies on sqlite3.h and
   // other internal classes.
   std::unique_ptr<IteratorImpl> iterator_;
+
+  // Non-owning alias of |iterator_| set if (and only if) the backing impl is the
+  // local, sqlite-backed SqliteIteratorImpl (which is `final`). The methods
+  // above call through this when set, so the local path stays a direct,
+  // devirtualized call: making IteratorImpl abstract (to allow a remote
+  // TraceProcessor to return a real Iterator) must not regress existing callers
+  // to virtual dispatch. Null for a remote iterator, which then dispatches
+  // through the virtual IteratorImpl* — a remote query is network-bound, so the
+  // indirect call there is irrelevant.
+  SqliteIteratorImpl* sqlite_fast_path_ = nullptr;
 };
 
 }  // namespace trace_processor

--- a/include/perfetto/trace_processor/iterator.h
+++ b/include/perfetto/trace_processor/iterator.h
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include "perfetto/base/export.h"
+#include "perfetto/base/status.h"
 #include "perfetto/trace_processor/basic_types.h"
 
 namespace perfetto {

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -160,6 +160,8 @@ if (enable_perfetto_trace_processor_sqlite) {
       "read_trace.cc",
       "read_trace_internal.cc",
       "read_trace_internal.h",
+      "sqlite_iterator_impl.cc",
+      "sqlite_iterator_impl.h",
       "trace_processor.cc",
       "trace_processor_impl.cc",
       "trace_processor_impl.h",
@@ -285,7 +287,7 @@ if (enable_perfetto_trace_processor_sqlite) {
     }
 
     public_deps = [
-      "../../gn:sqlite",  # iterator_impl.h includes sqlite3.h.
+      "../../gn:sqlite",  # sqlite_iterator_impl.h includes sqlite3.h.
       "../../include/perfetto/trace_processor",
     ]
     if (enable_perfetto_trace_processor_mac_instruments) {

--- a/src/trace_processor/iterator_impl.cc
+++ b/src/trace_processor/iterator_impl.cc
@@ -56,8 +56,9 @@ SqlValue Iterator::Get(uint32_t col) {
 }
 
 std::string Iterator::GetColumnName(uint32_t col) {
-  return PERFETTO_LIKELY(sqlite_fast_path_) ? sqlite_fast_path_->GetColumnName(col)
-                                            : iterator_->GetColumnName(col);
+  return PERFETTO_LIKELY(sqlite_fast_path_)
+             ? sqlite_fast_path_->GetColumnName(col)
+             : iterator_->GetColumnName(col);
 }
 
 uint32_t Iterator::ColumnCount() {
@@ -71,8 +72,9 @@ base::Status Iterator::Status() {
 }
 
 uint32_t Iterator::StatementCount() {
-  return PERFETTO_LIKELY(sqlite_fast_path_) ? sqlite_fast_path_->StatementCount()
-                                            : iterator_->StatementCount();
+  return PERFETTO_LIKELY(sqlite_fast_path_)
+             ? sqlite_fast_path_->StatementCount()
+             : iterator_->StatementCount();
 }
 
 uint32_t Iterator::StatementWithOutputCount() {

--- a/src/trace_processor/iterator_impl.cc
+++ b/src/trace_processor/iterator_impl.cc
@@ -22,77 +22,69 @@
 #include <utility>
 
 #include "perfetto/base/status.h"
-#include "perfetto/base/time.h"
-#include "perfetto/ext/base/status_or.h"
+#include "perfetto/public/compiler.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "perfetto/trace_processor/iterator.h"
-#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
-#include "src/trace_processor/storage/trace_storage.h"
-#include "src/trace_processor/trace_processor_impl.h"
+#include "src/trace_processor/sqlite_iterator_impl.h"
 
 namespace perfetto::trace_processor {
 
-IteratorImpl::IteratorImpl(
-    TraceProcessorImpl* trace_processor,
-    base::StatusOr<PerfettoSqlConnection::ExecutionResult> result,
-    uint32_t sql_stats_row)
-    : trace_processor_(trace_processor),
-      result_(std::move(result)),
-      sql_stats_row_(sql_stats_row) {}
-
-IteratorImpl::~IteratorImpl() {
-  if (trace_processor_) {
-    base::TimeNanos t_end = base::GetWallTimeNs();
-    auto* sql_stats =
-        trace_processor_.get()->context()->storage->mutable_sql_stats();
-    sql_stats->RecordQueryEnd(sql_stats_row_, t_end.count());
-  }
-}
-
-void IteratorImpl::RecordFirstNextInSqlStats() {
-  base::TimeNanos t_first_next = base::GetWallTimeNs();
-  auto* sql_stats =
-      trace_processor_.get()->context()->storage->mutable_sql_stats();
-  sql_stats->RecordQueryFirstNext(sql_stats_row_, t_first_next.count());
-}
+// Out-of-line anchor for the abstract base's vtable.
+IteratorImpl::~IteratorImpl() = default;
 
 Iterator::Iterator(std::unique_ptr<IteratorImpl> iterator)
-    : iterator_(std::move(iterator)) {}
+    : iterator_(std::move(iterator)),
+      sqlite_fast_path_(iterator_ ? iterator_->AsSqlite() : nullptr) {}
 Iterator::~Iterator() = default;
 
 Iterator::Iterator(Iterator&&) noexcept = default;
 Iterator& Iterator::operator=(Iterator&&) noexcept = default;
 
+// The forwarders below call through |sqlite_fast_path_| when set: it points at
+// the `final` SqliteIteratorImpl, so the compiler devirtualizes and the local
+// path keeps the direct-call cost it had before IteratorImpl became abstract.
+// Only a remote iterator (sqlite_fast_path_ == nullptr) pays a virtual call.
+
 bool Iterator::Next() {
-  return iterator_->Next();
+  return PERFETTO_LIKELY(sqlite_fast_path_) ? sqlite_fast_path_->Next()
+                                            : iterator_->Next();
 }
 
 SqlValue Iterator::Get(uint32_t col) {
-  return iterator_->Get(col);
+  return PERFETTO_LIKELY(sqlite_fast_path_) ? sqlite_fast_path_->Get(col)
+                                            : iterator_->Get(col);
 }
 
 std::string Iterator::GetColumnName(uint32_t col) {
-  return iterator_->GetColumnName(col);
+  return PERFETTO_LIKELY(sqlite_fast_path_) ? sqlite_fast_path_->GetColumnName(col)
+                                            : iterator_->GetColumnName(col);
 }
 
 uint32_t Iterator::ColumnCount() {
-  return iterator_->ColumnCount();
+  return PERFETTO_LIKELY(sqlite_fast_path_) ? sqlite_fast_path_->ColumnCount()
+                                            : iterator_->ColumnCount();
 }
 
 base::Status Iterator::Status() {
-  return iterator_->Status();
+  return PERFETTO_LIKELY(sqlite_fast_path_) ? sqlite_fast_path_->Status()
+                                            : iterator_->Status();
 }
 
 uint32_t Iterator::StatementCount() {
-  return iterator_->StatementCount();
+  return PERFETTO_LIKELY(sqlite_fast_path_) ? sqlite_fast_path_->StatementCount()
+                                            : iterator_->StatementCount();
 }
 
 uint32_t Iterator::StatementWithOutputCount() {
-  return iterator_->StatementCountWithOutput();
+  return PERFETTO_LIKELY(sqlite_fast_path_)
+             ? sqlite_fast_path_->StatementCountWithOutput()
+             : iterator_->StatementCountWithOutput();
 }
 
 std::string Iterator::LastStatementSql() {
-  return iterator_->LastStatementSql();
+  return PERFETTO_LIKELY(sqlite_fast_path_)
+             ? sqlite_fast_path_->LastStatementSql()
+             : iterator_->LastStatementSql();
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/iterator_impl.cc
+++ b/src/trace_processor/iterator_impl.cc
@@ -40,11 +40,6 @@ Iterator::~Iterator() = default;
 Iterator::Iterator(Iterator&&) noexcept = default;
 Iterator& Iterator::operator=(Iterator&&) noexcept = default;
 
-// The forwarders below call through |sqlite_fast_path_| when set: it points at
-// the `final` SqliteIteratorImpl, so the compiler devirtualizes and the local
-// path keeps the direct-call cost it had before IteratorImpl became abstract.
-// Only a remote iterator (sqlite_fast_path_ == nullptr) pays a virtual call.
-
 bool Iterator::Next() {
   return PERFETTO_LIKELY(sqlite_fast_path_) ? sqlite_fast_path_->Next()
                                             : iterator_->Next();

--- a/src/trace_processor/iterator_impl.h
+++ b/src/trace_processor/iterator_impl.h
@@ -17,149 +17,50 @@
 #ifndef SRC_TRACE_PROCESSOR_ITERATOR_IMPL_H_
 #define SRC_TRACE_PROCESSOR_ITERATOR_IMPL_H_
 
-#include <sqlite3.h>
-#include <cstddef>
 #include <cstdint>
 #include <string>
 
-#include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
-#include "perfetto/ext/base/scoped_file.h"
-#include "perfetto/ext/base/status_or.h"
 #include "perfetto/trace_processor/basic_types.h"
-#include "perfetto/trace_processor/iterator.h"
-#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
-#include "src/trace_processor/sqlite/sqlite_connection.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
-class TraceProcessorImpl;
+class SqliteIteratorImpl;
 
+// Abstract backing for the public Iterator class. Iterator owns a
+// std::unique_ptr<IteratorImpl> and forwards each call to it.
+//
+// There are two implementations:
+//   - SqliteIteratorImpl: the local, sqlite-backed iterator (sqlite_iterator_impl.h).
+//   - RemoteIteratorImpl: iterates results received from a remote trace
+//     processor over the RPC protocol.
+//
+// Keeping this an interface (rather than the single concrete sqlite class it
+// used to be) is what lets a remote TraceProcessor return a real Iterator. The
+// only perf-sensitive consumer (QueryResultSerializer) is always fed local
+// iterators, so it downcasts to the final SqliteIteratorImpl and the per-cell
+// calls devirtualize.
 class IteratorImpl {
  public:
-  IteratorImpl(TraceProcessorImpl* impl,
-               base::StatusOr<PerfettoSqlConnection::ExecutionResult>,
-               uint32_t sql_stats_row);
-  ~IteratorImpl();
+  virtual ~IteratorImpl();
 
-  IteratorImpl(IteratorImpl&) noexcept = delete;
-  IteratorImpl& operator=(IteratorImpl&) = delete;
+  // Methods called by the base Iterator class. See iterator.h for semantics.
+  virtual bool Next() = 0;
+  virtual SqlValue Get(uint32_t col) const = 0;
+  virtual std::string GetColumnName(uint32_t col) const = 0;
+  virtual base::Status Status() const = 0;
+  virtual uint32_t ColumnCount() const = 0;
+  virtual uint32_t StatementCount() const = 0;
+  virtual uint32_t StatementCountWithOutput() const = 0;
+  virtual std::string LastStatementSql() = 0;
 
-  IteratorImpl(IteratorImpl&&) noexcept = default;
-  IteratorImpl& operator=(IteratorImpl&&) = default;
-
-  // Methods called by the base Iterator class.
-  bool Next() {
-    // In the past, we used to call sqlite3_step for the first time in this
-    // function which 1:1 matched Next calls to sqlite3_step calls. However,
-    // with the introduction of multi-statement support, we tokenize the
-    // queries and so we need to *not* call step the first time Next is
-    // called.
-    //
-    // Aside: if we could, we would change the API to match the new setup
-    // (i.e. implement operator bool, make Next return nothing similar to C++
-    // iterators); however, too many clients depend on the current behavior so
-    // we have to keep the API as is.
-    if (!called_next_) {
-      // Delegate to the cc file to prevent trace_storage.h include in this
-      // file.
-      RecordFirstNextInSqlStats();
-      called_next_ = true;
-      return result_.ok() && !result_->stmt.IsDone();
-    }
-    if (!result_.ok()) {
-      return false;
-    }
-
-    bool has_more = result_->stmt.Step();
-    if (!result_->stmt.status().ok()) {
-      PERFETTO_DCHECK(!has_more);
-      result_ = result_->stmt.status();
-    }
-    return has_more;
-  }
-
-  SqlValue Get(uint32_t col) const {
-    PERFETTO_DCHECK(result_.ok());
-
-    auto column = static_cast<int>(col);
-    sqlite3_stmt* stmt = result_->stmt.sqlite_stmt();
-    auto col_type = sqlite3_column_type(stmt, column);
-    SqlValue value;
-    switch (col_type) {
-      case SQLITE_INTEGER:
-        value.type = SqlValue::kLong;
-        value.long_value = sqlite3_column_int64(stmt, column);
-        break;
-      case SQLITE_TEXT:
-        value.type = SqlValue::kString;
-        value.string_value =
-            reinterpret_cast<const char*>(sqlite3_column_text(stmt, column));
-        break;
-      case SQLITE_FLOAT:
-        value.type = SqlValue::kDouble;
-        value.double_value = sqlite3_column_double(stmt, column);
-        break;
-      case SQLITE_BLOB:
-        value.type = SqlValue::kBytes;
-        value.bytes_value = sqlite3_column_blob(stmt, column);
-        value.bytes_count =
-            static_cast<size_t>(sqlite3_column_bytes(stmt, column));
-        break;
-      case SQLITE_NULL:
-        value.type = SqlValue::kNull;
-        break;
-    }
-    return value;
-  }
-
-  std::string GetColumnName(uint32_t col) const {
-    return result_.ok() ? sqlite3_column_name(result_->stmt.sqlite_stmt(),
-                                              static_cast<int>(col))
-                        : "";
-  }
-
-  base::Status Status() const { return result_.status(); }
-
-  uint32_t ColumnCount() const {
-    return result_.ok() ? result_->stats.column_count : 0;
-  }
-
-  uint32_t StatementCount() const {
-    return result_.ok() ? result_->stats.statement_count : 0;
-  }
-
-  uint32_t StatementCountWithOutput() const {
-    return result_.ok() ? result_->stats.statement_count_with_output : 0;
-  }
-
-  std::string LastStatementSql() {
-    return result_.ok() ? result_->stmt.sql() : "";
-  }
-
- private:
-  // Dummy function to pass to ScopedResource.
-  static int DummyClose(TraceProcessorImpl*) { return 0; }
-
-  // Iterators hold onto an instance of TraceProcessor to track when the query
-  // ends in the sql stats table. As iterators are movable, we need to null out
-  // the TraceProcessor in the moved out iterator to avoid double recording
-  // query ends. We could manually define a move constructor instead, but given
-  // the error prone nature of keeping functions up to date, this seems like a
-  // nicer approach.
-  using ScopedTraceProcessor =
-      base::ScopedResource<TraceProcessorImpl*, &DummyClose, nullptr>;
-
-  void RecordFirstNextInSqlStats();
-
-  ScopedTraceProcessor trace_processor_;
-  base::StatusOr<PerfettoSqlConnection::ExecutionResult> result_;
-  uint32_t sql_stats_row_ = 0;
-  bool called_next_ = false;
+  // Returns |this| iff this is the local, sqlite-backed SqliteIteratorImpl,
+  // otherwise nullptr. Lets the public Iterator cache a typed pointer to the
+  // concrete |final| impl and keep the local path a direct, devirtualized call.
+  // See Iterator::sqlite_fast_path_.
+  virtual SqliteIteratorImpl* AsSqlite() { return nullptr; }
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_ITERATOR_IMPL_H_

--- a/src/trace_processor/iterator_impl.h
+++ b/src/trace_processor/iterator_impl.h
@@ -31,16 +31,9 @@ class SqliteIteratorImpl;
 // std::unique_ptr<IteratorImpl> and forwards each call to it.
 //
 // There are two implementations:
-//   - SqliteIteratorImpl: the local, sqlite-backed iterator
-//   (sqlite_iterator_impl.h).
-//   - RemoteIteratorImpl: iterates results received from a remote trace
+//   - SqliteIteratorImpl: the local iterator implementation.
+//   - RemoteIteratorImpl: results received from a remote trace
 //     processor over the RPC protocol.
-//
-// Keeping this an interface (rather than the single concrete sqlite class it
-// used to be) is what lets a remote TraceProcessor return a real Iterator. The
-// only perf-sensitive consumer (QueryResultSerializer) is always fed local
-// iterators, so it downcasts to the final SqliteIteratorImpl and the per-cell
-// calls devirtualize.
 class IteratorImpl {
  public:
   virtual ~IteratorImpl();
@@ -55,10 +48,8 @@ class IteratorImpl {
   virtual uint32_t StatementCountWithOutput() const = 0;
   virtual std::string LastStatementSql() = 0;
 
-  // Returns |this| iff this is the local, sqlite-backed SqliteIteratorImpl,
-  // otherwise nullptr. Lets the public Iterator cache a typed pointer to the
-  // concrete |final| impl and keep the local path a direct, devirtualized call.
-  // See Iterator::sqlite_fast_path_.
+  // Returns |this| if this is the local iterator implementation,
+  // otherwise nullptr. Allows for fast-path optimizations.
   virtual SqliteIteratorImpl* AsSqlite() { return nullptr; }
 };
 

--- a/src/trace_processor/iterator_impl.h
+++ b/src/trace_processor/iterator_impl.h
@@ -31,7 +31,8 @@ class SqliteIteratorImpl;
 // std::unique_ptr<IteratorImpl> and forwards each call to it.
 //
 // There are two implementations:
-//   - SqliteIteratorImpl: the local, sqlite-backed iterator (sqlite_iterator_impl.h).
+//   - SqliteIteratorImpl: the local, sqlite-backed iterator
+//   (sqlite_iterator_impl.h).
 //   - RemoteIteratorImpl: iterates results received from a remote trace
 //     processor over the RPC protocol.
 //

--- a/src/trace_processor/rpc/query_result_serializer.cc
+++ b/src/trace_processor/rpc/query_result_serializer.cc
@@ -21,7 +21,8 @@
 #include "perfetto/protozero/packed_repeated_fields.h"
 #include "perfetto/protozero/proto_utils.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
-#include "src/trace_processor/iterator_impl.h"
+#include "perfetto/trace_processor/iterator.h"
+#include "src/trace_processor/sqlite_iterator_impl.h"
 
 #include "protos/perfetto/trace_processor/trace_processor.pbzero.h"
 
@@ -48,7 +49,7 @@ uint8_t MakeLenDelimTag(uint32_t field_num) {
 QueryResultSerializer::QueryResultSerializer(
     Iterator iter,
     std::optional<base::TimeNanos> t_start)
-    : iter_(iter.take_impl()),
+    : iter_(iter.take_impl<SqliteIteratorImpl>()),
       num_cols_(iter_->ColumnCount()),
       t_start_(t_start) {}
 

--- a/src/trace_processor/sqlite_iterator_impl.cc
+++ b/src/trace_processor/sqlite_iterator_impl.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/sqlite_iterator_impl.h"
+
+#include <cstdint>
+#include <utility>
+
+#include "perfetto/base/time.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/trace_processor_impl.h"
+
+namespace perfetto::trace_processor {
+
+SqliteIteratorImpl::SqliteIteratorImpl(
+    TraceProcessorImpl* trace_processor,
+    base::StatusOr<PerfettoSqlConnection::ExecutionResult> result,
+    uint32_t sql_stats_row)
+    : trace_processor_(trace_processor),
+      result_(std::move(result)),
+      sql_stats_row_(sql_stats_row) {}
+
+SqliteIteratorImpl::~SqliteIteratorImpl() {
+  if (trace_processor_) {
+    base::TimeNanos t_end = base::GetWallTimeNs();
+    auto* sql_stats =
+        trace_processor_.get()->context()->storage->mutable_sql_stats();
+    sql_stats->RecordQueryEnd(sql_stats_row_, t_end.count());
+  }
+}
+
+void SqliteIteratorImpl::RecordFirstNextInSqlStats() {
+  base::TimeNanos t_first_next = base::GetWallTimeNs();
+  auto* sql_stats =
+      trace_processor_.get()->context()->storage->mutable_sql_stats();
+  sql_stats->RecordQueryFirstNext(sql_stats_row_, t_first_next.count());
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/sqlite_iterator_impl.h
+++ b/src/trace_processor/sqlite_iterator_impl.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SQLITE_ITERATOR_IMPL_H_
+#define SRC_TRACE_PROCESSOR_SQLITE_ITERATOR_IMPL_H_
+
+#include <sqlite3.h>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/scoped_file.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/trace_processor/basic_types.h"
+#include "src/trace_processor/iterator_impl.h"
+#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
+#include "src/trace_processor/sqlite/sqlite_connection.h"
+
+namespace perfetto {
+namespace trace_processor {
+
+class TraceProcessorImpl;
+
+// The local, sqlite-backed IteratorImpl. Wraps a PerfettoSqlConnection
+// ExecutionResult and reads cells directly from the sqlite statement.
+class SqliteIteratorImpl final : public IteratorImpl {
+ public:
+  SqliteIteratorImpl(TraceProcessorImpl* impl,
+                     base::StatusOr<PerfettoSqlConnection::ExecutionResult>,
+                     uint32_t sql_stats_row);
+  ~SqliteIteratorImpl() override;
+
+  SqliteIteratorImpl(SqliteIteratorImpl&) noexcept = delete;
+  SqliteIteratorImpl& operator=(SqliteIteratorImpl&) = delete;
+
+  SqliteIteratorImpl(SqliteIteratorImpl&&) noexcept = default;
+  SqliteIteratorImpl& operator=(SqliteIteratorImpl&&) = default;
+
+  bool Next() override {
+    // In the past, we used to call sqlite3_step for the first time in this
+    // function which 1:1 matched Next calls to sqlite3_step calls. However,
+    // with the introduction of multi-statement support, we tokenize the
+    // queries and so we need to *not* call step the first time Next is
+    // called.
+    //
+    // Aside: if we could, we would change the API to match the new setup
+    // (i.e. implement operator bool, make Next return nothing similar to C++
+    // iterators); however, too many clients depend on the current behavior so
+    // we have to keep the API as is.
+    if (!called_next_) {
+      // Delegate to the cc file to prevent trace_storage.h include in this
+      // file.
+      RecordFirstNextInSqlStats();
+      called_next_ = true;
+      return result_.ok() && !result_->stmt.IsDone();
+    }
+    if (!result_.ok()) {
+      return false;
+    }
+
+    bool has_more = result_->stmt.Step();
+    if (!result_->stmt.status().ok()) {
+      PERFETTO_DCHECK(!has_more);
+      result_ = result_->stmt.status();
+    }
+    return has_more;
+  }
+
+  SqlValue Get(uint32_t col) const override {
+    PERFETTO_DCHECK(result_.ok());
+
+    auto column = static_cast<int>(col);
+    sqlite3_stmt* stmt = result_->stmt.sqlite_stmt();
+    auto col_type = sqlite3_column_type(stmt, column);
+    SqlValue value;
+    switch (col_type) {
+      case SQLITE_INTEGER:
+        value.type = SqlValue::kLong;
+        value.long_value = sqlite3_column_int64(stmt, column);
+        break;
+      case SQLITE_TEXT:
+        value.type = SqlValue::kString;
+        value.string_value =
+            reinterpret_cast<const char*>(sqlite3_column_text(stmt, column));
+        break;
+      case SQLITE_FLOAT:
+        value.type = SqlValue::kDouble;
+        value.double_value = sqlite3_column_double(stmt, column);
+        break;
+      case SQLITE_BLOB:
+        value.type = SqlValue::kBytes;
+        value.bytes_value = sqlite3_column_blob(stmt, column);
+        value.bytes_count =
+            static_cast<size_t>(sqlite3_column_bytes(stmt, column));
+        break;
+      case SQLITE_NULL:
+        value.type = SqlValue::kNull;
+        break;
+    }
+    return value;
+  }
+
+  std::string GetColumnName(uint32_t col) const override {
+    return result_.ok() ? sqlite3_column_name(result_->stmt.sqlite_stmt(),
+                                              static_cast<int>(col))
+                        : "";
+  }
+
+  base::Status Status() const override { return result_.status(); }
+
+  uint32_t ColumnCount() const override {
+    return result_.ok() ? result_->stats.column_count : 0;
+  }
+
+  uint32_t StatementCount() const override {
+    return result_.ok() ? result_->stats.statement_count : 0;
+  }
+
+  uint32_t StatementCountWithOutput() const override {
+    return result_.ok() ? result_->stats.statement_count_with_output : 0;
+  }
+
+  std::string LastStatementSql() override {
+    return result_.ok() ? result_->stmt.sql() : "";
+  }
+
+  SqliteIteratorImpl* AsSqlite() override { return this; }
+
+ private:
+  // Dummy function to pass to ScopedResource.
+  static int DummyClose(TraceProcessorImpl*) { return 0; }
+
+  // Iterators hold onto an instance of TraceProcessor to track when the query
+  // ends in the sql stats table. As iterators are movable, we need to null out
+  // the TraceProcessor in the moved out iterator to avoid double recording
+  // query ends. We could manually define a move constructor instead, but given
+  // the error prone nature of keeping functions up to date, this seems like a
+  // nicer approach.
+  using ScopedTraceProcessor =
+      base::ScopedResource<TraceProcessorImpl*, &DummyClose, nullptr>;
+
+  void RecordFirstNextInSqlStats();
+
+  ScopedTraceProcessor trace_processor_;
+  base::StatusOr<PerfettoSqlConnection::ExecutionResult> result_;
+  uint32_t sql_stats_row_ = 0;
+  bool called_next_ = false;
+};
+
+}  // namespace trace_processor
+}  // namespace perfetto
+
+#endif  // SRC_TRACE_PROCESSOR_SQLITE_ITERATOR_IMPL_H_

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -77,7 +77,6 @@
 #include "src/trace_processor/importers/proto/heap_graph_tracker.h"
 #include "src/trace_processor/importers/simpleperf_proto/simpleperf_proto_tokenizer.h"
 #include "src/trace_processor/importers/systrace/systrace_trace_parser.h"
-#include "src/trace_processor/iterator_impl.h"
 #include "src/trace_processor/metrics/all_chrome_metrics.descriptor.h"
 #include "src/trace_processor/metrics/all_webview_metrics.descriptor.h"
 #include "src/trace_processor/metrics/metrics.descriptor.h"
@@ -142,6 +141,7 @@
 #include "src/trace_processor/sqlite/bindings/sqlite_function.h"
 #include "src/trace_processor/sqlite/bindings/sqlite_result.h"
 #include "src/trace_processor/sqlite/sql_source.h"
+#include "src/trace_processor/sqlite_iterator_impl.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tp_metatrace.h"
 #include "src/trace_processor/trace_processor_storage_impl.h"
@@ -644,9 +644,8 @@ Iterator TraceProcessorImpl::ExecuteQuery(const std::string& sql) {
   base::StatusOr<PerfettoSqlConnection::ExecutionResult> result =
       engine_->ExecuteUntilLastStatement(
           SqlSource::FromExecuteQuery(std::move(non_breaking_sql)));
-  std::unique_ptr<IteratorImpl> impl(
-      new IteratorImpl(this, std::move(result), sql_stats_row));
-  return Iterator(std::move(impl));
+  return Iterator(std::make_unique<SqliteIteratorImpl>(this, std::move(result),
+                                                       sql_stats_row));
 }
 
 base::Status TraceProcessorImpl::RegisterSqlPackage(SqlPackage sql_package) {

--- a/src/trace_processor/trace_processor_impl.h
+++ b/src/trace_processor/trace_processor_impl.h
@@ -36,7 +36,6 @@
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "perfetto/trace_processor/trace_processor.h"
 #include "src/trace_processor/core/plugin/plugin.h"
-#include "src/trace_processor/iterator_impl.h"
 #include "src/trace_processor/metrics/metrics.h"
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
 #include "src/trace_processor/storage/trace_storage.h"
@@ -45,6 +44,8 @@
 #include "src/trace_processor/util/descriptors.h"
 
 namespace perfetto::trace_processor {
+
+class SqliteIteratorImpl;
 
 // Coordinates the loading of traces from an arbitrary source and allows
 // execution of SQL queries on the events in these traces.
@@ -138,7 +139,7 @@ class TraceProcessorImpl : public TraceProcessor,
 
  private:
   // Needed for iterators to be able to access the context.
-  friend class IteratorImpl;
+  friend class SqliteIteratorImpl;
 
   // By-value RegisterMetric body. External callers go through the
   // |RegisterMetric| override (which copies its const-ref args into our


### PR DESCRIPTION
Split IteratorImpl into an abstract base plus final subclass, so a
remote TraceProcessor can have its own implementation. The
public ExecuteQuery function returns the Iterator by value, so the
polymorphism has to live behind the pImpl pattern.

To avoid regressing existing callers from direct calls to virtual valls,
Iterator caches the SqliteIteratorImpl* directly and forwarders to it directly.
Because SqliteIteratorImpl is `final`, the compiler should devirtualizes the local path to
a direct call (verified in the disassembly). QueryResultSerializer is unchanged: it
still takes the concrete impl and devirtualizes per cell.
