### PR TITLE
ui: Add global filter feature to DataGrid

### DIFF
--- a/ui/src/components/widgets/datagrid/data_source.ts
+++ b/ui/src/components/widgets/datagrid/data_source.ts
@@ -76,6 +76,11 @@ interface DataSourceModelBase {
     readonly alias: string;
     readonly direction: 'ASC' | 'DESC';
   };
+
+  // Free-text search term. When set, rows are filtered to those where any
+  // visible column contains the term (case-insensitive substring match).
+  // Currently only honored in flat mode.
+  readonly search?: string;
 }
 
 // Flat mode: simple column selection

--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -37,6 +37,7 @@ import {
 import {Icon} from '../../../widgets/icon';
 import {LinearProgress} from '../../../widgets/linear_progress';
 import {MenuDivider, MenuItem} from '../../../widgets/menu';
+import {TextInput} from '../../../widgets/text_input';
 import {
   AggregateMenu,
   ColumnMenu,
@@ -373,6 +374,35 @@ export interface DataGridAttrs {
    * Custom message to display in the empty state when there are no rows to show
    */
   readonly emptyStateMessage?: string;
+
+  /**
+   * When true, shows a free-text search box on the toolbar that filters rows to
+   * those where any visible column contains the search term. Only supported in
+   * flat mode (ignored when pivoting or in tree mode). Default = false.
+   */
+  readonly disableSearch?: boolean;
+
+  /**
+   * Free-text search term - can operate in controlled or uncontrolled mode.
+   *
+   * In controlled mode: Provide this prop along with onSearchChanged callback.
+   * In uncontrolled mode: Omit this prop to let the grid manage search state
+   * internally.
+   */
+  readonly search?: string;
+
+  /**
+   * Initial search term to apply on first load.
+   * This is ignored in controlled mode (i.e. when `search` is provided).
+   */
+  readonly initialSearch?: string;
+
+  /**
+   * Callback triggered when the search term changes.
+   * Required for controlled mode - when provided with search, the parent
+   * component becomes responsible for updating the search prop.
+   */
+  readonly onSearchChanged?: (search: string) => void;
 }
 
 export interface DataGridApi {
@@ -439,6 +469,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
   private filters: readonly Filter[] = [];
   private pivot?: Pivot;
   private tree?: IdBasedTree;
+  private search: string = '';
 
   // Track pagination state from virtual scrolling
   private paginationOffset: number = 0;
@@ -468,6 +499,10 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
     if (attrs.initialTree) {
       this.tree = attrs.initialTree;
     }
+
+    if (attrs.initialSearch !== undefined) {
+      this.search = attrs.initialSearch;
+    }
   }
 
   view({attrs}: m.Vnode<DataGridAttrs>) {
@@ -479,6 +514,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       filters,
       pivot,
       tree,
+      search,
       schema,
       rootSchema,
       structuredQueryCompatMode = false,
@@ -486,6 +522,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       toolbarItemsRight,
       showExportButton,
       emptyStateMessage,
+      disableSearch,
     } = attrs;
 
     // Update internal state if any are in controlled mode.
@@ -493,6 +530,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
     if (filters) this.filters = filters;
     if (pivot) this.pivot = pivot;
     if (tree) this.tree = tree;
+    if (search !== undefined) this.search = search;
 
     // Determine if we're in tree mode (has id-based tree config)
     const isTreeMode = this.tree !== undefined;
@@ -627,6 +665,16 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
         ],
         rightItems: [
           toolbarItemsRight,
+          // Search is only supported in flat mode (not pivot or tree).
+          !disableSearch &&
+            !isPivotMode &&
+            !isTreeMode &&
+            m(TextInput, {
+              leftIcon: 'search',
+              placeholder: 'Search…',
+              value: this.search,
+              onInput: (value: string) => this.updateSearch(value, attrs),
+            }),
           showExportButton &&
             m(ExportButton, {
               onExportData: (format) =>
@@ -748,6 +796,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
         ...baseModel,
         mode: 'flat',
         sort,
+        search: this.search || undefined,
         filters: [...(this.filters ?? []), ...drillDownFilters],
         columns: this.columns
           .map((col) => ({
@@ -811,6 +860,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
         ...baseModel,
         mode: 'flat',
         sort,
+        search: this.search || undefined,
         columns: this.columns
           .map((col) => ({
             field: col.field,
@@ -851,6 +901,13 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
   private clearFilters(attrs: DataGridAttrs): void {
     this.filters = [];
     attrs.onFiltersChanged?.([]);
+  }
+
+  private updateSearch(search: string, attrs: DataGridAttrs): void {
+    this.search = search;
+    // The result set changes, so jump back to the top.
+    this.paginationOffset = 0;
+    attrs.onSearchChanged?.(search);
   }
 
   private removeFilter(index: number, attrs: DataGridAttrs): void {

--- a/ui/src/components/widgets/datagrid/in_memory_data_source.ts
+++ b/ui/src/components/widgets/datagrid/in_memory_data_source.ts
@@ -38,6 +38,7 @@ export class InMemoryDataSource implements DataSource {
   private oldColumns?: readonly FlatColumn[];
   private oldFilters: ReadonlyArray<Filter> = [];
   private oldSort?: FlatModel['sort'];
+  private oldSearch?: string;
 
   constructor(data: ReadonlyArray<Row>) {
     this.data = data;
@@ -56,20 +57,26 @@ export class InMemoryDataSource implements DataSource {
     const columns = model.columns;
     const filters = model.filters ?? [];
     const sort = model.sort;
+    const search = model.search;
 
     if (
       !this.areColumnsEqual(columns, this.oldColumns) ||
       !this.areFiltersEqual(filters, this.oldFilters) ||
-      !this.isSortEqual(sort, this.oldSort)
+      !this.isSortEqual(sort, this.oldSort) ||
+      search !== this.oldSearch
     ) {
       this.oldColumns = columns;
       this.oldFilters = filters;
       this.oldSort = sort;
+      this.oldSearch = search;
 
       // Clear aggregate summaries cache
       this.aggregateSummariesCache = {};
 
       let result = this.applyFilters(this.data, filters);
+
+      // Apply free-text search across all visible columns
+      result = this.applySearch(result, columns, search);
 
       // Project columns to use aliases as keys (for consistency with SQL data source)
       result = this.projectColumns(result, columns);
@@ -327,6 +334,23 @@ export class InMemoryDataSource implements DataSource {
     });
   }
 
+  // Filter rows to those where any visible column contains the search term as a
+  // case-insensitive substring.
+  private applySearch(
+    data: ReadonlyArray<Row>,
+    columns: ReadonlyArray<FlatColumn>,
+    search: string | undefined,
+  ): ReadonlyArray<Row> {
+    if (!search) {
+      return data;
+    }
+
+    const needle = search.toLowerCase();
+    return data.filter((row) =>
+      columns.some((col) => searchValueMatches(row[col.field], needle)),
+    );
+  }
+
   private applySorting(
     data: ReadonlyArray<Row>,
     sortColumn: string,
@@ -395,6 +419,15 @@ function valuesEqual(a: SqlValue, b: SqlValue): boolean {
   }
 
   return false;
+}
+
+// Returns true if the string representation of `value` contains `needle`
+// (which must already be lower-cased). Nulls and blobs never match.
+function searchValueMatches(value: SqlValue, needle: string): boolean {
+  if (value === null || value === undefined || value instanceof Uint8Array) {
+    return false;
+  }
+  return String(value).toLowerCase().includes(needle);
 }
 
 function isNumeric(value: SqlValue): value is number | bigint {

--- a/ui/src/components/widgets/datagrid/in_memory_data_source_unittest.ts
+++ b/ui/src/components/widgets/datagrid/in_memory_data_source_unittest.ts
@@ -84,12 +84,14 @@ describe('InMemoryDataSource', () => {
     columns?: FlatModel['columns'];
     filters?: readonly Filter[];
     sort?: FlatModel['sort'];
+    search?: string;
   }): FlatModel {
     return {
       mode: 'flat',
       columns: options?.columns ?? defaultColumns,
       filters: options?.filters,
       sort: options?.sort,
+      search: options?.search,
     };
   }
 
@@ -295,6 +297,58 @@ describe('InMemoryDataSource', () => {
       // Sorted by value desc: Trent, Charlie, Alice, Eve (Alice/Eve order by original due to stable sort on value)
       expect(result.rows?.map((r) => r.id)).toEqual([7, 3, 1, 5]);
       result.rows?.forEach((row) => expect(row.active).toBe(1));
+    });
+  });
+
+  describe('search', () => {
+    test('matches a substring in any column', () => {
+      const result = dataSource.useRows(makeModel({search: 'li'}));
+      // Alice and Charlie both contain 'li' (case-insensitive substring)
+      expect(result.rows?.map((r) => r.id).sort()).toEqual([1, 3]);
+    });
+
+    test('matches against numeric columns', () => {
+      const result = dataSource.useRows(makeModel({search: '100'}));
+      // Alice and Eve both have value 100
+      expect(result.rows?.map((r) => r.id).sort()).toEqual([1, 5]);
+    });
+
+    test('matches bigint values', () => {
+      const result = dataSource.useRows(makeModel({search: '300'}));
+      expect(result.rows?.map((r) => r.id)).toEqual([6]); // Mallory (300n)
+    });
+
+    test('empty search returns all rows', () => {
+      const result = dataSource.useRows(makeModel({search: ''}));
+      expect(result.totalRows).toBe(sampleData.length);
+    });
+
+    test('no matches returns empty', () => {
+      const result = dataSource.useRows(makeModel({search: 'zzzzz'}));
+      expect(result.totalRows).toBe(0);
+    });
+
+    test('only searches visible columns', () => {
+      // 'Mallory' is in the name column; if name isn't visible it shouldn't match
+      const result = dataSource.useRows(
+        makeModel({
+          columns: [{field: 'tag', alias: 'tag'}],
+          search: 'Mallory',
+        }),
+      );
+      expect(result.totalRows).toBe(0);
+    });
+
+    test('blob columns never match', () => {
+      const result = dataSource.useRows(makeModel({search: 'Uint8'}));
+      expect(result.totalRows).toBe(0);
+    });
+
+    test('combines with filters', () => {
+      const filters: Filter[] = [{field: 'tag', op: '=', value: 'A'}];
+      const result = dataSource.useRows(makeModel({filters, search: 'li'}));
+      // tag A: Alice, Charlie, Trent; of those containing 'li': Alice, Charlie
+      expect(result.rows?.map((r) => r.id).sort()).toEqual([1, 3]);
     });
   });
 

--- a/ui/src/components/widgets/datagrid/sql_data_source/flat.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/flat.ts
@@ -22,7 +22,7 @@ import {NUM, type Row} from '../../../../trace_processor/query_result';
 import {runQueryForQueryTable} from '../../../query_table/queries';
 import type {DataSourceRows, FlatModel} from '../data_source';
 import {type SQLSchemaRegistry, SQLSchemaResolver} from '../sql_schema';
-import {filterToSql, toAlias} from '../sql_utils';
+import {filterToSql, searchToSql, toAlias} from '../sql_utils';
 
 export class SQLDataSourceFlat {
   private readonly rowCountSlot: QuerySlot<number>;
@@ -50,7 +50,7 @@ export class SQLDataSourceFlat {
    * Returns aggregate summaries for columns that have an aggregate function defined.
    */
   getSummaries(model: FlatModel): QueryResult<Row> {
-    const {columns, filters = []} = model;
+    const {columns, filters = [], search} = model;
 
     // Find columns with aggregate functions
     const aggColumns = columns.filter((col) => col.aggregate !== undefined);
@@ -64,6 +64,7 @@ export class SQLDataSourceFlat {
       key: {
         columns: aggColumns,
         filters: serializeFilters(filters),
+        search,
       },
       queryFn: async () => {
         const resolver = new SQLSchemaResolver(
@@ -82,7 +83,7 @@ export class SQLDataSourceFlat {
 
         let sql = `SELECT ${selectExprs.join(', ')}`;
         sql = addFromClause(sql, resolver);
-        sql = addFilterClause(sql, resolver, filters);
+        sql = addWhereClause(sql, resolver, filters, columns, search);
 
         const result = await this.engine.query(sql);
         return result.firstRow({}) as Row;
@@ -91,7 +92,7 @@ export class SQLDataSourceFlat {
   }
 
   getRows(model: FlatModel): DataSourceRows {
-    const {columns, filters = [], pagination, sort} = model;
+    const {columns, filters = [], pagination, sort, search} = model;
 
     // Load the row count first
     const rowCountResult = this.rowCountSlot.use({
@@ -99,12 +100,14 @@ export class SQLDataSourceFlat {
         // The row count doesn't depend on pagination or sort
         columns,
         filters: serializeFilters(filters),
+        search,
       },
       queryFn: async () => {
         const query = buildQuery(this.sqlSchema, this.rootSchemaName, {
           mode: 'flat',
           columns,
           filters,
+          search,
         });
         const result = await this.engine.query(
           `SELECT COUNT(*) as count FROM (${query})`,
@@ -117,6 +120,7 @@ export class SQLDataSourceFlat {
       key: {
         columns: model.columns,
         filters: serializeFilters(filters),
+        search,
         pagination,
         sort,
       },
@@ -170,13 +174,13 @@ function serializeFilters(filters: FlatModel['filters']) {
 function buildQuery(
   sqlSchema: SQLSchemaRegistry,
   rootSchemaName: string,
-  {columns, filters, pagination, sort}: FlatModel,
+  {columns, filters, pagination, sort, search}: FlatModel,
 ): string {
   const resolver = new SQLSchemaResolver(sqlSchema, rootSchemaName);
 
   let sql = buildSelectClause(resolver, columns);
   sql = addFromClause(sql, resolver);
-  sql = addFilterClause(sql, resolver, filters);
+  sql = addWhereClause(sql, resolver, filters, columns, search);
   sql = addOrderByClause(sql, sort);
   sql = addPaginationClause(sql, pagination);
 
@@ -216,17 +220,34 @@ function addFromClause(sql: string, resolver: SQLSchemaResolver): string {
   return sql;
 }
 
-function addFilterClause(
+function addWhereClause(
   sql: string,
   resolver: SQLSchemaResolver,
   filters: FlatModel['filters'],
+  columns: FlatModel['columns'],
+  search: FlatModel['search'],
 ): string {
+  const conditions: string[] = [];
+
   if (filters && filters.length > 0) {
-    const whereConditions = filters.map((filter) => {
+    for (const filter of filters) {
       const sqlExpr = resolver.resolveColumnPath(filter.field);
-      return filterToSql(filter, sqlExpr ?? filter.field);
-    });
-    sql += `\nWHERE ${whereConditions.join(' AND ')}`;
+      conditions.push(filterToSql(filter, sqlExpr ?? filter.field));
+    }
+  }
+
+  // Free-text search: match the term against any visible column.
+  if (search) {
+    const exprs = columns
+      .map((col) => resolver.resolveColumnPath(col.field))
+      .filter((expr): expr is string => expr !== undefined);
+    if (exprs.length > 0) {
+      conditions.push(searchToSql(exprs, search));
+    }
+  }
+
+  if (conditions.length > 0) {
+    sql += `\nWHERE ${conditions.join(' AND ')}`;
   }
   return sql;
 }

--- a/ui/src/components/widgets/datagrid/sql_utils.ts
+++ b/ui/src/components/widgets/datagrid/sql_utils.ts
@@ -191,6 +191,24 @@ export function filterToSql(filter: Filter, sqlExpr: string): string {
 }
 
 /**
+ * Builds a SQL condition that matches rows where any of the given column
+ * expressions contains `term` as a case-insensitive substring. Used to
+ * implement free-text search across all visible columns.
+ */
+export function searchToSql(sqlExprs: readonly string[], term: string): string {
+  // Escape the LIKE wildcards (% and _) and the escape character itself so the
+  // term is matched literally.
+  const escaped = term.replace(/[\\%_]/g, (c) => '\\' + c);
+  const pattern = sqlValue(`%${escaped}%`);
+  const conditions = sqlExprs.map(
+    (expr) => `CAST(${expr} AS TEXT) LIKE ${pattern} ESCAPE '\\'`,
+  );
+  return conditions.length === 1
+    ? conditions[0]
+    : `(${conditions.join(' OR ')})`;
+}
+
+/**
  * Builds an aggregate expression string from function and field.
  * E.g., sqlAggregateExpr('SUM', 'dur') returns 'SUM(dur)'.
  */

--- a/ui/src/components/widgets/datagrid/sql_utils_unittest.ts
+++ b/ui/src/components/widgets/datagrid/sql_utils_unittest.ts
@@ -14,6 +14,7 @@
 
 import {
   filterToSql,
+  searchToSql,
   sqlAggregateExpr,
   sqlPathMatch,
   sqlPathNotMatch,
@@ -357,5 +358,32 @@ describe('filterToSql', () => {
     expect(
       filterToSql({field: 'x', op: 'not in', value: ['a', 'b']}, 'col'),
     ).toBe("col NOT IN ('a', 'b')");
+  });
+});
+
+describe('searchToSql', () => {
+  test('single column', () => {
+    expect(searchToSql(['col'], 'foo')).toBe(
+      "CAST(col AS TEXT) LIKE '%foo%' ESCAPE '\\'",
+    );
+  });
+
+  test('multiple columns are OR-ed', () => {
+    expect(searchToSql(['a', 'b'], 'foo')).toBe(
+      "(CAST(a AS TEXT) LIKE '%foo%' ESCAPE '\\' OR " +
+        "CAST(b AS TEXT) LIKE '%foo%' ESCAPE '\\')",
+    );
+  });
+
+  test('escapes LIKE wildcards in the term', () => {
+    expect(searchToSql(['col'], '50%_x')).toBe(
+      "CAST(col AS TEXT) LIKE '%50\\%\\_x%' ESCAPE '\\'",
+    );
+  });
+
+  test('escapes single quotes in the term', () => {
+    expect(searchToSql(['col'], "it's")).toBe(
+      "CAST(col AS TEXT) LIKE '%it''s%' ESCAPE '\\'",
+    );
   });
 });

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
@@ -254,6 +254,7 @@ export function renderDataGrid(app: App): m.Children {
         });
       },
       initialOpts: {
+        searchable: true,
         showExportButton: false,
         structuredQueryCompatMode: false,
         disablePivotControls: false,


### PR DESCRIPTION
Add a global filter feature to DataGrid.

This feature allows searching all fields by string.

With the SQL backend it applies the filter using `LIKE %${searchTerm}%`.
With the InMem backend is uses `String(value).toLowerCase().includes(searchTerm)`.