### PR TITLE
ai/skills: add GPGPU compute kernel analysis skills

### DIFF
--- a/ai/skills/perfetto/SKILL-template.md
+++ b/ai/skills/perfetto/SKILL-template.md
@@ -54,6 +54,10 @@ retention, or optimize heap usage:
 If you have a resolved trace with GPU activity and want to know whether the
 workload is GPU-bound or host-bound:
 
+*   **GPU inventory:** To see what GPUs the trace describes — vendor, model,
+    architecture, per machine (multi-GPU and multi-machine aware), which decides
+    which vendor-specific analysis applies, read
+    [gpu_info.md](workflows/gpu/gpu_info.md).
 *   **GPU timeline occupancy:** To decompose the GPU timeline into device-busy
     vs idle time, get per-GPU busy percentages, and find the largest idle gaps
     with host-side attribution, read

--- a/ai/skills/perfetto/workflows/gpu/compute/kernel_analysis.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/kernel_analysis.md
@@ -1,0 +1,99 @@
+# GPU compute kernels — which kernel is the bottleneck, and why?
+
+This workflow decomposes a trace's GPU **compute** work (CUDA / ROCm / compute
+dispatches) kernel by kernel: which kernel dominates, whether it is
+compute-bound, memory-bound, or latency/occupancy-bound, and which specific
+resource — a pipeline, the occupancy limit, a cache level, the launch config —
+is the lever. A single device-wide "GPU utilization %" cannot answer any of
+these; you need the per-kernel decomposition.
+
+It decomposes each compute kernel into four lenses — Speed of Light, Occupancy,
+Workload Analysis, and Launch Statistics — computed directly from the trace's
+GPU counters and kernel launch args.
+
+If the user has not yet loaded a trace into `trace_processor`, follow
+`../../../infra-references/querying.md` first, then come back here.
+
+> If `scripts/kernels_summary.sql` returns no rows, the trace has no compute
+> dispatches (no GPU slices with `render_stage_category = 2`) and this workflow
+> does not apply.
+
+---
+
+## Phase 1: Mandatory first-pass triage — the all-kernels table
+
+Run this before drilling any single kernel; it names the hotspot. The table is
+**vendor-neutral** — slice timing and launch shape only. The compute-vs-memory
+verdict needs vendor throughput counters and comes from Phase 2 (Speed of Light).
+
+```bash
+trace_processor query --query-file scripts/kernels_summary.sql TRACE_FILE
+```
+
+Columns: `id` (launch order), `kernel`, `ugpu`, `dur_ns`, `block_size`,
+`grid_size`, `registers`.
+
+1.  **Pick the kernel that matters** — usually the one (or the recurring name)
+    that dominates `dur_ns`. Note its `id`; every deeper phase reports the same
+    `id`, so you can line the kernel up across tables.
+
+2.  **Identify the GPU and vendor.** Read the authoritative vendor and
+    architecture for the kernel's `ugpu` from [../gpu_info.md](../gpu_info.md);
+    that decides which vendor deep-dive to use, and enumerates every GPU and
+    machine so you scope correctly (per `ugpu`). The metrics below are described
+    by their vendor-neutral display names; each section forwards to the matching
+    vendor extraction for the concrete counters.
+
+3.  **Classify the kernel** in Phase 2 (Speed of Light) — compute-bound,
+    memory-bound, or latency/occupancy-bound — then follow the branch it points
+    to. (Classification needs vendor throughput counters, so it is not in this
+    neutral table.)
+
+---
+
+## Phase 2: Decompose the chosen kernel
+
+Follow the branch(es) your Phase 1 hypothesis points to. Each is its own
+workflow; read the one you need.
+
+- **Speed of Light** — compute vs memory vs latency bound, with the cache/DRAM
+  breakdown: [speed_of_light.md](speed_of_light.md).
+- **Occupancy** — is launch config / resource pressure the limit, and which
+  resource: [occupancy.md](occupancy.md).
+- **Workload Analysis** — which execution pipeline is saturated (for
+  compute-bound kernels): [workload_analysis.md](workload_analysis.md).
+- **Launch Statistics** — the raw launch configuration and whether it is sane:
+  [launch_statistics.md](launch_statistics.md).
+
+Each section workflow is vendor-neutral in its interpretation and forwards to a
+vendor-specific extraction (e.g. `nvidia/…`) for the actual counters.
+
+---
+
+## Phase 3: Reporting
+
+A good summary states:
+
+1.  **Which kernel** — the hotspot (`id`, name, `dur_ns`, and its share of GPU
+    time if known).
+2.  **The bound type** — compute / memory / latency-occupancy bound, with the
+    numbers (Compute Throughput, Memory Throughput, Achieved Occupancy, the
+    saturated pipe).
+3.  **The lever** — named concretely: a launch-config change (block size,
+    registers, shared memory) to lift occupancy; a precision / instruction-mix
+    change for a saturated pipe; a memory-layout / locality change for a
+    memory-bound kernel.
+
+To compare two kernels (e.g. before/after, or two variants), run the same
+Phase-2 scripts and diff the rows for the two `id`s — every script emits one row
+per kernel, so a baseline comparison is a row-vs-row read.
+
+Keep the SQL and kernel ids available so the user can audit.
+
+## Reference
+
+- GPU data sources: <https://perfetto.dev/docs/data-sources/gpu>
+- Compute kernel = `gpu_slice.render_stage_category = 2` (the COMPUTE
+  render-stage category); compute counters = `gpu_counter_group.group_id = 6`
+  (the `GpuCounterGroup` COMPUTE value), matched per `ugpu` over the kernel
+  window. (The two "compute" magic numbers, 2 and 6, are different enums.)

