### PR TITLE
bt-ui: keep SettingsPage mounted across route changes

### DIFF
--- a/ui/src/assets/bigtrace.scss
+++ b/ui/src/assets/bigtrace.scss
@@ -99,16 +99,6 @@
 
 // ---------- Layout ----------
 
-// QueryPage stays mounted across routes (preserves DataGrid state); contents
-// = no extra box when active, none = hidden but mounted.
-.pf-bt-route-pane {
-  display: contents;
-}
-
-.pf-bt-route-pane--hidden {
-  display: none;
-}
-
 // Bounds the page + SplitPanel/Tabs chain so DataGrid fillHeight scrolls.
 .pf-bt-query-page {
   height: 100%;

--- a/ui/src/bigtrace/index.ts
+++ b/ui/src/bigtrace/index.ts
@@ -18,6 +18,7 @@ import '../assets/bigtrace.scss';
 import '../frontend/ui_main.scss';
 import m from 'mithril';
 import {defer} from '../base/deferred';
+import {Gate} from '../base/mithril_utils';
 import {reportError, addErrorHandler, type ErrorDetails} from '../base/logging';
 import {initLiveReload} from '../core/live_reload';
 import {settingsStorage} from './settings/settings_storage';
@@ -222,14 +223,16 @@ class BigTraceRoot implements m.ClassComponent {
 
   private resolvePage(route: string): m.Children {
     return [
-      // QueryPage stays mounted across route changes to preserve DataGrid
-      // state (filters, scroll position, sort order).
+      // QueryPage stays mounted (Gate) to preserve its DataGrid state across
+      // route changes; while closed its view() isn't called.
       m(
-        'div.pf-bt-route-pane',
-        {className: route === Routes.QUERY ? '' : 'pf-bt-route-pane--hidden'},
+        Gate,
+        {open: route === Routes.QUERY},
         m(QueryPage, {useBigtraceBackend: true}),
       ),
-      route === Routes.SETTINGS && m(SettingsPage),
+      // SettingsPage stays mounted (Gate) so the trace-list grid keeps its
+      // loaded rows across route changes; while closed its view() isn't called.
+      m(Gate, {open: route === Routes.SETTINGS}, m(SettingsPage)),
       route !== Routes.QUERY && route !== Routes.SETTINGS && m(HomePage),
     ];
   }


### PR DESCRIPTION
Previously, navigating away from the settings route would unmount the SettingsPage, and returning would remount it. This caused its trace-list grid to rebuild its data source and refetch /trace_metadata every time the settings page was opened.

Instead, keep the SettingsPage mounted in the DOM at all times and hide it using the `pf-bt-route-pane--hidden` class when not on the settings route. This preserves the loaded rows in the trace-list grid across route changes, avoiding unnecessary refetches.
