### PR TITLE
ui: Wattson: Fix per thread track display

### DIFF
--- a/ui/src/plugins/org.kernel.Wattson/wattson_thread_utils.ts
+++ b/ui/src/plugins/org.kernel.Wattson/wattson_thread_utils.ts
@@ -66,6 +66,7 @@ export async function addWattsonThreadTrack(
       estimated_mw AS value
     FROM gapless
     WHERE dur > 0
+    ORDER BY ts
   `;
 
   const renderer = await CounterTrack.createMaterialized({


### PR DESCRIPTION
Fix the power per thread track display by sorting by timestamp before creating the track.

Bug: 525136431
Signed-off-by: Samuel Wu <wusamuel@google.com>
