### PR TITLE
Fix macOS crash when embedding trace processor in multithreaded apps

### DIFF
--- a/src/trace_processor/util/symbolizer/subprocess_posix.cc
+++ b/src/trace_processor/util/symbolizer/subprocess_posix.cc
@@ -23,6 +23,11 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE)
+#include <spawn.h>
+#include <crt_externs.h>
+#endif
+
 #include "perfetto/ext/base/utils.h"
 
 namespace perfetto {
@@ -37,6 +42,17 @@ Subprocess::Subprocess(const std::string& file, std::vector<std::string> args)
     c_str_args.push_back(&(arg[0]));
   c_str_args.push_back(nullptr);
 
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE)
+  posix_spawn_file_actions_t fa;
+  posix_spawn_file_actions_init(&fa);
+  posix_spawn_file_actions_adddup2(&fa, *input_pipe_.rd, STDIN_FILENO);
+  posix_spawn_file_actions_adddup2(&fa, *output_pipe_.wr, STDOUT_FILENO);
+  
+  if (posix_spawnp(&pid_, file.c_str(), &fa, nullptr, c_str_args.data(), *_NSGetEnviron()) != 0) {
+    pid_ = -1;
+  }
+  posix_spawn_file_actions_destroy(&fa);
+#else
   if ((pid_ = fork()) == 0) {
     // Child
     PERFETTO_CHECK(dup2(*input_pipe_.rd, STDIN_FILENO) != -1);
@@ -46,6 +62,7 @@ Subprocess::Subprocess(const std::string& file, std::vector<std::string> args)
     if (execvp(file.c_str(), c_str_args.data()) == -1)
       PERFETTO_FATAL("Failed to exec %s", file.c_str());
   }
+#endif
   PERFETTO_CHECK(pid_ != -1);
   input_pipe_.rd.reset();
   output_pipe_.wr.reset();


### PR DESCRIPTION
#### Problem:
    
When the Trace Processor is embedded as a library or daemon inside a larger, multithreaded host application
  (such as Android Studio), attempting to symbolize native traces crashes the host process on macOS.

  This happens because `subprocess_posix.cc` relies on `fork()` followed by `execvp()`. On macOS, calling
  `fork()` from a multithreaded process is highly dangerous. If any other threads are active, Apple's system
  library (`libsystem_c.dylib`) detects the unsafe `fork()` -> `exec()` sequence and immediately terminates the
  host process with a `SIGTRAP`. While the standalone, single-threaded `trace_processor_shell` avoids this fate,
  any multithreaded embedder invoking the symbolizer will crash.

#### Solution:
This patch migrates `subprocess_posix.cc` from using `fork()` + `execvp()` to the safer `posix_spawnp()`
  POSIX standard.