### PR TITLE
tp: speed up and shrink SliceTracker

### DIFF
--- a/src/trace_processor/importers/common/BUILD.gn
+++ b/src/trace_processor/importers/common/BUILD.gn
@@ -166,14 +166,18 @@ source_set("v8_profile_parser") {
 
 if (enable_perfetto_benchmarks) {
   source_set("benchmarks") {
-    sources = [ "clock_tracker_benchmark.cc" ]
     testonly = true
+    sources = [
+      "clock_tracker_benchmark.cc",
+      "slice_tracker_benchmark.cc",
+    ]
     deps = [
       ":common",
       "../../../../gn:benchmark",
       "../../../../gn:default_deps",
       "../../../../protos/perfetto/common:zero",
       "../../storage",
+      "../../tables",
       "../../types",
       "../../util:clock",
     ]

--- a/src/trace_processor/importers/common/args_tracker.h
+++ b/src/trace_processor/importers/common/args_tracker.h
@@ -295,6 +295,13 @@ class ArgsTracker {
   // Virtual for testing.
   virtual void Flush();
 
+  // Resets state for reuse (retaining buffer capacity); does not commit. Call
+  // Flush() first if pending args still need writing.
+  void Clear() {
+    args_.clear();
+    array_indexes_.Clear();
+  }
+
  private:
   template <typename T>
   BoundInserter AddArgsTo(T* table, typename T::Id id) {

--- a/src/trace_processor/importers/common/slice_tracker.cc
+++ b/src/trace_processor/importers/common/slice_tracker.cc
@@ -146,8 +146,8 @@ SliceTracker::StartedSlice SliceTracker::StartSlice(
 
 SliceTracker::EndedSlice SliceTracker::CompleteSliceBegin(int64_t timestamp,
                                                           TrackId track_id,
-                                                          StringId raw_name,
                                                           StringId category,
+                                                          StringId raw_name,
                                                           bool want_args) {
   const StringId name =
       context_->slice_translation_table->TranslateName(raw_name);

--- a/src/trace_processor/importers/common/slice_tracker.cc
+++ b/src/trace_processor/importers/common/slice_tracker.cc
@@ -17,7 +17,6 @@
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <optional>
 #include <utility>
 
@@ -69,89 +68,133 @@ SliceTracker::~SliceTracker() {
   FlushPendingSlices();
 }
 
-std::optional<SliceId> SliceTracker::Begin(int64_t timestamp,
-                                           TrackId track_id,
-                                           StringId category,
-                                           StringId raw_name,
-                                           SetArgsCallback args_callback) {
-  const StringId name =
-      context_->slice_translation_table->TranslateName(raw_name);
-  tables::SliceTable::Row row(timestamp, kPendingDuration, track_id, category,
-                              name);
-  return StartSlice(
-      timestamp, row.dur, track_id, args_callback, [this, &row]() {
-        return context_->storage->mutable_slice_table()->Insert(row).id;
-      });
+void SliceTracker::RecordSliceNegativeDuration(int64_t timestamp) {
+  context_->import_logs_tracker->RecordParserError(
+      stats::slice_negative_duration, timestamp);
 }
 
-void SliceTracker::BeginLegacyUnnestable(tables::SliceTable::Row row,
-                                         SetArgsCallback args_callback) {
-  if (row.name) {
-    row.name = context_->slice_translation_table->TranslateName(*row.name);
+bool SliceTracker::PrepareStartSlice(TrackInfo& track_info,
+                                     int64_t timestamp,
+                                     int64_t duration,
+                                     std::optional<OverlapInfo>* overlap_out) {
+  if (track_info.is_legacy_unnestable) {
+    PERFETTO_DCHECK(track_info.slice_stack.size() <= 1);
+
+    track_info.legacy_unnestable_begin_count++;
+    track_info.legacy_unnestable_last_begin_ts = timestamp;
+
+    // If this is an unnestable track, don't start a new slice if one already
+    // exists.
+    if (!track_info.slice_stack.empty()) {
+      return false;
+    }
   }
 
-  // Ensure that the duration is pending for this row.
-  // TODO(lalitm): change this to eventually use null instead of -1.
-  row.dur = kPendingDuration;
-
-  // Double check that if we've seen this track in the past, it was also
-  // marked as unnestable then.
-#if PERFETTO_DCHECK_IS_ON()
-  auto* it = stacks_.Find(row.track_id);
-  PERFETTO_DCHECK(!it || it->is_legacy_unnestable);
-#endif
-
-  // Ensure that StartSlice knows that this track is unnestable.
-  stacks_[row.track_id].is_legacy_unnestable = true;
-
-  StartSlice(row.ts, row.dur, row.track_id, args_callback, [this, &row]() {
-    return context_->storage->mutable_slice_table()->Insert(row).id;
-  });
+  return MaybeCloseStack(track_info, timestamp, duration, overlap_out);
 }
 
-std::optional<SliceId> SliceTracker::Scoped(
+void SliceTracker::LogMaxDepthExceeded(const SliceInfo& parent, StringId name) {
+  auto* slices = context_->storage->mutable_slice_table();
+  auto parent_name = context_->storage->GetString(
+      parent.row.ToRowReference(slices).name().value_or(kNullStringId));
+  auto current_name =
+      context_->storage->GetString(name.is_null() ? kNullStringId : name);
+  PERFETTO_DLOG("Last slice: %s", parent_name.c_str());
+  PERFETTO_DLOG("Current slice: %s", current_name.c_str());
+  PERFETTO_DFATAL("Slices with too large depth found.");
+}
+
+SliceTracker::StartedSlice SliceTracker::StartSlice(
     int64_t timestamp,
+    int64_t duration,
     TrackId track_id,
     StringId category,
     StringId raw_name,
-    int64_t duration,
-    SetArgsCallback args_callback,
+    bool want_args,
     std::optional<OverlapInfo>* overlap_out) {
-  if (duration < 0) {
-    context_->import_logs_tracker->RecordParserError(
-        stats::slice_negative_duration, timestamp);
-    return std::nullopt;
+  const StringId name =
+      context_->slice_translation_table->TranslateName(raw_name);
+
+  // Resolve the track once and thread it through; nothing below rehashes.
+  TrackInfo& track_info = GetOrCreateTrackInfo(track_id);
+  if (!PrepareStartSlice(track_info, timestamp, duration, overlap_out))
+    return {};
+
+  auto& stack = track_info.slice_stack;
+  size_t depth = stack.size();
+  if (PERFETTO_UNLIKELY(depth >= kMaxDepth)) {
+    LogMaxDepthExceeded(stack.back(), name);
+    return {};
   }
 
-  const StringId name =
-      context_->slice_translation_table->TranslateName(raw_name);
+  // Set depth/parent pre-insert so they ride the single table insert.
+  auto* slices = context_->storage->mutable_slice_table();
   tables::SliceTable::Row row(timestamp, duration, track_id, category, name);
-  return StartSlice(
-      timestamp, row.dur, track_id, args_callback,
-      [this, &row]() {
-        return context_->storage->mutable_slice_table()->Insert(row).id;
-      },
-      overlap_out);
+  row.depth = static_cast<uint32_t>(depth);
+  if (depth != 0)
+    row.parent_id = stack.back().row.ToRowReference(slices).id();
+
+  auto inserted = slices->Insert(std::move(row));
+  StackPush(track_info, track_id, inserted.row_number, inserted.id);
+
+  StartedSlice result;
+  result.id = inserted.id;
+  if (want_args)
+    result.inserter.emplace(ArgsInserter(stack.back(), inserted.id));
+  return result;
 }
 
-std::optional<SliceId> SliceTracker::End(int64_t timestamp,
-                                         TrackId track_id,
-                                         StringId category,
-                                         StringId raw_name,
-                                         SetArgsCallback args_callback) {
+SliceTracker::EndedSlice SliceTracker::CompleteSliceBegin(int64_t timestamp,
+                                                          TrackId track_id,
+                                                          StringId raw_name,
+                                                          StringId category,
+                                                          bool want_args) {
   const StringId name =
       context_->slice_translation_table->TranslateName(raw_name);
-  auto finder = [this, category, name](const SlicesStack& stack) {
-    return MatchingIncompleteSliceIndex(stack, name, category);
-  };
-  return CompleteSlice(timestamp, track_id, args_callback, finder);
+
+  EndedSlice result;
+  auto* it = FindTrackInfo(track_id);
+  if (!it)
+    return result;
+
+  TrackInfo& track_info = *it;
+  auto& stack = track_info.slice_stack;
+  if (!MaybeCloseStack(track_info, timestamp, kPendingDuration,
+                       /*overlap_out=*/nullptr)) {
+    return result;
+  }
+  if (stack.empty())
+    return result;
+
+  std::optional<uint32_t> stack_idx =
+      MatchingIncompleteSliceIndex(stack, name, category);
+
+  // If we are trying to close slices that are not open on the stack (e.g.,
+  // slices that began before tracing started), bail out.
+  if (!stack_idx)
+    return result;
+
+  auto* slices = context_->storage->mutable_slice_table();
+  SliceInfo& slice_info = stack[*stack_idx];
+  tables::SliceTable::RowReference ref = slice_info.row.ToRowReference(slices);
+  PERFETTO_DCHECK(ref.dur() == kPendingDuration);
+  ref.set_dur(timestamp - ref.ts());
+
+  result.id = ref.id();
+  result.state.track_info = &track_info;
+  result.state.stack_idx = *stack_idx;
+  if (want_args)
+    result.inserter.emplace(ArgsInserter(slice_info, ref.id()));
+  return result;
 }
 
-std::optional<uint32_t> SliceTracker::AddArgs(TrackId track_id,
-                                              StringId category,
-                                              StringId name,
-                                              SetArgsCallback args_callback) {
-  auto* it = stacks_.Find(track_id);
+std::optional<uint32_t> SliceTracker::AddArgsImpl(
+    TrackId track_id,
+    StringId category,
+    StringId name,
+    bool want_args,
+    std::optional<ArgsTracker::BoundInserter>* inserter) {
+  auto* it = FindTrackInfo(track_id);
   if (!it)
     return std::nullopt;
 
@@ -162,138 +205,59 @@ std::optional<uint32_t> SliceTracker::AddArgs(TrackId track_id,
   auto* slices = context_->storage->mutable_slice_table();
   std::optional<uint32_t> stack_idx =
       MatchingIncompleteSliceIndex(stack, name, category);
-  if (!stack_idx.has_value())
-    return std::nullopt;
-
-  tables::SliceTable::RowNumber num = stack[*stack_idx].row;
-  tables::SliceTable::RowReference ref = num.ToRowReference(slices);
-  PERFETTO_DCHECK(ref.dur() == kPendingDuration);
-
-  // Add args to current pending slice.
-  ArgsTracker* tracker = &stack[*stack_idx].args_tracker;
-  auto bound_inserter = tracker->AddArgsTo(ref.id());
-  args_callback(&bound_inserter);
-  return num.row_number();
-}
-
-std::optional<SliceId> SliceTracker::StartSlice(
-    int64_t timestamp,
-    int64_t duration,
-    TrackId track_id,
-    SetArgsCallback args_callback,
-    std::function<SliceId()> inserter,
-    std::optional<OverlapInfo>* overlap_out) {
-  auto& track_info = stacks_[track_id];
-  auto& stack = track_info.slice_stack;
-
-  if (track_info.is_legacy_unnestable) {
-    PERFETTO_DCHECK(stack.size() <= 1);
-
-    track_info.legacy_unnestable_begin_count++;
-    track_info.legacy_unnestable_last_begin_ts = timestamp;
-
-    // If this is an unnestable track, don't start a new slice if one already
-    // exists.
-    if (!stack.empty()) {
-      return std::nullopt;
-    }
-  }
-
-  auto* slices = context_->storage->mutable_slice_table();
-  if (!MaybeCloseStack(timestamp, duration, stack, track_id, overlap_out)) {
-    return std::nullopt;
-  }
-
-  size_t depth = stack.size();
-
-  std::optional<tables::SliceTable::RowReference> parent_ref =
-      depth == 0 ? std::nullopt
-                 : std::make_optional(stack.back().row.ToRowReference(slices));
-  std::optional<tables::SliceTable::Id> parent_id =
-      parent_ref ? std::make_optional(parent_ref->id()) : std::nullopt;
-
-  SliceId id = inserter();
-  tables::SliceTable::RowReference ref = (*slices)[id];
-  if (depth >= kMaxDepth) {
-    auto parent_name = context_->storage->GetString(
-        parent_ref->name().value_or(kNullStringId));
-    auto name =
-        context_->storage->GetString(ref.name().value_or(kNullStringId));
-    PERFETTO_DLOG("Last slice: %s", parent_name.c_str());
-    PERFETTO_DLOG("Current slice: %s", name.c_str());
-    PERFETTO_DFATAL("Slices with too large depth found.");
-    return std::nullopt;
-  }
-  StackPush(track_id, ref);
-
-  // Post fill all the relevant columns. All the other columns should have
-  // been filled by the inserter.
-  ref.set_depth(static_cast<uint32_t>(depth));
-  if (parent_id)
-    ref.set_parent_id(*parent_id);
-
-  if (args_callback) {
-    auto bound_inserter = stack.back().args_tracker.AddArgsTo(id);
-    args_callback(&bound_inserter);
-  }
-  return id;
-}
-
-std::optional<SliceId> SliceTracker::CompleteSlice(
-    int64_t timestamp,
-    TrackId track_id,
-    SetArgsCallback args_callback,
-    std::function<std::optional<uint32_t>(const SlicesStack&)> finder) {
-  auto* it = stacks_.Find(track_id);
-  if (!it)
-    return std::nullopt;
-
-  TrackInfo& track_info = *it;
-  SlicesStack& stack = track_info.slice_stack;
-  if (!MaybeCloseStack(timestamp, kPendingDuration, stack, track_id,
-                       /*overlap_out=*/nullptr)) {
-    return std::nullopt;
-  }
-  if (stack.empty()) {
-    return std::nullopt;
-  }
-
-  auto* slices = context_->storage->mutable_slice_table();
-  std::optional<uint32_t> stack_idx = finder(stack);
-
-  // If we are trying to close slices that are not open on the stack (e.g.,
-  // slices that began before tracing started), bail out.
   if (!stack_idx)
     return std::nullopt;
 
-  const auto& slice_info = stack[stack_idx.value()];
-
-  tables::SliceTable::RowReference ref = slice_info.row.ToRowReference(slices);
+  SliceInfo& slice_info = stack[*stack_idx];
+  tables::SliceTable::RowNumber num = slice_info.row;
+  tables::SliceTable::RowReference ref = num.ToRowReference(slices);
   PERFETTO_DCHECK(ref.dur() == kPendingDuration);
-  ref.set_dur(timestamp - ref.ts());
 
-  ArgsTracker& tracker = stack[stack_idx.value()].args_tracker;
-  if (args_callback) {
-    auto bound_inserter = tracker.AddArgsTo(ref.id());
-    args_callback(&bound_inserter);
-  }
+  if (want_args)
+    inserter->emplace(ArgsInserter(slice_info, ref.id()));
+  return num.row_number();
+}
+
+void SliceTracker::CompleteSliceFinalize(const CompleteSliceState& state) {
+  TrackInfo& track_info = *state.track_info;
+  auto& stack = track_info.slice_stack;
+  SliceInfo& slice_info = stack[state.stack_idx];
 
   // Add the legacy unnestable args if they exist.
-  if (track_info.is_legacy_unnestable) {
-    auto bound_inserter = tracker.AddArgsTo(ref.id());
-    bound_inserter.AddArg(
-        legacy_unnestable_begin_count_string_id_,
-        Variadic::Integer(track_info.legacy_unnestable_begin_count));
-    bound_inserter.AddArg(
-        legacy_unnestable_last_begin_ts_string_id_,
-        Variadic::Integer(track_info.legacy_unnestable_last_begin_ts));
-  }
+  if (track_info.is_legacy_unnestable)
+    AddLegacyUnnestableArgs(slice_info, track_info);
 
   // If this slice is the top slice on the stack, pop it off.
-  if (*stack_idx == stack.size() - 1) {
-    StackPop(track_id);
+  if (state.stack_idx == stack.size() - 1)
+    StackPop(track_info);
+}
+
+ArgsTracker::BoundInserter SliceTracker::ArgsInserter(SliceInfo& slice_info,
+                                                      SliceId id) {
+  // Lazily acquire a pooled ArgsTracker (deque => stable BoundInserter ptrs).
+  if (!slice_info.args) {
+    if (!free_args_.empty()) {
+      slice_info.args = free_args_.back();
+      free_args_.pop_back();
+    } else {
+      args_pool_.emplace_back(context_);
+      slice_info.args = &args_pool_.back();
+    }
   }
-  return ref.id();
+  return slice_info.args->AddArgsTo(id);
+}
+
+void SliceTracker::AddLegacyUnnestableArgs(SliceInfo& slice_info,
+                                           const TrackInfo& track_info) {
+  auto* slices = context_->storage->mutable_slice_table();
+  SliceId id = slice_info.row.ToRowReference(slices).id();
+  auto bound_inserter = ArgsInserter(slice_info, id);
+  bound_inserter.AddArg(
+      legacy_unnestable_begin_count_string_id_,
+      Variadic::Integer(track_info.legacy_unnestable_begin_count));
+  bound_inserter.AddArg(
+      legacy_unnestable_last_begin_ts_string_id_,
+      Variadic::Integer(track_info.legacy_unnestable_last_begin_ts));
 }
 
 // Returns the first incomplete slice in the stack with matching name and
@@ -325,8 +289,8 @@ std::optional<uint32_t> SliceTracker::MatchingIncompleteSliceIndex(
 }
 
 void SliceTracker::MaybeAddTranslatableArgs(SliceInfo& slice_info) {
-  if (!slice_info.args_tracker.NeedsTranslation(
-          *context_->args_translation_table)) {
+  PERFETTO_DCHECK(slice_info.args);
+  if (!slice_info.args->NeedsTranslation(*context_->args_translation_table)) {
     return;
   }
   const auto& table = context_->storage->slice_table();
@@ -334,7 +298,7 @@ void SliceTracker::MaybeAddTranslatableArgs(SliceInfo& slice_info) {
       slice_info.row.ToRowReference(table);
   translatable_args_.emplace_back(TranslatableArgs{
       ref.id(),
-      std::move(slice_info.args_tracker)
+      std::move(*slice_info.args)
           .ToCompactArgSet(table.dataframe(),
                            tables::SliceTable::ColumnIndex::arg_set_id,
                            slice_info.row.row_number())});
@@ -349,11 +313,13 @@ void SliceTracker::FlushPendingSlices() {
   // setting their duration to |trace_end - event_start|. Might still want some
   // additional way of flagging these events as "incomplete" to the UI.
 
-  // Make sure that args for all incomplete slice are translated.
+  // Defer translatable args; the rest are flushed when |args_pool_| is
+  // destroyed.
   for (auto it = stacks_.GetIterator(); it; ++it) {
     auto& track_info = it.value();
     for (auto& slice_info : track_info.slice_stack) {
-      MaybeAddTranslatableArgs(slice_info);
+      if (slice_info.args)
+        MaybeAddTranslatableArgs(slice_info);
     }
   }
 
@@ -367,10 +333,14 @@ void SliceTracker::FlushPendingSlices() {
   translatable_args_.clear();
 
   stacks_.Clear();
+
+  // Pool destruction flushes any remaining non-translatable args (dtor Flush).
+  args_pool_.clear();
+  free_args_.clear();
 }
 
 void SliceTracker::SetOnSliceBeginCallback(OnSliceBeginCallback callback) {
-  on_slice_begin_callback_ = callback;
+  on_slice_begin_callback_ = std::move(callback);
 }
 
 std::optional<SliceId> SliceTracker::GetTopmostSliceOnTrack(
@@ -385,11 +355,11 @@ std::optional<SliceId> SliceTracker::GetTopmostSliceOnTrack(
   return stack.back().row.ToRowReference(slice).id();
 }
 
-bool SliceTracker::MaybeCloseStack(int64_t new_ts,
+bool SliceTracker::MaybeCloseStack(TrackInfo& track_info,
+                                   int64_t new_ts,
                                    int64_t new_dur,
-                                   const SlicesStack& stack,
-                                   TrackId track_id,
                                    std::optional<OverlapInfo>* overlap_out) {
+  auto& stack = track_info.slice_stack;
   auto* slices = context_->storage->mutable_slice_table();
   bool incomplete_descendent = false;
   for (int i = static_cast<int>(stack.size()) - 1; i >= 0; i--) {
@@ -436,11 +406,11 @@ bool SliceTracker::MaybeCloseStack(int64_t new_ts,
             stack[static_cast<size_t>(j)].row.ToRowReference(slices);
         PERFETTO_DCHECK(child_ref.dur() == kPendingDuration);
         child_ref.set_dur(end_ts - child_ref.ts());
-        StackPop(track_id);
+        StackPop(track_info);
       }
 
       // Also pop the current row itself and reset the incomplete flag.
-      StackPop(track_id);
+      StackPop(track_info);
       incomplete_descendent = false;
 
       continue;
@@ -469,7 +439,7 @@ bool SliceTracker::MaybeCloseStack(int64_t new_ts,
         end_ts == new_ts && !(dur == 0 && new_dur == 0);
 
     if (ends_before || ends_same_and_should_drop) {
-      StackPop(track_id);
+      StackPop(track_info);
       continue;
     }
 
@@ -510,18 +480,28 @@ bool SliceTracker::MaybeCloseStack(int64_t new_ts,
   return true;
 }
 
-void SliceTracker::StackPop(TrackId track_id) {
-  auto& stack = stacks_[track_id].slice_stack;
-  MaybeAddTranslatableArgs(stack.back());
+void SliceTracker::StackPop(TrackInfo& track_info) {
+  auto& stack = track_info.slice_stack;
+  SliceInfo& info = stack.back();
+  if (info.args) {
+    // Order matters: translatable args are moved out first; Flush is then a
+    // no-op for them and commits the rest.
+    MaybeAddTranslatableArgs(info);
+    info.args->Flush();
+    info.args->Clear();
+    free_args_.push_back(info.args);
+    info.args = nullptr;
+  }
   stack.pop_back();
 }
 
-void SliceTracker::StackPush(TrackId track_id,
-                             tables::SliceTable::RowReference ref) {
-  stacks_[track_id].slice_stack.push_back(
-      SliceInfo{ref.ToRowNumber(), ArgsTracker(context_)});
+void SliceTracker::StackPush(TrackInfo& track_info,
+                             TrackId track_id,
+                             tables::SliceTable::RowNumber row_number,
+                             SliceId id) {
+  track_info.slice_stack.push_back(SliceInfo{row_number, nullptr});
   if (on_slice_begin_callback_) {
-    on_slice_begin_callback_(track_id, ref.id());
+    on_slice_begin_callback_(track_id, id);
   }
 }
 

--- a/src/trace_processor/importers/common/slice_tracker.h
+++ b/src/trace_processor/importers/common/slice_tracker.h
@@ -19,10 +19,14 @@
 
 #include <stdint.h>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <optional>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
+#include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
@@ -37,8 +41,12 @@ class TraceProcessorContext;
 
 class SliceTracker {
  public:
-  using SetArgsCallback = std::function<void(ArgsTracker::BoundInserter*)>;
   using OnSliceBeginCallback = std::function<void(TrackId, SliceId)>;
+
+  // Sentinel default args callback; ArgsPresent() compiles arg handling away.
+  struct NoArgsCallback {
+    void operator()(ArgsTracker::BoundInserter*) const {}
+  };
 
   // Describes a partial overlap detected while adding a scoped slice: the
   // incoming slice partially intersects an already-open slice on the same
@@ -65,15 +73,20 @@ class SliceTracker {
   void AddOverlapArgs(const OverlapInfo&, ArgsTracker::BoundInserter&) const;
 
   explicit SliceTracker(TraceProcessorContext*);
-  virtual ~SliceTracker();
+  ~SliceTracker();
 
-  // virtual for testing
-  virtual std::optional<SliceId> Begin(
-      int64_t timestamp,
-      TrackId track_id,
-      StringId category,
-      StringId raw_name,
-      SetArgsCallback args_callback = SetArgsCallback());
+  template <typename ArgsCb = NoArgsCallback>
+  std::optional<SliceId> Begin(int64_t timestamp,
+                               TrackId track_id,
+                               StringId category,
+                               StringId raw_name,
+                               ArgsCb args = {}) {
+    StartedSlice s =
+        StartSlice(timestamp, kPendingDuration, track_id, category, raw_name,
+                   WantsArgs(args), /*overlap_out=*/nullptr);
+    InvokeArgs(s.inserter, args);
+    return s.id;
+  }
 
   // Unnestable slices are slices which do not have any concept of nesting so
   // starting a new slice when a slice already exists leads to no new slice
@@ -81,68 +94,75 @@ class SliceTracker {
   // as the latest time we saw a begin event. For legacy Android use only. See
   // the comment in SystraceParser::ParseSystracePoint for information on why
   // this method exists.
-  void BeginLegacyUnnestable(tables::SliceTable::Row row,
-                             SetArgsCallback args_callback);
-
-  template <typename Table>
-  std::optional<SliceId> BeginTyped(
-      Table* table,
-      typename Table::Row row,
-      SetArgsCallback args_callback = SetArgsCallback()) {
-    // Ensure that the duration is pending for this row.
-    row.dur = kPendingDuration;
-    if (row.name) {
-      row.name = context_->slice_translation_table->TranslateName(*row.name);
-    }
-    return StartSlice(row.ts, row.dur, row.track_id, args_callback,
-                      [table, &row]() { return table->Insert(row).id; });
+  template <typename ArgsCb>
+  void BeginLegacyUnnestable(tables::SliceTable::Row row, ArgsCb args) {
+#if PERFETTO_DCHECK_IS_ON()
+    auto* it = stacks_.Find(row.track_id);
+    PERFETTO_DCHECK(!it || it->is_legacy_unnestable);
+#endif
+    GetOrCreateTrackInfo(row.track_id).is_legacy_unnestable = true;
+    StartedSlice s = StartSlice(row.ts, kPendingDuration, row.track_id,
+                                kNullStringId, row.name.value_or(kNullStringId),
+                                WantsArgs(args), /*overlap_out=*/nullptr);
+    InvokeArgs(s.inserter, args);
   }
 
-  // virtual for testing
-  //
   // If |overlap_out| is non-null and the slice partially overlaps an open slice
   // on the track, the overlap details are reported via |*overlap_out| (and
   // nullopt is returned) instead of dropping the slice and logging
   // |slice_drop_overlapping_complete_event|, letting the caller recover (e.g.
   // by spilling onto an overflow track). When |overlap_out| is null, the drop
   // is logged with the same overlap details.
-  virtual std::optional<SliceId> Scoped(
+  template <typename ArgsCb = NoArgsCallback>
+  std::optional<SliceId> Scoped(
       int64_t timestamp,
       TrackId track_id,
       StringId category,
       StringId raw_name,
       int64_t duration,
-      SetArgsCallback args_callback = SetArgsCallback(),
-      std::optional<OverlapInfo>* overlap_out = nullptr);
-
-  template <typename Table>
-  std::optional<SliceId> ScopedTyped(
-      Table* table,
-      typename Table::Row row,
-      SetArgsCallback args_callback = SetArgsCallback()) {
-    PERFETTO_DCHECK(row.dur >= 0);
-    if (row.name) {
-      row.name = context_->slice_translation_table->TranslateName(*row.name);
+      ArgsCb args = {},
+      std::optional<OverlapInfo>* overlap_out = nullptr) {
+    if (duration < 0) {
+      RecordSliceNegativeDuration(timestamp);
+      return std::nullopt;
     }
-    return StartSlice(row.ts, row.dur, row.track_id, args_callback,
-                      [table, &row]() { return table->Insert(row).id; });
+    StartedSlice s = StartSlice(timestamp, duration, track_id, category,
+                                raw_name, WantsArgs(args), overlap_out);
+    InvokeArgs(s.inserter, args);
+    return s.id;
   }
 
-  // virtual for testing
-  virtual std::optional<SliceId> End(
-      int64_t timestamp,
-      TrackId track_id,
-      StringId opt_category = {},
-      StringId opt_raw_name = {},
-      SetArgsCallback args_callback = SetArgsCallback());
+  template <typename ArgsCb = NoArgsCallback>
+  std::optional<SliceId> End(int64_t timestamp,
+                             TrackId track_id,
+                             StringId category = {},
+                             StringId raw_name = {},
+                             ArgsCb args = {}) {
+    // Split so args are invoked inline between setting the duration and the
+    // pop.
+    EndedSlice e = CompleteSliceBegin(timestamp, track_id, raw_name, category,
+                                      WantsArgs(args));
+    if (!e.id)
+      return std::nullopt;
+    InvokeArgs(e.inserter, args);
+    CompleteSliceFinalize(e.state);
+    return e.id;
+  }
 
   // Usually args should be added in the Begin or End args_callback but this
   // method is for the situation where new args need to be added to an
   // in-progress slice.
+  template <typename ArgsCb>
   std::optional<uint32_t> AddArgs(TrackId track_id,
                                   StringId category,
                                   StringId name,
-                                  SetArgsCallback args_callback);
+                                  ArgsCb args) {
+    std::optional<ArgsTracker::BoundInserter> inserter;
+    std::optional<uint32_t> row =
+        AddArgsImpl(track_id, category, name, WantsArgs(args), &inserter);
+    InvokeArgs(inserter, args);
+    return row;
+  }
 
   void FlushPendingSlices();
 
@@ -155,9 +175,11 @@ class SliceTracker {
   // with this duration placeholder.
   static constexpr int64_t kPendingDuration = -1;
 
+  // |args| is lazily acquired from |args_pool_| only if the slice gets args,
+  // and is null otherwise; recycled on pop.
   struct SliceInfo {
     tables::SliceTable::RowNumber row;
-    ArgsTracker args_tracker;
+    ArgsTracker* args = nullptr;
   };
   using SlicesStack = std::vector<SliceInfo>;
 
@@ -177,38 +199,125 @@ class SliceTracker {
     ArgsTracker::CompactArgSet compact_arg_set;
   };
 
-  // virtual for testing.
-  virtual std::optional<SliceId> StartSlice(
-      int64_t timestamp,
-      int64_t duration,
-      TrackId track_id,
-      SetArgsCallback args_callback,
-      std::function<SliceId()> inserter,
-      std::optional<OverlapInfo>* overlap_out = nullptr);
+  // Carried from CompleteSliceBegin to CompleteSliceFinalize across End()'s
+  // args.
+  struct CompleteSliceState {
+    TrackInfo* track_info;
+    uint32_t stack_idx;
+  };
 
-  std::optional<SliceId> CompleteSlice(
-      int64_t timestamp,
-      TrackId track_id,
-      SetArgsCallback args_callback,
-      std::function<std::optional<uint32_t>(const SlicesStack&)> finder);
+  // Return of the out-of-line Begin/End fast paths: the new/closed slice id
+  // and, when args were requested, a BoundInserter already bound to its
+  // ArgsTracker.
+  struct StartedSlice {
+    std::optional<SliceId> id;
+    std::optional<ArgsTracker::BoundInserter> inserter;
+  };
+  struct EndedSlice {
+    std::optional<SliceId> id;
+    std::optional<ArgsTracker::BoundInserter> inserter;
+    CompleteSliceState state;
+  };
 
-  [[nodiscard]] bool MaybeCloseStack(int64_t ts,
+  // Single out-of-line body for Begin/Scoped: translate, insert and push the
+  // slice, and (if want_args) acquire its BoundInserter. The only thing the
+  // templated callers inline is the args callback on the returned inserter.
+  StartedSlice StartSlice(int64_t timestamp,
+                          int64_t duration,
+                          TrackId track_id,
+                          StringId category,
+                          StringId raw_name,
+                          bool want_args,
+                          std::optional<OverlapInfo>* overlap_out);
+
+  // First half of End(): translate, find the slice and set its duration. The
+  // caller invokes args (if any) on the returned inserter, then calls
+  // CompleteSliceFinalize before any other op on the track.
+  EndedSlice CompleteSliceBegin(int64_t timestamp,
+                                TrackId track_id,
+                                StringId raw_name,
+                                StringId category,
+                                bool want_args);
+
+  // Second half of End(): legacy args + pop.
+  void CompleteSliceFinalize(const CompleteSliceState& state);
+
+  // Body of AddArgs(): finds the slice and (if want_args) returns its inserter.
+  std::optional<uint32_t> AddArgsImpl(
+      TrackId track_id,
+      StringId category,
+      StringId name,
+      bool want_args,
+      std::optional<ArgsTracker::BoundInserter>* inserter);
+
+  // True if |args| should run (false for NoArgsCallback / empty std::function).
+  template <typename ArgsCb>
+  static bool WantsArgs(const ArgsCb& args) {
+    if constexpr (std::is_same_v<ArgsCb, NoArgsCallback>) {
+      base::ignore_result(args);
+      return false;
+    } else if constexpr (std::is_constructible_v<bool, const ArgsCb&>) {
+      return static_cast<bool>(args);
+    } else {
+      base::ignore_result(args);
+      return true;
+    }
+  }
+
+  // Runs |args| on the inserter returned by the out-of-line entrypoints. The
+  // only per-callsite code for an arg-bearing slice; nothing for
+  // NoArgsCallback.
+  template <typename ArgsCb>
+  static void InvokeArgs(std::optional<ArgsTracker::BoundInserter>& inserter,
+                         ArgsCb& args) {
+    if constexpr (std::is_same_v<ArgsCb, NoArgsCallback>) {
+      base::ignore_result(inserter, args);
+    } else if (inserter) {
+      args(&*inserter);
+    }
+  }
+
+  // Legacy bookkeeping + MaybeCloseStack; false if the slice should be dropped.
+  [[nodiscard]] bool PrepareStartSlice(TrackInfo& track_info,
+                                       int64_t timestamp,
+                                       int64_t duration,
+                                       std::optional<OverlapInfo>* overlap_out);
+
+  void LogMaxDepthExceeded(const SliceInfo& parent, StringId name);
+
+  void AddLegacyUnnestableArgs(SliceInfo& slice_info,
+                               const TrackInfo& track_info);
+
+  void RecordSliceNegativeDuration(int64_t timestamp);
+
+  [[nodiscard]] bool MaybeCloseStack(TrackInfo& track_info,
+                                     int64_t ts,
                                      int64_t dur,
-                                     const SlicesStack&,
-                                     TrackId track_id,
                                      std::optional<OverlapInfo>* overlap_out);
 
   std::optional<uint32_t> MatchingIncompleteSliceIndex(const SlicesStack& stack,
                                                        StringId name,
                                                        StringId category);
 
-  void StackPop(TrackId track_id);
-  void StackPush(TrackId track_id, tables::SliceTable::RowReference);
+  void StackPop(TrackInfo& track_info);
+  void StackPush(TrackInfo& track_info,
+                 TrackId track_id,
+                 tables::SliceTable::RowNumber row_number,
+                 SliceId id);
 
-  // If args need translation, adds them to a list of pending translatable args,
-  // so that they are translated at the end of the trace. Takes ownership of the
-  // arg set for the slice. Otherwise, this is a noop, and the args are added to
-  // the args table immediately when the slice is popped.
+  // Resolve a track once per event and thread the reference through the call;
+  // the map is small and hot so a cross-call last-track cache measured as
+  // noise.
+  TrackInfo& GetOrCreateTrackInfo(TrackId track_id) {
+    return stacks_[track_id];
+  }
+  TrackInfo* FindTrackInfo(TrackId track_id) { return stacks_.Find(track_id); }
+
+  // BoundInserter for |slice_info|, lazily acquiring its pooled ArgsTracker.
+  ArgsTracker::BoundInserter ArgsInserter(SliceInfo& slice_info, SliceId id);
+
+  // Defers args needing translation to end-of-trace (taking ownership of the
+  // arg set), else no-op. Requires |slice_info.args| non-null.
   void MaybeAddTranslatableArgs(SliceInfo& slice_info);
 
   OnSliceBeginCallback on_slice_begin_callback_;
@@ -227,6 +336,11 @@ class SliceTracker {
 
   StackMap stacks_;
   std::vector<TranslatableArgs> translatable_args_;
+
+  // Recyclable per-slice ArgsTrackers; deque for pointer stability, free list
+  // of cleared ones.
+  std::deque<ArgsTracker> args_pool_;
+  std::vector<ArgsTracker*> free_args_;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/common/slice_tracker.h
+++ b/src/trace_processor/importers/common/slice_tracker.h
@@ -43,7 +43,7 @@ class SliceTracker {
  public:
   using OnSliceBeginCallback = std::function<void(TrackId, SliceId)>;
 
-  // Sentinel default args callback; ArgsPresent() compiles arg handling away.
+  // Sentinel default args callback; WantsArgs() compiles arg handling away.
   struct NoArgsCallback {
     void operator()(ArgsTracker::BoundInserter*) const {}
   };
@@ -140,7 +140,7 @@ class SliceTracker {
                              ArgsCb args = {}) {
     // Split so args are invoked inline between setting the duration and the
     // pop.
-    EndedSlice e = CompleteSliceBegin(timestamp, track_id, raw_name, category,
+    EndedSlice e = CompleteSliceBegin(timestamp, track_id, category, raw_name,
                                       WantsArgs(args));
     if (!e.id)
       return std::nullopt;
@@ -235,8 +235,8 @@ class SliceTracker {
   // CompleteSliceFinalize before any other op on the track.
   EndedSlice CompleteSliceBegin(int64_t timestamp,
                                 TrackId track_id,
-                                StringId raw_name,
                                 StringId category,
+                                StringId raw_name,
                                 bool want_args);
 
   // Second half of End(): legacy args + pop.

--- a/src/trace_processor/importers/common/slice_tracker_benchmark.cc
+++ b/src/trace_processor/importers/common/slice_tracker_benchmark.cc
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <memory>
+
+#include "src/trace_processor/importers/common/args_tracker.h"
+#include "src/trace_processor/importers/common/args_translation_table.h"
+#include "src/trace_processor/importers/common/global_args_tracker.h"
+#include "src/trace_processor/importers/common/global_stats_tracker.h"
+#include "src/trace_processor/importers/common/machine_tracker.h"
+#include "src/trace_processor/importers/common/slice_tracker.h"
+#include "src/trace_processor/importers/common/slice_translation_table.h"
+#include "src/trace_processor/importers/common/stats_tracker.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/types/variadic.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+// Builds a TraceProcessorContext with just the dependencies SliceTracker needs.
+struct Fixture {
+  explicit Fixture(TraceProcessorContext* context) {
+    context->storage = std::make_unique<TraceStorage>();
+    context->global_args_tracker =
+        std::make_unique<GlobalArgsTracker>(context->storage.get());
+    context->global_stats_tracker =
+        std::make_unique<GlobalStatsTracker>(context->storage.get());
+    context->machine_tracker =
+        std::make_unique<MachineTracker>(context, kDefaultMachineId);
+    context->args_translation_table =
+        std::make_unique<ArgsTranslationTable>(context->storage.get());
+    context->slice_translation_table =
+        std::make_unique<SliceTranslationTable>(context->storage.get());
+    context->trace_state =
+        TraceProcessorContextPtr<TraceProcessorContext::TraceState>::MakeRoot(
+            TraceProcessorContext::TraceState{TraceId{0}});
+    context->stats_tracker = std::make_unique<StatsTracker>(context);
+  }
+};
+
+// Number of slice events processed per timed iteration.
+constexpr int64_t kEvents = 1 << 14;
+
+// Arg-less begin/end: the common fast path.
+void BM_SliceTrackerBeginEnd(benchmark::State& state) {
+  constexpr TrackId track{0u};
+  for (auto _ : state) {
+    state.PauseTiming();
+    TraceProcessorContext context;
+    Fixture fixture(&context);
+    StringId name = context.storage->InternString("slice");
+    SliceTracker tracker(&context);
+    state.ResumeTiming();
+
+    for (int64_t i = 0; i < kEvents; i += 2) {
+      tracker.Begin(i, track, kNullStringId, name);
+      tracker.End(i + 1, track, kNullStringId, name);
+    }
+    benchmark::DoNotOptimize(context.storage->slice_table().row_count());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * kEvents);
+}
+
+// Begin/end with args on both ends: pooled ArgsTracker + inlined callback.
+void BM_SliceTrackerBeginEndArgs(benchmark::State& state) {
+  constexpr TrackId track{0u};
+  for (auto _ : state) {
+    state.PauseTiming();
+    TraceProcessorContext context;
+    Fixture fixture(&context);
+    StringId name = context.storage->InternString("slice");
+    StringId key1 = context.storage->InternString("key1");
+    StringId key2 = context.storage->InternString("key2");
+    SliceTracker tracker(&context);
+    state.ResumeTiming();
+
+    for (int64_t i = 0; i < kEvents; i += 2) {
+      tracker.Begin(i, track, kNullStringId, name,
+                    [&](ArgsTracker::BoundInserter* inserter) {
+                      inserter->AddArg(key1, Variadic::Integer(i));
+                      inserter->AddArg(key2, Variadic::Integer(i * 2));
+                    });
+      tracker.End(i + 1, track, kNullStringId, name,
+                  [&](ArgsTracker::BoundInserter* inserter) {
+                    inserter->AddArg(key1, Variadic::Integer(i + 1));
+                  });
+    }
+    benchmark::DoNotOptimize(context.storage->slice_table().row_count());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * kEvents);
+}
+
+// Deep nested stack, then unwind: stack push/pop at depth.
+void BM_SliceTrackerNested(benchmark::State& state) {
+  constexpr TrackId track{0u};
+  constexpr int64_t kDepth = 32;
+  for (auto _ : state) {
+    state.PauseTiming();
+    TraceProcessorContext context;
+    Fixture fixture(&context);
+    StringId name = context.storage->InternString("slice");
+    SliceTracker tracker(&context);
+    state.ResumeTiming();
+
+    int64_t ts = 0;
+    for (int64_t batch = 0; batch < kEvents / (2 * kDepth); batch++) {
+      for (int64_t d = 0; d < kDepth; d++)
+        tracker.Begin(ts++, track, kNullStringId, name);
+      for (int64_t d = 0; d < kDepth; d++)
+        tracker.End(ts++, track, kNullStringId, name);
+    }
+    benchmark::DoNotOptimize(context.storage->slice_table().row_count());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          (kEvents / (2 * kDepth)) * (2 * kDepth));
+}
+
+// Round-robin across many tracks so consecutive events always switch track:
+// the last-track cache misses every time, exercising the real map lookup.
+void BM_SliceTrackerMultiTrack(benchmark::State& state) {
+  constexpr int64_t kTracks = 512;
+  for (auto _ : state) {
+    state.PauseTiming();
+    TraceProcessorContext context;
+    Fixture fixture(&context);
+    StringId name = context.storage->InternString("slice");
+    SliceTracker tracker(&context);
+    state.ResumeTiming();
+
+    int64_t ts = 0;
+    for (int64_t b = 0; b < kEvents / (2 * kTracks); b++) {
+      for (int64_t t = 0; t < kTracks; t++)
+        tracker.Begin(ts++, TrackId(static_cast<uint32_t>(t)), kNullStringId,
+                      name);
+      for (int64_t t = 0; t < kTracks; t++)
+        tracker.End(ts++, TrackId(static_cast<uint32_t>(t)), kNullStringId,
+                    name);
+    }
+    benchmark::DoNotOptimize(context.storage->slice_table().row_count());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * kEvents);
+}
+
+BENCHMARK(BM_SliceTrackerBeginEnd);
+BENCHMARK(BM_SliceTrackerMultiTrack);
+BENCHMARK(BM_SliceTrackerBeginEndArgs);
+BENCHMARK(BM_SliceTrackerNested);
+
+}  // namespace
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/etw/disk_io_tracker.cc
+++ b/src/trace_processor/importers/etw/disk_io_tracker.cc
@@ -113,7 +113,7 @@ void DiskIoTracker::ParseDiskIo(int64_t timestamp,
       decoder.has_issuing_thread_id()
           ? std::optional(decoder.issuing_thread_id())
           : std::nullopt;
-  SliceTracker::SetArgsCallback set_args =
+  std::function<void(ArgsTracker::BoundInserter*)> set_args =
       [this, disk_number, irp_flags, transfer_size, byte_offset, file_object,
        irp, response_time,
        issuing_thread_id](ArgsTracker::BoundInserter* inserter) {

--- a/src/trace_processor/importers/etw/file_io_tracker.cc
+++ b/src/trace_processor/importers/etw/file_io_tracker.cc
@@ -227,7 +227,7 @@ void FileIoTracker::ParseFileIoCreate(int64_t timestamp,
                                       UniqueTid utid,
                                       ConstBytes blob) {
   protos::pbzero::FileIoCreateEtwEvent::Decoder decoder(blob);
-  SliceTracker::SetArgsCallback args =
+  std::function<void(ArgsTracker::BoundInserter*)> args =
       [this, &decoder](ArgsTracker::BoundInserter* inserter) {
         if (decoder.has_irp_ptr()) {
           inserter->AddArg(irp_arg_, Variadic::Pointer(decoder.irp_ptr()));
@@ -268,7 +268,7 @@ void FileIoTracker::ParseFileIoDirEnum(int64_t timestamp,
                                        UniqueTid utid,
                                        ConstBytes blob) {
   protos::pbzero::FileIoDirEnumEtwEvent::Decoder decoder(blob);
-  SliceTracker::SetArgsCallback args =
+  std::function<void(ArgsTracker::BoundInserter*)> args =
       [this, &decoder](ArgsTracker::BoundInserter* inserter) {
         if (decoder.has_irp_ptr()) {
           inserter->AddArg(irp_arg_, Variadic::Pointer(decoder.irp_ptr()));
@@ -314,7 +314,7 @@ void FileIoTracker::ParseFileIoInfo(int64_t timestamp,
                                     UniqueTid utid,
                                     ConstBytes blob) {
   protos::pbzero::FileIoInfoEtwEvent::Decoder decoder(blob);
-  SliceTracker::SetArgsCallback args =
+  std::function<void(ArgsTracker::BoundInserter*)> args =
       [this, &decoder](ArgsTracker::BoundInserter* inserter) {
         if (decoder.has_irp_ptr()) {
           inserter->AddArg(irp_arg_, Variadic::Pointer(decoder.irp_ptr()));
@@ -370,7 +370,7 @@ void FileIoTracker::ParseFileIoReadWrite(int64_t timestamp,
                                          UniqueTid utid,
                                          ConstBytes blob) {
   protos::pbzero::FileIoReadWriteEtwEvent::Decoder decoder(blob);
-  SliceTracker::SetArgsCallback args =
+  std::function<void(ArgsTracker::BoundInserter*)> args =
       [this, &decoder](ArgsTracker::BoundInserter* inserter) {
         if (decoder.has_irp_ptr()) {
           inserter->AddArg(irp_arg_, Variadic::Pointer(decoder.irp_ptr()));
@@ -414,7 +414,7 @@ void FileIoTracker::ParseFileIoSimpleOp(int64_t timestamp,
                                         UniqueTid utid,
                                         ConstBytes blob) {
   protos::pbzero::FileIoSimpleOpEtwEvent::Decoder decoder(blob);
-  SliceTracker::SetArgsCallback args =
+  std::function<void(ArgsTracker::BoundInserter*)> args =
       [this, &decoder](ArgsTracker::BoundInserter* inserter) {
         if (decoder.has_irp_ptr()) {
           inserter->AddArg(irp_arg_, Variadic::Pointer(decoder.irp_ptr()));
@@ -446,7 +446,7 @@ void FileIoTracker::ParseFileIoOpEnd(int64_t timestamp,
                                      UniqueTid utid,
                                      ConstBytes blob) {
   protos::pbzero::FileIoOpEndEtwEvent::Decoder decoder(blob);
-  SliceTracker::SetArgsCallback args =
+  std::function<void(ArgsTracker::BoundInserter*)> args =
       [this, &decoder](ArgsTracker::BoundInserter* inserter) {
         if (decoder.has_extra_info()) {
           inserter->AddArg(extra_info_arg_,
@@ -466,7 +466,7 @@ void FileIoTracker::ParseFileIoPathOperation(int64_t timestamp,
                                              UniqueTid utid,
                                              ConstBytes blob) {
   protos::pbzero::FileIoPathOperationEtwEvent::Decoder decoder(blob);
-  SliceTracker::SetArgsCallback args =
+  std::function<void(ArgsTracker::BoundInserter*)> args =
       [this, &decoder](ArgsTracker::BoundInserter* inserter) {
         if (decoder.has_irp_ptr()) {
           inserter->AddArg(irp_arg_, Variadic::Pointer(decoder.irp_ptr()));
@@ -517,11 +517,12 @@ void FileIoTracker::OnEventsFullyExtracted() {
   }
 }
 
-void FileIoTracker::StartEvent(std::optional<Irp> irp,
-                               StringId name,
-                               int64_t timestamp,
-                               UniqueTid utid,
-                               SliceTracker::SetArgsCallback args) {
+void FileIoTracker::StartEvent(
+    std::optional<Irp> irp,
+    StringId name,
+    int64_t timestamp,
+    UniqueTid utid,
+    std::function<void(ArgsTracker::BoundInserter*)> args) {
   if (!irp.has_value()) {
     RecordEventWithoutIrp(name, timestamp, utid, std::move(args));
     return;
@@ -548,10 +549,11 @@ void FileIoTracker::StartEvent(std::optional<Irp> irp,
   started_events_[*irp] = {name, timestamp, utid};
 }
 
-void FileIoTracker::EndEvent(std::optional<Irp> irp,
-                             int64_t timestamp,
-                             UniqueTid utid,
-                             SliceTracker::SetArgsCallback args) {
+void FileIoTracker::EndEvent(
+    std::optional<Irp> irp,
+    int64_t timestamp,
+    UniqueTid utid,
+    std::function<void(ArgsTracker::BoundInserter*)> args) {
   if (!irp.has_value()) {
     RecordEventWithoutIrp(
         event_types_.at(GetEventTypeIndex(EventType::kEndOperation)), timestamp,
@@ -586,9 +588,10 @@ void FileIoTracker::EndUnmatchedStart(Irp irp,
   });
 }
 
-void FileIoTracker::RecordUnmatchedEnd(int64_t timestamp,
-                                       UniqueTid utid,
-                                       SliceTracker::SetArgsCallback args) {
+void FileIoTracker::RecordUnmatchedEnd(
+    int64_t timestamp,
+    UniqueTid utid,
+    std::function<void(ArgsTracker::BoundInserter*)> args) {
   // Add a single "EndOperation" event with a duration of zero.
   const int64_t duration = 0;
   const auto track_id = context_->track_compressor->InternScoped(
@@ -605,10 +608,11 @@ void FileIoTracker::RecordUnmatchedEnd(int64_t timestamp,
       });
 }
 
-void FileIoTracker::RecordEventWithoutIrp(StringId name,
-                                          int64_t timestamp,
-                                          UniqueTid utid,
-                                          SliceTracker::SetArgsCallback args) {
+void FileIoTracker::RecordEventWithoutIrp(
+    StringId name,
+    int64_t timestamp,
+    UniqueTid utid,
+    std::function<void(ArgsTracker::BoundInserter*)> args) {
   const int64_t duration = 0;
   const auto track_id = context_->track_compressor->InternScoped(
       kBlueprint, tracks::Dimensions(utid), timestamp, duration);

--- a/src/trace_processor/importers/etw/file_io_tracker.h
+++ b/src/trace_processor/importers/etw/file_io_tracker.h
@@ -189,13 +189,13 @@ class FileIoTracker {
                   StringId name,
                   int64_t timestamp,
                   UniqueTid utid,
-                  SliceTracker::SetArgsCallback args);
+                  std::function<void(ArgsTracker::BoundInserter*)> args);
 
   // Adds the ending event to the trace as a slice.
   void EndEvent(std::optional<Irp> irp,
                 int64_t timestamp,
                 UniqueTid utid,
-                SliceTracker::SetArgsCallback args);
+                std::function<void(ArgsTracker::BoundInserter*)> args);
 
   // Ends the given event with a duration of zero, and adds an argument labeling
   // it as missing a matching end event.
@@ -203,16 +203,18 @@ class FileIoTracker {
 
   // Records an "EndOperation" event with a duration of zero, and adds an
   // argument labeling it as missing a matching start event.
-  void RecordUnmatchedEnd(int64_t timestamp,
-                          UniqueTid utid,
-                          SliceTracker::SetArgsCallback args);
+  void RecordUnmatchedEnd(
+      int64_t timestamp,
+      UniqueTid utid,
+      std::function<void(ArgsTracker::BoundInserter*)> args);
 
   // Records an event without an IRP identifier with a duration of zero (as it's
   // unable to be matched with a corresponding start or end event).
-  void RecordEventWithoutIrp(StringId name,
-                             int64_t timestamp,
-                             UniqueTid utid,
-                             SliceTracker::SetArgsCallback args);
+  void RecordEventWithoutIrp(
+      StringId name,
+      int64_t timestamp,
+      UniqueTid utid,
+      std::function<void(ArgsTracker::BoundInserter*)> args);
 
   // Helper function to get the value to display for `info_class`: either its
   // string representation, if known, or its numerical value.

--- a/src/trace_processor/importers/syscalls/syscall_tracker_unittest.cc
+++ b/src/trace_processor/importers/syscalls/syscall_tracker_unittest.cc
@@ -16,10 +16,12 @@
 
 #include "src/trace_processor/importers/syscalls/syscall_tracker.h"
 
+#include "src/trace_processor/importers/common/args_translation_table.h"
 #include "src/trace_processor/importers/common/global_args_tracker.h"
 #include "src/trace_processor/importers/common/global_stats_tracker.h"
 #include "src/trace_processor/importers/common/machine_tracker.h"
 #include "src/trace_processor/importers/common/slice_tracker.h"
+#include "src/trace_processor/importers/common/slice_translation_table.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 #include "test/gtest_and_gmock.h"
 
@@ -27,44 +29,9 @@ namespace perfetto {
 namespace trace_processor {
 namespace {
 
-using ::testing::_;
-using ::testing::DoAll;
-using ::testing::Return;
-using ::testing::SaveArg;
-
-class MockSliceTracker : public SliceTracker {
- public:
-  MockSliceTracker(TraceProcessorContext* context) : SliceTracker(context) {}
-  ~MockSliceTracker() override = default;
-
-  MOCK_METHOD(std::optional<SliceId>,
-              Begin,
-              (int64_t timestamp,
-               TrackId track_id,
-               StringId cat,
-               StringId name,
-               SetArgsCallback args_callback),
-              (override));
-  MOCK_METHOD(std::optional<SliceId>,
-              End,
-              (int64_t timestamp,
-               TrackId track_id,
-               StringId cat,
-               StringId name,
-               SetArgsCallback args_callback),
-              (override));
-  MOCK_METHOD(std::optional<SliceId>,
-              Scoped,
-              (int64_t timestamp,
-               TrackId track_id,
-               StringId cat,
-               StringId name,
-               int64_t duration,
-               SetArgsCallback args_callback,
-               std::optional<OverlapInfo>* overlap_out),
-              (override));
-};
-
+// These tests drive a real SliceTracker (SliceTracker's slice methods are
+// templated on the args callback and no longer virtual, so they cannot be
+// mocked) and assert on the slices that end up in storage.
 class SyscallTrackerTest : public ::testing::Test {
  public:
   SyscallTrackerTest() {
@@ -79,84 +46,85 @@ class SyscallTrackerTest : public ::testing::Test {
     context.stats_tracker = std::make_unique<StatsTracker>(&context);
     context.global_args_tracker.reset(
         new GlobalArgsTracker(context.storage.get()));
+    context.args_translation_table =
+        std::make_unique<ArgsTranslationTable>(context.storage.get());
+    context.slice_translation_table =
+        std::make_unique<SliceTranslationTable>(context.storage.get());
     track_tracker = new TrackTracker(&context);
     context.track_tracker.reset(track_tracker);
-    slice_tracker = new MockSliceTracker(&context);
-    context.slice_tracker.reset(slice_tracker);
+    context.slice_tracker.reset(new SliceTracker(&context));
+  }
+
+  const tables::SliceTable& slices() const {
+    return context.storage->slice_table();
+  }
+
+  std::string SliceName(uint32_t row) const {
+    return context.storage
+        ->GetString(slices()[row].name().value_or(kNullStringId))
+        .ToStdString();
   }
 
  protected:
   TraceProcessorContext context;
-  MockSliceTracker* slice_tracker;
   TrackTracker* track_tracker;
 };
 
 TEST_F(SyscallTrackerTest, ReportUnknownSyscalls) {
-  constexpr TrackId track{0u};
-  StringId begin_name = kNullStringId;
-  StringId end_name = kNullStringId;
-  EXPECT_CALL(*slice_tracker, Begin(100, track, kNullStringId, _, _))
-      .WillOnce(DoAll(SaveArg<3>(&begin_name), Return(std::nullopt)));
-  EXPECT_CALL(*slice_tracker, End(110, track, kNullStringId, _, _))
-      .WillOnce(DoAll(SaveArg<3>(&end_name), Return(std::nullopt)));
-
   SyscallTracker* syscall_tracker = SyscallTracker::GetOrCreate(&context);
   syscall_tracker->Enter(100 /*ts*/, 42 /*utid*/, 57 /*sys_read*/);
   syscall_tracker->Exit(110 /*ts*/, 42 /*utid*/, 57 /*sys_read*/);
-  EXPECT_EQ(context.storage->GetString(begin_name), "sys_57");
-  EXPECT_EQ(context.storage->GetString(end_name), "sys_57");
+
+  ASSERT_EQ(slices().row_count(), 1u);
+  EXPECT_EQ(slices()[0].ts(), 100);
+  EXPECT_EQ(slices()[0].dur(), 10);
+  EXPECT_EQ(SliceName(0), "sys_57");
 }
 
 TEST_F(SyscallTrackerTest, ReportSysreturn) {
-  EXPECT_CALL(*slice_tracker, Scoped(_, _, _, _, _, _, _)).Times(1);
-
   SyscallTracker* syscall_tracker = SyscallTracker::GetOrCreate(&context);
   syscall_tracker->SetArchitecture(Architecture::kArm64);
   syscall_tracker->Enter(100 /*ts*/, 42 /*utid*/, 139);
+
+  // sys_rt_sigreturn does not return, so it is emitted as an instant (Scoped)
+  // slice with zero duration from the Enter event alone.
+  ASSERT_EQ(slices().row_count(), 1u);
+  EXPECT_EQ(slices()[0].ts(), 100);
+  EXPECT_EQ(slices()[0].dur(), 0);
+  EXPECT_EQ(SliceName(0), "sys_rt_sigreturn");
 }
 
 TEST_F(SyscallTrackerTest, Arm64) {
-  constexpr TrackId track{0u};
-  StringId begin_name = kNullStringId;
-  StringId end_name = kNullStringId;
-  EXPECT_CALL(*slice_tracker, Begin(100, track, kNullStringId, _, _))
-      .WillOnce(DoAll(SaveArg<3>(&begin_name), Return(std::nullopt)));
-  EXPECT_CALL(*slice_tracker, End(110, track, kNullStringId, _, _))
-      .WillOnce(DoAll(SaveArg<3>(&end_name), Return(std::nullopt)));
-
   SyscallTracker* syscall_tracker = SyscallTracker::GetOrCreate(&context);
   syscall_tracker->SetArchitecture(Architecture::kArm64);
   syscall_tracker->Enter(100 /*ts*/, 42 /*utid*/, 63 /*sys_read*/);
   syscall_tracker->Exit(110 /*ts*/, 42 /*utid*/, 63 /*sys_read*/);
-  EXPECT_EQ(context.storage->GetString(begin_name), "sys_read");
-  EXPECT_EQ(context.storage->GetString(end_name), "sys_read");
+
+  ASSERT_EQ(slices().row_count(), 1u);
+  EXPECT_EQ(slices()[0].ts(), 100);
+  EXPECT_EQ(slices()[0].dur(), 10);
+  EXPECT_EQ(SliceName(0), "sys_read");
 }
 
 TEST_F(SyscallTrackerTest, x8664) {
-  constexpr TrackId track{0u};
-  StringId begin_name = kNullStringId;
-  StringId end_name = kNullStringId;
-  EXPECT_CALL(*slice_tracker, Begin(100, track, kNullStringId, _, _))
-      .WillOnce(DoAll(SaveArg<3>(&begin_name), Return(std::nullopt)));
-  EXPECT_CALL(*slice_tracker, End(110, track, kNullStringId, _, _))
-      .WillOnce(DoAll(SaveArg<3>(&end_name), Return(std::nullopt)));
-
   SyscallTracker* syscall_tracker = SyscallTracker::GetOrCreate(&context);
   syscall_tracker->SetArchitecture(Architecture::kX86_64);
   syscall_tracker->Enter(100 /*ts*/, 42 /*utid*/, 0 /*sys_read*/);
   syscall_tracker->Exit(110 /*ts*/, 42 /*utid*/, 0 /*sys_read*/);
-  EXPECT_EQ(context.storage->GetString(begin_name), "sys_read");
-  EXPECT_EQ(context.storage->GetString(end_name), "sys_read");
+
+  ASSERT_EQ(slices().row_count(), 1u);
+  EXPECT_EQ(slices()[0].ts(), 100);
+  EXPECT_EQ(slices()[0].dur(), 10);
+  EXPECT_EQ(SliceName(0), "sys_read");
 }
 
 TEST_F(SyscallTrackerTest, SyscallNumberTooLarge) {
-  EXPECT_CALL(*slice_tracker, Begin(_, _, _, _, _)).Times(0);
-  EXPECT_CALL(*slice_tracker, End(_, _, _, _, _)).Times(0);
-
   SyscallTracker* syscall_tracker = SyscallTracker::GetOrCreate(&context);
   syscall_tracker->SetArchitecture(Architecture::kArm64);
   syscall_tracker->Enter(100 /*ts*/, 42 /*utid*/, 9999);
   syscall_tracker->Exit(110 /*ts*/, 42 /*utid*/, 9999);
+
+  EXPECT_EQ(slices().row_count(), 0u);
 }
 
 }  // namespace


### PR DESCRIPTION
Rework SliceTracker's hot path to cut per-event overhead and code size
while keeping behaviour identical:

- Per-slice ArgsTracker is now lazily acquired from a pool and SliceInfo
  holds a pointer instead of an embedded tracker, so arg-less slices
  allocate nothing and the slice stack is trivially movable.
- Begin/Scoped/End are templated only on the args callback and call a
  single out-of-line entrypoint that returns the BoundInserter, so each
  caller inlines just the args lambda.
- depth/parent are folded into the row before insert and the track is
  resolved once per event.

Net: ~1.5x faster on the new SliceTracker microbenchmark and the
trace_processor binary shrinks ~10KB versus the std::function baseline.
The syscall unittest now drives a real SliceTracker instead of a mock.
