### PR TITLE
ui: Add Intelletto assistant plugin

### DIFF
--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -16,7 +16,7 @@ import {AsyncLimiter} from '../base/async_limiter';
 import {defer} from '../base/deferred';
 import {ensureExists, assertTrue} from '../base/assert';
 import {ServiceWorkerController} from '../frontend/service_worker_controller';
-import type {App} from '../public/app';
+import type {App, Route} from '../public/app';
 import type {SqlPackage} from '../public/extra_sql_packages';
 import type {FeatureFlagManager, FlagSettings} from '../public/feature_flag';
 import type {Raf} from '../public/raf';
@@ -284,6 +284,10 @@ export class AppImpl implements App {
 
   navigate(newHash: string): void {
     Router.navigate(newHash);
+  }
+
+  getCurrentRoute(): Route {
+    return Router.getCurrentRoute();
   }
 
   addSqlPackages(

--- a/ui/src/core/router.ts
+++ b/ui/src/core/router.ts
@@ -15,6 +15,7 @@
 import m from 'mithril';
 import {assertTrue} from '../base/assert';
 import {type RouteArgs, ROUTE_SCHEMA} from '../public/route_schema';
+import type {Route} from '../public/app';
 
 export const ROUTE_PREFIX = '#!';
 
@@ -37,16 +38,6 @@ export const ROUTE_PREFIX = '#!';
 function safeParseRoute(rawRoute: unknown): RouteArgs {
   const res = ROUTE_SCHEMA.safeParse(rawRoute);
   return res.success ? res.data : {};
-}
-
-// A broken down representation of a route.
-// For instance: #!/record/gpu?local_cache_key=a0b1
-// becomes: {page: '/record', subpage: '/gpu', args: {local_cache_key: 'a0b1'}}
-export interface Route {
-  page: string;
-  subpage: string;
-  fragment: string;
-  args: RouteArgs;
 }
 
 // This router does two things:

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -57,6 +57,7 @@ import type {TraceStream} from '../public/stream';
 import type {OmniboxModeDescriptor} from '../public/omnibox';
 import type {SidePanelManagerImpl} from './side_panel_manager';
 import type {SidePanelTabDescriptor} from '../public/side_panel';
+import type {Route} from '../public/app';
 
 /**
  * This implementation provides the plugin access to trace related resources,
@@ -320,6 +321,10 @@ export class TraceImpl implements Trace, Disposable {
 
   navigate(newHash: string): void {
     this.app.navigate(newHash);
+  }
+
+  getCurrentRoute(): Route {
+    return this.app.getCurrentRoute();
   }
 
   openTraceFromFile(file: File) {

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -32,7 +32,7 @@ import {maybeShowErrorDialog} from './error_dialog';
 import {installFileDropHandler} from './file_drop_handler';
 import {HomePage} from './home_page';
 import {postMessageHandler} from './post_message_handler';
-import {type Route, Router} from '../core/router';
+import {Router} from '../core/router';
 import {checkHttpRpcConnection} from './rpc_http_dialog';
 import {maybeOpenTraceFromRoute} from './trace_url_handler';
 import {HttpRpcEngine} from '../trace_processor/http_rpc_engine';
@@ -64,6 +64,7 @@ import {
 } from '../core/command_manager';
 import {type HotkeyConfig, HotkeyContext} from '../widgets/hotkey_context';
 import {sleepMs} from '../base/utils';
+import type {Route} from '../public/app';
 
 // =============================================================================
 // UI INITIALIZATION STAGES

--- a/ui/src/frontend/trace_url_handler.ts
+++ b/ui/src/frontend/trace_url_handler.ts
@@ -17,9 +17,10 @@ import {tryGetTrace} from '../core/cache_manager';
 import {showModal} from '../widgets/modal';
 import {loadPermalink} from './permalink';
 import {loadAndroidBugToolInfo} from './android_bug_tool';
-import {type Route, Router} from '../core/router';
+import {Router} from '../core/router';
 import {taskTracker} from './task_tracker';
 import {AppImpl} from '../core/app_impl';
+import type {Route} from '../public/app';
 
 function getCurrentTraceUrl(): undefined | string {
   const source = AppImpl.instance.trace?.traceInfo.source;

--- a/ui/src/plugins/dev.perfetto.Intelletto/agent.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/agent.ts
@@ -12,14 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The agent loop: the multi-step tool-use harness that sits on top of the LLM
-// gateway. The gateway stays a single request/response; the loop lives here, in
-// the consumer. One user turn drives: call the model -> if it asked for tools,
-// run them -> feed results back -> repeat, until the model answers with no tool
-// calls or the iteration cap is hit. The loop also owns lazy tool loading: it
-// starts with a bootstrap set (list_tools/more_tools) and grows the tool list
-// as the model asks, so not every tool schema sits in every request.
-
 import {z} from 'zod';
 import type {LlmGateway, ModelPath} from '../dev.perfetto.Llm/gateway';
 import type {
@@ -64,17 +56,23 @@ export class Agent {
   // endpoints are stateless and we resend it every request.
   private history: Message[] = [];
 
+  /**
+   * @param gateway - The LLM gateway used to drive the model.
+   * @param tools - The registry of tools available to the model.
+   * @param systemPrompt - The system prompt sent on every request.
+   * @param eagerTools - When true (the default), every tool definition is sent
+   *     on every request and the list_tools/more_tools meta-tools are omitted.
+   *     The lazy scheme (discover via list_tools, provision via more_tools) is
+   *     an optimisation for *large* tool sets, but the indirection reliably
+   *     trips up smaller / local models - they loop calling more_tools instead
+   *     of the real tool. We only have a handful of core tools, so eager is
+   *     both simpler and more robust. Flip this off once the tool count makes
+   *     eager loading expensive.
+   */
   constructor(
     private readonly gateway: LlmGateway,
     private readonly tools: ToolRegistry,
     private readonly systemPrompt: string,
-    // When true (the default), every tool definition is sent on every request
-    // and the list_tools/more_tools meta-tools are omitted. The lazy scheme
-    // (discover via list_tools, provision via more_tools) is an optimisation
-    // for *large* tool sets, but the indirection reliably trips up smaller /
-    // local models - they loop calling more_tools instead of the real tool. We
-    // only have a handful of core tools, so eager is both simpler and more
-    // robust. Flip this off once the tool count makes eager loading expensive.
     private readonly eagerTools: boolean = true,
   ) {}
 
@@ -82,15 +80,20 @@ export class Agent {
     this.history = [];
   }
 
-  // Run one user turn to completion, yielding events as they stream. Honours
-  // `signal` for cancellation: an aborted turn stops cleanly and what completed
-  // stays in the history (the transcript stays truthful).
-  //
-  // `dequeueFollowUp` implements queued follow-ups: it is polled once at the
-  // top of each tool-use round, and any message it returns is appended to the
-  // history as a user message, so something the user typed mid-loop ("oh wait,
-  // also check X") reaches the model at the next round without any
-  // interruption machinery.
+  /**
+   * Run one user turn to completion, yielding events as they stream.
+   *
+   * @param userText - The user's message for this turn.
+   * @param signal - Optional cancellation signal. An aborted turn stops
+   *     cleanly and what completed stays in the history (the transcript stays
+   *     truthful).
+   * @param dequeueFollowUp - Implements queued follow-ups: it is polled once at
+   *     the top of each tool-use round, and any message it returns is appended
+   *     to the history as a user message, so something the user typed mid-loop
+   *     ("oh wait, also check X") reaches the model at the next round without
+   *     any interruption machinery.
+   * @yields Events as the turn streams.
+   */
   async *sendMessage(
     userText: string,
     signal?: AbortSignal,

--- a/ui/src/plugins/dev.perfetto.Intelletto/agent.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/agent.ts
@@ -1,0 +1,301 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The agent loop: the multi-step tool-use harness that sits on top of the LLM
+// gateway. The gateway stays a single request/response; the loop lives here, in
+// the consumer. One user turn drives: call the model -> if it asked for tools,
+// run them -> feed results back -> repeat, until the model answers with no tool
+// calls or the iteration cap is hit. The loop also owns lazy tool loading: it
+// starts with a bootstrap set (list_tools/more_tools) and grows the tool list
+// as the model asks, so not every tool schema sits in every request.
+
+import {z} from 'zod';
+import type {LlmGateway, ModelPath} from '../dev.perfetto.Llm/gateway';
+import type {
+  Message,
+  ToolCall,
+  ToolDef,
+  ToolResult,
+} from '../dev.perfetto.Llm/protocol';
+import type {ToolRegistry} from './tools';
+
+// Hard bound on tool-use rounds per user turn. Stops a misbehaving model from
+// looping forever (and caps token spend). Hitting it surfaces to the user
+// rather than failing silently.
+const MAX_ITERATIONS = 50;
+
+// What the UI consumes as a turn streams.
+export type AgentEvent =
+  | {readonly type: 'text'; readonly text: string}
+  | {readonly type: 'thought'; readonly text: string}
+  | {readonly type: 'toolcall'; readonly name: string; readonly args: unknown}
+  | {
+      readonly type: 'toolresult';
+      readonly name: string;
+      readonly isError: boolean;
+      // The (possibly truncated) tool result string, so the UI can show a
+      // summary of what the tool returned. This is the same string fed back to
+      // the model.
+      readonly result: string;
+    }
+  | {
+      readonly type: 'usage';
+      readonly inputTokens?: number;
+      readonly outputTokens?: number;
+      readonly totalTokens?: number;
+    }
+  // A user-facing error (backend failure, iteration cap, no model configured).
+  // Distinct from a tool error, which is fed back to the model, not surfaced.
+  | {readonly type: 'error'; readonly message: string};
+
+export class Agent {
+  // The full conversation history (system prompt aside). Owned here because LLM
+  // endpoints are stateless and we resend it every request.
+  private history: Message[] = [];
+
+  constructor(
+    private readonly gateway: LlmGateway,
+    private readonly tools: ToolRegistry,
+    private readonly systemPrompt: string,
+    // When true (the default), every tool definition is sent on every request
+    // and the list_tools/more_tools meta-tools are omitted. The lazy scheme
+    // (discover via list_tools, provision via more_tools) is an optimisation
+    // for *large* tool sets, but the indirection reliably trips up smaller /
+    // local models - they loop calling more_tools instead of the real tool. We
+    // only have a handful of core tools, so eager is both simpler and more
+    // robust. Flip this off once the tool count makes eager loading expensive.
+    private readonly eagerTools: boolean = true,
+  ) {}
+
+  reset(): void {
+    this.history = [];
+  }
+
+  // Run one user turn to completion, yielding events as they stream. Honours
+  // `signal` for cancellation: an aborted turn stops cleanly and what completed
+  // stays in the history (the transcript stays truthful).
+  //
+  // `dequeueFollowUp` implements queued follow-ups: it is polled once at the
+  // top of each tool-use round, and any message it returns is appended to the
+  // history as a user message, so something the user typed mid-loop ("oh wait,
+  // also check X") reaches the model at the next round without any
+  // interruption machinery.
+  async *sendMessage(
+    userText: string,
+    signal?: AbortSignal,
+    dequeueFollowUp?: () => string | undefined,
+  ): AsyncGenerator<AgentEvent, void, void> {
+    this.history.push({role: 'user', text: userText});
+
+    // The model driving this turn: the first configured model advertising the
+    // 'agentic' role. Looked up per turn so adding/removing a provider between
+    // turns routes the next turn accordingly (history carries over).
+    const modelDetails = this.gateway
+      .listModels()
+      .find((m) => m.model.roles.includes('agentic'));
+    if (modelDetails === undefined) {
+      yield {
+        type: 'error',
+        message:
+          'No agentic model configured. Add a provider and a model with the ' +
+          'agentic role in the LLM settings.',
+      };
+      return;
+    }
+    const modelPath: ModelPath = {
+      providerId: modelDetails.provider.id,
+      modelId: modelDetails.model.id,
+    };
+
+    // createStream requires a signal; use a never-aborting fallback when the
+    // caller didn't supply one.
+    const abortSignal = signal ?? new AbortController().signal;
+
+    // The set of tool names exposed to the model this turn. In eager mode it's
+    // every tool up front; in lazy mode it starts empty and grows as the model
+    // pulls tools in via more_tools.
+    const loaded = new Set<string>(
+      this.eagerTools ? this.tools.list().map((t) => t.name) : [],
+    );
+
+    for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
+      if (signal?.aborted) return;
+
+      // Pick up any follow-up the user queued while the loop was running.
+      const followUp = dequeueFollowUp?.();
+      if (followUp !== undefined) {
+        this.history.push({role: 'user', text: followUp});
+      }
+
+      const toolDefs = this.buildToolDefs(loaded);
+      const calls: ToolCall[] = [];
+      let turnText = '';
+      let backendError: string | undefined;
+
+      for await (const evt of this.gateway.createStream(
+        modelPath,
+        {
+          systemPrompt: this.systemPrompt,
+          messages: this.history,
+          tools: toolDefs,
+        },
+        abortSignal,
+      )) {
+        switch (evt.type) {
+          case 'text':
+            turnText += evt.text;
+            yield {type: 'text', text: evt.text};
+            break;
+          case 'thought':
+            yield {type: 'thought', text: evt.text};
+            break;
+          case 'tool-call':
+            calls.push(evt.call);
+            yield {
+              type: 'toolcall',
+              name: evt.call.name,
+              args: evt.call.args,
+            };
+            break;
+          case 'usage':
+            yield {type: 'usage', ...evt.usage};
+            break;
+          case 'stop':
+            if (evt.reason === 'error') {
+              backendError = evt.error?.message ?? 'Unknown backend error';
+            }
+            break;
+        }
+      }
+
+      if (signal?.aborted) return;
+
+      if (backendError !== undefined) {
+        yield {type: 'error', message: backendError};
+        return;
+      }
+
+      // Record the model's turn (text and/or tool calls) in the history.
+      if (turnText.length > 0) {
+        this.history.push({role: 'model', text: turnText});
+      }
+      if (calls.length === 0) {
+        // No tool calls -> the model is done with this turn.
+        return;
+      }
+      this.history.push({role: 'tool-call', calls});
+
+      // Execute every requested tool, threading results back. Tool errors
+      // (bad SQL, invalid args) become tool results the model can self-correct
+      // from - they are NOT surfaced to the user as errors.
+      const results: ToolResult[] = [];
+      for (const call of calls) {
+        if (signal?.aborted) return;
+        const {result, isError} = await this.runTool(call, loaded);
+        yield {type: 'toolresult', name: call.name, isError, result};
+        results.push({name: call.name, result, isError});
+      }
+      this.history.push({role: 'tool-result', results});
+    }
+
+    yield {
+      type: 'error',
+      message:
+        `Stopped after ${MAX_ITERATIONS} tool-use rounds without a ` +
+        `final answer. Try narrowing the question.`,
+    };
+  }
+
+  // Execute one tool call. The meta-tools (list_tools / more_tools) are handled
+  // here because they mutate the loop's loaded-tool set; everything else goes
+  // through the registry (which validates args first).
+  private async runTool(
+    call: ToolCall,
+    loaded: Set<string>,
+  ): Promise<{result: string; isError: boolean}> {
+    try {
+      if (call.name === 'list_tools') {
+        const list = this.tools.list().map((t) => ({
+          name: t.name,
+          description: firstLine(t.description),
+        }));
+        return {result: JSON.stringify(list), isError: false};
+      }
+      if (call.name === 'more_tools') {
+        const names = z
+          .object({names: z.array(z.string())})
+          .parse(call.args).names;
+        const unknown = names.filter((n) => this.tools.get(n) === undefined);
+        names.forEach((n) => this.tools.get(n) && loaded.add(n));
+        const msg =
+          unknown.length > 0
+            ? `Loaded. Unknown (ignored): ${unknown.join(', ')}.`
+            : 'Loaded. The requested tools are now available.';
+        return {result: msg, isError: unknown.length > 0};
+      }
+      const result = await this.tools.call(call.name, call.args);
+      return {result, isError: false};
+    } catch (e) {
+      return {result: `Error: ${String(e)}`, isError: true};
+    }
+  }
+
+  // The tool list sent on a request. In lazy mode this is the bootstrap
+  // meta-tools (list_tools/more_tools) plus every tool the model has loaded so
+  // far; in eager mode the meta-tools are omitted and `loaded` already holds
+  // every tool. Order is stable and the set only grows within a turn,
+  // preserving the cached prompt prefix.
+  private buildToolDefs(loaded: Set<string>): ToolDef[] {
+    const defs: ToolDef[] = [];
+    if (!this.eagerTools) {
+      defs.push(
+        {
+          name: 'list_tools',
+          description:
+            'List the names and one-line descriptions of every tool ' +
+            'available. Call this first to discover what you can do, then ' +
+            'more_tools to load the ones you need before calling them.',
+          inputSchema: z.object({}),
+        },
+        {
+          name: 'more_tools',
+          description:
+            'Load tool definitions by name so you can call them. You can only ' +
+            'call a tool after loading it here. Discover names with list_tools.',
+          inputSchema: z.object({
+            names: z
+              .array(z.string())
+              .describe('Tool names to load, from list_tools.'),
+          }),
+        },
+      );
+    }
+    for (const tool of this.tools.list()) {
+      if (loaded.has(tool.name)) {
+        defs.push({
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+        });
+      }
+    }
+    return defs;
+  }
+}
+
+function firstLine(s: string): string {
+  const trimmed = s.trim();
+  const nl = trimmed.indexOf('\n');
+  return nl === -1 ? trimmed : trimmed.slice(0, nl);
+}

--- a/ui/src/plugins/dev.perfetto.Intelletto/api.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/api.ts
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Public API for the Intelletto assistant plugin. Other plugins depend on
+// IntellettoPlugin and reach this surface via
+// `ctx.plugins.getPlugin(IntellettoPlugin)` to contribute their own tools - the
+// assistant doesn't need to know a feature exists, only that a tool drives it.
+
+import type {z, ZodObject, ZodRawShape} from 'zod';
+
+// What a plugin provides to register a tool. The model decides *whether* to
+// call it (from `description`) and *how* (from `shape`); the harness validates
+// the args against `shape` before invoking `callback`, so a malformed call
+// becomes a tool-result error the model self-corrects from rather than an
+// exception in your plugin.
+export interface ToolRegistration<S extends ZodRawShape = ZodRawShape> {
+  // Stable identifier. Model APIs constrain tool names to roughly
+  // ^[a-zA-Z0-9_-]+$, so avoid dots/spaces. Must be unique.
+  readonly name: string;
+
+  // Prose telling the model *when* to call this tool, not just what it does.
+  // This is load-bearing: "Run a query" is weak; describe the situations that
+  // should trigger it and any constraints (e.g. "prefer aggregation").
+  readonly description: string;
+
+  // The argument shape as a zod raw shape, e.g. `{sql: z.string()}`. Add a
+  // `.describe(...)` to each field - the model reads those too. This buys typed
+  // callback args, the JSON Schema sent on the wire, and runtime validation
+  // from one declaration.
+  readonly shape: S;
+
+  // True if the tool mutates UI state (selection, navigation, ...) vs. being
+  // read-only. Not gated on in Phase 1, but recorded for a future consent hook.
+  readonly mutating?: boolean;
+
+  // The implementation. `args` arrive typed (inferred from `shape`) and already
+  // validated. Return the string fed back to the model: data for read tools, a
+  // short ack (e.g. 'OK') for mutating ones. Throwing turns into a tool-result
+  // error the model can recover from.
+  readonly callback: (args: z.infer<ZodObject<S>>) => Promise<string>;
+}
+
+// What a context provider returns when it has something relevant to say about
+// the current UI state. Both halves come from one callback so what the user
+// sees (the chip) and what the model receives (the payload) cannot drift apart.
+export interface ContextSnapshot {
+  // Plain-language summary, shown on the chip in the context strip.
+  readonly summary: string;
+  // JSON-serialisable payload sent to the model with the next prompt, and what
+  // the user sees when they expand the chip. Keep it small - it travels with
+  // every user turn. If the underlying data is large, expose it via a tool
+  // instead and put a reference here.
+  readonly data: unknown;
+}
+
+// What a plugin provides to register a context provider: a live view of some
+// piece of UI state the model should know about when answering ("what is the
+// user looking at?").
+export interface ContextProviderRegistration {
+  // Stable, unique id, e.g. 'dev.perfetto.Timeline#selection'. Used by the
+  // context strip to track which items the user toggled off.
+  readonly id: string;
+
+  // Optional *invariant* explanation of the payload format (units, what ids
+  // mean, which tools accept them). Folded once into the system prompt - NOT
+  // repeated with every user message - so it must not contain anything that
+  // changes per turn; volatile data belongs in the snapshot payload.
+  readonly description?: string;
+
+  // Called when a prompt is about to be sent (and continuously to render the
+  // context strip). Return undefined when there is nothing relevant right now:
+  // the chip disappears and nothing is sent.
+  getContext(): ContextSnapshot | undefined;
+}
+
+// The capability IntellettoPlugin exposes to dependent plugins. Obtain it with
+// `ctx.plugins.getPlugin(IntellettoPlugin)` in your plugin's onTraceLoad.
+export interface IntellettoToolRegistrar {
+  // Register a tool the assistant can call. Tools are trace-scoped: register in
+  // onTraceLoad; they live for the lifetime of the loaded trace.
+  registerTool<S extends ZodRawShape>(tool: ToolRegistration<S>): void;
+
+  // Register a context provider: a callback sampled on every prompt that
+  // describes what the user is currently looking at. Trace-scoped, like tools.
+  registerContextProvider(provider: ContextProviderRegistration): void;
+}

--- a/ui/src/plugins/dev.perfetto.Intelletto/api.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/api.ts
@@ -19,79 +19,63 @@
 
 import type {z, ZodObject, ZodRawShape} from 'zod';
 
-// What a plugin provides to register a tool. The model decides *whether* to
-// call it (from `description`) and *how* (from `shape`); the harness validates
-// the args against `shape` before invoking `callback`, so a malformed call
-// becomes a tool-result error the model self-corrects from rather than an
-// exception in your plugin.
+// What a plugin provides to register a tool the assistant can call. The model
+// decides *whether* to call it (from `description`) and *how* (from `shape`);
+// the harness validates args against `shape` before invoking `callback`.
 export interface ToolRegistration<S extends ZodRawShape = ZodRawShape> {
-  // Stable identifier. Model APIs constrain tool names to roughly
-  // ^[a-zA-Z0-9_-]+$, so avoid dots/spaces. Must be unique.
+  // Stable, unique identifier. Must match ^[a-zA-Z0-9_-]+$ (no dots/spaces).
   readonly name: string;
 
   // Prose telling the model *when* to call this tool, not just what it does.
-  // This is load-bearing: "Run a query" is weak; describe the situations that
-  // should trigger it and any constraints (e.g. "prefer aggregation").
+  // Load-bearing: describe the triggering situations and any constraints.
   readonly description: string;
 
-  // The argument shape as a zod raw shape, e.g. `{sql: z.string()}`. Add a
-  // `.describe(...)` to each field - the model reads those too. This buys typed
-  // callback args, the JSON Schema sent on the wire, and runtime validation
-  // from one declaration.
+  // The argument shape as a zod raw shape, e.g. `{sql: z.string()}`. Add
+  // `.describe(...)` to each field - the model reads those too.
   readonly shape: S;
 
-  // True if the tool mutates UI state (selection, navigation, ...) vs. being
-  // read-only. Not gated on in Phase 1, but recorded for a future consent hook.
+  // True if the tool mutates UI state (selection, navigation, ...).
   readonly mutating?: boolean;
 
-  // The implementation. `args` arrive typed (inferred from `shape`) and already
-  // validated. Return the string fed back to the model: data for read tools, a
-  // short ack (e.g. 'OK') for mutating ones. Throwing turns into a tool-result
-  // error the model can recover from.
+  // The implementation. `args` arrive typed and validated. Return the string
+  // fed back to the model (data for reads, a short ack for mutations); throwing
+  // becomes a tool-result error the model can recover from.
   readonly callback: (args: z.infer<ZodObject<S>>) => Promise<string>;
 }
 
 // What a context provider returns when it has something relevant to say about
-// the current UI state. Both halves come from one callback so what the user
-// sees (the chip) and what the model receives (the payload) cannot drift apart.
+// the current UI state. Both halves come from one callback so the chip and the
+// model payload cannot drift apart.
 export interface ContextSnapshot {
   // Plain-language summary, shown on the chip in the context strip.
   readonly summary: string;
-  // JSON-serialisable payload sent to the model with the next prompt, and what
-  // the user sees when they expand the chip. Keep it small - it travels with
-  // every user turn. If the underlying data is large, expose it via a tool
-  // instead and put a reference here.
+  // JSON-serialisable payload sent to the model with the next prompt (and shown
+  // when the chip is expanded). Keep it small - it travels with every turn.
   readonly data: unknown;
 }
 
 // What a plugin provides to register a context provider: a live view of some
-// piece of UI state the model should know about when answering ("what is the
-// user looking at?").
+// piece of UI state the model should know about ("what is the user looking
+// at?").
 export interface ContextProviderRegistration {
-  // Stable, unique id, e.g. 'dev.perfetto.Timeline#selection'. Used by the
-  // context strip to track which items the user toggled off.
+  // Stable, unique id, e.g. 'dev.perfetto.Timeline#selection'.
   readonly id: string;
 
-  // Optional *invariant* explanation of the payload format (units, what ids
-  // mean, which tools accept them). Folded once into the system prompt - NOT
-  // repeated with every user message - so it must not contain anything that
-  // changes per turn; volatile data belongs in the snapshot payload.
+  // Optional *invariant* explanation of the payload format, folded once into
+  // the system prompt. Must not contain anything that changes per turn.
   readonly description?: string;
 
-  // Called when a prompt is about to be sent (and continuously to render the
-  // context strip). Return undefined when there is nothing relevant right now:
-  // the chip disappears and nothing is sent.
+  // Sampled before each prompt (and to render the context strip). Return
+  // undefined when there is nothing relevant right now.
   getContext(): ContextSnapshot | undefined;
 }
 
 // The capability IntellettoPlugin exposes to dependent plugins. Obtain it with
 // `ctx.plugins.getPlugin(IntellettoPlugin)` in your plugin's onTraceLoad.
 export interface IntellettoToolRegistrar {
-  // Register a tool the assistant can call. Tools are trace-scoped: register in
-  // onTraceLoad; they live for the lifetime of the loaded trace.
+  // Register a tool the assistant can call. Trace-scoped.
   registerTool<S extends ZodRawShape>(tool: ToolRegistration<S>): void;
 
-  // Register a context provider: a callback sampled on every prompt that
-  // describes what the user is currently looking at. Trace-scoped, like tools.
+  // Register a context provider describing what the user is looking at.
   registerContextProvider(provider: ContextProviderRegistration): void;
 }

--- a/ui/src/plugins/dev.perfetto.Intelletto/chat_panel.scss
+++ b/ui/src/plugins/dev.perfetto.Intelletto/chat_panel.scss
@@ -1,0 +1,215 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-intelletto {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: 100%;
+
+  &__header {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0.5rem;
+    border-bottom: 1px solid var(--pf-color-border);
+  }
+
+  &__model {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__no-model {
+    flex: 1;
+    color: var(--pf-color-text-muted);
+    font-style: italic;
+  }
+
+  &__conversation {
+    flex-grow: 1;
+    overflow-y: scroll;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__msg {
+    margin-bottom: 1rem;
+    max-width: 90%;
+    padding: 0.5rem 1rem;
+    border-radius: 12px;
+    line-height: 1.5;
+
+    &-role {
+      font-weight: bold;
+      display: block;
+      margin-bottom: 4px;
+    }
+
+    &--ai {
+      background-color: var(--pf-color-background-secondary);
+      align-self: flex-start;
+    }
+
+    &--user {
+      background-color: var(--pf-color-primary);
+      color: var(--pf-color-text-on-primary);
+      align-self: flex-end;
+      margin-left: auto;
+    }
+
+    &--error {
+      background-color: color-mix(
+        in srgb,
+        var(--pf-color-danger),
+        85% transparent
+      );
+      color: var(--pf-color-danger);
+      border: 1px solid var(--pf-color-danger);
+    }
+
+    &--toolcall {
+      align-self: flex-start;
+      font-family: var(--pf-font-monospace);
+      font-size: 0.85em;
+      color: var(--pf-color-text-muted);
+      padding: 2px 8px;
+    }
+
+    &--thought {
+      align-self: flex-start;
+      font-style: italic;
+      font-size: 0.9em;
+      color: var(--pf-color-text-muted);
+    }
+
+    &--spacer {
+      margin: 0;
+      padding: 0;
+    }
+  }
+
+  &__tool {
+    align-self: flex-start;
+    width: 100%;
+    font-size: 0.85em;
+
+    &--error .pf-intelletto__tool-badge {
+      color: var(--pf-color-danger);
+    }
+  }
+
+  &__tool-summary {
+    cursor: pointer;
+    user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--pf-color-text-muted);
+
+    code {
+      font-family: var(--pf-font-monospace);
+    }
+  }
+
+  &__tool-badge {
+    font-weight: bold;
+  }
+
+  &__tool-section {
+    margin: 4px 0 0 16px;
+  }
+
+  &__tool-label {
+    font-size: 0.8em;
+    color: var(--pf-color-text-muted);
+    text-transform: uppercase;
+  }
+
+  &__tool-body {
+    margin: 2px 0;
+    padding: 6px 8px;
+    max-height: 240px;
+    overflow: auto;
+    background-color: var(--pf-color-background);
+    border: 1px solid var(--pf-color-border);
+    border-radius: 6px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--pf-font-monospace);
+    font-size: 0.95em;
+  }
+
+  &__context {
+    flex-shrink: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 4px 0.5rem;
+    border-top: 1px solid var(--pf-color-border);
+  }
+
+  &__context-chip {
+    cursor: pointer;
+    user-select: none;
+    font-size: 0.8em;
+    padding: 1px 6px;
+    border-radius: 8px;
+    background-color: var(--pf-color-background-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+
+    &--off {
+      opacity: 0.5;
+    }
+  }
+
+  &__system-prompt {
+    margin: 0;
+    max-width: 70vw;
+    max-height: 60vh;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--pf-font-monospace);
+    font-size: 0.9em;
+  }
+
+  &__tokens {
+    font-size: 0.8em;
+    color: var(--pf-color-text-muted);
+    white-space: nowrap;
+  }
+
+  &__input {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    padding: 0.5rem;
+    border-top: 1px solid var(--pf-color-border);
+    background-color: var(--pf-color-background-secondary);
+    box-sizing: border-box;
+    gap: 4px;
+
+    .pf-text-input {
+      flex: 1;
+    }
+  }
+}

--- a/ui/src/plugins/dev.perfetto.Intelletto/chat_panel.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/chat_panel.ts
@@ -31,15 +31,19 @@ import './chat_panel.scss';
 import type {ChatLine, ChatSession} from './chat_session';
 import type {ContextItem, ContextRegistry} from './context';
 
+/** Attrs for the ChatPanel component. */
 export interface ChatPanelAttrs {
   readonly gateway: LlmGateway;
-  // The trace-scoped conversation state, owned by IntellettoPlugin.
+  /** The trace-scoped conversation state, owned by IntellettoPlugin. */
   readonly session: ChatSession;
-  // The shared, trace-scoped context-provider registry (core providers + those
-  // contributed by other plugins). Sampled live for the context strip.
+  /** The shared context-provider registry, sampled live for the strip. */
   readonly context: ContextRegistry;
 }
 
+/**
+ * The Intelletto chat panel: a pure view over a ChatSession. Renders the
+ * transcript, input box, model header, and context strip.
+ */
 export class ChatPanel implements m.ClassComponent<ChatPanelAttrs> {
   private readonly md = markdownit();
   // Whether the conversation was scrolled to (near) the bottom as of the last
@@ -69,7 +73,7 @@ export class ChatPanel implements m.ClassComponent<ChatPanelAttrs> {
       m(Button, {
         icon: 'add_comment',
         title: 'New conversation',
-        onclick: session.newConversation,
+        onclick: () => session.newConversation(),
       }),
     );
   }
@@ -230,7 +234,7 @@ export class ChatPanel implements m.ClassComponent<ChatPanelAttrs> {
           ? m(Button, {
               icon: 'stop',
               title: 'Cancel',
-              onclick: session.cancel,
+              onclick: () => session.cancel(),
               intent: Intent.Danger,
             })
           : m(Button, {

--- a/ui/src/plugins/dev.perfetto.Intelletto/chat_panel.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/chat_panel.ts
@@ -1,0 +1,266 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The Intelletto chat panel - the sidebar surface for the conversational
+// assistant. Renders the transcript, the input box, the active-model indicator
+// (header), a cancel control for in-flight turns, and a context strip showing
+// what the next prompt will carry. All conversation state lives in the
+// ChatSession (owned by IntellettoPlugin, so it survives the panel unmounting);
+// this component is a pure view over it.
+
+import markdownit from 'markdown-it';
+import m from 'mithril';
+import {Button, ButtonVariant} from '../../widgets/button';
+import {Intent} from '../../widgets/common';
+import {EmptyState} from '../../widgets/empty_state';
+import {showModal} from '../../widgets/modal';
+import {TextInput} from '../../widgets/text_input';
+import type {LlmGateway, ModelDetails} from '../dev.perfetto.Llm/gateway';
+import './chat_panel.scss';
+import type {ChatLine, ChatSession} from './chat_session';
+import type {ContextItem, ContextRegistry} from './context';
+
+export interface ChatPanelAttrs {
+  readonly gateway: LlmGateway;
+  // The trace-scoped conversation state, owned by IntellettoPlugin.
+  readonly session: ChatSession;
+  // The shared, trace-scoped context-provider registry (core providers + those
+  // contributed by other plugins). Sampled live for the context strip.
+  readonly context: ContextRegistry;
+}
+
+export class ChatPanel implements m.ClassComponent<ChatPanelAttrs> {
+  private readonly md = markdownit();
+  // Whether the conversation was scrolled to (near) the bottom as of the last
+  // render. We only auto-scroll on update when this holds, so new content keeps
+  // the view pinned to the bottom but a user who has scrolled up to read is
+  // left alone. Sampled before Mithril patches the DOM (onbeforeupdate).
+  private stickToBottom = true;
+
+  private renderHeader(attrs: ChatPanelAttrs): m.Children {
+    const {gateway, session} = attrs;
+    // The model the agent will drive: the first configured model advertising
+    // the 'agentic' role (matches Agent.sendMessage).
+    const active = gateway
+      .listModels()
+      .find((rm) => rm.model.roles.includes('agentic'));
+
+    return m(
+      '.pf-intelletto__header',
+      active === undefined
+        ? m('span.pf-intelletto__no-model', 'No agentic model configured')
+        : m('span.pf-intelletto__model', modelName(active)),
+      m(Button, {
+        icon: 'manage_search',
+        title: 'Show system prompt',
+        onclick: () => this.showSystemPrompt(session),
+      }),
+      m(Button, {
+        icon: 'add_comment',
+        title: 'New conversation',
+        onclick: session.newConversation,
+      }),
+    );
+  }
+
+  // Transparency hatch: show the exact system prompt the agent sends, in a
+  // modal. Like the context strip's expand-to-raw-payload, no hidden context.
+  private showSystemPrompt(session: ChatSession) {
+    showModal({
+      title: 'System prompt',
+      content: m('pre.pf-intelletto__system-prompt', session.systemPrompt),
+      buttons: [{text: 'Close', primary: true}],
+    });
+  }
+
+  private renderContextStrip(attrs: ChatPanelAttrs): m.Children {
+    const {context, session} = attrs;
+    const items = context.buildContextItems();
+    return m(
+      '.pf-intelletto__context',
+      items.map((c: ContextItem) => {
+        const excluded = session.excludedContext.has(c.id);
+        return m(
+          'span.pf-intelletto__context-chip',
+          {
+            class: excluded ? 'pf-intelletto__context-chip--off' : '',
+            title: c.payload,
+            onclick: () => {
+              if (excluded) session.excludedContext.delete(c.id);
+              else session.excludedContext.add(c.id);
+            },
+          },
+          `${excluded ? '☐' : '☑'} ${c.label}`,
+        );
+      }),
+    );
+  }
+
+  // A tool call rendered as a collapsible summary: a one-line header (tool
+  // name + ok/error badge) that expands to show the args sent and the result
+  // returned. Defaults to collapsed so the transcript stays readable, but the
+  // full result is always one click away.
+  private renderToolCall(msg: ChatLine): m.Children {
+    const pending = msg.toolResult === undefined;
+    const badge = pending ? '…' : msg.toolError ? '✗' : '✓';
+    const argsStr = msg.toolArgs === undefined ? '' : prettyJson(msg.toolArgs);
+    const result = msg.toolResult ?? '';
+
+    return m(
+      '.pf-intelletto__msg.pf-intelletto__msg--toolcall',
+      m(
+        'details.pf-intelletto__tool',
+        {class: msg.toolError ? 'pf-intelletto__tool--error' : ''},
+        m(
+          'summary.pf-intelletto__tool-summary',
+          m('span.pf-intelletto__tool-badge', badge),
+          m('code', msg.text),
+        ),
+        argsStr &&
+          m('.pf-intelletto__tool-section', [
+            m('.pf-intelletto__tool-label', 'args'),
+            m('pre.pf-intelletto__tool-body', argsStr),
+          ]),
+        !pending &&
+          m('.pf-intelletto__tool-section', [
+            m('.pf-intelletto__tool-label', 'result'),
+            m('pre.pf-intelletto__tool-body', truncate(result, 4000)),
+          ]),
+      ),
+    );
+  }
+
+  view({attrs}: m.CVnode<ChatPanelAttrs>): m.Children {
+    const {session} = attrs;
+    return m(
+      '.pf-intelletto',
+      this.renderHeader(attrs),
+      m(
+        '.pf-intelletto__conversation',
+        {
+          oncreate: (vnode: m.VnodeDOM) => {
+            const el = vnode.dom as HTMLElement;
+            el.scrollTop = el.scrollHeight;
+          },
+          // Sample the scroll position *before* the DOM is patched: if the user
+          // is at the bottom we keep them pinned, otherwise we leave their
+          // scroll position untouched so they can read/select scrollback.
+          // NB: read `old.dom`, not `vnode.dom` - Mithril only copies the DOM
+          // ref onto the new vnode *after* onbeforeupdate runs, so `vnode.dom`
+          // is undefined here (and measuring it would leave stickToBottom stuck
+          // at its initial true, auto-scrolling every update).
+          onbeforeupdate: (_vnode: m.VnodeDOM, old: m.VnodeDOM) => {
+            const el = old.dom as HTMLElement | undefined;
+            if (el !== undefined) {
+              const distFromBottom =
+                el.scrollHeight - el.scrollTop - el.clientHeight;
+              this.stickToBottom = distFromBottom < 8;
+            }
+            return true;
+          },
+          onupdate: (vnode: m.VnodeDOM) => {
+            if (!this.stickToBottom) return;
+            const el = vnode.dom as HTMLElement;
+            el.scrollTop = el.scrollHeight;
+          },
+        },
+        session.lines.length === 0
+          ? m(EmptyState, {
+              fillHeight: true,
+              icon: 'psychology',
+              title: 'Ask about your trace',
+            })
+          : session.lines.map((msg) => {
+              if (!msg.text && msg.role !== 'spacer') return null;
+              if (msg.role === 'toolcall') return this.renderToolCall(msg);
+              const labels: Record<ChatLine['role'], string> = {
+                ai: 'Intelletto',
+                user: 'You',
+                error: 'Error',
+                toolcall: 'Tool',
+                thought: 'Thought',
+                spacer: '',
+              };
+              return m(
+                `.pf-intelletto__msg.pf-intelletto__msg--${msg.role}`,
+                m('b.pf-intelletto__msg-role', labels[msg.role]),
+                m(
+                  'span.pf-intelletto__msg-text',
+                  m.trust(this.md.render(msg.text)),
+                ),
+              );
+            }),
+      ),
+      this.renderContextStrip(attrs),
+      m(
+        'footer.pf-intelletto__input',
+        m(TextInput, {
+          value: session.input,
+          oninput: (e: Event) => {
+            session.input = (e.target as HTMLInputElement).value;
+          },
+          onkeydown: (e: KeyboardEvent) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              session.send();
+            }
+          },
+          placeholder: session.loading
+            ? 'Queue a follow-up...'
+            : 'Ask about your trace...',
+        }),
+        session.totalTokens !== undefined
+          ? m(
+              '.pf-intelletto__tokens',
+              `${(session.totalTokens / 1000).toFixed(1)} ktok`,
+            )
+          : null,
+        session.loading
+          ? m(Button, {
+              icon: 'stop',
+              title: 'Cancel',
+              onclick: session.cancel,
+              intent: Intent.Danger,
+            })
+          : m(Button, {
+              icon: 'arrow_forward',
+              title: 'Send',
+              onclick: () => session.send(),
+              variant: ButtonVariant.Filled,
+              intent: Intent.Primary,
+            }),
+      ),
+    );
+  }
+}
+
+function modelName(model: ModelDetails) {
+  const protocolName = model.provider.label || model.provider.protocolName;
+  const modelName = model.model.label || model.model.modelName;
+  return `${protocolName}/${modelName}`;
+}
+
+function prettyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max
+    ? s
+    : `${s.slice(0, max)}\n… (${s.length - max} more chars)`;
+}

--- a/ui/src/plugins/dev.perfetto.Intelletto/chat_session.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/chat_session.ts
@@ -1,0 +1,206 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The chat session: the conversation state (agent, transcript, queued
+// follow-ups) for one trace. Owned by IntellettoPlugin - NOT by the chat panel
+// component - so the conversation survives the side panel being closed and
+// reopened; the panel is just a view over this. Per the RFC, the session is
+// scoped to the open trace and kept in memory only.
+
+import m from 'mithril';
+import type {LlmGateway} from '../dev.perfetto.Llm/gateway';
+import {Agent} from './agent';
+import type {ContextRegistry} from './context';
+import type {ToolRegistry} from './tools';
+import {SYSTEM_PROMPT} from './system_prompt';
+
+export interface ChatLine {
+  role: 'ai' | 'user' | 'error' | 'thought' | 'toolcall' | 'spacer';
+  text: string;
+  // For 'toolcall' lines: the call args and (once it arrives) the result, so
+  // the line can show a collapsible summary of what the tool did and returned.
+  toolArgs?: unknown;
+  toolResult?: string;
+  toolError?: boolean;
+}
+
+export class ChatSession {
+  // The assembled system prompt in use for this conversation - kept so the
+  // "show system prompt" inspector displays exactly what the agent sends.
+  readonly systemPrompt: string;
+
+  lines: ChatLine[] = [];
+  input = '';
+  loading = false;
+  totalTokens?: number;
+  // Context items the user has toggled off for the next prompt.
+  readonly excludedContext = new Set<string>();
+
+  private readonly agent: Agent;
+  private abort?: AbortController;
+  // Messages typed while a turn was in flight. The agent polls this at the top
+  // of each tool-use round; anything still queued when the turn ends starts a
+  // fresh turn. Cancelling drops the queue.
+  private pendingFollowUps: string[] = [];
+
+  constructor(
+    gateway: LlmGateway,
+    tools: ToolRegistry,
+    private readonly context: ContextRegistry,
+  ) {
+    // The context providers' invariant payload-format descriptions are folded
+    // into the system prompt here, once per conversation - per-turn payloads
+    // stay data-only.
+    this.systemPrompt = assembleSystemPrompt(context);
+    this.agent = new Agent(gateway, tools, this.systemPrompt);
+    this.lines = [];
+  }
+
+  send = async (): Promise<void> => {
+    const text = this.input.trim();
+    if (text === '') return;
+
+    this.input = '';
+    this.lines.push({role: 'user', text});
+
+    if (this.loading) {
+      // Typed mid-turn: queue it as a follow-up. The running turn picks it up
+      // at its next tool-use round, or the loop below starts a new turn with
+      // it once the current one finishes.
+      this.pendingFollowUps.push(text);
+      return;
+    }
+
+    let next: string | undefined = text;
+    while (next !== undefined) {
+      await this.runTurn(next);
+      next = this.pendingFollowUps.shift();
+    }
+  };
+
+  cancel = (): void => {
+    this.abort?.abort();
+    // Cancelling drops anything queued too - "stop" means stop.
+    this.pendingFollowUps = [];
+    this.lines.push({role: 'error', text: '(turn cancelled)'});
+  };
+
+  newConversation = (): void => {
+    this.abort?.abort();
+    this.pendingFollowUps = [];
+    this.agent.reset();
+    this.totalTokens = undefined;
+    this.lines = [
+      {role: 'ai', text: 'New conversation. What would you like to know?'},
+    ];
+  };
+
+  private appendAi(text: string) {
+    const last = this.lines[this.lines.length - 1];
+    if (last?.role === 'ai') {
+      last.text += text;
+    } else {
+      this.lines.push({role: 'ai', text});
+    }
+  }
+
+  private async runTurn(text: string): Promise<void> {
+    // Fold in any non-excluded context as a preamble the model can see.
+    const context = this.context
+      .buildContextItems()
+      .filter((c) => !this.excludedContext.has(c.id));
+    const prompt =
+      context.length === 0
+        ? text
+        : `Context for this question:\n${context
+            .map((c) => `- ${c.label}: ${c.payload}`)
+            .join('\n')}\n\nQuestion: ${text}`;
+
+    this.loading = true;
+    this.abort = new AbortController();
+    m.redraw();
+
+    try {
+      for await (const evt of this.agent.sendMessage(
+        prompt,
+        this.abort.signal,
+        () => this.pendingFollowUps.shift(),
+      )) {
+        switch (evt.type) {
+          case 'text':
+            this.appendAi(evt.text);
+            break;
+          case 'thought':
+            this.lines.push({role: 'thought', text: evt.text});
+            break;
+          case 'toolcall':
+            this.lines.push({
+              role: 'toolcall',
+              text: evt.name,
+              toolArgs: evt.args,
+            });
+            this.lines.push({role: 'spacer', text: ''});
+            break;
+          case 'toolresult':
+            // Attach the result to the most recent matching tool-call line that
+            // doesn't have one yet (tool calls within a round execute in order).
+            for (let i = this.lines.length - 1; i >= 0; i--) {
+              const line = this.lines[i];
+              if (
+                line.role === 'toolcall' &&
+                line.text === evt.name &&
+                line.toolResult === undefined
+              ) {
+                line.toolResult = evt.result;
+                line.toolError = evt.isError;
+                break;
+              }
+            }
+            break;
+          case 'usage':
+            if (evt.totalTokens !== undefined) {
+              this.totalTokens = evt.totalTokens;
+            }
+            break;
+          case 'error':
+            this.lines.push({role: 'error', text: evt.message});
+            break;
+        }
+        m.redraw();
+      }
+      this.lines.push({role: 'spacer', text: ''});
+    } catch (e) {
+      this.lines.push({role: 'error', text: `Something went wrong: ${e}`});
+    } finally {
+      this.loading = false;
+      this.abort = undefined;
+      m.redraw();
+    }
+  }
+}
+
+// The assembled system prompt: the application brief plus the context
+// providers' payload-format descriptions (already sorted by provider id, so
+// the result is byte-identical across turns and the cached prefix survives).
+// Sampled once per conversation; providers registered mid-conversation take
+// effect on the next one.
+function assembleSystemPrompt(context: ContextRegistry): string {
+  const descriptions = context.descriptions();
+  if (descriptions.length === 0) return SYSTEM_PROMPT;
+  return [
+    SYSTEM_PROMPT,
+    'Context payload formats (for the context preamble on user messages):',
+    ...descriptions,
+  ].join('\n\n');
+}

--- a/ui/src/plugins/dev.perfetto.Intelletto/chat_session.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/chat_session.ts
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The chat session: the conversation state (agent, transcript, queued
-// follow-ups) for one trace. Owned by IntellettoPlugin - NOT by the chat panel
-// component - so the conversation survives the side panel being closed and
-// reopened; the panel is just a view over this. Per the RFC, the session is
-// scoped to the open trace and kept in memory only.
-
 import m from 'mithril';
 import type {LlmGateway} from '../dev.perfetto.Llm/gateway';
 import {Agent} from './agent';
@@ -25,26 +19,42 @@ import type {ContextRegistry} from './context';
 import type {ToolRegistry} from './tools';
 import {SYSTEM_PROMPT} from './system_prompt';
 
+/** A single line in the conversation transcript. */
 export interface ChatLine {
+  /** Which kind of line this is; drives how it renders. */
   role: 'ai' | 'user' | 'error' | 'thought' | 'toolcall' | 'spacer';
+  /** The line's text content (e.g. message body, or tool name for toolcalls). */
   text: string;
-  // For 'toolcall' lines: the call args and (once it arrives) the result, so
-  // the line can show a collapsible summary of what the tool did and returned.
+  /**
+   * For 'toolcall' lines: the call args and (once it arrives) the result, so
+   * the line can show a collapsible summary of what the tool did and returned.
+   */
   toolArgs?: unknown;
   toolResult?: string;
   toolError?: boolean;
 }
 
+/**
+ * The state and behaviour of one chat conversation with the agent: owns the
+ * transcript, the in-flight turn, the follow-up queue, and the Agent instance.
+ * The UI renders from this and calls its methods; there is no other state.
+ */
 export class ChatSession {
-  // The assembled system prompt in use for this conversation - kept so the
-  // "show system prompt" inspector displays exactly what the agent sends.
+  /**
+   * The assembled system prompt in use for this conversation - kept so the
+   * "show system prompt" inspector displays exactly what the agent sends.
+   */
   readonly systemPrompt: string;
 
+  /** The conversation transcript, in display order. */
   lines: ChatLine[] = [];
+  /** The current (uncommitted) text in the input box. */
   input = '';
+  /** True while a turn is in flight. */
   loading = false;
+  /** Total tokens reported by the most recent turn, if any. */
   totalTokens?: number;
-  // Context items the user has toggled off for the next prompt.
+  /** Context items the user has toggled off for the next prompt. */
   readonly excludedContext = new Set<string>();
 
   private readonly agent: Agent;
@@ -54,6 +64,13 @@ export class ChatSession {
   // fresh turn. Cancelling drops the queue.
   private pendingFollowUps: string[] = [];
 
+  /**
+   * @param gateway - The LLM gateway used to drive the agent.
+   * @param tools - The registry of tools available to the agent.
+   * @param context - The registry supplying per-turn context items and, at
+   *     construction, the payload-format descriptions folded into the system
+   *     prompt.
+   */
   constructor(
     gateway: LlmGateway,
     tools: ToolRegistry,
@@ -67,7 +84,12 @@ export class ChatSession {
     this.lines = [];
   }
 
-  send = async (): Promise<void> => {
+  /**
+   * Submit the current input. If a turn is already running the text is queued
+   * as a follow-up; otherwise it starts a new turn (and drains any follow-ups
+   * queued while it runs). No-op on empty input.
+   */
+  async send(): Promise<void> {
     const text = this.input.trim();
     if (text === '') return;
 
@@ -87,16 +109,23 @@ export class ChatSession {
       await this.runTurn(next);
       next = this.pendingFollowUps.shift();
     }
-  };
+  }
 
-  cancel = (): void => {
+  /**
+   * Abort the in-flight turn and drop any queued follow-ups - "stop" means
+   * stop. Leaves the transcript in place with a "(turn cancelled)" marker.
+   */
+  cancel(): void {
     this.abort?.abort();
-    // Cancelling drops anything queued too - "stop" means stop.
     this.pendingFollowUps = [];
     this.lines.push({role: 'error', text: '(turn cancelled)'});
-  };
+  }
 
-  newConversation = (): void => {
+  /**
+   * Reset to a fresh conversation: abort any in-flight turn, clear the agent's
+   * history and the token count, and replace the transcript with a greeting.
+   */
+  newConversation(): void {
     this.abort?.abort();
     this.pendingFollowUps = [];
     this.agent.reset();
@@ -104,7 +133,7 @@ export class ChatSession {
     this.lines = [
       {role: 'ai', text: 'New conversation. What would you like to know?'},
     ];
-  };
+  }
 
   private appendAi(text: string) {
     const last = this.lines[this.lines.length - 1];

--- a/ui/src/plugins/dev.perfetto.Intelletto/context.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/context.ts
@@ -12,33 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Context injection: what the user is currently looking at, sampled from
-// registered context providers into items the chat folds into the prompt (and
-// shows in the context strip so the user can see and toggle exactly what's
-// sent). Providers are pluggable - the core ones (page, selection) are
-// registered below by the Intelletto plugin itself; other plugins contribute
-// theirs via registerContextProvider, the same way they contribute tools.
-
 import type {Trace} from '../../public/trace';
 import type {ContextProviderRegistration} from './api';
 
-// One sampled context item, ready for the strip and the prompt.
+/** One sampled context item, ready for the strip and the prompt. */
 export interface ContextItem {
-  // The provider's stable id, used by the strip to track which items the user
-  // toggled off.
+  /** The provider's stable id; the strip uses it to track toggled-off items. */
   readonly id: string;
-  // Human-readable label shown in the strip (the provider's summary).
+  /** Human-readable label shown in the strip (the provider's summary). */
   readonly label: string;
-  // The raw payload sent to the model (also shown on hover / expand).
+  /** The raw payload sent to the model (also shown on hover / expand). */
   readonly payload: string;
 }
 
-// The concrete registry behind the public registerContextProvider. Mirrors
-// ToolRegistry: core providers and plugin-contributed providers both land here;
-// the chat panel samples it to build the context strip and the prompt.
+/**
+ * The concrete registry behind the public registerContextProvider. Core and
+ * plugin-contributed providers both land here; the chat panel samples it to
+ * build the context strip and the prompt.
+ */
 export class ContextRegistry {
   private readonly providers = new Map<string, ContextProviderRegistration>();
 
+  /** Register a context provider. Throws if the id is already registered. */
   registerContextProvider(provider: ContextProviderRegistration): void {
     if (this.providers.has(provider.id)) {
       throw new Error(`Context provider "${provider.id}" already registered`);
@@ -46,9 +41,10 @@ export class ContextRegistry {
     this.providers.set(provider.id, provider);
   }
 
-  // Sample every provider. Providers returning undefined ("nothing relevant
-  // right now") are skipped; a provider that throws is skipped too, so one
-  // broken contributor can't take out the whole prompt.
+  /**
+   * Sample every provider into context items. Providers returning undefined or
+   * throwing are skipped, so one broken contributor can't take out the prompt.
+   */
   buildContextItems(): ContextItem[] {
     const items: ContextItem[] = [];
     for (const provider of this.providers.values()) {
@@ -71,9 +67,10 @@ export class ContextRegistry {
     return items;
   }
 
-  // The invariant payload-format explanations, for the system prompt. Sorted by
-  // provider id so the assembled prompt is byte-identical across turns and the
-  // cached prefix survives.
+  /**
+   * The invariant payload-format explanations, for the system prompt. Sorted by
+   * provider id so the assembled prompt is byte-identical across turns.
+   */
   descriptions(): string[] {
     return Array.from(this.providers.values())
       .filter((p) => p.description !== undefined && p.description !== '')
@@ -82,9 +79,11 @@ export class ContextRegistry {
   }
 }
 
-// The core context providers, registered by the Intelletto plugin itself.
-// Phase 1 covers page + selection + viewport; richer providers (per-element, Data
-// Explorer node, pinned tracks) come later, from the plugins that own them.
+/**
+ * Register the core context providers (page, viewport, selection) owned by the
+ * Intelletto plugin itself. Richer providers come from the plugins that own
+ * them.
+ */
 export function registerCoreContextProviders(
   reg: ContextRegistry,
   trace: Trace,

--- a/ui/src/plugins/dev.perfetto.Intelletto/context.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/context.ts
@@ -1,0 +1,170 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Context injection: what the user is currently looking at, sampled from
+// registered context providers into items the chat folds into the prompt (and
+// shows in the context strip so the user can see and toggle exactly what's
+// sent). Providers are pluggable - the core ones (page, selection) are
+// registered below by the Intelletto plugin itself; other plugins contribute
+// theirs via registerContextProvider, the same way they contribute tools.
+
+import type {Trace} from '../../public/trace';
+import type {ContextProviderRegistration} from './api';
+
+// One sampled context item, ready for the strip and the prompt.
+export interface ContextItem {
+  // The provider's stable id, used by the strip to track which items the user
+  // toggled off.
+  readonly id: string;
+  // Human-readable label shown in the strip (the provider's summary).
+  readonly label: string;
+  // The raw payload sent to the model (also shown on hover / expand).
+  readonly payload: string;
+}
+
+// The concrete registry behind the public registerContextProvider. Mirrors
+// ToolRegistry: core providers and plugin-contributed providers both land here;
+// the chat panel samples it to build the context strip and the prompt.
+export class ContextRegistry {
+  private readonly providers = new Map<string, ContextProviderRegistration>();
+
+  registerContextProvider(provider: ContextProviderRegistration): void {
+    if (this.providers.has(provider.id)) {
+      throw new Error(`Context provider "${provider.id}" already registered`);
+    }
+    this.providers.set(provider.id, provider);
+  }
+
+  // Sample every provider. Providers returning undefined ("nothing relevant
+  // right now") are skipped; a provider that throws is skipped too, so one
+  // broken contributor can't take out the whole prompt.
+  buildContextItems(): ContextItem[] {
+    const items: ContextItem[] = [];
+    for (const provider of this.providers.values()) {
+      let snapshot;
+      try {
+        snapshot = provider.getContext();
+      } catch {
+        continue;
+      }
+      if (snapshot === undefined) continue;
+      items.push({
+        id: provider.id,
+        label: snapshot.summary,
+        payload:
+          typeof snapshot.data === 'string'
+            ? snapshot.data
+            : JSON.stringify(snapshot.data),
+      });
+    }
+    return items;
+  }
+
+  // The invariant payload-format explanations, for the system prompt. Sorted by
+  // provider id so the assembled prompt is byte-identical across turns and the
+  // cached prefix survives.
+  descriptions(): string[] {
+    return Array.from(this.providers.values())
+      .filter((p) => p.description !== undefined && p.description !== '')
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .map((p) => p.description!);
+  }
+}
+
+// The core context providers, registered by the Intelletto plugin itself.
+// Phase 1 covers page + selection + viewport; richer providers (per-element, Data
+// Explorer node, pinned tracks) come later, from the plugins that own them.
+export function registerCoreContextProviders(
+  reg: ContextRegistry,
+  trace: Trace,
+): void {
+  // The current page (where the user is looking). Never returns undefined -
+  // the strip is never empty and never silent about what's being sent.
+  reg.registerContextProvider({
+    id: 'dev.perfetto.Intelletto#page',
+    getContext() {
+      const route = trace.getCurrentRoute();
+      const page = `${route.page}${route.subpage}` || '/viewer';
+      return {
+        summary: `Page: ${page}`,
+        data: `Current page route: ${page}`,
+      };
+    },
+  });
+
+  // The timeline viewport: the time bounds currently visible. Like the page,
+  // it always has a value, so the model always knows what window the user is
+  // looking at.
+  reg.registerContextProvider({
+    id: 'dev.perfetto.Intelletto#viewport',
+    description: `Viewport context payloads (kind "viewport"):
+- "start" and "end" are the trace-processor-nanosecond bounds of the time range
+  currently visible on the timeline.`,
+    getContext() {
+      const span = trace.timeline.visibleWindow.toTimeSpan();
+      return {
+        summary: 'Visible time range',
+        data: {
+          kind: 'viewport',
+          start: Number(span.start),
+          end: Number(span.end),
+        },
+      };
+    },
+  });
+
+  // The current selection, if any.
+  reg.registerContextProvider({
+    id: 'dev.perfetto.Intelletto#selection',
+    description: `Selection context payloads:
+- "ts", "dur", "start" and "end" are trace-processor nanoseconds.
+- For kind "track_event", "eventId" is the row id in the SQL table backing the
+  track (e.g. the "id" column of "slice").
+- "trackUri" identifies a timeline track and is accepted verbatim by tools
+  taking track URIs.`,
+    getContext() {
+      const sel = trace.selection.selection;
+      switch (sel.kind) {
+        case 'track_event':
+          return {
+            summary: 'Selected event',
+            data: {
+              kind: 'track_event',
+              trackUri: sel.trackUri,
+              eventId: sel.eventId,
+              ts: Number(sel.ts),
+              dur: sel.dur === undefined ? undefined : Number(sel.dur),
+            },
+          };
+        case 'area':
+          return {
+            summary: 'Selected time range',
+            data: {
+              kind: 'area',
+              start: Number(sel.start),
+              end: Number(sel.end),
+              trackUris: sel.trackUris,
+            },
+          };
+        case 'track':
+          return {
+            summary: 'Selected track',
+            data: {kind: 'track', trackUri: sel.trackUri},
+          };
+        default:
+          return undefined;
+      }
+    },
+  });
+}

--- a/ui/src/plugins/dev.perfetto.Intelletto/core_tools.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/core_tools.ts
@@ -1,0 +1,151 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The core tool surface the assistant uses to inspect and drive the trace UI.
+// Read tools (run_query, get_schema, get_selection) return data; mutating tools
+// (select_event, show_timeline, show_query, navigate) just ack. All operate on
+// the already-open trace and nothing persists outside the session, so there is
+// no per-action consent gate (see the RFC's "no consent model" note).
+
+import {z} from 'zod';
+import type {Trace} from '../../public/trace';
+import QueryPagePlugin from '../dev.perfetto.QueryPage';
+import {runQueryForModel} from './query';
+import type {ToolRegistry} from './tools';
+
+export function registerCoreTools(reg: ToolRegistry, trace: Trace): void {
+  const engine = trace.engine;
+
+  reg.registerTool({
+    name: 'run_query',
+    description:
+      'Run a PerfettoSQL query against the open trace and return the rows ' +
+      'as JSON. Call this whenever the user asks about durations, counts, ' +
+      'timings, or relationships between trace events. Prefer aggregation ' +
+      '(COUNT / GROUP BY / LIMIT) over pulling raw rows - results are row-' +
+      'capped and large raw result sets are truncated. Use get_schema first ' +
+      "if you're unsure which tables/columns exist. Some stdlib tables need " +
+      'an `INCLUDE PERFETTO MODULE <name>;` first, run as a separate query.',
+    shape: {
+      sql: z.string().describe('The PerfettoSQL query to execute.'),
+    },
+    callback: async ({sql}) => runQueryForModel(engine, sql),
+  });
+
+  reg.registerTool({
+    name: 'get_schema',
+    description:
+      'List the trace tables/views (no argument) or the columns of one table ' +
+      '(pass `table`). Use this to write valid SQL without guessing schema. ' +
+      'Internal sqlite_* and _-prefixed tables are omitted from the table ' +
+      'list.',
+    shape: {
+      table: z
+        .string()
+        .optional()
+        .describe("If set, return this table's columns instead of the list."),
+    },
+    callback: async ({table}) => {
+      if (table !== undefined && table !== '') {
+        return runQueryForModel(
+          engine,
+          `SELECT name, type FROM pragma_table_info('${table.replace(/'/g, "''")}')`,
+        );
+      }
+      return runQueryForModel(
+        engine,
+        `SELECT name, type FROM sqlite_schema
+         WHERE type IN ('table', 'view')
+           AND name NOT LIKE 'sqlite_%'
+           AND name NOT LIKE '\\_%' ESCAPE '\\'
+         ORDER BY name`,
+      );
+    },
+  });
+
+  reg.registerTool({
+    name: 'get_selection',
+    description:
+      'Read what the user currently has selected in the UI (a track event, a ' +
+      'time-range area selection, a track, or nothing). Use this to resolve ' +
+      'what the user means by "this" / "the selected slice".',
+    shape: {},
+    callback: async () => {
+      const sel = trace.selection.selection;
+      switch (sel.kind) {
+        case 'track_event':
+          return JSON.stringify({
+            kind: 'track_event',
+            trackUri: sel.trackUri,
+            eventId: sel.eventId,
+            ts: Number(sel.ts),
+            dur: sel.dur === undefined ? undefined : Number(sel.dur),
+          });
+        case 'area':
+          return JSON.stringify({
+            kind: 'area',
+            start: Number(sel.start),
+            end: Number(sel.end),
+            trackUris: sel.trackUris,
+          });
+        case 'track':
+          return JSON.stringify({kind: 'track', trackUri: sel.trackUri});
+        case 'note':
+          return JSON.stringify({kind: 'note', id: sel.id});
+        case 'empty':
+          return JSON.stringify({kind: 'empty'});
+      }
+    },
+  });
+
+  // Note: select_event / show_timeline / select_area / get_viewport are
+  // timeline-specific and live in the dev.perfetto.IntellettoTimelineTools
+  // plugin, which registers them against this same registry when both the
+  // Timeline and Intelletto plugins are enabled.
+
+  reg.registerTool({
+    name: 'show_query',
+    description:
+      'Open a PerfettoSQL query in the Query page results view so the user ' +
+      'can see the full table (use this instead of run_query when the user ' +
+      'wants to browse results themselves, not have you summarise them).',
+    mutating: true,
+    shape: {
+      sql: z.string().describe('The PerfettoSQL query to display.'),
+      title: z.string().describe('A short title for the results tab.'),
+    },
+    callback: async ({sql, title}) => {
+      trace.plugins
+        .getPlugin(QueryPagePlugin)
+        .addQueryResultsTab({query: sql, title});
+      return 'OK';
+    },
+  });
+
+  reg.registerTool({
+    name: 'navigate',
+    description:
+      'Switch the UI to a top-level page by its route, e.g. "/viewer" for ' +
+      'the timeline or "/query" for the SQL page. Use when the user asks to ' +
+      'go somewhere.',
+    mutating: true,
+    shape: {
+      page: z.string().describe('Route to navigate to, e.g. "/viewer".'),
+    },
+    callback: async ({page}) => {
+      trace.navigate(page);
+      return 'OK';
+    },
+  });
+}

--- a/ui/src/plugins/dev.perfetto.Intelletto/core_tools.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/core_tools.ts
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The core tool surface the assistant uses to inspect and drive the trace UI.
-// Read tools (run_query, get_schema, get_selection) return data; mutating tools
-// (select_event, show_timeline, show_query, navigate) just ack. All operate on
-// the already-open trace and nothing persists outside the session, so there is
-// no per-action consent gate (see the RFC's "no consent model" note).
-
 import {z} from 'zod';
 import type {Trace} from '../../public/trace';
 import QueryPagePlugin from '../dev.perfetto.QueryPage';
 import {runQueryForModel} from './query';
 import type {ToolRegistry} from './tools';
 
+/**
+ * Register the core tools (run_query, get_schema, get_selection, show_query,
+ * navigate) the assistant always has, backed by the open trace.
+ */
 export function registerCoreTools(reg: ToolRegistry, trace: Trace): void {
   const engine = trace.engine;
 

--- a/ui/src/plugins/dev.perfetto.Intelletto/index.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/index.ts
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// dev.perfetto.Intelletto - the conversational assistant. Depends on the LLM
-// gateway (dev.perfetto.Llm) for models and on a protocol plugin (e.g.
-// dev.perfetto.LlmProtocolGemini) being enabled to actually talk to a backend.
-// Renders a chat panel in the global side panel and wires up commands to open
-// it.
-
 import m from 'mithril';
 import type {ZodRawShape} from 'zod';
 import type {PerfettoPlugin} from '../../public/plugin';
@@ -37,9 +31,11 @@ import {ToolRegistry} from './tools';
 
 const SIDE_PANEL_URI = 'dev.perfetto.Intelletto#Chat';
 
-// The assistant plugin. Trace-scoped: one instance (and one tool registry) per
-// loaded trace. Implements IntellettoToolRegistrar so dependent plugins can
-// contribute tools via `ctx.plugins.getPlugin(IntellettoPlugin).registerTool`.
+/**
+ * The assistant plugin. Trace-scoped: one instance (and one tool registry) per
+ * loaded trace. Implements IntellettoToolRegistrar so dependent plugins can
+ * contribute tools via `ctx.plugins.getPlugin(IntellettoPlugin).registerTool`.
+ */
 export default class IntellettoPlugin
   implements PerfettoPlugin, IntellettoToolRegistrar
 {
@@ -72,18 +68,23 @@ export default class IntellettoPlugin
     registerCoreContextProviders(this.context, this.trace);
   }
 
-  // IntellettoToolRegistrar: contribute a tool the assistant can call. Call
-  // this from a dependent plugin's onTraceLoad.
+  /**
+   * IntellettoToolRegistrar: contribute a tool the assistant can call. Call
+   * from a dependent plugin's onTraceLoad.
+   */
   registerTool<S extends ZodRawShape>(tool: ToolRegistration<S>): void {
     this.tools.registerTool(tool);
   }
 
-  // IntellettoToolRegistrar: contribute a context provider describing what the
-  // user is currently looking at. Call from a dependent plugin's onTraceLoad.
+  /**
+   * IntellettoToolRegistrar: contribute a context provider describing what the
+   * user is looking at. Call from a dependent plugin's onTraceLoad.
+   */
   registerContextProvider(provider: ContextProviderRegistration): void {
     this.context.registerContextProvider(provider);
   }
 
+  /** Register the chat side panel and the open-assistant command for a trace. */
   async onTraceLoad(trace: Trace): Promise<void> {
     const gateway = LlmPlugin.gateway;
 

--- a/ui/src/plugins/dev.perfetto.Intelletto/index.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/index.ts
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// dev.perfetto.Intelletto - the conversational assistant. Depends on the LLM
+// gateway (dev.perfetto.Llm) for models and on a protocol plugin (e.g.
+// dev.perfetto.LlmProtocolGemini) being enabled to actually talk to a backend.
+// Renders a chat panel in the global side panel and wires up commands to open
+// it.
+
+import m from 'mithril';
+import type {ZodRawShape} from 'zod';
+import type {PerfettoPlugin} from '../../public/plugin';
+import type {Trace} from '../../public/trace';
+import LlmPlugin from '../dev.perfetto.Llm';
+import QueryPagePlugin from '../dev.perfetto.QueryPage';
+import type {
+  ContextProviderRegistration,
+  IntellettoToolRegistrar,
+  ToolRegistration,
+} from './api';
+import {ChatPanel} from './chat_panel';
+import {ChatSession} from './chat_session';
+import {ContextRegistry, registerCoreContextProviders} from './context';
+import {registerCoreTools} from './core_tools';
+import {ToolRegistry} from './tools';
+
+const SIDE_PANEL_URI = 'dev.perfetto.Intelletto#Chat';
+
+// The assistant plugin. Trace-scoped: one instance (and one tool registry) per
+// loaded trace. Implements IntellettoToolRegistrar so dependent plugins can
+// contribute tools via `ctx.plugins.getPlugin(IntellettoPlugin).registerTool`.
+export default class IntellettoPlugin
+  implements PerfettoPlugin, IntellettoToolRegistrar
+{
+  static readonly id = 'dev.perfetto.Intelletto';
+  static readonly description =
+    'Conversational AI assistant. Ask about your trace in natural language; ' +
+    'it queries the trace and drives the UI. Requires the dev.perfetto.Llm ' +
+    'gateway and an LLM protocol plugin. Other plugins can register their own ' +
+    'tools via getPlugin(IntellettoPlugin).registerTool().';
+  static readonly dependencies = [LlmPlugin, QueryPagePlugin];
+
+  // The shared tool registry for this trace. Core tools plus any contributed by
+  // other plugins land here; the chat panel hands it to the agent.
+  private readonly tools = new ToolRegistry();
+
+  // The shared context-provider registry for this trace. Core providers (page,
+  // selection) plus any contributed by other plugins; the chat panel samples it
+  // for the context strip and the prompt.
+  private readonly context = new ContextRegistry();
+
+  // The conversation state for this trace. Owned here - not by the chat panel
+  // component - so the conversation survives the side panel being closed and
+  // reopened. Created lazily on first panel open, so context providers
+  // registered by dependent plugins are in by the time the system prompt is
+  // assembled.
+  private session?: ChatSession;
+
+  constructor(private readonly trace: Trace) {
+    registerCoreTools(this.tools, this.trace);
+    registerCoreContextProviders(this.context, this.trace);
+  }
+
+  // IntellettoToolRegistrar: contribute a tool the assistant can call. Call
+  // this from a dependent plugin's onTraceLoad.
+  registerTool<S extends ZodRawShape>(tool: ToolRegistration<S>): void {
+    this.tools.registerTool(tool);
+  }
+
+  // IntellettoToolRegistrar: contribute a context provider describing what the
+  // user is currently looking at. Call from a dependent plugin's onTraceLoad.
+  registerContextProvider(provider: ContextProviderRegistration): void {
+    this.context.registerContextProvider(provider);
+  }
+
+  async onTraceLoad(trace: Trace): Promise<void> {
+    const gateway = LlmPlugin.gateway;
+
+    // One chat session per trace - the conversation is scoped to the open
+    // trace and kept in memory only (re-created on the next trace load). It
+    // reads the shared registries, so tools registered by other plugins
+    // (before or after the panel is first opened) are all visible to the
+    // agent.
+    trace.sidePanel.registerTab({
+      uri: SIDE_PANEL_URI,
+      title: 'Intelletto',
+      icon: 'psychology',
+      render: () => {
+        this.session ??= new ChatSession(gateway, this.tools, this.context);
+        return m(ChatPanel, {
+          gateway,
+          session: this.session,
+          context: this.context,
+        });
+      },
+    });
+
+    trace.commands.registerCommand({
+      id: 'dev.perfetto.Intelletto#Open',
+      name: 'Intelletto: Open assistant',
+      callback: () => trace.sidePanel.showTab(SIDE_PANEL_URI),
+      defaultHotkey: 'Mod+Shift+A',
+    });
+  }
+}
+
+// Re-export the public API types so dependents can import them from the plugin
+// entry point: `import IntellettoPlugin, {ToolRegistration} from '...'`.
+export type {
+  ContextProviderRegistration,
+  ContextSnapshot,
+  IntellettoToolRegistrar,
+  ToolRegistration,
+} from './api';

--- a/ui/src/plugins/dev.perfetto.Intelletto/query.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/query.ts
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {Engine} from '../../trace_processor/engine';
+import type {SqlValue} from '../../trace_processor/query_result';
+
+// A hard row cap on what a single query can return to the model. A stray
+// `SELECT *` over a multi-million-row table would otherwise blow the context
+// window; we truncate and tell the model the result is partial so it doesn't
+// reason over it as complete (and is steered toward aggregation instead).
+const MAX_ROWS = 1000;
+
+// Run a PerfettoSQL query and serialise the result to a compact JSON string the
+// model can read. bigints are narrowed to numbers (JSON can't carry bigint);
+// this loses precision above 2^53 but trace ids/timestamps the model reasons
+// over are well within range, and it keeps the payload small.
+export async function runQueryForModel(
+  engine: Engine,
+  query: string,
+): Promise<string> {
+  const result = await engine.query(query);
+  const columns = result.columns();
+  const rows: Array<Record<string, SqlValue | number>> = [];
+  let truncated = false;
+  for (const it = result.iter({}); it.valid(); it.next()) {
+    if (rows.length >= MAX_ROWS) {
+      truncated = true;
+      break;
+    }
+    const row: Record<string, SqlValue | number> = {};
+    for (const name of columns) {
+      const value = it.get(name);
+      row[name] = typeof value === 'bigint' ? Number(value) : value;
+    }
+    rows.push(row);
+  }
+  const payload = JSON.stringify({columns, rows});
+  if (truncated) {
+    return (
+      payload +
+      `\n... ${MAX_ROWS}+ rows; result truncated. Prefer COUNT/GROUP BY/` +
+      `LIMIT or aggregate rather than pulling raw rows.`
+    );
+  }
+  return payload;
+}

--- a/ui/src/plugins/dev.perfetto.Intelletto/query.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/query.ts
@@ -19,12 +19,13 @@ import type {SqlValue} from '../../trace_processor/query_result';
 // `SELECT *` over a multi-million-row table would otherwise blow the context
 // window; we truncate and tell the model the result is partial so it doesn't
 // reason over it as complete (and is steered toward aggregation instead).
-const MAX_ROWS = 1000;
+const MAX_ROWS = 100;
 
-// Run a PerfettoSQL query and serialise the result to a compact JSON string the
-// model can read. bigints are narrowed to numbers (JSON can't carry bigint);
-// this loses precision above 2^53 but trace ids/timestamps the model reasons
-// over are well within range, and it keeps the payload small.
+/**
+ * Run a PerfettoSQL query and serialise the result to a compact JSON string the
+ * model can read. Row-capped at MAX_ROWS (with a truncation note), and bigints
+ * are narrowed to numbers since JSON can't carry bigint.
+ */
 export async function runQueryForModel(
   engine: Engine,
   query: string,

--- a/ui/src/plugins/dev.perfetto.Intelletto/system_prompt.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/system_prompt.ts
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The assistant plugin's application system prompt. Kept stable (it sits at the
+// front of the cache-stable prefix) and deliberately small - the model
+// bootstraps the rest of its knowledge via the lazy tool-loading meta-tools.
+// A per-model system prompt (from the Model config) is prepended to this by the
+// gateway.
+
+export const SYSTEM_PROMPT = `
+You are Intelletto, an assistant embedded in the Perfetto UI, a trace viewer.
+Your job is to help the user understand and debug the trace they have open, and
+to drive the UI on their behalf.
+
+You have tools available to query the trace and drive the UI. Call them
+directly when they help; you do not need to announce or "load" them first.
+
+Guidance:
+- To answer questions about the trace, load and use the query tools. Write
+  PerfettoSQL; check the schema with the schema tool rather than guessing table
+  or column names.
+- Prefer aggregation (COUNT / GROUP BY / LIMIT) over pulling raw rows. Query
+  results are row-capped.
+- When the user refers to "this" or "the selected slice", read the current
+  selection rather than guessing.
+- You can act on the user's behalf - select events, pan the timeline, open
+  views - but also teach: when a feature would help the user do something
+  themselves, explain it.
+- If a tool returns an error, read it and correct your call.
+- Be concise. Trace data is the source of truth; cite concrete numbers.
+`.trim();

--- a/ui/src/plugins/dev.perfetto.Intelletto/system_prompt.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/system_prompt.ts
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The assistant plugin's application system prompt. Kept stable (it sits at the
-// front of the cache-stable prefix) and deliberately small - the model
-// bootstraps the rest of its knowledge via the lazy tool-loading meta-tools.
-// A per-model system prompt (from the Model config) is prepended to this by the
-// gateway.
-
+/**
+ * The assistant plugin's application system prompt. Kept stable (it sits at the
+ * front of the cache-stable prefix) and deliberately small. A per-model system
+ * prompt (from the Model config) is prepended to this by the gateway.
+ */
 export const SYSTEM_PROMPT = `
 You are Intelletto, an assistant embedded in the Perfetto UI, a trace viewer.
 Your job is to help the user understand and debug the trace they have open, and

--- a/ui/src/plugins/dev.perfetto.Intelletto/tools.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/tools.ts
@@ -12,38 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The tool surface: how the model gets *hands* to drive the UI and query the
-// trace. A tool is a name + a description (telling the model *when* to call it)
-// + a zod input schema (validated before the callback runs) + a callback. The
-// registry validates the model's args up front, turning malformed args into a
-// clean tool-result error the model can self-correct from rather than an
-// exception in plugin code.
-
 import {z, type ZodObject, type ZodRawShape} from 'zod';
 import type {ToolRegistration} from './api';
 
-// A tool's callback returns a string (the tool result fed back to the model).
-// Read tools return data; mutating tools just ack ('OK') or throw.
+/**
+ * A registered tool, normalised from a ToolRegistration: the args shape is
+ * wrapped in a ZodObject and the callback takes unknown args (validated on
+ * call).
+ */
 export interface ToolDef {
   readonly name: string;
   readonly description: string;
   readonly inputSchema: ZodObject<ZodRawShape>;
-  // Whether the tool mutates UI state (vs. read-only). The harness doesn't gate
-  // on this in Phase 1 (no consent model - tools are non-destructive and
-  // session-scoped), but it's the natural hook to add a confirmation later.
+  /** Whether the tool mutates UI state (vs. read-only). */
   readonly mutating: boolean;
   readonly callback: (args: unknown) => Promise<string>;
 }
 
-// The concrete registry behind the public IntellettoToolRegistrar's
-// registerTool. Core tools and plugin-contributed tools both land here; the
-// agent reads it to expose tools to the model.
+/**
+ * The concrete registry behind IntellettoToolRegistrar.registerTool. Core and
+ * plugin-contributed tools both land here; the agent reads it to expose tools
+ * to the model.
+ */
 export class ToolRegistry {
   private readonly tools = new Map<string, ToolDef>();
 
-  // Register a tool. `shape` is a zod raw shape (e.g. {sql: z.string()}); we
-  // wrap it in a ZodObject so we can both validate at call time and emit JSON
-  // Schema for the model.
+  /** Register a tool. Throws if the name is already registered. */
   registerTool<S extends ZodRawShape>(opts: ToolRegistration<S>): void {
     if (this.tools.has(opts.name)) {
       throw new Error(`Tool "${opts.name}" already registered`);
@@ -58,17 +52,21 @@ export class ToolRegistry {
     });
   }
 
+  /** Look up a tool by name, or undefined if not registered. */
   get(name: string): ToolDef | undefined {
     return this.tools.get(name);
   }
 
-  list(): ReadonlyArray<ToolDef> {
+  /** All registered tools, in registration order. */
+  list(): readonly ToolDef[] {
     return Array.from(this.tools.values());
   }
 
-  // Validate args against the tool's schema, then invoke. Validation failures
-  // are returned as a thrown Error so the agent loop can fold them back into
-  // the conversation as a tool-result error (the model self-corrects).
+  /**
+   * Validate args against the tool's schema, then invoke. Throws on unknown
+   * tool or invalid args so the agent loop can fold it back as a tool-result
+   * error.
+   */
   async call(name: string, rawArgs: unknown): Promise<string> {
     const tool = this.tools.get(name);
     if (tool === undefined) throw new Error(`Unknown tool "${name}"`);

--- a/ui/src/plugins/dev.perfetto.Intelletto/tools.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/tools.ts
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The tool surface: how the model gets *hands* to drive the UI and query the
+// trace. A tool is a name + a description (telling the model *when* to call it)
+// + a zod input schema (validated before the callback runs) + a callback. The
+// registry validates the model's args up front, turning malformed args into a
+// clean tool-result error the model can self-correct from rather than an
+// exception in plugin code.
+
+import {z, type ZodObject, type ZodRawShape} from 'zod';
+import type {ToolRegistration} from './api';
+
+// A tool's callback returns a string (the tool result fed back to the model).
+// Read tools return data; mutating tools just ack ('OK') or throw.
+export interface ToolDef {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: ZodObject<ZodRawShape>;
+  // Whether the tool mutates UI state (vs. read-only). The harness doesn't gate
+  // on this in Phase 1 (no consent model - tools are non-destructive and
+  // session-scoped), but it's the natural hook to add a confirmation later.
+  readonly mutating: boolean;
+  readonly callback: (args: unknown) => Promise<string>;
+}
+
+// The concrete registry behind the public IntellettoToolRegistrar's
+// registerTool. Core tools and plugin-contributed tools both land here; the
+// agent reads it to expose tools to the model.
+export class ToolRegistry {
+  private readonly tools = new Map<string, ToolDef>();
+
+  // Register a tool. `shape` is a zod raw shape (e.g. {sql: z.string()}); we
+  // wrap it in a ZodObject so we can both validate at call time and emit JSON
+  // Schema for the model.
+  registerTool<S extends ZodRawShape>(opts: ToolRegistration<S>): void {
+    if (this.tools.has(opts.name)) {
+      throw new Error(`Tool "${opts.name}" already registered`);
+    }
+    const inputSchema = z.object(opts.shape);
+    this.tools.set(opts.name, {
+      name: opts.name,
+      description: opts.description,
+      inputSchema: inputSchema as unknown as ZodObject<ZodRawShape>,
+      mutating: opts.mutating ?? false,
+      callback: opts.callback as (args: unknown) => Promise<string>,
+    });
+  }
+
+  get(name: string): ToolDef | undefined {
+    return this.tools.get(name);
+  }
+
+  list(): ReadonlyArray<ToolDef> {
+    return Array.from(this.tools.values());
+  }
+
+  // Validate args against the tool's schema, then invoke. Validation failures
+  // are returned as a thrown Error so the agent loop can fold them back into
+  // the conversation as a tool-result error (the model self-corrects).
+  async call(name: string, rawArgs: unknown): Promise<string> {
+    const tool = this.tools.get(name);
+    if (tool === undefined) throw new Error(`Unknown tool "${name}"`);
+    const parsed = tool.inputSchema.safeParse(rawArgs ?? {});
+    if (!parsed.success) {
+      throw new Error(
+        `Invalid arguments for "${name}": ${parsed.error.message}`,
+      );
+    }
+    return tool.callback(parsed.data);
+  }
+}

--- a/ui/src/public/app.ts
+++ b/ui/src/public/app.ts
@@ -27,6 +27,16 @@ import type {TraceStream} from './stream';
 import type {TaskTracker} from './task_tracker';
 import type {Trace} from './trace';
 
+// A broken down representation of a route.
+// For instance: #!/record/gpu?local_cache_key=a0b1
+// becomes: {page: '/record', subpage: '/gpu', args: {local_cache_key: 'a0b1'}}
+export interface Route {
+  page: string;
+  subpage: string;
+  fragment: string;
+  args: RouteArgs;
+}
+
 /**
  * The API endpoint to interact programmatically with the UI before a trace has
  * been loaded. This is passed to plugins' OnActivate().
@@ -81,6 +91,11 @@ export interface App {
    * Navigate to a new page.
    */
   navigate(newHash: string): void;
+
+  /**
+   * Returns the route/page we're on.
+   */
+  getCurrentRoute(): Route;
 
   openTraceFromFile(file: File): Promise<Trace>;
   openTraceFromUrl(url: string): Promise<Trace>;


### PR DESCRIPTION
Adds dev.perfetto.Intelletto, the conversational assistant that sits in the sidebar and uses the LLM gateway plugin. It owns the agent loop (multi-step tool use with lazy tool loading), the trace-scoped chat session and context registry, the core query/schema tools, and the sidebar chat panel.

The agent drives the gateway directly: it picks the first configured model advertising the 'agentic' role and streams a turn via gateway.createStream(). The chat panel header shows that active model.

RFC: https://github.com/google/perfetto/discussions/6240

Note: Plugin is not enabled while in development - so for testing, enable `dev.perfetto.Intelletto` and open the sidebar.

Tools:

1. run_query — run PerfettoSQL, return rows as JSON
2. get_schema — list tables/views or a table's columns
3. get_selection — read the current UI selection
4. show_query — open a query in the Query page (mutating)
5. navigate — switch to a route, e.g. /viewer (mutating)
6. list_tools / more_tools — lazy-loading meta-tools (off by default)

Context injections:

1. page — current page route
2. viewport — visible time range (start/end ns)
3. selection — current selection, if any
