### PR TITLE
GN: Add default protobuf src dir to standalone proto_library

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3759,6 +3759,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_common_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
     ],
@@ -3766,7 +3767,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_cpp)",
     out: [
         "external/perfetto/protos/perfetto/common/android_energy_consumer_descriptor.gen.cc",
         "external/perfetto/protos/perfetto/common/android_log_constants.gen.cc",
@@ -3793,6 +3794,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_common_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
     ],
@@ -3800,7 +3802,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_cpp)",
     out: [
         "external/perfetto/protos/perfetto/common/android_energy_consumer_descriptor.gen.h",
         "external/perfetto/protos/perfetto/common/android_log_constants.gen.h",
@@ -3856,13 +3858,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_common_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_lite)",
     out: [
         "external/perfetto/protos/perfetto/common/android_energy_consumer_descriptor.pb.cc",
         "external/perfetto/protos/perfetto/common/android_log_constants.pb.cc",
@@ -3889,13 +3892,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_common_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_lite)",
     out: [
         "external/perfetto/protos/perfetto/common/android_energy_consumer_descriptor.pb.h",
         "external/perfetto/protos/perfetto/common/android_log_constants.pb.h",
@@ -3934,13 +3938,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_common_semantic_type_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_cpp)",
     out: [
         "external/perfetto/protos/perfetto/common/semantic_type.gen.cc",
     ],
@@ -3950,13 +3955,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_cpp)",
     out: [
         "external/perfetto/protos/perfetto/common/semantic_type.gen.h",
     ],
@@ -3978,12 +3984,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_common_semantic_type_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_lite)",
     out: [
         "external/perfetto/protos/perfetto/common/semantic_type.pb.cc",
     ],
@@ -3993,12 +4000,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_common_semantic_type_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_lite)",
     out: [
         "external/perfetto/protos/perfetto/common/semantic_type.pb.h",
     ],
@@ -4020,13 +4028,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_common_semantic_type_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_zero)",
     out: [
         "external/perfetto/protos/perfetto/common/semantic_type.pbzero.cc",
     ],
@@ -4036,13 +4045,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_zero)",
     out: [
         "external/perfetto/protos/perfetto/common/semantic_type.pbzero.h",
     ],
@@ -4081,6 +4091,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_common_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
     ],
@@ -4088,7 +4099,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_zero)",
     out: [
         "external/perfetto/protos/perfetto/common/android_energy_consumer_descriptor.pbzero.cc",
         "external/perfetto/protos/perfetto/common/android_log_constants.pbzero.cc",
@@ -4115,6 +4126,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_common_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
     ],
@@ -4122,7 +4134,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_zero)",
     out: [
         "external/perfetto/protos/perfetto/common/android_energy_consumer_descriptor.pbzero.h",
         "external/perfetto/protos/perfetto/common/android_log_constants.pbzero.h",
@@ -4180,6 +4192,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_android_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -4188,7 +4201,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/android/android_aflags_config.gen.cc",
         "external/perfetto/protos/perfetto/config/android/android_game_intervention_list_config.gen.cc",
@@ -4217,6 +4230,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_android_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -4225,7 +4239,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/android/android_aflags_config.gen.h",
         "external/perfetto/protos/perfetto/config/android/android_game_intervention_list_config.gen.h",
@@ -4285,6 +4299,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_android_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_android_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -4292,7 +4307,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/android/android_aflags_config.pb.cc",
         "external/perfetto/protos/perfetto/config/android/android_game_intervention_list_config.pb.cc",
@@ -4321,6 +4336,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_android_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_android_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -4328,7 +4344,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/android/android_aflags_config.pb.h",
         "external/perfetto/protos/perfetto/config/android/android_game_intervention_list_config.pb.h",
@@ -4388,6 +4404,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_android_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -4396,7 +4413,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/android/android_aflags_config.pbzero.cc",
         "external/perfetto/protos/perfetto/config/android/android_game_intervention_list_config.pbzero.cc",
@@ -4425,6 +4442,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_android_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -4433,7 +4451,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_android_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/android/android_aflags_config.pbzero.h",
         "external/perfetto/protos/perfetto/config/android/android_game_intervention_list_config.pbzero.h",
@@ -4484,6 +4502,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -4509,7 +4528,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/chrome/chrome_config.gen.cc",
         "external/perfetto/protos/perfetto/config/chrome/histogram_samples.gen.cc",
@@ -4529,6 +4548,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -4554,7 +4574,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/chrome/chrome_config.gen.h",
         "external/perfetto/protos/perfetto/config/chrome/histogram_samples.gen.h",
@@ -4578,6 +4598,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/common/android_energy_consumer_descriptor.proto",
         "protos/perfetto/common/android_log_constants.proto",
         "protos/perfetto/common/builtin_clock.proto",
@@ -4655,7 +4676,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_config_descriptor.bin",
     ],
@@ -4674,13 +4695,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_ftrace_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/ftrace/frozen_ftrace_config.gen.cc",
         "external/perfetto/protos/perfetto/config/ftrace/ftrace_config.gen.cc",
@@ -4691,13 +4713,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_ftrace_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/ftrace/frozen_ftrace_config.gen.h",
         "external/perfetto/protos/perfetto/config/ftrace/ftrace_config.gen.h",
@@ -4721,12 +4744,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_ftrace_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_ftrace_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/ftrace/frozen_ftrace_config.pb.cc",
         "external/perfetto/protos/perfetto/config/ftrace/ftrace_config.pb.cc",
@@ -4737,12 +4761,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_ftrace_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_ftrace_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/ftrace/frozen_ftrace_config.pb.h",
         "external/perfetto/protos/perfetto/config/ftrace/ftrace_config.pb.h",
@@ -4766,13 +4791,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_ftrace_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_ftrace_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/ftrace/frozen_ftrace_config.pbzero.cc",
         "external/perfetto/protos/perfetto/config/ftrace/ftrace_config.pbzero.cc",
@@ -4783,13 +4809,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_ftrace_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_ftrace_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_ftrace_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/ftrace/frozen_ftrace_config.pbzero.h",
         "external/perfetto/protos/perfetto/config/ftrace/ftrace_config.pbzero.h",
@@ -4814,13 +4841,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_gpu_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_gpu_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/gpu/gpu_counter_config.gen.cc",
         "external/perfetto/protos/perfetto/config/gpu/gpu_renderstages_config.gen.cc",
@@ -4832,13 +4860,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_gpu_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_gpu_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/gpu/gpu_counter_config.gen.h",
         "external/perfetto/protos/perfetto/config/gpu/gpu_renderstages_config.gen.h",
@@ -4864,12 +4893,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_gpu_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_gpu_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/gpu/gpu_counter_config.pb.cc",
         "external/perfetto/protos/perfetto/config/gpu/gpu_renderstages_config.pb.cc",
@@ -4881,12 +4911,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_gpu_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_gpu_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/gpu/gpu_counter_config.pb.h",
         "external/perfetto/protos/perfetto/config/gpu/gpu_renderstages_config.pb.h",
@@ -4912,13 +4943,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_gpu_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_gpu_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/gpu/gpu_counter_config.pbzero.cc",
         "external/perfetto/protos/perfetto/config/gpu/gpu_renderstages_config.pbzero.cc",
@@ -4930,13 +4962,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_gpu_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_gpu_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_gpu_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/gpu/gpu_counter_config.pbzero.h",
         "external/perfetto/protos/perfetto/config/gpu/gpu_renderstages_config.pbzero.h",
@@ -4960,13 +4993,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_inode_file_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_inode_file_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/inode_file/inode_file_config.gen.cc",
     ],
@@ -4976,13 +5010,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_inode_file_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_inode_file_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/inode_file/inode_file_config.gen.h",
     ],
@@ -5004,12 +5039,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_inode_file_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_inode_file_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/inode_file/inode_file_config.pb.cc",
     ],
@@ -5019,12 +5055,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_inode_file_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_inode_file_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/inode_file/inode_file_config.pb.h",
     ],
@@ -5046,13 +5083,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_inode_file_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_inode_file_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/inode_file/inode_file_config.pbzero.cc",
     ],
@@ -5062,13 +5100,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_inode_file_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_inode_file_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_inode_file_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/inode_file/inode_file_config.pbzero.h",
     ],
@@ -5090,6 +5129,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_interceptors_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_interceptors_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -5098,7 +5138,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/interceptors/console_config.gen.cc",
     ],
@@ -5108,6 +5148,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_interceptors_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_interceptors_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -5116,7 +5157,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/interceptors/console_config.gen.h",
     ],
@@ -5138,6 +5179,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_interceptors_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_interceptors_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -5145,7 +5187,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/interceptors/console_config.pb.cc",
     ],
@@ -5155,6 +5197,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_interceptors_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_interceptors_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -5162,7 +5205,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/interceptors/console_config.pb.h",
     ],
@@ -5184,6 +5227,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_interceptors_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_interceptors_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -5192,7 +5236,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/interceptors/console_config.pbzero.cc",
     ],
@@ -5202,6 +5246,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_interceptors_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_interceptors_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -5210,7 +5255,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_interceptors_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/interceptors/console_config.pbzero.h",
     ],
@@ -5232,13 +5277,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_linux_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_linux_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/linux/journald_config.gen.cc",
     ],
@@ -5248,13 +5294,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_linux_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_linux_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/linux/journald_config.gen.h",
     ],
@@ -5276,12 +5323,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_linux_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_linux_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/linux/journald_config.pb.cc",
     ],
@@ -5291,12 +5339,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_linux_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_linux_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/linux/journald_config.pb.h",
     ],
@@ -5318,13 +5367,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_linux_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_linux_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/linux/journald_config.pbzero.cc",
     ],
@@ -5334,13 +5384,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_linux_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_linux_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_linux_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/linux/journald_config.pbzero.h",
     ],
@@ -5372,6 +5423,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
@@ -5396,7 +5448,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/chrome/chrome_config.pb.cc",
         "external/perfetto/protos/perfetto/config/chrome/histogram_samples.pb.cc",
@@ -5416,6 +5468,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
@@ -5440,7 +5493,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/chrome/chrome_config.pb.h",
         "external/perfetto/protos/perfetto/config/chrome/histogram_samples.pb.h",
