### PR TITLE
rust-sdk: let the Perfetto team own simple changes

### DIFF
--- a/contrib/rust-sdk/OWNERS.github
+++ b/contrib/rust-sdk/OWNERS.github
@@ -5,4 +5,7 @@
 #
 # Syntax is the same as .github/CODEOWNERS but paths are relative to this directory.
 
-./ @dreveman @jon-rv @zytyz
+# The maintainers below own the Rust SDK. @google/perfetto-team is also listed
+# so the Perfetto team can approve cleanups and other simple changes; route
+# substantive changes to the maintainers.
+./ @dreveman @jon-rv @zytyz @google/perfetto-team


### PR DESCRIPTION
Add @google/perfetto-team to the Rust SDK GitHub code owners so the Perfetto team can approve cleanups and other simple changes. Substantive changes still go to the maintainers.