### PR TITLE
smb: add ipc splitting to smb scraping

### DIFF
--- a/src/tracing/core/shared_memory_arbiter_impl.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl.cc
@@ -53,6 +53,13 @@ uint32_t EstimateChunkToPatchSize(const CommitDataRequest::ChunkToPatch& ctp) {
   return size;
 }
 
+// Conservative upper bound of a ChunkToMove's serialized size: the inlined
+// chunk data plus field tags, varints and the submessage length prefix. As
+// above, over-estimating only causes an extra split.
+uint32_t EstimateChunkToMoveSize(const CommitDataRequest::ChunksToMove& ctm) {
+  return static_cast<uint32_t>(ctm.data().size()) + 32;
+}
+
 MaybeUnboundBufferID MakeTargetBufferIdForReservation(uint16_t reservation_id) {
   // Reservation IDs are stored in the upper bits.
   PERFETTO_CHECK(reservation_id > 0);
@@ -670,7 +677,7 @@ void SharedMemoryArbiterImpl::CommitDataWithSplitting(
   // which are serialized into the request too.
   uint32_t estimated_bytes = 0;
   for (const auto& ctm : req->chunks_to_move()) {
-    estimated_bytes += static_cast<uint32_t>(ctm.data().size());
+    estimated_bytes += EstimateChunkToMoveSize(ctm);
   }
   for (const auto& ctp : req->chunks_to_patch()) {
     estimated_bytes += EstimateChunkToPatchSize(ctp);
@@ -690,14 +697,15 @@ void SharedMemoryArbiterImpl::CommitDataWithSplitting(
     // cannot be greater than |kMaxPageSize| in size, which is less than
     // |kIPCBufferSize|. We provide 512-bytes of headroom for message
     // overhead.
-    if (current_req_bytes + ctm.data().size() >=
-        kMaxCommitDataRequestChunkSize) {
+    uint32_t ctm_bytes = EstimateChunkToMoveSize(ctm);
+    if (current_req_bytes != 0 &&
+        current_req_bytes + ctm_bytes >= kMaxCommitDataRequestChunkSize) {
       producer_endpoint_->CommitData(*split_req);
       split_req.reset(new CommitDataRequest());
       current_req_bytes = 0;
     }
 
-    current_req_bytes += ctm.data().size();
+    current_req_bytes += ctm_bytes;
     auto* new_ctm = split_req->add_chunks_to_move();
     new_ctm->set_page(ctm.page());
     new_ctm->set_chunk(ctm.chunk());
@@ -724,7 +732,8 @@ void SharedMemoryArbiterImpl::CommitDataWithSplitting(
     *split_req->add_chunks_to_patch() = std::move(ctp);
   }
 
-  split_req->set_flush_request_id(req->flush_request_id());
+  if (req->has_flush_request_id())
+    split_req->set_flush_request_id(req->flush_request_id());
   producer_endpoint_->CommitData(*split_req, std::move(callback));
 }
 
@@ -992,14 +1001,14 @@ void SharedMemoryArbiterImpl::ScrapeEmulatedSharedMemoryBuffer(
   // This function must be called on the IPC thread.
   PERFETTO_CHECK(task_runner_->RunsTasksOnCurrentThread());
 
-  CommitDataRequest commit_req;
+  auto commit_req = std::make_unique<CommitDataRequest>();
   ForEachScrapableChunk(&shmem_abi_, [&](SharedMemoryABI::Chunk* chunk,
                                          bool chunk_complete, auto, auto) {
     const auto writer = buffer_for_writers.find(chunk->writer_id());
     if (writer == buffer_for_writers.end())
       return;
     BufferID target_buffer_id = writer->second;
-    auto* ctm = commit_req.add_chunks_to_move();
+    auto* ctm = commit_req->add_chunks_to_move();
     auto page_and_chunk = shmem_abi_.GetPageAndChunkIndex(*chunk);
     ctm->set_page(static_cast<uint32_t>(page_and_chunk.first));
     ctm->set_chunk(static_cast<uint32_t>(page_and_chunk.second));
@@ -1007,9 +1016,12 @@ void SharedMemoryArbiterImpl::ScrapeEmulatedSharedMemoryBuffer(
     ctm->set_data(chunk->begin(), chunk->size());
     ctm->set_chunk_incomplete(!chunk_complete);
   });
-  if (commit_req.chunks_to_move_size() == 0)
+  if (commit_req->chunks_to_move_size() == 0)
     return;
-  producer_endpoint_->CommitData(commit_req);
+  // A scrape can pick up every in-flight chunk in the emulated SMB at once,
+  // which can easily exceed the IPC frame size limit, so it must go through
+  // the same splitting as regular commits.
+  CommitDataWithSplitting(std::move(commit_req), nullptr);
 }
 
 std::unique_ptr<TraceWriter> SharedMemoryArbiterImpl::CreateTraceWriterInternal(

--- a/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
@@ -382,6 +382,8 @@ TEST_P(SharedMemoryArbiterImplTest, CommitDataSplittingHonorsIpcBufferSize) {
     patch->set_data(patch_data);
   }
 
+  req->set_flush_request_id(1);
+
   // Capture every request emitted by the splitting logic. None of them must
   // exceed what the IPC layer is willing to receive, and together they must
   // carry all the moves and patches from the original request.
@@ -411,6 +413,94 @@ TEST_P(SharedMemoryArbiterImplTest, CommitDataSplittingHonorsIpcBufferSize) {
   EXPECT_EQ(total_moves, kNumChunks);
   EXPECT_EQ(total_patches, 2000u);
   EXPECT_EQ(flush_ids, 1u);
+}
+
+// Regression test for https://github.com/google/perfetto/issues/6426.
+// The splitting logic used to count only the raw chunk data against the size
+// limit, ignoring the per-ChunkToMove proto framing (field tags, varints,
+// submessage length prefix). With many small chunks the framing alone can
+// exceed the 512-byte headroom and push the serialized request past the IPC
+// frame size limit.
+TEST_P(SharedMemoryArbiterImplTest, CommitDataSplittingAccountsForFraming) {
+  constexpr size_t kMaxCommitDataRequestChunkSize = 128 * 1024 - 512;
+
+  arbiter_.reset(new SharedMemoryArbiterImpl(
+      buf(), buf_size(), ShmemMode::kShmemEmulation, page_size(),
+      &mock_producer_endpoint_, task_runner_.get()));
+
+  // 2000 chunks of 64 bytes: the payload (125 KB) is under the splitting
+  // threshold, but the ~10 bytes of framing per chunk push the serialized
+  // request over the IPC frame size limit.
+  auto req = std::make_unique<CommitDataRequest>();
+  const std::string chunk_payload(64, 'x');
+  for (uint32_t i = 0; i < 2000; i++) {
+    auto* ctm = req->add_chunks_to_move();
+    ctm->set_page(i % 14);
+    ctm->set_chunk(i % 14);
+    ctm->set_target_buffer(1);
+    ctm->set_data(chunk_payload);
+  }
+
+  size_t total_moves = 0;
+  EXPECT_CALL(mock_producer_endpoint_, CommitData(_, _))
+      .WillRepeatedly([&](const CommitDataRequest& r,
+                          MockProducerEndpoint::CommitDataCallback) {
+        EXPECT_LE(r.SerializeAsString().size(), kMaxCommitDataRequestChunkSize)
+            << "emitted commit data request exceeds the IPC frame size limit";
+        total_moves += r.chunks_to_move().size();
+      });
+
+  CommitDataWithSplitting(std::move(req), [] {});
+  EXPECT_EQ(total_moves, 2000u);
+}
+
+// Regression test for https://github.com/google/perfetto/issues/6426.
+// ScrapeEmulatedSharedMemoryBuffer used to send all scraped chunks in a
+// single CommitDataRequest, bypassing the splitting logic. Since a scrape
+// inlines the full data of every in-flight chunk, that single request could
+// far exceed the IPC frame size limit and get the producer disconnected.
+TEST_P(SharedMemoryArbiterImplTest, ScrapeEmulatedSharedMemoryBufferSplits) {
+  constexpr size_t kMaxCommitDataRequestChunkSize = 128 * 1024 - 512;
+
+  arbiter_.reset(new SharedMemoryArbiterImpl(
+      buf(), buf_size(), ShmemMode::kShmemEmulation, page_size(),
+      &mock_producer_endpoint_, task_runner_.get()));
+
+  SharedMemoryArbiterImpl::set_default_layout_for_testing(
+      SharedMemoryABI::PageLayout::kPageDiv1);
+
+  constexpr WriterID kWriterId = 7;
+  constexpr BufferID kTargetBuffer = 42;
+
+  // Acquire every chunk in the buffer and leave them all in the
+  // kChunkBeingWritten state with at least 2 packets, so that they are all
+  // scrapable. With 64 KB pages the inlined data alone (~14 * 64 KB) is far
+  // larger than a single IPC frame.
+  SharedMemoryABI::ChunkHeader header = {};
+  header.writer_id.store(kWriterId, std::memory_order_relaxed);
+  header.packets.store({}, std::memory_order_relaxed);
+  for (size_t i = 0; i < kNumPages; i++) {
+    header.chunk_id.store(static_cast<ChunkID>(i), std::memory_order_relaxed);
+    SharedMemoryABI::Chunk chunk =
+        arbiter_->GetNewChunk(header, BufferExhaustedPolicy::kStall);
+    ASSERT_TRUE(chunk.is_valid());
+    chunk.IncrementPacketCount();
+    chunk.IncrementPacketCount();
+  }
+
+  size_t total_moves = 0;
+  EXPECT_CALL(mock_producer_endpoint_, CommitData(_, _))
+      .WillRepeatedly([&](const CommitDataRequest& r,
+                          MockProducerEndpoint::CommitDataCallback) {
+        EXPECT_LE(r.SerializeAsString().size(), kMaxCommitDataRequestChunkSize)
+            << "emitted commit data request exceeds the IPC frame size limit";
+        total_moves += r.chunks_to_move().size();
+      });
+
+  std::map<WriterID, BufferID> buffer_for_writers = {
+      {kWriterId, kTargetBuffer}};
+  arbiter_->ScrapeEmulatedSharedMemoryBuffer(buffer_for_writers);
+  EXPECT_EQ(total_moves, kNumPages);
 }
 
 // Check that we can create up to many TraceWriter(s).


### PR DESCRIPTION
In the past, we were only doing IPC frame splits in the
CommitDataRequest codepath. However, emulated SMBs *also* support
scraping and we were *not* doing any IPC splitting there. If enough
chunks were scraped (e.g. a fast moving producer) then you could easily
end up in a position where this would overflow the IPC limit.

Use the same, well tested, logic for IPC splitting also in this
codepath.

While we're here, also fix a small bug where we were not correctly
adding some padding bytes for tags/varint overhead. Add that too.

Bug: https://github.com/google/perfetto/issues/6426
