### PR TITLE
ui: Add intelletto tools for building DE graphs

### DIFF
--- a/ui/src/plugins/dev.perfetto.DataExplorer/graph_check.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/graph_check.ts
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Runs a Data Explorer graph against the trace engine purely to surface errors,
+// so a caller (e.g. the Intelletto assistant) can check that a graph it built
+// actually works and iterate until it is clean. Mirrors what
+// QueryExecutionService does for the live UI, but as a one-shot, side-effect-
+// free pass: it spins up a throwaway "summarizer", analyses every node's
+// structured query, materialises each node to catch runtime-only errors, then
+// tears the summarizer down again.
+
+import protos from '../../protos';
+import {uuidv4Sql} from '../../base/uuid';
+import {getErrorMessage} from '../../base/errors';
+import type {Engine} from '../../trace_processor/engine';
+import type {QueryNode} from './query_node';
+
+export interface GraphNodeError {
+  // The id of the offending node, or a synthetic marker like "(engine)" for
+  // failures that aren't attributable to a single node.
+  readonly nodeId: string;
+  // The node's human title (e.g. "Sql source"), for friendlier messages.
+  readonly title: string;
+  readonly error: string;
+}
+
+function nonEmpty(s: string | undefined | null): string | undefined {
+  return s !== undefined && s !== null && s !== '' ? s : undefined;
+}
+
+/**
+ * Checks every node in `nodes` against the engine and returns one error per
+ * failing node (validation, query analysis, or materialisation). An empty array
+ * means the whole graph runs cleanly.
+ */
+export async function collectGraphErrors(
+  engine: Engine,
+  nodes: ReadonlyArray<QueryNode>,
+): Promise<GraphNodeError[]> {
+  // First error wins per node, in the order: client-side validation, then
+  // server-side analysis, then materialisation - the earliest is the most
+  // actionable.
+  const errors = new Map<string, GraphNodeError>();
+  const add = (nodeId: string, title: string, error: string) => {
+    if (!errors.has(nodeId)) errors.set(nodeId, {nodeId, title, error});
+  };
+  const titleOf = (nodeId: string) =>
+    nodes.find((n) => n.nodeId === nodeId)?.getTitle() ?? nodeId;
+
+  // Client-side validation, and collect the structured queries for the rest.
+  const structuredQueries: protos.PerfettoSqlStructuredQuery[] = [];
+  for (const node of nodes) {
+    if (!node.validate()) {
+      add(
+        node.nodeId,
+        node.getTitle(),
+        node.context.issues?.queryError?.message ??
+          'invalid configuration or missing input',
+      );
+      continue;
+    }
+    const sq = node.getStructuredQuery();
+    if (sq !== undefined) structuredQueries.push(sq);
+  }
+
+  if (structuredQueries.length === 0) {
+    return [...errors.values()];
+  }
+
+  const summarizerId = `assistant_check_${uuidv4Sql()}`;
+  const created = await engine.createSummarizer(summarizerId);
+  if (nonEmpty(created.error) !== undefined) {
+    add('(engine)', 'engine', created.error!);
+    return [...errors.values()];
+  }
+
+  try {
+    // Analysis pass: catches bad columns/tables and malformed queries with
+    // per-node attribution.
+    const spec = new protos.TraceSummarySpec();
+    spec.query = structuredQueries;
+    const updated = await engine.updateSummarizerSpec(summarizerId, spec);
+    if (nonEmpty(updated.error) !== undefined) {
+      add('(graph)', 'graph', updated.error!);
+    }
+    for (const q of updated.queries ?? []) {
+      const err = nonEmpty(q.error);
+      if (err !== undefined && nonEmpty(q.queryId) !== undefined) {
+        add(q.queryId!, titleOf(q.queryId!), err);
+      }
+    }
+
+    // Materialisation pass: surfaces runtime errors that only appear when the
+    // query actually runs.
+    for (const node of nodes) {
+      const res = await engine.querySummarizer(summarizerId, node.nodeId);
+      const err = nonEmpty(res.error);
+      if (err !== undefined) {
+        add(node.nodeId, node.getTitle(), err);
+      }
+    }
+  } catch (e) {
+    add('(engine)', 'engine', getErrorMessage(e));
+  } finally {
+    // Drop everything we materialised so the check leaves no trace behind.
+    await engine
+      .updateSummarizerSpec(summarizerId, new protos.TraceSummarySpec())
+      .catch(() => {});
+  }
+
+  return [...errors.values()];
+}
+
+/** Formats graph errors into a compact string for a tool result. */
+export function formatGraphErrors(
+  errors: ReadonlyArray<GraphNodeError>,
+): string {
+  return errors
+    .map((e) => `- node ${e.nodeId} (${e.title}): ${e.error}`)
+    .join('\n');
+}

