### PR TITLE
[state] Add state track tables and account for it in _process_available_info_summary

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -18445,6 +18445,7 @@ filegroup {
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/gpu.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/memory.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/slices.sql",
+        "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/state.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tracks.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/before_eof/functions.sql",

--- a/BUILD
+++ b/BUILD
@@ -4069,6 +4069,7 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/gpu.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/memory.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/slices.sql",
+        "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/state.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tracks.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql",
     ],

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/BUILD.gn
@@ -24,6 +24,7 @@ perfetto_sql_source_set("after_eof") {
     "gpu.sql",
     "memory.sql",
     "slices.sql",
+    "state.sql",
     "tracks.sql",
     "views.sql",
   ]

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/state.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/state.sql
@@ -1,0 +1,144 @@
+--
+-- Copyright 2024 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- @module prelude.after_eof.state
+-- State tracks and state events.
+--
+-- This module provides state-related tables and views for analyzing
+-- states collected across processes and other contexts.
+
+INCLUDE PERFETTO MODULE prelude.after_eof.views;
+
+-- Tracks containing state events.
+CREATE PERFETTO VIEW state_track(
+  -- Unique identifier for this state track.
+  id ID(track.id),
+  -- Name of the track.
+  name STRING,
+  -- The track which is the "parent" of this track. Only non-null for tracks
+  -- created using Perfetto's track_event API.
+  parent_id JOINID(track.id),
+  -- The type of a track indicates the type of data the track contains.
+  --
+  -- Every track is uniquely identified by the the combination of the
+  -- type and a set of dimensions: type allow identifying a set of tracks
+  -- with the same type of data within the whole universe of tracks while
+  -- dimensions allow distinguishing between different tracks in that set.
+  type STRING,
+  -- The dimensions of the track which uniquely identify the track within a
+  -- given type.
+  dimension_arg_set_id ARGSETID,
+  -- Args for this track which store information about "source" of this track in
+  -- the trace. For example: whether this track orginated from atrace, Chrome
+  -- tracepoints etc.
+  source_arg_set_id ARGSETID,
+  -- Machine identifier
+  machine_id JOINID(machine.id)
+)
+AS
+SELECT
+  id,
+  name,
+  parent_id,
+  type,
+  dimension_arg_set_id,
+  source_arg_set_id,
+  machine_id
+FROM __intrinsic_track
+WHERE
+  event_type = 'state';
+
+-- Tracks containing state events associated to a process.
+CREATE PERFETTO TABLE process_state_track(
+  -- Unique identifier for this process state track.
+  id ID(track.id),
+  -- Name of the track.
+  name STRING,
+  -- The type of a track indicates the type of data the track contains.
+  --
+  -- Every track is uniquely identified by the the combination of the
+  -- type and a set of dimensions: type allow identifying a set of tracks
+  -- with the same type of data within the whole universe of tracks while
+  -- dimensions allow distinguishing between different tracks in that set.
+  type STRING,
+  -- The track which is the "parent" of this track. Only non-null for tracks
+  -- created using Perfetto's track_event API.
+  parent_id JOINID(track.id),
+  -- Args for this track which store information about "source" of this track in
+  -- the trace. For example: whether this track orginated from atrace, Chrome
+  -- tracepoints etc.
+  source_arg_set_id ARGSETID,
+  -- Machine identifier
+  machine_id JOINID(machine.id),
+  -- The upid that the track is associated with.
+  upid JOINID(process.id)
+)
+AS
+SELECT
+  t.id,
+  t.name,
+  t.type,
+  t.parent_id,
+  t.source_arg_set_id,
+  t.machine_id,
+  a.int_value AS upid
+FROM __intrinsic_track AS t
+JOIN args AS a
+  ON t.dimension_arg_set_id = a.arg_set_id
+WHERE
+  t.event_type = 'state'
+  AND a.key = 'upid';
+
+-- Tracks containing state events associated to a thread.
+CREATE PERFETTO TABLE thread_state_track(
+  -- Unique identifier for this thread state track.
+  id ID(track.id),
+  -- Name of the track.
+  name STRING,
+  -- The type of a track indicates the type of data the track contains.
+  --
+  -- Every track is uniquely identified by the the combination of the
+  -- type and a set of dimensions: type allow identifying a set of tracks
+  -- with the same type of data within the whole universe of tracks while
+  -- dimensions allow distinguishing between different tracks in that set.
+  type STRING,
+  -- The track which is the "parent" of this track. Only non-null for tracks
+  -- created using Perfetto's track_event API.
+  parent_id JOINID(track.id),
+  -- Args for this track which store information about "source" of this track in
+  -- the trace. For example: whether this track orginated from atrace, Chrome
+  -- tracepoints etc.
+  source_arg_set_id ARGSETID,
+  -- Machine identifier
+  machine_id JOINID(machine.id),
+  -- The utid that the track is associated with.
+  utid JOINID(thread.id)
+)
+AS
+SELECT
+  t.id,
+  t.name,
+  t.type,
+  t.parent_id,
+  t.source_arg_set_id,
+  t.machine_id,
+  a.int_value AS utid
+FROM __intrinsic_track AS t
+JOIN args AS a
+  ON t.dimension_arg_set_id = a.arg_set_id
+WHERE
+  t.event_type = 'state'
+  AND a.key = 'utid';
+

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/state.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/state.sql
@@ -1,5 +1,5 @@
 --
