### PR TITLE
ci: switch to actions@v5

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -49,7 +49,7 @@ jobs:
       UI_ONLY_CHANGE: ${{ steps.ui_only.outputs.UI_ONLY_CHANGE }}
       BIGTRACE_CHANGE: ${{ steps.bigtrace.outputs.BIGTRACE_CHANGE }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -31,7 +31,7 @@ jobs:
       PERFETTO_CI_BUILD_CACHE_KEY: build-cache-android
       PERFETTO_TEST_GN_ARGS: 'is_debug=false target_os=\"android\" target_cpu=\"arm\" cc_wrapper=\"ccache\"'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/install-build-deps
         with:

--- a/.github/workflows/bazel-tests.yml
+++ b/.github/workflows/bazel-tests.yml
@@ -31,7 +31,7 @@ jobs:
       PERFETTO_CI_BUILD_CACHE_KEY: build-cache-bazel
       PERFETTO_CI_JOB_ID: gh-${{ github.run_id }}-bazel
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup artifacts
         shell: bash

--- a/.github/workflows/bigtrace-tests.yml
+++ b/.github/workflows/bigtrace-tests.yml
@@ -30,7 +30,7 @@ jobs:
       PERFETTO_GCS_DST: perfetto-ci-artifacts/gh-${{ github.run_id }}-${{ github.run_attempt }}-bigtrace
       CI: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/install-build-deps
         with:

--- a/.github/workflows/cut-canary.yml
+++ b/.github/workflows/cut-canary.yml
@@ -51,7 +51,7 @@ jobs:
           private-key: ${{ secrets.PERFETTO_BOT_PRIVATE_KEY }}
 
       - name: Checkout canary
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: canary
           fetch-depth: 0

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -67,7 +67,7 @@ jobs:
       # main is the base for the prebuilt-roll PR; tags are needed to pull this
       # release's ai/skills into the bundle.
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/fuzzer-tests.yml
+++ b/.github/workflows/fuzzer-tests.yml
@@ -32,7 +32,7 @@ jobs:
       PERFETTO_CI_BUILD_CACHE_KEY: build-cache-fuzzer
       PERFETTO_TEST_GN_ARGS: 'is_debug=false is_fuzzer=true is_asan=true cc_wrapper=\"ccache\"'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore cache
         uses: ./.github/actions/cache-on-google-cloud-storage/restore

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -53,7 +53,7 @@ jobs:
       PERFETTO_CI_BUILD_CACHE_KEY: build-cache-${{ matrix.config.name }}
       PERFETTO_CI_JOB_ID: gh-${{ github.run_id }}-${{ matrix.config.name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup artifacts
         shell: bash

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -46,7 +46,7 @@ jobs:
           private-key: ${{ secrets.PERFETTO_BOT_PRIVATE_KEY }}
 
       - name: Checkout stable
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: stable
           fetch-depth: 0

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -26,7 +26,7 @@ jobs:
       PERFETTO_CI_JOB_NAME: repochecks
       CI: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Fetches the merge commit and its parents, which is required for
           # the presubmit script to parse the commit message (for

--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: ./.github/actions/install-build-deps
         with:

--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -36,7 +36,7 @@ jobs:
           private-key: ${{ secrets.PERFETTO_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/tag-on-stable-push.yml
+++ b/.github/workflows/tag-on-stable-push.yml
@@ -55,7 +55,7 @@ jobs:
           private-key: ${{ secrets.PERFETTO_BOT_PRIVATE_KEY }}
 
       - name: Checkout stable
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: stable
           fetch-depth: 0

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -35,7 +35,7 @@ jobs:
       PERFETTO_GCS_DST: perfetto-ci-artifacts/gh-${{ github.run_id }}-${{ github.run_attempt }}-ui
       CI: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # TODO(stevegolton): Debug - remove.
       - name: 'Debug GL info'

--- a/.github/workflows/update-codeowners.yml
+++ b/.github/workflows/update-codeowners.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main  # Always use main branch to avoid running modified scripts from PRs
           fetch-depth: 0


### PR DESCRIPTION
v4 triggers some warning about node deprecation.
Doesn't affect us in reality as we use our own hermetic
node, but still creates an annoying warning banner on github.