### PR TITLE
ui: Add openai compatible LLM protocol

### DIFF
--- a/ui/src/base/sse.ts
+++ b/ui/src/base/sse.ts
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Parses a Server-Sent Events (SSE) stream from a fetch response body. SSE
+ * events are blank-line-separated, each consisting of one or more `data:
+ * <json>` lines. The terminal event is the literal `data: [DONE]`.
+ *
+ * @param body - The response body stream from a fetch request.
+ * @param signal - Optional abort signal to cancel the stream early.
+ * @yields The parsed JSON payload from each SSE event.
+ */
+export async function* parseSse(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): AsyncGenerator<unknown, void, void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  for (;;) {
+    if (signal?.aborted) return;
+    const {value, done} = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, {stream: true});
+    buf = buf.replace(/\r\n/g, '\n');
+    let sep: number;
+    while ((sep = buf.indexOf('\n\n')) !== -1) {
+      const event = buf.slice(0, sep);
+      buf = buf.slice(sep + 2);
+      const payload = event
+        .split('\n')
+        .filter((l) => l.startsWith('data:'))
+        .map((l) => l.slice(5).trimStart())
+        .join('');
+      if (!payload || payload === '[DONE]') continue;
+      try {
+        yield JSON.parse(payload);
+      } catch {
+        // Ignore unparseable events (keepalives, partial buffers).
+      }
+    }
+  }
+}

