### PR TITLE
tp: stdlib: Ensure fields without frames are populated

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/input.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/input.sql
@@ -412,8 +412,8 @@ SELECT
   dispatch.event_seq,
   dispatch.event_channel,
   _normalize_event_channel(dispatch.event_channel) AS normalized_event_channel,
-  frame.input_event_id,
-  frame.read_time,
+  seq_map.input_event_id,
+  read_time.read_time,
   dispatch.track_id AS dispatch_track_id,
   dispatch.ts AS dispatch_ts,
   dispatch.dur AS dispatch_dur,
@@ -422,7 +422,7 @@ SELECT
   receive.track_id AS receive_track_id,
   frame.frame_id,
   frame.is_speculative_match AS is_speculative_frame,
-  frame.event_time
+  read_time.event_time
 FROM dispatch
 JOIN receive
   ON receive.dispatch_event_channel = dispatch.event_channel
@@ -434,7 +434,12 @@ JOIN finish_ack
   ON finish_ack.event_channel = dispatch.event_channel
   AND dispatch.event_seq = finish_ack.event_seq
 LEFT JOIN _first_non_dropped_frame_after_input AS frame
-  ON frame.event_seq = dispatch.event_seq;
+  ON frame.event_seq = dispatch.event_seq
+LEFT JOIN _event_seq_to_input_event_id AS seq_map
+  ON seq_map.event_seq = dispatch.event_seq
+  AND seq_map.event_channel = dispatch.event_channel
+LEFT JOIN _input_read_time AS read_time
+  ON read_time.input_event_id = seq_map.input_event_id;
 
 -- Key events processed by the Android framework (from android.input.inputevent data source).
 CREATE PERFETTO VIEW android_key_events(


### PR DESCRIPTION
Previously, we used frame to extract fields such as input_event_id, read_time and event_time. In the case where no frame is associated with a sequence of input events we still want these fields to be populated.

This PR fixes this by using the field from the specific input stage's table as opposed to the frame table.

Bug: 454761692