### PR TITLE
tp: add perfetto_manifest machine overrides and cross-machine clocks

### DIFF
--- a/src/trace_processor/forwarding_trace_parser.cc
+++ b/src/trace_processor/forwarding_trace_parser.cc
@@ -25,10 +25,12 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/string_view.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/importers/common/chunked_trace_reader.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/common/global_stats_tracker.h"
+#include "src/trace_processor/importers/common/machine_tracker.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/common/trace_file_tracker.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
@@ -147,9 +149,10 @@ base::Status ForwardingTraceParser::Init(const TraceBlobView& blob) {
   input_context_->trace_file_tracker->StartParsing(file_id_, trace_type_);
 
   // If the perfetto_manifest file has an entry for this file (matched by
-  // exact path), it overrides clock handling below.
+  // exact path), it overrides clock/machine handling below.
   TraceManifestState::FileEntry* manifest_entry = FindManifestEntry();
-  if (manifest_entry && manifest_entry->clock_override &&
+  if (manifest_entry &&
+      (manifest_entry->clock_override || manifest_entry->machine_id) &&
       (IsContainerTraceType(trace_type_) ||
        trace_type_ == kPerfettoManifestTraceType)) {
     return base::ErrStatus(
@@ -166,12 +169,25 @@ base::Status ForwardingTraceParser::Init(const TraceBlobView& blob) {
     PERFETTO_DCHECK(!input_context_->trace_state);
     trace_context_ = input_context_;
   } else {
+    uint32_t raw_machine_id = manifest_entry && manifest_entry->machine_id
+                                  ? *manifest_entry->machine_id
+                                  : 0;
     // TODO(b/334978369) Make sure kProtoTraceType and kSystraceTraceType are
     // parsed first so that we do not get issues with
     // SetPidZeroIsUpidZeroIdleProcess()
-    trace_context_ = input_context_->ForkContextForTrace(file_id_, 0);
+    trace_context_ =
+        input_context_->ForkContextForTrace(file_id_, raw_machine_id);
     if (trace_type_ == kProtoTraceType || trace_type_ == kSystraceTraceType) {
       trace_context_->process_tracker->SetPidZeroIsUpidZeroIdleProcess();
+    }
+    if (manifest_entry) {
+      trace_context_->trace_state->has_machine_override =
+          manifest_entry->machine_id.has_value();
+      if (manifest_entry->machine_name) {
+        trace_context_->machine_tracker->SetMachineName(
+            input_context_->storage->InternString(
+                base::StringView(*manifest_entry->machine_name)));
+      }
     }
   }
   ASSIGN_OR_RETURN(reader_, input_context_->reader_registry->CreateTraceReader(

--- a/src/trace_processor/importers/common/clock_tracker.cc
+++ b/src/trace_processor/importers/common/clock_tracker.cc
@@ -277,12 +277,12 @@ void ClockTracker::BridgeToTraceTime(ClockId clock_id, ClockId trace_time) {
 
   // Prefer aligning on REALTIME. REALTIME is the same absolute (UTC) clock on
   // every machine, so if |clock_id| reaches this machine's REALTIME (there is a
-  // path through realtime, i.e. a boot<->realtime snapshot) we tie that REALTIME
-  // to the trace time machine's REALTIME (the global rendezvous node) with an
-  // assume-aligned zero-offset edge, and |clock_id| reaches trace time through
-  // it. Taken only when the rendezvous node itself reaches trace time. A real
-  // cross-machine sync (remote_clock_sync), if present, already connects the
-  // clocks and wins via the early return above.
+  // path through realtime, i.e. a boot<->realtime snapshot) we tie that
+  // REALTIME to the trace time machine's REALTIME (the global rendezvous node)
+  // with an assume-aligned zero-offset edge, and |clock_id| reaches trace time
+  // through it. Taken only when the rendezvous node itself reaches trace time.
+  // A real cross-machine sync (remote_clock_sync), if present, already connects
+  // the clocks and wins via the early return above.
   ClockId realtime = ClockId::Qualify(
       ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_REALTIME), machine_id_, 0);
   ClockId global_realtime = ClockId::Machine(
@@ -307,8 +307,8 @@ void ClockTracker::BridgeToTraceTime(ClockId clock_id, ClockId trace_time) {
   //    physical clock, e.g. two machines' BOOTTIME assumed to share a boot
   //    instant).
   // Across different real domains (e.g. BOOTTIME vs REALTIME) we do not
-  // fabricate a relationship: the conversion fails so the events are dropped and
-  // logged rather than silently misplaced.
+  // fabricate a relationship: the conversion fails so the events are dropped
+  // and logged rather than silently misplaced.
   bool either_private =
       clock_id.clock_id == protos::pbzero::BUILTIN_CLOCK_TRACE_FILE ||
       trace_time.clock_id == protos::pbzero::BUILTIN_CLOCK_TRACE_FILE;

--- a/src/trace_processor/importers/common/clock_tracker.cc
+++ b/src/trace_processor/importers/common/clock_tracker.cc
@@ -246,26 +246,89 @@ void ClockTracker::FlushDeferredClockSync() {
     if (qualified != canonical && !sync_->Convert(qualified, 0, canonical)) {
       AddSnapshotInternal({{qualified, 0}, {canonical, 0}});
     }
-    if (canonical != g && !sync_->Convert(canonical, 0, g)) {
-      AddSnapshotInternal({{canonical, 0}, {g, 0}});
-    }
+    BridgeToTraceTime(canonical, g);
     return;
   }
 
   // The perfetto_manifest clock-pin case: inject the offset edge directly from
-  // this file's (qualified) private clock to the requested target. An omitted
-  // target means trace time; a named target is the machine-canonical builtin so
-  // it connects to the shared graph. Real edges (e.g. a proto spine) win, so
-  // inject only if |from| cannot already reach |to|.
+  // this file's (qualified) private clock to the requested reference clock (its
+  // machine-canonical node, so it joins the shared graph). An omitted target is
+  // trace time itself. Real edges (e.g. a proto spine) win, so inject only if
+  // |from| cannot already reach |to|.
   ClockId from = ClockId::Qualify(sync.from, machine_id_, current_file_tag_);
   ClockId to = sync.to ? ClockId::Qualify(*sync.to, machine_id_, 0) : g;
-  if (from == to) {
+  if (from != to && !sync_->Convert(from, sync.from_ts, to)) {
+    AddSnapshotInternal({{from, sync.from_ts}, {to, sync.to_ts}});
+  }
+  // Then bridge the reference clock to trace time the same way every clock
+  // reaches it. A machine override can put |to| on a non-host machine with no
+  // path to G (its other clocks live in a different machine's domain); this is
+  // what lets independent single-machine captures pinned onto a shared clock
+  // (e.g. REALTIME) line up on one axis without a remote_clock_sync.
+  BridgeToTraceTime(to, g);
+}
+
+void ClockTracker::BridgeToTraceTime(ClockId clock_id, ClockId trace_time) {
+  // Already related to trace time: a real snapshot, an earlier bridge, or
+  // |clock_id| is itself the trace time clock. Nothing to do.
+  if (clock_id == trace_time || sync_->Convert(clock_id, 0, trace_time)) {
     return;
   }
-  if (sync_->Convert(from, sync.from_ts, to)) {
+
+  // Prefer aligning on REALTIME. REALTIME is the same absolute (UTC) clock on
+  // every machine, so if |clock_id| reaches this machine's REALTIME (there is a
+  // path through realtime, i.e. a boot<->realtime snapshot) we tie that REALTIME
+  // to the trace time machine's REALTIME (the global rendezvous node) with an
+  // assume-aligned zero-offset edge, and |clock_id| reaches trace time through
+  // it. Taken only when the rendezvous node itself reaches trace time. A real
+  // cross-machine sync (remote_clock_sync), if present, already connects the
+  // clocks and wins via the early return above.
+  ClockId realtime = ClockId::Qualify(
+      ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_REALTIME), machine_id_, 0);
+  ClockId global_realtime = ClockId::Machine(
+      trace_time.machine_id, protos::pbzero::BUILTIN_CLOCK_REALTIME);
+  if (realtime != global_realtime && sync_->Convert(clock_id, 0, realtime) &&
+      sync_->Convert(global_realtime, 0, trace_time)) {
+    if (!sync_->Convert(realtime, 0, global_realtime)) {
+      AddSnapshotInternal({{realtime, 0}, {global_realtime, 0}});
+    }
     return;
   }
-  AddSnapshotInternal({{from, sync.from_ts}, {to, sync.to_ts}});
+
+  // Last resort: nothing relates |clock_id| to the global trace time clock.
+  // Inject a zero-offset (assume-aligned) edge only when that assumption is
+  // defensible:
+  //  - either endpoint is a private per-file clock (BUILTIN_CLOCK_TRACE_FILE):
+  //    it has no intrinsic domain and may legitimately map to any clock,
+  //    whether it is the source (e.g. a JSON file) or the trace time itself
+  //    (e.g. a proto with no ClockSnapshot, whose master timeline is the
+  //    synthetic trace-file clock); or
+  //  - the two are the same clock domain on different machines/files (the same
+  //    physical clock, e.g. two machines' BOOTTIME assumed to share a boot
+  //    instant).
+  // Across different real domains (e.g. BOOTTIME vs REALTIME) we do not
+  // fabricate a relationship: the conversion fails so the events are dropped and
+  // logged rather than silently misplaced.
+  bool either_private =
+      clock_id.clock_id == protos::pbzero::BUILTIN_CLOCK_TRACE_FILE ||
+      trace_time.clock_id == protos::pbzero::BUILTIN_CLOCK_TRACE_FILE;
+  if (either_private || clock_id.clock_id == trace_time.clock_id) {
+    AddSnapshotInternal({{clock_id, 0}, {trace_time, 0}});
+    return;
+  }
+
+  // Declined: |clock_id| stays unconnected, so its events fail to convert and
+  // are dropped (and counted by clock_sync_failure_no_path). Record a clear
+  // analysis log explaining why, rather than leaving only that generic
+  // no-path error which advises emitting ClockSnapshots.
+  context_->import_logs_tracker->RecordAnalysisError(
+      stats::clock_sync_unrelatable_clock_domains,
+      [&](ArgsTracker::BoundInserter& inserter) {
+        inserter.AddArg(source_clock_id_key_,
+                        Variadic::Integer(clock_id.clock_id));
+        inserter.AddArg(target_clock_id_key_,
+                        Variadic::Integer(trace_time.clock_id));
+      });
 }
 
 std::optional<int64_t> ClockTracker::ToTraceTimeFromSnapshot(

--- a/src/trace_processor/importers/common/clock_tracker.h
+++ b/src/trace_processor/importers/common/clock_tracker.h
@@ -177,6 +177,14 @@ class ClockTracker {
 
   PERFETTO_NO_INLINE void FlushDeferredClockSync();
 
+  // Guarantees a flushed |clock_id| can reach the trace time clock. If the graph
+  // already relates them, does nothing. Otherwise prefers a cross-machine
+  // REALTIME alignment (routing through the trace time machine's REALTIME as a
+  // global rendezvous node), falling back to assuming |clock_id| is itself
+  // aligned with trace time. Both fallbacks are zero-offset (assume-aligned)
+  // edges; a real relationship always wins.
+  void BridgeToTraceTime(ClockId clock_id, ClockId trace_time);
+
   // Adds an edge directly to the global sync and records it in the
   // clock_snapshot table. Every graph mutation goes through here so the table
   // is a faithful record of the graph. Clocks must already be qualified.

--- a/src/trace_processor/importers/common/clock_tracker.h
+++ b/src/trace_processor/importers/common/clock_tracker.h
@@ -177,8 +177,8 @@ class ClockTracker {
 
   PERFETTO_NO_INLINE void FlushDeferredClockSync();
 
-  // Guarantees a flushed |clock_id| can reach the trace time clock. If the graph
-  // already relates them, does nothing. Otherwise prefers a cross-machine
+  // Guarantees a flushed |clock_id| can reach the trace time clock. If the
+  // graph already relates them, does nothing. Otherwise prefers a cross-machine
   // REALTIME alignment (routing through the trace time machine's REALTIME as a
   // global rendezvous node), falling back to assuming |clock_id| is itself
   // aligned with trace time. Both fallbacks are zero-offset (assume-aligned)

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -269,8 +269,9 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
       if (PERFETTO_UNLIKELY(inserted)) {
         auto* machine_context =
             context_->ForkContextForMachineInCurrentTrace(decoder.machine_id());
-        *it = std::make_unique<ProtoTraceReader>(machine_context,
-                                                 /*is_machine_dispatcher=*/false);
+        *it =
+            std::make_unique<ProtoTraceReader>(machine_context,
+                                               /*is_machine_dispatcher=*/false);
         auto parent_default = context_->clock_tracker->trace_default_clock();
         if (parent_default) {
           machine_context->clock_tracker->SetTraceDefaultClock(*parent_default);

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -170,9 +170,11 @@ std::optional<uint32_t> ParseTracingServiceMajorVersion(
 
 }  // namespace
 
-ProtoTraceReader::ProtoTraceReader(TraceProcessorContext* ctx)
+ProtoTraceReader::ProtoTraceReader(TraceProcessorContext* ctx,
+                                   bool is_machine_dispatcher)
     : context_(ctx),
       parser_(std::make_unique<ProtoTraceParserImpl>(ctx, &module_context_)),
+      is_machine_dispatcher_(is_machine_dispatcher),
       protovm_(ctx),
       skipped_packet_key_id_(ctx->storage->InternString("skipped_packet")),
       invalid_incremental_state_key_id_(
@@ -258,21 +260,17 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
   // using a different ProtoTraceReader instance. The packet will be parsed
   // in the context of the remote machine.
   if (PERFETTO_UNLIKELY(decoder.machine_id())) {
-    // A packet with a machine_id proves this trace contains data from more
-    // than one machine, which is incompatible with a perfetto_manifest
-    // clock pin: the pin is ambiguous across machines.
-    if (context_->has_clock_override()) {
-      return base::ErrStatus(
-          "perfetto_manifest: clock overrides require the trace to come "
-          "from a single machine");
-    }
-    if (context_->machine_id() == MachineId(kDefaultMachineId)) {
+    // A machine_id proves the trace is multi-machine, which a perfetto_manifest
+    // clock/machine override (single-machine by construction) cannot describe.
+    RETURN_IF_ERROR(CheckManifestSingleMachine());
+    if (is_machine_dispatcher_) {
       auto [it, inserted] =
           machine_to_proto_readers_.Insert(decoder.machine_id(), nullptr);
       if (PERFETTO_UNLIKELY(inserted)) {
         auto* machine_context =
             context_->ForkContextForMachineInCurrentTrace(decoder.machine_id());
-        *it = std::make_unique<ProtoTraceReader>(machine_context);
+        *it = std::make_unique<ProtoTraceReader>(machine_context,
+                                                 /*is_machine_dispatcher=*/false);
         auto parent_default = context_->clock_tracker->trace_default_clock();
         if (parent_default) {
           machine_context->clock_tracker->SetTraceDefaultClock(*parent_default);
@@ -286,10 +284,10 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
       return it->get()->ParsePacket(std::move(packet));
     }
   }
-  // Assert that the packet is parsed using the right instance of reader.
-  // machine_id is set only for remote machines.
-  PERFETTO_DCHECK(decoder.has_machine_id() ==
-                  (context_->machine_id() != MachineId(kDefaultMachineId)));
+  // Assert that the packet is parsed using the right instance of reader: the
+  // top-level dispatcher handles host packets (no machine_id), and the
+  // sub-readers it forks handle their own machine's packets (machine_id set).
+  PERFETTO_DCHECK(decoder.has_machine_id() == !is_machine_dispatcher_);
 
   // Execute ProtoVM logic right after the "machine ID fork" as detailed in
   // go/perfetto-proto-vm.
@@ -353,7 +351,7 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
   }
 
   if (decoder.has_remote_clock_sync()) {
-    PERFETTO_DCHECK(context_->machine_id() != MachineId(kDefaultMachineId));
+    PERFETTO_DCHECK(!is_machine_dispatcher_);
     return ParseRemoteClockSync(decoder.remote_clock_sync());
   }
 
@@ -761,7 +759,26 @@ base::Status ProtoTraceReader::ParseClockSnapshot(ConstBytes blob,
   return base::OkStatus();
 }
 
+base::Status ProtoTraceReader::CheckManifestSingleMachine() {
+  if (context_->has_machine_override()) {
+    return base::ErrStatus(
+        "perfetto_manifest: machine override requires the trace to come "
+        "from a single machine");
+  }
+  if (context_->has_clock_override()) {
+    return base::ErrStatus(
+        "perfetto_manifest: clock overrides require the trace to come "
+        "from a single machine");
+  }
+  return base::OkStatus();
+}
+
 base::Status ProtoTraceReader::ParseRemoteClockSync(ConstBytes blob) {
+  // Remote clock syncs prove the trace is multi-machine/multi-clock. The
+  // machine_id branch in ParsePacket normally rejects overridden traces
+  // first, but a packet carrying remote_clock_sync without a machine_id
+  // would bypass it (the DCHECK above is a no-op in release builds).
+  RETURN_IF_ERROR(CheckManifestSingleMachine());
   protos::pbzero::RemoteClockSync::Decoder evt(blob);
 
   std::vector<SyncClockSnapshots> sync_clock_snapshots;

--- a/src/trace_processor/importers/proto/proto_trace_reader.h
+++ b/src/trace_processor/importers/proto/proto_trace_reader.h
@@ -62,7 +62,12 @@ class ProtoTraceReader : public ChunkedTraceReader {
  public:
   // |reader| is the abstract method of getting chunks of size |chunk_size_b|
   // from a trace file with these chunks parsed into |trace|.
-  explicit ProtoTraceReader(TraceProcessorContext*);
+  // |is_machine_dispatcher| is true for the top-level reader of a trace, which
+  // owns dispatching remote-machine packets to per-machine sub-readers. The
+  // sub-readers it forks are created with false: they only parse their own
+  // machine's packets and never re-dispatch.
+  explicit ProtoTraceReader(TraceProcessorContext*,
+                            bool is_machine_dispatcher = true);
   ~ProtoTraceReader() override;
 
   // ChunkedTraceReader implementation.
@@ -115,6 +120,11 @@ class ProtoTraceReader : public ChunkedTraceReader {
   base::Status ParseServiceEvent(int64_t ts, ConstBytes);
   base::Status ParseClockSnapshot(ConstBytes blob, uint32_t seq_id);
   base::Status ParseRemoteClockSync(ConstBytes blob);
+
+  // Returns an error if a perfetto_manifest clock or machine override (both
+  // single-machine by construction) pinned this trace, given evidence that it
+  // is actually multi-machine (a remote machine_id or a remote_clock_sync).
+  base::Status CheckManifestSingleMachine();
   void HandleIncrementalStateCleared(const protos::pbzero::TracePacket_Decoder&,
                                      const TraceBlobView& packet);
   void HandleFirstPacketOnSequence(uint32_t packet_sequence_id);
@@ -150,6 +160,7 @@ class ProtoTraceReader : public ChunkedTraceReader {
   std::unique_ptr<ProtoTraceParserImpl> parser_;
   base::FlatHashMap<uint32_t, std::unique_ptr<ProtoTraceReader>>
       machine_to_proto_readers_;
+  const bool is_machine_dispatcher_;
   ProtoVmIncrementalTracing protovm_;
 
   // Temporary. Currently trace packets do not have a timestamp, so the

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -734,7 +734,8 @@ CREATE PERFETTO VIEW machine(
   id ID,
   -- Raw machine identifier in the trace packet.
   raw_id LONG,
-  -- Human-readable name of the machine, used as its label in the UI.
+  -- Human-readable name of the machine (e.g. from a perfetto_manifest
+  -- override), used as its label in the UI.
   name STRING,
   -- The name of the operating system.
   sysname STRING,

--- a/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.cc
+++ b/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.cc
@@ -246,7 +246,8 @@ base::StatusOr<FileEntry> ParseFileEntry(const json::Dom& file) {
     }
     if (machine.HasMember("id")) {
       if (!machine["id"].IsNumeric()) {
-        return base::ErrStatus("perfetto_manifest: machine: id must be numeric");
+        return base::ErrStatus(
+            "perfetto_manifest: machine: id must be numeric");
       }
       int64_t machine_id = machine["id"].AsInt64();
       if (machine_id < 1 || machine_id > std::numeric_limits<uint32_t>::max()) {

--- a/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.cc
+++ b/src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.cc
@@ -22,6 +22,8 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "perfetto/base/status.h"
@@ -139,81 +141,82 @@ base::StatusOr<int64_t> ParseAnchorTs(const json::Dom& obj,
   return ts;
 }
 
-base::StatusOr<ClockOverride> ParseAnchor(const json::Dom& anchor) {
-  ClockOverride result;
-  ASSIGN_OR_RETURN(result.file_ts_ns, ParseAnchorTs(anchor, "ts", "ts"));
-  if (!anchor.HasMember("is") || !anchor["is"].IsObject()) {
-    return base::ErrStatus(
-        "perfetto_manifest: anchor: missing required field: is");
-  }
-
-  const json::Dom& is = anchor["is"];
-  if (is.HasMember("utc")) {
-    if (is.HasMember("clock") || is.HasMember("ts")) {
-      return base::ErrStatus(
-          "perfetto_manifest: anchor: utc cannot be combined with clock/ts");
-    }
-    if (!is["utc"].IsString()) {
-      return base::ErrStatus("perfetto_manifest: anchor: utc must be a string");
-    }
-    std::string utc = is["utc"].AsString();
-    auto ts = ParseUtcTimestamp(utc);
-    if (!ts) {
-      return base::ErrStatus(
-          "perfetto_manifest: anchor: invalid utc timestamp: %s", utc.c_str());
-    }
-    result.clock = protos::pbzero::BUILTIN_CLOCK_REALTIME;
-    result.clock_ts_ns = *ts;
-    return result;
-  }
-  if (!is.HasMember("clock")) {
-    return base::ErrStatus(
-        "perfetto_manifest: anchor: missing required field: clock");
-  }
-  ASSIGN_OR_RETURN(uint32_t clock, ParseClockName(is["clock"]));
-  result.clock = clock;
-  ASSIGN_OR_RETURN(result.clock_ts_ns, ParseAnchorTs(is, "ts", "is.ts"));
-  return result;
-}
-
+// Parses a file's "clocks" block. The file's clock is related to a reference
+// |is| (a builtin clock, or trace time when |is| is omitted) by either an
+// |offset_ns| or a pair of coinciding readings (|ts| on this file, |is.ts| on
+// the reference). Normalized into ClockOverride: file reading |file_ts_ns|
+// corresponds to |clock_ts_ns| on |clock| (nullopt clock = trace time).
+//   {is:{clock:"X"}}                          file clock IS X (identity)
+//   {offset_ns:N}                             file = trace time + N
+//   {ts:A, is:{clock:"X", ts:B}}              file reads A when X reads B
+//   {is:{utc:"<ISO>"}}                        anchor onto REALTIME wall time
+// (is.file / is.machine and a source `clock` field arrive in later changes.)
 base::StatusOr<ClockOverride> ParseClocks(const json::Dom& clocks) {
-  // Exclusivity diagnostics: each rejected combination would override the
-  // file's timeline twice.
-  if (clocks.HasMember("offset_ns") && clocks.HasMember("anchor")) {
-    return base::ErrStatus(
-        "perfetto_manifest: offset_ns and anchor are mutually exclusive");
-  }
-  if (clocks.HasMember("native") && clocks.HasMember("anchor")) {
-    return base::ErrStatus(
-        "perfetto_manifest: native and anchor are mutually exclusive");
-  }
-  if (clocks.HasMember("anchor")) {
-    if (!clocks["anchor"].IsObject()) {
-      return base::ErrStatus("perfetto_manifest: anchor must be an object");
-    }
-    return ParseAnchor(clocks["anchor"]);
-  }
   ClockOverride result;
-  if (clocks.HasMember("native")) {
-    ASSIGN_OR_RETURN(uint32_t native, ParseClockName(clocks["native"]));
-    result.clock = native;
+
+  bool has_is_ts = false;
+  if (clocks.HasMember("is")) {
+    const json::Dom& is = clocks["is"];
+    if (!is.IsObject()) {
+      return base::ErrStatus("perfetto_manifest: clocks: is must be an object");
+    }
+    if (is.HasMember("utc")) {
+      if (is.HasMember("clock") || is.HasMember("ts")) {
+        return base::ErrStatus(
+            "perfetto_manifest: clocks: is.utc cannot be combined with "
+            "clock/ts");
+      }
+      if (!is["utc"].IsString()) {
+        return base::ErrStatus(
+            "perfetto_manifest: clocks: is.utc must be a string");
+      }
+      std::string utc = is["utc"].AsString();
+      auto ts = ParseUtcTimestamp(utc);
+      if (!ts) {
+        return base::ErrStatus(
+            "perfetto_manifest: clocks: invalid is.utc timestamp: %s",
+            utc.c_str());
+      }
+      result.clock = protos::pbzero::BUILTIN_CLOCK_REALTIME;
+      result.clock_ts_ns = *ts;
+    } else {
+      if (!is.HasMember("clock")) {
+        return base::ErrStatus(
+            "perfetto_manifest: clocks: is needs a clock (or utc)");
+      }
+      ASSIGN_OR_RETURN(uint32_t clock, ParseClockName(is["clock"]));
+      result.clock = clock;
+      if (is.HasMember("ts")) {
+        ASSIGN_OR_RETURN(result.clock_ts_ns, ParseAnchorTs(is, "ts", "is.ts"));
+        has_is_ts = true;
+      }
+    }
   }
+
   if (clocks.HasMember("offset_ns")) {
+    if (has_is_ts || clocks.HasMember("ts")) {
+      return base::ErrStatus(
+          "perfetto_manifest: clocks: offset_ns and a reading (ts) are "
+          "mutually exclusive");
+    }
     if (!clocks["offset_ns"].IsIntegral()) {
-      return base::ErrStatus("perfetto_manifest: offset_ns must be an integer");
+      return base::ErrStatus(
+          "perfetto_manifest: clocks: offset_ns must be an integer");
     }
     int64_t offset_ns = clocks["offset_ns"].AsInt64();
     if (offset_ns == std::numeric_limits<int64_t>::min()) {
-      return base::ErrStatus("perfetto_manifest: offset_ns is out of range");
+      return base::ErrStatus(
+          "perfetto_manifest: clocks: offset_ns is out of range");
     }
-    // Snapshot timestamps must never be negative: a backwards shift is
-    // expressed by mapping a later file timestamp to the clock's zero
-    // instead.
+    // Snapshot timestamps must never be negative: a backwards shift maps a
+    // later file reading onto the reference's zero instead.
     if (offset_ns < 0) {
       result.file_ts_ns = -offset_ns;
     } else {
       result.clock_ts_ns = offset_ns;
     }
+  } else if (clocks.HasMember("ts")) {
+    ASSIGN_OR_RETURN(result.file_ts_ns, ParseAnchorTs(clocks, "ts", "ts"));
   }
   return result;
 }
@@ -231,6 +234,39 @@ base::StatusOr<FileEntry> ParseFileEntry(const json::Dom& file) {
       return base::ErrStatus("perfetto_manifest: clocks must be an object");
     }
     ASSIGN_OR_RETURN(entry.clock_override, ParseClocks(file["clocks"]));
+  }
+  if (file.HasMember("machine")) {
+    const json::Dom& machine = file["machine"];
+    if (!machine.IsObject()) {
+      return base::ErrStatus("perfetto_manifest: machine must be an object");
+    }
+    if (!machine.HasMember("id") && !machine.HasMember("name")) {
+      return base::ErrStatus(
+          "perfetto_manifest: machine must have a name and/or an id");
+    }
+    if (machine.HasMember("id")) {
+      if (!machine["id"].IsNumeric()) {
+        return base::ErrStatus("perfetto_manifest: machine: id must be numeric");
+      }
+      int64_t machine_id = machine["id"].AsInt64();
+      if (machine_id < 1 || machine_id > std::numeric_limits<uint32_t>::max()) {
+        return base::ErrStatus(
+            "perfetto_manifest: machine: id must be in [1, 4294967295]");
+      }
+      entry.machine_id = static_cast<uint32_t>(machine_id);
+    }
+    if (machine.HasMember("name")) {
+      if (!machine["name"].IsString()) {
+        return base::ErrStatus(
+            "perfetto_manifest: machine: name must be a string");
+      }
+      std::string name = machine["name"].AsString();
+      if (name.empty()) {
+        return base::ErrStatus(
+            "perfetto_manifest: machine: name must be non-empty");
+      }
+      entry.machine_name = std::move(name);
+    }
   }
   return entry;
 }
@@ -291,6 +327,31 @@ base::Status PerfettoManifestReader::OnPushDataToSorter() {
       ASSIGN_OR_RETURN(FileEntry entry, ParseFileEntry(file));
       state->files.push_back(std::move(entry));
     }
+  }
+
+  // Assign a synthetic raw id to each distinct name-only machine, in first-seen
+  // order, skipping ids claimed explicitly so a named machine never collides
+  // with an id-keyed one.
+  std::unordered_set<uint32_t> explicit_ids;
+  for (const FileEntry& entry : state->files) {
+    if (entry.machine_id) {
+      explicit_ids.insert(*entry.machine_id);
+    }
+  }
+  std::unordered_map<std::string, uint32_t> name_to_id;
+  uint32_t next_id = 1;
+  for (FileEntry& entry : state->files) {
+    if (!entry.machine_name || entry.machine_id) {
+      continue;
+    }
+    auto [it, inserted] = name_to_id.try_emplace(*entry.machine_name, 0);
+    if (inserted) {
+      while (explicit_ids.count(next_id)) {
+        ++next_id;
+      }
+      it->second = next_id++;
+    }
+    entry.machine_id = it->second;
   }
 
   // This file has no per-trace context (and thus no ClockTracker), so it

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -365,6 +365,15 @@ namespace perfetto::trace_processor::stats {
       "time clock. Both clocks exist in snapshots, but never together or "     \
       "via a common intermediate clock. Ensure ClockSnapshots link all used "  \
       "clocks to the trace time clock."),                                      \
+  F(clock_sync_unrelatable_clock_domains, kSingle, kError, kAnalysis, Scope::kMachineAndTrace,         \
+      "A file's clock domain could not be related to the trace time clock, so "\
+      "its events were dropped. The two are different real clock domains (the "\
+      "args record the source and trace-time clock ids, e.g. BOOTTIME=6 "      \
+      "against a REALTIME=1 trace time) with nothing connecting them, and "    \
+      "trace_processor does not assume different real clocks are aligned. "    \
+      "Provide a relationship - a ClockSnapshot, a remote_clock_sync, or a "   \
+      "perfetto_manifest clock anchor - or attribute the file to a machine "   \
+      "that shares a clock with the rest of the trace."),                      \
   F(clock_sync_mixed_clock_sources,         kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
       "A non-primary trace file used both the primary trace's clock "          \
       "snapshots and its own for timestamp conversion. Timestamps "            \

--- a/src/trace_processor/tables/metadata_tables.py
+++ b/src/trace_processor/tables/metadata_tables.py
@@ -108,8 +108,9 @@ MACHINE_TABLE = Table(
             'name':
                 '''
                   Human-readable name of the machine (from
-                  SystemInfo.machine_name), used as the machine's label in the
-                  UI. NULL when the machine did not advertise a name.
+                  SystemInfo.machine_name or a perfetto_manifest machine
+                  override), used as the machine's label in the UI. NULL when
+                  the machine did not advertise a name.
                 ''',
             'sysname':
                 '''

--- a/src/trace_processor/types/trace_manifest_state.h
+++ b/src/trace_processor/types/trace_manifest_state.h
@@ -53,6 +53,10 @@ struct TraceManifestState {
     // Exact path of the member within the archive.
     std::string path;
     std::optional<ClockOverride> clock_override;
+    // Explicit id, or a synthetic id the reader allocates per distinct
+    // |machine_name| so files sharing a name land on the same machine.
+    std::optional<uint32_t> machine_id;
+    std::optional<std::string> machine_name;
   };
 
   // True once a perfetto_manifest file has been parsed; a second one is an

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -106,6 +106,10 @@ class TraceProcessorContext {
     // private clock. The trace must then stay single-clock and single-machine,
     // so ClockSnapshots and remote machine ids are rejected on it.
     bool has_clock_override = false;
+
+    // Set when a perfetto_manifest entry attributed this file to a machine;
+    // lets readers reject it later if it proves to be multi-machine.
+    bool has_machine_override = false;
   };
 
   struct UuidState {
@@ -266,6 +270,12 @@ class TraceProcessorContext {
   // per-trace state.
   bool has_clock_override() const {
     return trace_state && trace_state->has_clock_override;
+  }
+
+  // True when a perfetto_manifest entry attributed this trace to a single
+  // machine. False for root/container contexts that have no per-trace state.
+  bool has_machine_override() const {
+    return trace_state && trace_state->has_machine_override;
   }
 
  private:

--- a/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
+++ b/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
@@ -85,6 +85,27 @@ SYSTRACE = '''# tracer: nop
 # The same proto trace without any clock snapshot: a single-clock proto trace.
 SOLO_PROTO = TextProto(_PROTO_SLICE)
 
+# A second single-clock proto trace whose slice is named 'm7_slice'.
+M7_PROTO = TextProto(_PROTO_SLICE.replace('proto_slice', 'm7_slice'))
+
+# Packets emitted by a remote machine (machine_id 7).
+_M7_PROCESS = '''
+  packet {
+    machine_id: 7
+    process_tree { processes { pid: 30 ppid: 0 cmdline: "m7_proc" } }
+  }
+'''
+
+_M7_CLOCK_SNAPSHOT = '''
+  packet {
+    machine_id: 7
+    clock_snapshot {
+      clocks { clock_id: 6 timestamp: 50000000000 }
+      clocks { clock_id: 3 timestamp: 1000000000 }
+    }
+  }
+'''
+
 
 # A Chrome JSON trace with one complete event at ts=2000us, dur=500us and an
 # embedded systrace ('systemTraceEvents') with one slice 'sys_in_json' from
@@ -109,6 +130,56 @@ def _json_trace_with_systrace(name, pid=10):
 
 def _meta(payload):
   return json.dumps({'perfetto_manifest': payload})
+
+
+# Query used by the cross-machine alignment tests: each slice with its
+# trace-time ts and the machine it was attributed to.
+_ALIGN_QUERY = '''
+  SELECT s.name, s.ts, m.name AS machine
+  FROM slice s
+  JOIN track t ON s.track_id = t.id
+  JOIN machine m ON t.machine_id = m.id
+  WHERE s.name GLOB '*_slice'
+  ORDER BY s.ts;
+'''
+
+
+# A proto trace with a BOOTTIME<->REALTIME clock snapshot and one slice |name|
+# at BOOTTIME |at|. |boot|/|realtime| are the correlated snapshot readings.
+def _proto_rt(name, seq, uuid, boot, realtime, at):
+  return TextProto(
+      'packet { clock_snapshot {\n'
+      '  clocks { clock_id: 6 timestamp: %d }\n'
+      '  clocks { clock_id: 1 timestamp: %d }\n'
+      '} }\n'
+      'packet { trusted_packet_sequence_id: %d track_descriptor { uuid: %d } }\n'
+      'packet { trusted_packet_sequence_id: %d timestamp: %d\n'
+      '  track_event { type: TYPE_SLICE_BEGIN track_uuid: %d name: "%s" } }\n'
+      'packet { trusted_packet_sequence_id: %d timestamp: %d\n'
+      '  track_event { type: TYPE_SLICE_END track_uuid: %d } }\n' %
+      (boot, realtime, seq, uuid, seq, at, uuid, name, seq, at + 100000000, uuid))
+
+
+# A proto trace with a BOOTTIME-only clock snapshot (no REALTIME): its events
+# are on a real BOOTTIME clock. One slice |name| at BOOTTIME |at|.
+def _proto_boot_snap(name, seq, uuid, boot, at):
+  return TextProto(
+      'packet { clock_snapshot { clocks { clock_id: 6 timestamp: %d } } }\n'
+      'packet { trusted_packet_sequence_id: %d track_descriptor { uuid: %d } }\n'
+      'packet { trusted_packet_sequence_id: %d timestamp: %d\n'
+      '  track_event { type: TYPE_SLICE_BEGIN track_uuid: %d name: "%s" } }\n'
+      'packet { trusted_packet_sequence_id: %d timestamp: %d\n'
+      '  track_event { type: TYPE_SLICE_END track_uuid: %d } }\n' %
+      (boot, seq, uuid, seq, at, uuid, name, seq, at + 100000000, uuid))
+
+
+# A perfetto_manifest entry attributing |path| to machine |name|, optionally
+# with a REALTIME anchor mapping the file's clock ts 0 to REALTIME |realtime|.
+def _machine_file(path, name, realtime=None):
+  entry = {'path': path, 'machine': {'name': name}}
+  if realtime is not None:
+    entry['clocks'] = {'ts': 0, 'is': {'clock': 'REALTIME', 'ts': realtime}}
+  return entry
 
 
 class TraceManifest(TestSuite):
@@ -433,12 +504,10 @@ class TraceManifest(TestSuite):
                     'files': [{
                         'path': 'app.json',
                         'clocks': {
-                            'anchor': {
-                                'ts': 1000000,
-                                'is': {
-                                    'clock': 'BOOTTIME',
-                                    'ts': 1500000000
-                                },
+                            'ts': 1000000,
+                            'is': {
+                                'clock': 'BOOTTIME',
+                                'ts': 1500000000
                             },
                         },
                     }],
@@ -475,11 +544,8 @@ class TraceManifest(TestSuite):
                     'files': [{
                         'path': 'app.json',
                         'clocks': {
-                            'anchor': {
-                                'ts': 0,
-                                'is': {
-                                    'utc': '2023-11-14T22:13:21.5Z'
-                                },
+                            'is': {
+                                'utc': '2023-11-14T22:13:21.5Z'
                             },
                         },
                     }],
@@ -514,11 +580,8 @@ class TraceManifest(TestSuite):
                     'files': [{
                         'path': 'app.json',
                         'clocks': {
-                            'anchor': {
-                                'ts': 0,
-                                'is': {
-                                    'utc': '2023-11-14T22:13:21.5Z'
-                                },
+                            'is': {
+                                'utc': '2023-11-14T22:13:21.5Z'
                             },
                         },
                     }],
@@ -536,7 +599,7 @@ class TraceManifest(TestSuite):
         11,"[NULL]",0,0
         '''))
 
-  # --- clocks.native ---
+  # --- clocks: identity / native ---
 
   # Baseline (no metadata file): systrace timestamps are MONOTONIC, so via the
   # spine's MONOTONIC<->BOOTTIME snapshot the 1.0s slice lands at
@@ -555,7 +618,7 @@ class TraceManifest(TestSuite):
         "sys_slice",1500000000,500000000
         '''))
 
-  # clocks.native reinterprets the file's native clock: the same systrace with
+  # an is-with-clock identity reinterprets the file's native clock: the same systrace with
   # native=BOOTTIME keeps its timestamps unconverted at 1_000_000_000.
   def test_systrace_native_clock_override(self):
     return DiffTestBlueprint(
@@ -567,7 +630,7 @@ class TraceManifest(TestSuite):
                     'files': [{
                         'path': 'sys.systrace',
                         'clocks': {
-                            'native': 'BOOTTIME'
+                            'is': {'clock': 'BOOTTIME'}
                         }
                     }],
                 }),
@@ -598,7 +661,7 @@ class TraceManifest(TestSuite):
                     'files': [{
                         'path': 'sys.systrace',
                         'clocks': {
-                            'native': 'BOOTTIME',
+                            'is': {'clock': 'BOOTTIME'},
                             'offset_ns': 100000000
                         }
                     }],
@@ -630,12 +693,10 @@ class TraceManifest(TestSuite):
                     'files': [{
                         'path': 'sys.systrace',
                         'clocks': {
-                            'anchor': {
-                                'ts': 1000000000,
-                                'is': {
-                                    'clock': 'BOOTTIME',
-                                    'ts': 5000000000
-                                },
+                            'ts': 1000000000,
+                            'is': {
+                                'clock': 'BOOTTIME',
+                                'ts': 5000000000
                             },
                         },
                     }],
@@ -692,7 +753,7 @@ class TraceManifest(TestSuite):
 
   # --- Clock override errors ---
 
-  def test_error_offset_and_anchor_exclusive(self):
+  def test_error_offset_and_reading_exclusive(self):
     return DiffTestBlueprint(
         trace=Zip({
             'meta.json':
@@ -703,12 +764,10 @@ class TraceManifest(TestSuite):
                         'path': 'app.json',
                         'clocks': {
                             'offset_ns': 1,
-                            'anchor': {
-                                'ts': 0,
-                                'is': {
-                                    'clock': 'BOOTTIME',
-                                    'ts': 1
-                                }
+                            'ts': 0,
+                            'is': {
+                                'clock': 'BOOTTIME',
+                                'ts': 1
                             },
                         },
                     }],
@@ -718,35 +777,7 @@ class TraceManifest(TestSuite):
         }),
         query='SELECT 1;',
         out=ExpectedError(
-            'perfetto_manifest: offset_ns and anchor are mutually exclusive'))
-
-  def test_error_native_and_anchor_exclusive(self):
-    return DiffTestBlueprint(
-        trace=Zip({
-            'meta.json':
-                _meta({
-                    'version':
-                        1,
-                    'files': [{
-                        'path': 'app.json',
-                        'clocks': {
-                            'native': 'BOOTTIME',
-                            'anchor': {
-                                'ts': 0,
-                                'is': {
-                                    'clock': 'BOOTTIME',
-                                    'ts': 1
-                                }
-                            },
-                        },
-                    }],
-                }),
-            'app.json':
-                _json_trace('json_slice'),
-        }),
-        query='SELECT 1;',
-        out=ExpectedError(
-            'perfetto_manifest: native and anchor are mutually exclusive'))
+            'offset_ns and a reading (ts) are mutually exclusive'))
 
   def test_error_utc_impossible_date(self):
     return DiffTestBlueprint(
@@ -758,11 +789,8 @@ class TraceManifest(TestSuite):
                     'files': [{
                         'path': 'app.json',
                         'clocks': {
-                            'anchor': {
-                                'ts': 0,
-                                'is': {
-                                    'utc': '2026-13-40T99:00:00Z'
-                                }
+                            'is': {
+                                'utc': '2026-13-40T99:00:00Z'
                             },
                         },
                     }],
@@ -771,7 +799,8 @@ class TraceManifest(TestSuite):
                 _json_trace('json_slice'),
         }),
         query='SELECT 1;',
-        out=ExpectedError('perfetto_manifest: anchor: invalid utc timestamp'))
+        out=ExpectedError(
+            'perfetto_manifest: clocks: invalid is.utc timestamp'))
 
   # A clock override on a perfetto_manifest or archive member is rejected:
   # such files have no per-trace clock state to override.
@@ -840,13 +869,655 @@ class TraceManifest(TestSuite):
                     }],
                 }),
             'spine.pb':
-                TextProto(_PROTO_SLICE + '''
-  packet {
-    machine_id: 7
-    process_tree { processes { pid: 30 ppid: 0 cmdline: "m7_proc" } }
-  }
-'''),
+                TextProto(_PROTO_SLICE + _M7_PROCESS),
         }),
         query='SELECT 1;',
         out=ExpectedError(
             'clock overrides require the trace to come from a single machine'))
+
+  # --- Machines ---
+
+  # Assigning a file to a machine id no other trace establishes creates that
+  # machine. The JSON file's events land on machine 7; with no snapshots in
+  # machine 7's clock graph the identity sync applies and ts is unchanged.
+  def test_machine_assignment_fresh_machine(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [{
+                        'path': 'app.json',
+                        'machine': {
+                            'id': 7
+                        }
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT s.name, m.raw_id, s.ts
+          FROM slice s
+          JOIN thread_track tt ON s.track_id = tt.id
+          JOIN thread t USING(utid)
+          JOIN machine m ON t.machine_id = m.id
+          WHERE s.name = 'json_slice';
+        ''',
+        out=Csv('''
+        "name","raw_id","ts"
+        "json_slice",7,2000000
+        '''))
+
+  # A JSON file assigned to machine 7 shares per-machine state with proto
+  # packets from machine 7 in the same archive: pid 30 exists in the proto's
+  # machine-7 process tree and in the JSON trace, and must resolve to a single
+  # thread, and the JSON file's slice must be attributed to machine 7.
+  def test_machine_assignment_merges_with_proto(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [{
+                        'path': 'app.json',
+                        'machine': {
+                            'id': 7
+                        }
+                    }],
+                }),
+            'app.json':
+                _json_trace('m7_json_slice', pid=30),
+            'spine.pb':
+                TextProto(_SPINE_CLOCK_SNAPSHOT + _PROTO_SLICE + _M7_PROCESS),
+        }),
+        query='''
+          SELECT
+            (SELECT count(*) FROM thread WHERE tid = 30) AS threads,
+            (SELECT m.raw_id
+             FROM slice s
+             JOIN thread_track tt ON s.track_id = tt.id
+             JOIN thread t USING(utid)
+             JOIN machine m ON t.machine_id = m.id
+             WHERE s.name = 'm7_json_slice') AS slice_machine;
+        ''',
+        out=Csv('''
+        "threads","slice_machine"
+        1,7
+        '''))
+
+  # Anchor clock names resolve in the file's machine context: BOOTTIME means
+  # machine 7's BOOTTIME (50_000_000_000 per its snapshot), not the host's.
+  # The slice at 2000us lands at 50_000_000_000 + 2_000_000.
+  def test_machine_anchor_in_machine_domain(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'app.json',
+                        'machine': {
+                            'id': 7
+                        },
+                        'clocks': {
+                            'ts': 0,
+                            'is': {
+                                'clock': 'BOOTTIME',
+                                'ts': 50000000000
+                            },
+                        },
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+            'spine.pb':
+                TextProto(_SPINE_CLOCK_SNAPSHOT + _PROTO_SLICE +
+                          _M7_CLOCK_SNAPSHOT),
+        }),
+        query='''
+          SELECT name, ts FROM slice
+          WHERE name IN ('json_slice', 'proto_slice')
+          ORDER BY name;
+        ''',
+        out=Csv('''
+        "name","ts"
+        "json_slice",50002000000
+        "proto_slice",1100000000
+        '''))
+
+  # A machine override works alongside a sibling proto trace on the host
+  # machine: each proto keeps its own machine attribution.
+  def test_machine_override_with_sibling_proto(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [{
+                        'path': 'm7.pb',
+                        'machine': {
+                            'id': 7
+                        }
+                    }],
+                }),
+            'm7.pb':
+                M7_PROTO,
+            'solo.pb':
+                SOLO_PROTO,
+        }),
+        query='''
+          SELECT
+            (SELECT count(*) FROM slice) AS slices,
+            (SELECT m.raw_id
+             FROM slice s
+             JOIN track t ON s.track_id = t.id
+             JOIN machine m ON t.machine_id = m.id
+             WHERE s.name = 'm7_slice') AS m7_machine;
+        ''',
+        out=Csv('''
+        "slices","m7_machine"
+        2,7
+        '''))
+
+  # A name-keyed override attributes the file to a machine labelled with that
+  # name; trace_processor allocates the raw id.
+  def test_machine_name_assignment(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [{
+                        'path': 'app.json',
+                        'machine': {
+                            'name': 'phone'
+                        }
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT s.name, m.name AS machine_name, s.ts
+          FROM slice s
+          JOIN thread_track tt ON s.track_id = tt.id
+          JOIN thread t USING(utid)
+          JOIN machine m ON t.machine_id = m.id
+          WHERE s.name = 'json_slice';
+        ''',
+        out=Csv('''
+        "name","machine_name","ts"
+        "json_slice","phone",2000000
+        '''))
+
+  # Files sharing a name resolve to one machine; distinct names to distinct
+  # machines.
+  def test_machine_name_dedup(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'a.json',
+                        'machine': {
+                            'name': 'phone'
+                        }
+                    }, {
+                        'path': 'b.json',
+                        'machine': {
+                            'name': 'phone'
+                        }
+                    }, {
+                        'path': 'c.json',
+                        'machine': {
+                            'name': 'watch'
+                        }
+                    }],
+                }),
+            'a.json':
+                _json_trace('slice_a'),
+            'b.json':
+                _json_trace('slice_b'),
+            'c.json':
+                _json_trace('slice_c'),
+            'spine.pb':
+                SPINE,
+        }),
+        query='''
+          SELECT count(DISTINCT t.machine_id) AS machines
+          FROM slice s
+          JOIN thread_track tt ON s.track_id = tt.id
+          JOIN thread t USING(utid)
+          WHERE s.name IN ('slice_a', 'slice_b', 'slice_c');
+        ''',
+        out=Csv('''
+        "machines"
+        2
+        '''))
+
+  # Two separate single-machine captures combined into one multi-machine trace:
+  # each is named and pinned onto REALTIME, so their timelines align on a
+  # common absolute axis with no remote_clock_sync.
+  def test_machine_multi_machine_realtime_alignment(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'trace_time_clock':
+                        'REALTIME',
+                    'files': [{
+                        'path': 'phone.json',
+                        'machine': {
+                            'name': 'phone'
+                        },
+                        'clocks': {
+                            'ts': 0,
+                            'is': {
+                                'clock': 'REALTIME',
+                                'ts': 1000000000000
+                            },
+                        },
+                    }, {
+                        'path': 'server.json',
+                        'machine': {
+                            'name': 'server'
+                        },
+                        'clocks': {
+                            'ts': 0,
+                            'is': {
+                                'clock': 'REALTIME',
+                                'ts': 2000000000000
+                            },
+                        },
+                    }],
+                }),
+            'phone.json':
+                _json_trace('phone_slice'),
+            'server.json':
+                _json_trace('server_slice'),
+        }),
+        query='''
+          SELECT s.name, m.name AS machine, s.ts
+          FROM slice s
+          JOIN thread_track tt ON s.track_id = tt.id
+          JOIN thread t USING(utid)
+          JOIN machine m ON t.machine_id = m.id
+          WHERE s.name IN ('phone_slice', 'server_slice')
+          ORDER BY s.ts;
+        ''',
+        out=Csv('''
+        "name","machine","ts"
+        "phone_slice","phone",1000002000000
+        "server_slice","server",2000002000000
+        '''))
+
+  # --- Machine override errors ---
+
+  def test_error_machine_id_out_of_range(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'app.json',
+                        'machine': {
+                            'id': 4294967296
+                        }
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+        }),
+        query='SELECT 1;',
+        out=ExpectedError(
+            'perfetto_manifest: machine: id must be in [1, 4294967295]'))
+
+  # A machine override on a proto trace containing packets from a remote
+  # machine fails: the trace manages its own machine identity.
+  def test_error_proto_multi_machine_machine_override(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [{
+                        'path': 'spine.pb',
+                        'machine': {
+                            'id': 3
+                        }
+                    }],
+                }),
+            'spine.pb':
+                TextProto(_PROTO_SLICE + _M7_PROCESS),
+        }),
+        query='SELECT 1;',
+        out=ExpectedError(
+            'machine override requires the trace to come from a single machine')
+    )
+
+  def test_error_machine_empty(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [{
+                        'path': 'app.json',
+                        'machine': {}
+                    }],
+                }),
+            'app.json':
+                _json_trace('json_slice'),
+        }),
+        query='SELECT 1;',
+        out=ExpectedError(
+            'perfetto_manifest: machine must have a name and/or an id'))
+
+  # --- Cross-machine REALTIME alignment ---
+  #
+  # When several single-machine files share no clock sync, their per-machine
+  # clocks are aligned via REALTIME if a path through it exists (REALTIME is the
+  # same absolute wall clock everywhere), else assumed BOOTTIME-aligned.
+
+  # Two protos on different machines, no remote sync. Same BOOTTIME reading but
+  # wall clocks 1s apart: they align on REALTIME, so 'b' lands 1s after 'a' in
+  # the (BOOTTIME) trace-time domain owned by the first machine.
+  def test_realtime_two_machines(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [
+                        _machine_file('a.pb', 'phone'),
+                        _machine_file('b.pb', 'server'),
+                    ],
+                }),
+            'a.pb':
+                _proto_rt('a_slice', 1, 111, 1000000000,
+                          1700000001000000000, 1100000000),
+            'b.pb':
+                _proto_rt('b_slice', 2, 222, 1000000000,
+                          1700000002000000000, 1100000000),
+        }),
+        query=_ALIGN_QUERY,
+        out=Csv('''
+        "name","ts","machine"
+        "a_slice",1100000000,"phone"
+        "b_slice",2100000000,"server"
+        '''))
+
+  # Three machines, wall clocks 1s apart each: all align on REALTIME, evenly
+  # spaced in trace time.
+  def test_realtime_three_machines(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [
+                        _machine_file('a.pb', 'phone'),
+                        _machine_file('b.pb', 'server'),
+                        _machine_file('c.pb', 'watch'),
+                    ],
+                }),
+            'a.pb':
+                _proto_rt('a_slice', 1, 111, 1000000000,
+                          1700000001000000000, 1100000000),
+            'b.pb':
+                _proto_rt('b_slice', 2, 222, 1000000000,
+                          1700000002000000000, 1100000000),
+            'c.pb':
+                _proto_rt('c_slice', 3, 333, 1000000000,
+                          1700000003000000000, 1100000000),
+        }),
+        query=_ALIGN_QUERY,
+        out=Csv('''
+        "name","ts","machine"
+        "a_slice",1100000000,"phone"
+        "b_slice",2100000000,"server"
+        "c_slice",3100000000,"watch"
+        '''))
+
+  # REALTIME wins over BOOTTIME: the two machines have very different BOOTTIME
+  # bases but their slices are at the same wall-clock instant. Aligning on
+  # REALTIME places both at the same trace ts (1_100_000_000); a BOOTTIME
+  # overlay would instead put 'b' at 5_100_000_000.
+  def test_realtime_beats_boottime(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [
+                        _machine_file('a.pb', 'phone'),
+                        _machine_file('b.pb', 'server'),
+                    ],
+                }),
+            'a.pb':
+                _proto_rt('a_slice', 1, 111, 1000000000,
+                          1700000001000000000, 1100000000),
+            'b.pb':
+                _proto_rt('b_slice', 2, 222, 5000000000,
+                          1700000001000000000, 5100000000),
+        }),
+        query=_ALIGN_QUERY,
+        out=Csv('''
+        "name","ts","machine"
+        "a_slice",1100000000,"phone"
+        "b_slice",1100000000,"server"
+        '''))
+
+  # A peer machine with no REALTIME (BOOTTIME only) cannot align on wall clock,
+  # so it falls back to the same-domain BOOTTIME overlay with the trace time
+  # clock (here BOOTTIME, owned by the first machine), keeping its raw
+  # timestamp. The REALTIME machine is unaffected.
+  def test_no_realtime_on_peer_falls_back(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [
+                        _machine_file('a.pb', 'phone'),
+                        _machine_file('b.pb', 'server'),
+                    ],
+                }),
+            'a.pb':
+                _proto_rt('a_slice', 1, 111, 1000000000,
+                          1700000001000000000, 1100000000),
+            'b.pb':
+                _proto_boot_snap('b_slice', 2, 222, 1000000000, 3000000000),
+        }),
+        query=_ALIGN_QUERY,
+        out=Csv('''
+        "name","ts","machine"
+        "a_slice",1100000000,"phone"
+        "b_slice",3000000000,"server"
+        '''))
+
+  # When the trace-time machine itself has no REALTIME, there is no rendezvous
+  # node reaching trace time, so even a peer that has REALTIME falls back to the
+  # same-domain BOOTTIME overlay: its slice keeps its raw BOOTTIME,
+  # 1_100_000_000, rather than the 2_100_000_000 a REALTIME alignment would
+  # give.
+  def test_no_realtime_on_trace_time_machine_falls_back(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [
+                        _machine_file('a.pb', 'phone'),
+                        _machine_file('b.pb', 'server'),
+                    ],
+                }),
+            'a.pb':
+                _proto_boot_snap('a_slice', 1, 111, 1000000000, 1100000000),
+            'b.pb':
+                _proto_rt('b_slice', 2, 222, 1000000000,
+                          1700000002000000000, 1100000000),
+        }),
+        query=_ALIGN_QUERY,
+        out=Csv('''
+        "name","ts","machine"
+        "a_slice",1100000000,"phone"
+        "b_slice",1100000000,"server"
+        '''))
+
+  # Non-proto: a JSON file (REALTIME only, via a manifest anchor) on one machine
+  # aligns to a proto's BOOTTIME trace time on another machine, routed through
+  # REALTIME. The JSON event at wall clock 1_700_000_001_502_000_000 maps to the
+  # proto machine's BOOTTIME 1_502_000_000.
+  def test_realtime_json_aligns_to_proto_boottime(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [
+                        _machine_file('a.pb', 'phone'),
+                        _machine_file('b.json', 'server',
+                                      realtime=1700000001500000000),
+                    ],
+                }),
+            'a.pb':
+                _proto_rt('proto_slice', 1, 111, 1000000000,
+                          1700000001000000000, 1100000000),
+            'b.json':
+                _json_trace('json_slice'),
+        }),
+        query=_ALIGN_QUERY,
+        out=Csv('''
+        "name","ts","machine"
+        "proto_slice",1100000000,"phone"
+        "json_slice",1502000000,"server"
+        '''))
+
+  # Non-proto: two JSON machines (REALTIME anchors 1s apart) both align to a
+  # proto's BOOTTIME trace time through REALTIME, landing 1s apart.
+  def test_realtime_two_json_align_to_proto(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [
+                        _machine_file('a.pb', 'phone'),
+                        _machine_file('b.json', 'server',
+                                      realtime=1700000001500000000),
+                        _machine_file('c.json', 'watch',
+                                      realtime=1700000002500000000),
+                    ],
+                }),
+            'a.pb':
+                _proto_rt('proto_slice', 1, 111, 1000000000,
+                          1700000001000000000, 1100000000),
+            'b.json':
+                _json_trace('server_slice'),
+            'c.json':
+                _json_trace('watch_slice'),
+        }),
+        query=_ALIGN_QUERY,
+        out=Csv('''
+        "name","ts","machine"
+        "proto_slice",1100000000,"phone"
+        "server_slice",1502000000,"server"
+        "watch_slice",2502000000,"watch"
+        '''))
+
+  # Different real clock domains are not assumed aligned. trace_time_clock is
+  # REALTIME; a machine whose events are on a real BOOTTIME with no path to
+  # REALTIME cannot be related to trace time, so its events are dropped rather
+  # than misplaced. The REALTIME-anchored peer resolves normally.
+  def test_cross_domain_clocks_not_assumed(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'trace_time_clock': 'REALTIME',
+                    'files': [
+                        _machine_file('a.json', 'phone',
+                                      realtime=1700000001500000000),
+                        _machine_file('b.pb', 'server'),
+                    ],
+                }),
+            'a.json':
+                _json_trace('phone_slice'),
+            'b.pb':
+                _proto_boot_snap('boot_slice', 1, 111, 1000000000, 1100000000),
+        }),
+        query=_ALIGN_QUERY,
+        out=Csv('''
+        "name","ts","machine"
+        "phone_slice",1700000001502000000,"phone"
+        '''))
+
+  # Dropping events because of unrelatable clock domains is surfaced by a
+  # dedicated import log / stat (not just the generic no-path error), so the
+  # cause is discoverable.
+  def test_cross_domain_drop_is_logged(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'trace_time_clock': 'REALTIME',
+                    'files': [
+                        _machine_file('a.json', 'phone',
+                                      realtime=1700000001500000000),
+                        _machine_file('b.pb', 'server'),
+                    ],
+                }),
+            'a.json':
+                _json_trace('phone_slice'),
+            'b.pb':
+                _proto_boot_snap('boot_slice', 1, 111, 1000000000, 1100000000),
+        }),
+        query='''
+          SELECT name, sum(value) AS value FROM stats
+          WHERE name = 'clock_sync_unrelatable_clock_domains';
+        ''',
+        out=Csv('''
+        "name","value"
+        "clock_sync_unrelatable_clock_domains",1
+        '''))
+
+  # The same physical clock on different machines IS assumed aligned: two
+  # machines with only BOOTTIME (no REALTIME) are taken to share a boot instant
+  # and overlay on the BOOTTIME trace time.
+  def test_same_domain_boottime_overlay(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'meta.json':
+                _meta({
+                    'version': 1,
+                    'files': [
+                        _machine_file('a.pb', 'phone'),
+                        _machine_file('b.pb', 'server'),
+                    ],
+                }),
+            'a.pb':
+                _proto_boot_snap('a_slice', 1, 111, 1000000000, 1100000000),
+            'b.pb':
+                _proto_boot_snap('b_slice', 2, 222, 1000000000, 3000000000),
+        }),
+        query=_ALIGN_QUERY,
+        out=Csv('''
+        "name","ts","machine"
+        "a_slice",1100000000,"phone"
+        "b_slice",3000000000,"server"
+        '''))

