### PR TITLE
ui: Add LLM core gateway plugin + chrome API provider + test chat page

### DIFF
--- a/ui/src/base/query_slot.ts
+++ b/ui/src/base/query_slot.ts
@@ -350,6 +350,32 @@ export class QuerySlot<T> {
   }
 
   /**
+   * Clear the cached result and any stored error, forcing the next use()
+   * with any key to re-run its queryFn. Unlike dispose(), the slot remains
+   * usable. Cancels any in-flight query and disposes cached AsyncDisposable
+   * data through the queue to stay synchronized with pending work.
+   */
+  invalidate(): void {
+    if (this.disposed) return;
+
+    // Cancel any in-flight query and clear pending state so the next use()
+    // reschedules from scratch.
+    if (this.currentSignal) {
+      this.currentSignal.cancelled = true;
+      this.currentSignal = undefined;
+    }
+    this.pendingKey = undefined;
+    this.error = undefined;
+
+    // Schedule cache disposal/clearing through the queue so it runs after any
+    // in-flight query settles.
+    this.queue.schedule(this, async () => {
+      await this.disposeCache();
+      this.cache = undefined;
+    });
+  }
+
+  /**
    * Dispose this slot. Cancels pending work and disposes any cached
    * AsyncDisposable through the queue to maintain synchronization.
    * Call this in component's onremove() to prevent orphaned queries.

--- a/ui/src/core/embedder/default_plugins.ts
+++ b/ui/src/core/embedder/default_plugins.ts
@@ -75,6 +75,7 @@ export const defaultPlugins = [
   'dev.perfetto.InstrumentsSamplesProfile',
   'dev.perfetto.KernelTrackEvent',
   'dev.perfetto.LinuxPerf',
+  'dev.perfetto.LlmProtocolChromePrompt',
   'dev.perfetto.MetricsPage',
   'dev.perfetto.MultiTraceOpen',
   'dev.perfetto.Notes',

--- a/ui/src/plugins/dev.perfetto.Llm/config.ts
+++ b/ui/src/plugins/dev.perfetto.Llm/config.ts
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The Provider and Model layers: pure data. A Provider picks a Protocol (by
+// id), adds connection details + an API key, and lists the Models it offers. A
+// Model is one entry in that catalog, carrying its role(s). These shapes are
+// what get persisted to settings (user-supplied providers) or pushed down by an
+// extension server, so they're defined as zod schemas - one declaration buys us
+// the TypeScript types and the runtime validation of stored/pushed data.
+
+import {z} from 'zod';
+
+// A model's role guides where it can be used:
+// - agentic models can be used converstaionally and use tools.
+// - flash models are more for smaller tasks such as summarizing information.
+export const MODEL_ROLES = ['agentic', 'flash'] as const;
+export type ModelRole = (typeof MODEL_ROLES)[number];
+
+// One entry in a provider's catalog.
+export const MODEL_SCHEMA = z.object({
+  // Stable id, unique within the provider. Used in the selected-model pointer.
+  id: z.string(),
+  // Human-readable label for the picker.
+  label: z.string().optional(),
+  // The backend's own model name, e.g. 'gemini-2.5-flash'.
+  modelName: z.string(),
+  // The role(s) this model fills.
+  roles: z.array(z.enum(MODEL_ROLES)),
+});
+export type Model = z.infer<typeof MODEL_SCHEMA>;
+
+// A configured source of models. References a protocol by id and carries the
+// credential bag that protocol's credentialFields describe.
+export const PROVIDER_SCHEMA = z.object({
+  // Stable id, unique across all providers. Used in the selected-model pointer.
+  id: z.string(),
+  // Which protocol to talk through, e.g. 'gemini'.
+  protocol: z.string(),
+  // Human-readable label for the picker.
+  label: z.string().optional(),
+  // Credential bag keyed by the protocol's CredentialField.key. API keys live
+  // here; mark the field secret in the protocol so export can strip it.
+  credentials: z
+    .record(z.string(), z.string().meta({secret: true}))
+    .default({}),
+  // The models this provider surfaces.
+  models: z.array(MODEL_SCHEMA).default([]),
+});
+export type Provider = z.infer<typeof PROVIDER_SCHEMA>;
+
+// The persisted shape of the user's provider settings: a flat list. (Selected
+// model is stored separately; see store.ts.)
+export const PROVIDERS_SETTING_SCHEMA = z.array(PROVIDER_SCHEMA).default([]);
+export type ProvidersSetting = z.infer<typeof PROVIDERS_SETTING_SCHEMA>;

--- a/ui/src/plugins/dev.perfetto.Llm/gateway.ts
+++ b/ui/src/plugins/dev.perfetto.Llm/gateway.ts
@@ -1,0 +1,220 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The LLM gateway: owns all three config layers (Protocol -> Provider ->
+// Model) and exposes LLM capabilities to other plugins. This is the object the
+// Intelletto assistant (and any future LLM consumer - summarisers, SQL
+// autocomplete) talks to. It is deliberately app-scoped (not trace-scoped):
+// configuration is independent of any loaded trace.
+
+import type {Setting} from '../../public/settings';
+import type {Request, Protocol, StreamEvent, AvailableModel} from './protocol';
+import type {ModelRole, Provider, ProvidersSetting} from './config';
+
+// Fully qualified path to a model containing providerId/modelId.
+export interface ModelPath {
+  readonly providerId: string;
+  readonly modelId: string;
+}
+
+// Return result from listModels() - contains more in-depth information about
+// the provider and the models.
+export interface ModelDetails {
+  readonly model: {
+    readonly id: string;
+    readonly label?: string;
+    readonly modelName: string; // The name of the model at the protcol level
+    readonly roles: readonly ModelRole[];
+  };
+  readonly provider: {
+    readonly id: string;
+    readonly label?: string;
+    readonly protocolName: string;
+  };
+}
+
+export class LlmGateway {
+  // Protocols registered by plugins. Keyed by protocol id.
+  private readonly protocols = new Map<string, Protocol>();
+
+  // Providers pushed in at runtime rather than configured by the user: a
+  // protocol plugin offering its on-device model with zero config, or a
+  // connected extension server advertising its models. Held in memory only
+  // (never persisted), and not editable/removable in settings - whoever pushed
+  // them owns their lifetime. Keyed by id.
+  private readonly staticProviders = new Map<string, Provider>();
+
+  constructor(
+    // User-supplied providers (persisted to settings).
+    private readonly userProvidersSetting: Setting<ProvidersSetting>,
+  ) {}
+
+  // --- Protocol registry -----------------------------------------------------
+
+  /**
+   * Register a protocol (a backend integration, e.g. Gemini or an OpenAI-
+   * compatible API). Typically called from a protocol plugin's onActivate.
+   *
+   * @param protocol The protocol to register.
+   * @throws Error if a protocol with the same id is already registered.
+   */
+  registerProtocol(protocol: Protocol): void {
+    if (this.protocols.has(protocol.id)) {
+      throw new Error(`LLM protocol "${protocol.id}" already registered`);
+    }
+    this.protocols.set(protocol.id, protocol);
+  }
+
+  /**
+   * Look up a registered protocol by id.
+   *
+   * @param id The protocol id.
+   * @returns The protocol, or undefined if none is registered under that id.
+   */
+  getProtocol(id: string): Protocol | undefined {
+    return this.protocols.get(id);
+  }
+
+  /**
+   * List all registered protocols.
+   *
+   * @returns The registered protocols, in registration order.
+   */
+  listProtocols(): readonly Protocol[] {
+    return Array.from(this.protocols.values());
+  }
+
+  // --- Providers and Models --------------------------------------------------
+
+  /**
+   * Push a provider supplied at runtime rather than by the user: a protocol
+   * plugin's zero-config on-device model, or an extension server's advertised
+   * models. Surfaced automatically alongside user providers but never persisted
+   * and non-removable from settings. Typically called from a plugin's
+   * onActivate (guard with a runtime feature-detection so an unusable backend
+   * never gets registered), or when an extension server connects.
+   *
+   * @param provider The provider to register.
+   * @throws Error if a provider with the same id is already registered.
+   */
+  registerProvider(provider: Provider): void {
+    if (this.staticProviders.has(provider.id)) {
+      throw new Error(`LLM provider "${provider.id}" already registered`);
+    }
+    this.staticProviders.set(provider.id, provider);
+  }
+
+  /**
+   * The flat, concatenated provider list (user settings + runtime-pushed
+   * providers). No precedence: a logical model appearing in more than one
+   * source is just multiple entries.
+   *
+   * @returns All providers - user-configured first, then runtime-pushed.
+   */
+  listProviders(): readonly Provider[] {
+    return [
+      ...this.userProvidersSetting.get(),
+      ...this.staticProviders.values(),
+    ];
+  }
+
+  /**
+   * Ask a provider's backend which models it can serve. The settings UI uses
+   * this to populate the model-name combobox.
+   *
+   * @param providerId The id of the provider to query.
+   * @param signal Optional abort signal to cancel the request.
+   * @returns The available models, or undefined if the provider's protocol
+   *   isn't registered or doesn't support listing.
+   * @throws Rethrows network/auth errors so the caller can surface them.
+   */
+  async listAvailableModels(
+    providerId: string,
+    signal?: AbortSignal,
+  ): Promise<readonly AvailableModel[] | undefined> {
+    const provider = this.listProviders().find(({id}) => id === providerId);
+    if (!provider) return undefined;
+    const protocol = this.protocols.get(provider?.protocol);
+    if (!protocol?.listModels) return undefined;
+    return protocol.listModels(provider.credentials, signal);
+  }
+
+  // --- Model selection -------------------------------------------------------
+
+  /**
+   * Every (provider, model) pair across all providers - the flat list a picker
+   * renders. Providers whose protocol isn't registered are skipped.
+   *
+   * @returns One entry per configured model, with its provider details.
+   */
+  listModels(): readonly ModelDetails[] {
+    const out: ModelDetails[] = [];
+    for (const provider of this.listProviders()) {
+      // Look up the protocol in order to get the default protocol name
+      const protocol = this.listProtocols().find(
+        (p) => provider.protocol === p.id,
+      );
+      if (!protocol) continue;
+
+      for (const model of provider.models) {
+        out.push({
+          provider: {...provider, protocolName: protocol.label},
+          model,
+        });
+      }
+    }
+    return out;
+  }
+
+  // --- Running a turn --------------------------------------------------------
+
+  /**
+   * Start a new turn and stream back the result.
+   *
+   * This function is stateless - the full converstation history must be passed
+   * in every time. This reflects the statelesss nature of the vast majority of
+   * the backend APIs.
+   *
+   * @param model Fully qualified provider/model ids to use for this request.
+   * @param request System prompt, previous messages, and tool definitions.
+   * @param signal The abort signal called when we want to cancel the message.
+   * @yields StreamEvents as the turn progresses (incremental text, thoughts,
+   *   tool calls, usage, and a terminal stop event).
+   */
+  async *createStream(
+    model: ModelPath,
+    request: Request,
+    signal: AbortSignal,
+  ): AsyncGenerator<StreamEvent, void, void> {
+    // Find the provider config
+    const providers = this.listProviders();
+    const provider = providers.find((p) => p.id === model.providerId);
+    if (!provider) return undefined;
+
+    // Find the model config in that provider config
+    const modelInfo = provider.models.find((m) => m.id === model.modelId);
+    if (!modelInfo) return undefined;
+
+    // Look up the protocol listend in the provider config
+    const protocol = this.protocols.get(provider.protocol);
+    if (!protocol) return undefined;
+
+    yield* protocol.createStream(
+      modelInfo.modelName,
+      request,
+      provider.credentials,
+      signal,
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Llm/index.ts
+++ b/ui/src/plugins/dev.perfetto.Llm/index.ts
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// dev.perfetto.Llm - the common LLM gateway plugin. It owns the
+// Protocol/Provider/Model config and exposes an LlmGateway to other plugins
+// (the Intelletto assistant, and any future LLM consumer). Protocol plugins
+// register their protocol against the gateway; consumer plugins ask it for a
+// model handle to run a turn.
+
+import m from 'mithril';
+import {ensureExists} from '../../base/assert';
+import type {App} from '../../public/app';
+import type {PerfettoPlugin} from '../../public/plugin';
+import type {Setting} from '../../public/settings';
+import {PROVIDERS_SETTING_SCHEMA, type ProvidersSetting} from './config';
+import {LlmGateway} from './gateway';
+import {LlmSettings} from './settings_ui';
+
+export default class LlmPlugin implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.Llm';
+  static readonly description =
+    'Common LLM gateway. Owns Protocol/Provider/Model configuration and ' +
+    'exposes LLM capabilities to other plugins (e.g. the Intelletto ' +
+    'assistant). Protocol plugins register against it; consumers ask it for ' +
+    'a model to run.';
+
+  // The gateway is app-scoped: configuration is independent of any loaded
+  // trace, and protocol plugins register in onActivate (also pre-trace). We
+  // expose it via a static accessor so dependent plugins can reach it without
+  // a trace, mirroring how the gateway's own settings are app-level.
+  private static gatewayInstance?: LlmGateway;
+
+  private static providersSetting: Setting<ProvidersSetting>;
+
+  static onActivate(app: App): void {
+    // User-supplied providers. Persisted to local storage via settings.
+    // Credentials (API keys) are stored in plaintext - a conscious choice; see
+    // the RFC's credential-handling notes (the browser offers no storage that
+    // resists XSS, and it's the user's own key on their own machine). This is
+    // configurable directly from the settings page via the custom renderer
+    // below, which is driven off each protocol's declared credential fields.
+    LlmPlugin.providersSetting = app.settings.register({
+      id: `${LlmPlugin.id}#Providers`,
+      name: 'LLM providers',
+      description:
+        'LLM providers available to the assistant and other LLM features. ' +
+        'Each provider picks a protocol (e.g. Gemini), supplies its ' +
+        'credentials, and lists the models it offers.',
+      schema: PROVIDERS_SETTING_SCHEMA,
+      defaultValue: [],
+      // The renderer reads LlmPlugin.gateway at draw time (long after
+      // onActivate), so the gateway being constructed below is available.
+      render: (setting) =>
+        m(LlmSettings, {gateway: LlmPlugin.gateway, setting}),
+    });
+
+    LlmPlugin.gatewayInstance = new LlmGateway(LlmPlugin.providersSetting);
+  }
+
+  // Accessor for dependent plugins (protocol providers and consumers). Throws
+  // if called before onActivate, which can't happen for a plugin that declares
+  // a dependency on this one (dependencies activate first).
+  static get gateway(): LlmGateway {
+    return ensureExists(
+      LlmPlugin.gatewayInstance,
+      'LLM gateway accessed before dev.perfetto.Llm was activated',
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Llm/protocol.ts
+++ b/ui/src/plugins/dev.perfetto.Llm/protocol.ts
@@ -1,0 +1,195 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The Protocol layer: the code-behind that knows how to talk to a *kind* of
+// LLM API (gemini, anthropic, openai-compatible, ...). A protocol is provided
+// by a plugin and registered with the gateway; one protocol backs many
+// providers (see provider.ts). The rest of the gateway, and consumers like the
+// Intelletto assistant, only ever deal in the neutral request/response shapes
+// defined here - they never see a backend's native wire format.
+
+import type {z} from 'zod';
+
+// --- Neutral conversation shapes ---------------------------------------------
+
+// A neutral tool definition, as the model sees it. The Protocol is responsible
+// for down-converting `inputSchema` into whatever subset of JSON Schema the
+// backend accepts.
+export interface ToolDef {
+  readonly name: string;
+  readonly description: string;
+  // Authored in zod; the protocol converts to the backend's native schema.
+  readonly inputSchema: z.ZodType;
+}
+
+// One model->user message asking to invoke a tool.
+export interface ToolCall {
+  // Backend-specific id used to thread the result back to this call. Some
+  // backends (Gemini) key on the tool name instead of an id; protocols that
+  // don't need an id leave it undefined.
+  readonly id?: string;
+  readonly name: string;
+  readonly args: Record<string, unknown>;
+  // Opaque, protocol-private blob the consumer must carry through history and
+  // hand back unchanged when re-sending this call. Used by backends that
+  // require state to be echoed verbatim on the next request - e.g. Gemini's
+  // `thoughtSignature`, which the API rejects requests for if dropped. Other
+  // protocols leave it undefined and ignore it.
+  readonly signature?: string;
+}
+
+// The user->model result of a previously-requested tool call.
+export interface ToolResult {
+  readonly id?: string;
+  readonly name: string;
+  // The serialised tool output (or an error string the model can recover from).
+  readonly result: string;
+  readonly isError?: boolean;
+}
+
+// One entry in the conversation history. The consumer owns the history and
+// resends it on every request (LLM endpoints are stateless).
+export type Message =
+  | {readonly role: 'user'; readonly text: string}
+  | {readonly role: 'model'; readonly text: string}
+  | {readonly role: 'tool-call'; readonly calls: readonly ToolCall[]}
+  | {
+      readonly role: 'tool-result';
+      readonly results: readonly ToolResult[];
+    };
+
+// A complete request handed to the protocol. Everything the backend needs to
+// produce the next turn.
+export interface Request {
+  readonly systemPrompt: string;
+  readonly messages: readonly Message[];
+  readonly tools: readonly ToolDef[];
+}
+
+// --- Streamed response events ------------------------------------------------
+
+// Token usage, normalised across backends. Any field a backend doesn't report
+// is left undefined.
+export interface TokenUsage {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly totalTokens?: number;
+}
+
+// Why a turn stopped. Backends report a zoo of finish reasons; we collapse them
+// into this set.
+export type StopReason =
+  | 'end' // The model finished its turn normally.
+  | 'tool-calls' // The model wants to call tools and is waiting on results.
+  | 'length' // Hit the output-token limit.
+  | 'error'; // Aborted by a backend error (see NeutralError).
+
+// Normalised backend error categories. Surfaced to the user in the chat.
+export type ErrorKind =
+  | 'rate-limit'
+  | 'auth'
+  | 'context-length'
+  | 'network'
+  | 'unknown';
+
+export interface Error {
+  readonly kind: ErrorKind;
+  readonly message: string;
+}
+
+// The incremental events a protocol emits while streaming one turn. A turn is a
+// sequence of these ending in exactly one `stop`.
+export type StreamEvent =
+  // Incremental assistant text.
+  | {readonly type: 'text'; readonly text: string}
+  // Incremental "thinking" text, where the backend exposes it. Kept separate so
+  // consumers can show or hide it independently of the answer.
+  | {readonly type: 'thought'; readonly text: string}
+  // A fully-formed tool call the model wants executed.
+  | {readonly type: 'tool-call'; readonly call: ToolCall}
+  // Token accounting for the turn (may arrive incrementally; last one wins).
+  | {readonly type: 'usage'; readonly usage: TokenUsage}
+  // Terminal event. `error` is set iff reason === 'error'.
+  | {
+      readonly type: 'stop';
+      readonly reason: StopReason;
+      readonly error?: Error;
+    };
+
+// --- What a protocol declares about itself -----------------------------------
+
+export interface ProtocolCapabilities {
+  // Whether the backend natively supports tool/function calling. If false the
+  // gateway/consumer would have to emulate it via prompt injection (not done in
+  // Phase 1 - all Phase 1 protocols are native).
+  readonly nativeToolCalling: boolean;
+  // Whether the backend streams responses incrementally.
+  readonly streaming: boolean;
+}
+
+// Describes the credential/connection form a provider for this protocol needs.
+// The settings UI renders a field per entry; the protocol declares its shape so
+// the gateway never has to know about any specific backend's login form.
+export interface CredentialField {
+  readonly key: string;
+  readonly label: string;
+  // `secret` fields are masked in the UI and flagged for any future
+  // settings-export stripping (see settings.ts `.meta({secret: true})`).
+  readonly secret?: boolean;
+  readonly required?: boolean;
+  readonly placeholder?: string;
+}
+
+// One model the backend reports it can serve, as returned by listModels(). Just
+// the backend's own model identifier (e.g. 'gemini-2.5-flash') for now - the
+// settings UI uses these to populate the model-name combobox.
+export interface AvailableModel {
+  readonly name: string;
+}
+
+// The contract a protocol implementation must satisfy. Implemented by protocol
+// plugins (e.g. dev.perfetto.LlmProtocolGemini) and registered with the gateway
+// via registerProtocol().
+export interface Protocol {
+  // Stable id referenced by providers, e.g. 'gemini'.
+  readonly id: string;
+  // Human-readable name for the settings UI, e.g. 'Google Gemini'.
+  readonly label: string;
+  readonly capabilities: ProtocolCapabilities;
+  // The credential fields a provider using this protocol must supply.
+  readonly credentialFields: readonly CredentialField[];
+
+  // Ask the backend which models it can serve, using the provider's
+  // credentials. Optional: a protocol that has no models endpoint (or doesn't
+  // implement it) simply omits this, and the settings UI falls back to a
+  // free-text model name. Throws on a network/auth error so the caller can
+  // tell "couldn't reach the backend" from "backend served an empty list".
+  listModels?(
+    credentials: Readonly<Record<string, string>>,
+    signal?: AbortSignal,
+  ): Promise<readonly AvailableModel[]>;
+
+  // Take a neutral request and stream back a normalised response. The protocol
+  // owns translating tool defs/calls/results to and from the backend's native
+  // format and normalising errors into a terminal `stop` event (it must not
+  // throw for backend errors - it emits {type:'stop', reason:'error'} so the
+  // consumer can render it in the chat). `credentials` is the provider's
+  // configured credential bag (keyed by CredentialField.key).
+  createStream(
+    model: string,
+    request: Request,
+    credentials: Readonly<Record<string, string>>,
+    signal?: AbortSignal,
+  ): AsyncGenerator<StreamEvent, void, void>;
+}

--- a/ui/src/plugins/dev.perfetto.Llm/settings.scss
+++ b/ui/src/plugins/dev.perfetto.Llm/settings.scss
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-llm-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 720px;
+
+  &__empty {
+    color: var(--pf-color-text-muted);
+    font-style: italic;
+  }
+}
+
+.pf-llm-provider {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--pf-color-border);
+  border-radius: 8px;
+  background-color: var(--pf-color-background-secondary);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    .pf-text-input {
+      flex: 1;
+    }
+  }
+
+  &__warning {
+    color: var(--pf-color-danger);
+    font-size: 0.9em;
+  }
+
+  &__models-label {
+    font-weight: bold;
+    margin-top: 4px;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+}
+
+.pf-llm-models-status-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: normal;
+}
+
+.pf-llm-models-status {
+  font-size: 0.85em;
+  font-style: italic;
+  color: var(--pf-color-text-muted);
+
+  &--error {
+    color: var(--pf-color-danger);
+    cursor: help;
+  }
+}
+
+.pf-llm-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+
+  &__label {
+    font-size: 0.85em;
+    color: var(--pf-color-text-muted);
+  }
+}
+
+.pf-llm-model {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .pf-text-input {
+    flex: 1;
+  }
+
+  // The model-name combobox wraps its input in a Popup; make the wrapper flex
+  // like the sibling text inputs so the row lays out evenly.
+  &__name {
+    flex: 1;
+  }
+
+  &__roles {
+    display: flex;
+    gap: 8px;
+  }
+
+  &__role {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    font-size: 0.85em;
+    white-space: nowrap;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Llm/settings_ui.ts
+++ b/ui/src/plugins/dev.perfetto.Llm/settings_ui.ts
@@ -1,0 +1,357 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The settings-page UI for the LLM gateway: configure providers (pick a
+// protocol, fill in its credential fields, list the models to surface) and pick
+// the default model. Rendered inline on the settings page via the custom
+// `render` hook on the gateway's settings (see index.ts). The provider form is
+// data-driven off each protocol's declared `credentialFields`, so the gateway
+// never hard-codes any backend's login form.
+
+import './settings.scss';
+import m from 'mithril';
+import {uuidv4} from '../../base/uuid';
+import type {Setting} from '../../public/settings';
+import {Button, ButtonVariant} from '../../widgets/button';
+import {Combobox} from '../../widgets/combobox';
+import {Select} from '../../widgets/select';
+import {TextInput} from '../../widgets/text_input';
+import type {LlmGateway} from './gateway';
+import {
+  MODEL_ROLES,
+  type Model,
+  type ModelRole,
+  type Provider,
+  type ProvidersSetting,
+} from './config';
+import {Checkbox} from '../../widgets/checkbox';
+import {assertIsInstance} from '../../base/assert';
+import {QuerySlot} from '../../base/query_slot';
+
+type ModelFetchResult =
+  | {readonly status: 'done'; readonly models: readonly string[]}
+  // 'unsupported' = the protocol can't list models; fall back to free text with
+  // no suggestions. 'error' = it tried and failed (bad key, unreachable, ...).
+  | {readonly status: 'unsupported'}
+  | {readonly status: 'error'; readonly message: string};
+
+// Returns the current fetch state for a provider's available models, kicking off
+// a background fetch (and a redraw on completion) if none is in flight for the
+// current key.
+async function fetchAvailableModels(
+  gateway: LlmGateway,
+  provider: Provider,
+  signal?: AbortSignal,
+): Promise<ModelFetchResult> {
+  try {
+    const models = await gateway.listAvailableModels(provider.id, signal);
+    if (models === undefined) {
+      return {status: 'unsupported'};
+    } else {
+      return {status: 'done', models: models.map((mm) => mm.name)};
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return {status: 'error', message};
+  }
+}
+
+// Read-modify-write a provider list immutably. The setting persists on set().
+function update(
+  setting: Setting<ProvidersSetting>,
+  fn: (providers: Provider[]) => Provider[],
+): void {
+  const next = fn([...setting.get()]);
+  setting.set(next);
+}
+
+function patchProvider(
+  setting: Setting<ProvidersSetting>,
+  id: string,
+  fn: (p: Provider) => Provider,
+): void {
+  update(setting, (providers) =>
+    providers.map((p) => (p.id === id ? fn(p) : p)),
+  );
+}
+
+// --- The providers editor ----------------------------------------------------
+
+interface LlmSettingsAttrs {
+  readonly gateway: LlmGateway;
+  readonly setting: Setting<ProvidersSetting>;
+}
+
+export function LlmSettings(): m.Component<LlmSettingsAttrs> {
+  return {
+    view({attrs}: m.Vnode<LlmSettingsAttrs>) {
+      const {gateway, setting} = attrs;
+      const protocols = gateway.listProtocols();
+      const providers = setting.get();
+
+      return m(
+        '.pf-llm-settings',
+        providers.length === 0
+          ? m('.pf-llm-settings__empty', 'No providers configured yet.')
+          : providers.map((provider) =>
+              m(ProviderEditor, {gateway, setting, provider}),
+            ),
+        protocols.length === 0
+          ? m(
+              '.pf-llm-settings__empty',
+              'No LLM protocols are registered. Enable a protocol plugin (e.g. ' +
+                'dev.perfetto.LlmProtocolGemini) to add providers.',
+            )
+          : m(Button, {
+              label: 'Add provider',
+              icon: 'add',
+              variant: ButtonVariant.Filled,
+              onclick: () => {
+                // New providers default to the first registered protocol.
+                const protocol = protocols[0];
+                update(setting, (ps) => [
+                  ...ps,
+                  {
+                    id: uuidv4(),
+                    protocol: protocol.id,
+                    credentials: {},
+                    models: [],
+                  },
+                ]);
+              },
+            }),
+      );
+    },
+  };
+}
+
+interface ProviderEditorAttrs {
+  readonly gateway: LlmGateway;
+  readonly setting: Setting<ProvidersSetting>;
+  readonly provider: Provider;
+}
+
+function ProviderEditor(): m.Component<ProviderEditorAttrs> {
+  const modelsSlot = new QuerySlot<ModelFetchResult>();
+
+  return {
+    view({attrs}: m.Vnode<ProviderEditorAttrs>) {
+      const {gateway, setting, provider} = attrs;
+      const protocol = gateway.getProtocol(provider.protocol);
+
+      const availableModels = modelsSlot.use({
+        key: [provider.protocol, provider.credentials],
+        // TODO: wire the QuerySlot's CancellationSignal through to
+        // fetchAvailableModels' AbortSignal so in-flight fetches are actually
+        // cancelled when the key changes.
+        queryFn: () => fetchAvailableModels(gateway, provider),
+      });
+
+      let status: m.Children = null;
+      let modelsToPick: readonly string[] = [];
+      const models = availableModels.data;
+      if (!models) {
+        status = m('span.pf-llm-models-status', 'fetching available models…');
+      } else {
+        if (models.status === 'done') {
+          status = m(
+            'span.pf-llm-models-status',
+            `${models.models.length} models available`,
+          );
+          modelsToPick = models.models;
+        } else if (models.status === 'error') {
+          status = m(
+            'span.pf-llm-models-status.pf-llm-models-status--error',
+            {title: models.message},
+            'couldn’t fetch models — type the name manually',
+          );
+        } else if (models.status === 'unsupported') {
+          status = m(
+            'span.pf-llm-models-status',
+            `This protocol doesn't support listing models`,
+          );
+        }
+      }
+
+      const modelStatusRow = m(
+        'span.pf-llm-models-status-row',
+        status,
+        models?.status !== 'unsupported' &&
+          m(Button, {
+            icon: 'refresh',
+            title: 'Refresh available models',
+            onclick: () => {
+              modelsSlot.invalidate();
+            },
+          }),
+      );
+
+      return m(
+        '.pf-llm-provider',
+        m(
+          '.pf-llm-provider__header',
+          m(TextInput, {
+            value: provider.label,
+            placeholder: 'Provider label',
+            oninput: (e: Event) => {
+              assertIsInstance(e.target, HTMLInputElement);
+              const value = e.target.value;
+              patchProvider(setting, provider.id, (p) => ({
+                ...p,
+                label: value,
+              }));
+            },
+          }),
+          m(
+            Select,
+            {
+              value: provider.protocol,
+              onchange: (e: Event) =>
+                patchProvider(setting, provider.id, (p) => ({
+                  ...p,
+                  protocol: (e.target as HTMLSelectElement).value,
+                  // Credentials are protocol-specific; clear on protocol change.
+                  credentials: {},
+                })),
+            },
+            gateway
+              .listProtocols()
+              .map((pr) => m('option', {value: pr.id}, pr.label)),
+          ),
+          m(Button, {
+            icon: 'delete',
+            title: 'Remove provider',
+            onclick: () =>
+              update(setting, (ps) => ps.filter((p) => p.id !== provider.id)),
+          }),
+        ),
+
+        // Credential fields, driven by the protocol's declaration.
+        protocol === undefined
+          ? m(
+              '.pf-llm-provider__warning',
+              `Protocol "${provider.protocol}" is not registered. Enable its ` +
+                'plugin or pick another protocol.',
+            )
+          : protocol.credentialFields.map((field) =>
+              m('.pf-llm-field', [
+                m('label.pf-llm-field__label', field.label),
+                m(TextInput, {
+                  value: provider.credentials[field.key] ?? '',
+                  type: field.secret ? 'password' : 'text',
+                  placeholder: field.placeholder ?? '',
+                  oninput: (e: Event) =>
+                    patchProvider(setting, provider.id, (p) => ({
+                      ...p,
+                      credentials: {
+                        ...p.credentials,
+                        [field.key]: (e.target as HTMLInputElement).value,
+                      },
+                    })),
+                }),
+              ]),
+            ),
+
+        // The model catalog.
+        m('.pf-llm-provider__models-label', 'Models', modelStatusRow),
+        provider.models.map((model) =>
+          renderModelRow(setting, provider, model, modelsToPick),
+        ),
+        m(Button, {
+          label: 'Add model',
+          icon: 'add',
+          onclick: () =>
+            patchProvider(setting, provider.id, (p) => ({
+              ...p,
+              models: [
+                ...p.models,
+                {
+                  id: uuidv4(),
+                  modelName: '',
+                  roles: ['agentic', 'flash'],
+                },
+              ],
+            })),
+        }),
+      );
+    },
+  };
+}
+
+function renderModelRow(
+  setting: Setting<ProvidersSetting>,
+  provider: Provider,
+  model: Model,
+  availableModels: readonly string[],
+): m.Children {
+  const patchModel = (fn: (m: Model) => Model) =>
+    patchProvider(setting, provider.id, (p) => ({
+      ...p,
+      models: p.models.map((m) => (m.id === model.id ? fn(m) : m)),
+    }));
+
+  const toggleRole = (role: ModelRole) =>
+    patchModel((mdl) => ({
+      ...mdl,
+      roles: mdl.roles.includes(role)
+        ? mdl.roles.filter((r) => r !== role)
+        : [...mdl.roles, role],
+    }));
+
+  return m(
+    '.pf-llm-model',
+    m(TextInput, {
+      value: model.label,
+      placeholder: 'Display label',
+      oninput: (e: Event) =>
+        patchModel((mdl) => ({
+          ...mdl,
+          label: (e.target as HTMLInputElement).value,
+        })),
+    }),
+    // The backend model name. A combobox: suggestions come from the provider's
+    // listModels() when available, but the input stays free-text so a name the
+    // backend didn't advertise (or any backend that can't list) still works.
+    m(Combobox, {
+      className: 'pf-llm-model__name',
+      value: model.modelName,
+      placeholder: 'Backend model name, e.g. gemini-2.5-flash',
+      suggestions: availableModels,
+      onChange: (value: string) =>
+        patchModel((mdl) => ({...mdl, modelName: value})),
+    }),
+    m(
+      '.pf-llm-model__roles',
+      MODEL_ROLES.map((role) =>
+        m(
+          'label.pf-llm-model__role',
+          m(Checkbox, {
+            label: role,
+            checked: model.roles.includes(role),
+            onchange: () => toggleRole(role),
+          }),
+        ),
+      ),
+    ),
+    m(Button, {
+      icon: 'delete',
+      title: 'Remove model',
+      onclick: () =>
+        patchProvider(setting, provider.id, (p) => ({
+          ...p,
+          models: p.models.filter((m) => m.id !== model.id),
+        })),
+    }),
+  );
+}

--- a/ui/src/plugins/dev.perfetto.LlmProtocolChromePrompt/chrome_prompt_protocol.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolChromePrompt/chrome_prompt_protocol.ts
@@ -1,0 +1,495 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A Protocol backed by Chrome's experimental built-in Prompt API (the
+// `LanguageModel` global), which runs an on-device Gemma-based model ("Gemini
+// Nano") entirely in the browser - no network, no API key, no data leaving the
+// machine. Requires a recent Chrome with the feature enabled (chrome://flags ->
+// "Prompt API for Gemini Nano", or an origin trial). See
+// https://developer.chrome.com/docs/ai/prompt-api.
+//
+// The API has no native function calling, so tool use is *emulated*: tool
+// definitions are injected into the system prompt and the model is asked to
+// reply with a JSON object when it wants to call a tool, which we parse back
+// out. This is best-effort - small local models are unreliable tool callers -
+// but it lets the on-device model participate in the same agent loop as the
+// cloud protocols. Plain (tool-free) chat streams normally.
+
+import {z} from 'zod';
+import type {
+  AvailableModel,
+  CredentialField,
+  Message,
+  Request,
+  ToolCall,
+  ToolDef,
+  Protocol,
+  ProtocolCapabilities,
+  StreamEvent,
+} from '../dev.perfetto.Llm/protocol';
+import type {Provider} from '../dev.perfetto.Llm/config';
+
+// --- The Prompt API surface (the subset we use) ------------------------------
+// These globals aren't in the TS DOM lib yet, so we declare the shapes we touch.
+
+type Availability =
+  | 'unavailable'
+  | 'downloadable'
+  | 'downloading'
+  | 'available';
+
+interface LanguageModelMessage {
+  readonly role: 'system' | 'user' | 'assistant';
+  readonly content: string;
+}
+
+interface LanguageModelParams {
+  readonly defaultTopK: number;
+  readonly maxTopK: number;
+  readonly defaultTemperature: number;
+  readonly maxTemperature: number;
+}
+
+interface DownloadMonitor {
+  addEventListener(
+    type: 'downloadprogress',
+    cb: (e: {readonly loaded: number}) => void,
+  ): void;
+}
+
+// What languages we expect to read/write. Chrome warns (and may degrade
+// quality / safety attestation) if the output language is left unspecified.
+interface ExpectedLanguages {
+  readonly type: 'text';
+  readonly languages: ReadonlyArray<string>;
+}
+
+interface CreateOptions {
+  readonly initialPrompts?: ReadonlyArray<LanguageModelMessage>;
+  readonly temperature?: number;
+  readonly topK?: number;
+  readonly signal?: AbortSignal;
+  readonly monitor?: (m: DownloadMonitor) => void;
+  readonly expectedInputs?: ReadonlyArray<ExpectedLanguages>;
+  readonly expectedOutputs?: ReadonlyArray<ExpectedLanguages>;
+}
+
+interface LanguageModelSession {
+  prompt(input: string, opts?: {signal?: AbortSignal}): Promise<string>;
+  promptStreaming(
+    input: string,
+    opts?: {signal?: AbortSignal},
+  ): ReadableStream<string>;
+  destroy(): void;
+}
+
+interface LanguageModelStatic {
+  availability(): Promise<Availability>;
+  params(): Promise<LanguageModelParams>;
+  create(opts?: CreateOptions): Promise<LanguageModelSession>;
+}
+
+function getLanguageModel(): LanguageModelStatic | undefined {
+  return (globalThis as {LanguageModel?: LanguageModelStatic}).LanguageModel;
+}
+
+// Cheap synchronous feature-detection: is the Prompt API global present at all?
+// The plugin uses this to decide whether to push the zero-config provider - no
+// point offering a model this browser can't run. Finer-grained availability
+// ('downloadable' vs 'available') is async and handled at stream time.
+export function isChromePromptApiPresent(): boolean {
+  return getLanguageModel() !== undefined;
+}
+
+const NOT_AVAILABLE_MSG =
+  'The Chrome built-in Prompt API (LanguageModel) is not available in this ' +
+  'browser. It needs a recent Chrome with on-device AI enabled (see ' +
+  'chrome://flags -> "Prompt API for Gemini Nano").';
+
+// --- Tool-call emulation -----------------------------------------------------
+
+// Build the system-prompt addendum that teaches the model our tool protocol.
+function buildToolInstructions(tools: ReadonlyArray<ToolDef>): string {
+  const lines = ['You can call tools to help answer. The available tools are:'];
+  for (const t of tools) {
+    // Inline, self-contained JSON Schema (draft 2020-12) so the model sees the
+    // exact argument shape. zod 4's native converter; `target` keeps it free of
+    // $ref/$defs the model would have to chase.
+    const schema = z.toJSONSchema(t.inputSchema, {target: 'draft-2020-12'}) as {
+      $schema?: unknown;
+    };
+    delete schema.$schema;
+    lines.push(
+      `- ${t.name}: ${t.description}\n  arguments JSON Schema: ` +
+        JSON.stringify(schema),
+    );
+  }
+  lines.push(
+    'To call a tool, reply with ONLY a single JSON object and nothing else, ' +
+      'no prose and no markdown code fences:\n' +
+      '{"tool_call": {"name": "<tool name>", "arguments": { <args> }}}\n' +
+      'To answer the user directly, reply in plain text and do NOT output ' +
+      'any JSON. Call at most one tool per reply.',
+  );
+  return lines.join('\n\n');
+}
+
+// Flatten the neutral history into a single transcript string. The Prompt API
+// is multi-turn, but flattening sidesteps its role-alternation constraints
+// (which our emulated tool-call/tool-result turns would otherwise trip) and is
+// plenty for a small model. The system prompt is passed separately, via
+// initialPrompts, not here.
+function messagesToTranscript(messages: ReadonlyArray<Message>): string {
+  const parts: string[] = [];
+  for (const msg of messages) {
+    switch (msg.role) {
+      case 'user':
+        parts.push(`User: ${msg.text}`);
+        break;
+      case 'model':
+        parts.push(`Assistant: ${msg.text}`);
+        break;
+      case 'tool-call':
+        for (const c of msg.calls) {
+          parts.push(
+            `Assistant: ${JSON.stringify({
+              tool_call: {name: c.name, arguments: c.args},
+            })}`,
+          );
+        }
+        break;
+      case 'tool-result':
+        for (const r of msg.results) {
+          const tag = r.isError ? 'Tool error' : 'Tool result';
+          parts.push(`${tag} (${r.name}): ${r.result}`);
+        }
+        break;
+    }
+  }
+  // Cue the model to produce the next assistant turn.
+  parts.push('Assistant:');
+  return parts.join('\n\n');
+}
+
+// Strip a leading/trailing ```...``` markdown fence, if present.
+function stripFences(text: string): string {
+  const t = text.trim();
+  const fence = /^```(?:json)?\s*\n?([\s\S]*?)\n?```$/i.exec(t);
+  return fence ? fence[1].trim() : t;
+}
+
+// Return the first brace-balanced `{...}` substring, ignoring braces inside
+// strings. Lets us recover a tool call even if the model wrapped it in prose.
+function firstJsonObject(text: string): string | undefined {
+  const start = text.indexOf('{');
+  if (start === -1) return undefined;
+  let depth = 0;
+  let inStr = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inStr) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === '{') depth++;
+    else if (ch === '}' && --depth === 0) return text.slice(start, i + 1);
+  }
+  return undefined;
+}
+
+// Try to read an emulated tool call out of the model's reply. Returns undefined
+// if the reply isn't a (valid, known) tool call - in which case it's an answer.
+function extractToolCall(
+  text: string,
+  toolNames: ReadonlySet<string>,
+): ToolCall | undefined {
+  const cleaned = stripFences(text);
+  for (const candidate of [cleaned, firstJsonObject(cleaned)]) {
+    if (candidate === undefined) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+    const tc =
+      (obj as {tool_call?: unknown; toolCall?: unknown})?.tool_call ??
+      (obj as {toolCall?: unknown})?.toolCall;
+    if (tc === undefined || tc === null || typeof tc !== 'object') continue;
+    const name = (tc as {name?: unknown}).name;
+    if (typeof name !== 'string' || !toolNames.has(name)) continue;
+    const rawArgs =
+      (tc as {arguments?: unknown}).arguments ?? (tc as {args?: unknown}).args;
+    const args =
+      typeof rawArgs === 'object' && rawArgs !== null
+        ? (rawArgs as Record<string, unknown>)
+        : {};
+    return {name, args};
+  }
+  return undefined;
+}
+
+// --- Error normalisation -----------------------------------------------------
+
+function errorEvent(e: unknown): StreamEvent {
+  // Chrome surfaces these as DOMExceptions with a `name`. Map the ones we know.
+  const name = (e as {name?: string})?.name;
+  let kind: 'rate-limit' | 'auth' | 'context-length' | 'network' | 'unknown';
+  switch (name) {
+    case 'QuotaExceededError':
+      kind = 'context-length';
+      break;
+    case 'NotAllowedError':
+      kind = 'auth';
+      break;
+    default:
+      kind = 'unknown';
+  }
+  return {
+    type: 'stop',
+    reason: 'error',
+    error: {kind, message: `Chrome Prompt API error: ${String(e)}`},
+  };
+}
+
+// --- The protocol ------------------------------------------------------------
+
+const CAPABILITIES: ProtocolCapabilities = {
+  // No native function calling - emulated via prompt injection (see header).
+  nativeToolCalling: false,
+  streaming: true,
+};
+
+// Local on-device model: nothing to configure.
+const CREDENTIAL_FIELDS: ReadonlyArray<CredentialField> = [];
+
+// The zero-config provider this protocol contributes when the Prompt API is
+// present. Pushed into the gateway by the plugin so the assistant has a working
+// model out of the box on a capable Chrome, with no key and no settings.
+export const CHROME_PROMPT_BUILTIN_PROVIDER: Provider = {
+  id: 'chrome-prompt-builtin',
+  protocol: 'chrome-prompt',
+  label: 'Chrome',
+  credentials: {},
+  models: [
+    {
+      id: 'gemini-nano',
+      label: 'Gemini Nano',
+      modelName: 'gemini-nano',
+      // Backs both the assistant and cheap/background tasks so zero-config
+      // covers every consumer role.
+      roles: ['flash'],
+    },
+  ],
+};
+
+export class ChromePromptProtocol implements Protocol {
+  readonly id = 'chrome-prompt';
+  readonly label = 'Chrome built-in (on-device Gemini Nano)';
+  readonly capabilities = CAPABILITIES;
+  readonly credentialFields = CREDENTIAL_FIELDS;
+
+  // No models endpoint - the browser picks the device model. Surface a single
+  // logical entry, gated on the API actually being usable, so the settings UI
+  // can offer it (and reports clearly when it can't).
+  async listModels(): Promise<ReadonlyArray<AvailableModel>> {
+    const lm = getLanguageModel();
+    if (lm === undefined) throw new Error(NOT_AVAILABLE_MSG);
+    const availability = await lm.availability();
+    if (availability === 'unavailable') {
+      throw new Error('The on-device model is unavailable on this device.');
+    }
+    return [{name: 'gemini-nano'}];
+  }
+
+  async *createStream(
+    _modelName: string,
+    request: Request,
+    _credentials: Readonly<Record<string, string>>,
+    signal?: AbortSignal,
+  ): AsyncGenerator<StreamEvent, void, void> {
+    const lm = getLanguageModel();
+    if (lm === undefined) {
+      yield {
+        type: 'stop',
+        reason: 'error',
+        error: {kind: 'unknown', message: NOT_AVAILABLE_MSG},
+      };
+      return;
+    }
+
+    let availability: Availability;
+    try {
+      availability = await lm.availability();
+    } catch (e) {
+      yield errorEvent(e);
+      return;
+    }
+    if (availability === 'unavailable') {
+      yield {
+        type: 'stop',
+        reason: 'error',
+        error: {
+          kind: 'unknown',
+          message: 'The on-device model is unavailable on this device.',
+        },
+      };
+      return;
+    }
+
+    const hasTools = request.tools.length > 0;
+    const systemPrompt = hasTools
+      ? `${request.systemPrompt}\n\n${buildToolInstructions(request.tools)}`
+      : request.systemPrompt;
+    const toolNames = new Set(request.tools.map((t) => t.name));
+
+    const createOpts: {
+      initialPrompts: LanguageModelMessage[];
+      signal?: AbortSignal;
+      temperature?: number;
+      topK?: number;
+      monitor?: (m: DownloadMonitor) => void;
+      expectedInputs?: ReadonlyArray<ExpectedLanguages>;
+      expectedOutputs?: ReadonlyArray<ExpectedLanguages>;
+    } = {
+      initialPrompts: [{role: 'system', content: systemPrompt}],
+      signal,
+      // Declare English in/out. The model is English-only in practice, and
+      // leaving the output language unset makes Chrome warn and may hurt
+      // quality / safety attestation.
+      expectedInputs: [{type: 'text', languages: ['en']}],
+      expectedOutputs: [{type: 'text', languages: ['en']}],
+    };
+
+    // First use on a machine downloads the model (hundreds of MB). Give the
+    // user a heads-up and log progress; there's no neutral progress event.
+    if (availability !== 'available') {
+      yield {
+        type: 'thought',
+        text: 'Downloading the on-device model (first use only); this may take a while…',
+      };
+      createOpts.monitor = (m) =>
+        m.addEventListener('downloadprogress', (e) =>
+          console.log(
+            `[chrome-prompt] model download ${Math.round(e.loaded * 100)}%`,
+          ),
+        );
+    }
+
+    let session: LanguageModelSession;
+    try {
+      session = await lm.create(createOpts);
+    } catch (e) {
+      if (signal?.aborted) return;
+      yield errorEvent(e);
+      return;
+    }
+
+    try {
+      const input = messagesToTranscript(request.messages);
+
+      if (!hasTools) {
+        // Plain chat: stream tokens straight through.
+        yield* this.streamText(session, input, signal);
+        if (!signal?.aborted) yield {type: 'stop', reason: 'end'};
+        return;
+      }
+
+      // Tool mode: stream text, but if the reply opens like a JSON object (or a
+      // fenced block) treat it as a (silent) tool call and buffer until we can
+      // parse it - so we never leak the call JSON into the chat as text.
+      let acc = '';
+      let mode: 'undecided' | 'text' | 'json' = 'undecided';
+      try {
+        for await (const chunk of this.streamChunks(session, input, signal)) {
+          acc += chunk;
+          if (mode === 'undecided') {
+            const lead = acc.replace(/^\s+/, '');
+            if (lead === '') continue; // still only whitespace
+            if (lead.startsWith('{') || lead.startsWith('```')) {
+              mode = 'json';
+            } else {
+              mode = 'text';
+              yield {type: 'text', text: acc};
+            }
+          } else if (mode === 'text') {
+            yield {type: 'text', text: chunk};
+          }
+          // 'json' mode: keep buffering silently.
+        }
+      } catch (e) {
+        if (signal?.aborted) return;
+        yield errorEvent(e);
+        return;
+      }
+
+      if (signal?.aborted) return;
+
+      if (mode === 'json') {
+        const call = extractToolCall(acc, toolNames);
+        if (call !== undefined) {
+          yield {type: 'tool-call', call};
+          yield {type: 'stop', reason: 'tool-calls'};
+          return;
+        }
+        // Looked like JSON but wasn't a known tool call - surface as text.
+        yield {type: 'text', text: stripFences(acc)};
+      }
+      yield {type: 'stop', reason: 'end'};
+    } finally {
+      session.destroy();
+    }
+  }
+
+  // Stream a turn as plain `text` events.
+  private async *streamText(
+    session: LanguageModelSession,
+    input: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<StreamEvent, void, void> {
+    try {
+      for await (const chunk of this.streamChunks(session, input, signal)) {
+        yield {type: 'text', text: chunk};
+      }
+    } catch (e) {
+      if (signal?.aborted) return;
+      yield errorEvent(e);
+    }
+  }
+
+  // Read the promptStreaming ReadableStream chunk by chunk. Chunks are
+  // incremental text deltas.
+  private async *streamChunks(
+    session: LanguageModelSession,
+    input: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<string, void, void> {
+    const stream = session.promptStreaming(input, {signal});
+    const reader = stream.getReader();
+    try {
+      for (;;) {
+        if (signal?.aborted) return;
+        const {value, done} = await reader.read();
+        if (done) break;
+        if (value) yield value;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}

--- a/ui/src/plugins/dev.perfetto.LlmProtocolChromePrompt/index.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolChromePrompt/index.ts
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// dev.perfetto.LlmProtocolChromePrompt - registers the 'chrome-prompt' protocol
+// with the common LLM gateway. This protocol talks to Chrome's experimental
+// built-in Prompt API (the `LanguageModel` global), an on-device Gemma-based
+// model that runs entirely in the browser with no network or API key. Add a
+// provider pointing at this protocol to use it. Tool calling is emulated, so it
+// works best for plain chat / light tool use.
+
+import type {App} from '../../public/app';
+import type {PerfettoPlugin} from '../../public/plugin';
+import LlmPlugin from '../dev.perfetto.Llm';
+import {
+  ChromePromptProtocol,
+  CHROME_PROMPT_BUILTIN_PROVIDER,
+  isChromePromptApiPresent,
+} from './chrome_prompt_protocol';
+
+export default class LlmProtocolChromePromptPlugin implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.LlmProtocolChromePrompt';
+  static readonly description =
+    "Registers the 'chrome-prompt' LLM protocol (Chrome's built-in on-device " +
+    'Prompt API / Gemini Nano) with the dev.perfetto.Llm gateway. Runs ' +
+    'locally in the browser - no network or API key.';
+  static readonly dependencies = [LlmPlugin];
+
+  static onActivate(_app: App): void {
+    LlmPlugin.gateway.registerProtocol(new ChromePromptProtocol());
+    // Zero-config: if this browser actually exposes the Prompt API, push a
+    // ready-to-use provider so the assistant has a working on-device model with
+    // no key and no settings. Gated on the API being present so we don't offer a
+    // model that can't run.
+    if (isChromePromptApiPresent()) {
+      LlmPlugin.gateway.registerProvider(CHROME_PROMPT_BUILTIN_PROVIDER);
+    }
+  }
+}

--- a/ui/src/plugins/dev.perfetto.LlmTestChat/index.ts
+++ b/ui/src/plugins/dev.perfetto.LlmTestChat/index.ts
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// dev.perfetto.LlmTestChat - a minimal, tool-free chat page for exercising the
+// LLM gateway on its own, without the Intelletto assistant on top. Dev-only and
+// off by default: it registers a page (#!/llm_chat) only when the
+// 'llmTestChatPage' flag is enabled, so it costs nothing otherwise.
+
+import m from 'mithril';
+import type {App} from '../../public/app';
+import type {PerfettoPlugin} from '../../public/plugin';
+import LlmPlugin from '../dev.perfetto.Llm';
+import {LlmTestChatPage} from './test_chat_page';
+
+export default class LlmTestChatPlugin implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.LlmTestChat';
+  static readonly description =
+    'Dev-only chat page (#!/llm_chat) that talks directly to the ' +
+    'dev.perfetto.Llm gateway, for testing providers without the assistant. ' +
+    'Enable the "llmTestChatPage" flag to show it.';
+  static readonly dependencies = [LlmPlugin];
+
+  static onActivate(app: App): void {
+    const gateway = LlmPlugin.gateway;
+    app.pages.registerPage({
+      route: '/llm_chat',
+      render: () => m(LlmTestChatPage, {gateway}),
+    });
+    app.sidebar.addMenuItem({
+      section: 'support',
+      text: 'LLM test chat',
+      href: '#!/llm_chat',
+      icon: 'forum',
+    });
+  }
+}

--- a/ui/src/plugins/dev.perfetto.LlmTestChat/test_chat_page.scss
+++ b/ui/src/plugins/dev.perfetto.LlmTestChat/test_chat_page.scss
@@ -1,0 +1,128 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-llm-test-chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 16px;
+  gap: 12px;
+  box-sizing: border-box;
+  font-family: var(--pf-font-family, sans-serif);
+
+  &__header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+
+    h1 {
+      margin: 0;
+      font-size: 18px;
+    }
+  }
+
+  &__model {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    color: var(--pf-color-text-muted, #666);
+    font-size: 13px;
+  }
+
+  &__model--none {
+    color: var(--pf-color-danger);
+    font-size: 13px;
+  }
+
+  &__transcript {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 8px;
+    border: 1px solid var(--pf-color-border, #ddd);
+    border-radius: 4px;
+    background: var(--pf-color-surface, #fafafa);
+  }
+
+  &__empty {
+    color: #999;
+    font-style: italic;
+    margin: auto;
+  }
+
+  &__msg {
+    display: grid;
+    grid-template-columns: 56px 1fr auto;
+    gap: 8px;
+    align-items: start;
+
+    &--user .pf-llm-test-chat__role {
+      color: #1565c0;
+    }
+    &--model .pf-llm-test-chat__role {
+      color: #2e7d32;
+    }
+  }
+
+  &__role {
+    font-size: 11px;
+    text-transform: uppercase;
+    font-weight: 600;
+    padding-top: 2px;
+  }
+
+  &__text {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  &__spinner {
+    align-self: center;
+  }
+
+  &__thought {
+    display: grid;
+    grid-template-columns: 56px 1fr;
+    gap: 8px;
+    align-items: start;
+    opacity: 0.6;
+    font-style: italic;
+
+    .pf-llm-test-chat__role {
+      color: #6a1b9a;
+    }
+    .pf-llm-test-chat__text {
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  }
+
+  &__error {
+    color: #b71c1c;
+    font-size: 13px;
+    white-space: pre-wrap;
+  }
+
+  &__composer {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  &__input {
+    flex: 1;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.LlmTestChat/test_chat_page.ts
+++ b/ui/src/plugins/dev.perfetto.LlmTestChat/test_chat_page.ts
@@ -1,0 +1,288 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A deliberately minimal chat page for exercising the LLM gateway on its own,
+// without the Intelletto assistant (or any tool-calling) on top. Plain
+// user<->model turns against the default 'conversational' model, streamed live.
+// It's the smallest thing that proves the whole stack - provider selection,
+// protocol, streaming, error normalisation - works end to end. Registered only
+// when the dev-only 'llmTestChatPage' flag is on (see index.ts).
+
+import './test_chat_page.scss';
+import m from 'mithril';
+import {Button} from '../../widgets/button';
+import {Select} from '../../widgets/select';
+import {Spinner} from '../../widgets/spinner';
+import {TextInput} from '../../widgets/text_input';
+import type {LlmGateway, ModelDetails} from '../dev.perfetto.Llm/gateway';
+import type {Message} from '../dev.perfetto.Llm/protocol';
+import {assertTrue} from '../../base/assert';
+import {maybeUndefined} from '../../base/utils';
+
+// A stable key for a (provider, model) pair, used as the <select> value.
+function modelKey(rm: ModelDetails): string {
+  return `${rm.provider.id}/${rm.model.id}`;
+}
+
+const SYSTEM_PROMPT = 'For testing only';
+
+export interface LlmTestChatPageAttrs {
+  readonly gateway: LlmGateway;
+}
+
+export class LlmTestChatPage implements m.ClassComponent<LlmTestChatPageAttrs> {
+  // The committed conversation history (what we resend on every turn).
+  private readonly history: Message[] = [];
+  // The model the user picked from the dropdown (a modelKey). Undefined means
+  // "follow the gateway's default conversational model".
+  private selectedModel?: {providerId: string; modelId: string};
+  // Draft in the input box.
+  private draft = '';
+  // The model turn currently being streamed in, if any (not yet in history).
+  private streamingText?: string;
+  // Live "thinking"/reasoning for the in-flight turn, where the backend exposes
+  // it. Shown dimmed while streaming; not committed to history (NeutralMessage
+  // doesn't carry it), so it clears when the turn finishes.
+  private streamingThought?: string;
+  // A normalised error from the last turn, shown inline.
+  private error?: string;
+  // Lets the user abort an in-flight turn.
+  private abort?: AbortController;
+
+  // The model to chat with: the user's dropdown pick if it's still valid,
+  // otherwise the gateway's default conversational model (falling back to the
+  // first model of any kind so flash-only setups still work).
+  private activeModel(gateway: LlmGateway): ModelDetails | undefined {
+    const models = gateway.listModels();
+    if (this.selectedModel !== undefined) {
+      const sm = this.selectedModel;
+      const picked = models.find(
+        (rm) => rm.model.id === sm.modelId && rm.provider.id === sm.providerId,
+      );
+      if (picked !== undefined) return picked;
+    }
+
+    // If no model is specifically chosen, just return the first one
+    const firstModel = maybeUndefined(models[0]);
+    return firstModel;
+  }
+
+  view({attrs}: m.CVnode<LlmTestChatPageAttrs>): m.Children {
+    const {gateway} = attrs;
+    const activeModel = this.activeModel(gateway);
+    const busy = this.abort !== undefined;
+
+    return m(
+      '.pf-llm-test-chat',
+      m(
+        '.pf-llm-test-chat__header',
+        m('h1', 'LLM gateway test chat'),
+        this.renderModelPicker(gateway, activeModel, busy),
+      ),
+      this.renderTranscript(),
+      this.renderComposer(gateway, activeModel !== undefined, busy),
+    );
+  }
+
+  private renderModelPicker(
+    gateway: LlmGateway,
+    active: ModelDetails | undefined,
+    busy: boolean,
+  ): m.Children {
+    const models = gateway.listModels();
+    if (models.length === 0) {
+      return m(
+        'span.pf-llm-test-chat__model--none',
+        'No models available - configure a provider in settings, or enable ' +
+          'Chrome’s on-device Prompt API.',
+      );
+    }
+
+    // A lookup table of models keyed by some string we can use to dump into the
+    // select options keys
+    const mapOfModels = new Map(
+      models.map((model) => [modelKey(model), model]),
+    );
+
+    return m(
+      'label.pf-llm-test-chat__model',
+      'Model:',
+      m(
+        Select,
+        {
+          disabled: busy,
+          value: active !== undefined ? modelKey(active) : '',
+          onchange: (e: Event) => {
+            assertTrue(e.target instanceof HTMLSelectElement);
+            const key = e.target.value;
+            const modelFromMap = mapOfModels.get(key);
+            assertTrue(modelFromMap); // Safe to assume this is true as the map is generated every frame
+            this.selectedModel = {
+              modelId: modelFromMap.model.id,
+              providerId: modelFromMap.provider.id,
+            };
+          },
+        },
+        Array.from(mapOfModels).map(([key, rm]) => {
+          const protocolName = rm.provider.label ?? rm.provider.protocolName;
+          const modelName = rm.model.label || rm.model.modelName;
+          const label = `${protocolName}/${modelName}`;
+          return m('option', {value: key}, label);
+        }),
+      ),
+    );
+  }
+
+  private renderTranscript(): m.Children {
+    const rows: m.Children[] = this.history.map((msg) =>
+      this.renderMessage(msg),
+    );
+    if (
+      this.streamingThought !== undefined &&
+      this.streamingThought.length > 0
+    ) {
+      rows.push(
+        m(
+          '.pf-llm-test-chat__thought',
+          m('.pf-llm-test-chat__role', 'thinking'),
+          m('.pf-llm-test-chat__text', this.streamingThought),
+        ),
+      );
+    }
+    if (this.streamingText !== undefined) {
+      rows.push(
+        this.renderBubble('model', this.streamingText, /* streaming */ true),
+      );
+    }
+    if (this.error !== undefined) {
+      rows.push(m('.pf-llm-test-chat__error', `Error: ${this.error}`));
+    }
+    if (rows.length === 0) {
+      rows.push(m('.pf-llm-test-chat__empty', 'Send a message to start.'));
+    }
+    return m('.pf-llm-test-chat__transcript', rows);
+  }
+
+  private renderMessage(msg: Message): m.Children {
+    // This page never sends tools, so only user/model turns occur; render any
+    // unexpected tool turns as JSON so nothing is silently swallowed.
+    if (msg.role === 'user' || msg.role === 'model') {
+      return this.renderBubble(msg.role, msg.text, false);
+    }
+    return this.renderBubble('model', JSON.stringify(msg), false);
+  }
+
+  private renderBubble(
+    role: 'user' | 'model',
+    text: string,
+    streaming: boolean,
+  ): m.Children {
+    return m(
+      `.pf-llm-test-chat__msg.pf-llm-test-chat__msg--${role}`,
+      m('.pf-llm-test-chat__role', role),
+      m('.pf-llm-test-chat__text', text),
+      streaming && m(Spinner, {className: 'pf-llm-test-chat__spinner'}),
+    );
+  }
+
+  private renderComposer(
+    gateway: LlmGateway,
+    haveModel: boolean,
+    busy: boolean,
+  ): m.Children {
+    return m(
+      '.pf-llm-test-chat__composer',
+      m(TextInput, {
+        className: 'pf-llm-test-chat__input',
+        placeholder: 'Type a message and press Enter…',
+        value: this.draft,
+        disabled: busy || !haveModel,
+        autofocus: true,
+        onInput: (v: string) => (this.draft = v),
+        onkeydown: (e: KeyboardEvent) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            this.send(gateway);
+          }
+        },
+      }),
+      busy
+        ? m(Button, {
+            label: 'Stop',
+            onclick: () => this.abort?.abort(),
+          })
+        : m(Button, {
+            label: 'Send',
+            disabled: !haveModel || this.draft.trim().length === 0,
+            onclick: () => this.send(gateway),
+          }),
+      m(Button, {
+        label: 'Clear',
+        disabled: busy || this.history.length === 0,
+        onclick: () => {
+          this.history.length = 0;
+          this.error = undefined;
+        },
+      }),
+    );
+  }
+
+  private async send(gateway: LlmGateway): Promise<void> {
+    const text = this.draft.trim();
+    if (text.length === 0 || this.abort !== undefined) return;
+
+    const activeModel = this.activeModel(gateway);
+    if (!activeModel) return; // Do nothing if there is no model selected
+
+    this.history.push({role: 'user', text});
+    this.draft = '';
+    this.error = undefined;
+    this.streamingText = '';
+    this.streamingThought = undefined;
+    this.abort = new AbortController();
+
+    try {
+      const stream = gateway.createStream(
+        {
+          providerId: activeModel.provider.id,
+          modelId: activeModel.model.id,
+        },
+        {systemPrompt: SYSTEM_PROMPT, messages: this.history, tools: []},
+        this.abort.signal,
+      );
+      for await (const ev of stream) {
+        // This is a test/debug page - dump every stream event so the raw
+        // protocol output can be inspected in the devtools console.
+        console.log('[llm-test-chat] stream event', ev);
+        if (ev.type === 'text') {
+          this.streamingText = (this.streamingText ?? '') + ev.text;
+        } else if (ev.type === 'thought') {
+          this.streamingThought = (this.streamingThought ?? '') + ev.text;
+        } else if (ev.type === 'stop' && ev.reason === 'error') {
+          this.error = ev.error?.message ?? 'Unknown error';
+        }
+        m.redraw();
+      }
+    } finally {
+      // Commit whatever text we streamed (even a partial turn on abort/error).
+      if (this.streamingText !== undefined && this.streamingText.length > 0) {
+        this.history.push({role: 'model', text: this.streamingText});
+      }
+      this.streamingText = undefined;
+      this.streamingThought = undefined;
+      this.abort = undefined;
+      m.redraw();
+    }
+  }
+}

--- a/ui/src/widgets/combobox.scss
+++ b/ui/src/widgets/combobox.scss
@@ -31,7 +31,7 @@
 
   &.pf-highlight {
     background: var(--pf-color-primary);
-    color: var(--pf-on-color-primary);
+    color: var(--pf-color-text-on-primary);
   }
 }
 


### PR DESCRIPTION
This patch adds the following plugins:
- **dev.perfetto.Llm**: A common entry point for which other plugins can access language model functionality, and protocol provider plugins can register their protocols against.
- **dev.perfetto.LlmProtocolChromePrompt**: A language model provider exposing the Chrome Prompt API (on-device gemini nano model) as an LLM provider. This plugin also registers gemini-nano as a *static* provider & model, which will appear as an ever present option not available to user configuration (this is the same way that extension servers will register hard coded configurations). In the future we may disable this entire plugin, but for now it makes sense to keep it enabled and present for testing.
- **dev.perfetto.LlmTestChat**: A very simple test chatbot style page used for testing the API. No tools, just allows chatting with the model for the sake of testing.

RFC: https://github.com/google/perfetto/discussions/6241

Note - the LLM core registries are kept as plugins for now rather than merge into the UI core. This is to keep things cleaner while we're still working out the kinks in the protocol, and will be subsumed into the core at some point in the future.

Testing:
- In chrome, enable the prompt API `chrome://flags/#prompt-api-for-gemini-nano` if not enabled by default.
- Enable the dev.perfetto.LlmTestChat plugin
- Under `Support` in the sidebar, click the LLM test chat page
<img width="303" height="236" alt="image" src="https://github.com/user-attachments/assets/037e3408-1e16-4b18-bf45-875990b4dbd2" />
