### PR TITLE
ui: compute tracing time bounds per (machine, trace)

### DIFF
--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -678,25 +678,32 @@ async function getTraceErrors(engine: Engine): Promise<number> {
 }
 
 async function getTracingMetadataTimeBounds(engine: Engine): Promise<TimeSpan> {
-  const queryRes = await engine.query(`select
-       name,
-       int_value as intValue
-       from metadata
-       where name = 'tracing_started_ns' or name = 'tracing_disabled_ns'
-       or name = 'all_data_source_started_ns'`);
-  let startBound = Time.MIN;
-  let endBound = Time.MAX;
-  const it = queryRes.iter({name: STR, intValue: LONG_NULL});
-  for (; it.valid(); it.next()) {
-    const columnName = it.name;
-    const timestamp = it.intValue;
-    if (timestamp === null) continue;
-    if (columnName === 'tracing_disabled_ns') {
-      endBound = Time.min(endBound, Time.fromRaw(timestamp));
-    } else {
-      startBound = Time.max(startBound, Time.fromRaw(timestamp));
-    }
-  }
-
+  // The tracing window metadata is recorded per (machine, trace):
+  // tracing_started_ns / all_data_source_started_ns mark when that trace's
+  // tracing became fully active, tracing_disabled_ns when it stopped. Compute
+  // each trace's active window (start = the later of its start timestamps, end =
+  // its disabled timestamp) and take the union across all of them. This way a
+  // multi-machine session or several traces loaded together yields a window
+  // spanning all of them, instead of the intersection of the per-trace windows
+  // (which is empty when those windows are disjoint).
+  const queryRes = await engine.query(`
+    select
+      min(start_ns) as startBound,
+      max(end_ns) as endBound
+    from (
+      select
+        max(iif(
+          name in ('tracing_started_ns', 'all_data_source_started_ns'),
+          int_value, null)) as start_ns,
+        max(iif(name = 'tracing_disabled_ns', int_value, null)) as end_ns
+      from metadata
+      where name in (
+        'tracing_started_ns', 'all_data_source_started_ns', 'tracing_disabled_ns')
+      group by machine_id, trace_id
+    )`);
+  const it = queryRes.iter({startBound: LONG_NULL, endBound: LONG_NULL});
+  const startBound =
+    it.startBound === null ? Time.MIN : Time.fromRaw(it.startBound);
+  const endBound = it.endBound === null ? Time.MAX : Time.fromRaw(it.endBound);
   return new TimeSpan(startBound, endBound);
 }


### PR DESCRIPTION
getTracingMetadataTimeBounds aggregated tracing_started_ns,
all_data_source_started_ns and tracing_disabled_ns across the whole
metadata table as max(start) / min(end). These keys are recorded per
(machine, trace) (Scope::kMachineAndTrace), so for a single trace this
yields that trace's active window, but for several traces loaded
together (a multi-machine session, or per-machine traces opened as a
group) it computes the intersection of their windows. When the windows
are disjoint the intersection inverts (max(start) > min(end)), and
building the returned TimeSpan trips its start <= end assertion, failing
the whole trace load with "Span start ... cannot be greater than
end ...".

Compute each (machine, trace)'s window and take their union instead, so
the visible window spans all loaded traces. Single-trace behavior is
unchanged.