--- a/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
+++ b/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
@@ -157,7 +157,8 @@ def _proto_rt(name, seq, uuid, boot, realtime, at):
       '  track_event { type: TYPE_SLICE_BEGIN track_uuid: %d name: "%s" } }\n'
       'packet { trusted_packet_sequence_id: %d timestamp: %d\n'
       '  track_event { type: TYPE_SLICE_END track_uuid: %d } }\n' %
-      (boot, realtime, seq, uuid, seq, at, uuid, name, seq, at + 100000000, uuid))
+      (boot, realtime, seq, uuid, seq, at, uuid, name, seq, at + 100000000,
+       uuid))
 
 
 # A proto trace with a BOOTTIME-only clock snapshot (no REALTIME): its events
@@ -630,7 +631,9 @@ class TraceManifest(TestSuite):
                     'files': [{
                         'path': 'sys.systrace',
                         'clocks': {
-                            'is': {'clock': 'BOOTTIME'}
+                            'is': {
+                                'clock': 'BOOTTIME'
+                            }
                         }
                     }],
                 }),
@@ -661,7 +664,9 @@ class TraceManifest(TestSuite):
                     'files': [{
                         'path': 'sys.systrace',
                         'clocks': {
-                            'is': {'clock': 'BOOTTIME'},
+                            'is': {
+                                'clock': 'BOOTTIME'
+                            },
                             'offset_ns': 100000000
                         }
                     }],
