### PR TITLE
tp/ui: only surface machines that received packets

### DIFF
--- a/src/trace_processor/importers/common/machine_tracker.cc
+++ b/src/trace_processor/importers/common/machine_tracker.cc
@@ -86,6 +86,14 @@ void MachineTracker::SetSystemRamBytes(int64_t system_ram_bytes) {
   row.set_system_ram_gb(BytesToGB(system_ram_bytes));
 }
 
+void MachineTracker::SetRawMachineId(int64_t raw_machine_id) {
+  getRow().set_raw_id(raw_machine_id);
+}
+
+int64_t MachineTracker::raw_machine_id() const {
+  return context_->storage->machine_table()[machine_id_].raw_id();
+}
+
 PERFETTO_ALWAYS_INLINE
 MachineTable::RowReference MachineTracker::getRow() {
   auto& machines = *context_->storage->mutable_machine_table();

--- a/src/trace_processor/importers/common/machine_tracker.h
+++ b/src/trace_processor/importers/common/machine_tracker.h
@@ -44,6 +44,12 @@ class MachineTracker {
   void SetAndroidSdkVersion(int64_t sdk_version);
   void SetSystemRamBytes(int64_t system_ram_bytes);
 
+  // Relabels this machine's raw (embedded) machine id (used for adoption).
+  void SetRawMachineId(int64_t raw_machine_id);
+
+  // The raw (embedded) machine id of this machine's row.
+  int64_t raw_machine_id() const;
+
   MachineId machine_id() const { return machine_id_; }
 
  private:

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -44,6 +44,7 @@
 #include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/common/event_tracker.h"
 #include "src/trace_processor/importers/common/import_logs_tracker.h"
+#include "src/trace_processor/importers/common/machine_tracker.h"
 #include "src/trace_processor/importers/common/metadata_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
@@ -256,23 +257,30 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
   // Any compressed packets should have been handled by the tokenizer.
   PERFETTO_CHECK(!decoder.has_compressed_packets());
 
-  // When the trace packet is emitted from a remote machine, parse it with a
-  // separate ProtoTraceReader bound to that machine's context.
-  if (PERFETTO_UNLIKELY(decoder.machine_id())) {
-    RETURN_IF_ERROR(CheckManifestSingleMachine());
-    if (is_machine_dispatcher_) {
-      auto [it, inserted] =
-          machine_to_proto_readers_.Insert(decoder.machine_id(), nullptr);
-      if (PERFETTO_UNLIKELY(inserted)) {
-        RETURN_IF_ERROR(CreateRemoteMachineReader(decoder.machine_id(), it));
+  // The top-level reader dispatches packets from other machines to a
+  // per-machine reader; host and adopted-machine packets are parsed here.
+  if (is_machine_dispatcher_) {
+    const uint32_t machine_id = decoder.machine_id();
+    if (PERFETTO_UNLIKELY(machine_id)) {
+      // Resolve adoption once, on the first remote-machine packet.
+      if (PERFETTO_UNLIKELY(!adopted_machine_id_.has_value())) {
+        RETURN_IF_ERROR(ResolveAdoptedMachine(machine_id));
       }
-      return it->get()->ParsePacket(std::move(packet));
+      // Route packets from a non-adopted machine to their own reader.
+      if (machine_id != *adopted_machine_id_) {
+        auto [reader, inserted] =
+            machine_to_proto_readers_.Insert(machine_id, nullptr);
+        if (PERFETTO_UNLIKELY(inserted)) {
+          RETURN_IF_ERROR(CreateRemoteMachineReader(machine_id, reader));
+        }
+        return reader->get()->ParsePacket(std::move(packet));
+      }
+    } else if (!host_machine_used_ && !decoder.has_synchronization_marker()) {
+      // The host owns this packet, so it can no longer be adopted away.
+      host_machine_used_ = true;
     }
   }
-  // Assert that the packet is parsed using the right instance of reader: the
-  // top-level dispatcher handles host packets (no machine_id), and the
-  // sub-readers it forks handle their own machine's packets (machine_id set).
-  PERFETTO_DCHECK(decoder.has_machine_id() == !is_machine_dispatcher_);
+  PERFETTO_DCHECK(is_machine_dispatcher_ || decoder.has_machine_id());
 
   // Execute ProtoVM logic right after the "machine ID fork" as detailed in
   // go/perfetto-proto-vm.
@@ -741,6 +749,31 @@ base::Status ProtoTraceReader::ParseClockSnapshot(ConstBytes blob,
   if (!snapshot_id.ok()) {
     PERFETTO_ELOG("%s", snapshot_id.status().c_message());
   }
+  return base::OkStatus();
+}
+
+PERFETTO_NO_INLINE base::Status ProtoTraceReader::ResolveAdoptedMachine(
+    uint32_t machine_id) {
+  RETURN_IF_ERROR(CheckManifestSingleMachine());
+  // Adopt onto the host context only when the host has no data of its own, its
+  // row is still unclaimed (files in one session share it), the machine has no
+  // context yet, and the file is not a multi-machine manifest.
+  const bool host_has_data = host_machine_used_;
+  const bool host_row_claimed =
+      context_->machine_tracker->raw_machine_id() != 0;
+  const bool is_manifest_machine =
+      context_->trace_state && context_->trace_state->machine_remap;
+  const bool already_has_context =
+      context_->forked_context_state->trace_and_machine_to_context.Find(
+          std::make_pair(context_->trace_id().value,
+                         static_cast<int64_t>(machine_id))) != nullptr;
+  if (host_has_data || host_row_claimed || is_manifest_machine ||
+      already_has_context) {
+    adopted_machine_id_ = 0;
+    return base::OkStatus();
+  }
+  context_->machine_tracker->SetRawMachineId(machine_id);
+  adopted_machine_id_ = machine_id;
   return base::OkStatus();
 }
 

--- a/src/trace_processor/importers/proto/proto_trace_reader.h
+++ b/src/trace_processor/importers/proto/proto_trace_reader.h
@@ -116,6 +116,9 @@ class ProtoTraceReader : public ChunkedTraceReader {
 
   using ConstBytes = protozero::ConstBytes;
   base::Status ParsePacket(TraceBlobView);
+  // Cold path: on the first remote-machine packet, decides whether to adopt it
+  // onto the host context and sets adopted_machine_id_ (machine_id or 0).
+  base::Status ResolveAdoptedMachine(uint32_t machine_id);
   // Out-of-line cold path: forks the sub-reader for a remote machine.
   base::Status CreateRemoteMachineReader(
       uint32_t machine_id,
@@ -165,6 +168,11 @@ class ProtoTraceReader : public ChunkedTraceReader {
   base::FlatHashMap<uint32_t, std::unique_ptr<ProtoTraceReader>>
       machine_to_proto_readers_;
   const bool is_machine_dispatcher_;
+  // Machine adopted onto the host context (relabelled), or nullopt until the
+  // first remote-machine packet resolves it; 0 means no adoption.
+  std::optional<uint32_t> adopted_machine_id_;
+  // Whether the host machine has parsed a packet of its own (blocks adoption).
+  bool host_machine_used_ = false;
   ProtoVmIncrementalTracing protovm_;
 
   // Temporary. Currently trace packets do not have a timestamp, so the

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -756,10 +756,23 @@ CREATE PERFETTO VIEW machine(
   -- Total system RAM in bytes.
   system_ram_bytes LONG,
   -- Total system RAM in gigabytes (rounded).
-  system_ram_gb LONG
+  system_ram_gb LONG,
+  -- 1-based index of this machine among the non-host machines, used by the UI
+  -- to label tracks (e.g. "(machine 1)"). The host machine (raw_id 0) gets 0,
+  -- so it is never labelled.
+  label_index LONG
 )
 AS
-SELECT * FROM __intrinsic_machine;
+SELECT
+  *,
+  -- Machine ids are dense from 0. The host (raw_id 0), when present, takes id 0
+  -- but is unlabelled, so subtract it to keep the first labelled machine at 1.
+  iif(
+    raw_id = 0,
+    0,
+    id + 1 - (SELECT count(*) FROM __intrinsic_machine WHERE raw_id = 0)
+  ) AS label_index
+FROM __intrinsic_machine;
 
 -- Contains information of filedescriptors collected during the trace.
 CREATE PERFETTO VIEW filedescriptor(

--- a/src/trace_processor/tables/metadata_tables.py
+++ b/src/trace_processor/tables/metadata_tables.py
@@ -37,7 +37,11 @@ MACHINE_TABLE = Table(
     sql_name='__intrinsic_machine',
     wrapping_sql_view=WrappingSqlView('machine'),
     columns=[
-        C('raw_id', CppInt64()),
+        C(
+            'raw_id',
+            CppInt64(),
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
+        ),
         C(
             'name',
             CppOptional(CppString()),

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -418,6 +418,17 @@ TracingServiceImpl::ConnectProducer(Producer* producer,
       smb_scraping_enabled));
   auto it_and_inserted = producers_.emplace(id, endpoint.get());
   PERFETTO_DCHECK(it_and_inserted.second);
+
+  // Remember an in-process producer's machine so the service can attribute its
+  // own packets to it (see SetServiceTracePacketHeader), leaving a
+  // single-machine in-process trace with no separate host machine. Relayed
+  // producers connect with in_process=false and carry a remote machine id; they
+  // must not redirect the host service's own packets, so only an in-process
+  // producer is adopted here. A default machine id is fine to store; the stamp
+  // decision is made at emit time.
+  if (in_process)
+    local_machine_id_ = client_identity.machine_id();
+
   endpoint->shmem_size_hint_bytes_ = shared_memory_size_hint_bytes;
   endpoint->shmem_page_size_hint_bytes_ = shared_memory_page_size_hint_bytes;
 
@@ -1763,8 +1774,7 @@ void TracingServiceImpl::OnAllDataSourceStartedTimeout(TracingSessionID tsid) {
 
   protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
   packet->set_timestamp(static_cast<uint64_t>(timestamp));
-  packet->set_trusted_uid(static_cast<int32_t>(uid_));
-  packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+  SetServiceTracePacketHeader(packet.get());
 
   size_t i = 0;
   protos::pbzero::TracingServiceEvent::DataSources* slow_data_sources =
@@ -2238,8 +2248,7 @@ void TracingServiceImpl::OnFlushTimeout(TracingSessionID tsid,
 
     protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
     packet->set_timestamp(static_cast<uint64_t>(timestamp));
-    packet->set_trusted_uid(static_cast<int32_t>(uid_));
-    packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+    SetServiceTracePacketHeader(packet.get());
 
     size_t i = 0;
     protos::pbzero::TracingServiceEvent::DataSources* event =
@@ -2770,6 +2779,8 @@ std::vector<TracePacket> TracingServiceImpl::ReadBuffers(
           slice.own_data(), slice.size);
       const auto& client_identity_trusted =
           sequence_properties.client_identity_trusted;
+      // Producer data, not a service packet: keeps the producer's own sequence
+      // and machine id, so it can't use SetServiceTracePacketHeader.
       trusted_packet->set_trusted_uid(
           static_cast<int32_t>(client_identity_trusted.uid()));
       trusted_packet->set_trusted_packet_sequence_id(
@@ -3886,6 +3897,19 @@ bool TracingServiceImpl::SnapshotClocks(
   return true;
 }
 
+void TracingServiceImpl::SetServiceTracePacketHeader(
+    protos::pbzero::TracePacket* tp) {
+  tp->set_trusted_uid(static_cast<int32_t>(uid_));
+  tp->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+  // When a local machine was adopted (an in-process producer with a non-default
+  // machine id; see ConnectProducer), attribute the service's own packets to it
+  // so the trace has no separate host machine. Host and relay sessions leave
+  // local_machine_id_ at the default and keep these packets on the host
+  // machine.
+  if (local_machine_id_ != kDefaultMachineID)
+    tp->set_machine_id(local_machine_id_);
+}
+
 void TracingServiceImpl::EmitClockSnapshot(
     TracingSession* tracing_session,
     TracingSession::ClockSnapshotData snapshot_data,
@@ -3909,8 +3933,7 @@ void TracingServiceImpl::EmitClockSnapshot(
     c->set_timestamp(clock_id_and_ts.timestamp);
   }
 
-  packet->set_trusted_uid(static_cast<int32_t>(uid_));
-  packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+  SetServiceTracePacketHeader(packet.get());
   SerializeAndAppendPacket(packets, packet.SerializeAsArray());
 }
 
@@ -3923,6 +3946,9 @@ void TracingServiceImpl::EmitSyncMarker(std::vector<TracePacket>* packets) {
     // calls. The ResynchronizeTraceStreamUsingSyncMarker test verifies the ABI.
     protozero::StaticBuffered<protos::pbzero::TracePacket> packet(
         &sync_marker_packet_[0], sizeof(sync_marker_packet_));
+    // Can't use SetServiceTracePacketHeader: fixed ABI (marker written last,
+    // after uid) and cached/reused across machines, so it must not gain a
+    // machine_id field. It's a stream-resync marker; host is fine.
     packet->set_trusted_uid(static_cast<int32_t>(uid_));
     packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
 
@@ -3937,8 +3963,7 @@ void TracingServiceImpl::EmitSyncMarker(std::vector<TracePacket>* packets) {
 void TracingServiceImpl::EmitStats(TracingSession* tracing_session,
                                    std::vector<TracePacket>* packets) {
   protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
-  packet->set_trusted_uid(static_cast<int32_t>(uid_));
-  packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+  SetServiceTracePacketHeader(packet.get());
   GetTraceStats(tracing_session).Serialize(packet->set_trace_stats());
   SerializeAndAppendPacket(packets, packet.SerializeAsArray());
 }
@@ -4028,8 +4053,7 @@ TraceStats TracingServiceImpl::GetTraceStats(TracingSession* tracing_session) {
 void TracingServiceImpl::EmitUuid(TracingSession* tracing_session,
                                   std::vector<TracePacket>* packets) {
   protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
-  packet->set_trusted_uid(static_cast<int32_t>(uid_));
-  packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+  SetServiceTracePacketHeader(packet.get());
   auto* uuid = packet->set_trace_uuid();
   uuid->set_lsb(tracing_session->trace_uuid.lsb());
   uuid->set_msb(tracing_session->trace_uuid.msb());
@@ -4042,8 +4066,7 @@ void TracingServiceImpl::MaybeEmitTraceConfig(
   if (tracing_session->did_emit_initial_packets)
     return;
   protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
-  packet->set_trusted_uid(static_cast<int32_t>(uid_));
-  packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+  SetServiceTracePacketHeader(packet.get());
   tracing_session->config.Serialize(packet->set_trace_config());
   SerializeAndAppendPacket(packets, packet.SerializeAsArray());
 }
@@ -4092,8 +4115,7 @@ void TracingServiceImpl::EmitSystemInfo(std::vector<TracePacket>* packets) {
   if (!sys_info.android_serial_console.empty())
     info->set_android_serial_console(sys_info.android_serial_console);
 
-  packet->set_trusted_uid(static_cast<int32_t>(uid_));
-  packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+  SetServiceTracePacketHeader(packet.get());
   SerializeAndAppendPacket(packets, packet.SerializeAsArray());
 }
 
@@ -4125,8 +4147,7 @@ void TracingServiceImpl::EmitTraceProvenance(
       sequence_proto->set_producer_id(static_cast<int32_t>(producer_id));
     }
   }
-  packet->set_trusted_uid(static_cast<int32_t>(uid_));
-  packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+  SetServiceTracePacketHeader(packet.get());
   SerializeAndAppendPacket(packets, packet.SerializeAsArray());
 }
 
@@ -4154,6 +4175,8 @@ void TracingServiceImpl::MaybeEmitRemoteSystemInfo(
     packet->AppendBytes(kTracePacketSystemInfoFieldId, system_info.data(),
                         system_info.size());
 
+    // Relay path: stamps each remote machine's own id, not the adopted local
+    // one, so it can't use SetServiceTracePacketHeader.
     packet->set_machine_id(machine_id);
     packet->set_trusted_uid(static_cast<int32_t>(uid_));
     packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
@@ -4172,8 +4195,7 @@ void TracingServiceImpl::EmitLifecycleEvents(
     for (int64_t ts : event.timestamps) {
       protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
       packet->set_timestamp(static_cast<uint64_t>(ts));
-      packet->set_trusted_uid(static_cast<int32_t>(uid_));
-      packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+      SetServiceTracePacketHeader(packet.get());
 
       auto* service_event = packet->set_service_event();
       service_event->AppendVarInt(event.field_id, 1);
@@ -4199,8 +4221,7 @@ void TracingServiceImpl::EmitLifecycleEvents(
     protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
     int64_t ts = tracing_session->buffer_cloned_timestamps[i];
     packet->set_timestamp(static_cast<uint64_t>(ts));
-    packet->set_trusted_uid(static_cast<int32_t>(uid_));
-    packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+    SetServiceTracePacketHeader(packet.get());
 
     auto* service_event = packet->set_service_event();
     service_event->set_buffer_cloned(static_cast<uint32_t>(i));
@@ -4315,9 +4336,7 @@ void TracingServiceImpl::MaybeEmitProtoVmInstances(
   }
 
   if (maybe_packet) {
-    maybe_packet.value()->set_trusted_uid(static_cast<int32_t>(uid_));
-    maybe_packet.value()->set_trusted_packet_sequence_id(
-        kServicePacketSequenceID);
+    SetServiceTracePacketHeader(maybe_packet->get());
     SerializeAndAppendPacket(packets, maybe_packet->SerializeAsArray());
   }
 
@@ -4329,8 +4348,7 @@ void TracingServiceImpl::EmitExtensionDescriptors(
     std::vector<TracePacket>* packets) {
   for (const auto& desc : init_opts_.extension_descriptors) {
     protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
-    packet->set_trusted_uid(static_cast<int32_t>(uid_));
-    packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+    SetServiceTracePacketHeader(packet.get());
     auto* ext = packet->set_extension_descriptor();
     if (desc.gzipped) {
       ext->set_extension_set_gzip(desc.start, desc.size);
@@ -4362,8 +4380,7 @@ void TracingServiceImpl::MaybeEmitCloneTrigger(
     trigger->set_stop_delay_ms(info.trigger_delay_ms);
 
     packet->set_timestamp(info.boot_time_ns);
-    packet->set_trusted_uid(static_cast<int32_t>(uid_));
-    packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+    SetServiceTracePacketHeader(packet.get());
     SerializeAndAppendPacket(packets, packet.SerializeAsArray());
   }
 }
@@ -4384,8 +4401,7 @@ void TracingServiceImpl::MaybeEmitReceivedTriggers(
     trigger->set_stop_delay_ms(info.trigger_delay_ms);
 
     packet->set_timestamp(info.boot_time_ns);
-    packet->set_trusted_uid(static_cast<int32_t>(uid_));
-    packet->set_trusted_packet_sequence_id(kServicePacketSequenceID);
+    SetServiceTracePacketHeader(packet.get());
     SerializeAndAppendPacket(packets, packet.SerializeAsArray());
     ++tracing_session->num_triggers_emitted_into_trace;
   }

--- a/src/tracing/service/tracing_service_impl.h
+++ b/src/tracing/service/tracing_service_impl.h
@@ -54,6 +54,9 @@ namespace protos {
 namespace gen {
 enum TraceStats_FinalFlushOutcome : int;
 }
+namespace pbzero {
+class TracePacket;
+}
 }  // namespace protos
 
 class Consumer;
@@ -266,6 +269,10 @@ class TracingServiceImpl : public TracingService {
   void MaybeEmitTraceConfig(TracingSession*, std::vector<TracePacket>*);
   void EmitSystemInfo(std::vector<TracePacket>*);
   void EmitTraceProvenance(TracingSession*, std::vector<TracePacket>*);
+  // Sets the common header fields on a service-emitted packet (trusted uid +
+  // service sequence id), and, for a single-machine in-process session, stamps
+  // the local machine id so the trace has no separate host machine.
+  void SetServiceTracePacketHeader(protos::pbzero::TracePacket*);
   void MaybeEmitRemoteSystemInfo(std::vector<TracePacket>*);
   void MaybeEmitCloneTrigger(TracingSession*, std::vector<TracePacket>*);
   void MaybeEmitReceivedTriggers(TracingSession*, std::vector<TracePacket>*);
@@ -372,6 +379,12 @@ class TracingServiceImpl : public TracingService {
   std::multimap<std::string /*name*/, RegisteredDataSource> data_sources_;
   std::map<ProducerID, ProducerEndpointImpl*> producers_;
   std::map<RelayClientID, RelayEndpointImpl*> relay_clients_;
+
+  // Machine to attribute the service's own packets to. Adopted from an
+  // in-process producer (see ConnectProducer) so a single-machine in-process
+  // trace carries no separate host machine. Stays kDefaultMachineID for regular
+  // host/relay sessions, where service packets remain on the host machine.
+  MachineID local_machine_id_ = kDefaultMachineID;
   std::map<TracingSessionID, TracingSession> tracing_sessions_;
   std::map<BufferID, std::unique_ptr<TraceBuffer>> buffers_;
   std::map<std::string, int64_t> session_to_last_trace_s_;

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -451,6 +451,97 @@ TEST_F(TracingServiceImplTest, QueryServiceStateReportsMachine) {
   EXPECT_EQ(guest.machine_name(), "guest_machine");
 }
 
+// When an in-process producer connects with a non-default machine id, the
+// service attributes its own packets (clock snapshot, trace config, service
+// events) to that machine (see ConnectProducer / SetServiceTracePacketHeader),
+// so the trace has no separate empty host machine.
+TEST_F(TracingServiceImplTest, InProcessMachineIdStampsServicePackets) {
+  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
+  consumer->Connect(svc.get());
+
+  std::unique_ptr<MockProducer> producer = CreateMockProducer();
+  producer->Connect(svc.get(), "mock_producer", /*uid=*/42, /*pid=*/1025,
+                    /*machine_id=*/1234);
+  producer->RegisterDataSource("ds_1");
+
+  TraceConfig trace_config;
+  trace_config.add_buffers()->set_size_kb(128);
+  trace_config.add_data_sources()->mutable_config()->set_name("ds_1");
+  // The producer is on a non-default machine; without this its data source
+  // wouldn't match (a config with no machine filter targets the host only).
+  trace_config.set_trace_all_machines(true);
+
+  consumer->EnableTracing(trace_config);
+  producer->WaitForTracingSetup();
+  producer->WaitForDataSourceSetup("ds_1");
+  producer->WaitForDataSourceStart("ds_1");
+
+  consumer->DisableTracing();
+  producer->WaitForDataSourceStop("ds_1");
+  consumer->WaitForTracingDisabled();
+
+  auto packets = consumer->ReadBuffers();
+
+  bool saw_clock_snapshot = false;
+  bool saw_trace_config = false;
+  for (const auto& packet : packets) {
+    if (packet.has_clock_snapshot()) {
+      saw_clock_snapshot = true;
+      EXPECT_EQ(packet.machine_id(), 1234u);
+    }
+    if (packet.has_trace_config()) {
+      saw_trace_config = true;
+      EXPECT_EQ(packet.machine_id(), 1234u);
+    }
+    if (packet.has_service_event())
+      EXPECT_EQ(packet.machine_id(), 1234u);
+  }
+  EXPECT_TRUE(saw_clock_snapshot);
+  EXPECT_TRUE(saw_trace_config);
+}
+
+// A default (host) in-process producer is the common case: the service's own
+// packets stay on the host machine (no machine_id), unaffected by the
+// in-process machine-id adoption above.
+TEST_F(TracingServiceImplTest, HostProducerKeepsServicePacketsOnHost) {
+  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
+  consumer->Connect(svc.get());
+
+  std::unique_ptr<MockProducer> producer = CreateMockProducer();
+  producer->Connect(svc.get(), "mock_producer");  // kDefaultMachineID
+  producer->RegisterDataSource("ds_1");
+
+  TraceConfig trace_config;
+  trace_config.add_buffers()->set_size_kb(128);
+  trace_config.add_data_sources()->mutable_config()->set_name("ds_1");
+
+  consumer->EnableTracing(trace_config);
+  producer->WaitForTracingSetup();
+  producer->WaitForDataSourceSetup("ds_1");
+  producer->WaitForDataSourceStart("ds_1");
+
+  consumer->DisableTracing();
+  producer->WaitForDataSourceStop("ds_1");
+  consumer->WaitForTracingDisabled();
+
+  auto packets = consumer->ReadBuffers();
+
+  bool saw_clock_snapshot = false;
+  bool saw_trace_config = false;
+  for (const auto& packet : packets) {
+    if (packet.has_clock_snapshot()) {
+      saw_clock_snapshot = true;
+      EXPECT_FALSE(packet.has_machine_id());
+    }
+    if (packet.has_trace_config()) {
+      saw_trace_config = true;
+      EXPECT_FALSE(packet.has_machine_id());
+    }
+  }
+  EXPECT_TRUE(saw_clock_snapshot);
+  EXPECT_TRUE(saw_trace_config);
+}
+
 TEST_F(TracingServiceImplTest, EnableAndDisableTracing) {
   std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
   consumer->Connect(svc.get());

--- a/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
+++ b/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
@@ -124,8 +124,8 @@ class GraphicsGpuTrace(TestSuite):
         """,
         out=Csv("""
         "gpu","machine_id"
-        0,1
-        1,1
+        0,0
+        1,0
         """))
 
   def test_gpu_counter_specs(self):

--- a/test/trace_processor/diff_tests/parser/process_tracking/tests.py
+++ b/test/trace_processor/diff_tests/parser/process_tracking/tests.py
@@ -242,19 +242,19 @@ class ProcessTracking(TestSuite):
         """,
         out=Csv("""
         "tid","pid","pname","tname","tmachine","pmachine"
-        10,10,"process1","p1-t0",1,1
-        11,"[NULL]","[NULL]","p1-t1",1,"[NULL]"
-        12,10,"process1","p1-t2",1,1
-        20,20,"process_2","p2-t0",1,1
-        21,20,"process_2","p2-t1",1,1
-        22,20,"process_2","p2-t2",1,1
-        30,30,"process_3","p3-t0",1,1
-        31,30,"process_3","p3-t1",1,1
-        31,40,"process_4","p4-t1",1,1
-        32,30,"process_3","p3-t2",1,1
-        33,30,"process_3","p3-t3",1,1
-        34,30,"process_3","p3-t4",1,1
-        40,40,"process_4","p4-t0",1,1
+        10,10,"process1","p1-t0",0,0
+        11,"[NULL]","[NULL]","p1-t1",0,"[NULL]"
+        12,10,"process1","p1-t2",0,0
+        20,20,"process_2","p2-t0",0,0
+        21,20,"process_2","p2-t1",0,0
+        22,20,"process_2","p2-t2",0,0
+        30,30,"process_3","p3-t0",0,0
+        31,30,"process_3","p3-t1",0,0
+        31,40,"process_4","p4-t1",0,0
+        32,30,"process_3","p3-t2",0,0
+        33,30,"process_3","p3-t3",0,0
+        34,30,"process_3","p3-t4",0,0
+        40,40,"process_4","p4-t0",0,0
         """))
 
   def test_process_stats_process_runtime(self):

--- a/test/trace_processor/diff_tests/parser/track_event/tests.py
+++ b/test/trace_processor/diff_tests/parser/track_event/tests.py
@@ -993,9 +993,9 @@ class TrackEvent(TestSuite):
         """,
         out=Csv("""
         "name","machine_id"
-        "thread_time",1
-        "thread_time",1
-        "thread_instruction_count",1
+        "thread_time",0
+        "thread_time",0
+        "thread_instruction_count",0
         """))
 
   def test_track_event_name_resolution(self):

--- a/test/trace_processor/diff_tests/tables/tests.py
+++ b/test/trace_processor/diff_tests/tables/tests.py
@@ -711,8 +711,8 @@ class Tables(TestSuite):
         """,
         out=Csv("""
         "ucpu","cpu","machine_id"
-        4096,0,1
-        4097,1,1
+        0,0,0
+        1,1,0
         """))
 
   def test_async_slice_utid_arg_set_id(self):
@@ -774,9 +774,9 @@ class Tables(TestSuite):
         SELECT * FROM machine
         """,
         out=Csv("""
-        "id","raw_id","name","sysname","release","version","arch","num_cpus","android_build_fingerprint","android_device_manufacturer","android_sdk_version","system_ram_bytes","system_ram_gb"
-        0,0,"[NULL]","Darwin","22.6.0","Foobar","x86_64",4,"[NULL]","[NULL]","[NULL]",126598774784,127
-        1,2420838448,"[NULL]","Linux","6.6.82-android15-8-g1a7680db913a-ab13304129","#1 SMP PREEMPT Wed Apr  2 01:42:00 UTC 2025","x86_64",8,"android_test_fingerprint","Android",33,12008292352,12
+        "id","raw_id","name","sysname","release","version","arch","num_cpus","android_build_fingerprint","android_device_manufacturer","android_sdk_version","system_ram_bytes","system_ram_gb","label_index"
+        0,0,"[NULL]","Darwin","22.6.0","Foobar","x86_64",4,"[NULL]","[NULL]","[NULL]",126598774784,127,0
+        1,2420838448,"[NULL]","Linux","6.6.82-android15-8-g1a7680db913a-ab13304129","#1 SMP PREEMPT Wed Apr  2 01:42:00 UTC 2025","x86_64",8,"android_test_fingerprint","Android",33,12008292352,12,1
         """))
 
   # user list table

--- a/ui/src/components/cpu.ts
+++ b/ui/src/components/cpu.ts
@@ -20,10 +20,16 @@ export class Cpu {
     readonly cpu: number,
     readonly machine: number,
     readonly machineName?: string,
+    readonly labelIndex?: number,
+    readonly numMachines?: number,
   ) {}
 
   public maybeMachineLabel(): string {
-    return maybeMachineLabel(this.machine, this.machineName);
+    return maybeMachineLabel(
+      this.labelIndex,
+      this.machineName,
+      this.numMachines,
+    );
   }
 
   public toString(): string {

--- a/ui/src/components/gpu.ts
+++ b/ui/src/components/gpu.ts
@@ -23,6 +23,8 @@ export class Gpu {
     readonly machine: number,
     readonly name?: string,
     readonly machineName?: string,
+    readonly labelIndex?: number,
+    readonly numMachines?: number,
   ) {}
 
   get displayName(): string {
@@ -30,7 +32,11 @@ export class Gpu {
   }
 
   public maybeMachineLabel(): string {
-    return maybeMachineLabel(this.machine, this.machineName);
+    return maybeMachineLabel(
+      this.labelIndex,
+      this.machineName,
+      this.numMachines,
+    );
   }
 
   // Sort order for deterministic track ordering: machine first (unbounded),

--- a/ui/src/plugins/dev.perfetto.CoarseCpu/index.ts
+++ b/ui/src/plugins/dev.perfetto.CoarseCpu/index.ts
@@ -17,10 +17,11 @@ import {ensureExists} from '../../base/assert';
 import {Icons} from '../../base/semantic_icons';
 import {Cpu} from '../../components/cpu';
 import {COUNTER_TRACK_KIND} from '../../public/track_kinds';
+import {getMachineCount} from '../../public/utils';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {NUM, STR, STR_NULL} from '../../trace_processor/query_result';
+import {NUM, NUM_NULL, STR, STR_NULL} from '../../trace_processor/query_result';
 import {Anchor} from '../../widgets/anchor';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import TraceProcessorTrackPlugin from '../dev.perfetto.TraceProcessorTrack';
@@ -110,6 +111,7 @@ export default class implements PerfettoPlugin {
   ];
 
   async onTraceLoad(ctx: Trace): Promise<void> {
+    const numMachines = await getMachineCount(ctx.engine);
     const result = await ctx.engine.query(`
       include perfetto module viz.summary.counters;
 
@@ -119,6 +121,7 @@ export default class implements PerfettoPlugin {
         extract_arg(ct.dimension_arg_set_id, 'cpustat_key') as metric,
         ct.machine_id as machineId,
         machine.name as machineName,
+        machine.label_index as machineLabelIndex,
         ifnull(cpu.ucpu, extract_arg(ct.dimension_arg_set_id, 'cpu')) as ucpu
       from counter_track ct
       join _counter_track_summary using (id)
@@ -136,6 +139,7 @@ export default class implements PerfettoPlugin {
       metric: STR,
       machineId: NUM,
       machineName: STR_NULL,
+      machineLabelIndex: NUM_NULL,
       ucpu: NUM,
     });
     if (!it.valid()) return;
@@ -147,7 +151,15 @@ export default class implements PerfettoPlugin {
     const metricGroups = new Map<string, TrackNode>();
 
     for (; it.valid(); it.next()) {
-      const {trackId, cpu, metric, machineId, machineName, ucpu} = it;
+      const {
+        trackId,
+        cpu,
+        metric,
+        machineId,
+        machineName,
+        machineLabelIndex,
+        ucpu,
+      } = it;
 
       const info = ensureExists(METRICS[metric]);
 
@@ -162,7 +174,7 @@ export default class implements PerfettoPlugin {
         cpuStandardGroup.addChildInOrder(metricGroup);
       }
 
-      const trackName = `${info.groupName} (CPU ${new Cpu(ucpu, cpu, machineId, machineName ?? undefined).toString()})`;
+      const trackName = `${info.groupName} (CPU ${new Cpu(ucpu, cpu, machineId, machineName ?? undefined, machineLabelIndex ?? undefined, numMachines).toString()})`;
       const uri = `/coarse_cpu_${trackId}`;
 
       ctx.tracks.registerTrack({

--- a/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
@@ -21,12 +21,14 @@ import {CpuFreqTrack} from './cpu_freq_track';
 import {Anchor} from '../../widgets/anchor';
 import {Icons} from '../../base/semantic_icons';
 import {Cpu} from '../../components/cpu';
+import {getMachineCount} from '../../public/utils';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.CpuFreq';
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     const {engine} = ctx;
+    const numMachines = await getMachineCount(engine);
 
     // Find the list of CPU frequency track ids and their corresponding CPU idle
     // track ids if they exist
@@ -37,6 +39,7 @@ export default class implements PerfettoPlugin {
         cpu.ucpu AS ucpu,
         track.machine_id AS machineId,
         machine.name AS machineName,
+        machine.label_index AS machineLabelIndex,
         track.cpu AS cpu
       FROM cpu_counter_track track
       JOIN cpu
@@ -76,6 +79,7 @@ export default class implements PerfettoPlugin {
         freqTrackId: NUM,
         machineId: NUM,
         machineName: STR_NULL,
+        machineLabelIndex: NUM_NULL,
         cpu: NUM,
         ucpu: NUM,
         idleTrackId: NUM_NULL,
@@ -83,7 +87,15 @@ export default class implements PerfettoPlugin {
       it.valid();
       it.next()
     ) {
-      const {freqTrackId, idleTrackId, machineId, machineName, cpu, ucpu} = it;
+      const {
+        freqTrackId,
+        idleTrackId,
+        machineId,
+        machineName,
+        machineLabelIndex,
+        cpu,
+        ucpu,
+      } = it;
       const uri = `/cpu_freq_cpu${ucpu}`;
 
       ctx.tracks.registerTrack({
@@ -120,7 +132,7 @@ export default class implements PerfettoPlugin {
 
       const trackNode = new TrackNode({
         uri,
-        name: `CPU ${new Cpu(ucpu, cpu, machineId, machineName ?? undefined).toString()} Frequency`,
+        name: `CPU ${new Cpu(ucpu, cpu, machineId, machineName ?? undefined, machineLabelIndex ?? undefined, numMachines).toString()} Frequency`,
       });
 
       group.addChildInOrder(trackNode);

--- a/ui/src/plugins/dev.perfetto.Ftrace/index.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/index.ts
@@ -18,8 +18,9 @@ import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {NUM, STR_NULL} from '../../trace_processor/query_result';
+import {NUM, NUM_NULL, STR_NULL} from '../../trace_processor/query_result';
 import {Cpu} from '../../components/cpu';
+import {getMachineCount} from '../../public/utils';
 import type {FtraceFilter, FtracePluginState as FtraceFilters} from './common';
 import {FtraceExplorer, type FtraceExplorerCache} from './ftrace_explorer';
 import {createFtraceTrack} from './ftrace_track';
@@ -63,7 +64,8 @@ export default class implements PerfettoPlugin {
 
     let hasExpandedOnce = false;
 
-    const cpus = await getFtraceCpus(ctx);
+    const numMachines = await getMachineCount(ctx.engine);
+    const cpus = await getFtraceCpus(ctx, numMachines);
     const group = new TrackNode({
       name: 'Ftrace Events',
       sortOrder: -5,
@@ -132,13 +134,14 @@ export default class implements PerfettoPlugin {
 /**
  * Get the list of unique cpus in the ftrace_event table.
  */
-async function getFtraceCpus(ctx: Trace): Promise<Cpu[]> {
+async function getFtraceCpus(ctx: Trace, numMachines: number): Promise<Cpu[]> {
   const queryRes = await ctx.engine.query(`
     SELECT DISTINCT
       ucpu,
       cpu.machine_id AS machine_id,
       cpu.cpu AS cpu,
-      machine.name AS machine_name
+      machine.name AS machine_name,
+      machine.label_index AS machine_label_index
     FROM ftrace_event
     JOIN cpu USING (ucpu)
     LEFT JOIN machine ON machine.id = cpu.machine_id
@@ -152,12 +155,20 @@ async function getFtraceCpus(ctx: Trace): Promise<Cpu[]> {
       machine_id: NUM,
       cpu: NUM,
       machine_name: STR_NULL,
+      machine_label_index: NUM_NULL,
     });
     it.valid();
     it.next()
   ) {
     ucpus.push(
-      new Cpu(it.ucpu, it.cpu, it.machine_id, it.machine_name ?? undefined),
+      new Cpu(
+        it.ucpu,
+        it.cpu,
+        it.machine_id,
+        it.machine_name ?? undefined,
+        it.machine_label_index ?? undefined,
+        numMachines,
+      ),
     );
   }
 

--- a/ui/src/plugins/dev.perfetto.Gpu/index.ts
+++ b/ui/src/plugins/dev.perfetto.Gpu/index.ts
@@ -16,7 +16,7 @@ import {Gpu} from '../../components/gpu';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {COUNTER_TRACK_KIND, SLICE_TRACK_KIND} from '../../public/track_kinds';
-import {getTrackName} from '../../public/utils';
+import {getMachineCount, getTrackName} from '../../public/utils';
 import {TrackNode} from '../../public/workspace';
 import {NUM, NUM_NULL, STR, STR_NULL} from '../../trace_processor/query_result';
 import {createPerfettoTable} from '../../trace_processor/sql_utils';
@@ -162,12 +162,14 @@ export default class GpuPlugin implements PerfettoPlugin {
 
   private groups = new Map<string, TrackNode>();
   private gpuCount = 0;
+  private numMachines = 0;
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     const gpuCountResult = await ctx.engine.query(`
       select count(*) as cnt from gpu
     `);
     this.gpuCount = gpuCountResult.firstRow({cnt: NUM}).cnt;
+    this.numMachines = await getMachineCount(ctx.engine);
 
     await this.addGpuFreq(ctx);
     await this.addCounters(ctx);
@@ -181,6 +183,7 @@ export default class GpuPlugin implements PerfettoPlugin {
         gct.gpu_id as gpuId,
         gct.machine_id as machineId,
         m.name as machineName,
+        m.label_index as machineLabelIndex,
         gct.ugpu,
         g.name as gpuName
       from gpu_counter_track gct
@@ -200,6 +203,7 @@ export default class GpuPlugin implements PerfettoPlugin {
       gpuId: NUM,
       machineId: NUM,
       machineName: STR_NULL,
+      machineLabelIndex: NUM_NULL,
       ugpu: NUM_NULL,
       gpuName: STR_NULL,
     });
@@ -212,6 +216,8 @@ export default class GpuPlugin implements PerfettoPlugin {
           it.machineId,
           it.gpuName ?? undefined,
           it.machineName ?? undefined,
+          it.machineLabelIndex ?? undefined,
+          this.numMachines,
         ),
       });
     }
@@ -334,7 +340,8 @@ export default class GpuPlugin implements PerfettoPlugin {
           extract_arg(ct.dimension_arg_set_id, 'gpu') as gpu_id,
           extract_arg(ct.source_arg_set_id, 'description') as description,
           g.name as gpu_name,
-          m.name as machine_name
+          m.name as machine_name,
+          m.label_index as machine_label_index
         from counter_track ct
         join _counter_track_summary using (id)
         left join gpu g on extract_arg(ct.dimension_arg_set_id, 'ugpu') = g.id
@@ -366,6 +373,7 @@ export default class GpuPlugin implements PerfettoPlugin {
       ugpu: NUM_NULL,
       gpu_name: STR_NULL,
       machine_name: STR_NULL,
+      machine_label_index: NUM_NULL,
     });
     for (; it.valid(); it.next()) {
       const {
@@ -379,6 +387,7 @@ export default class GpuPlugin implements PerfettoPlugin {
         ugpu,
         gpu_name: gpuName,
         machine_name: machineName,
+        machine_label_index: machineLabelIndex,
       } = it;
       const schema = schemas.get(type);
       if (schema === undefined) {
@@ -392,6 +401,8 @@ export default class GpuPlugin implements PerfettoPlugin {
               machineId,
               gpuName ?? undefined,
               machineName ?? undefined,
+              machineLabelIndex ?? undefined,
+              this.numMachines,
             )
           : null;
       let trackName = getTrackName({name, kind: COUNTER_TRACK_KIND});
@@ -598,7 +609,8 @@ export default class GpuPlugin implements PerfettoPlugin {
             __max_layout_depth(count(), group_concat(t.id)) as maxDepth,
             extract_arg(t.dimension_arg_set_id, 'gpu') as gpu_id,
             g.name as gpu_name,
-            m.name as machine_name
+            m.name as machine_name,
+            m.label_index as machine_label_index
           from _slice_track_summary s
           join track t using (id)
           left join gpu g on extract_arg(t.dimension_arg_set_id, 'ugpu') = g.id
@@ -628,6 +640,7 @@ export default class GpuPlugin implements PerfettoPlugin {
       ugpu: NUM_NULL,
       gpu_name: STR_NULL,
       machine_name: STR_NULL,
+      machine_label_index: NUM_NULL,
     });
     for (; it.valid(); it.next()) {
       const {
@@ -640,6 +653,7 @@ export default class GpuPlugin implements PerfettoPlugin {
         ugpu,
         gpu_name: gpuName,
         machine_name: machineName,
+        machine_label_index: machineLabelIndex,
       } = it;
       const schema = schemas.get(type);
       if (schema === undefined) {
@@ -654,6 +668,8 @@ export default class GpuPlugin implements PerfettoPlugin {
               machineId,
               gpuName ?? undefined,
               machineName ?? undefined,
+              machineLabelIndex ?? undefined,
+              this.numMachines,
             )
           : null;
       const trackName = getTrackName({name, kind: SLICE_TRACK_KIND});

--- a/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
@@ -26,6 +26,7 @@ import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
 import {Gpu} from '../../components/gpu';
+import {getMachineCount} from '../../public/utils';
 import ProcessThreadGroupsPlugin from '../dev.perfetto.ProcessThreadGroups';
 
 function getProcessDisplayName(
@@ -223,7 +224,10 @@ async function discoverCudaHipTracks(ctx: Trace): Promise<LeafTrack[]> {
 // (process, hw_queue_id) tuple gets one leaf track named after the global
 // hw queue track ("Channel #1", "Channel #2", ...). When a process spans
 // multiple GPUs, those leaves are nested under per-GPU sub-groups.
-async function discoverFallbackTracks(ctx: Trace): Promise<LeafTrack[]> {
+async function discoverFallbackTracks(
+  ctx: Trace,
+  numMachines: number,
+): Promise<LeafTrack[]> {
   const result = await ctx.engine.query(`
     SELECT
       s.upid AS upid,
@@ -234,6 +238,7 @@ async function discoverFallbackTracks(ctx: Trace): Promise<LeafTrack[]> {
       t.machine_id AS machine_id,
       g.name AS gpu_name,
       m.name AS machine_name,
+      m.label_index AS machine_label_index,
       p.pid AS pid,
       p.name AS process_name
     FROM gpu_slice s
@@ -257,6 +262,7 @@ async function discoverFallbackTracks(ctx: Trace): Promise<LeafTrack[]> {
     machine_id: NUM,
     gpu_name: STR_NULL,
     machine_name: STR_NULL,
+    machine_label_index: NUM_NULL,
     pid: NUM_NULL,
     process_name: STR_NULL,
   });
@@ -281,6 +287,8 @@ async function discoverFallbackTracks(ctx: Trace): Promise<LeafTrack[]> {
             it.machine_id,
             it.gpu_name ?? undefined,
             it.machine_name ?? undefined,
+            it.machine_label_index ?? undefined,
+            numMachines,
           )
         : null;
     rows.push({
@@ -360,8 +368,9 @@ export default class implements PerfettoPlugin {
   static readonly dependencies = [ProcessThreadGroupsPlugin];
 
   async onTraceLoad(ctx: Trace): Promise<void> {
+    const numMachines = await getMachineCount(ctx.engine);
     const apiTracks = await discoverApiTracks(ctx);
-    const fallbackTracks = await discoverFallbackTracks(ctx);
+    const fallbackTracks = await discoverFallbackTracks(ctx, numMachines);
     const allTracks = [...apiTracks, ...fallbackTracks];
 
     const processGroups = ctx.plugins.getPlugin(ProcessThreadGroupsPlugin);

--- a/ui/src/plugins/dev.perfetto.PowerRails/index.ts
+++ b/ui/src/plugins/dev.perfetto.PowerRails/index.ts
@@ -17,9 +17,9 @@ import {CounterTrack} from '../../components/tracks/counter_track';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {COUNTER_TRACK_KIND} from '../../public/track_kinds';
-import {getTrackName} from '../../public/utils';
+import {getMachineCount, getTrackName} from '../../public/utils';
 import {TrackNode} from '../../public/workspace';
-import {NUM, STR_NULL} from '../../trace_processor/query_result';
+import {NUM, NUM_NULL, STR_NULL} from '../../trace_processor/query_result';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import {PowerCounterSelectionAggregator} from './power_counter_selection_aggregator';
 
@@ -39,6 +39,7 @@ export default class implements PerfettoPlugin {
   }
 
   private async addPowerRailCounterTracks(ctx: Trace): Promise<void> {
+    const numMachines = await getMachineCount(ctx.engine);
     const result = await ctx.engine.query(`
       INCLUDE PERFETTO MODULE android.power_rails;
 
@@ -46,8 +47,10 @@ export default class implements PerfettoPlugin {
         track_id as trackId,
         COALESCE(friendly_name, raw_power_rail_name) as name,
         subsystem_name as subsystem,
-        machine_id as machine
+        machine_id as machine,
+        machine.label_index as machineLabelIndex
       FROM android_power_rails_metadata
+      LEFT JOIN machine ON machine.id = machine_id
       ORDER BY machine_id, subsystem_name, name
     `);
 
@@ -60,6 +63,7 @@ export default class implements PerfettoPlugin {
       name: STR_NULL,
       subsystem: STR_NULL,
       machine: NUM,
+      machineLabelIndex: NUM_NULL,
     });
 
     const powerRailsGroup = new TrackNode({
@@ -74,11 +78,12 @@ export default class implements PerfettoPlugin {
     const subsystemGroups = new Map<string, TrackNode>();
 
     for (; it.valid(); it.next()) {
-      const {trackId, name, subsystem, machine} = it;
+      const {trackId, name, subsystem, machineLabelIndex} = it;
       const trackName = getTrackName({
         name,
         kind: COUNTER_TRACK_KIND,
-        machine,
+        machineLabelIndex,
+        numMachines,
       });
       const uri = `/counter_${trackId}`;
       const track = await CounterTrack.createMaterialized({

--- a/ui/src/plugins/dev.perfetto.ProcessThreadGroups/index.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessThreadGroups/index.ts
@@ -15,8 +15,14 @@
 import type {Trace} from '../../public/trace';
 import type {PerfettoPlugin} from '../../public/plugin';
 import {TrackNode} from '../../public/workspace';
-import {LONG, NUM, STR, STR_NULL} from '../../trace_processor/query_result';
-import {maybeMachineLabel} from '../../public/utils';
+import {
+  LONG,
+  NUM,
+  NUM_NULL,
+  STR,
+  STR_NULL,
+} from '../../trace_processor/query_result';
+import {getMachineCount, maybeMachineLabel} from '../../public/utils';
 
 function stripPathFromExecutable(path: string) {
   if (path[0] === '/') {
@@ -135,6 +141,7 @@ export default class implements PerfettoPlugin {
   // Adds top level groups for processes and thread that don't belong to a
   // process.
   private async addProcessGroups(): Promise<void> {
+    const numMachines = await getMachineCount(this.ctx.engine);
     const result = await this.ctx.engine.query(`
       with processGroups as (
         select
@@ -189,7 +196,8 @@ export default class implements PerfettoPlugin {
           pid as id,
           processName as name,
           processGroups.machine as machine,
-          m.name as machineName
+          m.name as machineName,
+          m.label_index as machineLabelIndex
         from processGroups
         left join machine m on m.id = processGroups.machine
         order by
@@ -213,7 +221,8 @@ export default class implements PerfettoPlugin {
           tid as id,
           threadName as name,
           threadGroups.machine as machine,
-          m.name as machineName
+          m.name as machineName,
+          m.label_index as machineLabelIndex
         from threadGroups
         left join machine m on m.id = threadGroups.machine
         order by
@@ -234,6 +243,7 @@ export default class implements PerfettoPlugin {
       name: STR_NULL,
       machine: NUM,
       machineName: STR_NULL,
+      machineLabelIndex: NUM_NULL,
     });
     for (; it.valid(); it.next()) {
       const {kind, uid, id, name} = it;
@@ -244,7 +254,11 @@ export default class implements PerfettoPlugin {
           continue;
         }
 
-        const machineLabel = maybeMachineLabel(it.machine, it.machineName);
+        const machineLabel = maybeMachineLabel(
+          it.machineLabelIndex ?? undefined,
+          it.machineName,
+          numMachines,
+        );
         function getProcessDisplayName(
           processName: string | undefined,
           pid: number,

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -25,7 +25,11 @@ import {
   CPU_SLICE_TRACK_KIND,
   THREAD_STATE_TRACK_KIND,
 } from '../../public/track_kinds';
-import {getThreadUriPrefix, getTrackName} from '../../public/utils';
+import {
+  getMachineCount,
+  getThreadUriPrefix,
+  getTrackName,
+} from '../../public/utils';
 import {TrackNode} from '../../public/workspace';
 import type {Engine} from '../../trace_processor/engine';
 import {
@@ -92,7 +96,8 @@ export default class SchedPlugin implements PerfettoPlugin {
   }
 
   async onTraceLoad(ctx: Trace): Promise<void> {
-    const cpus = await getSchedCpus(ctx);
+    const numMachines = await getMachineCount(ctx.engine);
+    const cpus = await getSchedCpus(ctx, numMachines);
     this._schedCpus = cpus;
 
     const hasSched = await this.hasSched(ctx.engine);
@@ -532,13 +537,14 @@ export default class SchedPlugin implements PerfettoPlugin {
 /**
  * Get the list of unique cpus in the sched table.
  */
-async function getSchedCpus(ctx: Trace): Promise<Cpu[]> {
+async function getSchedCpus(ctx: Trace, numMachines: number): Promise<Cpu[]> {
   const queryRes = await ctx.engine.query(`
     SELECT DISTINCT
       ucpu,
       cpu.machine_id AS machine_id,
       cpu.cpu AS cpu,
-      machine.name AS machine_name
+      machine.name AS machine_name,
+      machine.label_index AS machine_label_index
     FROM sched
     JOIN cpu USING (ucpu)
     LEFT JOIN machine ON machine.id = cpu.machine_id
@@ -552,12 +558,20 @@ async function getSchedCpus(ctx: Trace): Promise<Cpu[]> {
       machine_id: NUM,
       cpu: NUM,
       machine_name: STR_NULL,
+      machine_label_index: NUM_NULL,
     });
     it.valid();
     it.next()
   ) {
     ucpus.push(
-      new Cpu(it.ucpu, it.cpu, it.machine_id, it.machine_name ?? undefined),
+      new Cpu(
+        it.ucpu,
+        it.cpu,
+        it.machine_id,
+        it.machine_name ?? undefined,
+        it.machine_label_index ?? undefined,
+        numMachines,
+      ),
     );
   }
 

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -33,7 +33,7 @@ import type {PerfettoPlugin} from '../../public/plugin';
 import {type AreaSelection, areaSelectionsEqual} from '../../public/selection';
 import type {Trace} from '../../public/trace';
 import {COUNTER_TRACK_KIND, SLICE_TRACK_KIND} from '../../public/track_kinds';
-import {getTrackName} from '../../public/utils';
+import {getMachineCount, getTrackName} from '../../public/utils';
 import {TrackNode} from '../../public/workspace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {
@@ -116,6 +116,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
   }
 
   private async addCounters(ctx: Trace) {
+    const numMachines = await getMachineCount(ctx.engine);
     const result = await ctx.engine.query(`
       include perfetto module viz.threads;
 
@@ -126,12 +127,14 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
           ct.id,
           ct.unit,
           ct.machine_id as machine,
+          machine.label_index as machineLabelIndex,
           extract_arg(ct.dimension_arg_set_id, 'utid') as utid,
           extract_arg(ct.dimension_arg_set_id, 'upid') as upid,
           extract_arg(ct.dimension_arg_set_id, 'gpu') as gpu_id,
           extract_arg(ct.source_arg_set_id, 'description') as description
         from counter_track ct
         join _counter_track_summary using (id)
+        left join machine on machine.id = ct.machine_id
         order by ct.name
       )
       select
@@ -166,6 +169,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
       isMainThread: NUM,
       isKernelThread: NUM,
       machine: NUM,
+      machineLabelIndex: NUM_NULL,
       description: STR_NULL,
     });
     for (; it.valid(); it.next()) {
@@ -182,7 +186,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
         pid,
         isMainThread,
         isKernelThread,
-        machine,
+        machineLabelIndex,
         description,
       } = it;
       const schema = schemas.get(type);
@@ -200,7 +204,8 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
         utid,
         kind: COUNTER_TRACK_KIND,
         threadTrack: utid !== undefined,
-        machine,
+        machineLabelIndex,
+        numMachines,
       });
       const uri = `/counter_${trackId}`;
 

--- a/ui/src/public/utils.ts
+++ b/ui/src/public/utils.ts
@@ -14,7 +14,17 @@
 
 import {TimeSpan} from '../base/time';
 import {exists} from '../base/utils';
+import type {Engine} from '../trace_processor/engine';
+import {NUM} from '../trace_processor/query_result';
 import type {Trace} from './trace';
+
+// Number of machines in the trace. Used to decide whether tracks should be
+// disambiguated with a "(machine N)" label: with a single machine there's no
+// ambiguity, so no label is shown.
+export async function getMachineCount(engine: Engine): Promise<number> {
+  const res = await engine.query(`select count(*) as cnt from machine`);
+  return res.firstRow({cnt: NUM}).cnt;
+}
 
 export function getTrackName(
   args: Partial<{
@@ -30,8 +40,9 @@ export function getTrackName(
     kind: string;
     threadTrack: boolean;
     uidTrack: boolean;
-    machine: number | null;
+    machineLabelIndex: number | null;
     machineName: string | null;
+    numMachines: number | null;
   }>,
 ) {
   const {
@@ -47,8 +58,9 @@ export function getTrackName(
     kind,
     threadTrack,
     uidTrack,
-    machine,
+    machineLabelIndex,
     machineName,
+    numMachines,
   } = args;
 
   const hasName = name !== undefined && name !== null && name !== '[NULL]';
@@ -68,7 +80,11 @@ export function getTrackName(
   // upid/utid) we show the track kind to help with tracking
   // down where this is coming from.
   const kindSuffix = hasKind ? ` (${kind})` : '';
-  const machineLabel = maybeMachineLabel(machine ?? undefined, machineName);
+  const machineLabel = maybeMachineLabel(
+    machineLabelIndex ?? undefined,
+    machineName,
+    numMachines ?? undefined,
+  );
 
   if (isThreadTrack && hasName && hasTid) {
     return `${name} (${tid})`;
@@ -135,15 +151,21 @@ export async function getTimeSpanOfSelectionOrVisibleWindow(
 }
 
 export function maybeMachineLabel(
-  machine?: number,
+  labelIndex?: number,
   machineName?: string | null,
+  numMachines?: number,
 ): string {
-  const m = machine ?? 0;
-  if (m <= 0) return '';
+  // No label for: a single machine, or the host (index 0/null). With more than
+  // one machine, every non-host machine is labelled. `label_index` is the
+  // machine's 1-based index among non-host machines (see the `machine` table
+  // view).
+  if (numMachines === undefined || numMachines <= 1 || (labelIndex ?? 0) <= 0) {
+    return '';
+  }
   // Prefer the human-readable machine name (machine.name) when the trace
-  // provides one; otherwise fall back to the numeric machine id.
+  // provides one; otherwise use the 1-based machine index.
   if (machineName !== undefined && machineName !== null && machineName !== '') {
     return ` (${machineName})`;
   }
-  return ` (machine ${m})`;
+  return ` (machine ${labelIndex})`;
 }


### PR DESCRIPTION
When a producer connects to the in-process service with a non-default
machine id, only the producer's own packets carried that id. The
service-emitted packets (clock snapshot, trace config, trace uuid,
system info, trace provenance, lifecycle events, stats, extension
descriptors and triggers) were written without a machine id and so
attributed to the default host machine. As a result the trace contained
a separate host machine with no data alongside the real machine, and the
real machine had no service clock snapshot of its own.

Stamp the service's own packets with the machine id of the connected
in-process producer so a single-machine in-process trace contains
exactly that machine and its timestamps resolve against the service
clock snapshot. Host and relay (multi-machine) sessions are unaffected:
the stamping is gated on there being no relay clients and a non-default
local machine id, and the relay paths keep setting their own machine id.

trace_processor creates a synthetic host machine (machine_id 0) per
trace file even when every packet is attributed to another machine, so
the UI showed an extra empty machine and stamped tracks with noisy
"(machine N)" suffixes for traces that really have a single machine.

Add a packet_count column to the machine table, incremented as each
packet is attributed to its machine; a machine that never receives a
packet keeps a count of zero. The UI then labels tracks by machine only
when more than one machine has a non-zero packet count, and omits
zero-packet machines from the Machines tab.

Single-machine traces show no machine suffixes and no empty machine;
multi-machine traces are unaffected.