@@ -5472,13 +5525,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_power_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_power_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/power/android_power_config.gen.cc",
     ],
@@ -5488,13 +5542,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_power_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_power_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/power/android_power_config.gen.h",
     ],
@@ -5516,12 +5571,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_power_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_power_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/power/android_power_config.pb.cc",
     ],
@@ -5531,12 +5587,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_power_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_power_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/power/android_power_config.pb.h",
     ],
@@ -5558,13 +5615,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_power_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_power_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/power/android_power_config.pbzero.cc",
     ],
@@ -5574,13 +5632,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_power_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_power_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_power_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/power/android_power_config.pbzero.h",
     ],
@@ -5602,13 +5661,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_priority_boost_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_priority_boost_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/priority_boost/priority_boost_config.gen.cc",
     ],
@@ -5618,13 +5678,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_priority_boost_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_priority_boost_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/priority_boost/priority_boost_config.gen.h",
     ],
@@ -5646,12 +5707,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_priority_boost_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_priority_boost_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/priority_boost/priority_boost_config.pb.cc",
     ],
@@ -5661,12 +5723,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_priority_boost_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_priority_boost_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/priority_boost/priority_boost_config.pb.h",
     ],
@@ -5688,13 +5751,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_priority_boost_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_priority_boost_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/priority_boost/priority_boost_config.pbzero.cc",
     ],
@@ -5704,13 +5768,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_priority_boost_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_priority_boost_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_priority_boost_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/priority_boost/priority_boost_config.pbzero.h",
     ],
@@ -5732,13 +5797,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_process_stats_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_process_stats_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/process_stats/process_stats_config.gen.cc",
     ],
@@ -5748,13 +5814,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_process_stats_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_process_stats_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/process_stats/process_stats_config.gen.h",
     ],
@@ -5776,12 +5843,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_process_stats_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_process_stats_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/process_stats/process_stats_config.pb.cc",
     ],
@@ -5791,12 +5859,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_process_stats_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_process_stats_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/process_stats/process_stats_config.pb.h",
     ],
@@ -5818,13 +5887,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_process_stats_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_process_stats_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/process_stats/process_stats_config.pbzero.cc",
     ],
@@ -5834,13 +5904,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_process_stats_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_process_stats_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_process_stats_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/process_stats/process_stats_config.pbzero.h",
     ],
@@ -5865,6 +5936,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_profiling_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_profiling_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -5873,7 +5945,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/profiling/heapprofd_config.gen.cc",
         "external/perfetto/protos/perfetto/config/profiling/java_hprof_config.gen.cc",
@@ -5886,6 +5958,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_profiling_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_profiling_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -5894,7 +5967,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/profiling/heapprofd_config.gen.h",
         "external/perfetto/protos/perfetto/config/profiling/java_hprof_config.gen.h",
@@ -5922,6 +5995,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_profiling_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_profiling_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -5929,7 +6003,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/profiling/heapprofd_config.pb.cc",
         "external/perfetto/protos/perfetto/config/profiling/java_hprof_config.pb.cc",
@@ -5942,6 +6016,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_profiling_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_profiling_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -5949,7 +6024,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/profiling/heapprofd_config.pb.h",
         "external/perfetto/protos/perfetto/config/profiling/java_hprof_config.pb.h",
@@ -5977,6 +6052,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_profiling_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_profiling_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -5985,7 +6061,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/profiling/heapprofd_config.pbzero.cc",
         "external/perfetto/protos/perfetto/config/profiling/java_hprof_config.pbzero.cc",
@@ -5998,6 +6074,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_profiling_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_profiling_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -6006,7 +6083,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_profiling_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/profiling/heapprofd_config.pbzero.h",
         "external/perfetto/protos/perfetto/config/profiling/java_hprof_config.pbzero.h",
@@ -6031,13 +6108,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_protovm_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_protovm_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/protovm/protovm_config.gen.cc",
     ],
@@ -6047,13 +6125,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_protovm_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_protovm_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/protovm/protovm_config.gen.h",
     ],
@@ -6075,12 +6154,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_protovm_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_protovm_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/protovm/protovm_config.pb.cc",
     ],
@@ -6090,12 +6170,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_protovm_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_protovm_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/protovm/protovm_config.pb.h",
     ],
@@ -6117,13 +6198,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_protovm_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_protovm_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/protovm/protovm_config.pbzero.cc",
     ],
@@ -6133,13 +6215,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_protovm_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_protovm_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_protovm_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/protovm/protovm_config.pbzero.h",
     ],
@@ -6161,6 +6244,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_qnx_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_qnx_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -6169,7 +6253,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/qnx/qnx_config.gen.cc",
     ],
@@ -6179,6 +6263,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_qnx_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_qnx_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -6187,7 +6272,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/qnx/qnx_config.gen.h",
     ],
@@ -6209,6 +6294,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_qnx_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_qnx_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -6216,7 +6302,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/qnx/qnx_config.pb.cc",
     ],
@@ -6226,6 +6312,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_qnx_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_qnx_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -6233,7 +6320,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/qnx/qnx_config.pb.h",
     ],
@@ -6255,6 +6342,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_qnx_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_qnx_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -6263,7 +6351,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/qnx/qnx_config.pbzero.cc",
     ],
@@ -6273,6 +6361,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_qnx_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_qnx_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -6281,7 +6370,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_qnx_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/qnx/qnx_config.pbzero.h",
     ],
@@ -6304,13 +6393,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_statsd_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_statsd_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/statsd/atom_ids.gen.cc",
         "external/perfetto/protos/perfetto/config/statsd/statsd_tracing_config.gen.cc",
@@ -6321,13 +6411,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_statsd_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_statsd_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/statsd/atom_ids.gen.h",
         "external/perfetto/protos/perfetto/config/statsd/statsd_tracing_config.gen.h",
@@ -6351,12 +6442,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_statsd_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_statsd_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/statsd/atom_ids.pb.cc",
         "external/perfetto/protos/perfetto/config/statsd/statsd_tracing_config.pb.cc",
@@ -6367,12 +6459,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_statsd_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_statsd_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/statsd/atom_ids.pb.h",
         "external/perfetto/protos/perfetto/config/statsd/statsd_tracing_config.pb.h",
@@ -6396,13 +6489,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_statsd_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_statsd_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/statsd/atom_ids.pbzero.cc",
         "external/perfetto/protos/perfetto/config/statsd/statsd_tracing_config.pbzero.cc",
@@ -6413,13 +6507,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_statsd_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_statsd_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_statsd_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/statsd/atom_ids.pbzero.h",
         "external/perfetto/protos/perfetto/config/statsd/statsd_tracing_config.pbzero.h",
@@ -6442,6 +6537,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_sys_stats_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_sys_stats_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -6450,7 +6546,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/sys_stats/sys_stats_config.gen.cc",
     ],
@@ -6460,6 +6556,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_sys_stats_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_sys_stats_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
@@ -6468,7 +6565,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/sys_stats/sys_stats_config.gen.h",
     ],
@@ -6490,6 +6587,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_sys_stats_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_sys_stats_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -6497,7 +6595,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/sys_stats/sys_stats_config.pb.cc",
     ],
@@ -6507,6 +6605,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_sys_stats_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_sys_stats_lite",
         ":perfetto_protos_perfetto_protovm_lite",
@@ -6514,7 +6613,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/sys_stats/sys_stats_config.pb.h",
     ],
@@ -6536,6 +6635,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_sys_stats_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_sys_stats_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -6544,7 +6644,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/sys_stats/sys_stats_config.pbzero.cc",
     ],
@@ -6554,6 +6654,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_sys_stats_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_sys_stats_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -6562,7 +6663,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_sys_stats_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/sys_stats/sys_stats_config.pbzero.h",
     ],
@@ -6584,13 +6685,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_system_info_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/system_info/system_info_config.gen.cc",
     ],
@@ -6600,13 +6702,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_system_info_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/system_info/system_info_config.gen.h",
     ],
@@ -6628,12 +6731,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_system_info_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/system_info/system_info_config.pb.cc",
     ],
@@ -6643,12 +6747,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_system_info_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/system_info/system_info_config.pb.h",
     ],
@@ -6670,13 +6775,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_system_info_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/system_info/system_info_config.pbzero.cc",
     ],
@@ -6686,13 +6792,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_system_info_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_system_info_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/system_info/system_info_config.pbzero.h",
     ],
@@ -6714,13 +6821,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_track_event_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_track_event_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/track_event/track_event_config.gen.cc",
     ],
@@ -6730,13 +6838,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_track_event_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_track_event_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_cpp)",
     out: [
         "external/perfetto/protos/perfetto/config/track_event/track_event_config.gen.h",
     ],
@@ -6758,12 +6867,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_track_event_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_track_event_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/track_event/track_event_config.pb.cc",
     ],
@@ -6773,12 +6883,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_track_event_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_track_event_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_lite)",
     out: [
         "external/perfetto/protos/perfetto/config/track_event/track_event_config.pb.h",
     ],
@@ -6800,13 +6911,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_track_event_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_track_event_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/track_event/track_event_config.pbzero.cc",
     ],
@@ -6816,13 +6928,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_track_event_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_config_track_event_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_track_event_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/track_event/track_event_config.pbzero.h",
     ],
@@ -6854,6 +6967,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -6879,7 +6993,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/chrome/chrome_config.pbzero.cc",
         "external/perfetto/protos/perfetto/config/chrome/histogram_samples.pbzero.cc",
