### PR TITLE
tp: add perfetto_manifest clock overrides

### DIFF
--- a/src/trace_processor/forwarding_trace_parser.cc
+++ b/src/trace_processor/forwarding_trace_parser.cc
@@ -16,9 +16,11 @@
 
 #include "src/trace_processor/forwarding_trace_parser.h"
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <utility>
+#include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
@@ -144,9 +146,17 @@ base::Status ForwardingTraceParser::Init(const TraceBlobView& blob) {
   }
   input_context_->trace_file_tracker->StartParsing(file_id_, trace_type_);
 
-  // The matching perfetto_manifest entry, if any, will carry per-file
-  // overrides in future versions of the schema; nothing consumes it yet.
-  FindManifestEntry();
+  // If the perfetto_manifest file has an entry for this file (matched by
+  // exact path), it overrides clock handling below.
+  TraceManifestState::FileEntry* manifest_entry = FindManifestEntry();
+  if (manifest_entry && manifest_entry->clock_override &&
+      (IsContainerTraceType(trace_type_) ||
+       trace_type_ == kPerfettoManifestTraceType)) {
+    return base::ErrStatus(
+        "perfetto_manifest: overrides are not supported for trace files "
+        "which are themselves archives or perfetto_manifest files: %s",
+        manifest_entry->path.c_str());
+  }
 
   if (IsContainerTraceType(trace_type_) ||
       trace_type_ == kPerfettoManifestTraceType) {
@@ -169,27 +179,34 @@ base::Status ForwardingTraceParser::Init(const TraceBlobView& blob) {
 
   // Centralize clock setup for all trace formats. Every format declares the
   // clock domain its native timestamps are expressed in (its "trace clock"),
-  // and we do two things with it:
+  // and we do three things with it:
   //
-  //   1. Claim it as the global trace-time clock. The first trace to claim
+  //   1. Record it as the file's default clock, which tokenizers convert their
+  //      events through via ClockTracker::ConvertDefaultClockToTraceTime. Proto
+  //      is the exception (see below).
+  //
+  //   2. Claim it as the global trace-time clock. The first trace to claim
   //      wins; later claims are silently ignored, so the global clock is
   //      stable regardless of how many traces an archive (e.g. a ZIP) holds.
   //
-  //   2. Register a deferred identity sync for the same clock. If this trace
-  //      does NOT win the global clock (e.g. a proto trace in the same archive
-  //      claimed BOOTTIME first) and the trace clock is not otherwise linked
-  //      into the clock graph via a ClockSnapshot, a zero-offset identity edge
-  //      is injected on the first conversion. This keeps the trace's
-  //      timestamps convertible instead of silently dropping every event. When
-  //      a real ClockSnapshot does link the clock (e.g. proto provides
-  //      BOOTTIME<->MONOTONIC), that real relationship is used instead.
+  //   3. Register a deferred clock sync for the same clock (an implicit edge).
+  //      If this trace does NOT win the global clock (e.g. a proto trace in the
+  //      same archive claimed BOOTTIME first) and the trace clock is not
+  //      otherwise linked into the clock graph via a ClockSnapshot, a
+  //      zero-offset identity edge is injected on the first conversion. This
+  //      keeps the trace's timestamps convertible instead of silently dropping
+  //      every event. When a real ClockSnapshot does link the clock (e.g. proto
+  //      provides BOOTTIME<->MONOTONIC), that real relationship is used
+  //      instead.
   //
   // Proto traces are special: their clock is whatever ParseClockSnapshot reads
   // from primary_trace_clock, set later, so here we only register BOOTTIME as
-  // the deferred fallback and do not claim the global clock now.
+  // the deferred fallback, do not set the default clock, and do not claim the
+  // global clock now.
   //
-  // TODO: once a perfetto_manifest entry can carry clock overrides, the
-  // per-format selection below should consult it.
+  // A perfetto_manifest clock override for this file replaces the format's
+  // best-effort source clock (below) with the file's own private clock and
+  // customizes its implicit edge into the graph (see the manifest branch).
   using ClockId = ClockTracker::ClockId;
   std::optional<ClockId> trace_clock;
   bool claim_global_clock = true;
@@ -206,17 +223,48 @@ base::Status ForwardingTraceParser::Init(const TraceBlobView& blob) {
   } else if (trace_type_ == kFuchsiaTraceType) {
     trace_clock = ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_BOOTTIME);
   } else if (trace_type_ == kGeckoTraceType || trace_type_ == kJsonTraceType ||
-             trace_type_ == kInstrumentsXmlTraceType) {
+             trace_type_ == kInstrumentsXmlTraceType ||
+             trace_type_ == kPrimesTraceType) {
     trace_clock = ClockId::TraceFile(trace_context_->trace_id().value);
   } else if (trace_type_ == kAndroidDumpstateTraceType ||
              trace_type_ == kAndroidLogcatTraceType) {
     trace_clock = ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_REALTIME);
   }
-  if (trace_clock) {
+  auto& clock_tracker = trace_context_->clock_tracker;
+  if (manifest_entry && manifest_entry->clock_override) {
+    // The manifest overrules the format's best-effort clock: move this file's
+    // events onto a private TraceFile clock and register a single implicit
+    // edge connecting that clock to the graph as the manifest dictates. The
+    // file is now single-clock / single-machine; stray ClockSnapshots or
+    // remote machine ids on it are rejected (see has_clock_override()).
+    const TraceManifestState::ClockOverride& clock_override =
+        *manifest_entry->clock_override;
+    ClockId file_clock = ClockId::TraceFile(trace_context_->trace_id().value);
+    clock_tracker->SetTraceDefaultClock(file_clock);
+    trace_context_->trace_state->has_clock_override = true;
     if (claim_global_clock) {
-      trace_context_->clock_tracker->SetGlobalClock(*trace_clock);
+      clock_tracker->SetGlobalClock(file_clock);
     }
-    trace_context_->clock_tracker->AddDeferredIdentitySync(*trace_clock);
+    // An omitted reference clock means trace time; a named clock means that
+    // builtin domain (which the rest of the graph is expected to reach).
+    std::optional<ClockId> target =
+        clock_override.clock
+            ? std::make_optional(ClockId::Machine(*clock_override.clock))
+            : std::nullopt;
+    clock_tracker->AddDeferredClockSync(file_clock, clock_override.file_ts_ns,
+                                        target, clock_override.clock_ts_ns);
+  } else if (trace_clock) {
+    // Proto manages its own default clock (primary_trace_clock / ClockSnapshot)
+    // so it must not be set here; every other format converts its events
+    // through the default clock via
+    // ClockTracker::ConvertDefaultClockToTraceTime.
+    if (trace_type_ != kProtoTraceType) {
+      clock_tracker->SetTraceDefaultClock(*trace_clock);
+    }
+    if (claim_global_clock) {
+      clock_tracker->SetGlobalClock(*trace_clock);
+    }
+    clock_tracker->AddDeferredClockSync(*trace_clock);
   }
   return base::OkStatus();
 }

--- a/src/trace_processor/importers/art_method/art_method_tokenizer.cc
+++ b/src/trace_processor/importers/art_method/art_method_tokenizer.cc
@@ -45,8 +45,6 @@
 #include "src/trace_processor/util/clock_synchronizer.h"
 #include "src/trace_processor/util/trace_blob_view_reader.h"
 
