### PR TITLE
tp: rename perfetto_metadata to perfetto_manifest

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5513,7 +5513,7 @@ perfetto_filegroup(
         "src/trace_processor/types/task_state.cc",
         "src/trace_processor/types/task_state.h",
         "src/trace_processor/types/tcp_state.h",
-        "src/trace_processor/types/trace_metadata_state.h",
+        "src/trace_processor/types/trace_manifest_state.h",
         "src/trace_processor/types/trace_processor_context.h",
         "src/trace_processor/types/trace_processor_context_ptr.h",
         "src/trace_processor/types/variadic.h",

--- a/src/trace_processor/forwarding_trace_parser.cc
+++ b/src/trace_processor/forwarding_trace_parser.cc
@@ -33,7 +33,7 @@
 #include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/tables/metadata_tables_py.h"
 #include "src/trace_processor/trace_reader_registry.h"
-#include "src/trace_processor/types/trace_metadata_state.h"
+#include "src/trace_processor/types/trace_manifest_state.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/util/clock_synchronizer.h"
 #include "src/trace_processor/util/trace_type.h"
@@ -146,7 +146,7 @@ base::Status ForwardingTraceParser::Init(const TraceBlobView& blob) {
 
   // The matching perfetto_manifest entry, if any, will carry per-file
   // overrides in future versions of the schema; nothing consumes it yet.
-  FindMetadataEntry();
+  FindManifestEntry();
 
   if (IsContainerTraceType(trace_type_) ||
       trace_type_ == kPerfettoManifestTraceType) {
@@ -221,9 +221,9 @@ base::Status ForwardingTraceParser::Init(const TraceBlobView& blob) {
   return base::OkStatus();
 }
 
-TraceMetadataState::FileEntry* ForwardingTraceParser::FindMetadataEntry()
+TraceManifestState::FileEntry* ForwardingTraceParser::FindManifestEntry()
     const {
-  auto* state = input_context_->trace_metadata_state.get();
+  auto* state = input_context_->trace_manifest_state.get();
   if (state->files.empty()) {
     return nullptr;
   }

--- a/src/trace_processor/forwarding_trace_parser.h
+++ b/src/trace_processor/forwarding_trace_parser.h
@@ -24,7 +24,7 @@
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/common/chunked_trace_reader.h"
 #include "src/trace_processor/tables/metadata_tables_py.h"
-#include "src/trace_processor/types/trace_metadata_state.h"
+#include "src/trace_processor/types/trace_manifest_state.h"
 #include "src/trace_processor/util/trace_type.h"
 
 namespace perfetto::trace_processor {
@@ -49,7 +49,7 @@ class ForwardingTraceParser : public ChunkedTraceReader {
 
   // Returns the perfetto_manifest entry matching this file's path, or
   // nullptr if none.
-  TraceMetadataState::FileEntry* FindMetadataEntry() const;
+  TraceManifestState::FileEntry* FindManifestEntry() const;
 
   TraceProcessorContext* const input_context_;
 

--- a/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.cc
+++ b/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.cc
@@ -27,7 +27,7 @@
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/common/global_metadata_tracker.h"
 #include "src/trace_processor/storage/metadata.h"
-#include "src/trace_processor/types/trace_metadata_state.h"
+#include "src/trace_processor/types/trace_manifest_state.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/types/variadic.h"
 #include "src/trace_processor/util/clock_synchronizer.h"
@@ -74,7 +74,7 @@ base::Status PerfettoManifestReader::Parse(TraceBlobView blob) {
 }
 
 base::Status PerfettoManifestReader::OnPushDataToSorter() {
-  auto* state = context_->trace_metadata_state.get();
+  auto* state = context_->trace_manifest_state.get();
   if (state->config_seen) {
     return base::ErrStatus("multiple perfetto_manifest files in archive");
   }

--- a/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.h
+++ b/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.h
@@ -33,7 +33,7 @@ namespace perfetto::trace_processor::perfetto_manifest {
 // Reads a perfetto_manifest sidecar file: a JSON file which, as the first
 // file of the trace, overrides clock and machine handling for the files
 // that follow. The parsed configuration is stored on the global
-// TraceMetadataState and consulted by ForwardingTraceParser for each trace
+// TraceManifestState and consulted by ForwardingTraceParser for each trace
 // file.
 class PerfettoManifestReader : public ChunkedTraceReader {
  public:

--- a/src/trace_processor/trace_processor_context.cc
+++ b/src/trace_processor/trace_processor_context.cc
@@ -56,7 +56,7 @@
 #include "src/trace_processor/importers/proto/user_tracker.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/trace_reader_registry.h"
-#include "src/trace_processor/types/trace_metadata_state.h"
+#include "src/trace_processor/types/trace_manifest_state.h"
 #include "src/trace_processor/types/trace_processor_context_ptr.h"
 #include "src/trace_processor/util/clock_synchronizer.h"
 
@@ -177,7 +177,7 @@ void InitGlobalState(TraceProcessorContext* context, const Config& config) {
   context->clock_converter = Ptr<ClockConverter>::MakeRoot(context);
   context->trace_time_state =
       Ptr<TraceTimeState>::MakeRoot(ClockId::TraceFile(0));
-  context->trace_metadata_state = Ptr<TraceMetadataState>::MakeRoot();
+  context->trace_manifest_state = Ptr<TraceManifestState>::MakeRoot();
   context->track_group_idx_state =
       Ptr<TrackCompressorGroupIdxState>::MakeRoot();
   context->stack_profile_tracker = Ptr<StackProfileTracker>::MakeRoot(context);
@@ -207,7 +207,7 @@ void CopyGlobalState(const TraceProcessorContext* source,
   dest->forked_context_state = source->forked_context_state.Fork();
   dest->clock_converter = source->clock_converter.Fork();
   dest->trace_time_state = source->trace_time_state.Fork();
-  dest->trace_metadata_state = source->trace_metadata_state.Fork();
+  dest->trace_manifest_state = source->trace_manifest_state.Fork();
   dest->track_group_idx_state = source->track_group_idx_state.Fork();
   dest->register_additional_proto_modules =
       source->register_additional_proto_modules;

--- a/src/trace_processor/types/BUILD.gn
+++ b/src/trace_processor/types/BUILD.gn
@@ -22,7 +22,7 @@ source_set("types") {
     "task_state.cc",
     "task_state.h",
     "tcp_state.h",
-    "trace_metadata_state.h",
+    "trace_manifest_state.h",
     "trace_processor_context.h",
     "trace_processor_context_ptr.h",
     "variadic.h",

--- a/src/trace_processor/types/trace_manifest_state.h
+++ b/src/trace_processor/types/trace_manifest_state.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_TRACE_PROCESSOR_TYPES_TRACE_METADATA_STATE_H_
-#define SRC_TRACE_PROCESSOR_TYPES_TRACE_METADATA_STATE_H_
+#ifndef SRC_TRACE_PROCESSOR_TYPES_TRACE_MANIFEST_STATE_H_
+#define SRC_TRACE_PROCESSOR_TYPES_TRACE_MANIFEST_STATE_H_
 
 #include <cstdint>
 #include <optional>
@@ -29,7 +29,7 @@ namespace perfetto::trace_processor {
 // puts it first), overrides clock and machine handling for the files that
 // follow. Populated by the perfetto_manifest plugin's reader and consulted
 // by ForwardingTraceParser for each trace file.
-struct TraceMetadataState {
+struct TraceManifestState {
   struct FileEntry {
     // Exact path of the member within the archive.
     std::string path;
@@ -54,4 +54,4 @@ struct TraceMetadataState {
 
 }  // namespace perfetto::trace_processor
 
-#endif  // SRC_TRACE_PROCESSOR_TYPES_TRACE_METADATA_STATE_H_
+#endif  // SRC_TRACE_PROCESSOR_TYPES_TRACE_MANIFEST_STATE_H_

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -69,7 +69,7 @@ class TraceStorage;
 class TrackCompressor;
 class TrackTracker;
 struct ProtoImporterModuleContext;
-struct TraceMetadataState;
+struct TraceManifestState;
 struct TraceTimeState;
 struct TrackCompressorGroupIdxState;
 
@@ -158,7 +158,7 @@ class TraceProcessorContext {
   GlobalPtr<ForkedContextState> forked_context_state;
   GlobalPtr<ClockConverter> clock_converter;
   GlobalPtr<TraceTimeState> trace_time_state;
-  GlobalPtr<TraceMetadataState> trace_metadata_state;
+  GlobalPtr<TraceManifestState> trace_manifest_state;
   GlobalPtr<TrackCompressorGroupIdxState> track_group_idx_state;
   GlobalPtr<StackProfileTracker> stack_profile_tracker;
   GlobalPtr<Destructible> deobfuscation_tracker;  // DeobfuscationTracker

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -124,7 +124,7 @@ from diff_tests.parser.smoke.tests import Smoke
 from diff_tests.parser.smoke.tests_compute_metrics import SmokeComputeMetrics
 from diff_tests.parser.smoke.tests_json import SmokeJson
 from diff_tests.parser.smoke.tests_sched_events import SmokeSchedEvents
-from diff_tests.parser.trace_metadata.tests import TraceMetadata
+from diff_tests.parser.trace_manifest.tests import TraceManifest
 from diff_tests.parser.track_event.tests import TrackEvent
 from diff_tests.parser.translated_args.tests import TranslatedArgs
 from diff_tests.parser.ufs.tests import Ufs
@@ -280,7 +280,7 @@ def fetch_all_diff_tests(
       Kprobes,
       ThermalExynos,
       ParsingTracedStats,
-      TraceMetadata,
+      TraceManifest,
       Zip,
       AndroidInputEvent,
       Instruments,

--- a/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
+++ b/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
@@ -79,7 +79,7 @@ def _meta(payload):
   return json.dumps({'perfetto_manifest': payload})
 
 
-class TraceMetadata(TestSuite):
+class TraceManifest(TestSuite):
   """Tests for the perfetto_manifest sidecar JSON.
 
   A perfetto_manifest file, as the first file of the trace (typically inside


### PR DESCRIPTION
Upon the suggestion of @primiano, metadata is overloaded, manifest is a lot clearer.
