### PR TITLE
ui: Add memory over time chart + mini memory breakdown flamegraph

### DIFF
--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
@@ -89,7 +89,6 @@
 .pf-memscope-tabs {
   display: flex;
   gap: 4px;
-  margin-bottom: 12px;
   border-bottom: 1px solid var(--pf-col-border);
 }
 
@@ -130,5 +129,67 @@
     font-weight: 600;
     font-size: var(--pf-font-size-m);
     color: var(--pf-color-text-muted);
+  }
+}
+
+// Empty-state caption shown inside section panels (emptyPanel helper).
+.pf-memscope-landing__empty {
+  margin-block: 48px;
+  color: var(--pf-color-text-muted);
+}
+
+// Memory-composition chart: the line chart plus its snapshot-pill selector and
+// the "compare" badge in the header.
+.pf-memscope-memmap {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  &__badge {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    margin-left: auto;
+    padding: 4px 10px;
+    border: 0.5px solid var(--pf-col-border);
+    border-radius: 6px;
+    background: var(--pf-col-base);
+    font-size: var(--pf-font-size-s);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--pf-color-text);
+
+    .pf-icon {
+      align-self: center;
+      font-size: 14px;
+      color: var(--pf-color-text-muted);
+    }
+  }
+
+  .pf-chip {
+    padding: 2px 6px;
+  }
+
+  // Per-snapshot header for the flamegraph (memory_map), showing the snapshot
+  // index/time, or "diffing #a → #b" in compare mode.
+  &__section-header {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 10px;
+
+    .pf-memscope-memmap__section-title {
+      font-weight: 600;
+      color: var(--pf-color-text);
+
+      &--diff {
+        color: var(--pf-color-primary);
+      }
+    }
+
+    .pf-memscope-memmap__section-hint {
+      font-size: var(--pf-font-size-s);
+      color: var(--pf-color-text-muted);
+    }
   }
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
@@ -21,6 +21,9 @@ import {EmptyState} from '../../../../widgets/empty_state';
 import {Icon} from '../../../../widgets/icon';
 import {Panel} from '../../components/panel';
 import {SubPage} from '../../components/page';
+import type {MemSelection} from './selection';
+import {CompositionTimeline} from './summary/composition_timeline';
+import {MemoryMap} from './summary/memory_map';
 import {TraceOverview} from './summary/trace_overview';
 import './landing_page.scss';
 
@@ -53,6 +56,9 @@ export class ProcessMemDetails
   // slot keyed by (trace, upid) so it reloads when the selected process changes.
   private readonly captureSlot = new QuerySlot<CaptureInfo>();
   private activeTab: 'summary' | 'smaps' = 'summary';
