### PR TITLE
ui: Use shift + mouse wheel to horizontally scroll timeline + DE page

### DIFF
--- a/ui/src/base/zoned_interaction_handler.ts
+++ b/ui/src/base/zoned_interaction_handler.ts
@@ -136,8 +136,9 @@ export interface Zone {
   onClick?(e: ClickEvent): void;
 
   // Optional: If present, this function will be called when the wheel is
-  // scrolled while hovering over this zone.
-  onWheel?(e: InteractionWheelEvent): void;
+  // scrolled while hovering over this zone. If the return value is truthy
+  // then we call e.preventDefault() on the underlying event.
+  onWheel?(e: InteractionWheelEvent): boolean | void;
 }
 
 interface InProgressGesture {
@@ -296,12 +297,15 @@ export class ZonedInteractionHandler implements Disposable {
     const mousePositionClient = new Vector2D({x: e.clientX, y: e.clientY});
     const mouse = mousePositionClient.sub(this.target.getBoundingClientRect());
     const zone = this.findZone((z) => z.onWheel && this.hitTestZone(z, mouse));
-    zone?.onWheel?.({
+    const handled = zone?.onWheel?.({
       position: mouse,
       deltaX: e.deltaX,
       deltaY: e.deltaY,
       ctrlKey: e.ctrlKey,
     });
+    if (handled) {
+      e.preventDefault();
+    }
   }
 
   private handleDrag(

--- a/ui/src/core_plugins/dev.perfetto.Timeline/timeline_interactions.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/timeline_interactions.ts
@@ -41,6 +41,12 @@ export function shiftDragPanInteraction(
         trace.timeline.pan(timescale.pxToDuration(-e.deltaSinceLastEvent.x));
       },
     },
+    onWheel: (e) => {
+      // We know shift is held so we translate Y scrolling into X scrolling instead
+      const tDelta = timescale.pxToDuration(e.deltaY);
+      trace.timeline.pan(tDelta);
+      return true; // Return true to prevent vertical scroll
+    },
   };
 }
 

--- a/ui/src/widgets/nodegraph.ts
+++ b/ui/src/widgets/nodegraph.ts
@@ -1518,6 +1518,9 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
         x: mouseX - canvasX * newZoom,
         y: mouseY - canvasY * newZoom,
       };
+    } else if (e.shiftKey) {
+      // Emulate horizontal scroll while shift held
+      panBy(-e.deltaY, 0);
     } else {
       // Pan the canvas based on wheel delta
       panBy(-e.deltaX, -e.deltaY);


### PR DESCRIPTION
Use shift + mouse wheel to horizontally scroll the timeline and in NodeGraph (e.g. the Data Explorer page)

Fixes: https://github.com/google/perfetto/issues/6255