@@ -6899,6 +7013,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -6924,7 +7039,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_config_zero)",
     out: [
         "external/perfetto/protos/perfetto/config/chrome/chrome_config.pbzero.h",
         "external/perfetto/protos/perfetto/config/chrome/histogram_samples.pbzero.h",
@@ -6958,6 +7073,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_ipc_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -6984,7 +7100,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_cpp)",
     out: [
         "external/perfetto/protos/perfetto/ipc/consumer_port.gen.cc",
         "external/perfetto/protos/perfetto/ipc/producer_port.gen.cc",
@@ -6996,6 +7112,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_ipc_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -7022,7 +7139,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_cpp)",
     out: [
         "external/perfetto/protos/perfetto/ipc/consumer_port.gen.h",
         "external/perfetto/protos/perfetto/ipc/producer_port.gen.h",
@@ -7048,6 +7165,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_ipc_ipc_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -7076,7 +7194,7 @@ genrule {
         "aprotoc",
         "ipc_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location ipc_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_ipc)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location ipc_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_ipc)",
     out: [
         "external/perfetto/protos/perfetto/ipc/consumer_port.ipc.cc",
         "external/perfetto/protos/perfetto/ipc/producer_port.ipc.cc",
@@ -7088,6 +7206,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_ipc_ipc_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -7116,7 +7235,7 @@ genrule {
         "aprotoc",
         "ipc_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location ipc_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_ipc)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location ipc_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_ipc)",
     out: [
         "external/perfetto/protos/perfetto/ipc/consumer_port.ipc.h",
         "external/perfetto/protos/perfetto/ipc/producer_port.ipc.h",
@@ -7140,13 +7259,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_ipc_wire_protocol_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_ipc_wire_protocol_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_wire_protocol_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_wire_protocol_cpp)",
     out: [
         "external/perfetto/protos/perfetto/ipc/wire_protocol.gen.cc",
     ],
@@ -7156,13 +7276,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_ipc_wire_protocol_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_ipc_wire_protocol_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_wire_protocol_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_ipc_wire_protocol_cpp)",
     out: [
         "external/perfetto/protos/perfetto/ipc/wire_protocol.gen.h",
     ],
@@ -7276,6 +7397,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_metrics_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/metrics/android/ad_services_metric.proto",
         "protos/perfetto/metrics/android/android_anomaly_metric.proto",
         "protos/perfetto/metrics/android/android_blocking_call.proto",
@@ -7346,7 +7468,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_metrics_descriptor.bin",
     ],
@@ -7447,13 +7569,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_perfetto_sql_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_perfetto_sql_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_perfetto_sql_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_perfetto_sql_cpp)",
     out: [
         "external/perfetto/protos/perfetto/perfetto_sql/structured_query.gen.cc",
     ],
@@ -7463,13 +7586,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_perfetto_sql_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_perfetto_sql_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_perfetto_sql_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_perfetto_sql_cpp)",
     out: [
         "external/perfetto/protos/perfetto/perfetto_sql/structured_query.gen.h",
     ],
@@ -7483,12 +7607,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_perfetto_sql_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/perfetto_sql/structured_query.proto",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_perfetto_sql_descriptor.bin",
     ],
@@ -7506,13 +7631,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_perfetto_sql_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_perfetto_sql_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_perfetto_sql_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_perfetto_sql_zero)",
     out: [
         "external/perfetto/protos/perfetto/perfetto_sql/structured_query.pbzero.cc",
     ],
@@ -7522,13 +7648,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_perfetto_sql_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_perfetto_sql_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_perfetto_sql_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_perfetto_sql_zero)",
     out: [
         "external/perfetto/protos/perfetto/perfetto_sql/structured_query.pbzero.h",
     ],
@@ -7588,12 +7715,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_protovm_compile_config_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/protovm/compile_config.proto",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_protovm_compile_config_descriptor.bin",
     ],
@@ -7611,13 +7739,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_protovm_compile_config_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_protovm_compile_config_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_compile_config_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_compile_config_zero)",
     out: [
         "external/perfetto/protos/perfetto/protovm/compile_config.pbzero.cc",
     ],
@@ -7627,13 +7756,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_protovm_compile_config_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_protovm_compile_config_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_compile_config_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_compile_config_zero)",
     out: [
         "external/perfetto/protos/perfetto/protovm/compile_config.pbzero.h",
     ],
@@ -7655,13 +7785,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_protovm_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_protovm_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_cpp)",
     out: [
         "external/perfetto/protos/perfetto/protovm/vm_program.gen.cc",
     ],
@@ -7671,13 +7802,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_protovm_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_protovm_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_cpp)",
     out: [
         "external/perfetto/protos/perfetto/protovm/vm_program.gen.h",
     ],
@@ -7691,12 +7823,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_protovm_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/protovm/vm_program.proto",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_protovm_descriptor.bin",
     ],
@@ -7714,12 +7847,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_protovm_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_protovm_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_lite)",
     out: [
         "external/perfetto/protos/perfetto/protovm/vm_program.pb.cc",
     ],
@@ -7729,12 +7863,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_protovm_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_protovm_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_lite)",
     out: [
         "external/perfetto/protos/perfetto/protovm/vm_program.pb.h",
     ],
@@ -7756,13 +7891,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_protovm_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_protovm_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_zero)",
     out: [
         "external/perfetto/protos/perfetto/protovm/vm_program.pbzero.cc",
     ],
@@ -7772,13 +7908,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_protovm_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_protovm_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_protovm_zero)",
     out: [
         "external/perfetto/protos/perfetto/protovm/vm_program.pbzero.h",
     ],
@@ -7812,6 +7949,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_android_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_android_cpp",
@@ -7820,7 +7958,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/android/android_aflags.gen.cc",
         "external/perfetto/protos/perfetto/trace/android/android_game_intervention_list.gen.cc",
@@ -7842,6 +7980,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_android_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_android_cpp",
@@ -7850,7 +7989,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/android/android_aflags.gen.h",
         "external/perfetto/protos/perfetto/trace/android/android_game_intervention_list.gen.h",
@@ -7896,6 +8035,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_android_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_android_lite",
@@ -7903,7 +8043,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/android/android_aflags.pb.cc",
         "external/perfetto/protos/perfetto/trace/android/android_game_intervention_list.pb.cc",
@@ -7925,6 +8065,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_android_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_android_lite",
@@ -7932,7 +8073,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/android/android_aflags.pb.h",
         "external/perfetto/protos/perfetto/trace/android/android_game_intervention_list.pb.h",
@@ -7978,6 +8119,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_android_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_android_zero",
@@ -7986,7 +8128,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/android/android_aflags.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/android/android_game_intervention_list.pbzero.cc",
@@ -8008,6 +8150,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_android_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_android_zero",
@@ -8016,7 +8159,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_android_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/android/android_aflags.pbzero.h",
         "external/perfetto/protos/perfetto/trace/android/android_game_intervention_list.pbzero.h",
@@ -8054,13 +8197,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_chrome_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_chrome_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/chrome/chrome_benchmark_metadata.gen.cc",
         "external/perfetto/protos/perfetto/trace/chrome/chrome_metadata.gen.cc",
@@ -8074,13 +8218,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_chrome_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_chrome_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/chrome/chrome_benchmark_metadata.gen.h",
         "external/perfetto/protos/perfetto/trace/chrome/chrome_metadata.gen.h",
@@ -8110,12 +8255,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_chrome_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_chrome_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/chrome/chrome_benchmark_metadata.pb.cc",
         "external/perfetto/protos/perfetto/trace/chrome/chrome_metadata.pb.cc",
@@ -8129,12 +8275,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_chrome_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_chrome_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/chrome/chrome_benchmark_metadata.pb.h",
         "external/perfetto/protos/perfetto/trace/chrome/chrome_metadata.pb.h",
@@ -8164,13 +8311,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_chrome_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_chrome_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/chrome/chrome_benchmark_metadata.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/chrome/chrome_metadata.pbzero.cc",
@@ -8184,13 +8332,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_chrome_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_chrome_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_chrome_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/chrome/chrome_benchmark_metadata.pbzero.h",
         "external/perfetto/protos/perfetto/trace/chrome/chrome_metadata.pbzero.h",
@@ -8208,6 +8357,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/common/android_energy_consumer_descriptor.proto",
         "protos/perfetto/common/android_log_constants.proto",
         "protos/perfetto/common/builtin_clock.proto",
@@ -8462,7 +8612,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_trace_descriptor.bin",
     ],
@@ -8482,13 +8632,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_etw_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_etw_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/etw/etw.gen.cc",
         "external/perfetto/protos/perfetto/trace/etw/etw_event.gen.cc",
@@ -8500,13 +8651,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_etw_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_etw_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/etw/etw.gen.h",
         "external/perfetto/protos/perfetto/trace/etw/etw_event.gen.h",
@@ -8532,12 +8684,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_etw_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_etw_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/etw/etw.pb.cc",
         "external/perfetto/protos/perfetto/trace/etw/etw_event.pb.cc",
@@ -8549,12 +8702,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_etw_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_etw_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/etw/etw.pb.h",
         "external/perfetto/protos/perfetto/trace/etw/etw_event.pb.h",
@@ -8580,13 +8734,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_etw_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_etw_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/etw/etw.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/etw/etw_event.pbzero.cc",
@@ -8598,13 +8753,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_etw_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_etw_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_etw_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/etw/etw.pbzero.h",
         "external/perfetto/protos/perfetto/trace/etw/etw_event.pbzero.h",
@@ -8628,13 +8784,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_filesystem_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_filesystem_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/filesystem/inode_file_map.gen.cc",
     ],
@@ -8644,13 +8801,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_filesystem_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_filesystem_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/filesystem/inode_file_map.gen.h",
     ],
@@ -8672,12 +8830,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_filesystem_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_filesystem_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/filesystem/inode_file_map.pb.cc",
     ],
@@ -8687,12 +8846,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_filesystem_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_filesystem_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/filesystem/inode_file_map.pb.h",
     ],
@@ -8714,13 +8874,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_filesystem_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_filesystem_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/filesystem/inode_file_map.pbzero.cc",
     ],
@@ -8730,13 +8891,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_filesystem_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_filesystem_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_filesystem_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/filesystem/inode_file_map.pbzero.h",
     ],
@@ -8841,13 +9003,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_ftrace_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ftrace_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/ftrace/android_fs.gen.cc",
         "external/perfetto/protos/perfetto/trace/ftrace/bcl_exynos.gen.cc",
@@ -8940,13 +9103,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_ftrace_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ftrace_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/ftrace/android_fs.gen.h",
         "external/perfetto/protos/perfetto/trace/ftrace/bcl_exynos.gen.h",
@@ -9134,12 +9298,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_ftrace_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ftrace_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/ftrace/android_fs.pb.cc",
         "external/perfetto/protos/perfetto/trace/ftrace/bcl_exynos.pb.cc",
@@ -9232,12 +9397,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_ftrace_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ftrace_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/ftrace/android_fs.pb.h",
         "external/perfetto/protos/perfetto/trace/ftrace/bcl_exynos.pb.h",
