### PR TITLE
ui: complete multi-trace merging dialog

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/merge_manifest.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/merge_manifest.ts
@@ -13,25 +13,34 @@
 // limitations under the License.
 
 // Serializes the merge configurator state into a perfetto_manifest object.
-// Contract: test/trace_processor/diff_tests/parser/trace_manifest/tests.py.
+// The schema mirrors the reader in
+// src/trace_processor/plugins/perfetto_manifest/perfetto_manifest_reader.cc;
+// the diff tests in
+// test/trace_processor/diff_tests/parser/trace_manifest/tests.py are the
+// contract.
 
 import type {
+  AlignMode,
   ClockName,
-  FileMergeConfig,
+  MachineRemap,
   TraceTimeConfig,
 } from './multi_trace_types';
 
-// "Manual" mode: relate this file's clock to a clock in another trace
-// (sync_to) at a fixed offset. The reference is the baseline trace (the
-// trace-time master, i.e. the first file); its clock is left unnamed so the
-// importer uses the baseline's sole clock.
+// A file's "clocks" block: relate this file's own clock (`clock`) to a clock in
+// another trace (`sync_to`) at a fixed `offset_ns`. `clock` names the file's
+// builtin clock to relate (omit for a clockless file, which pins its private
+// per-file clock); sync_to.file is required; sync_to.clock is omitted when the
+// reference exposes a single clock (the reader resolves it).
 export interface ManifestClocks {
+  clock?: ClockName;
   sync_to: {file: string; clock?: ClockName};
   offset_ns?: number;
 }
 
 export interface ManifestFileEntry {
   path: string;
+  machine?: {name: string};
+  machines?: Array<{id: number; name: string}>;
   clocks?: ManifestClocks;
 }
 
@@ -41,37 +50,82 @@ export interface PerfettoManifest {
   files?: ManifestFileEntry[];
 }
 
+// One file's contribution to the merge, resolved from the UI state by the
+// controller: the manual reference is already resolved to a file path + clock,
+// and the single-machine assignment to a name.
 export interface MergeFile {
   readonly path: string;
-  readonly config: FileMergeConfig;
-  // This file's single real clock, if it has exactly one; undefined for a
-  // clockless trace. Names the reference clock when this file is the baseline.
-  readonly clock?: ClockName;
+  readonly alignMode: AlignMode;
+  readonly offsetNs?: number;
+  // This file's own builtin clock to relate to the reference (undefined => a
+  // clockless file, whose private clock is pinned instead).
+  readonly sourceClock?: ClockName;
+  // Resolved manual reference: the file (and optionally clock) to offset
+  // against. Undefined for `auto` or until a reference resolves.
+  readonly reference?: {file: string; clock?: ClockName};
+  // Resolved single-machine assignment (trimmed, non-empty), else undefined.
+  readonly machineName?: string;
+  // Multi-machine proto remap, straight from the config.
+  readonly machines?: ReadonlyArray<MachineRemap>;
 }
 
 const MANIFEST_FILENAME = 'perfetto_manifest.json';
 
