### PR TITLE
trace_processor: reject overflowing offset+length in TraceBlobViewReader::SliceOff

### DIFF
--- a/src/trace_processor/importers/perf/perf_data_tokenizer.cc
+++ b/src/trace_processor/importers/perf/perf_data_tokenizer.cc
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -219,9 +220,9 @@ PerfDataTokenizer::ParseHeader() {
 static base::Status CheckSectionInBounds(uint64_t offset,
                                          uint64_t size,
                                          const char* name) {
-  if (offset + size < offset) {
+  if (size > std::numeric_limits<uint64_t>::max() - offset) {
     return base::ErrStatus("Invalid %s section: offset (%" PRIu64
-                           ") + size (%" PRIu64 ") overflows",
+                           ") + size (%" PRIu64 ") exceeds uint64 max",
                            name, offset, size);
   }
   return base::OkStatus();

--- a/src/trace_processor/importers/perf/perf_data_tokenizer.cc
+++ b/src/trace_processor/importers/perf/perf_data_tokenizer.cc
@@ -213,8 +213,24 @@ PerfDataTokenizer::ParseHeader() {
   return ParsingResult::kSuccess;
 }
 
+// Rejects a section whose attacker-controlled `offset + size` overflows. Such a
+// range can never be satisfied by more data, so it must reject the trace rather
+// than be treated as "more data needed" (an empty/absent slice).
+static base::Status CheckSectionInBounds(uint64_t offset,
+                                         uint64_t size,
+                                         const char* name) {
+  if (offset + size < offset) {
+    return base::ErrStatus("Invalid %s section: offset (%" PRIu64
+                           ") + size (%" PRIu64 ") overflows",
+                           name, offset, size);
+  }
+  return base::OkStatus();
+}
+
 base::StatusOr<PerfDataTokenizer::ParsingResult>
 PerfDataTokenizer::ParseAttrs() {
+  RETURN_IF_ERROR(CheckSectionInBounds(header_.attrs.offset,
+                                       header_.attrs.size, "attrs"));
   std::optional<TraceBlobView> tbv =
       buffer_.SliceOff(header_.attrs.offset, header_.attrs.size);
   if (!tbv) {
@@ -233,6 +249,8 @@ PerfDataTokenizer::ParseAttrs() {
       return base::ErrStatus("Invalid id section size: %" PRIu64,
                              entry.ids.size);
     }
+    RETURN_IF_ERROR(
+        CheckSectionInBounds(entry.ids.offset, entry.ids.size, "id"));
 
     tbv = buffer_.SliceOff(entry.ids.offset, entry.ids.size);
     if (!tbv) {
@@ -396,6 +414,9 @@ void PerfDataTokenizer::MaybePushRecord(Record record) {
 base::StatusOr<PerfDataTokenizer::ParsingResult>
 PerfDataTokenizer::ParseFeatureSections() {
   PERFETTO_CHECK(buffer_.start_offset() == header_.data.end());
+  RETURN_IF_ERROR(CheckSectionInBounds(feature_headers_section_.offset,
+                                       feature_headers_section_.size,
+                                       "feature headers"));
   auto tbv = buffer_.SliceOff(feature_headers_section_.offset,
                               feature_headers_section_.size);
   if (!tbv) {
@@ -433,6 +454,8 @@ PerfDataTokenizer::ParseFeatures() {
   while (!feature_sections_.empty()) {
     const auto feature_id = feature_sections_.back().first;
     const auto& section = feature_sections_.back().second;
+    RETURN_IF_ERROR(
+        CheckSectionInBounds(section.offset, section.size, "feature"));
     auto tbv = buffer_.SliceOff(section.offset, section.size);
     if (!tbv) {
       return ParsingResult::kMoreDataNeeded;

--- a/src/trace_processor/importers/perf/perf_data_tokenizer.cc
+++ b/src/trace_processor/importers/perf/perf_data_tokenizer.cc
@@ -217,21 +217,19 @@ PerfDataTokenizer::ParseHeader() {
 // Rejects a section whose attacker-controlled `offset + size` overflows. Such a
 // range can never be satisfied by more data, so it must reject the trace rather
 // than be treated as "more data needed" (an empty/absent slice).
-static base::Status CheckSectionInBounds(uint64_t offset,
-                                         uint64_t size,
+static base::Status CheckSectionInBounds(const PerfFile::Section& section,
                                          const char* name) {
-  if (size > std::numeric_limits<uint64_t>::max() - offset) {
+  if (section.size > std::numeric_limits<uint64_t>::max() - section.offset) {
     return base::ErrStatus("Invalid %s section: offset (%" PRIu64
                            ") + size (%" PRIu64 ") exceeds uint64 max",
-                           name, offset, size);
+                           name, section.offset, section.size);
   }
   return base::OkStatus();
 }
 
 base::StatusOr<PerfDataTokenizer::ParsingResult>
 PerfDataTokenizer::ParseAttrs() {
-  RETURN_IF_ERROR(CheckSectionInBounds(header_.attrs.offset,
-                                       header_.attrs.size, "attrs"));
+  RETURN_IF_ERROR(CheckSectionInBounds(header_.attrs, "attrs"));
   std::optional<TraceBlobView> tbv =
       buffer_.SliceOff(header_.attrs.offset, header_.attrs.size);
   if (!tbv) {
@@ -251,7 +249,7 @@ PerfDataTokenizer::ParseAttrs() {
                              entry.ids.size);
     }
     RETURN_IF_ERROR(
-        CheckSectionInBounds(entry.ids.offset, entry.ids.size, "id"));
+        CheckSectionInBounds(entry.ids, "id"));
 
     tbv = buffer_.SliceOff(entry.ids.offset, entry.ids.size);
     if (!tbv) {
@@ -415,9 +413,8 @@ void PerfDataTokenizer::MaybePushRecord(Record record) {
 base::StatusOr<PerfDataTokenizer::ParsingResult>
 PerfDataTokenizer::ParseFeatureSections() {
   PERFETTO_CHECK(buffer_.start_offset() == header_.data.end());
-  RETURN_IF_ERROR(CheckSectionInBounds(feature_headers_section_.offset,
-                                       feature_headers_section_.size,
-                                       "feature headers"));
+  RETURN_IF_ERROR(
+      CheckSectionInBounds(feature_headers_section_, "feature headers"));
   auto tbv = buffer_.SliceOff(feature_headers_section_.offset,
                               feature_headers_section_.size);
   if (!tbv) {
@@ -456,7 +453,7 @@ PerfDataTokenizer::ParseFeatures() {
     const auto feature_id = feature_sections_.back().first;
     const auto& section = feature_sections_.back().second;
     RETURN_IF_ERROR(
-        CheckSectionInBounds(section.offset, section.size, "feature"));
+        CheckSectionInBounds(section, "feature"));
     auto tbv = buffer_.SliceOff(section.offset, section.size);
     if (!tbv) {
       return ParsingResult::kMoreDataNeeded;

--- a/src/trace_processor/importers/perf/perf_data_tokenizer.cc
+++ b/src/trace_processor/importers/perf/perf_data_tokenizer.cc
@@ -248,8 +248,7 @@ PerfDataTokenizer::ParseAttrs() {
       return base::ErrStatus("Invalid id section size: %" PRIu64,
                              entry.ids.size);
     }
-    RETURN_IF_ERROR(
-        CheckSectionInBounds(entry.ids, "id"));
+    RETURN_IF_ERROR(CheckSectionInBounds(entry.ids, "id"));
 
     tbv = buffer_.SliceOff(entry.ids.offset, entry.ids.size);
     if (!tbv) {
@@ -452,8 +451,7 @@ PerfDataTokenizer::ParseFeatures() {
   while (!feature_sections_.empty()) {
     const auto feature_id = feature_sections_.back().first;
     const auto& section = feature_sections_.back().second;
-    RETURN_IF_ERROR(
-        CheckSectionInBounds(section, "feature"));
+    RETURN_IF_ERROR(CheckSectionInBounds(section, "feature"));
     auto tbv = buffer_.SliceOff(section.offset, section.size);
     if (!tbv) {
       return ParsingResult::kMoreDataNeeded;

--- a/src/trace_processor/util/trace_blob_view_reader.cc
+++ b/src/trace_processor/util/trace_blob_view_reader.cc
@@ -69,14 +69,11 @@ auto TraceBlobViewReader::SliceOffImpl(const size_t offset,
     return visitor.OneSlice(TraceBlobView());
   }
 
-  // Reject requests where `offset + length` would overflow. The bounds checks
-  // below compute `offset + length` in size_t arithmetic, so an overflowing
-  // (offset, length) pair -- e.g. an attacker-controlled section offset read
-  // from a perf.data file -- could wrap to a small value, spuriously pass the
-  // fast-path check and produce an out-of-bounds slice.
-  if (PERFETTO_UNLIKELY(offset > std::numeric_limits<size_t>::max() - length)) {
-    return visitor.NoData();
-  }
+  // `offset + length` is computed in size_t arithmetic below, so an overflowing
+  // (offset, length) pair would wrap and produce an out-of-bounds slice. Callers
+  // that read untrusted section bounds (e.g. the perf.data tokenizer) reject
+  // such traces before slicing, so we should never reach here with one.
+  PERFETTO_CHECK(offset <= std::numeric_limits<size_t>::max() - length);
 
   PERFETTO_DCHECK(offset >= start_offset());
 

--- a/src/trace_processor/util/trace_blob_view_reader.cc
+++ b/src/trace_processor/util/trace_blob_view_reader.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
+#include <limits>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -66,6 +67,15 @@ auto TraceBlobViewReader::SliceOffImpl(const size_t offset,
   // If the length is zero, then a zero-sized blob view is always appropriate.
   if (PERFETTO_UNLIKELY(length == 0)) {
     return visitor.OneSlice(TraceBlobView());
+  }
+
+  // Reject requests where `offset + length` would overflow. The bounds checks
+  // below compute `offset + length` in size_t arithmetic, so an overflowing
+  // (offset, length) pair -- e.g. an attacker-controlled section offset read
+  // from a perf.data file -- could wrap to a small value, spuriously pass the
+  // fast-path check and produce an out-of-bounds slice.
+  if (PERFETTO_UNLIKELY(offset > std::numeric_limits<size_t>::max() - length)) {
+    return visitor.NoData();
   }
 
   PERFETTO_DCHECK(offset >= start_offset());

--- a/src/trace_processor/util/trace_blob_view_reader.cc
+++ b/src/trace_processor/util/trace_blob_view_reader.cc
@@ -70,9 +70,9 @@ auto TraceBlobViewReader::SliceOffImpl(const size_t offset,
   }
 
   // `offset + length` is computed in size_t arithmetic below, so an overflowing
-  // (offset, length) pair would wrap and produce an out-of-bounds slice. Callers
-  // that read untrusted section bounds (e.g. the perf.data tokenizer) reject
-  // such traces before slicing, so we should never reach here with one.
+  // (offset, length) pair would wrap and produce an out-of-bounds slice.
+  // Callers that read untrusted section bounds (e.g. the perf.data tokenizer)
+  // reject such traces before slicing, so we should never reach here with one.
   PERFETTO_CHECK(offset <= std::numeric_limits<size_t>::max() - length);
 
   PERFETTO_DCHECK(offset >= start_offset());


### PR DESCRIPTION
**trace_processor: reject overflowing offset+length in TraceBlobViewReader::SliceOff**

`TraceBlobViewReader::SliceOffImpl` bounds-checks a requested slice with `offset + length <= ...` (fast path)
and `offset + length > end_offset_`, computing `offset + length` in `size_t` without checking for overflow.

A caller can pass an attacker-controlled `offset`. For example the perf.data importer reads each attrs
`ids` section as a `PerfFile::Section {uint64 offset, uint64 size}` directly from the file and validates only
that `ids.size` is a multiple of 8 (`perf_data_tokenizer.cc`), then calls `SliceOff(ids.offset, ids.size)`.
With `offset + length` wrapping past `2^64`, the sum becomes a small value that spuriously passes the
fast-path check. `SliceOff` then returns a `TraceBlobView` pointing outside the backing buffer
(`TraceBlobView::slice_off` only `DCHECK`s, which is compiled out in release builds), and the subsequent
`Reader::ReadVector`/read performs an out-of-bounds heap access.

Reject `offset`/`length` pairs whose sum overflows, before the bounds checks. This fixes the issue for every
importer that reaches `SliceOff` with a file-controlled offset, not just perf.data.