--- a/ui/src/plugins/dev.perfetto.DataExplorer/graph_format.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/graph_format.ts
@@ -1,0 +1,275 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Documentation for each node designed to be consumed by an LLM.
+// TODO(stevegolton): Find a better way to keep this in sync with the actual
+// JSON model for each node - this may involve defining a zod schema or similar
+// on each node directly.
+
+export const GRAPH_FORMAT = `
+================================================================================
+DATA EXPLORER GRAPH JSON FORMAT
+================================================================================
+
+Send the whole graph as a JSON string. Top-level shape:
+
+{
+  "nodes": [ <node>, ... ],          // every node in the graph
+  "rootNodeIds": [ "<id>", ... ],    // ids of nodes with no input feeding them
+  "nodeLayouts": { "<id>": {"x":0,"y":0} },  // OPTIONAL - omit for auto-layout
+  "selectedNodeId": "<id>"           // OPTIONAL - node to select after loading
+}
+
+Each <node>:
+
+{
+  "nodeId": "<unique string id, e.g. \\"0\\", \\"1\\">",
+  "type": "<one of the node types below>",
+  "state": { ...type-specific fields, see catalog... },
+  "nextNodes": [ "<downstream nodeId>", ... ],
+  "primaryInputId": "<nodeId>",                  // OPTIONAL: the node above this one
+  "secondaryInputIds": { "0": "<nodeId>", ... }  // OPTIONAL: side inputs, keyed by port
+}
+
+--------------------------------------------------------------------------------
+CONNECTION MODEL (read carefully - this is where graphs break)
+--------------------------------------------------------------------------------
+Edges are stored BOTH directions and must agree:
+- The upstream node lists the downstream id in its "nextNodes".
+- The downstream node names the upstream id in EITHER "primaryInputId" (the
+  single input that flows in from above) OR "secondaryInputIds" (side inputs,
+  keyed by port number "0","1",... ).
+If only one side is set the edge is dropped on load. Always set both.
+
+- "rootNodeIds" = exactly the nodes that have NO input (no primaryInputId and no
+  secondaryInputIds). Source nodes are always roots. Every other node must be
+  reachable from a root via nextNodes, or it is lost on load.
+- No cycles.
+
+Which input a node uses:
+- Source nodes (table, simple_slices, sql_source, time_range_source): no input.
+- Single-input operations (aggregation, modify_columns, filter, sort,
+  limit_and_offset, counter_to_intervals, visualisation, dashboard, metrics):
+  use "primaryInputId".
+- add_columns, filter_during, filter_in: "primaryInputId" for the main data,
+  PLUS "secondaryInputIds":{"0": <the other input>}.
+- Multi-source nodes (join, union, interval_intersect, create_slices,
+  trace_summary): NO primaryInputId; all inputs go in "secondaryInputIds" by
+  port. join/create_slices use ports "0" and "1"; union/interval_intersect take
+  two or more ports "0","1","2",...
+
+--------------------------------------------------------------------------------
+SHARED SUB-TYPES (used inside several nodes' "state")
+--------------------------------------------------------------------------------
+ColumnInfo = {
+  "name": "<column name>",
+  "checked": true,            // true = keep/use this column (usually what you want)
+  "alias": "<rename>",        // OPTIONAL
+  "type": { "kind": "<k>" }   // OPTIONAL; kind is one of:
+                              //   int double boolean string bytes timestamp duration arg_set_id
+}
+You can omit "type"; it is re-derived from the upstream schema on load.
+
+--------------------------------------------------------------------------------
+RECOMMENDED DEFAULT: real nodes (STRONGLY PREFERRED)
+--------------------------------------------------------------------------------
+STRONGLY prefer building the graph out of real, structured nodes (a "table" or
+"slice" source feeding "filter", "sort", "aggregation", "modify_columns",
+"limit_and_offset", joins, etc.) rather than packing everything into one
+"sql_source" node. Each real node shows up in the UI as its own editable step:
+the user can see exactly what every stage does, tweak it, reorder it, and learn
+from it. A single "sql_source" collapses all of that into an opaque blob of SQL
+the user cannot inspect or adjust without reading raw SQL.
+
+So: decompose the request into one node per logical operation. Use a source node
+for the data, then a separate node for each filter / sort / group-by / column
+selection / limit.
+
+Fall back to "sql_source" ONLY when no real node can express the operation (an
+exotic SQL construct, a CTE, a window function, etc.), or when the user
+explicitly asks for raw SQL. type "sql_source", state:
+  { "sql": "<a single PerfettoSQL SELECT>" }
+Rules for "sql":
+- Exactly ONE SELECT (a leading "WITH ... SELECT" is allowed). No trailing ";".
+- To use stdlib tables, prepend "INCLUDE PERFETTO MODULE <name>;" statements
+  (each ending in ";"), then the SELECT last.
+- It can read upstream nodes connected via secondaryInputIds as $input_0,
+  $input_1, ... (port number).
+- Confirm tables/columns with run_query / get_schema first; do not guess schema.
+
+Preferred shape (the common case) - real nodes, one operation each:
+{
+  "nodes": [
+    { "nodeId": "0", "type": "table",
+      "state": { "sqlTable": "slice" },
+      "nextNodes": ["1"] },
+    { "nodeId": "1", "type": "sort",
+      "state": { "sortCriteria": [ { "colName": "dur", "direction": "DESC" } ] },
+      "primaryInputId": "0", "nextNodes": ["2"] },
+    { "nodeId": "2", "type": "limit_and_offset",
+      "state": { "limit": 20, "offset": 0 },
+      "primaryInputId": "1", "nextNodes": [] }
+  ],
+  "rootNodeIds": ["0"]
+}
+
+Equivalent with sql_source (use ONLY as a fallback, less visible to the user):
+{
+  "nodes": [
+    { "nodeId": "0", "type": "sql_source",
+      "state": { "sql": "SELECT name, dur FROM slice ORDER BY dur DESC LIMIT 20" },
+      "nextNodes": [] }
+  ],
+  "rootNodeIds": ["0"]
+}
+
+================================================================================
+FULL NODE CATALOG (the "state" object for each "type")
+================================================================================
+
+SOURCES (no input; always go in rootNodeIds)
+
+- "sql_source"  -> see RECOMMENDED DEFAULT above. state: { "sql": string }
+
+- "table"  -> read a whole trace table.
+  state: { "sqlTable": "<table name, e.g. \\"slice\\">" }
+
+- "simple_slices"  -> all slices in the trace. state: {} (no fields)
+
+- "time_range_source"  -> a time window (ns).
+  state: { "start": "<ns as string>", "end": "<ns as string>", "isDynamic": false }
+  isDynamic true = follows the timeline selection; false = fixed snapshot.
+
+SINGLE-INPUT OPERATIONS (set "primaryInputId" to the upstream node)
+
+- "filter"  -> keep rows matching a condition.
+  Freeform (preferred, simplest):
+    state: { "filterMode": "freeform", "sqlExpression": "dur > 1000000 AND name GLOB 'foo*'" }
+  Structured:
+    state: {
+      "filterMode": "structured",
+      "filterOperator": "AND",            // or "OR"
+      "filters": [
+        { "column": "dur", "op": ">", "value": 1000000 }
+      ]
+    }
+    op is one of: "=" "!=" "<" "<=" ">" ">=" "glob" | "in" "not in" (value is an
+    array) | "is null" "is not null" (no value).
+
+- "sort"  -> order rows.
+  state: { "sortCriteria": [ { "colName": "dur", "direction": "DESC" } ] }  // ASC | DESC
+
+- "limit_and_offset"  -> cap row count.
+  state: { "limit": 100, "offset": 0 }
+
+- "aggregation"  -> GROUP BY + aggregate.
+  state: {
+    "groupByColumns": [ { "name": "name", "checked": true } ],   // ColumnInfo[]
+    "aggregations": [
+      { "column": { "name": "dur" }, "aggregationOp": "SUM", "newColumnName": "total_dur" }
+    ]
+  }
+  aggregationOp: COUNT | COUNT(*) | COUNT_DISTINCT | SUM | MIN | MAX | MEAN |
+  MEDIAN | DURATION_WEIGHTED_MEAN | PERCENTILE. For COUNT(*) omit "column". For
+  PERCENTILE add "percentile": <number 0-100>.
+
+- "modify_columns"  -> select / rename columns.
+  state: { "selectedColumns": [ { "name": "name", "checked": true, "alias": "slice_name" } ] }  // ColumnInfo[]
+
+- "counter_to_intervals"  -> turn counter rows (ts, value) into intervals
+  (adds dur, next_value, delta_value). Input must have id, ts, track_id, value
+  and NOT already have dur. state: {} (no fields)
+
+- "visualisation"  -> charts over the input rows.
+  state: {
+    "chartConfigs": [
+      { "id": "c1", "column": "name", "chartType": "bar", "aggregation": "COUNT" }
+    ]
+  }
+  chartType: bar | histogram | line | scatter | pie | treemap | boxplot |
+  heatmap | cdf | scorecard. aggregation (bar/pie/treemap): COUNT (default) |
+  SUM | MIN | MAX | MEAN ... For non-count add "measureColumn". histogram uses
+  "column" (+ optional "binCount"); line/scatter need "yColumn".
+
+SINGLE-INPUT + ONE SIDE INPUT (set "primaryInputId" AND "secondaryInputIds":{"0":...})
+
+- "add_columns"  -> LEFT JOIN columns from the side node onto the main rows.
+  state: {
+    "selectedColumns": [ "<col from side node>", ... ],
+    "leftColumn": "<join key in main input>",
+    "rightColumn": "<join key in side input>",
+    "columnAliases": { "<col>": "<alias>" }   // OPTIONAL
+  }
+
+- "filter_during"  -> keep only main-input intervals that overlap intervals from
+  the side node. Both inputs need ts and dur.
+  state: { "partitionColumns": ["utid"], "clipToIntervals": true }
+  clipToIntervals true (default) = output uses the intersected ts/dur.
+
+- "filter_in"  -> keep main rows whose value appears in the side node.
+  state: { "baseColumn": "<col in main input>", "matchColumn": "<col in side input>" }
+
+MULTI-SOURCE (no primaryInputId; inputs in "secondaryInputIds" by port)
+
+- "join"  -> join two inputs. Ports "0" (left) and "1" (right).
+  state: {
+    "joinType": "INNER",            // or "LEFT"
+    "conditionType": "equality",    // or "freeform"
+    "leftColumn": "<left key>",     // for equality
+    "rightColumn": "<right key>",   // for equality
+    "sqlExpression": "",            // for freeform, e.g. "left.id = right.parent_id"
+    "leftQueryAlias": "left",
+    "rightQueryAlias": "right",
+    "leftColumns": [ { "name": "...", "checked": true } ],   // ColumnInfo[], columns to keep
+    "rightColumns": [ { "name": "...", "checked": true } ]   // ColumnInfo[]
+  }
+
+- "union"  -> stack rows from 2+ inputs (ports "0","1",...).
+  state: { "selectedColumns": [ { "name": "...", "checked": true } ] }  // ColumnInfo[] common cols
+
+- "interval_intersect"  -> intersect intervals from 2+ inputs (ports "0","1",...).
+  All inputs need ts and dur.
+  state: { "partitionColumns": ["utid"], "tsDurSource": "intersection" }
+  tsDurSource: "intersection" or an input index number.
+
+- "create_slices"  -> build slices by pairing start/end timestamps from two
+  inputs. Ports "0" (starts) and "1" (ends).
+  state: { "startsTsColumn": "ts", "endsTsColumn": "ts" }
+  ( optional: "startsDurColumn", "endsDurColumn", "startsMode", "endsMode" )
+
+EXPORT NODES (advanced; usually only when the user asks for metrics/dashboards)
+
+- "metrics"  -> define a metric (primaryInputId = the data).
+  state: {
+    "metricIdPrefix": "my_metric",
+    "valueColumns": [ { "column": "dur", "unit": "NS", "polarity": "POSITIVE" } ],
+    "dimensionConfigs": { "<dim col>": { "displayName": "..." } },
+    "dimensionUniqueness": ""
+  }
+
+- "trace_summary"  -> bundle metrics. Inputs are metrics nodes via
+  "secondaryInputIds" ("0","1",...). state: {} (no fields)
+
+- "dashboard"  -> export the input for use on dashboards (primaryInputId = data).
+  state: { "exportName": "<name>" }
+
+================================================================================
+WORKFLOW
+================================================================================
+- Call get_graph FIRST when editing an existing graph; copy its exact shape and
+  reuse its nodeIds rather than rebuilding from scratch.
+- Prefer a single sql_source node for most requests.
+- Use real node types only when the user explicitly wants that operation/UI.
+- An invalid graph comes back as a tool error - read it, fix the JSON, retry.
+`.trim();

