### PR TITLE
tp: don't filter on machine id in remote_clock_sync test

### DIFF
--- a/test/trace_processor/diff_tests/parser/parsing/tests.py
+++ b/test/trace_processor/diff_tests/parser/parsing/tests.py
@@ -1800,29 +1800,29 @@ class Parsing(TestSuite):
   # materialised rows for absolute clocks (REALTIME, REALTIME_COARSE) converted
   # the 1970 epoch into a wildly negative trace time. Anchoring at a real host
   # reading keeps every remote clock snapshot at a sane, positive timestamp.
+  #
+  # The output aggregates over all machines deliberately: machine_id is an
+  # unstable surrogate id, so filtering or grouping by it would make the test
+  # flaky. Asserting the min/max trace time per clock is enough to catch the
+  # regression (a negative min_ts would mean the epoch leaked back in).
   def test_remote_clock_sync_snapshot_timestamps(self):
     return DiffTestBlueprint(
         trace=DataPath('multi_machine_trace.pb'),
         query="""
-        SELECT clock_name, clock_value, ts
+        SELECT clock_name, MIN(ts) AS min_ts, MAX(ts) AS max_ts
         FROM clock_snapshot
-        WHERE machine_id = 1 AND clock_name IS NOT NULL
-        ORDER BY clock_name, clock_value
+        WHERE clock_name IS NOT NULL
+        GROUP BY clock_name
+        ORDER BY clock_name
         """,
         out=Csv("""
-        "clock_name","clock_value","ts"
-        "BOOTTIME",2890363618846,5218684183615
-        "BOOTTIME",5218684183615,5218684183615
-        "MONOTONIC",2890363619390,5218684183776
-        "MONOTONIC",5218684183989,5218684183776
-        "MONOTONIC_COARSE",2890363212637,5218684036772
-        "MONOTONIC_COARSE",5218683914708,5218684036772
-        "MONOTONIC_RAW",2890222891864,5218684183843
-        "MONOTONIC_RAW",5218631083965,5218684183843
-        "REALTIME",1719185606706808973,5218684183748
-        "REALTIME",1719185606981249395,5218684183748
-        "REALTIME_COARSE",1719185606706402343,5218684036772
-        "REALTIME_COARSE",1719185606980980186,5218684036772
+        "clock_name","min_ts","max_ts"
+        "BOOTTIME",5218684183615,5232377520710
+        "MONOTONIC",5218684183776,5232377520710
+        "MONOTONIC_COARSE",5218684036772,5232377520710
+        "MONOTONIC_RAW",5218684183843,5232377520710
+        "REALTIME",5218684183748,5232377520710
+        "REALTIME_COARSE",5218684036772,5232377520710
         """))
 
   # Kernel idle tasks created by /sbin/init should be filtered.


### PR DESCRIPTION
machine_ids are not stable across TP versions so we should not hardcode
them
