### PR TITLE
ui: Don't null-check WebGL object creation

### DIFF
--- a/ui/src/base/gl/chevrons.ts
+++ b/ui/src/base/gl/chevrons.ts
@@ -15,12 +15,7 @@
 import {createSDFTexture, generatePolygonSDF} from './sdf';
 import type {Point2D, Transform1D, Transform2D} from '../geom';
 import type {MarkerBuffers, RowLayout} from '../renderer';
-import {
-  createBuffer,
-  createProgram,
-  getAttribLocation,
-  getUniformLocation,
-} from './gl';
+import {createProgram, getAttribLocation, getUniformLocation} from './gl';
 
 // Static quad geometry shared by all sprite batches
 const QUAD_CORNERS = new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]);
@@ -215,18 +210,18 @@ export class ChevronBatch {
     this.chevronTexture = createChevronTexture(gl);
 
     // Create static quad buffers
-    this.quadCornerBuffer = createBuffer(gl);
+    this.quadCornerBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, this.quadCornerBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, QUAD_CORNERS, gl.STATIC_DRAW);
 
-    this.quadIndexBuffer = createBuffer(gl);
+    this.quadIndexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.quadIndexBuffer);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, QUAD_INDICES, gl.STATIC_DRAW);
 
     // Create dynamic instance buffers
-    this.xBuffer = createBuffer(gl);
-    this.depthBuffer = createBuffer(gl);
-    this.colorBuffer = createBuffer(gl);
+    this.xBuffer = gl.createBuffer();
+    this.depthBuffer = gl.createBuffer();
+    this.colorBuffer = gl.createBuffer();
   }
 
   /**

--- a/ui/src/base/gl/gl.ts
+++ b/ui/src/base/gl/gl.ts
@@ -12,30 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Various WebGL helper functions that throw on error instead of returning null
-// or -1.
-
-export function createShader(
-  gl: WebGL2RenderingContext,
-  type: number,
-): WebGLShader {
-  const shader = gl.createShader(type);
-  if (!shader) throw new Error(`Failed to create shader`);
-  return shader;
-}
-
-export function createBuffer(gl: WebGL2RenderingContext): WebGLBuffer {
-  const buffer = gl.createBuffer();
-  if (!buffer) throw new Error(`Failed to create buffer`);
-  return buffer;
-}
-
-export function createTexture(gl: WebGL2RenderingContext): WebGLTexture {
-  const texture = gl.createTexture();
-  if (!texture) throw new Error(`Failed to create texture`);
-  return texture;
-}
-
 export function getUniformLocation(
   gl: WebGL2RenderingContext,
   program: WebGLProgram,
@@ -88,7 +64,6 @@ export function linkProgram(
   fragmentShader: WebGLShader,
 ): WebGLProgram {
   const program = gl.createProgram();
-  if (!program) throw new Error('Failed to create program');
 
   gl.attachShader(program, vertexShader);
   gl.attachShader(program, fragmentShader);

--- a/ui/src/base/gl/slices.ts
+++ b/ui/src/base/gl/slices.ts
@@ -20,7 +20,7 @@ import {
   type SliceBuffers,
   SLICE_GAP_PX,
 } from '../renderer';
-import {createBuffer, createProgram, getUniformLocation} from './gl';
+import {createProgram, getUniformLocation} from './gl';
 
 // Static quad geometry shared by all slice batches
 const QUAD_CORNERS = new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]);
@@ -215,20 +215,20 @@ export class SliceBatch {
     this.prog = createSliceProgram(gl);
 
     // Create static quad buffers
-    this.quadCornerBuffer = createBuffer(gl);
+    this.quadCornerBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, this.quadCornerBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, QUAD_CORNERS, gl.STATIC_DRAW);
 
-    this.quadIndexBuffer = createBuffer(gl);
+    this.quadIndexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.quadIndexBuffer);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, QUAD_INDICES, gl.STATIC_DRAW);
 
     // Create dynamic instance buffers
-    this.leftBuffer = createBuffer(gl);
-    this.rightBuffer = createBuffer(gl);
-    this.depthBuffer = createBuffer(gl);
-    this.colorBuffer = createBuffer(gl);
-    this.flagsBuffer = createBuffer(gl);
+    this.leftBuffer = gl.createBuffer();
+    this.rightBuffer = gl.createBuffer();
+    this.depthBuffer = gl.createBuffer();
+    this.colorBuffer = gl.createBuffer();
+    this.flagsBuffer = gl.createBuffer();
   }
 
   /**

--- a/ui/src/base/gl/step_area.ts
+++ b/ui/src/base/gl/step_area.ts
@@ -14,7 +14,7 @@
 
 import type {Transform2D} from '../geom';
 import type {StepAreaBuffers} from '../renderer';
-import {createBuffer, createProgram, getUniformLocation} from './gl';
+import {createProgram, getUniformLocation} from './gl';
 
 // Static quad geometry shared by all step area batches
 const QUAD_CORNERS = new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]);
@@ -230,21 +230,21 @@ export class StepAreaBatch {
     this.program = createStepAreaProgram(gl);
 
     // Create static quad buffers
-    this.quadCornerBuffer = createBuffer(gl);
+    this.quadCornerBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, this.quadCornerBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, QUAD_CORNERS, gl.STATIC_DRAW);
 
-    this.quadIndexBuffer = createBuffer(gl);
+    this.quadIndexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.quadIndexBuffer);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, QUAD_INDICES, gl.STATIC_DRAW);
 
     // Create dynamic instance buffers
-    this.xBuffer = createBuffer(gl);
-    this.nextXBuffer = createBuffer(gl);
-    this.yBuffer = createBuffer(gl);
-    this.minYBuffer = createBuffer(gl);
-    this.maxYBuffer = createBuffer(gl);
-    this.fillBuffer = createBuffer(gl);
+    this.xBuffer = gl.createBuffer();
+    this.nextXBuffer = gl.createBuffer();
+    this.yBuffer = gl.createBuffer();
+    this.minYBuffer = gl.createBuffer();
+    this.maxYBuffer = gl.createBuffer();
+    this.fillBuffer = gl.createBuffer();
   }
 
   /**


### PR DESCRIPTION
The create* functions (createBuffer, createTexture, createProgram, etc.) only return null when the GL context is lost. Per the WebGL spec (1.0 section 5.14), once the context-lost flag is set every subsequent call becomes a no-op that returns null for nullable types, so a null handle fed to the next call is silently ignored rather than blowing up. Guarding each creation site therefore buys nothing: the failure can't be recovered there, and real context-loss handling would be much better served by handling webglcontextlost / webglcontextrestored events instead.

This is also why the DOM typings declare these as non-nullable - the only null case is context loss, which the platform is designed to absorb. createShader stays nullable because it can also fail on a bad shader type enum, which is a genuine programmer error worth surfacing.

Drop the throwing createShader/createBuffer/createTexture wrappers and the createProgram null check, and call gl.create*() directly throughout.

Patching this also fixes some eslint errors that were in the removed code.