+  // The page-wide snapshot selection, driven by the composition timeline and
+  // shared with the other summary sections as they're added.
+  private selection?: MemSelection;
 
   onremove() {
     this.captureSlot.dispose();
@@ -84,7 +90,22 @@ export class ProcessMemDetails
           {open: this.activeTab === 'summary'},
           // SubPage gives its direct children the cascading fade-up entrance
           // animation (.pf-memscope-subpage > *), matching the rest of the page.
-          m(SubPage, m(TraceOverview, {trace, upid})),
+          m(
+            SubPage,
+            m(TraceOverview, {trace, upid}),
+            m(CompositionTimeline, {
+              trace,
+              upid,
+              selection: this.selection,
+              onSelect: (s: MemSelection) => (this.selection = s),
+            }),
+            m(MemoryMap, {
+              trace,
+              upid,
+              selTs: this.selection?.sel,
+              baseTs: this.selection?.base,
+            }),
+          ),
         ),
       error === undefined &&
         m(

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
@@ -1,0 +1,261 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Presentational widgets shared by the Memscope per-section panels (Java,
+// bitmaps, native): the compact top-N table, class-name cells, the share bar,
+// the delta cell and the single-ratio bar.
+
+import m from 'mithril';
+import {ProportionBar} from '../../../../components/widgets/charts/proportion_bar';
+import {Panel} from '../../components/panel';
+import {Table} from '../../components/table';
+import {Inset} from '../../components/inset';
+import {deltaColor, formatBytes, formatDelta} from './mem_format';
+import {EmptyState} from '../../../../widgets/empty_state';
+import {Stack} from '../../../../widgets/stack';
+
+// A section panel shown when the trace has no data for it: keeps the panel's
+// title/subtitle (so the page reads consistently) and states what's missing
+// in the body, rather than rendering nothing.
+export function emptyPanel(opts: {
+  title: string;
+  subtitle?: string;
+  message: string;
+  detail?: m.Children;
+}): m.Child {
+  return m(
+    Panel,
+    m(Panel.Header, {title: opts.title, subtitle: opts.subtitle}),
+    m(
+      Panel.Body,
+      m(
+        Stack,
+        {spacing: 'large'},
+        m(
+          '.pf-memscope-landing__empty',
+          m(EmptyState, {title: opts.message}, opts.detail),
+        ),
+      ),
+    ),
+  );
+}
+
+// A section panel shown while its data is loading: the panel (title/subtitle)
+// is laid out immediately with a loading placeholder in the body, so the page
+// doesn't jump as sections resolve.
+export function loadingPanel(opts: {
+  title: string;
+  subtitle?: string;
+}): m.Child {
+  return m(
+    Panel,
+    m(Panel.Header, {title: opts.title, subtitle: opts.subtitle}),
+    m(
+      Panel.Body,
+      m(
+        Stack,
+        {spacing: 'large'},
+        m(
+          '.pf-memscope-placeholder',
+          m(EmptyState, {icon: 'hourglass', title: 'Loading...'}),
+        ),
+      ),
+    ),
+  );
+}
+
+// Trims a fully-qualified class name to its last segment(s) for legends, e.g.
+// 'java.util.HashMap$Node' -> 'HashMap$Node'. Arrays and 'Other' pass through.
+export function shortClassName(name: string): string {
+  if (name === 'Other') return name;
+  const arrayDepth = (name.match(/\[\]/g) ?? []).length;
+  const base = name.replace(/\[\]/g, '');
+  const last = base.slice(base.lastIndexOf('.') + 1);
+  return last + '[]'.repeat(arrayDepth);
+}
+
+// Compact titled table used by the Java / bitmaps / native sections.
+export function topTable(opts: {
+  title: string;
+  subtitle?: string;
+  cols: {label: string; num?: boolean}[];
+  rows: m.Children[][];
+}): m.Child {
+  return m('.pf-memscope-toptable', [
+    m('.pf-memscope-toptable__title', [
+      opts.title,
+      opts.subtitle !== undefined &&
+        m('span.pf-memscope-toptable__subtitle', ` · ${opts.subtitle}`),
+    ]),
+    m(
+      Table,
+      {className: 'pf-memscope-table--flush'},
+      m(
+        'thead',
+        m(
+          'tr',
+          opts.cols.map((c) =>
+            m(c.num ? 'th.pf-memscope-table__num' : 'th', c.label),
+          ),
+        ),
+      ),
+      m(
+        'tbody',
+        opts.rows.map((cells) =>
+          m(
+            'tr',
+            cells.map((cell, i) =>
+              m(opts.cols[i].num ? 'td.pf-memscope-table__num' : 'td', cell),
+            ),
+          ),
+        ),
+      ),
+    ),
+  ]);
+}
+
+// Link to the Heap Dump Explorer's object list, filtered to one class. The HDE
+// page (com.android.HeapDumpExplorer) parses `cls` out of the query string, so
+// the value is URI-encoded the same way the explorer's own links are.
+export function heapDumpClassHref(cls: string): string {
+  return `#!/heapdump/objects?cls=${encodeURIComponent(cls)}`;
+}
+
+// A class-name cell. The class name links to that class's instances in the Heap
+// Dump Explorer. When `retainers` are given, each one adds a `↳ via <owner>`
+// line naming an app-side class that dominates this (library) class's instances
+// up the dominator chain, with the bytes attributed to that owner; the owner
+// name links to the explorer too. A class held through several owners shows
+// several lines, so a single misleading "via" can't imply all the retained
+// bytes flow through one owner.
+export function classNameCell(
+  full: string,
+  retainers?: ReadonlyArray<{name: string; bytes: number}>,
+): m.Child {
+  const vias = (retainers ?? []).filter((r) => r.name !== full);
+  // With one owner the byte count just echoes the row's retained size, so omit
+  // it; with several, the split is the whole point, so show each owner's bytes.
+  const showBytes = vias.length > 1;
+  return m('.pf-memscope-classcell', [
+    m(
+      'a.pf-memscope-classname',
+      {href: heapDumpClassHref(full), title: full},
+      shortClassName(full),
+    ),
+    ...vias.map((r) =>
+      m(
+        'span.pf-memscope-classcell__via',
+        {title: `Retained via ${r.name}: ${formatBytes(r.bytes)}`},
+        [
+          '↳ via ',
+          m(
+            'a.pf-memscope-classcell__vialink',
+            {href: heapDumpClassHref(r.name)},
+            shortClassName(r.name),
+          ),
+          showBytes ? ` · ${formatBytes(r.bytes)}` : '',
+        ],
+      ),
+    ),
+  ]);
+}
+
+// Two-line table cell: value on top, signed Δ vs baseline below (colored
+// red up / green down, "new" when the row has no baseline). When not
+// comparing, just the value.
+export function deltaCell(
+  text: m.Children,
+  delta: number | undefined,
+  comparing: boolean,
+  fmt: (n: number) => string = formatDelta,
+): m.Children {
+  if (!comparing) return text;
+  return [
+    m('div', text),
+    m(
+      'div.pf-memscope-table__delta',
+      {style: {color: delta === undefined ? undefined : deltaColor(delta)}},
+      delta === undefined ? 'new' : fmt(delta),
+    ),
+  ];
+}
+
+// Tiny horizontal progress bar used for the "share %" table columns.
+export function shareBar(frac: number): m.Child {
+  const pct = Math.max(0, Math.min(100, frac * 100));
+  return m('.pf-memscope-sharebar', [
+    m(
+      '.pf-memscope-sharebar__track',
+      m('.pf-memscope-sharebar__fill', {style: {width: `${pct}%`}}),
+    ),
+    m('span.pf-memscope-sharebar__pct', `${Math.round(pct)}%`),
+  ]);
+}
+
+// Single-ratio bar (heap reachability, profiler coverage): an uppercase
+// label, a big percentage headline, a two-tone bar and a two-entry legend.
+export function ratioBar(opts: {
+  label: string;
+  tooltip: string;
+  pct: number;
+  headline: string;
+  color: string;
+  aLabel: string;
+  aBytes: number;
+  bLabel: string;
+  bBytes: number;
+  // When comparing, the change in each leg vs the baseline dump. Rendered as
+  // a muted "(±X)" beside the absolute value, and a "Δ … pts" on the headline.
+  aDelta?: number;
+  bDelta?: number;
+  pctDelta?: number;
+}): m.Child {
+  const pct = Math.max(0, Math.min(100, opts.pct));
+  const legDelta = (d?: number) =>
+    d !== undefined &&
+    m(
+      'span.pf-memscope-ratio__legend-change',
+      {style: {color: deltaColor(d)}},
+      ` (${formatDelta(d)})`,
+    );
+  return m(Inset, {className: 'pf-memscope-ratio'}, [
+    m('.pf-memscope-ratio__label', {title: opts.tooltip}, opts.label),
+    m('.pf-memscope-ratio__headline', [
+      m('span.pf-memscope-ratio__pct', `${Math.round(pct)}%`),
+      m('span.pf-memscope-ratio__text', opts.headline),
+      opts.pctDelta !== undefined &&
+        m(
+          'span.pf-memscope-ratio__pct-delta',
+          {style: {color: deltaColor(opts.pctDelta)}},
+          `Δ ${opts.pctDelta >= 0 ? '+' : ''}${Math.round(opts.pctDelta)} pts vs baseline`,
+        ),
+    ]),
+    m(ProportionBar, {
+      segments: [
+        {
+          label: opts.aLabel,
+          weight: pct,
+          color: opts.color,
+          value: [formatBytes(opts.aBytes), legDelta(opts.aDelta)],
+        },
+        {
+          label: opts.bLabel,
+          weight: 100 - pct,
+          color: '#c3c7cc',
+          value: [formatBytes(opts.bBytes), legDelta(opts.bDelta)],
+        },
+      ],
+    }),
+  ]);
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/selection.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/selection.ts
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The page-wide snapshot selection, shared between the composition timeline
+// (which drives it) and the sections below (which render relative to it).
+// Identified by absolute timestamp so each section — which loads its own
+// snapshots/dumps — can correlate by nearest ts.
+
+import type {time} from '../../../../base/time';
+
+export interface MemSelection {
+  // The inspected snapshot's timestamp.
+  readonly sel: time;
+  // When a range was brushed, the earlier baseline snapshot to diff against.
+  readonly base?: time;
+}
+
+// The row of a ts-ascending series nearest to `ts`. Falls back to the last row
+// when `ts` is undefined (no selection yet → sections show their latest data).
+export function nearestByTs<T extends {ts: time}>(
+  rows: readonly T[],
+  ts?: time,
+): T | undefined {
+  if (rows.length === 0) return undefined;
+  if (ts === undefined) return rows[rows.length - 1];
+  let best = rows[0];
+  let bestDist = ts > best.ts ? ts - best.ts : best.ts - ts;
+  for (const r of rows) {
+    const dist = ts > r.ts ? ts - r.ts : r.ts - ts;
+    if (dist < bestDist) {
+      best = r;
+      bestDist = dist;
+    }
+  }
+  return best;
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/smaps_categories.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/smaps_categories.ts
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shared smaps category taxonomy: the SQL path → category classifier and the
+// display metadata (labels / colors) for each category. Used by the
+// composition-over-time chart and the memory map.
+
+// Path → category classification. Keys match SMAPS_CATEGORIES. Expects the
+// profiler_smaps row to be aliased `s` in the query.
+export const SMAPS_CATEGORY_CASE_SQL = `
+  CASE
+    WHEN s.path GLOB '*dalvik*' OR s.path GLOB '/dev/ashmem/dalvik*'
+      THEN 'java'
+    WHEN s.path GLOB '[anon:scudo*' OR s.path GLOB '[anon:libc_malloc*'
+      OR s.path GLOB '[anon:jemalloc*' OR s.path GLOB '[anon:GWP-ASan*'
+      OR s.path = '[heap]'
+      THEN 'native'
+    WHEN s.path = '[stack]' OR s.path GLOB '[anon:stack*'
+      THEN 'stack'
+    WHEN s.path GLOB '/dev/kgsl*' OR s.path GLOB '/dev/mali*'
+      OR s.path GLOB '/dev/dri*' OR s.path GLOB '*dmabuf*'
+      THEN 'graphics'
+    WHEN s.path GLOB '/*'
+      THEN 'file'
+    ELSE 'other'
+  END
+`;
+
+// File-backed mapping → bucket classification, for breaking the File-backed
+// block down by path. Keys match FILE_BUCKETS. Expects the profiler_smaps row
+// to be aliased `s`.
+export const SMAPS_FILE_BUCKET_CASE_SQL = `
+  CASE
+    WHEN s.path GLOB '*.so' OR s.path GLOB '*.so.*' THEN 'so'
+    WHEN s.path GLOB '*.jar' OR s.path GLOB '*.oat'
+      OR s.path GLOB '*.odex' OR s.path GLOB '*.vdex'
+      OR s.path GLOB '*.art' OR s.path GLOB '*.dex' THEN 'java_code'
+    WHEN s.path GLOB '*.apk' OR s.path GLOB '*.ttf'
+      OR s.path GLOB '*.otf' OR s.path GLOB '*.dat' THEN 'resources'
+    ELSE 'other_file'
+  END
+`;
+
+// Display metadata for the smaps categories, in stack/legend order. The keys
+// match the `category` values produced by SMAPS_CATEGORY_CASE_SQL.
+export const SMAPS_CATEGORIES = [
+  {key: 'native', label: 'Native', color: '#4285f4'},
+  {key: 'java', label: 'Java', color: '#f4b400'},
+  {key: 'file', label: 'File-backed', color: '#34a853'},
+  {key: 'graphics', label: 'Graphics', color: '#a142f4'},
+  {key: 'stack', label: 'Thread stacks', color: '#26c6da'},
+  {key: 'other', label: 'Other', color: '#9aa0a6'},
+];
+
+export const MEMMAP_GREY = '#9aa0a6';
+
+// Color for a smaps category key, falling back to grey for unknown keys.
+export function smapsCategoryColor(key: string): string {
+  return SMAPS_CATEGORIES.find((c) => c.key === key)?.color ?? MEMMAP_GREY;
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/composition_timeline.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/composition_timeline.ts
@@ -1,0 +1,271 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The "Composition over time" line graph: resident memory by smaps category,
+// one stacked point per snapshot, for one process across the whole trace. Owns
+// its own query slot, loading logic and (currently internal) snapshot
+// selection.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import {
+  LineChartSvg,
+  type LineChartData,
+} from '../../../../../components/widgets/charts_svg/line_chart_svg';
+import type {Trace} from '../../../../../public/trace';
+import {LONG, NUM, STR} from '../../../../../trace_processor/query_result';
+import {Chip} from '../../../../../widgets/chip';
+import {Intent} from '../../../../../widgets/common';
+import {Icon} from '../../../../../widgets/icon';
+import {Stack} from '../../../../../widgets/stack';
+import {Panel} from '../../../components/panel';
+import {niceKbInterval} from '../../../utils';
+import {deltaText, formatBytes} from '../mem_format';
+import {type MemSelection, nearestByTs} from '../selection';
+import {emptyPanel, loadingPanel} from '../section_widgets';
+import {SMAPS_CATEGORIES, SMAPS_CATEGORY_CASE_SQL} from '../smaps_categories';
+
+// One smaps snapshot (a single ts): per-category resident+swap bytes and the
+// total footprint. The x position (seconds from trace start) is precomputed.
+interface TimelineSnapshot {
+  readonly ts: time;
+  readonly x: number; // seconds from trace start
+  readonly total: number;
+  readonly byCategory: ReadonlyMap<string, number>; // category key → rss+swap
+}
+
+interface TimelineData {
+  readonly snapshots: TimelineSnapshot[];
+  readonly chart?: LineChartData;
+}
+
+export interface CompositionTimelineAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  // The page-wide selection (by ts), or undefined when nothing is selected
+  // yet (the timeline then highlights the latest snapshot).
+  readonly selection?: MemSelection;
+  // Called when the user clicks a snapshot or brushes a range.
+  readonly onSelect: (selection: MemSelection) => void;
+  // Optional content rendered inside the panel, below the chart (e.g. the
+  // whole-trace "where the growth went" bar).
+  readonly belowChart?: m.Children;
+}
+
+export class CompositionTimeline
+  implements m.ClassComponent<CompositionTimelineAttrs>
+{
+  private readonly slot = new QuerySlot<TimelineData>();
+
+  onremove() {
+    this.slot.dispose();
+  }
+
+  view({attrs}: m.Vnode<CompositionTimelineAttrs>): m.Children {
+    const {trace, upid, selection, onSelect, belowChart} = attrs;
+    const data = this.slot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadTimelineData(trace, upid),
+    }).data;
+    if (data === undefined) {
+      return loadingPanel({title: 'Composition over time'}); // Still loading.
+    }
+
+    const snaps = data.snapshots;
+    if (snaps.length === 0 || data.chart === undefined) {
+      return emptyPanel({
+        title: 'Composition over time',
+        message: 'No smaps snapshots in this trace for this process.',
+      });
+    }
+
+    // Resolve the page selection (by ts) to snapshot indices for rendering.
+    // No selection → highlight the latest snapshot.
+    const lastIdx = snaps.length - 1;
+    const idxOfTs = (ts: time) => snaps.indexOf(nearestByTs(snaps, ts)!);
+    const selIdx = selection !== undefined ? idxOfTs(selection.sel) : lastIdx;
+    let baseIdx =
+      selection?.base !== undefined ? idxOfTs(selection.base) : undefined;
+    if (baseIdx === selIdx) baseIdx = undefined;
+    const snap = snaps[selIdx];
+    const base = baseIdx !== undefined ? snaps[baseIdx] : undefined;
+
+    // Index of the snapshot whose x is closest to a clicked/brushed time.
+    const nearestSnap = (x: number) => {
+      let bestIdx = 0;
+      for (let i = 1; i < snaps.length; i++) {
+        if (Math.abs(snaps[i].x - x) < Math.abs(snaps[bestIdx].x - x)) {
+          bestIdx = i;
+        }
+      }
+      return bestIdx;
+    };
+
+    return m(
+      Panel,
+      m(Panel.Header, {
+        title: 'Composition over time',
+        subtitle:
+          'Resident memory by region, one point per smaps snapshot. Click ' +
+          'a snapshot to inspect it, or drag to compare two.',
+        controls: m('span.pf-memscope-memmap__badge', [
+          m(Icon, {icon: 'photo_camera'}),
+          base !== undefined && baseIdx !== undefined
+            ? [
+                `Snapshot #${baseIdx + 1} → #${selIdx + 1} · `,
+                deltaText(snap.total - base.total),
+              ]
+            : `Snapshot #${selIdx + 1} · ${formatBytes(snap.total)}`,
+        ]),
+      }),
+      m(
+        Panel.Body,
+        m('.pf-memscope-memmap', [
+          m(LineChartSvg, {
+            data: data.chart,
+            height: 160,
+            stacked: true,
+            xAxisLabel: 'Time (s)',
+            yAxisLabel: 'Size',
+            showLegend: true,
+            showPoints: true,
+            gridLines: 'vertical',
+            formatXValue: (v: number) => `${v.toFixed(0)}s`,
+            formatYValue: (v: number) => formatBytes(v),
+            // Snap ticks to power-of-2 (MiB) boundaries so the IEC labels read as
+            // clean MiB/GiB values rather than fractional decimals.
+            // This axis is in bytes; niceKbInterval works in KB, so scale in
+            // and back out by 1024 to get a power-of-2-aligned byte interval.
+            yAxisMinInterval:
+              niceKbInterval(Math.max(0, ...snaps.map((s) => s.total)) / 1024) *
+              1024,
+            markers: [
+              // In compare mode the range runs baseline → selected; colour the
+              // baseline (start) red and the selected end snapshot green.
+              base !== undefined &&
+                baseIdx !== undefined && {
+                  x: base.x,
+                  label: `#${baseIdx + 1}`,
+                  color: 'var(--pf-color-danger)',
+                },
+              {
+                x: snap.x,
+                label: `#${selIdx + 1}`,
+                color: 'var(--pf-color-success)',
+              },
+            ].filter(Boolean) as ReadonlyArray<{
+              x: number;
+              label?: string;
+              color?: string;
+            }>,
+            selection:
+              base !== undefined ? {start: base.x, end: snap.x} : undefined,
+            onPointClick: (x: number) => {
+              onSelect({sel: snaps[nearestSnap(x)].ts});
+            },
+            onBrush: ({start, end}: {start: number; end: number}) => {
+              const a = nearestSnap(start);
+              const b = nearestSnap(end);
+              onSelect(
+                a === b
+                  ? {sel: snaps[a].ts}
+                  : {sel: snaps[b].ts, base: snaps[a].ts},
+              );
+            },
+          }),
+          belowChart,
+          m(
+            Stack,
+            {orientation: 'horizontal', wrap: true, spacing: 'small'},
+            snaps.map((s, i) =>
+              m(Chip, {
+                label: `#${i + 1}`,
+                rounded: true,
+                compact: true,
+                // Match the chart's range markers: the selected end snapshot is
+                // green, the baseline (start) is red.
+                intent:
+                  i === selIdx
+                    ? Intent.Success
+                    : i === baseIdx
+                      ? Intent.Danger
+                      : Intent.None,
+                title: `t=${s.x.toFixed(1)}s · ${formatBytes(s.total)}`,
+                onclick: () => onSelect({sel: s.ts}),
+              }),
+            ),
+          ),
+        ]),
+      ),
+    );
+  }
+}
+
+async function loadTimelineData(
+  trace: Trace,
+  upid: number,
+): Promise<TimelineData> {
+  const byTs = new Map<bigint, Map<string, number>>();
+  const res = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      ${SMAPS_CATEGORY_CASE_SQL} AS category,
+      CAST(ifnull(SUM(s.rss_kb + s.swap_kb), 0) * 1024 AS INT) AS bytes
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+    GROUP BY s.ts, category
+    ORDER BY s.ts ASC
+  `);
+  for (
+    const it = res.iter({ts: LONG, category: STR, bytes: NUM});
+    it.valid();
+    it.next()
+  ) {
+    let cats = byTs.get(it.ts);
+    if (cats === undefined) {
+      cats = new Map();
+      byTs.set(it.ts, cats);
+    }
+    cats.set(it.category, (cats.get(it.category) ?? 0) + it.bytes);
+  }
+
+  const start = trace.traceInfo.start;
+  const snapshots: TimelineSnapshot[] = Array.from(byTs.entries()).map(
+    ([ts, byCategory]) => {
+      let total = 0;
+      for (const v of byCategory.values()) total += v;
+      return {
+        ts: Time.fromRaw(ts),
+        x: Number(ts - start) / 1e9,
+        total,
+        byCategory,
+      };
+    },
+  );
+
+  // Stacked composition chart: one series per category, dropping categories
+  // that are zero everywhere.
+  let chart: LineChartData | undefined;
+  if (snapshots.length > 0) {
+    const series = SMAPS_CATEGORIES.map((c) => ({
+      name: c.label,
+      color: c.color,
+      points: snapshots.map((s) => ({x: s.x, y: s.byCategory.get(c.key) ?? 0})),
+    })).filter((s) => s.points.some((p) => p.y > 0));
+    chart = {series};
+  }
+
+  return {snapshots, chart};
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/memory_map.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/memory_map.ts
@@ -1,0 +1,588 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The "Where did all the memory go?" panel: a complete breakdown of resident
+// memory for one process, from smaps, rendered as a nested flame-chart. The
+// Native and Java blocks are optionally split a third level using cross-source
+// figures (heapprofd unreleased / heap-graph reachable). Self-contained: owns
+// its own query slot and loading logic and shows the latest smaps snapshot.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import {
+  FlamegraphChart,
+  type FlamegraphChartSegment,
+} from '../../../../../components/widgets/charts/flamegraph_chart';
+import type {Trace} from '../../../../../public/trace';
+import {LONG, NUM, STR} from '../../../../../trace_processor/query_result';
+import {Callout} from '../../../components/callout';
+import {Intent} from '../../../../../widgets/common';
+import {Panel} from '../../../components/panel';
+import {deltaText, formatBytes, formatDelta} from '../mem_format';
+import {nearestByTs} from '../selection';
+import {emptyPanel, loadingPanel} from '../section_widgets';
+import {
+  MEMMAP_GREY,
+  SMAPS_CATEGORIES,
+  SMAPS_CATEGORY_CASE_SQL,
+  SMAPS_FILE_BUCKET_CASE_SQL,
+  smapsCategoryColor,
+} from '../smaps_categories';
+
+// File-backed subcategories for the memory map's second level, in display
+// order. Keys match the buckets produced by SMAPS_FILE_BUCKET_CASE_SQL. All
+// share the file-backed colour; they're distinguished by label.
+const FILE_BUCKETS = [
+  {key: 'so', label: 'Native libs (.so)', color: '#34a853'},
+  {key: 'java_code', label: 'Java code (.jar/.oat)', color: '#2e7d46'},
+  {key: 'resources', label: 'Resources / APK', color: '#46b966'},
+  {key: 'other_file', label: 'Other files', color: '#7cc596'},
+];
+
+// Lightens a block colour for its "remainder" sub-block (the part we can't
+// attribute to a profiler/reachability figure).
+const MEMMAP_LIGHTEN: Record<string, string> = {
+  '#4285f4': '#a6c8fa', // native blue → light
+  '#f4b400': '#fad470', // java amber → light
+};
+
+// Plain-language explanation shown under the block breakdown while hovering
+// each block of the memory map.
+const MEMMAP_BLOCK_INFO: Record<string, string> = {
+  'File-backed':
+    'Memory backed by files on disk: code (.so/.oat), fonts and resources. ' +
+    'Mostly clean — the kernel can drop and re-read it under pressure.',
+  'Anonymous':
+    'Memory not backed by any file: heaps and runtime allocations. This is ' +
+    'what your process truly costs; it can only be reclaimed by swapping.',
+  'Graphics':
+    'GPU buffers and driver mappings (kgsl / mali / dri / dmabuf) mapped ' +
+    'into this process.',
+  'Other':
+    'Non-anonymous regions that do not fit the other buckets (devices, ' +
+    'shared memory files, …).',
+  'Native':
+    'Native allocator arenas (scudo / jemalloc / libc malloc / GWP-ASan) ' +
+    'and the legacy [heap]. What malloc() costs you in resident memory.',
+  'Java':
+    'Dalvik/ART managed heap and runtime spaces — everything the Java ' +
+    'garbage collector manages.',
+  'Thread stacks': 'Stack memory for every live thread in the process.',
+  'Other anon':
+    'Anonymous memory not attributable to a specific allocator: plain ' +
+    'mmap() regions, untagged buffers, IPC shared memory.',
+  'Native libs (.so)':
+    'Shared libraries (.so) mapped into the process — code and read-only ' +
+    'data, mostly clean and shared between processes.',
+  'Java code (.jar/.oat)':
+    'Compiled and bytecode Java artifacts (.jar/.oat/.odex/.vdex/.art) ' +
+    'backing the managed runtime.',
+  'Resources / APK':
+    'APK archives, fonts and asset files mapped by the app and framework.',
+  'Other files': 'File-backed mappings that do not fit the other buckets.',
+  'Seen by profiler':
+    'Native allocations the heapprofd profiler observed as still unreleased ' +
+    'at this snapshot. Allocations made before tracing started are invisible.',
+  'Allocator overhead':
+    'Native resident memory the profiler could not attribute: allocator ' +
+    'metadata, fragmentation and allocations that predate the trace.',
+  'Reachable':
+    'Java heap still reachable from GC roots at the nearest heap dump — live ' +
+    'objects the collector cannot free.',
+  'Unreachable / other':
+    'Managed heap not accounted for as reachable at the nearest dump: ' +
+    'garbage awaiting collection, runtime overhead and dump skew.',
+};
+
+// Per-category resident/swap/anon bytes at one snapshot.
+interface CategoryBytes {
+  rss: number;
+  swap: number;
+  anon: number;
+}
+
+// One smaps snapshot (a single ts): per-category bytes, the file-backed
+// breakdown by bucket and the total footprint. x is seconds from trace start.
+interface MemSnapshot {
+  readonly ts: time;
+  readonly x: number;
+  readonly total: number;
+  readonly byCategory: ReadonlyMap<string, CategoryBytes>;
+  readonly fileByBucket: ReadonlyMap<string, number>;
+  // MIN(profiler_smaps.id) for this snapshot — the Smaps track event id used to
+  // select it on the timeline (mirrors dev.perfetto.Smaps' _smaps_snapshots).
+  readonly eventId: number;
+}
+
+// Cross-source figures layered onto the memory map's third level.
+interface MemExtras {
+  readonly nativeSeen: number; // heapprofd unreleased bytes
+  readonly javaReachable: number; // reachable Java heap + native registry bytes
+}
+
+// The flame-tree for the selected snapshot, built in a slot keyed by the
+// selection so it's constructed once per snapshot change rather than on every
+// redraw — the chart's hover tooltip drives frequent redraws, and rebuilding
+// the whole tree (and its baseline diff) on each one is wasted work. In compare
+// mode each block carries its Δ vs the baseline snapshot's tree.
+interface MemTreeResult {
+  readonly tree: FlamegraphChartSegment;
+}
+
+interface MemoryMapData {
+  readonly snapshots: MemSnapshot[];
+}
+
+const TITLE = 'Where did all the memory go?';
+
+export interface MemoryMapAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  // The page-wide selection (by ts). Undefined → latest snapshot.
+  readonly selTs?: time;
+  readonly baseTs?: time;
+}
+
+export class MemoryMap implements m.ClassComponent<MemoryMapAttrs> {
+  // Per-snapshot tree inputs (keyed by upid; the selection doesn't reload it).
+  private readonly slot = new QuerySlot<MemoryMapData>();
+  // The flame-tree for the selected/baseline snapshot, keyed by selection so it
+  // is only (re)built when the snapshot changes, not on every redraw.
+  private readonly treeSlot = new QuerySlot<MemTreeResult>();
+
+  onremove() {
+    this.slot.dispose();
+    this.treeSlot.dispose();
+  }
+
+  view({attrs}: m.Vnode<MemoryMapAttrs>): m.Children {
+    const {trace, upid, selTs, baseTs} = attrs;
+    const subtitle =
+      'A complete breakdown of resident memory, from smaps, for the ' +
+      'selected snapshot.';
+    const data = this.slot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadMemoryMapData(trace, upid),
+    }).data;
+    if (data === undefined) {
+      return loadingPanel({title: TITLE, subtitle}); // Still loading.
+    }
+
+    const snaps = data.snapshots;
+    if (snaps.length === 0) {
+      return emptyPanel({
+        title: TITLE,
+        subtitle,
+        message: 'No smaps data in this trace for this process.',
+      });
+    }
+
+    // Resolve the selection to snapshots. No selection → latest.
+    const snap = nearestByTs(snaps, selTs)!;
+    const selIdx = snaps.indexOf(snap);
+    const baseSnap =
+      baseTs !== undefined ? nearestByTs(snaps, baseTs) : undefined;
+    const base =
+      baseSnap !== undefined && baseSnap.ts !== snap.ts ? baseSnap : undefined;
+    const baseIdx = base !== undefined ? snaps.indexOf(base) : undefined;
+    const comparing = base !== undefined;
+
+    // The flame-tree for the resolved snapshot, built (with its baseline diff)
+    // in a slot keyed by the selection so it's only constructed when the
+    // snapshot changes, not on every (hover-driven) redraw.
+    const tree = this.treeSlot.use({
+      key: {
+        traceId: trace.traceInfo.uuid,
+        upid,
+        sel: snap.ts.toString(),
+        base: base !== undefined ? base.ts.toString() : null,
+      },
+      queryFn: async () => {
+        // In compare mode, annotate each block with its Δ vs the baseline tree.
+        const baseByLabel =
+          base !== undefined
+            ? flattenMemTree(
+                buildMemTree(base, await loadExtras(trace, upid, base.ts)),
+                new Map(),
+              )
+            : undefined;
+        const selExtras = await loadExtras(trace, upid, snap.ts);
+        return {tree: buildMemTree(snap, selExtras, baseByLabel)};
+      },
+    }).data?.tree;
+
+    const first = snaps[0];
+    const last = snaps[snaps.length - 1];
+    // Insight: biggest slice of the latest snapshot + fastest-growing slice.
+    const catVal = (s: MemSnapshot, key: string) => {
+      const r = s.byCategory.get(key);
+      return r ? r.rss + r.swap : 0;
+    };
+    const stats = SMAPS_CATEGORIES.map((c) => ({
+      ...c,
+      last: catVal(last, c.key),
+      delta: catVal(last, c.key) - catVal(first, c.key),
+    }));
+    const biggest = stats.reduce((a, b) => (b.last > a.last ? b : a));
+    const fastest = stats.reduce((a, b) => (b.delta > a.delta ? b : a));
+    const pct =
+      last.total > 0 ? Math.round((biggest.last / last.total) * 100) : 0;
+    const insight: m.Children = [
+      m('b', `${biggest.label} memory`),
+      ' is ',
+      m('b', `${pct}% of the footprint`),
+    ];
+    if (snaps.length > 1 && fastest.delta > 0) {
+      if (fastest.key === biggest.key) {
+        insight.push(
+          ' and the fastest-growing slice (',
+          m('b', formatDelta(fastest.delta)),
+          ').',
+        );
+      } else {
+        insight.push(
+          '; ',
+          m('b', fastest.label),
+          ' is the fastest-growing slice (',
+          m('b', formatDelta(fastest.delta)),
+          ').',
+        );
+      }
+    } else {
+      insight.push('.');
+    }
+
+    return m(
+      Panel,
+      m(Panel.Header, {
+        title: TITLE,
+        subtitle,
+      }),
+      m(
+        Panel.Body,
+        m('.pf-memscope-memmap', [
+          m(Callout, {intent: Intent.Primary}, insight),
+          m('.pf-memscope-memmap__section-header', [
+            m(
+              'span.pf-memscope-memmap__section-title',
+              {
+                className:
+                  comparing && baseIdx !== undefined
+                    ? 'pf-memscope-memmap__section-title--diff'
+                    : 'pf-memscope-memmap__section-title--straight',
+              },
+              comparing && baseIdx !== undefined
+                ? `Diffing snapshot #${baseIdx + 1} → #${selIdx + 1}`
+                : `Snapshot #${selIdx + 1} — t=${snap.x.toFixed(0)}s`,
+            ),
+            m(
+              'span.pf-memscope-memmap__section-hint',
+              comparing
+                ? 'block widths from the later snapshot · hover for Δ vs baseline'
+                : 'absolute resident memory · hover a block for details',
+            ),
+          ]),
+          tree !== undefined
+            ? m(FlamegraphChart, {
+                data: tree,
+                formatValue: formatBytes,
+                hideRoot: true,
+              })
+            : m('.pf-memscope-placeholder', 'Building memory map…'),
+        ]),
+      ),
+    );
+  }
+}
+
+async function loadMemoryMapData(
+  trace: Trace,
+  upid: number,
+): Promise<MemoryMapData> {
+  // Per-(snapshot, category) resident/swap/anon.
+  const cats = new Map<bigint, Map<string, CategoryBytes>>();
+  const catRes = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      ${SMAPS_CATEGORY_CASE_SQL} AS category,
+      CAST(ifnull(SUM(s.rss_kb), 0) * 1024 AS INT) AS rss,
+      CAST(ifnull(SUM(s.swap_kb), 0) * 1024 AS INT) AS swap,
+      CAST(ifnull(SUM(s.anonymous_kb), 0) * 1024 AS INT) AS anon
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+    GROUP BY s.ts, category
+    ORDER BY s.ts ASC
+  `);
+  for (
+    const it = catRes.iter({
+      ts: LONG,
+      category: STR,
+      rss: NUM,
+      swap: NUM,
+      anon: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    let byCat = cats.get(it.ts);
+    if (byCat === undefined) {
+      byCat = new Map();
+      cats.set(it.ts, byCat);
+    }
+    byCat.set(it.category, {rss: it.rss, swap: it.swap, anon: it.anon});
+  }
+
+  // Per-(snapshot, file-bucket) resident+swap for file-backed mappings.
+  const files = new Map<bigint, Map<string, number>>();
+  const fileRes = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      ${SMAPS_FILE_BUCKET_CASE_SQL} AS bucket,
+      CAST(ifnull(SUM(s.rss_kb + s.swap_kb), 0) * 1024 AS INT) AS bytes
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid} AND s.path GLOB '/*'
+    GROUP BY s.ts, bucket
+    ORDER BY s.ts ASC
+  `);
+  for (
+    const it = fileRes.iter({ts: LONG, bucket: STR, bytes: NUM});
+    it.valid();
+    it.next()
+  ) {
+    let byBucket = files.get(it.ts);
+    if (byBucket === undefined) {
+      byBucket = new Map();
+      files.set(it.ts, byBucket);
+    }
+    byBucket.set(it.bucket, (byBucket.get(it.bucket) ?? 0) + it.bytes);
+  }
+
+  // MIN(object id) per snapshot — the Smaps track event id for that ts
+  // (mirrors how dev.perfetto.Smaps builds its _smaps_snapshots events).
+  const eventIdByTs = new Map<bigint, number>();
+  const eventRes = await trace.engine.query(`
+    SELECT ts, MIN(id) AS event_id
+    FROM profiler_smaps
+    WHERE upid = ${upid}
+    GROUP BY ts
+  `);
+  for (
+    const it = eventRes.iter({ts: LONG, event_id: NUM});
+    it.valid();
+    it.next()
+  ) {
+    eventIdByTs.set(it.ts, it.event_id);
+  }
+
+  const start = trace.traceInfo.start;
+  const snapshots: MemSnapshot[] = Array.from(cats.entries()).map(
+    ([ts, byCategory]) => {
+      let total = 0;
+      for (const r of byCategory.values()) total += r.rss + r.swap;
+      return {
+        ts: Time.fromRaw(ts),
+        x: Number(ts - start) / 1e9,
+        total,
+        byCategory,
+        fileByBucket: files.get(ts) ?? new Map(),
+        eventId: eventIdByTs.get(ts) ?? -1,
+      };
+    },
+  );
+
+  return {snapshots};
+}
+
+// Cross-source figures for the snapshot at `ts`. nativeSeen is the cumulative
+// heapprofd unreleased footprint up to ts (summed across heaps); javaReachable
+// is the reachable Java heap of the heap-graph dump nearest ts. Both are
+// best-effort — absent data yields 0 and the third-level split is skipped.
+async function loadExtras(
+  trace: Trace,
+  upid: number,
+  ts: time | undefined,
+): Promise<MemExtras> {
+  if (ts === undefined) return {nativeSeen: 0, javaReachable: 0};
+
+  let nativeSeen = 0;
+  const nativeRes = await trace.engine.query(`
+    SELECT CAST(ifnull(SUM(a.size), 0) AS INT) AS seen
+    FROM heap_profile_allocation a
+    WHERE a.upid = ${upid} AND a.ts <= ${ts}
+  `);
+  const nativeIt = nativeRes.firstRow({seen: NUM});
+  nativeSeen = Math.max(0, nativeIt.seen);
+
+  let javaReachable = 0;
+  try {
+    await trace.engine.query(
+      'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;',
+    );
+    const javaRes = await trace.engine.query(`
+      SELECT
+        CAST(s.reachable_heap_size + s.reachable_native_alloc_registry_size
+          AS INT) AS reachable
+      FROM android_heap_graph_stats s
+      WHERE s.upid = ${upid}
+      ORDER BY ABS(s.graph_sample_ts - ${ts}) ASC
+      LIMIT 1
+    `);
+    const javaIt = javaRes.iter({reachable: NUM});
+    if (javaIt.valid()) javaReachable = Math.max(0, javaIt.reachable);
+  } catch {
+    // No heap graph — leave javaReachable at 0.
+  }
+
+  return {nativeSeen, javaReachable};
+}
+
+// Builds the nested region tree for one snapshot, shaped for FlameChartSimple.
+// The root is the resident+swap total; each level splits proportionally:
+//   root        → File-backed / Anonymous / Graphics / Other
+//   File-backed → .so / .jar-.oat / resources / other
+//   Anonymous   → Native / Java / Thread stacks / Other anon
+//   Native      → Seen by profiler / Allocator overhead
+//   Java        → Reachable / Unreachable / other
+// `baseByLabel` (compare mode) adds a "Δ vs baseline" line to each tooltip.
+function buildMemTree(
+  snap: MemSnapshot,
+  extras: MemExtras,
+  baseByLabel?: Map<string, number>,
+): FlamegraphChartSegment {
+  const get = (key: string) => snap.byCategory.get(key);
+  const resSwap = (r?: CategoryBytes) => (r ? r.rss + r.swap : 0);
+
+  const file = get('file');
+  const graphics = get('graphics');
+  const other = get('other');
+  const native = get('native');
+  const java = get('java');
+  const stack = get('stack');
+  // The "other" category mixes anonymous and non-anonymous regions; its
+  // anonymous part (plus swap, which is always anonymous) belongs in the
+  // Anonymous block, the remainder in Other.
+  const otherAnon = other ? other.anon + other.swap : 0;
+  const otherNonAnon = other ? Math.max(0, other.rss - other.anon) : 0;
+  const fileBytes = resSwap(file);
+  const nativeBytes = resSwap(native);
+  const javaBytes = resSwap(java);
+  const stackBytes = resSwap(stack);
+  const graphicsBytes = resSwap(graphics);
+  const anonBytes = nativeBytes + javaBytes + stackBytes + otherAnon;
+  const total = fileBytes + anonBytes + graphicsBytes + otherNonAnon;
+
+  const nativeColor = smapsCategoryColor('native');
+  const javaColor = smapsCategoryColor('java');
+  // Clamp the cross-source figures to the smaps block size so a sub-block
+  // never overflows its parent.
+  const nativeSeen = Math.min(Math.max(0, extras.nativeSeen), nativeBytes);
+  const javaReachable = Math.min(Math.max(0, extras.javaReachable), javaBytes);
+
+  // One node, with a tooltip carrying the share and the plain-language
+  // explanation (when one is known for the label).
+  const seg = (
+    label: string,
+    bytes: number,
+    color: string,
+    children: FlamegraphChartSegment[] = [],
+  ): FlamegraphChartSegment => {
+    const share = total > 0 ? ((bytes / total) * 100).toFixed(1) : '0';
+    const tip: m.Children = [
+      m('.pf-flamechart-tooltip__name', label),
+      m('.pf-flamechart-tooltip__value', `${formatBytes(bytes)} · ${share}%`),
+    ];
+    const baseBytes = baseByLabel?.get(label);
+    if (baseBytes !== undefined) {
+      tip.push(
+        deltaText(bytes - baseBytes, `Δ ${formatDelta(bytes - baseBytes)}`),
+      );
+    }
+    const info = MEMMAP_BLOCK_INFO[label];
+    if (info !== undefined) {
+      tip.push(m('.pf-flamechart-tooltip__desc', info));
+    }
+    return {name: label, value: bytes, cssColor: color, children, tooltip: tip};
+  };
+
+  // File-backed second level: split into path buckets, scaled so they sum to
+  // exactly fileBytes (the bucket query and the category query round
+  // independently). If no bucket data, dump it all into "other files".
+  const bucketBytes = FILE_BUCKETS.map(
+    (b) => snap.fileByBucket.get(b.key) ?? 0,
+  );
+  const bucketTotal = bucketBytes.reduce((s, b) => s + b, 0);
+  const fileChildren = FILE_BUCKETS.map((b, i) =>
+    seg(
+      b.label,
+      bucketTotal > 0
+        ? (bucketBytes[i] / bucketTotal) * fileBytes
+        : b.key === 'other_file'
+          ? fileBytes
+          : 0,
+      b.color,
+    ),
+  ).filter((s) => s.value > 0);
+
+  const anonChildren = [
+    seg(
+      'Native',
+      nativeBytes,
+      nativeColor,
+      [
+        seg('Seen by profiler', nativeSeen, nativeColor),
+        seg(
+          'Allocator overhead',
+          nativeBytes - nativeSeen,
+          MEMMAP_LIGHTEN[nativeColor] ?? nativeColor,
+        ),
+      ].filter((s) => s.value > 0),
+    ),
+    seg(
+      'Java',
+      javaBytes,
+      javaColor,
+      [
+        seg('Reachable', javaReachable, javaColor),
+        seg(
+          'Unreachable / other',
+          javaBytes - javaReachable,
+          MEMMAP_LIGHTEN[javaColor] ?? javaColor,
+        ),
+      ].filter((s) => s.value > 0),
+    ),
+    seg('Thread stacks', stackBytes, smapsCategoryColor('stack')),
+    seg('Other anon', otherAnon, smapsCategoryColor('other')),
+  ].filter((s) => s.value > 0);
+
+  const children = [
+    seg('File-backed', fileBytes, smapsCategoryColor('file'), fileChildren),
+    seg('Anonymous', anonBytes, smapsCategoryColor('native'), anonChildren),
+    seg('Graphics', graphicsBytes, smapsCategoryColor('graphics')),
+    seg('Other', otherNonAnon, smapsCategoryColor('other')),
+  ].filter((s) => s.value > 0);
+
+  return seg('Resident + swap', total, MEMMAP_GREY, children);
+}
+
+// Flattens a region tree to a label → bytes map, for diffing one snapshot's
+// tree against another's (labels are unique across the tree).
+function flattenMemTree(
+  seg: FlamegraphChartSegment,
+  out: Map<string, number>,
+): Map<string, number> {
+  out.set(seg.name, seg.value);
+  for (const c of seg.children) flattenMemTree(c, out);
+  return out;
+}


### PR DESCRIPTION
Add smaps based memory composition over time chart to the summary tab of the memscope landing page.

This shows smaps composition over time broken down into various categories, and also doubles as a snapshot selector.

<img width="1086" height="580" alt="image" src="https://github.com/user-attachments/assets/394dfc14-aa50-4fd0-9841-6d7f61b546c1" />