### PR TITLE
tp: process_tracker: treat parent pid changes as reparenting

### DIFF
--- a/src/trace_processor/importers/common/process_tracker.cc
+++ b/src/trace_processor/importers/common/process_tracker.cc
@@ -26,6 +26,7 @@
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 #include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/storage/trace_storage.h"
@@ -132,6 +133,11 @@ void ProcessTracker::EndThread(int64_t timestamp, int64_t tid) {
 
   // If the process pid and thread tid are equal then, as is the main thread
   // of the process, we should also finish the process itself.
+  // Note: this works on linux because even if the leader thread exits before
+  // the rest of the thread-group, the kernel keeps the leader in a zombie state
+  // until the last group member exits. So sched_process_free for the main
+  // thread is deferred until the thread-group is fully dead (see
+  // delay_group_leader() in kernel sources).
   PERFETTO_DCHECK(*td.is_main_thread());
   ps.set_end_ts(timestamp);
   pids_.Erase(tid);
@@ -433,24 +439,28 @@ void ProcessTracker::AssociateCreatedProcessToParentThread(
   }
 }
 
-UniquePid ProcessTracker::UpdateProcessWithParent(UniquePid upid,
-                                                  UniquePid pupid,
-                                                  bool associate_main_thread) {
+void ProcessTracker::SetProcessParent(UniquePid upid,
+                                      UniquePid pupid,
+                                      std::optional<int64_t> timestamp) {
   auto& process_table = *context_->storage->mutable_process_table();
-
   auto prr = process_table[upid];
 
-  // If the previous and new parent pid don't match, the process must have
-  // died and the pid reused. Create a new process.
+  // A changed parent pid is treated as process reparenting, and we keep the
+  // original parent as that is usually more informative.
+  // Before perfetto v58, a changed parent pid was instead treated as a case of
+  // pid reuse.
   std::optional<UniquePid> prev_parent_upid = prr.parent_upid();
-  if (prev_parent_upid && *prev_parent_upid != pupid) {
-    upid = StartNewProcessInternal(std::nullopt, pupid, prr.pid(),
-                                   kNullStringId, ThreadNamePriority::kOther,
-                                   associate_main_thread);
-  } else {
+  if (!prev_parent_upid) {
     prr.set_parent_upid(pupid);
+  } else if (*prev_parent_upid != pupid) {
+    if (timestamp) {
+      context_->import_logs_tracker->RecordParserError(
+          stats::process_tracker_parent_pid_changed, *timestamp);
+    } else {
+      context_->import_logs_tracker->RecordAnalysisError(
+          stats::process_tracker_parent_pid_changed, {});
+    }
   }
-  return upid;
 }
 
 void ProcessTracker::SetProcessMetadata(UniquePid upid,

--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -80,10 +80,6 @@ class ProcessTracker {
   using UniqueThreadBounds =
       std::pair<UniqueThreadIterator, UniqueThreadIterator>;
 
-  // TODO(b/110409911): Invalidation of process and threads is yet to be
-  // implemented. This will include passing timestamps into the below methods
-  // to ensure the correct upid/utid is found.
-
   // Called when a task_newtask is observed. This force the tracker to start
   // a new UTID for the thread, which is needed for TID-recycling resolution.
   UniqueTid StartNewThread(std::optional<int64_t> timestamp, int64_t tid);
@@ -91,8 +87,12 @@ class ProcessTracker {
   // Returns whether a thread is considered alive by the process tracker.
   bool IsThreadAlive(UniqueTid utid);
 
-  // Called when sched_process_exit is observed. This forces the tracker to
-  // end the thread lifetime for the utid associated with the given tid.
+  // Ends the thread lifetime of the utid associated with the given tid, *and*
+  // the process lifetime if it was the main thread.
+  // Called when the thread stops existing. On linux this is sched_process_free,
+  // which is emitted when the task_struct is freed. Not to be confused with
+  // sched_process_exit, which is an earlier point when the thread starts
+  // exiting (do_exit()).
   void EndThread(int64_t timestamp, int64_t tid);
 
   // Returns the thread utid or std::nullopt if it doesn't exist.
@@ -165,14 +165,13 @@ class ProcessTracker {
   void AssociateCreatedProcessToParentThread(UniquePid upid,
                                              UniqueTid parent_utid);
 
-  // Updates a process' parent. If the upid was previously associated with
-  // a different parent process, then the upid process is considered reused
-  // and a new upid for a new process is returned. If no new process is
-  // created, the same upid is returned.
+  // Sets the parent pid of a process if it is not already set.
+  // |timestamp| is used only for logging purposes.
   // Virtual for testing.
-  virtual UniquePid UpdateProcessWithParent(UniquePid upid,
-                                            UniquePid pupid,
-                                            bool associate_main_thread);
+  virtual void SetProcessParent(
+      UniquePid upid,
+      UniquePid pupid,
+      std::optional<int64_t> timestamp = std::nullopt);
 
   // Set the process metadata. Called when a process is seen in a process tree.
   // Virtual for testing.

--- a/src/trace_processor/importers/common/process_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/process_tracker_unittest.cc
@@ -24,6 +24,7 @@
 #include "src/trace_processor/importers/common/event_tracker.h"
 #include "src/trace_processor/importers/common/global_args_tracker.h"
 #include "src/trace_processor/importers/common/global_stats_tracker.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/machine_tracker.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 #include "src/trace_processor/storage/trace_storage.h"
@@ -49,6 +50,8 @@ class ProcessTrackerTest : public ::testing::Test {
         TraceProcessorContextPtr<TraceProcessorContext::TraceState>::MakeRoot(
             TraceProcessorContext::TraceState{TraceId{0}});
     context.stats_tracker = std::make_unique<StatsTracker>(&context);
+    context.import_logs_tracker.reset(
+        new ImportLogsTracker(&context, TraceId{1}));
     context.process_tracker = std::make_unique<ProcessTracker>(&context);
     context.event_tracker = std::make_unique<EventTracker>(&context);
   }
@@ -97,27 +100,18 @@ TEST_F(ProcessTrackerTest, StartNewProcessWithoutMainThread_withUpdateThread) {
   ASSERT_TRUE(context.process_tracker->GetThreadOrNull(12345).has_value());
 }
 
-TEST_F(ProcessTrackerTest, UpdateProcessWithParent) {
-  UniquePid cur_upid;
-  std::optional<UniquePid> cur_pupid;
+TEST_F(ProcessTrackerTest, SetProcessParent) {
   UniquePid pupid1 = context.process_tracker->GetOrCreateProcess(123);
   UniquePid pupid2 = context.process_tracker->GetOrCreateProcess(234);
   UniquePid upid = context.process_tracker->GetOrCreateProcess(345);
 
-  cur_upid =
-      context.process_tracker->UpdateProcessWithParent(upid, pupid1, true);
-  cur_pupid = context.storage->process_table()[cur_upid].parent_upid();
+  context.process_tracker->SetProcessParent(upid, pupid1);
+  ASSERT_EQ(pupid1, context.storage->process_table()[upid].parent_upid());
 
-  ASSERT_EQ(upid, cur_upid);
-  ASSERT_EQ(pupid1, *cur_pupid);
-
-  // Must create new process
-  cur_upid =
-      context.process_tracker->UpdateProcessWithParent(upid, pupid2, true);
-  cur_pupid = context.storage->process_table()[cur_upid].parent_upid();
-
-  ASSERT_NE(upid, cur_upid);
-  ASSERT_EQ(pupid2, *cur_pupid);
+  // A changed parent is treated as the same process being reparented: the
+  // original parent is kept.
+  context.process_tracker->SetProcessParent(upid, pupid2);
+  ASSERT_EQ(pupid1, context.storage->process_table()[upid].parent_upid());
 }
 
 TEST_F(ProcessTrackerTest, SetProcessMetadata) {

--- a/src/trace_processor/importers/generic_kernel/generic_kernel_parser.cc
+++ b/src/trace_processor/importers/generic_kernel/generic_kernel_parser.cc
@@ -306,8 +306,7 @@ void GenericKernelParser::ParseGenericProcessTree(protozero::ConstBytes data) {
     auto pupid = process_tracker->GetOrCreateProcessWithoutMainThread(ppid);
     auto upid = process_tracker->GetOrCreateProcessWithoutMainThread(pid);
 
-    upid = process_tracker->UpdateProcessWithParent(
-        upid, pupid, /*associate_main_thread*/ false);
+    process_tracker->SetProcessParent(upid, pupid);
     process_tracker->SetProcessMetadata(upid, name, cmdline);
   }
 

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -201,9 +201,11 @@ class MockProcessTracker : public ProcessTracker {
                ThreadNamePriority priority),
               (override));
 
-  MOCK_METHOD(UniquePid,
-              UpdateProcessWithParent,
-              (UniquePid upid, UniquePid pupid, bool associate_main_thread),
+  MOCK_METHOD(void,
+              SetProcessParent,
+              (UniquePid upid,
+               UniquePid pupid,
+               std::optional<int64_t> timestamp),
               (override));
 
   MOCK_METHOD(void,
@@ -804,8 +806,7 @@ TEST_F(ProtoTraceParserTest, LoadProcessPacket) {
 
   EXPECT_CALL(*process_, GetOrCreateProcess(3)).WillOnce(testing::Return(2u));
   EXPECT_CALL(*process_, GetOrCreateProcess(1)).WillOnce(testing::Return(4u));
-  EXPECT_CALL(*process_, UpdateProcessWithParent(4u, 2u, true))
-      .WillOnce(testing::Return(4u));
+  EXPECT_CALL(*process_, SetProcessParent(4u, 2u, _));
   EXPECT_CALL(*process_, SetProcessMetadata(4u, base::StringView(kProcName1),
                                             base::StringView(kProcName1)));
   Tokenize();
@@ -825,8 +826,7 @@ TEST_F(ProtoTraceParserTest, LoadProcessPacket_FirstCmdline) {
 
   EXPECT_CALL(*process_, GetOrCreateProcess(3)).WillOnce(testing::Return(2u));
   EXPECT_CALL(*process_, GetOrCreateProcess(1)).WillOnce(testing::Return(4u));
-  EXPECT_CALL(*process_, UpdateProcessWithParent(4u, 2u, true))
-      .WillOnce(testing::Return(4u));
+  EXPECT_CALL(*process_, SetProcessParent(4u, 2u, _));
   EXPECT_CALL(*process_, SetProcessMetadata(4u, base::StringView(kProcName1),
                                             base::StringView("proc1 proc2")));
   Tokenize();

--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -754,9 +754,7 @@ void SystemProbesParser::ParseProcessTree(int64_t ts, ConstBytes blob) {
     UniquePid pupid = context_->process_tracker->GetOrCreateProcess(ppid);
     UniquePid upid = context_->process_tracker->GetOrCreateProcess(pid);
 
-    upid = context_->process_tracker->UpdateProcessWithParent(
-        upid, pupid, /*associate_main_thread=*/true);
-
+    context_->process_tracker->SetProcessParent(upid, pupid, ts);
     context_->process_tracker->SetProcessMetadata(upid, argv0, joined_cmdline);
 
     // perfetto v50+: additionally, if we know that the "cmdline" contents are

--- a/src/trace_processor/importers/systrace/systrace_trace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_trace_parser.cc
@@ -233,8 +233,7 @@ base::Status SystraceTraceParser::Parse(TraceBlobView blob) {
               ctx_->process_tracker->GetOrCreateProcess(ppid.value());
           UniquePid upid =
               ctx_->process_tracker->GetOrCreateProcess(pid.value());
-          upid =
-              ctx_->process_tracker->UpdateProcessWithParent(upid, pupid, true);
+          ctx_->process_tracker->SetProcessParent(upid, pupid);
           ctx_->process_tracker->SetProcessMetadata(upid, name,
                                                     base::StringView());
         } else if (state_ == ParseState::kProcessDumpShort &&

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -397,6 +397,9 @@ namespace perfetto::trace_processor::stats {
       "has already started flushing."),                                        \
   F(clock_sync_cache_miss,                kSingle,  kInfo,     kAnalysis, Scope::kGlobal, ""), \
   F(process_tracker_errors,               kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
+  F(process_tracker_parent_pid_changed,     kSingle, kInfo,   kAnalysis, Scope::kMachineAndTrace,         \
+      "A process was seen with a changed parent pid and was treated as the "   \
+      "same process being reparented rather than pid reuse."),                 \
   F(namespaced_thread_missing_process,    kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
       "A namespaced thread association was received but the corresponding "    \
       "process association was not found. This can happen due to data losses " \

--- a/test/trace_processor/diff_tests/parser/process_tracking/process_reparent_and_reuse.py
+++ b/test/trace_processor/diff_tests/parser/process_tracking/process_reparent_and_reuse.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os import sys, path
+
+import synth_common
+
+trace = synth_common.create_trace()
+
+# Scenario 1: reparenting. Child 200 is first seen under parent 100, then under
+# init (pid 1).
+trace.add_packet(ts=1)
+trace.add_process(100, 1, "parent_a")
+trace.add_process(200, 100, "child_a")
+
+trace.add_packet(ts=30)
+trace.add_process(200, 1, "child_a")
+
+# Scenario 2: pid reuse. Process 300 is ended by sched_process_free, then the
+# pid reappears as an unrelated process.
+trace.add_packet(ts=2)
+trace.add_process(300, 1, "orig_b")
+
+trace.add_ftrace_packet(0)
+trace.add_process_free(ts=20, tid=300, comm="orig_b", prio=0)
+
+trace.add_packet(ts=40)
+trace.add_process(300, 2000, "reused_b")
+
+sys.stdout.buffer.write(trace.trace.SerializeToString())

--- a/test/trace_processor/diff_tests/parser/process_tracking/tests.py
+++ b/test/trace_processor/diff_tests/parser/process_tracking/tests.py
@@ -153,6 +153,28 @@ class ProcessTracking(TestSuite):
         20,10
         """))
 
+  # Changed parent pid is treated as reparenting, keeping the original parent pid (pid 200 -> one process)
+  # Pid reuse detection now relies on sched_process_free, as that ends the lifetime of the previous process (pid 300 -> two processes).
+  def test_process_reparent_and_reuse(self):
+    return DiffTestBlueprint(
+        trace=Path('process_reparent_and_reuse.py'),
+        query="""
+        SELECT
+          p.pid,
+          p.name,
+          parent.pid AS parent_pid
+        FROM process p
+        LEFT JOIN process parent ON p.parent_upid = parent.upid
+        WHERE p.pid IN (200, 300)
+        ORDER BY p.pid, p.name;
+        """,
+        out=Csv("""
+        "pid","name","parent_pid"
+        200,"child_a",100
+        300,"orig_b",1
+        300,"reused_b",2000
+        """))
+
   # Tracking thread reuse
   def test_process_tracking_reused_thread_print(self):
     return DiffTestBlueprint(


### PR DESCRIPTION
Right now, the process_tracker always assumes that the same pid under a
different parent must mean that this is a new process reusing the pid, and
therefore creates a new process to track. There is another underlying
possibility - the process' parent has exited and the original process got
reparented. Note that the reparenting isn't always to pid=1 (init), since things
like PR_SET_CHILD_SUBREAPER exist.

In retrospect, this heuristic is the wrong way around. Reparenting is way more
frequent than pid reuse, and the latter can be cleanly detected via
sched_process_free. (Note: the reverse isn't true, because sched_process_exit is
when a thread becomes reparentable, and only the most recent kernels include the
group_dead tracepoint field.)

Hence this patch makes the process_tracker assume reparenting instead. We also
discard the new parent pid since the original is more informative.

PS: I have considered merging the SetProcessParent with SetProcessMetadata, but
decided to keep them separate for readability.
