### PR TITLE
ui: Extract reusable components and utils out of memscope

### DIFF
--- a/ui/src/base/bytes_format.ts
+++ b/ui/src/base/bytes_format.ts
@@ -1,0 +1,102 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Human-readable byte-size formatters.
+//
+// Two flavours, because the right base depends on what's being measured:
+//   - formatBytesIec: base-1024 with IEC units (KiB/MiB/GiB). Use for RAM,
+//     heap and other memory sizes — the kernel and allocators count in powers
+//     of two.
+//   - formatBytesSi: base-1000 with SI units (KB/MB/GB). Use for on-disk
+//     file sizes, network transfer and anything quoted decimally.
+//
+// Both keep the sign, render whole bytes without a decimal point ("512 B"),
+// and otherwise show two decimals ("1.50 MiB").
+//
+// By default the unit is auto-scaled to the largest that keeps the value >= 1.
+// Pass a `forceUnit` ('B' or one of the IEC/SI unit strings) to pin every value
+// to the same unit instead — useful for aligned/comparable table columns.
+
+const IEC_UNITS = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB'] as const;
+const SI_UNITS = ['KB', 'MB', 'GB', 'TB', 'PB'] as const;
+
+export type IecUnit = 'B' | (typeof IEC_UNITS)[number];
+export type SiUnit = 'B' | (typeof SI_UNITS)[number];
+
+export interface BytesFormatOptions {
+  forceUnit?: IecUnit | SiUnit;
+  fractionDigits?: number;
+}
+
+function formatScaled(
+  bytes: number,
+  base: number,
+  units: readonly string[],
+  forceUnit?: string,
+  fractionDigits = 1,
+): string {
+  const sign = bytes < 0 ? '-' : '';
+  const absBytes = Math.abs(bytes);
+
+  // Forced unit: skip auto-scaling and render every value in this unit.
+  if (forceUnit !== undefined) {
+    if (forceUnit === 'B') return `${sign}${absBytes} B`;
+    const i = units.indexOf(forceUnit);
+    const v = absBytes / Math.pow(base, i + 1);
+    return `${sign}${v.toLocaleString(undefined, {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    })} ${forceUnit}`;
+  }
+
+  if (absBytes < base) return `${sign}${absBytes} B`;
+  let v = absBytes / base;
+  let i = 0;
+  while (v >= base && i < units.length - 1) {
+    v /= base;
+    i++;
+  }
+  return `${sign}${v.toLocaleString(undefined, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })} ${units[i]}`;
+}
+
+// Base-1024 with IEC units: "512 B", "1.50 KiB", "2.00 MiB". Use for memory.
+export function formatBytesIec(
+  bytes: number,
+  options?: BytesFormatOptions,
+): string {
+  return formatScaled(
+    bytes,
+    1024,
+    IEC_UNITS,
+    options?.forceUnit,
+    options?.fractionDigits,
+  );
+}
+
+// Base-1000 with SI units: "512 B", "1.50 KB", "2.00 MB". Use for file sizes.
+export function formatBytesSi(
+  bytes: number,
+  options?: BytesFormatOptions,
+): string {
+  return formatScaled(
+    bytes,
+    1000,
+    SI_UNITS,
+    options?.forceUnit,
+    options?.fractionDigits,
+  );
+}

--- a/ui/src/components/widgets/charts/flamegraph_chart.ts
+++ b/ui/src/components/widgets/charts/flamegraph_chart.ts
@@ -17,6 +17,8 @@ import {PopupPosition} from '../../../widgets/popup';
 import {CursorTooltip} from '../../../widgets/cursor_tooltip';
 import './flamegraph_chart.scss';
 
