### PR TITLE
ui: fix missing machine labels on process/thread groups

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -769,11 +769,7 @@ SELECT
   -- position rather than arithmetic on id because the host does not always take
   -- the lowest id: the perfetto_manifest reader pre-allocates named machine rows
   -- before the host row is created lazily, so a named machine can precede it.
-  iif(
-    raw_id = 0,
-    0,
-    sum(iif(raw_id = 0, 0, 1)) OVER (ORDER BY id)
-  ) AS label_index
+  iif(raw_id = 0, 0, sum(iif(raw_id = 0, 0, 1)) OVER (ORDER BY id)) AS label_index
 FROM __intrinsic_machine;
 
 -- Contains information of filedescriptors collected during the trace.

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -765,12 +765,14 @@ CREATE PERFETTO VIEW machine(
 AS
 SELECT
   *,
-  -- Machine ids are dense from 0. The host (raw_id 0), when present, takes id 0
-  -- but is unlabelled, so subtract it to keep the first labelled machine at 1.
+  -- A dense 1-based rank among the non-host machines, ordered by id. We rank by
+  -- position rather than arithmetic on id because the host does not always take
+  -- the lowest id: the perfetto_manifest reader pre-allocates named machine rows
+  -- before the host row is created lazily, so a named machine can precede it.
   iif(
     raw_id = 0,
     0,
-    id + 1 - (SELECT count(*) FROM __intrinsic_machine WHERE raw_id = 0)
+    sum(iif(raw_id = 0, 0, 1)) OVER (ORDER BY id)
   ) AS label_index
 FROM __intrinsic_machine;
 

--- a/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
+++ b/test/trace_processor/diff_tests/parser/trace_manifest/tests.py
@@ -734,6 +734,43 @@ class TraceManifest(TestSuite):
         2
         '''))
 
+  # The named machine gets a positive 1-based label_index even though the
+  # manifest pre-allocates its row before the host row is created lazily, so the
+  # named machine has the lower machine id. Regression test: a formula keyed on
+  # the machine id assumed the host always took id 0 and produced 0 here, which
+  # made the UI treat the machine as the host and drop its track label.
+  def test_machine_label_index(self):
+    return DiffTestBlueprint(
+        trace=Tar({
+            'meta.json':
+                _meta({
+                    'version':
+                        1,
+                    'files': [{
+                        'path': 'host.json'
+                    }, {
+                        'path': 'vm.json',
+                        'machine': {
+                            'name': 'vm'
+                        }
+                    }],
+                }),
+            'host.json':
+                _json_trace('host_slice', pid=100),
+            'vm.json':
+                _json_trace('vm_slice', pid=200),
+        }),
+        query='''
+          SELECT name, raw_id != 0 AS remote, label_index
+          FROM machine
+          ORDER BY label_index;
+        ''',
+        out=Csv('''
+        "name","remote","label_index"
+        "[NULL]",0,0
+        "vm",1,1
+        '''))
+
   # --- Machine override errors ---
 
   def test_error_machines_id_out_of_range(self):

--- a/ui/src/plugins/dev.perfetto.ProcessThreadGroups/index.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessThreadGroups/index.ts
@@ -35,11 +35,12 @@ function stripPathFromExecutable(path: string) {
 function getThreadDisplayName(
   threadName: string | undefined,
   tid: bigint | number,
+  machineLabel: string = '',
 ) {
   if (threadName) {
-    return `${stripPathFromExecutable(threadName)} ${tid}`;
+    return `${stripPathFromExecutable(threadName)} ${tid}${machineLabel}`;
   } else {
-    return `Thread ${tid}`;
+    return `Thread ${tid}${machineLabel}`;
   }
 }
 
@@ -289,7 +290,18 @@ export default class implements PerfettoPlugin {
           continue;
         }
 
-        const displayName = getThreadDisplayName(name ?? undefined, id);
+        // These are orphan threads (no parent process), so they appear as
+        // top-level groups: label them with their machine like processes.
+        const machineLabel = maybeMachineLabel(
+          it.machineLabelIndex ?? undefined,
+          it.machineName,
+          numMachines,
+        );
+        const displayName = getThreadDisplayName(
+          name ?? undefined,
+          id,
+          machineLabel,
+        );
         const group = new TrackNode({
           uri: `/thread_${uid}`,
           name: displayName,


### PR DESCRIPTION
Fix the machine label indexes which were off and also the orphan thread
groups as well
