### PR TITLE
ui: open multiple traces from drag and drop and the file picker

### DIFF
--- a/ui/src/core/open_trace_files.ts
+++ b/ui/src/core/open_trace_files.ts
@@ -13,21 +13,14 @@
 // limitations under the License.
 
 import {AppImpl} from './app_impl';
-
-// Registered by the dev.perfetto.MultiTraceOpen plugin; referenced by id to
-// avoid a core -> plugin import.
-const OPEN_MULTIPLE_TRACES_COMMAND =
-  'dev.perfetto.MultiTraceOpen#openMultipleTraces';
+import {OPEN_MULTIPLE_TRACES_CMD} from '../public/exposed_commands';
 
 // Opens one or more trace files: a single file loads directly, several files
 // go through the multi-trace merge dialog.
 export function openTraceFiles(files: ReadonlyArray<File>) {
   const app = AppImpl.instance;
-  if (
-    files.length > 1 &&
-    app.commands.hasCommand(OPEN_MULTIPLE_TRACES_COMMAND)
-  ) {
-    app.commands.runCommand(OPEN_MULTIPLE_TRACES_COMMAND, files);
+  if (files.length > 1 && app.commands.hasCommand(OPEN_MULTIPLE_TRACES_CMD)) {
+    app.commands.runCommand(OPEN_MULTIPLE_TRACES_CMD, files);
   } else if (files.length > 0) {
     app.openTraceFromFile(files[0]);
   }

--- a/ui/src/core/open_trace_files.ts
+++ b/ui/src/core/open_trace_files.ts
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AppImpl} from './app_impl';
+
+// Registered by the dev.perfetto.MultiTraceOpen plugin; referenced by id to
+// avoid a core -> plugin import.
+const OPEN_MULTIPLE_TRACES_COMMAND =
+  'dev.perfetto.MultiTraceOpen#openMultipleTraces';
+
+// Opens one or more trace files: a single file loads directly, several files
+// go through the multi-trace merge dialog.
+export function openTraceFiles(files: ReadonlyArray<File>) {
+  const app = AppImpl.instance;
+  if (
+    files.length > 1 &&
+    app.commands.hasCommand(OPEN_MULTIPLE_TRACES_COMMAND)
+  ) {
+    app.commands.runCommand(OPEN_MULTIPLE_TRACES_COMMAND, files);
+  } else if (files.length > 0) {
+    app.openTraceFromFile(files[0]);
+  }
+}

--- a/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
@@ -25,6 +25,7 @@ import {exists} from '../../base/utils';
 import {JsonSettingsEditor} from '../../components/json_settings_editor';
 import QueryPagePlugin from '../../plugins/dev.perfetto.QueryPage';
 import {AppImpl} from '../../core/app_impl';
+import {openTraceFiles} from '../../core/open_trace_files';
 import {macroSchema} from '../../core/command_manager';
 import {featureFlags} from '../../core/feature_flags';
 import {OmniboxMode} from '../../core/omnibox_manager';
@@ -237,6 +238,7 @@ export default class CoreCommands implements PerfettoPlugin {
     const input = document.createElement('input');
     input.classList.add('trace_file');
     input.setAttribute('type', 'file');
+    input.setAttribute('multiple', 'multiple');
     input.style.display = 'none';
     input.addEventListener('change', onInputElementFileSelectionChanged);
     document.body.appendChild(input);
@@ -882,10 +884,10 @@ function onInputElementFileSelectionChanged(e: Event) {
     throw new Error('Not an input element');
   }
   if (!e.target.files) return;
-  const file = e.target.files[0];
+  const files = Array.from(e.target.files);
   // Reset the value so onchange will be fired with the same file.
   e.target.value = '';
 
   AppImpl.instance.analytics.logEvent('Trace Actions', 'Open trace from file');
-  AppImpl.instance.openTraceFromFile(file);
+  openTraceFiles(files);
 }

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/index.ts
@@ -15,9 +15,8 @@
 import './styles.scss';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {App} from '../../public/app';
+import {OPEN_MULTIPLE_TRACES_CMD} from '../../public/exposed_commands';
 import {showMultiTraceModal} from './multi_trace_modal';
-
-const MULTI_TRACE_COMMAND_ID = 'dev.perfetto.MultiTraceOpen#openMultipleTraces';
 
 function isFileArray(value: unknown): value is File[] {
   return Array.isArray(value) && value.every((f) => f instanceof File);
@@ -42,11 +41,15 @@ export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.MultiTraceOpen';
 
   static onActivate(app: App): void {
+    // This command is used in two contexts:
+    // 1. From the sidebar or the command palette. In this case the files
+    //    argument is undefined and we show a file picker.
+    // 2. Invoked via runCommand(...) by openTraceFiles() when the user drags
+    //    several files onto the UI or multi-selects in the "Open trace file"
+    //    picker. In this case the caller passes the files explicitly.
     app.commands.registerCommand({
-      id: MULTI_TRACE_COMMAND_ID,
+      id: OPEN_MULTIPLE_TRACES_CMD,
       name: 'Open multiple trace files',
-      // Accepts an optional list of files (e.g. from drag and drop); without
-      // one it falls back to showing a file picker.
       callback: (filesArg?: unknown) => {
         if (isFileArray(filesArg)) {
           if (filesArg.length > 0) {
@@ -58,7 +61,7 @@ export default class implements PerfettoPlugin {
       },
     });
     app.sidebar.addMenuItem({
-      commandId: MULTI_TRACE_COMMAND_ID,
+      commandId: OPEN_MULTIPLE_TRACES_CMD,
       section: 'trace_files',
       icon: 'library_books',
       // Just below "Open trace file" and above everything else.

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/index.ts
@@ -19,6 +19,10 @@ import {showMultiTraceModal} from './multi_trace_modal';
 
 const MULTI_TRACE_COMMAND_ID = 'dev.perfetto.MultiTraceOpen#openMultipleTraces';
 
+function isFileArray(value: unknown): value is File[] {
+  return Array.isArray(value) && value.every((f) => f instanceof File);
+}
+
 function openFilePickerAndShowModal() {
   const input = document.createElement('input');
   input.setAttribute('type', 'file');
@@ -41,7 +45,17 @@ export default class implements PerfettoPlugin {
     app.commands.registerCommand({
       id: MULTI_TRACE_COMMAND_ID,
       name: 'Open multiple trace files',
-      callback: () => openFilePickerAndShowModal(),
+      // Accepts an optional list of files (e.g. from drag and drop); without
+      // one it falls back to showing a file picker.
+      callback: (filesArg?: unknown) => {
+        if (isFileArray(filesArg)) {
+          if (filesArg.length > 0) {
+            showMultiTraceModal(filesArg);
+          }
+          return;
+        }
+        openFilePickerAndShowModal();
+      },
     });
     app.sidebar.addMenuItem({
       commandId: MULTI_TRACE_COMMAND_ID,

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
@@ -587,6 +587,12 @@ class MergeConfigurator implements m.ClassComponent<MergeConfiguratorAttrs> {
           autofocus: true,
           placeholder: 'machine name',
           value: machines.find((mm) => mm.id === selectedId)?.name ?? '',
+          // Select the prefilled default name so typing replaces it.
+          onfocus: (e: FocusEvent) => {
+            if (e.target instanceof HTMLInputElement) {
+              e.target.select();
+            }
+          },
           onInput: (value: string) =>
             controller.renameMachine(selectedId, value),
           // Enter or blur finishes the edit.

--- a/ui/src/frontend/file_drop_handler.ts
+++ b/ui/src/frontend/file_drop_handler.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AppImpl} from '../core/app_impl';
+import {openTraceFiles} from '../core/open_trace_files';
 
 let lastDragTarget: EventTarget | null = null;
 
@@ -39,11 +39,7 @@ export function installFileDropHandler() {
     evt.stopPropagation();
     document.body.classList.remove('filedrag');
     if (evt.dataTransfer && dragEventHasFiles(evt)) {
-      const file = evt.dataTransfer.files[0];
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      if (file) {
-        AppImpl.instance.openTraceFromFile(file);
-      }
+      openTraceFiles(Array.from(evt.dataTransfer.files));
     }
     evt.preventDefault();
   };

--- a/ui/src/public/exposed_commands.ts
+++ b/ui/src/public/exposed_commands.ts
@@ -24,3 +24,5 @@
 
 export const CRITICAL_PATH_CMD = 'dev.perfetto.CriticalPath';
 export const CRITICAL_PATH_LITE_CMD = 'dev.perfetto.CriticalPathLite';
+export const OPEN_MULTIPLE_TRACES_CMD =
+  'dev.perfetto.MultiTraceOpen#openMultipleTraces';


### PR DESCRIPTION
Dropping several files onto the UI silently opened only the first one,
and the "Open trace file" picker did not allow selecting more than one
file. Route both entry points through the multi-trace merge dialog when
more than one file is given, via the command registered by the
MultiTraceOpen plugin (referenced by id to avoid a core -> plugin
import).

Also select the prefilled "Machine N" name when the inline machine
rename field opens, so typing replaces it instead of appending to it.
