### PR TITLE
trace_processor: fix stdlib docs enumeration for dotted package names

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
@@ -319,6 +319,10 @@ class PerfettoSqlConnection {
   sql_modules::RegisteredPackage* FindPackageForModule(const std::string& key) {
     return database_->FindPackageForModule(key);
   }
+  const sql_modules::RegisteredPackage* FindPackageForModule(
+      const std::string& key) const {
+    return database_->FindPackageForModule(key);
+  }
 
   // Returns the number of objects (tables, views, functions etc) registered
   // with SQLite.

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.cc
@@ -98,6 +98,18 @@ sql_modules::RegisteredPackage* PerfettoSqlDatabase::FindPackageForModule(
   return nullptr;
 }
 
+const sql_modules::RegisteredPackage* PerfettoSqlDatabase::FindPackageForModule(
+    const std::string& key) const {
+  // Find the package whose name is a prefix of the key. Due to prefix clash
+  // checking during registration, at most one package can match any given key.
+  for (auto pkg = packages_.GetIterator(); pkg; ++pkg) {
+    if (sql_modules::IsPackagePrefixOf(pkg.key(), key)) {
+      return &pkg.value();
+    }
+  }
+  return nullptr;
+}
+
 std::vector<std::pair<std::string, std::string>>
 PerfettoSqlDatabase::GetModules() const {
   std::vector<std::pair<std::string, std::string>> result;

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_database.h
@@ -68,6 +68,8 @@ class PerfettoSqlDatabase {
   const sql_modules::RegisteredPackage* FindPackage(
       const std::string& name) const;
   sql_modules::RegisteredPackage* FindPackageForModule(const std::string& key);
+  const sql_modules::RegisteredPackage* FindPackageForModule(
+      const std::string& key) const;
   std::vector<std::pair<std::string, std::string>> GetModules() const;
   base::FlatHashMap<std::string, sql_modules::RegisteredPackage>& packages() {
     return packages_;

--- a/src/trace_processor/plugins/stdlib_docs/stdlib_docs.cc
+++ b/src/trace_processor/plugins/stdlib_docs/stdlib_docs.cc
@@ -59,11 +59,12 @@ std::string SerializeEntries(const std::vector<Entry>& entries) {
   });
 }
 
+// Parses |module_key| in the caller-resolved |package|. The package must not
+// be re-derived from the key: names can contain dots (e.g. "dev.perfetto.test"
+// owns "dev.perfetto.test.common").
 base::StatusOr<stdlib_doc::ParsedModule> ParseModule(
-    const PerfettoSqlConnection* connection,
+    const sql_modules::RegisteredPackage* package,
     const std::string& module_key) {
-  const auto* package =
-      connection->FindPackage(sql_modules::GetPackageName(module_key));
   if (!package) {
     return base::ErrStatus("Module not found: %s", module_key.c_str());
   }
@@ -189,15 +190,18 @@ base::Status ForEachModule(const PerfettoSqlConnection* engine,
                            Fn callback) {
   if (arg == "*") {
     for (const auto& kv : engine->GetModules()) {
+      const std::string& pkg = kv.first;
       const std::string& mod = kv.second;
-      auto parsed_or = ParseModule(engine, mod);
+      // The package name comes straight from the registry, so no re-derivation
+      // from the module key is needed (and would be wrong for dotted packages).
+      auto parsed_or = ParseModule(engine->FindPackage(pkg), mod);
       if (!parsed_or.ok()) {
         return parsed_or.status();
       }
       callback(mod, *parsed_or);
     }
   } else {
-    auto parsed_or = ParseModule(engine, arg);
+    auto parsed_or = ParseModule(engine->FindPackageForModule(arg), arg);
     if (!parsed_or.ok()) {
       return parsed_or.status();
     }

--- a/src/trace_processor/trace_database_integrationtest.cc
+++ b/src/trace_processor/trace_database_integrationtest.cc
@@ -916,6 +916,26 @@ TEST_F(TraceProcessorIntegrationTest, PackagePrefixClash_NewIsPrefix) {
   ASSERT_THAT(status.message(), HasSubstr("clashes"));
 }
 
+TEST_F(TraceProcessorIntegrationTest, StdlibDocsWildcardDottedPackage) {
+  ASSERT_OK(NotifyEndOfFile());
+
+  // A package whose *name* itself contains dots, owning a module beneath it.
+  // The stdlib docs table functions must resolve the owning package via the
+  // (package, module) pairs from the registry, not by splitting the module key
+  // on the first '.' (which would yield "dev" and fail to find the package).
+  SqlPackage pkg;
+  pkg.name = "dev.perfetto.test";
+  pkg.modules.push_back({"dev.perfetto.test.common", "SELECT 1"});
+  ASSERT_OK(Processor()->RegisterSqlPackage(pkg));
+
+  // The wildcard enumerates every registered module, including the dotted one.
+  // Before the fix this failed with "Module not found: dev.perfetto.test.common"
+  // and aborted the whole query.
+  auto it = Query("SELECT COUNT(*) AS c FROM __intrinsic_stdlib_tables('*')");
+  ASSERT_TRUE(it.Next());
+  ASSERT_OK(it.Status());
+}
+
 TEST_F(TraceProcessorIntegrationTest, PackageSameNameOverride) {
   ASSERT_OK(NotifyEndOfFile());
 

--- a/src/trace_processor/trace_database_integrationtest.cc
+++ b/src/trace_processor/trace_database_integrationtest.cc
@@ -929,8 +929,8 @@ TEST_F(TraceProcessorIntegrationTest, StdlibDocsWildcardDottedPackage) {
   ASSERT_OK(Processor()->RegisterSqlPackage(pkg));
 
   // The wildcard enumerates every registered module, including the dotted one.
-  // Before the fix this failed with "Module not found: dev.perfetto.test.common"
-  // and aborted the whole query.
+  // Before the fix this failed with "Module not found:
+  // dev.perfetto.test.common" and aborted the whole query.
   auto it = Query("SELECT COUNT(*) AS c FROM __intrinsic_stdlib_tables('*')");
   ASSERT_TRUE(it.Next());
   ASSERT_OK(it.Status());


### PR DESCRIPTION
Fixes a trace-load regression from #6437 reported by @LalitMaganti: `Module not found: dev.perfetto.test.common`.

`__intrinsic_stdlib_tables('*')` (and `_functions`/`_macros`) re-derived each module's package with `GetPackageName()`, which splits on the first `.` — fine for compiled-in stdlib (single-segment names) but wrong for runtime-registered packages with dotted names. For a `dev.perfetto.test` package, `FindPackage("dev")` returns null and the whole query aborts.

Fix: thread the package through instead of re-deriving it — the wildcard path uses the package name already returned by `GetModules()`; the single-module path uses `FindPackageForModule()` (prefix match). Adds a regression test with a dotted-name package (fails pre-fix, passes after).