### PR TITLE
Make boot tracing trigger robust

### DIFF
--- a/perfetto.rc
+++ b/perfetto.rc
@@ -108,26 +108,21 @@ on post-fs-data
 #  perfetto_trace_on_boot - Starts a perfetto trace on boot
 #############################################################################
 #
-# There are two separate actions (a trigger action and a start action) to make
-# sure that perfetto_trace_on_boot is started only once on boot (otherwise,
-# whenever persist.debug.perfetto.boottrace=1 is set, perfetto_trace_on_boot
-# would start immediately).
+# Start perfetto_trace_on_boot safely during boot if boot tracing is enabled.
 #
-# persist.debug.perfetto.boottrace=1 can be manually set after boot (to record
-# a trace on the next reboot) and we don't want to immediately start a trace
-# when setting the debug property. So we turn "ro.persistent_properties.ready"
-# into a trigger, and then check whether we should start tracing when the
-# trigger fires.
-# sys.trace.traced_started is set by traced after listen()ing on the consumer
-# socket. Without this, perfetto could try to connect to traced before traced
-# is ready to listen. 
-on perfetto_maybe_trace_on_boot && property:persist.debug.perfetto.boottrace=1 && property:persist.traced.enable=1 && property:sys.trace.traced_started=1
+# We use a property trigger gated by sys.boot_completed= (empty) to ensure
+# that we only start tracing during boot, and not immediately if the
+# persist.debug.perfetto.boottrace property is set post-boot.
+#
+# We also wait for sys.trace.traced_started=1 to ensure that the traced
+# daemon is fully initialized and listening on the socket before perfetto
+# tries to connect. Using a property trigger instead of a one-shot event
+# trigger avoids race conditions if traced startup is delayed (e.g. due to
+# CPU starvation from other services starting during boot).
+on property:persist.debug.perfetto.boottrace=1 && property:persist.traced.enable=1 && property:sys.trace.traced_started=1 && property:sys.boot_completed=
     setprop persist.debug.perfetto.boottrace ""
     rm /data/misc/perfetto-traces/boottrace.perfetto-trace
     start perfetto_trace_on_boot
-
-on property:ro.persistent_properties.ready=true
-    trigger perfetto_maybe_trace_on_boot
 
 service perfetto_trace_on_boot /system/bin/perfetto -c /data/misc/perfetto-configs/boottrace.pbtxt --txt -o /data/misc/perfetto-traces/boottrace.perfetto-trace
     disabled


### PR DESCRIPTION
Resolve a race condition where perfetto_trace_on_boot fails to start if the traced daemon is slow to initialize and set traced_started=1. By using a property trigger gated by "sys.boot_completed=", we ensure the trace starts as soon as traced is ready, even under heavy boot load.
