### PR TITLE
tp: handle being invoked as traceconv

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20043,6 +20043,7 @@ filegroup {
     name: "perfetto_src_trace_processor_shell_subcommands",
     srcs: [
         "src/trace_processor/shell/subcommand.cc",
+        "src/trace_processor/shell/traceconv_compat.cc",
     ],
 }
 

--- a/BUILD
+++ b/BUILD
@@ -5384,6 +5384,8 @@ perfetto_filegroup(
     srcs = [
         "src/trace_processor/shell/subcommand.cc",
         "src/trace_processor/shell/subcommand.h",
+        "src/trace_processor/shell/traceconv_compat.cc",
+        "src/trace_processor/shell/traceconv_compat.h",
     ],
 )
 

--- a/src/trace_processor/shell/BUILD.gn
+++ b/src/trace_processor/shell/BUILD.gn
@@ -94,6 +94,8 @@ source_set("subcommands") {
   sources = [
     "subcommand.cc",
     "subcommand.h",
+    "traceconv_compat.cc",
+    "traceconv_compat.h",
   ]
   deps = [
     "../../../gn:default_deps",

--- a/src/trace_processor/shell/find_subcommand_unittest.cc
+++ b/src/trace_processor/shell/find_subcommand_unittest.cc
@@ -16,10 +16,12 @@
 
 #include "src/trace_processor/shell/subcommand.h"
 
+#include <string>
 #include <unordered_set>
 #include <vector>
 
 #include "perfetto/base/status.h"
+#include "src/trace_processor/shell/traceconv_compat.h"
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto::trace_processor::shell {
@@ -122,6 +124,149 @@ TEST(FindSubcommandTest, SubcommandAfterFlags) {
   auto result = FindSubcommandInArgs(args.argc(), args.argv(), subs, {});
   EXPECT_EQ(result.subcommand, &query);
   EXPECT_EQ(result.argv_index, 2);
+}
+
+// ---------------------------------------------------------------------------
+// traceconv compatibility shim.
+// ---------------------------------------------------------------------------
+
+TEST(InvokedAsTraceconvTest, BareNameMatches) {
+  EXPECT_TRUE(InvokedAsTraceconv("traceconv"));
+}
+
+TEST(InvokedAsTraceconvTest, WithDirectoryMatches) {
+  EXPECT_TRUE(InvokedAsTraceconv("/usr/local/bin/traceconv"));
+  EXPECT_TRUE(InvokedAsTraceconv("./traceconv"));
+}
+
+TEST(InvokedAsTraceconvTest, WindowsExeMatches) {
+  EXPECT_TRUE(InvokedAsTraceconv("traceconv.exe"));
+  EXPECT_TRUE(InvokedAsTraceconv("C:\\tools\\traceconv.exe"));
+}
+
+TEST(InvokedAsTraceconvTest, PrebuiltCacheNameMatches) {
+  // The prebuilt wrapper caches the binary as "traceconv-<sha16>".
+  EXPECT_TRUE(InvokedAsTraceconv(
+      "/home/u/.local/share/perfetto/prebuilts/traceconv-0123456789abcdef"));
+  EXPECT_TRUE(InvokedAsTraceconv("traceconv-0123456789abcdef.exe"));
+}
+
+TEST(InvokedAsTraceconvTest, TraceProcessorDoesNotMatch) {
+  EXPECT_FALSE(InvokedAsTraceconv("trace_processor_shell"));
+  EXPECT_FALSE(InvokedAsTraceconv("/opt/perfetto/trace_processor_shell"));
+  EXPECT_FALSE(InvokedAsTraceconv("tp"));
+}
+
+TEST(InvokedAsTraceconvTest, SimilarNamesDoNotMatch) {
+  // A binary whose name merely starts with the letters "traceconv" but is a
+  // different tool must not be hijacked into traceconv-compatible mode.
+  EXPECT_FALSE(InvokedAsTraceconv("traceconverter"));
+  EXPECT_FALSE(InvokedAsTraceconv("my_traceconv"));
+}
+
+// Helper: turns the rewritten arg vector into a single space-joined string for
+// concise assertions.
+std::string Join(const std::vector<std::string>& v) {
+  std::string out;
+  for (const auto& s : v) {
+    if (!out.empty())
+      out += ' ';
+    out += s;
+  }
+  return out;
+}
+
+TEST(RewriteTraceconvArgsTest, ConvertFormatGetsConvertInserted) {
+  auto args = ArgvHolder::Make({"traceconv", "json", "in.pb", "out.json"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv convert json in.pb out.json");
+}
+
+TEST(RewriteTraceconvArgsTest, ProfileFormatGetsConvertInserted) {
+  auto args = ArgvHolder::Make({"traceconv", "profile", "in.pb"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv convert profile in.pb");
+}
+
+TEST(RewriteTraceconvArgsTest, SymbolizeGetsUtilInserted) {
+  auto args = ArgvHolder::Make({"traceconv", "symbolize", "in.pb", "out"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv util symbolize in.pb out");
+}
+
+TEST(RewriteTraceconvArgsTest, DeobfuscateGetsUtilInserted) {
+  auto args = ArgvHolder::Make({"traceconv", "deobfuscate", "in.pb"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv util deobfuscate in.pb");
+}
+
+TEST(RewriteTraceconvArgsTest, BundleIsLeftUnchanged) {
+  // "bundle" is itself a subcommand name; no word is inserted.
+  auto args = ArgvHolder::Make({"traceconv", "bundle", "in.pb", "out.tar"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_TRUE(out.empty());
+}
+
+TEST(RewriteTraceconvArgsTest, DecompressPacketsGetsUtilInserted) {
+  auto args =
+      ArgvHolder::Make({"traceconv", "decompress_packets", "in.pb", "out.pb"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv util decompress_packets in.pb out.pb");
+}
+
+TEST(RewriteTraceconvArgsTest, BinaryIsRenamedToUtilTextToBinary) {
+  // The legacy "binary" mode moved to "util text_to_binary".
+  auto args = ArgvHolder::Make({"traceconv", "binary", "in.txt", "out.pb"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv util text_to_binary in.txt out.pb");
+}
+
+TEST(RewriteTraceconvArgsTest, JavaHeapProfileBecomesConvertProfileJavaHeap) {
+  // The legacy "java_heap_profile" alias became "convert profile --java-heap".
+  auto args = ArgvHolder::Make(
+      {"traceconv", "java_heap_profile", "in.pb", "--output-dir", "/tmp/x"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out),
+            "traceconv convert profile --java-heap in.pb --output-dir /tmp/x");
+}
+
+TEST(RewriteTraceconvArgsTest, UnknownModeRoutesToConvert) {
+  // An unrecognised MODE is routed to convert, which emits a clear error.
+  auto args = ArgvHolder::Make({"traceconv", "wibble", "in.pb"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv convert wibble in.pb");
+}
+
+TEST(RewriteTraceconvArgsTest, NoPositionalLeavesArgsUnchanged) {
+  // Bare invocation and version/help flags have no MODE positional.
+  auto bare = ArgvHolder::Make({"traceconv"});
+  EXPECT_TRUE(RewriteTraceconvArgs(bare.argc(), bare.argv()).empty());
+
+  auto version = ArgvHolder::Make({"traceconv", "--version"});
+  EXPECT_TRUE(RewriteTraceconvArgs(version.argc(), version.argv()).empty());
+}
+
+TEST(RewriteTraceconvArgsTest, ValuedFlagBeforeModeSkipsItsArgument) {
+  // -t consumes "end"; the MODE is "json", which must still be found and the
+  // leading flags preserved ahead of the inserted subcommand word.
+  auto args =
+      ArgvHolder::Make({"traceconv", "-t", "end", "json", "in.pb", "out.json"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv -t end convert json in.pb out.json");
+}
+
+TEST(RewriteTraceconvArgsTest, LongValuedFlagBeforeModeSkipsItsArgument) {
+  auto args =
+      ArgvHolder::Make({"traceconv", "--pid", "1234", "profile", "in.pb"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv --pid 1234 convert profile in.pb");
+}
+
+TEST(RewriteTraceconvArgsTest, BooleanFlagBeforeModeIsNotTreatedAsValued) {
+  // --full-sort takes no argument, so the very next token ("json") is the MODE.
+  auto args = ArgvHolder::Make({"traceconv", "--full-sort", "json", "in.pb"});
+  auto out = RewriteTraceconvArgs(args.argc(), args.argv());
+  EXPECT_EQ(Join(out), "traceconv --full-sort convert json in.pb");
 }
 
 }  // namespace

--- a/src/trace_processor/shell/traceconv_compat.cc
+++ b/src/trace_processor/shell/traceconv_compat.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/traceconv_compat.h"
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace perfetto::trace_processor::shell {
+
+bool InvokedAsTraceconv(const char* argv0) {
+  std::string_view name(argv0);
+  size_t slash = name.find_last_of("/\\");
+  if (slash != std::string_view::npos)
+    name = name.substr(slash + 1);
+  constexpr std::string_view kExe = ".exe";
+  if (name.size() >= kExe.size() &&
+      name.substr(name.size() - kExe.size()) == kExe) {
+    name = name.substr(0, name.size() - kExe.size());
+  }
+  // Match the bare tool name or the prebuilt cache form "traceconv-<sha>", but
+  // not unrelated tools that merely share the prefix (e.g. "traceconverter").
+  return name == "traceconv" || name.rfind("traceconv-", 0) == 0;
+}
+
+std::vector<std::string> RewriteTraceconvArgs(int argc, char** argv) {
+  // traceconv options that consume a following argument; used to find the MODE
+  // positional regardless of where options appear on the command line.
+  static constexpr const char* kFlagsWithArg[] = {
+      "-t",           "--truncate",     "--pid",
+      "--timestamps", "--symbol-paths", "--proguard-map",
+      "--output-dir"};
+
+  int mode_idx = -1;
+  for (int i = 1; i < argc; ++i) {
+    std::string_view arg(argv[i]);
+    if (!arg.empty() && arg[0] == '-') {
+      for (const char* f : kFlagsWithArg) {
+        if (arg == f) {
+          ++i;  // Skip the flag's argument.
+          break;
+        }
+      }
+      continue;
+    }
+    mode_idx = i;
+    break;
+  }
+  if (mode_idx == -1)
+    return {};
+
+  std::string_view mode(argv[mode_idx]);
+
+  // Map the traceconv MODE onto the new subcommand structure. Most modes just
+  // get a subcommand word inserted before them, but a few are renamed (and one
+  // gains a flag) because the underlying CLI moved:
+  //   - util utilities: symbolize, deobfuscate, decompress_packets
+  //   - "binary" was renamed to "util text_to_binary"
+  //   - "java_heap_profile" became "convert profile --java-heap"
+  //   - "bundle" is already a subcommand name, so it is left untouched
+  //   - anything else is a convert format ('convert' validates it)
+  const char* subcommand = nullptr;
+  const char* replacement_mode = nullptr;  // null => keep the original token
+  const char* extra_arg = nullptr;         // inserted after the mode, if set
+  if (mode == "symbolize" || mode == "deobfuscate" ||
+      mode == "decompress_packets") {
+    subcommand = "util";
+  } else if (mode == "binary") {
+    subcommand = "util";
+    replacement_mode = "text_to_binary";
+  } else if (mode == "java_heap_profile") {
+    subcommand = "convert";
+    replacement_mode = "profile";
+    extra_arg = "--java-heap";
+  } else if (mode != "bundle") {
+    subcommand = "convert";
+  }
+  if (!subcommand)
+    return {};
+
+  std::vector<std::string> out;
+  out.reserve(static_cast<size_t>(argc) + 2);
+  for (int i = 0; i < mode_idx; ++i)
+    out.emplace_back(argv[i]);
+  out.emplace_back(subcommand);
+  out.emplace_back(replacement_mode ? replacement_mode : argv[mode_idx]);
+  if (extra_arg)
+    out.emplace_back(extra_arg);
+  for (int i = mode_idx + 1; i < argc; ++i)
+    out.emplace_back(argv[i]);
+  return out;
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/traceconv_compat.h
+++ b/src/trace_processor/shell/traceconv_compat.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_TRACECONV_COMPAT_H_
+#define SRC_TRACE_PROCESSOR_SHELL_TRACECONV_COMPAT_H_
+
+#include <string>
+#include <vector>
+
+namespace perfetto::trace_processor::shell {
+
+// Returns true if the binary was invoked under the legacy "traceconv" name.
+// The traceconv prebuilt wrapper downloads trace_processor_shell but caches and
+// execs it as "traceconv-<sha>" (or "traceconv.exe" on Windows), so a basename
+// starting with "traceconv" means we should present the traceconv-compatible
+// CLI.
+bool InvokedAsTraceconv(const char* argv0);
+
+// Maps a traceconv-style command line onto the new subcommand structure,
+// inserting the matching subcommand word before the traceconv MODE positional
+// and, for a few modes, rewriting the MODE token itself:
+//   - "symbolize"/"deobfuscate"/"decompress_packets" -> insert "util"
+//   - "binary"                  -> "util text_to_binary" (renamed)
+//   - "java_heap_profile"       -> "convert profile --java-heap"
+//   - "bundle" (already a subcommand name) -> no change
+//   - any other MODE            -> insert "convert" (which validates it)
+// Returns the rewritten argv as a vector of strings, or an empty vector if no
+// rewrite is needed (no positional MODE found, or MODE is "bundle"). Callers
+// should only invoke this when InvokedAsTraceconv() is true.
+std::vector<std::string> RewriteTraceconvArgs(int argc, char** argv);
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_TRACECONV_COMPAT_H_

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -63,6 +63,7 @@
 #include "src/trace_processor/shell/server_subcommand.h"
 #include "src/trace_processor/shell/subcommand.h"
 #include "src/trace_processor/shell/summarize_subcommand.h"
+#include "src/trace_processor/shell/traceconv_compat.h"
 #include "src/trace_processor/shell/util_subcommand.h"
 #include "src/trace_processor/util/symbolizer/symbolize_database.h"
 
@@ -783,6 +784,25 @@ TraceProcessorShell::CreateWithDefaultPlatform() {
 }
 
 base::Status TraceProcessorShell::Run(int argc, char** argv) {
+  // traceconv compatibility shim: when invoked under the legacy "traceconv"
+  // name, the first positional is a traceconv MODE. Map it onto the new
+  // subcommands (e.g. `traceconv json a b` -> `convert json a b`,
+  // `traceconv symbolize ...` -> `util symbolize ...`, `traceconv bundle ...`
+  // stays `bundle ...`). The rewritten argv is owned by these vectors for the
+  // rest of Run and flows through the normal dispatch below.
+  std::vector<std::string> traceconv_storage;
+  std::vector<char*> traceconv_ptrs;
+  if (shell::InvokedAsTraceconv(argv[0])) {
+    traceconv_storage = shell::RewriteTraceconvArgs(argc, argv);
+    if (!traceconv_storage.empty()) {
+      for (auto& s : traceconv_storage)
+        traceconv_ptrs.push_back(s.data());
+      traceconv_ptrs.push_back(nullptr);
+      argc = static_cast<int>(traceconv_storage.size());
+      argv = traceconv_ptrs.data();
+    }
+  }
+
   // Subcommand dispatch: if a positional argument matches a known subcommand
   // name, route to it. Otherwise fall through to classic path.
   {


### PR DESCRIPTION
When argv[0] looks like traceconv (the bare name, or the traceconv-<sha>
the prebuilt wrapper caches it under, with an optional .exe), treat the
first positional as a traceconv mode and rewrite it onto the new
subcommands:

  traceconv json a b       ->  convert json a b
  traceconv symbolize a b  ->  util symbolize a b
  traceconv bundle a b     ->  bundle a b
  traceconv <other>        ->  convert <other>

This is what lets the repointed download wrapper, later in the stack, keep
working without changes. The name check and the rewrite live in
traceconv_compat so they can be unit tested.
