### PR TITLE
ui: Fix omnibox test (again) & integration tests running under docker

### DIFF
--- a/ui/run-integrationtests
+++ b/ui/run-integrationtests
@@ -186,6 +186,7 @@ def run_in_docker(args):
   docker_cmd = [
       'docker', 'run',
       '--rm', # Remove the container after it exits
+      '--ipc=host', # Share host IPC/shared memory to prevent Chrome crashes with high worker counts
       '-t', # Allocate a pseudo-TTY for better output formatting
       '-v', f'{REPO_ROOT}:{REPO_ROOT}', # Mount the repo root into the container
       '-w', f'{REPO_ROOT}/ui', # Set working directory to /ui

--- a/ui/src/test/omnibox.test.ts
+++ b/ui/src/test/omnibox.test.ts
@@ -27,7 +27,7 @@ test('command palette keyboard navigation', async ({browser}) => {
   await omnibox.fill('>');
   await pth.waitForPerfettoIdle();
 
-  const commands = page.locator('.pf-omnibox-options-container');
+  const commands = page.locator('.pf-omnibox-options-container > li');
 
   // Initially the first command should be highlighted.
   expect(commands.first()).toHaveClass('pf-highlighted');


### PR DESCRIPTION
Two changes:
- Use the correct CSS selector to select the command list items in the omnibox popup correctly rather than their parent container.
- Use ipc=host for docker to fix exhausting shm when running multiple simultaneous chrome instances under docker - fixes issues when attempting to rebaseline screenshot tests on cloudtops.
