### PR TITLE
Move android_jank_cuj_layer_name from metrics to stdlib

### DIFF
--- a/src/trace_processor/metrics/sql/android/android_jank_cuj.sql
+++ b/src/trace_processor/metrics/sql/android/android_jank_cuj.sql
@@ -128,5 +128,5 @@ SELECT
         ))
       FROM android_jank_cuj cuj
       LEFT JOIN android_jank_cuj_boundary boundary USING (cuj_id)
-      LEFT JOIN android_jank_cuj_layer_name cuj_layer USING (cuj_id)
+      LEFT JOIN _android_jank_cuj_layer_name cuj_layer USING (cuj_id)
       ORDER BY cuj.cuj_id ASC));

--- a/src/trace_processor/metrics/sql/android/jank/frames.sql
+++ b/src/trace_processor/metrics/sql/android/jank/frames.sql
@@ -54,24 +54,11 @@ JOIN actual_timeline_with_vsync timeline
 LEFT JOIN expected_frame_timeline_slice expected
   ON expected.upid = timeline.upid AND expected.name = timeline.name
 LEFT JOIN _vsync_missed_callback missed_callback USING(vsync)
+LEFT JOIN _android_jank_cuj_layer_name cuj_layer USING (cuj_id)
 WHERE
-  boundary.layer_id IS NULL
-  OR (
-    timeline.layer_name GLOB '*#*'
-    AND boundary.layer_id
-      = CAST(STR_SPLIT(timeline.layer_name, '#', 1) AS INTEGER))
+  cuj_layer.layer_name IS NULL
+  OR timeline.layer_name = cuj_layer.layer_name
 GROUP BY cuj_id, vsync;
-
-DROP TABLE IF EXISTS android_jank_cuj_layer_name;
-CREATE PERFETTO TABLE android_jank_cuj_layer_name AS
-SELECT
-    cuj_id,
-    MAX(frame_layer_name) as layer_name
-FROM android_jank_cuj_frame_timeline timeline
-GROUP BY cuj_id
--- Return only cujs where the max number of layers for all frames in the whole cuj equals 1,
--- this is to infer the layer name if the cuj marker for layer id is not present
-HAVING MAX(number_of_layers_for_frame) = 1;
 
 -- Matches slices and boundaries to compute estimated frame boundaries across
 -- all threads. Joins with the actual timeline to figure out which frames missed
@@ -126,11 +113,10 @@ WITH android_jank_cuj_timeline_sf_frame AS (
         boundary.upid = timeline.upid
         AND CAST(timeline.name AS INTEGER) >= vsync_min
         AND CAST(timeline.name AS INTEGER) <= vsync_max
+    LEFT JOIN _android_jank_cuj_layer_name cuj_layer USING (cuj_id)
     WHERE
-        boundary.layer_id IS NULL
-      OR (
-        timeline.layer_name GLOB '*#*'
-        AND boundary.layer_id = CAST(STR_SPLIT(timeline.layer_name, '#', 1) AS INTEGER))
+        cuj_layer.layer_name IS NULL
+      OR timeline.layer_name = cuj_layer.layer_name
 ),
 android_jank_cuj_sf_frame_base AS (
     SELECT DISTINCT

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
@@ -258,6 +258,70 @@ WHERE
   AND (vsync >= begin_vsync OR begin_vsync IS NULL)
   AND (vsync <= end_vsync OR end_vsync IS NULL);
 
+-- Resolves the layer name for each CUJ.
+-- The layer can be identified in two ways:
+-- 1. Explicit Marker: The Android framework may log a 'layerId#<id>' instant event. If
+--    present, this is extracted into `cuj_layer_id` inside `_cuj_instant_events`.
+--    We then filter `_all_frames_in_cuj` to exactly that layer.
+-- 2. Fallback Inference: On older versions and when the proper way to report CUJs
+--    is not used (e.g. on some apps that copy the same convention to report CUJs),
+--    we try to infer the layer name. We check if the app rendered exactly one layer
+--    per frame during the CUJ (`HAVING MAX(layers_per_frame) = 1`). If so, we safely
+--    use that layer's name (extracted via `MAX(layer_name)`). If multiple layers
+--    were rendered simultaneously, we can't safely guess, and return NULL.
+CREATE PERFETTO TABLE _android_jank_cuj_layer_name(
+  -- CUJ id.
+  cuj_id LONG,
+  -- Layer name of the CUJ.
+  layer_name STRING
+)
+AS
+WITH
+  -- 1. Explicit Marker
+  -- If the CUJ logged a 'layerId#<id>' marker, _all_frames_in_cuj contains
+  -- the extracted cuj_layer_id. We simply filter frames by that layer ID.
+  explicit_layer_name AS (
+    SELECT cuj_id, MAX(layer_name) AS layer_name
+    FROM _all_frames_in_cuj
+    WHERE
+      cuj_layer_id IS NOT NULL
+      AND layer_id = cuj_layer_id
+    GROUP BY
+      cuj_id
+  ),
+  -- 2. Fallback Inference
+  -- If the marker is missing (cuj_layer_id IS NULL), we look at all layers
+  -- rendered during the CUJ timeframe.
+  fallback_frames AS (
+    SELECT cuj_id, frame_id, layer_name
+    FROM _all_frames_in_cuj
+    WHERE
+      cuj_layer_id IS NULL
+    GROUP BY
+      cuj_id,
+      frame_id,
+      layer_name
+  ),
+  fallback_layer_counts AS (
+    SELECT
+      cuj_id,
+      layer_name,
+      COUNT(1) OVER (PARTITION BY cuj_id, frame_id) AS layers_per_frame
+    FROM fallback_frames
+  ),
+  fallback_layer_name AS (
+    SELECT cuj_id, MAX(layer_name) AS layer_name
+    FROM fallback_layer_counts
+    GROUP BY
+      cuj_id
+    -- Only use the fallback if every single frame in the CUJ rendered exactly 1 layer.
+    HAVING
+      MAX(layers_per_frame) = 1
+  )
+SELECT cuj_id, layer_name FROM explicit_layer_name
+UNION ALL
+SELECT cuj_id, layer_name FROM fallback_layer_name;
+
 -- Table tracking all jank CUJs information.
 CREATE PERFETTO TABLE android_jank_cuj(
   -- Unique incremental ID for each CUJ.


### PR DESCRIPTION
This moves us one step closer to migrating the android jank tables to the stdlib entirely.

The implementation was relying on some assumptions that were not obvious. The new implementation made it much easier to understand what was going on there, and clearly splits the default case (where the instant event is parsed), from the legacy/"officially unsupported 3p apps" case (with the heuristic checking for only one layer to be there, and if it's the case, assigning that to the cuj). Existing tests should be enough to capture any issue here.
