### PR TITLE
stdlib, ui: Add partitioned interval self intersect and use in breakdown tracks

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/intervals/intersect.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/intersect.sql
@@ -15,6 +15,8 @@
 
 -- sqlformat file off
 
+INCLUDE PERFETTO MODULE std.metasql.unparenthesize;
+
 CREATE PERFETTO MACRO _ii_df_agg(x ColumnName, y ColumnName)
 RETURNS _ProjectionFragment
 AS __intrinsic_stringify!($x), input.$y;
@@ -293,3 +295,74 @@ AS (
   JOIN _atomic_segments a ON a.ts = e.ts
   WHERE e.is_start = FALSE
 );
+
+-- Like interval_self_intersect but partitions by a set of columns. Intervals
+-- in different partitions do not intersect with each other.
+--
+-- Runtime is O(n log n + m) per partition, where n is the number of intervals in
+-- each partition and m is the size of the output.
+CREATE PERFETTO MACRO interval_self_intersect_partitioned(
+  -- Table or subquery containing interval data.
+  intervals TableOrSubquery,
+  -- Columns to partition by
+  partition_columns ColumnNameList
+)
+RETURNS TableOrSubquery
+AS
+(
+  WITH
+    _all_endpoints AS (
+      SELECT id AS original_id, ts, TRUE as is_start
+      __intrinsic_token_apply_prefix!(_ii_df_select, $partition_columns, $partition_columns)
+      FROM $intervals
+      UNION
+      SELECT id AS original_id, ts + dur AS ts, FALSE as is_start
+      __intrinsic_token_apply_prefix!(_ii_df_select, $partition_columns, $partition_columns)
+      FROM $intervals
+    ),
+    _atomic_segments AS (
+      SELECT
+        ROW_NUMBER() OVER (ORDER BY metasql_unparenthesize_exprlist!($partition_columns), ts) AS id,
+        ts,
+        IFNULL(LEAD(ts) OVER (PARTITION BY metasql_unparenthesize_exprlist!($partition_columns) ORDER BY ts) - ts, 0) AS dur
+        __intrinsic_token_apply_prefix!(_ii_df_select, $partition_columns, $partition_columns)
+      FROM _all_endpoints
+      GROUP BY ts, metasql_unparenthesize_exprlist!($partition_columns)
+    ),
+    _ii AS (
+      SELECT
+        ii.ts,
+        ii.dur,
+        ii.id_0 AS group_id,
+        ii.id_1 AS original_id
+        __intrinsic_token_apply_prefix!(_ii_df_select, $partition_columns, $partition_columns)
+      FROM _interval_intersect!((_atomic_segments, $intervals), $partition_columns) ii
+    )
+  -- Part A: Standard segments
+  SELECT
+    ts,
+    dur,
+    group_id,
+    original_id AS id,
+    FALSE AS interval_ends_at_ts
+    __intrinsic_token_apply_prefix!(_ii_df_select, $partition_columns, $partition_columns)
+  FROM _ii
+  WHERE dur > 0
+
+  UNION ALL
+
+  -- Part B: End markers.
+  -- We join back to _atomic_segments to get the 'next' duration
+  -- to match the original implementation's quirk.
+  SELECT
+    e.ts AS ts,
+    a.dur AS dur,
+    a.id AS group_id,
+    e.original_id AS id,
+    TRUE AS interval_ends_at_ts
+    __intrinsic_token_apply_prefix!(_ii_df_select, $partition_columns, $partition_columns)
+  FROM _all_endpoints e
+  NATURAL JOIN _atomic_segments a
+  WHERE e.is_start = FALSE
+);
+

