### PR TITLE
uI: Add two new charts: ProportionBar and Flamegraph

### DIFF
--- a/ui/src/components/widgets/charts/flamegraph_chart.scss
+++ b/ui/src/components/widgets/charts/flamegraph_chart.scss
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-flamechart {
+  position: relative;
+  width: 100%;
+  // Guard against sub-pixel rounding pushing the rightmost segment past the
+  // chart box. Tooltips are portaled, so they're unaffected.
+  overflow: hidden;
+}
+
+.pf-flamechart-segment {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  min-width: 1px;
+  border-radius: 4px;
+  overflow: hidden;
+  // Hairline gap between adjacent segments without eating into the colour.
+  box-shadow: inset -1px 0 0 rgb(255 255 255 / 25%);
+  transition: filter 0.12s ease;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+}
+
+.pf-flamechart-segment__label {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  padding: 0 8px;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.pf-flamechart-segment__name {
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: var(--pf-font-size-xs, 11px);
+  font-weight: 600;
+  text-shadow: 0 0 2px rgb(0 0 0 / 25%);
+}
+
+.pf-flamechart-segment__value {
+  flex-shrink: 0;
+  font-size: var(--pf-font-size-xs, 11px);
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 0 2px rgb(0 0 0 / 25%);
+  opacity: 0.85;
+}
+
+.pf-flamechart-tooltip {
+  &__name {
+    font-weight: 600;
+    font-size: var(--pf-font-size-s, 12px);
+    color: var(--pf-color-text, rgb(0 0 0 / 85%));
+  }
+
+  &__value {
+    margin-top: 2px;
+    font-size: var(--pf-font-size-xs, 11px);
+    font-variant-numeric: tabular-nums;
+    color: var(--pf-color-text-muted, rgb(0 0 0 / 60%));
+  }
+
+  &__desc {
+    margin-top: 6px;
+    max-width: 280px;
+    white-space: normal;
+    font-size: var(--pf-font-size-xs, 11px);
+    line-height: 1.4;
+    color: var(--pf-color-text-muted, rgb(0 0 0 / 60%));
+  }
+}
+
+// Note: __desc is available for custom tooltip content via the segment's
+// tooltip prop; the default tooltip only uses __name and __value.

--- a/ui/src/components/widgets/charts/flamegraph_chart.ts
+++ b/ui/src/components/widgets/charts/flamegraph_chart.ts
@@ -1,0 +1,229 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {PopupPosition} from '../../../widgets/popup';
+import {CursorTooltip} from '../../../widgets/cursor_tooltip';
+import './flamegraph_chart.scss';
+
+export interface FlamegraphChartSegment {
+  readonly name: string;
+  readonly value: number;
+  readonly cssColor: string;
+  readonly children: readonly FlamegraphChartSegment[];
+  // Optional rich tooltip body. When omitted a default tooltip is shown with
+  // the name, the formatted value and the share of the root.
+  readonly tooltip?: m.Children;
+}
+
+export interface FlamegraphChartAttrs {
+  readonly data: FlamegraphChartSegment;
+  // Formats a segment's value for labels and the default tooltip. Defaults to
+  // String(value) — pass e.g. formatBytes for a memory breakdown.
+  readonly formatValue?: (value: number) => string;
+  // Height of a single row, in px. Defaults to ROW_HEIGHT.
+  readonly rowHeight?: number;
+  // Invoked when a segment is clicked.
+  readonly onSegmentClick?: (seg: FlamegraphChartSegment) => void;
+  // When true, the root segment is not drawn: its children become the top row
+  // (spanning the full width, since they already sum to the root). Useful when
+  // the root is just a redundant total. Tooltip shares stay relative to the
+  // (hidden) root.
+  readonly hideRoot?: boolean;
+}
+
+const ROW_HEIGHT = 26;
+const ROW_GAP = 3;
+// Horizontal gap (px) shaved off each segment's right edge, so adjacent
+// segments are visually separated. Kept small; thin segments fall back to the
+// CSS min-width.
+const SEG_GAP = 3;
+// Below this width fraction (of the whole chart) a segment renders no label —
+// a sliver of "…" is just noise. The tooltip still works.
+const MIN_LABEL_FRACTION = 0.04;
+
+// A segment placed in the layout: fractions are 0..1 of the chart width.
+interface PlacedSegment {
+  readonly seg: FlamegraphChartSegment;
+  readonly depth: number;
+  readonly xFrac: number; // left edge, fraction of chart width
+  readonly widthFrac: number; // width, fraction of chart width (== share of root)
+}
+
+// Recursively lays the tree out left-to-right. Each node spans its share of its
+// parent's width; the root spans the full width, so a node's widthFrac is also
+// its share of the root total.
+// Children are distributed proportionally to their sum — if they don't sum to
+// the parent's value, the remaining width is left empty (useful for showing
+// "unaccounted" portions in profiles).
+function placeSegments(
+  seg: FlamegraphChartSegment,
+  depth: number,
+  xFrac: number,
+  widthFrac: number,
+  out: PlacedSegment[],
+): void {
+  out.push({seg, depth, xFrac, widthFrac});
+
+  const childTotal = seg.children.reduce((s, c) => s + c.value, 0);
+  if (childTotal <= 0) return;
+  let childX = xFrac;
+  for (const child of seg.children) {
+    const childWidth = (child.value / childTotal) * widthFrac;
+    placeSegments(child, depth + 1, childX, childWidth, out);
+    childX += childWidth;
+  }
+}
+
+// Parses a #rgb / #rrggbb colour. Returns undefined for anything else (e.g. a
+// gradient or a var()), in which case we fall back to a neutral label colour.
+function parseHexColor(c: string): [number, number, number] | undefined {
+  const short = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i.exec(c);
+  if (short) {
+    return [
+      parseInt(short[1] + short[1], 16),
+      parseInt(short[2] + short[2], 16),
+      parseInt(short[3] + short[3], 16),
+    ];
+  }
+  const long = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(c);
+  if (long) {
+    return [
+      parseInt(long[1], 16),
+      parseInt(long[2], 16),
+      parseInt(long[3], 16),
+    ];
+  }
+  return undefined;
+}
+
+// Picks a dark or light label colour for legibility against `bg`.
+function labelColor(bg: string): string {
+  const rgb = parseHexColor(bg);
+  if (rgb === undefined) return 'rgba(0, 0, 0, 0.82)';
+  const [r, g, b] = rgb;
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.6 ? 'rgba(0, 0, 0, 0.82)' : 'rgba(255, 255, 255, 0.95)';
+}
+
+function defaultTooltip(
+  seg: FlamegraphChartSegment,
+  shareFrac: number,
+  formatValue: (v: number) => string,
+): m.Children {
+  return [
+    m('.pf-flamechart-tooltip__name', seg.name),
+    m(
+      '.pf-flamechart-tooltip__value',
+      `${formatValue(seg.value)} · ${(shareFrac * 100).toFixed(1)}%`,
+    ),
+  ];
+}
+
+function renderSegment(
+  placed: PlacedSegment,
+  index: number,
+  attrs: FlamegraphChartAttrs,
+  onHover: (index: number) => void,
+  onUnhover: (index: number) => void,
+): m.Children {
+  const {seg, depth, xFrac, widthFrac} = placed;
+  const {formatValue = String, rowHeight = ROW_HEIGHT, onSegmentClick} = attrs;
+
+  const showLabel = widthFrac >= MIN_LABEL_FRACTION;
+
+  return m(
+    '.pf-flamechart-segment',
+    {
+      style: {
+        top: `${depth * (rowHeight + ROW_GAP)}px`,
+        left: `${xFrac * 100}%`,
+        width: `calc(${widthFrac * 100}% - ${SEG_GAP}px)`,
+        height: `${rowHeight}px`,
+        background: seg.cssColor,
+        color: labelColor(seg.cssColor),
+        cursor: onSegmentClick !== undefined ? 'pointer' : 'default',
+      },
+      onclick:
+        onSegmentClick !== undefined ? () => onSegmentClick(seg) : undefined,
+      onmouseenter: () => onHover(index),
+      onmouseleave: () => onUnhover(index),
+    },
+    showLabel &&
+      m('.pf-flamechart-segment__label', [
+        m('span.pf-flamechart-segment__name', seg.name),
+        m('span.pf-flamechart-segment__value', formatValue(seg.value)),
+      ]),
+  );
+}
+
+export function FlamegraphChart(): m.Component<FlamegraphChartAttrs> {
+  // Index (into `placed`) of the hovered segment, or undefined. Tracked by
+  // index rather than object identity because `placed` is rebuilt every redraw.
+  let hovered: number | undefined;
+
+  return {
+    view({attrs}: m.Vnode<FlamegraphChartAttrs>) {
+      const {rowHeight = ROW_HEIGHT, formatValue = String} = attrs;
+
+      const all: PlacedSegment[] = [];
+      placeSegments(attrs.data, 0, 0, 1, all);
+      // Optionally drop the root row and pull every level up one. The root's
+      // children already span [0, 1], so the breakdown fills the full width.
+      const placed = attrs.hideRoot
+        ? all
+            .filter((p) => p.depth > 0)
+            .map((p) => ({...p, depth: p.depth - 1}))
+        : all;
+
+      const maxDepth = placed.reduce((d, p) => Math.max(d, p.depth), 0) + 1;
+      const height = maxDepth * (rowHeight + ROW_GAP) - ROW_GAP;
+
+      const hoveredSeg =
+        hovered !== undefined && hovered < placed.length
+          ? placed[hovered]
+          : undefined;
+
+      return m(
+        '.pf-flamechart',
+        {style: {height: `${height}px`}},
+        placed.map((p, i) =>
+          renderSegment(
+            p,
+            i,
+            attrs,
+            (idx) => (hovered = idx),
+            (idx) => {
+              if (hovered === idx) hovered = undefined;
+            },
+          ),
+        ),
+        hoveredSeg !== undefined &&
+          m(
+            CursorTooltip,
+            {position: PopupPosition.BottomStart, offset: 12, skidding: 12},
+            m(
+              '.pf-flamechart-tooltip',
+              hoveredSeg.seg.tooltip ??
+                defaultTooltip(
+                  hoveredSeg.seg,
+                  hoveredSeg.widthFrac,
+                  formatValue,
+                ),
+            ),
+          ),
+      );
+    },
+  };
+}

--- a/ui/src/components/widgets/charts/line_chart.ts
+++ b/ui/src/components/widgets/charts/line_chart.ts
@@ -196,6 +196,13 @@ export interface LineChartAttrs {
    * Callback when a series is clicked. Called with the series name.
    */
   readonly onSeriesClick?: (seriesName: string) => void;
+
+  /**
+   * Callback when the plot area is clicked without dragging (a point-in-time
+   * select, as opposed to `onBrush`'s range drag). Called with the X value at
+   * the cursor. Only wired up by the SVG renderer.
+   */
+  readonly onPointClick?: (x: number) => void;
 }
 
 export class LineChart implements m.ClassComponent<LineChartAttrs> {

--- a/ui/src/components/widgets/charts/proportion_bar.scss
+++ b/ui/src/components/widgets/charts/proportion_bar.scss
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-chart-svg--proportion {
+  // Left-align the legend for proportion bars (top/bottom positions default to
+  // centered for the plotted charts).
+  &.pf-chart-svg--legend-top .pf-chart-svg__legend,
+  &.pf-chart-svg--legend-bottom .pf-chart-svg__legend {
+    justify-content: flex-start;
+  }
+
+  // A horizontal stacked "bar-like pie chart": one bar split into proportional
+  // slices. Sits where the SVG canvas would in the other charts_svg widgets.
+  .pf-chart-svg__proportion-bar {
+    display: flex;
+    height: 8px;
+    border-radius: 4px;
+    overflow: hidden;
+    gap: 2px;
+    flex: 0 0 auto;
+  }
+
+  .pf-chart-svg__proportion-segment {
+    height: 100%;
+  }
+}

--- a/ui/src/components/widgets/charts/proportion_bar.ts
+++ b/ui/src/components/widgets/charts/proportion_bar.ts
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {classNames} from '../../../base/classnames';
+import {chartColorVar} from '../charts_svg/common';
+import {ChartLegend} from '../charts_svg/legend';
+import './proportion_bar.scss';
+
+// One slice of a proportion bar. `weight` decides the slice width (the bar is
+// "pie-like": each slice is its share of the summed weights); the legend lists
+// every segment regardless of weight.
+export interface ProportionBarSegment {
+  readonly label: string;
+  // Non-negative magnitude that sets the slice width. Segments with weight 0
+  // are dropped from the bar but still shown in the legend.
+  readonly weight: number;
+  // Slice/swatch colour. Falls back to the theme chart palette by index.
+  readonly color?: string;
+  // Optional value rendered after the label in the legend (e.g. "+1.2 MiB").
+  readonly value?: m.Children;
+  // Optional CSS colour for the legend value text.
+  readonly valueColor?: string;
+}
+
+export interface ProportionBarAttrs {
+  readonly segments: readonly ProportionBarSegment[];
+  // Show the swatch legend (default true).
+  readonly showLegend?: boolean;
+  readonly className?: string;
+}
+
+// A single horizontal stacked bar — a bar-shaped pie chart — that shows each
+// segment as its proportion of the total, with a swatch legend. Styling and
+// the legend are shared with the other charts_svg widgets.
+export class ProportionBar implements m.ClassComponent<ProportionBarAttrs> {
+  view({attrs}: m.Vnode<ProportionBarAttrs>) {
+    const {segments} = attrs;
+    const total = segments.reduce((sum, s) => sum + Math.max(0, s.weight), 0);
+    const showLegend = attrs.showLegend ?? true;
+
+    const legend =
+      showLegend &&
+      m(
+        ChartLegend,
+        segments.map((s, i) =>
+          m(ChartLegend.Entry, {
+            name: s.label,
+            value: s.value,
+            valueColor: s.valueColor,
+            swatch: s.color ?? chartColorVar(i),
+          }),
+        ),
+      );
+
+    return m(
+      '.pf-chart-svg',
+      {
+        className: classNames(
+          'pf-chart-svg--proportion',
+          `pf-chart-svg--legend-bottom`,
+          attrs.className,
+        ),
+      },
+      m(
+        '.pf-chart-svg__proportion-bar',
+        total > 0 &&
+          segments.map(
+            (s, i) =>
+              s.weight > 0 &&
+              m('.pf-chart-svg__proportion-segment', {
+                style: {
+                  width: `${(s.weight / total) * 100}%`,
+                  background: s.color ?? chartColorVar(i),
+                },
+              }),
+          ),
+      ),
+      legend,
+    );
+  }
+}

--- a/ui/src/components/widgets/charts_svg/legend.ts
+++ b/ui/src/components/widgets/charts_svg/legend.ts
@@ -19,7 +19,9 @@ import type {HTMLAttrs} from '../../../widgets/common';
 export interface ChartLegendEntryAttrs {
   readonly name: string;
   /** Optional trailing value (e.g. last data point). */
-  readonly value?: string;
+  readonly value?: m.Children;
+  /** Optional CSS colour for the value text. */
+  readonly valueColor?: string;
   /** Optional colour swatch (CSS colour). */
   readonly swatch?: string;
   /** Render with the hidden/struck-through style. */
@@ -37,20 +39,26 @@ export interface ChartLegendEntryAttrs {
  * `ChartLegend` is just the styled container; `ChartLegend.Entry` is one
  * swatch+name+value row inside it.
  */
-export const ChartLegend = {
-  view({attrs, children}: m.Vnode<HTMLAttrs>) {
-    const {className, ...rest} = attrs;
-    return m(
-      '.pf-chart-svg__legend',
-      {...rest, className: classNames(className)},
-      children,
-    );
-  },
-  Entry: {
+export function ChartLegend(): m.Component<HTMLAttrs> {
+  return {
+    view({attrs, children}: m.Vnode<HTMLAttrs>) {
+      const {className, ...rest} = attrs;
+      return m(
+        '.pf-chart-svg__legend',
+        {...rest, className: classNames(className)},
+        children,
+      );
+    },
+  };
+}
+
+export namespace ChartLegend {
+  export const Entry: m.Component<ChartLegendEntryAttrs> = {
     view({attrs}: m.Vnode<ChartLegendEntryAttrs>) {
       const {
         name,
         value,
+        valueColor,
         swatch,
         hidden,
         onToggle,
@@ -71,8 +79,15 @@ export const ChartLegend = {
             style: {backgroundColor: swatch},
           }),
         m('.pf-chart-svg__legend-name', name),
-        value !== undefined && m('.pf-chart-svg__legend-value', value),
+        value !== undefined &&
+          m(
+            '.pf-chart-svg__legend-value',
+            {
+              style: valueColor ? {color: valueColor} : undefined,
+            },
+            value,
+          ),
       );
     },
-  },
-};
+  };
+}

--- a/ui/src/components/widgets/charts_svg/line_chart_svg.ts
+++ b/ui/src/components/widgets/charts_svg/line_chart_svg.ts
@@ -95,16 +95,24 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
   }
 
   view({attrs}: m.Vnode<LineChartAttrs>) {
-    const {data} = attrs;
+    const {
+      data,
+      legendPosition = 'bottom',
+      showLegend = data !== undefined && data.series.length > 1,
+      formatYValue = defaultFmt,
+      formatXValue = defaultFmt,
+      stacked,
+      height = 200,
+      fillParent,
+      className,
+    } = attrs;
+
     const isLoading = data === undefined;
     const isEmpty =
       data !== undefined &&
       (data.series.length === 0 ||
         data.series.every((s) => s.points.length === 0));
-    const showLegend =
-      attrs.showLegend ?? (data !== undefined && data.series.length > 1);
 
-    const fmtYLegend = attrs.formatYValue ?? defaultFmt;
     const legend =
       showLegend &&
       data !== undefined &&
@@ -116,7 +124,7 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
           const hidden = this.hiddenSeries.has(s.name);
           return m(ChartLegend.Entry, {
             name: s.name,
-            value: last !== undefined ? fmtYLegend(last) : undefined,
+            value: last !== undefined ? formatYValue(last) : undefined,
             swatch: s.color ?? chartColorVar(i),
             hidden,
             onToggle: () => this.toggleSeries(s.name),
@@ -139,9 +147,7 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
 
     const tooltip = (() => {
       if (this.hover === undefined || seriesHover === undefined) return false;
-      const ordered = attrs.stacked ? [...seriesHover].reverse() : seriesHover;
-      const fmtX = attrs.formatXValue ?? defaultFmt;
-      const fmtY = attrs.formatYValue ?? defaultFmt;
+      const ordered = stacked ? [...seriesHover].reverse() : seriesHover;
       const idx = this.hover.index;
       // X value comes from the first series with a point at `idx`.
       let xValue: number | undefined;
@@ -152,13 +158,13 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
         }
       }
       return m(ChartTooltip, [
-        exists(xValue) && m(ChartTooltip.Header, fmtX(xValue)),
+        exists(xValue) && m(ChartTooltip.Header, formatXValue(xValue)),
         ordered.map((s, i) => {
           const p = s.series.points[idx];
           if (p === undefined) return undefined;
           return m(ChartTooltip.Row, {
             name: s.series.name,
-            value: fmtY(p.y),
+            value: formatYValue(p.y),
             swatch: s.series.color ?? chartColorVar(i),
             tweak:
               s.style === 'emphasis' || s.style === 'muted'
@@ -169,19 +175,15 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
       ]);
     })();
 
-    const legendPosition = attrs.legendPosition ?? 'top';
-
     return m(
       '.pf-chart-svg',
       {
         className: classNames(
-          attrs.fillParent && 'pf-chart-svg--fill-parent',
+          fillParent && 'pf-chart-svg--fill-parent',
           `pf-chart-svg--legend-${legendPosition}`,
-          attrs.className,
+          className,
         ),
-        style: attrs.fillParent
-          ? undefined
-          : {height: `${attrs.height ?? 200}px`},
+        style: fillParent ? undefined : {height: `${height}px`},
       },
       m(SvgChartFrame, {
         isLoading,
@@ -295,7 +297,7 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
         width: width,
         height: height,
         viewBox: `0 0 ${width} ${height}`,
-        style: attrs.onBrush && {cursor: 'crosshair'},
+        style: (attrs.onBrush || attrs.onPointClick) && {cursor: 'crosshair'},
         oncontextmenu: (e: Event) => {
           // Chrome has a bug where right click to bring up the context menu
           // breaks pointer capture - simply disable context menus for the
@@ -303,14 +305,15 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
           e.preventDefault();
         },
         onpointerdown:
-          attrs.onBrush &&
+          (attrs.onBrush || attrs.onPointClick) &&
           ((e: PointerEvent) =>
             this.handleBrushDown(e, padLeft, plotW, xRange)),
         onpointermove: (e: PointerEvent) =>
           this.handlePointerMove(e, seriesPlots, padLeft, plotW, xRange),
         onpointerup:
-          attrs.onBrush &&
-          ((e: PointerEvent) => this.handleBrushUp(e, attrs.onBrush!)),
+          (attrs.onBrush || attrs.onPointClick) &&
+          ((e: PointerEvent) =>
+            this.handleBrushUp(e, attrs.onBrush, attrs.onPointClick)),
         onpointerleave: () => {
           if (this.brushing) return; // capture keeps the drag alive.
           if (this.hover !== undefined) {
@@ -563,14 +566,21 @@ export class LineChartSvg implements m.ClassComponent<LineChartAttrs> {
 
   private handleBrushUp(
     e: PointerEvent,
-    onBrush: (range: {start: number; end: number}) => void,
+    onBrush?: (range: {start: number; end: number}) => void,
+    onPointClick?: (x: number) => void,
   ) {
     if (!this.brushing || this.brushing.pointerId !== e.pointerId) return;
     const {start, current} = this.brushing;
     const lo = Math.min(start, current);
     const hi = Math.max(start, current);
     this.brushing = undefined;
-    if (hi > lo) onBrush({start: lo, end: hi});
+    // A drag (the cursor moved more than a tiny threshold) is a range select;
+    // movement within the dead-zone is treated as a click on a single point.
+    if (hi - lo > 1e-9) {
+      onBrush?.({start: lo, end: hi});
+    } else {
+      onPointClick?.(start);
+    }
   }
 
   private handlePointerMove(

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
@@ -104,6 +104,11 @@ import {EnumOption, renderWidgetShowcase} from '../widgets_page_utils';
 import type {Trace} from '../../../public/trace';
 import {LineChartSvg} from '../../../components/widgets/charts_svg/line_chart_svg';
 import {HistogramSvg} from '../../../components/widgets/charts_svg/histogram_svg';
+import {ProportionBar} from '../../../components/widgets/charts/proportion_bar';
+import {
+  FlamegraphChart,
+  type FlamegraphChartSegment,
+} from '../../../components/widgets/charts/flamegraph_chart';
 
 // Generate sample data with normal distribution
 function generateNormalData(
@@ -509,6 +514,41 @@ export function renderCharts(app: App): m.Children {
         value: 1234,
         label: 'Total Events',
         fillParent: false,
+      },
+    }),
+
+    // FlamegraphChart section
+    m('h2', {style: {marginTop: '32px'}}, 'FlamegraphChart'),
+    renderWidgetShowcase({
+      renderWidget: (opts) => {
+        return m(FlamegraphChart, {
+          data: FLAMECHART_SAMPLE_DATA,
+          formatValue: (v: number) => `${v} ms`,
+          rowHeight: opts.rowHeight,
+        });
+      },
+      initialOpts: {
+        rowHeight: 26,
+      },
+    }),
+
+    // ProportionBar section
+    m('h2', {style: {marginTop: '32px'}}, 'ProportionBar'),
+    renderWidgetShowcase({
+      renderWidget: (opts) => {
+        return m(ProportionBar, {
+          showLegend: opts.showLegend,
+          segments: [
+            {label: 'Native heap', weight: 53.39, value: '53.39 MiB'},
+            {label: 'Java heap', weight: 42.14, value: '42.14 MiB'},
+            {label: 'Other', weight: 0, value: '0 B'}, // 0 weight segment test
+            {label: 'Graphics', weight: 12.7, value: '12.70 MiB'},
+            {label: 'File-backed', weight: 8.0, value: '8.00 MiB'},
+          ],
+        });
+      },
+      initialOpts: {
+        showLegend: true,
       },
     }),
 
@@ -1644,6 +1684,200 @@ function PieChartDemo(): m.Component<{
     },
   };
 }
+
+// Static sample data for the FlamegraphChart demo: a synthetic CPU profile.
+const FLAMECHART_SAMPLE_DATA: FlamegraphChartSegment = {
+  name: 'Total',
+  value: 1000,
+  cssColor: '#5f6368',
+  children: [
+    {
+      name: 'JavaScript',
+      value: 650,
+      cssColor: '#f7b853',
+      children: [
+        {
+          name: 'GC',
+          value: 120,
+          cssColor: '#e07a5f',
+          children: [
+            {name: 'Scavenge', value: 70, cssColor: '#e07a5f', children: []},
+            {name: 'Full GC', value: 50, cssColor: '#d6644d', children: []},
+          ],
+        },
+        {
+          name: 'Eval',
+          value: 80,
+          cssColor: '#f2cc6f',
+          children: [
+            {
+              name: 'Function.apply',
+              value: 50,
+              cssColor: '#f2cc6f',
+              children: [],
+            },
+            {name: 'JSON.parse', value: 30, cssColor: '#f5d98f', children: []},
+          ],
+        },
+        {
+          name: 'Rendering',
+          value: 280,
+          cssColor: '#3daee9',
+          children: [
+            {
+              name: 'Layout',
+              value: 140,
+              cssColor: '#2d9bd8',
+              children: [
+                {
+                  name: 'Reflow',
+                  value: 90,
+                  cssColor: '#2d9bd8',
+                  children: [
+                    {
+                      name: 'updateDOM',
+                      value: 55,
+                      cssColor: '#2d9bd8',
+                      children: [],
+                    },
+                    {
+                      name: 'recalcStyle',
+                      value: 35,
+                      cssColor: '#3daee9',
+                      children: [],
+                    },
+                  ],
+                },
+                {
+                  name: 'ResizeObserver',
+                  value: 50,
+                  cssColor: '#5bc4f5',
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'Paint',
+              value: 90,
+              cssColor: '#2d9bd8',
+              children: [
+                {
+                  name: 'CompositeLayers',
+                  value: 55,
+                  cssColor: '#2d9bd8',
+                  children: [],
+                },
+                {
+                  name: 'Rasterize',
+                  value: 35,
+                  cssColor: '#5bc4f5',
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'Style',
+              value: 50,
+              cssColor: '#7dcaf0',
+              children: [
+                {
+                  name: 'MatchCSSRules',
+                  value: 30,
+                  cssColor: '#7dcaf0',
+                  children: [],
+                },
+                {
+                  name: 'UpdateStyle',
+                  value: 20,
+                  cssColor: '#a8dff5',
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'Parsing',
+          value: 80,
+          cssColor: '#95d5b5',
+          children: [
+            {name: 'HTML.parse', value: 50, cssColor: '#95d5b5', children: []},
+            {name: 'CSS.parse', value: 30, cssColor: '#74c69d', children: []},
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Native',
+      value: 200,
+      cssColor: '#7c4dff',
+      children: [
+        {
+          name: 'IO',
+          value: 110,
+          cssColor: '#6a3bdb',
+          children: [
+            {
+              name: 'Network',
+              value: 70,
+              cssColor: '#6a3bdb',
+              children: [
+                {
+                  name: 'DNS.resolve',
+                  value: 25,
+                  cssColor: '#6a3bdb',
+                  children: [],
+                },
+                {
+                  name: 'TCP.connect',
+                  value: 30,
+                  cssColor: '#7c4dff',
+                  children: [],
+                },
+                {
+                  name: 'HTTP.parse',
+                  value: 15,
+                  cssColor: '#9b72ff',
+                  children: [],
+                },
+              ],
+            },
+            {name: 'Disk.read', value: 40, cssColor: '#8a5fff', children: []},
+          ],
+        },
+        {
+          name: 'Crypto',
+          value: 50,
+          cssColor: '#b388ff',
+          children: [
+            {name: 'AES.encrypt', value: 30, cssColor: '#b388ff', children: []},
+            {name: 'SHA256.hash', value: 20, cssColor: '#d0a8ff', children: []},
+          ],
+        },
+        {
+          name: 'ThreadMgr',
+          value: 40,
+          cssColor: '#e0b0ff',
+          children: [
+            {name: 'Mutex.lock', value: 25, cssColor: '#e0b0ff', children: []},
+            {
+              name: 'CondVar.wait',
+              value: 15,
+              cssColor: '#f0d0ff',
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Idle',
+      value: 150,
+      cssColor: '#c0c0c0',
+      children: [],
+    },
+  ],
+};
 
 // Simple seeded pseudo-random number generator for reproducible demo data.
 function seededRandom(seed: number): () => number {


### PR DESCRIPTION
This patch adds two new DOM based charts:

### ProportionBar

A bar showing how a given metric is split across varioius categories (E.g. memory). Features an optional legend (reused from the bar chart). Similar to a pie chart.

<img width="588" height="91" alt="image" src="https://github.com/user-attachments/assets/2128c314-86ad-4abf-8a60-aabce2675c87" />

### FlamegraphChart

A simpler version of the flamegraph, and a hover tooltip - to be used in overview pages. In the future we may merge this with its bigger brother flamegraph.ts or at least tweak the styling to make it more visually consistent.

<img width="587" height="205" alt="image" src="https://github.com/user-attachments/assets/87bd01eb-2a64-4b36-bccd-822c054d9442" />