@@ -1030,7 +1035,8 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
+                    'version':
+                        1,
                     'files': [{
                         'path': 'app.json',
                         'machine': {
@@ -1239,18 +1245,19 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
+                    'version':
+                        1,
                     'files': [
                         _machine_file('a.pb', 'phone'),
                         _machine_file('b.pb', 'server'),
                     ],
                 }),
             'a.pb':
-                _proto_rt('a_slice', 1, 111, 1000000000,
-                          1700000001000000000, 1100000000),
+                _proto_rt('a_slice', 1, 111, 1000000000, 1700000001000000000,
+                          1100000000),
             'b.pb':
-                _proto_rt('b_slice', 2, 222, 1000000000,
-                          1700000002000000000, 1100000000),
+                _proto_rt('b_slice', 2, 222, 1000000000, 1700000002000000000,
+                          1100000000),
         }),
         query=_ALIGN_QUERY,
         out=Csv('''
@@ -1266,7 +1273,8 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
+                    'version':
+                        1,
                     'files': [
                         _machine_file('a.pb', 'phone'),
                         _machine_file('b.pb', 'server'),
@@ -1274,14 +1282,14 @@ class TraceManifest(TestSuite):
                     ],
                 }),
             'a.pb':
-                _proto_rt('a_slice', 1, 111, 1000000000,
-                          1700000001000000000, 1100000000),
+                _proto_rt('a_slice', 1, 111, 1000000000, 1700000001000000000,
+                          1100000000),
             'b.pb':
-                _proto_rt('b_slice', 2, 222, 1000000000,
-                          1700000002000000000, 1100000000),
+                _proto_rt('b_slice', 2, 222, 1000000000, 1700000002000000000,
+                          1100000000),
             'c.pb':
-                _proto_rt('c_slice', 3, 333, 1000000000,
-                          1700000003000000000, 1100000000),
+                _proto_rt('c_slice', 3, 333, 1000000000, 1700000003000000000,
+                          1100000000),
         }),
         query=_ALIGN_QUERY,
         out=Csv('''
@@ -1300,18 +1308,19 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
+                    'version':
+                        1,
                     'files': [
                         _machine_file('a.pb', 'phone'),
                         _machine_file('b.pb', 'server'),
                     ],
                 }),
             'a.pb':
