### PR TITLE
ui: normalize postMessage trace buffers to a pure ArrayBuffer

### DIFF
--- a/ui/src/base/utils.ts
+++ b/ui/src/base/utils.ts
@@ -103,3 +103,25 @@ export const maybeUndefined = <T>(value: T) => value as T | undefined;
 export function isNumeric(value: unknown): value is number | bigint {
   return typeof value === 'number' || typeof value === 'bigint';
 }
+
+// Normalizes an ArrayBuffer or any ArrayBufferView (e.g. a Uint8Array, possibly
+// with a non-zero byteOffset) into a *pure* ArrayBuffer whose bytes are exactly
+// the region the view spans. Various parts of the codebase assume a pure
+// ArrayBuffer with byteOffset 0 and break subtly on a view (see b/390473162).
+// It's also needed because untyped external input (e.g. a trace posted via
+// postMessage) can supply a view at runtime despite the static type saying
+// ArrayBuffer.
+export function toArrayBuffer(buf: ArrayBuffer | ArrayBufferView): ArrayBuffer {
+  if (!ArrayBuffer.isView(buf)) {
+    return buf;
+  }
+  // A view over the whole, exactly-sized backing buffer can be unwrapped
+  // without copying; otherwise slice out just the view's region.
+  if (buf.byteOffset === 0 && buf.byteLength === buf.buffer.byteLength) {
+    return buf.buffer as ArrayBuffer;
+  }
+  return buf.buffer.slice(
+    buf.byteOffset,
+    buf.byteOffset + buf.byteLength,
+  ) as ArrayBuffer;
+}

--- a/ui/src/base/utils_unittest.ts
+++ b/ui/src/base/utils_unittest.ts
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {toArrayBuffer} from './utils';
+
+describe('toArrayBuffer', () => {
+  test('passes through a pure ArrayBuffer unchanged', () => {
+    const buf = new Uint8Array([1, 2, 3, 4]).buffer;
+    expect(toArrayBuffer(buf)).toBe(buf);
+  });
+
+  test('unwraps a full-span Uint8Array without copying', () => {
+    const u8 = new Uint8Array([1, 2, 3, 4]);
+    const out = toArrayBuffer(u8);
+    expect(out).toBeInstanceOf(ArrayBuffer);
+    expect(out).toBe(u8.buffer);
+    expect(new Uint8Array(out)).toEqual(u8);
+  });
+
+  test('slices out a view with a non-zero byteOffset', () => {
+    const backing = new Uint8Array([0, 1, 2, 3, 4, 5]).buffer;
+    // View covering bytes [2, 4).
+    const view = new Uint8Array(backing, 2, 2);
+    const out = toArrayBuffer(view);
+    expect(out).toBeInstanceOf(ArrayBuffer);
+    expect(out.byteLength).toBe(2);
+    expect(new Uint8Array(out)).toEqual(new Uint8Array([2, 3]));
+    // Must be a fresh buffer, not the oversized backing one.
+    expect(out).not.toBe(backing);
+  });
+
+  test('slices out a view shorter than its backing buffer', () => {
+    const backing = new Uint8Array([9, 8, 7, 6]).buffer;
+    const view = new Uint8Array(backing, 0, 2);
+    const out = toArrayBuffer(view);
+    expect(out.byteLength).toBe(2);
+    expect(new Uint8Array(out)).toEqual(new Uint8Array([9, 8]));
+  });
+
+  test('handles a DataView', () => {
+    const backing = new Uint8Array([1, 2, 3, 4]).buffer;
+    const dv = new DataView(backing, 1, 2);
+    const out = toArrayBuffer(dv);
+    expect(new Uint8Array(out)).toEqual(new Uint8Array([2, 3]));
+  });
+});

--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -21,6 +21,7 @@ import {AppImpl} from '../core/app_impl';
 import type {SerializedAppState} from '../core/state_serialization_schema';
 import {parseAppState} from '../core/state_serialization';
 import {BUCKET_NAME, isValidGcsFileName} from '../base/gcs_uploader';
+import {toArrayBuffer} from '../base/utils';
 
 const TRUSTED_ORIGINS_KEY = 'trustedOrigins';
 
@@ -206,8 +207,14 @@ export function postMessageHandler(messageEvent: MessageEvent) {
     if (postedTrace.keepApiOpen) {
       keepApiOpen = true;
     }
-  } else if (messageEvent.data instanceof ArrayBuffer) {
-    postedTrace = {title: 'External trace', buffer: messageEvent.data};
+  } else if (
+    messageEvent.data instanceof ArrayBuffer ||
+    ArrayBuffer.isView(messageEvent.data)
+  ) {
+    postedTrace = {
+      title: 'External trace',
+      buffer: toArrayBuffer(messageEvent.data),
+    };
   } else {
     console.warn(
       'Unknown postMessage() event received. If you are trying to open a ' +
@@ -304,7 +311,12 @@ export function postMessageHandler(messageEvent: MessageEvent) {
 function sanitizePostedTrace(postedTrace: PostedTrace): PostedTrace {
   const result: PostedTrace = {
     title: sanitizeString(postedTrace.title),
-    buffer: postedTrace.buffer,
+    // `buffer` is typed ArrayBuffer, but this is untyped data coming off
+    // postMessage(): senders routinely pass a Uint8Array (or other view).
+    // Normalize it to a pure ArrayBuffer here, at the boundary, so the rest of
+    // the codebase (TraceBufferStream, cache_manager) can rely on the type.
+    // See b/390473162.
+    buffer: toArrayBuffer(postedTrace.buffer),
     keepApiOpen: postedTrace.keepApiOpen,
     // For external traces, we need to disable other features such as
     // downloading and sharing a trace, unless the caller allows it.


### PR DESCRIPTION
Traces opened via postMessage() from other dashboards carry an untyped
messageEvent.data, and senders routinely pass a Uint8Array rather than a
pure ArrayBuffer. AppImpl.openTrace() used to convert such a buffer into
a pure ArrayBuffer (the invariant TraceBufferStream and cache_manager
rely on), but that guard was removed in #6160.
