### PR TITLE
tp: Fix LogMaxDepthExceeded build failure in debug builds

### DIFF
--- a/src/trace_processor/importers/common/slice_tracker.cc
+++ b/src/trace_processor/importers/common/slice_tracker.cc
@@ -33,9 +33,6 @@
 #include "src/trace_processor/types/variadic.h"
 
 namespace perfetto::trace_processor {
-namespace {
-constexpr uint32_t kMaxDepth = 512;
-}
 
 SliceTracker::SliceTracker(TraceProcessorContext* context)
     : legacy_unnestable_begin_count_string_id_(
@@ -50,7 +47,11 @@ SliceTracker::SliceTracker(TraceProcessorContext* context)
       overlap_conflicting_ts_key_(
           context->storage->InternString("conflicting_slice_ts")),
       overlap_conflicting_dur_key_(
-          context->storage->InternString("conflicting_slice_dur")) {}
+          context->storage->InternString("conflicting_slice_dur")),
+      max_depth_parent_name_key_(
+          context->storage->InternString("parent_slice_name")),
+      max_depth_current_name_key_(
+          context->storage->InternString("current_slice_name")) {}
 
 void SliceTracker::AddOverlapArgs(const OverlapInfo& info,
                                   ArgsTracker::BoundInserter& inserter) const {
@@ -101,15 +102,14 @@ void SliceTracker::LogMaxDepthExceeded(const SliceInfo& parent,
       parent.row.ToRowReference(slices).name().value_or(kNullStringId);
   StringId current_name_id = name.is_null() ? kNullStringId : name;
 
-  StringId parent_key = context_->storage->InternString("parent_slice_name");
-  StringId current_key = context_->storage->InternString("current_slice_name");
-
   context_->import_logs_tracker->RecordParserError(
       stats::slice_max_depth_exceeded, timestamp,
-      [parent_key, parent_name_id, current_key,
+      [this, parent_name_id,
        current_name_id](ArgsTracker::BoundInserter& inserter) {
-        inserter.AddArg(parent_key, Variadic::String(parent_name_id));
-        inserter.AddArg(current_key, Variadic::String(current_name_id));
+        inserter.AddArg(max_depth_parent_name_key_,
+                        Variadic::String(parent_name_id));
+        inserter.AddArg(max_depth_current_name_key_,
+                        Variadic::String(current_name_id));
       });
 }
 

--- a/src/trace_processor/importers/common/slice_tracker.cc
+++ b/src/trace_processor/importers/common/slice_tracker.cc
@@ -65,6 +65,13 @@ void SliceTracker::AddOverlapArgs(const OverlapInfo& info,
                   Variadic::Integer(info.conflicting_dur));
 }
 
+void SliceTracker::AddMaxDepthArgs(StringId parent_name,
+                                   StringId current_name,
+                                   ArgsTracker::BoundInserter& inserter) const {
+  inserter.AddArg(max_depth_parent_name_key_, Variadic::String(parent_name));
+  inserter.AddArg(max_depth_current_name_key_, Variadic::String(current_name));
+}
+
 SliceTracker::~SliceTracker() {
   FlushPendingSlices();
 }
@@ -106,10 +113,7 @@ void SliceTracker::LogMaxDepthExceeded(const SliceInfo& parent,
       stats::slice_max_depth_exceeded, timestamp,
       [this, parent_name_id,
        current_name_id](ArgsTracker::BoundInserter& inserter) {
-        inserter.AddArg(max_depth_parent_name_key_,
-                        Variadic::String(parent_name_id));
-        inserter.AddArg(max_depth_current_name_key_,
-                        Variadic::String(current_name_id));
+        AddMaxDepthArgs(parent_name_id, current_name_id, inserter);
       });
 }
 

--- a/src/trace_processor/importers/common/slice_tracker.cc
+++ b/src/trace_processor/importers/common/slice_tracker.cc
@@ -93,15 +93,24 @@ bool SliceTracker::PrepareStartSlice(TrackInfo& track_info,
   return MaybeCloseStack(track_info, timestamp, duration, overlap_out);
 }
 
-void SliceTracker::LogMaxDepthExceeded(const SliceInfo& parent, StringId name) {
+void SliceTracker::LogMaxDepthExceeded(const SliceInfo& parent,
+                                       StringId name,
+                                       int64_t timestamp) {
   auto* slices = context_->storage->mutable_slice_table();
-  auto parent_name = context_->storage->GetString(
-      parent.row.ToRowReference(slices).name().value_or(kNullStringId));
-  auto current_name =
-      context_->storage->GetString(name.is_null() ? kNullStringId : name);
-  PERFETTO_DLOG("Last slice: %s", parent_name.c_str());
-  PERFETTO_DLOG("Current slice: %s", current_name.c_str());
-  PERFETTO_DFATAL("Slices with too large depth found.");
+  StringId parent_name_id =
+      parent.row.ToRowReference(slices).name().value_or(kNullStringId);
+  StringId current_name_id = name.is_null() ? kNullStringId : name;
+
+  StringId parent_key = context_->storage->InternString("parent_slice_name");
+  StringId current_key = context_->storage->InternString("current_slice_name");
+
+  context_->import_logs_tracker->RecordParserError(
+      stats::slice_max_depth_exceeded, timestamp,
+      [parent_key, parent_name_id, current_key,
+       current_name_id](ArgsTracker::BoundInserter& inserter) {
+        inserter.AddArg(parent_key, Variadic::String(parent_name_id));
+        inserter.AddArg(current_key, Variadic::String(current_name_id));
+      });
 }
 
 SliceTracker::StartedSlice SliceTracker::StartSlice(
@@ -123,7 +132,7 @@ SliceTracker::StartedSlice SliceTracker::StartSlice(
   auto& stack = track_info.slice_stack;
   size_t depth = stack.size();
   if (PERFETTO_UNLIKELY(depth >= kMaxDepth)) {
-    LogMaxDepthExceeded(stack.back(), name);
+    LogMaxDepthExceeded(stack.back(), name, timestamp);
     return {};
   }
 

--- a/src/trace_processor/importers/common/slice_tracker.h
+++ b/src/trace_processor/importers/common/slice_tracker.h
@@ -73,6 +73,12 @@ class SliceTracker {
   // the same queryable context in the TraceImportLogsTable.
   void AddOverlapArgs(const OverlapInfo&, ArgsTracker::BoundInserter&) const;
 
+  // Writes args describing parent and current slice names when max depth is
+  // exceeded onto |inserter|.
+  void AddMaxDepthArgs(StringId parent_name,
+                       StringId current_name,
+                       ArgsTracker::BoundInserter&) const;
+
   explicit SliceTracker(TraceProcessorContext*);
   ~SliceTracker();
 

--- a/src/trace_processor/importers/common/slice_tracker.h
+++ b/src/trace_processor/importers/common/slice_tracker.h
@@ -40,6 +40,8 @@ class TraceProcessorContext;
 
 class SliceTracker {
  public:
+  static constexpr uint32_t kMaxDepth = 512;
+
   using OnSliceBeginCallback = std::function<void(TrackId, SliceId)>;
 
   // Sentinel default args callback; WantsArgs() compiles arg handling away.
@@ -334,6 +336,10 @@ class SliceTracker {
   const StringId overlap_conflicting_name_key_;
   const StringId overlap_conflicting_ts_key_;
   const StringId overlap_conflicting_dur_key_;
+
+  // Interned arg-name keys for max depth exceeded import logs.
+  const StringId max_depth_parent_name_key_;
+  const StringId max_depth_current_name_key_;
 
   StackMap stacks_;
   std::vector<TranslatableArgs> translatable_args_;

--- a/src/trace_processor/importers/common/slice_tracker.h
+++ b/src/trace_processor/importers/common/slice_tracker.h
@@ -281,7 +281,9 @@ class SliceTracker {
                                        int64_t duration,
                                        std::optional<OverlapInfo>* overlap_out);
 
-  void LogMaxDepthExceeded(const SliceInfo& parent, StringId name);
+  void LogMaxDepthExceeded(const SliceInfo& parent,
+                           StringId name,
+                           int64_t timestamp);
 
   void AddLegacyUnnestableArgs(SliceInfo& slice_info,
                                const TrackInfo& track_info);

--- a/src/trace_processor/importers/common/slice_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/slice_tracker_unittest.cc
@@ -24,6 +24,7 @@
 #include "src/trace_processor/importers/common/args_tracker.h"
 #include "src/trace_processor/importers/common/args_translation_table.h"
 #include "src/trace_processor/importers/common/global_stats_tracker.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/machine_tracker.h"
 #include "src/trace_processor/importers/common/slice_tracker.h"
 #include "src/trace_processor/importers/common/slice_translation_table.h"
@@ -79,6 +80,8 @@ class SliceTrackerTest : public ::testing::Test {
         TraceProcessorContextPtr<TraceProcessorContext::TraceState>::MakeRoot(
             TraceProcessorContext::TraceState{TraceId{0}});
     context_.stats_tracker = std::make_unique<StatsTracker>(&context_);
+    context_.import_logs_tracker =
+        std::make_unique<ImportLogsTracker>(&context_);
   }
 
  protected:
@@ -503,6 +506,26 @@ TEST_F(SliceTrackerTest, OnSliceBeginCallback) {
   EXPECT_THAT(track_records,
               ElementsAre(TrackId{1u}, TrackId{2u}, TrackId{1u}));
   EXPECT_THAT(slice_records, ElementsAre(slice1, slice2, slice3));
+}
+
+TEST_F(SliceTrackerTest, MaxDepthExceeded) {
+  SliceTracker tracker(&context_);
+
+  constexpr TrackId track{1u};
+  StringId name_id = context_.storage->InternString("slice_name");
+  for (uint32_t i = 0; i < 512; ++i) {
+    tracker.Begin(100 + i, track, kNullStringId, name_id);
+  }
+
+  EXPECT_EQ(context_.storage->slice_table().row_count(), 512u);
+  EXPECT_EQ(context_.storage->stats()[stats::slice_max_depth_exceeded], 0);
+
+  // 513th slice exceeds kMaxDepth (512)
+  tracker.Begin(1000, track, kNullStringId, name_id);
+
+  // 513th slice should be dropped, row count remains 512
+  EXPECT_EQ(context_.storage->slice_table().row_count(), 512u);
+  EXPECT_EQ(context_.storage->stats()[stats::slice_max_depth_exceeded], 1);
 }
 
 }  // namespace

--- a/src/trace_processor/importers/common/slice_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/slice_tracker_unittest.cc
@@ -80,8 +80,8 @@ class SliceTrackerTest : public ::testing::Test {
         TraceProcessorContextPtr<TraceProcessorContext::TraceState>::MakeRoot(
             TraceProcessorContext::TraceState{TraceId{0}});
     context_.stats_tracker = std::make_unique<StatsTracker>(&context_);
-    context_.import_logs_tracker =
-        std::make_unique<ImportLogsTracker>(&context_);
+    context_.import_logs_tracker = std::make_unique<ImportLogsTracker>(
+        &context_, tables::TraceFileTable::Id{0});
   }
 
  protected:
@@ -512,20 +512,47 @@ TEST_F(SliceTrackerTest, MaxDepthExceeded) {
   SliceTracker tracker(&context_);
 
   constexpr TrackId track{1u};
-  StringId name_id = context_.storage->InternString("slice_name");
-  for (uint32_t i = 0; i < 512; ++i) {
-    tracker.Begin(100 + i, track, kNullStringId, name_id);
+  StringId parent_name_id = context_.storage->InternString("parent_slice");
+  StringId current_name_id = context_.storage->InternString("current_slice");
+  StringId parent_key = context_.storage->InternString("parent_slice_name");
+  StringId current_key = context_.storage->InternString("current_slice_name");
+
+  for (uint32_t i = 0; i < SliceTracker::kMaxDepth; ++i) {
+    tracker.Begin(100 + i, track, kNullStringId, parent_name_id);
   }
 
-  EXPECT_EQ(context_.storage->slice_table().row_count(), 512u);
-  EXPECT_EQ(context_.storage->stats()[stats::slice_max_depth_exceeded], 0);
+  EXPECT_EQ(context_.storage->slice_table().row_count(),
+            SliceTracker::kMaxDepth);
+  EXPECT_EQ(context_.stats_tracker->GetStats(stats::slice_max_depth_exceeded),
+            0);
 
-  // 513th slice exceeds kMaxDepth (512)
-  tracker.Begin(1000, track, kNullStringId, name_id);
+  // (kMaxDepth + 1)th slice exceeds kMaxDepth
+  tracker.Begin(1000, track, kNullStringId, current_name_id);
 
-  // 513th slice should be dropped, row count remains 512
-  EXPECT_EQ(context_.storage->slice_table().row_count(), 512u);
-  EXPECT_EQ(context_.storage->stats()[stats::slice_max_depth_exceeded], 1);
+  // Exceeded slice should be dropped, row count remains kMaxDepth
+  EXPECT_EQ(context_.storage->slice_table().row_count(),
+            SliceTracker::kMaxDepth);
+  EXPECT_EQ(context_.stats_tracker->GetStats(stats::slice_max_depth_exceeded),
+            1);
+
+  // Verify import logs and args
+  const auto& logs = context_.storage->trace_import_logs_table();
+  EXPECT_EQ(logs.row_count(), 1u);
+  EXPECT_TRUE(logs[0].arg_set_id().has_value());
+
+  bool found_parent = false;
+  bool found_current = false;
+  const auto& args = context_.storage->arg_table();
+  for (auto it = args.IterateRows(); it; ++it) {
+    if (it.key() == parent_key && it.string_value() == parent_name_id) {
+      found_parent = true;
+    }
+    if (it.key() == current_key && it.string_value() == current_name_id) {
+      found_current = true;
+    }
+  }
+  EXPECT_TRUE(found_parent);
+  EXPECT_TRUE(found_current);
 }
 
 }  // namespace

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -753,6 +753,9 @@ namespace perfetto::trace_processor::stats {
   F(slice_negative_duration,                    kSingle,  kError,  kAnalysis, Scope::kMachineAndTrace,  \
       "Number of slices dropped due to negative duration. This usually "       \
       "indicates incorrect timestamps in the trace data."),                    \
+  F(slice_max_depth_exceeded,                   kSingle,  kError,  kAnalysis, Scope::kMachineAndTrace,  \
+      "A slice was dropped because the slice nesting depth exceeded the max "  \
+      "supported limit."),                                                     \
   F(gpu_work_period_negative_duration,          kSingle,  kError,  kAnalysis, Scope::kMachineAndTrace,  \
       "Number of GPU work period events with negative duration (end < start). "\
       "Check the GPU driver for timestamp bugs."),                             \


### PR DESCRIPTION
In debug builds (-DPERFETTO_IMPLEMENTATION / is_debug=true), PERFETTO_DFATAL expands to PERFETTO_FATAL which does not return. This caused clang's -Wmissing-noreturn compiler check to fail on LogMaxDepthExceeded.

Fix this by replacing PERFETTO_DFATAL/PERFETTO_DLOG with RecordParserError, recording the new stat key
slice_max_depth_exceeded along with the parent and current slice names as error arguments.

Bug: 530244645