-                _proto_rt('a_slice', 1, 111, 1000000000,
-                          1700000001000000000, 1100000000),
+                _proto_rt('a_slice', 1, 111, 1000000000, 1700000001000000000,
+                          1100000000),
             'b.pb':
-                _proto_rt('b_slice', 2, 222, 5000000000,
-                          1700000001000000000, 5100000000),
+                _proto_rt('b_slice', 2, 222, 5000000000, 1700000001000000000,
+                          5100000000),
         }),
         query=_ALIGN_QUERY,
         out=Csv('''
@@ -1329,15 +1338,16 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
+                    'version':
+                        1,
                     'files': [
                         _machine_file('a.pb', 'phone'),
                         _machine_file('b.pb', 'server'),
                     ],
                 }),
             'a.pb':
-                _proto_rt('a_slice', 1, 111, 1000000000,
-                          1700000001000000000, 1100000000),
+                _proto_rt('a_slice', 1, 111, 1000000000, 1700000001000000000,
+                          1100000000),
             'b.pb':
                 _proto_boot_snap('b_slice', 2, 222, 1000000000, 3000000000),
         }),
@@ -1358,7 +1368,8 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
+                    'version':
+                        1,
                     'files': [
                         _machine_file('a.pb', 'phone'),
                         _machine_file('b.pb', 'server'),
@@ -1367,8 +1378,8 @@ class TraceManifest(TestSuite):
             'a.pb':
                 _proto_boot_snap('a_slice', 1, 111, 1000000000, 1100000000),
             'b.pb':
-                _proto_rt('b_slice', 2, 222, 1000000000,
-                          1700000002000000000, 1100000000),
+                _proto_rt('b_slice', 2, 222, 1000000000, 1700000002000000000,
+                          1100000000),
         }),
         query=_ALIGN_QUERY,
         out=Csv('''
@@ -1386,11 +1397,12 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
+                    'version':
+                        1,
                     'files': [
                         _machine_file('a.pb', 'phone'),
-                        _machine_file('b.json', 'server',
-                                      realtime=1700000001500000000),
+                        _machine_file(
+                            'b.json', 'server', realtime=1700000001500000000),
                     ],
                 }),
             'a.pb':
