### PR TITLE
ui: Fix eslint errors

### DIFF
--- a/ui/src/core/event_set.ts
+++ b/ui/src/core/event_set.ts
@@ -293,7 +293,7 @@ class NaiveFilterEventSet<P extends KeySet>
     const events = concreteParent.events;
     let total = 0;
     for (const e of events) {
-      if (this.filters.every((f) => f.execute(e))) {
+      if (this.filters.every((f) => Boolean(f.execute(e)))) {
         total += 1;
       }
     }
@@ -305,7 +305,7 @@ class NaiveFilterEventSet<P extends KeySet>
     const concreateParent = await this.parent.materialise(keys);
     const events = concreateParent.events;
     for (const e of events) {
-      if (this.filters.every((f) => f.execute(e))) {
+      if (this.filters.every((f) => Boolean(f.execute(e)))) {
         return false;
       }
     }
@@ -321,7 +321,7 @@ class NaiveFilterEventSet<P extends KeySet>
     const concreateParent = await this.parent.materialise(combined);
     let events = concreateParent.events;
     for (const filter of this.filters) {
-      events = events.filter((e) => filter.execute(e));
+      events = events.filter((e) => Boolean(filter.execute(e)));
     }
     return new ConcreteEventSet(combined, events).materialise(
       keys,

--- a/ui/src/core/event_set_nocompile_test.ts
+++ b/ui/src/core/event_set_nocompile_test.ts
@@ -25,13 +25,13 @@ import {
 } from './event_set';
 
 export function eventMustHaveAllKeys(): Event<KeySet> {
-  const ks = {
+  const _ks = {
     id: Id,
     foo: Str,
   };
 
   // @ts-expect-error
-  const event: Event<typeof ks> = {
+  const event: Event<typeof _ks> = {
     id: 'myid',
   };
 
@@ -39,7 +39,7 @@ export function eventMustHaveAllKeys(): Event<KeySet> {
 }
 
 export function eventMustNotHaveExtraKeys(): Event<KeySet> {
-  const ks = {
+  const _ks = {
     id: Id,
     foo: Str,
     bar: Num,
@@ -47,7 +47,7 @@ export function eventMustNotHaveExtraKeys(): Event<KeySet> {
     xyzzy: Null,
   };
 
-  const event: Event<typeof ks> = {
+  const event: Event<typeof _ks> = {
     id: 'myid',
     foo: 'foo',
     bar: 32,
@@ -61,7 +61,7 @@ export function eventMustNotHaveExtraKeys(): Event<KeySet> {
 }
 
 export function eventsCanBeWellFormed(): Event<KeySet> {
-  const ks = {
+  const _ks = {
     id: Id,
     foo: Str,
     bar: Num,
@@ -69,7 +69,7 @@ export function eventsCanBeWellFormed(): Event<KeySet> {
     xyzzy: Null,
   };
 
-  const event: Event<typeof ks> = {
+  const event: Event<typeof _ks> = {
     id: 'myid',
     foo: 'foo',
     bar: 32,

--- a/ui/src/core/event_set_unittest.ts
+++ b/ui/src/core/event_set_unittest.ts
@@ -35,17 +35,17 @@ import {
 describe('EventSet', () => {
   test('Event', () => {
     {
-      const keyset: EmptyKeySet = {};
-      const event: Event<typeof keyset> = {
+      const _keyset: EmptyKeySet = {};
+      const event: Event<typeof _keyset> = {
         id: 'foo',
       };
       void event;
     }
     {
-      const keyset = {
+      const _keyset = {
         bar: Num,
       };
-      const event: Event<typeof keyset> = {
+      const event: Event<typeof _keyset> = {
         id: 'foo',
         bar: 42,
       };

--- a/ui/src/plugins/dev.perfetto.DataExplorer/help_modal.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/help_modal.ts
@@ -47,7 +47,7 @@ function hotkey(combo: Hotkey): m.Children {
 function getNodeCreationEntries(): HelpEntry[] {
   return nodeRegistry
     .list()
-    .filter(([_, desc]) => desc.type === 'source' && desc.hotkey)
+    .filter(([_, desc]) => desc.type === 'source' && desc.hotkey !== undefined)
     .sort((a, b) => a[1].name.localeCompare(b[1].name))
     .flatMap(([_, desc]) => {
       const hk = desc.hotkey;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/function_list_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/function_list_unittest.ts
@@ -179,7 +179,7 @@ describe('FunctionList search logic', () => {
       const query = 'nanoseconds';
       const results = allFunctions.filter(
         (f) =>
-          f.fn.description &&
+          f.fn.description !== undefined &&
           f.fn.description.toLowerCase().includes(query.toLowerCase()),
       );
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
@@ -311,7 +311,8 @@ export class ModifyColumnsNode implements QueryNode {
     if (this.primaryInput === undefined) return undefined;
 
     const hasModification = this.attrs.selectedColumns.some(
-      (col) => !col.checked || (col.alias && col.alias.trim() !== ''),
+      (col) =>
+        !col.checked || (col.alias !== undefined && col.alias.trim() !== ''),
     );
 
     if (!hasModification) {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
@@ -386,7 +386,7 @@ export class TableList implements m.ClassComponent<TableListAttrs> {
 
         const hasMatch = tableWithModule.table.columns.some(
           (col) =>
-            col.description &&
+            col.description !== undefined &&
             col.description.toLowerCase().includes(lowerQuery),
         );
 

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_by_cpu_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_by_cpu_aggregator.ts
@@ -97,7 +97,7 @@ export class ThreadStateByCpuAggregator implements Aggregator {
         });
 
         const states: BarChartData[] = [];
-        for (let i = 0; it.valid(); ++i, it.next()) {
+        for (; it.valid(); it.next()) {
           const name = it.state ?? 'Unknown';
           states.push({
             title: `${name}: ${Duration.humanise(it.totalDur)}`,

--- a/ui/src/types/vitest.d.ts
+++ b/ui/src/types/vitest.d.ts
@@ -17,4 +17,5 @@
 // importing from 'vitest' in every *_unittest.ts file. Note: type aliases
 // like `Mock` and `Mocked` are NOT injected as globals — those must be
 // imported explicitly: `import type {Mock, Mocked} from 'vitest';`
+// eslint-disable-next-line spaced-comment
 /// <reference types="vitest/globals" />


### PR DESCRIPTION
Fix remaining eslint errors.

Typical offenders:
- Checking a non nullable type for truthiness.
- Unused variables not starting with an underscore.