### PR TITLE
tp: avoid duplicate machine row for an adopted machine

### DIFF
--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -755,24 +755,32 @@ base::Status ProtoTraceReader::ParseClockSnapshot(ConstBytes blob,
 PERFETTO_NO_INLINE base::Status ProtoTraceReader::ResolveAdoptedMachine(
     uint32_t machine_id) {
   RETURN_IF_ERROR(CheckManifestSingleMachine());
-  // Adopt onto the host context only when the host has no data of its own, its
-  // row is still unclaimed (files in one session share it), the machine has no
-  // context yet, and the file is not a multi-machine manifest.
+  // Adopt the embedded machine onto the host context (relabelling its row) only
+  // when the host has no data of its own, its row isn't already claimed by
+  // another machine, the file is not a multi-machine manifest, and the machine
+  // has no row/context yet. Otherwise route to the fork path, which reuses any
+  // existing row for this machine; adopting here would relabel a second row to
+  // the same raw id and surface a duplicate machine.
   const bool host_has_data = host_machine_used_;
   const bool host_row_claimed =
       context_->machine_tracker->raw_machine_id() != 0;
   const bool is_manifest_machine =
       context_->trace_state && context_->trace_state->machine_remap;
-  const bool already_has_context =
-      context_->forked_context_state->trace_and_machine_to_context.Find(
-          std::make_pair(context_->trace_id().value,
-                         static_cast<int64_t>(machine_id))) != nullptr;
+  const bool machine_already_materialized =
+      context_->forked_context_state->machine_to_context.Find(
+          static_cast<int64_t>(machine_id)) != nullptr;
   if (host_has_data || host_row_claimed || is_manifest_machine ||
-      already_has_context) {
+      machine_already_materialized) {
     adopted_machine_id_ = 0;
     return base::OkStatus();
   }
   context_->machine_tracker->SetRawMachineId(machine_id);
+  // Register the adopted machine in the per-machine dedup map so a later fork
+  // for the same id (e.g. another co-located trace routed through
+  // CreateRemoteMachineReader) reuses this context and row instead of inserting
+  // a duplicate machine row.
+  context_->forked_context_state->machine_to_context.Insert(
+      static_cast<int64_t>(machine_id), context_);
   adopted_machine_id_ = machine_id;
   return base::OkStatus();
 }

--- a/test/trace_processor/diff_tests/tables/tests.py
+++ b/test/trace_processor/diff_tests/tables/tests.py
@@ -17,6 +17,7 @@ from python.generators.diff_tests.testing import Path, DataPath, Metric
 from python.generators.diff_tests.testing import Csv, Json, TextProto
 from python.generators.diff_tests.testing import DiffTestBlueprint, TraceInjector
 from python.generators.diff_tests.testing import TestSuite
+from python.generators.diff_tests.testing import Zip
 
 
 class Tables(TestSuite):
@@ -777,6 +778,47 @@ class Tables(TestSuite):
         "id","raw_id","name","sysname","release","version","arch","num_cpus","android_build_fingerprint","android_device_manufacturer","android_sdk_version","system_ram_bytes","system_ram_gb","label_index"
         0,0,"[NULL]","Darwin","22.6.0","Foobar","x86_64",4,"[NULL]","[NULL]","[NULL]",126598774784,127,0
         1,2420838448,"[NULL]","Linux","6.6.82-android15-8-g1a7680db913a-ab13304129","#1 SMP PREEMPT Wed Apr  2 01:42:00 UTC 2025","x86_64",8,"android_test_fingerprint","Android",33,12008292352,12,1
+        """))
+
+  # Two co-located traces (an archive of two proto files) carrying the same
+  # embedded machine id must resolve to a single machine row. Regression test:
+  # adopting the id onto the host row while a later fork inserted a second row
+  # for it surfaced one physical machine as two in the UI.
+  def test_same_machine_id_across_traces_not_duplicated(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'a.pb':
+                TextProto(r'''
+                packet { machine_id: 7
+                  clock_snapshot { clocks { clock_id: 6 timestamp: 1000000000 } } }
+                packet { machine_id: 7 trusted_packet_sequence_id: 2
+                  track_descriptor { uuid: 71 } }
+                packet { machine_id: 7 trusted_packet_sequence_id: 2 timestamp: 1000000000
+                  track_event { type: TYPE_SLICE_BEGIN track_uuid: 71 name: "a_slice" } }
+                packet { machine_id: 7 trusted_packet_sequence_id: 2 timestamp: 1100000000
+                  track_event { type: TYPE_SLICE_END track_uuid: 71 } }
+                '''),
+            'b.pb':
+                TextProto(r'''
+                packet { machine_id: 7
+                  clock_snapshot { clocks { clock_id: 6 timestamp: 2000000000 } } }
+                packet { machine_id: 7 trusted_packet_sequence_id: 3
+                  track_descriptor { uuid: 72 } }
+                packet { machine_id: 7 trusted_packet_sequence_id: 3 timestamp: 2000000000
+                  track_event { type: TYPE_SLICE_BEGIN track_uuid: 72 name: "b_slice" } }
+                packet { machine_id: 7 trusted_packet_sequence_id: 3 timestamp: 2100000000
+                  track_event { type: TYPE_SLICE_END track_uuid: 72 } }
+                '''),
+        }),
+        query="""
+        SELECT raw_id, count(*) AS row_count
+        FROM machine
+        GROUP BY raw_id
+        ORDER BY raw_id
+        """,
+        out=Csv("""
+        "raw_id","row_count"
+        7,1
         """))
 
   # user list table


### PR DESCRIPTION
When an embedded machine id is adopted onto the host row, register it in the per-machine context map so a later fork for the same id reuses that row instead of inserting a second machine. Without this a single machine could show up twice in the UI.