### PR TITLE
sdk: support machine_id on the in-process backend

### DIFF
--- a/contrib/rust-sdk/Cargo.lock
+++ b/contrib/rust-sdk/Cargo.lock
@@ -350,7 +350,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perfetto-sdk"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "bitflags",
  "paste",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/contrib/rust-sdk/perfetto-sys/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-sys"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["David Reveman <reveman@meta.com>"]
 build = "build.rs"
 description = "Low-level FFI bindings for Perfetto"

--- a/contrib/rust-sdk/perfetto-sys/src/bindings.rs
+++ b/contrib/rust-sdk/perfetto-sys/src/bindings.rs
@@ -385,6 +385,12 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    pub fn PerfettoProducerBackendInitArgsSetMachineId(
+        arg1: *mut PerfettoProducerBackendInitArgs,
+        machine_id: u32,
+    );
+}
+unsafe extern "C" {
     pub fn PerfettoProducerBackendInitArgsDestroy(arg1: *mut PerfettoProducerBackendInitArgs);
 }
 unsafe extern "C" {

--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["David Reveman <reveman@meta.com>"]
 description = "Bindings for the Perfetto tracing framework"
 readme = "README.md"
@@ -20,7 +20,7 @@ intrinsics = []
 vendored = ["perfetto-sdk-sys/vendored"]
 
 [dependencies]
-perfetto-sdk-sys = { path = "../perfetto-sys", version = "1", default-features = false }
+perfetto-sdk-sys = { path = "../perfetto-sys", version = "1.1.1", default-features = false }
 bitflags = "2"
 paste = "1"
 thiserror = "1"

--- a/contrib/rust-sdk/perfetto/src/producer.rs
+++ b/contrib/rust-sdk/perfetto/src/producer.rs
@@ -45,6 +45,7 @@ bitflags! {
 pub struct ProducerInitArgs {
     backends: Backends,
     shmem_size_hint_kb: u32,
+    machine_id: u32,
 }
 
 /// Producer arguments builder.
@@ -78,6 +79,17 @@ impl ProducerInitArgsBuilder {
         self
     }
 
+    /// Sets the machine id this process's trace data is attributed to. Only
+    /// honored by the in-process backend; the system backend derives the
+    /// machine id service-side and ignores this. Lets separate in-process
+    /// traces be recorded under distinct machine ids. 0 (the default) means the
+    /// host machine.
+    #[must_use = "Builder methods return an updated builder; use the returned value or keep chaining."]
+    pub fn machine_id(mut self, machine_id: u32) -> Self {
+        self.args.machine_id = machine_id;
+        self
+    }
+
     /// Returns producer arguments struct.
     pub fn build(&self) -> &ProducerInitArgs {
         &self.args
@@ -102,6 +114,7 @@ impl Producer {
                 backend_args,
                 args.shmem_size_hint_kb,
             );
+            PerfettoProducerBackendInitArgsSetMachineId(backend_args, args.machine_id);
             if args.backends.contains(Backends::IN_PROCESS) {
                 PerfettoProducerInProcessInit(backend_args);
             }

--- a/include/perfetto/public/abi/producer_abi.h
+++ b/include/perfetto/public/abi/producer_abi.h
@@ -43,6 +43,14 @@ PERFETTO_SDK_EXPORT void PerfettoProducerBackendInitArgsSetShmemSizeHintKb(
     struct PerfettoProducerBackendInitArgs*,
     uint32_t size);
 
+// Sets the machine id this process's trace data is attributed to. Only honored
+// by the in-process backend (PerfettoProducerInProcessInit); ignored by the
+// system backend. Lets separate in-process traces be recorded under distinct
+// machine ids. 0 means the default (host) machine.
+PERFETTO_SDK_EXPORT void PerfettoProducerBackendInitArgsSetMachineId(
+    struct PerfettoProducerBackendInitArgs*,
+    uint32_t machine_id);
+
 PERFETTO_SDK_EXPORT void PerfettoProducerBackendInitArgsDestroy(
     struct PerfettoProducerBackendInitArgs*);
 

--- a/include/perfetto/tracing/tracing.h
+++ b/include/perfetto/tracing/tracing.h
@@ -76,6 +76,17 @@ struct TracingInitArgs {
   uint32_t backends = 0;                     // One or more BackendTypes.
   TracingBackend* custom_backend = nullptr;  // [Optional].
 
+  // [Optional] Machine id to attribute this process's trace data to. Only
+  // honored by the in-process backend; the system backend derives the machine
+  // id service-side and ignores this. Lets separate in-process traces be
+  // recorded under distinct machine ids. 0 means the default (host) machine.
+  //
+  // For a non-default (non-host) machine id, the tracing session's TraceConfig
+  // must opt into matching non-host machines (set trace_all_machines, or a
+  // machine_name_filter that matches); otherwise the data sources are filtered
+  // out and record no data.
+  uint32_t machine_id = 0;
+
   // [Optional] Platform implementation. It allows the embedder to take control
   // of platform-specific bits like thread creation and TLS slot handling. If
   // not set it will use Platform::GetDefaultPlatform().

--- a/include/perfetto/tracing/tracing_backend.h
+++ b/include/perfetto/tracing/tracing_backend.h
@@ -75,6 +75,10 @@ class PERFETTO_EXPORT_COMPONENT TracingProducerBackend {
     uint32_t shmem_size_hint_bytes = 0;
     uint32_t shmem_page_size_hint_bytes = 0;
 
+    // Machine id propagated from TracingInitArgs; honored by the in-process
+    // backend only.
+    uint32_t machine_id = 0;
+
     // If true, the backend should allocate a shared memory buffer and provide
     // it to the service when connecting.
     // It's used in startup tracing.

--- a/src/shared_lib/producer.cc
+++ b/src/shared_lib/producer.cc
@@ -39,6 +39,7 @@ void ResetForTesting() {
 
 struct PerfettoProducerBackendInitArgs {
   uint32_t shmem_size_hint_kb = 0;
+  uint32_t machine_id = 0;
 };
 
 struct PerfettoProducerBackendInitArgs*
@@ -52,6 +53,12 @@ void PerfettoProducerBackendInitArgsSetShmemSizeHintKb(
   backend_args->shmem_size_hint_kb = size;
 }
 
+void PerfettoProducerBackendInitArgsSetMachineId(
+    struct PerfettoProducerBackendInitArgs* backend_args,
+    uint32_t machine_id) {
+  backend_args->machine_id = machine_id;
+}
+
 void PerfettoProducerBackendInitArgsDestroy(
     struct PerfettoProducerBackendInitArgs* backend_args) {
   delete backend_args;
@@ -62,6 +69,7 @@ void PerfettoProducerInProcessInit(
   perfetto::TracingInitArgs args;
   args.backends = perfetto::kInProcessBackend;
   args.shmem_size_hint_kb = backend_args->shmem_size_hint_kb;
+  args.machine_id = backend_args->machine_id;
   perfetto::Tracing::Initialize(args);
 }
 

--- a/src/tracing/internal/in_process_tracing_backend.cc
+++ b/src/tracing/internal/in_process_tracing_backend.cc
@@ -54,7 +54,8 @@ std::unique_ptr<ProducerEndpoint> InProcessTracingBackend::ConnectProducer(
     const ConnectProducerArgs& args) {
   PERFETTO_DCHECK(args.task_runner->RunsTasksOnCurrentThread());
   return GetOrCreateService(args.task_runner)
-      ->ConnectProducer(args.producer, ClientIdentity(/*uid=*/0, /*pid=*/0),
+      ->ConnectProducer(args.producer,
+                        ClientIdentity(/*uid=*/0, /*pid=*/0, args.machine_id),
                         args.producer_name, args.shmem_size_hint_bytes,
                         /*in_process=*/true,
                         TracingService::ProducerSMBScrapingMode::kEnabled,

--- a/src/tracing/internal/tracing_muxer_impl.cc
+++ b/src/tracing/internal/tracing_muxer_impl.cc
@@ -1015,6 +1015,7 @@ void TracingMuxerImpl::AddProducerBackend(TracingProducerBackend* backend,
   rb.producer_conn_args.shmem_page_size_hint_bytes =
       args.shmem_page_size_hint_kb * 1024;
   rb.producer_conn_args.create_socket_async = args.create_socket_async;
+  rb.producer_conn_args.machine_id = args.machine_id;
   rb.producer->Initialize(rb.backend->ConnectProducer(rb.producer_conn_args));
 }
 

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -342,6 +342,16 @@ void AppendOwnedSlicesToPacket(std::unique_ptr<uint8_t[]> data,
   }
 }
 
+// Shmem emulation is only for relay (remote-host) producers whose SMB is copied
+// over IPC. An in-process producer always has a real shared SMB, so it must use
+// kDefault even when it carries a non-default machine id.
+SharedMemoryABI::ShmemMode GetShmemMode(const ClientIdentity& client_identity,
+                                        bool in_process) {
+  return (client_identity.machine_id() == kDefaultMachineID || in_process)
+             ? SharedMemoryABI::ShmemMode::kDefault
+             : SharedMemoryABI::ShmemMode::kShmemEmulation;
+}
+
 }  // namespace
 
 TracingServiceImpl::TracingServiceImpl(
@@ -430,9 +440,7 @@ TracingServiceImpl::ConnectProducer(Producer* producer,
       PERFETTO_DLOG(
           "Adopting producer-provided SMB of %zu kB for producer \"%s\"",
           shm_size / 1024, endpoint->name_.c_str());
-      auto shmem_mode = client_identity.machine_id() == kDefaultMachineID
-                            ? SharedMemoryABI::ShmemMode::kDefault
-                            : SharedMemoryABI::ShmemMode::kShmemEmulation;
+      auto shmem_mode = GetShmemMode(client_identity, in_process);
       endpoint->SetupSharedMemory(std::move(shm), page_size,
                                   /*provided_by_producer=*/true, shmem_mode);
     } else {
@@ -3462,9 +3470,7 @@ DataSourceInstance* TracingServiceImpl::SetupDataSource(
     // physical memory.
     auto shared_memory = shm_factory_->CreateSharedMemory(shm_size);
     auto shmem_mode =
-        producer->client_identity().machine_id() == kDefaultMachineID
-            ? SharedMemoryABI::ShmemMode::kDefault
-            : SharedMemoryABI::ShmemMode::kShmemEmulation;
+        GetShmemMode(producer->client_identity(), producer->in_process_);
     producer->SetupSharedMemory(std::move(shared_memory), page_size,
                                 /*provided_by_producer=*/false, shmem_mode);
   }


### PR DESCRIPTION
Add a machine_id to TracingInitArgs that the in-process backend attributes its trace data to, so separate in-process traces can be recorded under distinct machine ids.

The id flows from TracingInitArgs to ConnectProducerArgs (via the muxer) and into ClientIdentity(uid, pid, machine_id) in InProcessTracingBackend, so the service stamps TracePacket.machine_id on the trusted packets. The C ABI gains
PerfettoProducerBackendInitArgsSetMachineId, wired into PerfettoProducerInProcessInit.

It also fixes shared-memory mode selection: a non-default machine_id previously forced ShmemMode::kShmemEmulation, which is only valid for relay (remote-host) producers whose SMB is copied over IPC. An in-process producer has a real shared SMB, so emulation mode violated the SMB chunk-state invariant and crashed on first emit. Both SMB-setup paths now select kDefault for in-process producers regardless of machine id. The system backend is unaffected: it derives the machine id service-side and ignores this field.