### PR TITLE
tp: fix missing null check when doing dfs

### DIFF
--- a/src/trace_processor/plugins/type_builder_functions/type_builders.cc
+++ b/src/trace_processor/plugins/type_builder_functions/type_builders.cc
@@ -172,9 +172,20 @@ struct NodeAgg : public sqlite::AggregateFunction<NodeAgg> {
     PERFETTO_DCHECK(argc == kArgCount);
 
     auto source_id = static_cast<uint32_t>(sqlite::value::Int64(argv[0]));
+    auto& agg_ctx = AggCtx::GetOrCreateContextForStep(ctx);
+
+    // A NULL target means the source node has no edge (e.g. a root in a tree
+    // whose parent_id is NULL). Without this check, Int64() would coerce the
+    // NULL to 0 and create a spurious edge to node 0.
+    if (sqlite::value::IsNull(argv[1])) {
+      if (source_id >= agg_ctx.graph.size()) {
+        agg_ctx.graph.resize(source_id + 1);
+      }
+      return;
+    }
+
     auto target_id = static_cast<uint32_t>(sqlite::value::Int64(argv[1]));
     uint32_t max_id = std::max(source_id, target_id);
-    auto& agg_ctx = AggCtx::GetOrCreateContextForStep(ctx);
     if (max_id >= agg_ctx.graph.size()) {
       agg_ctx.graph.resize(max_id + 1);
     }

--- a/test/trace_processor/diff_tests/stdlib/graphs/search_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/graphs/search_tests.py
@@ -81,6 +81,33 @@ class GraphSearchTests(TestSuite):
         11,10
         """))
 
+  # Regression test: a NULL dest_node_id (e.g. a tree root whose parent_id is
+  # NULL) must not be coerced into an edge to node 0. Here node 0 is a separate
+  # root; traversing from node 2 must stop at its NULL-parent root (node 1) and
+  # never reach node 0.
+  def test_dfs_null_dest_does_not_link_to_node_zero(self):
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE graphs.search;
+
+          CREATE PERFETTO TABLE foo AS
+          SELECT NULL AS source_node_id, NULL AS dest_node_id WHERE FALSE
+          UNION ALL
+          VALUES (2, 1)
+          UNION ALL
+          VALUES (1, NULL)
+          UNION ALL
+          VALUES (0, NULL);
+
+          SELECT * FROM graph_reachable_dfs!(foo, (SELECT 2 AS node_id));
+        """,
+        out=Csv("""
+        "node_id","parent_node_id"
+        2,"[NULL]"
+        1,2
+        """))
+
   def test_dfs_lengauer_tarjan_example(self):
     return DiffTestBlueprint(
         trace=DataPath('counters.json'),


### PR DESCRIPTION
We were accidentally falling back to frame id at 0 which is just wrong.
