### PR TITLE
ui: Add trace summary billboards to the memory overview page

### DIFF
--- a/ui/src/plugins/dev.perfetto.Memscope/process_data.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/process_data.ts
@@ -85,20 +85,33 @@ export const OOM_SCORE_BUCKETS: readonly OomScoreBucket[] = [
   },
 ];
 
+// The OOM bucket an oom_score_adj value falls into, or undefined if it's out of
+// every range.
+export function oomScoreBucket(score: number): OomScoreBucket | undefined {
+  return OOM_SCORE_BUCKETS.find(
+    (b) => score >= b.minScore && score <= b.maxScore,
+  );
+}
+
+// The bucket name without its trailing "(range)" suffix, e.g. "Foreground".
+export function oomBucketLabel(bucket: OomScoreBucket): string {
+  return bucket.name.replace(/ \(.*\)$/, '');
+}
+
 // Per-process memory row (latest value only, for the table).
 export interface ProcessMemoryRow {
-  processName: string;
-  pid: number;
-  rssKb: number;
-  anonKb: number;
-  fileKb: number;
-  shmemKb: number;
-  swapKb: number;
-  dmabufKb: number;
-  oomScore: number;
-  debuggable: boolean;
-  ageSeconds: number | null;
+  readonly processName: string;
+  readonly pid: number;
+  readonly rssKb: number;
+  readonly anonKb: number;
+  readonly fileKb: number;
+  readonly shmemKb: number;
+  readonly swapKb: number;
+  readonly dmabufKb: number;
+  readonly oomScore: number;
+  readonly debuggable: boolean;
+  readonly ageSeconds: number | null;
   // RSS time series in KB, sorted ascending by ts (nanoseconds). Used to
   // render a per-row sparkline.
-  rssTrendKb: ReadonlyArray<number>;
+  readonly rssTrendKb: readonly number[];
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
@@ -85,6 +85,41 @@
   }
 }
 
