### PR TITLE
tp: Refuse to write binary trace output to a TTY

### DIFF
--- a/include/perfetto/ext/base/utils.h
+++ b/include/perfetto/ext/base/utils.h
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #include <atomic>
@@ -115,6 +116,13 @@ void SetEnv(const std::string& key, const std::string& value);
 
 // unsetenv(2)-equivalent. Deals with Windows vs Posix discrepancies.
 void UnsetEnv(const std::string& key);
+
+// Returns true if |fd| is connected to an interactive terminal (TTY). Deals
+// with Windows vs Posix discrepancies (isatty() vs _isatty()).
+bool IsTty(int fd);
+
+// Convenience overload for C stdio streams (e.g. stdin/stdout/stderr).
+bool IsTty(FILE* stream);
 
 // Calls mallopt(M_PURGE, 0) on Android. Does nothing on other platforms.
 // This forces the allocator to release freed memory. This is used to work

--- a/src/base/utils.cc
+++ b/src/base/utils.cc
@@ -31,7 +31,11 @@
     PERFETTO_BUILDFLAG(PERFETTO_OS_FUCHSIA)
 #include <limits.h>
 #include <stdlib.h>  // For _exit()
-#include <unistd.h>  // For getpagesize() and geteuid() & fork() & sysconf()
+#endif
+
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+// For isatty(), getpagesize(), geteuid(), fork() & sysconf().
+#include <unistd.h>
 #endif
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE)
@@ -240,6 +244,22 @@ void UnsetEnv(const std::string& key) {
   PERFETTO_CHECK(::_putenv_s(key.c_str(), "") == 0);
 #else
   PERFETTO_CHECK(::unsetenv(key.c_str()) == 0);
+#endif
+}
+
+bool IsTty(int fd) {
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  return ::_isatty(fd) != 0;
+#else
+  return ::isatty(fd) != 0;
+#endif
+}
+
+bool IsTty(FILE* stream) {
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  return IsTty(::_fileno(stream));
+#else
+  return IsTty(::fileno(stream));
 #endif
 }
 

