### PR TITLE
Migrate CUJ ui thread resolution queries to stdlib

### DIFF
--- a/src/trace_processor/metrics/sql/android/jank/relevant_threads.sql
+++ b/src/trace_processor/metrics/sql/android/jank/relevant_threads.sql
@@ -18,28 +18,24 @@ INCLUDE PERFETTO MODULE android.surfaceflinger;
 INCLUDE PERFETTO MODULE slices.with_context;
 INCLUDE PERFETTO MODULE android.cujs.threads;
 
+-- NOTE: We preserve the legacy view and table names in this file because external
+-- consumers and analytical pipelines outside the Perfetto project rely on them.
+
 DROP TABLE IF EXISTS android_jank_cuj_main_thread;
 CREATE PERFETTO TABLE android_jank_cuj_main_thread AS
-SELECT cuj_id, cuj.upid, utid, thread.name, thread_track.id AS track_id
-FROM thread
-JOIN android_jank_cuj cuj USING (upid)
-JOIN thread_track USING (utid)
-WHERE
-  (cuj.ui_thread IS NULL AND thread.is_main_thread)
-  -- Some CUJs use a dedicated thread for Choreographer callbacks
-  OR (cuj.ui_thread = thread.utid);
+SELECT * FROM _android_jank_cuj_main_thread;
 
 DROP TABLE IF EXISTS android_jank_cuj_gpu_completion_thread;
 CREATE PERFETTO TABLE android_jank_cuj_gpu_completion_thread AS
-SELECT * FROM ANDROID_JANK_CUJ_APP_THREAD('GPU completion');
+SELECT * FROM _android_jank_cuj_gpu_completion_thread;
 
 DROP TABLE IF EXISTS android_jank_cuj_hwc_release_thread;
 CREATE PERFETTO TABLE android_jank_cuj_hwc_release_thread AS
-SELECT * FROM ANDROID_JANK_CUJ_APP_THREAD('HWC release');
+SELECT * FROM _android_jank_cuj_hwc_release_thread;
 
 DROP TABLE IF EXISTS android_jank_cuj_sf_process;
 CREATE PERFETTO TABLE android_jank_cuj_sf_process AS
-SELECT * FROM _android_sf_process;
+SELECT * FROM _android_jank_cuj_sf_process;
 
 -- TODO(devianb): Remove table once we migrate google3 pipelines away from using them.
 DROP TABLE IF EXISTS android_jank_cuj_sf_main_thread;
@@ -53,8 +49,8 @@ SELECT * FROM _android_sf_thread($thread_name);
 
 DROP TABLE IF EXISTS android_jank_cuj_sf_gpu_completion_thread;
 CREATE PERFETTO TABLE android_jank_cuj_sf_gpu_completion_thread AS
-SELECT * FROM _ANDROID_SF_THREAD('GPU completion');
+SELECT * FROM _android_jank_cuj_sf_gpu_completion_thread;
 
 DROP TABLE IF EXISTS android_jank_cuj_sf_render_engine_thread;
 CREATE PERFETTO TABLE android_jank_cuj_sf_render_engine_thread AS
-SELECT * FROM _ANDROID_SF_THREAD('RenderEngine');
+SELECT * FROM _android_jank_cuj_sf_render_engine_thread;

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/threads.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/threads.sql
@@ -15,6 +15,8 @@
 
 INCLUDE PERFETTO MODULE android.cujs.base;
 
