### PR TITLE
ui: escape regex to deal with functions and arrays

### DIFF
--- a/ui/src/components/query_flamegraph.ts
+++ b/ui/src/components/query_flamegraph.ts
@@ -40,6 +40,7 @@ import {
 } from '../widgets/flamegraph';
 import type {Trace} from '../public/trace';
 import {sqliteString} from '../base/string_utils';
+import {escapeRegexEmptyBrackets} from '../widgets/flamegraph_regex';
 import {SharedAsyncDisposable} from '../base/shared_disposable';
 import {Monitor} from '../base/monitor';
 
@@ -291,8 +292,13 @@ async function computeFlamegraphTree(
   const unaggCols = unagg.map((x) => x.name);
 
   const matchingColumns = ['name', ...unaggCols];
+  // Frame names commonly contain literal `[]` (e.g. Java arrays), which is
+  // not valid regex syntax; rewrite it so such filters match literally.
   const matchExpr = (x: string) =>
-    matchingColumns.map((c) => `(IFNULL(${c}, '') REGEXP ${sqliteString(x)})`);
+    matchingColumns.map(
+      (c) =>
+        `(IFNULL(${c}, '') REGEXP ${sqliteString(escapeRegexEmptyBrackets(x))})`,
+    );
 
   const showStackFilter =
     showStackAndPivot.length === 0

--- a/ui/src/widgets/flamegraph.ts
+++ b/ui/src/widgets/flamegraph.ts
@@ -41,6 +41,7 @@ import {
 import {MenuItem, type MenuItemAttrs, PopupMenu} from './menu';
 import {type Color, HSLColor} from '../base/color';
 import {hash} from '../base/hash';
+import {escapeRegex} from './flamegraph_regex';
 import type {MithrilEvent} from '../base/mithril_utils';
 import {Icons} from '../base/semantic_icons';
 
@@ -1217,6 +1218,9 @@ export class Flamegraph implements m.ClassComponent<FlamegraphAttrs> {
     };
     const addF = (kind: FlamegraphFilter['kind'], filter: string) =>
       applyState(addFilter(this.attrs.state, {kind, filter}));
+    // Names are literal, so escape regex metacharacters (e.g. `[]` in Java
+    // array types, `()` in function names).
+    const exactNameRegex = `^${escapeRegex(name)}$`;
     const ft = (v: FilterType) =>
       ensureExists(FILTER_TYPES.find((o) => o.value === v));
     const filterAction = (v: FilterType, execute: () => void): NodeAction => {
@@ -1251,17 +1255,17 @@ export class Flamegraph implements m.ClassComponent<FlamegraphAttrs> {
         },
       },
       filterAction('SHOW_FROM_FRAME', () =>
-        addF('SHOW_FROM_FRAME', `^${name}$`),
+        addF('SHOW_FROM_FRAME', exactNameRegex),
       ),
       filterAction('PIVOT', () =>
         applyState({
           ...this.attrs.state,
-          view: {kind: 'PIVOT', pivot: `^${name}$`},
+          view: {kind: 'PIVOT', pivot: exactNameRegex},
         }),
       ),
-      filterAction('SHOW_STACK', () => addF('SHOW_STACK', `^${name}$`)),
-      filterAction('HIDE_STACK', () => addF('HIDE_STACK', `^${name}$`)),
-      filterAction('HIDE_FRAME', () => addF('HIDE_FRAME', `^${name}$`)),
+      filterAction('SHOW_STACK', () => addF('SHOW_STACK', exactNameRegex)),
+      filterAction('HIDE_STACK', () => addF('HIDE_STACK', exactNameRegex)),
+      filterAction('HIDE_FRAME', () => addF('HIDE_FRAME', exactNameRegex)),
       {
         label: 'Copy stack',
         icon: Icons.Copy,

--- a/ui/src/widgets/flamegraph_regex.ts
+++ b/ui/src/widgets/flamegraph_regex.ts
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regex helpers for flamegraph filters. Frame names routinely contain regex
+// metacharacters (`byte[]`, `operator()`, Java lambda `$` names), which
+// break or silently mis-match when interpolated into REGEXP patterns.
+
+// Escapes all regex metacharacters so the result matches |str| literally
+// when embedded in a regular expression. Used when a known-literal frame
+// name is turned into a filter (e.g. via the node menu).
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Rewrites every bare `[]` in a user-typed filter into `\[\]`.
+//
+// Filters like `byte[]` or `.*Object[]` are common for Java heap dumps, but
+// an empty character class is either a compile error (RE2, PCRE2) or matches
+// nothing (ECMAScript). No working pattern can contain a bare `[]`, so this
+// rewrite only revives dead patterns and never changes a valid one.
+export function escapeRegexEmptyBrackets(pattern: string): string {
+  let res = '';
+  let inClass = false;
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i];
+    if (c === '\\' && i + 1 < pattern.length) {
+      res += c + pattern[i + 1];
+      i++;
+    } else if (!inClass && c === '[') {
+      if (pattern[i + 1] === ']') {
+        res += '\\[\\]';
+        i++;
+      } else {
+        inClass = true;
+        res += c;
+      }
+    } else {
+      if (inClass && c === ']') {
+        inClass = false;
+      }
+      res += c;
+    }
+  }
+  return res;
+}

--- a/ui/src/widgets/flamegraph_regex_unittest.ts
+++ b/ui/src/widgets/flamegraph_regex_unittest.ts
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {escapeRegex, escapeRegexEmptyBrackets} from './flamegraph_regex';
+
+test('flamegraph_regex.escapeRegex', () => {
+  expect(escapeRegex('byte[]')).toEqual('byte\\[\\]');
+  expect(escapeRegex('java.lang.Object[]')).toEqual(
+    'java\\.lang\\.Object\\[\\]',
+  );
+  expect(escapeRegex('operator()')).toEqual('operator\\(\\)');
+  expect(escapeRegex('std::vector<int*>')).toEqual('std::vector<int\\*>');
+  expect(escapeRegex('a$b^c|d')).toEqual('a\\$b\\^c\\|d');
+  expect(escapeRegex('plain_name')).toEqual('plain_name');
+});
+
+test('flamegraph_regex.escapeRegexEmptyBrackets', () => {
+  // Bare [] is rewritten to match literally.
+  expect(escapeRegexEmptyBrackets('byte[]')).toEqual('byte\\[\\]');
+  expect(escapeRegexEmptyBrackets('.*Object[] com\\..*')).toEqual(
+    '.*Object\\[\\] com\\..*',
+  );
+  expect(escapeRegexEmptyBrackets('[][]')).toEqual('\\[\\]\\[\\]');
+
+  // Valid regex constructs are left untouched.
+  expect(escapeRegexEmptyBrackets('[abc]+')).toEqual('[abc]+');
+  expect(escapeRegexEmptyBrackets('\\[]')).toEqual('\\[]');
+  expect(escapeRegexEmptyBrackets('\\[\\]')).toEqual('\\[\\]');
+  expect(escapeRegexEmptyBrackets('[a[]]')).toEqual('[a[]]');
+  expect(escapeRegexEmptyBrackets('[^]]')).toEqual('[^]]');
+  expect(escapeRegexEmptyBrackets('plain')).toEqual('plain');
+  expect(escapeRegexEmptyBrackets('')).toEqual('');
+
+  // Trailing backslash does not drop characters.
+  expect(escapeRegexEmptyBrackets('foo\\')).toEqual('foo\\');
+});


### PR DESCRIPTION
Arrays and function call syntax are both very common in flamegraphs but
unfortunately they cause RE2 to just straight reject our regexes leading
to crashes. Automatically escape common patterns to prevent this.
