### PR TITLE
ui: Fix bad type assertion in isPostedTraceWrapped

### DIFF
--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -49,8 +49,15 @@ interface PostedTrace {
   pluginArgs?: {[pluginId: string]: {[key: string]: unknown}};
 }
 
+// The raw, un-sanitized trace as received over postMessage(). Senders routinely
+// pass a view (e.g. Uint8Array) for |buffer| despite PostedTrace typing it as a
+// pure ArrayBuffer, so model that here. sanitizePostedTrace() normalizes it.
+interface RawPostedTrace extends Omit<PostedTrace, 'buffer'> {
+  buffer: ArrayBuffer | ArrayBufferView;
+}
+
 interface PostedTraceWrapped {
-  perfetto: PostedTrace;
+  perfetto: RawPostedTrace;
 }
 
 interface PostedScrollToRangeWrapped {
@@ -121,6 +128,21 @@ function saveUserTrustedOrigin(hostname: string) {
 // the 'perfettoIgnore' field in the event data.
 function shouldGracefullyIgnoreMessage(messageEvent: MessageEvent) {
   return messageEvent.data.perfettoIgnore === true;
+}
+
+export function parsePostedTrace(
+  data: MessageEvent['data'],
+): PostedTrace | undefined {
+  if (isPostedTraceWrapped(data)) {
+    return sanitizePostedTrace(data.perfetto);
+  } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+    return {
+      title: 'External trace',
+      buffer: toArrayBuffer(data),
+    };
+  } else {
+    return undefined;
+  }
 }
 
 // The message handler supports loading traces from an ArrayBuffer.
@@ -200,22 +222,8 @@ export function postMessageHandler(messageEvent: MessageEvent) {
     return;
   }
 
-  let postedTrace: PostedTrace;
-  let keepApiOpen = false;
-  if (isPostedTraceWrapped(messageEvent.data)) {
-    postedTrace = sanitizePostedTrace(messageEvent.data.perfetto);
-    if (postedTrace.keepApiOpen) {
-      keepApiOpen = true;
-    }
-  } else if (
-    messageEvent.data instanceof ArrayBuffer ||
-    ArrayBuffer.isView(messageEvent.data)
-  ) {
-    postedTrace = {
-      title: 'External trace',
-      buffer: toArrayBuffer(messageEvent.data),
-    };
-  } else {
+  const postedTrace = parsePostedTrace(messageEvent.data);
+  if (!postedTrace) {
     console.warn(
       'Unknown postMessage() event received. If you are trying to open a ' +
         'trace via postMessage(), this is a bug in your code. If not, this ' +
@@ -229,7 +237,7 @@ export function postMessageHandler(messageEvent: MessageEvent) {
     throw new Error('Incoming message trace buffer is empty');
   }
 
-  if (!keepApiOpen) {
+  if (!postedTrace.keepApiOpen) {
     /* Removing this event listener to avoid callers posting the trace multiple
      * times. If the callers add an event listener which upon receiving 'PONG'
      * posts the trace to ui.perfetto.dev, the callers can receive multiple
@@ -308,7 +316,7 @@ export function postMessageHandler(messageEvent: MessageEvent) {
   });
 }
 
-function sanitizePostedTrace(postedTrace: PostedTrace): PostedTrace {
+function sanitizePostedTrace(postedTrace: RawPostedTrace): PostedTrace {
   const result: PostedTrace = {
     title: sanitizeString(postedTrace.title),
     // Senders routinely pass a view (e.g. Uint8Array) despite the static type;
@@ -379,8 +387,13 @@ function isPostedTraceWrapped(obj: any): obj is PostedTraceWrapped {
   if (wrapped.perfetto === undefined) {
     return false;
   }
+  // Senders routinely pass a view (e.g. Uint8Array) for |buffer| despite the
+  // static ArrayBuffer type, so accept either. Anything else (string, number,
+  // undefined) is rejected here rather than slipping through and being treated
+  // as an ArrayBuffer downstream.
+  const buffer = wrapped.perfetto.buffer;
   return (
-    wrapped.perfetto.buffer !== undefined &&
-    wrapped.perfetto.title !== undefined
+    (buffer instanceof ArrayBuffer || ArrayBuffer.isView(buffer)) &&
+    typeof wrapped.perfetto.title === 'string'
   );
 }

--- a/ui/src/frontend/post_message_handler_unittest.ts
+++ b/ui/src/frontend/post_message_handler_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {isTrustedOrigin} from './post_message_handler';
+import {isTrustedOrigin, parsePostedTrace} from './post_message_handler';
 
 describe('postMessageHandler', () => {
   test('baked-in trusted origins are trusted', () => {
@@ -55,5 +55,69 @@ describe('postMessageHandler', () => {
     // IPv6 localhost
     expect(isTrustedOrigin('https://[::1]')).toBeTruthy();
     expect(isTrustedOrigin('http://[::1]')).toBeTruthy();
+  });
+});
+
+describe('parsePostedTrace', () => {
+  describe('flat buffer', () => {
+    test('arraybuffer returned verbatim', () => {
+      const buffer = new ArrayBuffer();
+      const result = parsePostedTrace(buffer);
+      expect(result?.buffer).toBe(buffer);
+    });
+
+    test('view converted to arraybuffer', () => {
+      const result = parsePostedTrace(new Uint8Array());
+      expect(result?.buffer).toBeInstanceOf(ArrayBuffer);
+    });
+
+    test('view is snipped to the view, not the underlying buffer', () => {
+      // A 10-byte view starting at offset 2 of a 16-byte buffer.
+      const underlying = new Uint8Array(16);
+      underlying.forEach((_, i) => (underlying[i] = i));
+      const view = new Uint8Array(underlying.buffer, 2, 10);
+
+      const result = parsePostedTrace(view);
+
+      expect(result?.buffer).toBeInstanceOf(ArrayBuffer);
+      // Spans exactly the view's bytes, not the full 16-byte buffer.
+      expect(result?.buffer.byteLength).toBe(10);
+      expect(new Uint8Array(result!.buffer)).toEqual(
+        new Uint8Array([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+      );
+    });
+  });
+
+  describe('wrapped trace', () => {
+    test('arraybuffer returned verbatim', () => {
+      const buffer = new ArrayBuffer();
+      const result = parsePostedTrace({perfetto: {buffer, title: 'foo'}});
+      expect(result?.buffer).toBe(buffer);
+    });
+
+    test('view converted to arraybuffer', () => {
+      const result = parsePostedTrace({
+        perfetto: {buffer: new Uint8Array(), title: 'foo'},
+      });
+      expect(result?.buffer).toBeInstanceOf(ArrayBuffer);
+    });
+
+    test('view is snipped to the view, not the underlying buffer', () => {
+      // A 10-byte view starting at offset 2 of a 16-byte buffer.
+      const underlying = new Uint8Array(16);
+      underlying.forEach((_, i) => (underlying[i] = i));
+      const view = new Uint8Array(underlying.buffer, 2, 10);
+
+      const result = parsePostedTrace({
+        perfetto: {buffer: view, title: 'foo'},
+      });
+
+      expect(result?.buffer).toBeInstanceOf(ArrayBuffer);
+      // Spans exactly the view's bytes, not the full 16-byte buffer.
+      expect(result?.buffer.byteLength).toBe(10);
+      expect(new Uint8Array(result!.buffer)).toEqual(
+        new Uint8Array([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+      );
+    });
   });
 });


### PR DESCRIPTION
https://github.com/google/perfetto/pull/6311 fixed the problem with arraybuffer views being passed in (e.g. Uint8Array) via postmessage, the typesystem is still a mess because isPostedTraceWrapped() asserts that perfetto.buffer is an ArrayBuffer without checking. Typescript won't warn us if we mess this up in the future.

This patch widens the buffer type (making it a union of ArrayBuffer | ArrayBufferView) and asserts the type properly in isPostedTraceWrapped().

Also extracted the message parsing logic out into a function and added some unit tests around it to ensure the buffer is converted properly in all cases.