### PR TITLE
ui: Remove unused error bindings from catch clauses

### DIFF
--- a/ui/src/base/errors.ts
+++ b/ui/src/base/errors.ts
@@ -47,7 +47,7 @@ export function getErrorMessage(e: unknown | undefined | null) {
   if (asString === '[object Object]') {
     try {
       return JSON.stringify(e);
-    } catch (stringifyError) {
+    } catch {
       // ignore failures and just fall through
     }
   }

--- a/ui/src/base/json_utils.ts
+++ b/ui/src/base/json_utils.ts
@@ -46,7 +46,7 @@ export function parseJsonWithBigints(text: string): any {
       // so we try converting sources for all values to BigInt and fallback to the original value if it fails.
       try {
         return BigInt(context.source);
-      } catch (e) {
+      } catch {
         return value;
       }
     }

--- a/ui/src/core/analytics_impl.ts
+++ b/ui/src/core/analytics_impl.ts
@@ -24,7 +24,7 @@ function isValidUrl(s: string) {
   let url;
   try {
     url = new URL(s);
-  } catch (_) {
+  } catch {
     return false;
   }
   return url.protocol === 'http:' || url.protocol === 'https:';

--- a/ui/src/core/cache_manager.ts
+++ b/ui/src/core/cache_manager.ts
@@ -43,7 +43,7 @@ async function cacheDelete(key: Request): Promise<boolean> {
     const cache = await getCache();
     if (cache === undefined) return false; // Cache storage not supported.
     return await cache.delete(key);
-  } catch (_) {
+  } catch {
     // TODO(288483453): Reinstate:
     // return ignoreCacheUnactionableErrors(e, false);
     return false;
@@ -55,7 +55,7 @@ async function cachePut(key: string, value: Response): Promise<void> {
     const cache = await getCache();
     if (cache === undefined) return; // Cache storage not supported.
     await cache.put(key, value);
-  } catch (_) {
+  } catch {
     // TODO(288483453): Reinstate:
     // ignoreCacheUnactionableErrors(e, undefined);
   }
@@ -68,7 +68,7 @@ async function cacheMatch(
     const cache = await getCache();
     if (cache === undefined) return undefined; // Cache storage not supported.
     return await cache.match(key);
-  } catch (_) {
+  } catch {
     // TODO(288483453): Reinstate:
     // ignoreCacheUnactionableErrors(e, undefined);
     return undefined;
@@ -80,7 +80,7 @@ async function cacheKeys(): Promise<readonly Request[]> {
     const cache = await getCache();
     if (cache === undefined) return []; // Cache storage not supported.
     return await cache.keys();
-  } catch (e) {
+  } catch {
     // TODO(288483453): Reinstate:
     // return ignoreCacheUnactionableErrors(e, []);
     return [];

--- a/ui/src/core/local_storage.ts
+++ b/ui/src/core/local_storage.ts
@@ -22,7 +22,7 @@ export class LocalStorage implements Storage {
     let parsed: Record<string, unknown>;
     try {
       parsed = JSON.parse(s ?? '{}');
-    } catch (e) {
+    } catch {
       return {};
     }
     if (typeof parsed !== 'object' || parsed === null) {

--- a/ui/src/core/selection_manager.ts
+++ b/ui/src/core/selection_manager.ts
@@ -145,7 +145,7 @@ export class SelectionManagerImpl implements SelectionManager {
             trackUris: serialized.trackUris,
           });
       }
-    } catch (ex) {
+    } catch {
       showModal({
         title: 'Failed to restore the selected event',
         content: m(

--- a/ui/src/frontend/rpc_http_dialog.ts
+++ b/ui/src/frontend/rpc_http_dialog.ts
@@ -353,7 +353,7 @@ async function isVersionAvailable(
   let r;
   try {
     r = await fetch(url, {signal: controller.signal});
-  } catch (e) {
+  } catch {
     console.error(
       `No UI version for ${versionCode} at ${url}. ` +
         `This is an error if ${versionCode} is a released Perfetto version`,

--- a/ui/src/frontend/service_worker_controller.ts
+++ b/ui/src/frontend/service_worker_controller.ts
@@ -31,7 +31,7 @@ class BypassCache {
   static async isBypassed(): Promise<boolean> {
     try {
       return await caches.has(BYPASS_ID);
-    } catch (_) {
+    } catch {
       // TODO(288483453): Reinstate:
       // return ignoreCacheUnactionableErrors(e, false);
       return false;
@@ -45,7 +45,7 @@ class BypassCache {
       } else {
         await caches.delete(BYPASS_ID);
       }
-    } catch (_) {
+    } catch {
       // TODO(288483453): Reinstate:
       // ignoreCacheUnactionableErrors(e, undefined);
     }

--- a/ui/src/plugins/com.android.AndroidLongBatterySupport/index.ts
+++ b/ui/src/plugins/com.android.AndroidLongBatterySupport/index.ts
@@ -157,7 +157,7 @@ export default class implements PerfettoPlugin {
               google3.wireless.android.telemetry.trace_extractor.modules.atom_counters_slices`,
       );
       features.add('google3');
-    } catch (e) {}
+    } catch {}
 
     return features;
   }

--- a/ui/src/plugins/com.google.YouTubeTrace/index.ts
+++ b/ui/src/plugins/com.google.YouTubeTrace/index.ts
@@ -90,7 +90,7 @@ export default class implements PerfettoPlugin {
         `INCLUDE PERFETTO MODULE google3.video.youtube.analytics.client_apps.system_health.tools.trace.perfetto_module.local_director`,
       );
       return true;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/timerange_source.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/timerange_source.ts
@@ -312,7 +312,7 @@ export class TimeRangeSourceNode implements QueryNode {
               const parsed = BigInt(value.trim());
               this.start = Time.fromRaw(parsed);
               this.attrs.start = value.trim();
-            } catch (e) {
+            } catch {
               // Keep current value if invalid
             }
             this.context.onchange?.();
@@ -340,7 +340,7 @@ export class TimeRangeSourceNode implements QueryNode {
               const parsed = BigInt(value.trim());
               this.end = Time.fromRaw(parsed);
               this.attrs.end = value.trim();
-            } catch (e) {
+            } catch {
               // Keep current value if invalid
             }
             this.context.onchange?.();
@@ -371,7 +371,7 @@ export class TimeRangeSourceNode implements QueryNode {
                   this.end = Time.fromRaw(this.start + parsed);
                   this.attrs.end = this.end.toString();
                 }
-              } catch (e) {
+              } catch {
                 // Keep current value if invalid
               }
               this.context.onchange?.();

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_impl.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_impl.ts
@@ -47,7 +47,7 @@ async function runDataCheck(trace: Trace, sql: string): Promise<boolean> {
     return typeof hasDataValue === 'bigint'
       ? hasDataValue !== 0n
       : Number(hasDataValue) !== 0;
-  } catch (_e) {
+  } catch {
     // If query fails, assume no data
     return false;
   }


### PR DESCRIPTION
Eslint marks unused error bindings in catch clauses as an error now, even if they start with _.

Since ES2019 we can simply omit the error from the catch if unused.

E.g.

Instead of:
```ts
catch (_error) {}
```
Do this:
```ts
catch {}
```

This change is mechanical, and a functional no-op.