### PR TITLE
[state] Fix overly strict state track tokenization

### DIFF
--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -32,6 +32,7 @@
 #include "perfetto/trace_processor/basic_types.h"
 #include "perfetto/trace_processor/trace_blob.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
+#include "protos/perfetto/trace/track_event/state_descriptor.pbzero.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
 #include "src/trace_processor/importers/common/args_translation_table.h"
@@ -52,6 +53,7 @@
 #include "src/trace_processor/importers/common/slice_tracker.h"
 #include "src/trace_processor/importers/common/slice_translation_table.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
+#include "src/trace_processor/importers/common/state_tracker.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 #include "src/trace_processor/importers/common/track_compressor.h"
 #include "src/trace_processor/importers/common/track_tracker.h"
@@ -291,6 +293,8 @@ class ProtoTraceParserTest : public ::testing::Test {
     context_.clock_tracker = std::make_unique<ClockTracker>(
         &context_, primary_sync_.get(), /*is_primary=*/true);
     context_.stats_tracker = std::make_unique<StatsTracker>(&context_);
+    context_.state_tracker =
+        TraceProcessorContextPtr<StateTracker>::MakeRoot(&context_);
     context_.flow_tracker = std::make_unique<FlowTracker>(&context_);
     context_.sorter = std::make_unique<TraceSorter>(
         &context_, TraceSorter::SortingMode::kFullSort);
@@ -1716,6 +1720,99 @@ TEST_F(ProtoTraceParserTest, TrackEventWithResortedCounterDescriptor) {
   auto rr_0 = storage_->slice_table()[SliceId(0u)];
   EXPECT_EQ(rr_0.thread_ts(), 1000000);
   EXPECT_EQ(rr_0.thread_dur(), 10000);
+}
+
+TEST_F(ProtoTraceParserTest, TrackEventStateOnNonStateTrack) {
+  {
+    auto* packet = trace_->add_packet();
+    packet->set_trusted_packet_sequence_id(1);
+    packet->set_incremental_state_cleared(true);
+    packet->set_timestamp(1000);
+    auto* track_desc = packet->set_track_descriptor();
+    track_desc->set_uuid(100);
+    track_desc->set_name("Process track");
+    auto* process_desc = track_desc->set_process();
+    process_desc->set_pid(10);
+  }
+  {
+    // Non-state track (regular track descriptor without set_state()).
+    auto* packet = trace_->add_packet();
+    packet->set_trusted_packet_sequence_id(1);
+    packet->set_timestamp(1000);
+    auto* track_desc = packet->set_track_descriptor();
+    track_desc->set_uuid(101);
+    track_desc->set_parent_uuid(100);
+    track_desc->set_name("Regular Track");
+  }
+  {
+    // State event targeting a non-state track.
+    auto* packet = trace_->add_packet();
+    packet->set_trusted_packet_sequence_id(1);
+    packet->set_timestamp(2000);
+    auto* event = packet->set_track_event();
+    event->set_track_uuid(101);
+    event->set_name("High");
+    event->set_type(protos::pbzero::TrackEvent::TYPE_STATE);
+  }
+
+  EXPECT_CALL(*process_, GetOrCreateProcess(10)).WillRepeatedly(Return(1u));
+
+  Tokenize();
+  context_.sorter->ExtractEventsForced();
+
+  // Parsing error stat should be incremented.
+  EXPECT_GT(context_.stats_tracker->GetStats(stats::track_event_parser_errors),
+            0u);
+}
+
+TEST_F(ProtoTraceParserTest, TrackEventWithResortedStateDescriptor) {
+  {
+    // Child state track descriptor emitted before parent descriptor.
+    auto* packet = trace_->add_packet();
+    packet->set_trusted_packet_sequence_id(1);
+    packet->set_incremental_state_cleared(true);
+    packet->set_timestamp(1000);
+    auto* track_desc = packet->set_track_descriptor();
+    track_desc->set_uuid(101);
+    track_desc->set_parent_uuid(100);
+    track_desc->set_name("Priority");
+    track_desc->set_state();
+  }
+  {
+    // Parent process track descriptor emitted after child.
+    auto* packet = trace_->add_packet();
+    packet->set_trusted_packet_sequence_id(1);
+    packet->set_timestamp(1000);
+    auto* track_desc = packet->set_track_descriptor();
+    track_desc->set_uuid(100);
+    track_desc->set_name("Process track");
+    auto* process_desc = track_desc->set_process();
+    process_desc->set_pid(10);
+  }
+  {
+    auto* packet = trace_->add_packet();
+    packet->set_trusted_packet_sequence_id(1);
+    packet->set_timestamp(2000);
+    auto* event = packet->set_track_event();
+    event->set_track_uuid(101);
+    event->set_name("High");
+    event->set_type(protos::pbzero::TrackEvent::TYPE_STATE);
+  }
+
+  EXPECT_CALL(*process_, GetOrCreateProcess(10)).WillRepeatedly(Return(1u));
+
+  Tokenize();
+  context_.sorter->ExtractEventsForced();
+
+  bool found_state_track = false;
+  for (uint32_t i = 0; i < storage_->track_table().row_count(); ++i) {
+    if (storage_->track_table()[i].name() ==
+        storage_->InternString("Priority")) {
+      found_state_track = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_state_track);
 }
 
 TEST_F(ProtoTraceParserTest, TrackEventWithoutIncrementalStateReset) {

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -32,7 +32,6 @@
 #include "perfetto/trace_processor/basic_types.h"
 #include "perfetto/trace_processor/trace_blob.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
-#include "protos/perfetto/trace/track_event/state_descriptor.pbzero.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
 #include "src/trace_processor/importers/common/args_translation_table.h"
@@ -53,7 +52,6 @@
 #include "src/trace_processor/importers/common/slice_tracker.h"
 #include "src/trace_processor/importers/common/slice_translation_table.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
-#include "src/trace_processor/importers/common/state_tracker.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 #include "src/trace_processor/importers/common/track_compressor.h"
 #include "src/trace_processor/importers/common/track_tracker.h"
@@ -293,8 +291,6 @@ class ProtoTraceParserTest : public ::testing::Test {
     context_.clock_tracker = std::make_unique<ClockTracker>(
         &context_, primary_sync_.get(), /*is_primary=*/true);
     context_.stats_tracker = std::make_unique<StatsTracker>(&context_);
-    context_.state_tracker =
-        TraceProcessorContextPtr<StateTracker>::MakeRoot(&context_);
     context_.flow_tracker = std::make_unique<FlowTracker>(&context_);
     context_.sorter = std::make_unique<TraceSorter>(
         &context_, TraceSorter::SortingMode::kFullSort);
@@ -1720,99 +1716,6 @@ TEST_F(ProtoTraceParserTest, TrackEventWithResortedCounterDescriptor) {
   auto rr_0 = storage_->slice_table()[SliceId(0u)];
   EXPECT_EQ(rr_0.thread_ts(), 1000000);
   EXPECT_EQ(rr_0.thread_dur(), 10000);
-}
-
-TEST_F(ProtoTraceParserTest, TrackEventStateOnNonStateTrack) {
-  {
-    auto* packet = trace_->add_packet();
-    packet->set_trusted_packet_sequence_id(1);
-    packet->set_incremental_state_cleared(true);
-    packet->set_timestamp(1000);
-    auto* track_desc = packet->set_track_descriptor();
-    track_desc->set_uuid(100);
-    track_desc->set_name("Process track");
-    auto* process_desc = track_desc->set_process();
-    process_desc->set_pid(10);
-  }
-  {
-    // Non-state track (regular track descriptor without set_state()).
-    auto* packet = trace_->add_packet();
-    packet->set_trusted_packet_sequence_id(1);
-    packet->set_timestamp(1000);
-    auto* track_desc = packet->set_track_descriptor();
-    track_desc->set_uuid(101);
-    track_desc->set_parent_uuid(100);
-    track_desc->set_name("Regular Track");
-  }
-  {
-    // State event targeting a non-state track.
-    auto* packet = trace_->add_packet();
-    packet->set_trusted_packet_sequence_id(1);
-    packet->set_timestamp(2000);
-    auto* event = packet->set_track_event();
-    event->set_track_uuid(101);
-    event->set_name("High");
-    event->set_type(protos::pbzero::TrackEvent::TYPE_STATE);
-  }
-
-  EXPECT_CALL(*process_, GetOrCreateProcess(10)).WillRepeatedly(Return(1u));
-
-  Tokenize();
-  context_.sorter->ExtractEventsForced();
-
-  // Parsing error stat should be incremented.
-  EXPECT_GT(context_.stats_tracker->GetStats(stats::track_event_parser_errors),
-            0u);
-}
-
-TEST_F(ProtoTraceParserTest, TrackEventWithResortedStateDescriptor) {
-  {
-    // Child state track descriptor emitted before parent descriptor.
-    auto* packet = trace_->add_packet();
-    packet->set_trusted_packet_sequence_id(1);
-    packet->set_incremental_state_cleared(true);
-    packet->set_timestamp(1000);
-    auto* track_desc = packet->set_track_descriptor();
-    track_desc->set_uuid(101);
-    track_desc->set_parent_uuid(100);
-    track_desc->set_name("Priority");
-    track_desc->set_state();
-  }
-  {
-    // Parent process track descriptor emitted after child.
-    auto* packet = trace_->add_packet();
-    packet->set_trusted_packet_sequence_id(1);
-    packet->set_timestamp(1000);
-    auto* track_desc = packet->set_track_descriptor();
-    track_desc->set_uuid(100);
-    track_desc->set_name("Process track");
-    auto* process_desc = track_desc->set_process();
-    process_desc->set_pid(10);
-  }
-  {
-    auto* packet = trace_->add_packet();
-    packet->set_trusted_packet_sequence_id(1);
-    packet->set_timestamp(2000);
-    auto* event = packet->set_track_event();
-    event->set_track_uuid(101);
-    event->set_name("High");
-    event->set_type(protos::pbzero::TrackEvent::TYPE_STATE);
-  }
-
-  EXPECT_CALL(*process_, GetOrCreateProcess(10)).WillRepeatedly(Return(1u));
-
-  Tokenize();
-  context_.sorter->ExtractEventsForced();
-
-  bool found_state_track = false;
-  for (uint32_t i = 0; i < storage_->track_table().row_count(); ++i) {
-    if (storage_->track_table()[i].name() ==
-        storage_->InternString("Priority")) {
-      found_state_track = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(found_state_track);
 }
 
 TEST_F(ProtoTraceParserTest, TrackEventWithoutIncrementalStateReset) {

--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -573,23 +573,9 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
   }
 
   if (event.type() == protos::pbzero::TrackEvent::TYPE_STATE) {
-    // Consider track_uuid from the packet and TrackEventDefaults.
-    uint64_t track_uuid;
-    if (event.has_track_uuid()) {
-      track_uuid = event.track_uuid();
-    } else if (defaults && defaults->has_track_uuid()) {
-      track_uuid = defaults->track_uuid();
-    } else {
+    if (!event.has_track_uuid() && (!defaults || !defaults->has_track_uuid())) {
       RecordTokenizationError(stats::track_event_state_missing_track_uuid,
                               &data.trace_packet_data.packet);
-      return ModuleResult::Handled();
-    }
-
-    auto resolved = track_event_tracker_->ResolveDescriptorTrack(track_uuid);
-    if (!resolved || !resolved->is_state()) {
-      RecordTokenizationErrorWithTrackUuid(
-          stats::track_event_state_invalid_track_uuid, track_uuid,
-          &data.trace_packet_data.packet);
       return ModuleResult::Handled();
     }
   }

--- a/src/trace_processor/importers/proto/track_event_tracker.h
+++ b/src/trace_processor/importers/proto/track_event_tracker.h
@@ -301,7 +301,7 @@ class TrackEventTracker {
       std::optional<uint32_t> packet_sequence_id) {
     State* s =
         EnsureDescriptorTrackInterned(uuid, event_name, packet_sequence_id);
-    if (!s) {
+    if (!s || !s->resolved || !s->resolved->is_state()) {
       return std::nullopt;
     }
     if (std::holds_alternative<TrackId>(*s->track_id_or_factory)) {

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -882,10 +882,6 @@ namespace perfetto::trace_processor::stats {
       "A TrackEvent with TYPE_STATE was received without a track_uuid. "       \
       "State events require a track_uuid to identify which state track to "     \
       "use. The event is dropped. This is a bug in the trace producer."),       \
-  F(track_event_state_invalid_track_uuid,     kSingle,  kError,  kAnalysis, Scope::kMachineAndTrace, \
-      "A TrackEvent with TYPE_STATE specified a track_uuid that was not "      \
-      "declared as a state track. The event is dropped. This is a bug in the " \
-      "trace producer."),  \
   F(track_event_extra_counter_track_uuid_mismatch, kSingle, kError, kAnalysis, Scope::kMachineAndTrace, \
       "A TrackEvent provided more extra counter values than "                  \
       "extra_counter_track_uuids. Arrays must have matching lengths. The "     \

--- a/test/trace_processor/diff_tests/parser/track_event/tests.py
+++ b/test/trace_processor/diff_tests/parser/track_event/tests.py
@@ -1298,19 +1298,7 @@ class TrackEvent(TestSuite):
           timestamp: 0
           incremental_state_cleared: true
           track_descriptor {
-            uuid: 100
-            name: "Process track"
-            process {
-              pid: 10
-            }
-          }
-        }
-        packet {
-          trusted_packet_sequence_id: 1
-          timestamp: 0
-          track_descriptor {
             uuid: 101
-            parent_uuid: 100
             name: "Regular Track"
           }
         }

--- a/test/trace_processor/diff_tests/parser/track_event/tests.py
+++ b/test/trace_processor/diff_tests/parser/track_event/tests.py
@@ -1289,3 +1289,93 @@ class TrackEvent(TestSuite):
         "ThreadState","[NULL]","t1","Browser",2000,"Running"
         "GlobalState","[NULL]","[NULL]","[NULL]",3000,"Active"
         """))
+
+  def test_track_event_state_on_non_state_track(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 0
+          incremental_state_cleared: true
+          track_descriptor {
+            uuid: 100
+            name: "Process track"
+            process {
+              pid: 10
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 0
+          track_descriptor {
+            uuid: 101
+            parent_uuid: 100
+            name: "Regular Track"
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 1000
+          track_event {
+            track_uuid: 101
+            type: 5
+            categories: "cat"
+            name: "High"
+          }
+        }
+        """),
+        query="""
+        SELECT name, value FROM stats WHERE name = 'track_event_parser_errors';
+        """,
+        out=Csv("""
+        "name","value"
+        "track_event_parser_errors",1
+        """))
+
+  def test_track_event_out_of_order_state_descriptors(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 0
+          incremental_state_cleared: true
+          track_descriptor {
+            uuid: 101
+            parent_uuid: 100
+            name: "Priority"
+            state {}
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 0
+          track_descriptor {
+            uuid: 100
+            name: "Process track"
+            process {
+              pid: 10
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 1000
+          track_event {
+            track_uuid: 101
+            type: 5
+            categories: "cat"
+            name: "High"
+          }
+        }
+        """),
+        query="""
+        SELECT state.id, ts, value, track.name AS track_name
+        FROM state
+        JOIN track ON track.id = state.track_id
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "id","ts","value","track_name"
+        0,1000,"High","Priority"
+        """))


### PR DESCRIPTION
This PR fixes tokenization error when getting out of order tracks (child before parent) for state tracks.
Regular tracks don't check this, so this aligns behavior for StateTrack.
This moves the check to parsing, which would translate to a track_event_parser_errors.