### PR TITLE
ui: MemoryViz: Sort LMK buckets by OOM score adjustment

### DIFF
--- a/ui/src/plugins/com.android.MemoryViz/index.ts
+++ b/ui/src/plugins/com.android.MemoryViz/index.ts
@@ -277,10 +277,11 @@ export default class MemoryViz implements PerfettoPlugin {
     });
 
     const buckets = await ctx.engine.query(`
-      SELECT DISTINCT oom_bucket
+      SELECT oom_bucket
       FROM ${tableName}
       WHERE oom_bucket IS NOT NULL
-      ORDER BY oom_bucket
+      GROUP BY oom_bucket
+      ORDER BY MIN(oom_score_adj) ASC
     `);
     if (buckets.numRows() === 0) {
       return undefined;


### PR DESCRIPTION
Sorts the LMK buckets based on their underlying
oom_score_adj values. This ensures the buckets are displayed in a logical order, from system processes at the top to cached processes at the bottom, rather than alphabetically.
