### PR TITLE
trace_processor: bounds-check id lookups in the instruments importer

### DIFF
--- a/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
+++ b/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
@@ -352,8 +352,9 @@ class InstrumentsXmlTokenizer::Impl {
         }
         current_new_frame_ = new_frame.id;
       }
-      data_.GetBacktrace(current_row_.backtrace)
-          ->frames.push_back(frame_lookup.ref);
+      if (Backtrace* backtrace = data_.GetBacktrace(current_row_.backtrace)) {
+        backtrace->frames.push_back(frame_lookup.ref);
+      }
     } else if (tag_name == "binary") {
       // Can only be processing a binary when processing a new frame.
       PERFETTO_DCHECK(current_new_frame_ != kNullId);
@@ -376,8 +377,10 @@ class InstrumentsXmlTokenizer::Impl {
         }
         new_binary.ptr->max_addr = new_binary.ptr->load_addr;
       }
-      PERFETTO_DCHECK(data_.GetFrame(current_new_frame_)->binary == kNullId);
-      data_.GetFrame(current_new_frame_)->binary = binary_lookup.ref;
+      if (Frame* frame = data_.GetFrame(current_new_frame_)) {
+        PERFETTO_DCHECK(frame->binary == kNullId);
+        frame->binary = binary_lookup.ref;
+      }
     }
   }
 