@@ -9425,13 +9591,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_ftrace_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ftrace_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/ftrace/android_fs.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/ftrace/bcl_exynos.pbzero.cc",
@@ -9524,13 +9691,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_ftrace_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ftrace_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ftrace_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/ftrace/android_fs.pbzero.h",
         "external/perfetto/protos/perfetto/trace/ftrace/bcl_exynos.pbzero.h",
@@ -9637,13 +9805,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_generic_kernel_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_generic_kernel_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_gpu_frequency.gen.cc",
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_power.gen.cc",
@@ -9655,13 +9824,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_generic_kernel_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_generic_kernel_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_gpu_frequency.gen.h",
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_power.gen.h",
@@ -9687,12 +9857,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_generic_kernel_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_generic_kernel_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_gpu_frequency.pb.cc",
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_power.pb.cc",
@@ -9704,12 +9875,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_generic_kernel_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_generic_kernel_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_gpu_frequency.pb.h",
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_power.pb.h",
@@ -9735,13 +9907,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_generic_kernel_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_generic_kernel_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_gpu_frequency.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_power.pbzero.cc",
@@ -9753,13 +9926,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_generic_kernel_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_generic_kernel_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_generic_kernel_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_gpu_frequency.pbzero.h",
         "external/perfetto/protos/perfetto/trace/generic_kernel/generic_power.pbzero.h",
@@ -9788,6 +9962,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_gpu_cpp",
@@ -9796,7 +9971,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_counter_event.gen.cc",
         "external/perfetto/protos/perfetto/trace/gpu/gpu_log.gen.cc",
@@ -9811,6 +9986,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_gpu_cpp",
@@ -9819,7 +9995,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_counter_event.gen.h",
         "external/perfetto/protos/perfetto/trace/gpu/gpu_log.gen.h",
@@ -9838,6 +10014,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_gpu_interned_data_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/common/android_energy_consumer_descriptor.proto",
         "protos/perfetto/common/android_log_constants.proto",
         "protos/perfetto/common/builtin_clock.proto",
@@ -9920,7 +10097,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_trace_gpu_gpu_interned_data_descriptor.bin",
     ],
@@ -9938,6 +10115,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_gpu_interned_data_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_android_zero",
@@ -9952,7 +10130,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_gpu_interned_data_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_gpu_interned_data_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_interned_data.pbzero.cc",
     ],
@@ -9962,6 +10140,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_gpu_interned_data_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_android_zero",
@@ -9976,7 +10155,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_gpu_interned_data_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_gpu_interned_data_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_interned_data.pbzero.h",
     ],
@@ -9990,6 +10169,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_gpu_track_event_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/trace/gpu/gpu_track_event.proto",
         "protos/perfetto/trace/track_event/chrome_active_processes.proto",
         "protos/perfetto/trace/track_event/chrome_application_state_info.proto",
@@ -10023,7 +10203,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_trace_gpu_gpu_track_event_descriptor.bin",
     ],
@@ -10041,6 +10221,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
     ],
@@ -10048,7 +10229,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_track_event.pbzero.cc",
     ],
@@ -10058,6 +10239,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
     ],
@@ -10065,7 +10247,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_track_event.pbzero.h",
     ],
@@ -10092,6 +10274,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_gpu_lite",
@@ -10099,7 +10282,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_counter_event.pb.cc",
         "external/perfetto/protos/perfetto/trace/gpu/gpu_log.pb.cc",
@@ -10114,6 +10297,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_gpu_lite",
@@ -10121,7 +10305,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_counter_event.pb.h",
         "external/perfetto/protos/perfetto/trace/gpu/gpu_log.pb.h",
@@ -10153,6 +10337,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_gpu_zero",
@@ -10161,7 +10346,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_counter_event.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/gpu/gpu_log.pbzero.cc",
@@ -10176,6 +10361,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_gpu_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_gpu_zero",
@@ -10184,7 +10370,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_gpu_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/gpu/gpu_counter_event.pbzero.h",
         "external/perfetto/protos/perfetto/trace/gpu/gpu_log.pbzero.h",
@@ -10211,6 +10397,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_interned_data_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_android_cpp",
@@ -10224,7 +10411,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/interned_data/interned_data.gen.cc",
     ],
@@ -10234,6 +10421,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_interned_data_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_android_cpp",
@@ -10247,7 +10435,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/interned_data/interned_data.gen.h",
     ],
@@ -10269,6 +10457,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_interned_data_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_android_lite",
@@ -10281,7 +10470,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/interned_data/interned_data.pb.cc",
     ],
@@ -10291,6 +10480,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_interned_data_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_android_lite",
@@ -10303,7 +10493,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/interned_data/interned_data.pb.h",
     ],
@@ -10325,6 +10515,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_interned_data_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_android_zero",
@@ -10338,7 +10529,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/interned_data/interned_data.pbzero.cc",
     ],
@@ -10348,6 +10539,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_interned_data_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_android_zero",
@@ -10361,7 +10553,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_interned_data_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/interned_data/interned_data.pbzero.h",
     ],
@@ -10383,13 +10575,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_linux_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_linux_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/linux/journald_event.gen.cc",
     ],
@@ -10399,13 +10592,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_linux_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_linux_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/linux/journald_event.gen.h",
     ],
@@ -10427,12 +10621,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_linux_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_linux_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/linux/journald_event.pb.cc",
     ],
@@ -10442,12 +10637,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_linux_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_linux_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/linux/journald_event.pb.h",
     ],
@@ -10469,13 +10665,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_linux_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_linux_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/linux/journald_event.pbzero.cc",
     ],
@@ -10485,13 +10682,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_linux_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_linux_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_linux_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/linux/journald_event.pbzero.h",
     ],
@@ -10515,6 +10713,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_minimal_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -10541,7 +10740,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/clock_snapshot.gen.cc",
         "external/perfetto/protos/perfetto/trace/trace_uuid.gen.cc",
@@ -10553,6 +10752,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_minimal_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -10579,7 +10779,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/clock_snapshot.gen.h",
         "external/perfetto/protos/perfetto/trace/trace_uuid.gen.h",
@@ -10605,6 +10805,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_minimal_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
@@ -10630,7 +10831,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/clock_snapshot.pb.cc",
         "external/perfetto/protos/perfetto/trace/trace_uuid.pb.cc",
@@ -10642,6 +10843,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_minimal_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
@@ -10667,7 +10869,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/clock_snapshot.pb.h",
         "external/perfetto/protos/perfetto/trace/trace_uuid.pb.h",
@@ -10693,6 +10895,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_minimal_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -10719,7 +10922,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/clock_snapshot.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/trace_uuid.pbzero.cc",
@@ -10731,6 +10934,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_minimal_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -10757,7 +10961,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_minimal_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/clock_snapshot.pbzero.h",
         "external/perfetto/protos/perfetto/trace/trace_uuid.pbzero.h",
@@ -10789,6 +10993,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -10834,7 +11039,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/extension_descriptor.gen.cc",
         "external/perfetto/protos/perfetto/trace/memory_graph.gen.cc",
@@ -10852,6 +11057,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
@@ -10897,7 +11103,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/extension_descriptor.gen.h",
         "external/perfetto/protos/perfetto/trace/memory_graph.gen.h",
@@ -10935,6 +11141,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
@@ -10979,7 +11186,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/extension_descriptor.pb.cc",
         "external/perfetto/protos/perfetto/trace/memory_graph.pb.cc",
@@ -10997,6 +11204,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
@@ -11041,7 +11249,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/extension_descriptor.pb.h",
         "external/perfetto/protos/perfetto/trace/memory_graph.pb.h",
@@ -11336,6 +11544,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -11381,7 +11590,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/extension_descriptor.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/memory_graph.pbzero.cc",
@@ -11399,6 +11608,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -11444,7 +11654,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_non_minimal_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/extension_descriptor.pbzero.h",
         "external/perfetto/protos/perfetto/trace/memory_graph.pbzero.h",
@@ -11476,13 +11686,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_perfetto_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_perfetto_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.gen.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.gen.cc",
@@ -11494,13 +11705,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_perfetto_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_perfetto_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.gen.h",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.gen.h",
@@ -11526,12 +11738,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_perfetto_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_perfetto_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.pb.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.pb.cc",
@@ -11543,12 +11756,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_perfetto_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_perfetto_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.pb.h",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.pb.h",
@@ -11574,13 +11788,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_perfetto_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_perfetto_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.pbzero.cc",
@@ -11592,13 +11807,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_perfetto_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.pbzero.h",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.pbzero.h",
@@ -11625,6 +11841,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_power_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_power_cpp",
@@ -11633,7 +11850,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/power/android_energy_estimation_breakdown.gen.cc",
         "external/perfetto/protos/perfetto/trace/power/android_entity_state_residency.gen.cc",
@@ -11646,6 +11863,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_power_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_power_cpp",
@@ -11654,7 +11872,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/power/android_energy_estimation_breakdown.gen.h",
         "external/perfetto/protos/perfetto/trace/power/android_entity_state_residency.gen.h",
@@ -11682,6 +11900,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_power_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_power_lite",
@@ -11689,7 +11908,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/power/android_energy_estimation_breakdown.pb.cc",
         "external/perfetto/protos/perfetto/trace/power/android_entity_state_residency.pb.cc",
@@ -11702,6 +11921,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_power_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_power_lite",
@@ -11709,7 +11929,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/power/android_energy_estimation_breakdown.pb.h",
         "external/perfetto/protos/perfetto/trace/power/android_entity_state_residency.pb.h",
@@ -11737,6 +11957,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_power_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_power_zero",
@@ -11745,7 +11966,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/power/android_energy_estimation_breakdown.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/power/android_entity_state_residency.pbzero.cc",
@@ -11758,6 +11979,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_power_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_power_zero",
@@ -11766,7 +11988,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_power_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/power/android_energy_estimation_breakdown.pbzero.h",
         "external/perfetto/protos/perfetto/trace/power/android_entity_state_residency.pbzero.h",
@@ -11791,13 +12013,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_processor_metrics_impl_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_processor_metrics_impl_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_processor_metrics_impl_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace_processor/metrics_impl.pbzero.cc",
     ],