--- a/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
@@ -14,6 +14,7 @@
 
 import './styles.scss';
 import m from 'mithril';
+import {z} from 'zod';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import type {Store} from '../../base/store';
@@ -22,15 +23,27 @@ import {getErrorMessage} from '../../base/errors';
 import {debounce} from '../../base/rate_limiters';
 import QueryPagePlugin from '../dev.perfetto.QueryPage';
 import SqlModulesPlugin from '../dev.perfetto.SqlModules';
+import IntellettoPlugin from '../dev.perfetto.Intelletto';
 import {
   DataExplorer,
   type DataExplorerState,
   type DataExplorerTab,
 } from './data_explorer';
 import {nodeRegistry} from './query_builder/node_registry';
-import {deserializeState, serializeState} from './json_handler';
+import {
+  deserializeState,
+  serializeState,
+  validateSerializedGraph,
+} from './json_handler';
+import {
+  collectGraphErrors,
+  formatGraphErrors,
+  type GraphNodeError,
+} from './graph_check';
 import {recentGraphsStorage} from './recent_graphs';
 import {getAllNodes} from './query_builder/graph_utils';
+import {getPrimarySelectedNode} from './selection_utils';
+import {GRAPH_FORMAT} from './graph_format';
 import {isDashboardNode} from './query_builder/nodes/dashboard_node';
 import {
   dataExplorerTabsStorage,
@@ -77,7 +90,11 @@ function isValidPersistedState(
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.DataExplorer';
-  static readonly dependencies = [QueryPagePlugin, SqlModulesPlugin];
+  static readonly dependencies = [
+    QueryPagePlugin,
+    SqlModulesPlugin,
+    IntellettoPlugin,
+  ];
 
   // Multi-tab state
   private tabs: DataExplorerTab[] = [];
@@ -483,9 +500,258 @@ export default class implements PerfettoPlugin {
     this.ensureAtLeastOneTab();
   }
 
+  // --- Public API for other plugins ---
+
+  /**
+   * Returns the active tab's graph serialized as JSON (the same format the
+   * "Export" button produces and importStateFromJson consumes), or undefined
+   * if there is no trace loaded or the active graph is empty.
+   *
+   * Used by dependent plugins (e.g. the Intelletto assistant) to read what the
+   * user is currently exploring.
+   */
+  getActiveGraphJson(): string | undefined {
+    const tab = this.getActiveTab();
+    if (tab === undefined || tab.state.rootNodes.length === 0) {
+      return undefined;
+    }
+    return serializeState(tab.state);
+  }
+
+  /**
+   * Replaces the active tab's graph with the one described by `json` (same
+   * format as getActiveGraphJson) and navigates to the Data Explorer so the
+   * user sees the result. Throws if the JSON is invalid or SQL modules are not
+   * ready yet.
+   *
+   * Used by dependent plugins (e.g. the Intelletto assistant) to build a graph
+   * on the user's behalf.
+   */
+  setActiveGraphJson(trace: Trace, json: string): void {
+    const sqlModulesPlugin = trace.plugins.getPlugin(SqlModulesPlugin);
+    sqlModulesPlugin.ensureInitialized();
+    const sqlModules = sqlModulesPlugin.getSqlModules();
+    if (!sqlModules) {
+      throw new Error(
+        'SQL modules are not ready yet. Open the Data Explorer once and retry.',
+      );
+    }
+    // Structural pre-check: aggregate ALL problems (bad JSON, unknown node
+    // types, dangling/one-sided edges, ...) into one clear message rather than
+    // throwing on whatever deserializeState happens to trip over first.
+    const {errors} = validateSerializedGraph(json);
+    if (errors.length > 0) {
+      throw new Error(
+        `Invalid graph (${errors.length} problem` +
+          `${errors.length === 1 ? '' : 's'}):\n- ${errors.join('\n- ')}`,
+      );
+    }
+    // deserializeState can still throw on deeper per-node-state issues; let it
+    // propagate so the caller (and, for the assistant, the model) sees it.
+    const state = deserializeState(json, trace, sqlModules);
+    // Make sure tabs are hydrated and there is a tab to write into.
+    this.tryLoadState(trace);
+    this.ensureAtLeastOneTab();
+    // makeOnStateUpdate handles persistence (localStorage + permalink) and
+    // triggers a redraw.
+    this.makeOnStateUpdate(this.activeTabId)(state);
+    trace.navigate('#!/explore');
+  }
+
+  /**
+   * Runs the active graph against the trace engine and returns one error per
+   * failing node (bad SQL, missing column/table, invalid config). An empty
+   * array means the graph runs cleanly. Lets a caller (e.g. the assistant)
+   * verify a graph it built and iterate until it works.
+   */
+  async checkActiveGraph(trace: Trace): Promise<GraphNodeError[]> {
+    const tab = this.getActiveTab();
+    if (tab === undefined || tab.state.rootNodes.length === 0) {
+      return [];
+    }
+    return collectGraphErrors(trace.engine, getAllNodes(tab.state.rootNodes));
+  }
+
+  /**
+   * Checks a graph JSON for problems WITHOUT applying it: structural validation
+   * first (aggregated), then - if structurally sound - it is deserialized into
+   * a throwaway state and run against the engine to catch runtime errors. The
+   * active graph and the UI are left untouched. Returns a human-readable
+   * report. Lets the assistant verify a graph before committing it.
+   */
+  async dryRunGraph(trace: Trace, json: string): Promise<string> {
+    const {errors: structuralErrors} = validateSerializedGraph(json);
+    if (structuralErrors.length > 0) {
+      return (
+        `Invalid graph (${structuralErrors.length} problem` +
+        `${structuralErrors.length === 1 ? '' : 's'}):\n- ` +
+        structuralErrors.join('\n- ')
+      );
+    }
+
+    const sqlModulesPlugin = trace.plugins.getPlugin(SqlModulesPlugin);
+    sqlModulesPlugin.ensureInitialized();
+    const sqlModules = sqlModulesPlugin.getSqlModules();
+    if (!sqlModules) {
+      throw new Error(
+        'SQL modules are not ready yet. Open the Data Explorer once and retry.',
+      );
+    }
+
+    let state;
+    try {
+      // Build the nodes in isolation - this is NOT assigned to any tab.
+      state = deserializeState(json, trace, sqlModules);
+    } catch (e) {
+      return `Graph could not be built: ${getErrorMessage(e)}`;
+    }
+
+    const runtimeErrors = await collectGraphErrors(
+      trace.engine,
+      getAllNodes(state.rootNodes),
+    );
+    if (runtimeErrors.length === 0) {
+      return 'OK: graph is valid and runs cleanly.';
+    }
+    return (
+      'Graph is structurally valid, but some nodes fail to run:\n' +
+      formatGraphErrors(runtimeErrors)
+    );
+  }
+
+  // --- Assistant tools ---
+
+  // Contribute get_graph / set_graph tools to the Intelletto assistant so it
+  // can read and build Data Explorer graphs on the user's behalf.
+  private registerIntellettoTools(trace: Trace): void {
+    const intelletto = trace.plugins.getPlugin(IntellettoPlugin);
+
+    intelletto.registerTool({
+      name: 'get_graph',
+      description:
+        'Read the current Data Explorer query graph as JSON. Call this to see ' +
+        'what the user is exploring before answering questions about it, and ' +
+        'ALWAYS before set_graph when editing an existing graph - copy its ' +
+        'shape rather than rebuilding from scratch. Returns the string ' +
+        '"<empty>" when there is no graph yet.',
+      shape: {},
+      callback: async () => this.getActiveGraphJson() ?? '<empty>',
+    });
+
+    intelletto.registerTool({
+      name: 'set_graph',
+      description:
+        'Replace the Data Explorer query graph with a new one and switch the ' +
+        'UI to the Data Explorer so the user sees it. Use this when the user ' +
+        'asks you to build, change, or visualise a query/pipeline in the Data ' +
+        'Explorer. The argument is the whole graph as a JSON string. A ' +
+        'structurally invalid graph (bad JSON, unknown node type, dangling or ' +
+        'one-sided edge) comes back as a tool error listing every problem - ' +
+        'fix them and retry. If the graph is structurally fine but a node ' +
+        'fails to run (bad SQL, missing column/table), it is still applied and ' +
+        'the per-node runtime errors are returned; fix the SQL and call ' +
+        'set_graph again until it reports it runs cleanly.\n\n' +
+        GRAPH_FORMAT,
+      mutating: true,
+      shape: {
+        graph: z
+          .string()
+          .describe(
+            'The complete graph, as a JSON string in the documented format ' +
+              '(an object with "nodes" and "rootNodeIds").',
+          ),
+      },
+      callback: async ({graph}) => {
+        // Throws (-> tool error) on structural problems, before any UI change.
+        this.setActiveGraphJson(trace, graph);
+        // Applied; now report any runtime errors so the model can iterate.
+        const errors = await this.checkActiveGraph(trace);
+        if (errors.length === 0) {
+          return 'OK: graph applied and runs cleanly.';
+        }
+        return (
+          'Graph applied, but some nodes fail to run. Fix these and call ' +
+          'set_graph again:\n' +
+          formatGraphErrors(errors)
+        );
+      },
+    });
+
+    intelletto.registerTool({
+      name: 'check_graph',
+      description:
+        'Run the current Data Explorer graph against the trace and report any ' +
+        'per-node errors (bad SQL, missing columns/tables, invalid config) ' +
+        'without changing it. Returns "OK: graph runs cleanly." when there are ' +
+        'none. Use this to verify the graph after editing, or to diagnose what ' +
+        'the user means by "my graph is broken".',
+      shape: {},
+      callback: async () => {
+        const errors = await this.checkActiveGraph(trace);
+        if (errors.length === 0) {
+          return 'OK: graph runs cleanly.';
+        }
+        return 'Graph has errors:\n' + formatGraphErrors(errors);
+      },
+    });
+
+    intelletto.registerTool({
+      name: 'validate_graph',
+      description:
+        'Check a candidate graph JSON for problems WITHOUT applying it - the ' +
+        'current graph and the UI are left untouched. Reports structural ' +
+        'problems (bad JSON, unknown node type, dangling or one-sided edges) ' +
+        'and, if structurally sound, runtime errors from running it (bad SQL, ' +
+        'missing columns/tables). Returns "OK: graph is valid and runs ' +
+        'cleanly." when there are none. Use this to iterate on a graph before ' +
+        'committing it with set_graph. See set_graph for the JSON format.',
+      shape: {
+        graph: z
+          .string()
+          .describe(
+            'The candidate graph as a JSON string, same format as set_graph.',
+          ),
+      },
+      callback: async ({graph}) => this.dryRunGraph(trace, graph),
+    });
+
+    // Tell the assistant which node the user currently has selected in the
+    // query builder, so it can answer "this node" / "the selected step"
+    // questions and edit the right node without asking.
+    intelletto.registerContextProvider({
+      id: 'dev.perfetto.DataExplorer#selected_node',
+      description:
+        'The node the user has selected in the Data Explorer query builder. ' +
+        '"nodeId" and "type" match the get_graph / set_graph JSON format, so ' +
+        'the selected node can be located and edited there. "state" is that ' +
+        'node\'s serialized config; "columns" are the column names it outputs.',
+      getContext: () => {
+        const tab = this.getActiveTab();
+        if (tab === undefined) return undefined;
+        const node = getPrimarySelectedNode(
+          tab.state.selectedNodes,
+          tab.state.rootNodes,
+        );
+        if (node === undefined) return undefined;
+        return {
+          summary: `Selected node: ${node.getTitle()}`,
+          data: {
+            nodeId: node.nodeId,
+            type: node.type,
+            title: node.getTitle(),
+            state: node.attrs,
+            columns: node.finalCols.map((c) => c.name),
+          },
+        };
+      },
+    });
+  }
+
   // --- Plugin lifecycle ---
 
   async onTraceLoad(trace: Trace): Promise<void> {
+    this.registerIntellettoTools(trace);
+
     // Flush pending localStorage saves on page unload
     window.addEventListener('beforeunload', this.onBeforeUnload);
     trace.trash.defer(() => {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
@@ -14,7 +14,6 @@
 
 import './styles.scss';
 import m from 'mithril';
-import {z} from 'zod';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import type {Store} from '../../base/store';
@@ -23,7 +22,6 @@ import {getErrorMessage} from '../../base/errors';
 import {debounce} from '../../base/rate_limiters';
 import QueryPagePlugin from '../dev.perfetto.QueryPage';
 import SqlModulesPlugin from '../dev.perfetto.SqlModules';
-import IntellettoPlugin from '../dev.perfetto.Intelletto';
 import {
   DataExplorer,
   type DataExplorerState,
@@ -43,7 +41,6 @@ import {
 import {recentGraphsStorage} from './recent_graphs';
 import {getAllNodes} from './query_builder/graph_utils';
 import {getPrimarySelectedNode} from './selection_utils';
-import {GRAPH_FORMAT} from './graph_format';
 import {isDashboardNode} from './query_builder/nodes/dashboard_node';
 import {
   dataExplorerTabsStorage,
@@ -90,11 +87,7 @@ function isValidPersistedState(
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.DataExplorer';
-  static readonly dependencies = [
-    QueryPagePlugin,
-    SqlModulesPlugin,
-    IntellettoPlugin,
-  ];
+  static readonly dependencies = [QueryPagePlugin, SqlModulesPlugin];
 
   // Multi-tab state
   private tabs: DataExplorerTab[] = [];
@@ -619,139 +612,43 @@ export default class implements PerfettoPlugin {
     );
   }
 
-  // --- Assistant tools ---
+  // --- Assistant hook ---
 
-  // Contribute get_graph / set_graph tools to the Intelletto assistant so it
-  // can read and build Data Explorer graphs on the user's behalf.
-  private registerIntellettoTools(trace: Trace): void {
-    const intelletto = trace.plugins.getPlugin(IntellettoPlugin);
-
-    intelletto.registerTool({
-      name: 'get_graph',
-      description:
-        'Read the current Data Explorer query graph as JSON. Call this to see ' +
-        'what the user is exploring before answering questions about it, and ' +
-        'ALWAYS before set_graph when editing an existing graph - copy its ' +
-        'shape rather than rebuilding from scratch. Returns the string ' +
-        '"<empty>" when there is no graph yet.',
-      shape: {},
-      callback: async () => this.getActiveGraphJson() ?? '<empty>',
-    });
-
-    intelletto.registerTool({
-      name: 'set_graph',
-      description:
-        'Replace the Data Explorer query graph with a new one and switch the ' +
-        'UI to the Data Explorer so the user sees it. Use this when the user ' +
-        'asks you to build, change, or visualise a query/pipeline in the Data ' +
-        'Explorer. The argument is the whole graph as a JSON string. A ' +
-        'structurally invalid graph (bad JSON, unknown node type, dangling or ' +
-        'one-sided edge) comes back as a tool error listing every problem - ' +
-        'fix them and retry. If the graph is structurally fine but a node ' +
-        'fails to run (bad SQL, missing column/table), it is still applied and ' +
-        'the per-node runtime errors are returned; fix the SQL and call ' +
-        'set_graph again until it reports it runs cleanly.\n\n' +
-        GRAPH_FORMAT,
-      mutating: true,
-      shape: {
-        graph: z
-          .string()
-          .describe(
-            'The complete graph, as a JSON string in the documented format ' +
-              '(an object with "nodes" and "rootNodeIds").',
-          ),
-      },
-      callback: async ({graph}) => {
-        // Throws (-> tool error) on structural problems, before any UI change.
-        this.setActiveGraphJson(trace, graph);
-        // Applied; now report any runtime errors so the model can iterate.
-        const errors = await this.checkActiveGraph(trace);
-        if (errors.length === 0) {
-          return 'OK: graph applied and runs cleanly.';
-        }
-        return (
-          'Graph applied, but some nodes fail to run. Fix these and call ' +
-          'set_graph again:\n' +
-          formatGraphErrors(errors)
-        );
-      },
-    });
-
-    intelletto.registerTool({
-      name: 'check_graph',
-      description:
-        'Run the current Data Explorer graph against the trace and report any ' +
-        'per-node errors (bad SQL, missing columns/tables, invalid config) ' +
-        'without changing it. Returns "OK: graph runs cleanly." when there are ' +
-        'none. Use this to verify the graph after editing, or to diagnose what ' +
-        'the user means by "my graph is broken".',
-      shape: {},
-      callback: async () => {
-        const errors = await this.checkActiveGraph(trace);
-        if (errors.length === 0) {
-          return 'OK: graph runs cleanly.';
-        }
-        return 'Graph has errors:\n' + formatGraphErrors(errors);
-      },
-    });
-
-    intelletto.registerTool({
-      name: 'validate_graph',
-      description:
-        'Check a candidate graph JSON for problems WITHOUT applying it - the ' +
-        'current graph and the UI are left untouched. Reports structural ' +
-        'problems (bad JSON, unknown node type, dangling or one-sided edges) ' +
-        'and, if structurally sound, runtime errors from running it (bad SQL, ' +
-        'missing columns/tables). Returns "OK: graph is valid and runs ' +
-        'cleanly." when there are none. Use this to iterate on a graph before ' +
-        'committing it with set_graph. See set_graph for the JSON format.',
-      shape: {
-        graph: z
-          .string()
-          .describe(
-            'The candidate graph as a JSON string, same format as set_graph.',
-          ),
-      },
-      callback: async ({graph}) => this.dryRunGraph(trace, graph),
-    });
-
-    // Tell the assistant which node the user currently has selected in the
-    // query builder, so it can answer "this node" / "the selected step"
-    // questions and edit the right node without asking.
-    intelletto.registerContextProvider({
-      id: 'dev.perfetto.DataExplorer#selected_node',
-      description:
-        'The node the user has selected in the Data Explorer query builder. ' +
-        '"nodeId" and "type" match the get_graph / set_graph JSON format, so ' +
-        'the selected node can be located and edited there. "state" is that ' +
-        'node\'s serialized config; "columns" are the column names it outputs.',
-      getContext: () => {
-        const tab = this.getActiveTab();
-        if (tab === undefined) return undefined;
-        const node = getPrimarySelectedNode(
-          tab.state.selectedNodes,
-          tab.state.rootNodes,
-        );
-        if (node === undefined) return undefined;
-        return {
-          summary: `Selected node: ${node.getTitle()}`,
-          data: {
-            nodeId: node.nodeId,
-            type: node.type,
-            title: node.getTitle(),
-            state: node.attrs,
-            columns: node.finalCols.map((c) => c.name),
-          },
-        };
-      },
-    });
+  /**
+   * Snapshot of the node the user has selected in the Data Explorer query
+   * builder, for the Intelletto assistant's context strip. Returns undefined
+   * when there is no active tab or no selected node. The Intelletto plugin owns
+   * the model-facing prose and wires this into its context registry; DE itself
+   * does not depend on Intelletto.
+   */
+  getSelectedNodeContext():
+    | {
+        nodeId: string;
+        type: string;
+        title: string;
+        state: unknown;
+        columns: string[];
+      }
+    | undefined {
+    const tab = this.getActiveTab();
+    if (tab === undefined) return undefined;
+    const node = getPrimarySelectedNode(
+      tab.state.selectedNodes,
+      tab.state.rootNodes,
+    );
+    if (node === undefined) return undefined;
+    return {
+      nodeId: node.nodeId,
+      type: node.type,
+      title: node.getTitle(),
+      state: node.attrs,
+      columns: node.finalCols.map((c) => c.name),
+    };
   }
 
   // --- Plugin lifecycle ---
 
   async onTraceLoad(trace: Trace): Promise<void> {
-    this.registerIntellettoTools(trace);
-
     // Flush pending localStorage saves on page unload
     window.addEventListener('beforeunload', this.onBeforeUnload);
     trace.trash.defer(() => {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
@@ -18,6 +18,7 @@ import {getAllNodes as getAllNodesUtil} from './query_builder/graph_utils';
 import type {Trace} from '../../public/trace';
 import type {SqlModules} from '../../plugins/dev.perfetto.SqlModules/sql_modules';
 import {nodeRegistry} from './query_builder/node_registry';
+import {getErrorMessage} from '../../base/errors';
 import {restoreLegacySecondaryInputs} from './query_builder/legacy_connections';
 import {
   type PerfettoSqlType,
@@ -57,6 +58,156 @@ export interface SerializedGraph {
   }>;
   isExplorerCollapsed?: boolean;
   sidebarWidth?: number;
+}
+
+/**
+ * Validates the *structure* of a serialized graph JSON string without touching
+ * the trace engine: valid JSON, the right envelope, unique node ids, known node
+ * types, and internally-consistent connections (no dangling references, edges
+ * set on both sides). Returns the parsed graph plus a list of human-readable
+ * problems - empty `errors` means the structure is sound (deeper, per-node-state
+ * issues are caught later by deserialize/execution).
+ *
+ * This exists so a tool (or the assistant) can report ALL the structural
+ * problems at once, with actionable messages, instead of throwing on the first
+ * one the way deserializeState does.
+ */
+export function validateSerializedGraph(json: string): {
+  graph?: SerializedGraph;
+  errors: string[];
+} {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (e) {
+    return {errors: [`Not valid JSON: ${getErrorMessage(e)}`]};
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      errors: [
+        'Top-level value must be a JSON object with "nodes" and "rootNodeIds".',
+      ],
+    };
+  }
+
+  const g = parsed as Partial<SerializedGraph>;
+  const errors: string[] = [];
+
+  if (!Array.isArray(g.nodes)) {
+    errors.push('"nodes" must be an array of node objects.');
+  }
+  if (!Array.isArray(g.rootNodeIds)) {
+    errors.push('"rootNodeIds" must be an array of node id strings.');
+  }
+  if (errors.length > 0) {
+    return {errors};
+  }
+
+  const nodes = g.nodes as SerializedNode[];
+  const rootNodeIds = g.rootNodeIds as string[];
+
+  // The set of node-type strings the registry knows about, for error messages.
+  const validTypes = [
+    ...new Set(nodeRegistry.list().map(([, d]) => d.nodeType as string)),
+  ].sort();
+
+  // First pass: per-node shape + collect ids (for reference checks).
+  const ids = new Set<string>();
+  nodes.forEach((node, i) => {
+    if (node === null || typeof node !== 'object') {
+      errors.push(`nodes[${i}] is not an object.`);
+      return;
+    }
+    if (typeof node.nodeId !== 'string' || node.nodeId === '') {
+      errors.push(`nodes[${i}] is missing a string "nodeId".`);
+      return;
+    }
+    if (ids.has(node.nodeId)) {
+      errors.push(`Duplicate nodeId "${node.nodeId}".`);
+    }
+    ids.add(node.nodeId);
+
+    if (
+      typeof node.type !== 'string' ||
+      nodeRegistry.getByNodeType(node.type as NodeType) === undefined
+    ) {
+      errors.push(
+        `Node "${node.nodeId}" has unknown type ${JSON.stringify(node.type)}. ` +
+          `Valid types: ${validTypes.join(', ')}.`,
+      );
+    }
+    if (node.state === null || typeof node.state !== 'object') {
+      errors.push(`Node "${node.nodeId}" is missing a "state" object.`);
+    }
+    if (node.nextNodes !== undefined && !Array.isArray(node.nextNodes)) {
+      errors.push(`Node "${node.nodeId}" "nextNodes" must be an array of ids.`);
+    }
+  });
+
+  const has = (id: string) => ids.has(id);
+  const byId = new Map(
+    nodes
+      .filter((n) => typeof n?.nodeId === 'string')
+      .map((n) => [n.nodeId, n] as const),
+  );
+
+  // Second pass: reference + edge-consistency checks.
+  for (const node of nodes) {
+    if (typeof node?.nodeId !== 'string') continue;
+
+    for (const next of node.nextNodes ?? []) {
+      if (!has(next)) {
+        errors.push(
+          `Node "${node.nodeId}" nextNodes references missing node "${next}".`,
+        );
+      }
+    }
+    if (node.primaryInputId !== undefined && !has(node.primaryInputId)) {
+      errors.push(
+        `Node "${node.nodeId}" primaryInputId references missing node ` +
+          `"${node.primaryInputId}".`,
+      );
+    }
+    for (const [port, id] of Object.entries(node.secondaryInputIds ?? {})) {
+      if (!has(id)) {
+        errors.push(
+          `Node "${node.nodeId}" secondaryInputIds["${port}"] references ` +
+            `missing node "${id}".`,
+        );
+      }
+    }
+
+    // Every input edge must be mirrored by the upstream node's nextNodes, or
+    // the downstream node is unreachable from the roots and is dropped on load.
+    const inputIds = [
+      ...(node.primaryInputId !== undefined ? [node.primaryInputId] : []),
+      ...Object.values(node.secondaryInputIds ?? {}),
+    ];
+    for (const upId of inputIds) {
+      const up = byId.get(upId);
+      if (up !== undefined && !(up.nextNodes ?? []).includes(node.nodeId)) {
+        errors.push(
+          `Edge is one-sided: node "${node.nodeId}" lists "${upId}" as an ` +
+            `input, but "${upId}".nextNodes does not include "${node.nodeId}". ` +
+            `Set the edge on both nodes.`,
+        );
+      }
+    }
+  }
+
+  for (const id of rootNodeIds) {
+    if (!has(id)) {
+      errors.push(`rootNodeIds references missing node "${id}".`);
+    }
+  }
+  if (nodes.length > 0 && rootNodeIds.length === 0) {
+    errors.push(
+      'rootNodeIds is empty; list every input-less (source) node id there.',
+    );
+  }
+
+  return {graph: g as SerializedGraph, errors};
 }
 
 function serializeNode(node: QueryNode): SerializedNode {

--- a/ui/src/plugins/dev.perfetto.Intelletto/data_explorer_tools.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/data_explorer_tools.ts
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {z} from 'zod';
+import type {Trace} from '../../public/trace';
+import DataExplorerPlugin from '../dev.perfetto.DataExplorer';
+import {GRAPH_FORMAT} from '../dev.perfetto.DataExplorer/graph_format';
+import {formatGraphErrors} from '../dev.perfetto.DataExplorer/graph_check';
+import type {ContextRegistry} from './context';
+import type {ToolRegistry} from './tools';
+
+/**
+ * Register the Data Explorer's graph tools (get_graph, set_graph, check_graph,
+ * validate_graph) and selected-node context provider against the Intelletto
+ * registries. The tool descriptions live here (Intelletto owns the model-
+ * facing prose); the implementations call the Data Explorer plugin's public
+ * hooks (getActiveGraphJson, setActiveGraphJson, checkActiveGraph, dryRunGraph,
+ * getSelectedNodeContext). DE has no dependency on Intelletto and isn't
+ * transitively enabled by it.
+ */
+export function registerDataExplorerTools(
+  tools: ToolRegistry,
+  context: ContextRegistry,
+  trace: Trace,
+): void {
+  const de = trace.plugins.getPlugin(DataExplorerPlugin);
+
+  tools.registerTool({
+    name: 'get_graph',
+    description:
+      'Read the current Data Explorer query graph as JSON. Call this to see ' +
+      'what the user is exploring before answering questions about it, and ' +
+      'ALWAYS before set_graph when editing an existing graph - copy its ' +
+      'shape rather than rebuilding from scratch. Returns the string ' +
+      '"<empty>" when there is no graph yet.',
+    shape: {},
+    callback: async () => de.getActiveGraphJson() ?? '<empty>',
+  });
+
+  tools.registerTool({
+    name: 'set_graph',
+    description:
+      'Replace the Data Explorer query graph with a new one and switch the ' +
+      'UI to the Data Explorer so the user sees it. Use this when the user ' +
+      'asks you to build, change, or visualise a query/pipeline in the Data ' +
+      'Explorer. The argument is the whole graph as a JSON string. A ' +
+      'structurally invalid graph (bad JSON, unknown node type, dangling or ' +
+      'one-sided edge) comes back as a tool error listing every problem - ' +
+      'fix them and retry. If the graph is structurally fine but a node ' +
+      'fails to run (bad SQL, missing column/table), it is still applied and ' +
+      'the per-node runtime errors are returned; fix the SQL and call ' +
+      'set_graph again until it reports it runs cleanly.\n\n' +
+      GRAPH_FORMAT,
+    mutating: true,
+    shape: {
+      graph: z
+        .string()
+        .describe(
+          'The complete graph, as a JSON string in the documented format ' +
+            '(an object with "nodes" and "rootNodeIds").',
+        ),
+    },
+    callback: async ({graph}) => {
+      // Throws (-> tool error) on structural problems, before any UI change.
+      de.setActiveGraphJson(trace, graph);
+      // Applied; now report any runtime errors so the model can iterate.
+      const errors = await de.checkActiveGraph(trace);
+      if (errors.length === 0) {
+        return 'OK: graph applied and runs cleanly.';
+      }
+      return (
+        'Graph applied, but some nodes fail to run. Fix these and call ' +
+        'set_graph again:\n' +
+        formatGraphErrors(errors)
+      );
+    },
+  });
+
+  tools.registerTool({
+    name: 'check_graph',
+    description:
+      'Run the current Data Explorer graph against the trace and report any ' +
+      'per-node errors (bad SQL, missing columns/tables, invalid config) ' +
+      'without changing it. Returns "OK: graph runs cleanly." when there are ' +
+      'none. Use this to verify the graph after editing, or to diagnose what ' +
+      'the user means by "my graph is broken".',
+    shape: {},
+    callback: async () => {
+      const errors = await de.checkActiveGraph(trace);
+      if (errors.length === 0) {
+        return 'OK: graph runs cleanly.';
+      }
+      return 'Graph has errors:\n' + formatGraphErrors(errors);
+    },
+  });
+
+  tools.registerTool({
+    name: 'validate_graph',
+    description:
+      'Check a candidate graph JSON for problems WITHOUT applying it - the ' +
+      'current graph and the UI are left untouched. Reports structural ' +
+      'problems (bad JSON, unknown node type, dangling or one-sided edges) ' +
+      'and, if structurally sound, runtime errors from running it (bad SQL, ' +
+      'missing columns/tables). Returns "OK: graph is valid and runs ' +
+      'cleanly." when there are none. Use this to iterate on a graph before ' +
+      'committing it with set_graph. See set_graph for the JSON format.',
+    shape: {
+      graph: z
+        .string()
+        .describe(
+          'The candidate graph as a JSON string, same format as set_graph.',
+        ),
+    },
+    callback: async ({graph}) => de.dryRunGraph(trace, graph),
+  });
+
+  // Tell the assistant which node the user currently has selected in the
+  // query builder, so it can answer "this node" / "the selected step"
+  // questions and edit the right node without asking.
+  context.registerContextProvider({
+    id: 'dev.perfetto.DataExplorer#selected_node',
+    description:
+      'The node the user has selected in the Data Explorer query builder. ' +
+      '"nodeId" and "type" match the get_graph / set_graph JSON format, so ' +
+      'the selected node can be located and edited there. "state" is that ' +
+      'node\'s serialized config; "columns" are the column names it outputs.',
+    getContext: () => {
+      const ctx = de.getSelectedNodeContext();
+      if (ctx === undefined) return undefined;
+      return {
+        summary: `Selected node: ${ctx.title}`,
+        data: ctx,
+      };
+    },
+  });
+}

--- a/ui/src/plugins/dev.perfetto.Intelletto/index.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/index.ts
@@ -18,6 +18,7 @@ import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import LlmPlugin from '../dev.perfetto.Llm';
 import QueryPagePlugin from '../dev.perfetto.QueryPage';
+import DataExplorerPlugin from '../dev.perfetto.DataExplorer';
 import type {
   ContextProviderRegistration,
   IntellettoToolRegistrar,
@@ -25,6 +26,7 @@ import type {
 } from './api';
 import {ChatPanel} from './chat_panel';
 import {ChatSession} from './chat_session';
+import {registerDataExplorerTools} from './data_explorer_tools';
 import {ContextRegistry, registerCoreContextProviders} from './context';
 import {registerCoreTools} from './core_tools';
 import {ToolRegistry} from './tools';
@@ -45,7 +47,11 @@ export default class IntellettoPlugin
     'it queries the trace and drives the UI. Requires the dev.perfetto.Llm ' +
     'gateway and an LLM protocol plugin. Other plugins can register their own ' +
     'tools via getPlugin(IntellettoPlugin).registerTool().';
-  static readonly dependencies = [LlmPlugin, QueryPagePlugin];
+  static readonly dependencies = [
+    LlmPlugin,
+    QueryPagePlugin,
+    DataExplorerPlugin,
+  ];
 
   // The shared tool registry for this trace. Core tools plus any contributed by
   // other plugins land here; the chat panel hands it to the agent.
@@ -113,6 +119,9 @@ export default class IntellettoPlugin
       callback: () => trace.sidePanel.showTab(SIDE_PANEL_URI),
       defaultHotkey: 'Mod+Shift+A',
     });
+
+    // Pull in the Data Explorer graph tools and selected-node context.
+    registerDataExplorerTools(this.tools, this.context, trace);
   }
 }
 


### PR DESCRIPTION
Inject the following tools and context injections to allow the agent to build, read and modify DE graphs.

Note 1: For now, these tools are defined in the Intelletto plugin. Keeping all tool calls in this plugin doesn't scale, and plugins in general should register their own tools with the intelletto plugin to expose more functionality to the assistant (or use commands when we adapt them for model use), but this introduces a dependency that transitively enables the intelletto plugin when depended on by an default enabled plugin. I want to avoid default enabling the intelletto plugin while in development, thus we flip the dependency for the DE tools - for now.

Note 2: The tools expect the model to build the DE JSON directly, so we teach it how to understand the JSON schema in the tool descriptions. Once we have Perfetto SQL Next we can transition to this.

Tools:

| Tool | Mutating | What it does |
|------|----------|--------------|
| `get_graph` | no | Returns the active Data Explorer graph as JSON (or `"<empty>"`). For the model to read what the user is exploring. |
| `set_graph` | yes | Replaces the graph with supplied JSON and navigates to the Data Explorer. Structural pre-check → apply → returns per-node runtime errors so the model can iterate. Its description embeds the whole `GRAPH_FORMAT` catalog. |
| `check_graph` | no | Runs the *current* graph against the trace, reports per-node errors, changes nothing. |
| `validate_graph` | no | Dry-runs a *candidate* graph JSON (structural + runtime) without applying it. |

Context injections:

| Id | Kind | What it injects |
|----|------|-----------------|
| `dev.perfetto.DataExplorer#selected_node` | context | The node the user has selected in the query builder: `nodeId`, `type`, `title`, serialized `state`, and output `columns`. Lets the model resolve "this node" / "the selected step" and edit the right one. |