+INCLUDE PERFETTO MODULE android.surfaceflinger;
+
 -- Returns a table with all CUJs and an additional column for the track id of thread_name
 -- passed as parameter, if present in the same process of the cuj.
 CREATE PERFETTO FUNCTION android_jank_cuj_app_thread(
@@ -56,3 +58,98 @@ CREATE PERFETTO TABLE android_jank_cuj_render_thread(
 )
 AS
 SELECT * FROM android_jank_cuj_app_thread('RenderThread');
+
+-- Private table capturing thread information for main/UI thread for all CUJs.
+CREATE PERFETTO TABLE _android_jank_cuj_main_thread(
+  -- Unique incremental ID for each CUJ.
+  cuj_id LONG,
+  -- process id.
+  upid JOINID(process.id),
+  -- thread id of the main/UI thread.
+  utid JOINID(thread.id),
+  -- thread name.
+  name STRING,
+  -- track_id for the thread.
+  track_id JOINID(track.id)
+)
+AS
+SELECT cuj_id, cuj.upid, utid, thread.name, thread_track.id AS track_id
+FROM thread
+JOIN android_jank_cuj AS cuj USING (upid)
+JOIN thread_track USING (utid)
+WHERE
+  (cuj.ui_thread IS NULL AND thread.is_main_thread)
+  -- Some CUJs use a ui thread different than the main thread. We get the ui
+  -- thread thanks to an instant event. If that is not available, we use the app
+  -- main thread (typically pid == tid).
+  OR (cuj.ui_thread = thread.utid);
+
+-- Private table capturing thread information for 'GPU completion' thread for all CUJs.
+CREATE PERFETTO TABLE _android_jank_cuj_gpu_completion_thread(
+  -- Unique incremental ID for each CUJ.
+  cuj_id LONG,
+  -- process id.
+  upid JOINID(process.id),
+  -- thread id of the thread.
+  utid JOINID(thread.id),
+  -- thread name.
+  name STRING,
+  -- track_id for the thread.
+  track_id JOINID(track.id)
+)
+AS
+SELECT * FROM android_jank_cuj_app_thread('GPU completion');
+
+-- Private table capturing thread information for 'HWC release' thread for all CUJs.
+CREATE PERFETTO TABLE _android_jank_cuj_hwc_release_thread(
+  -- Unique incremental ID for each CUJ.
+  cuj_id LONG,
+  -- process id.
+  upid JOINID(process.id),
+  -- thread id of the thread.
+  utid JOINID(thread.id),
+  -- thread name.
+  name STRING,
+  -- track_id for the thread.
+  track_id JOINID(track.id)
+)
+AS
+SELECT * FROM android_jank_cuj_app_thread('HWC release');
+
+-- Private table capturing the SurfaceFlinger process.
+CREATE PERFETTO TABLE _android_jank_cuj_sf_process(
+  -- process id.
+  upid JOINID(process.id),
+  -- process name.
+  name STRING
+)
+AS
+SELECT upid, name FROM _android_sf_process;
+
+-- Private table capturing the SurfaceFlinger 'GPU completion' thread.
+CREATE PERFETTO TABLE _android_jank_cuj_sf_gpu_completion_thread(
+  -- process id.
+  upid JOINID(process.id),
+  -- thread id of the thread.
+  utid JOINID(thread.id),
+  -- thread name.
+  name STRING,
+  -- track_id for the thread.
+  track_id JOINID(track.id)
+)
+AS
+SELECT * FROM _android_sf_thread('GPU completion');
+
+-- Private table capturing the SurfaceFlinger 'RenderEngine' thread.
+CREATE PERFETTO TABLE _android_jank_cuj_sf_render_engine_thread(
+  -- process id.
+  upid JOINID(process.id),
+  -- thread id of the thread.
+  utid JOINID(thread.id),
+  -- thread name.
+  name STRING,
+  -- track_id for the thread.
+  track_id JOINID(track.id)
+)
+AS
+SELECT * FROM _android_sf_thread('RenderEngine');


### PR DESCRIPTION
Move resolved threads logic from metrics to private tables in the android.cujs.threads stdlib module, replacing them with thin views in the metric file to avoid duplication and maintain compatibility.

I also made the comments better.

I would be happy to delete [relevant_threads.sql](https://github.com/google/perfetto/compare/dev/nicomazz/migrate-cuj-threads-stdlib?expand=1#diff-0789130dbac434c6c5b43cdc9287215e72df316946221f42ac98b9ac4231bec9), but we first need to find and replace all the places that are using those tables (which requires this cl getting in first)