### PR TITLE
tp: support `--remote host:port` over WebSocket

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -19725,6 +19725,7 @@ filegroup {
     name: "perfetto_src_trace_processor_rpc_client",
     srcs: [
         "src/trace_processor/rpc/remote_trace_processor.cc",
+        "src/trace_processor/rpc/rpc_transport.cc",
     ],
 }
 

--- a/BUILD
+++ b/BUILD
@@ -5234,6 +5234,8 @@ perfetto_filegroup(
     srcs = [
         "src/trace_processor/rpc/remote_trace_processor.cc",
         "src/trace_processor/rpc/remote_trace_processor.h",
+        "src/trace_processor/rpc/rpc_transport.cc",
+        "src/trace_processor/rpc/rpc_transport.h",
     ],
 )
 

--- a/src/trace_processor/rpc/BUILD.gn
+++ b/src/trace_processor/rpc/BUILD.gn
@@ -136,11 +136,14 @@ source_set("deserializer") {
 }
 
 # The --remote client: a TraceProcessor implementation that marshals every
-# method over the RPC wire to a warm server.
+# method over the RPC wire to a warm server, over either an AF_UNIX byte pipe
+# or a WebSocket (to an http server).
 source_set("client") {
   sources = [
     "remote_trace_processor.cc",
     "remote_trace_processor.h",
+    "rpc_transport.cc",
+    "rpc_transport.h",
   ]
   deps = [
     ":deserializer",

--- a/src/trace_processor/rpc/remote_trace_processor.cc
+++ b/src/trace_processor/rpc/remote_trace_processor.cc
@@ -28,14 +28,13 @@
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
-#include "perfetto/ext/base/unix_socket.h"
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "perfetto/trace_processor/iterator.h"
 #include "src/trace_processor/iterator_impl.h"
 #include "src/trace_processor/rpc/query_result_deserializer.h"
-#include "src/trace_processor/rpc/session_paths.h"
+#include "src/trace_processor/rpc/rpc_transport.h"
 
 #include "protos/perfetto/trace_processor/trace_processor.pbzero.h"
 #include "protos/perfetto/trace_summary/file.pbzero.h"
@@ -219,53 +218,24 @@ class RemoteSummarizer : public Summarizer {
 
 base::StatusOr<std::unique_ptr<RemoteTraceProcessor>>
 RemoteTraceProcessor::Connect(const std::string& addr) {
-  std::string socket_path;
-  switch (session::ClassifyRemoteAddr(addr)) {
-    case session::RemoteAddrKind::kHttp:
-      return base::ErrStatus(
-          "--remote over HTTP (%s) is not supported yet; use a unix session "
-          "(tp server unix --name <name> <trace>) or the Python API.",
-          addr.c_str());
-    case session::RemoteAddrKind::kUnixPath:
-      socket_path = addr;
-      break;
-    case session::RemoteAddrKind::kSessionName: {
-      ASSIGN_OR_RETURN(socket_path, session::SessionSocketPath(addr));
-      break;
-    }
-  }
-
-  auto sock = base::UnixSocketRaw::CreateMayFail(base::SockFamily::kUnix,
-                                                 base::SockType::kStream);
-  if (!sock || !sock.Connect(socket_path)) {
-    return base::ErrStatus(
-        "No live session at '%s'. Start one with: tp server unix --name <name> "
-        "<trace>",
-        addr.c_str());
-  }
-  sock.SetBlocking(true);
+  ASSIGN_OR_RETURN(std::unique_ptr<RpcTransport> transport,
+                   ConnectRpcTransport(addr));
   return std::unique_ptr<RemoteTraceProcessor>(
-      new RemoteTraceProcessor(std::move(sock)));
+      new RemoteTraceProcessor(std::move(transport)));
 }
 
-RemoteTraceProcessor::RemoteTraceProcessor(base::UnixSocketRaw sock)
-    : sock_(std::move(sock)) {}
+RemoteTraceProcessor::RemoteTraceProcessor(
+    std::unique_ptr<RpcTransport> transport)
+    : transport_(std::move(transport)) {}
 
 RemoteTraceProcessor::~RemoteTraceProcessor() = default;
 
 base::Status RemoteTraceProcessor::SendStream(
     const std::vector<uint8_t>& framed) {
-  // A live query stream owns the socket; a concurrent request would interleave
-  // with its unread batches. That's a caller bug, so fail fast.
+  // A live query stream owns the transport; a concurrent request would
+  // interleave with its unread batches. That's a caller bug, so fail fast.
   PERFETTO_CHECK(!stream_in_flight_);
-  size_t off = 0;
-  while (off < framed.size()) {
-    ssize_t n = sock_.Send(framed.data() + off, framed.size() - off);
-    if (n <= 0)
-      return base::ErrStatus("Failed to send request to session");
-    off += static_cast<size_t>(n);
-  }
-  return base::OkStatus();
+  return transport_->Send(framed.data(), framed.size());
 }
 
 base::Status RemoteTraceProcessor::ReadResponse(std::vector<uint8_t>* out) {
@@ -280,12 +250,10 @@ base::Status RemoteTraceProcessor::ReadResponse(std::vector<uint8_t>* out) {
       out->assign(msg.start, msg.start + msg.len);
       return base::OkStatus();
     }
-    ssize_t n = sock_.Receive(buf, sizeof(buf));
+    ASSIGN_OR_RETURN(size_t n, transport_->Recv(buf, sizeof(buf)));
     if (n == 0)
       return base::ErrStatus("Session closed the connection");
-    if (n < 0)
-      return base::ErrStatus("Error reading from session");
-    rxbuf_.Append(buf, static_cast<size_t>(n));
+    rxbuf_.Append(buf, n);
   }
 }
 
@@ -517,8 +485,8 @@ base::Status RemoteTraceProcessor::NotifyEndOfFile() {
 }
 
 void RemoteTraceProcessor::InterruptQuery() {
-  // Best-effort: closing the socket aborts the in-flight request.
-  sock_.Shutdown();
+  // No-op over a remote transport: the in-flight request runs to completion on
+  // the server. (The local one-shot path still handles Ctrl-C itself.)
 }
 
 // --- Methods with no RPC-protocol equivalent --------------------------------

--- a/src/trace_processor/rpc/remote_trace_processor.h
+++ b/src/trace_processor/rpc/remote_trace_processor.h
@@ -25,13 +25,13 @@
 
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_or.h"
-#include "perfetto/ext/base/unix_socket.h"
 #include "perfetto/ext/protozero/proto_ring_buffer.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "perfetto/trace_processor/iterator.h"
 #include "perfetto/trace_processor/summarizer.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "perfetto/trace_processor/trace_processor.h"
+#include "src/trace_processor/rpc/rpc_transport.h"
 
 namespace perfetto::trace_processor {
 
@@ -45,7 +45,8 @@ class RemoteTraceProcessor : public TraceProcessor {
  public:
   // Connects to |addr|, which is resolved as in `--remote`: an absolute path or
   // *.sock is a socket path; a bare name is a session name resolved to the
-  // convention socket path; host:port/scheme:// is HTTP (not yet supported).
+  // convention socket path; host:port/scheme:// is a WebSocket to an http
+  // server.
   static base::StatusOr<std::unique_ptr<RemoteTraceProcessor>> Connect(
       const std::string& addr);
 
@@ -91,12 +92,13 @@ class RemoteTraceProcessor : public TraceProcessor {
   friend class RemoteSummarizer;
   friend class RemoteIteratorImpl;
 
-  explicit RemoteTraceProcessor(base::UnixSocketRaw sock);
+  explicit RemoteTraceProcessor(std::unique_ptr<RpcTransport> transport);
 
-  // Sends a serialized TraceProcessorRpcStream, blocking until fully written.
+  // Sends |framed| (a fully-serialized TraceProcessorRpcStream) over the
+  // transport, blocking until all bytes are written.
   base::Status SendStream(const std::vector<uint8_t>& framed);
-  // Reads one TraceProcessorRpc message into |out| (framing stripped),
-  // blocking.
+  // Reads exactly one TraceProcessorRpc message into |out| (the serialized
+  // message bytes, stream framing already stripped), blocking.
   base::Status ReadResponse(std::vector<uint8_t>* out);
 
   // Shared shape for non-streaming methods: build the request with |populate|,
@@ -105,7 +107,7 @@ class RemoteTraceProcessor : public TraceProcessor {
   template <typename Fn, typename Handle>
   base::Status RoundTrip(uint32_t method, Fn populate, Handle handle);
 
-  base::UnixSocketRaw sock_;
+  std::unique_ptr<RpcTransport> transport_;
   protozero::ProtoRingBuffer rxbuf_;
   int next_summarizer_id_ = 0;
 

--- a/src/trace_processor/rpc/rpc_transport.cc
+++ b/src/trace_processor/rpc/rpc_transport.cc
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/rpc/rpc_transport.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/base64.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/unix_socket.h"
+#include "src/trace_processor/rpc/session_paths.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+// ---- AF_UNIX byte-pipe transport ------------------------------------------
+
+class UnixByteTransport : public RpcTransport {
+ public:
+  explicit UnixByteTransport(base::UnixSocketRaw sock)
+      : sock_(std::move(sock)) {}
+
+  base::Status Send(const uint8_t* data, size_t len) override {
+    size_t off = 0;
+    while (off < len) {
+      ssize_t n = sock_.Send(data + off, len - off);
+      if (n <= 0)
+        return base::ErrStatus("Failed to send request to session");
+      off += static_cast<size_t>(n);
+    }
+    return base::OkStatus();
+  }
+
+  base::StatusOr<size_t> Recv(uint8_t* buf, size_t len) override {
+    ssize_t n = sock_.Receive(buf, len);
+    if (n < 0)
+      return base::ErrStatus("Error reading from session");
+    return static_cast<size_t>(n);
+  }
+
+ private:
+  base::UnixSocketRaw sock_;
+};
+
+// ---- WebSocket transport (to the http server's /websocket) ----------------
+
+class WebSocketTransport : public RpcTransport {
+ public:
+  explicit WebSocketTransport(base::UnixSocketRaw sock)
+      : sock_(std::move(sock)) {}
+
+  base::Status Handshake(const std::string& host_port);
+
+  base::Status Send(const uint8_t* data, size_t len) override;
+  base::StatusOr<size_t> Recv(uint8_t* buf, size_t len) override;
+
+ private:
+  // Blocking read of exactly |n| bytes. Returns false on EOF/error.
+  bool ReadExactly(void* dst, size_t n);
+  // Reads one complete WebSocket frame's payload into inbound_. Returns false
+  // if the connection closed.
+  bool ReadFrameIntoBuffer();
+
+  base::UnixSocketRaw sock_;
+  std::string inbound_;  // Un-consumed payload bytes from received frames.
+  size_t inbound_pos_ = 0;
+};
+
+bool WebSocketTransport::ReadExactly(void* dst, size_t n) {
+  auto* p = static_cast<uint8_t*>(dst);
+  size_t got = 0;
+  while (got < n) {
+    ssize_t r = sock_.Receive(p + got, n - got);
+    if (r <= 0)
+      return false;
+    got += static_cast<size_t>(r);
+  }
+  return true;
+}
+
+base::Status WebSocketTransport::Handshake(const std::string& host_port) {
+  // The server requires a Sec-WebSocket-Key of 16 base64-decoded bytes and an
+  // Origin in its allow-list (defaults include http://localhost:10000). It does
+  // not validate the key's value, so a fixed key is fine.
+  std::string key = base::Base64Encode("perfetto-tp-wsclient", 16);
+  std::string req =
+      "GET /websocket HTTP/1.1\r\n"
+      "Host: " + host_port + "\r\n"
+      "Upgrade: websocket\r\n"
+      "Connection: Upgrade\r\n"
+      "Sec-WebSocket-Version: 13\r\n"
+      "Origin: http://localhost:10000\r\n"
+      "Sec-WebSocket-Key: " + key + "\r\n\r\n";
+  if (sock_.Send(req.data(), req.size()) < 0)
+    return base::ErrStatus("WebSocket handshake send failed");
+
+  // Read response headers up to the blank line. Keep it simple: read byte by
+  // byte until "\r\n\r\n". Handshake responses are small.
+  std::string resp;
+  char c;
+  while (resp.find("\r\n\r\n") == std::string::npos) {
+    ssize_t r = sock_.Receive(&c, 1);
+    if (r <= 0)
+      return base::ErrStatus("WebSocket handshake closed by peer");
+    resp.push_back(c);
+    if (resp.size() > 8192)
+      return base::ErrStatus("WebSocket handshake response too large");
+  }
+  if (resp.find("101") == std::string::npos) {
+    size_t eol = resp.find("\r\n");
+    return base::ErrStatus("WebSocket upgrade rejected: %s",
+                           resp.substr(0, eol).c_str());
+  }
+  return base::OkStatus();
+}
+
+base::Status WebSocketTransport::Send(const uint8_t* data, size_t len) {
+  // Client frames must be masked (RFC 6455). A zero mask leaves the payload
+  // unchanged, which the server unmasks back to the original bytes.
+  std::string frame;
+  frame.push_back(static_cast<char>(0x82));  // FIN | binary opcode.
+  if (len < 126) {
+    frame.push_back(static_cast<char>(0x80 | len));
+  } else if (len <= 0xFFFF) {
+    frame.push_back(static_cast<char>(0x80 | 126));
+    frame.push_back(static_cast<char>((len >> 8) & 0xFF));
+    frame.push_back(static_cast<char>(len & 0xFF));
+  } else {
+    frame.push_back(static_cast<char>(0x80 | 127));
+    for (int shift = 56; shift >= 0; shift -= 8)
+      frame.push_back(static_cast<char>((len >> shift) & 0xFF));
+  }
+  frame.append(4, '\0');  // 4-byte mask key, all zeros.
+  frame.append(reinterpret_cast<const char*>(data), len);
+
+  size_t off = 0;
+  while (off < frame.size()) {
+    ssize_t n = sock_.Send(frame.data() + off, frame.size() - off);
+    if (n <= 0)
+      return base::ErrStatus("Failed to send to WebSocket session");
+    off += static_cast<size_t>(n);
+  }
+  return base::OkStatus();
+}
+
+bool WebSocketTransport::ReadFrameIntoBuffer() {
+  for (;;) {
+    uint8_t hdr[2];
+    if (!ReadExactly(hdr, 2))
+      return false;
+    uint8_t opcode = hdr[0] & 0x0F;
+    bool masked = (hdr[1] & 0x80) != 0;
+    uint64_t len = hdr[1] & 0x7F;
+    if (len == 126) {
+      uint8_t ext[2];
+      if (!ReadExactly(ext, 2))
+        return false;
+      len = (static_cast<uint64_t>(ext[0]) << 8) | ext[1];
+    } else if (len == 127) {
+      uint8_t ext[8];
+      if (!ReadExactly(ext, 8))
+        return false;
+      len = 0;
+      for (uint8_t b : ext)
+        len = (len << 8) | b;
+    }
+    uint8_t mask[4] = {0, 0, 0, 0};
+    if (masked && !ReadExactly(mask, 4))
+      return false;
+
+    std::string payload;
+    payload.resize(static_cast<size_t>(len));
+    if (len > 0 && !ReadExactly(payload.data(), payload.size()))
+      return false;
+    if (masked) {
+      for (size_t i = 0; i < payload.size(); ++i)
+        payload[i] = static_cast<char>(payload[i] ^ mask[i % 4]);
+    }
+
+    switch (opcode) {
+      case 0x1:  // Text.
+      case 0x2:  // Binary.
+        inbound_ += payload;
+        inbound_pos_ = 0;
+        return true;
+      case 0x8:  // Close.
+        return false;
+      case 0x9:  // Ping: ignore (server tolerates a missing pong for our use).
+      case 0xA:  // Pong.
+      default:
+        continue;  // Skip control frames and read the next one.
+    }
+  }
+}
+
+base::StatusOr<size_t> WebSocketTransport::Recv(uint8_t* buf, size_t len) {
+  if (inbound_pos_ >= inbound_.size()) {
+    inbound_.clear();
+    inbound_pos_ = 0;
+    if (!ReadFrameIntoBuffer())
+      return size_t{0};  // Closed.
+  }
+  size_t avail = inbound_.size() - inbound_pos_;
+  size_t n = avail < len ? avail : len;
+  memcpy(buf, inbound_.data() + inbound_pos_, n);
+  inbound_pos_ += n;
+  return n;
+}
+
+}  // namespace
+
+RpcTransport::~RpcTransport() = default;
+
+base::StatusOr<std::unique_ptr<RpcTransport>> ConnectRpcTransport(
+    const std::string& addr) {
+  switch (session::ClassifyRemoteAddr(addr)) {
+    case session::RemoteAddrKind::kHttp: {
+      auto sock = base::UnixSocketRaw::CreateMayFail(base::SockFamily::kInet,
+                                                     base::SockType::kStream);
+      sock.SetBlocking(true);
+      if (!sock || !sock.Connect(addr)) {
+        return base::ErrStatus("Could not connect to '%s'", addr.c_str());
+      }
+      auto ws = std::make_unique<WebSocketTransport>(std::move(sock));
+      RETURN_IF_ERROR(ws->Handshake(addr));
+      return std::unique_ptr<RpcTransport>(std::move(ws));
+    }
+    case session::RemoteAddrKind::kUnixPath:
+    case session::RemoteAddrKind::kSessionName: {
+      std::string socket_path = addr;
+      if (session::ClassifyRemoteAddr(addr) ==
+          session::RemoteAddrKind::kSessionName) {
+        ASSIGN_OR_RETURN(socket_path, session::SessionSocketPath(addr));
+      }
+      auto sock = base::UnixSocketRaw::CreateMayFail(base::SockFamily::kUnix,
+                                                     base::SockType::kStream);
+      if (!sock || !sock.Connect(socket_path)) {
+        return base::ErrStatus(
+            "No live session at '%s'. Start one with: tp server unix --name "
+            "<name> <trace>",
+            addr.c_str());
+      }
+      sock.SetBlocking(true);
+      return std::unique_ptr<RpcTransport>(
+          std::make_unique<UnixByteTransport>(std::move(sock)));
+    }
+  }
+  PERFETTO_FATAL("Unreachable");
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/rpc/rpc_transport.cc
+++ b/src/trace_processor/rpc/rpc_transport.cc
@@ -105,12 +105,15 @@ base::Status WebSocketTransport::Handshake(const std::string& host_port) {
   std::string key = base::Base64Encode("perfetto-tp-wsclient", 16);
   std::string req =
       "GET /websocket HTTP/1.1\r\n"
-      "Host: " + host_port + "\r\n"
+      "Host: " +
+      host_port +
+      "\r\n"
       "Upgrade: websocket\r\n"
       "Connection: Upgrade\r\n"
       "Sec-WebSocket-Version: 13\r\n"
       "Origin: http://localhost:10000\r\n"
-      "Sec-WebSocket-Key: " + key + "\r\n\r\n";
+      "Sec-WebSocket-Key: " +
+      key + "\r\n\r\n";
   if (sock_.Send(req.data(), req.size()) < 0)
     return base::ErrStatus("WebSocket handshake send failed");
 

--- a/src/trace_processor/rpc/rpc_transport.cc
+++ b/src/trace_processor/rpc/rpc_transport.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <utility>
 
+#include "perfetto/base/compiler.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/base64.h"
 #include "perfetto/ext/base/status_macros.h"
@@ -75,9 +76,25 @@ class WebSocketTransport : public RpcTransport {
   base::StatusOr<size_t> Recv(uint8_t* buf, size_t len) override;
 
  private:
+  // The decoded fixed-size part of a WebSocket frame header: everything up to,
+  // but not including, the payload bytes. See RFC 6455 §5.2.
+  struct FrameHeader {
+    uint8_t opcode = 0;          // 0x1 text, 0x2 binary, 0x8 close, etc.
+    bool masked = false;         // Whether the payload is XOR-masked.
+    uint64_t payload_len = 0;    // Number of payload bytes that follow.
+    uint8_t mask[4] = {0, 0, 0, 0};  // Mask key, valid only if |masked|.
+  };
+
   // Blocking read of exactly |n| bytes. Returns false on EOF/error.
   bool ReadExactly(void* dst, size_t n);
-  // Reads one complete WebSocket frame's payload into inbound_. Returns false
+  // Reads and decodes the next frame header off the wire (base bytes, extended
+  // length and, if present, the mask key). Returns false on EOF/error.
+  bool ReadFrameHeader(FrameHeader* out);
+  // Reads the |hdr.payload_len| payload bytes that follow |hdr|, unmasking them
+  // in place if needed. Returns false on EOF/error.
+  bool ReadFramePayload(const FrameHeader& hdr, std::string* payload);
+  // Reads complete WebSocket frames until a data frame arrives, appending its
+  // payload to inbound_. Control frames (ping/pong) are skipped. Returns false
   // if the connection closed.
   bool ReadFrameIntoBuffer();
 
@@ -166,52 +183,83 @@ base::Status WebSocketTransport::Send(const uint8_t* data, size_t len) {
   return base::OkStatus();
 }
 
+PERFETTO_ALWAYS_INLINE bool WebSocketTransport::ReadFrameHeader(
+    FrameHeader* out) {
+  // Byte 0 holds FIN/RSV/opcode; byte 1 holds the MASK bit and the 7-bit base
+  // payload length. We ignore FIN and assume unfragmented frames (the server
+  // never fragments our RPC responses).
+  uint8_t base[2];
+  if (!ReadExactly(base, 2))
+    return false;
+  out->opcode = base[0] & 0x0F;
+  out->masked = (base[1] & 0x80) != 0;
+
+  // The 7-bit length is either the real length, or a sentinel saying the real
+  // length follows in a 16-bit (126) or 64-bit (127) big-endian field.
+  uint64_t len = base[1] & 0x7F;
+  if (len == 126) {
+    uint8_t ext[2];
+    if (!ReadExactly(ext, 2))
+      return false;
+    len = (static_cast<uint64_t>(ext[0]) << 8) | ext[1];
+  } else if (len == 127) {
+    uint8_t ext[8];
+    if (!ReadExactly(ext, 8))
+      return false;
+    len = 0;
+    for (uint8_t b : ext)
+      len = (len << 8) | b;
+  }
+  out->payload_len = len;
+
+  // A masked frame is followed by a 4-byte mask key, used to XOR the payload.
+  if (out->masked && !ReadExactly(out->mask, 4))
+    return false;
+  return true;
+}
+
+PERFETTO_ALWAYS_INLINE bool WebSocketTransport::ReadFramePayload(
+    const FrameHeader& hdr,
+    std::string* payload) {
+  payload->resize(static_cast<size_t>(hdr.payload_len));
+  if (hdr.payload_len > 0 && !ReadExactly(payload->data(), payload->size()))
+    return false;
+  // Each payload byte is XORed with mask[i % 4] to recover the original bytes.
+  if (hdr.masked) {
+    for (size_t i = 0; i < payload->size(); ++i)
+      (*payload)[i] = static_cast<char>((*payload)[i] ^ hdr.mask[i % 4]);
+  }
+  return true;
+}
+
 bool WebSocketTransport::ReadFrameIntoBuffer() {
+  // The server can interleave control frames (ping/pong) at any point, so loop
+  // until we get a data frame, skipping anything that isn't payload for us.
   for (;;) {
-    uint8_t hdr[2];
-    if (!ReadExactly(hdr, 2))
-      return false;
-    uint8_t opcode = hdr[0] & 0x0F;
-    bool masked = (hdr[1] & 0x80) != 0;
-    uint64_t len = hdr[1] & 0x7F;
-    if (len == 126) {
-      uint8_t ext[2];
-      if (!ReadExactly(ext, 2))
-        return false;
-      len = (static_cast<uint64_t>(ext[0]) << 8) | ext[1];
-    } else if (len == 127) {
-      uint8_t ext[8];
-      if (!ReadExactly(ext, 8))
-        return false;
-      len = 0;
-      for (uint8_t b : ext)
-        len = (len << 8) | b;
-    }
-    uint8_t mask[4] = {0, 0, 0, 0};
-    if (masked && !ReadExactly(mask, 4))
+    FrameHeader hdr;
+    if (!ReadFrameHeader(&hdr))
       return false;
 
-    std::string payload;
-    payload.resize(static_cast<size_t>(len));
-    if (len > 0 && !ReadExactly(payload.data(), payload.size()))
-      return false;
-    if (masked) {
-      for (size_t i = 0; i < payload.size(); ++i)
-        payload[i] = static_cast<char>(payload[i] ^ mask[i % 4]);
-    }
-
-    switch (opcode) {
+    switch (hdr.opcode) {
       case 0x1:  // Text.
       case 0x2:  // Binary.
-        inbound_ += payload;
+        // Read straight into inbound_, which Recv has already emptied before
+        // calling us, so the payload is never copied a second time.
+        if (!ReadFramePayload(hdr, &inbound_))
+          return false;
         inbound_pos_ = 0;
         return true;
       case 0x8:  // Close.
         return false;
       case 0x9:  // Ping: ignore (server tolerates a missing pong for our use).
       case 0xA:  // Pong.
-      default:
-        continue;  // Skip control frames and read the next one.
+      default: {
+        // Drain and discard the control frame's payload, then read the next.
+        std::string discard;
+        if (!ReadFramePayload(hdr, &discard))
+          return false;
+        continue;
+      }
     }
   }
 }

--- a/src/trace_processor/rpc/rpc_transport.h
+++ b/src/trace_processor/rpc/rpc_transport.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_RPC_RPC_TRANSPORT_H_
+#define SRC_TRACE_PROCESSOR_RPC_RPC_TRANSPORT_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_or.h"
+
+namespace perfetto::trace_processor {
+
+// A bidirectional byte channel carrying the TraceProcessor RPC byte-pipe
+// protocol (serialized TraceProcessorRpcStream messages). Two implementations
+// exist: a raw AF_UNIX byte pipe and a WebSocket client (to the http server's
+// /websocket endpoint). Both ultimately carry the same framed bytes, so the
+// RemoteTraceProcessor's encode/decode logic is transport-agnostic.
+class RpcTransport {
+ public:
+  virtual ~RpcTransport();
+
+  // Sends a complete, already-serialized TraceProcessorRpcStream.
+  virtual base::Status Send(const uint8_t* data, size_t len) = 0;
+
+  // Receives up to |len| bytes into |buf|. Returns the number of bytes read;
+  // 0 means the peer closed the channel.
+  virtual base::StatusOr<size_t> Recv(uint8_t* buf, size_t len) = 0;
+};
+
+// Connects an RpcTransport for |addr|, resolved as in `--remote`:
+//   - host:port / scheme://  -> WebSocket to the http server's /websocket.
+//   - absolute path / *.sock  -> AF_UNIX byte pipe at that path.
+//   - bare session name       -> AF_UNIX byte pipe at the convention path.
+base::StatusOr<std::unique_ptr<RpcTransport>> ConnectRpcTransport(
+    const std::string& addr);
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_RPC_RPC_TRANSPORT_H_

--- a/test/trace_processor_shell_integrationtest.cc
+++ b/test/trace_processor_shell_integrationtest.cc
@@ -28,8 +28,10 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/time.h"
 #include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/subprocess.h"
 #include "perfetto/ext/base/temp_file.h"
+#include "perfetto/ext/base/unix_socket.h"
 #include "perfetto/ext/base/utils.h"
 #include "protos/perfetto/trace/profiling/deobfuscation.gen.h"
 #include "protos/perfetto/trace/trace.gen.h"
@@ -386,6 +388,30 @@ bool WaitForSocketBound(const std::string& path) {
   return false;
 }
 
+// Binds an ephemeral TCP port on 127.0.0.1 and returns it (the socket is closed
+// on return, so there is a small TOCTOU window before the server rebinds it).
+int GetFreeInetPort() {
+  auto sock = base::UnixSocketRaw::CreateMayFail(base::SockFamily::kInet,
+                                                 base::SockType::kStream);
+  PERFETTO_CHECK(sock && sock.Bind("127.0.0.1:0"));
+  std::string addr = sock.GetSockAddr();  // "127.0.0.1:PORT"
+  return base::StringToInt32(addr.substr(addr.rfind(':') + 1)).value_or(0);
+}
+
+// Polls until a TCP connect to 127.0.0.1:|port| succeeds, up to ~5s.
+bool WaitForTcpPort(int port) {
+  std::string addr = "127.0.0.1:" + std::to_string(port);
+  for (int i = 0; i < 500; ++i) {
+    auto sock = base::UnixSocketRaw::CreateMayFail(base::SockFamily::kInet,
+                                                   base::SockType::kStream);
+    sock.SetBlocking(true);
+    if (sock && sock.Connect(addr))
+      return true;
+    base::SleepMicroseconds(10 * 1000);
+  }
+  return false;
+}
+
 TEST(TraceProcessorShellIntegrationTest, ServerUnixBindAndCleanup) {
   // `server unix` binds the socket, then unlinks it on SIGTERM.
   auto trace = WriteSimpleSystrace();
@@ -535,6 +561,28 @@ TEST(TraceProcessorShellIntegrationTest, ServerKillHttpDeferred) {
   EXPECT_THAT(result.out, HasSubstr("not supported"));
 }
 
+TEST(TraceProcessorShellIntegrationTest, RemoteWebSocketRoundTrip) {
+  // `query --remote host:port` connects to the http server's /websocket
+  // endpoint and runs over the same RPC byte-pipe as the unix transport.
+  auto trace = WriteSimpleSystrace();
+  int port = GetFreeInetPort();
+  std::string addr = "127.0.0.1:" + std::to_string(port);
+
+  base::Subprocess server({ShellPath(), "server", "http", "--ip-address",
+                           "127.0.0.1", "--port", std::to_string(port),
+                           trace.path()});
+  server.args.stdout_mode = base::Subprocess::OutputMode::kDevNull;
+  server.args.stderr_mode = base::Subprocess::OutputMode::kDevNull;
+  server.Start();
+  ASSERT_TRUE(WaitForTcpPort(port));
+
+  auto r = RunShell({"query", "--remote", addr, "SELECT 200 + 61 AS v"});
+  EXPECT_EQ(r.exit_code, 0) << r.out;
+  EXPECT_THAT(r.out, HasSubstr("261"));
+
+  server.KillAndWaitForTermination(SIGTERM);
+}
+
 TEST(TraceProcessorShellIntegrationTest, RemoteNoSession) {
   // Querying a session that isn't running fails with a clear, actionable error.
   auto result = RunShell({"query", "--remote", "no-such-session", "SELECT 1"});
@@ -542,11 +590,13 @@ TEST(TraceProcessorShellIntegrationTest, RemoteNoSession) {
   EXPECT_THAT(result.out, HasSubstr("No live session"));
 }
 
-TEST(TraceProcessorShellIntegrationTest, RemoteHttpDeferred) {
-  // --remote to an HTTP address reports the not-yet-supported error.
-  auto result = RunShell({"query", "--remote", "localhost:9001", "SELECT 1"});
+TEST(TraceProcessorShellIntegrationTest, RemoteHttpNoServer) {
+  // --remote to an HTTP address with nothing listening fails to connect.
+  int port = GetFreeInetPort();  // Free now; nothing is listening.
+  auto result = RunShell(
+      {"query", "--remote", "127.0.0.1:" + std::to_string(port), "SELECT 1"});
   EXPECT_NE(result.exit_code, 0);
-  EXPECT_THAT(result.out, HasSubstr("not supported"));
+  EXPECT_THAT(result.out, HasSubstr("Could not connect"));
 }
 
 TEST(TraceProcessorShellIntegrationTest, RemoteRejectsIncompatibleFlags) {


### PR DESCRIPTION
Enable `--remote` against an http server by connecting to its existing
/websocket endpoint, which already speaks the same TraceProcessorRpc byte-pipe
protocol as the unix transport. 