-// The clocks block for a file, or undefined. The baseline (first) trace is the
-// reference others sync to, so it never carries a sync_to of its own; a
-// non-baseline file with a fixed offset syncs to the baseline's clock (named
-// when the baseline has one, else its private timeline) at that offset.
-function entryClocks(
-  files: ReadonlyArray<MergeFile>,
-  index: number,
-): ManifestClocks | undefined {
-  const baseline = files[0];
-  if (index === 0 || baseline === undefined) {
+// The clocks block for a file, or undefined. Only `manual` mode with an offset
+// and a resolved reference emits one; everything else auto-aligns.
+function fileClocks(file: MergeFile): ManifestClocks | undefined {
+  if (
+    file.alignMode !== 'manual' ||
+    file.offsetNs === undefined ||
+    file.reference === undefined
+  ) {
     return undefined;
   }
-  const {alignMode, offsetNs} = files[index].config;
-  if (alignMode !== 'offset' || offsetNs === undefined) {
-    return undefined;
+  const {file: refFile, clock} = file.reference;
+  const syncTo = clock === undefined ? {file: refFile} : {file: refFile, clock};
+  const clocks: ManifestClocks = {sync_to: syncTo, offset_ns: file.offsetNs};
+  if (file.sourceClock !== undefined) {
+    clocks.clock = file.sourceClock;
   }
-  const syncTo =
-    baseline.clock === undefined
-      ? {file: baseline.path}
-      : {file: baseline.path, clock: baseline.clock};
-  return {sync_to: syncTo, offset_ns: offsetNs};
+  return clocks;
+}
+
+// Full file entry: machine identity (machine.name or machines[]) plus clocks.
+// machine.name (single-machine) and machines[] (multi-machine) are mutually
+// exclusive: a file is one or the other.
+function serializeFile(file: MergeFile): ManifestFileEntry {
+  const entry: ManifestFileEntry = {path: file.path};
+
+  const name = file.machineName?.trim();
+  if (name !== undefined && name.length > 0) {
+    entry.machine = {name};
+  } else if (file.machines !== undefined) {
+    // Emit only when every id is named: the importer rejects a partial
+    // machines[] and blank names are not valid.
+    const allNamed =
+      file.machines.length > 0 &&
+      file.machines.every((mm) => mm.name.trim().length > 0);
+    if (allNamed) {
+      entry.machines = file.machines.map((mm) => ({
+        id: mm.id,
+        name: mm.name.trim(),
+      }));
+    }
+  }
+
+  const clocks = fileClocks(file);
+  if (clocks !== undefined) {
+    entry.clocks = clocks;
+  }
+  return entry;
+}
+
+function hasConfig(entry: ManifestFileEntry): boolean {
+  return (
+    entry.machine !== undefined ||
+    entry.machines !== undefined ||
+    entry.clocks !== undefined
+  );
 }
 
 function buildManifest(
@@ -82,12 +136,9 @@ function buildManifest(
   if (traceTime.clock !== undefined) {
     manifest.trace_time = {clock: traceTime.clock};
   }
-  const entries = files.map(({path}, i) => {
-    const clocks = entryClocks(files, i);
-    return clocks === undefined ? {path} : {path, clocks};
-  });
+  const entries = files.map(serializeFile);
   // Bare {path} entries are no-ops; omit `files` when none carry config.
-  if (entries.some((e) => e.clocks !== undefined)) {
+  if (entries.some(hasConfig)) {
     manifest.files = entries;
   }
   return manifest;
@@ -100,7 +151,7 @@ export function isTrivialManifest(
 ): boolean {
   return (
     traceTime.clock === undefined &&
-    !files.some((_, i) => entryClocks(files, i) !== undefined)
+    !files.some((f) => hasConfig(serializeFile(f)))
   );
 }
 

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
@@ -333,7 +333,10 @@ export class MultiTraceController {
       clearTimeout(this._checkTimer);
       this._checkTimer = undefined;
     }
-    if (this.getLoadingError() !== undefined || this.configError() !== undefined) {
+    if (
+      this.getLoadingError() !== undefined ||
+      this.configError() !== undefined
+    ) {
       return;
     }
     const sinceLast = Date.now() - this._lastCheckStart;
@@ -341,11 +344,16 @@ export class MultiTraceController {
       this.runCheck();
       return;
     }
-    const wait = this._checking ? CHECK_DEBOUNCE_MS : CHECK_DEBOUNCE_MS - sinceLast;
-    this._checkTimer = setTimeout(() => {
-      this._checkTimer = undefined;
-      this.runCheck();
-    }, Math.max(0, wait));
+    const wait = this._checking
+      ? CHECK_DEBOUNCE_MS
+      : CHECK_DEBOUNCE_MS - sinceLast;
+    this._checkTimer = setTimeout(
+      () => {
+        this._checkTimer = undefined;
+        this.runCheck();
+      },
+      Math.max(0, wait),
+    );
   }
 
   private runCheck() {

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
@@ -20,7 +20,11 @@ import type {
   TraceFileAnalyzed,
   TraceTimeConfig,
 } from './multi_trace_types';
-import {BUILTIN_CLOCKS, defaultFileMergeConfig} from './multi_trace_types';
+import {
+  BUILTIN_CLOCKS,
+  defaultFileMergeConfig,
+  parseOffsetNs,
+} from './multi_trace_types';
 import {uuidv4} from '../../base/uuid';
 import {getErrorMessage as toErrorMessage} from '../../base/errors';
 import type {AlignmentVerdict, TraceAnalyzer} from './trace_analyzer';
@@ -40,13 +44,19 @@ function getErrorMessage(e: unknown): string {
 }
 
 // A trace's single real (builtin) clock, if it has exactly one; undefined for a
-// clockless trace or one exposing several clocks. Names the reference clock
-// when this trace is the baseline others sync to.
-function singleRealClock(trace: TraceFile): ClockName | undefined {
+// clockless trace or one exposing several clocks. Used as the default reference
+// clock when a manual offset targets this trace.
+function soleRealClock(trace: TraceFile): ClockName | undefined {
   if (trace.status !== 'analyzed') return undefined;
   const ids = trace.analysis.builtinClockIds ?? [];
   if (ids.length !== 1) return undefined;
   return BUILTIN_CLOCKS.find((c) => c.id === ids[0])?.name;
+}
+
+// A user-defined machine in the shared registry.
+export interface MachineEntry {
+  readonly id: number;
+  readonly name: string;
 }
 
 // The possible error states for the modal, used to show a helpful message
@@ -57,6 +67,11 @@ export type LoadingError =
   | 'ANALYZING'
   | 'TRACE_ERROR';
 
+// Minimum spacing between auto-run alignment dry-runs. The first change after a
+// quiet period checks immediately (leading edge); rapid follow-ups coalesce
+// into one trailing check this long after the last change.
+const CHECK_DEBOUNCE_MS = 1500;
+
 /**
  * The controller for the multi-trace modal.
  * This class manages the state of the traces and their analysis.
@@ -65,6 +80,11 @@ export class MultiTraceController {
   private _traces: TraceFile[] = [];
   // Per-file merge configuration, keyed by trace uuid. Absent => default.
   private _configByUuid = new Map<string, FileMergeConfig>();
+  // Shared, user-defined machines a single-machine file can be assigned to.
+  // Files reference these by id (config.machineId); the name is resolved here
+  // so renaming a machine propagates to every file using it.
+  private _machines: ReadonlyArray<MachineEntry> = [];
+  private _nextMachineId = 1;
   private _traceTime: TraceTimeConfig = {};
   // User-chosen baseline trace for all-private sets; undefined => first file.
   private _anchorUuid?: string;
@@ -73,6 +93,10 @@ export class MultiTraceController {
   private _checking = false;
   // Bumped on every config change; lets checkAlignment drop a stale result.
   private _generation = 0;
+  // Pending debounced auto-check; cancelled and rescheduled on each change.
+  private _checkTimer?: ReturnType<typeof setTimeout>;
+  // When the last auto-check started, to space out leading-edge checks.
+  private _lastCheckStart = 0;
   private traceAnalyzer: TraceAnalyzer;
   private onStateChanged: () => void;
   private onAnalysisStarted?: (traceUuid: string) => void;
@@ -166,6 +190,102 @@ export class MultiTraceController {
     this.invalidate();
   }
 
+  // The shared machine registry single-machine files pick from.
+  get machines(): ReadonlyArray<MachineEntry> {
+    return this._machines;
+  }
+
+  // Creates a machine (default-named so it never shows as blank) and returns
+  // its id for the caller to assign to a file.
+  addMachine(): number {
+    const id = this._nextMachineId++;
+    this._machines = [...this._machines, {id, name: `Machine ${id}`}];
+    this.invalidate();
+    return id;
+  }
+
+  renameMachine(id: number, name: string) {
+    this._machines = this._machines.map((mm) =>
+      mm.id === id ? {id, name} : mm,
+    );
+    this.invalidate();
+  }
+
+  // The resolved (trimmed, non-empty) machine name a file is assigned to, or
+  // undefined for the host machine / an unnamed registry entry.
+  machineNameForTrace(uuid: string): string | undefined {
+    const {machineId} = this.getConfig(uuid);
+    if (machineId === undefined) {
+      return undefined;
+    }
+    const name = this._machines.find((mm) => mm.id === machineId)?.name.trim();
+    return name !== undefined && name.length > 0 ? name : undefined;
+  }
+
+  // The baseline trace a manual offset is measured against: the first ordered
+  // trace (the trace-time master). Its name labels the offset control.
+  baselineName(uuid: string): string | undefined {
+    const baseline = this.orderedTraces()[0];
+    return baseline !== undefined && baseline.uuid !== uuid
+      ? baseline.file.name
+      : undefined;
+  }
+
+  // The {file, clock} a manual offset syncs to: the baseline's path and its sole
+  // real clock (omitted when the baseline is clockless, so the importer
+  // resolves it). Undefined when |uuid| is itself the baseline.
+  private baselineReference(
+    uuid: string,
+  ): {file: string; clock?: ClockName} | undefined {
+    const baseline = this.orderedTraces()[0];
+    if (baseline === undefined || baseline.uuid === uuid) {
+      return undefined;
+    }
+    return {file: baseline.file.name, clock: soleRealClock(baseline)};
+  }
+
+  // A message for the status line when the config has an entry the user must fix
+  // before opening. Undefined when every entry is well-formed. Covers a manual
+  // offset that isn't a whole number, and an offset between two traces that
+  // share a machine (an offset relates two distinct clocks, so the offset file
+  // must be on its own machine, else the importer rejects the self-relation).
+  configError(): string | undefined {
+    for (const trace of this._traces) {
+      const config = this.getConfig(trace.uuid);
+      const text = config.offsetText?.trim() ?? '';
+      if (
+        config.alignMode === 'manual' &&
+        text.length > 0 &&
+        parseOffsetNs(text) === undefined
+      ) {
+        return `Enter a whole number of nanoseconds for ${trace.file.name}'s offset.`;
+      }
+    }
+    const baseline = this.orderedTraces()[0];
+    if (baseline !== undefined) {
+      const baselineMachine = this.machineNameForTrace(baseline.uuid);
+      for (const trace of this._traces) {
+        const config = this.getConfig(trace.uuid);
+        if (
+          config.alignMode === 'manual' &&
+          trace.uuid !== baseline.uuid &&
+          parseOffsetNs(config.offsetText) !== undefined &&
+          // A clockless file pins a distinct private clock, so it may share a
+          // machine; a real-clock file would relate its clock to itself.
+          soleRealClock(trace) !== undefined &&
+          this.machineNameForTrace(trace.uuid) === baselineMachine
+        ) {
+          return (
+            `${trace.file.name} has an offset but shares a machine with ` +
+            `${baseline.file.name}. An offset relates two different clocks, ` +
+            `so put ${trace.file.name} on its own machine.`
+          );
+        }
+      }
+    }
+    return undefined;
+  }
+
   private analyzedAnalyses(): FileAnalysis[] {
     return this._traces
       .filter((t): t is TraceFileAnalyzed => t.status === 'analyzed')
@@ -201,7 +321,36 @@ export class MultiTraceController {
     ) {
       this._anchorUuid = undefined;
     }
+    this.scheduleCheck();
     this.onStateChanged();
+  }
+
+  // Keep the alignment status current without a manual button. The first change
+  // after a quiet period checks immediately; bursts coalesce into one trailing
+  // check. Only runs once the set is openable.
+  private scheduleCheck() {
+    if (this._checkTimer !== undefined) {
+      clearTimeout(this._checkTimer);
+      this._checkTimer = undefined;
+    }
+    if (this.getLoadingError() !== undefined || this.configError() !== undefined) {
+      return;
+    }
+    const sinceLast = Date.now() - this._lastCheckStart;
+    if (!this._checking && sinceLast >= CHECK_DEBOUNCE_MS) {
+      this.runCheck();
+      return;
+    }
+    const wait = this._checking ? CHECK_DEBOUNCE_MS : CHECK_DEBOUNCE_MS - sinceLast;
+    this._checkTimer = setTimeout(() => {
+      this._checkTimer = undefined;
+      this.runCheck();
+    }, Math.max(0, wait));
+  }
+
+  private runCheck() {
+    this._lastCheckStart = Date.now();
+    void this.checkAlignment();
   }
 
   // Empty unless there are >=2 real clocks to choose between; with one (or
@@ -280,6 +429,10 @@ export class MultiTraceController {
     } finally {
       this._checking = false;
       this.onStateChanged();
+      // A change landed mid-run: its result was dropped, so check again for it.
+      if (gen !== this._generation) {
+        this.scheduleCheck();
+      }
     }
   }
 
@@ -297,11 +450,23 @@ export class MultiTraceController {
   }
 
   private mergeFiles(): MergeFile[] {
-    return this.orderedTraces().map((t) => ({
-      path: t.file.name,
-      config: this.getConfig(t.uuid),
-      clock: singleRealClock(t),
-    }));
+    return this.orderedTraces().map((t) => {
+      const config = this.getConfig(t.uuid);
+      return {
+        path: t.file.name,
+        alignMode: config.alignMode,
+        offsetNs: parseOffsetNs(config.offsetText),
+        // Relate this file's own clock (if it has one) to the baseline; a
+        // clockless file leaves it undefined so its private clock is pinned.
+        sourceClock: soleRealClock(t),
+        reference:
+          config.alignMode === 'manual'
+            ? this.baselineReference(t.uuid)
+            : undefined,
+        machineName: this.machineNameForTrace(t.uuid),
+        machines: config.machines,
+      };
+    });
   }
 
   hasManifestConfig(): boolean {
@@ -362,6 +527,17 @@ export class MultiTraceController {
         analysis: result,
       };
       this._traces[index] = analyzedTrace;
+      // Autodetect gives the embedded ids, not names; seed blank names so the
+      // remap table renders one row per machine.
+      if (
+        result.singleMachine === false &&
+        result.embeddedMachineIds !== undefined
+      ) {
+        this._configByUuid.set(trace.uuid, {
+          ...this.getConfig(trace.uuid),
+          machines: result.embeddedMachineIds.map((id) => ({id, name: ''})),
+        });
+      }
       this.invalidate();
       this.onAnalysisCompleted?.(trace.uuid);
     } catch (e) {

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller_unittest.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller_unittest.ts
@@ -293,4 +293,101 @@ describe('MultiTraceController', () => {
       }
     });
   });
+
+  describe('manifest serialization', () => {
+    // A single-machine, single-clock (BOOTTIME) analyzed trace.
+    function analyzed(uuid: string, name: string): TraceFileAnalyzed {
+      return {
+        uuid,
+        file: new File([], name),
+        status: 'analyzed',
+        analysis: {
+          format: 'Perfetto',
+          singleClock: true,
+          singleMachine: true,
+          builtinClockIds: [6],
+        },
+      };
+    }
+
+    function manifest(): {files?: Array<Record<string, unknown>>} {
+      return JSON.parse(controller.getManifestJson()).perfetto_manifest;
+    }
+
+    beforeEach(() => {
+      controller.setTracesForTesting([
+        analyzed('u1', 'a.pftrace'),
+        analyzed('u2', 'b.pftrace'),
+      ]);
+    });
+
+    it('is trivial until a file carries config', () => {
+      expect(controller.hasManifestConfig()).toBe(false);
+      expect(manifest().files).toBeUndefined();
+    });
+
+    it('manual mode emits nothing until an offset is set', () => {
+      controller.updateConfig('u2', {alignMode: 'manual'});
+      expect(controller.hasManifestConfig()).toBe(false);
+    });
+
+    it('serializes a manual offset against the baseline clock', () => {
+      controller.updateConfig('u2', {alignMode: 'manual', offsetText: '500'});
+      const entry = manifest().files?.find((f) => f.path === 'b.pftrace');
+      // b's own BOOTTIME relates to a's BOOTTIME at +500ns.
+      expect(entry?.clocks).toEqual({
+        clock: 'BOOTTIME',
+        sync_to: {file: 'a.pftrace', clock: 'BOOTTIME'},
+        offset_ns: 500,
+      });
+    });
+
+    it('ignores a non-integer offset (free-text not yet valid)', () => {
+      controller.updateConfig('u2', {alignMode: 'manual', offsetText: '-'});
+      expect(controller.hasManifestConfig()).toBe(false);
+    });
+
+    it('flags an offset that shares a machine with the baseline', () => {
+      controller.updateConfig('u2', {alignMode: 'manual', offsetText: '500'});
+      // Both on the default machine: relating BOOTTIME to itself is rejected.
+      expect(controller.configError()).toContain('its own machine');
+
+      // Put u2 on its own machine: the offset is now valid.
+      const id = controller.addMachine();
+      controller.renameMachine(id, 'phone');
+      controller.updateConfig('u2', {machineId: id});
+      expect(controller.configError()).toBeUndefined();
+    });
+
+    it('assigns a file to a named machine', () => {
+      const id = controller.addMachine();
+      controller.renameMachine(id, 'phone');
+      controller.updateConfig('u2', {machineId: id});
+      const entry = manifest().files?.find((f) => f.path === 'b.pftrace');
+      expect(entry?.machine).toEqual({name: 'phone'});
+    });
+
+    it('emits machines[] only once every embedded id is named', () => {
+      controller.updateConfig('u1', {
+        machines: [
+          {id: 0, name: ''},
+          {id: 1, name: 'server'},
+        ],
+      });
+      // One id still blank: the importer rejects a partial remap, so emit none.
+      expect(controller.hasManifestConfig()).toBe(false);
+
+      controller.updateConfig('u1', {
+        machines: [
+          {id: 0, name: 'host'},
+          {id: 1, name: 'server'},
+        ],
+      });
+      const entry = manifest().files?.find((f) => f.path === 'a.pftrace');
+      expect(entry?.machines).toEqual([
+        {id: 0, name: 'host'},
+        {id: 1, name: 'server'},
+      ]);
+    });
+  });
 });

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
@@ -137,12 +137,7 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
     return m(
       Callout,
       {intent: Intent.None},
-      m(
-        Stack,
-        {orientation: 'horizontal', spacing: 'small'},
-        m(Spinner),
-        text,
-      ),
+      m(Stack, {orientation: 'horizontal', spacing: 'small'}, m(Spinner), text),
     );
   }
 
@@ -556,11 +551,15 @@ class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
       if (value === 'default') {
         controller.updateConfig(trace.uuid, {machineId: undefined});
       } else if (value === 'add') {
-        controller.updateConfig(trace.uuid, {machineId: controller.addMachine()});
+        controller.updateConfig(trace.uuid, {
+          machineId: controller.addMachine(),
+        });
         // Jump straight into naming the machine just created.
         this.editingMachine = trace.uuid;
       } else {
-        controller.updateConfig(trace.uuid, {machineId: Number(value.slice(2))});
+        controller.updateConfig(trace.uuid, {
+          machineId: Number(value.slice(2)),
+        });
       }
     };
 

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
@@ -32,7 +32,8 @@ import {TextInput} from '../../widgets/text_input';
 import {Tooltip} from '../../widgets/tooltip';
 import {TextParagraph} from '../../widgets/text_paragraph';
 import {MultiTraceController} from './multi_trace_controller';
-import type {AlignMode, ClockName, TraceFile} from './multi_trace_types';
+import type {ClockName, TraceFile} from './multi_trace_types';
+import {parseOffsetNs} from './multi_trace_types';
 import type {AlignmentVerdict} from './trace_analyzer';
 import {WasmTraceAnalyzer} from './trace_analyzer';
 
@@ -74,14 +75,98 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
       Stack,
       {className: 'pf-multi-trace-modal', orientation: 'vertical'},
       this.renderDescription(),
-      this.currentTab === 'merge' && this.renderLoadingError(),
       this.currentTab === 'merge' &&
         m(MergeConfigurator, {controller: this.controller}),
+      this.currentTab === 'merge' && this.renderStatus(),
       m(
         Stack,
         {className: 'pf-multi-trace-modal__footer', orientation: 'horizontal'},
         this.renderActions(),
       ),
+    );
+  }
+
+  // A single, always-present status line for the whole merge: processing, a
+  // blocking error, the latest (auto-run) alignment verdict, or all-clear.
+  // Lives outside the scrollable list, with reserved height, so it is always
+  // visible and the layout doesn't jump as the state changes.
+  private renderStatus() {
+    return m('.pf-multi-trace-modal__status-panel', this.statusContent());
+  }
+
+  private statusContent() {
+    const controller = this.controller;
+    if (controller.isAnalyzing()) {
+      return this.processingCallout('Analyzing traces...');
+    }
+    switch (controller.getLoadingError()) {
+      case 'NO_TRACES':
+        return m(Callout, {icon: 'info'}, 'Add at least one trace to open.');
+      case 'DUPLICATE_NAMES':
+        return m(
+          Callout,
+          {intent: Intent.Danger, icon: 'error_outline'},
+          'Two traces share the same file name. Remove or rename one.',
+        );
+      case 'TRACE_ERROR':
+        return m(
+          Callout,
+          {intent: Intent.Danger, icon: 'error_outline'},
+          'Remove the traces that failed to load before opening.',
+        );
+      default:
+        break;
+    }
+    // A config error (bad offset, or an offset that shares a machine with the
+    // baseline) takes priority over the verdict, and blocks opening.
+    const configError = controller.configError();
+    if (configError !== undefined) {
+      return m(Callout, {intent: Intent.Warning, icon: 'warning'}, configError);
+    }
+    // A verdict means a check finished; otherwise one is running or queued.
+    const verdict = controller.alignmentVerdict;
+    if (verdict !== undefined) {
+      return this.renderVerdict(verdict);
+    }
+    return this.processingCallout(
+      'Checking if the traces line up on the timeline...',
+    );
+  }
+
+  private processingCallout(text: string) {
+    return m(
+      Callout,
+      {intent: Intent.None},
+      m(
+        Stack,
+        {orientation: 'horizontal', spacing: 'small'},
+        m(Spinner),
+        text,
+      ),
+    );
+  }
+
+  private renderVerdict(verdict: AlignmentVerdict) {
+    if (verdict.validationError !== undefined) {
+      return m(
+        Callout,
+        {intent: Intent.Danger, icon: 'error_outline'},
+        `Manifest error: ${verdict.validationError}`,
+      );
+    }
+    if (!verdict.ok) {
+      return m(
+        Callout,
+        {intent: Intent.Warning, icon: 'warning'},
+        `${verdict.droppedEvents.toLocaleString()} events would be dropped: ` +
+          'some traces share no clock with the shared timeline and will be ' +
+          'omitted. Set an explicit alignment, or check the manifest.',
+      );
+    }
+    return m(
+      Callout,
+      {intent: Intent.Success, icon: 'check_circle'},
+      'All traces line up on the shared timeline.',
     );
   }
 
@@ -168,19 +253,13 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
     }
 
     const disabled = this.controller.getLoadingError() !== undefined;
-    const checking = this.controller.isCheckingAlignment;
+    // A config error (e.g. an offset sharing a machine with the baseline) is not
+    // openable, but the manifest is still copyable/downloadable for debugging.
+    const openBlocked = disabled || this.controller.configError() !== undefined;
 
+    // Alignment runs automatically (debounced) and its result shows in the
+    // status callout above; the footer is just the output actions.
     return [
-      m(Button, {
-        label: 'Check alignment',
-        icon: 'rule',
-        disabled: checking || disabled,
-        onclick: () => this.controller.checkAlignment(),
-      }),
-      renderHelp(
-        'Dry-runs the merge and reports whether every trace lines up on the ' +
-          'shared timeline, or how many events would be dropped.',
-      ),
       m('.pf-multi-trace-modal__footer-spacer'),
       m(Button, {
         label: 'Copy manifest',
@@ -198,41 +277,10 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
         label: 'Open Traces',
         intent: Intent.Primary,
         variant: ButtonVariant.Filled,
-        disabled,
+        disabled: openBlocked,
         onclick: () => this.openTraces(),
       }),
     ];
-  }
-
-  private renderLoadingError() {
-    const error = this.controller.getLoadingError();
-    if (error === undefined) {
-      return undefined;
-    }
-    return m(
-      Callout,
-      {
-        className: 'pf-multi-trace-modal__panel-error',
-        intent: Intent.Danger,
-        icon: 'error_outline',
-      },
-      this.errorMessage(error),
-    );
-  }
-
-  private errorMessage(error: string): string {
-    switch (error) {
-      case 'NO_TRACES':
-        return 'Add at least one trace to open.';
-      case 'DUPLICATE_NAMES':
-        return 'Two traces share the same file name. Remove or rename one.';
-      case 'ANALYZING':
-        return 'Wait for all traces to be analyzed.';
-      case 'TRACE_ERROR':
-        return 'Remove traces with errors before opening.';
-      default:
-        return 'An unknown error occurred.';
-    }
   }
 
   private openTraces() {
@@ -271,6 +319,10 @@ interface MergeConfiguratorAttrs {
 }
 
 class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
+  // The trace uuid whose assigned machine is currently being renamed inline,
+  // toggled by the per-row edit button. undefined => no rename in progress.
+  private editingMachine?: string;
+
   view({attrs}: m.Vnode<MergeConfiguratorAttrs>) {
     const {controller} = attrs;
     return m(
@@ -287,56 +339,6 @@ class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
         m(Icon, {icon: 'add'}),
         'Add more traces',
       ),
-      this.renderVerdictPanel(controller),
-    );
-  }
-
-  // Verdict for "Check alignment"; the button lives in the footer.
-  private renderVerdictPanel(controller: MultiTraceController) {
-    const verdict = controller.alignmentVerdict;
-    const checking = controller.isCheckingAlignment;
-    if (!checking && verdict === undefined) {
-      return undefined;
-    }
-    return m(
-      Stack,
-      {
-        className: 'pf-multi-trace-modal__align-panel',
-        orientation: 'vertical',
-        spacing: 'small',
-      },
-      checking &&
-        m(
-          Stack,
-          {orientation: 'horizontal', spacing: 'small'},
-          m(Spinner),
-          'Checking how these traces line up...',
-        ),
-      !checking && verdict !== undefined && this.renderVerdict(verdict),
-    );
-  }
-
-  private renderVerdict(verdict: AlignmentVerdict) {
-    if (verdict.validationError !== undefined) {
-      return m(
-        Callout,
-        {intent: Intent.Danger, icon: 'error_outline'},
-        `Manifest error: ${verdict.validationError}`,
-      );
-    }
-    if (!verdict.ok) {
-      return m(
-        Callout,
-        {intent: Intent.Warning, icon: 'warning'},
-        `${verdict.droppedEvents.toLocaleString()} events would be dropped: ` +
-          'some traces share no clock with the shared timeline and will be ' +
-          'omitted. Set an explicit alignment, or check the manifest.',
-      );
-    }
-    return m(
-      Callout,
-      {intent: Intent.Success, icon: 'check_circle'},
-      'All traces line up on the shared timeline.',
     );
   }
 
@@ -485,9 +487,13 @@ class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
       return undefined;
     }
     const a = trace.analysis;
+    const isMultiMachine = a.singleMachine === false;
     const children: m.Children[] = [];
 
-    if (a.singleClock === false) {
+    // Clock alignment first. Multi-machine and multi-clock files carry their own
+    // snapshots and align automatically; only single-machine single-clock files
+    // take a manual placement.
+    if (a.singleClock === false || isMultiMachine) {
       children.push(
         m(
           '.pf-multi-trace-modal__note',
@@ -504,6 +510,15 @@ class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
       }
     }
 
+    // Machine identity, independent of clock alignment. A single-machine file's
+    // assignment only matters when merging >=2 traces (it tells them apart); a
+    // multi-machine trace always offers the per-id remap.
+    if (isMultiMachine) {
+      children.push(this.renderMachineRemap(trace, controller));
+    } else if (controller.traces.length >= 2) {
+      children.push(this.renderMachineControl(trace, controller));
+    }
+
     if (children.length === 0) {
       return undefined;
     }
@@ -511,13 +526,154 @@ class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
       Stack,
       {
         className: 'pf-multi-trace-modal__config',
-        orientation: 'horizontal',
-        spacing: 'large',
+        orientation: 'vertical',
+        spacing: 'small',
       },
       children,
     );
   }
 
+  // Picks which machine this file belongs to from the shared registry; the
+  // selection serializes to files[].machine.name. Host is the default; "Add
+  // machine..." creates one (available to every file) and the inline box names
+  // it. Renaming here renames the registry entry for every file using it.
+  private renderMachineControl(
+    trace: TraceFile,
+    controller: MultiTraceController,
+  ) {
+    const config = controller.getConfig(trace.uuid);
+    const selectedId = config.machineId;
+    const machines = controller.machines;
+    const options = [
+      {value: 'default', label: 'Default'},
+      ...machines.map((mm) => ({
+        value: `m:${mm.id}`,
+        label: mm.name.trim().length > 0 ? mm.name : '(unnamed)',
+      })),
+      {value: 'add', label: '+ Add machine...'},
+    ];
+    const onSelect = (value: string) => {
+      if (value === 'default') {
+        controller.updateConfig(trace.uuid, {machineId: undefined});
+      } else if (value === 'add') {
+        controller.updateConfig(trace.uuid, {machineId: controller.addMachine()});
+        // Jump straight into naming the machine just created.
+        this.editingMachine = trace.uuid;
+      } else {
+        controller.updateConfig(trace.uuid, {machineId: Number(value.slice(2))});
+      }
+    };
+
+    const help = renderHelp(
+      'A machine is one device or host: a phone, a server, a VM. Keep ' +
+        '"Default" to merge this trace onto the shared timeline, or assign ' +
+        "it to its own machine so the merged trace keeps each device's CPUs, " +
+        'processes and threads grouped separately. Add a machine once and ' +
+        'pick it for several files to place them all on the same machine.',
+    );
+
+    // While renaming, the picker is replaced by an inline name field. The edit
+    // is an explicit action (the pencil button below), so the field is not a
+    // permanent box morphing next to the picker.
+    if (selectedId !== undefined && this.editingMachine === trace.uuid) {
+      return m(
+        Stack,
+        {
+          className: 'pf-multi-trace-modal__control-row',
+          orientation: 'horizontal',
+          spacing: 'small',
+        },
+        m('strong', 'Machine:'),
+        m(TextInput, {
+          autofocus: true,
+          placeholder: 'machine name',
+          value: machines.find((mm) => mm.id === selectedId)?.name ?? '',
+          onInput: (value: string) =>
+            controller.renameMachine(selectedId, value),
+          // Enter or blur finishes the edit.
+          onChange: () => {
+            this.editingMachine = undefined;
+          },
+        }),
+        m(Button, {
+          icon: 'check',
+          onclick: () => {
+            this.editingMachine = undefined;
+          },
+        }),
+        help,
+      );
+    }
+
+    return m(
+      Stack,
+      {
+        className: 'pf-multi-trace-modal__control-row',
+        orientation: 'horizontal',
+        spacing: 'small',
+      },
+      m('strong', 'Machine:'),
+      this.renderDropdown(
+        selectedId !== undefined ? `m:${selectedId}` : 'default',
+        options,
+        onSelect,
+      ),
+      // Rename the selected machine (a real machine, not the default).
+      selectedId !== undefined &&
+        m(Button, {
+          icon: 'edit',
+          onclick: () => {
+            this.editingMachine = trace.uuid;
+          },
+        }),
+      help,
+    );
+  }
+
+  // Name each embedded machine_id of a multi-machine proto. Names are emitted
+  // as files[].machines[] only once all are filled (see serializer).
+  private renderMachineRemap(
+    trace: TraceFile,
+    controller: MultiTraceController,
+  ) {
+    const machines = controller.getConfig(trace.uuid).machines ?? [];
+    return m(
+      Stack,
+      {orientation: 'vertical', spacing: 'small'},
+      m(
+        Stack,
+        {orientation: 'horizontal', spacing: 'small'},
+        m('strong', `Machines (${machines.length}):`),
+        renderHelp(
+          'A machine is one device or host (a phone, a server, a VM). This ' +
+            'trace was itself recorded across several of them, each tagged ' +
+            'with only a numeric id. Give every id a readable name to label ' +
+            'it in the merged trace. The names take effect only once all ids ' +
+            'are named.',
+        ),
+      ),
+      machines.map((mm) =>
+        m(
+          Stack,
+          {orientation: 'horizontal', spacing: 'small', key: mm.id},
+          m('span', `id ${mm.id} →`),
+          m(TextInput, {
+            placeholder: 'machine name',
+            value: mm.name,
+            onInput: (v: string) => {
+              const next = machines.map((x) =>
+                x.id === mm.id ? {id: x.id, name: v} : x,
+              );
+              controller.updateConfig(trace.uuid, {machines: next});
+            },
+          }),
+        ),
+      ),
+    );
+  }
+
+  // One sentence on a single line: "Align: [automatically] " or
+  // "Align: [by a fixed offset] [N] ns from [file] clock [name]".
   private renderAlignControl(
     trace: TraceFile,
     controller: MultiTraceController,
@@ -526,7 +682,7 @@ class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
     return m(
       Stack,
       {
-        className: 'pf-multi-trace-modal__control-row',
+        className: 'pf-multi-trace-modal__align-row',
         orientation: 'horizontal',
         spacing: 'small',
       },
@@ -534,32 +690,52 @@ class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
       this.renderDropdown(
         config.alignMode,
         [
-          {value: 'auto', label: 'Automatic'},
-          {value: 'offset', label: 'Fixed offset'},
+          {value: 'auto', label: 'automatically'},
+          {value: 'manual', label: 'by a fixed offset'},
         ],
         (value) =>
-          controller.updateConfig(trace.uuid, {alignMode: value as AlignMode}),
+          controller.updateConfig(trace.uuid, {
+            alignMode: value === 'manual' ? 'manual' : 'auto',
+          }),
       ),
-      config.alignMode === 'offset' &&
-        m(TextInput, {
-          type: 'number',
-          placeholder: 'offset (ns)',
-          value: config.offsetNs !== undefined ? String(config.offsetNs) : '',
-          onChange: (value: string) => {
-            const n = Number(value);
-            const valid = value.trim().length > 0 && Number.isFinite(n);
-            controller.updateConfig(trace.uuid, {
-              offsetNs: valid ? n : undefined,
-            });
-          },
-        }),
+      ...(config.alignMode === 'manual'
+        ? this.manualFieldChildren(trace, controller)
+        : []),
       renderHelp(
-        'Where this trace sits on the shared timeline. Automatic lines it up ' +
-          'using its own clocks. Fixed offset shifts it by a set number of ' +
-          'nanoseconds relative to the baseline trace; a positive value moves ' +
-          'it later.',
+        'Where this trace sits on the shared timeline. Automatically lines ' +
+          'it up using its own clocks. By a fixed offset moves it by a set ' +
+          'number of nanoseconds relative to the baseline trace; a positive ' +
+          'value moves it later.',
       ),
     );
+  }
+
+  // The manual-offset inputs, as inline tokens of the Align sentence: a free-
+  // text offset (so a partial "-" survives) relative to the baseline trace.
+  // Invalid text is flagged rather than silently dropped.
+  private manualFieldChildren(
+    trace: TraceFile,
+    controller: MultiTraceController,
+  ): m.Children[] {
+    const uuid = trace.uuid;
+    const offsetText = controller.getConfig(uuid).offsetText ?? '';
+    const offsetInvalid =
+      offsetText.trim().length > 0 && parseOffsetNs(offsetText) === undefined;
+    const baseline = controller.baselineName(uuid);
+    return [
+      m(TextInput, {
+        className: offsetInvalid
+          ? 'pf-multi-trace-modal__offset--invalid'
+          : undefined,
+        placeholder: 'offset',
+        value: offsetText,
+        onInput: (v: string) => controller.updateConfig(uuid, {offsetText: v}),
+      }),
+      m('span', 'ns'),
+      offsetInvalid && m('span.pf-multi-trace-modal__hint', '(whole number)'),
+      baseline !== undefined &&
+        m('span.pf-multi-trace-modal__note', `from ${baseline}`),
+    ];
   }
 
   private renderCardActions(

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_types.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_types.ts
@@ -73,13 +73,40 @@ export const BUILTIN_CLOCKS: ReadonlyArray<{id: number; name: ClockName}> = [
   {id: 6, name: 'BOOTTIME'},
 ];
 
-// Manual modes supply values the UI doesn't compute (offset only, for now).
-export type AlignMode = 'auto' | 'offset';
+// Resolve builtin clock ids to their names, in BUILTIN_CLOCKS (display) order.
+export function clockNamesForIds(
+  ids: ReadonlyArray<number>,
+): ReadonlyArray<ClockName> {
+  return BUILTIN_CLOCKS.filter((c) => ids.includes(c.id)).map((c) => c.name);
+}
+
+// Two placements only: `auto` lets the importer line the file up from its own
+// clocks; `manual` shifts it by a fixed offset relative to a reference clock in
+// another file. (The old anchor/native/peg split was removed in favour of this
+// single manual knob.)
+export type AlignMode = 'auto' | 'manual';
+
+// A single embedded machine id of a multi-machine proto, paired with the name
+// to remap it to.
+export interface MachineRemap {
+  id: number;
+  name: string;
+}
 
 // Defaults emit nothing beyond the path, so the importer auto-aligns.
 export interface FileMergeConfig {
+  // Single-machine files: the shared-registry machine this file is assigned to
+  // (the controller owns the registry). undefined => the host machine.
+  // Serializes to files[].machine.name once the machine has a name.
+  machineId?: number;
+  // Multi-machine protos: per embedded id name remap, auto-seeded on analysis.
+  // Serializes to files[].machines[] once every id is named.
+  machines?: ReadonlyArray<MachineRemap>;
   alignMode: AlignMode;
-  offsetNs?: number;
+  // Manual offset from the baseline trace, as the raw text the user typed (so a
+  // partial "-" survives editing); parsed to an integer ns at serialize time.
+  // Positive moves this file later.
+  offsetText?: string;
 }
 
 export interface TraceTimeConfig {
@@ -90,6 +117,16 @@ export function defaultFileMergeConfig(): FileMergeConfig {
   return {alignMode: 'auto'};
 }
 
+// Parses the manual offset text to an integer ns, or undefined when blank or
+// not a whole number (the manifest's offset_ns must be integral).
+export function parseOffsetNs(text: string | undefined): number | undefined {
+  if (text === undefined) return undefined;
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return undefined;
+  const n = Number(trimmed);
+  return Number.isFinite(n) && Number.isInteger(n) ? n : undefined;
+}
+
 // Populated by the tokenize-only dry-run; gates which controls each file shows.
 export interface FileAnalysis {
   format: string;
@@ -98,4 +135,8 @@ export interface FileAnalysis {
   privateClockOnly?: boolean;
   // The builtin clock ids present (a subset of BUILTIN_CLOCKS).
   builtinClockIds?: ReadonlyArray<number>;
+  // True when every embedded machine is the host (raw_id 0).
+  singleMachine?: boolean;
+  // The embedded machine raw_ids, present for multi-machine protos.
+  embeddedMachineIds?: ReadonlyArray<number>;
 }

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/styles.scss
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/styles.scss
@@ -128,8 +128,15 @@
     font-size: 0.9em;
   }
 
-  &__panel-error {
-    margin: 8px 0;
+  // Invalid free-text offset: flag it instead of silently dropping the value.
+  &__offset--invalid {
+    outline: 1px solid var(--pf-color-danger);
+    border-radius: 2px;
+  }
+
+  &__hint {
+    color: var(--pf-color-danger);
+    font-size: 0.85em;
   }
 
   &__help {
@@ -146,15 +153,21 @@
     align-items: center;
   }
 
+  // The whole align sentence on one line; wrap at word boundaries if long.
+  &__align-row {
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
   &__row-top {
     align-items: flex-start;
     justify-content: space-between;
     width: 100%;
   }
 
+  // Stacked vertically: each control (Machine, Align, ...) on its own line.
   &__config {
-    align-items: center;
-    flex-wrap: wrap;
+    align-items: flex-start;
     padding-top: 8px;
     margin-top: 8px;
     border-top: 1px solid var(--pf-color-border);
@@ -167,9 +180,12 @@
     color: var(--pf-color-text-secondary);
   }
 
-  &__align-panel {
-    align-items: flex-start;
+  // Reserved status line: min-height keeps the layout stable as the state
+  // cycles through processing / verdict / ready.
+  &__status-panel {
     padding: 12px 0 4px;
+    min-height: 60px;
+    box-sizing: border-box;
   }
 
   &__footer {

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
@@ -85,8 +85,8 @@ function newTokenizeOnlyEngine(): WasmEngineProxy {
   return engine;
 }
 
-// Best-effort clock signals; on query failure the fields stay undefined and the
-// UI degrades to showing all controls.
+// Best-effort clock/machine signals; on query failure the fields stay undefined
+// and the UI degrades to showing all controls.
 async function queryFileSignals(
   engine: WasmEngineProxy,
 ): Promise<Partial<FileAnalysis>> {
@@ -94,7 +94,25 @@ async function queryFileSignals(
     singleClock?: boolean;
     privateClockOnly?: boolean;
     builtinClockIds?: number[];
+    singleMachine?: boolean;
+    embeddedMachineIds?: number[];
   } = {};
+
+  try {
+    const res = await engine.query(`SELECT raw_id FROM machine ORDER BY raw_id`);
+    const it = res.iter({raw_id: NUM});
+    const ids: number[] = [];
+    for (; it.valid(); it.next()) {
+      ids.push(it.raw_id);
+    }
+    if (ids.length > 0) {
+      out.embeddedMachineIds = ids;
+      // A trace is single-machine if every machine seen is the host (raw_id 0).
+      out.singleMachine = ids.every((id) => id === 0);
+    }
+  } catch {
+    // machine table unavailable in tokenize-only on this build.
+  }
 
   try {
     const builtinIds = BUILTIN_CLOCKS.map((c) => c.id).join(', ');

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
@@ -99,7 +99,9 @@ async function queryFileSignals(
   } = {};
 
   try {
-    const res = await engine.query(`SELECT raw_id FROM machine ORDER BY raw_id`);
+    const res = await engine.query(
+      `SELECT raw_id FROM machine ORDER BY raw_id`,
+    );
     const it = res.iter({raw_id: NUM});
     const ids: number[] = [];
     for (; it.valid(); it.next()) {


### PR DESCRIPTION
This CL completes support for all the complexity of trace merging
both across clocks and across machines. This now makes it possible
to open all sorts of combinations of traces in the UI.