--- a/src/perfetto_cmd/perfetto_cmd.cc
+++ b/src/perfetto_cmd/perfetto_cmd.cc
@@ -1038,8 +1038,8 @@ int PerfettoCmd::ConnectToServiceAndRun() {
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
   if (!background_ && !is_detach() && !upload_flag_ &&
-      triggers_to_activate_.empty() && !isatty(STDIN_FILENO) &&
-      !isatty(STDERR_FILENO) && getenv("TERM")) {
+      triggers_to_activate_.empty() && !base::IsTty(STDIN_FILENO) &&
+      !base::IsTty(STDERR_FILENO) && getenv("TERM")) {
     fprintf(stderr,
             "Warning: No PTY. CTRL+C won't gracefully stop the trace. If you "
             "are running perfetto via adb shell, use the -tt arg (adb shell "

--- a/src/trace_processor/shell/convert_helpers.cc
+++ b/src/trace_processor/shell/convert_helpers.cc
@@ -25,6 +25,7 @@
 
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
+#include "perfetto/ext/base/utils.h"
 #include "src/protozero/text_to_proto/text_to_proto.h"
 #include "src/traceconv/android_extension.descriptor.h"
 #include "src/traceconv/trace.descriptor.h"
@@ -32,8 +33,6 @@
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 #include <fcntl.h>
 #include <io.h>
-#else
-#include <unistd.h>
 #endif
 
 namespace perfetto::trace_processor::shell {
@@ -48,18 +47,17 @@ base::Status OpenConversionInput(const std::string& path,
     *out_stream = owned_file;
     return base::OkStatus();
   }
-#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-  if (isatty(STDIN_FILENO)) {
+  if (base::IsTty(stdin)) {
     return base::ErrStatus(
         "Reading from stdin but it's connected to a TTY. Either pass a file "
         "path on the command line or pipe data into stdin.");
   }
-#endif
   *out_stream = &std::cin;
   return base::OkStatus();
 }
 
 base::Status OpenConversionOutput(const std::string& path,
+                                  bool binary_output,
                                   std::ofstream* owned_file,
                                   std::ostream** out_stream) {
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
@@ -73,6 +71,12 @@ base::Status OpenConversionOutput(const std::string& path,
       return base::ErrStatus("Could not open %s", path.c_str());
     *out_stream = owned_file;
     return base::OkStatus();
+  }
+  if (binary_output && base::IsTty(stdout)) {
+    return base::ErrStatus(
+        "Refusing to write binary output to stdout as it's connected to a TTY "
+        "(this would corrupt your terminal). Either pass an output file path "
+        "on the command line or redirect stdout to a file or pipe.");
   }
   *out_stream = &std::cout;
   return base::OkStatus();

--- a/src/trace_processor/shell/convert_helpers.h
+++ b/src/trace_processor/shell/convert_helpers.h
@@ -38,7 +38,10 @@ base::Status OpenConversionInput(const std::string& path,
 // Opens the output stream for a conversion. An empty |path| (or "-") means
 // write to stdout; otherwise the file at |path| is opened into |owned_file|. On
 // success |*out_stream| points at either |owned_file| or std::cout.
+// If |binary_output| is true, stdout is refused when connected to a TTY, as
+// dumping binary data would corrupt the terminal.
 base::Status OpenConversionOutput(const std::string& path,
+                                  bool binary_output,
                                   std::ofstream* owned_file,
                                   std::ostream** out_stream);
 

--- a/src/trace_processor/shell/convert_helpers_unittest.cc
+++ b/src/trace_processor/shell/convert_helpers_unittest.cc
@@ -74,7 +74,8 @@ TEST(ConvertHelpersTest, OpenConversionOutputWritesFile) {
 
   std::ofstream owned;
   std::ostream* stream = nullptr;
-  base::Status s = OpenConversionOutput(path, &owned, &stream);
+  base::Status s =
+      OpenConversionOutput(path, /*binary_output=*/true, &owned, &stream);
   ASSERT_TRUE(s.ok()) << s.c_message();
   ASSERT_NE(stream, nullptr);
 
@@ -95,7 +96,8 @@ TEST(ConvertHelpersTest, OpenConversionOutputBadPathFails) {
   std::ostream* stream = nullptr;
   // The intermediate directory does not exist, so the open must fail.
   base::Status s =
-      OpenConversionOutput(PathIn(dir, "no_such_dir/out.bin"), &owned, &stream);
+      OpenConversionOutput(PathIn(dir, "no_such_dir/out.bin"),
+                           /*binary_output=*/true, &owned, &stream);
   EXPECT_FALSE(s.ok());
 }
 

--- a/src/trace_processor/shell/convert_subcommand.cc
+++ b/src/trace_processor/shell/convert_subcommand.cc
@@ -155,7 +155,11 @@ base::Status ConvertSubcommand::Run(const SubcommandContext& ctx) {
 
   std::ofstream output_file;
   std::ostream* output = nullptr;
-  RETURN_IF_ERROR(OpenConversionOutput(output_path, &output_file, &output));
+  // ctrace is the only convert format that emits binary; the rest are
+  // human-readable.
+  const bool binary_output = format == "ctrace";
+  RETURN_IF_ERROR(
+      OpenConversionOutput(output_path, binary_output, &output_file, &output));
 
   int ret = 0;
   if (format == "json") {

--- a/src/trace_processor/shell/query_subcommand.cc
+++ b/src/trace_processor/shell/query_subcommand.cc
@@ -30,6 +30,7 @@
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/utils.h"
 #include "perfetto/trace_processor/summarizer.h"
 #include "perfetto/trace_processor/trace_processor.h"
 #include "src/protozero/text_to_proto/text_to_proto.h"
@@ -40,14 +41,11 @@
 #include "src/trace_processor/shell/subcommand.h"
 #include "src/trace_processor/trace_summary/trace_summary.descriptor.h"
 
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <io.h>
-#else
-#include <unistd.h>
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+#include <unistd.h>  // For STDIN_FILENO.
 #endif
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN) && !defined(STDIN_FILENO)
 #define STDIN_FILENO 0
-#define STDOUT_FILENO 1
 #endif
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) ||   \
@@ -186,7 +184,7 @@ base::Status QuerySubcommand::Run(const SubcommandContext& ctx) {
   //   4. Stdin pipe:  query trace.pb < file.sql
   std::string sql;
   bool read_stdin =
-      query_file_ == "-" || (query_file_.empty() && !isatty(STDIN_FILENO));
+      query_file_ == "-" || (query_file_.empty() && !base::IsTty(STDIN_FILENO));
   if (ctx.positional_args.size() > sql_pos) {
     sql = ctx.positional_args[sql_pos];
   } else if (read_stdin) {

--- a/src/trace_processor/shell/util_subcommand.cc
+++ b/src/trace_processor/shell/util_subcommand.cc
@@ -218,7 +218,9 @@ base::Status UtilSubcommand::Run(const SubcommandContext& ctx) {
 
   std::ofstream output_file;
   std::ostream* output = nullptr;
-  RETURN_IF_ERROR(OpenConversionOutput(output_path, &output_file, &output));
+  // All the utilities emit binary protobuf output.
+  RETURN_IF_ERROR(OpenConversionOutput(output_path, /*binary_output=*/true,
+                                       &output_file, &output));
 
   int ret;
   if (util == "symbolize") {

--- a/src/traceconv/traceconv.cc
+++ b/src/traceconv/traceconv.cc
@@ -31,6 +31,7 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/utils.h"
 #include "perfetto/ext/base/version.h"
 #include "perfetto/profiling/pprof_builder.h"
 #include "src/protozero/text_to_proto/text_to_proto.h"
@@ -49,8 +50,6 @@
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 #include <fcntl.h>
 #include <io.h>
-#else
-#include <unistd.h>
 #endif
 
 namespace perfetto::traceconv {
@@ -263,14 +262,12 @@ int Main(int argc, char** argv) {
       PERFETTO_FATAL("Could not open %s", file_path);
     input_stream = &file_istream;
   } else {
-#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-    if (isatty(STDIN_FILENO)) {
+    if (base::IsTty(stdin)) {
       PERFETTO_ELOG("Reading from stdin but it's connected to a TTY");
       PERFETTO_LOG("It is unlikely that you want to type in some binary.");
       PERFETTO_LOG("Either pass a file path to the cmdline or pipe stdin");
       return Usage(argv[0]);
     }
-#endif
     input_stream = &std::cin;
   }
 
@@ -278,6 +275,8 @@ int Main(int argc, char** argv) {
   // We don't want the runtime to replace "\n" with "\r\n" on `std::cout`.
   _setmode(_fileno(stdout), _O_BINARY);
 #endif
+
+  std::string format(positional_args[0]);
 
   std::ostream* output_stream;
   std::ofstream file_ostream;
@@ -289,10 +288,18 @@ int Main(int argc, char** argv) {
       PERFETTO_FATAL("Could not open %s", file_path);
     output_stream = &file_ostream;
   } else {
+    // Binary formats would corrupt an interactive terminal if printed on it.
+    if ((format == "binary" || format == "ctrace" ||
+         format == "decompress_packets" || format == "symbolize" ||
+         format == "deobfuscate") &&
+        base::IsTty(stdout)) {
+      PERFETTO_ELOG(
+          "Refusing to write binary output to a terminal. Pass an output "
+          "file path or redirect stdout.");
+      return 1;
+    }
     output_stream = &std::cout;
   }
-
-  std::string format(positional_args[0]);
 
   if ((format != "profile" && format != "java_heap_profile") &&
       (pid != 0 || !timestamps.empty())) {

--- a/test/stress_test/stress_producer.cc
+++ b/test/stress_test/stress_producer.cc
@@ -27,6 +27,7 @@
 #include "perfetto/base/time.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/utils.h"
 #include "perfetto/tracing.h"
 
 #include "protos/perfetto/config/stress_test_config.gen.h"
@@ -199,7 +200,7 @@ int main() {
   args.backends = perfetto::kSystemBackend;
 
   std::string config_blob;
-  if (isatty(fileno(stdin)))
+  if (perfetto::base::IsTty(stdin))
     PERFETTO_LOG("Reading StressTestConfig proto from stdin");
   perfetto::base::ReadFileStream(stdin, &config_blob);
 


### PR DESCRIPTION
The traceconv/util conversion commands (decompress_packets, text_to_binary, symbolize, deobfuscate) emit raw binary protobuf. 

When no output path is given they write to stdout; if stdout is a terminal this dumps binary bytes (including control/escape sequences) straight to the TTY and corrupts it.

The input side already guarded against this (it refuses to read from a TTY), but the output side had no equivalent check. Add the mirror-image guard so that when stdout is a TTY we error out with a clear message telling the user to pass an output file or redirect stdout. 

To avoid duplicating the platform-specific TTY detection (which several call sites open-coded via isatty()/STDIN_FILENO with per-file Windows ifdefs), introduce a shared base::IsTty(FILE*) helper that wraps the isatty()/_isatty() discrepancy in one place.