@@ -1413,13 +1425,14 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
+                    'version':
+                        1,
                     'files': [
                         _machine_file('a.pb', 'phone'),
-                        _machine_file('b.json', 'server',
-                                      realtime=1700000001500000000),
-                        _machine_file('c.json', 'watch',
-                                      realtime=1700000002500000000),
+                        _machine_file(
+                            'b.json', 'server', realtime=1700000001500000000),
+                        _machine_file(
+                            'c.json', 'watch', realtime=1700000002500000000),
                     ],
                 }),
             'a.pb':
@@ -1447,11 +1460,13 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
-                    'trace_time_clock': 'REALTIME',
+                    'version':
+                        1,
+                    'trace_time_clock':
+                        'REALTIME',
                     'files': [
-                        _machine_file('a.json', 'phone',
-                                      realtime=1700000001500000000),
+                        _machine_file(
+                            'a.json', 'phone', realtime=1700000001500000000),
                         _machine_file('b.pb', 'server'),
                     ],
                 }),
@@ -1474,11 +1489,13 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
-                    'trace_time_clock': 'REALTIME',
+                    'version':
+                        1,
+                    'trace_time_clock':
+                        'REALTIME',
                     'files': [
-                        _machine_file('a.json', 'phone',
-                                      realtime=1700000001500000000),
+                        _machine_file(
+                            'a.json', 'phone', realtime=1700000001500000000),
                         _machine_file('b.pb', 'server'),
                     ],
                 }),
