### PR TITLE
tp+ui: add SystemInfo.machine_name for machine UI labels

### DIFF
--- a/protos/perfetto/common/system_info.proto
+++ b/protos/perfetto/common/system_info.proto
@@ -25,7 +25,7 @@ message Utsname {
   optional string machine = 4;
 }
 
-// Next id: 17
+// Next id: 18
 message SystemInfo {
   optional Utsname utsname = 1;
   optional string android_build_fingerprint = 2;
@@ -90,4 +90,12 @@ message SystemInfo {
   //
   // Introduced in perfetto v54 / Android 26Q1+.
   optional uint64 system_ram_bytes = 16;
+
+  // Human-readable name of the machine this SystemInfo describes, used as the
+  // machine's label in the UI (falling back to "machine <id>" when unset).
+  //
+  // A producer attributing its data to a non-host machine can set this by
+  // emitting a SystemInfo packet to give that machine a name. Only meaningful
+  // when the packet carries a non-zero machine_id.
+  optional string machine_name = 17;
 }

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -5898,7 +5898,7 @@ message Utsname {
   optional string machine = 4;
 }
 
-// Next id: 17
+// Next id: 18
 message SystemInfo {
   optional Utsname utsname = 1;
   optional string android_build_fingerprint = 2;
@@ -5963,6 +5963,14 @@ message SystemInfo {
   //
   // Introduced in perfetto v54 / Android 26Q1+.
   optional uint64 system_ram_bytes = 16;
+
+  // Human-readable name of the machine this SystemInfo describes, used as the
+  // machine's label in the UI (falling back to "machine <id>" when unset).
+  //
+  // A producer attributing its data to a non-host machine can set this by
+  // emitting a SystemInfo packet to give that machine a name. Only meaningful
+  // when the packet carries a non-zero machine_id.
+  optional string machine_name = 17;
 }
 
 // End of protos/perfetto/common/system_info.proto

--- a/src/trace_processor/importers/common/machine_tracker.cc
+++ b/src/trace_processor/importers/common/machine_tracker.cc
@@ -44,6 +44,10 @@ void MachineTracker::SetMachineInfo(StringId sysname,
   row.set_arch(arch);
 }
 
+void MachineTracker::SetMachineName(StringId name) {
+  getRow().set_name(name);
+}
+
 void MachineTracker::SetNumCpus(uint32_t cpus) {
   getRow().set_num_cpus(cpus);
 }

--- a/src/trace_processor/importers/common/machine_tracker.h
+++ b/src/trace_processor/importers/common/machine_tracker.h
@@ -37,6 +37,7 @@ class MachineTracker {
                       StringId release,
                       StringId version,
                       StringId arch);
+  void SetMachineName(StringId name);
   void SetNumCpus(uint32_t cpus);
   void SetAndroidBuildFingerprint(StringId build_fingerprint);
   void SetAndroidDeviceManufacturer(StringId device_manufacturer);

--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -924,6 +924,12 @@ void SystemProbesParser::ParseSystemInfo(ConstBytes blob) {
   MachineTracker* machine_tracker = context_->machine_tracker.get();
   SystemInfoTracker* system_info_tracker =
       SystemInfoTracker::GetOrCreate(context_);
+
+  if (packet.has_machine_name()) {
+    machine_tracker->SetMachineName(
+        context_->storage->InternString(packet.machine_name()));
+  }
+
   if (packet.has_utsname()) {
     ConstBytes utsname_blob = packet.utsname();
     protos::pbzero::Utsname::Decoder utsname(utsname_blob);

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -734,6 +734,8 @@ CREATE PERFETTO VIEW machine(
   id ID,
   -- Raw machine identifier in the trace packet.
   raw_id LONG,
+  -- Human-readable name of the machine, used as its label in the UI.
+  name STRING,
   -- The name of the operating system.
   sysname STRING,
   -- The current release of the operating system.

--- a/src/trace_processor/tables/metadata_tables.py
+++ b/src/trace_processor/tables/metadata_tables.py
@@ -39,6 +39,11 @@ MACHINE_TABLE = Table(
     columns=[
         C('raw_id', CppUint32()),
         C(
+            'name',
+            CppOptional(CppString()),
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
+        ),
+        C(
             'sysname',
             CppOptional(CppString()),
             cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
@@ -99,6 +104,12 @@ MACHINE_TABLE = Table(
                 '''
                   Raw machine identifier in the trace packet, non-zero for
                   remote machines.
+                ''',
+            'name':
+                '''
+                  Human-readable name of the machine (from
+                  SystemInfo.machine_name), used as the machine's label in the
+                  UI. NULL when the machine did not advertise a name.
                 ''',
             'sysname':
                 '''

--- a/test/trace_processor/diff_tests/parser/sched/tests.py
+++ b/test/trace_processor/diff_tests/parser/sched/tests.py
@@ -110,7 +110,7 @@ class SchedParser(TestSuite):
           ON c.track_id = t.id
         JOIN machine as m on t.machine_id = m.id
         WHERE
-          name GLOB "Cpu ? Cap" OR name GLOB "Cpu ? Util" OR name GLOB "Cpu ? Nr Running"
+          t.name GLOB "Cpu ? Cap" OR t.name GLOB "Cpu ? Util" OR t.name GLOB "Cpu ? Nr Running"
         ORDER BY ts;
         """,
         out=Csv("""

--- a/test/trace_processor/diff_tests/tables/tests.py
+++ b/test/trace_processor/diff_tests/tables/tests.py
@@ -774,9 +774,9 @@ class Tables(TestSuite):
         SELECT * FROM machine
         """,
         out=Csv("""
-        "id","raw_id","sysname","release","version","arch","num_cpus","android_build_fingerprint","android_device_manufacturer","android_sdk_version","system_ram_bytes","system_ram_gb"
-        0,0,"Darwin","22.6.0","Foobar","x86_64",4,"[NULL]","[NULL]","[NULL]",126598774784,127
-        1,2420838448,"Linux","6.6.82-android15-8-g1a7680db913a-ab13304129","#1 SMP PREEMPT Wed Apr  2 01:42:00 UTC 2025","x86_64",8,"android_test_fingerprint","Android",33,12008292352,12
+        "id","raw_id","name","sysname","release","version","arch","num_cpus","android_build_fingerprint","android_device_manufacturer","android_sdk_version","system_ram_bytes","system_ram_gb"
+        0,0,"[NULL]","Darwin","22.6.0","Foobar","x86_64",4,"[NULL]","[NULL]","[NULL]",126598774784,127
+        1,2420838448,"[NULL]","Linux","6.6.82-android15-8-g1a7680db913a-ab13304129","#1 SMP PREEMPT Wed Apr  2 01:42:00 UTC 2025","x86_64",8,"android_test_fingerprint","Android",33,12008292352,12
         """))
 
   # user list table

--- a/ui/src/components/cpu.ts
+++ b/ui/src/components/cpu.ts
@@ -19,10 +19,11 @@ export class Cpu {
     readonly ucpu: number,
     readonly cpu: number,
     readonly machine: number,
+    readonly machineName?: string,
   ) {}
 
   public maybeMachineLabel(): string {
-    return maybeMachineLabel(this.machine);
+    return maybeMachineLabel(this.machine, this.machineName);
   }
 
   public toString(): string {

--- a/ui/src/components/gpu.ts
+++ b/ui/src/components/gpu.ts
@@ -22,6 +22,7 @@ export class Gpu {
     readonly gpu: number,
     readonly machine: number,
     readonly name?: string,
+    readonly machineName?: string,
   ) {}
 
   get displayName(): string {
@@ -29,7 +30,7 @@ export class Gpu {
   }
 
   public maybeMachineLabel(): string {
-    return maybeMachineLabel(this.machine);
+    return maybeMachineLabel(this.machine, this.machineName);
   }
 
   // Sort order for deterministic track ordering: machine first (unbounded),

--- a/ui/src/plugins/dev.perfetto.CoarseCpu/index.ts
+++ b/ui/src/plugins/dev.perfetto.CoarseCpu/index.ts
@@ -20,7 +20,7 @@ import {COUNTER_TRACK_KIND} from '../../public/track_kinds';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {NUM, STR} from '../../trace_processor/query_result';
+import {NUM, STR, STR_NULL} from '../../trace_processor/query_result';
 import {Anchor} from '../../widgets/anchor';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import TraceProcessorTrackPlugin from '../dev.perfetto.TraceProcessorTrack';
@@ -118,12 +118,14 @@ export default class implements PerfettoPlugin {
         extract_arg(ct.dimension_arg_set_id, 'cpu') as cpu,
         extract_arg(ct.dimension_arg_set_id, 'cpustat_key') as metric,
         ct.machine_id as machineId,
+        machine.name as machineName,
         ifnull(cpu.ucpu, extract_arg(ct.dimension_arg_set_id, 'cpu')) as ucpu
       from counter_track ct
       join _counter_track_summary using (id)
       left join cpu
         on cpu.cpu = extract_arg(ct.dimension_arg_set_id, 'cpu')
        and cpu.machine_id = ct.machine_id
+      left join machine on machine.id = ct.machine_id
       where ct.type = 'cpustat'
       order by metric, ucpu
     `);
@@ -133,6 +135,7 @@ export default class implements PerfettoPlugin {
       cpu: NUM,
       metric: STR,
       machineId: NUM,
+      machineName: STR_NULL,
       ucpu: NUM,
     });
     if (!it.valid()) return;
@@ -144,7 +147,7 @@ export default class implements PerfettoPlugin {
     const metricGroups = new Map<string, TrackNode>();
 
     for (; it.valid(); it.next()) {
-      const {trackId, cpu, metric, machineId, ucpu} = it;
+      const {trackId, cpu, metric, machineId, machineName, ucpu} = it;
 
       const info = assertExists(METRICS[metric]);
 
@@ -159,7 +162,7 @@ export default class implements PerfettoPlugin {
         cpuStandardGroup.addChildInOrder(metricGroup);
       }
 
-      const trackName = `${info.groupName} (CPU ${new Cpu(ucpu, cpu, machineId).toString()})`;
+      const trackName = `${info.groupName} (CPU ${new Cpu(ucpu, cpu, machineId, machineName ?? undefined).toString()})`;
       const uri = `/coarse_cpu_${trackId}`;
 
       ctx.tracks.registerTrack({

--- a/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {NUM, NUM_NULL} from '../../trace_processor/query_result';
+import {NUM, NUM_NULL, STR_NULL} from '../../trace_processor/query_result';
 import {CpuFreqTrack} from './cpu_freq_track';
 import {Anchor} from '../../widgets/anchor';
 import {Icons} from '../../base/semantic_icons';
@@ -36,6 +36,7 @@ export default class implements PerfettoPlugin {
         t2.id AS idleTrackId,
         cpu.ucpu AS ucpu,
         track.machine_id AS machineId,
+        machine.name AS machineName,
         track.cpu AS cpu
       FROM cpu_counter_track track
       JOIN cpu
@@ -45,6 +46,8 @@ export default class implements PerfettoPlugin {
         ON track.cpu = t2.cpu
        AND track.machine_id = t2.machine_id
        AND t2.type = 'cpu_idle'
+      LEFT JOIN machine
+        ON machine.id = track.machine_id
       WHERE
         track.type = 'cpu_frequency'
       ORDER BY ucpu
@@ -72,6 +75,7 @@ export default class implements PerfettoPlugin {
       const it = tracksResult.iter({
         freqTrackId: NUM,
         machineId: NUM,
+        machineName: STR_NULL,
         cpu: NUM,
         ucpu: NUM,
         idleTrackId: NUM_NULL,
@@ -79,7 +83,7 @@ export default class implements PerfettoPlugin {
       it.valid();
       it.next()
     ) {
-      const {freqTrackId, idleTrackId, machineId, cpu, ucpu} = it;
+      const {freqTrackId, idleTrackId, machineId, machineName, cpu, ucpu} = it;
       const uri = `/cpu_freq_cpu${ucpu}`;
 
       ctx.tracks.registerTrack({
@@ -116,7 +120,7 @@ export default class implements PerfettoPlugin {
 
       const trackNode = new TrackNode({
         uri,
-        name: `CPU ${new Cpu(ucpu, cpu, machineId).toString()} Frequency`,
+        name: `CPU ${new Cpu(ucpu, cpu, machineId, machineName ?? undefined).toString()} Frequency`,
       });
 
       group.addChildInOrder(trackNode);

--- a/ui/src/plugins/dev.perfetto.Ftrace/index.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/index.ts
@@ -18,7 +18,7 @@ import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {NUM} from '../../trace_processor/query_result';
+import {NUM, STR_NULL} from '../../trace_processor/query_result';
 import {Cpu} from '../../components/cpu';
 import type {FtraceFilter, FtracePluginState as FtraceFilters} from './common';
 import {FtraceExplorer, type FtraceExplorerCache} from './ftrace_explorer';
@@ -137,19 +137,28 @@ async function getFtraceCpus(ctx: Trace): Promise<Cpu[]> {
     SELECT DISTINCT
       ucpu,
       cpu.machine_id AS machine_id,
-      cpu.cpu AS cpu
+      cpu.cpu AS cpu,
+      machine.name AS machine_name
     FROM ftrace_event
     JOIN cpu USING (ucpu)
+    LEFT JOIN machine ON machine.id = cpu.machine_id
     ORDER BY ucpu
   `);
 
   const ucpus: Cpu[] = [];
   for (
-    const it = queryRes.iter({ucpu: NUM, machine_id: NUM, cpu: NUM});
+    const it = queryRes.iter({
+      ucpu: NUM,
+      machine_id: NUM,
+      cpu: NUM,
+      machine_name: STR_NULL,
+    });
     it.valid();
     it.next()
   ) {
-    ucpus.push(new Cpu(it.ucpu, it.cpu, it.machine_id));
+    ucpus.push(
+      new Cpu(it.ucpu, it.cpu, it.machine_id, it.machine_name ?? undefined),
+    );
   }
 
   return ucpus;

--- a/ui/src/plugins/dev.perfetto.Gpu/index.ts
+++ b/ui/src/plugins/dev.perfetto.Gpu/index.ts
@@ -180,11 +180,13 @@ export default class GpuPlugin implements PerfettoPlugin {
         gct.id,
         gct.gpu_id as gpuId,
         gct.machine_id as machineId,
+        m.name as machineName,
         gct.ugpu,
         g.name as gpuName
       from gpu_counter_track gct
       join _counter_track_summary using (id)
       left join gpu g on gct.ugpu = g.id
+      left join machine m on m.id = gct.machine_id
       where gct.name = 'gpufreq'
       order by machineId, gct.ugpu
     `);
@@ -197,6 +199,7 @@ export default class GpuPlugin implements PerfettoPlugin {
       id: NUM,
       gpuId: NUM,
       machineId: NUM,
+      machineName: STR_NULL,
       ugpu: NUM_NULL,
       gpuName: STR_NULL,
     });
@@ -208,6 +211,7 @@ export default class GpuPlugin implements PerfettoPlugin {
           it.gpuId,
           it.machineId,
           it.gpuName ?? undefined,
+          it.machineName ?? undefined,
         ),
       });
     }
@@ -329,10 +333,12 @@ export default class GpuPlugin implements PerfettoPlugin {
           extract_arg(ct.dimension_arg_set_id, 'ugpu') as ugpu,
           extract_arg(ct.dimension_arg_set_id, 'gpu') as gpu_id,
           extract_arg(ct.source_arg_set_id, 'description') as description,
-          g.name as gpu_name
+          g.name as gpu_name,
+          m.name as machine_name
         from counter_track ct
         join _counter_track_summary using (id)
         left join gpu g on extract_arg(ct.dimension_arg_set_id, 'ugpu') = g.id
+        left join machine m on m.id = ct.machine_id
         where ct.type in (${counterTypes})
         order by ct.name
       )
@@ -359,6 +365,7 @@ export default class GpuPlugin implements PerfettoPlugin {
       description: STR_NULL,
       ugpu: NUM_NULL,
       gpu_name: STR_NULL,
+      machine_name: STR_NULL,
     });
     for (; it.valid(); it.next()) {
       const {
@@ -371,6 +378,7 @@ export default class GpuPlugin implements PerfettoPlugin {
         description,
         ugpu,
         gpu_name: gpuName,
+        machine_name: machineName,
       } = it;
       const schema = schemas.get(type);
       if (schema === undefined) {
@@ -378,7 +386,13 @@ export default class GpuPlugin implements PerfettoPlugin {
       }
       const gpu =
         gpuId !== null
-          ? new Gpu(ugpu ?? trackId, gpuId, machineId, gpuName ?? undefined)
+          ? new Gpu(
+              ugpu ?? trackId,
+              gpuId,
+              machineId,
+              gpuName ?? undefined,
+              machineName ?? undefined,
+            )
           : null;
       let trackName = getTrackName({name, kind: COUNTER_TRACK_KIND});
       if (gpu !== null && schema.gpuTrackName !== undefined) {
@@ -583,10 +597,12 @@ export default class GpuPlugin implements PerfettoPlugin {
             count() as trackCount,
             __max_layout_depth(count(), group_concat(t.id)) as maxDepth,
             extract_arg(t.dimension_arg_set_id, 'gpu') as gpu_id,
-            g.name as gpu_name
+            g.name as gpu_name,
+            m.name as machine_name
           from _slice_track_summary s
           join track t using (id)
           left join gpu g on extract_arg(t.dimension_arg_set_id, 'ugpu') = g.id
+          left join machine m on m.id = t.machine_id
           where t.type in (${sliceTypes})
           group by type, t.track_group_id, ifnull(t.track_group_id, t.id),
             extract_arg(t.dimension_arg_set_id, 'ugpu')
@@ -611,6 +627,7 @@ export default class GpuPlugin implements PerfettoPlugin {
       description: STR_NULL,
       ugpu: NUM_NULL,
       gpu_name: STR_NULL,
+      machine_name: STR_NULL,
     });
     for (; it.valid(); it.next()) {
       const {
@@ -622,6 +639,7 @@ export default class GpuPlugin implements PerfettoPlugin {
         machine_id: machineId,
         ugpu,
         gpu_name: gpuName,
+        machine_name: machineName,
       } = it;
       const schema = schemas.get(type);
       if (schema === undefined) {
@@ -630,7 +648,13 @@ export default class GpuPlugin implements PerfettoPlugin {
       const trackIds = rawTrackIds.split(',').map((v) => Number(v));
       const gpu =
         gpuId !== null
-          ? new Gpu(ugpu ?? trackIds[0], gpuId, machineId, gpuName ?? undefined)
+          ? new Gpu(
+              ugpu ?? trackIds[0],
+              gpuId,
+              machineId,
+              gpuName ?? undefined,
+              machineName ?? undefined,
+            )
           : null;
       const trackName = getTrackName({name, kind: SLICE_TRACK_KIND});
       const uri = `/slice_${ugpu ?? trackIds[0]}_${trackIds[0]}`;

--- a/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
@@ -233,12 +233,14 @@ async function discoverFallbackTracks(ctx: Trace): Promise<LeafTrack[]> {
       extract_arg(t.dimension_arg_set_id, 'gpu') AS gpu_id,
       t.machine_id AS machine_id,
       g.name AS gpu_name,
+      m.name AS machine_name,
       p.pid AS pid,
       p.name AS process_name
     FROM gpu_slice s
     JOIN gpu_track t ON s.track_id = t.id
     JOIN process p USING (upid)
     LEFT JOIN gpu g ON extract_arg(t.dimension_arg_set_id, 'ugpu') = g.id
+    LEFT JOIN machine m ON m.id = t.machine_id
     WHERE s.upid IS NOT NULL AND s.hw_queue_id IS NOT NULL
       AND (extract_arg(s.arg_set_id, 'device') IS NULL
            OR extract_arg(s.arg_set_id, 'stream') IS NULL)
@@ -254,6 +256,7 @@ async function discoverFallbackTracks(ctx: Trace): Promise<LeafTrack[]> {
     gpu_id: NUM_NULL,
     machine_id: NUM,
     gpu_name: STR_NULL,
+    machine_name: STR_NULL,
     pid: NUM_NULL,
     process_name: STR_NULL,
   });
@@ -277,6 +280,7 @@ async function discoverFallbackTracks(ctx: Trace): Promise<LeafTrack[]> {
             it.gpu_id,
             it.machine_id,
             it.gpu_name ?? undefined,
+            it.machine_name ?? undefined,
           )
         : null;
     rows.push({

--- a/ui/src/plugins/dev.perfetto.ProcessThreadGroups/index.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessThreadGroups/index.ts
@@ -188,8 +188,10 @@ export default class implements PerfettoPlugin {
           upid as uid,
           pid as id,
           processName as name,
-          machine
+          processGroups.machine as machine,
+          m.name as machineName
         from processGroups
+        left join machine m on m.id = processGroups.machine
         order by
           processSortIndexHint asc,
           chromeProcessRank desc,
@@ -210,8 +212,10 @@ export default class implements PerfettoPlugin {
           utid as uid,
           tid as id,
           threadName as name,
-          machine
+          threadGroups.machine as machine,
+          m.name as machineName
         from threadGroups
+        left join machine m on m.id = threadGroups.machine
         order by
           threadSortIndexHint asc,
           perfSampleCount desc,
@@ -229,6 +233,7 @@ export default class implements PerfettoPlugin {
       id: NUM,
       name: STR_NULL,
       machine: NUM,
+      machineName: STR_NULL,
     });
     for (; it.valid(); it.next()) {
       const {kind, uid, id, name} = it;
@@ -239,7 +244,7 @@ export default class implements PerfettoPlugin {
           continue;
         }
 
-        const machineLabel = maybeMachineLabel(it.machine);
+        const machineLabel = maybeMachineLabel(it.machine, it.machineName);
         function getProcessDisplayName(
           processName: string | undefined,
           pid: number,

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -537,19 +537,28 @@ async function getSchedCpus(ctx: Trace): Promise<Cpu[]> {
     SELECT DISTINCT
       ucpu,
       cpu.machine_id AS machine_id,
-      cpu.cpu AS cpu
+      cpu.cpu AS cpu,
+      machine.name AS machine_name
     FROM sched
     JOIN cpu USING (ucpu)
+    LEFT JOIN machine ON machine.id = cpu.machine_id
     ORDER BY ucpu
   `);
 
   const ucpus: Cpu[] = [];
   for (
-    const it = queryRes.iter({ucpu: NUM, machine_id: NUM, cpu: NUM});
+    const it = queryRes.iter({
+      ucpu: NUM,
+      machine_id: NUM,
+      cpu: NUM,
+      machine_name: STR_NULL,
+    });
     it.valid();
     it.next()
   ) {
-    ucpus.push(new Cpu(it.ucpu, it.cpu, it.machine_id));
+    ucpus.push(
+      new Cpu(it.ucpu, it.cpu, it.machine_id, it.machine_name ?? undefined),
+    );
   }
 
   return ucpus;

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/machines.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/machines.ts
@@ -22,6 +22,7 @@ import {Grid, GridCell, GridHeaderCell} from '../../../widgets/grid';
 const machineRowSpec = {
   id: NUM_NULL,
   rawId: NUM_NULL,
+  name: STR_NULL,
   sysname: STR_NULL,
   release: STR_NULL,
   version: STR_NULL,
@@ -44,6 +45,7 @@ export async function loadMachinesData(engine: Engine): Promise<MachinesData> {
     select
       id,
       raw_id as rawId,
+      name,
       sysname,
       release,
       version,
@@ -63,6 +65,7 @@ export async function loadMachinesData(engine: Engine): Promise<MachinesData> {
     machines.push({
       id: iter.id,
       rawId: iter.rawId,
+      name: iter.name,
       sysname: iter.sysname,
       release: iter.release,
       version: iter.version,

--- a/ui/src/public/utils.ts
+++ b/ui/src/public/utils.ts
@@ -31,6 +31,7 @@ export function getTrackName(
     threadTrack: boolean;
     uidTrack: boolean;
     machine: number | null;
+    machineName: string | null;
   }>,
 ) {
   const {
@@ -47,6 +48,7 @@ export function getTrackName(
     threadTrack,
     uidTrack,
     machine,
+    machineName,
   } = args;
 
   const hasName = name !== undefined && name !== null && name !== '[NULL]';
@@ -66,7 +68,7 @@ export function getTrackName(
   // upid/utid) we show the track kind to help with tracking
   // down where this is coming from.
   const kindSuffix = hasKind ? ` (${kind})` : '';
-  const machineLabel = maybeMachineLabel(machine ?? undefined);
+  const machineLabel = maybeMachineLabel(machine ?? undefined, machineName);
 
   if (isThreadTrack && hasName && hasTid) {
     return `${name} (${tid})`;
@@ -132,7 +134,16 @@ export async function getTimeSpanOfSelectionOrVisibleWindow(
   }
 }
 
-export function maybeMachineLabel(machine?: number): string {
+export function maybeMachineLabel(
+  machine?: number,
+  machineName?: string | null,
+): string {
   const m = machine ?? 0;
-  return m > 0 ? ` (machine ${m})` : '';
+  if (m <= 0) return '';
+  // Prefer the human-readable machine name (machine.name) when the trace
+  // provides one; otherwise fall back to the numeric machine id.
+  if (machineName !== undefined && machineName !== null && machineName !== '') {
+    return ` (${machineName})`;
+  }
+  return ` (machine ${m})`;
 }


### PR DESCRIPTION
Add an optional machine_name field to SystemInfo so a machine can be given a human-readable name instead of only a numeric id.

A producer attributing its data to a non-host machine (a non-zero machine_id) can emit a SystemInfo packet with machine_name; the tracing service stamps the machine_id onto it as it does for any producer packet. Trace Processor records the name on a new machine.name column, and the UI uses it as the machine's label, falling back to "machine <id>" when unset. This updates the per-machine suffix on the CPU, GPU, process and thread tracks in multi-machine traces.

Nothing populates machine_name automatically, so traces without an explicit name are unchanged and keep the numeric label.