### PR TITLE
tp: improve performance of IsThreadAlive by adding a fast cache

### DIFF
--- a/src/trace_processor/importers/common/process_tracker.cc
+++ b/src/trace_processor/importers/common/process_tracker.cc
@@ -80,6 +80,7 @@ UniqueTid ProcessTracker::StartNewThread(std::optional<int64_t> timestamp,
   auto* thread_table = context_->storage->mutable_thread_table();
   UniqueTid new_utid = thread_table->Insert(row).row;
   tids_[tid].emplace_back(new_utid);
+  live_tid_[tid] = new_utid;
 
   if (PERFETTO_UNLIKELY(thread_name_priorities_.size() <= new_utid)) {
     // This condition can happen in a multi-machine tracing session:
@@ -118,6 +119,8 @@ void ProcessTracker::EndThread(int64_t timestamp, int64_t tid) {
   auto& vector = tids_[tid];
   vector.erase(std::remove(vector.begin(), vector.end(), utid), vector.end());
 
+  RefreshLiveTid(tid);
+
   auto opt_upid = td.upid();
   if (!opt_upid) {
     return;
@@ -132,6 +135,7 @@ void ProcessTracker::EndThread(int64_t timestamp, int64_t tid) {
   PERFETTO_DCHECK(*td.is_main_thread());
   ps.set_end_ts(timestamp);
   pids_.Erase(tid);
+  InvalidateProcessThreads(*opt_upid);
 }
 
 std::optional<UniqueTid> ProcessTracker::GetThreadOrNull(int64_t tid) {
@@ -226,6 +230,12 @@ bool ProcessTracker::IsThreadAlive(UniqueTid utid) {
 std::optional<UniqueTid> ProcessTracker::GetThreadOrNull(
     int64_t tid,
     std::optional<int64_t> pid) {
+  // Hot path: bare lookups are a single cache probe.
+  if (!pid) {
+    auto* live = live_tid_.Find(tid);
+    return live ? std::make_optional(*live) : std::nullopt;
+  }
+
   auto& threads = *context_->storage->mutable_thread_table();
   auto& processes = *context_->storage->mutable_process_table();
 
@@ -264,6 +274,28 @@ std::optional<UniqueTid> ProcessTracker::GetThreadOrNull(
       return current_utid;
   }
   return std::nullopt;
+}
+
+void ProcessTracker::RefreshLiveTid(int64_t tid) {
+  if (auto* vec = tids_.Find(tid); vec) {
+    for (auto it = vec->rbegin(); it != vec->rend(); ++it) {
+      if (IsThreadAlive(*it)) {
+        live_tid_[tid] = *it;
+        return;
+      }
+    }
+  }
+  live_tid_.Erase(tid);
+}
+
+void ProcessTracker::InvalidateProcessThreads(UniquePid upid) {
+  auto* threads = process_threads_.Find(upid);
+  if (!threads)
+    return;
+  auto& thread_table = *context_->storage->mutable_thread_table();
+  for (UniqueTid utid : *threads) {
+    RefreshLiveTid(thread_table[utid].tid());
+  }
 }
 
 UniqueTid ProcessTracker::UpdateThread(int64_t tid, int64_t pid) {
@@ -321,11 +353,18 @@ UniquePid ProcessTracker::StartNewProcessInternal(
     StringId process_name,
     ThreadNamePriority priority,
     bool associate_main_thread) {
+  // Any process previously mapped to |pid| is superseded; invalidate its
+  // threads once the new mapping is in place (end of function).
+  std::optional<UniquePid> recycled_upid;
+  if (auto* prev = pids_.Find(pid); prev) {
+    recycled_upid = *prev;
+  }
   pids_.Erase(pid);
 
   // Same pid is never used concurrently by multiple processes, therefore remove
   // the tid completely
   tids_.Erase(pid);
+  live_tid_.Erase(pid);
 
   // Note that we erased the pid above so this should always return a new
   // process.
@@ -351,6 +390,10 @@ UniquePid ProcessTracker::StartNewProcessInternal(
 
   if (parent_upid) {
     prr.set_parent_upid(*parent_upid);
+  }
+
+  if (recycled_upid) {
+    InvalidateProcessThreads(*recycled_upid);
   }
   return upid;
 }
@@ -657,6 +700,7 @@ void ProcessTracker::AssociateThreadToProcessInternal(UniqueTid utid,
   auto trr = thread_table[utid];
   trr.set_upid(upid);
   trr.set_is_main_thread(is_main_thread);
+  process_threads_[upid].push_back(utid);
 }
 
 void ProcessTracker::SetMainThread(UniqueTid utid, bool is_main_thread) {
@@ -676,6 +720,7 @@ void ProcessTracker::SetIdleThread(UniqueTid utid, bool is_idle) {
 void ProcessTracker::SetPidZeroIsUpidZeroIdleProcess() {
   // Create a mapping from (t|p)id 0 -> u(t|p)id for the idle process.
   tids_.Insert(0, std::vector<UniqueTid>{swapper_utid_});
+  live_tid_[0] = swapper_utid_;
   pids_.Insert(0, swapper_upid_);
 
   auto swapper_id = context_->storage->InternString("swapper");
@@ -706,6 +751,8 @@ void ProcessTracker::OnEventsFullyExtracted() {
 
   args_tracker_.Flush();
   tids_.Clear();
+  live_tid_.Clear();
+  process_threads_.Clear();
   pids_.Clear();
   pending_assocs_.clear();
   pending_parent_assocs_.clear();

--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -278,6 +278,13 @@ class ProcessTracker {
   std::optional<uint32_t> GetThreadOrNull(int64_t tid,
                                           std::optional<int64_t> pid);
 
+  // Repoints live_tid_[tid] at the newest alive incarnation in |tids_| (or
+  // erases it). Cold path: lifecycle transitions only.
+  void RefreshLiveTid(int64_t tid);
+
+  // Refreshes live_tid_ for every thread of |upid|, when it ends or is recycled.
+  void InvalidateProcessThreads(UniquePid upid);
+
   // Returns the utid of a thread whos parent matches the provided pid
   // or creates a new thread if not present. If a new thread is created,
   // |is_main_thread| determines if it is marked as the main thread.
@@ -319,6 +326,14 @@ class ProcessTracker {
   // (though it seems like there are subtle things which break in Chrome if this
   // changes).
   base::FlatHashMap<int64_t /* tid */, std::vector<UniqueTid>> tids_;
+
+  // Cache of the newest alive incarnation of each tid: the answer to a bare
+  // (no parent pid) lookup. Kept in sync via tids_ on lifecycle transitions.
+  base::FlatHashMap<int64_t /* tid */, UniqueTid> live_tid_;
+
+  // upid -> its utids, used to refresh live_tid_ when a process ends or its pid
+  // is recycled.
+  base::FlatHashMap<UniquePid, std::vector<UniqueTid>> process_threads_;
 
   // Mapping of the most recently seen pid to the associated upid.
   base::FlatHashMap<int64_t /* pid (aka tgid) */, UniquePid> pids_;

--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -282,7 +282,8 @@ class ProcessTracker {
   // erases it). Cold path: lifecycle transitions only.
   void RefreshLiveTid(int64_t tid);
 
-  // Refreshes live_tid_ for every thread of |upid|, when it ends or is recycled.
+  // Refreshes live_tid_ for every thread of |upid|, when it ends or is
+  // recycled.
   void InvalidateProcessThreads(UniquePid upid);
 
   // Returns the utid of a thread whos parent matches the provided pid

--- a/src/trace_processor/importers/common/process_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/process_tracker_unittest.cc
@@ -347,5 +347,312 @@ TEST_F(ProcessTrackerTest, NamespacedThreadMissingProcess) {
   // In this test, we just verify the function returns false.
 }
 
+// Characterization tests pinning the tid -> utid lookup semantics (bare and
+// pid-qualified lookups, tid/pid recycling, resurrection). A failure here is a
+// real behavioral change, not a test to be "fixed".
+
+// An unknown tid resolves to nothing and is not created by GetThreadOrNull.
+TEST_F(ProcessTrackerTest, BareLookupUnknownTidIsNull) {
+  ASSERT_FALSE(context.process_tracker->GetThreadOrNull(42).has_value());
+  // The table still only has the reserved idle thread (utid 0).
+  ASSERT_EQ(context.storage->thread_table().row_count(), 1u);
+}
+
+// A single created thread resolves to itself.
+TEST_F(ProcessTrackerTest, BareLookupSingleThread) {
+  UniqueTid t = context.process_tracker->GetOrCreateThread(/*tid=*/42);
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(42), t);
+  // Idempotent: a second GetOrCreate returns the same utid, no new row.
+  ASSERT_EQ(context.process_tracker->GetOrCreateThread(42), t);
+  ASSERT_EQ(context.storage->thread_table().row_count(), 2u);
+}
+
+// Starting a second incarnation of the same tid shadows the older one: bare
+// lookups return the newest live incarnation.
+TEST_F(ProcessTrackerTest, BareLookupReturnsNewestIncarnation) {
+  UniqueTid t1 = context.process_tracker->StartNewThread(1000, /*tid=*/42);
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(42), t1);
+
+  UniqueTid t2 = context.process_tracker->StartNewThread(2000, /*tid=*/42);
+  ASSERT_NE(t1, t2);
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(42), t2);
+  ASSERT_EQ(context.process_tracker->GetOrCreateThread(42), t2);
+
+  // Both incarnations still exist as rows in the table (history preserved).
+  ASSERT_EQ(context.storage->thread_table()[t1].tid(), 42);
+  ASSERT_EQ(context.storage->thread_table()[t2].tid(), 42);
+}
+
+// A bare-created thread (no known parent process) is considered alive.
+TEST_F(ProcessTrackerTest, BareThreadIsAliveWithoutProcess) {
+  UniqueTid t = context.process_tracker->GetOrCreateThread(/*tid=*/42);
+  ASSERT_FALSE(context.storage->thread_table()[t].upid().has_value());
+  ASSERT_TRUE(context.process_tracker->IsThreadAlive(t));
+}
+
+
+// After an explicit EndThread the tid no longer resolves; a fresh incarnation
+// is minted on the next GetOrCreateThread, and the old row gets an end_ts.
+TEST_F(ProcessTrackerTest, EndThreadRemovesFromBareLookupAndStampsEndTs) {
+  UniqueTid t1 = context.process_tracker->GetOrCreateThread(/*tid=*/77);
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(77), t1);
+
+  context.process_tracker->EndThread(500, /*tid=*/77);
+  ASSERT_EQ(context.storage->thread_table()[t1].end_ts(), 500);
+  ASSERT_FALSE(context.process_tracker->IsThreadAlive(t1));
+  ASSERT_FALSE(context.process_tracker->GetThreadOrNull(77).has_value());
+
+  UniqueTid t2 = context.process_tracker->GetOrCreateThread(/*tid=*/77);
+  ASSERT_NE(t1, t2);
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(77), t2);
+}
+
+// EndThread for a tid that was never seen is a no-op: it must not create a
+// thread (see b/193520421 - a free event after the process already ended).
+TEST_F(ProcessTrackerTest, EndThreadOnUnknownTidIsNoOp) {
+  size_t before = context.storage->thread_table().row_count();
+  context.process_tracker->EndThread(500, /*tid=*/999);
+  ASSERT_EQ(context.storage->thread_table().row_count(), before);
+  ASSERT_FALSE(context.process_tracker->GetThreadOrNull(999).has_value());
+}
+
+// Ending a non-main thread ends only the thread; the process stays alive and
+// its main thread keeps resolving.
+TEST_F(ProcessTrackerTest, EndNonMainThreadKeepsProcessAlive) {
+  context.process_tracker->StartNewProcess(
+      100, std::nullopt, /*pid=*/123, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  UniqueTid sub =
+      context.process_tracker->UpdateThread(/*tid=*/124, /*pid=*/123);
+
+  context.process_tracker->EndThread(200, /*tid=*/124);
+  ASSERT_FALSE(context.process_tracker->GetThreadOrNull(124).has_value());
+
+  // Main thread (tid 123) of the still-alive process resolves fine.
+  ASSERT_TRUE(context.process_tracker->GetThreadOrNull(123).has_value());
+  UniquePid upid = *context.process_tracker->UpidForPidForTesting(123);
+  ASSERT_FALSE(context.storage->process_table()[upid].end_ts().has_value());
+  ASSERT_TRUE(context.process_tracker->IsThreadAlive(sub) == false);
+}
+
+// Ending the main thread (tid == pid) ends the whole process, so its other
+// threads stop resolving by bare tid.
+TEST_F(ProcessTrackerTest, EndMainThreadEndsProcessAndOrphansThreads) {
+  context.process_tracker->StartNewProcess(
+      100, std::nullopt, /*pid=*/123, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  UniqueTid sub =
+      context.process_tracker->UpdateThread(/*tid=*/124, /*pid=*/123);
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(124), sub);
+  UniquePid upid = *context.process_tracker->UpidForPidForTesting(123);
+
+  context.process_tracker->EndThread(200, /*tid=*/123);
+
+  ASSERT_TRUE(context.storage->process_table()[upid].end_ts().has_value());
+  // The sub-thread's process is dead -> it must not resolve and is not alive.
+  ASSERT_FALSE(context.process_tracker->IsThreadAlive(sub));
+  ASSERT_FALSE(context.process_tracker->GetThreadOrNull(124).has_value());
+  // And the pid mapping was cleared, so GetOrCreateProcess re-mints.
+  ASSERT_NE(context.process_tracker->GetOrCreateProcess(123), upid);
+}
+
+// EndThread on a worker thread after its process already ended must not
+// resurrect the process or create rows (regression b/193520421).
+TEST_F(ProcessTrackerTest, EndThreadAfterProcessEndCreatesNothing) {
+  context.process_tracker->StartNewProcess(
+      100, std::nullopt, /*pid=*/123, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  context.process_tracker->UpdateThread(/*tid=*/124, /*pid=*/123);
+
+  context.process_tracker->EndThread(200, /*tid=*/123);  // ends process
+  size_t threads = context.storage->thread_table().row_count();
+  size_t procs = context.storage->process_table().row_count();
+
+  context.process_tracker->EndThread(201, /*tid=*/124);  // worker, late
+  ASSERT_EQ(context.storage->thread_table().row_count(), threads);
+  ASSERT_EQ(context.storage->process_table().row_count(), procs);
+}
+
+
+// GetOrCreateProcess is stable: repeated calls for the same pid return the
+// same upid (no implicit recycle).
+TEST_F(ProcessTrackerTest, GetOrCreateProcessIsStable) {
+  UniquePid u = context.process_tracker->GetOrCreateProcess(/*pid=*/500);
+  ASSERT_EQ(context.process_tracker->GetOrCreateProcess(500), u);
+  ASSERT_EQ(context.process_tracker->GetOrCreateProcess(500), u);
+}
+
+// A second StartNewProcess for a live pid recycles it: a new upid is minted,
+// the old upid row is retained, and pids_ now points at the new upid.
+TEST_F(ProcessTrackerTest, StartNewProcessRecyclesLivePid) {
+  UniquePid p1 = context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/10, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  UniquePid p2 = context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/10, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  ASSERT_NE(p1, p2);
+  ASSERT_EQ(context.process_tracker->UpidForPidForTesting(10), p2);
+  // p1 still exists as history.
+  ASSERT_EQ(context.storage->process_table()[p1].pid(), 10);
+}
+
+// The crux case: implicit pid recycle (StartNewProcess again, no EndThread)
+// must invalidate the *old* process's worker threads for bare lookups. This
+// is what the lazy `pids_` check inside IsThreadAlive currently provides.
+TEST_F(ProcessTrackerTest, ImplicitPidRecycleInvalidatesOldWorkerThreads) {
+  context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/10, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  UniqueTid worker =
+      context.process_tracker->UpdateThread(/*tid=*/20, /*pid=*/10);
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(20), worker);
+  ASSERT_TRUE(context.process_tracker->IsThreadAlive(worker));
+
+  // Recycle pid 10 into a brand new process without ending anything.
+  context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/10, kNullStringId,
+      ThreadNamePriority::kFtrace);
+
+  // The old worker's process was superseded -> dead, must not resolve.
+  ASSERT_FALSE(context.process_tracker->IsThreadAlive(worker));
+  ASSERT_NE(context.process_tracker->GetThreadOrNull(20), worker);
+}
+
+// Full PidReuseWithoutStartAndEndThread shape: each recycle yields fresh
+// utids/upids and the right row counts (mirrors the existing test, kept here
+// for completeness with the lookup-focused asserts above).
+TEST_F(ProcessTrackerTest, PidReuseMintsFreshThreadsAndProcesses) {
+  UniquePid p1 = context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/1, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  UniqueTid t1 = context.process_tracker->UpdateThread(/*tid=*/2, /*pid=*/1);
+  UniquePid p2 = context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/1, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  UniqueTid t2 = context.process_tracker->UpdateThread(/*tid=*/2, /*pid=*/1);
+
+  ASSERT_NE(p1, p2);
+  ASSERT_NE(t1, t2);
+  // The latest worker for tid 2 is the one parented to the latest process.
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(2), t2);
+}
+
+
+// A bare-created thread (unknown process) is adopted by the first WithParent
+// call rather than creating a new utid.
+TEST_F(ProcessTrackerTest, WithParentAdoptsExistingBareThread) {
+  UniqueTid bare = context.process_tracker->GetOrCreateThread(/*tid=*/600);
+  ASSERT_FALSE(context.storage->thread_table()[bare].upid().has_value());
+
+  UniquePid upid = context.process_tracker->GetOrCreateProcess(/*pid=*/700);
+  UniqueTid adopted = context.process_tracker->GetOrCreateThreadWithParent(
+      /*tid=*/600, upid, /*associate_main_threads=*/false);
+
+  ASSERT_EQ(adopted, bare);
+  ASSERT_EQ(context.storage->thread_table()[bare].upid(), upid);
+}
+
+// The same tid associated to two different parents in turn yields two distinct
+// incarnations, and a pid-qualified lookup returns the matching one.
+TEST_F(ProcessTrackerTest, WithParentDisambiguatesSameTidAcrossProcesses) {
+  UniquePid upid_a = context.process_tracker->GetOrCreateProcess(/*pid=*/1000);
+  UniquePid upid_b = context.process_tracker->GetOrCreateProcess(/*pid=*/2000);
+
+  UniqueTid in_a = context.process_tracker->GetOrCreateThreadWithParent(
+      /*tid=*/555, upid_a, false);
+  UniqueTid in_b = context.process_tracker->GetOrCreateThreadWithParent(
+      /*tid=*/555, upid_b, false);
+  ASSERT_NE(in_a, in_b);
+
+  // Re-resolving with each parent returns the matching incarnation.
+  ASSERT_EQ(
+      context.process_tracker->GetOrCreateThreadWithParent(555, upid_a, false),
+      in_a);
+  ASSERT_EQ(
+      context.process_tracker->GetOrCreateThreadWithParent(555, upid_b, false),
+      in_b);
+}
+
+// UpdateThread(tid==pid) marks the thread as the process main thread.
+TEST_F(ProcessTrackerTest, UpdateThreadMainThreadFlag) {
+  UniqueTid main = context.process_tracker->UpdateThread(/*tid=*/42, /*pid=*/42);
+  UniqueTid worker =
+      context.process_tracker->UpdateThread(/*tid=*/43, /*pid=*/42);
+  ASSERT_TRUE(context.storage->thread_table()[main].is_main_thread().value());
+  ASSERT_FALSE(
+      context.storage->thread_table()[worker].is_main_thread().value());
+}
+
+//
+// When the newest incarnation of a tid goes stale (its process was recycled)
+// but an older one is still alive, a bare lookup falls back to the older one.
+TEST_F(ProcessTrackerTest, ResurrectsOlderLiveIncarnationWhenNewestStale) {
+  // Older incarnation A of tid 5 under a process (pid 1) that stays alive.
+  UniquePid p1 = context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/1, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  UniqueTid a = context.process_tracker->UpdateThread(/*tid=*/5, /*pid=*/1);
+
+  // Newer incarnation B of the same tid 5 under a different process (pid 2).
+  context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/2, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  UniqueTid b = context.process_tracker->UpdateThread(/*tid=*/5, /*pid=*/2);
+  ASSERT_NE(a, b);
+  // B is newest, so it wins the bare lookup right now.
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(5), b);
+
+  // Recycle pid 2: B becomes stale, but A (pid 1) is still alive.
+  context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/2, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  ASSERT_FALSE(context.process_tracker->IsThreadAlive(b));
+  ASSERT_TRUE(context.process_tracker->IsThreadAlive(a));
+  ASSERT_EQ(p1, *context.process_tracker->UpidForPidForTesting(1));
+
+  // Falls back to the older live incarnation A.
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(5), a);
+}
+
+
+// Before declaring the idle process, tid 0 is an ordinary tid: it does not map
+// to the reserved swapper utid and GetOrCreateThread mints a fresh utid.
+TEST_F(ProcessTrackerTest, TidZeroIsOrdinaryBeforeIdleDeclared) {
+  ASSERT_FALSE(context.process_tracker->GetThreadOrNull(0).has_value());
+  UniqueTid t0 = context.process_tracker->GetOrCreateThread(/*tid=*/0);
+  ASSERT_NE(t0, context.process_tracker->swapper_utid());
+}
+
+// After SetPidZeroIsUpidZeroIdleProcess, tid 0 resolves to the swapper utid.
+TEST_F(ProcessTrackerTest, TidZeroResolvesToSwapperAfterIdleDeclared) {
+  context.process_tracker->SetPidZeroIsUpidZeroIdleProcess();
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(0),
+            context.process_tracker->swapper_utid());
+  ASSERT_EQ(context.process_tracker->GetOrCreateThread(0),
+            context.process_tracker->swapper_utid());
+}
+
+
+// IsThreadAlive returns false once a thread's own end_ts is set, false once its
+// process ends, and false once its process pid is recycled; true otherwise.
+TEST_F(ProcessTrackerTest, IsThreadAliveTruthTable) {
+  // (1) bare thread, no process -> alive.
+  UniqueTid bare = context.process_tracker->GetOrCreateThread(/*tid=*/9001);
+  ASSERT_TRUE(context.process_tracker->IsThreadAlive(bare));
+
+  // (2) thread with a live process -> alive.
+  context.process_tracker->StartNewProcess(
+      std::nullopt, std::nullopt, /*pid=*/30, kNullStringId,
+      ThreadNamePriority::kFtrace);
+  UniqueTid worker =
+      context.process_tracker->UpdateThread(/*tid=*/31, /*pid=*/30);
+  ASSERT_TRUE(context.process_tracker->IsThreadAlive(worker));
+
+  // (3) explicit end -> dead.
+  context.process_tracker->EndThread(1000, /*tid=*/31);
+  ASSERT_FALSE(context.process_tracker->IsThreadAlive(worker));
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/common/process_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/process_tracker_unittest.cc
@@ -390,7 +390,6 @@ TEST_F(ProcessTrackerTest, BareThreadIsAliveWithoutProcess) {
   ASSERT_TRUE(context.process_tracker->IsThreadAlive(t));
 }
 
-
 // After an explicit EndThread the tid no longer resolves; a fresh incarnation
 // is minted on the next GetOrCreateThread, and the old row gets an end_ts.
 TEST_F(ProcessTrackerTest, EndThreadRemovesFromBareLookupAndStampsEndTs) {
@@ -419,9 +418,9 @@ TEST_F(ProcessTrackerTest, EndThreadOnUnknownTidIsNoOp) {
 // Ending a non-main thread ends only the thread; the process stays alive and
 // its main thread keeps resolving.
 TEST_F(ProcessTrackerTest, EndNonMainThreadKeepsProcessAlive) {
-  context.process_tracker->StartNewProcess(
-      100, std::nullopt, /*pid=*/123, kNullStringId,
-      ThreadNamePriority::kFtrace);
+  context.process_tracker->StartNewProcess(100, std::nullopt, /*pid=*/123,
+                                           kNullStringId,
+                                           ThreadNamePriority::kFtrace);
   UniqueTid sub =
       context.process_tracker->UpdateThread(/*tid=*/124, /*pid=*/123);
 
@@ -438,9 +437,9 @@ TEST_F(ProcessTrackerTest, EndNonMainThreadKeepsProcessAlive) {
 // Ending the main thread (tid == pid) ends the whole process, so its other
 // threads stop resolving by bare tid.
 TEST_F(ProcessTrackerTest, EndMainThreadEndsProcessAndOrphansThreads) {
-  context.process_tracker->StartNewProcess(
-      100, std::nullopt, /*pid=*/123, kNullStringId,
-      ThreadNamePriority::kFtrace);
+  context.process_tracker->StartNewProcess(100, std::nullopt, /*pid=*/123,
+                                           kNullStringId,
+                                           ThreadNamePriority::kFtrace);
   UniqueTid sub =
       context.process_tracker->UpdateThread(/*tid=*/124, /*pid=*/123);
   ASSERT_EQ(context.process_tracker->GetThreadOrNull(124), sub);
@@ -459,9 +458,9 @@ TEST_F(ProcessTrackerTest, EndMainThreadEndsProcessAndOrphansThreads) {
 // EndThread on a worker thread after its process already ended must not
 // resurrect the process or create rows (regression b/193520421).
 TEST_F(ProcessTrackerTest, EndThreadAfterProcessEndCreatesNothing) {
-  context.process_tracker->StartNewProcess(
-      100, std::nullopt, /*pid=*/123, kNullStringId,
-      ThreadNamePriority::kFtrace);
+  context.process_tracker->StartNewProcess(100, std::nullopt, /*pid=*/123,
+                                           kNullStringId,
+                                           ThreadNamePriority::kFtrace);
   context.process_tracker->UpdateThread(/*tid=*/124, /*pid=*/123);
 
   context.process_tracker->EndThread(200, /*tid=*/123);  // ends process
@@ -472,7 +471,6 @@ TEST_F(ProcessTrackerTest, EndThreadAfterProcessEndCreatesNothing) {
   ASSERT_EQ(context.storage->thread_table().row_count(), threads);
   ASSERT_EQ(context.storage->process_table().row_count(), procs);
 }
-
 
 // GetOrCreateProcess is stable: repeated calls for the same pid return the
 // same upid (no implicit recycle).
@@ -501,18 +499,18 @@ TEST_F(ProcessTrackerTest, StartNewProcessRecyclesLivePid) {
 // must invalidate the *old* process's worker threads for bare lookups. This
 // is what the lazy `pids_` check inside IsThreadAlive currently provides.
 TEST_F(ProcessTrackerTest, ImplicitPidRecycleInvalidatesOldWorkerThreads) {
-  context.process_tracker->StartNewProcess(
-      std::nullopt, std::nullopt, /*pid=*/10, kNullStringId,
-      ThreadNamePriority::kFtrace);
+  context.process_tracker->StartNewProcess(std::nullopt, std::nullopt,
+                                           /*pid=*/10, kNullStringId,
+                                           ThreadNamePriority::kFtrace);
   UniqueTid worker =
       context.process_tracker->UpdateThread(/*tid=*/20, /*pid=*/10);
   ASSERT_EQ(context.process_tracker->GetThreadOrNull(20), worker);
   ASSERT_TRUE(context.process_tracker->IsThreadAlive(worker));
 
   // Recycle pid 10 into a brand new process without ending anything.
-  context.process_tracker->StartNewProcess(
-      std::nullopt, std::nullopt, /*pid=*/10, kNullStringId,
-      ThreadNamePriority::kFtrace);
+  context.process_tracker->StartNewProcess(std::nullopt, std::nullopt,
+                                           /*pid=*/10, kNullStringId,
+                                           ThreadNamePriority::kFtrace);
 
   // The old worker's process was superseded -> dead, must not resolve.
   ASSERT_FALSE(context.process_tracker->IsThreadAlive(worker));
@@ -537,7 +535,6 @@ TEST_F(ProcessTrackerTest, PidReuseMintsFreshThreadsAndProcesses) {
   // The latest worker for tid 2 is the one parented to the latest process.
   ASSERT_EQ(context.process_tracker->GetThreadOrNull(2), t2);
 }
-
 
 // A bare-created thread (unknown process) is adopted by the first WithParent
 // call rather than creating a new utid.
@@ -576,7 +573,8 @@ TEST_F(ProcessTrackerTest, WithParentDisambiguatesSameTidAcrossProcesses) {
 
 // UpdateThread(tid==pid) marks the thread as the process main thread.
 TEST_F(ProcessTrackerTest, UpdateThreadMainThreadFlag) {
-  UniqueTid main = context.process_tracker->UpdateThread(/*tid=*/42, /*pid=*/42);
+  UniqueTid main =
+      context.process_tracker->UpdateThread(/*tid=*/42, /*pid=*/42);
   UniqueTid worker =
       context.process_tracker->UpdateThread(/*tid=*/43, /*pid=*/42);
   ASSERT_TRUE(context.storage->thread_table()[main].is_main_thread().value());
@@ -595,18 +593,18 @@ TEST_F(ProcessTrackerTest, ResurrectsOlderLiveIncarnationWhenNewestStale) {
   UniqueTid a = context.process_tracker->UpdateThread(/*tid=*/5, /*pid=*/1);
 
   // Newer incarnation B of the same tid 5 under a different process (pid 2).
-  context.process_tracker->StartNewProcess(
-      std::nullopt, std::nullopt, /*pid=*/2, kNullStringId,
-      ThreadNamePriority::kFtrace);
+  context.process_tracker->StartNewProcess(std::nullopt, std::nullopt,
+                                           /*pid=*/2, kNullStringId,
+                                           ThreadNamePriority::kFtrace);
   UniqueTid b = context.process_tracker->UpdateThread(/*tid=*/5, /*pid=*/2);
   ASSERT_NE(a, b);
   // B is newest, so it wins the bare lookup right now.
   ASSERT_EQ(context.process_tracker->GetThreadOrNull(5), b);
 
   // Recycle pid 2: B becomes stale, but A (pid 1) is still alive.
-  context.process_tracker->StartNewProcess(
-      std::nullopt, std::nullopt, /*pid=*/2, kNullStringId,
-      ThreadNamePriority::kFtrace);
+  context.process_tracker->StartNewProcess(std::nullopt, std::nullopt,
+                                           /*pid=*/2, kNullStringId,
+                                           ThreadNamePriority::kFtrace);
   ASSERT_FALSE(context.process_tracker->IsThreadAlive(b));
   ASSERT_TRUE(context.process_tracker->IsThreadAlive(a));
   ASSERT_EQ(p1, *context.process_tracker->UpidForPidForTesting(1));
@@ -614,7 +612,6 @@ TEST_F(ProcessTrackerTest, ResurrectsOlderLiveIncarnationWhenNewestStale) {
   // Falls back to the older live incarnation A.
   ASSERT_EQ(context.process_tracker->GetThreadOrNull(5), a);
 }
-
 
 // Before declaring the idle process, tid 0 is an ordinary tid: it does not map
 // to the reserved swapper utid and GetOrCreateThread mints a fresh utid.
@@ -633,7 +630,6 @@ TEST_F(ProcessTrackerTest, TidZeroResolvesToSwapperAfterIdleDeclared) {
             context.process_tracker->swapper_utid());
 }
 
-
 // IsThreadAlive returns false once a thread's own end_ts is set, false once its
 // process ends, and false once its process pid is recycled; true otherwise.
 TEST_F(ProcessTrackerTest, IsThreadAliveTruthTable) {
@@ -642,9 +638,9 @@ TEST_F(ProcessTrackerTest, IsThreadAliveTruthTable) {
   ASSERT_TRUE(context.process_tracker->IsThreadAlive(bare));
 
   // (2) thread with a live process -> alive.
-  context.process_tracker->StartNewProcess(
-      std::nullopt, std::nullopt, /*pid=*/30, kNullStringId,
-      ThreadNamePriority::kFtrace);
+  context.process_tracker->StartNewProcess(std::nullopt, std::nullopt,
+                                           /*pid=*/30, kNullStringId,
+                                           ThreadNamePriority::kFtrace);
   UniqueTid worker =
       context.process_tracker->UpdateThread(/*tid=*/31, /*pid=*/30);
   ASSERT_TRUE(context.process_tracker->IsThreadAlive(worker));


### PR DESCRIPTION
IsThreadAlive is an expensive function to run all the time: as the
existing TODO implies, instead of doing a pass over threads every time,
it's just as valid to do the inverse: on every lifecycle event refresh
the cache.

This is a lot more efficient as utid lookups happen *much* more often
than process lifecycle events.
