### PR TITLE
Fix AddressRange creation in JitCache::MoveCode

### DIFF
--- a/src/trace_processor/importers/common/jit_cache.cc
+++ b/src/trace_processor/importers/common/jit_cache.cc
@@ -122,7 +122,8 @@ tables::JitCodeTable::Id JitCache::MoveCode(int64_t timestamp,
   functions_.erase(it);
 
   auto code_id = func.jit_code_id();
-  AddressRange new_code_range(to_code_start, old_code_range.size());
+  AddressRange new_code_range =
+      AddressRange::FromStartAndSize(to_code_start, old_code_range.size());
 
   functions_.DeleteOverlapsAndEmplace(
       [&](std::pair<const AddressRange, JittedFunction>& entry) {


### PR DESCRIPTION
JitCache::MoveCode was incorrectly constructing AddressRange by passing
the size of the old range as the 'end' argument to the AddressRange constructor.
This CL fixes it by using AddressRange::FromStartAndSize to correctly
construct the range.