@@ -1504,7 +1521,8 @@ class TraceManifest(TestSuite):
         trace=Zip({
             'meta.json':
                 _meta({
-                    'version': 1,
+                    'version':
+                        1,
                     'files': [
                         _machine_file('a.pb', 'phone'),
                         _machine_file('b.pb', 'server'),


### PR DESCRIPTION
Add a machine section to perfetto_manifest file entries. A file can be
put on a machine by name and/or raw id. A name makes trace_processor
allocate the id, put files that share a name on one machine, and fill
the new machine.name column. A raw id lines up with an embedded
machine_id.

Files on one machine share per-machine state like the process tracker
and clock graph. An override is single machine only, so a proto fails
if a remote machine_id or remote_clock_sync shows otherwise.

These files share no clock sync, so their clocks used to be assumed
aligned with trace time at zero offset. That overlays them on BOOTTIME
and throws away REALTIME. BridgeToTraceTime now prefers REALTIME: a
clock that reaches its machine's REALTIME is tied to the trace time
machine's REALTIME and aligned through it. The zero offset fallback is
kept only where it is safe: a private trace file clock, or the same
clock domain on another machine. Different real domains like BOOTTIME
and REALTIME are not assumed aligned; those events are dropped and
logged as clock_sync_unrelatable_clock_domains.

The per-file clocks block now has one grammar: a reference is, a
builtin clock or trace time when omitted, plus one relationship,
either offset_ns or a pair of readings ts and is.ts. This replaces the
old native, anchor and offset_ns keys, and lets is later name another
file for cross-file sync.
