### PR TITLE
ui: Add 'where the growth went' bar to memscope overview

### DIFF
--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.scss
@@ -295,6 +295,41 @@ a.pf-memscope-classname {
   gap: 12px;
 }
 
+// "Where the growth went" bar below the composition chart: label + big signed
+// delta + a per-category ProportionBar. Layout only — the recessed chrome comes
+// from the Inset this class is applied to.
+.pf-memscope-growth {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  &__label {
+    font-size: var(--pf-font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pf-color-text-muted);
+  }
+
+  &__headline {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  &__delta {
+    font-size: var(--pf-font-size-xl);
+    font-weight: 700;
+    color: var(--pf-color-text);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__context {
+    font-size: var(--pf-font-size-s);
+    color: var(--pf-color-text-muted);
+  }
+}
+
 // Small colour swatch marking a smaps category/group.
 .pf-memscope-growth__swatch {
   align-self: center;

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
@@ -15,13 +15,23 @@
 import m from 'mithril';
 import {Gate} from '../../../../base/mithril_utils';
 import {QuerySlot} from '../../../../base/query_slot';
+import {Time, type time} from '../../../../base/time';
+import {ProportionBar} from '../../../../components/widgets/charts/proportion_bar';
 import type {Trace} from '../../../../public/trace';
-import {LONG_NULL, NUM, STR} from '../../../../trace_processor/query_result';
+import {
+  LONG,
+  LONG_NULL,
+  NUM,
+  STR,
+} from '../../../../trace_processor/query_result';
 import {Icon} from '../../../../widgets/icon';
+import {Inset} from '../../components/inset';
 import {Panel} from '../../components/panel';
 import {SubPage} from '../../components/page';
-import type {MemSelection} from './selection';
+import {deltaColor, formatDelta} from './mem_format';
+import {type MemSelection, nearestByTs} from './selection';
 import {SmapsDetail} from './smaps_detail';
+import {SMAPS_CATEGORIES, SMAPS_CATEGORY_CASE_SQL} from './smaps_categories';
 import {BitmapsSection} from './summary/bitmaps_section';
 import {CompositionTimeline} from './summary/composition_timeline';
 import {JavaSection} from './summary/java_section';
@@ -47,6 +57,56 @@ interface CaptureInfo {
   readonly native: SourceFacts;
 }
 
+// One smaps snapshot's resident+swap memory for one process, split by the full
+// smaps category taxonomy. Powers the "where the growth went" bar, which spans
+// the whole trace. Uses the same rss+swap metric and category split as the
+// composition-over-time chart so the two read consistently.
+interface GrowthSnapshot {
+  ts: time;
+  total: number;
+  byCategory: ReadonlyMap<string, number>; // category key → rss+swap bytes
+}
+
+// Loads the per-snapshot rss+swap breakdown for one process across the whole
+// trace, for the growth bar (same path → category classification as the
+// composition chart).
+async function loadGrowthData(
+  trace: Trace,
+  upid: number,
+): Promise<GrowthSnapshot[]> {
+  const byTs = new Map<
+    bigint,
+    {ts: time; total: number; byCategory: Map<string, number>}
+  >();
+  const res = await trace.engine.query(`
+    SELECT
+      s.ts AS ts,
+      ${SMAPS_CATEGORY_CASE_SQL} AS category,
+      CAST(ifnull(SUM(s.rss_kb + s.swap_kb), 0) * 1024 AS INT) AS bytes
+    FROM profiler_smaps s
+    WHERE s.upid = ${upid}
+    GROUP BY s.ts, category
+    ORDER BY s.ts ASC
+  `);
+  for (
+    const it = res.iter({ts: LONG, category: STR, bytes: NUM});
+    it.valid();
+    it.next()
+  ) {
+    let snap = byTs.get(it.ts);
+    if (snap === undefined) {
+      snap = {ts: Time.fromRaw(it.ts), total: 0, byCategory: new Map()};
+      byTs.set(it.ts, snap);
+    }
+    snap.total += it.bytes;
+    snap.byCategory.set(
+      it.category,
+      (snap.byCategory.get(it.category) ?? 0) + it.bytes,
+    );
+  }
+  return Array.from(byTs.values());
+}
+
 export interface ProcessMemDetailsAttrs {
   readonly trace: Trace;
   readonly upid: number;
@@ -58,6 +118,9 @@ export class ProcessMemDetails
   // The capture-strip facts: process name + per-source sample counts. Its own
   // slot keyed by (trace, upid) so it reloads when the selected process changes.
   private readonly captureSlot = new QuerySlot<CaptureInfo>();
+  // Whole-trace per-snapshot smaps breakdown for the growth bar (keyed by
+  // upid; independent of the page's snapshot selection).
+  private readonly growthSlot = new QuerySlot<GrowthSnapshot[]>();
   private activeTab: 'summary' | 'smaps' = 'summary';
   // The page-wide snapshot selection, driven by the composition timeline and
   // shared with the other summary sections as they're added.
@@ -65,6 +128,7 @@ export class ProcessMemDetails
 
   onremove() {
     this.captureSlot.dispose();
+    this.growthSlot.dispose();
   }
 
   view({attrs}: m.Vnode<ProcessMemDetailsAttrs>) {
@@ -101,6 +165,12 @@ export class ProcessMemDetails
               upid,
               selection: this.selection,
               onSelect: (s: MemSelection) => (this.selection = s),
+              belowChart: this.renderGrowthBar(
+                trace,
+                upid,
+                this.selection?.sel,
+                this.selection?.base,
+              ),
             }),
             m(MemoryMap, {
               trace,
@@ -156,6 +226,92 @@ export class ProcessMemDetails
         ),
       ),
     );
+  }
+
+  // "Where the growth went" bar (rendered below the composition chart): the
+  // per-category memory delta between the baseline and selected snapshots (or
+  // over the whole trace when unselected). Undefined while loading, or when
+  // there aren't two snapshots to diff (the composition panel covers that case).
+  private renderGrowthBar(
+    trace: Trace,
+    upid: number,
+    selTs?: time,
+    baseTs?: time,
+  ): m.Children {
+    const snaps = this.growthSlot.use({
+      key: {traceId: trace.traceInfo.uuid, upid},
+      queryFn: () => loadGrowthData(trace, upid),
+    }).data;
+    if (snaps === undefined || snaps.length < 2) return undefined;
+    const firstSnap = snaps[0];
+    const lastSnap = snaps[snaps.length - 1];
+    // Selected endpoint (nearest snapshot), or the latest when unselected.
+    const sel = selTs !== undefined ? nearestByTs(snaps, selTs)! : lastSnap;
+    // Baseline endpoint: an explicit baseline (when diffing), otherwise the
+    // first snapshot so a single selection reads as "growth up to here".
+    const resolvedBase =
+      baseTs !== undefined ? nearestByTs(snaps, baseTs) : undefined;
+    const base =
+      resolvedBase !== undefined && resolvedBase.ts !== sel.ts
+        ? resolvedBase
+        : firstSnap;
+    const diffing = resolvedBase !== undefined && resolvedBase.ts !== sel.ts;
+    const wholeTrace = base.ts === firstSnap.ts && sel.ts === lastSnap.ts;
+    const first = base;
+    const last = sel;
+    const total = last.total - first.total;
+    const categories = SMAPS_CATEGORIES.map((c) => ({
+      name: c.label,
+      color: c.color,
+      delta:
+        (last.byCategory.get(c.key) ?? 0) - (first.byCategory.get(c.key) ?? 0),
+    }));
+    const shrinking = total < 0;
+    // Growth rate, normalised to bytes/hour over the observed snapshot span.
+    const spanSeconds = Number(last.ts - first.ts) / 1e9;
+    const ratePerHour =
+      spanSeconds > 0 ? (total / spanSeconds) * 3600 : undefined;
+
+    return m(Inset, {className: 'pf-memscope-growth'}, [
+      m(
+        '.pf-memscope-growth__label',
+        shrinking ? 'Where the shrinkage went' : 'Where the growth went',
+      ),
+      m('.pf-memscope-growth__headline', [
+        m(
+          'span.pf-memscope-growth__delta',
+          {style: {color: deltaColor(total)}},
+          formatDelta(total),
+        ),
+        m(
+          'span.pf-memscope-growth__context',
+          `${shrinking ? 'removed' : 'added'} ` +
+            (diffing
+              ? 'vs baseline'
+              : wholeTrace
+                ? 'over the trace'
+                : 'up to selection'),
+        ),
+        ratePerHour !== undefined &&
+          m(
+            'span.pf-memscope-growth__context',
+            `· ${formatDelta(ratePerHour)}/hour`,
+          ),
+      ]),
+      m(ProportionBar, {
+        segments: categories.map((c) => ({
+          label: c.name,
+          // Only regions moving in the dominant direction size the bar; the
+          // rest get zero width but still appear in the legend.
+          weight: (shrinking ? c.delta < 0 : c.delta > 0)
+            ? Math.abs(c.delta)
+            : 0,
+          color: c.color,
+          value: formatDelta(c.delta),
+          valueColor: deltaColor(c.delta),
+        })),
+      }),
+    ]);
   }
 
   // Header capture strip: trace identity plus one colored dot + terse facts


### PR DESCRIPTION
Renders below the composition chart: the per-smaps-category memory delta between the baseline and selected snapshots (or over the whole trace when unselected), with a signed total and a growth rate.