--- a/ai/skills/perfetto/workflows/gpu/compute/launch_statistics.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/launch_statistics.md
@@ -1,0 +1,45 @@
+# Compute kernel — launch statistics
+
+The launch configuration defines the size of the work, how it divides into
+blocks, and the per-block GPU resources. An inefficient config caps device
+utilization before a single instruction runs. This data is **vendor-neutral** —
+it comes from launch args the trace records the same way for every compute
+producer — so this workflow is self-contained (no vendor layer).
+
+> **Naming note — the one exception.** The launch-arg names below
+> (`workgroup_size`, `grid_size`, `registers_per_thread`, `occupancy_limit_*`, …)
+> are CUDA-derived, but the trace records them under these same keys regardless
+> of GPU vendor. This is the **only** generic compute skill that uses
+> vendor-origin names; every other generic skill uses vendor-neutral display
+> names. The concepts are universal (block ≈ workgroup, grid ≈ NDRange, compute
+> unit ≈ SM / CU).
+
+## Get the data
+
+```bash
+trace_processor query --query-file scripts/launch_statistics.sql TRACE_FILE
+```
+
+Columns: `id`, `kernel`, `block_size`, `grid_size`, `thread_count`,
+`registers`, `shared_mem_static`, `shared_mem_dynamic`, `shared_mem_config`,
+`barriers_per_block`, `waves_per_sm`, `func_cache_config`.
+
+## Interpret
+
+- **`block_size`** should be a multiple of the warp/wavefront size (**32 on
+  NVIDIA, 64 on AMD**). A non-multiple wastes part of every warp/wavefront. Very
+  small blocks underuse each compute unit; very large blocks raise
+  register/shared-memory pressure.
+- **`grid_size` / `waves_per_sm`** gauge whether the launch fills the GPU:
+  `waves_per_sm < 1` means the grid is too small (idle compute units); `1–2`
+  risks tail effects; `≥ 4` balances load. (Occupancy analysis goes deeper —
+  [occupancy.md](occupancy.md).)
+- **`registers` and `shared_mem_*`** are the resources that most often cap
+  occupancy; high values for either limit how many blocks fit per compute unit.
+  Cross-check against the binding resource in [occupancy.md](occupancy.md).
+- **`func_cache_config`** (e.g. prefer-L1 vs prefer-shared) should match the
+  kernel's actual shared-memory use; a mismatch wastes the carveout.
+
+Launch Statistics is descriptive: it tells you what was requested. Whether the
+config actually limited the kernel is answered by [occupancy.md](occupancy.md)
+(resource limits) and [speed_of_light.md](speed_of_light.md) (bound type).

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/occupancy.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/occupancy.md
@@ -1,0 +1,33 @@
+# NVIDIA — occupancy extraction
+
+The NVIDIA extraction behind the occupancy analysis. Run it, then apply the
+block-size / waves / binding-resource interpretation from
+[../occupancy.md](../occupancy.md).
+
+```bash
+trace_processor query --query-file scripts/occupancy.sql TRACE_FILE
+```
+
+One row per compute kernel (longest first). Display label → output column →
+NVIDIA counter / launch arg:
+
+| Display label (generic) | Column | NVIDIA counter / arg |
+|---|---|---|
+| Theoretical Occupancy | `theoretical_occ_pct` | `sm__maximum_warps_per_active_cycle_pct` (arg) |
+| Achieved Occupancy | `achieved_occ_pct` | `sm__warps_active.avg.pct_of_peak_sustained_active` (counter) |
+| Block Limit (blocks) | `limit_blocks` | `occupancy_limit_blocks` (arg) |
+| Block Limit (registers) | `limit_registers` | `occupancy_limit_registers` (arg) |
+| Block Limit (shared memory) | `limit_shared_mem` | `occupancy_limit_shared_mem` (arg) |
+| Block Limit (warps) | `limit_warps` | `occupancy_limit_warps` (arg) |
+| Block Limit (barriers) | `limit_barriers` | `occupancy_limit_barriers` (arg) |
+
+Also emitted (launch shape): `block_size`, `grid_size`, `registers`,
+`shared_mem_static`, `shared_mem_dynamic`, `waves_per_sm`, and
+`binding_resource` (the resource at the smallest block limit).
+
+On NVIDIA the compute unit is the **SM** and the warp size is **32**, so
+`block_size` should be a multiple of 32. `binding_resource` is the
+`occupancy_limit_*` with the fewest blocks per SM — the resource to relax.
+
+<!-- Architecture-specific guidance (e.g. nvidia/h100/) would forward from here:
+     SM count, max warps/registers/shared-mem per SM for the exact arch. -->

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/scripts/occupancy.sql
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/scripts/occupancy.sql
@@ -1,0 +1,141 @@
+-- NVIDIA compute kernels — occupancy and its limiting factor.
+--
+-- For every compute kernel: theoretical vs achieved occupancy, the launch
+-- resources that bound it, and which resource is the binding constraint. This
+-- is the data for "is occupancy limiting this kernel, and what caps it?".
+--
+-- Theoretical occupancy and the per-resource block limits are recorded as
+-- launch ARGS on the kernel slice (sm__maximum_warps_*, occupancy_limit_*);
+-- achieved occupancy is a COMPUTE-group COUNTER (sm__warps_active.*, AVG),
+-- matched to the kernel's GPU over its window. The binding resource is the
+-- occupancy_limit_* with the smallest value (fewest blocks/SM allowed);
+-- limits that are absent are skipped, and ties resolve in the order
+-- blocks, registers, shared_mem, warps, barriers.
+--
+-- No parameters; operates on the whole trace. One row per compute kernel,
+-- longest first. Columns:
+--   id                  : launch order (matches kernels_summary.sql).
+--   kernel              : demangled kernel name.
+--   theoretical_occ_pct : sm__maximum_warps_per_active_cycle_pct (arg).
+--   achieved_occ_pct    : sm__warps_active.avg.pct_of_peak_sustained_active (AVG).
+--   block_size          : threads per block (workgroup_size).
+--   grid_size           : number of blocks.
+--   registers           : registers per thread.
+--   shared_mem_static   : static shared memory per block, bytes.
+--   shared_mem_dynamic  : dynamic shared memory per block, bytes.
+--   waves_per_sm        : waves_per_multiprocessor (grid / SM-resident blocks).
+--   limit_blocks/registers/shared_mem/warps/barriers : blocks/SM allowed by
+--                         each resource (occupancy_limit_*).
+--   binding_resource    : the resource at the smallest limit (the bottleneck);
+--                         NULL only if no limit arg is present at all.
+--
+-- Interpret: block_size should be a multiple of the warp size (32 on NVIDIA);
+-- waves_per_sm < 1 = grid too small to fill the GPU, 1-2 = tail effects, >= 4 =
+-- good load balance. A large theoretical-vs-achieved gap means imbalance/tails;
+-- reduce the binding_resource to raise theoretical occupancy if occupancy is
+-- the limit. See compute/occupancy.md.
+
+CREATE PERFETTO TABLE _kernels AS
+SELECT
+  s.id,
+  s.ts,
+  s.dur,
+  s.arg_set_id,
+  ROW_NUMBER() OVER (ORDER BY s.ts) AS launch_id,
+  EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu') AS ugpu,
+  COALESCE(
+    EXTRACT_ARG(s.arg_set_id, 'kernel_demangled_name'),
+    EXTRACT_ARG(s.arg_set_id, 'kernel_name'),
+    s.name
+  ) AS kernel
+FROM gpu_slice AS s
+JOIN gpu_track AS t
+  ON s.track_id = t.id
+WHERE
+  s.render_stage_category = 2
+  AND s.dur > 0;
+
+CREATE PERFETTO TABLE _achieved AS
+SELECT k.id AS kernel_id, AVG(c.value) AS achieved_occ_pct
+FROM _kernels AS k
+JOIN gpu_counter_group AS g ON g.group_id = 6
+JOIN gpu_counter_track AS ct
+  ON ct.id = g.track_id
+  AND ct.ugpu = k.ugpu
+  AND ct.name = 'sm__warps_active.avg.pct_of_peak_sustained_active'
+JOIN counter AS c ON c.track_id = ct.id AND c.ts >= k.ts AND c.ts < k.ts + k.dur
+GROUP BY
+  k.id;
+
+CREATE PERFETTO TABLE _occ AS
+SELECT
+  k.id AS kernel_id,
+  k.launch_id AS id,
+  k.kernel,
+  k.dur,
+  CAST(EXTRACT_ARG(k.arg_set_id, 'sm__maximum_warps_per_active_cycle_pct') AS REAL) AS theoretical_occ_pct,
+  ROUND(a.achieved_occ_pct, 1) AS achieved_occ_pct,
+  EXTRACT_ARG(k.arg_set_id, 'workgroup_size') AS block_size,
+  EXTRACT_ARG(k.arg_set_id, 'grid_size') AS grid_size,
+  EXTRACT_ARG(k.arg_set_id, 'registers_per_thread') AS registers,
+  EXTRACT_ARG(k.arg_set_id, 'shared_mem_static') AS shared_mem_static,
+  EXTRACT_ARG(k.arg_set_id, 'shared_mem_dynamic') AS shared_mem_dynamic,
+  EXTRACT_ARG(k.arg_set_id, 'waves_per_multiprocessor') AS waves_per_sm,
+  EXTRACT_ARG(k.arg_set_id, 'occupancy_limit_blocks') AS limit_blocks,
+  EXTRACT_ARG(k.arg_set_id, 'occupancy_limit_registers') AS limit_registers,
+  EXTRACT_ARG(k.arg_set_id, 'occupancy_limit_shared_mem') AS limit_shared_mem,
+  EXTRACT_ARG(k.arg_set_id, 'occupancy_limit_warps') AS limit_warps,
+  EXTRACT_ARG(k.arg_set_id, 'occupancy_limit_barriers') AS limit_barriers
+FROM _kernels AS k
+LEFT JOIN _achieved AS a ON a.kernel_id = k.id;
+
+-- Unpivot the per-resource block limits to one row each, so the binding
+-- resource is the smallest PRESENT limit (NULLs skipped) with a deterministic
+-- tie-break. SQLite's scalar MIN(a,b,...) would instead return NULL whenever any
+-- single limit arg is absent, hiding an otherwise-unambiguous bottleneck.
+CREATE PERFETTO TABLE _limits AS
+SELECT kernel_id, 1 AS rank, 'blocks' AS resource, limit_blocks AS v FROM _occ
+UNION ALL
+SELECT kernel_id, 2, 'registers', limit_registers FROM _occ
+UNION ALL
+SELECT kernel_id, 3, 'shared_mem', limit_shared_mem FROM _occ
+UNION ALL
+SELECT kernel_id, 4, 'warps', limit_warps FROM _occ
+UNION ALL
+SELECT kernel_id, 5, 'barriers', limit_barriers FROM _occ;
+
+CREATE PERFETTO TABLE _binding AS
+SELECT kernel_id, resource AS binding_resource
+FROM (
+  SELECT
+    kernel_id,
+    resource,
+    ROW_NUMBER() OVER (PARTITION BY kernel_id ORDER BY v, rank) AS rn
+  FROM _limits
+  WHERE
+    v IS NOT NULL
+)
+WHERE
+  rn = 1;
+
+SELECT
+  o.id,
+  o.kernel,
+  o.theoretical_occ_pct,
+  o.achieved_occ_pct,
+  o.block_size,
+  o.grid_size,
+  o.registers,
+  o.shared_mem_static,
+  o.shared_mem_dynamic,
+  o.waves_per_sm,
+  o.limit_blocks,
+  o.limit_registers,
+  o.limit_shared_mem,
+  o.limit_warps,
+  o.limit_barriers,
+  b.binding_resource
+FROM _occ AS o
+LEFT JOIN _binding AS b ON b.kernel_id = o.kernel_id
+ORDER BY
+  o.dur DESC;

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/scripts/speed_of_light.sql
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/scripts/speed_of_light.sql
@@ -1,0 +1,131 @@
+-- NVIDIA compute kernels — Speed of Light throughput (compute vs memory).
+--
+-- For every compute kernel, the high-level throughput picture: how close the
+-- SM (compute) and the memory system ran to their peaks, plus the cache /
+-- DRAM throughput and cycle counts behind it. This is the data for the
+-- "compute-bound vs memory-bound vs latency-bound" verdict. The percentages are
+-- throughput vs peak, not cache hit rates.
+--
+-- Counters come from the COMPUTE counter group (gpu_counter_group.group_id = 6)
+-- matched to each kernel's GPU and aggregated over the kernel's window.
+-- Aggregation per metric: throughput percentages and frequencies use AVG; cycle
+-- counts and duration use SUM.
+--
+-- No parameters; operates on the whole trace. One row per compute kernel,
+-- longest first. Columns:
+--   id                : launch order (matches kernels_summary.sql).
+--   kernel            : demangled kernel name.
+--   compute_pct       : sm__throughput, % of peak (AVG). The compute ceiling.
+--   memory_pct        : gpu__compute_memory_throughput, % of peak (AVG). The
+--                       memory-system ceiling.
+--   l1_pct, l2_pct    : l1tex / lts throughput, % of peak (AVG).
+--   dram_pct          : gpu__dram_throughput, % of peak (AVG).
+--   elapsed_cycles    : gpc__cycles_elapsed.max (SUM).
+--   active_cycles     : sm__cycles_active.avg (SUM).
+--   dur_ns            : gpu__time_duration.sum (SUM); slice dur if absent.
+--
+-- Interpret: high compute_pct & lower memory_pct -> compute-bound; high
+-- memory_pct -> memory-bound (use l1/l2/dram_pct to locate it); both low ->
+-- latency/occupancy-bound; active_cycles << elapsed_cycles corroborates a
+-- latency/occupancy stall. See compute/speed_of_light.md.
+
+CREATE PERFETTO TABLE _kernels AS
+SELECT
+  s.id,
+  s.ts,
+  s.dur,
+  s.arg_set_id,
+  ROW_NUMBER() OVER (ORDER BY s.ts) AS launch_id,
+  EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu') AS ugpu,
+  COALESCE(
+    EXTRACT_ARG(s.arg_set_id, 'kernel_demangled_name'),
+    EXTRACT_ARG(s.arg_set_id, 'kernel_name'),
+    s.name
+  ) AS kernel
+FROM gpu_slice AS s
+JOIN gpu_track AS t
+  ON s.track_id = t.id
+WHERE
+  s.render_stage_category = 2
+  AND s.dur > 0;
+
+CREATE PERFETTO TABLE _kernel_counters AS
+SELECT
+  k.id AS kernel_id,
+  ct.name AS counter_name,
+  SUM(c.value) AS sum_v,
+  AVG(c.value) AS avg_v
+FROM _kernels AS k
+JOIN gpu_counter_group AS g ON g.group_id = 6
+JOIN gpu_counter_track AS ct ON ct.id = g.track_id AND ct.ugpu = k.ugpu
+JOIN counter AS c ON c.track_id = ct.id AND c.ts >= k.ts AND c.ts < k.ts + k.dur
+GROUP BY
+  k.id,
+  ct.name;
+
+SELECT
+  k.launch_id AS id,
+  k.kernel,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'sm__throughput.avg.pct_of_peak_sustained_elapsed' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS compute_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'gpu__compute_memory_throughput.avg.pct_of_peak_sustained_elapsed' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS memory_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'l1tex__throughput.avg.pct_of_peak_sustained_active' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS l1_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'lts__throughput.avg.pct_of_peak_sustained_elapsed' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS l2_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'gpu__dram_throughput.avg.pct_of_peak_sustained_elapsed' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS dram_pct,
+  CAST(MAX(
+    CASE WHEN kc.counter_name = 'gpc__cycles_elapsed.max' THEN kc.sum_v END
+  ) AS INT) AS elapsed_cycles,
+  CAST(MAX(
+    CASE WHEN kc.counter_name = 'sm__cycles_active.avg' THEN kc.sum_v END
+  ) AS INT) AS active_cycles,
+  CAST(IFNULL(
+    MAX(CASE WHEN kc.counter_name = 'gpu__time_duration.sum' THEN kc.sum_v END),
+    k.dur
+  ) AS INT) AS dur_ns
+FROM _kernels AS k
+LEFT JOIN _kernel_counters AS kc ON kc.kernel_id = k.id
+GROUP BY
+  k.launch_id,
+  k.kernel,
+  k.dur
+ORDER BY
+  k.dur DESC;

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/scripts/workload_analysis.sql
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/scripts/workload_analysis.sql
@@ -1,0 +1,136 @@
+-- NVIDIA compute kernels — workload analysis (instruction throughput & pipes).
+--
+-- For every compute kernel: how busy the SM was issuing instructions and which
+-- execution pipelines carried the work. This is the data for "which pipe is the
+-- limit, and is the instruction mix balanced?".
+--
+-- All values are COMPUTE-group counters (gpu_counter_group.group_id = 6),
+-- matched to each kernel's GPU and averaged over its window (these are all
+-- rate/percentage metrics -> AVG).
+--
+-- No parameters; operates on the whole trace. One row per compute kernel,
+-- longest first. Columns:
+--   id          : launch order (matches kernels_summary.sql).
+--   kernel      : demangled kernel name.
+--   ipc_active  : instructions executed per active cycle (sm__inst_executed
+--                 .avg.per_cycle_active).
+--   sm_busy_pct : instruction-issue throughput, % of peak (sm__instruction
+--                 _throughput.avg.pct_of_peak_sustained_active).
+--   alu/fma/fp16/fp32/fp64/tensor_pct : that pipe's active cycles, % of peak
+--                 (sm__pipe_<x>_cycles_active.avg.pct_of_peak_sustained_active).
+--
+-- Interpret: the highest pipe % is the most-utilized pipeline; a single pipe
+-- near peak while sm_busy_pct is lower points to a pipe bottleneck / imbalance;
+-- consider a different precision or instruction mix. See compute/workload_analysis.md.
+
+CREATE PERFETTO TABLE _kernels AS
+SELECT
+  s.id,
+  s.ts,
+  s.dur,
+  ROW_NUMBER() OVER (ORDER BY s.ts) AS launch_id,
+  EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu') AS ugpu,
+  COALESCE(
+    EXTRACT_ARG(s.arg_set_id, 'kernel_demangled_name'),
+    EXTRACT_ARG(s.arg_set_id, 'kernel_name'),
+    s.name
+  ) AS kernel
+FROM gpu_slice AS s
+JOIN gpu_track AS t
+  ON s.track_id = t.id
+WHERE
+  s.render_stage_category = 2
+  AND s.dur > 0;
+
+CREATE PERFETTO TABLE _kernel_counters AS
+SELECT k.id AS kernel_id, ct.name AS counter_name, AVG(c.value) AS avg_v
+FROM _kernels AS k
+JOIN gpu_counter_group AS g ON g.group_id = 6
+JOIN gpu_counter_track AS ct ON ct.id = g.track_id AND ct.ugpu = k.ugpu
+JOIN counter AS c ON c.track_id = ct.id AND c.ts >= k.ts AND c.ts < k.ts + k.dur
+GROUP BY
+  k.id,
+  ct.name;
+
+SELECT
+  k.launch_id AS id,
+  k.kernel,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name = 'sm__inst_executed.avg.per_cycle_active' THEN kc.avg_v
+      END
+    ),
+    2
+  ) AS ipc_active,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'sm__instruction_throughput.avg.pct_of_peak_sustained_active' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS sm_busy_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'sm__pipe_alu_cycles_active.avg.pct_of_peak_sustained_active' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS alu_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'sm__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS fma_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'sm__pipe_fp16_cycles_active.avg.pct_of_peak_sustained_active' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS fp16_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'sm__pipe_fp32_cycles_active.avg.pct_of_peak_sustained_active' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS fp32_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'sm__pipe_fp64_cycles_active.avg.pct_of_peak_sustained_active' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS fp64_pct,
+  ROUND(
+    MAX(
+      CASE
+        WHEN kc.counter_name
+        = 'sm__pipe_tensor_cycles_active.avg.pct_of_peak_sustained_active' THEN kc.avg_v
+      END
+    ),
+    1
+  ) AS tensor_pct
+FROM _kernels AS k
+LEFT JOIN _kernel_counters AS kc ON kc.kernel_id = k.id
+GROUP BY
+  k.launch_id,
+  k.kernel,
+  k.dur
+ORDER BY
+  k.dur DESC;

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/speed_of_light.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/speed_of_light.md
@@ -1,0 +1,32 @@
+# NVIDIA — Speed of Light extraction
+
+The NVIDIA counter extraction behind the compute-vs-memory-vs-latency verdict.
+Run it, then apply the bound-type interpretation from
+[../speed_of_light.md](../speed_of_light.md).
+
+```bash
+trace_processor query --query-file scripts/speed_of_light.sql TRACE_FILE
+```
+
+One row per compute kernel (longest first). Display label → output column →
+NVIDIA counter:
+
+| Display label (generic) | Column | NVIDIA counter |
+|---|---|---|
+| Compute Throughput | `compute_pct` | `sm__throughput.avg.pct_of_peak_sustained_elapsed` |
+| Memory Throughput | `memory_pct` | `gpu__compute_memory_throughput.avg.pct_of_peak_sustained_elapsed` |
+| L1 Cache Throughput | `l1_pct` | `l1tex__throughput.avg.pct_of_peak_sustained_active` |
+| L2 Cache Throughput | `l2_pct` | `lts__throughput.avg.pct_of_peak_sustained_elapsed` |
+| DRAM Throughput | `dram_pct` | `gpu__dram_throughput.avg.pct_of_peak_sustained_elapsed` |
+| Elapsed Cycles | `elapsed_cycles` | `gpc__cycles_elapsed.max` |
+| Active Cycles | `active_cycles` | `sm__cycles_active.avg` |
+| Duration | `dur_ns` | `gpu__time_duration.sum` |
+
+On NVIDIA the compute unit is the **SM**. The throughput columns are *% of peak*
+(how saturated the level was), **not** cache hit rates: a high `dram_pct` is a
+true DRAM-bandwidth bound, while high `l1_pct`/`l2_pct` with low `dram_pct` means
+the working set is served from cache rather than DRAM.
+
+<!-- Architecture-specific peak/lever guidance (e.g. nvidia/h100/) would forward
+     from here once added: compare achieved % against the arch's absolute peaks
+     (HBM bandwidth, tensor TFLOPs) and arch-specific levers (FP8, TMA). -->

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/workload_analysis.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/workload_analysis.md
@@ -1,0 +1,41 @@
+# NVIDIA — workload analysis extraction
+
+The NVIDIA extraction behind the saturated-pipe / instruction-mix analysis. Run
+it, then apply the interpretation from
+[../workload_analysis.md](../workload_analysis.md).
+
+```bash
+trace_processor query --query-file scripts/workload_analysis.sql TRACE_FILE
+```
+
+One row per compute kernel (longest first). Display label → output column →
+NVIDIA counter:
+
+| Display label (generic) | Column | NVIDIA counter |
+|---|---|---|
+| Compute-unit busy | `sm_busy_pct` | `sm__instruction_throughput.avg.pct_of_peak_sustained_active` |
+| Executed IPC | `ipc_active` | `sm__inst_executed.avg.per_cycle_active` |
+| Pipeline utilization | `alu_pct`, `fma_pct`, `fp16_pct`, `fp32_pct`, `fp64_pct`, `tensor_pct` | `sm__pipe_<x>_cycles_active.avg.pct_of_peak_sustained_active` |
+
+On NVIDIA the compute unit is the **SM**; the per-pipe columns are the SM
+execution units. The highest pipe is the bottleneck candidate, and the lever
+depends on which pipe it is:
+
+- **`tensor_pct`** high → already on the tensor-core / matrix path (good for
+  matmul-like work); gains need larger tiles or a different algorithm, not a mix
+  change.
+- **`fma_pct` / `fp32_pct`** high → FP32 math bound; consider lower precision
+  (fp16 / bf16) if the algorithm tolerates it. (bf16 work shows up under the
+  fp16 / tensor pipes — there is no dedicated bf16 cycles-active counter in this
+  set.)
+- **`fp64_pct`** high → double precision is expensive; drop to fp32 where
+  accuracy allows.
+- **`alu_pct`** high → integer / address math bound; reduce index arithmetic, or
+  precompute.
+
+These are the pipe **cycles-active** counters (the saturation signal); the
+paired `sm__inst_executed_pipe_*` (instructions-executed-per-pipe) counters are
+not extracted here.
+
+<!-- Architecture-specific guidance (e.g. nvidia/h100/) would forward from here:
+     per-arch peak issue rate, tensor-core generation and supported precisions. -->

