### PR TITLE
tp: ui: warn about dropped events before opening merged traces

### DIFF
--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
@@ -512,14 +512,12 @@ FtraceTokenizer::HandleFtraceClockSnapshot(
     PERFETTO_DCHECK(clock_id !=
                     ClockId::Machine(BuiltinClock::BUILTIN_CLOCK_BOOTTIME));
     int64_t ftrace_timestamp = decoder.ftrace_timestamp();
-    auto x = context_->clock_tracker->AddSnapshot({
+    context_->clock_tracker->AddSnapshot({
         ClockTracker::ClockTimestamp(clock_id, ftrace_timestamp),
         ClockTracker::ClockTimestamp(
             ClockId::Machine(BuiltinClock::BUILTIN_CLOCK_BOOTTIME),
             decoder.boot_timestamp()),
     });
-    PERFETTO_ELOG("%s", x.ok() ? "Added ftrace clock snapshot"
-                               : x.status().message().c_str());
     latest_ftrace_clock_snapshot_ts_ = ftrace_timestamp;
   }
   return clock_id;

--- a/src/trace_processor/sorter/trace_sorter.h
+++ b/src/trace_processor/sorter/trace_sorter.h
@@ -364,12 +364,15 @@ class TraceSorter::Stream {
  public:
   // Public API for tokenizers.
   void Push(int64_t ts, T data) {
-    if (PERFETTO_UNLIKELY(sorter_->event_handling_ == EventHandling::kDrop)) {
-      return;
-    }
+    // Record the negative timestamp drop even when events are dropped
+    // (tokenize-only mode): the UI's merge dialog dry-runs a tokenize-only
+    // pass and relies on this stat to warn about misconfigured offsets.
     if (PERFETTO_UNLIKELY(ts < 0)) {
       sorter_->global_stats_tracker_->IncrementGlobalStats(
           stats::trace_sorter_negative_timestamp_dropped);
+      return;
+    }
+    if (PERFETTO_UNLIKELY(sorter_->event_handling_ == EventHandling::kDrop)) {
       return;
     }
     if constexpr (std::is_same_v<T, JsonEvent>) {

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -717,7 +717,9 @@ namespace perfetto::trace_processor::stats {
       "the presence of one is usually a sign that something went wrong while " \
       "recording a trace. Common causes of this include incorrect "            \
       "incremental timestamps, bad clock synchronization or kernel bugs in "   \
-      "drivers emitting timestamps"),                                          \
+      "drivers emitting timestamps. When merging multiple traces, a clock "    \
+      "offset which moves events before the start of the trace-time clock "    \
+      "also causes this."),                                                    \
   F(slice_drop_overlapping_complete_event,        kSingle,  kError,  kAnalysis, Scope::kMachineAndTrace,   \
       "A complete slice was dropped because it partially overlaps another "    \
       "slice on the same track. Overlapping duration events are out of spec "  \

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_modal.ts
@@ -154,8 +154,10 @@ class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
         Callout,
         {intent: Intent.Warning, icon: 'warning'},
         `${verdict.droppedEvents.toLocaleString()} events would be dropped: ` +
-          'some traces share no clock with the shared timeline and will be ' +
-          'omitted. Set an explicit alignment, or check the manifest.',
+          'they cannot be placed on the shared timeline, either because ' +
+          'their trace shares no clock with it or because an offset moves ' +
+          'them before its start. Adjust the alignment, or check the ' +
+          'manifest.',
       );
     }
     return m(

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/trace_analyzer.ts
@@ -203,7 +203,8 @@ export class WasmTraceAnalyzer implements TraceAnalyzer {
         FROM stats
         WHERE name IN (
           'clock_sync_unrelatable_clock_domains',
-          'clock_sync_failure_no_path'
+          'clock_sync_failure_no_path',
+          'trace_sorter_negative_timestamp_dropped'
         )
       `);
       const it = res.iter({dropped: NUM});


### PR DESCRIPTION
The multi-trace merge dialog's alignment dry-run only summed the
clock-sync drop stats, so a fixed offset which moves events before the
start of the merged timeline reported "All traces line up" and then
silently dropped those events at load, surfacing only as a post-load
data-loss badge.

Count trace_sorter_negative_timestamp_dropped in the dry-run and make
TraceSorter record it even in tokenize-only mode, which the dry-run
uses. Also generalize the dialog's warning copy and mention the merge
offset cause in the stat's description.

Also remove a leftover debug log in FtraceTokenizer which printed a
line for every ftrace clock snapshot added.
