### PR TITLE
ui: add multi-trace "at the same time" merge configurator

### DIFF
--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -627,7 +627,8 @@ async function getTraceInfo(
   const downloadable =
     (traceSource.type === 'ARRAY_BUFFER' && !traceSource.localOnly) ||
     traceSource.type === 'FILE' ||
-    traceSource.type === 'URL';
+    traceSource.type === 'URL' ||
+    traceSource.type === 'MULTIPLE_FILES';
 
   return {
     ...traceTime,

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -38,6 +38,7 @@ import type {PluginManagerImpl} from './plugin_manager';
 import type {RouteArgs} from '../public/route_schema';
 import type {Analytics} from '../public/analytics';
 import {fetchWithProgress} from '../base/http_utils';
+import {tarFileListToBlob} from './trace_stream';
 import type {TraceInfoImpl} from './trace_info_impl';
 import type {PageHandler, PageManager} from '../public/page';
 import {createProxy} from '../base/utils';
@@ -243,6 +244,10 @@ export class TraceImpl implements Trace, Disposable {
             `Downloading trace ${progressPercent}%`,
           ),
         );
+      } else if (src.type === 'MULTIPLE_FILES') {
+        // Re-materialize the merged TAR (manifest + traces) from the retained
+        // file list; reopening it reproduces the merge.
+        return await tarFileListToBlob(src.files);
       }
     }
     // Not available in HTTP+RPC mode. Rather than propagating an undefined,

--- a/ui/src/core/trace_stream.ts
+++ b/ui/src/core/trace_stream.ts
@@ -308,3 +308,19 @@ export class TraceMultipleFilesStream implements TraceStream {
     }
   }
 }
+
+// Materializes the on-the-fly TAR (manifest + traces) of a multi-file set into a
+// single in-memory blob, for the "download the merged trace" sinks. Reopening
+// this blob reproduces the merge. Revisit for very large sets.
+export async function tarFileListToBlob(
+  files: ReadonlyArray<File>,
+): Promise<Blob> {
+  const stream = new TraceMultipleFilesStream(files);
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const chunk = await stream.readChunk();
+    chunks.push(chunk.data);
+    if (chunk.eof) break;
+  }
+  return new Blob(chunks as BlobPart[], {type: 'application/x-tar'});
+}

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/merge_manifest.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/merge_manifest.ts
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Serializes the merge configurator state into a perfetto_manifest object.
+// Contract: test/trace_processor/diff_tests/parser/trace_manifest/tests.py.
+
+import type {
+  ClockName,
+  FileMergeConfig,
+  TraceTimeConfig,
+} from './multi_trace_types';
+
+export interface ManifestFileEntry {
+  path: string;
+  clocks?: {offset_ns: number};
+}
+
+export interface PerfettoManifest {
+  version: 1;
+  trace_time?: {clock: ClockName};
+  files?: ManifestFileEntry[];
+}
+
+export interface MergeFile {
+  readonly path: string;
+  readonly config: FileMergeConfig;
+}
+
+const MANIFEST_FILENAME = 'perfetto_manifest.json';
+
+function fileClocks(config: FileMergeConfig): {offset_ns: number} | undefined {
+  if (config.alignMode === 'offset' && config.offsetNs !== undefined) {
+    return {offset_ns: config.offsetNs};
+  }
+  return undefined;
+}
+
+function buildManifest(
+  files: ReadonlyArray<MergeFile>,
+  traceTime: TraceTimeConfig,
+): PerfettoManifest {
+  const manifest: PerfettoManifest = {version: 1};
+  if (traceTime.clock !== undefined) {
+    manifest.trace_time = {clock: traceTime.clock};
+  }
+  const entries = files.map(({path, config}) => {
+    const clocks = fileClocks(config);
+    return clocks === undefined ? {path} : {path, clocks};
+  });
+  // Bare {path} entries are no-ops; omit `files` when none carry config.
+  if (entries.some((e) => e.clocks !== undefined)) {
+    manifest.files = entries;
+  }
+  return manifest;
+}
+
+// Empty beyond auto-align: callers skip the manifest and open plain files.
+export function isTrivialManifest(
+  files: ReadonlyArray<MergeFile>,
+  traceTime: TraceTimeConfig,
+): boolean {
+  return (
+    traceTime.clock === undefined &&
+    !files.some((f) => fileClocks(f.config) !== undefined)
+  );
+}
+
+export function manifestToJson(
+  files: ReadonlyArray<MergeFile>,
+  traceTime: TraceTimeConfig,
+): string {
+  const manifest = {perfetto_manifest: buildManifest(files, traceTime)};
+  return JSON.stringify(manifest, null, 2);
+}
+
+export function buildManifestFile(
+  files: ReadonlyArray<MergeFile>,
+  traceTime: TraceTimeConfig,
+): File {
+  const json = manifestToJson(files, traceTime);
+  return new File([json], MANIFEST_FILENAME, {type: 'application/json'});
+}

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
@@ -12,12 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type {TraceFile, TraceFileAnalyzed} from './multi_trace_types';
+import type {
+  ClockName,
+  FileAnalysis,
+  FileMergeConfig,
+  TraceFile,
+  TraceFileAnalyzed,
+  TraceTimeConfig,
+} from './multi_trace_types';
+import {BUILTIN_CLOCKS, defaultFileMergeConfig} from './multi_trace_types';
 import {uuidv4} from '../../base/uuid';