--- a/ai/skills/perfetto/workflows/gpu/compute/occupancy.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/occupancy.md
@@ -1,0 +1,55 @@
+# Compute kernel — occupancy and its limiting factor
+
+Occupancy is the ratio of active warps/wavefronts per compute unit to the
+hardware maximum. Higher occupancy helps hide memory and instruction latency,
+but more is not always better — once latency is hidden, extra occupancy does
+nothing, and chasing it can cost registers or shared memory. This workflow asks
+two things: is *this* kernel limited by occupancy, and if so, which resource
+caps it. This is the interpretation layer; run the vendor extraction and read
+the values back here.
+
+## Get the data
+
+- **NVIDIA / CUDA:** [nvidia/occupancy.md](nvidia/occupancy.md).
+- Other vendors: the per-resource block limits are launch args (often present
+  regardless of vendor); achieved occupancy needs a vendor counter.
+
+## The metrics
+
+By their display names (the vendor extraction maps these to its counters/args):
+
+- **Theoretical Occupancy** — the ceiling the launch config allows (% of max).
+- **Achieved Occupancy** — what actually ran (% of max).
+- **Block Limit (registers / shared memory / warps / blocks / barriers)** — how
+  many blocks fit per compute unit under each resource; the smallest is the
+  binding constraint.
+- **Block Size**, **Grid Size**, **Registers**, **Shared Memory**, **Waves per
+  compute unit** — the launch shape.
+
+## Interpret
+
+- **Block size rule.** Block size should be a multiple of the warp/wavefront
+  size — **32 on NVIDIA, 64 on AMD**. A non-multiple wastes a fraction of every
+  warp/wavefront. Very small blocks underuse each compute unit; very large
+  blocks raise register/shared-memory pressure and can cap occupancy.
+- **Waves rule.** Waves per compute unit (grid size / resident blocks per unit):
+  - **< 1** → the grid is too small to fill the GPU; units sit idle. Lever: more
+    parallelism (larger grid) or fuse with other work.
+  - **1–2** → tail effects: some units finish early and idle while the last wave
+    drains. Lever: size the grid to a larger whole number of waves.
+  - **≥ 4** → good load balance.
+- **Theoretical vs Achieved gap.** A large gap (Achieved ≪ Theoretical) means
+  the kernel isn't sustaining the warps/wavefronts the config allows — imbalance,
+  tail effects, or early exits. A small gap with low Theoretical means the launch
+  config itself is the cap → look at the binding Block Limit.
+- **Binding resource.** The Block Limit with the fewest blocks per compute unit
+  is the thing to relax to raise Theoretical Occupancy:
+  - **registers** → reduce register pressure (smaller types, fewer live values,
+    or a launch-bounds hint).
+  - **shared memory** → use less per block, or a smaller carveout.
+  - **warps / blocks** → block size or the per-unit hardware limit; resize blocks.
+  - **barriers** → fewer named barriers per block.
+
+Only chase occupancy if the kernel is actually latency-bound (Speed of Light
+showed both ceilings low). A compute- or memory-bound kernel at modest occupancy
+is fine — raising occupancy won't help.

