### PR TITLE
android_sdk: add a boolean addField overload to the track event builder

### DIFF
--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
@@ -631,6 +631,14 @@ public final class PerfettoTrackEventBuilder {
     return this;
   }
 
+  /**
+   * Adds a proto boolean field with field id {@code id}, encoded as the varint 1
+   * ({@code true}) or 0 ({@code false}).
+   */
+  public PerfettoTrackEventBuilder addField(long id, boolean val) {
+    return addField(id, val ? 1L : 0L);
+  }
+
   /** Adds a proto field with field id {@code id} and value {@code val}. */
   public PerfettoTrackEventBuilder addField(long id, double val) {
     if (!mIsCategoryEnabled) {


### PR DESCRIPTION
The proto builder has no boolean addField; callers had to write 1/0 by hand. Add addField(long id, boolean val) that to long. On the wire it encodes to varint so the net effect is same.