-#include "protos/perfetto/common/builtin_clock.pbzero.h"
-
 namespace perfetto::trace_processor::art_method {
 namespace {
 
@@ -231,9 +229,9 @@ base::Status ArtMethodTokenizer::ParseRecord(uint32_t tid,
       evt.action = ArtMethodEvent::kExit;
       break;
   }
-  std::optional<int64_t> ts = context_->clock_tracker->ToTraceTime(
-      ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_MONOTONIC),
-      (ts_ + ts_delta) * 1000);
+  std::optional<int64_t> ts =
+      context_->clock_tracker->ConvertDefaultClockToTraceTime((ts_ + ts_delta) *
+                                                              1000);
   if (ts) {
     stream_->Push(*ts, evt);
   }

--- a/src/trace_processor/importers/art_method/art_method_v2_tokenizer.cc
+++ b/src/trace_processor/importers/art_method/art_method_v2_tokenizer.cc
@@ -29,7 +29,6 @@
 #include "perfetto/ext/base/string_splitter.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/utils.h"
-#include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "src/trace_processor/importers/art_method/art_method_event.h"
 #include "src/trace_processor/importers/art_method/art_method_parser.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
@@ -446,9 +445,8 @@ void ArtMethodV2Tokenizer::PushRecord(uint32_t tid,
       break;
   }
 
-  std::optional<int64_t> trace_ts = context_->clock_tracker->ToTraceTime(
-      ClockTracker::ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_MONOTONIC),
-      ts_ + ts);
+  std::optional<int64_t> trace_ts =
+      context_->clock_tracker->ConvertDefaultClockToTraceTime(ts_ + ts);
   if (trace_ts) {
     stream_->Push(*trace_ts, evt);
   }

