### PR TITLE
ui: Add java memory breakdown sections to memscope

### DIFF
--- a/ui/src/plugins/dev.perfetto.Memscope/components/ratio.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/ratio.scss
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Ratio: an uppercase label, a big % headline, and a two-tone ProportionBar.
+// The recessed chrome comes from the Inset this class is applied to.
+.pf-memscope-ratio {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  &__label {
+    font-size: var(--pf-font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pf-color-text-muted);
+  }
+
+  &__headline {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  &__pct {
+    font-size: var(--pf-font-size-xl);
+    font-weight: 700;
+    color: var(--pf-color-text);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__text {
+    font-size: var(--pf-font-size-s);
+    color: var(--pf-color-text-muted);
+  }
+
+  &__pct-delta {
+    margin-left: auto;
+    font-size: var(--pf-font-size-xs);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--pf-color-text-muted);
+  }
+
+  &__legend-change {
+    color: var(--pf-color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/ratio.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/ratio.ts
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './ratio.scss';
+import m from 'mithril';
+import {ProportionBar} from '../../../components/widgets/charts/proportion_bar';
+import {Inset} from './inset';
+import {
+  deltaColor,
+  formatBytes,
+  formatDelta,
+} from '../views/landing_page/mem_format';
+
+// A single ratio shown as a labelled block (recessed in an Inset): an uppercase
+// label, a big percentage headline, and a two-tone ProportionBar that splits a
+// whole into its "A" part and "B" remainder — e.g. reachable vs unreachable
+// Java heap, or native RSS seen-vs-unseen by the profiler. In compare mode each
+// leg carries its Δ vs the baseline dump, and the headline shows the pts delta.
+export interface RatioAttrs {
+  // Uppercase caption, e.g. "Heap reachability".
+  readonly label: string;
+  readonly tooltip: string;
+  // The A-part share, 0..100 (clamped).
+  readonly pct: number;
+  // Text beside the big percentage, e.g. "of the Java heap is reachable".
+  readonly headline: string;
+  // Colour of the A segment; the B (remainder) segment is a neutral grey.
+  readonly color: string;
+  readonly aLabel: string;
+  readonly aBytes: number;
+  readonly bLabel: string;
+  readonly bBytes: number;
+  // When comparing, the change in each leg vs the baseline dump — rendered as a
+  // muted "(±X)" beside the absolute value, and a "Δ … pts" on the headline.
+  readonly aDelta?: number;
+  readonly bDelta?: number;
+  readonly pctDelta?: number;
+}
+
+export class Ratio implements m.ClassComponent<RatioAttrs> {
+  view({attrs}: m.Vnode<RatioAttrs>): m.Children {
+    const pct = Math.max(0, Math.min(100, attrs.pct));
+    const legDelta = (d?: number) =>
+      d !== undefined &&
+      m(
+        'span.pf-memscope-ratio__legend-change',
+        {style: {color: deltaColor(d)}},
+        ` (${formatDelta(d)})`,
+      );
+    return m(Inset, {className: 'pf-memscope-ratio'}, [
+      m('.pf-memscope-ratio__label', {title: attrs.tooltip}, attrs.label),
+      m('.pf-memscope-ratio__headline', [
+        m('span.pf-memscope-ratio__pct', `${Math.round(pct)}%`),
+        m('span.pf-memscope-ratio__text', attrs.headline),
+        attrs.pctDelta !== undefined &&
+          m(
+            'span.pf-memscope-ratio__pct-delta',
+            {style: {color: deltaColor(attrs.pctDelta)}},
+            `Δ ${attrs.pctDelta >= 0 ? '+' : ''}${Math.round(attrs.pctDelta)} pts vs baseline`,
+          ),
+      ]),
+      m(ProportionBar, {
+        segments: [
+          {
+            label: attrs.aLabel,
+            weight: pct,
+            color: attrs.color,
+            value: [formatBytes(attrs.aBytes), legDelta(attrs.aDelta)],
+          },
+          {
+            label: attrs.bLabel,
+            weight: 100 - pct,
+            color: '#c3c7cc',
+            value: [formatBytes(attrs.bBytes), legDelta(attrs.bDelta)],
+          },
+        ],
+      }),
+    ]);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/share_bar.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/share_bar.scss
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Inline "share %" bar used in table columns.
+.pf-memscope-sharebar {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  &__track {
+    width: 80px;
+    height: 8px;
+    border-radius: 4px;
+    background: var(--pf-col-border);
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
+  &__fill {
+    height: 100%;
+    border-radius: 4px;
+    background: var(--pf-color-accent, #4285f4);
+  }
+
+  &__pct {
+    min-width: 30px;
+    text-align: right;
+    font-size: var(--pf-font-size-xs);
+    color: var(--pf-color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/components/share_bar.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/components/share_bar.ts
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './share_bar.scss';
+import m from 'mithril';
+
+export interface ShareBarAttrs {
+  // The fraction of the whole, 0..1 (clamped).
+  readonly frac: number;
+}
+
+// A tiny inline "share %" bar — a filled track followed by its percentage —
+// used in table columns to show a row's fraction of the whole at a glance.
+export class ShareBar implements m.ClassComponent<ShareBarAttrs> {
+  view({attrs}: m.Vnode<ShareBarAttrs>): m.Children {
+    const pct = Math.max(0, Math.min(100, attrs.frac * 100));
+    return m('.pf-memscope-sharebar', [
+      m(
+        '.pf-memscope-sharebar__track',
+        m('.pf-memscope-sharebar__fill', {style: {width: `${pct}%`}}),
+      ),
+      m('span.pf-memscope-sharebar__pct', `${Math.round(pct)}%`),
+    ]);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
@@ -193,3 +193,65 @@
     }
   }
 }
+
+// Grid of side-by-side top-N tables (the Java / bitmaps section bodies).
+.pf-memscope-tables {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+  gap: 8px 32px;
+  align-items: start;
+}
+
+.pf-memscope-toptable {
+  min-width: 0;
+
+  .pf-memscope-toptable__title {
+    margin-bottom: 4px;
+    font-weight: 600;
+    color: var(--pf-color-text);
+  }
+
+  .pf-memscope-toptable__subtitle {
+    font-weight: 400;
+    font-size: var(--pf-font-size-s);
+    color: var(--pf-color-text-muted);
+  }
+}
+
+// Monospace class-name cell + its "↳ via <owner>" retainer annotation lines.
+.pf-memscope-classname {
+  font-family: var(--pf-font-family-mono, monospace);
+  font-size: var(--pf-font-size-xs);
+}
+
+a.pf-memscope-classname {
+  color: var(--pf-color-primary);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.pf-memscope-classcell {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+
+  &__via {
+    font-family: var(--pf-font-family-mono, monospace);
+    font-size: var(--pf-font-size-xs);
+    color: var(--pf-color-text-muted);
+  }
+
+  // The via owner is a link too, but it stays in the muted retainer color so the
+  // annotation reads as one line; only the hover underline signals the link.
+  &__vialink {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
@@ -22,7 +22,9 @@ import {Icon} from '../../../../widgets/icon';
 import {Panel} from '../../components/panel';
 import {SubPage} from '../../components/page';
 import type {MemSelection} from './selection';
+import {BitmapsSection} from './summary/bitmaps_section';
 import {CompositionTimeline} from './summary/composition_timeline';
+import {JavaSection} from './summary/java_section';
 import {MemoryMap} from './summary/memory_map';
 import {TraceOverview} from './summary/trace_overview';
 import './landing_page.scss';
@@ -100,6 +102,18 @@ export class ProcessMemDetails
               onSelect: (s: MemSelection) => (this.selection = s),
             }),
             m(MemoryMap, {
+              trace,
+              upid,
+              selTs: this.selection?.sel,
+              baseTs: this.selection?.base,
+            }),
+            m(JavaSection, {
+              trace,
+              upid,
+              selTs: this.selection?.sel,
+              baseTs: this.selection?.base,
+            }),
+            m(BitmapsSection, {
               trace,
               upid,
               selTs: this.selection?.sel,

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
@@ -17,10 +17,8 @@
 // the delta cell and the single-ratio bar.
 
 import m from 'mithril';
-import {ProportionBar} from '../../../../components/widgets/charts/proportion_bar';
 import {Panel} from '../../components/panel';
 import {Table} from '../../components/table';
-import {Inset} from '../../components/inset';
 import {deltaColor, formatBytes, formatDelta} from './mem_format';
 import {EmptyState} from '../../../../widgets/empty_state';
 import {Stack} from '../../../../widgets/stack';
@@ -189,73 +187,4 @@ export function deltaCell(
       delta === undefined ? 'new' : fmt(delta),
     ),
   ];
-}
-
-// Tiny horizontal progress bar used for the "share %" table columns.
-export function shareBar(frac: number): m.Child {
-  const pct = Math.max(0, Math.min(100, frac * 100));
-  return m('.pf-memscope-sharebar', [
-    m(
-      '.pf-memscope-sharebar__track',
-      m('.pf-memscope-sharebar__fill', {style: {width: `${pct}%`}}),
-    ),
-    m('span.pf-memscope-sharebar__pct', `${Math.round(pct)}%`),
-  ]);
-}
-
-// Single-ratio bar (heap reachability, profiler coverage): an uppercase
-// label, a big percentage headline, a two-tone bar and a two-entry legend.
-export function ratioBar(opts: {
-  label: string;
-  tooltip: string;
-  pct: number;
-  headline: string;
-  color: string;
-  aLabel: string;
-  aBytes: number;
-  bLabel: string;
-  bBytes: number;
-  // When comparing, the change in each leg vs the baseline dump. Rendered as
-  // a muted "(±X)" beside the absolute value, and a "Δ … pts" on the headline.
-  aDelta?: number;
-  bDelta?: number;
-  pctDelta?: number;
-}): m.Child {
-  const pct = Math.max(0, Math.min(100, opts.pct));
-  const legDelta = (d?: number) =>
-    d !== undefined &&
-    m(
-      'span.pf-memscope-ratio__legend-change',
-      {style: {color: deltaColor(d)}},
-      ` (${formatDelta(d)})`,
-    );
-  return m(Inset, {className: 'pf-memscope-ratio'}, [
-    m('.pf-memscope-ratio__label', {title: opts.tooltip}, opts.label),
-    m('.pf-memscope-ratio__headline', [
-      m('span.pf-memscope-ratio__pct', `${Math.round(pct)}%`),
-      m('span.pf-memscope-ratio__text', opts.headline),
-      opts.pctDelta !== undefined &&
-        m(
-          'span.pf-memscope-ratio__pct-delta',
-          {style: {color: deltaColor(opts.pctDelta)}},
-          `Δ ${opts.pctDelta >= 0 ? '+' : ''}${Math.round(opts.pctDelta)} pts vs baseline`,
-        ),
-    ]),
-    m(ProportionBar, {
-      segments: [
-        {
-          label: opts.aLabel,
-          weight: pct,
-          color: opts.color,
-          value: [formatBytes(opts.aBytes), legDelta(opts.aDelta)],
-        },
-        {
-          label: opts.bLabel,
-          weight: 100 - pct,
-          color: '#c3c7cc',
-          value: [formatBytes(opts.bBytes), legDelta(opts.bDelta)],
-        },
-      ],
-    }),
-  ]);
 }

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
@@ -1,0 +1,503 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// "What about bitmaps?" — reachable android.graphics.Bitmap instances grouped
+// by dimensions and storage backing, from the latest heap dump of one process.
+// Self-contained: owns its query slot and loading logic.
+
+import m from 'mithril';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import type {Trace} from '../../../../../public/trace';
+import {
+  LONG,
+  NUM,
+  NUM_NULL,
+  STR,
+  STR_NULL,
+} from '../../../../../trace_processor/query_result';
+import {Panel} from '../../../components/panel';
+import {Callout} from '../../../components/callout';
+import {Intent} from '../../../../../widgets/common';
+import {
+  deltaText,
+  formatBytes,
+  formatCountDelta,
+  formatDelta,
+  statCard,
+} from '../mem_format';
+import {nearestByTs} from '../selection';
+import {
+  deltaCell,
+  emptyPanel,
+  loadingPanel,
+  shortClassName,
+  topTable,
+} from '../section_widgets';
+import {ShareBar} from '../../../components/share_bar';
+import {Stack} from '../../../../../widgets/stack';
+import {BillboardStrip} from '../../../components/billboard';
+
+const TITLE = 'What about bitmaps?';
+const SUBTITLE =
+  'Usually the largest and most reducible cost on Android — pulled out on ' +
+  'their own.';
+
+// One reachable-bitmap group at the latest dump: (dimensions, storage backing)
+// with its count and sizes. width/height are undefined on proto-format heap
+// graphs (only ART HPROF dumps record field values).
+interface BitmapGroup {
+  width?: number;
+  height?: number;
+  storage?: string;
+  count: number;
+  selfSize: number;
+  nativeSize: number;
+}
+
+interface BitmapsData {
+  // All dumps with reachable bitmaps, ts-ascending (empty → none).
+  readonly dumps: {ts: time}[];
+  // Bitmap groups per dump, keyed by dump ts (raw bigint).
+  readonly groupsByTs: ReadonlyMap<bigint, BitmapGroup[]>;
+  // Reachable Java heap + registered native per dump (for the "share of Java
+  // retained" card), keyed by dump ts.
+  readonly javaRetainedByTs: ReadonlyMap<bigint, number>;
+  // Nearest non-library class retaining the bitmaps (last dump), if resolvable.
+  readonly bitmapRetainer?: string;
+}
+
+async function loadBitmapsData(
+  trace: Trace,
+  upid: number,
+): Promise<BitmapsData> {
+  await trace.engine.query(
+    'INCLUDE PERFETTO MODULE android.memory.heap_graph.bitmap;',
+  );
+  const groupsByTs = new Map<bigint, BitmapGroup[]>();
+  const res = await trace.engine.query(`
+    SELECT
+      b.graph_sample_ts AS ts,
+      b.width AS width,
+      b.height AS height,
+      b.bitmap_storage_type AS storage,
+      COUNT(*) AS cnt,
+      CAST(ifnull(SUM(b.self_size), 0) AS INT) AS self_size,
+      CAST(ifnull(SUM(b.native_size), 0) AS INT) AS native_size
+    FROM heap_graph_bitmaps b
+    WHERE b.upid = ${upid} AND b.reachable
+    GROUP BY b.graph_sample_ts, b.width, b.height, b.bitmap_storage_type
+    ORDER BY b.graph_sample_ts ASC
+  `);
+  for (
+    const it = res.iter({
+      ts: LONG,
+      width: NUM_NULL,
+      height: NUM_NULL,
+      storage: STR_NULL,
+      cnt: NUM,
+      self_size: NUM,
+      native_size: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    let list = groupsByTs.get(it.ts);
+    if (list === undefined) {
+      list = [];
+      groupsByTs.set(it.ts, list);
+    }
+    list.push({
+      width: it.width ?? undefined,
+      height: it.height ?? undefined,
+      storage: it.storage ?? undefined,
+      count: it.cnt,
+      selfSize: it.self_size,
+      nativeSize: it.native_size,
+    });
+  }
+  const dumps = Array.from(groupsByTs.keys())
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    .map((ts) => ({ts: Time.fromRaw(ts)}));
+
+  const javaRetainedByTs = new Map<bigint, number>();
+  try {
+    await trace.engine.query(
+      'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;',
+    );
+    const statsRes = await trace.engine.query(`
+      SELECT
+        s.graph_sample_ts AS ts,
+        CAST(s.reachable_heap_size + s.reachable_native_alloc_registry_size
+          AS INT) AS retained
+      FROM android_heap_graph_stats s
+      WHERE s.upid = ${upid}
+    `);
+    for (
+      const it = statsRes.iter({ts: LONG, retained: NUM});
+      it.valid();
+      it.next()
+    ) {
+      javaRetainedByTs.set(it.ts, Math.max(0, it.retained));
+    }
+  } catch {
+    // No heap-graph stats — leave the "of Java retained" card hidden.
+  }
+
+  const bitmapRetainer = await loadBitmapRetainer(trace, upid);
+
+  return {dumps, groupsByTs, javaRetainedByTs, bitmapRetainer};
+}
+
+// The nearest non-library class that dominates the reachable Bitmap instances
+// at the latest dump (the app-side owner up the dominator chain).
+async function loadBitmapRetainer(
+  trace: Trace,
+  upid: number,
+): Promise<string | undefined> {
+  try {
+    await trace.engine.query(
+      'INCLUDE PERFETTO MODULE android.memory.heap_graph.raw_dominator_tree;',
+    );
+    const res = await trace.engine.query(`
+      WITH RECURSIVE
+      last_ts AS (
+        SELECT MAX(graph_sample_ts) AS ts
+        FROM heap_graph_object WHERE upid = ${upid}
+      ),
+      ck AS (
+        SELECT c.id,
+          CASE WHEN c.name GLOB 'java.*' OR c.name GLOB 'javax.*'
+            OR c.name GLOB 'kotlin.*' OR c.name GLOB 'kotlinx.*'
+            OR c.name GLOB 'dalvik.*' OR c.name GLOB 'sun.*'
+            OR c.name GLOB 'libcore.*' OR c.name GLOB 'android.*'
+            OR c.name GLOB 'androidx.*' OR c.name GLOB 'com.android.*'
+            OR c.name GLOB 'com.google.android.*'
+            OR c.name LIKE '%[]%'
+            OR c.name NOT GLOB '*.*'
+            THEN 0 ELSE 1 END AS is_app,
+          c.name AS name
+        FROM heap_graph_class c
+      ),
+      obj AS (
+        SELECT o.id, ck.is_app, ck.name AS class_name,
+          o.self_size + o.native_size AS size
+        FROM heap_graph_object o
+        JOIN last_ts l ON o.graph_sample_ts = l.ts
+        JOIN ck ON ck.id = o.type_id
+        WHERE o.upid = ${upid} AND o.reachable
+      ),
+      walk(seed_size, cur_id, depth) AS (
+        SELECT ob.size, d.idom_id, 1
+        FROM obj ob
+        JOIN _raw_heap_graph_dominator_tree d ON d.id = ob.id
+        WHERE ob.class_name = 'android.graphics.Bitmap' AND d.idom_id IS NOT NULL
+        UNION ALL
+        SELECT w.seed_size, d.idom_id, w.depth + 1
+        FROM walk w
+        JOIN obj cur ON cur.id = w.cur_id
+        JOIN _raw_heap_graph_dominator_tree d ON d.id = w.cur_id
+        WHERE cur.is_app = 0 AND d.idom_id IS NOT NULL AND w.depth < 24
+      ),
+      hits AS (
+        SELECT cur.class_name AS retainer, w.seed_size,
+          ROW_NUMBER() OVER (PARTITION BY w.cur_id ORDER BY w.depth) AS rn
+        FROM walk w
+        JOIN obj cur ON cur.id = w.cur_id
+        WHERE cur.is_app = 1
+      )
+      SELECT retainer FROM hits WHERE rn = 1
+      GROUP BY retainer
+      ORDER BY SUM(seed_size) DESC
+      LIMIT 1
+    `);
+    const it = res.iter({retainer: STR});
+    if (it.valid()) return it.retainer;
+  } catch {
+    // No dominator tree — skip the retainer note.
+  }
+  return undefined;
+}
+
+// Pixel bytes for non-heap backings (ashmem / hardware) are not part of
+// self/native size — estimate them as w*h*4 when dimensions are known.
+function bytesOf(g: BitmapGroup): number {
+  const estPixels =
+    g.storage !== 'heap' && g.width !== undefined && g.height !== undefined
+      ? g.width * g.height * 4 * g.count
+      : 0;
+  return g.selfSize + g.nativeSize + estPixels;
+}
+
+// Group bitmaps by dimensions only (current dump's count + bytes per size).
+function groupByDims(
+  groups: BitmapGroup[],
+): Map<string, {count: number; bytes: number}> {
+  const byDims = new Map<string, {count: number; bytes: number}>();
+  for (const g of groups) {
+    const key =
+      g.width !== undefined && g.height !== undefined
+        ? `${g.width}×${g.height}`
+        : 'unknown';
+    const e = byDims.get(key) ?? {count: 0, bytes: 0};
+    e.count += g.count;
+    e.bytes += bytesOf(g);
+    byDims.set(key, e);
+  }
+  return byDims;
+}
+
+export interface BitmapsSectionAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  // The page-wide selection (by ts). Undefined → latest dump.
+  readonly selTs?: time;
+  readonly baseTs?: time;
+}
+
+export class BitmapsSection implements m.ClassComponent<BitmapsSectionAttrs> {
+  private readonly slot = new QuerySlot<BitmapsData>();
+
+  onremove() {
+    this.slot.dispose();
+  }
+
+  view({attrs}: m.Vnode<BitmapsSectionAttrs>): m.Children {
+    const {trace, upid, selTs, baseTs} = attrs;
+    const data = this.slot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadBitmapsData(trace, upid),
+      // Emulate an empty response
+      // queryFn: async () => ({
+      //   dumps: [],
+      //   groupsByTs: new Map<bigint, BitmapGroup[]>(),
+      //   javaRetainedByTs: new Map<bigint, number>(),
+      // }),
+    }).data;
+    if (data === undefined) {
+      return loadingPanel({title: TITLE, subtitle: SUBTITLE}); // Still loading.
+    }
+    if (data.dumps.length === 0) {
+      return emptyPanel({
+        title: TITLE,
+        subtitle: SUBTITLE,
+        message: 'No reachable bitmaps found',
+        detail:
+          'This trace has no Java heap graph, or the process allocated none.',
+      });
+    }
+
+    // Resolve the selection to dumps. No selection → latest.
+    const cur = nearestByTs(data.dumps, selTs)!;
+    const baseDump =
+      baseTs !== undefined ? nearestByTs(data.dumps, baseTs) : undefined;
+    const comparing = baseDump !== undefined && baseDump.ts !== cur.ts;
+    const groups = data.groupsByTs.get(cur.ts) ?? [];
+    const baseGroups = comparing ? data.groupsByTs.get(baseDump.ts) ?? [] : [];
+
+    const totalCount = groups.reduce((s, g) => s + g.count, 0);
+    const totalBytes = groups.reduce((s, g) => s + bytesOf(g), 0);
+    const baseCount = baseGroups.reduce((s, g) => s + g.count, 0);
+    const baseBytes = baseGroups.reduce((s, g) => s + bytesOf(g), 0);
+    const heapBytes = groups
+      .filter((g) => g.storage === 'heap')
+      .reduce((s, g) => s + g.selfSize + g.nativeSize, 0);
+    const ashmemBytes = groups
+      .filter((g) => g.storage === 'ashmem')
+      .reduce((s, g) => s + bytesOf(g), 0);
+
+    const byDims = groupByDims(groups);
+    const byDimsBase = comparing ? groupByDims(baseGroups) : undefined;
+    const dims = Array.from(byDims.entries()).map(([key, e]) => ({key, ...e}));
+    const bySize = dims.slice().sort((a, b) => b.bytes - a.bytes);
+    const byCount = dims.slice().sort((a, b) => b.count - a.count);
+    const hasDims = dims.some((d) => d.key !== 'unknown');
+    const largest = bySize[0];
+
+    const javaRetained = data.javaRetainedByTs.get(cur.ts) ?? 0;
+    // Bitmap heap-self + registered-native bytes (excludes the estimated ashmem
+    // pixels, which aren't part of the Java retained total) as a % of the
+    // dump's reachable heap + native, with the baseline equivalent for the diff.
+    const bitmapHeapNative = groups.reduce(
+      (s, g) => s + g.selfSize + g.nativeSize,
+      0,
+    );
+    const javaRetainedPct =
+      javaRetained > 0 ? (bitmapHeapNative / javaRetained) * 100 : 0;
+    const baseJavaRetained = comparing
+      ? data.javaRetainedByTs.get(baseDump.ts) ?? 0
+      : 0;
+    const baseBitmapHeapNative = baseGroups.reduce(
+      (s, g) => s + g.selfSize + g.nativeSize,
+      0,
+    );
+    const baseJavaRetainedPct =
+      baseJavaRetained > 0
+        ? (baseBitmapHeapNative / baseJavaRetained) * 100
+        : 0;
+    const javaRetainedPtsDelta = javaRetainedPct - baseJavaRetainedPct;
+    const retainerNote: m.Children =
+      data.bitmapRetainer !== undefined
+        ? [
+            ' Mostly retained by ',
+            m('b', shortClassName(data.bitmapRetainer)),
+            '.',
+          ]
+        : '';
+
+    const insight: m.Children = hasDims
+      ? [
+          m('b', largest.count.toLocaleString()),
+          ' bitmaps of ',
+          m('b', largest.key),
+          ' alone account for ',
+          m('b', formatBytes(largest.bytes)),
+          ashmemBytes > heapBytes
+            ? [
+                '. Most bitmap bytes live in ',
+                m('b', 'ashmem'),
+                ` (${formatBytes(ashmemBytes)}) rather than the Java heap ` +
+                  `(${formatBytes(heapBytes)}).`,
+              ]
+            : '.',
+          retainerNote,
+        ]
+      : [
+          'This trace format does not record bitmap dimensions — only ' +
+            'counts and sizes are available.',
+        ];
+
+    const dimRows = (list: {key: string; count: number; bytes: number}[]) =>
+      list.slice(0, 5).map((d) => {
+        const base = byDimsBase?.get(d.key);
+        const shareFrac = totalBytes > 0 ? d.bytes / totalBytes : 0;
+        const baseShareFrac =
+          base !== undefined && baseBytes > 0 ? base.bytes / baseBytes : 0;
+        return [
+          d.key,
+          deltaCell(
+            d.count.toLocaleString(),
+            base !== undefined ? d.count - base.count : undefined,
+            comparing,
+            formatCountDelta,
+          ),
+          deltaCell(
+            formatBytes(d.bytes),
+            base !== undefined ? d.bytes - base.bytes : undefined,
+            comparing,
+          ),
+          // Share of all bitmap bytes, with the change in share (percentage
+          // points, this snapshot's total vs the baseline's) below in diff mode.
+          deltaCell(
+            m(ShareBar, {frac: shareFrac}),
+            comparing ? (shareFrac - baseShareFrac) * 100 : undefined,
+            comparing,
+            (n) =>
+              n === 0 ? '±0 pts' : `${n > 0 ? '+' : ''}${n.toFixed(1)} pts`,
+          ),
+        ];
+      });
+
+    const tableSubtitle = comparing
+      ? 'grouped by dimensions · Δ vs baseline'
+      : 'grouped by dimensions';
+
+    return m(
+      Panel,
+      m(Panel.Header, {title: TITLE, subtitle: SUBTITLE}),
+      m(
+        Panel.Body,
+        m(Stack, {spacing: 'large'}, [
+          m(Callout, {intent: Intent.Primary}, insight),
+          m(BillboardStrip, [
+            statCard([
+              {
+                label: 'Total bitmaps',
+                value: totalCount.toLocaleString(),
+                sub: comparing
+                  ? deltaText(
+                      totalCount - baseCount,
+                      `Δ ${formatCountDelta(totalCount - baseCount)} vs baseline`,
+                    )
+                  : 'live android.graphics.Bitmap',
+              },
+            ]),
+            statCard([
+              {
+                label: 'Bitmap memory',
+                value: formatBytes(totalBytes),
+                sub: comparing
+                  ? deltaText(
+                      totalBytes - baseBytes,
+                      `Δ ${formatDelta(totalBytes - baseBytes)} vs baseline`,
+                    )
+                  : `${formatBytes(heapBytes)} heap · ${formatBytes(
+                      ashmemBytes,
+                    )} ashmem (est.)`,
+              },
+            ]),
+            hasDims &&
+              statCard([
+                {
+                  label: 'Largest group',
+                  value: formatBytes(largest.bytes),
+                  sub: `${largest.key} ×${largest.count}`,
+                },
+              ]),
+            javaRetained > 0 &&
+              statCard([
+                {
+                  label: 'Of Java retained',
+                  value: `${Math.round(javaRetainedPct)}%`,
+                  sub: comparing
+                    ? deltaText(
+                        javaRetainedPtsDelta,
+                        `Δ ${javaRetainedPtsDelta >= 0 ? '+' : ''}${Math.round(
+                          javaRetainedPtsDelta,
+                        )} pts vs baseline`,
+                      )
+                    : 'share of heap + native',
+                },
+              ]),
+          ]),
+          hasDims &&
+            m('.pf-memscope-tables', [
+              topTable({
+                title: 'Largest bitmaps',
+                subtitle: tableSubtitle,
+                cols: [
+                  {label: 'Dimensions'},
+                  {label: 'Count', num: true},
+                  {label: 'Size', num: true},
+                  {label: 'Share of all bitmap', num: true},
+                ],
+                rows: dimRows(bySize),
+              }),
+              topTable({
+                title: 'Most frequent bitmaps',
+                subtitle: tableSubtitle,
+                cols: [
+                  {label: 'Dimensions'},
+                  {label: 'Count', num: true},
+                  {label: 'Size', num: true},
+                  {label: 'Share of all bitmap', num: true},
+                ],
+                rows: dimRows(byCount),
+              }),
+            ]),
+        ]),
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/java_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/java_section.ts
@@ -1,0 +1,794 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// "How much Java memory did you use, and where did it go?" — from the full
+// heap graph: reachability, totals and the three top-classes tables, for the
+// latest heap dump of one process. Self-contained: owns its query slot and
+// loading logic.
+
+import m from 'mithril';
+import {Icons} from '../../../../../base/semantic_icons';
+import {QuerySlot} from '../../../../../base/query_slot';
+import {Time, type time} from '../../../../../base/time';
+import type {Trace} from '../../../../../public/trace';
+import {LONG, NUM, STR} from '../../../../../trace_processor/query_result';
+import {Anchor} from '../../../../../widgets/anchor';
+import {Panel} from '../../../components/panel';
+import {Callout} from '../../../components/callout';
+import {Intent} from '../../../../../widgets/common';
+import {
+  deltaText,
+  formatBytes,
+  formatCountDelta,
+  formatDelta,
+  statCard,
+} from '../mem_format';
+import {Ratio} from '../../../components/ratio';
+import {nearestByTs} from '../selection';
+import {
+  classNameCell,
+  deltaCell,
+  emptyPanel,
+  loadingPanel,
+  shortClassName,
+  topTable,
+} from '../section_widgets';
+import {ShareBar} from '../../../components/share_bar';
+import {Stack} from '../../../../../widgets/stack';
+import {BillboardStrip} from '../../../components/billboard';
+
+const TITLE = 'How much Java memory did you use, and where did it go?';
+const SUBTITLE =
+  'From the full heap graph — complete and exact, with retention but no ' +
+  'callstacks.';
+
+// Per-class aggregation row at a dump. All sizes/counts are reachable-only (see
+// landing_page_spec.md): unreachable garbage is excluded so the three tables'
+// columns are comparable and retained >= shallow always holds. rnRetained/
+// rnShallow/rnCount are the class's rank under each of the three orderings.
+interface ClassAggRow {
+  typeName: string;
+  // Reachable instance count of this class.
+  reachableObjCount: number;
+  // Shallow: sum of self_size over reachable instances (Java heap only).
+  reachableSizeBytes: number;
+  // Native self: registered native owned by this class's reachable instances.
+  reachableNativeSizeBytes: number;
+  // Retained = dominatedSizeBytes + dominatedNativeSizeBytes (Java + native).
+  dominatedSizeBytes: number;
+  dominatedNativeSizeBytes: number;
+  rnRetained: number; // by retained (dominated Java + native)
+  rnShallow: number; // by shallow (reachable self)
+  rnCount: number; // by reachable instance count
+}
+
+// Per-dump heap-graph stats.
+interface DumpStats {
+  readonly ts: time;
+  readonly totalHeapSize: number;
+  readonly totalObjCount: number;
+  readonly reachableHeapSize: number;
+  readonly reachableNativeSize: number;
+  readonly reachableObjCount: number;
+  // MIN(heap_graph_object.id) for this dump — the HeapProfile track event id
+  // used to select the dump on the timeline.
+  readonly eventId: number;
+}
+
+// One app-side owner of a (library) class's instances: the nearest app class up
+// the dominator chain, and the bytes of that class attributed to it.
+export interface ClassRetainer {
+  readonly name: string;
+  readonly bytes: number;
+}
+
+interface JavaData {
+  // All dumps for this process, ts-ascending (empty → no heap graph).
+  readonly dumps: DumpStats[];
+  // Top classes per dump, keyed by dump ts (raw bigint).
+  readonly classesByTs: ReadonlyMap<bigint, ClassAggRow[]>;
+  // App-side retainers per class (last dump): the distinct nearest app-side
+  // dominators of a library class's instances, each with the bytes attributed
+  // to it, largest first. A class held through several owners gets several
+  // entries instead of a single (misleading) "via".
+  readonly retainerOf: ReadonlyMap<string, ReadonlyArray<ClassRetainer>>;
+  // ART images + JIT cache resident bytes, one entry per smaps snapshot
+  // (ts-ascending). Lets the card align to the selected/baseline dump and diff.
+  readonly artByTs: readonly {ts: time; art: number}[];
+}
+
+async function loadJavaData(trace: Trace, upid: number): Promise<JavaData> {
+  await trace.engine.query(
+    'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;',
+  );
+  // MIN(object id) per dump — the HeapProfile track event id for that dump
+  // (mirrors how dev.perfetto.HeapProfile builds its timeline events).
+  const eventIdByTs = new Map<bigint, number>();
+  const eventRes = await trace.engine.query(`
+    SELECT graph_sample_ts AS ts, MIN(id) AS event_id
+    FROM heap_graph_object
+    WHERE upid = ${upid}
+    GROUP BY graph_sample_ts
+  `);
+  for (
+    const it = eventRes.iter({ts: LONG, event_id: NUM});
+    it.valid();
+    it.next()
+  ) {
+    eventIdByTs.set(it.ts, it.event_id);
+  }
+
+  const dumps: DumpStats[] = [];
+  const statsRes = await trace.engine.query(`
+    SELECT
+      s.graph_sample_ts AS ts,
+      s.total_heap_size AS total_heap_size,
+      s.total_obj_count AS total_obj_count,
+      s.reachable_heap_size AS reachable_heap_size,
+      s.reachable_native_alloc_registry_size AS reachable_native_size,
+      s.reachable_obj_count AS reachable_obj_count
+    FROM android_heap_graph_stats s
+    WHERE s.upid = ${upid}
+    ORDER BY s.graph_sample_ts ASC
+  `);
+  for (
+    const it = statsRes.iter({
+      ts: LONG,
+      total_heap_size: NUM,
+      total_obj_count: NUM,
+      reachable_heap_size: NUM,
+      reachable_native_size: NUM,
+      reachable_obj_count: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    dumps.push({
+      ts: Time.fromRaw(it.ts),
+      totalHeapSize: it.total_heap_size,
+      totalObjCount: it.total_obj_count,
+      reachableHeapSize: it.reachable_heap_size,
+      reachableNativeSize: it.reachable_native_size,
+      reachableObjCount: it.reachable_obj_count,
+      eventId: eventIdByTs.get(it.ts) ?? -1,
+    });
+  }
+  const classesByTs = new Map<bigint, ClassAggRow[]>();
+  if (dumps.length === 0) {
+    return {dumps, classesByTs, retainerOf: new Map(), artByTs: []};
+  }
+
+  // Top classes (per the three orderings) at every dump, so picking any
+  // snapshot (or diffing two) is in-memory.
+  await trace.engine.query(
+    'INCLUDE PERFETTO MODULE ' +
+      'android.memory.heap_graph.heap_graph_class_aggregation;',
+  );
+  const aggRes = await trace.engine.query(`
+    WITH ranked AS (
+      SELECT
+        a.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY a.graph_sample_ts
+          ORDER BY a.dominated_size_bytes + a.dominated_native_size_bytes DESC
+        ) AS rn_retained,
+        ROW_NUMBER() OVER (
+          PARTITION BY a.graph_sample_ts
+          ORDER BY a.reachable_size_bytes DESC
+        ) AS rn_shallow,
+        ROW_NUMBER() OVER (
+          PARTITION BY a.graph_sample_ts ORDER BY a.reachable_obj_count DESC
+        ) AS rn_count
+      FROM android_heap_graph_class_aggregation a
+      WHERE a.upid = ${upid}
+    )
+    SELECT
+      r.graph_sample_ts AS ts,
+      r.type_name AS type_name,
+      r.reachable_obj_count AS reachable_obj_count,
+      r.reachable_size_bytes AS reachable_size_bytes,
+      r.reachable_native_size_bytes AS reachable_native_size_bytes,
+      r.dominated_size_bytes AS dominated_size_bytes,
+      r.dominated_native_size_bytes AS dominated_native_size_bytes,
+      r.rn_retained AS rn_retained,
+      r.rn_shallow AS rn_shallow,
+      r.rn_count AS rn_count
+    FROM ranked r
+    WHERE r.rn_retained <= 8 OR r.rn_shallow <= 8 OR r.rn_count <= 8
+  `);
+  for (
+    const it = aggRes.iter({
+      ts: LONG,
+      type_name: STR,
+      reachable_obj_count: NUM,
+      reachable_size_bytes: NUM,
+      reachable_native_size_bytes: NUM,
+      dominated_size_bytes: NUM,
+      dominated_native_size_bytes: NUM,
+      rn_retained: NUM,
+      rn_shallow: NUM,
+      rn_count: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    let list = classesByTs.get(it.ts);
+    if (list === undefined) {
+      list = [];
+      classesByTs.set(it.ts, list);
+    }
+    list.push({
+      typeName: it.type_name,
+      reachableObjCount: it.reachable_obj_count,
+      reachableSizeBytes: it.reachable_size_bytes,
+      reachableNativeSizeBytes: it.reachable_native_size_bytes,
+      dominatedSizeBytes: it.dominated_size_bytes,
+      dominatedNativeSizeBytes: it.dominated_native_size_bytes,
+      rnRetained: it.rn_retained,
+      rnShallow: it.rn_shallow,
+      rnCount: it.rn_count,
+    });
+  }
+
+  const retainerOf = await loadRetainers(trace, upid);
+  const artByTs = await loadArtByTs(trace, upid);
+
+  return {dumps, classesByTs, retainerOf, artByTs};
+}
+
+// For each library class at the latest dump, the app-side classes that dominate
+// its instances, walking up the dominator tree to the nearest non-library
+// (app/third-party) ancestor of each object. Instances of one class can resolve
+// to different owners, so we report up to RETAINER_MAX_VIAS of them, each with
+// the bytes attributed to it (the shallow size of the library objects that
+// terminate at that owner — a clean partition, not the overlapping dominated
+// sizes shown in the table). When the chain reaches the super root without
+// passing through an app class — i.e. the object is held directly by the GC
+// root set — the retainer is reported as "GC root". Wrapped defensively: a heap
+// graph without a dominator tree yields an empty map.
+//
+// At most this many distinct owners are surfaced per class, ...
+const RETAINER_MAX_VIAS = 3;
+// ...and owners contributing less than this fraction of the class's largest
+// owner are dropped as noise.
+const RETAINER_MIN_SHARE = 0.1;
+async function loadRetainers(
+  trace: Trace,
+  upid: number,
+): Promise<ReadonlyMap<string, ReadonlyArray<ClassRetainer>>> {
+  const retainerOf = new Map<string, ClassRetainer[]>();
+  try {
+    await trace.engine.query(
+      'INCLUDE PERFETTO MODULE android.memory.heap_graph.raw_dominator_tree;',
+    );
+    const res = await trace.engine.query(`
+      WITH RECURSIVE
+      last_ts AS (
+        SELECT MAX(graph_sample_ts) AS ts
+        FROM heap_graph_object WHERE upid = ${upid}
+      ),
+      ck AS (
+        -- Classify by the *wrapped* name: a class object is named
+        -- "java.lang.Class<X>" and holds X's statics, so an app class's class
+        -- object must count as app (an app-side owner), not library. The
+        -- original name is kept for display/joins; only is_app uses the
+        -- unwrapped form.
+        SELECT id, name,
+          CASE WHEN cname GLOB 'java.*' OR cname GLOB 'javax.*'
+            OR cname GLOB 'kotlin.*' OR cname GLOB 'kotlinx.*'
+            OR cname GLOB 'dalvik.*' OR cname GLOB 'sun.*'
+            OR cname GLOB 'libcore.*' OR cname GLOB 'android.*'
+            OR cname GLOB 'androidx.*' OR cname GLOB 'com.android.*'
+            OR cname GLOB 'com.google.android.*'
+            OR cname LIKE '%[]%'
+            OR cname NOT GLOB '*.*'
+            THEN 0 ELSE 1 END AS is_app
+        FROM (
+          SELECT c.id, c.name AS name,
+            CASE WHEN c.name GLOB 'java.lang.Class<*>'
+              THEN substr(c.name, 17, length(c.name) - 17)
+              ELSE c.name END AS cname
+          FROM heap_graph_class c
+        )
+      ),
+      obj AS (
+        SELECT o.id, ck.is_app, ck.name AS class_name,
+          o.self_size + o.native_size AS size
+        FROM heap_graph_object o
+        JOIN last_ts l ON o.graph_sample_ts = l.ts
+        JOIN ck ON ck.id = o.type_id
+        WHERE o.upid = ${upid} AND o.reachable
+      ),
+      walk(seed_id, owned_class, seed_size, anc_id, depth) AS (
+        SELECT ob.id, ob.class_name, ob.size, d.idom_id, 1
+        FROM obj ob
+        JOIN _raw_heap_graph_dominator_tree d ON d.id = ob.id
+        WHERE ob.is_app = 0
+        UNION ALL
+        SELECT w.seed_id, w.owned_class, w.seed_size, d.idom_id, w.depth + 1
+        FROM walk w
+        JOIN obj cur ON cur.id = w.anc_id
+        JOIN _raw_heap_graph_dominator_tree d ON d.id = w.anc_id
+        WHERE cur.is_app = 0 AND w.depth < 24
+      ),
+      -- Each rung is a dominator-tree ancestor of the seed. A NULL anc_id is
+      -- the rung above the topmost node: the synthetic super root, i.e. the
+      -- object is retained directly by the GC root set. The search terminates
+      -- at the nearest app-side ancestor, or at that root if the whole chain
+      -- up to it is library/system.
+      classified AS (
+        SELECT w.seed_id, w.owned_class, w.seed_size, w.depth,
+          CASE
+            WHEN w.anc_id IS NULL THEN 'GC root'
+            WHEN a.class_name GLOB 'java.lang.Class<*>'
+              THEN substr(a.class_name, 17, length(a.class_name) - 17)
+            ELSE a.class_name
+          END AS retainer,
+          CASE WHEN w.anc_id IS NULL THEN 1 ELSE a.is_app END AS terminal
+        FROM walk w
+        LEFT JOIN obj a ON a.id = w.anc_id
+      ),
+      hits AS (
+        SELECT seed_id, owned_class, seed_size, retainer,
+          ROW_NUMBER() OVER (PARTITION BY seed_id ORDER BY depth) AS rn
+        FROM classified
+        WHERE terminal = 1
+      ),
+      -- Rank the distinct retainers of each class by attributed bytes, largest
+      -- first, so the UI can show the few dominant owners instead of just one.
+      -- "GC root" ranks last on ties so a real app owner wins an equal split.
+      agg AS (
+        SELECT owned_class, retainer, SUM(seed_size) AS bytes,
+          ROW_NUMBER() OVER (
+            PARTITION BY owned_class
+            ORDER BY SUM(seed_size) DESC, (retainer = 'GC root') ASC
+          ) AS rrn
+        FROM hits WHERE rn = 1
+        GROUP BY owned_class, retainer
+      )
+      SELECT a.owned_class AS type_name, a.retainer AS retainer_name,
+        a.bytes AS bytes
+      FROM agg a
+      WHERE a.rrn <= ${RETAINER_MAX_VIAS}
+      ORDER BY a.owned_class, a.rrn
+    `);
+    for (
+      const it = res.iter({type_name: STR, retainer_name: STR, bytes: NUM});
+      it.valid();
+      it.next()
+    ) {
+      let list = retainerOf.get(it.type_name);
+      if (list === undefined) {
+        list = [];
+        retainerOf.set(it.type_name, list);
+      }
+      list.push({name: it.retainer_name, bytes: it.bytes});
+    }
+    // Drop trailing owners that are tiny next to the class's biggest one; the
+    // SQL already ordered each list largest-first.
+    for (const [cls, list] of retainerOf) {
+      const cutoff = list[0].bytes * RETAINER_MIN_SHARE;
+      retainerOf.set(
+        cls,
+        list.filter((r) => r.bytes >= cutoff),
+      );
+    }
+  } catch {
+    // No dominator tree (e.g. non-Android heap graph) — skip the annotation.
+  }
+  return retainerOf;
+}
+
+// ART images + JIT cache resident bytes per smaps snapshot (ts-ascending), so
+// the card can align to the selected/baseline dump and diff between them.
+async function loadArtByTs(
+  trace: Trace,
+  upid: number,
+): Promise<{ts: time; art: number}[]> {
+  const res = await trace.engine.query(`
+    SELECT s.ts AS ts, CAST(ifnull(SUM(s.rss_kb), 0) * 1024 AS INT) AS art
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+      AND (s.path GLOB '*.art*' OR s.path GLOB '*.oat*'
+        OR s.path GLOB '*.odex*' OR s.path GLOB '*.vdex*'
+        OR s.path GLOB '*dalvik-jit*')
+    GROUP BY s.ts
+    ORDER BY s.ts ASC
+  `);
+  const out: {ts: time; art: number}[] = [];
+  for (const it = res.iter({ts: LONG, art: NUM}); it.valid(); it.next()) {
+    out.push({ts: Time.fromRaw(it.ts), art: it.art});
+  }
+  return out;
+}
+
+export interface JavaSectionAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  // The page-wide selection (by ts). Undefined → latest dump.
+  readonly selTs?: time;
+  readonly baseTs?: time;
+}
+
+export class JavaSection implements m.ClassComponent<JavaSectionAttrs> {
+  private readonly slot = new QuerySlot<JavaData>();
+
+  onremove() {
+    this.slot.dispose();
+  }
+
+  view({attrs}: m.Vnode<JavaSectionAttrs>): m.Children {
+    const {trace, upid, selTs, baseTs} = attrs;
+    const data = this.slot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadJavaData(trace, upid),
+      // Emulate no data available
+      // queryFn: async () => ({
+      //   dumps: [],
+      //   classesByTs: new Map<bigint, ClassAggRow[]>(),
+      //   retainerOf: new Map<string, string>(),
+      //   artByTs: [],
+      // }),
+    }).data;
+    if (data === undefined) {
+      return loadingPanel({title: TITLE, subtitle: SUBTITLE}); // Still loading.
+    }
+    if (data.dumps.length === 0) {
+      return emptyPanel({
+        title: TITLE,
+        subtitle: SUBTITLE,
+        message: 'No Java heap graph in this trace for this process',
+        detail: 'Capture a java_hprof dump to see the managed heap',
+      });
+    }
+
+    // Resolve the selection to dumps (nearest by ts). No selection → latest.
+    const cur = nearestByTs(data.dumps, selTs)!;
+    const baseDump =
+      baseTs !== undefined ? nearestByTs(data.dumps, baseTs) : undefined;
+    // Both endpoints can resolve to the same dump (dumps are sparser than
+    // smaps snapshots) — that's not a comparison.
+    const baseStats =
+      baseDump !== undefined && baseDump.ts !== cur.ts ? baseDump : undefined;
+    const comparing = baseStats !== undefined;
+    const selIdx = data.dumps.indexOf(cur);
+    const baseIdx =
+      baseStats !== undefined ? data.dumps.indexOf(baseStats) : undefined;
+
+    // ART overhead is smaps-sourced, so align to the smaps snapshot nearest
+    // each dump's ts (rather than always the latest) so it diffs alongside the
+    // heap-graph cards in compare mode.
+    const curArt = nearestByTs(data.artByTs, cur.ts)?.art;
+    const baseArt = comparing
+      ? nearestByTs(data.artByTs, baseStats.ts)?.art
+      : undefined;
+
+    const classes = data.classesByTs.get(cur.ts) ?? [];
+    const baseClassByName = new Map(
+      comparing
+        ? (data.classesByTs.get(baseStats.ts) ?? []).map(
+            (c) => [c.typeName, c] as const,
+          )
+        : [],
+    );
+    const withDelta = (
+      text: m.Children,
+      delta: number | undefined,
+      fmt: (n: number) => string = formatDelta,
+    ): m.Children => deltaCell(text, delta, comparing, fmt);
+
+    const tOf = (ts: time) =>
+      (Number(ts - trace.traceInfo.start) / 1e9).toFixed(1);
+
+    const reachableTotal = cur.reachableHeapSize + cur.reachableNativeSize;
+    const baseReachableTotal = comparing
+      ? baseStats.reachableHeapSize + baseStats.reachableNativeSize
+      : 0;
+
+    // A share-% cell that, in compare mode, shows the change in share below the
+    // bar as signed percentage points (cur share − baseline share).
+    const shareCell = (
+      value: number,
+      total: number,
+      baseValue: number | undefined,
+      baseTotal: number,
+    ): m.Children => {
+      const frac = total > 0 ? value / total : 0;
+      if (!comparing) return m(ShareBar, {frac});
+      const baseFrac =
+        baseValue !== undefined && baseTotal > 0 ? baseValue / baseTotal : 0;
+      return withDelta(m(ShareBar, {frac}), (frac - baseFrac) * 100, (n) =>
+        n === 0 ? '±0 pts' : `${n > 0 ? '+' : ''}${n.toFixed(1)} pts`,
+      );
+    };
+    const unreachableHeap = cur.totalHeapSize - cur.reachableHeapSize;
+    const reachPct =
+      cur.totalHeapSize > 0
+        ? (cur.reachableHeapSize / cur.totalHeapSize) * 100
+        : 0;
+
+    // Insight: the class with the largest retained (dominated) size.
+    const topRetainer = classes
+      .slice()
+      .sort((a, b) => a.rnRetained - b.rnRetained)[0];
+    const insight: m.Children = [];
+    if (topRetainer !== undefined && reachableTotal > 0) {
+      const retained =
+        topRetainer.dominatedSizeBytes + topRetainer.dominatedNativeSizeBytes;
+      insight.push(
+        m('b', shortClassName(topRetainer.typeName)),
+        ' retains ',
+        m('b', formatBytes(retained)),
+        ' — ',
+        m(
+          'b',
+          `${Math.round((retained / reachableTotal) * 100)}% of the ` +
+            'Java heap',
+        ),
+        '.',
+      );
+    }
+    if (cur.totalHeapSize > 0) {
+      insight.push(
+        ' ',
+        m('b', `${Math.round(100 - reachPct)}%`),
+        ' of the heap is currently unreachable (awaiting GC).',
+      );
+    }
+
+    // All three class tables show the same five reachable-only columns
+    // (Class · Instances · Shallow · Retained · Share); only the ranking and
+    // the share denominator differ. `shareMetric` selects the value the share
+    // bar measures and `shareTotal`/`shareBaseTotal` its denominator.
+    const classCols = [
+      {label: 'Class'},
+      {label: 'Instances', num: true},
+      {label: 'Shallow', num: true},
+      {label: 'Native', num: true},
+      {label: 'Retained', num: true},
+      {label: 'Share', num: true},
+    ];
+    const classRow = (
+      c: ClassAggRow,
+      shareMetric: (r: ClassAggRow) => number,
+      shareTotal: number,
+      shareBaseTotal: number,
+    ): m.Children[] => {
+      const b = baseClassByName.get(c.typeName);
+      const retained = c.dominatedSizeBytes + c.dominatedNativeSizeBytes;
+      const baseRetained =
+        b !== undefined
+          ? b.dominatedSizeBytes + b.dominatedNativeSizeBytes
+          : undefined;
+      return [
+        classNameCell(c.typeName, data.retainerOf.get(c.typeName)),
+        withDelta(
+          c.reachableObjCount.toLocaleString(),
+          b !== undefined
+            ? c.reachableObjCount - b.reachableObjCount
+            : undefined,
+          formatCountDelta,
+        ),
+        withDelta(
+          formatBytes(c.reachableSizeBytes),
+          b !== undefined
+            ? c.reachableSizeBytes - b.reachableSizeBytes
+            : undefined,
+        ),
+        withDelta(
+          c.reachableNativeSizeBytes > 0
+            ? formatBytes(c.reachableNativeSizeBytes)
+            : '—',
+          b !== undefined
+            ? c.reachableNativeSizeBytes - b.reachableNativeSizeBytes
+            : undefined,
+        ),
+        withDelta(
+          formatBytes(retained),
+          baseRetained !== undefined ? retained - baseRetained : undefined,
+        ),
+        shareCell(
+          shareMetric(c),
+          shareTotal,
+          b !== undefined ? shareMetric(b) : undefined,
+          shareBaseTotal,
+        ),
+      ];
+    };
+
+    const retainedRows = classes
+      .filter((c) => c.rnRetained <= 5)
+      .sort((a, b) => a.rnRetained - b.rnRetained)
+      .map((c) =>
+        classRow(
+          c,
+          (r) => r.dominatedSizeBytes + r.dominatedNativeSizeBytes,
+          reachableTotal,
+          baseReachableTotal,
+        ),
+      );
+
+    const shallowRows = classes
+      .filter((c) => c.rnShallow <= 5)
+      .sort((a, b) => a.rnShallow - b.rnShallow)
+      .map((c) =>
+        classRow(
+          c,
+          (r) => r.reachableSizeBytes,
+          cur.reachableHeapSize,
+          comparing ? baseStats.reachableHeapSize : 0,
+        ),
+      );
+
+    const countRows = classes
+      .filter((c) => c.rnCount <= 5)
+      .sort((a, b) => a.rnCount - b.rnCount)
+      .map((c) =>
+        classRow(
+          c,
+          (r) => r.reachableObjCount,
+          cur.reachableObjCount,
+          comparing ? baseStats.reachableObjCount : 0,
+        ),
+      );
+
+    return m(
+      Panel,
+      m(Panel.Header, {
+        title: TITLE,
+        subtitle: SUBTITLE,
+        controls: m(
+          Anchor,
+          {
+            disabled: true,
+            title:
+              'Direct linking to specific heap dumps in HDE is not yet ' +
+              'supported',
+            icon: Icons.ExternalLink,
+          },
+          'Show in Heap Dump Explorer',
+        ),
+      }),
+      m(
+        Panel.Body,
+        m(Stack, {spacing: 'large'}, [
+          m('.pf-memscope-memmap__section-header', [
+            m(
+              'span.pf-memscope-memmap__section-title',
+              {
+                className: comparing
+                  ? 'pf-memscope-memmap__section-title--diff'
+                  : 'pf-memscope-memmap__section-title--straight',
+              },
+              comparing && baseStats !== undefined
+                ? `Dump @ t=${tOf(baseStats.ts)}s → t=${tOf(cur.ts)}s`
+                : `Dump @ t=${tOf(cur.ts)}s`,
+            ),
+            m(
+              'span.pf-memscope-memmap__section-hint',
+              comparing && baseIdx !== undefined
+                ? `dumps #${baseIdx + 1} → #${selIdx + 1} · Δ vs baseline`
+                : `dump #${selIdx + 1} of ${data.dumps.length}`,
+            ),
+          ]),
+          insight.length > 0 && m(Callout, {intent: Intent.Primary}, insight),
+          m(BillboardStrip, [
+            statCard([
+              {
+                label: 'Heap',
+                value: formatBytes(cur.totalHeapSize),
+                sub: comparing
+                  ? deltaText(
+                      cur.totalHeapSize - baseStats.totalHeapSize,
+                      `Δ ${formatDelta(cur.totalHeapSize - baseStats.totalHeapSize)} vs baseline`,
+                    )
+                  : 'reachable + unreachable',
+              },
+            ]),
+            statCard([
+              {
+                label: 'Live objects',
+                value: cur.totalObjCount.toLocaleString(),
+                sub: comparing
+                  ? deltaText(
+                      cur.totalObjCount - baseStats.totalObjCount,
+                      `Δ ${formatCountDelta(cur.totalObjCount - baseStats.totalObjCount)} vs baseline`,
+                    )
+                  : `${cur.reachableObjCount.toLocaleString()} reach · ` +
+                    `${(
+                      cur.totalObjCount - cur.reachableObjCount
+                    ).toLocaleString()} unreach`,
+              },
+            ]),
+            statCard([
+              {
+                label: 'Registered native',
+                value: formatBytes(cur.reachableNativeSize),
+                sub: comparing
+                  ? deltaText(
+                      cur.reachableNativeSize - baseStats.reachableNativeSize,
+                      `Δ ${formatDelta(cur.reachableNativeSize - baseStats.reachableNativeSize)} vs baseline`,
+                    )
+                  : 'owned by Java (bitmaps, NIO)',
+              },
+            ]),
+            curArt !== undefined &&
+              curArt > 0 &&
+              statCard([
+                {
+                  label: 'ART overhead',
+                  value: formatBytes(curArt),
+                  sub:
+                    comparing && baseArt !== undefined
+                      ? deltaText(
+                          curArt - baseArt,
+                          `Δ ${formatDelta(curArt - baseArt)} vs baseline`,
+                        )
+                      : '.art images + JIT cache',
+                },
+              ]),
+          ]),
+          m(Ratio, {
+            label: 'Heap reachability',
+            tooltip:
+              'Reachable = objects a GC root still references. Unreachable ' +
+              'objects are garbage awaiting collection.',
+            pct: reachPct,
+            headline: 'of the Java heap is reachable',
+            color: '#f4b400',
+            aLabel: 'Reachable',
+            aBytes: cur.reachableHeapSize,
+            bLabel: 'Unreachable',
+            bBytes: unreachableHeap,
+            ...(comparing
+              ? {
+                  aDelta: cur.reachableHeapSize - baseStats.reachableHeapSize,
+                  bDelta:
+                    unreachableHeap -
+                    (baseStats.totalHeapSize - baseStats.reachableHeapSize),
+                  pctDelta:
+                    reachPct -
+                    (baseStats.totalHeapSize > 0
+                      ? (baseStats.reachableHeapSize /
+                          baseStats.totalHeapSize) *
+                        100
+                      : 0),
+                }
+              : {}),
+          }),
+          m('.pf-memscope-tables', [
+            retainedRows.length > 0 &&
+              topTable({
+                title: 'Top classes by retained size',
+                cols: classCols,
+                rows: retainedRows,
+              }),
+            shallowRows.length > 0 &&
+              topTable({
+                title: 'Top classes by shallow size',
+                cols: classCols,
+                rows: shallowRows,
+              }),
+            countRows.length > 0 &&
+              topTable({
+                title: 'Top classes by instance count',
+                cols: classCols,
+                rows: countRows,
+              }),
+          ]),
+        ]),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Add java sections to the memory overview page.

- Java memory breakdown
- Bitmaps breakdown

Also pull out ratio and share bar into dedicated components.
