### PR TITLE
Make android_jank_cuj_layer_name public table to fix downstream dependencies

### DIFF
--- a/src/trace_processor/metrics/sql/android/android_jank_cuj.sql
+++ b/src/trace_processor/metrics/sql/android/android_jank_cuj.sql
@@ -128,5 +128,5 @@ SELECT
         ))
       FROM android_jank_cuj cuj
       LEFT JOIN android_jank_cuj_boundary boundary USING (cuj_id)
-      LEFT JOIN _android_jank_cuj_layer_name cuj_layer USING (cuj_id)
+      LEFT JOIN android_jank_cuj_layer_name cuj_layer USING (cuj_id)
       ORDER BY cuj.cuj_id ASC));

--- a/src/trace_processor/metrics/sql/android/jank/frames.sql
+++ b/src/trace_processor/metrics/sql/android/jank/frames.sql
@@ -54,7 +54,7 @@ JOIN actual_timeline_with_vsync timeline
 LEFT JOIN expected_frame_timeline_slice expected
   ON expected.upid = timeline.upid AND expected.name = timeline.name
 LEFT JOIN _vsync_missed_callback missed_callback USING(vsync)
-LEFT JOIN _android_jank_cuj_layer_name cuj_layer USING (cuj_id)
+LEFT JOIN android_jank_cuj_layer_name cuj_layer USING (cuj_id)
 WHERE
   cuj_layer.layer_name IS NULL
   OR timeline.layer_name = cuj_layer.layer_name
@@ -113,7 +113,7 @@ WITH android_jank_cuj_timeline_sf_frame AS (
         boundary.upid = timeline.upid
         AND CAST(timeline.name AS INTEGER) >= vsync_min
         AND CAST(timeline.name AS INTEGER) <= vsync_max
-    LEFT JOIN _android_jank_cuj_layer_name cuj_layer USING (cuj_id)
+    LEFT JOIN android_jank_cuj_layer_name cuj_layer USING (cuj_id)
     WHERE
         cuj_layer.layer_name IS NULL
       OR timeline.layer_name = cuj_layer.layer_name

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
@@ -269,7 +269,7 @@ WHERE
 --    per frame during the CUJ (`HAVING MAX(layers_per_frame) = 1`). If so, we safely
 --    use that layer's name (extracted via `MAX(layer_name)`). If multiple layers
 --    were rendered simultaneously, we can't safely guess, and return NULL.
-CREATE PERFETTO TABLE _android_jank_cuj_layer_name(
+CREATE PERFETTO TABLE android_jank_cuj_layer_name(
   -- CUJ id.
   cuj_id LONG,
   -- Layer name of the CUJ.


### PR DESCRIPTION
Make android_jank_cuj_layer_name public table to fix downstream dependencies

Downstream perfetto sql scripts was broken by https://github.com/google/perfetto/pull/6341/ as the table name changed from `android_jank_cuj_layer_name` to be private `_android_jank_cuj_layer_name` 