### PR TITLE
tp: make ArgsInserter non-virtual

### DIFF
--- a/src/trace_processor/importers/common/args_tracker.h
+++ b/src/trace_processor/importers/common/args_tracker.h
@@ -78,11 +78,10 @@ class ArgsInserter {
     return AddArg(key, key, v, update_policy);
   }
 
-  ArgsInserter& AddArg(
-      StringId flat_key,
-      StringId key,
-      Variadic v,
-      UpdatePolicy update_policy = UpdatePolicy::kAddOrUpdate);
+  ArgsInserter& AddArg(StringId flat_key,
+                       StringId key,
+                       Variadic v,
+                       UpdatePolicy update_policy = UpdatePolicy::kAddOrUpdate);
 
   // IncrementArrayEntryIndex() and GetNextArrayEntryIndex() provide a way to
   // track the next array index for an array under a specific key.

--- a/src/trace_processor/importers/common/args_tracker.h
+++ b/src/trace_processor/importers/common/args_tracker.h
@@ -59,10 +59,10 @@ class ArgsInserter {
   using CompactArgSet = base::SmallVector<CompactArg, 16>;
 
   // Constructs an empty inserter that owns no buffer and commits nothing. Used
-  // for the moved-from state and as a base for test mocks.
+  // for the moved-from state and for default-constructed (empty) map entries.
   ArgsInserter() = default;
 
-  virtual ~ArgsInserter();
+  ~ArgsInserter();
 
   ArgsInserter(ArgsInserter&&) noexcept;
   ArgsInserter& operator=(ArgsInserter&&) noexcept;
@@ -78,7 +78,7 @@ class ArgsInserter {
     return AddArg(key, key, v, update_policy);
   }
 
-  virtual ArgsInserter& AddArg(
+  ArgsInserter& AddArg(
       StringId flat_key,
       StringId key,
       Variadic v,

--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -425,7 +425,6 @@ TEST_F(FuchsiaTraceParserTest, FxtWithProtos) {
   row.upid = 1u;
   storage_->mutable_thread_table()->Insert(row);
 
-
   StringId unknown_cat = storage_->InternString("unknown(1)");
   ASSERT_NE(storage_, nullptr);
 

--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -127,21 +127,6 @@ class MockProcessTracker : public ProcessTracker {
                ProcessNamePriority priority),
               (override));
 };
-class MockBoundInserter : public ArgsTracker::BoundInserter {
- public:
-  MockBoundInserter() {
-    ON_CALL(*this, AddArg(_, _, _, _)).WillByDefault(ReturnRef(*this));
-  }
-
-  MOCK_METHOD(ArgsTracker::BoundInserter&,
-              AddArg,
-              (StringId flat_key,
-               StringId key,
-               Variadic v,
-               ArgsTracker::UpdatePolicy update_policy),
-              (override));
-};
-
 class MockEventTracker : public EventTracker {
  public:
   explicit MockEventTracker(TraceProcessorContext* context)
@@ -440,7 +425,6 @@ TEST_F(FuchsiaTraceParserTest, FxtWithProtos) {
   row.upid = 1u;
   storage_->mutable_thread_table()->Insert(row);
 
-  MockBoundInserter inserter;
 
   StringId unknown_cat = storage_->InternString("unknown(1)");
   ASSERT_NE(storage_, nullptr);

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -995,7 +995,6 @@ TEST_F(ProtoTraceParserTest, TrackEventWithoutInternedData) {
   row.upid = 1u;
   storage_->mutable_thread_table()->Insert(row);
 
-
   constexpr TrackId thread_time_track{0u};
 
   InSequence in_sequence;  // Below slices should be sorted by timestamp.
@@ -1069,7 +1068,6 @@ TEST_F(ProtoTraceParserTest, TrackEventWithoutInternedDataWithTypes) {
   tables::ThreadTable::Row row(16);
   row.upid = 1u;
   storage_->mutable_thread_table()->Insert(row);
-
 
   constexpr TrackId thread_time_track{0u};
 
@@ -2019,7 +2017,6 @@ TEST_F(ProtoTraceParserTest, TrackEventMultipleSequences) {
 }
 
 TEST_F(ProtoTraceParserTest, TrackEventWithDebugAnnotations) {
-
   {
     auto* packet = trace_->add_packet();
     packet->set_trusted_packet_sequence_id(1);

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -230,21 +230,6 @@ class MockProcessTracker : public ProcessTracker {
               (override));
 };
 
-class MockBoundInserter : public ArgsTracker::BoundInserter {
- public:
-  MockBoundInserter() {
-    ON_CALL(*this, AddArg(_, _, _, _)).WillByDefault(ReturnRef(*this));
-  }
-
-  MOCK_METHOD(ArgsTracker::BoundInserter&,
-              AddArg,
-              (StringId flat_key,
-               StringId key,
-               Variadic v,
-               ArgsTracker::UpdatePolicy update_policy),
-              (override));
-};
-
 class ProtoTraceParserTest : public ::testing::Test {
  public:
   ProtoTraceParserTest() {
@@ -1010,7 +995,6 @@ TEST_F(ProtoTraceParserTest, TrackEventWithoutInternedData) {
   row.upid = 1u;
   storage_->mutable_thread_table()->Insert(row);
 
-  MockBoundInserter inserter;
 
   constexpr TrackId thread_time_track{0u};
 
@@ -1086,7 +1070,6 @@ TEST_F(ProtoTraceParserTest, TrackEventWithoutInternedDataWithTypes) {
   row.upid = 1u;
   storage_->mutable_thread_table()->Insert(row);
 
-  MockBoundInserter inserter;
 
   constexpr TrackId thread_time_track{0u};
 
@@ -1252,7 +1235,6 @@ TEST_F(ProtoTraceParserTest, TrackEventWithInternedData) {
 
   InSequence in_sequence;  // Below slices should be sorted by timestamp.
 
-  MockBoundInserter inserter;
   // Only the begin timestamp counters can be imported into the counter table.
   EXPECT_CALL(*event_, PushCounter(1005000, testing::DoubleEq(2003000),
                                    thread_time_track));
@@ -2037,7 +2019,6 @@ TEST_F(ProtoTraceParserTest, TrackEventMultipleSequences) {
 }
 
 TEST_F(ProtoTraceParserTest, TrackEventWithDebugAnnotations) {
-  MockBoundInserter inserter;
 
   {
     auto* packet = trace_->add_packet();


### PR DESCRIPTION
This was causing crashes in Chrome due to vtable complications in
uninitialized memory in cfi builds of trace processor.

There's very little reason for it to be virtual - just remove it
from tests.
