### PR TITLE
smb: account for size of patches when splitting commit IPCs

### DIFF
--- a/src/tracing/core/shared_memory_arbiter_impl.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl.cc
@@ -706,10 +706,11 @@ void SharedMemoryArbiterImpl::CommitDataWithSplitting(
     new_ctm->set_data(ctm.data());
   }
 
-  // Split the patches too, instead of appending all of them to the last request:
-  // a flush with many patched chunks could otherwise exceed the limit (see
-  // https://github.com/google/perfetto/issues/6426). Patches are applied after
-  // moves and IPC is ordered, so trailing patch requests preserve ordering.
+  // Split the patches too, instead of appending all of them to the last
+  // request: a flush with many patched chunks could otherwise exceed the limit
+  // (see https://github.com/google/perfetto/issues/6426). Patches are applied
+  // after moves and IPC is ordered, so trailing patch requests preserve
+  // ordering.
   for (auto& ctp : *req->mutable_chunks_to_patch()) {
     uint32_t ctp_bytes = EstimateChunkToPatchSize(ctp);
     // A lone ChunkToPatch always fits, so only ever split a non-empty request.

--- a/src/tracing/core/shared_memory_arbiter_impl.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl.cc
@@ -42,6 +42,17 @@ constexpr size_t kMaxCommitDataRequestChunkSize =
     128 * 1024 - 512;  // This is ipc::kIPCBufferSize - 512, see
                        // |kMaxTracePacketSliceSize| in tracing_service_impl.h
 
+// Conservative upper bound of a ChunkToPatch's serialized size, used to bound
+// how many patches are packed into one request. Over-estimating only causes an
+// extra split, never an oversized frame.
+uint32_t EstimateChunkToPatchSize(const CommitDataRequest::ChunkToPatch& ctp) {
+  uint32_t size = 32;  // Fixed fields + repeated-field tag/length.
+  for (const auto& patch : ctp.patches()) {
+    size += static_cast<uint32_t>(patch.data().size()) + 16;  // data + framing.
+  }
+  return size;
+}
+
 MaybeUnboundBufferID MakeTargetBufferIdForReservation(uint16_t reservation_id) {
   // Reservation IDs are stored in the upper bits.
   PERFETTO_CHECK(reservation_id > 0);
@@ -654,13 +665,17 @@ void SharedMemoryArbiterImpl::CommitDataWithSplitting(
     std::function<void()> callback) {
   PERFETTO_DCHECK(use_shmem_emulation_);
 
-  // If the request is small enough to be sent in a single IPC
-  // avoid the request splitting.
-  uint32_t total_bytes = 0;
+  // If the request is small enough to be sent in a single IPC avoid the request
+  // splitting. |estimated_bytes| includes a conservative bound for the patches,
+  // which are serialized into the request too.
+  uint32_t estimated_bytes = 0;
   for (const auto& ctm : req->chunks_to_move()) {
-    total_bytes += static_cast<uint32_t>(ctm.data().size());
+    estimated_bytes += static_cast<uint32_t>(ctm.data().size());
   }
-  if (total_bytes < kMaxCommitDataRequestChunkSize) {
+  for (const auto& ctp : req->chunks_to_patch()) {
+    estimated_bytes += EstimateChunkToPatchSize(ctp);
+  }
+  if (estimated_bytes < kMaxCommitDataRequestChunkSize) {
     producer_endpoint_->CommitData(*req, std::move(callback));
     return;
   }
@@ -691,15 +706,24 @@ void SharedMemoryArbiterImpl::CommitDataWithSplitting(
     new_ctm->set_data(ctm.data());
   }
 
-  // In shmem emulation mode, the pending commit data requests splitting
-  // is done on a best effort basis, meaning that although rare it is
-  // possible for the last commit data request to exceed the
-  // |kIPCBufferSize| since, we aren't checking the size of the chunk
-  // patches.
-  *split_req->mutable_chunks_to_patch() =
-      std::move(*req->mutable_chunks_to_patch());
-  split_req->set_flush_request_id(req->flush_request_id());
+  // Split the patches too, instead of appending all of them to the last request:
+  // a flush with many patched chunks could otherwise exceed the limit (see
+  // https://github.com/google/perfetto/issues/6426). Patches are applied after
+  // moves and IPC is ordered, so trailing patch requests preserve ordering.
+  for (auto& ctp : *req->mutable_chunks_to_patch()) {
+    uint32_t ctp_bytes = EstimateChunkToPatchSize(ctp);
+    // A lone ChunkToPatch always fits, so only ever split a non-empty request.
+    if (current_req_bytes != 0 &&
+        current_req_bytes + ctp_bytes >= kMaxCommitDataRequestChunkSize) {
+      producer_endpoint_->CommitData(*split_req);
+      split_req.reset(new CommitDataRequest());
+      current_req_bytes = 0;
+    }
+    current_req_bytes += ctp_bytes;
+    *split_req->add_chunks_to_patch() = std::move(ctp);
+  }
 
+  split_req->set_flush_request_id(req->flush_request_id());
   producer_endpoint_->CommitData(*split_req, std::move(callback));
 }
 

--- a/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
@@ -340,8 +340,8 @@ TEST_P(SharedMemoryArbiterImplTest, ScrapeEmulatedSharedMemoryBuffer) {
 TEST_P(SharedMemoryArbiterImplTest, CommitDataSplittingHonorsIpcBufferSize) {
   // Mirror of the anonymous-namespace kMaxCommitDataRequestChunkSize in
   // shared_memory_arbiter_impl.cc: ipc::kIPCBufferSize (128 KB) minus 512 bytes
-  // of headroom for the IPC Frame that wraps the request. This is the budget the
-  // splitting logic must keep each emitted request under.
+  // of headroom for the IPC Frame that wraps the request. This is the budget
+  // the splitting logic must keep each emitted request under.
   constexpr size_t kMaxCommitDataRequestChunkSize = 128 * 1024 - 512;
 
   arbiter_.reset(new SharedMemoryArbiterImpl(
@@ -354,8 +354,8 @@ TEST_P(SharedMemoryArbiterImplTest, CommitDataSplittingHonorsIpcBufferSize) {
   // frame, while staying just under the splitting threshold so that the moved
   // chunks alone would fit in one request. Each chunk carries a full default
   // (4 KB) page worth of data. The moved bytes stay under
-  // kMaxCommitDataRequestChunkSize (128 KB - 512), so on their own they would be
-  // sent as a single, unsplit request.
+  // kMaxCommitDataRequestChunkSize (128 KB - 512), so on their own they would
+  // be sent as a single, unsplit request.
   constexpr size_t kChunkData = 4096;
   constexpr size_t kNumChunks = 30;  // 120 KB of chunk payload.
   const std::string chunk_payload(kChunkData, 'x');

--- a/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
@@ -59,6 +59,11 @@ class SharedMemoryArbiterImplTest : public AlignedBufferTest {
 
   bool IsArbiterFullyBound() { return arbiter_->fully_bound_; }
 
+  void CommitDataWithSplitting(std::unique_ptr<CommitDataRequest> req,
+                               std::function<void()> callback) {
+    arbiter_->CommitDataWithSplitting(std::move(req), std::move(callback));
+  }
+
   void TearDown() override {
     arbiter_.reset();
     task_runner_.reset();
@@ -321,6 +326,91 @@ TEST_P(SharedMemoryArbiterImplTest, ScrapeEmulatedSharedMemoryBuffer) {
   // Scraping must not disturb the chunk: the writer still owns it.
   ASSERT_EQ(SharedMemoryABI::kChunkBeingWritten,
             abi->GetChunkState(page_idx, chunk_idx));
+}
+
+// Regression test for https://github.com/google/perfetto/issues/6426.
+// In shmem emulation mode the chunk data is inlined into the CommitDataRequest
+// and sent over an IPC socket. Frames larger than |kIPCBufferSize| (128 KB) are
+// rejected by the receiver with "IPC Frame too large", which eventually
+// disconnects the producer. CommitDataWithSplitting is meant to split large
+// requests to stay under that limit, but it used to account only for the moved
+// chunk data and ignore the size of the appended |chunks_to_patch|. A request
+// whose moved chunks nearly fill the buffer and which also carries a realistic
+// number of patches therefore serialized larger than the limit.
+TEST_P(SharedMemoryArbiterImplTest, CommitDataSplittingHonorsIpcBufferSize) {
+  // Mirror of the anonymous-namespace kMaxCommitDataRequestChunkSize in
+  // shared_memory_arbiter_impl.cc: ipc::kIPCBufferSize (128 KB) minus 512 bytes
+  // of headroom for the IPC Frame that wraps the request. This is the budget the
+  // splitting logic must keep each emitted request under.
+  constexpr size_t kMaxCommitDataRequestChunkSize = 128 * 1024 - 512;
+
+  arbiter_.reset(new SharedMemoryArbiterImpl(
+      buf(), buf_size(), ShmemMode::kShmemEmulation, page_size(),
+      &mock_producer_endpoint_, task_runner_.get()));
+
+  auto req = std::make_unique<CommitDataRequest>();
+
+  // Fill |chunks_to_move| with enough inlined data to nearly fill a single IPC
+  // frame, while staying just under the splitting threshold so that the moved
+  // chunks alone would fit in one request. Each chunk carries a full default
+  // (4 KB) page worth of data. The moved bytes stay under
+  // kMaxCommitDataRequestChunkSize (128 KB - 512), so on their own they would be
+  // sent as a single, unsplit request.
+  constexpr size_t kChunkData = 4096;
+  constexpr size_t kNumChunks = 30;  // 120 KB of chunk payload.
+  const std::string chunk_payload(kChunkData, 'x');
+  for (size_t i = 0; i < kNumChunks; i++) {
+    auto* ctm = req->add_chunks_to_move();
+    ctm->set_page(0);
+    ctm->set_chunk(0);
+    ctm->set_target_buffer(1);
+    ctm->set_data(chunk_payload);
+  }
+
+  // Add a realistic number of patches for chunks committed in earlier requests.
+  // Each ChunkToPatch normally carries a single 4-byte patch, but a busy
+  // producer with hundreds of threads can accumulate thousands of them within a
+  // single flush period.
+  const std::string patch_data(4, 'p');
+  for (uint32_t i = 0; i < 2000; i++) {
+    auto* ctp = req->add_chunks_to_patch();
+    ctp->set_target_buffer(1);
+    ctp->set_writer_id(1);
+    ctp->set_chunk_id(i);
+    auto* patch = ctp->add_patches();
+    patch->set_offset(0);
+    patch->set_data(patch_data);
+  }
+
+  // Capture every request emitted by the splitting logic. None of them must
+  // exceed what the IPC layer is willing to receive, and together they must
+  // carry all the moves and patches from the original request.
+  std::vector<size_t> emitted_sizes;
+  size_t total_moves = 0;
+  size_t total_patches = 0;
+  size_t flush_ids = 0;
+  EXPECT_CALL(mock_producer_endpoint_, CommitData(_, _))
+      .WillRepeatedly([&](const CommitDataRequest& r,
+                          MockProducerEndpoint::CommitDataCallback) {
+        emitted_sizes.push_back(r.SerializeAsString().size());
+        total_moves += r.chunks_to_move().size();
+        total_patches += r.chunks_to_patch().size();
+        flush_ids += r.has_flush_request_id() ? 1 : 0;
+      });
+
+  CommitDataWithSplitting(std::move(req), [] {});
+
+  ASSERT_FALSE(emitted_sizes.empty());
+  for (size_t size : emitted_sizes) {
+    EXPECT_LE(size, kMaxCommitDataRequestChunkSize)
+        << "emitted commit data request exceeds the IPC frame size limit";
+  }
+
+  // The splitting must be lossless: every move and patch is delivered exactly
+  // once, and the flush id is stamped on exactly one request.
+  EXPECT_EQ(total_moves, kNumChunks);
+  EXPECT_EQ(total_patches, 2000u);
+  EXPECT_EQ(flush_ids, 1u);
 }
 
 // Check that we can create up to many TraceWriter(s).


### PR DESCRIPTION
We were not taking into account patch sizes when splitting commit data
IPC messages which was leading us to occasionally overflow this and
error out.

Just take into account patch sizes by counting them upfront with
over-estimation of overhead.

Fixes: https://github.com/google/perfetto/issues/6426