@@ -11807,13 +12030,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_processor_metrics_impl_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_processor_metrics_impl_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_processor_metrics_impl_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace_processor/metrics_impl.pbzero.h",
     ],
@@ -11838,6 +12062,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_processor_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_perfetto_sql_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -11848,7 +12073,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_processor_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_processor_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace_processor/metatrace_categories.pbzero.cc",
         "external/perfetto/protos/perfetto/trace_processor/serialization.pbzero.cc",
@@ -11861,6 +12086,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_processor_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_perfetto_sql_zero",
         ":perfetto_protos_perfetto_protovm_zero",
@@ -11871,7 +12097,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_processor_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_processor_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace_processor/metatrace_categories.pbzero.h",
         "external/perfetto/protos/perfetto/trace_processor/serialization.pbzero.h",
@@ -11900,6 +12126,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_profiling_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_profiling_cpp",
@@ -11908,7 +12135,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/profiling/art_process_metadata.gen.cc",
         "external/perfetto/protos/perfetto/trace/profiling/deobfuscation.gen.cc",
@@ -11922,6 +12149,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_profiling_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_profiling_cpp",
@@ -11930,7 +12158,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/profiling/art_process_metadata.gen.h",
         "external/perfetto/protos/perfetto/trace/profiling/deobfuscation.gen.h",
@@ -11960,6 +12188,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_profiling_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_profiling_lite",
@@ -11967,7 +12196,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/profiling/art_process_metadata.pb.cc",
         "external/perfetto/protos/perfetto/trace/profiling/deobfuscation.pb.cc",
@@ -11981,6 +12210,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_profiling_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_profiling_lite",
@@ -11988,7 +12218,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/profiling/art_process_metadata.pb.h",
         "external/perfetto/protos/perfetto/trace/profiling/deobfuscation.pb.h",
@@ -12018,6 +12248,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_profiling_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_profiling_zero",
@@ -12026,7 +12257,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/profiling/art_process_metadata.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/profiling/deobfuscation.pbzero.cc",
@@ -12040,6 +12271,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_profiling_zero",
@@ -12048,7 +12280,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/profiling/art_process_metadata.pbzero.h",
         "external/perfetto/protos/perfetto/trace/profiling/deobfuscation.pbzero.h",
@@ -12075,13 +12307,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_ps_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ps_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/ps/process_stats.gen.cc",
         "external/perfetto/protos/perfetto/trace/ps/process_tree.gen.cc",
@@ -12092,13 +12325,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_ps_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ps_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/ps/process_stats.gen.h",
         "external/perfetto/protos/perfetto/trace/ps/process_tree.gen.h",
@@ -12122,12 +12356,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_ps_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ps_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/ps/process_stats.pb.cc",
         "external/perfetto/protos/perfetto/trace/ps/process_tree.pb.cc",
@@ -12138,12 +12373,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_ps_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ps_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/ps/process_stats.pb.h",
         "external/perfetto/protos/perfetto/trace/ps/process_tree.pb.h",
@@ -12167,13 +12403,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_ps_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ps_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/ps/process_stats.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/ps/process_tree.pbzero.cc",
@@ -12184,13 +12421,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_ps_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_ps_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/ps/process_stats.pbzero.h",
         "external/perfetto/protos/perfetto/trace/ps/process_tree.pbzero.h",
@@ -12213,6 +12451,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_statsd_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_statsd_cpp",
@@ -12221,7 +12460,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/statsd/statsd_atom.gen.cc",
     ],
@@ -12231,6 +12470,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_statsd_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_statsd_cpp",
@@ -12239,7 +12479,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/statsd/statsd_atom.gen.h",
     ],
@@ -12261,6 +12501,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_statsd_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_statsd_lite",
@@ -12268,7 +12509,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/statsd/statsd_atom.pb.cc",
     ],
@@ -12278,6 +12519,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_statsd_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_statsd_lite",
@@ -12285,7 +12527,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/statsd/statsd_atom.pb.h",
     ],
@@ -12307,6 +12549,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_statsd_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_statsd_zero",
@@ -12315,7 +12558,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/statsd/statsd_atom.pbzero.cc",
     ],
@@ -12325,6 +12568,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_statsd_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_statsd_zero",
@@ -12333,7 +12577,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_statsd_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/statsd/statsd_atom.pbzero.h",
     ],
@@ -12356,6 +12600,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_summary_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_perfetto_sql_cpp",
         ":perfetto_protos_perfetto_trace_summary_cpp",
     ],
@@ -12363,7 +12608,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_summary_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_summary_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace_summary/file.gen.cc",
         "external/perfetto/protos/perfetto/trace_summary/v2_metric.gen.cc",
@@ -12374,6 +12619,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_summary_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_perfetto_sql_cpp",
         ":perfetto_protos_perfetto_trace_summary_cpp",
     ],
@@ -12381,7 +12627,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_summary_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_summary_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace_summary/file.gen.h",
         "external/perfetto/protos/perfetto/trace_summary/v2_metric.gen.h",
@@ -12396,6 +12642,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_summary_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/perfetto_sql/structured_query.proto",
         "protos/perfetto/trace_summary/file.proto",
         "protos/perfetto/trace_summary/v2_metric.proto",
@@ -12403,7 +12650,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_trace_summary_descriptor.bin",
     ],
@@ -12422,6 +12669,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_summary_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_perfetto_sql_zero",
         ":perfetto_protos_perfetto_trace_summary_zero",
     ],
@@ -12429,7 +12677,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_summary_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_summary_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace_summary/file.pbzero.cc",
         "external/perfetto/protos/perfetto/trace_summary/v2_metric.pbzero.cc",
@@ -12440,6 +12688,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_summary_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_perfetto_sql_zero",
         ":perfetto_protos_perfetto_trace_summary_zero",
     ],
@@ -12447,7 +12696,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_summary_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_summary_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace_summary/file.pbzero.h",
         "external/perfetto/protos/perfetto/trace_summary/v2_metric.pbzero.h",
@@ -12470,6 +12719,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_sys_stats_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_sys_stats_cpp",
@@ -12478,7 +12728,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/sys_stats/sys_stats.gen.cc",
     ],
@@ -12488,6 +12738,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_sys_stats_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_protovm_cpp",
         ":perfetto_protos_perfetto_trace_sys_stats_cpp",
@@ -12496,7 +12747,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/sys_stats/sys_stats.gen.h",
     ],
@@ -12518,6 +12769,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_sys_stats_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_sys_stats_lite",
@@ -12525,7 +12777,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/sys_stats/sys_stats.pb.cc",
     ],
@@ -12535,6 +12787,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_sys_stats_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_protovm_lite",
         ":perfetto_protos_perfetto_trace_sys_stats_lite",
@@ -12542,7 +12795,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/sys_stats/sys_stats.pb.h",
     ],
@@ -12564,6 +12817,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_sys_stats_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_sys_stats_zero",
@@ -12572,7 +12826,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/sys_stats/sys_stats.pbzero.cc",
     ],
@@ -12582,6 +12836,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_sys_stats_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_sys_stats_zero",
@@ -12590,7 +12845,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_sys_stats_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/sys_stats/sys_stats.pbzero.h",
     ],
@@ -12614,13 +12869,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_system_info_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_system_info_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/system_info/cpu_info.gen.cc",
         "external/perfetto/protos/perfetto/trace/system_info/gpu_info.gen.cc",
@@ -12632,13 +12888,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_system_info_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_system_info_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/system_info/cpu_info.gen.h",
         "external/perfetto/protos/perfetto/trace/system_info/gpu_info.gen.h",
@@ -12664,12 +12921,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_system_info_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_system_info_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/system_info/cpu_info.pb.cc",
         "external/perfetto/protos/perfetto/trace/system_info/gpu_info.pb.cc",
@@ -12681,12 +12939,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_system_info_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_system_info_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/system_info/cpu_info.pb.h",
         "external/perfetto/protos/perfetto/trace/system_info/gpu_info.pb.h",
@@ -12712,13 +12971,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_system_info_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_system_info_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/system_info/cpu_info.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/system_info/gpu_info.pbzero.cc",
@@ -12730,13 +12990,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_system_info_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_system_info_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_system_info_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/system_info/cpu_info.pbzero.h",
         "external/perfetto/protos/perfetto/trace/system_info/gpu_info.pbzero.h",
@@ -12787,13 +13048,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/track_event/chrome_active_processes.gen.cc",
         "external/perfetto/protos/perfetto/trace/track_event/chrome_application_state_info.gen.cc",
@@ -12830,13 +13092,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/track_event/chrome_active_processes.gen.h",
         "external/perfetto/protos/perfetto/trace/track_event/chrome_application_state_info.gen.h",
@@ -12877,6 +13140,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/trace/track_event/chrome_active_processes.proto",
         "protos/perfetto/trace/track_event/chrome_application_state_info.proto",
         "protos/perfetto/trace/track_event/chrome_compositor_scheduler_state.proto",
@@ -12909,7 +13173,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_perfetto_trace_track_event_descriptor.bin",
     ],
@@ -12954,12 +13218,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/track_event/chrome_active_processes.pb.cc",
         "external/perfetto/protos/perfetto/trace/track_event/chrome_application_state_info.pb.cc",
@@ -12996,12 +13261,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/track_event/chrome_active_processes.pb.h",
         "external/perfetto/protos/perfetto/trace/track_event/chrome_application_state_info.pb.h",
@@ -13077,13 +13343,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/track_event/chrome_active_processes.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/track_event/chrome_application_state_info.pbzero.cc",
@@ -13120,13 +13387,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_track_event_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/track_event/chrome_active_processes.pbzero.h",
         "external/perfetto/protos/perfetto/trace/track_event/chrome_application_state_info.pbzero.h",
@@ -13175,13 +13443,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_translation_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_translation_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/translation/translation_table.gen.cc",
     ],
@@ -13191,13 +13460,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_translation_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_translation_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_cpp)",
     out: [
         "external/perfetto/protos/perfetto/trace/translation/translation_table.gen.h",
     ],
@@ -13219,12 +13489,13 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_translation_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_translation_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/translation/translation_table.pb.cc",
     ],
@@ -13234,12 +13505,13 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_translation_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_translation_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_lite)",
     out: [
         "external/perfetto/protos/perfetto/trace/translation/translation_table.pb.h",
     ],
