### PR TITLE
perfetto: publish the Python package to PyPI from CI

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -246,3 +246,75 @@ jobs:
           EOF
           )"
           echo "::notice::Opened ai-agents bundle PR and tagged $VERSION."
+
+  # Builds the pure-Python `perfetto` package from the release tag and uploads
+  # it to PyPI via Trusted Publishing (OIDC, no stored token). Runs on a
+  # GitHub-hosted runner since the sdist needs no buildtools, and only after
+  # `finalize` succeeds so we never publish to PyPI if the rest of the release
+  # broke. PyPI upload is irreversible; this is gated by the manual dispatch of
+  # this workflow.
+  #
+  # One-time setup (see https://docs.pypi.org/trusted-publishers/):
+  #   * Create a `pypi` Environment in this repo's settings.
+  #   * On PyPI, add a trusted publisher for project `perfetto`:
+  #       owner `google`, repo `perfetto`, workflow `finalize-release.yml`,
+  #       environment `pypi`.
+  publish-pypi:
+    name: Publish Python package to PyPI
+    needs: finalize
+    runs-on: ubuntu-latest
+    environment: pypi
+    timeout-minutes: 15
+    permissions:
+      id-token: write  # OIDC token for PyPI Trusted Publishing.
+    steps:
+      - name: Validate input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must match vX.Y (got: $VERSION)"
+            exit 1
+          fi
+
+      - name: Checkout release tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.version }}
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Build sdist + wheel
+        env:
+          VERSION: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          # The package version is derived by setup.py from the CHANGELOG's
+          # first vX.Y entry (vX.Y -> 0.X.Y). Verify that entry matches the tag
+          # we are publishing before doing anything else. Done with grep (not by
+          # importing setup.py) so this check needs no setuptools on the runner.
+          TOP_VER="$(grep -m1 -oE '^v[0-9]+\.[0-9]+' CHANGELOG)"
+          if [[ "$TOP_VER" != "$VERSION" ]]; then
+            echo "::error::CHANGELOG top release entry ($TOP_VER) != tag $VERSION. The CHANGELOG's first vX.Y entry must be $VERSION."
+            exit 1
+          fi
+          # Point download_url at this tag's source archive. This is PyPI
+          # metadata only and is NOT committed back; the checked-in value in
+          # setup.py is a placeholder overwritten here at build time.
+          ARCHIVE="https://github.com/${REPO}/archive/refs/tags/${VERSION}.zip"
+          sed -i -E "s#download_url\s*=\s*'[^']*'#download_url='${ARCHIVE}'#" \
+            python/setup.py
+          python -m pip install --upgrade build
+          python -m build python
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist
+          # Make re-runs safe: PyPI rejects duplicate versions, so a version
+          # already uploaded is skipped instead of failing the job.
+          skip-existing: true

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -247,18 +247,10 @@ jobs:
           )"
           echo "::notice::Opened ai-agents bundle PR and tagged $VERSION."
 
-  # Builds the pure-Python `perfetto` package from the release tag and uploads
-  # it to PyPI via Trusted Publishing (OIDC, no stored token). Runs on a
-  # GitHub-hosted runner since the sdist needs no buildtools, and only after
-  # `finalize` succeeds so we never publish to PyPI if the rest of the release
-  # broke. PyPI upload is irreversible; this is gated by the manual dispatch of
-  # this workflow.
-  #
-  # One-time setup (see https://docs.pypi.org/trusted-publishers/):
-  #   * Create a `pypi` Environment in this repo's settings.
-  #   * On PyPI, add a trusted publisher for project `perfetto`:
-  #       owner `google`, repo `perfetto`, workflow `finalize-release.yml`,
-  #       environment `pypi`.
+  # Builds and uploads the perfetto package to PyPI via Trusted Publishing.
+  # Requires a `pypi` Environment and a PyPI trusted publisher for
+  # (google/perfetto, finalize-release.yml, env: pypi). See
+  # https://docs.pypi.org/trusted-publishers/.
   publish-pypi:
     name: Publish Python package to PyPI
     needs: finalize
@@ -266,7 +258,7 @@ jobs:
     environment: pypi
     timeout-minutes: 15
     permissions:
-      id-token: write  # OIDC token for PyPI Trusted Publishing.
+      id-token: write  # OIDC token for Trusted Publishing.
     steps:
       - name: Validate input
         env:
@@ -293,18 +285,14 @@ jobs:
           VERSION: ${{ inputs.version }}
           REPO: ${{ github.repository }}
         run: |
-          # The package version is derived by setup.py from the CHANGELOG's
-          # first vX.Y entry (vX.Y -> 0.X.Y). Verify that entry matches the tag
-          # we are publishing before doing anything else. Done with grep (not by
-          # importing setup.py) so this check needs no setuptools on the runner.
+          # setup.py derives the version from the CHANGELOG's first vX.Y entry;
+          # fail early if it doesn't match the tag being published.
           TOP_VER="$(grep -m1 -oE '^v[0-9]+\.[0-9]+' CHANGELOG)"
           if [[ "$TOP_VER" != "$VERSION" ]]; then
             echo "::error::CHANGELOG top release entry ($TOP_VER) != tag $VERSION. The CHANGELOG's first vX.Y entry must be $VERSION."
             exit 1
           fi
-          # Point download_url at this tag's source archive. This is PyPI
-          # metadata only and is NOT committed back; the checked-in value in
-          # setup.py is a placeholder overwritten here at build time.
+          # download_url is PyPI metadata only; point it at this tag's archive.
           ARCHIVE="https://github.com/${REPO}/archive/refs/tags/${VERSION}.zip"
           sed -i -E "s#download_url\s*=\s*'[^']*'#download_url='${ARCHIVE}'#" \
             python/setup.py
@@ -315,6 +303,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/dist
-          # Make re-runs safe: PyPI rejects duplicate versions, so a version
-          # already uploaded is skipped instead of failing the job.
-          skip-existing: true
+          skip-existing: true  # Safe re-runs: skip a version already on PyPI.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,5 @@
-# Minimal build-system declaration so `python -m build` is reproducible on
-# modern Python (distutils was removed in 3.12). All package metadata still
-# comes from setup.py; intentionally no [project] table to avoid conflicts
-# with the dynamic, CHANGELOG-derived version.
+# Build-system only; package metadata stays in setup.py. distutils was removed
+# in Python 3.12, so declare setuptools explicitly.
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,7 @@
+# Minimal build-system declaration so `python -m build` is reproducible on
+# modern Python (distutils was removed in 3.12). All package metadata still
+# comes from setup.py; intentionally no [project] table to avoid conflicts
+# with the dynamic, CHANGELOG-derived version.
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from distutils.core import setup
+from setuptools import setup
 
 
 def _version_from_changelog():


### PR DESCRIPTION
Add a publish-pypi job to the finalize-release workflow that builds the
perfetto wheel from the release tag and uploads it via PyPI Trusted
Publishing.