+// Tab strip selecting between the Summary and Smaps Detail bodies.
+.pf-memscope-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--pf-col-border);
+}
+
+.pf-memscope-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  font-size: var(--pf-font-size-m);
+  color: var(--pf-color-text-muted);
+  cursor: pointer;
+
+  .pf-icon {
+    font-size: 16px;
+  }
+
+  &:hover {
+    color: var(--pf-color-text);
+  }
+
+  &--active {
+    color: var(--pf-color-accent);
+    border-bottom-color: var(--pf-color-accent);
+    font-weight: 600;
+  }
+}
+
 // Process picker at the top of the overview page.
 .pf-memscope-process-select {
   display: flex;

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/mem_format.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/mem_format.ts
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Small formatting/widget helpers shared between the Memscope overview views
+// (the per-process overview page and the top-level trace overview cards).
+
+import m from 'mithril';
+import {
+  formatBytesIec,
+  type BytesFormatOptions,
+} from '../../../../base/bytes_format';
+import {Billboard} from '../../components/billboard';
+
+// Memory sizes are always shown in mebibytes (base-1024) for consistency across
+// the page, rather than auto-scaling to B/KiB/GiB. Pass an explicit forceUnit to
+// override for a specific call.
+const UNIT: BytesFormatOptions['forceUnit'] = 'MiB';
+
+export function formatBytes(
+  bytes: number,
+  options?: BytesFormatOptions,
+): string {
+  return formatBytesIec(bytes, {
+    ...options,
+    forceUnit: options?.forceUnit ?? UNIT,
+  });
+}
+
+// Formats a signed byte delta, e.g. "+1.20 MiB" / "-0.50 MiB" / "±0.00 MiB".
+// Pass {fractionDigits} to control decimal places (default 2). Uses the
+// current locale for grouping/decimals automatically.
+export function formatDelta(
+  bytes: number,
+  options?: BytesFormatOptions,
+): string {
+  if (bytes === 0) return `±${formatBytes(0, options)}`;
+  const sign = bytes > 0 ? '+' : '-';
+  const absBytes = Math.abs(bytes);
+  return `${sign}${formatBytes(absBytes, options)}`;
+}
+
+// Consistent delta coloring across the page: red when a value grew (up),
+// green when it shrank (down), neutral (default text color) at zero. Matches
+// the Billboard delta convention (--pf-color-danger / --pf-color-success).
+export function deltaColor(n: number): string | undefined {
+  if (n > 0) return 'var(--pf-color-danger)';
+  if (n < 0) return 'var(--pf-color-success)';
+  return undefined;
+}
+
+// Signed integer delta, e.g. "+1,024" / "-7".
+export function formatCountDelta(n: number): string {
+  return `${n > 0 ? '+' : ''}${n.toLocaleString()}`;
+}
+
+// A delta rendered as colored text (red up / green down). `text` defaults to
+// formatDelta(n); pass a custom string for rates, counts or "Δ … vs baseline".
+export function deltaText(n: number, text: string = formatDelta(n)): m.Child {
+  return m('span', {style: {color: deltaColor(n)}}, text);
+}
+
+// One score card holding 1–2 stat groups (label above, value, optional
+// sub-line). Used for the top billboard row and the per-section cards. Each
+// group is a Billboard.Section, so multiple groups lay out side by side.
+export function statCard(
+  stats: {label: string; value: m.Children; sub?: m.Children}[],
+): m.Child {
+  return m(
+    '.pf-memscope-billboard',
+    stats.map((s) => m(Billboard.Section, s)),
+  );
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
@@ -13,10 +13,15 @@
 // limitations under the License.
 
 import m from 'mithril';
+import {Gate} from '../../../../base/mithril_utils';
 import {QuerySlot} from '../../../../base/query_slot';
 import type {Trace} from '../../../../public/trace';
 import {LONG_NULL, NUM, STR} from '../../../../trace_processor/query_result';
+import {EmptyState} from '../../../../widgets/empty_state';
+import {Icon} from '../../../../widgets/icon';
 import {Panel} from '../../components/panel';
+import {SubPage} from '../../components/page';
+import {TraceOverview} from './summary/trace_overview';
 import './landing_page.scss';
 
 // Sample count and observed time span of one capture source (smaps / heapprofd)
@@ -47,6 +52,7 @@ export class ProcessMemDetails
   // The capture-strip facts: process name + per-source sample counts. Its own
   // slot keyed by (trace, upid) so it reloads when the selected process changes.
   private readonly captureSlot = new QuerySlot<CaptureInfo>();
+  private activeTab: 'summary' | 'smaps' = 'summary';
 
   onremove() {
     this.captureSlot.dispose();
@@ -65,10 +71,55 @@ export class ProcessMemDetails
       error = String(e);
     }
 
+    // Both tab bodies stay mounted and are toggled with a Gate (display:none
+    // when hidden) rather than conditionally rendered, so switching tabs doesn't
+    // remount each tab's components and re-run their data loads.
     return [
       error !== undefined && m('p.pf-error', `Error: ${error}`),
       error === undefined && this.renderCaptureStrip(trace, capture),
+      error === undefined && this.renderTabs(),
+      error === undefined &&
+        m(
+          Gate,
+          {open: this.activeTab === 'summary'},
+          // SubPage gives its direct children the cascading fade-up entrance
+          // animation (.pf-memscope-subpage > *), matching the rest of the page.
+          m(SubPage, m(TraceOverview, {trace, upid})),
+        ),
+      error === undefined &&
+        m(
+          Gate,
+          {open: this.activeTab === 'smaps'},
+          m(
+            SubPage,
+            m(EmptyState, {
+              icon: 'table_rows',
+              title: 'Smaps detail coming soon',
+            }),
+          ),
+        ),
     ];
+  }
+
+  private renderTabs(): m.Children {
+    const tabs: {key: 'summary' | 'smaps'; label: string; icon: string}[] = [
+      {key: 'summary', label: 'Summary', icon: 'description'},
+      {key: 'smaps', label: 'Smaps Detail', icon: 'table_rows'},
+    ];
+    return m(
+      '.pf-memscope-tabs',
+      tabs.map((t) =>
+        m(
+          'button.pf-memscope-tab',
+          {
+            className:
+              this.activeTab === t.key ? 'pf-memscope-tab--active' : undefined,
+            onclick: () => (this.activeTab = t.key),
+          },
+          [m(Icon, {icon: t.icon}), t.label],
+        ),
+      ),
+    );
   }
 
   // Header capture strip: trace identity plus one colored dot + terse facts

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/trace_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/trace_overview.ts
@@ -1,0 +1,285 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The top-level "trace overview" billboard: a row of headline stat cards for
+// one process (uptime / OOM score, peak RSS + spike, memory Δ + trend). Each
+// underlying query has its own slot so they load independently, and every card
+// is always rendered: missing facts show "N/A" rather than dropping the card.
+// Spans the whole trace, independent of the page's snapshot selection.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import type {Trace} from '../../../../../public/trace';
+import {
+  LONG,
+  NUM,
+  NUM_NULL,
+  STR,
+} from '../../../../../trace_processor/query_result';
+import {deltaText, formatBytes, formatDelta, statCard} from '../mem_format';
+import {BillboardStrip} from '../../../components/billboard';
+import {ColorChip} from '../../../components/color_chip';
+import {oomScoreBucket, oomBucketLabel} from '../../../process_data';
+
+// Uptime + OOM score, from the process's last heap-graph dump.
+interface StatsData {
+  readonly uptime?: number; // ns, at the last heap dump
+  readonly oomScoreAdj?: number; // at the last heap dump
+}
+
+// RSS counter maxima over the whole trace.
+interface CounterData {
+  readonly rssWatermark?: number; // max of mem.rss.watermark
+  readonly rssMax?: number; // max of mem.rss
+}
+
+// Per-snapshot total anon+swap (smaps), ts-sorted across the whole trace.
+type AnonSwapSeries = readonly {ts: time; total: number}[];
+
+async function loadStats(trace: Trace, upid: number): Promise<StatsData> {
+  await trace.engine.query(
+    'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;',
+  );
+  const res = await trace.engine.query(`
+    SELECT
+      s.process_uptime AS uptime,
+      s.oom_score_adj AS oom_score_adj
+    FROM android_heap_graph_stats s
+    WHERE s.upid = ${upid}
+    ORDER BY s.graph_sample_ts DESC
+    LIMIT 1
+  `);
+  const it = res.iter({uptime: NUM_NULL, oom_score_adj: NUM_NULL});
+  if (!it.valid()) return {};
+  return {
+    uptime: it.uptime ?? undefined,
+    oomScoreAdj: it.oom_score_adj ?? undefined,
+  };
+}
+
+async function loadCounters(trace: Trace, upid: number): Promise<CounterData> {
+  let rssWatermark: number | undefined;
+  let rssMax: number | undefined;
+  const res = await trace.engine.query(`
+    SELECT t.name AS counter_name, MAX(c.value) AS max_value
+    FROM counter c
+    JOIN process_counter_track t ON c.track_id = t.id
+    WHERE t.upid = ${upid}
+      AND t.name IN ('mem.rss.watermark', 'mem.rss')
+    GROUP BY t.name
+  `);
+  for (
+    const it = res.iter({counter_name: STR, max_value: NUM});
+    it.valid();
+    it.next()
+  ) {
+    if (it.counter_name === 'mem.rss.watermark') rssWatermark = it.max_value;
+    else if (it.counter_name === 'mem.rss') rssMax = it.max_value;
+  }
+  return {rssWatermark, rssMax};
+}
+
+async function loadAnonSwap(
+  trace: Trace,
+  upid: number,
+): Promise<AnonSwapSeries> {
+  const anonSwap: {ts: time; total: number}[] = [];
+  const res = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      CAST(ifnull(SUM(s.anonymous_kb + s.swap_kb), 0) * 1024 AS INT) AS total
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+    GROUP BY s.ts
+    ORDER BY s.ts ASC
+  `);
+  for (const it = res.iter({ts: LONG, total: NUM}); it.valid(); it.next()) {
+    anonSwap.push({ts: Time.fromRaw(it.ts), total: it.total});
+  }
+  return anonSwap;
+}
+
+// "4h 12m" / "5m 3s" / "37s" from a duration in nanoseconds.
+function formatDurationShort(ns: number): string {
+  const secs = ns / 1e9;
+  if (secs < 60) return `${secs.toFixed(0)}s`;
+  const mins = secs / 60;
+  if (mins < 60) return `${Math.floor(mins)}m ${Math.round(secs % 60)}s`;
+  return `${Math.floor(mins / 60)}h ${Math.round(mins % 60)}m`;
+}
+
+// One stat slot: the value when known, `undefined` once loaded but absent
+// (→ "N/A"), and a `loading` flag while the underlying query is in flight
+// (→ "…"). `sub` is an optional caption shown under an available value.
+interface Cell {
+  readonly label: string;
+  readonly loading: boolean;
+  readonly value?: m.Children;
+  readonly sub?: m.Children;
+}
+
+// Renders a cell into the {label, value, sub} shape statCard expects, mapping
+// the loading/absent states to "…" / "N/A — not available".
+function renderCell(c: Cell): {
+  label: string;
+  value: m.Children;
+  sub?: m.Children;
+} {
+  if (c.loading) return {label: c.label, value: '…'};
+  if (c.value === undefined) {
+    return {label: c.label, value: '-', sub: 'not available'};
+  }
+  return {label: c.label, value: c.value, sub: c.sub};
+}
+
+// A card whose stats are all Cells — always rendered, so missing facts surface
+// as "N/A" rather than dropping the whole card.
+function cellCard(cells: Cell[]): m.Child {
+  return statCard(cells.map(renderCell));
+}
+
+export interface TraceOverviewAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+}
+
+export class TraceOverview implements m.ClassComponent<TraceOverviewAttrs> {
+  // One slot per query, so the three load and redraw independently.
+  private readonly statsSlot = new QuerySlot<StatsData>();
+  private readonly counterSlot = new QuerySlot<CounterData>();
+  private readonly smapsSlot = new QuerySlot<AnonSwapSeries>();
+
+  onremove() {
+    this.statsSlot.dispose();
+    this.counterSlot.dispose();
+    this.smapsSlot.dispose();
+  }
+
+  view({attrs}: m.Vnode<TraceOverviewAttrs>): m.Children {
+    const {trace, upid} = attrs;
+    const key = {traceId: trace.traceInfo.uuid, upid};
+    const stats = this.statsSlot.use({
+      key,
+      queryFn: () => loadStats(trace, upid),
+    }).data;
+    const counters = this.counterSlot.use({
+      key,
+      queryFn: () => loadCounters(trace, upid),
+    }).data;
+    const snaps = this.smapsSlot.use({
+      key,
+      queryFn: () => loadAnonSwap(trace, upid),
+    }).data;
+
+    const statsLoading = stats === undefined;
+    const countersLoading = counters === undefined;
+    const snapsLoading = snaps === undefined;
+
+    // Card 1: uptime + OOM score (heap-graph dump). The OOM chip reuses the
+    // same ColorChip + bucket palette as the dashboard process table.
+    const oomBucket =
+      stats?.oomScoreAdj !== undefined
+        ? oomScoreBucket(stats.oomScoreAdj)
+        : undefined;
+    const uptimeCard = cellCard([
+      {
+        label: 'Uptime',
+        loading: statsLoading,
+        value:
+          stats?.uptime !== undefined
+            ? formatDurationShort(stats.uptime)
+            : undefined,
+      },
+      {
+        label: 'OOM score',
+        loading: statsLoading,
+        value:
+          stats?.oomScoreAdj !== undefined ? `${stats.oomScoreAdj}` : undefined,
+        sub:
+          oomBucket !== undefined
+            ? m(ColorChip, {color: oomBucket.color}, oomBucketLabel(oomBucket))
+            : undefined,
+      },
+    ]);
+
+    // Card 2: peak RSS (smaps) + RSS spike (counters).
+    const peak =
+      snaps !== undefined && snaps.length > 0
+        ? Math.max(...snaps.map((r) => r.total))
+        : undefined;
+    const wm = counters?.rssWatermark;
+    const rssMax = counters?.rssMax;
+    // Spike is the watermark's overshoot above the best-sampled RSS. When the
+    // poll caught the peak (wm == rssMax) that's a real "no spike" → 0, not
+    // missing data; only an absent counter leaves it undefined.
+    const spike =
+      wm !== undefined && rssMax !== undefined
+        ? Math.max(0, wm - rssMax)
+        : undefined;
+    const rssCard = cellCard([
+      {
+        label: 'Peak RSS',
+        loading: snapsLoading,
+        value: peak !== undefined ? formatBytes(peak) : undefined,
+        sub: 'rss anon + swap',
+      },
+      {
+        label: 'RSS spike',
+        loading: countersLoading,
+        value: spike !== undefined ? deltaText(spike) : undefined,
+        sub: 'hi-watermark − max',
+      },
+    ]);
+
+    // Card 3: memory Δ + trend (smaps, first → last snapshot).
+    const haveDelta = snaps !== undefined && snaps.length > 1;
+    const first = haveDelta ? snaps[0] : undefined;
+    const last = haveDelta ? snaps[snaps.length - 1] : undefined;
+    const total =
+      first !== undefined && last !== undefined
+        ? last.total - first.total
+        : undefined;
+    const spanSeconds =
+      first !== undefined && last !== undefined
+        ? Number(last.ts - first.ts) / 1e9
+        : 0;
+    const deltaCard = cellCard([
+      {
+        label: 'Memory Δ',
+        loading: snapsLoading,
+        value: total !== undefined ? deltaText(total) : undefined,
+        sub: 'first → last',
+      },
+      {
+        label: 'Trend',
+        loading: snapsLoading,
+        value:
+          total !== undefined && spanSeconds > 0
+            ? deltaText(total, `${formatDelta((total / spanSeconds) * 3600)}/h`)
+            : undefined,
+      },
+    ]);
+
+    // GC / Java allocation churn: not yet wired to a data source (needs ART GC
+    // events + allocation-rate sampling), so both cells report "not available"
+    // rather than placeholder numbers.
+    const churnCard = cellCard([
+      {label: 'GC churn', loading: false, value: undefined},
+      {label: 'Java churn', loading: false, value: undefined},
+    ]);
+
+    return m(BillboardStrip, [uptimeCard, rssCard, deltaCard, churnCard]);
+  }
+}


### PR DESCRIPTION
Add tab strip and trace summary billboards to the memory overview page - summary section.

Trace summary billboards:
- Process uptime
- Process OOM score
- Peak RSS (Anon + swap - from counters)
- Rss spike (RSS high watermark - max RSS seen - from counters)
- Memory delta (smaps)
- Memory rate (spams)
- GC/Java churn (placeholders - not implemented yet)

Also added a smaps page tab that's currently stubbed out.

<img width="1405" height="310" alt="image" src="https://github.com/user-attachments/assets/454702c0-1b37-4219-b905-8b1ee67c7aaf" />