### PR TITLE
ui: fail the Android version preflight check on unparsable SDK version

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_platform_checks.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_platform_checks.ts
@@ -34,6 +34,16 @@ export async function* checkAndroidTarget(
       if (!status.ok) return status;
       const sdkVer = parseInt(status.value);
       const minApi = 29;
+      if (isNaN(sdkVer)) {
+        // Without this, NaN < minApi is false and the check reports a
+        // bogus pass ("API level NaN >= 29"). This happens on non-Android
+        // devices reachable over adb, where getprop is absent or empty.
+        return errResult(
+          `Could not determine the Android version: 'getprop ` +
+            `ro.build.version.sdk' returned ${JSON.stringify(status.value)}. ` +
+            `Is this an Android device?`,
+        );
+      }
       if (sdkVer < minApi) {
         return errResult(`Android API level ${minApi}+ (Q+) required`);
       }


### PR DESCRIPTION
When `getprop ro.build.version.sdk` does not return a number (e.g. a non-Android device reachable over adb, where getprop is absent or prints nothing), `parseInt()` yields NaN, `NaN < minApi` is `false`, and the preflight check reports a bogus pass: **"API level NaN >= 29"**.

This change makes the check report an explicit error instead, quoting what getprop returned, so it's clear the device's Android version could not be determined rather than pretending the check passed.

No behavior change for real Android devices: they always report a numeric SDK level, so the new `isNaN` branch never triggers for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)