### PR TITLE
github: regenerate CODEOWNERS for the rust-sdk perfetto-team owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,5 +34,5 @@
 /protos/third_party/chromium/ @google/chromium-stdlib-owners
 /test/data/chrome/**.sha256 @google/chromium-stdlib-owners
 /test/trace_processor/diff_tests/stdlib/chrome/ @google/chromium-stdlib-owners
-/contrib/rust-sdk/ @dreveman @jon-rv @zytyz
+/contrib/rust-sdk/ @dreveman @jon-rv @zytyz @google/perfetto-team
 /src/trace_processor/perfetto_sql/stdlib/chrome/ @google/chromium-stdlib-owners


### PR DESCRIPTION
contrib/rust-sdk/OWNERS.github added @google/perfetto-team, but the generated .github/CODEOWNERS (the file GitHub enforces) was not regenerated, so the rust-sdk rule did not actually include the team. Run tools/gen_github_codeowners to update it.