--- Copyright 2024 The Android Open Source Project
+-- Copyright 2026 The Android Open Source Project
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -141,4 +141,3 @@ JOIN args AS a
 WHERE
   t.event_type = 'state'
   AND a.key = 'utid';
-

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tracks.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tracks.sql
@@ -159,6 +159,47 @@ WHERE
   t.event_type = 'slice'
   AND a.key = 'upid';
 
+-- Tracks containing state events associated to a process.
+CREATE PERFETTO TABLE process_state_track(
+  -- Unique identifier for this process state track.
+  id ID(track.id),
+  -- Name of the track.
+  name STRING,
+  -- The type of a track indicates the type of data the track contains.
+  --
+  -- Every track is uniquely identified by the the combination of the
+  -- type and a set of dimensions: type allow identifying a set of tracks
+  -- with the same type of data within the whole universe of tracks while
+  -- dimensions allow distinguishing between different tracks in that set.
+  type STRING,
+  -- The track which is the "parent" of this track. Only non-null for tracks
+  -- created using Perfetto's track_event API.
+  parent_id JOINID(track.id),
+  -- Args for this track which store information about "source" of this track in
+  -- the trace. For example: whether this track orginated from atrace, Chrome
+  -- tracepoints etc.
+  source_arg_set_id ARGSETID,
+  -- Machine identifier
+  machine_id JOINID(machine.id),
+  -- The upid that the track is associated with.
+  upid JOINID(process.id)
+)
+AS
+SELECT
+  t.id,
+  t.name,
+  t.type,
+  t.parent_id,
+  t.source_arg_set_id,
+  t.machine_id,
+  a.int_value AS upid
+FROM __intrinsic_track AS t
+JOIN args AS a
+  ON t.dimension_arg_set_id = a.arg_set_id
+WHERE
+  t.event_type = 'state'
+  AND a.key = 'upid';
+
 -- Tracks which are associated to a single CPU.
 CREATE PERFETTO TABLE cpu_track(
   -- Unique identifier for this cpu track.

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tracks.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tracks.sql
@@ -159,47 +159,6 @@ WHERE
   t.event_type = 'slice'
   AND a.key = 'upid';
 
--- Tracks containing state events associated to a process.
-CREATE PERFETTO TABLE process_state_track(
-  -- Unique identifier for this process state track.
-  id ID(track.id),
-  -- Name of the track.
-  name STRING,
-  -- The type of a track indicates the type of data the track contains.
-  --
-  -- Every track is uniquely identified by the the combination of the
-  -- type and a set of dimensions: type allow identifying a set of tracks
-  -- with the same type of data within the whole universe of tracks while
-  -- dimensions allow distinguishing between different tracks in that set.
-  type STRING,
-  -- The track which is the "parent" of this track. Only non-null for tracks
-  -- created using Perfetto's track_event API.
-  parent_id JOINID(track.id),
-  -- Args for this track which store information about "source" of this track in
-  -- the trace. For example: whether this track orginated from atrace, Chrome
-  -- tracepoints etc.
-  source_arg_set_id ARGSETID,
-  -- Machine identifier
-  machine_id JOINID(machine.id),
-  -- The upid that the track is associated with.
-  upid JOINID(process.id)
-)
-AS
-SELECT
-  t.id,
-  t.name,
-  t.type,
-  t.parent_id,
-  t.source_arg_set_id,
-  t.machine_id,
-  a.int_value AS upid
-FROM __intrinsic_track AS t
-JOIN args AS a
-  ON t.dimension_arg_set_id = a.arg_set_id
-WHERE
-  t.event_type = 'state'
-  AND a.key = 'upid';
-
 -- Tracks which are associated to a single CPU.
 CREATE PERFETTO TABLE cpu_track(
   -- Unique identifier for this cpu track.

--- a/src/trace_processor/perfetto_sql/stdlib/viz/summary/processes.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/summary/processes.sql
@@ -95,4 +95,5 @@ WHERE
   AND allocation_count IS NULL
   AND graph_object_count IS NULL)
   OR upid IN (SELECT upid FROM process_counter_track)
+  OR upid IN (SELECT upid FROM process_state_track)
   OR upid IN (SELECT DISTINCT upid FROM profiler_smaps);

--- a/test/trace_processor/diff_tests/parser/track_event/tests.py
+++ b/test/trace_processor/diff_tests/parser/track_event/tests.py
@@ -1309,4 +1309,3 @@ class TrackEvent(TestSuite):
         "id","ts","value","track_name","utid"
         0,1000,"Running","ThreadStatus",2
         """))
-

--- a/test/trace_processor/diff_tests/parser/track_event/tests.py
+++ b/test/trace_processor/diff_tests/parser/track_event/tests.py
@@ -1262,3 +1262,51 @@ class TrackEvent(TestSuite):
         "name","value"
         "track_event_parser_errors",1
         """))