@@ -13261,13 +13533,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_translation_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_translation_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/translation/translation_table.pbzero.cc",
     ],
@@ -13277,13 +13550,14 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_translation_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_translation_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_translation_zero)",
     out: [
         "external/perfetto/protos/perfetto/trace/translation/translation_table.pbzero.h",
     ],
@@ -13628,6 +13902,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_android_art_art_heap_graph_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -13674,7 +13949,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_art_art_heap_graph_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_art_art_heap_graph_zero)",
     out: [
         "external/perfetto/protos/third_party/android/art/heap_graph.pbzero.cc",
     ],
@@ -13684,6 +13959,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_android_art_art_heap_graph_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -13730,7 +14006,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_art_art_heap_graph_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_art_art_heap_graph_zero)",
     out: [
         "external/perfetto/protos/third_party/android/art/heap_graph.pbzero.h",
     ],
@@ -13752,6 +14028,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -13798,7 +14075,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero)",
     out: [
         "external/perfetto/protos/third_party/android/connectivity/network_trace.pbzero.cc",
     ],
@@ -13808,6 +14085,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -13854,7 +14132,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero)",
     out: [
         "external/perfetto/protos/third_party/android/connectivity/network_trace.pbzero.h",
     ],
@@ -13892,6 +14170,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -13938,7 +14217,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_interned_data.pbzero.cc",
     ],
@@ -13948,6 +14227,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -13994,7 +14274,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_interned_data.pbzero.h",
     ],
@@ -14016,6 +14296,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -14063,7 +14344,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.pbzero.cc",
     ],
@@ -14073,6 +14354,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -14120,7 +14402,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.pbzero.h",
     ],
@@ -14348,6 +14630,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -14394,7 +14677,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/winscope/app/statusbarmanager.pbzero.cc",
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/winscope/content/activityinfo.pbzero.cc",
@@ -14437,6 +14720,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -14483,7 +14767,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/winscope/app/statusbarmanager.pbzero.h",
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/winscope/content/activityinfo.pbzero.h",
@@ -14538,6 +14822,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_android_packages_modules_bluetooth_tracing_bluetooth_tracing_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -14584,7 +14869,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_packages_modules_bluetooth_tracing_bluetooth_tracing_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_packages_modules_bluetooth_tracing_bluetooth_tracing_zero)",
     out: [
         "external/perfetto/protos/third_party/android/packages/modules/bluetooth/tracing/bluetooth_trace.pbzero.cc",
     ],
@@ -14594,6 +14879,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_android_packages_modules_bluetooth_tracing_bluetooth_tracing_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -14640,7 +14926,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_packages_modules_bluetooth_tracing_bluetooth_tracing_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_packages_modules_bluetooth_tracing_bluetooth_tracing_zero)",
     out: [
         "external/perfetto/protos/third_party/android/packages/modules/bluetooth/tracing/bluetooth_trace.pbzero.h",
     ],
@@ -14654,6 +14940,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_chromium_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "protos/perfetto/trace/track_event/chrome_active_processes.proto",
         "protos/perfetto/trace/track_event/chrome_application_state_info.proto",
         "protos/perfetto/trace/track_event/chrome_compositor_scheduler_state.proto",
@@ -14689,7 +14976,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_protos_third_party_chromium_descriptor.bin",
     ],
@@ -14724,6 +15011,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_chromium_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_chromium_zero",
     ],
@@ -14731,7 +15019,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_chromium_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_chromium_zero)",
     out: [
         "external/perfetto/protos/third_party/chromium/chrome_enums.pbzero.cc",
         "external/perfetto/protos/third_party/chromium/chrome_track_event.pbzero.cc",
@@ -14742,6 +15030,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_chromium_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_chromium_zero",
     ],
@@ -14749,7 +15038,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_chromium_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_chromium_zero)",
     out: [
         "external/perfetto/protos/third_party/chromium/chrome_enums.pbzero.h",
         "external/perfetto/protos/third_party/chromium/chrome_track_event.pbzero.h",
@@ -14772,13 +15061,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_pprof_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_third_party_pprof_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_pprof_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_pprof_zero)",
     out: [
         "external/perfetto/protos/third_party/pprof/profile.pbzero.cc",
     ],
@@ -14788,13 +15078,14 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_pprof_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_third_party_pprof_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_pprof_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_pprof_zero)",
     out: [
         "external/perfetto/protos/third_party/pprof/profile.pbzero.h",
     ],
