### PR TITLE
ui: Allow createPerfettoTable() to take a list of rows as records

### DIFF
--- a/ui/src/trace_processor/sql_utils.ts
+++ b/ui/src/trace_processor/sql_utils.ts
@@ -153,9 +153,42 @@ async function createDisposableSqlEntity(
 
 type CreateTableArgs = {
   readonly engine: Engine;
-  readonly as: string;
+  readonly as: string | readonly Record<string, SqlValue>[];
   readonly name?: string;
 };
+
+/**
+ * Builds a SELECT statement that materializes the given rows inline, e.g. for
+ * use as a subquery or to define a table without a source trace.
+ *
+ * Each row becomes `SELECT <value> AS <col>, ...` and the rows are combined
+ * with `UNION ALL`, so the result is a self-contained query yielding exactly
+ * those rows. Column names are taken from the first row; every row is expected
+ * to have the same keys. Values are rendered via sqlValueToSqliteString().
+ *
+ * Example: [{id: 1, name: 'a'}, {id: 2, name: 'b'}] produces
+ *   SELECT 1 AS id, 'a' AS name UNION ALL SELECT 2 AS id, 'b' AS name
+ *
+ * @param rows The rows to materialize; must be non-empty.
+ * @returns The combined SELECT ... UNION ALL ... query string.
+ */
+export function rowsToSelectStatement(
+  rows: readonly Record<string, SqlValue>[],
+) {
+  const firstRow = rows[0];
+  const columnNames = Object.keys(firstRow);
+  const queryRows: string[] = [];
+  for (const row of rows) {
+    const queryCols: string[] = [];
+    for (const key of columnNames) {
+      const value = row[key] ?? null;
+      queryCols.push(`${sqlValueToSqliteString(value)} AS ${key}`);
+    }
+    queryRows.push(`SELECT ${queryCols.join(', ')}`);
+  }
+
+  return queryRows.join(' UNION ALL ');
+}
 
 /**
  * Asynchronously creates a "perfetto" SQL table using the given engine and
@@ -163,7 +196,7 @@ type CreateTableArgs = {
  *
  * @param args The arguments for creating the table.
  * @param args.engine The database engine to execute the query.
- * @param args.as The SQL expression to define the table.
+ * @param args.as The SQL expression to define the table or an array of row-like objects.
  * @param args.name The name of the table to be created.
  * @returns An AsyncDisposable which drops the created table when disposed.
  */
@@ -171,7 +204,13 @@ export async function createPerfettoTable(
   args: CreateTableArgs,
 ): Promise<DisposableSqlEntity> {
   const {engine, as, name = makeTempName()} = args;
-  await engine.query(`CREATE PERFETTO TABLE ${name} AS ${as}`);
+  let asQuery: string;
+  if (typeof as === 'string') {
+    asQuery = as;
+  } else {
+    asQuery = rowsToSelectStatement(as);
+  }
+  await engine.query(`CREATE PERFETTO TABLE ${name} AS ${asQuery}`);
   return createDisposableSqlEntity(engine, name, 'TABLE');
 }
 

--- a/ui/src/trace_processor/sql_utils_unittest.ts
+++ b/ui/src/trace_processor/sql_utils_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {constraintsToQuerySuffix} from './sql_utils';
+import {constraintsToQuerySuffix, rowsToSelectStatement} from './sql_utils';
 
 // Clean up repeated whitespaces to allow for easier testing.
 function normalize(s: string): string {
@@ -81,4 +81,59 @@ test('constraintsToQuerySuffix: all undefined', () => {
       }),
     ),
   ).toEqual('');
+});
+
+describe('createTableQuery', () => {
+  test('single row', () => {
+    const query = rowsToSelectStatement([
+      {foo: 123, bar: 'bar', baz: 123n, qux: null},
+    ]);
+    expect(query).toBe(
+      "SELECT 123 AS foo, 'bar' AS bar, 123 AS baz, NULL AS qux",
+    );
+  });
+
+  test('multiple rows', () => {
+    const query = rowsToSelectStatement([
+      {foo: 123, bar: 'bar', baz: 123n, qux: null},
+      {foo: 456, bar: 'baz', baz: 456n, qux: null},
+    ]);
+    expect(query).toBe(
+      "SELECT 123 AS foo, 'bar' AS bar, 123 AS baz, NULL AS qux " +
+        "UNION ALL SELECT 456 AS foo, 'baz' AS bar, 456 AS baz, NULL AS qux",
+    );
+  });
+
+  test('out of order columns', () => {
+    const query = rowsToSelectStatement([
+      {foo: 123, bar: 'bar', baz: 123n, qux: null},
+      {bar: 'baz', baz: 456n, qux: null, foo: 456},
+    ]);
+    expect(query).toBe(
+      "SELECT 123 AS foo, 'bar' AS bar, 123 AS baz, NULL AS qux " +
+        "UNION ALL SELECT 456 AS foo, 'baz' AS bar, 456 AS baz, NULL AS qux",
+    );
+  });
+
+  test('missing columns treated as nulls', () => {
+    const query = rowsToSelectStatement([
+      {foo: 123, bar: 'bar', baz: 123n, qux: null},
+      {bar: 'baz', baz: 456n},
+    ]);
+    expect(query).toBe(
+      "SELECT 123 AS foo, 'bar' AS bar, 123 AS baz, NULL AS qux " +
+        "UNION ALL SELECT NULL AS foo, 'baz' AS bar, 456 AS baz, NULL AS qux",
+    );
+  });
+
+  test('additional columns after first row ignored', () => {
+    const query = rowsToSelectStatement([
+      {foo: 123, bar: 'bar', baz: 123n, qux: null},
+      {notacol: 123},
+    ]);
+    expect(query).toBe(
+      "SELECT 123 AS foo, 'bar' AS bar, 123 AS baz, NULL AS qux " +
+        'UNION ALL SELECT NULL AS foo, NULL AS bar, NULL AS baz, NULL AS qux',
+    );
+  });
 });


### PR DESCRIPTION
Allow the `as` param in `createPerfettoTable()` to be an array of records in order to pre-populate the table with a type-safe list of types.

I.e.

```ts
as: string | readonly Record<string, SqlValue>[];
```

So we can use the function like this to initialise a table without having to hand craft the SQL.

```ts
await createPerfettoTable({
  engine,
  name: 'myTable',
  as: [
    {id: 1, ts: 100n, dur: 10, name: 'foo'},
    {id: 2, ts: 200n, dur: 50, name: 'bar'},
    {id: 3, ts: 300n, dur: 5, name: 'foo'},
  ],
});
```

This is simply a convenience feature to make it easier to create pre-filled tables, mainly for testing.