+
+  def test_thread_state_track(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 0
+          incremental_state_cleared: true
+          track_descriptor {
+            uuid: 10
+            thread {
+              pid: 1
+              tid: 2
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 0
+          track_descriptor {
+            uuid: 20
+            parent_uuid: 10
+            name: "ThreadStatus"
+            state {}
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 1000
+          track_event {
+            track_uuid: 20
+            type: 5
+            categories: "cat"
+            name: "Running"
+          }
+        }
+        """),
+        query="""
+        SELECT state.id, ts, value, thread_state_track.name AS track_name, utid
+        FROM state
+        JOIN thread_state_track ON thread_state_track.id = state.track_id
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "id","ts","value","track_name","utid"
+        0,1000,"Running","ThreadStatus",2
+        """))
+

--- a/test/trace_processor/diff_tests/parser/track_event/tests.py
+++ b/test/trace_processor/diff_tests/parser/track_event/tests.py
@@ -1263,49 +1263,29 @@ class TrackEvent(TestSuite):
         "track_event_parser_errors",1
         """))
 
-  def test_thread_state_track(self):
+  def test_track_event_state_state(self):
     return DiffTestBlueprint(
-        trace=TextProto(r"""
-        packet {
-          trusted_packet_sequence_id: 1
-          timestamp: 0
-          incremental_state_cleared: true
-          track_descriptor {
-            uuid: 10
-            thread {
-              pid: 1
-              tid: 2
-            }
-          }
-        }
-        packet {
-          trusted_packet_sequence_id: 1
-          timestamp: 0
-          track_descriptor {
-            uuid: 20
-            parent_uuid: 10
-            name: "ThreadStatus"
-            state {}
-          }
-        }
-        packet {
-          trusted_packet_sequence_id: 1
-          timestamp: 1000
-          track_event {
-            track_uuid: 20
-            type: 5
-            categories: "cat"
-            name: "Running"
-          }
-        }
-        """),
+        trace=Path('track_event_state.textproto'),
         query="""
-        SELECT state.id, ts, value, thread_state_track.name AS track_name, utid
+        SELECT
+          state_track.name AS state_name,
+          process.name AS process,
+          thread.name AS thread,
+          thread_process.name AS thread_process,
+          state.ts,
+          state.value
         FROM state
-        JOIN thread_state_track ON thread_state_track.id = state.track_id
-        ORDER BY ts;
+        LEFT JOIN state_track ON state.track_id = state_track.id
+        LEFT JOIN process_state_track ON state.track_id = process_state_track.id
+        LEFT JOIN process ON process_state_track.upid = process.upid
+        LEFT JOIN thread_state_track ON state.track_id = thread_state_track.id
+        LEFT JOIN thread ON thread_state_track.utid = thread.utid
+        LEFT JOIN process thread_process ON thread.upid = thread_process.upid
+        ORDER BY ts ASC;
         """,
         out=Csv("""
-        "id","ts","value","track_name","utid"
-        0,1000,"Running","ThreadStatus",2
+        "state_name","process","thread","thread_process","ts","value"
+        "ProcState","Browser","[NULL]","[NULL]",1000,"Foreground"
+        "ThreadState","[NULL]","t1","Browser",2000,"Running"
+        "GlobalState","[NULL]","[NULL]","[NULL]",3000,"Active"
         """))

--- a/test/trace_processor/diff_tests/parser/track_event/track_event_state.textproto
+++ b/test/trace_processor/diff_tests/parser/track_event/track_event_state.textproto
@@ -1,0 +1,99 @@
+# Process descriptor.
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 0
+  incremental_state_cleared: true
+  track_descriptor {
+    uuid: 3
+    process {
+      pid: 5
+      process_name: "Browser"
+    }
+  }
+}
+
+# Thread descriptor.
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 0
+  track_descriptor {
+    uuid: 1
+    parent_uuid: 3
+    thread {
+      pid: 5
+      tid: 10
+      thread_name: "t1"
+    }
+  }
+}
+
+# Process state track.
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 0
+  track_descriptor {
+    uuid: 20
+    parent_uuid: 3
+    name: "ProcState"
+    state {}
+  }
+}
+
+# Thread state track.
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 0
+  track_descriptor {
+    uuid: 21
+    parent_uuid: 1
+    name: "ThreadState"
+    state {}
+  }
+}
+
+# Global state track.
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 0
+  track_descriptor {
+    uuid: 22
+    name: "GlobalState"
+    state {}
+  }
+}
+
+# State events on process state track.
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 1000
+  track_event {
+    track_uuid: 20
+    type: 5
+    categories: "cat"
+    name: "Foreground"
+  }
+}
+
+# State event on thread state track.
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 2000
+  track_event {
+    track_uuid: 21
+    type: 5
+    categories: "cat"
+    name: "Running"
+  }
+}
+
+# State event on global state track.
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 3000
+  track_event {
+    track_uuid: 22
+    type: 5
+    categories: "cat"
+    name: "Active"
+  }
+}


### PR DESCRIPTION
This PR adds state.sql to define state_track, process_state_track and thread_state_track with tests.

This also fixes a UI crash when a process contains only state tracks;
_process_available_info_summary needs to include process_state_track to be considered non-empty.