### PR TITLE
MessageTest: Avoid null reference

### DIFF
--- a/src/protozero/message_unittest.cc
+++ b/src/protozero/message_unittest.cc
@@ -403,7 +403,7 @@ TEST_F(MessageTest, MessageHandle) {
   MessageHandle<FakeRootMessage> handle4(msg4);
   ASSERT_EQ(msg4, &*handle4);
   msg4->Finalize();
-  ASSERT_EQ(nullptr, &*handle4);
+  ASSERT_THAT(handle4.operator->(), testing::IsNull());
 #endif
 
   // Test also the behavior of handle with non-root (nested) messages.

--- a/src/protozero/message_unittest.cc
+++ b/src/protozero/message_unittest.cc
@@ -403,7 +403,7 @@ TEST_F(MessageTest, MessageHandle) {
   MessageHandle<FakeRootMessage> handle4(msg4);
   ASSERT_EQ(msg4, &*handle4);
   msg4->Finalize();
-  ASSERT_THAT(handle4.operator->(), testing::IsNull());
+  ASSERT_THAT(handle4.get(), testing::IsNull());
 #endif
 
   // Test also the behavior of handle with non-root (nested) messages.


### PR DESCRIPTION
`MessageTest.MessageHandle` currently crashes when the build is both `DCHECK()`-enabled and built with `-fsanitize=null`. This is because

1.  `MessageHandleBase::operator*()` dereferences `operator->()` (to mint a reference),
2.  the test takes the address of a call to `MessageHandleBase::operator*()` and
3.  the test then asserts that the address is nullptr.

I'm not clear on the details (perhaps the compiler is cancelling out the operators to just manifest a nullptr in the right place, so that the assertion doesn't usually crash), but either dereferencing a nullptr or using it to mint a null reference is probably undefined behavior.

Either way, this prevents us from doing more things with `-fsanitize=null`. To get around this, this CL changes the test to directly assert that the value of `message_` is not nullptr.

Bug: 524864598