--- a/ai/skills/perfetto/workflows/gpu/compute/scripts/kernels_summary.sql
+++ b/ai/skills/perfetto/workflows/gpu/compute/scripts/kernels_summary.sql
@@ -1,0 +1,59 @@
+-- GPU compute-kernel summary — one row per compute kernel.
+--
+-- The cross-kernel triage: every compute kernel in the trace with its duration
+-- and launch shape, so you can pick the kernel that matters. This is the
+-- vendor-neutral first pass — it uses only data available regardless of GPU
+-- vendor (slice timing and launch args). The compute-vs-memory bound-type
+-- split needs vendor throughput counters and lives in the Speed of Light step.
+--
+-- A compute kernel is a GPU render-stage slice with render_stage_category = 2
+-- (0=OTHER, 1=GRAPHICS, 2=COMPUTE). Only kernels with dur > 0 are listed (a
+-- zero/NULL-duration kernel has no time window to analyse); the same filter is
+-- used by every compute script so the launch-order id lines up across them.
+--
+-- No parameters; operates on the whole trace. One row per compute kernel,
+-- longest first. Columns:
+--   id          : launch order (1 = first-launched kernel), stable within a run.
+--   kernel      : demangled kernel name (falls back to mangled / slice name).
+--   ugpu        : host-unique GPU id the kernel ran on (see gpu_info.md).
+--   dur_ns      : kernel duration.
+--   block_size  : threads per block (launch arg).
+--   grid_size   : number of blocks (launch arg).
+--   registers   : registers per thread (launch arg).
+--
+-- Interpret: the kernel(s) dominating dur_ns are the hotspots to drill. To find
+-- whether a kernel is compute- or memory-bound, run the Speed of Light step
+-- (vendor-specific counters). Block/grid/registers are the launch shape; see
+-- launch_statistics.md for the full configuration.
+
+CREATE PERFETTO TABLE _kernels AS
+SELECT
+  s.id,
+  s.ts,
+  s.dur,
+  s.arg_set_id,
+  ROW_NUMBER() OVER (ORDER BY s.ts) AS launch_id,
+  EXTRACT_ARG(t.dimension_arg_set_id, 'ugpu') AS ugpu,
+  COALESCE(
+    EXTRACT_ARG(s.arg_set_id, 'kernel_demangled_name'),
+    EXTRACT_ARG(s.arg_set_id, 'kernel_name'),
+    s.name
+  ) AS kernel
+FROM gpu_slice AS s
+JOIN gpu_track AS t
+  ON s.track_id = t.id
+WHERE
+  s.render_stage_category = 2
+  AND s.dur > 0;
+
+SELECT
+  launch_id AS id,
+  kernel,
+  ugpu,
+  dur AS dur_ns,
+  EXTRACT_ARG(arg_set_id, 'workgroup_size') AS block_size,
+  EXTRACT_ARG(arg_set_id, 'grid_size') AS grid_size,
+  EXTRACT_ARG(arg_set_id, 'registers_per_thread') AS registers
+FROM _kernels
+ORDER BY
+  dur DESC;