--- a/src/trace_processor/importers/instruments/row_data_tracker.cc
+++ b/src/trace_processor/importers/instruments/row_data_tracker.cc
@@ -35,9 +35,9 @@ IdPtr<Thread> RowDataTracker::NewThread() {
   return {id + 1, ptr};
 }
 Thread* RowDataTracker::GetThread(ThreadId id) {
-  // Ids are 1-based and come (transitively) from the parsed trace, so a malformed
-  // file can supply kNullId or an out-of-range id. Fail closed rather than indexing
-  // out of bounds (see GetBinary for the same pattern).
+  // Ids are 1-based and come (transitively) from the parsed trace, so a
+  // malformed file can supply kNullId or an out-of-range id. Fail closed rather
+  // than indexing out of bounds (see GetBinary for the same pattern).
   if (id == kNullId || id > threads_.size()) {
     return nullptr;
   }
@@ -51,9 +51,9 @@ IdPtr<Process> RowDataTracker::NewProcess() {
   return {id + 1, ptr};
 }
 Process* RowDataTracker::GetProcess(ProcessId id) {
-  // Ids are 1-based and come (transitively) from the parsed trace, so a malformed
-  // file can supply kNullId or an out-of-range id. Fail closed rather than indexing
-  // out of bounds (see GetBinary for the same pattern).
+  // Ids are 1-based and come (transitively) from the parsed trace, so a
+  // malformed file can supply kNullId or an out-of-range id. Fail closed rather
+  // than indexing out of bounds (see GetBinary for the same pattern).
   if (id == kNullId || id > processes_.size()) {
     return nullptr;
   }
@@ -67,9 +67,9 @@ IdPtr<Frame> RowDataTracker::NewFrame() {
   return {id + 1, ptr};
 }
 Frame* RowDataTracker::GetFrame(BacktraceFrameId id) {
-  // Ids are 1-based and come (transitively) from the parsed trace, so a malformed
-  // file can supply kNullId or an out-of-range id. Fail closed rather than indexing
-  // out of bounds (see GetBinary for the same pattern).
+  // Ids are 1-based and come (transitively) from the parsed trace, so a
+  // malformed file can supply kNullId or an out-of-range id. Fail closed rather
+  // than indexing out of bounds (see GetBinary for the same pattern).
   if (id == kNullId || id > frames_.size()) {
     return nullptr;
   }
@@ -83,9 +83,9 @@ IdPtr<Backtrace> RowDataTracker::NewBacktrace() {
   return {id + 1, ptr};
 }
 Backtrace* RowDataTracker::GetBacktrace(BacktraceId id) {
-  // Ids are 1-based and come (transitively) from the parsed trace, so a malformed
-  // file can supply kNullId or an out-of-range id. Fail closed rather than indexing
-  // out of bounds (see GetBinary for the same pattern).
+  // Ids are 1-based and come (transitively) from the parsed trace, so a
+  // malformed file can supply kNullId or an out-of-range id. Fail closed rather
+  // than indexing out of bounds (see GetBinary for the same pattern).
   if (id == kNullId || id > backtraces_.size()) {
     return nullptr;
   }
@@ -99,8 +99,9 @@ IdPtr<Binary> RowDataTracker::NewBinary() {
   return {id + 1, ptr};
 }
 Binary* RowDataTracker::GetBinary(BinaryId id) {
-  // Frames are allowed to have null binaries.
-  if (id == kNullId)
+  // Frames are allowed to have null binaries; an out-of-range id comes from a
+  // malformed trace, so fail closed rather than indexing out of bounds.
+  if (id == kNullId || id > binaries_.size())
     return nullptr;
   return &binaries_[id - 1];
 }

--- a/src/trace_processor/importers/instruments/row_data_tracker.cc
+++ b/src/trace_processor/importers/instruments/row_data_tracker.cc
@@ -35,7 +35,12 @@ IdPtr<Thread> RowDataTracker::NewThread() {
   return {id + 1, ptr};
 }
 Thread* RowDataTracker::GetThread(ThreadId id) {
-  PERFETTO_DCHECK(id != kNullId);
+  // Ids are 1-based and come (transitively) from the parsed trace, so a malformed
+  // file can supply kNullId or an out-of-range id. Fail closed rather than indexing
+  // out of bounds (see GetBinary for the same pattern).
+  if (id == kNullId || id > threads_.size()) {
+    return nullptr;
+  }
   return &threads_[id - 1];
 }
 
@@ -46,7 +51,12 @@ IdPtr<Process> RowDataTracker::NewProcess() {
   return {id + 1, ptr};
 }
 Process* RowDataTracker::GetProcess(ProcessId id) {
-  PERFETTO_DCHECK(id != kNullId);
+  // Ids are 1-based and come (transitively) from the parsed trace, so a malformed
+  // file can supply kNullId or an out-of-range id. Fail closed rather than indexing
+  // out of bounds (see GetBinary for the same pattern).
+  if (id == kNullId || id > processes_.size()) {
+    return nullptr;
+  }
   return &processes_[id - 1];
 }
 
@@ -57,7 +67,12 @@ IdPtr<Frame> RowDataTracker::NewFrame() {
   return {id + 1, ptr};
 }
 Frame* RowDataTracker::GetFrame(BacktraceFrameId id) {
-  PERFETTO_DCHECK(id != kNullId);
+  // Ids are 1-based and come (transitively) from the parsed trace, so a malformed
+  // file can supply kNullId or an out-of-range id. Fail closed rather than indexing
+  // out of bounds (see GetBinary for the same pattern).
+  if (id == kNullId || id > frames_.size()) {
+    return nullptr;
+  }
   return &frames_[id - 1];
 }
 
@@ -68,7 +83,12 @@ IdPtr<Backtrace> RowDataTracker::NewBacktrace() {
   return {id + 1, ptr};
 }
 Backtrace* RowDataTracker::GetBacktrace(BacktraceId id) {
-  PERFETTO_DCHECK(id != kNullId);
+  // Ids are 1-based and come (transitively) from the parsed trace, so a malformed
+  // file can supply kNullId or an out-of-range id. Fail closed rather than indexing
+  // out of bounds (see GetBinary for the same pattern).
+  if (id == kNullId || id > backtraces_.size()) {
+    return nullptr;
+  }
   return &backtraces_[id - 1];
 }
 

--- a/src/trace_processor/importers/instruments/row_parser.cc
+++ b/src/trace_processor/importers/instruments/row_parser.cc
@@ -23,12 +23,14 @@
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/string_view.h"
 #include "src/trace_processor/importers/common/address_range.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/mapping_tracker.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
 #include "src/trace_processor/importers/common/virtual_memory_mapping.h"
 #include "src/trace_processor/importers/instruments/row.h"
 #include "src/trace_processor/importers/instruments/row_data_tracker.h"
+#include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/util/build_id.h"
 
@@ -51,10 +53,14 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
 
   Thread* thread = data_.GetThread(row.thread);
   if (!thread) {
+    context_->import_logs_tracker->RecordParserError(
+        stats::instruments_row_missing_thread, ts);
     return;
   }
   Process* process = data_.GetProcess(thread->process);
   if (!process) {
+    context_->import_logs_tracker->RecordParserError(
+        stats::instruments_row_missing_process, ts);
     return;
   }
   uint32_t tid = static_cast<uint32_t>(thread->tid);
@@ -74,6 +80,8 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
 
   Backtrace* backtrace = data_.GetBacktrace(row.backtrace);
   if (!backtrace) {
+    context_->import_logs_tracker->RecordParserError(
+        stats::instruments_row_missing_backtrace, ts);
     return;
   }
   std::optional<CallsiteId> parent;
@@ -83,6 +91,8 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
        ++it) {
     Frame* frame = data_.GetFrame(*it);
     if (!frame) {
+      context_->import_logs_tracker->RecordParserError(
+          stats::instruments_row_missing_frame, ts);
       continue;
     }
     Binary* binary = data_.GetBinary(frame->binary);

--- a/src/trace_processor/importers/instruments/row_parser.cc
+++ b/src/trace_processor/importers/instruments/row_parser.cc
@@ -50,7 +50,13 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
   }
 
   Thread* thread = data_.GetThread(row.thread);
+  if (!thread) {
+    return;
+  }
   Process* process = data_.GetProcess(thread->process);
+  if (!process) {
+    return;
+  }
   uint32_t tid = static_cast<uint32_t>(thread->tid);
   uint32_t pid = static_cast<uint32_t>(process->pid);
 
@@ -67,12 +73,18 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
   auto& stack_profile_tracker = *context_->stack_profile_tracker;
 
   Backtrace* backtrace = data_.GetBacktrace(row.backtrace);
+  if (!backtrace) {
+    return;
+  }
   std::optional<CallsiteId> parent;
   uint32_t depth = 0;
   auto leaf = backtrace->frames.rend() - 1;
   for (auto it = backtrace->frames.rbegin(); it != backtrace->frames.rend();
        ++it) {
     Frame* frame = data_.GetFrame(*it);
+    if (!frame) {
+      continue;
+    }
     Binary* binary = data_.GetBinary(frame->binary);
 
     uint64_t pc = static_cast<uint64_t>(frame->addr);

--- a/src/trace_processor/importers/instruments/row_parser.cc
+++ b/src/trace_processor/importers/instruments/row_parser.cc
@@ -98,7 +98,9 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
     Binary* binary = data_.GetBinary(frame->binary);
 
     uint64_t pc = static_cast<uint64_t>(frame->addr);
-    if (frame->binary) {
+    // GetBinary returns null for a null or out-of-range binary id, so gate the
+    // load_addr adjustment on the resolved pointer rather than the raw id.
+    if (binary) {
       pc -= static_cast<uint64_t>(binary->load_addr);
     }
 

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -140,14 +140,18 @@ namespace perfetto::trace_processor::stats {
   F(gpu_render_stage_parser_errors,       kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
   F(graphics_frame_event_parser_errors,   kSingle,  kInfo,     kAnalysis, Scope::kMachineAndTrace, ""), \
   F(guess_trace_type_duration_ns,         kSingle,  kInfo,     kAnalysis, Scope::kGlobal, ""), \
-  F(instruments_row_missing_thread, kSingle, kError, kAnalysis, Scope::kMachineAndTrace,               \
-    "An instruments trace row referenced an unknown thread id; the row was skipped."),                 \
-  F(instruments_row_missing_process, kSingle, kError, kAnalysis, Scope::kMachineAndTrace,              \
-    "An instruments trace row's thread referenced an unknown process id; the row was skipped."),       \
-  F(instruments_row_missing_backtrace, kSingle, kError, kAnalysis, Scope::kMachineAndTrace,            \
-    "An instruments trace row referenced an unknown backtrace id; the row was skipped."),              \
-  F(instruments_row_missing_frame, kSingle, kError, kAnalysis, Scope::kMachineAndTrace,                \
-    "An instruments trace backtrace referenced an unknown frame id; the frame was skipped."),          \
+  F(instruments_row_missing_thread,       kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
+      "An instruments trace row referenced an unknown thread id; the "         \
+      "row was skipped."),                                                     \
+  F(instruments_row_missing_process,      kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
+      "An instruments trace row's thread referenced an unknown "               \
+      "process id; the row was skipped."),                                     \
+  F(instruments_row_missing_backtrace,    kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
+      "An instruments trace row referenced an unknown backtrace id; "          \
+      "the row was skipped."),                                                 \
+  F(instruments_row_missing_frame,        kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
+      "An instruments trace backtrace referenced an unknown frame id; "        \
+      "the frame was skipped."),                                               \
   F(interned_data_tokenizer_errors,       kSingle,  kInfo,     kAnalysis, Scope::kMachineAndTrace, ""), \
   F(invalid_clock_snapshots,              kSingle,  kError,    kAnalysis, Scope::kGlobal, ""), \
   F(invalid_cpu_times,                    kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -140,6 +140,14 @@ namespace perfetto::trace_processor::stats {
   F(gpu_render_stage_parser_errors,       kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
   F(graphics_frame_event_parser_errors,   kSingle,  kInfo,     kAnalysis, Scope::kMachineAndTrace, ""), \
   F(guess_trace_type_duration_ns,         kSingle,  kInfo,     kAnalysis, Scope::kGlobal, ""), \
+  F(instruments_row_missing_thread, kSingle, kError, kAnalysis, Scope::kMachineAndTrace,               \
+    "An instruments trace row referenced an unknown thread id; the row was skipped."),                 \
+  F(instruments_row_missing_process, kSingle, kError, kAnalysis, Scope::kMachineAndTrace,              \
+    "An instruments trace row's thread referenced an unknown process id; the row was skipped."),       \
+  F(instruments_row_missing_backtrace, kSingle, kError, kAnalysis, Scope::kMachineAndTrace,            \
+    "An instruments trace row referenced an unknown backtrace id; the row was skipped."),              \
+  F(instruments_row_missing_frame, kSingle, kError, kAnalysis, Scope::kMachineAndTrace,                \
+    "An instruments trace backtrace referenced an unknown frame id; the frame was skipped."),          \
   F(interned_data_tokenizer_errors,       kSingle,  kInfo,     kAnalysis, Scope::kMachineAndTrace, ""), \
   F(invalid_clock_snapshots,              kSingle,  kError,    kAnalysis, Scope::kGlobal, ""), \
   F(invalid_cpu_times,                    kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \


### PR DESCRIPTION
**trace_processor: bounds-check id lookups in the instruments importer**

`RowDataTracker::GetThread/GetProcess/GetFrame/GetBacktrace` index
`threads_/processes_/frames_/backtraces_` at `[id - 1]`, guarded only by a
`PERFETTO_DCHECK(id != kNullId)` — which is compiled out in release builds
(`PERFETTO_DCHECK_IS_ON()` is 0 for `NDEBUG` non-standalone/chromium/android builds,
including the shipped WASM UI).

These ids come (transitively) from an untrusted Apple Instruments `.trace` file. A `<frame>`
emitted with no enclosing `<backtrace>`, or a `<backtrace>`/`<frame>`/`<thread>` referencing an
undefined id, leaves the id as `kNullId` (0) or out of range. In a release build
`GetBacktrace(0)` then evaluates `&backtraces_[0u - 1]` = `&backtraces_[0xFFFFFFFF]`, a wild
pointer that the following `frames.push_back(...)` (out-of-bounds write) or the field reads in
`RowParser` (out-of-bounds read) dereference — a memory-unsafe crash on a crafted trace
(confirmed under ASan).

`GetBinary` already guards this (`if (id == kNullId) return nullptr;`). Extend the same
fail-closed pattern to the other four getters (also rejecting out-of-range ids) and null-check at
the call sites so a malformed row/frame is skipped rather than dereferencing a wild pointer.