-import type {TraceAnalyzer} from './trace_analyzer';
+import {getErrorMessage as toErrorMessage} from '../../base/errors';
+import type {AlignmentVerdict, TraceAnalyzer} from './trace_analyzer';
+import type {MergeFile} from './merge_manifest';
+import {
+  buildManifestFile,
+  isTrivialManifest,
+  manifestToJson,
+} from './merge_manifest';
 
 function getErrorMessage(e: unknown): string {
-  const err = e instanceof Error ? e.message : `${e}`;
+  const err = toErrorMessage(e);
   if (err.includes('(ERR:fmt)')) {
     return `The file opened doesn't look like a Perfetto trace or any other supported trace format.`;
   }
@@ -26,7 +41,11 @@ function getErrorMessage(e: unknown): string {
 
 // The possible error states for the modal, used to show a helpful message
 // to the user and disable the "Open Traces" button.
-export type LoadingError = 'NO_TRACES' | 'ANALYZING' | 'TRACE_ERROR';
+export type LoadingError =
+  | 'NO_TRACES'
+  | 'DUPLICATE_NAMES'
+  | 'ANALYZING'
+  | 'TRACE_ERROR';
 
 /**
  * The controller for the multi-trace modal.
@@ -34,6 +53,16 @@ export type LoadingError = 'NO_TRACES' | 'ANALYZING' | 'TRACE_ERROR';
  */
 export class MultiTraceController {
   private _traces: TraceFile[] = [];
+  // Per-file merge configuration, keyed by trace uuid. Absent => default.
+  private _configByUuid = new Map<string, FileMergeConfig>();
+  private _traceTime: TraceTimeConfig = {};
+  // User-chosen baseline trace for all-private sets; undefined => first file.
+  private _anchorUuid?: string;
+  // The last whole-set alignment verdict; cleared whenever the config changes.
+  private _verdict?: AlignmentVerdict;
+  private _checking = false;
+  // Bumped on every config change; lets checkAlignment drop a stale result.
+  private _generation = 0;
   private traceAnalyzer: TraceAnalyzer;
   private onStateChanged: () => void;
   private onAnalysisStarted?: (traceUuid: string) => void;
@@ -68,6 +97,10 @@ export class MultiTraceController {
     if (this.traces.length === 0) {
       return 'NO_TRACES';
     }
+    // Manifest and tar both key on file.name; duplicates would collide.
+    if (this.hasDuplicateNames()) {
+      return 'DUPLICATE_NAMES';
+    }
     if (this.isAnalyzing()) {
       return 'ANALYZING';
     }
@@ -75,6 +108,11 @@ export class MultiTraceController {
       return 'TRACE_ERROR';
     }
     return undefined;
+  }
+
+  private hasDuplicateNames(): boolean {
+    const names = this._traces.map((t) => t.file.name);
+    return new Set(names).size !== names.length;
   }
 
   addFiles(files: ReadonlyArray<File>) {
@@ -87,15 +125,186 @@ export class MultiTraceController {
       this._traces.push(trace);
       this.analyzeTrace(trace);
     }
-    this.onStateChanged();
+    this.invalidate();
   }
 
   removeTrace(uuid: string) {
     const index = this._traces.findIndex((t) => t.uuid === uuid);
     if (index !== -1) {
       this._traces.splice(index, 1);
+      this._configByUuid.delete(uuid);
+      this.invalidate();
+    }
+  }
+
+  get traceTime(): Readonly<TraceTimeConfig> {
+    return this._traceTime;
+  }
+
+  setTraceTimeClock(clock: ClockName | undefined) {
+    this._traceTime = {...this._traceTime, clock};
+    this.invalidate();
+  }
+
+  getConfig(uuid: string): FileMergeConfig {
+    return this._configByUuid.get(uuid) ?? defaultFileMergeConfig();
+  }
+
+  updateConfig(uuid: string, patch: Partial<FileMergeConfig>) {
+    const next = {...this.getConfig(uuid), ...patch};
+    this._configByUuid.set(uuid, next);
+    this.invalidate();
+  }
+
+  private analyzedAnalyses(): FileAnalysis[] {
+    return this._traces
+      .filter((t): t is TraceFileAnalyzed => t.status === 'analyzed')
+      .map((t) => t.analysis);
+  }
+
+  private allAnalyzed(): boolean {
+    return (
+      this._traces.length > 0 &&
+      this._traces.every((t) => t.status === 'analyzed')
+    );
+  }
+
+  private allPrivateClock(): boolean {
+    return this.analyzedAnalyses().every((a) => a.privateClockOnly === true);
+  }
+
+  // Run after any trace-set or config change. The clock is reconciled only once
+  // analysis settles, else adding a file would transiently wipe the choice.
+  private invalidate() {
+    this._generation++;
+    this._verdict = undefined;
+    if (
+      this.allAnalyzed() &&
+      this._traceTime.clock !== undefined &&
+      !this.availableTraceTimeOptions().includes(this._traceTime.clock)
+    ) {
+      this._traceTime = {...this._traceTime, clock: undefined};
+    }
+    if (
+      this._anchorUuid !== undefined &&
+      !this._traces.some((t) => t.uuid === this._anchorUuid)
+    ) {
+      this._anchorUuid = undefined;
+    }
+    this.onStateChanged();
+  }
+
+  // Empty unless there are >=2 real clocks to choose between; with one (or
+  // none) everything aligns to that single domain and the choice is moot.
+  availableTraceTimeOptions(): ReadonlyArray<ClockName> {
+    if (this._traces.length < 2 || !this.allAnalyzed()) {
+      return [];
+    }
+    const ids = new Set<number>();
+    for (const a of this.analyzedAnalyses()) {
+      for (const id of a.builtinClockIds ?? []) {
+        ids.add(id);
+      }
+    }
+    const present = BUILTIN_CLOCKS.filter((c) => ids.has(c.id)).map(
+      (c) => c.name,
+    );
+    return present.length >= 2 ? present : [];
+  }
+
+  // The baseline trace for an all-private set (user's choice, else the first);
+  // undefined when a real clock anchors instead.
+  referenceTraceUuid(): string | undefined {
+    if (this._traces.length < 2 || !this.allAnalyzed() || !this.allPrivateClock()) {
+      return undefined;
+    }
+    if (
+      this._anchorUuid !== undefined &&
+      this._traces.some((t) => t.uuid === this._anchorUuid)
+    ) {
+      return this._anchorUuid;
+    }
+    return this._traces[0]?.uuid;
+  }
+
+  setAnchor(uuid: string) {
+    this._anchorUuid = uuid;
+    this.invalidate();
+  }
+
+  get alignmentVerdict(): AlignmentVerdict | undefined {
+    return this._verdict;
+  }
+
+  get isCheckingAlignment(): boolean {
+    return this._checking;
+  }
+
+  async checkAlignment() {
+    if (this._traces.length === 0 || this._checking) {
+      return;
+    }
+    this._checking = true;
+    this._verdict = undefined;
+    this.onStateChanged();
+    const gen = this._generation;
+    try {
+      const verdict = await this.traceAnalyzer.analyzeMergedAlignment(
+        this.getMergeFileList(),
+      );
+      if (gen === this._generation) {
+        this._verdict = verdict;
+      }
+    } catch (e) {
+      if (gen === this._generation) {
+        this._verdict = {
+          ok: false,
+          droppedEvents: 0,
+          validationError: getErrorMessage(e),
+        };
+      }
+    } finally {
+      this._checking = false;
       this.onStateChanged();
     }
+  }
+
+  // Baseline first: TraceProcessor makes the first trace the trace-time master.
+  private orderedTraces(): TraceFile[] {
+    const ref = this.referenceTraceUuid();
+    const idx =
+      ref === undefined ? -1 : this._traces.findIndex((t) => t.uuid === ref);
+    if (idx <= 0) {
+      return this._traces;
+    }
+    const copy = [...this._traces];
+    const [anchor] = copy.splice(idx, 1);
+    return [anchor, ...copy];
+  }
+
+  private mergeFiles(): MergeFile[] {
+    return this.orderedTraces().map((t) => ({
+      path: t.file.name,
+      config: this.getConfig(t.uuid),
+    }));
+  }
+
+  hasManifestConfig(): boolean {
+    return !isTrivialManifest(this.mergeFiles(), this._traceTime);
+  }
+
+  getManifestJson(): string {
+    return manifestToJson(this.mergeFiles(), this._traceTime);
+  }
+
+  // Manifest first (when non-trivial), then the trace files (baseline leading).
+  getMergeFileList(): ReadonlyArray<File> {
+    const traceFiles = this.orderedTraces().map((t) => t.file);
+    if (!this.hasManifestConfig()) {
+      return traceFiles;
+    }
+    const manifest = buildManifestFile(this.mergeFiles(), this._traceTime);
+    return [manifest, ...traceFiles];
   }
 
   isAnalyzing(): boolean {
@@ -135,10 +344,10 @@ export class MultiTraceController {
       const analyzedTrace: TraceFileAnalyzed = {
         ...trace,
         status: 'analyzed',
-        format: result.format,
+        analysis: result,
       };
       this._traces[index] = analyzedTrace;
-      this.onStateChanged();
+      this.invalidate();
       this.onAnalysisCompleted?.(trace.uuid);
     } catch (e) {
       this._traces[index] = {
@@ -146,7 +355,7 @@ export class MultiTraceController {
         status: 'error',
         error: getErrorMessage(e),
       };
-      this.onStateChanged();
+      this.invalidate();
       this.onAnalysisCompleted?.(trace.uuid);
     }
   }

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
@@ -215,7 +215,11 @@ export class MultiTraceController {
   // The baseline trace for an all-private set (user's choice, else the first);
   // undefined when a real clock anchors instead.
   referenceTraceUuid(): string | undefined {
-    if (this._traces.length < 2 || !this.allAnalyzed() || !this.allPrivateClock()) {
+    if (
+      this._traces.length < 2 ||
+      !this.allAnalyzed() ||
+      !this.allPrivateClock()
+    ) {
       return undefined;
     }
     if (

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller_unittest.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller_unittest.ts
@@ -16,11 +16,12 @@ import type {Mock} from 'vitest';
 import {ensureExists} from '../../base/assert';
 import {MultiTraceController} from './multi_trace_controller';
 import type {
+  FileAnalysis,
   TraceFileAnalyzed,
   TraceFileAnalyzing,
   TraceFileError,
 } from './multi_trace_types';
-import type {TraceAnalysisResult, TraceAnalyzer} from './trace_analyzer';
+import type {AlignmentVerdict, TraceAnalyzer} from './trace_analyzer';
 
 // Helper to create a mock TraceFileAnalyzed object for tests
 function createMockAnalyzedTrace(
@@ -31,7 +32,7 @@ function createMockAnalyzedTrace(
     uuid,
     file: new File([], `${uuid}.pftrace`),
     status: 'analyzed',
-    format,
+    analysis: {format},
   };
 }
 
@@ -60,10 +61,10 @@ function createMockErrorTrace(uuid: string, error: string): TraceFileError {
 
 // A fake TraceAnalyzer for testing purposes.
 class FakeTraceAnalyzer implements TraceAnalyzer {
-  private results = new Map<string, TraceAnalysisResult>();
+  private results = new Map<string, FileAnalysis>();
   private errors = new Map<string, Error>();
 
-  setResult(fileName: string, result: TraceAnalysisResult) {
+  setResult(fileName: string, result: FileAnalysis) {
     this.results.set(fileName, result);
   }
 
@@ -74,7 +75,7 @@ class FakeTraceAnalyzer implements TraceAnalyzer {
   async analyze(
     file: File,
     onProgress: (progress: number) => void,
-  ): Promise<TraceAnalysisResult> {
+  ): Promise<FileAnalysis> {
     // Simulate progress
     onProgress(0.5);
     onProgress(1.0);
@@ -87,6 +88,12 @@ class FakeTraceAnalyzer implements TraceAnalyzer {
       return result;
     }
     throw new Error(`No mock result set for ${file.name}`);
+  }
+
+  async analyzeMergedAlignment(
+    _files: ReadonlyArray<File>,
+  ): Promise<AlignmentVerdict> {
+    return {ok: true, droppedEvents: 0};
   }
 }
 
@@ -263,7 +270,7 @@ describe('MultiTraceController', () => {
 
       expect(controller.traces[0].status).toBe('analyzed');
       if (controller.traces[0].status === 'analyzed') {
-        expect(controller.traces[0].format).toBe('Perfetto');
+        expect(controller.traces[0].analysis.format).toBe('Perfetto');
       }
     });
 

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
@@ -478,11 +478,7 @@ class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
     if (trace.status === 'error') {
       return m(
         '.pf-multi-trace-modal__config',
-        m(
-          Callout,
-          {intent: Intent.Danger, icon: 'error_outline'},
-          trace.error,
-        ),
+        m(Callout, {intent: Intent.Danger, icon: 'error_outline'}, trace.error),
       );
     }
     if (trace.status !== 'analyzed') {

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
@@ -14,6 +14,9 @@
 
 import m from 'mithril';
 import {AppImpl} from '../../core/app_impl';
+import {copyToClipboard} from '../../base/clipboard';
+import {download} from '../../base/download_utils';
+import {tarFileListToBlob} from '../../core/trace_stream';
 import {Anchor} from '../../widgets/anchor';
 import {Button, ButtonVariant} from '../../widgets/button';
 import {CardStack} from '../../widgets/card';
@@ -21,15 +24,32 @@ import {Intent} from '../../widgets/common';
 import {Icon} from '../../widgets/icon';
 import {closeModal, redrawModal, showModal} from '../../widgets/modal';
 import {Callout} from '../../widgets/callout';
+import {MenuItem, PopupMenu} from '../../widgets/menu';
 import {Spinner} from '../../widgets/spinner';
 import {Stack} from '../../widgets/stack';
 import {TabStrip, type TabOption} from '../../widgets/tab_strip';
+import {TextInput} from '../../widgets/text_input';
+import {Tooltip} from '../../widgets/tooltip';
 import {TextParagraph} from '../../widgets/text_paragraph';
 import {MultiTraceController} from './multi_trace_controller';
-import type {TraceFile} from './multi_trace_types';
+import type {AlignMode, ClockName, TraceFile} from './multi_trace_types';
+import type {AlignmentVerdict} from './trace_analyzer';
 import {WasmTraceAnalyzer} from './trace_analyzer';
 
 const MODAL_KEY = 'multi-trace-modal';
+
+function renderHelp(text: string) {
+  return m(
+    Tooltip,
+    {
+      trigger: m(Icon, {
+        className: 'pf-multi-trace-modal__help',
+        icon: 'help_outline',
+      }),
+    },
+    text,
+  );
+}
 
 // =============================================================================
 // Shell Component
@@ -43,7 +63,7 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
   private controller = new MultiTraceController(new WasmTraceAnalyzer(), () =>
     redrawModal(),
   );
-  private currentTab = 'synchronous';
+  private currentTab = 'merge';
 
   oncreate({attrs}: m.Vnode<MultiTraceModalAttrs>) {
     this.controller.addFiles(attrs.initialFiles);
@@ -54,10 +74,9 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
       Stack,
       {className: 'pf-multi-trace-modal', orientation: 'vertical'},
       this.renderDescription(),
-      m(TraceListComponent, {
-        traces: this.controller.traces,
-        controller: this.controller,
-      }),
+      this.currentTab === 'merge' && this.renderLoadingError(),
+      this.currentTab === 'merge' &&
+        m(MergeConfigurator, {controller: this.controller}),
       m(
         Stack,
         {className: 'pf-multi-trace-modal__footer', orientation: 'horizontal'},
@@ -68,8 +87,7 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
 
   private renderDescription() {
     const tabs: TabOption[] = [
-      {key: 'synchronous', title: 'Synchronous Traces'},
-      {key: 'cross-machine', title: 'Cross-Machine Traces'},
+      {key: 'merge', title: 'At the same time'},
       {key: 'comparison', title: 'Trace Comparison'},
     ];
 
@@ -94,16 +112,14 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
 
   private renderTabContent() {
     switch (this.currentTab) {
-      case 'synchronous':
+      case 'merge':
         return [
           m(TextParagraph, {
-            text: '🔗 Combine multiple trace files that were captured at the same time on the same device or system. This allows you to view traces from different sources (e.g., system traces, app traces, custom instrumentation) on a unified timeline.',
-          }),
-        ];
-      case 'cross-machine':
-        return [
-          m(TextParagraph, {
-            text: '🌐 Merge traces captured on different machines or devices with distributed time synchronization.',
+            text:
+              'Combine traces that were captured at the same time (on one ' +
+              'device or across several) onto a single shared timeline. ' +
+              'Each file is placed automatically where its clocks line up; ' +
+              'where they cannot, you can tell Perfetto how, per file.',
           }),
         ];
       case 'comparison':
@@ -118,17 +134,7 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
   }
 
   private renderActions() {
-    const footerContent = this.getFooterContent();
-    const isDisabled = footerContent !== undefined;
-    const openButton = m(Button, {
-      label: 'Open Traces',
-      intent: Intent.Primary,
-      variant: ButtonVariant.Filled,
-      onclick: () => this.openTraces(),
-      disabled: isDisabled,
-    });
-
-    if (footerContent !== undefined) {
+    if (this.currentTab === 'comparison') {
       return [
         m(
           Callout,
@@ -137,53 +143,89 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
             intent: Intent.Danger,
             icon: 'error_outline',
           },
-          footerContent,
+          [
+            'This feature is not yet supported. Please +1 ',
+            m(
+              Anchor,
+              {
+                href: 'https://github.com/google/perfetto/issues/2780',
+                target: '_blank',
+              },
+              'this GitHub issue',
+            ),
+            ' to prioritize development, or select "At the same time" to ' +
+              'continue.',
+          ],
         ),
         m('.pf-multi-trace-modal__footer-spacer'),
-        openButton,
+        m(Button, {
+          label: 'Open Traces',
+          intent: Intent.Primary,
+          variant: ButtonVariant.Filled,
+          disabled: true,
+        }),
       ];
-    } else {
-      return [m('.pf-multi-trace-modal__footer-spacer'), openButton];
     }
+
+    const disabled = this.controller.getLoadingError() !== undefined;
+    const checking = this.controller.isCheckingAlignment;
+
+    return [
+      m(Button, {
+        label: 'Check alignment',
+        icon: 'rule',
+        disabled: checking || disabled,
+        onclick: () => this.controller.checkAlignment(),
+      }),
+      renderHelp(
+        'Dry-runs the merge and reports whether every trace lines up on the ' +
+          'shared timeline, or how many events would be dropped.',
+      ),
+      m('.pf-multi-trace-modal__footer-spacer'),
+      m(Button, {
+        label: 'Copy manifest',
+        icon: 'content_copy',
+        disabled,
+        onclick: () => this.copyManifest(),
+      }),
+      m(Button, {
+        label: 'Download .tar',
+        icon: 'download',
+        disabled,
+        onclick: () => this.downloadTar(),
+      }),
+      m(Button, {
+        label: 'Open Traces',
+        intent: Intent.Primary,
+        variant: ButtonVariant.Filled,
+        disabled,
+        onclick: () => this.openTraces(),
+      }),
+    ];
   }
 
-  private getFooterContent(): m.Children | undefined {
-    if (this.currentTab === 'cross-machine') {
-      return [
-        'This feature is not yet supported. Please +1 ',
-        m(
-          Anchor,
-          {
-            href: 'https://github.com/google/perfetto/issues/2781',
-            target: '_blank',
-          },
-          'this GitHub issue',
-        ),
-        ' to prioritize development, or select "Synchronous Traces" to continue.',
-      ];
-    }
-    if (this.currentTab === 'comparison') {
-      return [
-        'This feature is not yet supported. Please +1 ',
-        m(
-          Anchor,
-          {
-            href: 'https://github.com/google/perfetto/issues/2780',
-            target: '_blank',
-          },
-          'this GitHub issue',
-        ),
-        ' to prioritize development, or select "Synchronous Traces" to continue.',
-      ];
-    }
-
+  private renderLoadingError() {
     const error = this.controller.getLoadingError();
     if (error === undefined) {
       return undefined;
     }
+    return m(
+      Callout,
+      {
+        className: 'pf-multi-trace-modal__panel-error',
+        intent: Intent.Danger,
+        icon: 'error_outline',
+      },
+      this.errorMessage(error),
+    );
+  }
+
+  private errorMessage(error: string): string {
     switch (error) {
       case 'NO_TRACES':
         return 'Add at least one trace to open.';
+      case 'DUPLICATE_NAMES':
+        return 'Two traces share the same file name. Remove or rename one.';
       case 'ANALYZING':
         return 'Wait for all traces to be analyzed.';
       case 'TRACE_ERROR':
@@ -197,37 +239,180 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
     if (this.controller.traces.length === 0) {
       return;
     }
-    const files = this.controller.traces.map((t) => t.file);
-    AppImpl.instance.openTraceFromMultipleFiles(files);
+    // MULTIPLE_FILES (rather than a one-shot STREAM) retains the file list on
+    // the trace source, so the merged trace stays downloadable from the
+    // timeline once loaded.
+    AppImpl.instance.openTraceFromMultipleFiles(
+      this.controller.getMergeFileList(),
+    );
     closeModal(MODAL_KEY);
+  }
+
+  private async downloadTar() {
+    const blob = await tarFileListToBlob(this.controller.getMergeFileList());
+    await download({
+      content: blob,
+      fileName: 'merged-trace.tar',
+      mimeType: 'application/x-tar',
+    });
+  }
+
+  private async copyManifest() {
+    await copyToClipboard(this.controller.getManifestJson());
   }
 }
 
 // =============================================================================
-// Trace List Component
+// Merge Configurator (per-file rows)
 // =============================================================================
 
-interface TraceListComponentAttrs {
-  traces: ReadonlyArray<TraceFile>;
+interface MergeConfiguratorAttrs {
   controller: MultiTraceController;
 }
 
-class TraceListComponent implements m.ClassComponent<TraceListComponentAttrs> {
-  view({attrs}: m.Vnode<TraceListComponentAttrs>) {
-    const {traces, controller} = attrs;
+class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
+  view({attrs}: m.Vnode<MergeConfiguratorAttrs>) {
+    const {controller} = attrs;
     return m(
       Stack,
       {className: 'pf-multi-trace-modal__list-panel', orientation: 'vertical'},
-      traces.map((trace) => this.renderTraceItem(trace, controller)),
+      this.renderReference(controller),
+      controller.traces.map((trace) => this.renderTraceItem(trace, controller)),
       m(
         CardStack,
         {
           className: 'pf-multi-trace-modal__add-card',
-          onclick: () => this.addTraces(controller),
+          onclick: () => addTraces(controller),
         },
         m(Icon, {icon: 'add'}),
         'Add more traces',
       ),
+      this.renderVerdictPanel(controller),
+    );
+  }
+
+  // Verdict for "Check alignment"; the button lives in the footer.
+  private renderVerdictPanel(controller: MultiTraceController) {
+    const verdict = controller.alignmentVerdict;
+    const checking = controller.isCheckingAlignment;
+    if (!checking && verdict === undefined) {
+      return undefined;
+    }
+    return m(
+      Stack,
+      {
+        className: 'pf-multi-trace-modal__align-panel',
+        orientation: 'vertical',
+        spacing: 'small',
+      },
+      checking &&
+        m(
+          Stack,
+          {orientation: 'horizontal', spacing: 'small'},
+          m(Spinner),
+          'Checking how these traces line up...',
+        ),
+      !checking && verdict !== undefined && this.renderVerdict(verdict),
+    );
+  }
+
+  private renderVerdict(verdict: AlignmentVerdict) {
+    if (verdict.validationError !== undefined) {
+      return m(
+        Callout,
+        {intent: Intent.Danger, icon: 'error_outline'},
+        `Manifest error: ${verdict.validationError}`,
+      );
+    }
+    if (!verdict.ok) {
+      return m(
+        Callout,
+        {intent: Intent.Warning, icon: 'warning'},
+        `${verdict.droppedEvents.toLocaleString()} events would be dropped: ` +
+          'some traces share no clock with the shared timeline and will be ' +
+          'omitted. Set an explicit alignment, or check the manifest.',
+      );
+    }
+    return m(
+      Callout,
+      {intent: Intent.Success, icon: 'check_circle'},
+      'All traces line up on the shared timeline.',
+    );
+  }
+
+  // Themed dropdown, in place of a native <select>.
+  private renderDropdown(
+    value: string,
+    options: ReadonlyArray<{value: string; label: string}>,
+    onSelect: (value: string) => void,
+  ) {
+    const current = options.find((o) => o.value === value);
+    return m(
+      PopupMenu,
+      {
+        trigger: m(Button, {
+          label: current?.label ?? value,
+          rightIcon: 'arrow_drop_down',
+        }),
+      },
+      options.map((o) =>
+        m(MenuItem, {
+          label: o.label,
+          rightIcon: o.value === value ? 'check' : undefined,
+          onclick: () => onSelect(o.value),
+        }),
+      ),
+    );
+  }
+
+  // The single reference everything aligns to: a clock when there are multiple
+  // real clocks to choose between, otherwise the baseline trace (clockless
+  // sets). Hidden when there is no meaningful choice.
+  private renderReference(controller: MultiTraceController) {
+    const clocks = controller.availableTraceTimeOptions();
+    if (clocks.length > 0) {
+      return this.renderReferenceRow(
+        this.renderDropdown(
+          controller.traceTime.clock ?? 'auto',
+          [
+            {value: 'auto', label: 'Automatic (recommended)'},
+            ...clocks.map((c) => ({value: c, label: c})),
+          ],
+          (value) =>
+            controller.setTraceTimeClock(
+              value === 'auto' ? undefined : (value as ClockName),
+            ),
+        ),
+        'The clock the merged traces share. Automatic lets Perfetto choose; ' +
+          'picking one projects every trace onto that clock.',
+      );
+    }
+    const reference = controller.referenceTraceUuid();
+    if (reference !== undefined) {
+      return this.renderReferenceRow(
+        this.renderDropdown(
+          reference,
+          controller.traces.map((t) => ({value: t.uuid, label: t.file.name})),
+          (uuid) => controller.setAnchor(uuid),
+        ),
+        'The baseline trace, kept at its own timestamps. Every other trace is ' +
+          'positioned relative to it.',
+      );
+    }
+    return undefined;
+  }
+
+  private renderReferenceRow(control: m.Children, help: string) {
+    return m(
+      Stack,
+      {
+        className: 'pf-multi-trace-modal__reference-row',
+        orientation: 'horizontal',
+        spacing: 'small',
+      },
+      m('strong', 'Align to:'),
+      control,
+      renderHelp(help),
     );
   }
 
@@ -236,11 +421,16 @@ class TraceListComponent implements m.ClassComponent<TraceListComponentAttrs> {
       CardStack,
       {
         className: 'pf-multi-trace-modal__card',
-        direction: 'horizontal',
+        direction: 'vertical',
         key: trace.uuid,
       },
-      this.renderTraceInfo(trace),
-      this.renderCardActions(trace, controller),
+      m(
+        Stack,
+        {orientation: 'horizontal', className: 'pf-multi-trace-modal__row-top'},
+        this.renderTraceInfo(trace),
+        this.renderCardActions(trace, controller),
+      ),
+      this.renderConfigControls(trace, controller),
     );
   }
 
@@ -273,9 +463,105 @@ class TraceListComponent implements m.ClassComponent<TraceListComponentAttrs> {
                 orientation: 'horizontal',
               },
               m('strong', 'Format:'),
-              m('span', trace.format),
+              m('span', trace.analysis.format),
             )
           : this.renderTraceStatus(trace),
+      ),
+    );
+  }
+
+  // Per-file controls, shown only where they'd change the merge.
+  private renderConfigControls(
+    trace: TraceFile,
+    controller: MultiTraceController,
+  ) {
+    if (trace.status === 'error') {
+      return m(
+        '.pf-multi-trace-modal__config',
+        m(
+          Callout,
+          {intent: Intent.Danger, icon: 'error_outline'},
+          trace.error,
+        ),
+      );
+    }
+    if (trace.status !== 'analyzed') {
+      return undefined;
+    }
+    const a = trace.analysis;
+    const children: m.Children[] = [];
+
+    if (a.singleClock === false) {
+      children.push(
+        m(
+          '.pf-multi-trace-modal__note',
+          'Carries its own clock snapshots, aligned automatically.',
+        ),
+      );
+    } else if (controller.traces.length >= 2) {
+      if (controller.referenceTraceUuid() === trace.uuid) {
+        children.push(
+          m('.pf-multi-trace-modal__note', 'Baseline. Others align to this.'),
+        );
+      } else {
+        children.push(this.renderAlignControl(trace, controller));
+      }
+    }
+
+    if (children.length === 0) {
+      return undefined;
+    }
+    return m(
+      Stack,
+      {
+        className: 'pf-multi-trace-modal__config',
+        orientation: 'horizontal',
+        spacing: 'large',
+      },
+      children,
+    );
+  }
+
+  private renderAlignControl(
+    trace: TraceFile,
+    controller: MultiTraceController,
+  ) {
+    const config = controller.getConfig(trace.uuid);
+    return m(
+      Stack,
+      {
+        className: 'pf-multi-trace-modal__control-row',
+        orientation: 'horizontal',
+        spacing: 'small',
+      },
+      m('strong', 'Align:'),
+      this.renderDropdown(
+        config.alignMode,
+        [
+          {value: 'auto', label: 'Automatic'},
+          {value: 'offset', label: 'Fixed offset'},
+        ],
+        (value) =>
+          controller.updateConfig(trace.uuid, {alignMode: value as AlignMode}),
+      ),
+      config.alignMode === 'offset' &&
+        m(TextInput, {
+          type: 'number',
+          placeholder: 'offset (ns)',
+          value: config.offsetNs !== undefined ? String(config.offsetNs) : '',
+          onChange: (value: string) => {
+            const n = Number(value);
+            const valid = value.trim().length > 0 && Number.isFinite(n);
+            controller.updateConfig(trace.uuid, {
+              offsetNs: valid ? n : undefined,
+            });
+          },
+        }),
+      renderHelp(
+        'Where this trace sits on the shared timeline. Automatic lines it up ' +
+          'using its own clocks. Fixed offset shifts it by a set number of ' +
+          'nanoseconds relative to the baseline trace; a positive value moves ' +
+          'it later.',
       ),
     );
   }
@@ -314,18 +600,6 @@ class TraceListComponent implements m.ClassComponent<TraceListComponentAttrs> {
       ),
     );
   }
-
-  private addTraces(controller: MultiTraceController) {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.multiple = true;
-    input.addEventListener('change', () => {
-      if (input.files) {
-        controller.addFiles([...input.files]);
-      }
-    });
-    input.click();
-  }
 }
 
 // =============================================================================
@@ -340,6 +614,18 @@ export function showMultiTraceModal(initialFiles: ReadonlyArray<File>) {
     className: 'pf-multi-trace-modal-override',
     content: () => m(MultiTraceModalShell, {initialFiles}),
   });
+}
+
+function addTraces(controller: MultiTraceController) {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.multiple = true;
+  input.addEventListener('change', () => {
+    if (input.files) {
+      controller.addFiles([...input.files]);
+    }
+  });
+  input.click();
 }
 
 function getStatusInfo(trace: TraceFile) {

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_types.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_types.ts
@@ -40,7 +40,7 @@ export interface TraceFileAnalyzing extends TraceFileBase {
 // A trace file that has been successfully analyzed.
 export interface TraceFileAnalyzed extends TraceFileBase {
   status: 'analyzed';
-  format: string;
+  analysis: FileAnalysis;
 }
 
 // A trace file that failed to be analyzed.
@@ -58,3 +58,44 @@ export type TraceFile =
 
 // A union of all possible status strings.
 export type TraceStatus = TraceFile['status'];
+
+// =============================================================================
+// Merge configuration: how each file is placed on the shared timeline.
+// Serializes to a perfetto_manifest (see merge_manifest.ts).
+// =============================================================================
+
+export type ClockName = 'REALTIME' | 'BOOTTIME' | 'MONOTONIC';
+
+// Builtin clock id<->name, in display order. Single source of truth.
+export const BUILTIN_CLOCKS: ReadonlyArray<{id: number; name: ClockName}> = [
+  {id: 1, name: 'REALTIME'},
+  {id: 3, name: 'MONOTONIC'},
+  {id: 6, name: 'BOOTTIME'},
+];
+
+// Manual modes supply values the UI doesn't compute (offset only, for now).
+export type AlignMode = 'auto' | 'offset';
+
+// Defaults emit nothing beyond the path, so the importer auto-aligns.
+export interface FileMergeConfig {
+  alignMode: AlignMode;
+  offsetNs?: number;
+}
+
+export interface TraceTimeConfig {
+  clock?: ClockName; // undefined => omit trace_time
+}
+
+export function defaultFileMergeConfig(): FileMergeConfig {
+  return {alignMode: 'auto'};
+}
+
+// Populated by the tokenize-only dry-run; gates which controls each file shows.
+export interface FileAnalysis {
+  format: string;
+  singleClock?: boolean;
+  // No real clock, only a private trace-file clock (e.g. a Chrome JSON trace).
+  privateClockOnly?: boolean;
+  // The builtin clock ids present (a subset of BUILTIN_CLOCKS).
+  builtinClockIds?: ReadonlyArray<number>;
+}

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/styles.scss
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/styles.scss
@@ -50,8 +50,9 @@
 
   &__card {
     padding: 16px;
-    justify-content: space-between;
-    align-items: center;
+    align-items: stretch;
+    // Keep full size so the list scrolls instead of squishing cards.
+    flex-shrink: 0;
   }
 
   &__name {
@@ -114,10 +115,61 @@
     font-size: 0.9em;
     font-weight: bold;
     align-items: center;
+    flex-shrink: 0;
 
     &:hover {
       background: color_hover(var(--pf-color-background-secondary));
     }
+  }
+
+  &__reference-row {
+    align-items: center;
+    padding: 8px 0;
+    font-size: 0.9em;
+  }
+
+  &__panel-error {
+    margin: 8px 0;
+  }
+
+  &__help {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
+    color: var(--pf-color-text-secondary);
+    cursor: help;
+    font-size: 1.1em;
+  }
+
+  // pf-stack defaults to baseline, which drops the help icon low.
+  &__control-row {
+    align-items: center;
+  }
+
+  &__row-top {
+    align-items: flex-start;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  &__config {
+    align-items: center;
+    flex-wrap: wrap;
+    padding-top: 8px;
+    margin-top: 8px;
+    border-top: 1px solid var(--pf-color-border);
+    font-size: 0.9em;
+    color: var(--pf-color-text-secondary);
+  }
+
+  &__note {
+    font-style: italic;
+    color: var(--pf-color-text-secondary);
+  }
+
+  &__align-panel {
+    align-items: flex-start;
+    padding: 12px 0 4px;
   }
 
   &__footer {
@@ -147,7 +199,9 @@
     margin-top: 16px;
   }
   padding: 16px;
-  overflow-y: hidden;
+  // Both axes: overflow-y:hidden alone computes overflow-x to auto, adding a
+  // spurious horizontal scrollbar when a dropdown mounts inside the modal.
+  overflow: hidden;
   max-width: none;
   max-height: none;
 }

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
@@ -14,20 +14,33 @@
 
 import {WasmEngineProxy} from '../../trace_processor/wasm_engine_proxy';
 import {uuidv4} from '../../base/uuid';
-import {TraceFileStream} from '../../core/trace_stream';
-import {STR} from '../../trace_processor/query_result';
+import {getErrorMessage} from '../../base/errors';
+import {TraceFileStream, TraceMultipleFilesStream} from '../../core/trace_stream';
+import {NUM, STR, STR_NULL} from '../../trace_processor/query_result';
+import type {TraceStream} from '../../public/stream';
+import {BUILTIN_CLOCKS, type FileAnalysis} from './multi_trace_types';
 
-// The result of analyzing a trace file.
-export interface TraceAnalysisResult {
-  format: string;
+export interface AlignmentVerdict {
+  // True if there are no dropped events and no manifest validation error.
+  readonly ok: boolean;
+  // Events that would be dropped because their clock domain can't be related
+  // to the shared timeline (clock_sync_unrelatable_clock_domains et al).
+  readonly droppedEvents: number;
+  // Set if the manifest itself is invalid (e.g. is.file names an unknown file).
+  readonly validationError?: string;
 }
 
-// Interface for analyzing trace files to extract metadata.
 export interface TraceAnalyzer {
+  // Per-file analysis: format + best-effort clock/machine shape.
   analyze(
     file: File,
     onProgress: (progress: number) => void,
-  ): Promise<TraceAnalysisResult>;
+  ): Promise<FileAnalysis>;
+
+  // Whole-set dry-run: build the manifest+files archive and report alignment.
+  analyzeMergedAlignment(
+    files: ReadonlyArray<File>,
+  ): Promise<AlignmentVerdict>;
 }
 
 // Maps internal trace type names to user-friendly format names.
@@ -40,31 +53,90 @@ function mapTraceType(rawType: string): string {
   }
 }
 
-// Implementation of TraceAnalyzer using the WASM trace processor.
+async function parseStream(
+  engine: WasmEngineProxy,
+  stream: TraceStream,
+  onProgress?: (bytesRead: number) => void,
+): Promise<void> {
+  for (;;) {
+    const res = await stream.readChunk();
+    onProgress?.(res.bytesRead);
+    await engine.parse(res.data);
+    if (res.eof) {
+      await engine.notifyEof();
+      return;
+    }
+  }
+}
+
+// Tokenization populates trace_type, machine and clock_snapshot and records the
+// clock-sync drop stats (conversion runs in the tokenizer), so it suffices here.
+function newTokenizeOnlyEngine(): WasmEngineProxy {
+  const engine = new WasmEngineProxy(uuidv4());
+  engine.resetTraceProcessor({
+    tokenizeOnly: true,
+    cropTrackEvents: false,
+    ingestFtraceInRawTable: false,
+    analyzeTraceProtoContent: false,
+    ftraceDropUntilAllCpusValid: false,
+    forceFullSort: false,
+  });
+  return engine;
+}
+
+// Best-effort clock signals; on query failure the fields stay undefined and the
+// UI degrades to showing all controls.
+async function queryFileSignals(
+  engine: WasmEngineProxy,
+): Promise<Partial<FileAnalysis>> {
+  const out: {
+    singleClock?: boolean;
+    privateClockOnly?: boolean;
+    builtinClockIds?: number[];
+  } = {};
+
+  try {
+    const builtinIds = BUILTIN_CLOCKS.map((c) => c.id).join(', ');
+    const res = await engine.query(`
+      SELECT
+        (SELECT COUNT(DISTINCT clock_id) FROM clock_snapshot) AS distinctClocks,
+        (SELECT GROUP_CONCAT(DISTINCT clock_id) FROM clock_snapshot
+           WHERE clock_id IN (${builtinIds})) AS builtinClockIds
+    `);
+    const it = res.iter({
+      distinctClocks: NUM,
+      builtinClockIds: STR_NULL,
+    });
+    if (it.valid()) {
+      // ClockSnapshots tie multiple domains; single-clock traces emit <= 1.
+      out.singleClock = it.distinctClocks <= 1;
+      // No snapshot at all => only the private trace-file clock (e.g. JSON).
+      out.privateClockOnly = it.distinctClocks === 0;
+      out.builtinClockIds = parseClockIds(it.builtinClockIds);
+    }
+  } catch {
+    // clock_snapshot unavailable in tokenize-only on this build.
+  }
+
+  return out;
+}
+
+function parseClockIds(s: string | null): number[] {
+  if (s === null || s.length === 0) {
+    return [];
+  }
+  return s.split(',').map(Number);
+}
+
 export class WasmTraceAnalyzer implements TraceAnalyzer {
   async analyze(
     file: File,
     onProgress: (progress: number) => void,
-  ): Promise<TraceAnalysisResult> {
-    using engine = new WasmEngineProxy(uuidv4());
-    engine.resetTraceProcessor({
-      tokenizeOnly: true,
-      cropTrackEvents: false,
-      ingestFtraceInRawTable: false,
-      analyzeTraceProtoContent: false,
-      ftraceDropUntilAllCpusValid: false,
-      forceFullSort: false,
-    });
-    const stream = new TraceFileStream(file);
-    for (;;) {
-      const res = await stream.readChunk();
-      onProgress(res.bytesRead / file.size);
-      await engine.parse(res.data);
-      if (res.eof) {
-        await engine.notifyEof();
-        break;
-      }
-    }
+  ): Promise<FileAnalysis> {
+    using engine = newTokenizeOnlyEngine();
+    await parseStream(engine, new TraceFileStream(file), (n) =>
+      onProgress(n / file.size),
+    );
     const result = await engine.query(`
         SELECT trace_type
         FROM __intrinsic_trace_file
@@ -86,8 +158,38 @@ export class WasmTraceAnalyzer implements TraceAnalyzer {
       throw new Error('Could not determine trace type');
     }
 
+    const signals = await queryFileSignals(engine);
     return {
       format: mapTraceType(leafNodes[0]),
+      ...signals,
     };
+  }
+
+  async analyzeMergedAlignment(
+    files: ReadonlyArray<File>,
+  ): Promise<AlignmentVerdict> {
+    using engine = newTokenizeOnlyEngine();
+    try {
+      await parseStream(engine, new TraceMultipleFilesStream(files));
+    } catch (e) {
+      // A manifest validation error (or unreadable input) surfaces here.
+      return {ok: false, droppedEvents: 0, validationError: getErrorMessage(e)};
+    }
+
+    try {
+      const res = await engine.query(`
+        SELECT COALESCE(SUM(value), 0) AS dropped
+        FROM stats
+        WHERE name IN (
+          'clock_sync_unrelatable_clock_domains',
+          'clock_sync_failure_no_path'
+        )
+      `);
+      const it = res.iter({dropped: NUM});
+      const dropped = it.valid() ? it.dropped : 0;
+      return {ok: dropped === 0, droppedEvents: dropped};
+    } catch (e) {
+      return {ok: false, droppedEvents: 0, validationError: getErrorMessage(e)};
+    }
   }
 }

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
@@ -15,7 +15,10 @@
 import {WasmEngineProxy} from '../../trace_processor/wasm_engine_proxy';
 import {uuidv4} from '../../base/uuid';
 import {getErrorMessage} from '../../base/errors';
-import {TraceFileStream, TraceMultipleFilesStream} from '../../core/trace_stream';
+import {
+  TraceFileStream,
+  TraceMultipleFilesStream,
+} from '../../core/trace_stream';
 import {NUM, STR, STR_NULL} from '../../trace_processor/query_result';
 import type {TraceStream} from '../../public/stream';
 import {BUILTIN_CLOCKS, type FileAnalysis} from './multi_trace_types';
@@ -38,9 +41,7 @@ export interface TraceAnalyzer {
   ): Promise<FileAnalysis>;
 
   // Whole-set dry-run: build the manifest+files archive and report alignment.
-  analyzeMergedAlignment(
-    files: ReadonlyArray<File>,
-  ): Promise<AlignmentVerdict>;
+  analyzeMergedAlignment(files: ReadonlyArray<File>): Promise<AlignmentVerdict>;
 }
 
 // Maps internal trace type names to user-friendly format names.

--- a/ui/src/frontend/trace_actions.ts
+++ b/ui/src/frontend/trace_actions.ts
@@ -45,7 +45,7 @@ export async function convertTraceToJson(trace: Trace): Promise<void> {
   await convertTraceToJsonAndDownload(file);
 }
 
-export function downloadTrace(trace: TraceImpl) {
+export async function downloadTrace(trace: TraceImpl) {
   if (!trace.traceInfo.downloadable) return;
   AppImpl.instance.analytics.logEvent('Trace Actions', 'Download trace');
 
@@ -56,7 +56,22 @@ export function downloadTrace(trace: TraceImpl) {
       accept: {'*/*': ['.pftrace', '.gz']},
     },
   ];
-  if (src.type === 'URL') {
+  if (src.type === 'MULTIPLE_FILES') {
+    // A merged set is downloaded as the same on-the-fly TAR (manifest + traces)
+    // that was opened; reopening it reproduces the merge.
+    download({
+      content: await trace.getTraceFile(),
+      fileName: 'merged-trace.tar',
+      filePicker: {
+        types: [
+          {
+            description: 'Merged Perfetto trace',
+            accept: {'application/x-tar': ['.tar']},
+          },
+        ],
+      },
+    });
+  } else if (src.type === 'URL') {
     const fileName = src.url.split('/').slice(-1)[0];
     downloadUrl({url: src.url, fileName});
   } else if (src.type === 'ARRAY_BUFFER') {

--- a/ui/src/frontend/views/sidebar.ts
+++ b/ui/src/frontend/views/sidebar.ts
@@ -213,7 +213,7 @@ function getCurrentTraceItems(trace: TraceImpl): SidebarMenuItemInternal[] {
     section: 'current_trace',
     sortOrder: 51,
     text: 'Download',
-    action: () => downloadTrace(trace),
+    action: async () => await downloadTrace(trace),
     icon: 'file_download',
     disabled: downloadDisabled,
   });


### PR DESCRIPTION
This CL introduces the first part of the final shape of the merge
trace configuration tool in the UI. Right now we're focusing on
exposing things who owns the global clock and alignment between
them. Followup CLs will deal with multi-machine clocks and all
the problems that come from that