--- a/src/trace_processor/importers/common/clock_tracker.cc
+++ b/src/trace_processor/importers/common/clock_tracker.cc
@@ -70,6 +70,17 @@ ClockTracker::ClockTracker(
 
 base::StatusOr<uint32_t> ClockTracker::AddSnapshot(
     const std::vector<ClockTimestamp>& clock_timestamps) {
+  // A snapshot correlates multiple clock domains, which proves this trace is
+  // not single-clock; perfetto_manifest clock overrides are only valid for
+  // single-clock traces. This is the chokepoint for all snapshot producers
+  // (proto ClockSnapshots, ftrace bundles, instruments); rejecting the
+  // snapshot here also prevents an overridden trace from switching away from
+  // the shared primary sync.
+  if (PERFETTO_UNLIKELY(context_->has_clock_override())) {
+    return base::ErrStatus(
+        "perfetto_manifest: clock overrides require the trace to use a "
+        "single clock");
+  }
   if (PERFETTO_UNLIKELY(!is_primary_)) {
     // Non-primary trace: if we were using the primary's pool and already
     // converted timestamps, those conversions may have used different clock
@@ -115,7 +126,7 @@ void ClockTracker::AddSnapshotToTable(
     // future conversions. Don't pass byte_offset since we expect failures
     // here (e.g., non-monotonic clocks). Convert directly rather than via
     // ToTraceTime: recording is bookkeeping, so it must not flush the
-    // deferred identity sync or count as an event conversion.
+    // deferred clock sync or count as an event conversion.
     auto* state = context_->trace_time_state.get();
     std::optional<int64_t> converted = active_sync_->Convert(
         clock_timestamp.clock.id, ts_to_convert, state->clock_id,
@@ -201,25 +212,31 @@ void ClockTracker::SetTraceDefaultClock(ClockId clock_id) {
   trace_default_clock_ = clock_id;
 }
 
-void ClockTracker::AddDeferredIdentitySync(ClockId clock_id) {
-  deferred_identity_clock_ = clock_id;
+void ClockTracker::AddDeferredClockSync(ClockId from,
+                                        int64_t from_ts,
+                                        std::optional<ClockId> to,
+                                        int64_t to_ts) {
+  PERFETTO_DCHECK(from_ts >= 0 && to_ts >= 0);
+  deferred_clock_sync_ = {from, from_ts, to, to_ts};
 }
 
-void ClockTracker::FlushDeferredIdentitySync() {
-  ClockId clock_id = *deferred_identity_clock_;
-  deferred_identity_clock_.reset();
-  auto* state = context_->trace_time_state.get();
-  if (clock_id == state->clock_id) {
+void ClockTracker::FlushDeferredClockSync() {
+  DeferredSync sync = *deferred_clock_sync_;
+  deferred_clock_sync_.reset();
+  // An omitted target means the trace time clock, resolved now.
+  ClockId to = sync.to.value_or(context_->trace_time_state->clock_id);
+  if (sync.from == to) {
     return;
   }
-  // Inject only if the clock cannot already reach trace time: a clock can
-  // be in the graph yet disconnected from the trace time clock.
-  if (active_sync_->Convert(clock_id, 0, state->clock_id, std::nullopt,
+  // Inject only if |from| cannot already reach |to|: a real snapshot (e.g. a
+  // proto spine that bridges the target to trace time) takes precedence over
+  // the deferred edge.
+  if (active_sync_->Convert(sync.from, sync.from_ts, to, std::nullopt,
                             /*suppress_errors=*/true)) {
     return;
   }
   // The lazy edge becomes real here, so it is recorded like any other.
-  AddSnapshotInternal({{clock_id, 0}, {state->clock_id, 0}});
+  AddSnapshotInternal({{sync.from, sync.from_ts}, {to, sync.to_ts}});
 }
 
 std::optional<int64_t> ClockTracker::ToTraceTimeFromSnapshot(

--- a/src/trace_processor/importers/common/clock_tracker.h
+++ b/src/trace_processor/importers/common/clock_tracker.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include "perfetto/base/status.h"
@@ -66,14 +67,27 @@ class ClockTracker {
       int64_t timestamp,
       std::optional<size_t> byte_offset = std::nullopt,
       bool suppress_errors = false) {
-    if (PERFETTO_UNLIKELY(deferred_identity_clock_.has_value())) {
-      FlushDeferredIdentitySync();
+    if (PERFETTO_UNLIKELY(deferred_clock_sync_.has_value())) {
+      FlushDeferredClockSync();
     }
     auto* state = context_->trace_time_state.get();
     ++num_conversions_;
     auto ts = active_sync_->Convert(clock_id, timestamp, state->clock_id,
                                     byte_offset, suppress_errors);
     return ts ? std::optional(ToHostTraceTime(*ts)) : ts;
+  }
+
+  // Converts |ts|, expressed in this trace file's default clock (set by
+  // ForwardingTraceParser via SetTraceDefaultClock), to trace time. Tokenizers
+  // for single-clock formats call this instead of naming a builtin clock, so a
+  // perfetto_manifest override that swaps the default clock for the file's
+  // private clock transparently redirects them.
+  PERFETTO_ALWAYS_INLINE std::optional<int64_t> ConvertDefaultClockToTraceTime(
+      int64_t ts,
+      std::optional<size_t> byte_offset = std::nullopt,
+      bool suppress_errors = false) {
+    PERFETTO_DCHECK(trace_default_clock_.has_value());
+    return ToTraceTime(*trace_default_clock_, ts, byte_offset, suppress_errors);
   }
 
   // Converts a timestamp between two arbitrary clock domains.
@@ -108,10 +122,18 @@ class ClockTracker {
   // Used as fallback when no timestamp_clock_id is specified.
   void SetTraceDefaultClock(ClockId clock_id);
 
-  // Registers a deferred identity sync: on the first ToTraceTime call, if
-  // |clock_id| cannot reach the global trace time clock through the clock
-  // graph, a zero-offset identity edge between the two is injected.
-  void AddDeferredIdentitySync(ClockId clock_id);
+  // Registers a deferred clock edge: on the first ToTraceTime call, if |from|
+  // (at |from_ts|) cannot already reach |to| through the clock graph, an edge
+  // correlating |from|:|from_ts| with |to|:|to_ts| is injected into the shared
+  // machine graph. |to| defaults to the trace time clock (resolved at flush);
+  // |from_ts|/|to_ts| default to zero. With all defaults this is the plain
+  // identity-to-trace-time edge every trace file registers for its source
+  // clock; a perfetto_manifest override passes a non-zero offset and/or an
+  // explicit target. All timestamps must be non-negative.
+  void AddDeferredClockSync(ClockId from,
+                            int64_t from_ts = 0,
+                            std::optional<ClockId> to = std::nullopt,
+                            int64_t to_ts = 0);
 
   // Returns the trace default clock, if one has been set.
   std::optional<ClockId> trace_default_clock() const {
@@ -144,12 +166,12 @@ class ClockTracker {
     return timestamp - (clock_offset ? *clock_offset : 0);
   }
 
-  PERFETTO_NO_INLINE void FlushDeferredIdentitySync();
+  PERFETTO_NO_INLINE void FlushDeferredClockSync();
 
-  // Adds an edge directly to |active_sync_| (bypassing the non-primary sync
-  // switch of the public AddSnapshot) and records it in the clock_snapshot
-  // table. Every graph mutation goes through here so the table is a
-  // faithful record of the graph.
+  // Adds an edge directly to |active_sync_| (bypassing the single-clock
+  // rejection and the non-primary sync switch of the public AddSnapshot)
+  // and records it in the clock_snapshot table. Every graph mutation goes
+  // through here so the table is a faithful record of the graph.
   base::StatusOr<uint32_t> AddSnapshotInternal(
       const std::vector<ClockTimestamp>& clock_timestamps);
 
@@ -197,10 +219,16 @@ class ClockTracker {
   // is specified.
   std::optional<ClockId> trace_default_clock_;
 
-  // Clock registered via AddDeferredIdentitySync. Flushed (and cleared) on
-  // first ToTraceTime call: if the clock cannot reach trace time, a 0:0
-  // identity edge is injected.
-  std::optional<ClockId> deferred_identity_clock_;
+  // Edge registered via AddDeferredClockSync, flushed (and cleared) on the
+  // first ToTraceTime call. |to| == nullopt means the trace time clock,
+  // resolved at flush time.
+  struct DeferredSync {
+    ClockId from;
+    int64_t from_ts;
+    std::optional<ClockId> to;
+    int64_t to_ts;
+  };
+  std::optional<DeferredSync> deferred_clock_sync_;
 };
 
 class ClockSynchronizerListenerImpl : public ClockSynchronizerListener {

--- a/src/trace_processor/importers/common/clock_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/clock_tracker_unittest.cc
@@ -654,11 +654,11 @@ TEST_F(ClockTrackerTest, SetTraceTimeClockBehavior) {
   EXPECT_EQ(*ct_->ToTraceTime(REALTIME, 10), 10010);
 }
 
-TEST_F(ClockTrackerTest, AddDeferredIdentitySync_InjectsEdge) {
-  // AddDeferredIdentitySync injects a zero-offset edge between the given clock
+TEST_F(ClockTrackerTest, AddDeferredClockSync_InjectsEdge) {
+  // AddDeferredClockSync injects a zero-offset edge between the given clock
   // and the trace time clock (BOOTTIME in test fixture).
   constexpr ClockTracker::ClockId TRACE_FILE = ClockId::TraceFile(0);
-  ct_->AddDeferredIdentitySync(TRACE_FILE);
+  ct_->AddDeferredClockSync(TRACE_FILE);
 
   // The identity edge allows conversion: TRACE_FILE timestamps pass through.
   EXPECT_EQ(*ct_->ToTraceTime(TRACE_FILE, 42), 42);
@@ -673,20 +673,20 @@ TEST_F(ClockTrackerTest, SetTraceDefaultClock_SetsDefaultClock) {
   EXPECT_EQ(*ct_->trace_default_clock(), TRACE_FILE);
 }
 
-TEST_F(ClockTrackerTest, AddDeferredIdentitySync_MatchesTraceTimeClock) {
+TEST_F(ClockTrackerTest, AddDeferredClockSync_MatchesTraceTimeClock) {
   // If the identity clock IS the trace time clock, no edge needed.
-  ct_->AddDeferredIdentitySync(BOOTTIME);
+  ct_->AddDeferredClockSync(BOOTTIME);
 
   ct_->AddSnapshot({{REALTIME, 10}, {BOOTTIME, 10010}});
   EXPECT_EQ(*ct_->ToTraceTime(REALTIME, 10), 10010);
   EXPECT_EQ(*ct_->ToTraceTime(BOOTTIME, 42), 42);
 }
 
-TEST_F(ClockTrackerTest, AddDeferredIdentitySync_WithExplicitSnapshot) {
-  // AddDeferredIdentitySync creates a zero-offset edge TRACE_FILE ↔ BOOTTIME
+TEST_F(ClockTrackerTest, AddDeferredClockSync_WithExplicitSnapshot) {
+  // AddDeferredClockSync creates a zero-offset edge TRACE_FILE ↔ BOOTTIME
   // (since BOOTTIME is the global trace time clock in the test fixture).
   constexpr ClockTracker::ClockId TRACE_FILE = ClockId::TraceFile(0);
-  ct_->AddDeferredIdentitySync(TRACE_FILE);
+  ct_->AddDeferredClockSync(TRACE_FILE);
 
   // Without any other snapshot, TRACE_FILE converts to BOOTTIME at offset 0.
   EXPECT_EQ(*ct_->ToTraceTime(TRACE_FILE, 42), 42);
@@ -697,13 +697,37 @@ TEST_F(ClockTrackerTest, AddDeferredIdentitySync_WithExplicitSnapshot) {
   EXPECT_EQ(*ct_->ToTraceTime(BOOTTIME, 1100), 1100);
 }
 
-TEST_F(ClockTrackerTest,
-       AddDeferredIdentitySync_DoesNotChangeGlobalTraceClock) {
+TEST_F(ClockTrackerTest, AddDeferredClockSync_WithOffset) {
+  // A non-zero offset pins from_ts on |from| to to_ts on trace time, so the
+  // file's events are shifted (a perfetto_manifest bare offset).
+  constexpr ClockTracker::ClockId TRACE_FILE = ClockId::TraceFile(7);
+  ct_->AddDeferredClockSync(TRACE_FILE, /*from_ts=*/0, /*to=*/std::nullopt,
+                            /*to_ts=*/500);
+
+  // TRACE_FILE 0 == BOOTTIME 500, so a TRACE_FILE event is shifted by +500.
+  EXPECT_EQ(*ct_->ToTraceTime(TRACE_FILE, 100), 600);
+}
+
+TEST_F(ClockTrackerTest, AddDeferredClockSync_NamedTargetComposesWithGraph) {
+  // A named target (not trace time) is bridged to trace time by a real
+  // snapshot already in the graph (a perfetto_manifest anchor to REALTIME with
+  // trace time BOOTTIME, as a proto spine would provide REALTIME<->BOOTTIME).
+  constexpr ClockTracker::ClockId TRACE_FILE = ClockId::TraceFile(7);
+  ct_->AddSnapshot({{REALTIME, 1000}, {BOOTTIME, 5000}});  // REALTIME = BT+4000
+  ct_->AddDeferredClockSync(TRACE_FILE, /*from_ts=*/0, /*to=*/REALTIME,
+                            /*to_ts=*/1000);
+
+  // TRACE_FILE 0 == REALTIME 1000 == BOOTTIME 5000, so a TRACE_FILE event
+  // routes TRACE_FILE -> REALTIME -> BOOTTIME.
+  EXPECT_EQ(*ct_->ToTraceTime(TRACE_FILE, 10), 5010);
+}
+
+TEST_F(ClockTrackerTest, AddDeferredClockSync_DoesNotChangeGlobalTraceClock) {
   // Trace time starts as BOOTTIME (test fixture default).
   constexpr ClockTracker::ClockId TRACE_FILE = ClockId::TraceFile(0);
-  ct_->AddDeferredIdentitySync(TRACE_FILE);
+  ct_->AddDeferredClockSync(TRACE_FILE);
 
-  // AddDeferredIdentitySync does NOT change the global trace time clock.
+  // AddDeferredClockSync does NOT change the global trace time clock.
   EXPECT_EQ(context_.trace_time_state->clock_id, BOOTTIME);
 }
 

--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -214,6 +214,11 @@ class FuchsiaTraceParserTest : public ::testing::Test {
         &context_, std::make_unique<ClockSynchronizerListenerImpl>(&context_),
         primary_sync_.get(), true);
     clock_ = context_.clock_tracker.get();
+    // ForwardingTraceParser normally sets the file's default clock; the
+    // tokenizer converts its events through it
+    // (ConvertDefaultClockToTraceTime).
+    clock_->SetTraceDefaultClock(
+        ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_BOOTTIME));
     context_.stats_tracker = std::make_unique<StatsTracker>(&context_);
     context_.flow_tracker = std::make_unique<FlowTracker>(&context_);
     context_.sorter = std::make_unique<TraceSorter>(

--- a/src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.cc
@@ -447,8 +447,8 @@ void FuchsiaTraceTokenizer::ParseRecord(TraceBlobView tbv) {
         return;
       }
       {
-        auto trace_ts = context_->clock_tracker->ToTraceTime(
-            ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_BOOTTIME), ts);
+        auto trace_ts =
+            context_->clock_tracker->ConvertDefaultClockToTraceTime(ts);
         if (trace_ts) {
           stream_->Push(*trace_ts, std::move(record));
         }
@@ -626,8 +626,8 @@ void FuchsiaTraceTokenizer::ParseRecord(TraceBlobView tbv) {
                 current_provider_->GetThread(incoming_thread_ref));
           }
           {
-            auto trace_ts = context_->clock_tracker->ToTraceTime(
-                ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_BOOTTIME), ts);
+            auto trace_ts =
+                context_->clock_tracker->ConvertDefaultClockToTraceTime(ts);
             if (trace_ts) {
               stream_->Push(*trace_ts, std::move(record));
             }
@@ -670,8 +670,8 @@ void FuchsiaTraceTokenizer::ParseRecord(TraceBlobView tbv) {
             return;
           }
           {
-            auto trace_ts = context_->clock_tracker->ToTraceTime(
-                ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_BOOTTIME), ts);
+            auto trace_ts =
+                context_->clock_tracker->ConvertDefaultClockToTraceTime(ts);
             if (trace_ts) {
               stream_->Push(*trace_ts, std::move(record));
             }
@@ -707,8 +707,8 @@ void FuchsiaTraceTokenizer::ParseRecord(TraceBlobView tbv) {
             return;
           }
           {
-            auto trace_ts = context_->clock_tracker->ToTraceTime(
-                ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_BOOTTIME), ts);
+            auto trace_ts =
+                context_->clock_tracker->ConvertDefaultClockToTraceTime(ts);
             if (trace_ts) {
               stream_->Push(*trace_ts, std::move(record));
             }

--- a/src/trace_processor/importers/gecko/gecko_trace_tokenizer.cc
+++ b/src/trace_processor/importers/gecko/gecko_trace_tokenizer.cc
@@ -464,8 +464,7 @@ base::StatusOr<GeckoProfile> ParseGeckoProfile(std::string_view json) {
 GeckoTraceTokenizer::GeckoTraceTokenizer(TraceProcessorContext* ctx)
     : context_(ctx),
       stream_(
-          ctx->sorter->CreateStream(std::make_unique<GeckoTraceParser>(ctx))),
-      trace_file_clock_(ClockId::TraceFile(ctx->trace_id().value)) {}
+          ctx->sorter->CreateStream(std::make_unique<GeckoTraceParser>(ctx))) {}
 GeckoTraceTokenizer::~GeckoTraceTokenizer() = default;
 
 base::Status GeckoTraceTokenizer::Parse(TraceBlobView blob) {
@@ -638,7 +637,7 @@ void GeckoTraceTokenizer::ProcessLegacySamples(
 
     auto ts = static_cast<int64_t>(time_val * 1000 * 1000);
     std::optional<int64_t> converted =
-        context_->clock_tracker->ToTraceTime(trace_file_clock_, ts);
+        context_->clock_tracker->ConvertDefaultClockToTraceTime(ts);
     if (!converted) {
       continue;
     }
@@ -717,7 +716,7 @@ void GeckoTraceTokenizer::ProcessSamples(
 
     auto ts = static_cast<int64_t>(t.sample_times[i] * 1000 * 1000);
     std::optional<int64_t> converted =
-        context_->clock_tracker->ToTraceTime(trace_file_clock_, ts);
+        context_->clock_tracker->ConvertDefaultClockToTraceTime(ts);
     if (!converted) {
       continue;
     }
@@ -783,7 +782,7 @@ void GeckoTraceTokenizer::ProcessMarkers(
     double end_ms = t.marker_end_times[i];
     int64_t ts = MarkerEventTimeNs(phase, start_ms, end_ms);
     std::optional<int64_t> converted =
-        context_->clock_tracker->ToTraceTime(trace_file_clock_, ts);
+        context_->clock_tracker->ConvertDefaultClockToTraceTime(ts);
     if (!converted) {
       continue;
     }

--- a/src/trace_processor/importers/gecko/gecko_trace_tokenizer.h
+++ b/src/trace_processor/importers/gecko/gecko_trace_tokenizer.h
@@ -83,7 +83,6 @@ class GeckoTraceTokenizer : public ChunkedTraceReader {
   TraceProcessorContext* const context_;
   std::unique_ptr<TraceSorter::Stream<GeckoEvent>> stream_;
   std::string pending_json_;
-  ClockTracker::ClockId trace_file_clock_;
 
   // Shared across all threads to avoid creating duplicate mappings.
   DummyMemoryMapping* dummy_mapping_ = nullptr;

--- a/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
+++ b/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
@@ -469,7 +469,7 @@ class InstrumentsXmlTokenizer::Impl {
 
   std::optional<int64_t> ToTraceTimestamp(int64_t time) {
     std::optional<int64_t> trace_ts =
-        context_->clock_tracker->ToTraceTime(clock_, time);
+        context_->clock_tracker->ConvertDefaultClockToTraceTime(time);
     if (PERFETTO_LIKELY(trace_ts.has_value())) {
       latest_timestamp_ = std::max(latest_timestamp_, *trace_ts);
     }

--- a/src/trace_processor/importers/json/json_trace_tokenizer.cc
+++ b/src/trace_processor/importers/json/json_trace_tokenizer.cc
@@ -494,8 +494,7 @@ JsonTraceTokenizer::JsonTraceTokenizer(TraceProcessorContext* ctx)
       systrace_stream_(context_->sorter->CreateStream(
           std::make_unique<SystraceSink>(&parser_))),
       v8_stream_(context_->sorter->CreateStream(
-          std::make_unique<V8Sink>(v8_tracker_.get()))),
-      trace_file_clock_(ClockId::TraceFile(ctx->trace_id().value)) {}
+          std::make_unique<V8Sink>(v8_tracker_.get()))) {}
 JsonTraceTokenizer::~JsonTraceTokenizer() = default;
 
 int64_t JsonTraceTokenizer::CurrentByteOffset() const {
@@ -839,7 +838,7 @@ bool JsonTraceTokenizer::ParseTraceEventContents() {
     }
     return true;
   }
-  auto trace_ts = context_->clock_tracker->ToTraceTime(trace_file_clock_, ts);
+  auto trace_ts = context_->clock_tracker->ConvertDefaultClockToTraceTime(ts);
   if (trace_ts) {
     json_stream_->Push(*trace_ts, std::move(event));
   }
@@ -897,7 +896,7 @@ base::Status JsonTraceTokenizer::ParseV8SampleEvent(const JsonEvent& event) {
     ASSIGN_OR_RETURN(int64_t ts,
                      v8_tracker_->AddDeltaAndGetTs(
                          id, event.pid, profile.time_deltas[i] * 1000));
-    auto trace_ts = context_->clock_tracker->ToTraceTime(trace_file_clock_, ts);
+    auto trace_ts = context_->clock_tracker->ConvertDefaultClockToTraceTime(ts);
     if (trace_ts) {
       v8_stream_->Push(*trace_ts,
                        LegacyV8CpuProfileEvent{id, event.pid, event.tid,
@@ -1017,7 +1016,7 @@ base::Status JsonTraceTokenizer::HandleSystemTraceEvent(const char* start,
     SystraceLine line;
     RETURN_IF_ERROR(systrace_line_tokenizer_.Tokenize(raw_line, &line));
     auto trace_ts =
-        context_->clock_tracker->ToTraceTime(trace_file_clock_, line.ts);
+        context_->clock_tracker->ConvertDefaultClockToTraceTime(line.ts);
     if (trace_ts) {
       // SystraceLineParser populates tables from line.ts, so the conversion
       // must be written back, not just used as the sorting key.

--- a/src/trace_processor/importers/json/json_trace_tokenizer.h
+++ b/src/trace_processor/importers/json/json_trace_tokenizer.h
@@ -157,7 +157,6 @@ class JsonTraceTokenizer : public ChunkedTraceReader {
   json::Iterator it_;
   json::Iterator inner_it_;
 
-  ClockTracker::ClockId trace_file_clock_;
   uint64_t offset_ = 0;
   // Points at the start of the trace event object currently being parsed (i.e.
   // the opening '{'). Valid only while inside ParseTraceEventContents.

--- a/src/trace_processor/importers/primes/primes_trace_tokenizer.cc
+++ b/src/trace_processor/importers/primes/primes_trace_tokenizer.cc
@@ -38,7 +38,6 @@ namespace perfetto::trace_processor::primes {
 
 PrimesTraceTokenizer::PrimesTraceTokenizer(TraceProcessorContext* ctx)
     : context_(ctx),
-      trace_file_clock_(ClockId::TraceFile(ctx->trace_id().value)),
       stream_(
           ctx->sorter->CreateStream(std::make_unique<PrimesTraceParser>(ctx))) {
 }
@@ -100,7 +99,7 @@ base::Status PrimesTraceTokenizer::OnPushDataToSorter() {
     TraceBlobView edge_slice = slice->slice_off(
         static_cast<size_t>((*edge).data - slice->data()), (*edge).size);
     auto trace_ts =
-        context_->clock_tracker->ToTraceTime(trace_file_clock_, edge_timestamp);
+        context_->clock_tracker->ConvertDefaultClockToTraceTime(edge_timestamp);
     if (trace_ts) {
       stream_->Push(*trace_ts, std::move(edge_slice));
     }

--- a/src/trace_processor/importers/primes/primes_trace_tokenizer.h
+++ b/src/trace_processor/importers/primes/primes_trace_tokenizer.h
@@ -43,7 +43,6 @@ class PrimesTraceTokenizer : public ChunkedTraceReader {
  private:
   util::TraceBlobViewReader reader_;
   TraceProcessorContext* const context_;
-  ClockTracker::ClockId trace_file_clock_;
   std::unique_ptr<TraceSorter::Stream<TraceBlobView>> stream_;
 };
 

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -258,6 +258,14 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
   // using a different ProtoTraceReader instance. The packet will be parsed
   // in the context of the remote machine.
   if (PERFETTO_UNLIKELY(decoder.machine_id())) {
+    // A packet with a machine_id proves this trace contains data from more
+    // than one machine, which is incompatible with a perfetto_manifest
+    // clock pin: the pin is ambiguous across machines.
+    if (context_->has_clock_override()) {
+      return base::ErrStatus(
+          "perfetto_manifest: clock overrides require the trace to come "
+          "from a single machine");
+    }
     if (context_->machine_id() == MachineId(kDefaultMachineId)) {
       auto [it, inserted] =
           machine_to_proto_readers_.Insert(decoder.machine_id(), nullptr);
@@ -269,7 +277,7 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
         if (parent_default) {
           machine_context->clock_tracker->SetTraceDefaultClock(*parent_default);
         }
-        machine_context->clock_tracker->AddDeferredIdentitySync(
+        machine_context->clock_tracker->AddDeferredClockSync(
             ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_BOOTTIME));
         // TODO(lalitm): this doesn't seem the right place for this but I cannot
         // think of a much better place either.
@@ -449,8 +457,9 @@ base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
     if (PERFETTO_UNLIKELY(!timestamp_clock_id && defaults)) {
       timestamp_clock_id = defaults->timestamp_clock_id();
     }
+    std::optional<ClockTracker::ClockId> default_clock;
     if (PERFETTO_UNLIKELY(!timestamp_clock_id)) {
-      auto default_clock = context_->clock_tracker->trace_default_clock();
+      default_clock = context_->clock_tracker->trace_default_clock();
       if (default_clock) {
         timestamp_clock_id = default_clock->clock_id;
       }
@@ -473,7 +482,12 @@ base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
       // If the TracePacket specifies a non-zero clock-id, translate the
       // timestamp into the trace-time clock domain.
       ClockTracker::ClockId converted_clock_id;
-      if (ClockId::IsSequenceClock(timestamp_clock_id)) {
+      if (default_clock) {
+        // The clock came from the trace default: use it as-is, as it may be
+        // scoped beyond the raw clock id (e.g. a perfetto_manifest override
+        // moved this file onto its private TraceFile clock).
+        converted_clock_id = *default_clock;
+      } else if (ClockId::IsSequenceClock(timestamp_clock_id)) {
         if (!seq_id) {
           return base::ErrStatus(
               "TracePacket specified a sequence-local clock id (%" PRIu32
@@ -651,6 +665,16 @@ void ProtoTraceReader::ParseInternedData(
 
 base::Status ProtoTraceReader::ParseClockSnapshot(ConstBytes blob,
                                                   uint32_t seq_id) {
+  // A ClockSnapshot correlates two or more clock domains, which proves this
+  // trace is not single-clock; perfetto_manifest clock pins are only valid
+  // for single-clock traces. ClockTracker::AddSnapshot also rejects this,
+  // but its error is logged and swallowed below; check here to fail the
+  // load on what is a configuration error.
+  if (context_->has_clock_override()) {
+    return base::ErrStatus(
+        "perfetto_manifest: clock overrides require the trace to use a "
+        "single clock");
+  }
   std::vector<ClockTracker::ClockTimestamp> clock_timestamps;
   protos::pbzero::ClockSnapshot::Decoder evt(blob.data, blob.size);
   for (auto it = evt.clocks(); it; ++it) {

--- a/src/trace_processor/importers/systrace/systrace_trace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_trace_parser.cc
@@ -33,7 +33,6 @@
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
-#include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "src/trace_processor/forwarding_trace_parser.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
@@ -187,9 +186,8 @@ base::Status SystraceTraceParser::Parse(TraceBlobView blob) {
         SystraceLine line;
         base::Status status = line_tokenizer_.Tokenize(buffer, &line);
         if (status.ok()) {
-          auto trace_ts = ctx_->clock_tracker->ToTraceTime(
-              ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_MONOTONIC),
-              line.ts);
+          auto trace_ts =
+              ctx_->clock_tracker->ConvertDefaultClockToTraceTime(line.ts);
           if (trace_ts) {
             // The converted timestamp is both the sorting key and the value
             // the parser stage reads: SystraceLineParser populates tables

--- a/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.cc
+++ b/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.cc
@@ -18,10 +18,14 @@
 
 #include <cinttypes>
 #include <cstdint>
+#include <cstdio>
+#include <limits>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "perfetto/base/status.h"
+#include "perfetto/base/time.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
@@ -37,6 +41,63 @@
 
 namespace perfetto::trace_processor::perfetto_manifest {
 namespace {
+
+using FileEntry = TraceManifestState::FileEntry;
+using ClockOverride = TraceManifestState::ClockOverride;
+
+bool IsLeapYear(int y) {
+  return (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
+}
+
+// Parses an ISO-8601 UTC timestamp ("2026-06-10T10:15:30.123Z") into
+// nanoseconds since the unix epoch. All fields are range-validated and the
+// arithmetic is integer-only: a double-based epoch computation loses up to
+// ~256ns near the current epoch (1.7e18 ns exceeds double's 2^53
+// exact-integer range). The seconds fraction is parsed by hand to stay
+// independent of the LC_NUMERIC locale of embedding applications.
+std::optional<int64_t> ParseUtcTimestamp(const std::string& utc) {
+  int y, mon, day, h, min, sec;
+  int consumed = 0;
+  if (sscanf(utc.c_str(), "%4d-%2d-%2dT%2d:%2d:%2d%n", &y, &mon, &day, &h, &min,
+             &sec, &consumed) != 6) {
+    return std::nullopt;
+  }
+  // The upper year bound keeps the result well inside int64 nanoseconds
+  // (which overflows in 2262).
+  static constexpr int kDaysPerMonth[] = {31, 28, 31, 30, 31, 30,
+                                          31, 31, 30, 31, 30, 31};
+  if (y < 1970 || y > 2200 || mon < 1 || mon > 12 || h < 0 || h > 23 ||
+      min < 0 || min > 59 || sec < 0 || sec > 60) {
+    return std::nullopt;
+  }
+  int max_day = kDaysPerMonth[mon - 1] + (mon == 2 && IsLeapYear(y) ? 1 : 0);
+  if (day < 1 || day > max_day) {
+    return std::nullopt;
+  }
+  const char* rest = utc.c_str() + consumed;
+  int64_t frac_ns = 0;
+  if (*rest == '.') {
+    ++rest;
+    int significant = 0;
+    int total = 0;
+    for (; *rest >= '0' && *rest <= '9'; ++rest, ++total) {
+      if (significant < 9) {
+        frac_ns = frac_ns * 10 + (*rest - '0');
+        ++significant;
+      }
+    }
+    if (total == 0) {
+      return std::nullopt;
+    }
+    for (; significant < 9; ++significant) {
+      frac_ns *= 10;
+    }
+  }
+  if (rest[0] != 'Z' || rest[1] != '\0') {
+    return std::nullopt;
+  }
+  return base::MkTime(y, mon, day, h, min, sec) * 1000000000 + frac_ns;
+}
 
 base::StatusOr<uint32_t> ParseClockName(const json::Dom& value) {
   if (!value.IsString()) {
@@ -58,6 +119,120 @@ base::StatusOr<uint32_t> ParseClockName(const json::Dom& value) {
     return BuiltinClock::BUILTIN_CLOCK_BOOTTIME;
   return base::ErrStatus("perfetto_manifest: unknown clock name: %s",
                          name.c_str());
+}
+
+// Reads a required, non-negative integral nanosecond timestamp stored under
+// `key` in `obj`. `label` names the field in error messages (it may be
+// qualified, e.g. "is.ts").
+base::StatusOr<int64_t> ParseAnchorTs(const json::Dom& obj,
+                                      const char* key,
+                                      const char* label) {
+  if (!obj.HasMember(key) || !obj[key].IsIntegral()) {
+    return base::ErrStatus(
+        "perfetto_manifest: anchor: missing required field: %s", label);
+  }
+  int64_t ts = obj[key].AsInt64();
+  if (ts < 0) {
+    return base::ErrStatus("perfetto_manifest: anchor: %s must not be negative",
+                           label);
+  }
+  return ts;
+}
+
+base::StatusOr<ClockOverride> ParseAnchor(const json::Dom& anchor) {
+  ClockOverride result;
+  ASSIGN_OR_RETURN(result.file_ts_ns, ParseAnchorTs(anchor, "ts", "ts"));
+  if (!anchor.HasMember("is") || !anchor["is"].IsObject()) {
+    return base::ErrStatus(
+        "perfetto_manifest: anchor: missing required field: is");
+  }
+
+  const json::Dom& is = anchor["is"];
+  if (is.HasMember("utc")) {
+    if (is.HasMember("clock") || is.HasMember("ts")) {
+      return base::ErrStatus(
+          "perfetto_manifest: anchor: utc cannot be combined with clock/ts");
+    }
+    if (!is["utc"].IsString()) {
+      return base::ErrStatus("perfetto_manifest: anchor: utc must be a string");
+    }
+    std::string utc = is["utc"].AsString();
+    auto ts = ParseUtcTimestamp(utc);
+    if (!ts) {
+      return base::ErrStatus(
+          "perfetto_manifest: anchor: invalid utc timestamp: %s", utc.c_str());
+    }
+    result.clock = protos::pbzero::BUILTIN_CLOCK_REALTIME;
+    result.clock_ts_ns = *ts;
+    return result;
+  }
+  if (!is.HasMember("clock")) {
+    return base::ErrStatus(
+        "perfetto_manifest: anchor: missing required field: clock");
+  }
+  ASSIGN_OR_RETURN(uint32_t clock, ParseClockName(is["clock"]));
+  result.clock = clock;
+  ASSIGN_OR_RETURN(result.clock_ts_ns, ParseAnchorTs(is, "ts", "is.ts"));
+  return result;
+}
+
+base::StatusOr<ClockOverride> ParseClocks(const json::Dom& clocks) {
+  // Exclusivity diagnostics: each rejected combination would override the
+  // file's timeline twice.
+  if (clocks.HasMember("offset_ns") && clocks.HasMember("anchor")) {
+    return base::ErrStatus(
+        "perfetto_manifest: offset_ns and anchor are mutually exclusive");
+  }
+  if (clocks.HasMember("native") && clocks.HasMember("anchor")) {
+    return base::ErrStatus(
+        "perfetto_manifest: native and anchor are mutually exclusive");
+  }
+  if (clocks.HasMember("anchor")) {
+    if (!clocks["anchor"].IsObject()) {
+      return base::ErrStatus("perfetto_manifest: anchor must be an object");
+    }
+    return ParseAnchor(clocks["anchor"]);
+  }
+  ClockOverride result;
+  if (clocks.HasMember("native")) {
+    ASSIGN_OR_RETURN(uint32_t native, ParseClockName(clocks["native"]));
+    result.clock = native;
+  }
+  if (clocks.HasMember("offset_ns")) {
+    if (!clocks["offset_ns"].IsIntegral()) {
+      return base::ErrStatus("perfetto_manifest: offset_ns must be an integer");
+    }
+    int64_t offset_ns = clocks["offset_ns"].AsInt64();
+    if (offset_ns == std::numeric_limits<int64_t>::min()) {
+      return base::ErrStatus("perfetto_manifest: offset_ns is out of range");
+    }
+    // Snapshot timestamps must never be negative: a backwards shift is
+    // expressed by mapping a later file timestamp to the clock's zero
+    // instead.
+    if (offset_ns < 0) {
+      result.file_ts_ns = -offset_ns;
+    } else {
+      result.clock_ts_ns = offset_ns;
+    }
+  }
+  return result;
+}
+
+base::StatusOr<FileEntry> ParseFileEntry(const json::Dom& file) {
+  if (!file.IsObject() || !file["path"].IsString()) {
+    return base::ErrStatus(
+        "perfetto_manifest: files entries must be objects with a string "
+        "path");
+  }
+  FileEntry entry;
+  entry.path = file["path"].AsString();
+  if (file.HasMember("clocks")) {
+    if (!file["clocks"].IsObject()) {
+      return base::ErrStatus("perfetto_manifest: clocks must be an object");
+    }
+    ASSIGN_OR_RETURN(entry.clock_override, ParseClocks(file["clocks"]));
+  }
+  return entry;
 }
 
 }  // namespace
@@ -113,12 +288,8 @@ base::Status PerfettoManifestReader::OnPushDataToSorter() {
       return base::ErrStatus("perfetto_manifest: files must be an array");
     }
     for (const json::Dom& file : meta["files"]) {
-      if (!file["path"].IsString()) {
-        return base::ErrStatus(
-            "perfetto_manifest: files entries must be objects with a string "
-            "path");
-      }
-      state->files.push_back({file["path"].AsString()});
+      ASSIGN_OR_RETURN(FileEntry entry, ParseFileEntry(file));
+      state->files.push_back(std::move(entry));
     }
   }
 

--- a/src/trace_processor/types/trace_manifest_state.h
+++ b/src/trace_processor/types/trace_manifest_state.h
@@ -30,9 +30,29 @@ namespace perfetto::trace_processor {
 // follow. Populated by the perfetto_manifest plugin's reader and consulted
 // by ForwardingTraceParser for each trace file.
 struct TraceManifestState {
+  // A file's "clocks" override, normalized to a single concept: file time
+  // |file_ts_ns| (nanoseconds, the unit every tokenizer normalizes to)
+  // corresponds to |clock_ts_ns| on |clock|. "native" parses to a zero/zero
+  // mapping onto the named clock, "offset_ns" to a mapping of file time 0 onto
+  // the file's per-format clock at the offset (or, for a negative offset, of
+  // file time -offset onto the clock's zero), and an "anchor" sets all three
+  // fields explicitly.
+  //
+  // Invariant: both timestamps are non-negative, so the override never
+  // introduces negative timestamps into the clock graph. The reader rebases
+  // offsets and rejects negative anchors to maintain this.
+  struct ClockOverride {
+    // Builtin clock id this file's timeline is correlated with; nullopt = the
+    // file's per-format clock.
+    std::optional<uint32_t> clock;
+    int64_t file_ts_ns = 0;
+    int64_t clock_ts_ns = 0;
+  };
+
   struct FileEntry {
     // Exact path of the member within the archive.
     std::string path;
+    std::optional<ClockOverride> clock_override;
   };
 
   // True once a perfetto_manifest file has been parsed; a second one is an

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -101,6 +101,11 @@ class TraceProcessorContext {
 
   struct TraceState {
     TraceId trace_id;
+
+    // True when a perfetto_manifest override pinned this trace onto a single
+    // private clock. The trace must then stay single-clock and single-machine,
+    // so ClockSnapshots and remote machine ids are rejected on it.
+    bool has_clock_override = false;
   };
 
   struct UuidState {
@@ -253,6 +258,13 @@ class TraceProcessorContext {
 
   MachineId machine_id() const;
   TraceId trace_id() const;
+
+  // True when a perfetto_manifest clock override constrains this trace to a
+  // single clock and machine. False for root/container contexts that have no
+  // per-trace state.
+  bool has_clock_override() const {
+    return trace_state && trace_state->has_clock_override;
+  }
 
  private:
   explicit TraceProcessorContext(const Config& config);

--- a/src/trace_processor/util/json_value.h
+++ b/src/trace_processor/util/json_value.h
@@ -85,7 +85,8 @@ class Dom {
   bool IsInt() const { return std::holds_alternative<int64_t>(data_); }
   bool IsUint() const { return std::holds_alternative<uint64_t>(data_); }
   bool IsDouble() const { return std::holds_alternative<double>(data_); }
-  bool IsNumeric() const { return IsInt() || IsUint() || IsDouble(); }
+  bool IsIntegral() const { return IsInt() || IsUint(); }
+  bool IsNumeric() const { return IsIntegral() || IsDouble(); }
   bool IsString() const { return std::holds_alternative<std::string>(data_); }
   bool IsArray() const { return std::holds_alternative<Array>(data_); }
   bool IsObject() const { return std::holds_alternative<Object>(data_); }

--- a/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
+++ b/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
@@ -75,6 +75,38 @@ def _json_trace(name, pid=10):
   })
 
 
+# A systrace with one slice 'sys_slice' from 1.0s to 1.5s (MONOTONIC).
+SYSTRACE = '''# tracer: nop
+#
+  app-100 (  100) [001] ...1  1.000000: tracing_mark_write: B|100|sys_slice
+  app-100 (  100) [001] ...1  1.500000: tracing_mark_write: E|100
+'''
+
+# The same proto trace without any clock snapshot: a single-clock proto trace.
+SOLO_PROTO = TextProto(_PROTO_SLICE)
+
+
+# A Chrome JSON trace with one complete event at ts=2000us, dur=500us and an
+# embedded systrace ('systemTraceEvents') with one slice 'sys_in_json' from
+# 1.0s to 1.5s.
+def _json_trace_with_systrace(name, pid=10):
+  return json.dumps({
+      'traceEvents': [{
+          'pid': pid,
+          'tid': pid,
+          'ts': 2000,
+          'dur': 500,
+          'ph': 'X',
+          'name': name,
+      }],
+      'systemTraceEvents':
+          '# tracer: nop\n'
+          '  app-100 (  100) [001] ...1  1.000000: '
+          'tracing_mark_write: B|100|sys_in_json\n'
+          '  app-100 (  100) [001] ...1  1.500000: tracing_mark_write: E|100\n',
+  })
+
+
 def _meta(payload):
   return json.dumps({'perfetto_manifest': payload})
 
@@ -270,3 +302,551 @@ class TraceManifest(TestSuite):
         }),
         query='SELECT 1;',
         out=ExpectedError('multiple perfetto_manifest files in archive'))
+
+  # --- offset_ns ---
+
+  # offset_ns shifts a file's events relative to where they would land by
+  # default. Two JSON files (slices at 2000us = 2_000_000ns identity) get
+  # different offsets; the proto spine is unaffected.
+  def test_json_offsets_two_files(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [
+                        {
+                            'path': 'a.json',
+                            'clocks': {
+                                'offset_ns': 500000000
+                            }
+                        },
+                        {
+                            'path': 'b.json',
+                            'clocks': {
+                                'offset_ns': -1000000
+                            }
+                        },
+                    ],
+                }),
+            'a.json':
+                _json_trace('a_slice', pid=10),
+            'b.json':
+                _json_trace('b_slice', pid=11),
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT name, ts, dur FROM slice
+          WHERE name IN ('a_slice', 'b_slice', 'proto_slice')
+          ORDER BY name;
+        ''',
+        out=Csv('''
+        "name","ts","dur"
+        "a_slice",502000000,500000
+        "b_slice",1000000,500000
+        "proto_slice",1100000000,100000000
+        '''))
+
+  # The offset also applies in tar archives, and composes with an explicit
+  # trace_time_clock.
+  def test_offset_in_tar_with_trace_time_clock(self):
+    return DiffTestBlueprint(
+        trace=Tar({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'trace_time_clock':
+                        'BOOTTIME',
+                    'files': [{
+                        'path': 'a.json',
+                        'clocks': {
+                            'offset_ns': 1000000
+                        }
+                    }],
+                }),
+            'a.json':
+                _json_trace('a_slice'),
+        }),
+        query='''
+          SELECT
+            (SELECT int_value FROM metadata
+             WHERE name = 'trace_time_clock_id') AS clock_id,
+            (SELECT ts FROM slice WHERE name = 'a_slice') AS ts;
+        ''',
+        out=Csv('''
+        "clock_id","ts"
+        6,3000000
+        '''))
+
+  # Clock overrides on a JSON file also apply to the sched/slice rows derived
+  # from its embedded systrace (systemTraceEvents), not just to traceEvents.
+  # The proto spine provides the trace time domain the offset is relative to:
+  # a lone file's private clock is itself the trace time, so an offset there
+  # would be a no-op.
+  def test_json_embedded_systrace_offset(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'app.json',
+                        'clocks': {
+                            'offset_ns': 500000000
+                        }
+                    }],
+                }),
+            'app.json':
+                _json_trace_with_systrace('json_slice'),
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT name, ts, dur FROM slice
+          WHERE name IN ('json_slice', 'sys_in_json')
+          ORDER BY name;
+        ''',
+        out=Csv('''
+        "name","ts","dur"
+        "json_slice",502000000,500000
+        "sys_in_json",1500000000,500000000
+        '''))
+
+  # --- anchor ---
+
+  # An anchor maps a file timestamp (always nanoseconds, the unit every
+  # tokenizer normalizes to) to a value on a named builtin clock.
+  # ts=1_000_000 (the file's 1000us point) corresponds to BOOTTIME
+  # 1_500_000_000, so the slice at 2000us lands at
+  # 1_500_000_000 + 1_000_000 = 1_501_000_000.
+  def test_json_anchor_to_boottime(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'app.json',
+                        'clocks': {
+                            'anchor': {
+                                'ts': 1000000,
+                                'is': {
+                                    'clock': 'BOOTTIME',
+                                    'ts': 1500000000
+                                },
+                            },
+                        },
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT name, ts FROM slice
+          WHERE name IN ('json_slice', 'proto_slice')
+          ORDER BY name;
+        ''',
+        out=Csv('''
+        "name","ts"
+        "json_slice",1501000000
+        "proto_slice",1100000000
+        '''))
+
+  # A utc anchor is sugar for clock=REALTIME. ts=0 (ns) corresponds to
+  # 2023-11-14T22:13:21.5Z = REALTIME 1_700_000_001_500_000_000. Via the proto
+  # spine's REALTIME<->BOOTTIME snapshot the slice at 2000us lands at
+  # 1_500_000_000 + 2_000_000 = 1_502_000_000. This exercises routing the
+  # anchor through the machine's shared clock graph (TraceFile -> REALTIME ->
+  # BOOTTIME) rather than the file's isolated one.
+  def test_json_anchor_to_utc(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'app.json',
+                        'clocks': {
+                            'anchor': {
+                                'ts': 0,
+                                'is': {
+                                    'utc': '2023-11-14T22:13:21.5Z'
+                                },
+                            },
+                        },
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT name, ts FROM slice
+          WHERE name IN ('json_slice', 'proto_slice')
+          ORDER BY name;
+        ''',
+        out=Csv('''
+        "name","ts"
+        "json_slice",1502000000
+        "proto_slice",1100000000
+        '''))
+
+  # The anchor correlation is mirrored into the clock_snapshot table (one row
+  # per clock in the override, like proto ClockSnapshots) so that ClockConverter
+  # (to_realtime, abs_time_str, the UI wall-clock axis) can see it even when
+  # no proto trace provides snapshots.
+  def test_utc_anchor_visible_in_clock_snapshot_table(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'app.json',
+                        'clocks': {
+                            'anchor': {
+                                'ts': 0,
+                                'is': {
+                                    'utc': '2023-11-14T22:13:21.5Z'
+                                },
+                            },
+                        },
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+        }),
+        query='''
+          SELECT clock_id, clock_name, ts, clock_value FROM clock_snapshot
+          ORDER BY clock_id;
+        ''',
+        out=Csv('''
+        "clock_id","clock_name","ts","clock_value"
+        1,"REALTIME",0,1700000001500000000
+        11,"[NULL]",0,0
+        '''))
+
+  # --- clocks.native ---
+
+  # Baseline (no metadata file): systrace timestamps are MONOTONIC, so via the
+  # spine's MONOTONIC<->BOOTTIME snapshot the 1.0s slice lands at
+  # 1_000_000_000 + 500_000_000 = 1_500_000_000.
+  def test_systrace_clock_baseline_no_config(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'sys.systrace': SYSTRACE,
+            'spine.pb': SPINE,
+        }),
+        query='''
+          SELECT name, ts, dur FROM slice WHERE name = 'sys_slice';
+        ''',
+        out=Csv('''
+        "name","ts","dur"
+        "sys_slice",1500000000,500000000
+        '''))
+
+  # clocks.native reinterprets the file's native clock: the same systrace with
+  # native=BOOTTIME keeps its timestamps unconverted at 1_000_000_000.
+  def test_systrace_native_clock_override(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'sys.systrace',
+                        'clocks': {
+                            'native': 'BOOTTIME'
+                        }
+                    }],
+                }),
+            'sys.systrace':
+                SYSTRACE,
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT name, ts, dur FROM slice WHERE name = 'sys_slice';
+        ''',
+        out=Csv('''
+        "name","ts","dur"
+        "sys_slice",1000000000,500000000
+        '''))
+
+  # native and offset_ns compose: the file's timeline is mapped onto the named
+  # clock at the offset (file time 0 == BOOTTIME 100_000_000), so the 1.0s
+  # slice lands at 1_100_000_000 instead of converting through the spine's
+  # MONOTONIC<->BOOTTIME snapshot.
+  def test_systrace_native_clock_with_offset(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'sys.systrace',
+                        'clocks': {
+                            'native': 'BOOTTIME',
+                            'offset_ns': 100000000
+                        }
+                    }],
+                }),
+            'sys.systrace':
+                SYSTRACE,
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT name, ts, dur FROM slice WHERE name = 'sys_slice';
+        ''',
+        out=Csv('''
+        "name","ts","dur"
+        "sys_slice",1100000000,500000000
+        '''))
+
+  # An anchor overrides the weak per-format clock guess (MONOTONIC for
+  # systrace): the anchored file is moved onto its own private TraceFile
+  # clock, so a sibling systrace without an override still converts through
+  # the spine's real MONOTONIC<->BOOTTIME snapshot, unaffected by the anchor.
+  def test_systrace_anchor_overrides_weak_clock(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'sys.systrace',
+                        'clocks': {
+                            'anchor': {
+                                'ts': 1000000000,
+                                'is': {
+                                    'clock': 'BOOTTIME',
+                                    'ts': 5000000000
+                                },
+                            },
+                        },
+                    }],
+                }),
+            'sys.systrace':
+                SYSTRACE,
+            'sys2.systrace':
+                SYSTRACE,
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT name, ts, dur FROM slice
+          WHERE name = 'sys_slice'
+          ORDER BY ts;
+        ''',
+        out=Csv('''
+        "name","ts","dur"
+        "sys_slice",1500000000,500000000
+        "sys_slice",5000000000,500000000
+        '''))
+
+  # --- Proto traces with a single clock ---
+
+  # A proto trace which uses a single clock (no ClockSnapshot, no explicit
+  # timestamp_clock_id, no remote machines) accepts clock overrides like any
+  # other single-clock format. The offset is negative to exercise a
+  # backwards shift: the reader rebases it onto the file timestamp so the
+  # injected edge keeps non-negative timestamps.
+  def test_proto_single_clock_negative_offset(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'solo.pb',
+                        'clocks': {
+                            'offset_ns': -250
+                        }
+                    }],
+                }),
+            'solo.pb':
+                SOLO_PROTO,
+        }),
+        query='''
+          SELECT name, ts FROM slice WHERE name = 'proto_slice';
+        ''',
+        out=Csv('''
+        "name","ts"
+        "proto_slice",1099999750
+        '''))
+
+  # --- Clock override errors ---
+
+  def test_error_offset_and_anchor_exclusive(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'app.json',
+                        'clocks': {
+                            'offset_ns': 1,
+                            'anchor': {
+                                'ts': 0,
+                                'is': {
+                                    'clock': 'BOOTTIME',
+                                    'ts': 1
+                                }
+                            },
+                        },
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+        }),
+        query='SELECT 1;',
+        out=ExpectedError(
+            'perfetto_manifest: offset_ns and anchor are mutually exclusive'))
+
+  def test_error_native_and_anchor_exclusive(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'app.json',
+                        'clocks': {
+                            'native': 'BOOTTIME',
+                            'anchor': {
+                                'ts': 0,
+                                'is': {
+                                    'clock': 'BOOTTIME',
+                                    'ts': 1
+                                }
+                            },
+                        },
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+        }),
+        query='SELECT 1;',
+        out=ExpectedError(
+            'perfetto_manifest: native and anchor are mutually exclusive'))
+
+  def test_error_utc_impossible_date(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'app.json',
+                        'clocks': {
+                            'anchor': {
+                                'ts': 0,
+                                'is': {
+                                    'utc': '2026-13-40T99:00:00Z'
+                                }
+                            },
+                        },
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+        }),
+        query='SELECT 1;',
+        out=ExpectedError('perfetto_manifest: anchor: invalid utc timestamp'))
+
+  # A clock override on a perfetto_manifest or archive member is rejected:
+  # such files have no per-trace clock state to override.
+  def test_error_clock_override_on_metadata_file(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta1.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'meta2.json',
+                        'clocks': {
+                            'offset_ns': 1
+                        }
+                    }],
+                }),
+            'meta2.json':
+                _meta({'version': 1}),
+            'app.json':
+                _json_trace('json_slice'),
+        }),
+        query='SELECT 1;',
+        out=ExpectedError(
+            'overrides are not supported for trace files which are '
+            'themselves archives or perfetto_manifest files'))
+
+  # --- Proto single-ness enforcement (optimistic + lazy) ---
+
+  # A clocks override on a proto trace which emits a ClockSnapshot (proof of
+  # multiple clocks) fails when the snapshot is parsed.
+  def test_error_proto_multi_clock(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [{
+                        'path': 'spine.pb',
+                        'clocks': {
+                            'offset_ns': 1
+                        }
+                    }],
+                }),
+            'spine.pb':
+                SPINE,
+        }),
+        query='SELECT 1;',
+        out=ExpectedError(
+            'clock overrides require the trace to use a single clock'))
+
+  # A clocks override on a proto trace containing packets from a remote
+  # machine (machine_id != 0) fails: anchors/offsets are ambiguous across
+  # machines.
+  def test_error_proto_multi_machine_clock_override(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [{
+                        'path': 'spine.pb',
+                        'clocks': {
+                            'offset_ns': 1
+                        }
+                    }],
+                }),
+            'spine.pb':
+                TextProto(_PROTO_SLICE + '''
+  packet {
+    machine_id: 7
+    process_tree { processes { pid: 30 ppid: 0 cmdline: "m7_proc" } }
+  }
+'''),
+        }),
+        query='SELECT 1;',
+        out=ExpectedError(
+            'clock overrides require the trace to come from a single machine'))


### PR DESCRIPTION
Allow overriding the clocks chosen by TP and their offsets and
instead manually specify what the offset should be.