--- a/ai/skills/perfetto/workflows/gpu/compute/scripts/launch_statistics.sql
+++ b/ai/skills/perfetto/workflows/gpu/compute/scripts/launch_statistics.sql
@@ -1,0 +1,63 @@
+-- Compute kernels — launch configuration (vendor-neutral).
+--
+-- For every compute kernel, the configuration it was launched with: the work
+-- size, how it divides into blocks, and the per-block GPU resources. This is
+-- the data for "is the launch config efficient?". These are all launch ARGS on
+-- the kernel slice and are vendor-neutral (the same keys are emitted by CUDA,
+-- HIP and other compute producers), so this script needs no vendor layer.
+--
+-- No parameters; operates on the whole trace. One row per compute kernel,
+-- longest first. Columns:
+--   id                 : launch order (matches kernels_summary.sql).
+--   kernel             : demangled kernel name.
+--   block_size         : threads per block (workgroup_size).
+--   grid_size          : number of blocks.
+--   thread_count       : total threads (thread_count).
+--   registers          : registers per thread.
+--   shared_mem_static  : static shared memory per block, bytes.
+--   shared_mem_dynamic : dynamic shared memory per block, bytes.
+--   shared_mem_config  : shared memory carveout / config size, bytes.
+--   barriers_per_block : named barriers per block.
+--   waves_per_sm       : waves_per_multiprocessor.
+--   func_cache_config  : function cache configuration.
+--
+-- Interpret: block_size should be a multiple of the warp/wavefront size (32 on
+-- NVIDIA, 64 on AMD); very small blocks underuse each SM, very large blocks can
+-- cap occupancy via register/shared-memory pressure; waves_per_sm >= 4 balances
+-- load. See compute/launch_statistics.md.
+
+CREATE PERFETTO TABLE _kernels AS
+SELECT
+  s.id,
+  s.ts,
+  s.dur,
+  s.arg_set_id,
+  ROW_NUMBER() OVER (ORDER BY s.ts) AS launch_id,
+  COALESCE(
+    EXTRACT_ARG(s.arg_set_id, 'kernel_demangled_name'),
+    EXTRACT_ARG(s.arg_set_id, 'kernel_name'),
+    s.name
+  ) AS kernel
+FROM gpu_slice AS s
+JOIN gpu_track AS t
+  ON s.track_id = t.id
+WHERE
+  s.render_stage_category = 2
+  AND s.dur > 0;
+
+SELECT
+  launch_id AS id,
+  kernel,
+  EXTRACT_ARG(arg_set_id, 'workgroup_size') AS block_size,
+  EXTRACT_ARG(arg_set_id, 'grid_size') AS grid_size,
+  EXTRACT_ARG(arg_set_id, 'thread_count') AS thread_count,
+  EXTRACT_ARG(arg_set_id, 'registers_per_thread') AS registers,
+  EXTRACT_ARG(arg_set_id, 'shared_mem_static') AS shared_mem_static,
+  EXTRACT_ARG(arg_set_id, 'shared_mem_dynamic') AS shared_mem_dynamic,
+  EXTRACT_ARG(arg_set_id, 'shared_mem_config_size') AS shared_mem_config,
+  EXTRACT_ARG(arg_set_id, 'barriers_per_block') AS barriers_per_block,
+  EXTRACT_ARG(arg_set_id, 'waves_per_multiprocessor') AS waves_per_sm,
+  EXTRACT_ARG(arg_set_id, 'func_cache_config') AS func_cache_config
+FROM _kernels
+ORDER BY
+  dur DESC;

