### PR TITLE
tp: fix HASH(NULL) crash on heap-graph classes without a name

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
@@ -19,8 +19,11 @@ INCLUDE PERFETTO MODULE graphs.scan;
 -- Distinct classes (e.g. the same class loaded by different class loaders)
 -- have distinct type_ids but the same name; hashing the name here lets the
 -- path-hash scan coalesce them while keeping the hot loop purely int64.
+-- A class can have no name (e.g. in an incomplete/non-finalized graph), so
+-- coalesce to '' to keep HASH out of NULL (which it rejects); nameless classes
+-- collapse to one node.
 CREATE PERFETTO TABLE _heap_graph_class_name_hash AS
-SELECT id, HASH(coalesce(deobfuscated_name, name)) AS name_hash
+SELECT id, HASH(coalesce(deobfuscated_name, name, '')) AS name_hash
 FROM heap_graph_class;
 
 -- Given a table containing a "tree-ified" heap graph object table (i.e.


### PR DESCRIPTION
c4dd8ae343 ("tp: deduplicate on class name not on type id") switched the class tree from keying on type_id to hashing the class name. A class with neither a deobfuscated_name nor a name then yields HASH(NULL), which trace_processor rejects with "HASH: arg 0 has unknown type", aborting the whole _heap_graph_class_name_hash build. The class-tree flamegraph then fails to load on any heap graph that contains a nameless class -- including incomplete/non-finalized dumps, where every class is nameless.

Coalesce the name to '' before hashing: nameless classes hash to a stable bucket instead of crashing, and classes that have a name are unaffected.