### PR TITLE
ui: Add status msg before notifying onTraceReady listeners

### DIFF
--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -292,6 +292,11 @@ async function loadTraceIntoEngine(
   }
 
   // notify() will await that all listeners' promises have resolved.
+  //
+  // Annoyingly, since listeners are registered through an event interface we
+  // don't know which plugins we are calling so we cannot display the name of
+  // the plugin in the status bar or collect stats about a particular plugin.
+  updateStatus(app, 'Notifying onTraceReady listeners');
   await trace.onTraceReady.notify();
 
   if (serializedAppState !== undefined) {


### PR DESCRIPTION
Avoid the status bar hanging wrongly on the previous status message 'Loading minimap' when listeners are slow.