@@ -14909,13 +15200,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_simpleperf_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_third_party_simpleperf_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_simpleperf_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_simpleperf_zero)",
     out: [
         "external/perfetto/protos/third_party/simpleperf/cmd_report_sample.pbzero.cc",
         "external/perfetto/protos/third_party/simpleperf/record_file.pbzero.cc",
@@ -14926,13 +15218,14 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_simpleperf_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_third_party_simpleperf_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_simpleperf_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_simpleperf_zero)",
     out: [
         "external/perfetto/protos/third_party/simpleperf/cmd_report_sample.pbzero.h",
         "external/perfetto/protos/third_party/simpleperf/record_file.pbzero.h",
@@ -14956,13 +15249,14 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_statsd_config_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_third_party_statsd_config_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_statsd_config_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_statsd_config_zero)",
     out: [
         "external/perfetto/protos/third_party/statsd/shell_config.pbzero.cc",
         "external/perfetto/protos/third_party/statsd/shell_data.pbzero.cc",
@@ -14973,13 +15267,14 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_statsd_config_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_third_party_statsd_config_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_statsd_config_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_statsd_config_zero)",
     out: [
         "external/perfetto/protos/third_party/statsd/shell_config.pbzero.h",
         "external/perfetto/protos/third_party/statsd/shell_data.pbzero.h",
@@ -15314,13 +15609,14 @@ filegroup {
 genrule {
     name: "perfetto_src_ipc_test_messages_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_ipc_test_messages_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_ipc_test_messages_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_ipc_test_messages_cpp)",
     out: [
         "external/perfetto/src/ipc/test/client_unittest_messages.gen.cc",
         "external/perfetto/src/ipc/test/deferred_unittest_messages.gen.cc",
@@ -15332,13 +15628,14 @@ genrule {
 genrule {
     name: "perfetto_src_ipc_test_messages_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_ipc_test_messages_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_ipc_test_messages_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_ipc_test_messages_cpp)",
     out: [
         "external/perfetto/src/ipc/test/client_unittest_messages.gen.h",
         "external/perfetto/src/ipc/test/deferred_unittest_messages.gen.h",
@@ -15364,6 +15661,7 @@ filegroup {
 genrule {
     name: "perfetto_src_ipc_test_messages_ipc_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_ipc_wire_protocol_cpp",
         ":perfetto_src_ipc_test_messages_cpp",
         ":perfetto_src_ipc_test_messages_ipc",
@@ -15372,7 +15670,7 @@ genrule {
         "aprotoc",
         "ipc_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location ipc_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_ipc_test_messages_ipc)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location ipc_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_ipc_test_messages_ipc)",
     out: [
         "external/perfetto/src/ipc/test/client_unittest_messages.ipc.cc",
         "external/perfetto/src/ipc/test/deferred_unittest_messages.ipc.cc",
@@ -15384,6 +15682,7 @@ genrule {
 genrule {
     name: "perfetto_src_ipc_test_messages_ipc_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_ipc_wire_protocol_cpp",
         ":perfetto_src_ipc_test_messages_cpp",
         ":perfetto_src_ipc_test_messages_ipc",
@@ -15392,7 +15691,7 @@ genrule {
         "aprotoc",
         "ipc_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location ipc_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_ipc_test_messages_ipc)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location ipc_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_ipc_test_messages_ipc)",
     out: [
         "external/perfetto/src/ipc/test/client_unittest_messages.ipc.h",
         "external/perfetto/src/ipc/test/deferred_unittest_messages.ipc.h",
@@ -15510,13 +15809,14 @@ filegroup {
 genrule {
     name: "perfetto_src_perfetto_cmd_protos_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_perfetto_cmd_protos_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_perfetto_cmd_protos_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_perfetto_cmd_protos_cpp)",
     out: [
         "external/perfetto/src/perfetto_cmd/perfetto_cmd_state.gen.cc",
     ],
@@ -15526,13 +15826,14 @@ genrule {
 genrule {
     name: "perfetto_src_perfetto_cmd_protos_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_perfetto_cmd_protos_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_perfetto_cmd_protos_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_perfetto_cmd_protos_cpp)",
     out: [
         "external/perfetto/src/perfetto_cmd/perfetto_cmd_state.gen.h",
     ],
@@ -16000,12 +16301,13 @@ filegroup {
 genrule {
     name: "perfetto_src_protovm_test_messages_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protovm_test_messages_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protovm_test_messages_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protovm_test_messages_lite)",
     out: [
         "external/perfetto/src/protovm/test/protos/incremental_trace.pb.cc",
     ],
@@ -16015,12 +16317,13 @@ genrule {
 genrule {
     name: "perfetto_src_protovm_test_messages_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protovm_test_messages_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protovm_test_messages_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protovm_test_messages_lite)",
     out: [
         "external/perfetto/src/protovm/test/protos/incremental_trace.pb.h",
     ],
@@ -16263,6 +16566,7 @@ filegroup {
 genrule {
     name: "perfetto_src_protozero_testing_messages_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_cpp",
         ":perfetto_src_protozero_testing_messages_other_package_cpp",
         ":perfetto_src_protozero_testing_messages_subpackage_cpp",
@@ -16271,7 +16575,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_cpp)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/extensions.gen.cc",
         "external/perfetto/src/protozero/test/example_proto/library.gen.cc",
@@ -16285,6 +16589,7 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_cpp",
         ":perfetto_src_protozero_testing_messages_other_package_cpp",
         ":perfetto_src_protozero_testing_messages_subpackage_cpp",
@@ -16293,7 +16598,7 @@ genrule {
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_cpp)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/extensions.gen.h",
         "external/perfetto/src/protozero/test/example_proto/library.gen.h",
@@ -16311,6 +16616,7 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_descriptor",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         "src/protozero/test/example_proto/extensions.proto",
         "src/protozero/test/example_proto/library.proto",
         "src/protozero/test/example_proto/library_internals/galaxies.proto",
@@ -16322,7 +16628,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --descriptor_set_out=$(out) $(in)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --descriptor_set_out=$(out) $(in)",
     out: [
         "perfetto_src_protozero_testing_messages_descriptor.bin",
     ],
@@ -16344,6 +16650,7 @@ filegroup {
 genrule {
     name: "perfetto_src_protozero_testing_messages_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_lite",
         ":perfetto_src_protozero_testing_messages_other_package_lite",
         ":perfetto_src_protozero_testing_messages_subpackage_lite",
@@ -16351,7 +16658,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_lite)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/extensions.pb.cc",
         "external/perfetto/src/protozero/test/example_proto/library.pb.cc",
@@ -16365,6 +16672,7 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_lite",
         ":perfetto_src_protozero_testing_messages_other_package_lite",
         ":perfetto_src_protozero_testing_messages_subpackage_lite",
@@ -16372,7 +16680,7 @@ genrule {
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_lite)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/extensions.pb.h",
         "external/perfetto/src/protozero/test/example_proto/library.pb.h",
@@ -16398,13 +16706,14 @@ filegroup {
 genrule {
     name: "perfetto_src_protozero_testing_messages_other_package_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_other_package_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_cpp)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/other_package/test_messages.gen.cc",
     ],
@@ -16414,13 +16723,14 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_other_package_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_other_package_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_cpp)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/other_package/test_messages.gen.h",
     ],
@@ -16442,12 +16752,13 @@ filegroup {
 genrule {
     name: "perfetto_src_protozero_testing_messages_other_package_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_other_package_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_lite)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/other_package/test_messages.pb.cc",
     ],
@@ -16457,12 +16768,13 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_other_package_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_other_package_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_lite)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/other_package/test_messages.pb.h",
     ],
@@ -16484,13 +16796,14 @@ filegroup {
 genrule {
     name: "perfetto_src_protozero_testing_messages_other_package_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_other_package_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_zero)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/other_package/test_messages.pbzero.cc",
     ],
@@ -16500,13 +16813,14 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_other_package_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_other_package_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_other_package_zero)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/other_package/test_messages.pbzero.h",
     ],
@@ -16528,13 +16842,14 @@ filegroup {
 genrule {
     name: "perfetto_src_protozero_testing_messages_subpackage_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_subpackage_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_cpp)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/subpackage/test_messages.gen.cc",
     ],
@@ -16544,13 +16859,14 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_subpackage_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_subpackage_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_cpp)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/subpackage/test_messages.gen.h",
     ],
@@ -16572,12 +16888,13 @@ filegroup {
 genrule {
     name: "perfetto_src_protozero_testing_messages_subpackage_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_subpackage_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_lite)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/subpackage/test_messages.pb.cc",
     ],
@@ -16587,12 +16904,13 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_subpackage_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_subpackage_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_lite)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/subpackage/test_messages.pb.h",
     ],
@@ -16614,13 +16932,14 @@ filegroup {
 genrule {
     name: "perfetto_src_protozero_testing_messages_subpackage_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_subpackage_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_zero)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/subpackage/test_messages.pbzero.cc",
     ],
@@ -16630,13 +16949,14 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_subpackage_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_subpackage_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_subpackage_zero)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/subpackage/test_messages.pbzero.h",
     ],
@@ -16662,6 +16982,7 @@ filegroup {
 genrule {
     name: "perfetto_src_protozero_testing_messages_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_other_package_zero",
         ":perfetto_src_protozero_testing_messages_subpackage_zero",
         ":perfetto_src_protozero_testing_messages_zero",
@@ -16670,7 +16991,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_zero)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/extensions.pbzero.cc",
         "external/perfetto/src/protozero/test/example_proto/library.pbzero.cc",
@@ -16684,6 +17005,7 @@ genrule {
 genrule {
     name: "perfetto_src_protozero_testing_messages_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_protozero_testing_messages_other_package_zero",
         ":perfetto_src_protozero_testing_messages_subpackage_zero",
         ":perfetto_src_protozero_testing_messages_zero",
@@ -16692,7 +17014,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_protozero_testing_messages_zero)",
     out: [
         "external/perfetto/src/protozero/test/example_proto/extensions.pbzero.h",
         "external/perfetto/src/protozero/test/example_proto/library.pbzero.h",
@@ -21250,13 +21572,14 @@ filegroup {
 genrule {
     name: "perfetto_src_traced_probes_ftrace_test_messages_cpp_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_traced_probes_ftrace_test_messages_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_cpp)",
     out: [
         "external/perfetto/src/traced/probes/ftrace/test/test_messages.gen.cc",
     ],
@@ -21266,13 +21589,14 @@ genrule {
 genrule {
     name: "perfetto_src_traced_probes_ftrace_test_messages_cpp_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_traced_probes_ftrace_test_messages_cpp",
     ],
     tools: [
         "aprotoc",
         "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_cpp)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_cpp)",
     out: [
         "external/perfetto/src/traced/probes/ftrace/test/test_messages.gen.h",
     ],
@@ -21294,12 +21618,13 @@ filegroup {
 genrule {
     name: "perfetto_src_traced_probes_ftrace_test_messages_lite_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_traced_probes_ftrace_test_messages_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_lite)",
     out: [
         "external/perfetto/src/traced/probes/ftrace/test/test_messages.pb.cc",
     ],
@@ -21309,12 +21634,13 @@ genrule {
 genrule {
     name: "perfetto_src_traced_probes_ftrace_test_messages_lite_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_traced_probes_ftrace_test_messages_lite",
     ],
     tools: [
         "aprotoc",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_lite)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_lite)",
     out: [
         "external/perfetto/src/traced/probes/ftrace/test/test_messages.pb.h",
     ],
@@ -21336,13 +21662,14 @@ filegroup {
 genrule {
     name: "perfetto_src_traced_probes_ftrace_test_messages_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_traced_probes_ftrace_test_messages_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_zero)",
     out: [
         "external/perfetto/src/traced/probes/ftrace/test/test_messages.pbzero.cc",
     ],
@@ -21352,13 +21679,14 @@ genrule {
 genrule {
     name: "perfetto_src_traced_probes_ftrace_test_messages_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_src_traced_probes_ftrace_test_messages_zero",
     ],
     tools: [
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_src_traced_probes_ftrace_test_messages_zero)",
     out: [
         "external/perfetto/src/traced/probes/ftrace/test/test_messages.pbzero.h",
     ],

--- a/BUILD
+++ b/BUILD
@@ -8339,7 +8339,7 @@ perfetto_proto_library(
         ":protos_perfetto_config_system_info_protos",
         ":protos_perfetto_config_track_event_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/ipc:wire_protocol_cpp
@@ -8477,7 +8477,7 @@ perfetto_proto_library(
         ":protos_perfetto_metrics_common_protos",
         ":protos_perfetto_metrics_custom_options_protos",
         ":protos_perfetto_metrics_protos",
-    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
+    ],
 )
 
 # GN target: //protos/perfetto/metrics/common:source_set
@@ -8500,8 +8500,6 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
-    deps = [
-    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/metrics:descriptor
@@ -8555,7 +8553,7 @@ perfetto_proto_library(
         ":protos_perfetto_metrics_android_protos",
         ":protos_perfetto_metrics_common_protos",
         ":protos_perfetto_metrics_protos",
-    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
+    ],
 )
 
 # GN target: //protos/perfetto/perfetto_sql:source_set
@@ -8596,7 +8594,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_common_semantic_type_protos",
-    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
+    ],
 )
 
 # GN target: //protos/perfetto/protovm:cpp
@@ -9674,7 +9672,7 @@ perfetto_proto_library(
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_protos",
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_protos",
         ":protos_third_party_android_packages_modules_bluetooth_tracing_bluetooth_tracing_protos",
-    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
+    ],
     exports = [
         ":protos_third_party_android_art_art_heap_graph_protos",
         ":protos_third_party_android_connectivity_connectivity_network_trace_protos",
@@ -10210,7 +10208,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_protos",
-    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
+    ],
     exports = [
         ":protos_perfetto_trace_non_minimal_protos",
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_protos",
@@ -10582,8 +10580,6 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
-    deps = [
-    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/third_party/primes:zero

--- a/BUILD
+++ b/BUILD
@@ -7598,7 +7598,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/common:semantic_type_cpp
@@ -7626,6 +7626,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/common:semantic_type_zero
@@ -7686,7 +7688,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/android:zero
@@ -7755,6 +7757,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/ftrace:zero
@@ -7784,6 +7788,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/gpu:zero
@@ -7811,6 +7817,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/inode_file:zero
@@ -7843,7 +7851,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/interceptors:zero
@@ -7873,6 +7881,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/linux:zero
@@ -7900,6 +7910,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/power:zero
@@ -7927,6 +7939,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/priority_boost:zero
@@ -7954,6 +7968,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/process_stats:zero
@@ -7989,7 +8005,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/profiling:zero
@@ -8041,7 +8057,7 @@ perfetto_proto_library(
         ":protos_perfetto_config_system_info_protos",
         ":protos_perfetto_config_track_event_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/protovm:cpp
@@ -8061,6 +8077,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/protovm:zero
@@ -8093,7 +8111,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/qnx:zero
@@ -8124,6 +8142,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/statsd:zero
@@ -8156,7 +8176,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/sys_stats:zero
@@ -8186,6 +8206,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/system_info:zero
@@ -8213,6 +8235,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/config/track_event:zero
@@ -8359,6 +8383,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/metrics/android:source_set
@@ -8433,6 +8459,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/metrics/chrome:descriptor
@@ -8477,7 +8505,7 @@ perfetto_proto_library(
         ":protos_perfetto_metrics_common_protos",
         ":protos_perfetto_metrics_custom_options_protos",
         ":protos_perfetto_metrics_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/metrics/common:source_set
@@ -8489,6 +8517,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/metrics:custom_options_source_set
@@ -8500,6 +8530,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/metrics:descriptor
@@ -8525,7 +8557,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_metrics_android_protos",
         ":protos_perfetto_metrics_common_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/metrics/webview:descriptor
@@ -8553,7 +8585,7 @@ perfetto_proto_library(
         ":protos_perfetto_metrics_android_protos",
         ":protos_perfetto_metrics_common_protos",
         ":protos_perfetto_metrics_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/perfetto_sql:source_set
@@ -8565,6 +8597,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/perfetto_sql:zero
@@ -8594,7 +8628,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_common_semantic_type_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/protovm:cpp
@@ -8614,6 +8648,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/protovm:zero
@@ -8648,7 +8684,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/android:zero
@@ -8674,6 +8710,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/chrome:zero
@@ -8706,6 +8744,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/etw:zero
@@ -8725,6 +8765,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/filesystem:zero
@@ -8827,6 +8869,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/ftrace:zero
@@ -8848,6 +8892,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/generic_kernel:zero
@@ -8887,7 +8933,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_interned_data_protos",
         ":protos_perfetto_trace_profiling_protos",
         ":protos_perfetto_trace_track_event_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_interned_data_protos",
     ],
@@ -8931,7 +8977,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_trace_track_event_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_track_event_protos",
     ],
@@ -8963,7 +9009,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/gpu:zero
@@ -8993,7 +9039,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_gpu_protos",
         ":protos_perfetto_trace_profiling_protos",
         ":protos_perfetto_trace_track_event_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/interned_data:zero
@@ -9020,6 +9066,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/linux:zero
@@ -9062,7 +9110,7 @@ perfetto_proto_library(
         ":protos_perfetto_config_system_info_protos",
         ":protos_perfetto_config_track_event_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace:minimal_zero
@@ -9150,7 +9198,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_system_info_protos",
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_track_event_protos",
     ],
@@ -9214,6 +9262,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/perfetto:zero
@@ -9239,7 +9289,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/power:zero
@@ -9261,6 +9311,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace_processor:metrics_impl_zero
@@ -9288,7 +9340,7 @@ perfetto_proto_library(
         ":protos_perfetto_perfetto_sql_protos",
         ":protos_perfetto_protovm_protos",
         ":protos_perfetto_trace_summary_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace_processor:zero
@@ -9319,7 +9371,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/profiling:zero
@@ -9379,7 +9431,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_system_info_protos",
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/ps:source_set
@@ -9392,6 +9444,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/ps:zero
@@ -9424,7 +9478,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/statsd:zero
@@ -9460,7 +9514,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_perfetto_sql_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace_summary:zero
@@ -9484,7 +9538,7 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/sys_stats:zero
@@ -9508,6 +9562,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/system_info:zero
@@ -9573,6 +9629,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/track_event:zero
@@ -9592,6 +9650,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/perfetto/trace/translation:zero
@@ -9672,7 +9732,7 @@ perfetto_proto_library(
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_protos",
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_protos",
         ":protos_third_party_android_packages_modules_bluetooth_tracing_bluetooth_tracing_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_third_party_android_art_art_heap_graph_protos",
         ":protos_third_party_android_connectivity_connectivity_network_trace_protos",
@@ -9736,7 +9796,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_system_info_protos",
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_non_minimal_protos",
         ":protos_perfetto_trace_profiling_protos",
@@ -9841,7 +9901,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_system_info_protos",
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_interned_data_protos",
         ":protos_perfetto_trace_non_minimal_protos",
@@ -9946,7 +10006,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_system_info_protos",
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_interned_data_protos",
         ":protos_perfetto_trace_non_minimal_protos",
@@ -10052,7 +10112,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_non_minimal_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
@@ -10119,7 +10179,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_trace_track_event_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_track_event_protos",
     ],
@@ -10136,7 +10196,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_trace_track_event_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_track_event_protos",
     ],
@@ -10208,7 +10268,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_non_minimal_protos",
         ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_regular_protos",
@@ -10347,7 +10407,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_system_info_protos",
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_trace_non_minimal_protos",
@@ -10452,7 +10512,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_system_info_protos",
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_non_minimal_protos",
     ],
@@ -10529,7 +10589,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_trace_track_event_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_track_event_protos",
     ],
@@ -10553,6 +10613,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/third_party/pprof:zero
@@ -10580,6 +10642,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/third_party/primes:zero
@@ -10600,6 +10664,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/third_party/simpleperf:zero
@@ -10620,6 +10686,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # GN target: //protos/third_party/statsd:config_zero
@@ -10647,6 +10715,8 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
 )
 
 # ##############################################################################

--- a/gn/standalone/proto_library.gni
+++ b/gn/standalone/proto_library.gni
@@ -56,15 +56,7 @@ template("proto_library") {
   if (defined(perfetto_protobuf_src_dir)) {
     _protobuf_src_dir = perfetto_protobuf_src_dir
   }
-  _has_protobuf_src = false
-  foreach(d, import_dirs) {
-    if (rebase_path(d, "//") == rebase_path(_protobuf_src_dir, "//")) {
-      _has_protobuf_src = true
-    }
-  }
-  if (!_has_protobuf_src) {
-    import_dirs += [ _protobuf_src_dir ]
-  }
+  import_dirs += [ _protobuf_src_dir ]
 
   # If false will not generate the default .pb.{cc,h} files. Used for custom
   # codegen plugins.

--- a/gn/standalone/proto_library.gni
+++ b/gn/standalone/proto_library.gni
@@ -52,6 +52,20 @@ template("proto_library") {
     import_dirs = invoker.import_dirs
   }
 
+  _protobuf_src_dir = "//buildtools/protobuf/src"
+  if (defined(perfetto_protobuf_src_dir)) {
+    _protobuf_src_dir = perfetto_protobuf_src_dir
+  }
+  _has_protobuf_src = false
+  foreach(d, import_dirs) {
+    if (rebase_path(d, "//") == rebase_path(_protobuf_src_dir, "//")) {
+      _has_protobuf_src = true
+    }
+  }
+  if (!_has_protobuf_src) {
+    import_dirs += [ _protobuf_src_dir ]
+  }
+
   # If false will not generate the default .pb.{cc,h} files. Used for custom
   # codegen plugins.
   generate_cc = true

--- a/protos/perfetto/metrics/BUILD.gn
+++ b/protos/perfetto/metrics/BUILD.gn
@@ -31,5 +31,4 @@ perfetto_proto_library("@TYPE@") {
 perfetto_proto_library("custom_options_@TYPE@") {
   proto_generators = [ "zero" ]
   sources = [ "custom_options.proto" ]
-  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
 }

--- a/protos/perfetto/metrics/chrome/BUILD.gn
+++ b/protos/perfetto/metrics/chrome/BUILD.gn
@@ -16,7 +16,6 @@ import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
   proto_generators = [ "zero" ]
-  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
   deps = [
     "..:@TYPE@",
     "..:custom_options_@TYPE@",

--- a/protos/perfetto/metrics/webview/BUILD.gn
+++ b/protos/perfetto/metrics/webview/BUILD.gn
@@ -16,7 +16,6 @@ import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
   proto_generators = []
-  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
   sources = [
     "all_webview_metrics.proto",
     "webview_jank_approximation.proto",

--- a/protos/perfetto/proto_filtering/BUILD.gn
+++ b/protos/perfetto/proto_filtering/BUILD.gn
@@ -18,7 +18,6 @@ import("../../../gn/proto_library.gni")
 perfetto_proto_library("@TYPE@") {
   sources = [ "proto_filter_options.proto" ]
   deps = [ "../common:semantic_type_@TYPE@" ]
-  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
   proto_generators = [
     "zero",
     "lite",

--- a/protos/third_party/android/BUILD.gn
+++ b/protos/third_party/android/BUILD.gn
@@ -34,10 +34,6 @@ perfetto_proto_library("android_extensions_@TYPE@") {
   ]
   generate_descriptor = "android_extensions.descriptor"
   descriptor_root_source = "android_extensions.proto"
-
-  # Some of these protos use custom options, so the descriptor build needs the
-  # well-known protobuf types on its import path.
-  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
 }
 
 protozero_descriptor_diff("extension_descriptor") {

--- a/protos/third_party/android/frameworks/native/tracing/winscope/BUILD.gn
+++ b/protos/third_party/android/frameworks/native/tracing/winscope/BUILD.gn
@@ -103,5 +103,4 @@ perfetto_proto_library("winscope_extensions_@TYPE@") {
     ":winscope_regular_@TYPE@",
     "../../../../../../perfetto/trace:non_minimal_@TYPE@",
   ]
-  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
 }

--- a/protos/third_party/primes/BUILD.gn
+++ b/protos/third_party/primes/BUILD.gn
@@ -16,6 +16,5 @@ import("../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
   sources = [ "primes_tracing.proto" ]
-  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
   deps = []
 }

--- a/src/protozero/filtering/BUILD.gn
+++ b/src/protozero/filtering/BUILD.gn
@@ -114,7 +114,6 @@ perfetto_proto_library("filter_util_test_messages_@TYPE@") {
   testonly = true
   sources = [ "filter_util_test_messages.proto" ]
   deps = [ "../../../protos/perfetto/proto_filtering:@TYPE@" ]
-  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
   proto_generators = []
   generate_descriptor = "filter_util_test_messages.descriptor"
   descriptor_root_source = "filter_util_test_messages.proto"

--- a/tools/gen_bazel
+++ b/tools/gen_bazel
@@ -575,10 +575,12 @@ def gen_proto_label(target: GnParser.Target):
     # For example, we include the proto_path |buildtools_protobuf_src| because
     # we want to depend on the "google/protobuf/descriptor.proto" proto file.
     # This will be exposed by the |protobuf_descriptor_proto| dep.
-    if buildtools_protobuf_src in target.proto_paths:
-      sources_label.external_deps = [
-          'PERFETTO_CONFIG.deps.protobuf_descriptor_proto'
-      ]
+    # In GN, the proto_library template automatically includes the protobuf
+    # src dir by default. We mimic this in Bazel by unconditionally adding the
+    # descriptor proto dependency.
+    sources_label.external_deps = [
+        'PERFETTO_CONFIG.deps.protobuf_descriptor_proto'
+    ]
 
     sources_label.visibility = ['PERFETTO_CONFIG.proto_library_visibility']
 


### PR DESCRIPTION
In standalone builds, the proto_library template did not automatically include the protobuf source directory in import_dirs. This forced targets to explicitly pass it.

This change adds it by default in the standalone template, allowing us to remove the redundant import_dirs from individual targets, matching Chromium proto_library's behavior.

Bug: http://crbug.com/521299828