### PR TITLE
perfetto: consolidate Android OOT allocations in extensions.json

### DIFF
--- a/protos/perfetto/trace/extensions.json
+++ b/protos/perfetto/trace/extensions.json
@@ -66,7 +66,9 @@
         },
         {
           "name": "unallocated",
-          "comment": ["The next allocation goes here. Shrink and take from here."],
+          "comment": [
+            "The next allocation goes here. Shrink and take from here."
+          ],
           "range": [3100, 4999]
         },
         {
@@ -88,119 +90,79 @@
     },
     {
       "scope": "perfetto.protos.TracePacket",
-      "ranges": [[56, 56], [88, 88], [92, 92], [93, 94], [96, 97], [104, 105], [112, 112], [114, 114], [116, 116], [121, 121], [1000, 1999]],
+      "ranges": [
+        [56, 56],
+        [88, 88],
+        [92, 92],
+        [93, 94],
+        [96, 97],
+        [104, 105],
+        [112, 112],
+        [114, 114],
+        [116, 116],
+        [121, 121],
+        [1000, 9999]
+      ],
       "allocations": [
         {
-          "name": "android_frameworks_base",
-          "description": "frameworks/base TracePacket extensions",
+          "name": "android_system",
+          "description": "Android OS platform (System image)",
           "comment": [
-            "Defined in third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.proto.",
-            "Wrapper: FrameworksBaseTracePacket."
+            "Sub-registry lives in the Android tree. Wrappers span multiple",
+            "components (ART, Bluetooth, Connectivity, frameworks/base,",
+            "frameworks/native, Winscope), aggregated into the descriptor zip",
+            "installed at the path below. See",
+            "https://github.com/google/perfetto/discussions/4783."
           ],
-          "ranges": [[116, 116], [1000, 1001]],
-          "registry": "/system/extras/tracing/system_tracing_protos.json",
-          "repo": "android-internal"
-        },
-        {
-          "name": "android_frameworks_native",
-          "description": "frameworks/native TracePacket extensions",
-          "comment": [
-            "Defined in third_party/android/frameworks/native/tracing/frameworks_native_trace_packet.proto.",
-            "Wrapper: FrameworksNativeTracePacket."
+          "ranges": [
+            [56, 56],
+            [88, 88],
+            [92, 92],
+            [93, 94],
+            [96, 97],
+            [104, 105],
+            [112, 112],
+            [114, 114],
+            [116, 116],
+            [121, 121],
+            [1000, 1999]
           ],
-          "ranges": [[121, 121]],
-          "registry": "/system/extras/tracing/system_tracing_protos.json",
-          "repo": "android-internal"
-        },
-        {
-          "name": "art_heap_graph",
-          "description": "ART Java heap graph",
-          "comment": [
-            "Defined in the Android tree under art/perfetto_hprof/proto/, mirrored",
-            "here at third_party/android/art/heap_graph.proto.",
-            "Wrapper: ArtHeapGraphTracePacket (56). Field number matches the",
-            "original in-tree field for wire compatibility."
-          ],
-          "ranges": [[56, 56]],
-          "registry": "/system/extras/tracing/system_tracing_protos.json",
-          "repo": "android-internal"
-        },
-        {
-          "name": "bluetooth",
-          "description": "Bluetooth HCI trace events",
-          "comment": [
-            "Defined in the Android tree under",
-            "packages/modules/Bluetooth/system/gd/proto/tracing/, mirrored here at",
-            "third_party/android/packages/modules/bluetooth/tracing/bluetooth_trace.proto.",
-            "Wrapper: BluetoothTracePacket (114). Field number matches the original",
-            "in-tree field for wire compatibility."
-          ],
-          "ranges": [[114, 114]],
-          "registry": "/system/extras/tracing/system_tracing_protos.json",
-          "repo": "android-internal"
-        },
-        {
-          "name": "connectivity_network",
-          "description": "Connectivity network packet trace",
-          "comment": [
-            "Defined in the Android tree under",
-            "packages/modules/Connectivity/service-t/native/libs/libnetworkstats/proto/,",
-            "mirrored here at third_party/android/connectivity/network_trace.proto.",
-            "Wrapper: ConnectivityTracePacket (88: network_packet,",
-            "92: network_packet_bundle). Field numbers match the original in-tree",
-            "fields for wire compatibility."
-          ],
-          "ranges": [[88, 88], [92, 92]],
           "registry": "/system/extras/tracing/system_tracing_protos.json",
           "repo": "android-internal"
         },
         {
           "name": "unallocated",
-          "comment": ["The next allocation goes here. Shrink and take from here."],
-          "range": [1002, 1999]
-        },
-        {
-          "name": "winscope",
-          "description": "Winscope TracePacket payloads (SurfaceFlinger, Shell, ProtoLog)",
           "comment": [
-            "Defined in the Android tree under frameworks/{native,base}/tracing/winscope/,",
-            "mirrored here at third_party/android/frameworks/{native,base}/.../winscope/.",
-            "Wrappers: FrameworksNativeWinscopeTracePacket (93,94,104,105,112) and",
-            "FrameworksBaseWinscopeTracePacket (96,97). Field numbers match the original",
-            "in-tree fields for wire compatibility."
+            "The next allocation goes here. Shrink and take from here."
           ],
-          "ranges": [[93, 94], [96, 97], [104, 105], [112, 112]],
-          "registry": "/system/extras/tracing/system_tracing_protos.json",
-          "repo": "android-internal"
+          "range": [2000, 9999]
         }
       ]
     },
     {
       "scope": "perfetto.protos.InternedData",
-      "ranges": [[30, 30], [42, 42], [44, 44], [1000, 9999]],
+      "ranges": [
+        [30, 30],
+        [42, 42],
+        [44, 44],
+        [1000, 9999]
+      ],
       "allocations": [
         {
-          "name": "android_frameworks_base",
-          "description": "frameworks/base InternedData extensions",
+          "name": "android_system",
+          "description": "Android OS platform (System image)",
           "comment": [
-            "Defined in third_party/android/frameworks/base/proto/tracing/frameworks_base_interned_data.proto.",
-            "Wrapper: FrameworksBaseInternedData."
+            "Sub-registry lives in the Android tree. Wrappers span",
+            "frameworks/base (42, 44) and Connectivity (30), aggregated into",
+            "the descriptor zip installed at the path below. See",
+            "https://github.com/google/perfetto/discussions/4783."
           ],
-          "ranges": [[42, 42], [44, 44]],
-          "registry": "/system/extras/tracing/system_tracing_protos.json",
-          "repo": "android-internal"
-        },
-        {
-          "name": "connectivity_network",
-          "description": "Connectivity network packet interned context",
-          "comment": [
-            "Defined in the Android tree under",
-            "packages/modules/Connectivity/service-t/native/libs/libnetworkstats/proto/,",
-            "mirrored here at third_party/android/connectivity/network_trace.proto.",
-            "Wrapper: ConnectivityInternedData (30: packet_context). Field number",
-            "matches the original in-tree field for wire compatibility."
+          "ranges": [
+            [30, 30],
+            [42, 42],
+            [44, 44],
+            [1100, 1999]
           ],
-          "ranges": [[30, 30]],
           "registry": "/system/extras/tracing/system_tracing_protos.json",
           "repo": "android-internal"
         },
@@ -213,8 +175,10 @@
         },
         {
           "name": "unallocated",
-          "comment": ["The next allocation goes here. Shrink and take from here."],
-          "range": [1100, 9999]
+          "comment": [
+            "The next allocation goes here. Shrink and take from here."
+          ],
+          "range": [2000, 9999]
         }
       ]
     }


### PR DESCRIPTION
Replace the per-component Android entries (android_frameworks_base, android_frameworks_native, art_heap_graph, bluetooth, connectivity_network, winscope) in TracePacket and InternedData scopes with a single android_system entry that delegates to the Android sub-registry, matching the pattern already used for TrackEvent.

Expand the TracePacket android_system range to [1000, 1999] with [2000, 2999] unallocated. For InternedData, android_system covers [1100, 1999] (perfetto_gpu retains [1000, 1099]) with [2000, 2999] unallocated.