--- a/ai/skills/perfetto/workflows/gpu/compute/speed_of_light.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/speed_of_light.md
@@ -1,0 +1,54 @@
+# Compute kernel — Speed of Light (compute vs memory vs latency bound)
+
+"Speed of Light" is how close a kernel ran to the hardware's two ceilings:
+**compute** (the compute units' math throughput) and **memory** (the memory
+system's throughput). Comparing the two classifies the kernel and points to the
+lever. This is the interpretation layer; the concrete counters are
+vendor-specific — run the extraction for your GPU vendor and read the values
+back here.
+
+## Get the data
+
+- **NVIDIA / CUDA:** [nvidia/speed_of_light.md](nvidia/speed_of_light.md).
+- Other vendors: only NVIDIA has the full Speed-of-Light counter set in the
+  trace today; for others use whatever throughput / duration that vendor exposes.
+
+## The metrics
+
+By their display names (each vendor extraction maps these to its own counters):
+
+- **Compute Throughput** — compute-unit math throughput, % of peak.
+- **Memory Throughput** — memory-system throughput, % of peak.
+- **L1 / L2 Cache Throughput**, **DRAM Throughput** — % of peak at each level of
+  the memory hierarchy.
+- **Elapsed Cycles**, **Active Cycles** — compute-unit cycle counts (elapsed vs
+  the cycles actually doing work).
+- **Duration** — kernel wall-clock time.
+
+## Interpret
+
+Read Compute Throughput vs Memory Throughput (both are achieved-vs-theoretical —
+% of peak; the gap to 100% is the unused headroom against that ceiling):
+
+- **Compute Throughput high, Memory Throughput lower → compute-bound.** The
+  compute units are the ceiling; the lever is the math — go to
+  [workload_analysis.md](workload_analysis.md) for the saturated pipeline, and
+  consider a cheaper precision or doing less work.
+- **Memory Throughput high, Compute Throughput lower → memory-bound.** The
+  memory system is the ceiling; locate it in the hierarchy:
+  - **DRAM Throughput high** → DRAM-bandwidth bound; the lever is locality /
+    reuse (tiling, fusion) or better access patterns.
+  - **L2 / L1 Cache Throughput high with lower DRAM Throughput** → the working
+    set is being served from cache rather than DRAM; the lever is data reuse /
+    working-set size. (These are throughput vs peak, not cache hit rates.)
+- **both low → latency / occupancy-bound.** Neither ceiling is near peak, so the
+  kernel is stalling. Go to [occupancy.md](occupancy.md).
+- **both high → near a real ceiling**; the kernel is well-packed and further
+  gains need an algorithmic change, not tuning.
+
+Sanity check: Active Cycles well below Elapsed Cycles means the compute units sat
+idle during the kernel (launch/scheduling gaps or tails) — corroborates a
+latency/occupancy problem.
+
+Any numeric cutoffs you apply ("high" ≈ ≥ 60% of peak) are rules of thumb, not
+vendor- or plugin-defined.

--- a/ai/skills/perfetto/workflows/gpu/compute/workload_analysis.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/workload_analysis.md
@@ -1,0 +1,42 @@
+# Compute kernel — workload analysis (which pipeline is the limit?)
+
+For a compute-bound kernel, "compute-bound" isn't the end of the story — *which*
+execution pipeline is saturated determines the lever. This workflow looks at
+instruction-issue throughput and per-pipeline utilization to find the saturated
+pipe and spot instruction-mix imbalance. Run it when Speed of Light showed the
+kernel compute-bound. This is the interpretation layer; run the vendor
+extraction and read the values back here.
+
+## Get the data
+
+- **NVIDIA / CUDA:** [nvidia/workload_analysis.md](nvidia/workload_analysis.md).
+- Other vendors: the per-pipeline breakdown is vendor-specific; for others use
+  whatever instruction-throughput / IPC that vendor exposes.
+
+## The metrics
+
+By their display names (the vendor extraction maps these to its counters and
+lists the concrete pipelines that vendor exposes):
+
+- **Compute-unit busy** — instruction-issue throughput, % of peak.
+- **Executed IPC** — instructions executed per active cycle.
+- **Per-pipeline utilization** — % of peak for each execution pipeline. *The set
+  of pipelines is vendor-specific* — see the vendor extraction for which pipes
+  exist and what each maps to.
+
+## Interpret
+
+- **One pipe near peak, others low → that pipe is the bottleneck.** The lever is
+  to move work off it: a cheaper precision/instruction mix if the work can use
+  one, or an algorithm that needs less of that pipe. Which precision is cheaper,
+  and which pipe carries it, is vendor-specific — see the vendor extraction.
+- **Compute-unit busy high but no single pipe near peak → issue-bound / mixed.**
+  The unit is busy issuing but work is spread across pipes; the limit is
+  instruction issue itself. Lever: fewer instructions (algorithmic), or better
+  ILP.
+- **Compute-unit busy low and all pipes low → not compute-bound after all.** The
+  kernel is stalling — it is memory- or latency-bound; the lever is in the Speed
+  of Light / occupancy view, not here.
+- **Imbalance across precision pipes** (two precision paths both moderate) can
+  mean the kernel mixes precisions; consolidating onto the cheapest sufficient
+  precision frees issue slots.

--- a/ai/skills/perfetto/workflows/gpu/frequency_residency.md
+++ b/ai/skills/perfetto/workflows/gpu/frequency_residency.md
@@ -8,9 +8,8 @@ but pinned at half its clock is leaving half its throughput on the table — and
 busy/idle view, or a steady-state frequency average, cannot see that.
 
 It works on any trace that has a canonical GPU **frequency** track — the
-`gpufreq` counter track (one per GPU) that the Perfetto UI renders as the
-per-GPU *Frequency* track. It catches the two classic, workload-agnostic
-clock pathologies:
+`gpufreq` counter track (one per GPU). It catches the two classic,
+workload-agnostic clock pathologies:
 
 - **Slow DVFS ramp** after an idle→busy transition: the clock starts at a floor
   state and takes time to ramp up, so the work that woke the GPU runs slow.
@@ -46,7 +45,10 @@ Run this before any open-ended exploration. It produces the headline verdict.
 
     - **`eff_occupancy_pct` ≈ `busy_pct_of_active`** — when the GPU is busy it
       runs at (near) peak clock. The clock is healthy; the lever is elsewhere —
-      the device work itself, or the idle between work, not the clock. Stop here.
+      the device work itself, or the idle between work, not the clock. When that
+      device work is GPU **compute** kernels, decompose it — which kernel, and
+      what bounds it — with
+      [compute/kernel_analysis.md](compute/kernel_analysis.md); otherwise stop here.
     - **`eff_occupancy_pct` ≪ `busy_pct_of_active`** — the GPU is busy but
       underclocked. The clock *is* the problem. Proceed to Phase 2 (ramp) and
       Phase 3 (throttling) to find out why.

--- a/ai/skills/perfetto/workflows/gpu/gpu_info.md
+++ b/ai/skills/perfetto/workflows/gpu/gpu_info.md
@@ -1,0 +1,74 @@
+# GPU inventory — what GPUs (and machines) is this trace from?
+
+Before any GPU analysis, know what hardware the trace describes: how many GPUs,
+which vendor/model/architecture each is, and — for multi-machine captures — which
+machine each belongs to. Vendor and architecture in particular decide which
+vendor-specific analysis applies (e.g. NVIDIA vs AMD counter sets). **Do not
+assume a single GPU or a single machine**: a trace can contain several GPUs, and
+a multi-machine capture records a host plus remote machines, each with its own
+GPUs.
+
+This information comes from the `gpu` table, which trace_processor builds from
+`GpuInfo` trace packets
+([gpu\_info.proto](/protos/perfetto/trace/system_info/gpu_info.proto)).
+
+If the user has not yet loaded a trace into `trace_processor`, follow
+`../../infra-references/querying.md` first, then come back here.
+
+## Enumerate the GPUs
+
+```bash
+trace_processor query --query-file scripts/gpu_info.sql TRACE_FILE
+```
+
+Columns: `machine_id`, `is_host`, `ugpu`, `gpu_index`, `vendor`, `name`,
+`model`, `architecture`, `uuid`, `pci_bdf`. One row per GPU.
+
+> No rows means the trace has no `GpuInfo` packet — GPU activity (slices /
+> counters) may still be present, but vendor/model/architecture are unknown.
+
+## The two GPU identifiers — don't confuse them
+
+- **`ugpu` — host-unique GPU id.** Unique across the *whole* trace, every
+  machine included. **This is the join key**: counters (`gpu_counter_track`),
+  slices (via `gpu_track`), and the frequency track all reference `ugpu`. Always
+  scope and join per `ugpu`.
+- **`gpu_index` — the 0-based GPU index within its machine.** *Not* unique across
+  machines: machine A's GPU 0 and machine B's GPU 0 are different devices. Use it
+  for display, never as a cross-trace key.
+
+For a single-machine trace `ugpu == gpu_index`; for multi-machine they diverge,
+which is exactly why downstream analysis keys on `ugpu`.
+
+## Machines
+
+`machine_id` links to the `machine` table; `machine_id = 0` (`is_host = 1`) is
+the host/local machine, non-zero ids are remote machines. To identify a machine
+further (OS, arch, RAM, CPU count), join the `machine` table:
+
+```sql
+SELECT g.ugpu, g.name AS gpu, g.machine_id, m.sysname, m.arch, m.num_cpus
+FROM gpu AS g
+LEFT JOIN machine AS m ON m.id = g.machine_id
+ORDER BY g.machine_id, g.gpu;
+```
+
+## Using it
+
+- **Pick the vendor / architecture** for vendor-specific analysis from the
+  `vendor` / `architecture` columns (authoritative — read them rather than
+  guessing from counter names).
+- **Enumerate, then scope.** When a trace has more than one GPU, run the
+  per-GPU analyses once per `ugpu` (or filter to the GPU of interest), and label
+  results with `name` + `machine_id` so multiple devices stay distinguishable.
+- **Extra vendor fields.** `GpuInfo` carries optional `extra_info` key/value
+  pairs; they land in the `gpu.arg_set_id` and can be read with
+  `EXTRACT_ARG(arg_set_id, '<key>')`.
+
+## Reference
+
+- GPU data sources: <https://perfetto.dev/docs/data-sources/gpu>
+- `gpu` table (built from `GpuInfo`): `ugpu` (host-unique), `gpu` (per-machine
+  index), `vendor`, `model`, `architecture`, `uuid`, `pci_bdf`, `machine_id`.
+- Multi-machine tracing:
+  <https://perfetto.dev/docs/deployment/multi-machine-architecture>

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_dvfs_ramp.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_dvfs_ramp.sql
@@ -14,7 +14,8 @@
 -- target = 90% of the per-GPU max OBSERVED frequency. To change it, edit the
 -- 0.9 factor below.
 --
--- Columns (worst ramps first):
+-- No parameters; operates on the whole trace. One row per idle->busy ramp event
+-- (the top 20 by ramp_ns), per GPU. Columns (worst ramps first):
 --   edge_rel_ns       : edge timestamp, relative to trace start.
 --   idle_gap_ns       : idle gap immediately before the edge; NULL for the
 --                       first burst (cold start / trace boundary). A larger gap

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_frequency_residency.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_frequency_residency.sql
@@ -9,8 +9,7 @@
 -- intervals (concurrency on multiple hardware queues is merged, not summed), and
 -- each slice of busy time is attributed to the GPU frequency in effect during
 -- it. The frequency source is the canonical per-GPU "gpufreq" counter track
--- (type gpu_frequency, kHz) -- the same track the Perfetto UI renders as the
--- per-GPU "Frequency" track -- expanded into gapless intervals.
+-- (type gpu_frequency, kHz), expanded into gapless intervals.
 --
 -- No parameters; operates over each GPU's active span (first..last activity).
 -- One row per GPU that has a gpufreq track. Columns:

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_idle_gaps.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_idle_gaps.sql
@@ -6,9 +6,9 @@
 -- submission/launch latency, host-side synchronization or waits, device memory
 -- allocation, host-device copies, or host-side work starving the device.
 --
--- No parameters; operates on the whole trace. Returns the top idle gaps as
--- (gap_start_rel_ns, gap_dur_ns), where gap_start_rel_ns is relative to
--- trace_start(). To attribute a gap to host work, take a gap's
+-- No parameters; operates on the whole trace. One row per idle gap (the 10
+-- largest, biggest first): gap_start_rel_ns (relative to trace_start()),
+-- gap_dur_ns. To attribute a gap to host work, take a gap's
 -- [gap_start, gap_start + gap_dur] window and run the host-attribution query
 -- in timeline_occupancy.md.
 --

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_info.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_info.sql
@@ -1,0 +1,49 @@
+-- GPU inventory — every GPU in the trace, across every machine.
+--
+-- A trace can describe more than one GPU, and more than one machine (a
+-- multi-machine setup records a host plus one or more remote machines, each
+-- with its own GPUs). This lists them all so downstream analysis can scope to a
+-- specific device. The data comes from the `gpu` table, which trace_processor
+-- builds from GpuInfo trace packets (protos/perfetto/trace/system_info/
+-- gpu_info.proto).
+--
+-- Two GPU identifiers exist and must not be confused:
+--   ugpu  : host-unique GPU id. Unique across the WHOLE trace (all machines).
+--           This is the join key — counters, slices and tracks reference ugpu.
+--   gpu_index : the 0-based GPU index WITHIN its machine (from the `gpu` table's
+--           `gpu` column). NOT unique across machines (machine A's index 0 and
+--           machine B's index 0 are different devices).
+-- machine_id links to the `machine` table; machine_id 0 is the host/local
+-- machine, non-zero ids are remote machines.
+--
+-- No parameters; operates on the whole trace. One row per GPU. Columns:
+--   machine_id   : owning machine (0 = host/local, non-zero = remote).
+--   is_host      : 1 if this GPU is on the host machine, else 0.
+--   ugpu         : host-unique GPU id — use this to join counters/slices/tracks.
+--   gpu_index    : 0-based GPU index within its machine (not trace-unique).
+--   vendor       : e.g. "NVIDIA", "AMD", "Qualcomm" (drives vendor-specific
+--                  analysis; may be NULL if the producer did not report it).
+--   name         : e.g. "NVIDIA A100-SXM4-80GB", "Adreno 740".
+--   model        : product identifier.
+--   architecture : e.g. "Ampere", "RDNA 3".
+--   uuid         : 16-byte device UUID, hex-encoded (NULL if not reported).
+--   pci_bdf      : PCI bus location domain:bus:device.function (NULL if absent).
+--
+-- If this returns no rows the trace carries no GpuInfo packet; GPU activity may
+-- still be present (slices/counters), but vendor/model/architecture are unknown.
+
+SELECT
+  g.machine_id,
+  g.machine_id = 0 AS is_host,
+  g.ugpu,
+  g.gpu AS gpu_index,
+  g.vendor,
+  g.name,
+  g.model,
+  g.architecture,
+  g.uuid,
+  g.pci_bdf
+FROM gpu AS g
+ORDER BY
+  g.machine_id,
+  g.gpu;

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_sustained_throttle.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_sustained_throttle.sql
@@ -21,6 +21,8 @@
 -- such track, or no sample landed inside a short interval. High temp + capped
 -- clock => thermal; high power + capped clock => power-limited.
 --
+-- No parameters (thresholds are inline); operates on the whole trace. One row
+-- per sustained-throttle interval (the top 20 by duration), per GPU.
 -- Columns (longest throttle intervals first):
 --   start_rel_ns : interval start, relative to trace start.
 --   dur_ns       : how long the clock was held below target.

--- a/ai/skills/perfetto/workflows/gpu/scripts/gpu_timeline_decomposition.sql
+++ b/ai/skills/perfetto/workflows/gpu/scripts/gpu_timeline_decomposition.sql
@@ -9,10 +9,16 @@
 -- multiple hardware queues is merged, not summed, so concurrency is never
 -- double-counted). Covers all GPU render-stage activity, not just one category.
 --
--- No parameters; operates on the whole trace. One row per GPU.
---   busy_pct_of_active : busy / (first .. last activity) span -> packing.
---   busy_pct_of_trace  : busy / whole-trace wall clock        -> idle outside
---                        the active span (setup, I/O, teardown) shows up here.
+-- No parameters; operates on the whole trace. One row per GPU. Columns:
+--   gpu                : unique GPU id (ugpu).
+--   gpu_name           : GPU name, or "GPU <id>" if unnamed.
+--   activities         : count of GPU activity slices on this GPU.
+--   trace_wall_ns      : whole-trace wall-clock duration.
+--   active_span_ns     : first .. last GPU activity span.
+--   gpu_busy_ns        : busy time (union of activity intervals).
+--   busy_pct_of_active : busy / active span -> packing.
+--   busy_pct_of_trace  : busy / whole-trace wall clock -> idle outside the
+--                        active span (setup, I/O, teardown) shows up here.
 
 INCLUDE PERFETTO MODULE intervals.overlap;
 

--- a/ai/skills/perfetto/workflows/gpu/timeline_occupancy.md
+++ b/ai/skills/perfetto/workflows/gpu/timeline_occupancy.md
@@ -16,6 +16,9 @@ allocation, host-device copies, or host work starving the device.
 If the user has not yet loaded a trace into `trace_processor`, follow
 `../../infra-references/querying.md` first, then come back here.
 
+> If `gpu_timeline_decomposition.sql` returns no rows, the trace has no GPU
+> render-stage activity and this workflow does not apply.
+
 ---
 
 ## Phase 1: Mandatory first-pass triage
@@ -40,7 +43,10 @@ Run this before any open-ended exploration. It produces the headline verdict.
       device-side question is *at what clock* the GPU ran while busy — a device
       packed at half its peak frequency looks GPU-bound but is really
       clock-limited. To check, read
-      [frequency_residency.md](frequency_residency.md).
+      [frequency_residency.md](frequency_residency.md). And when the device work
+      is GPU **compute** kernels (CUDA / ROCm / compute dispatches), decompose
+      the kernels themselves — which kernel, and what bounds it — with
+      [compute/kernel_analysis.md](compute/kernel_analysis.md).
     - **`busy_pct_of_active` is low** — there are meaningful idle gaps *between*
       activities even while the workload is "running." This is **host-bound** /
       stalled. Proceed to Phase 2 to find and attribute the gaps.


### PR DESCRIPTION
Add per-compute-kernel analysis under the GPU skills: pick the hotspot kernel, then classify it as compute-, memory-, or latency/occupancy- bound and find the lever (saturated pipeline, occupancy limit, cache level, or launch config) across speed-of-light, occupancy, workload, and launch-statistics workflows. The skills form a vendor-neutral over vendor-specific hierarchy: generic workflows describe each metric by its neutral display name plus interpretation and route to a vendor layer (nvidia/) that maps those names to concrete GPU counters and runs the extraction. Reached as a drill-down from the GPU timeline-occupancy and frequency-residency workflows.