--- a/ui/src/core/embedder/default_plugins.ts
+++ b/ui/src/core/embedder/default_plugins.ts
@@ -77,6 +77,7 @@ export const defaultPlugins = [
   'dev.perfetto.LinuxPerf',
   'dev.perfetto.LlmProtocolChromePrompt',
   'dev.perfetto.LlmProtocolGemini',
+  'dev.perfetto.LlmProtocolOpenAi',
   'dev.perfetto.MetricsPage',
   'dev.perfetto.MultiTraceOpen',
   'dev.perfetto.Notes',

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -167,6 +167,7 @@ function setupContentSecurityPolicy() {
     'connect-src': [
       `'self'`,
       'ws://127.0.0.1:8037', // For the adb websocket server.
+      'http://localhost:8080', // For local llama-server.
       'https:', // Allow any HTTPS; service worker firewall adds granular filtering.
       'blob:',
       'data:',

--- a/ui/src/plugins/com.google.PerfettoMcp/gemini_client.ts
+++ b/ui/src/plugins/com.google.PerfettoMcp/gemini_client.ts
@@ -16,6 +16,7 @@
 // generateContent endpoint, drives a function-calling loop against a local
 // ToolRegistry, and emits incremental events the chat UI consumes.
 
+import {parseSse} from '../../base/sse';
 import {type ToolRegistry, zodToGeminiSchema} from './tool_registry';
 
 // --- Gemini wire types (subset of what generateContent returns) ---
@@ -215,33 +216,8 @@ export class GeminiChat {
       throw new Error(`Gemini API error ${resp.status}: ${text}`);
     }
 
-    const reader = resp.body.getReader();
-    const decoder = new TextDecoder();
-    let buf = '';
-    for (;;) {
-      const {value, done} = await reader.read();
-      if (done) break;
-      buf += decoder.decode(value, {stream: true});
-      // Normalize CRLF so both \n\n and \r\n\r\n separators work.
-      buf = buf.replace(/\r\n/g, '\n');
-      // SSE messages are separated by blank lines. Each message is one or more
-      // "data: <payload>" lines; payload is a JSON GenerateContentResponse.
-      let sep: number;
-      while ((sep = buf.indexOf('\n\n')) !== -1) {
-        const event = buf.slice(0, sep);
-        buf = buf.slice(sep + 2);
-        const payload = event
-          .split('\n')
-          .filter((l) => l.startsWith('data:'))
-          .map((l) => l.slice(5).trimStart())
-          .join('');
-        if (!payload || payload === '[DONE]') continue;
-        try {
-          yield JSON.parse(payload) as GeminiStreamChunk;
-        } catch {
-          // Ignore unparseable events (keepalives, partial buffers).
-        }
-      }
+    for await (const chunk of parseSse(resp.body, signal)) {
+      yield chunk as GeminiStreamChunk;
     }
   }
 }

--- a/ui/src/plugins/dev.perfetto.LlmProtocolGemini/gemini_protocol.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolGemini/gemini_protocol.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {parseSse} from '../../base/sse';
 import {z} from 'zod';
 import type {
   AvailableModel,
@@ -241,7 +242,8 @@ export class GeminiProtocol implements Protocol {
 
     let sawToolCall = false;
     let stopReason: 'end' | 'length' = 'end';
-    for await (const chunk of parseSse(resp.body, signal)) {
+    for await (const rawChunk of parseSse(resp.body, signal)) {
+      const chunk = rawChunk as GeminiStreamChunk;
       const candidate = chunk.candidates?.[0];
       for (const part of candidate?.content?.parts ?? []) {
         if ('text' in part) {
@@ -282,39 +284,5 @@ export class GeminiProtocol implements Protocol {
       type: 'stop',
       reason: sawToolCall ? 'tool-calls' : stopReason,
     };
-  }
-}
-
-// POSTed body comes back as SSE: blank-line-separated events, each one or more
-// `data: <json>` lines carrying a GenerateContentResponse fragment.
-async function* parseSse(
-  body: ReadableStream<Uint8Array>,
-  signal?: AbortSignal,
-): AsyncGenerator<GeminiStreamChunk, void, void> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buf = '';
-  for (;;) {
-    if (signal?.aborted) return;
-    const {value, done} = await reader.read();
-    if (done) break;
-    buf += decoder.decode(value, {stream: true});
-    buf = buf.replace(/\r\n/g, '\n');
-    let sep: number;
-    while ((sep = buf.indexOf('\n\n')) !== -1) {
-      const event = buf.slice(0, sep);
-      buf = buf.slice(sep + 2);
-      const payload = event
-        .split('\n')
-        .filter((l) => l.startsWith('data:'))
-        .map((l) => l.slice(5).trimStart())
-        .join('');
-      if (!payload || payload === '[DONE]') continue;
-      try {
-        yield JSON.parse(payload) as GeminiStreamChunk;
-      } catch {
-        // Ignore unparseable events (keepalives, partial buffers).
-      }
-    }
   }
 }

--- a/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/index.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/index.ts
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {App} from '../../public/app';
+import type {PerfettoPlugin} from '../../public/plugin';
+import LlmPlugin from '../dev.perfetto.Llm';
+import {OpenAiProtocol} from './openai_protocol';
+
+export default class LlmProtocolOpenAiPlugin implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.LlmProtocolOpenAi';
+  static readonly description =
+    "Registers the 'openai-compatible' LLM protocol (the " +
+    '/v1/chat/completions wire format) with the dev.perfetto.Llm gateway. ' +
+    'Works with OpenAI, llama-server, vLLM, LM Studio, Ollama and any other ' +
+    'OpenAI-compatible endpoint.';
+  static readonly dependencies = [LlmPlugin];
+
+  static onActivate(_app: App): void {
+    LlmPlugin.gateway.registerProtocol(new OpenAiProtocol());
+  }
+}

--- a/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/json_schema.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/json_schema.ts
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {z} from 'zod';
+
+/**
+ * Convert a zod schema (how tools author their input shape) into the JSON
+ * Schema that an OpenAI-compatible `tools[].function.parameters` expects.
+ *
+ * @param schema The zod schema to convert.
+ * @returns The JSON schema as a POJO.
+ */
+export function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
+  const json = z.toJSONSchema(schema, {
+    // Inline everything: tool parameter schemas must be self-contained, not
+    // carry $defs/$ref that some servers reject.
+    target: 'draft-2020-12',
+  });
+  // Strip the $schema declaration - it's noise in a tool parameters object and
+  // some servers are picky about extra keys.
+  delete json.$schema;
+  return json;
+}

--- a/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/openai_protocol.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/openai_protocol.ts
@@ -22,6 +22,7 @@ import type {
   StreamEvent,
   ToolCall,
 } from '../dev.perfetto.Llm/protocol';
+import {parseSse} from '../../base/sse';
 import {zodToJsonSchema} from './json_schema';
 
 // Sensible default openai-compatible placeholder URL for local llama.cpp.
@@ -311,7 +312,8 @@ export class OpenAiProtocol implements Protocol {
 
     const assembler = new ToolCallAssembler();
     let finishReason: string | null = null;
-    for await (const chunk of parseSse(resp.body, signal)) {
+    for await (const rawChunk of parseSse(resp.body, signal)) {
+      const chunk = rawChunk as StreamChunk;
       const choice = chunk.choices?.[0];
       // Prefer incremental `delta`, but accept `message` for servers that
       // return the whole turn in one chunk.
@@ -351,40 +353,6 @@ export class OpenAiProtocol implements Protocol {
       yield {type: 'stop', reason: 'length'};
     } else {
       yield {type: 'stop', reason: 'end'};
-    }
-  }
-}
-
-// SSE: blank-line-separated events, each a `data: <json>` line. The terminal
-// event is the literal `data: [DONE]`.
-async function* parseSse(
-  body: ReadableStream<Uint8Array>,
-  signal?: AbortSignal,
-): AsyncGenerator<StreamChunk, void, void> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buf = '';
-  for (;;) {
-    if (signal?.aborted) return;
-    const {value, done} = await reader.read();
-    if (done) break;
-    buf += decoder.decode(value, {stream: true});
-    buf = buf.replace(/\r\n/g, '\n');
-    let sep: number;
-    while ((sep = buf.indexOf('\n\n')) !== -1) {
-      const event = buf.slice(0, sep);
-      buf = buf.slice(sep + 2);
-      const payload = event
-        .split('\n')
-        .filter((l) => l.startsWith('data:'))
-        .map((l) => l.slice(5).trimStart())
-        .join('');
-      if (!payload || payload === '[DONE]') continue;
-      try {
-        yield JSON.parse(payload) as StreamChunk;
-      } catch {
-        // Ignore unparseable events (keepalives, partial buffers).
-      }
     }
   }
 }

--- a/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/openai_protocol.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/openai_protocol.ts
@@ -1,0 +1,390 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+  AvailableModel,
+  CredentialField,
+  Message,
+  Protocol,
+  ProtocolCapabilities,
+  Request,
+  StreamEvent,
+  ToolCall,
+} from '../dev.perfetto.Llm/protocol';
+import {zodToJsonSchema} from './json_schema';
+
+// Sensible default openai-compatible placeholder URL for local llama.cpp.
+// Since a lot of backends use the openapi protocol, it makes sense to be
+// relatively unopinionated here (e.g. not perfer any organization).
+const DEFAULT_BASE_URL = 'http://localhost:8080/v1';
+
+interface OpenAiToolCall {
+  readonly id?: string;
+  readonly type?: 'function';
+  readonly function: {readonly name?: string; readonly arguments?: string};
+}
+
+interface OpenAiMessage {
+  readonly role: 'system' | 'user' | 'assistant' | 'tool';
+  readonly content?: string | null;
+  readonly tool_calls?: readonly OpenAiToolCall[];
+  readonly tool_call_id?: string;
+}
+
+// A tool-call fragment as it appears in a streamed delta. Per the OpenAI spec
+// these arrive piecemeal keyed by `index`, with `arguments` a JSON *string*
+// accumulated across chunks. But OpenAI-compatible servers vary:
+//   - llama.cpp / some builds omit `index` (single call, sent whole),
+//   - some emit `arguments` as an already-parsed object rather than a string.
+// The assembler tolerates all of these.
+interface ToolCallFragment {
+  readonly index?: number;
+  readonly id?: string;
+  readonly function?: {
+    readonly name?: string;
+    readonly arguments?: string | Record<string, unknown>;
+  };
+}
+
+interface StreamDelta {
+  readonly role?: string;
+  readonly content?: string | null;
+  readonly tool_calls?: readonly ToolCallFragment[];
+}
+
+interface StreamChunk {
+  readonly choices?: readonly {
+    readonly delta?: StreamDelta;
+    // Non-streaming-style servers may return the whole turn under `message`
+    // instead of incremental `delta`s; accept that too.
+    readonly message?: StreamDelta;
+    readonly finish_reason?: string | null;
+  }[];
+  readonly usage?: {
+    readonly prompt_tokens?: number;
+    readonly completion_tokens?: number;
+    readonly total_tokens?: number;
+  } | null;
+}
+
+function messagesToOpenAi(
+  systemPrompt: string,
+  messages: readonly Message[],
+): OpenAiMessage[] {
+  const out: OpenAiMessage[] = [{role: 'system', content: systemPrompt}];
+  for (const msg of messages) {
+    switch (msg.role) {
+      case 'user':
+        out.push({role: 'user', content: msg.text});
+        break;
+      case 'model':
+        out.push({role: 'assistant', content: msg.text});
+        break;
+      case 'tool-call':
+        // The assistant turn that requested the tools. OpenAI threads results
+        // back by tool_call_id, so we must surface an id even though Gemini
+        // doesn't need one - synthesise a stable one from name+index if the
+        // backend didn't give us one when it streamed the call.
+        out.push({
+          role: 'assistant',
+          content: null,
+          tool_calls: msg.calls.map((c, i) => ({
+            id: c.id ?? `call_${i}_${c.name}`,
+            type: 'function',
+            function: {name: c.name, arguments: JSON.stringify(c.args)},
+          })),
+        });
+        break;
+      case 'tool-result':
+        for (const [i, r] of msg.results.entries()) {
+          out.push({
+            role: 'tool',
+            tool_call_id: r.id ?? `call_${i}_${r.name}`,
+            content: r.result,
+          });
+        }
+        break;
+    }
+  }
+  return out;
+}
+
+function toolsToOpenAi(request: Request) {
+  if (request.tools.length === 0) return undefined;
+  return request.tools.map((t) => ({
+    type: 'function' as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: zodToJsonSchema(t.inputSchema),
+    },
+  }));
+}
+
+function classifyError(status: number, body: string): StreamEvent {
+  let kind: 'rate-limit' | 'auth' | 'context-length' | 'network' | 'unknown';
+  if (status === 429) kind = 'rate-limit';
+  else if (status === 401 || status === 403) kind = 'auth';
+  else if (status === 400 && /context|maximum.*token|too long/i.test(body)) {
+    kind = 'context-length';
+  } else kind = 'unknown';
+  return {
+    type: 'stop',
+    reason: 'error',
+    error: {kind, message: `OpenAI-compatible API error ${status}: ${body}`},
+  };
+}
+
+const CAPABILITIES: ProtocolCapabilities = {
+  nativeToolCalling: true,
+  streaming: true,
+};
+
+const CREDENTIAL_FIELDS: readonly CredentialField[] = [
+  {
+    key: 'endpoint',
+    label: 'Base URL',
+    required: true,
+    placeholder: DEFAULT_BASE_URL,
+  },
+  {
+    // Optional: local servers (llama-server, LM Studio, Ollama) usually run
+    // without auth. Sent as a bearer token when present.
+    key: 'apiKey',
+    label: 'API key (optional for local servers)',
+    secret: true,
+  },
+];
+
+// Accumulates streamed tool-call fragments into whole calls. Fragments are
+// grouped by `index` where present; servers that omit it (sending a call whole)
+// fall back to a positional key so multiple distinct calls don't collide. The
+// `arguments` field is concatenated as a string, but if a server hands us an
+// already-parsed object we stash it directly rather than string-concatenating
+// (which would otherwise produce "[object Object]" and lose all the args).
+class ToolCallAssembler {
+  private readonly byKey = new Map<
+    string,
+    {
+      id?: string;
+      name: string;
+      argsStr: string;
+      argsObj?: Record<string, unknown>;
+    }
+  >();
+  private fallbackSeq = 0;
+
+  add(fragments: readonly ToolCallFragment[]): void {
+    for (const tc of fragments) {
+      const key =
+        tc.index !== undefined
+          ? `i${tc.index}`
+          : tc.id ?? `seq${this.fallbackSeq++}`;
+      const cur = this.byKey.get(key) ?? {name: '', argsStr: ''};
+
+      const rawArgs = tc.function?.arguments;
+      if (typeof rawArgs === 'object' && rawArgs !== null) {
+        cur.argsObj = rawArgs;
+      } else if (typeof rawArgs === 'string') {
+        cur.argsStr += rawArgs;
+      }
+
+      this.byKey.set(key, {
+        id: tc.id ?? cur.id,
+        name: cur.name + (tc.function?.name ?? ''),
+        argsStr: cur.argsStr,
+        argsObj: cur.argsObj,
+      });
+    }
+  }
+
+  finish(): ToolCall[] {
+    const calls: ToolCall[] = [];
+    for (const {id, name, argsStr, argsObj} of this.byKey.values()) {
+      if (name === '') continue;
+      let parsed: Record<string, unknown> = argsObj ?? {};
+      if (argsObj === undefined && argsStr.trim() !== '') {
+        try {
+          parsed = JSON.parse(argsStr);
+        } catch {
+          // Leave args empty on malformed JSON; the registry will validate and
+          // the model can self-correct from the resulting tool error.
+        }
+      }
+      calls.push({id, name, args: parsed});
+    }
+    return calls;
+  }
+}
+
+export class OpenAiProtocol implements Protocol {
+  readonly id = 'openai-compatible';
+  readonly label = 'OpenAI-compatible (OpenAI, llama-server, vLLM, ...)';
+  readonly capabilities = CAPABILITIES;
+  readonly credentialFields = CREDENTIAL_FIELDS;
+
+  // GET {base}/models is part of the OpenAI spec and implemented by virtually
+  // every compatible server (OpenAI, llama-server, vLLM, LM Studio, Ollama).
+  // Returns {data: [{id, ...}]}.
+  async listModels(
+    credentials: Readonly<Record<string, string>>,
+    signal?: AbortSignal,
+  ): Promise<readonly AvailableModel[]> {
+    const base = (credentials.endpoint || DEFAULT_BASE_URL).replace(/\/$/, '');
+    const apiKey = credentials.apiKey ?? '';
+    const resp = await fetch(`${base}/models`, {
+      headers: apiKey ? {Authorization: `Bearer ${apiKey}`} : {},
+      signal,
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '<no body>');
+      throw new Error(
+        `OpenAI-compatible listModels error ${resp.status}: ${text}`,
+      );
+    }
+    const json = (await resp.json()) as {
+      readonly data?: readonly {readonly id?: string}[];
+    };
+    return (json.data ?? [])
+      .map((m) => m.id ?? '')
+      .filter((id) => id !== '')
+      .map((id) => ({name: id}));
+  }
+
+  async *createStream(
+    model: string,
+    request: Request,
+    credentials: Readonly<Record<string, string>>,
+    signal?: AbortSignal,
+  ): AsyncGenerator<StreamEvent, void, void> {
+    const base = (credentials.endpoint || DEFAULT_BASE_URL).replace(/\/$/, '');
+    const apiKey = credentials.apiKey ?? '';
+    const url = `${base}/chat/completions`;
+
+    const tools = toolsToOpenAi(request);
+    const body = {
+      model,
+      messages: messagesToOpenAi(request.systemPrompt, request.messages),
+      ...(tools ? {tools} : {}),
+      stream: true,
+      // Ask for usage in the final chunk (supported by OpenAI and most clones).
+      stream_options: {include_usage: true},
+    };
+
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(apiKey ? {Authorization: `Bearer ${apiKey}`} : {}),
+        },
+        body: JSON.stringify(body),
+        signal,
+      });
+    } catch (e) {
+      if (signal?.aborted) return;
+      yield {
+        type: 'stop',
+        reason: 'error',
+        error: {kind: 'network', message: String(e)},
+      };
+      return;
+    }
+
+    if (!resp.ok || !resp.body) {
+      const text = await resp.text().catch(() => '<no body>');
+      yield classifyError(resp.status, text);
+      return;
+    }
+
+    const assembler = new ToolCallAssembler();
+    let finishReason: string | null = null;
+    for await (const chunk of parseSse(resp.body, signal)) {
+      const choice = chunk.choices?.[0];
+      // Prefer incremental `delta`, but accept `message` for servers that
+      // return the whole turn in one chunk.
+      const delta = choice?.delta ?? choice?.message;
+      if (delta?.content) {
+        yield {type: 'text', text: delta.content};
+      }
+      if (delta?.tool_calls) {
+        assembler.add(delta.tool_calls);
+      }
+      if (choice?.finish_reason) {
+        finishReason = choice.finish_reason;
+      }
+      if (chunk.usage) {
+        yield {
+          type: 'usage',
+          usage: {
+            inputTokens: chunk.usage.prompt_tokens,
+            outputTokens: chunk.usage.completion_tokens,
+            totalTokens: chunk.usage.total_tokens,
+          },
+        };
+      }
+    }
+
+    if (signal?.aborted) return;
+
+    // Emit assembled tool calls (if any) before the terminal stop event.
+    const calls = assembler.finish();
+    for (const call of calls) {
+      yield {type: 'tool-call', call};
+    }
+
+    if (calls.length > 0 || finishReason === 'tool_calls') {
+      yield {type: 'stop', reason: 'tool-calls'};
+    } else if (finishReason === 'length') {
+      yield {type: 'stop', reason: 'length'};
+    } else {
+      yield {type: 'stop', reason: 'end'};
+    }
+  }
+}
+
+// SSE: blank-line-separated events, each a `data: <json>` line. The terminal
+// event is the literal `data: [DONE]`.
+async function* parseSse(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): AsyncGenerator<StreamChunk, void, void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  for (;;) {
+    if (signal?.aborted) return;
+    const {value, done} = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, {stream: true});
+    buf = buf.replace(/\r\n/g, '\n');
+    let sep: number;
+    while ((sep = buf.indexOf('\n\n')) !== -1) {
+      const event = buf.slice(0, sep);
+      buf = buf.slice(sep + 2);
+      const payload = event
+        .split('\n')
+        .filter((l) => l.startsWith('data:'))
+        .map((l) => l.slice(5).trimStart())
+        .join('');
+      if (!payload || payload === '[DONE]') continue;
+      try {
+        yield JSON.parse(payload) as StreamChunk;
+      } catch {
+        // Ignore unparseable events (keepalives, partial buffers).
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add openai compatible LLM protocol plugin, which supports a wide range of model provider backends:

- OpenAI
- Local (llama.cpp, vLLM, etc...)
- Openrouter
- etc...

Also added CSP exception to http://localhost:8080 for use with llama-server.