--- a/src/trace_processor/perfetto_sql/stdlib/intervals/intersect.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/intersect.sql
@@ -96,7 +96,7 @@ AS (
     -- Columns for partitions, one for each column with partition.
     __intrinsic_token_apply_prefix!(
       _ii_df_select,
-      (c17, c18, c19, c20),
+      (c17, c18, c19, c20, c21, c22, c23, c24, c25, c26),
       $agg_columns
     )
   -- Interval intersect result table.
@@ -138,7 +138,7 @@ AS (
     -- Partition columns.
     __intrinsic_token_apply_and_prefix!(
       _ii_df_bind,
-      (c17, c18, c19, c20),
+      (c17, c18, c19, c20, c21, c22, c23, c24, c25, c26),
       $agg_columns
     )
 );
@@ -308,8 +308,7 @@ CREATE PERFETTO MACRO interval_self_intersect_partitioned(
   partition_columns ColumnNameList
 )
 RETURNS TableOrSubquery
-AS
-(
+AS (
   WITH
     _all_endpoints AS (
       SELECT id AS original_id, ts, TRUE as is_start
@@ -365,4 +364,3 @@ AS
   NATURAL JOIN _atomic_segments a
   WHERE e.is_start = FALSE
 );
-

--- a/src/trace_processor/plugins/interval_intersect/interval_intersect.cc
+++ b/src/trace_processor/plugins/interval_intersect/interval_intersect.cc
@@ -262,9 +262,9 @@ struct IntervalIntersect : public sqlite::Function<IntervalIntersect> {
     }
     std::vector<std::string> partition_columns =
         base::SplitString(base::StripChars(partition_list, "()", ' '), ",");
-    if (partition_columns.size() > 4) {
+    if (partition_columns.size() > 10) {
       return sqlite::result::Error(
-          ctx, "interval intersect: Can take at most 4 partitions.");
+          ctx, "interval intersect: Can take at most 10 partitions.");
     }
     for (const auto& c : partition_columns) {
       std::string p_col_name = base::TrimWhitespace(c);

--- a/test/trace_processor/diff_tests/stdlib/intervals/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/intervals/tests.py
@@ -305,6 +305,84 @@ class StdlibIntervals(TestSuite):
         310,0,11,5,1
         """))
 
+  def test_interval_self_intersect_partitioned(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        WITH
+          data(ts, dur, id, group_name) AS (
+            VALUES
+              -- Group A: overlapping intervals
+              (10, 100, 0, 'A'),
+              (20, 40, 1, 'A'),
+              (30, 120, 2, 'A'),
+              -- Group B: separate intervals
+              (200, 10, 3, 'B'),
+              (200, 20, 4, 'B'),
+              -- Group C: single interval
+              (300, 10, 5, 'C')
+          )
+        SELECT *
+        FROM interval_self_intersect_partitioned!(data, (group_name))
+        ORDER BY group_name ASC, ts ASC, id ASC;
+        """,
+        out=Csv("""
+        "ts","dur","group_id","id","interval_ends_at_ts","group_name"
+        10,10,1,0,0,"A"
+        20,10,2,0,0,"A"
+        20,10,2,1,0,"A"
+        30,30,3,0,0,"A"
+        30,30,3,1,0,"A"
+        30,30,3,2,0,"A"
+        60,50,4,0,0,"A"
+        60,50,4,1,1,"A"
+        60,50,4,2,0,"A"
+        110,40,5,0,1,"A"
+        110,40,5,2,0,"A"
+        150,0,6,2,1,"A"
+        200,10,7,3,0,"B"
+        200,10,7,4,0,"B"
+        210,10,8,3,1,"B"
+        210,10,8,4,0,"B"
+        220,0,9,4,1,"B"
+        300,10,10,5,0,"C"
+        310,0,11,5,1,"C"
+        """))
+
+  def test_interval_self_intersect_partitioned_multiple_keys(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+        
+        WITH
+          data(ts, dur, id, partition_a, partition_b) AS (
+            VALUES
+              (0, 10, 0, 'A', 1),
+              (5, 10, 1, 'A', 1),
+              (5, 10, 2, 'B', 1),
+              (10, 5, 3, 'B', 2)
+          )
+        SELECT *
+        FROM interval_self_intersect_partitioned!(data, (partition_a, partition_b))
+        ORDER BY partition_a ASC, partition_b ASC, ts ASC, id ASC;
+        """,
+        out=Csv("""
+        "ts","dur","group_id","id","interval_ends_at_ts","partition_a","partition_b"
+        0,5,1,0,0,"A",1
+        5,5,2,0,0,"A",1
+        5,5,2,1,0,"A",1
+        10,5,3,0,1,"A",1
+        10,5,3,1,0,"A",1
+        15,0,4,1,1,"A",1
+        5,10,5,2,0,"B",1
+        15,0,6,2,1,"B",1
+        10,5,7,3,0,"B",2
+        15,0,8,3,1,"B",2
+        """))
+
   def test_interval_merge_overlapping_partitioned(self):
     return DiffTestBlueprint(
         trace=TextProto(""),

--- a/ui/src/components/tracks/breakdown_tracks.ts
+++ b/ui/src/components/tracks/breakdown_tracks.ts
@@ -361,9 +361,16 @@ export class BreakdownTracks {
 
       CREATE PERFETTO TABLE ${this.segmentsTableName} AS
       SELECT iss.ts, iss.group_id, iss.interval_ends_at_ts, ${denormCols}
-      FROM interval_self_intersect!((
-        SELECT id, ts, dur FROM ${this.intervalsTableName}
-      )) iss
+      FROM ${
+        this.aggColNames.length > 0
+          ? `interval_self_intersect_partitioned!(
+            (SELECT id, ts, dur, ${this.aggColNames.join(', ')} FROM ${this.intervalsTableName}),
+            (${this.aggColNames.join(', ')})
+          )`
+          : `interval_self_intersect!((
+            SELECT id, ts, dur FROM ${this.intervalsTableName}
+          ))`
+      } iss
       JOIN ${this.intervalsTableName} i USING(id);
 
       CREATE PERFETTO TABLE ${this.projectedTableName} AS


### PR DESCRIPTION
When the UI computes breakdown tracks, it currently uses  interval_self_intersect . If there are many different breakdown groups (e.g. in AndroidBinderViz), this causes an O(N^2) explosion because the engine tries to intersect intervals across completely unrelated groups.     
  
  This PR fixes that by:
  
  1. Adding  interval_self_intersect_partitioned!  to the SQL stdlib to restrict self-intersections to only happen within specific partition keys.
  2. Increasing the partition column limit in  __intrinsic_interval_intersect  (C++ and SQL) from 4 to 10.
  3. Updating  breakdown_tracks.ts  to use the partitioned macro whenever there are breakdown columns present.
