### PR TITLE
ui: constrain multi-trace status panel to the list width

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/styles.scss
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/styles.scss
@@ -181,10 +181,12 @@
   }
 
   // Reserved status line: min-height keeps the layout stable as the state
-  // cycles through processing / verdict / ready.
+  // cycles through processing / verdict / ready. Same width as the list
+  // panel so a long verdict wraps instead of stretching the modal.
   &__status-panel {
     padding: 12px 0 4px;
     min-height: 60px;
+    width: 550px;
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
The status panel in the Open Multiple Traces dialog had no width constraint, so a long alignment verdict stretched the whole modal wider than the 550px trace list, leaving a dead gutter next to the cards. Give it the same width as the list so long verdicts wrap instead.

Follow-up to #6491, whose longer warning copy made this visible.