### PR TITLE
tp: fix negative timestamps in remote clock sync

### DIFF
--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -817,16 +817,31 @@ base::Status ProtoTraceReader::ParseRemoteClockSync(ConstBytes blob) {
   }
 
   // Express each per-clock offset as a cross-machine edge in the single clock
-  // graph: at the synced instant the host clock reads 0 and this (client)
-  // machine's clock reads |offset|, so the two are linked directly.
+  // graph: at a synced instant the host clock reads |host_anchor| and this
+  // (client) machine's clock reads |host_anchor + offset|, so the two are
+  // linked directly. The anchor is a real host reading (the last sync round
+  // that observed this clock) rather than a literal 0: that keeps the snapshot
+  // rows we materialise to the clock_snapshot table at meaningful, in-bounds
+  // timestamps instead of converting the epoch (e.g. REALTIME 0) into a wildly
+  // negative trace time.
   uint32_t client_machine = context_->machine_id().value;
   uint32_t host_machine = context_->trace_time_state->clock_id.machine_id;
   auto clock_offsets = CalculateClockOffsets(sync_clock_snapshots);
   for (auto it = clock_offsets.GetIterator(); it; ++it) {
     uint32_t builtin = it.key().clock_id;
+    int64_t offset = it.value();
+
+    // CalculateClockOffsets only emits an offset for a clock that was observed
+    // on both sides, so at least one round carries a non-zero host reading.
+    int64_t host_anchor = 0;
+    for (const auto& round : sync_clock_snapshots) {
+      if (auto* clocks = round.Find(builtin); clocks && clocks->first)
+        host_anchor = static_cast<int64_t>(clocks->first);
+    }
+
     context_->clock_tracker->AddQualifiedSnapshot(
-        {{ClockId::Machine(host_machine, builtin), 0},
-         {ClockId::Machine(client_machine, builtin), it.value()}});
+        {{ClockId::Machine(host_machine, builtin), host_anchor},
+         {ClockId::Machine(client_machine, builtin), host_anchor + offset}});
   }
   return base::OkStatus();
 }

--- a/test/trace_processor/diff_tests/parser/parsing/tests.py
+++ b/test/trace_processor/diff_tests/parser/parsing/tests.py
@@ -1795,6 +1795,36 @@ class Parsing(TestSuite):
         5230425693562,0,49,1
         """))
 
+  # remote_clock_sync offsets are recorded as synthetic cross-machine clock
+  # snapshots. These used to be anchored at a literal host value of 0, so the
+  # materialised rows for absolute clocks (REALTIME, REALTIME_COARSE) converted
+  # the 1970 epoch into a wildly negative trace time. Anchoring at a real host
+  # reading keeps every remote clock snapshot at a sane, positive timestamp.
+  def test_remote_clock_sync_snapshot_timestamps(self):
+    return DiffTestBlueprint(
+        trace=DataPath('multi_machine_trace.pb'),
+        query="""
+        SELECT clock_name, clock_value, ts
+        FROM clock_snapshot
+        WHERE machine_id = 1 AND clock_name IS NOT NULL
+        ORDER BY clock_name, clock_value
+        """,
+        out=Csv("""
+        "clock_name","clock_value","ts"
+        "BOOTTIME",2890363618846,5218684183615
+        "BOOTTIME",5218684183615,5218684183615
+        "MONOTONIC",2890363619390,5218684183776
+        "MONOTONIC",5218684183989,5218684183776
+        "MONOTONIC_COARSE",2890363212637,5218684036772
+        "MONOTONIC_COARSE",5218683914708,5218684036772
+        "MONOTONIC_RAW",2890222891864,5218684183843
+        "MONOTONIC_RAW",5218631083965,5218684183843
+        "REALTIME",1719185606706808973,5218684183748
+        "REALTIME",1719185606981249395,5218684183748
+        "REALTIME_COARSE",1719185606706402343,5218684036772
+        "REALTIME_COARSE",1719185606980980186,5218684036772
+        """))
+
   # Kernel idle tasks created by /sbin/init should be filtered.
   def test_task_newtask_swapper_by_init(self):
     return DiffTestBlueprint(


### PR DESCRIPTION
Instead of 0s we should be inserting at the actual clock value which
was specified in remote clock sync

Bug: b/527353594