+const TOOLTIP_OFFSET_PX = 12;
+
 export interface FlamegraphChartSegment {
   readonly name: string;
   readonly value: number;
@@ -212,7 +214,11 @@ export function FlamegraphChart(): m.Component<FlamegraphChartAttrs> {
         hoveredSeg !== undefined &&
           m(
             CursorTooltip,
-            {position: PopupPosition.BottomStart, offset: 12, skidding: 12},
+            {
+              position: PopupPosition.BottomStart,
+              offset: TOOLTIP_OFFSET_PX,
+              skidOffset: TOOLTIP_OFFSET_PX,
+            },
             m(
               '.pf-flamechart-tooltip',
               hoveredSeg.seg.tooltip ??

--- a/ui/src/plugins/dev.perfetto.Memscope/components/billboard.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/billboard.scss
@@ -15,8 +15,35 @@
 .pf-memscope-billboard {
   padding: 14px 16px;
   border-radius: 8px;
-  border: 1px solid var(--pf-color-border-secondary);
-  background: var(--pf-color-background-secondary);
+  border: 0.5px solid var(--pf-col-border);
+  background: var(--pf-col-surface);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+// A card holding Billboard.Sections lays them out as equal-width columns.
+.pf-memscope-billboard:has(> .pf-memscope-billboard__section) {
+  display: flex;
+  gap: 24px;
+}
+
+.pf-memscope-billboard__section {
+  flex: 1 1 0;
+  min-width: 0;
+
+  // Thin divider between adjacent sections.
+  & + & {
+    border-left: 1px solid var(--pf-col-border);
+    padding-left: 24px;
+  }
+}
+
+// Muted caption beneath a section's value.
+.pf-memscope-billboard__sub {
+  font-size: var(--pf-font-size-s);
+  color: var(--pf-color-text-muted);
+  margin-top: 2px;
 }
 
 .pf-memscope-billboard__value {
@@ -58,5 +85,23 @@
   }
   &--down {
     color: var(--pf-color-success);
+  }
+}
+
+.pf-billboard-strip {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+
+  & > * {
+    flex-grow: 1;
+  }
+}
+
+// Style billboards inside a panel differently
+.pf-memscope-panel {
+  .pf-memscope-billboard {
+    background: var(--pf-col-inset);
+    box-shadow: none;
   }
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/components/billboard.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/billboard.ts
@@ -15,12 +15,19 @@
 import './billboard.scss';
 import m from 'mithril';
 
+// Billboard — a single "stat card" that surfaces one headline number (value +
+// unit) with a label, an optional description, and an optional delta badge that
+// colours itself green/red from the leading sign of `delta`. Use it to draw the
+// eye to the handful of figures that matter on a dashboard or summary panel
+// (e.g. total RSS, swap used, page-cache size). Lay several side by side with
+// BillboardStrip for an at-a-glance metrics row.
+
 export interface BillboardAttrs {
   // The primary value to display prominently. Accepts m.Children so callers
-  // can pass the output of billboardKb() which embeds a unit span.
+  // can pass the output of billboardBytes() which embeds a unit span.
   readonly value: m.Children;
   // Unit to display next to the value, e.g. "MB". Accepts m.Children for
-  // flexibility, but typically the output of billboardKb().
+  // flexibility, but typically the output of billboardBytes().
   readonly unit: m.Children;
   // Short label displayed below the value.
   readonly label: string;
@@ -33,8 +40,10 @@ export interface BillboardAttrs {
   readonly color?: string;
 }
 
-// A single stat card. Wrap multiple in billboards() for a row layout.
-export const Billboard: m.Component<BillboardAttrs> = {
+// A single stat card. Lay several side by side in a BillboardStrip for a
+// metrics row, or pack several Billboard.Sections into one card to pair related
+// stats in a single tile.
+export class Billboard implements m.ClassComponent<BillboardAttrs> {
   view({attrs}: m.Vnode<BillboardAttrs>) {
     const {value, unit, label, desc, delta, color} = attrs;
 
@@ -64,5 +73,38 @@ export const Billboard: m.Component<BillboardAttrs> = {
       m('.pf-memscope-billboard__label', label),
       desc !== undefined && m('.pf-memscope-billboard__desc', desc),
     ]);
+  }
+}
+
+export namespace Billboard {
+  export interface SectionAttrs {
+    // Heading shown above the value (rendered uppercase).
+    readonly label: m.Children;
+    // The headline figure for this segment.
+    readonly value: m.Children;
+    // Optional muted caption shown beneath the value.
+    readonly sub?: m.Children;
+  }
+
+  // One labelled segment within a Billboard card. Drop two or three directly
+  // inside a `.pf-memscope-billboard` element and they lay out side by side, so
+  // related figures share a single tile (uptime + OOM score, peak RSS + spike,
+  // memory Δ + trend …) instead of needing a card each.
+  export class Section implements m.ClassComponent<SectionAttrs> {
+    view({attrs}: m.Vnode<SectionAttrs>) {
+      return m('.pf-memscope-billboard__section', [
+        m('.pf-memscope-billboard__label', attrs.label),
+        m('.pf-memscope-billboard__value', attrs.value),
+        attrs.sub !== undefined && m('.pf-memscope-billboard__sub', attrs.sub),
+      ]);
+    }
+  }
+}
+
+// BillboardStrip — a horizontal flex row that lays out a set of Billboards with
+// equal growth, so a group of related stats reads as one cohesive metrics band.
+export const BillboardStrip: m.Component = {
+  view({children}: m.Vnode) {
+    return m('.pf-billboard-strip', children);
   },
 };

--- a/ui/src/plugins/dev.perfetto.Memscope/components/callout.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/callout.scss
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Callout strip: a leading icon plus a one-line message, tinted by intent.
+// Mirrors the colour treatment of the shared `widgets/callout` Callout
+// (pf-color-primary/success/warning/danger via the `pf-intent-*` classes), with
+// a Memscope-specific geometry — slightly larger padding/gap to match the
+// page's panel rhythm.
+
+.pf-memscope-callout {
+  @mixin color-theme($base-color) {
+    color: $base-color;
+    background: color-mix(in srgb, $base-color 15%, transparent);
+  }
+
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--pf-color-background-secondary);
+  border: solid 1px color-mix(in srgb, currentColor, transparent 50%);
+  border-radius: 8px;
+  font-size: var(--pf-font-size-s);
+
+  & > .pf-left-icon {
+    flex-shrink: 0;
+    align-self: center;
+  }
+
+  &__content {
+    flex: 1;
+  }
+
+  &.pf-intent-primary {
+    @include color-theme(var(--pf-color-primary));
+  }
+
+  &.pf-intent-danger {
+    @include color-theme(var(--pf-color-danger));
+  }
+
+  &.pf-intent-success {
+    @include color-theme(var(--pf-color-success));
+  }
+
+  &.pf-intent-warning {
+    @include color-theme(var(--pf-color-warning));
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/callout.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/callout.ts
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './callout.scss';
+import m from 'mithril';
+import {Button} from '../../../widgets/button';
+import {Icon} from '../../../widgets/icon';
+import {classNames} from '../../../base/classnames';
+import {classForIntent, type HTMLAttrs, Intent} from '../../../widgets/common';
+
+// Default leading icon per intent. The shared Callout widget renders an icon
+// only when one is explicitly supplied; this Memscope variant additionally
+// falls back to an intent-specific default so callers can omit `icon` and
+// still get a sensible glyph.
+const DEFAULT_ICONS: Record<Intent, string | undefined> = {
+  [Intent.None]: undefined,
+  [Intent.Primary]: 'lightbulb',
+  [Intent.Success]: 'check_circle',
+  [Intent.Warning]: 'info',
+  [Intent.Danger]: 'error',
+};
+
+interface CalloutAttrs extends HTMLAttrs {
+  // An icon to show to the left of the callout content. Falls back to a
+  // default glyph based on `intent` when omitted.
+  readonly icon?: string;
+
+  // Color the callout by specifying an intent. Uses the same palette as the
+  // shared `widgets/callout` (pf-color-primary/success/warning/danger).
+  readonly intent?: Intent;
+
+  // Adds a close button to the callout.
+  readonly dismissible?: boolean;
+
+  // A callback to be invoked when the callout's close button is clicked.
+  readonly onDismiss?: () => void;
+}
+
+// Callout — a compact strip pairing a leading icon with a one-line message,
+// tinted by intent. Use it to surface the single most relevant takeaway or
+// caveat next to a panel's figures (a hint, a success confirmation, a warning).
+// Mirrors the interface and colour treatment of the shared `widgets/callout`
+// Callout, with a Memscope-specific geometry and intent-based default icons.
+export class Callout implements m.ClassComponent<CalloutAttrs> {
+  view({attrs, children}: m.CVnode<CalloutAttrs>) {
+    const {
+      icon,
+      intent = Intent.None,
+      className,
+      dismissible = false,
+      onDismiss,
+      ...htmlAttrs
+    } = attrs;
+    const resolvedIcon = icon ?? DEFAULT_ICONS[intent];
+
+    return m(
+      '.pf-memscope-callout',
+      {
+        className: classNames(classForIntent(intent), className),
+        ...htmlAttrs,
+      },
+      resolvedIcon && m(Icon, {className: 'pf-left-icon', icon: resolvedIcon}),
+      m('span.pf-memscope-callout__content', children),
+      dismissible &&
+        m(Button, {
+          icon: 'close',
+          onclick: onDismiss,
+          compact: true,
+          title: 'Dismiss callout',
+        }),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/color_chip.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/color_chip.scss
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Colored category chip — shape only; colors injected via inline styles.
+// Colored category chip. The hue is injected per-instance via the
+// --pf-memscope-chip-color custom property (set inline); it gets softened
+// against the page background so the chip reads as a tint rather than a
+// saturated block.
 .pf-memscope-color-chip {
   display: inline-flex;
   align-items: center;
@@ -23,4 +26,13 @@
   border: 1px solid transparent;
   white-space: nowrap;
   line-height: 1.4;
+
+  --_mixed: color-mix(
+    in srgb,
+    var(--pf-memscope-chip-color, var(--pf-color-text)) 75%,
+    var(--pf-color-background)
+  );
+  color: var(--pf-chart-color-on);
+  background: var(--_mixed);
+  border-color: var(--_mixed);
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/components/color_chip.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/color_chip.ts
@@ -15,6 +15,13 @@
 import './color_chip.scss';
 import m from 'mithril';
 
+// ColorChip — a small rounded pill tinted with a caller-supplied colour, used
+// to tag a row or legend entry with the same hue as its data series (memory
+// category, process group, chart slice). The raw colour is softened against the
+// page background so the chip reads as a tint rather than a saturated block;
+// use chipColor() to compute that exact softened colour elsewhere (e.g. for a
+// matching chart series) so the chip and the thing it labels stay in sync.
+
 export interface ColorChipAttrs {
   // Hex color string - can be any valid CSS.
   readonly color?: string;

--- a/ui/src/plugins/dev.perfetto.Memscope/components/hero.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/hero.scss
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Hero connect / idle state.
+.pf-memscope-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 48px 24px;
+  border-radius: 8px;
+  border: 0.5px dashed var(--pf-col-border);
+  text-align: center;
+  // Subtle inset shadow for depth
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+.pf-memscope-hero__icon {
+  font-size: 48px;
+  color: var(--pf-color-text-muted);
+  opacity: 0.5;
+}
+
+.pf-memscope-hero__text {
+  font-size: var(--pf-font-size-m);
+  color: var(--pf-color-text-muted);
+  max-width: 420px;
+  line-height: 1.5;
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/hero.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/hero.ts
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import './hero.scss';
+import {Icon as RawIcon, type IconAttrs} from '../../../widgets/icon';
+
+// Hero — a prominent banner row that introduces a page or major section,
+// typically pairing a leading Hero.Icon with a block of Hero.Text (heading +
+// blurb). Use it at the top of a view to give the user immediate context for
+// what they're looking at. Compose via the namespaced slots:
+//
+//   m(Hero, m(Hero.Icon, {icon: 'memory'}), m(Hero.Text, 'Memory overview'))
+
+export function Hero(): m.Component {
+  return {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-hero', children);
+    },
+  };
+}
+
+export namespace Hero {
+  export const Icon: m.Component<IconAttrs> = {
+    view({attrs}: m.Vnode<IconAttrs>) {
+      return m(RawIcon, {...attrs, className: 'pf-memscope-hero__icon'});
+    },
+  };
+  export const Text: m.Component = {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-hero__text', children);
+    },
+  };
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/inset.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/inset.scss
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-memscope-inset {
+  padding: 12px 16px;
+  border: 0.5px solid var(--pf-col-border);
+  border-radius: 8px;
+  background: var(--pf-col-inset);
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/inset.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/inset.ts
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './inset.scss';
+import m from 'mithril';
+
+// A recessed well meant to sit inside a Panel (or other surface). Where a
+// Panel reads as a raised card against the page, an Inset reads as carved into
+// it — use it to group secondary content (ratios, nested billboards, callouts)
+// within a panel so it doesn't disappear surface-on-surface.
+export interface InsetAttrs {
+  readonly className?: string;
+}
+
+export class Inset implements m.ClassComponent<InsetAttrs> {
+  view({attrs, children}: m.CVnode<InsetAttrs>): m.Children {
+    return m('.pf-memscope-inset', {className: attrs.className}, children);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/page.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/page.scss
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-memscope-page {
+  --pf-border-width: 0.5px;
+  // Light-mode page chrome: a slightly cool-grey page so the white panels
+  // read as raised cards. Dark mode keeps the theme defaults (left unset).
+  --pf-col-base: #f6f6f6;
+  --pf-col-surface: #ffffff;
+  --pf-col-inset: #f1f1f1;
+  --pf-col-border: #e0e0e0;
+
+  .pf-theme-provider--dark & {
+    --pf-col-base: lch(4.52 0.3 272);
+    --pf-col-surface: lch(7.67 0.75 272);
+    --pf-col-inset: #242424;
+    --pf-col-border: #242424;
+  }
+
+  background: var(--pf-col-base);
+  height: 100%;
+  overflow-y: auto;
+
+  .pf-memscope-page__content {
+    max-width: 1400px;
+    margin-inline: auto; // Center the div
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .pf-memscope-page__title {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--pf-color-text-muted);
+  }
+
+  // Override some compoents from the base class
+  .pf-grid__header {
+    background: var(--pf-col-inset);
+    color: var(--pf-color-text-muted);
+    user-select: none;
+    text-transform: uppercase;
+  }
+
+  // Drop the panel body padding when it wraps a grid — the grid's own
+  // header/cell padding is enough.
+  .pf-memscope-panel__body:has(> .pf-grid) {
+    padding: 0;
+  }
+}
+
+.pf-memscope-subpage {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+// First-load entrance: each block fades in and rises a little into place.
+// Runs once when the element mounts (every section mounts at page open now,
+// showing its loading panel), so it plays on first load rather than on every
+// data swap. The 4-panel row cascades via nth-child.
+@keyframes pf-memscope-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+// Direct children of the page/subpage each fade up, cascading in document
+// order via nth-child.
+.pf-memscope-page__content > *,
+.pf-memscope-subpage > * {
+  animation: pf-memscope-enter 0.35s ease-out both;
+
+  @for $i from 1 through 8 {
+    &:nth-child(#{$i}) {
+      animation-delay: #{($i - 1) * 60}ms;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pf-memscope-page__content > *,
+  .pf-memscope-subpage > * {
+    animation: none;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/page.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/page.ts
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import './page.scss';
+
+// Page — the outermost shell for a Memscope view. It owns the scroll container,
+// the light/dark theme variables, and a centred, max-width content column, so
+// every Memscope page shares the same chrome and "raised cards on a cool-grey
+// canvas" look. Wrap a view's whole content in it and drop a Page.Title (and
+// optional Page.Subtitle) at the top. SubPage is a lighter wrapper for a nested
+// section that just needs the standard vertical gap + entrance animation
+// without re-establishing the full page chrome.
+
+export function Page(): m.Component {
+  return {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-page', m('.pf-memscope-page__content', children));
+    },
+  };
+}
+
+export namespace Page {
+  export const Title: m.Component = {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-page__title', children);
+    },
+  };
+
+  export const Subtitle: m.Component = {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-page__subtitle', children);
+    },
+  };
+}
+
+export function SubPage(): m.Component {
+  return {
+    view({children}: m.Vnode) {
+      return m('.pf-memscope-subpage', children);
+    },
+  };
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/panel.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/panel.scss
@@ -14,27 +14,26 @@
 
 .pf-memscope-panel {
   border-radius: 8px;
-  background: var(--pf-color-background-secondary);
-  border: 1px solid var(--pf-color-border-secondary);
+  background: var(--pf-col-surface);
+  border: 0.5px solid var(--pf-col-border);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
 .pf-memscope-panel__title-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-
-  h2 {
-    flex: 1;
-  }
+  gap: 6px;
 }
 
 .pf-memscope-panel__header {
   padding: 12px 16px;
-  border-bottom: 1px solid var(--pf-color-border);
+  border-bottom: 1px solid var(--pf-col-border);
 
   h2 {
     margin: 0;
-    font-size: 14px;
+    font-size: 18px;
     font-weight: 600;
     color: var(--pf-color-text);
   }
@@ -52,16 +51,40 @@
   gap: 8px;
   flex-wrap: wrap;
   flex-shrink: 0;
+  margin-left: auto;
 }
 
 .pf-memscope-panel__body {
   padding: 12px;
 }
 
+// Content fades in when it mounts. The body keeps its DOM node across the
+// loading→loaded swap, but its single child is replaced, so this animation
+// fires once at that moment (and once for the initial placeholder). The
+// panel's height still snaps to the new content; the fade is what masks it.
+@keyframes pf-memscope-body-fade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.pf-memscope-panel__body > * {
+  animation: pf-memscope-body-fade 0.3s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pf-memscope-panel__body > * {
+    animation: none;
+  }
+}
+
 .pf-memscope-placeholder {
   color: var(--pf-color-text-muted);
   font-size: var(--pf-font-size-s);
-  font-style: italic;
   padding: 32px 0;
   text-align: center;
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/components/panel.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/panel.ts
@@ -15,21 +15,77 @@
 import './panel.scss';
 import m from 'mithril';
 
+// Panel — the workhorse "card" of the Memscope UI: a bordered, raised surface
+// that groups a titled header with a body of content (a chart, a table, a strip
+// of Billboards). Nearly every block on a Memscope page is a Panel, which is
+// what gives the pages their consistent rhythm.
+//
+// Compose one from the two namespaced slots: a Panel.Header (a flat
+// {title, subtitle, controls} shape — every call site wants the same layout, so
+// it takes attrs rather than hand-assembled sub-slots) above a Panel.Body that
+// holds the payload. See the example at the bottom of this file.
+
 export interface PanelAttrs {
-  readonly title: string;
-  readonly subtitle?: string;
+  readonly className?: string;
 }
 
-export const Panel: m.Component<PanelAttrs> = {
-  view({attrs, children}) {
-    return m(
-      '.pf-memscope-panel',
-      m(
+export class Panel implements m.ClassComponent<PanelAttrs> {
+  view({attrs, children}: m.CVnode<PanelAttrs>): m.Children {
+    return m('.pf-memscope-panel', {className: attrs.className}, children);
+  }
+}
+
+export namespace Panel {
+  export interface HeaderAttrs {
+    readonly title: m.Children;
+    readonly subtitle?: m.Children;
+    readonly controls?: m.Children;
+  }
+
+  // The panel's header: a title row (title on the left, optional right-aligned
+  // controls) above an optional subtitle line.
+  export class Header implements m.ClassComponent<HeaderAttrs> {
+    view({attrs}: m.CVnode<HeaderAttrs>): m.Children {
+      return m(
         '.pf-memscope-panel__header',
-        m('h2', attrs.title),
-        attrs.subtitle !== undefined && m('p', attrs.subtitle),
-      ),
-      m('.pf-memscope-panel__body', children),
-    );
-  },
-};
+        m(
+          '.pf-memscope-panel__title-row',
+          m('h2.pf-memscope-panel__title', attrs.title),
+          attrs.controls !== undefined &&
+            m('.pf-memscope-panel__controls', attrs.controls),
+        ),
+        attrs.subtitle !== undefined &&
+          m('p.pf-memscope-panel__subtitle', attrs.subtitle),
+      );
+    }
+  }
+
+  export interface BodyAttrs {
+    readonly className?: string;
+  }
+
+  // The content area below the header. Holds the panel's actual payload
+  // (chart, table, billboards, free text).
+  export class Body implements m.ClassComponent<BodyAttrs> {
+    view({attrs, children}: m.CVnode<BodyAttrs>): m.Children {
+      return m(
+        '.pf-memscope-panel__body',
+        {className: attrs.className},
+        children,
+      );
+    }
+  }
+}
+
+// === Example usage ===
+//
+// import {Button} from '../../../../widgets/button';
+//
+// m(Panel,
+//   m(Panel.Header, {
+//     title: 'Memory Overview',
+//     subtitle: 'Heap usage across all processes',
+//     controls: m(Button, {label: 'Refresh', icon: 'refresh', onclick: reload}),
+//   }),
+//   m(Panel.Body, m(HeapChart, {data})),
+// );

--- a/ui/src/plugins/dev.perfetto.Memscope/components/progress_bar.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/progress_bar.ts
@@ -16,6 +16,12 @@ import './progress_bar.scss';
 import m from 'mithril';
 import {clamp} from '../../../base/math_utils';
 
+// ProgressBar — a horizontal "X of Y used" meter: an optional left label, a
+// filled track, and a right-aligned value (defaulting to "<pct>%") with an
+// optional muted suffix like " / 640 MB". Use it to show a bounded ratio at a
+// glance — memory or swap utilisation, cache fill, quota consumed. The pct is
+// clamped to 0..100 so out-of-range inputs can't overflow the track.
+
 export interface ProgressBarAttrs {
   // Percentage 0..100. Values outside the range are clamped.
   readonly pct: number;

--- a/ui/src/plugins/dev.perfetto.Memscope/components/table.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/table.scss
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-memscope-table {
+  border: solid 1px var(--pf-col-border);
+  border-radius: 8px;
+  overflow-x: auto;
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--pf-font-size-s);
+  }
+
+  th,
+  td {
+    padding: 8px 12px;
+    text-align: left;
+    vertical-align: baseline;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    font-size: var(--pf-font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pf-color-text-muted);
+    background: var(--pf-col-base);
+    border-bottom: 1px solid var(--pf-col-border);
+    white-space: nowrap;
+  }
+
+  tbody tr {
+    border-bottom: 1px solid var(--pf-col-border);
+
+    &:hover {
+      background: var(--pf-color-background-hover);
+    }
+  }
+
+  .pf-memscope-table__num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .pf-memscope-table__size {
+    font-weight: 600;
+  }
+
+  .pf-memscope-table__delta {
+    margin-top: 2px;
+    font-weight: 400;
+    font-size: var(--pf-font-size-xs);
+    color: var(--pf-color-text-muted);
+  }
+}
+
+.pf-memscope-table--flush {
+  margin-top: 0;
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/table.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/table.ts
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {HTMLAttrs} from '../../../widgets/common';
+import './table.scss';
+
+export class Table implements m.ClassComponent<HTMLAttrs> {
+  view({attrs, children}: m.CVnode<HTMLAttrs>): m.Children {
+    return m(
+      '.pf-memscope-table',
+      {className: attrs.className},
+      m('table', children),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/sessions/live_session.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/sessions/live_session.ts
@@ -23,6 +23,7 @@ import {createAdbTracingSession} from '../../dev.perfetto.RecordTraceV2/adb/adb_
 import type {TracingSession} from '../../dev.perfetto.RecordTraceV2/interfaces/tracing_session';
 import type {TracedWebsocketTarget} from '../../dev.perfetto.RecordTraceV2/traced_over_websocket/traced_websocket_target';
 import type {ConnectionResult} from '../views/connection';
+import {download} from '../../../base/download_utils';
 import {ProfileSession, type ProfileState} from './profile_session';
 
 export interface ProfileView {
@@ -207,6 +208,24 @@ export class LiveSession {
       this.app.openTraceFromBuffer({
         buffer: traceData,
         title: fileName,
+        fileName,
+      });
+    }
+  }
+
+  /** Stops the active profile and downloads the trace file. */
+  async stopAndDownloadProfile(): Promise<void> {
+    const profile = this.profileImpl?.session;
+    if (!profile) return;
+    const processName = profile.processName;
+    const pid = profile.pid;
+    await profile.stop();
+    const traceData = profile.getTraceData();
+    this.profileImpl = undefined;
+    if (traceData) {
+      const fileName = `heap-${processName}-${pid}.perfetto-trace`;
+      await download({
+        content: new Uint8Array(traceData),
         fileName,
       });
     }
@@ -429,7 +448,7 @@ function createMonitoringConfig(
               'task/task_newtask',
               'task/task_rename',
               'lowmemorykiller/lowmemory_kill',
-              'oom/oom_score_adj_update',
+              // 'oom/oom_score_adj_update',
             ],
             atraceApps: ['lmkd'],
             disableGenericEvents: true,

--- a/ui/src/plugins/dev.perfetto.Memscope/sessions/profile_session.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/sessions/profile_session.ts
@@ -19,10 +19,11 @@ import type {TracingSession} from '../../dev.perfetto.RecordTraceV2/interfaces/t
 import {TracedWebsocketTarget} from '../../dev.perfetto.RecordTraceV2/traced_over_websocket/traced_websocket_target';
 
 const DUMP_INTERVAL_MS = 10_000;
+const HEAPPROFD_DUMP_INTERVAL_MS = 5_000;
 const PROC_STATS_BUFFER_SIZE_KB = 4 * 1024;
-const HEAPPROFD_BUFFER_SIZE_KB = 128 * 1024;
-const JAVA_HPROF_BUFFER_SIZE_KB = 256 * 1024;
-const STATS_POLL_INTERVAL_MS = 3000;
+const HEAPPROFD_BUFFER_SIZE_KB = 512 * 1024;
+const JAVA_HPROF_BUFFER_SIZE_KB = 512 * 1024;
+const STATS_POLL_INTERVAL_MS = 3_000;
 
 export type ProfileState = 'recording' | 'stopping' | 'finished' | 'error';
 
@@ -50,7 +51,7 @@ export class ProfileSession {
     startX: number,
   ): Promise<ProfileSession> {
     const self = new ProfileSession(pid, processName, startX);
-    const config = buildProcessProfileConfig(pid);
+    const config = buildProcessProfileConfig(pid, processName);
     const result =
       targetOrDevice instanceof TracedWebsocketTarget
         ? await targetOrDevice.startTracing(config)
@@ -125,7 +126,10 @@ export class ProfileSession {
   }
 }
 
-function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
+function buildProcessProfileConfig(
+  pid: number,
+  processName: string,
+): protos.ITraceConfig {
   return {
     compressionType:
       protos.TraceConfig.CompressionType.COMPRESSION_TYPE_DEFLATE,
@@ -145,6 +149,11 @@ function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
         sizeKb: JAVA_HPROF_BUFFER_SIZE_KB,
         fillPolicy: protos.TraceConfig.BufferConfig.FillPolicy.RING_BUFFER,
       },
+      {
+        name: 'ftrace',
+        sizeKb: 4 * 1024,
+        fillPolicy: protos.TraceConfig.BufferConfig.FillPolicy.RING_BUFFER,
+      },
     ],
     dataSources: [
       {
@@ -153,6 +162,8 @@ function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
           targetBufferName: 'process_stats',
           processStatsConfig: {
             scanAllProcessesOnStart: true, // Necessary for track names.
+            procStatsPollMs: 1000,
+            recordProcessAge: true, // Necessary for process uptime.
           },
         },
       },
@@ -166,7 +177,7 @@ function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
             shmemSizeBytes: 16 * 1024 * 1024,
             blockClient: true, // Important for trace integrity.
             continuousDumpConfig: {
-              dumpIntervalMs: DUMP_INTERVAL_MS, // Important for getting regular heap snapshots to see how memory usage evolves over time.
+              dumpIntervalMs: HEAPPROFD_DUMP_INTERVAL_MS, // Important for getting regular heap snapshots to see how memory usage evolves over time.
             },
           },
         },
@@ -180,6 +191,18 @@ function buildProcessProfileConfig(pid: number): protos.ITraceConfig {
             continuousDumpConfig: {
               dumpIntervalMs: DUMP_INTERVAL_MS, // Required for Java profiles.
             },
+            smapsConfig: {},
+          },
+        },
+      },
+      {
+        config: {
+          name: 'linux.ftrace',
+          targetBufferName: 'ftrace',
+          ftraceConfig: {
+            ftraceEvents: ['ftrace/print'],
+            atraceCategories: ['dalvik'],
+            atraceApps: [processName],
           },
         },
       },

--- a/ui/src/plugins/dev.perfetto.Memscope/styles.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/styles.scss
@@ -12,24 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.pf-memscope-page__container {
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  height: 100%;
-  background: var(--pf-color-background);
-}
-
-.pf-memscope-page {
-  width: 100%;
-  max-width: 1600px;
-  margin-inline: auto;
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
 // Page title bar.
 .pf-memscope-title-bar {
   display: flex;
@@ -89,86 +71,10 @@
   padding: 8px;
 }
 
-// Hero connect / idle state.
-.pf-memscope-hero {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  padding: 48px 24px;
-  border-radius: 8px;
-  border: 1px dashed var(--pf-color-border-secondary);
-  text-align: center;
-}
-
-.pf-memscope-hero__icon {
-  font-size: 48px;
-  color: var(--pf-color-text-muted);
-  opacity: 0.5;
-}
-
-.pf-memscope-hero__text {
-  font-size: var(--pf-font-size-m);
-  color: var(--pf-color-text-muted);
-  max-width: 420px;
-  line-height: 1.5;
-}
-
-.pf-memscope-hero__actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 .pf-memscope-device-list {
   display: flex;
   flex-direction: column;
   gap: 8px;
   width: 100%;
   max-width: 400px;
-}
-
-.pf-memscope-page {
-  .pf-memscope-profile-btn {
-    visibility: hidden;
-  }
-
-  .pf-grid__row:hover .pf-memscope-profile-btn {
-    visibility: visible;
-  }
-
-  .pf-grid__header {
-    background: var(--pf-color-background);
-    color: var(--pf-color-text-muted);
-    user-select: none;
-    text-transform: uppercase;
-  }
-
-  .pf-grid__body {
-    background: var(--pf-color-background-secondary);
-  }
-
-  // Zero-padding for the profile button cell in the process table.
-  .pf-grid-cell:has(.pf-memscope-profile-btn) {
-    --pf-cell-padding-block: 0;
-    --pf-cell-padding-inline: 2px;
-  }
-
-  // Drop the panel body padding when it wraps a grid — the grid's own
-  // header/cell padding is enough.
-  .pf-memscope-panel__body:has(> .pf-grid) {
-    padding: 0;
-  }
-}
-
-.pf-memscope-color-chip {
-  --_mixed: color-mix(
-    in srgb,
-    var(--pf-memscope-chip-color, var(--pf-color-text)) 75%,
-    var(--pf-color-background)
-  );
-  color: var(--pf-chart-color-on);
-  background: var(--_mixed);
-  border-color: var(--_mixed);
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/utils.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/utils.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {formatBytesIec} from '../../base/bytes_format';
 import type {TsValue} from './sessions/live_session';
 
 /** Maps counter samples to chart points with x in seconds since `t0` (ns). */
@@ -24,23 +25,22 @@ export function counterPoints(
 }
 
 /**
- * Returns a Y-axis tick interval (in KB) that produces clean KB/MB/GB labels.
- * Targets ~5 ticks by picking the smallest interval from the sequence
- * 1, 2, 5, 10, 20, 50, 100, 200, 500 × {KB, MB, GB} that keeps tick count ≤ 6.
- *
- * Uses SI units (1 MB = 1000 KB, 1 GB = 1000 MB) to match `formatKb`.
+ * Returns a Y-axis tick interval (in KB) that lands on power-of-2 (IEC)
+ * boundaries, so labels rendered with `formatBytesIec` read as clean
+ * KiB/MiB/GiB values. Targets ~5 ticks by picking the smallest interval from
+ * 1, 2, 4, 8 … 512 × {KiB, MiB, GiB} (1 MiB = 1024 KiB) that keeps ticks ≤ 6.
  */
 export function niceKbInterval(maxKb: number): number {
   if (maxKb <= 0) return 1;
   const rawInterval = maxKb / 5;
-  const steps = [1, 2, 5, 10, 20, 50, 100, 200, 500];
-  for (const unit of [1, 1000, 1000 * 1000]) {
+  const steps = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512];
+  for (const unit of [1, 1024, 1024 * 1024]) {
     for (const step of steps) {
       const candidate = unit * step;
       if (candidate >= rawInterval) return candidate;
     }
   }
-  return 1000 * 1000 * 500; // fallback: 500 GB
+  return 1024 * 1024 * 512; // fallback: 512 GiB
 }
 
 /** Returns the maximum y value across all series in a chart dataset. */
@@ -56,25 +56,8 @@ export function maxSeriesKb(
   return max;
 }
 
-export function formatKb(kb: number): string {
-  if (kb < 1000) return `${kb.toLocaleString()} KB`;
-  if (kb < 1000 * 1000) return `${(kb / 1000).toFixed(1)} MB`;
-  return `${(kb / (1000 * 1000)).toFixed(1)} GB`;
-}
-
-/** Renders a KB value for a billboard with the unit in a smaller span. */
-export function billboardKb(kb: number) {
-  let value: string;
-  let unit: string;
-  if (kb < 1000) {
-    value = kb.toLocaleString();
-    unit = 'KB';
-  } else if (kb < 1000 * 1000) {
-    value = (kb / 1000).toFixed(1);
-    unit = 'MB';
-  } else {
-    value = (kb / (1000 * 1000)).toFixed(1);
-    unit = 'GB';
-  }
+/** Renders a byte value for a billboard with the unit in a smaller span. */
+export function billboardBytes(bytes: number) {
+  const [value, unit] = formatBytesIec(bytes).split(' ');
   return {value, unit};
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/views/connection.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/connection.ts
@@ -18,7 +18,6 @@ import {showPopupWindow} from '../../../base/popup_window';
 import {exists} from '../../../base/utils';
 import {Button, ButtonVariant} from '../../../widgets/button';
 import {Intent} from '../../../widgets/common';
-import {Icon} from '../../../widgets/icon';
 import {TextInput} from '../../../widgets/text_input';
 import {RadioGroup} from '../../../widgets/radio_group';
 import type {AdbDevice} from '../../dev.perfetto.RecordTraceV2/adb/adb_device';
@@ -36,6 +35,8 @@ import {
 } from '../../dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_utils';
 import {TracedWebsocketTarget} from '../../dev.perfetto.RecordTraceV2/traced_over_websocket/traced_websocket_target';
 import {AsyncWebsocket} from '../../dev.perfetto.RecordTraceV2/websocket/async_websocket';
+import {Page} from '../components/page';
+import {Hero} from '../components/hero';
 
 export interface ConnectionResult {
   device?: AdbDevice;
@@ -85,44 +86,37 @@ export class ConnectionPage implements m.ClassComponent<ConnectionPageAttrs> {
 
   view({attrs}: m.CVnode<ConnectionPageAttrs>) {
     return m(
-      '.pf-memscope-page__container',
+      Page,
+      m(Page.Title, 'Memscope'),
       m(
-        '.pf-memscope-page',
-        m('.pf-memscope-title-bar', m('h1', 'Memscope')),
+        Hero,
+        m(Hero.Icon, {icon: 'memory'}),
         m(
-          '.pf-memscope-hero',
-          m(Icon, {icon: 'memory', className: 'pf-memscope-hero__icon'}),
-          m(
-            '.pf-memscope-hero__text',
-            'Connect to an Android device or Linux host to monitor ' +
-              'per-process memory usage in real time via traced.',
-          ),
-          m(
-            RadioGroup,
-            {
-              intent: Intent.Primary,
-              selectedValue: this.connectionMethod,
-              onValueChange: (value) => {
-                this.connectionMethod = value as ConnectionMethod;
-                this.error = undefined;
-              },
-            },
-            m(RadioGroup.Button, {value: 'usb', icon: 'usb'}, 'USB'),
-            m(
-              RadioGroup.Button,
-              {value: 'websocket', icon: 'lan'},
-              'WebSocket',
-            ),
-            m(
-              RadioGroup.Button,
-              {value: 'web_proxy', icon: 'corporate_fare'},
-              'Web Proxy',
-            ),
-            m(RadioGroup.Button, {value: 'linux', icon: 'computer'}, 'Linux'),
-          ),
-          this.renderConnectBox(attrs),
-          this.error && m('.pf-memscope-error', this.error),
+          Hero.Text,
+          'Connect to an Android device or Linux host to monitor ' +
+            'per-process memory usage in real time via traced.',
         ),
+        m(
+          RadioGroup,
+          {
+            intent: Intent.Primary,
+            selectedValue: this.connectionMethod,
+            onValueChange: (value) => {
+              this.connectionMethod = value as ConnectionMethod;
+              this.error = undefined;
+            },
+          },
+          m(RadioGroup.Button, {value: 'usb', icon: 'usb'}, 'USB'),
+          m(RadioGroup.Button, {value: 'websocket', icon: 'lan'}, 'WebSocket'),
+          m(
+            RadioGroup.Button,
+            {value: 'web_proxy', icon: 'corporate_fare'},
+            'Web Proxy',
+          ),
+          m(RadioGroup.Button, {value: 'linux', icon: 'computer'}, 'Linux'),
+        ),
+        this.renderConnectBox(attrs),
+        this.error && m('.pf-memscope-error', this.error),
       ),
     );
   }

--- a/ui/src/plugins/dev.perfetto.Memscope/views/dashboard.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/dashboard.scss
@@ -12,33 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.pf-memscope--muted {
-  color: var(--pf-color-text-muted);
-}
-
-// Title bar sub-layout (left group, separator, device badge, actions).
+// Title bar sub-layout (left group, actions).
 .pf-memscope-title-bar__left {
   display: flex;
   align-items: baseline;
   gap: 12px;
   flex-shrink: 0;
-}
-
-// Thin vertical rule that separates logical groups in the toolbar.
-.pf-memscope-title-bar__sep {
-  width: 1px;
-  height: 18px;
-  background: var(--pf-color-border);
-  flex-shrink: 0;
-}
-
-.pf-memscope-title-bar__device {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  font-size: var(--pf-font-size-m);
-  font-weight: 500;
-  color: var(--pf-color-text-muted);
 }
 
 // Right-side cluster: device identity + button group.
@@ -55,27 +34,6 @@
   font-size: var(--pf-font-size-m);
   font-weight: 500;
   color: var(--pf-color-text-hint);
-}
-
-.pf-memscope-session-pill__sep {
-  width: 1px;
-  height: 18px;
-  background: var(--pf-color-border);
-  flex-shrink: 0;
-}
-
-.pf-memscope-session-pill__snapshot {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 4px;
-  font-size: var(--pf-font-size-s);
-  font-variant-numeric: tabular-nums;
-  color: var(--pf-color-text-muted);
-  cursor: help;
-
-  .material-icons {
-    font-size: 16px;
-  }
 }
 
 // Snapshot info popup content.
@@ -111,7 +69,7 @@
   &.pf-memscope-snapshot-info__sum {
     margin-top: 6px;
     padding-top: 8px;
-    border-top: 1px solid var(--pf-color-border);
+    border-top: 1px solid var(--pf-col-border);
     font-weight: 600;
     font-size: var(--pf-font-size-m);
 

--- a/ui/src/plugins/dev.perfetto.Memscope/views/dashboard.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/dashboard.ts
@@ -12,30 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import './dashboard.scss';
 import m from 'mithril';
-import type {App} from '../../../public/app';
-import {Button, ButtonGroup, ButtonVariant} from '../../../widgets/button';
-import {Intent} from '../../../widgets/common';
-import {RadioGroup} from '../../../widgets/radio_group';
+import {GateDetector} from '../../../base/mithril_utils';
 import type {
   LineChartData,
   LineChartSeries,
 } from '../../../components/widgets/charts/line_chart';
-import {GateDetector} from '../../../base/mithril_utils';
+import type {App} from '../../../public/app';
+import {Button, ButtonGroup, ButtonVariant} from '../../../widgets/button';
+import {Chip} from '../../../widgets/chip';
+import {Intent} from '../../../widgets/common';
+import {MenuDivider, MenuItem, PopupMenu} from '../../../widgets/menu';
+import {PopupPosition} from '../../../widgets/popup';
+import {RadioGroup} from '../../../widgets/radio_group';
+import {Page} from '../components/page';
 import type {
   LiveSession,
   ProfileView,
   SnapshotData,
 } from '../sessions/live_session';
+import './dashboard.scss';
 import {ProfilePage} from './profile_page';
-import {ProcessesTab} from './tabs/processes';
-import {renderSystemTab} from './tabs/system';
 import {renderPageCacheTab} from './tabs/page_cache';
 import {renderPressureSwapTab} from './tabs/pressure_swap';
-import {Chip} from '../../../widgets/chip';
-import {PopupPosition} from '../../../widgets/popup';
-import {MenuDivider, MenuItem, PopupMenu} from '../../../widgets/menu';
+import {ProcessesTab} from './tabs/processes';
+import {renderSystemTab} from './tabs/system';
 
 type Tab = 'processes' | 'system' | 'file_cache' | 'pressure_swap';
 
@@ -120,18 +121,15 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
           visible ? session.resume() : session.pause(),
       },
       m(
-        '.pf-memscope-page__container',
-        m(
-          '.pf-memscope-page',
+        Page,
 
-          // Title bar with status and actions (always shown).
-          this.renderTitleBar(attrs),
+        // Title bar with status and actions (always shown).
+        this.renderTitleBar(attrs),
 
-          // Profile page or dashboard content.
-          session.profile !== undefined
-            ? this.renderProfilePage(attrs, session.profile)
-            : this.renderDashboard(attrs),
-        ),
+        // Profile page or dashboard content.
+        session.profile !== undefined
+          ? this.renderProfilePage(attrs, session.profile)
+          : this.renderDashboard(attrs),
       ),
     );
   }
@@ -359,6 +357,12 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
       baseline: this.profileBaseline,
       onStop: () => {
         session.stopAndOpenProfile().then(() => {
+          this.profileBaseline = undefined;
+          m.redraw();
+        });
+      },
+      onStopAndDownload: () => {
+        session.stopAndDownloadProfile().then(() => {
           this.profileBaseline = undefined;
           m.redraw();
         });

--- a/ui/src/plugins/dev.perfetto.Memscope/views/profile_page.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/profile_page.scss
@@ -18,7 +18,7 @@
   align-items: stretch;
   border-radius: 8px;
   background: var(--pf-color-background-secondary);
-  border: 1px solid var(--pf-color-danger);
+  border: 0.5px solid var(--pf-color-danger);
   overflow: hidden;
   box-shadow: 0 0 0 3px
     color-mix(in srgb, var(--pf-color-danger) 25%, transparent);
@@ -43,7 +43,7 @@
   min-width: 0;
 
   & + & {
-    border-left: 1px solid var(--pf-color-border-secondary);
+    border-left: 1px solid var(--pf-col-border);
   }
 }
 
@@ -121,7 +121,7 @@
   font-weight: 600;
   color: var(--pf-color-text);
   background: var(--pf-color-background);
-  border: 1px solid var(--pf-color-border-secondary);
+  border: 0.5px solid var(--pf-col-border);
   border-radius: 4px;
   padding: 2px 8px;
   white-space: nowrap;

--- a/ui/src/plugins/dev.perfetto.Memscope/views/profile_page.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/profile_page.ts
@@ -23,7 +23,8 @@ import {Intent} from '../../../widgets/common';
 import {Icon} from '../../../widgets/icon';
 import {Billboard} from '../components/billboard';
 import {ProgressBar} from '../components/progress_bar';
-import {billboardKb, formatKb, maxSeriesKb, niceKbInterval} from '../utils';
+import {billboardBytes, maxSeriesKb, niceKbInterval} from '../utils';
+import {formatBytesIec} from '../../../base/bytes_format';
 import {Icons} from '../../../base/semantic_icons';
 import {Stack} from '../../../widgets/stack';
 
@@ -36,6 +37,7 @@ export interface ProfilePageAttrs {
   readonly chartData?: LineChartData;
   readonly baseline?: {anonSwap: number; file: number; dmabuf: number};
   readonly onStop: () => void;
+  readonly onStopAndDownload: () => void;
   readonly onCancel: () => void;
 }
 
@@ -122,6 +124,13 @@ export class ProfilePage implements m.ClassComponent<ProfilePageAttrs> {
                 onclick: () => attrs.onCancel(),
               }),
               m(Button, {
+                label: 'Stop & Download',
+                icon: 'download',
+                variant: ButtonVariant.Filled,
+                intent: Intent.Primary,
+                onclick: () => attrs.onStopAndDownload(),
+              }),
+              m(Button, {
                 label: 'Stop & Open Trace',
                 icon: Icons.ExternalLink,
                 variant: ButtonVariant.Filled,
@@ -162,10 +171,10 @@ function renderBillboards(
     const delta = baselineVal !== undefined ? current - baselineVal : undefined;
     const deltaStr =
       delta !== undefined
-        ? `${delta >= 0 ? '+' : ''}${formatKb(delta)}`
+        ? `${delta >= 0 ? '+' : ''}${formatBytesIec(delta * 1024)}`
         : undefined;
     return m(Billboard, {
-      ...billboardKb(current),
+      ...billboardBytes(current * 1024),
       label,
       desc,
       delta: deltaStr,
@@ -217,7 +226,7 @@ function renderBreakdownChart(attrs: ProfilePageAttrs): m.Children {
           xAxisMin: xMin,
           xAxisMax: xMax,
           formatXValue: (v: number) => `${v.toFixed(0)}s`,
-          formatYValue: (v: number) => formatKb(v),
+          formatYValue: (v: number) => formatBytesIec(v * 1024),
           yAxisMinInterval: niceKbInterval(maxSeriesKb(chartData.series)),
         });
       })()

--- a/ui/src/plugins/dev.perfetto.Memscope/views/tabs/page_cache.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/tabs/page_cache.ts
@@ -20,15 +20,14 @@ import {
 } from '../../../../components/widgets/charts_svg/line_chart_svg';
 import type {LiveSession, SnapshotData} from '../../sessions/live_session';
 import {
-  billboardKb,
+  billboardBytes,
   counterPoints,
-  formatKb,
   maxSeriesKb,
   niceKbInterval,
 } from '../../utils';
-import {Billboard} from '../../components/billboard';
+import {formatBytesIec} from '../../../../base/bytes_format';
+import {Billboard, BillboardStrip} from '../../components/billboard';
 import {Panel} from '../../components/panel';
-import {Stack} from '../../../../widgets/stack';
 
 function buildPageCacheTimeSeries(
   data: SnapshotData,
@@ -222,23 +221,22 @@ export function renderPageCacheTab(session: LiveSession): m.Children {
   const fileCacheActivityData = buildFileCacheActivityTimeSeries(data, t0);
   const bb = getPageCacheBillboards(fileCacheBreakdownData);
 
-  return m(Stack, {spacing: 'large'}, [
+  return m.fragment({}, [
     bb !== undefined &&
       m(
-        Stack,
-        {orientation: 'horizontal', spacing: 'large'},
+        BillboardStrip,
         m(Billboard, {
-          ...billboardKb(bb.total),
+          ...billboardBytes(bb.total * 1024),
           label: 'Total Page Cache',
           desc: 'Derived: Active(file) + Inactive(file) from /proc/meminfo',
         }),
         m(Billboard, {
-          ...billboardKb(bb.dirty),
+          ...billboardBytes(bb.dirty * 1024),
           label: 'Dirty',
           desc: 'Source: Dirty from /proc/meminfo',
         }),
         m(Billboard, {
-          ...billboardKb(bb.mapped),
+          ...billboardBytes(bb.mapped * 1024),
           label: 'Mapped',
           desc: 'Source: Mapped from /proc/meminfo',
         }),
@@ -246,58 +244,64 @@ export function renderPageCacheTab(session: LiveSession): m.Children {
 
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'Page Cache',
         subtitle:
           'Source: /proc/meminfo counters Active(file), Inactive(file), Shmem. ' +
           'Stacked: Active(file) + Inactive(file) + Shmem \u2248 Cached.',
-      },
-      pageCacheChartData
-        ? m(LineChartSvg, {
-            data: pageCacheChartData,
-            height: 250,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Cache',
-            showLegend: true,
-            showPoints: false,
-            stacked: true,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => formatKb(v),
-            yAxisMinInterval: niceKbInterval(
-              maxSeriesKb(pageCacheChartData.series),
-            ),
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        pageCacheChartData
+          ? m(LineChartSvg, {
+              data: pageCacheChartData,
+              height: 250,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Cache',
+              showLegend: true,
+              showPoints: false,
+              stacked: true,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => formatBytesIec(v * 1024),
+              yAxisMinInterval: niceKbInterval(
+                maxSeriesKb(pageCacheChartData.series),
+              ),
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
 
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'Page Cache Activity',
         subtitle:
           'Source: /proc/vmstat counters, shown as rates (delta/s). ' +
           'Refaults = workingset_refault_file (evicted pages needed again). ' +
           'Stolen = pgsteal_file (pages reclaimed). ' +
           'Scanned = pgscan_file (pages considered for reclaim).',
-      },
-      fileCacheActivityData
-        ? m(LineChartSvg, {
-            data: fileCacheActivityData,
-            height: 200,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Pages/s',
-            showLegend: true,
-            showPoints: false,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => v.toLocaleString(),
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        fileCacheActivityData
+          ? m(LineChartSvg, {
+              data: fileCacheActivityData,
+              height: 200,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Pages/s',
+              showLegend: true,
+              showPoints: false,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => v.toLocaleString(),
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
   ]);
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/views/tabs/pressure_swap.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/tabs/pressure_swap.ts
@@ -19,12 +19,8 @@ import {
   type LineChartSeries,
 } from '../../../../components/widgets/charts_svg/line_chart_svg';
 import type {LiveSession, SnapshotData} from '../../sessions/live_session';
-import {
-  counterPoints,
-  formatKb,
-  maxSeriesKb,
-  niceKbInterval,
-} from '../../utils';
+import {counterPoints, maxSeriesKb, niceKbInterval} from '../../utils';
+import {formatBytesIec} from '../../../../base/bytes_format';
 import {Panel} from '../../components/panel';
 import {Grid, GridCell, GridHeaderCell} from '../../../../widgets/grid';
 
@@ -162,32 +158,39 @@ function renderLmkPanel(
 ): m.Children {
   return m(
     Panel,
-    {
+    m(Panel.Header, {
       title: `LMK Kills (${events.length})`,
       subtitle:
         'Low Memory Killer events recorded during this session. ' +
         'Source: lmkd atrace / lowmemorykiller ftrace.',
-    },
-    events.length > 0 &&
-      m(Grid, {
-        columns: [
-          {key: 'time', header: m(GridHeaderCell, 'Time')},
-          {key: 'pid', header: m(GridHeaderCell, 'PID')},
-          {
-            key: 'process',
-            header: m(GridHeaderCell, 'Process'),
-            maxInitialWidthPx: 400,
-          },
-          {key: 'oom', header: m(GridHeaderCell, 'OOM Adj')},
-        ],
-        rowData: events.map((ev) => [
-          m(GridCell, {align: 'right'}, `${((ev.ts - t0) / 1e9).toFixed(1)}s`),
-          m(GridCell, {align: 'right'}, String(ev.pid)),
-          m(GridCell, ev.processName || '(unknown)'),
-          m(GridCell, {align: 'right'}, String(ev.oomScoreAdj)),
-        ]),
-        fillHeight: false,
-      }),
+    }),
+    m(
+      Panel.Body,
+      events.length > 0 &&
+        m(Grid, {
+          columns: [
+            {key: 'time', header: m(GridHeaderCell, 'Time')},
+            {key: 'pid', header: m(GridHeaderCell, 'PID')},
+            {
+              key: 'process',
+              header: m(GridHeaderCell, 'Process'),
+              maxInitialWidthPx: 400,
+            },
+            {key: 'oom', header: m(GridHeaderCell, 'OOM Adj')},
+          ],
+          rowData: events.map((ev) => [
+            m(
+              GridCell,
+              {align: 'right'},
+              `${((ev.ts - t0) / 1e9).toFixed(1)}s`,
+            ),
+            m(GridCell, {align: 'right'}, String(ev.pid)),
+            m(GridCell, ev.processName || '(unknown)'),
+            m(GridCell, {align: 'right'}, String(ev.oomScoreAdj)),
+          ]),
+          fillHeight: false,
+        }),
+    ),
   );
 }
 
@@ -204,109 +207,121 @@ export function renderPressureSwapTab(session: LiveSession): m.Children {
   return [
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'Memory Pressure (PSI)',
         subtitle:
           'Source: /proc/pressure/memory (psi.mem.some, psi.mem.full). ' +
           'Derived: cumulative \u00b5s converted to ms/s rate. ' +
           '"some" = at least one task stalled, "full" = all tasks stalled.',
-      },
-      psiChartData
-        ? m(LineChartSvg, {
-            data: psiChartData,
-            height: 200,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Stall (ms/s)',
-            showLegend: true,
-            showPoints: false,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => `${v.toFixed(1)} ms/s`,
-            // TODO(stevegolton): Add markers back in when we support them in LineChartSvg.
-            //   x: (ev.ts - t0) / 1e9,
-            // })),
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        psiChartData
+          ? m(LineChartSvg, {
+              data: psiChartData,
+              height: 200,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Stall (ms/s)',
+              showLegend: true,
+              showPoints: false,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => `${v.toFixed(1)} ms/s`,
+              // TODO(stevegolton): Add markers back in when we support them in LineChartSvg.
+              //   x: (ev.ts - t0) / 1e9,
+              // })),
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
 
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'Page Faults',
         subtitle:
           'Source: /proc/vmstat counters pgfault, pgmajfault. ' +
           'Derived: cumulative counts converted to faults/s rate. ' +
           'Minor (pgfault) = page in RAM but not in TLB. Major (pgmajfault) = page must be read from disk.',
-      },
-      pageFaultChartData
-        ? m(LineChartSvg, {
-            data: pageFaultChartData,
-            height: 200,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Faults/s',
-            showLegend: true,
-            showPoints: false,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => `${v.toFixed(0)} f/s`,
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        pageFaultChartData
+          ? m(LineChartSvg, {
+              data: pageFaultChartData,
+              height: 200,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Faults/s',
+              showLegend: true,
+              showPoints: false,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => `${v.toFixed(0)} f/s`,
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
 
     swapChartData &&
       m(
         Panel,
-        {
+        m(Panel.Header, {
           title: 'Swap Usage',
           subtitle:
             'Source: /proc/meminfo counters SwapTotal, SwapFree, SwapCached. ' +
             'Derived: Swap dirty = (SwapTotal \u2212 SwapFree) \u2212 SwapCached.',
-        },
-        m(LineChartSvg, {
-          data: swapChartData,
-          height: 200,
-          xAxisMin: data.xMin,
-          xAxisMax: data.xMax,
-          xAxisLabel: 'Time (s)',
-          yAxisLabel: 'Swap',
-          showLegend: true,
-          showPoints: false,
-          stacked: true,
-          gridLines: 'both',
-          formatXValue: (v: number) => `${v.toFixed(0)}s`,
-          formatYValue: (v: number) => formatKb(v),
-          yAxisMinInterval: niceKbInterval(
-            maxSeriesKb(swapChartData?.series ?? []),
-          ),
         }),
+        m(
+          Panel.Body,
+          m(LineChartSvg, {
+            data: swapChartData,
+            height: 200,
+            xAxisMin: data.xMin,
+            xAxisMax: data.xMax,
+            xAxisLabel: 'Time (s)',
+            yAxisLabel: 'Swap',
+            showLegend: true,
+            showPoints: false,
+            stacked: true,
+            gridLines: 'both',
+            formatXValue: (v: number) => `${v.toFixed(0)}s`,
+            formatYValue: (v: number) => formatBytesIec(v * 1024),
+            yAxisMinInterval: niceKbInterval(
+              maxSeriesKb(swapChartData?.series ?? []),
+            ),
+          }),
+        ),
       ),
 
     vmstatChartData &&
       m(
         Panel,
-        {
+        m(Panel.Header, {
           title: 'Swap I/O (pswpin / pswpout)',
           subtitle:
             'Source: /proc/vmstat counters pswpin, pswpout. ' +
             'Derived: cumulative page counts converted to pages/s rate.',
-        },
-        m(LineChartSvg, {
-          data: vmstatChartData,
-          xAxisMin: data.xMin,
-          xAxisMax: data.xMax,
-          height: 200,
-          xAxisLabel: 'Time (s)',
-          yAxisLabel: 'Pages/s',
-          showLegend: true,
-          showPoints: false,
-          gridLines: 'both',
-          formatXValue: (v: number) => `${v.toFixed(0)}s`,
-          formatYValue: (v: number) => `${v.toFixed(0)} pg/s`,
         }),
+        m(
+          Panel.Body,
+          m(LineChartSvg, {
+            data: vmstatChartData,
+            xAxisMin: data.xMin,
+            xAxisMax: data.xMax,
+            height: 200,
+            xAxisLabel: 'Time (s)',
+            yAxisLabel: 'Pages/s',
+            showLegend: true,
+            showPoints: false,
+            gridLines: 'both',
+            formatXValue: (v: number) => `${v.toFixed(0)}s`,
+            formatYValue: (v: number) => `${v.toFixed(0)} pg/s`,
+          }),
+        ),
       ),
 
     renderLmkPanel(data.lmkEvents, t0),

--- a/ui/src/plugins/dev.perfetto.Memscope/views/tabs/processes.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/tabs/processes.ts
@@ -42,9 +42,10 @@ import {
   CATEGORIES,
   type CategoryId,
 } from '../../process_categories';
-import {Billboard} from '../../components/billboard';
+import {Billboard, BillboardStrip} from '../../components/billboard';
 import {ColorChip, chipColor} from '../../components/color_chip';
-import {billboardKb, formatKb, maxSeriesKb, niceKbInterval} from '../../utils';
+import {billboardBytes, maxSeriesKb, niceKbInterval} from '../../utils';
+import {formatBytesIec} from '../../../../base/bytes_format';
 import {
   type ProcessGrouping,
   type ProcessMetric,
@@ -52,7 +53,6 @@ import {
   PROCESS_METRIC_OPTIONS,
   OOM_SCORE_BUCKETS,
 } from '../../process_data';
-import {Stack} from '../../../../widgets/stack';
 
 export type {ProcessGrouping, ProcessMetric, ProcessMemoryRow};
 export {PROCESS_METRIC_OPTIONS, OOM_SCORE_BUCKETS};
@@ -511,23 +511,22 @@ export class ProcessesTab implements m.ClassComponent<ProcessesTabAttrs> {
     const totalFileKb = latestProcesses.reduce((s, p) => s + p.fileKb, 0);
     const totalDmabufKb = latestProcesses.reduce((s, p) => s + p.dmabufKb, 0);
 
-    return m(Stack, {spacing: 'large'}, [
+    return m.fragment({}, [
       latestProcesses.length > 0 &&
         m(
-          Stack,
-          {orientation: 'horizontal', spacing: 'large'},
+          BillboardStrip,
           m(Billboard, {
-            ...billboardKb(totalAnonSwapKb),
+            ...billboardBytes(totalAnonSwapKb * 1024),
             label: 'RSS Anon + Swap',
             desc: 'Sum of anonymous RSS + swap across all processes',
           }),
           m(Billboard, {
-            ...billboardKb(totalFileKb),
+            ...billboardBytes(totalFileKb * 1024),
             label: 'File',
             desc: 'Sum of file-backed RSS across all processes',
           }),
           m(Billboard, {
-            ...billboardKb(totalDmabufKb),
+            ...billboardBytes(totalDmabufKb * 1024),
             label: 'DMA-BUF',
             desc: 'Sum of DMA-BUF heap RSS across all processes',
           }),
@@ -607,7 +606,7 @@ export class ProcessesTab implements m.ClassComponent<ProcessesTabAttrs> {
                 xAxisMin: chartXMin,
                 xAxisMax: chartXMax,
                 formatXValue: (v: number) => `${v.toFixed(0)}s`,
-                formatYValue: (v: number) => formatKb(v),
+                formatYValue: (v: number) => formatBytesIec(v * 1024),
                 yAxisMinInterval: niceKbInterval(maxSeriesKb(chartData.series)),
                 onSeriesClick: isDrilledDown
                   ? undefined
@@ -818,22 +817,28 @@ class ProcessTable implements m.ClassComponent<ProcessTableAttrs> {
             : oomLabel,
         ),
         m(GridCell, {align: 'right', style: mutedStyle}, ageStr),
-        m(GridCell, {align: 'right', style: mutedStyle}, formatKb(p.rssKb)),
+        m(
+          GridCell,
+          {align: 'right', style: mutedStyle},
+          formatBytesIec(p.rssKb * 1024),
+        ),
         m(GridCell, {style: mutedStyle}, sparkline(p.rssTrendKb)),
         m(
           GridCell,
           {align: 'right', style: mutedStyle},
-          p.anonKb + p.swapKb > 0 ? formatKb(p.anonKb + p.swapKb) : '-',
+          p.anonKb + p.swapKb > 0
+            ? formatBytesIec((p.anonKb + p.swapKb) * 1024)
+            : '-',
         ),
         m(
           GridCell,
           {align: 'right', style: mutedStyle},
-          p.fileKb > 0 ? formatKb(p.fileKb) : '-',
+          p.fileKb > 0 ? formatBytesIec(p.fileKb * 1024) : '-',
         ),
         m(
           GridCell,
           {align: 'right', style: mutedStyle},
-          p.shmemKb > 0 ? formatKb(p.shmemKb) : '-',
+          p.shmemKb > 0 ? formatBytesIec(p.shmemKb * 1024) : '-',
         ),
       ];
     });
@@ -850,6 +855,14 @@ class ProcessTable implements m.ClassComponent<ProcessTableAttrs> {
             ? `Stopping and reading trace for ${profile.processName}\u2026`
             : `Recording heap profile for ${profile.processName} (PID ${profile.pid})`,
           !isStopping && [
+            m(Button, {
+              label: 'Stop & Download',
+              icon: 'download',
+              minimal: true,
+              intent: Intent.Danger,
+              onclick: () =>
+                session.stopAndDownloadProfile().then(() => m.redraw()),
+            }),
             m(Button, {
               label: 'Stop & Open',
               icon: 'stop',

--- a/ui/src/plugins/dev.perfetto.Memscope/views/tabs/system.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/tabs/system.ts
@@ -19,10 +19,10 @@ import {
   type LineChartSeries,
 } from '../../../../components/widgets/charts_svg/line_chart_svg';
 import type {LiveSession, SnapshotData} from '../../sessions/live_session';
-import {billboardKb, formatKb, maxSeriesKb, niceKbInterval} from '../../utils';
-import {Billboard} from '../../components/billboard';
+import {billboardBytes, maxSeriesKb, niceKbInterval} from '../../utils';
+import {formatBytesIec} from '../../../../base/bytes_format';
+import {Billboard, BillboardStrip} from '../../components/billboard';
 import {Panel} from '../../components/panel';
-import {Stack} from '../../../../widgets/stack';
 
 /** System memory breakdown from /proc/meminfo, partitioning MemTotal. */
 function buildSystemTimeSeries(
@@ -195,31 +195,31 @@ export function renderSystemTab(session: LiveSession): m.Children {
   const bb = buildSystemBillboards(data);
   const chartData = buildSystemTimeSeries(data, t0);
 
-  return m(Stack, {spacing: 'large'}, [
+  return m.fragment({}, [
     bb !== undefined &&
-      m(Stack, {orientation: 'horizontal', spacing: 'large'}, [
+      m(BillboardStrip, [
         m(Billboard, {
-          ...billboardKb(bb.totalKb),
+          ...billboardBytes(bb.totalKb * 1024),
           label: 'MemTotal',
           desc: 'Total physical RAM',
         }),
         m(Billboard, {
-          ...billboardKb(bb.availableKb),
+          ...billboardBytes(bb.availableKb * 1024),
           label: 'MemAvailable',
           desc: 'Available without swapping',
         }),
         m(Billboard, {
-          ...billboardKb(bb.anonKb),
+          ...billboardBytes(bb.anonKb * 1024),
           label: 'Anon',
           desc: 'Active(anon) + Inactive(anon)',
         }),
         m(Billboard, {
-          ...billboardKb(bb.fileCacheKb),
+          ...billboardBytes(bb.fileCacheKb * 1024),
           label: 'Page Cache',
           desc: 'File LRU \u2212 Shmem',
         }),
         m(Billboard, {
-          ...billboardKb(bb.freeKb),
+          ...billboardBytes(bb.freeKb * 1024),
           label: 'MemFree',
           desc: 'Completely unused RAM',
         }),
@@ -227,30 +227,33 @@ export function renderSystemTab(session: LiveSession): m.Children {
 
     m(
       Panel,
-      {
+      m(Panel.Header, {
         title: 'System Memory',
         subtitle:
           'Stacked areas partition MemTotal. Source: /proc/meminfo. ' +
           'Anon = Active(anon) + Inactive(anon). Page cache = Active(file) + Inactive(file) \u2212 Shmem. ' +
           'Unaccounted = MemTotal \u2212 sum of all other categories.',
-      },
-      chartData
-        ? m(LineChartSvg, {
-            data: chartData,
-            height: 400,
-            xAxisLabel: 'Time (s)',
-            yAxisLabel: 'Memory',
-            showLegend: true,
-            showPoints: false,
-            stacked: true,
-            gridLines: 'both',
-            xAxisMin: data.xMin,
-            xAxisMax: data.xMax,
-            formatXValue: (v: number) => `${v.toFixed(0)}s`,
-            formatYValue: (v: number) => formatKb(v),
-            yAxisMinInterval: niceKbInterval(maxSeriesKb(chartData.series)),
-          })
-        : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      }),
+      m(
+        Panel.Body,
+        chartData
+          ? m(LineChartSvg, {
+              data: chartData,
+              height: 400,
+              xAxisLabel: 'Time (s)',
+              yAxisLabel: 'Memory',
+              showLegend: true,
+              showPoints: false,
+              stacked: true,
+              gridLines: 'both',
+              xAxisMin: data.xMin,
+              xAxisMax: data.xMax,
+              formatXValue: (v: number) => `${v.toFixed(0)}s`,
+              formatYValue: (v: number) => formatBytesIec(v * 1024),
+              yAxisMinInterval: niceKbInterval(maxSeriesKb(chartData.series)),
+            })
+          : m('.pf-memscope-placeholder', 'Waiting for data\u2026'),
+      ),
     ),
   ]);
 }

--- a/ui/src/widgets/cursor_tooltip.ts
+++ b/ui/src/widgets/cursor_tooltip.ts
@@ -32,8 +32,15 @@ import type {ExtendedModifiers} from './popper_utils';
 export interface CursorTooltipAttrs extends HTMLAttrs {
   // Which side of the cursor to place the tooltip. Defaults to Right.
   readonly position?: PopupPosition;
-  // Distance in px between the tooltip and the cursor. Default = 8.
+  // Gap in px between the tooltip and the cursor, measured along the placement
+  // axis — i.e. how far out in the `position` direction (e.g. how far to the
+  // right for the default Right placement). Default = 8.
   readonly offset?: number;
+  // Shift in px along the cross axis (perpendicular to `position`), sliding the
+  // tooltip sideways past the cursor without changing its distance. Positive
+  // values move toward the end of that axis — e.g. downward for the default
+  // Right placement. Default = 0.
+  readonly skidOffset?: number;
 }
 
 class VElement implements VirtualElement {
@@ -132,7 +139,7 @@ export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
   }
 
   private createOrUpdatePopper(attrs: CursorTooltipAttrs) {
-    const {position = PopupPosition.Right, offset = 8} = attrs;
+    const {position = PopupPosition.Right, offset = 8, skidOffset = 0} = attrs;
 
     // Custom modifier to hide the tooltip when our canary - and hence the
     // tooltip's parent - is not visible. This can be due to the canary or one
@@ -161,7 +168,7 @@ export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
         {
           name: 'offset',
           options: {
-            offset: [0, offset], // Shift away from cursor
+            offset: [skidOffset, offset],
           },
         },
         hideOnInvisible,


### PR DESCRIPTION
Widgets:
- Panel
- Hero
- Page
- Billboard
- ProgressBar
- ColorChip
- Callout (special memscope themed version)

Utils:
- Byte formatters (bytes_formate.ts)
- Switch to using IEC units (e.g. MiB, GiB, etc) for memory

Tweak styling:
- In light mode make the panels white and the background gray (invert).
- Add staggered fade-in animation.