### PR TITLE
tp: Fix Fuchsia process-scoped and cross-process flow correlation

### DIFF
--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -770,5 +770,460 @@ TEST_F(FuchsiaTraceParserTest, LegacySchedulerEvents) {
   context_.sorter->ExtractEventsForced();
 }
 
+TEST_F(FuchsiaTraceParserTest, FlowEvents) {
+  // Setup thread mapping
+  EXPECT_CALL(*process_, UpdateThread(2, 1)).WillRepeatedly(Return(1u));
+  EXPECT_CALL(*process_, UpdateThread(3, 1)).WillRepeatedly(Return(2u));
+
+  // 1. ts=10: Thread 1 (pid=1, tid=2) - Duration Begin
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "NAME_S_1"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 2 << 16;  // kDurationBegin
+    uint64_t size = 6 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(10);                  // Timestamp
+    push_word(1);                   // inline thread: pid
+    push_word(2);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x315f535f454d414e);  // "NAME_S_1"
+  }
+
+  // 2. ts=12: Thread 1 (pid=1, tid=2) - Flow Begin (correlation_id=100)
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "FLOW_XXX"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 8 << 16;  // kFlowBegin
+    uint64_t size = 7 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(12);                  // Timestamp
+    push_word(1);                   // inline thread: pid
+    push_word(2);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x5858585f574f4c46);  // "FLOW_XXX"
+    push_word(100);                 // correlation_id
+  }
+
+  // 3. ts=13: Thread 1 (pid=1, tid=2) - Duration End
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "NAME_S_1"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 3 << 16;  // kDurationEnd
+    uint64_t size = 6 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(13);                  // Timestamp
+    push_word(1);                   // inline thread: pid
+    push_word(2);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x315f535f454d414e);  // "NAME_S_1"
+  }
+
+  // 4. ts=14: Thread 2 (pid=1, tid=3) - Duration Begin
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "NAME_S_2"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 2 << 16;  // kDurationBegin
+    uint64_t size = 6 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(14);                  // Timestamp
+    push_word(1);                   // inline thread: pid
+    push_word(3);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x325f535f454d414e);  // "NAME_S_2"
+  }
+
+  // 5. ts=15: Thread 2 (pid=1, tid=3) - Flow End (correlation_id=100)
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "FLOW_XXX"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 10 << 16;  // kFlowEnd
+    uint64_t size = 7 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(15);                  // Timestamp
+    push_word(1);                   // inline thread: pid
+    push_word(3);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x5858585f574f4c46);  // "FLOW_XXX"
+    push_word(100);                 // correlation_id
+  }
+
+  // 6. ts=16: Thread 2 (pid=1, tid=3) - Duration End
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "NAME_S_2"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 3 << 16;  // kDurationEnd
+    uint64_t size = 6 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(16);                  // Timestamp
+    push_word(1);                   // inline thread: pid
+    push_word(3);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x325f535f454d414e);  // "NAME_S_2"
+  }
+
+  EXPECT_TRUE(Tokenize().ok());
+  context_.sorter->ExtractEventsForced();
+
+  // Verify slice table
+  const auto& slices = storage_->slice_table();
+  ASSERT_EQ(slices.row_count(), 2u);
+
+  auto slice_1 = slices[SliceId(0u)];
+  EXPECT_EQ(slice_1.ts(), 10);
+  EXPECT_EQ(slice_1.dur(), 3);
+  EXPECT_EQ(
+      storage_->GetString(slice_1.name().value_or(kNullStringId)).ToStdString(),
+      "NAME_S_1");
+
+  auto slice_2 = slices[SliceId(1u)];
+  EXPECT_EQ(slice_2.ts(), 14);
+  EXPECT_EQ(slice_2.dur(), 2);
+  EXPECT_EQ(
+      storage_->GetString(slice_2.name().value_or(kNullStringId)).ToStdString(),
+      "NAME_S_2");
+
+  // Verify flow table
+  const auto& flows = storage_->flow_table();
+  ASSERT_EQ(flows.row_count(), 1u);
+
+  auto flow = flows[0u];
+  EXPECT_EQ(flow.slice_out(), SliceId(0u));
+  EXPECT_EQ(flow.slice_in(), SliceId(1u));
+}
+
+TEST_F(FuchsiaTraceParserTest, CrossProcessFlowEvents) {
+  // Setup thread mapping
+  EXPECT_CALL(*process_, UpdateThread(2, 1)).WillRepeatedly(Return(1u));
+  EXPECT_CALL(*process_, UpdateThread(3, 2)).WillRepeatedly(Return(2u));
+
+  // 1. ts=10: Thread 1 (pid=1, tid=2) - Duration Begin
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "NAME_S_1"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 2 << 16;  // kDurationBegin
+    uint64_t size = 6 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(10);                  // Timestamp
+    push_word(1);                   // inline thread: pid
+    push_word(2);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x315f535f454d414e);  // "NAME_S_1"
+  }
+
+  // 2. ts=12: Thread 1 (pid=1, tid=2) - Flow Begin (correlation_id=100)
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "FLOW_XXX"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 8 << 16;  // kFlowBegin
+    uint64_t size = 7 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(12);                  // Timestamp
+    push_word(1);                   // inline thread: pid
+    push_word(2);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x5858585f574f4c46);  // "FLOW_XXX"
+    push_word(100);                 // correlation_id
+  }
+
+  // 3. ts=13: Thread 1 (pid=1, tid=2) - Duration End
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "NAME_S_1"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 3 << 16;  // kDurationEnd
+    uint64_t size = 6 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(13);                  // Timestamp
+    push_word(1);                   // inline thread: pid
+    push_word(2);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x315f535f454d414e);  // "NAME_S_1"
+  }
+
+  // 4. ts=14: Thread 2 (pid=2, tid=3) - Duration Begin
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "NAME_S_2"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 2 << 16;  // kDurationBegin
+    uint64_t size = 6 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(14);                  // Timestamp
+    push_word(2);                   // inline thread: pid
+    push_word(3);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x325f535f454d414e);  // "NAME_S_2"
+  }
+
+  // 5. ts=15: Thread 2 (pid=2, tid=3) - Flow End (correlation_id=100)
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "FLOW_XXX"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 10 << 16;  // kFlowEnd
+    uint64_t size = 7 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(15);                  // Timestamp
+    push_word(2);                   // inline thread: pid
+    push_word(3);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x5858585f574f4c46);  // "FLOW_XXX"
+    push_word(100);                 // correlation_id
+  }
+
+  // 6. ts=16: Thread 2 (pid=2, tid=3) - Duration End
+  {
+    uint64_t name_ref = uint64_t{0x8008} << 48;      // inline "NAME_S_2"
+    uint64_t category_ref = uint64_t{0x8008} << 32;  // inline "CAT_AAAA"
+    uint64_t threadref = uint64_t{0};
+    uint64_t event_type = 3 << 16;  // kDurationEnd
+    uint64_t size = 6 << 4;
+    uint64_t record_type = 4;
+
+    auto header =
+        name_ref | category_ref | threadref | event_type | size | record_type;
+    push_word(header);
+    push_word(16);                  // Timestamp
+    push_word(2);                   // inline thread: pid
+    push_word(3);                   // inline thread: tid
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x325f535f454d414e);  // "NAME_S_2"
+  }
+
+  EXPECT_TRUE(Tokenize().ok());
+  context_.sorter->ExtractEventsForced();
+
+  // Verify slice table
+  const auto& slices = storage_->slice_table();
+  ASSERT_EQ(slices.row_count(), 2u);
+
+  auto slice_1 = slices[SliceId(0u)];
+  EXPECT_EQ(slice_1.ts(), 10);
+  EXPECT_EQ(slice_1.dur(), 3);
+
+  auto slice_2 = slices[SliceId(1u)];
+  EXPECT_EQ(slice_2.ts(), 14);
+  EXPECT_EQ(slice_2.dur(), 2);
+
+  // Verify flow table contains the cross-process flow
+  const auto& flows = storage_->flow_table();
+  ASSERT_EQ(flows.row_count(), 1u);
+
+  auto flow = flows[0u];
+  EXPECT_EQ(flow.slice_out(), SliceId(0u));
+  EXPECT_EQ(flow.slice_in(), SliceId(1u));
+}
+
+TEST_F(FuchsiaTraceParserTest, AmbiguousFlowEvents) {
+  // Setup thread mapping
+  EXPECT_CALL(*process_, UpdateThread(2, 1)).WillRepeatedly(Return(1u));
+  EXPECT_CALL(*process_, UpdateThread(3, 2)).WillRepeatedly(Return(2u));
+  EXPECT_CALL(*process_, UpdateThread(4, 3)).WillRepeatedly(Return(3u));
+
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 2 << 16 | 6 << 4 |
+              4);  // event_type=2 (kDurationBegin), size=6, record_type=4
+    push_word(10);
+    push_word(1);                   // pid=1
+    push_word(2);                   // tid=2
+    push_word(0x414141415f544143);  // "CAT_AAAA"
+    push_word(0x315f535f454d414e);  // "NAME_S_1"
+  }
+  // Flow Begin (correlation_id=100) from PID 1
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 8 << 16 | 7 << 4 | 4);
+    push_word(12);
+    push_word(1);
+    push_word(2);
+    push_word(0x414141415f544143);
+    push_word(0x5858585f574f4c46);
+    push_word(100);
+  }
+  // Duration End
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 3 << 16 | 6 << 4 | 4);
+    push_word(13);
+    push_word(1);
+    push_word(2);
+    push_word(0x414141415f544143);
+    push_word(0x315f535f454d414e);
+  }
+
+  // 2. Process 3 (TID 4) - Duration Begin (Slice 1)
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 2 << 16 | 6 << 4 | 4);
+    push_word(10);
+    push_word(3);  // pid=3
+    push_word(4);  // tid=4
+    push_word(0x414141415f544143);
+    push_word(0x345f535f454d414e);  // "NAME_S_4"
+  }
+  // Flow Begin (correlation_id=100) from PID 3 (creates ambiguity!)
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 8 << 16 | 7 << 4 | 4);
+    push_word(12);
+    push_word(3);
+    push_word(4);
+    push_word(0x414141415f544143);
+    push_word(0x5858585f574f4c46);
+    push_word(100);
+  }
+  // Duration End
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 3 << 16 | 6 << 4 | 4);
+    push_word(13);
+    push_word(3);
+    push_word(4);
+    push_word(0x414141415f544143);
+    push_word(0x345f535f454d414e);
+  }
+
+  // 3. Process 1 (TID 2) - Same-Process Flow End (Slice 2)
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 2 << 16 | 6 << 4 | 4);
+    push_word(14);
+    push_word(1);
+    push_word(2);
+    push_word(0x414141415f544143);
+    push_word(0x335f535f454d414e);  // "NAME_S_3"
+  }
+  // Flow End (correlation_id=100) under PID 1
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 10 << 16 | 7 << 4 | 4);
+    push_word(15);
+    push_word(1);
+    push_word(2);
+    push_word(0x414141415f544143);
+    push_word(0x5858585f574f4c46);
+    push_word(100);
+  }
+  // Duration End
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 3 << 16 | 6 << 4 | 4);
+    push_word(16);
+    push_word(1);
+    push_word(2);
+    push_word(0x414141415f544143);
+    push_word(0x335f535f454d414e);
+  }
+
+  // 4. Process 2 (TID 3) - Cross-Process Flow End (Slice 3)
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 2 << 16 | 6 << 4 | 4);
+    push_word(14);
+    push_word(2);
+    push_word(3);
+    push_word(0x414141415f544143);
+    push_word(0x325f535f454d414e);  // "NAME_S_2"
+  }
+  // Flow End (correlation_id=100) under PID 2 (cross-process, should fail)
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 10 << 16 | 7 << 4 | 4);
+    push_word(15);
+    push_word(2);
+    push_word(3);
+    push_word(0x414141415f544143);
+    push_word(0x5858585f574f4c46);
+    push_word(100);
+  }
+  // Duration End
+  {
+    uint64_t name = uint64_t{0x8008} << 48;
+    uint64_t cat = uint64_t{0x8008} << 32;
+    push_word(name | cat | 3 << 16 | 6 << 4 | 4);
+    push_word(16);
+    push_word(2);
+    push_word(3);
+    push_word(0x414141415f544143);
+    push_word(0x325f535f454d414e);
+  }
+
+  EXPECT_TRUE(Tokenize().ok());
+  context_.sorter->ExtractEventsForced();
+
+  // Verify flow table contains ONLY the same-process flow (Slice 0 -> Slice 2)
+  // and NOT the cross-process flow (Slice 1 -> Slice 3) because ID 100 was
+  // ambiguous.
+  const auto& flows = storage_->flow_table();
+  ASSERT_EQ(flows.row_count(), 1u);
+
+  auto flow = flows[0u];
+  EXPECT_EQ(flow.slice_out(), SliceId(0u));  // Slice 0 (NAME_S_1)
+  EXPECT_EQ(flow.slice_in(), SliceId(2u));   // Slice 2 (NAME_S_3)
+}
 }  // namespace
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/fuchsia/fuchsia_trace_parser.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_trace_parser.cc
@@ -492,7 +492,12 @@ void FuchsiaTraceParser::Parse(int64_t, FuchsiaRecord fr) {
               procs->UpdateThread(static_cast<uint32_t>(tinfo.tid),
                                   static_cast<uint32_t>(tinfo.pid));
           TrackId track_id = context_->track_tracker->InternThreadTrack(utid);
-          context_->flow_tracker->Begin(track_id, correlation_id);
+          auto opt_resolved =
+              GetGlobalFlowId(static_cast<uint32_t>(tinfo.pid), correlation_id,
+                              /* step_or_end = */ false);
+          if (opt_resolved) {
+            context_->flow_tracker->Begin(track_id, opt_resolved->global_id);
+          }
           break;
         }
         case kFlowStep: {
@@ -506,7 +511,12 @@ void FuchsiaTraceParser::Parse(int64_t, FuchsiaRecord fr) {
               procs->UpdateThread(static_cast<uint32_t>(tinfo.tid),
                                   static_cast<uint32_t>(tinfo.pid));
           TrackId track_id = context_->track_tracker->InternThreadTrack(utid);
-          context_->flow_tracker->Step(track_id, correlation_id);
+          auto opt_resolved =
+              GetGlobalFlowId(static_cast<uint32_t>(tinfo.pid), correlation_id,
+                              /* step_or_end = */ true);
+          if (opt_resolved) {
+            context_->flow_tracker->Step(track_id, opt_resolved->global_id);
+          }
           break;
         }
         case kFlowEnd: {
@@ -520,7 +530,17 @@ void FuchsiaTraceParser::Parse(int64_t, FuchsiaRecord fr) {
               procs->UpdateThread(static_cast<uint32_t>(tinfo.tid),
                                   static_cast<uint32_t>(tinfo.pid));
           TrackId track_id = context_->track_tracker->InternThreadTrack(utid);
-          context_->flow_tracker->End(track_id, correlation_id, true, true);
+          auto opt_resolved =
+              GetGlobalFlowId(static_cast<uint32_t>(tinfo.pid), correlation_id,
+                              /* step_or_end = */ true);
+          if (opt_resolved) {
+            context_->flow_tracker->End(track_id, opt_resolved->global_id,
+                                        /* bind_enclosing_slice = */ true,
+                                        /* close_flow = */ true);
+            fuchsia_active_flows_.Erase(opt_resolved->matched_scoped);
+            fuchsia_global_flows_.Erase(
+                opt_resolved->matched_scoped.correlation_id);
+          }
           break;
         }
       }
@@ -918,6 +938,54 @@ StringId FuchsiaTraceParser::IdForOutgoingThreadState(uint32_t state) {
     default:
       return kNullStringId;
   }
+}
+
+std::optional<FuchsiaTraceParser::ResolvedFlow>
+FuchsiaTraceParser::GetGlobalFlowId(uint32_t pid,
+                                    uint64_t correlation_id,
+                                    bool step_or_end) {
+  FuchsiaScopedFlowId scoped_id = {pid, correlation_id};
+
+  // First, check if there is an exact match for the process-scoped flow.
+  auto* it = fuchsia_active_flows_.Find(scoped_id);
+  if (it) {
+    return ResolvedFlow{*it, scoped_id};
+  }
+
+  // If this is a flow begin event, allocate a new globally unique flow ID.
+  if (!step_or_end) {
+    uint64_t global_id = fuchsia_global_flow_id_counter_++;
+    fuchsia_active_flows_.Insert(scoped_id, global_id);
+
+    auto* global_it = fuchsia_global_flows_.Find(correlation_id);
+    if (global_it) {
+      if (global_it->pid != pid) {
+        global_it->is_ambiguous = true;
+      }
+    } else {
+      fuchsia_global_flows_.Insert(correlation_id, GlobalFlowInfo{pid, false});
+    }
+    return ResolvedFlow{global_id, scoped_id};
+  }
+
+  // For step or end events, check if the correlation ID is registered under a
+  // different process PID, indicating a cross-process flow.
+  auto* global_it = fuchsia_global_flows_.Find(correlation_id);
+  if (global_it) {
+    if (global_it->is_ambiguous) {
+      // The correlation ID is defined in multiple processes, so we cannot
+      // disambiguate it for cross-process correlation.
+      return std::nullopt;
+    }
+    uint32_t owner_pid = global_it->pid;
+    FuchsiaScopedFlowId owner_scoped_id = {owner_pid, correlation_id};
+    auto* global_id_it = fuchsia_active_flows_.Find(owner_scoped_id);
+    if (global_id_it) {
+      return ResolvedFlow{*global_id_it, owner_scoped_id};
+    }
+  }
+
+  return std::nullopt;
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/fuchsia/fuchsia_trace_parser.h
+++ b/src/trace_processor/importers/fuchsia/fuchsia_trace_parser.h
@@ -22,6 +22,8 @@
 #include <optional>
 #include <unordered_map>
 #include <vector>
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/hash.h"
 
 #include "perfetto/ext/base/string_view.h"
 #include "src/trace_processor/importers/fuchsia/fuchsia_record.h"
@@ -111,6 +113,53 @@ class FuchsiaTraceParser
 
   // Map from tid to Thread.
   std::unordered_map<uint64_t, Thread> threads_;
+
+  // Fuchsia flow correlation IDs are scoped to the process (PID) that created
+  // them. A FuchsiaScopedFlowId represents this process-scoped identifier.
+  struct FuchsiaScopedFlowId {
+    uint32_t pid;
+    uint64_t correlation_id;
+
+    bool operator==(const FuchsiaScopedFlowId& o) const {
+      return pid == o.pid && correlation_id == o.correlation_id;
+    }
+  };
+
+  struct FuchsiaScopedFlowIdHasher {
+    size_t operator()(const FuchsiaScopedFlowId& c) const {
+      return base::MurmurHashCombine(c.pid, c.correlation_id);
+    }
+  };
+
+  struct ResolvedFlow {
+    uint64_t global_id;
+    FuchsiaScopedFlowId matched_scoped;
+  };
+
+  struct GlobalFlowInfo {
+    uint32_t pid;
+    bool is_ambiguous = false;
+  };
+
+  // Resolves a process-scoped correlation ID to a globally unique flow ID.
+  // If no flow with the matching (pid, correlation_id) exists and we are
+  // processing a step or end event, it falls back to checking if the
+  // correlation_id exists in another process (assuming the ID is globally
+  // unique).
+  std::optional<ResolvedFlow> GetGlobalFlowId(uint32_t pid,
+                                              uint64_t correlation_id,
+                                              bool step_or_end);
+
+  // Counter used to generate globally unique flow IDs.
+  uint64_t fuchsia_global_flow_id_counter_ = 1;
+
+  // Maps a process-scoped Fuchsia flow identifier to its globally unique ID.
+  base::FlatHashMap<FuchsiaScopedFlowId, uint64_t, FuchsiaScopedFlowIdHasher>
+      fuchsia_active_flows_;
+
+  // Maps a correlation ID to its global flow info.
+  // Used for cross-process flow resolution.
+  base::FlatHashMap<uint64_t, GlobalFlowInfo> fuchsia_global_flows_;
 };
 
 }  // namespace perfetto::trace_processor


### PR DESCRIPTION
Fuchsia flow correlation IDs can either be

- scoped to the process (PID) that emitted them, where the flow remains within the process, and the ids are unique within the process.
- global, and the flow can cross processes, and the ids are unique globally.

The current implementation assumed that the IDs are globally unique, where some process local correlation ids collided.

This change resolves process-scoped correlation IDs to globally unique flow IDs during trace processing, and implements fallback matching for cross-process flow events.