### PR TITLE
tp: memoize and unify string-like interned messages

### DIFF
--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -71,6 +71,7 @@
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/types/variadic.h"
 #include "src/trace_processor/types/version_number.h"
+#include "src/trace_processor/util/interned_message_view.h"
 
 #include "protos/perfetto/trace/ftrace/android_fs.pbzero.h"
 #include "protos/perfetto/trace/ftrace/bcl_exynos.pbzero.h"
@@ -1843,18 +1844,13 @@ void FtraceParser::ParseTypedFtraceToRaw(
     if (it != kKernelFunctionFields.end()) {
       PERFETTO_CHECK(type == ProtoSchemaType::kUint64);
 
-      auto* interned_string = seq_state->LookupInternedMessage<
-          protos::pbzero::InternedData::kKernelSymbolsFieldNumber,
-          protos::pbzero::InternedString>(fld.as_uint64());
-
       // If we don't have the string for this field (can happen if
       // symbolization wasn't enabled, if reading the symbols errored out or
       // on legacy traces) then just add the field as a normal arg.
-      if (interned_string) {
-        protozero::ConstBytes str = interned_string->str();
-        StringId str_id = context_->storage->InternString(base::StringView(
-            reinterpret_cast<const char*>(str.data), str.size));
-        inserter.AddArg(name_id, Variadic::String(str_id));
+      if (auto str_id = seq_state->InternedStringId(
+              protos::pbzero::InternedData::kKernelSymbolsFieldNumber,
+              fld.as_uint64())) {
+        inserter.AddArg(name_id, Variadic::String(*str_id));
         continue;
       }
     }
@@ -3283,16 +3279,8 @@ void FtraceParser::ParseSchedBlockedReason(
   uint32_t pid = static_cast<uint32_t>(event.pid());
   auto utid = context_->process_tracker->GetOrCreateThread(pid);
   uint32_t caller_iid = static_cast<uint32_t>(event.caller());
-  auto* interned_string = seq_state->LookupInternedMessage<
-      protos::pbzero::InternedData::kKernelSymbolsFieldNumber,
-      protos::pbzero::InternedString>(caller_iid);
-
-  std::optional<StringId> blocked_function_str_id = std::nullopt;
-  if (interned_string) {
-    protozero::ConstBytes str = interned_string->str();
-    blocked_function_str_id = context_->storage->InternString(
-        base::StringView(reinterpret_cast<const char*>(str.data), str.size));
-  }
+  std::optional<StringId> blocked_function_str_id = seq_state->InternedStringId(
+      protos::pbzero::InternedData::kKernelSymbolsFieldNumber, caller_iid);
 
   ThreadStateTracker::GetOrCreate(context_)->PushBlockedReason(
       utid, event.io_wait(), blocked_function_str_id);
@@ -4419,19 +4407,12 @@ void FtraceParser::ParsePanelWriteGeneric(int64_t timestamp,
 StringId FtraceParser::InternedKernelSymbolOrFallback(
     uint64_t key,
     PacketSequenceStateGeneration* seq_state) {
-  auto* interned_string = seq_state->LookupInternedMessage<
-      protos::pbzero::InternedData::kKernelSymbolsFieldNumber,
-      protos::pbzero::InternedString>(key);
-  StringId name_id;
-  if (interned_string) {
-    protozero::ConstBytes str = interned_string->str();
-    name_id = context_->storage->InternString(
-        base::StringView(reinterpret_cast<const char*>(str.data), str.size));
-  } else {
-    base::StackString<255> slice_name("%#" PRIx64, key);
-    name_id = context_->storage->InternString(slice_name.string_view());
+  if (std::optional<StringId> name_id = seq_state->InternedStringId(
+          protos::pbzero::InternedData::kKernelSymbolsFieldNumber, key)) {
+    return *name_id;
   }
-  return name_id;
+  base::StackString<255> slice_name("%#" PRIx64, key);
+  return context_->storage->InternString(slice_name.string_view());
 }
 
 void FtraceParser::ParseDeviceFrequency(int64_t ts,

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -285,6 +285,7 @@ source_set("packet_sequence_state_generation_hdr") {
     "../../../../include/perfetto/ext/base",
     "../../../../protos/perfetto/trace:non_minimal_zero",
     "../../../../protos/perfetto/trace/track_event:zero",
+    "../../containers",
     "../../types:types",
     "../../util:interned_message_view",
     "../common:synthetic_tid_hdr",

--- a/src/trace_processor/importers/proto/gpu_event_parser.cc
+++ b/src/trace_processor/importers/proto/gpu_event_parser.cc
@@ -634,16 +634,11 @@ void GpuEventParser::ParseExtraComputeArg(
   } else if (arg.has_double_value()) {
     inserter->AddArg(name_id, Variadic::Real(arg.double_value()));
   } else if (arg.has_string_value_iid()) {
-    auto* interned = sequence_state->LookupInternedMessage<
-        protos::pbzero::InternedData::kDebugAnnotationStringValuesFieldNumber,
-        protos::pbzero::InternedString>(
-        static_cast<size_t>(arg.string_value_iid()));
-    if (interned) {
-      inserter->AddArg(
-          name_id,
-          Variadic::String(context_->storage->InternString(base::StringView(
-              reinterpret_cast<const char*>(interned->str().data),
-              interned->str().size))));
+    if (auto id = sequence_state->InternedStringId(
+            protos::pbzero::InternedData::
+                kDebugAnnotationStringValuesFieldNumber,
+            arg.string_value_iid())) {
+      inserter->AddArg(name_id, Variadic::String(*id));
     }
   } else if (arg.has_string_value()) {
     inserter->AddArg(

--- a/src/trace_processor/importers/proto/packet_sequence_state_generation.cc
+++ b/src/trace_processor/importers/proto/packet_sequence_state_generation.cc
@@ -16,10 +16,52 @@
 
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 
+#include <cstdint>
+#include <optional>
+
+#include "perfetto/ext/base/string_view.h"
+#include "perfetto/protozero/proto_decoder.h"
 #include "src/trace_processor/importers/proto/incremental_state.h"
 #include "src/trace_processor/importers/proto/track_event_thread_descriptor.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
 
 namespace perfetto::trace_processor {
+
+namespace {
+// For all "string-like" interned messages (InternedString and the EventName /
+// EventCategory / DebugAnnotationName / ... family) the iid is field 1 and the
+// string value is field 2.
+constexpr uint32_t kInternedStringValueFieldNumber = 2;
+
+// Decodes the value field directly from the raw interned message: this works
+// for any string-like interned message regardless of its proto type, and
+// avoids touching the entry's typed decoder cache (which other code may use).
+base::StringView DecodeInternedStringValue(InternedMessageView* view) {
+  protozero::ProtoDecoder decoder(view->message().data(),
+                                  view->message().length());
+  protozero::Field value = decoder.FindField(kInternedStringValueFieldNumber);
+  return value.valid() ? value.as_string() : base::StringView();
+}
+}  // namespace
+
+std::optional<base::StringView>
+PacketSequenceStateGeneration::InternedStringView(uint32_t field_id,
+                                                  uint64_t iid) {
+  InternedMessageView* view = GetInternedMessageView(field_id, iid);
+  if (!view) {
+    return std::nullopt;
+  }
+  return DecodeInternedStringValue(view);
+}
+
+StringPool::Id PacketSequenceStateGeneration::InternAndCacheStringValue(
+    InternedMessageView* view) {
+  StringId id = incremental_state_->context_->storage->InternString(
+      DecodeInternedStringValue(view));
+  view->set_cached_value(id.raw_id());
+  return id;
+}
 
 // static
 RefPtr<PacketSequenceStateGeneration>

--- a/src/trace_processor/importers/proto/packet_sequence_state_generation.h
+++ b/src/trace_processor/importers/proto/packet_sequence_state_generation.h
@@ -22,8 +22,10 @@
 #include <type_traits>
 #include <utility>
 
+#include "perfetto/ext/base/string_view.h"
 #include "perfetto/trace_processor/ref_counted.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
+#include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/importers/proto/incremental_state.h"
 #include "src/trace_processor/importers/proto/track_event_thread_descriptor.h"
 #include "src/trace_processor/util/interned_message_view.h"
@@ -81,6 +83,37 @@ class PacketSequenceStateGeneration : public RefCounted {
     return incremental_state_->GetInternedMessageView(field_id, iid);
   }
 
+  // Resolves a "string-like" interned message - one whose iid is field 1 and
+  // whose string value is field 2 (i.e. InternedString, and the EventName /
+  // EventCategory / DebugAnnotationName / LogMessageBody / ... family) - to the
+  // StringId of its value. The resolved StringId is memoized on the interned
+  // entry, so repeated lookups of the same iid (the common case: a few distinct
+  // names referenced by very many events) are O(1) and avoid re-decoding and
+  // re-interning. Returns nullopt if no entry with |iid| exists for |field_id|.
+  //
+  // The hot path (cache hit) is kept inline; only the first-time decode and
+  // intern is out of line.
+  std::optional<StringPool::Id> InternedStringId(uint32_t field_id,
+                                                 uint64_t iid) {
+    InternedMessageView* view = GetInternedMessageView(field_id, iid);
+    if (!view) {
+      return std::nullopt;
+    }
+    if (std::optional<uint32_t> cached = view->cached_value()) {
+      return StringPool::Id::Raw(*cached);
+    }
+    return InternAndCacheStringValue(view);
+  }
+
+  // Like InternedStringId, but returns the value of the string-like interned
+  // message as a view over the interned message bytes (no interning). Use this
+  // when the raw string is needed - e.g. to compare it, concatenate it or hand
+  // it to something that interns itself - rather than its StringId. The view is
+  // valid for as long as the interned entry (this generation). Returns nullopt
+  // if no entry with |iid| exists for |field_id|.
+  std::optional<base::StringView> InternedStringView(uint32_t field_id,
+                                                     uint64_t iid);
+
   // Returns |nullptr| if no defaults were set.
   InternedMessageView* GetTracePacketDefaultsView() {
     if (!trace_packet_defaults_.has_value()) {
@@ -128,6 +161,11 @@ class PacketSequenceStateGeneration : public RefCounted {
 
  private:
   friend class PacketSequenceStateBuilder;
+
+  // Slow path of InternedStringId: decodes the value field of |view|, interns
+  // it and memoizes the result on |view|. Out of line to keep the common cache
+  // hit small.
+  StringPool::Id InternAndCacheStringValue(InternedMessageView* view);
 
   PacketSequenceStateGeneration(
       RefPtr<IncrementalState> incremental_state,

--- a/src/trace_processor/importers/proto/stack_profile_sequence_state.cc
+++ b/src/trace_processor/importers/proto/stack_profile_sequence_state.cc
@@ -43,11 +43,6 @@
 namespace perfetto {
 namespace trace_processor {
 namespace {
-base::StringView ToStringView(protozero::ConstBytes bytes) {
-  return base::StringView(reinterpret_cast<const char*>(bytes.data),
-                          bytes.size);
-}
-
 // Determine wether this is the magical kernel mapping created in
 // `perfetto::::profiling::Unwinder::SymbolizeKernelCallchain`
 bool IsMagicalKernelMapping(const CreateMappingParams& params) {
@@ -153,32 +148,28 @@ StackProfileSequenceState::LookupInternedBuildId(
   if (iid == 0) {
     return "";
   }
-  auto* decoder = state->LookupInternedMessage<
-      protos::pbzero::InternedData::kBuildIdsFieldNumber,
-      protos::pbzero::InternedString>(iid);
-  if (!decoder) {
+  std::optional<base::StringView> str = state->InternedStringView(
+      protos::pbzero::InternedData::kBuildIdsFieldNumber, iid);
+  if (!str) {
     context_->stats_tracker->IncrementStats(
         stats::stackprofile_invalid_string_id);
     return std::nullopt;
   }
-
-  return ToStringView(decoder->str());
+  return *str;
 }
 
 std::optional<base::StringView>
 StackProfileSequenceState::LookupInternedMappingPath(
     PacketSequenceStateGeneration* state,
     uint64_t iid) {
-  auto* decoder = state->LookupInternedMessage<
-      protos::pbzero::InternedData::kMappingPathsFieldNumber,
-      protos::pbzero::InternedString>(iid);
-  if (!decoder) {
+  std::optional<base::StringView> str = state->InternedStringView(
+      protos::pbzero::InternedData::kMappingPathsFieldNumber, iid);
+  if (!str) {
     context_->stats_tracker->IncrementStats(
         stats::stackprofile_invalid_string_id);
     return std::nullopt;
   }
-
-  return ToStringView(decoder->str());
+  return *str;
 }
 
 std::optional<CallsiteId> StackProfileSequenceState::FindOrInsertCallstack(
@@ -304,16 +295,14 @@ StackProfileSequenceState::LookupInternedFunctionName(
   if (iid == 0) {
     return "";
   }
-  auto* decoder = state->LookupInternedMessage<
-      protos::pbzero::InternedData::kFunctionNamesFieldNumber,
-      protos::pbzero::InternedString>(iid);
-  if (!decoder) {
+  std::optional<base::StringView> str = state->InternedStringView(
+      protos::pbzero::InternedData::kFunctionNamesFieldNumber, iid);
+  if (!str) {
     context_->stats_tracker->IncrementStats(
         stats::stackprofile_invalid_string_id);
     return std::nullopt;
   }
-
-  return ToStringView(decoder->str());
+  return *str;
 }
 
 std::optional<base::StringView>
@@ -323,16 +312,14 @@ StackProfileSequenceState::LookupInternedSourcePath(
   if (iid == 0) {
     return std::nullopt;
   }
-  auto* decoder = state->LookupInternedMessage<
-      protos::pbzero::InternedData::kSourcePathsFieldNumber,
-      protos::pbzero::InternedString>(iid);
-  if (!decoder) {
+  std::optional<base::StringView> str = state->InternedStringView(
+      protos::pbzero::InternedData::kSourcePathsFieldNumber, iid);
+  if (!str) {
     context_->stats_tracker->IncrementStats(
         stats::stackprofile_invalid_string_id);
     return std::nullopt;
   }
-
-  return ToStringView(decoder->str());
+  return *str;
 }
 
 }  // namespace trace_processor

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -271,11 +271,10 @@ class TrackEventEventImporter {
     // string.
     if (PERFETTO_LIKELY(category_iids.size() == 1 &&
                         category_strings.empty())) {
-      auto* decoder = sequence_state_->LookupInternedMessage<
-          protos::pbzero::InternedData::kEventCategoriesFieldNumber,
-          protos::pbzero::EventCategory>(category_iids[0]);
-      if (decoder) {
-        category_id = storage_->InternString(decoder->name());
+      if (auto id = sequence_state_->InternedStringId(
+              protos::pbzero::InternedData::kEventCategoriesFieldNumber,
+              category_iids[0])) {
+        category_id = *id;
       } else {
         base::DynamicStringWriter writer;
         writer.AppendLiteral("unknown(");
@@ -291,15 +290,13 @@ class TrackEventEventImporter {
       // TODO(eseckler): Support multi-category events in the table schema.
       std::string categories;
       for (uint64_t iid : category_iids) {
-        auto* decoder = sequence_state_->LookupInternedMessage<
-            protos::pbzero::InternedData::kEventCategoriesFieldNumber,
-            protos::pbzero::EventCategory>(iid);
-        if (!decoder)
+        auto name = sequence_state_->InternedStringView(
+            protos::pbzero::InternedData::kEventCategoriesFieldNumber, iid);
+        if (!name)
           continue;
-        base::StringView name = decoder->name();
         if (!categories.empty())
           categories.append(",");
-        categories.append(name.data(), name.size());
+        categories.append(name->data(), name->size());
       }
       for (const protozero::ConstChars& cat : category_strings) {
         if (!categories.empty())
@@ -319,11 +316,9 @@ class TrackEventEventImporter {
       name_iid = legacy_event_.name_iid();
 
     if (PERFETTO_LIKELY(name_iid)) {
-      auto* decoder = sequence_state_->LookupInternedMessage<
-          protos::pbzero::InternedData::kEventNamesFieldNumber,
-          protos::pbzero::EventName>(name_iid);
-      if (decoder)
-        return storage_->InternString(decoder->name());
+      if (auto id = sequence_state_->InternedStringId(
+              protos::pbzero::InternedData::kEventNamesFieldNumber, name_iid))
+        return *id;
     } else if (event_.has_name()) {
       return storage_->InternString(event_.name());
     }
@@ -683,11 +678,10 @@ class TrackEventEventImporter {
     StringId state_id = kNullStringId;
 
     if (event_.has_name_iid()) {
-      auto* decoder = sequence_state_->LookupInternedMessage<
-          protos::pbzero::InternedData::kEventNamesFieldNumber,
-          protos::pbzero::EventName>(event_.name_iid());
-      if (decoder) {
-        state_id = storage_->InternString(decoder->name());
+      if (auto id = sequence_state_->InternedStringId(
+              protos::pbzero::InternedData::kEventNamesFieldNumber,
+              event_.name_iid())) {
+        state_id = *id;
       }
     } else if (event_.has_name()) {
       state_id = storage_->InternString(event_.name());
@@ -1361,13 +1355,12 @@ class TrackEventEventImporter {
                            base::StringView(event_.correlation_id_str()))));
     }
     if (event_.has_correlation_id_str_iid()) {
-      auto* decoder = sequence_state_->LookupInternedMessage<
-          protos::pbzero::InternedData::kCorrelationIdStrFieldNumber,
-          protos::pbzero::InternedString>(event_.correlation_id_str_iid());
-      inserter->AddArg(parser_->correlation_id_key_id_,
-                       Variadic::String(storage_->InternString(base::StringView(
-                           reinterpret_cast<const char*>(decoder->str().data),
-                           decoder->str().size))));
+      if (auto id = sequence_state_->InternedStringId(
+              protos::pbzero::InternedData::kCorrelationIdStrFieldNumber,
+              event_.correlation_id_str_iid())) {
+        inserter->AddArg(parser_->correlation_id_key_id_,
+                         Variadic::String(*id));
+      }
     }
     if (legacy_trace_source_id_) {
       inserter->AddArg(parser_->legacy_trace_source_id_key_id_,
@@ -1483,14 +1476,13 @@ class TrackEventEventImporter {
 
     protos::pbzero::LogMessage::Decoder message(blob);
 
-    auto* body_decoder = sequence_state_->LookupInternedMessage<
+    std::optional<StringId> body_id = sequence_state_->InternedStringId(
         protos::pbzero::InternedData::kLogMessageBodyFieldNumber,
-        protos::pbzero::LogMessageBody>(message.body_iid());
-    if (!body_decoder)
+        message.body_iid());
+    if (!body_id)
       return base::ErrStatus("LogMessage with invalid body_iid");
 
-    const StringId log_message_id =
-        storage_->InternString(body_decoder->body());
+    const StringId log_message_id = *body_id;
     inserter->AddArg(parser_->log_message_body_key_id_,
                      Variadic::String(log_message_id));
 
@@ -1555,14 +1547,14 @@ class TrackEventEventImporter {
           "name_iid can be set.");
     }
 
-    auto* decoder = sequence_state_->LookupInternedMessage<
+    std::optional<StringId> name_id = sequence_state_->InternedStringId(
         protos::pbzero::InternedData::kHistogramNamesFieldNumber,
-        protos::pbzero::HistogramName>(sample.name_iid());
-    if (!decoder)
+        sample.name_iid());
+    if (!name_id)
       return base::ErrStatus("HistogramName with invalid name_iid");
 
     inserter->AddArg(parser_->histogram_name_key_id_,
-                     Variadic::String(storage_->InternString(decoder->name())));
+                     Variadic::String(*name_id));
     return base::OkStatus();
   }
 

--- a/src/trace_processor/importers/proto/track_event_parser.cc
+++ b/src/trace_processor/importers/proto/track_event_parser.cc
@@ -120,19 +120,17 @@ std::optional<base::Status> MaybeParseSourceLocation(
 std::optional<base::Status> MaybeParseAndroidJobName(
     const protozero::Field& field,
     util::ProtoToArgsParser::Delegate& delegate) {
-  auto* decoder =
-      delegate.seq_state()
-          ->LookupInternedMessage<
-              com::android::internal::pbzero::FrameworksBaseInternedData::
-                  kAndroidJobNameFieldNumber,
-              com::android::internal::pbzero::AndroidJobName>(
-              field.as_uint64());
-  if (!decoder) {
+  std::optional<base::StringView> name =
+      delegate.seq_state()->InternedStringView(
+          com::android::internal::pbzero::FrameworksBaseInternedData::
+              kAndroidJobNameFieldNumber,
+          field.as_uint64());
+  if (!name) {
     return std::nullopt;
   }
 
   delegate.AddString(util::ProtoToArgsParser::Key("job_scheduler_job.job_name"),
-                     decoder->name());
+                     protozero::ConstChars{name->data(), name->size()});
   return base::OkStatus();
 }
 

--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -677,11 +677,10 @@ base::Status TrackEventTokenizer::TokenizeLegacySampleEvent(
   const auto& thread = state.thread_descriptor();
   for (auto it = event.debug_annotations(); it; ++it) {
     protos::pbzero::DebugAnnotation::Decoder da(*it);
-    auto* interned_name = state.LookupInternedMessage<
+    std::optional<base::StringView> name = state.InternedStringView(
         protos::pbzero::InternedData::kDebugAnnotationNamesFieldNumber,
-        protos::pbzero::DebugAnnotationName>(da.name_iid());
-    base::StringView name(interned_name->name());
-    if (name != "data" || !da.has_legacy_json_value()) {
+        da.name_iid());
+    if (!name || *name != "data" || !da.has_legacy_json_value()) {
       continue;
     }
     auto json = da.legacy_json_value();

--- a/src/trace_processor/plugins/winscope_importer/protolog_parser.cc
+++ b/src/trace_processor/plugins/winscope_importer/protolog_parser.cc
@@ -90,13 +90,11 @@ void ProtoLogParser::ParseProtoLogMessage(
   std::vector<std::string> string_params;
   if (protolog_message.has_str_param_iids()) {
     for (auto it = protolog_message.str_param_iids(); it; ++it) {
-      auto* decoder =
-          sequence_state
-              ->LookupInternedMessage<perfetto::protos::pbzero::InternedData::
-                                          kProtologStringArgsFieldNumber,
-                                      perfetto::protos::pbzero::InternedString>(
-                  it.field().as_uint32());
-      if (!decoder) {
+      std::optional<base::StringView> str = sequence_state->InternedStringView(
+          perfetto::protos::pbzero::InternedData::
+              kProtologStringArgsFieldNumber,
+          it.field().as_uint32());
+      if (!str) {
         // This shouldn't happen since we already checked the incremental
         // state is valid.
         string_params.emplace_back("<ERROR>");
@@ -104,26 +102,23 @@ void ProtoLogParser::ParseProtoLogMessage(
             stats::winscope_protolog_missing_interned_arg_parse_errors);
         continue;
       }
-      string_params.emplace_back(decoder->str().ToStdString());
+      string_params.emplace_back(str->ToStdString());
     }
   }
 
   std::optional<StringId> stacktrace = std::nullopt;
   if (protolog_message.has_stacktrace_iid()) {
-    auto* stacktrace_decoder = sequence_state->LookupInternedMessage<
-        perfetto::protos::pbzero::InternedData::kProtologStacktraceFieldNumber,
-        perfetto::protos::pbzero::InternedString>(
-        protolog_message.stacktrace_iid());
-
-    if (!stacktrace_decoder) {
+    if (auto id = sequence_state->InternedStringId(
+            perfetto::protos::pbzero::InternedData::
+                kProtologStacktraceFieldNumber,
+            protolog_message.stacktrace_iid())) {
+      stacktrace = *id;
+    } else {
       // This shouldn't happen since we already checked the incremental
       // state is valid.
       string_params.emplace_back("<ERROR>");
       context_->trace_processor_context_->stats_tracker->IncrementStats(
           stats::winscope_protolog_missing_interned_stacktrace_parse_errors);
-    } else {
-      stacktrace = storage->InternString(
-          base::StringView(stacktrace_decoder->str().ToStdString()));
     }
   }
 

--- a/src/trace_processor/plugins/winscope_importer/viewcapture_args_parser.cc
+++ b/src/trace_processor/plugins/winscope_importer/viewcapture_args_parser.cc
@@ -132,13 +132,12 @@ std::optional<ConstChars> ViewCaptureArgsParser::DeinternString(
 
 template <uint32_t FieldNumber>
 std::optional<ConstChars> ViewCaptureArgsParser::DeinternString(uint64_t iid) {
-  auto* decoder =
-      seq_state()->LookupInternedMessage<FieldNumber, InternedString>(iid);
-  if (!decoder) {
+  std::optional<base::StringView> sv =
+      seq_state()->InternedStringView(FieldNumber, iid);
+  if (!sv) {
     return std::nullopt;
   }
-  auto blob = decoder->str();
-  return ConstChars{reinterpret_cast<const char*>(blob.data), blob.size};
+  return ConstChars{sv->data(), sv->size()};
 }
 
 }  // namespace perfetto::trace_processor::winscope

--- a/src/trace_processor/util/interned_message_view.h
+++ b/src/trace_processor/util/interned_message_view.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include "perfetto/base/compiler.h"
@@ -55,6 +56,7 @@ class InternedMessageView {
     this->decoder_ = nullptr;
     this->decoder_type_ = nullptr;
     this->submessages_.Clear();
+    this->cached_value_.reset();
     return *this;
   }
 
@@ -110,6 +112,17 @@ class InternedMessageView {
 
   const TraceBlobView& message() const { return message_; }
 
+  // A value previously memoized on this interned entry via set_cached_value(),
+  // if any. Callers that repeatedly derive the same value from an interned
+  // entry - e.g. the StringId obtained by interning an interned name - can
+  // cache it here to avoid re-decoding and re-interning on every lookup. The
+  // interpretation of the value (here, a StringId's raw id) is up to the
+  // caller. The cache lives exactly as long as the interned entry, i.e. the
+  // sequence-state generation, so it is implicitly invalidated on incremental
+  // state reset.
+  std::optional<uint32_t> cached_value() const { return cached_value_; }
+  void set_cached_value(uint32_t value) { cached_value_ = value; }
+
  private:
   using SubMessageViewMap =
       base::FlatHashMap<uint32_t /*field_id*/,
@@ -135,6 +148,9 @@ class InternedMessageView {
   // decoders, we avoid having to decode submessages multiple times if they
   // looked up often.
   SubMessageViewMap submessages_;
+
+  // Optional caller-memoized value for this entry. See cached_value().
+  std::optional<uint32_t> cached_value_;
 };
 
 }  // namespace perfetto::trace_processor


### PR DESCRIPTION
Many interned message types are "string-like": their iid is field 1 and
their string value is field 2. This covers InternedString) as well as
EventName, EventCategory, DebugAnnotationName, LogMessageBody,
HistogramName and AndroidJobName. Each call site re-implemented the same
lookup + typed-decode + (re-)intern dance, and the value-resolving ones
re-decoded and re-interned the same few strings on every event - on a
funcgraph trace that is millions of re-interns for ~540 names.

Add two helpers on PacketSequenceStateGeneration that decode field 2
directly with a plain ProtoDecoder (so they are independent of the proto
type and don't disturb the entry's typed decoder cache):
 - InternedStringId(field_id, iid) -> StringId, memoized on the interned
   entry via a new generic cached-value slot on InternedMessageView. The
   cache-hit path is inline; the cache lives with the interned entry (per
   sequence-state generation) so it is invalidated on incremental reset,
   and is stored as a raw uint32 to keep InternedMessageView free of any
   StringPool dependency.
 - InternedStringView(field_id, iid) -> base::StringView, for sites that
   need the raw string (to compare, concatenate, or hand to something
   that interns itself) rather than a StringId.

Convert all the string-like call sites across ftrace, track_event, gpu,
stack-profile, winscope and protolog importers to these helpers, dropping
a `LookupInternedMessage<Field, Type>` template instantiation and its
decode block at each. trace_processor shrinks ~6.3KB stripped, the
value-resolving sites get the memoization speedup (funcgraph
--no-ftrace-raw ~1.88s -> ~1.64s; a large track-event trace ~1.00s ->
~0.96s), and several sites that previously dereferenced the lookup result
with no null check become safe via the nullopt-returning helpers.
