### PR TITLE
tp: plumb CpuInfo features bitmap into cpu table args

### DIFF
--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -27,8 +27,10 @@
 
 #include "perfetto/base/flat_set.h"
 #include "perfetto/base/logging.h"
+#include "perfetto/ext/base/cpu_info_features_allowlist.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
+#include "perfetto/ext/base/utils.h"
 #include "perfetto/ext/traced/sys_stats_counters.h"
 #include "perfetto/protozero/field.h"
 #include "perfetto/protozero/proto_decoder.h"
@@ -171,6 +173,8 @@ struct CpuInfo {
   std::optional<uint32_t> capacity;
   std::vector<uint32_t> frequencies;
   protozero::ConstChars processor;
+  // Bitmap of CPU features, indexed by base::kCpuInfoFeatures.
+  uint64_t features = 0;
   // Extend the variant to support additional identifiers
   std::variant<std::nullopt_t, ArmCpuIdentifier> identifier = std::nullopt;
 };
@@ -271,10 +275,17 @@ SystemProbesParser::SystemProbesParser(TraceProcessorContext* context)
       arm_cpu_variant(context->storage->InternString("arm_cpu_variant")),
       arm_cpu_part(context->storage->InternString("arm_cpu_part")),
       arm_cpu_revision(context->storage->InternString("arm_cpu_revision")),
+      cpu_features_raw_id_(
+          context->storage->InternString("cpu_features.raw_bitmap")),
       pages_per_slab_id_(context->storage->InternString("pages_per_slab")),
       num_slabs_id_(context->storage->InternString("num_slabs")),
       meminfo_strs_(BuildMeminfoCounterNames()),
-      vmstat_strs_(BuildVmstatCounterNames()) {}
+      vmstat_strs_(BuildVmstatCounterNames()) {
+  for (size_t i = 0; i < base::ArraySize(base::kCpuInfoFeatures); ++i) {
+    base::StackString<1024> key("cpu_features.%s", base::kCpuInfoFeatures[i]);
+    cpu_features_ids_[i] = context->storage->InternString(key.string_view());
+  }
+}
 
 void SystemProbesParser::ParseDiskStats(int64_t ts, ConstBytes blob) {
   protos::pbzero::SysStats::DiskStat::Decoder ds(blob);
@@ -1133,6 +1144,7 @@ void SystemProbesParser::ParseCpuInfo(ConstBytes blob) {
     if (cpu.has_capacity()) {
       current_cpu_info.capacity = cpu.capacity();
     }
+    current_cpu_info.features = cpu.features();
 
     if (cpu.has_arm_identifier()) {
       protos::pbzero::CpuInfo::ArmCpuIdentifier::Decoder identifier(
@@ -1216,9 +1228,10 @@ void SystemProbesParser::ParseCpuInfo(ConstBytes blob) {
       context_->storage->mutable_cpu_freq_table()->Insert(cpu_freq_row);
     }
 
+    ArgsTracker args_tracker(context_);
+    auto inserter = args_tracker.AddArgsTo(ucpu);
     if (auto* id = std::get_if<ArmCpuIdentifier>(&cpu_info.identifier)) {
-      ArgsTracker args_tracker(context_);
-      args_tracker.AddArgsTo(ucpu)
+      inserter
           .AddArg(arm_cpu_implementer,
                   Variadic::UnsignedInteger(id->implementer))
           .AddArg(arm_cpu_architecture,
@@ -1226,6 +1239,22 @@ void SystemProbesParser::ParseCpuInfo(ConstBytes blob) {
           .AddArg(arm_cpu_variant, Variadic::UnsignedInteger(id->variant))
           .AddArg(arm_cpu_part, Variadic::UnsignedInteger(id->part))
           .AddArg(arm_cpu_revision, Variadic::UnsignedInteger(id->revision));
+    }
+
+    for (size_t i = 0; i < base::ArraySize(base::kCpuInfoFeatures); ++i) {
+      if (cpu_info.features & (1ull << i)) {
+        inserter.AddArg(cpu_features_ids_[i], Variadic::Boolean(true));
+      }
+    }
+    if (cpu_info.features != 0) {
+      inserter.AddArg(cpu_features_raw_id_,
+                      Variadic::UnsignedInteger(cpu_info.features));
+    }
+    // Bits beyond the allowlist come from a recorder newer than this
+    // version of trace_processor; they stay queryable via the raw bitmap.
+    if ((cpu_info.features >> base::ArraySize(base::kCpuInfoFeatures)) != 0) {
+      context_->stats_tracker->IncrementStats(
+          stats::cpu_info_unknown_cpu_features);
     }
   }
 }

--- a/src/trace_processor/importers/proto/system_probes_parser.h
+++ b/src/trace_processor/importers/proto/system_probes_parser.h
@@ -17,11 +17,14 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_SYSTEM_PROBES_PARSER_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_SYSTEM_PROBES_PARSER_H_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
 
+#include "perfetto/ext/base/cpu_info_features_allowlist.h"
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/utils.h"
 #include "perfetto/protozero/field.h"
 #include "src/trace_processor/storage/trace_storage.h"
 
@@ -62,6 +65,14 @@ class SystemProbesParser {
   const StringId arm_cpu_variant;
   const StringId arm_cpu_part;
   const StringId arm_cpu_revision;
+
+  // Arg keys for the CPU features recorded in CpuInfo.Cpu.features:
+  // "cpu_features.<name>" per allowlisted feature, plus the verbatim bitmap
+  // under "cpu_features.raw_bitmap" so no data is lost when the trace comes
+  // from a recorder with a newer allowlist.
+  std::array<StringId, base::ArraySize(base::kCpuInfoFeatures)>
+      cpu_features_ids_;
+  const StringId cpu_features_raw_id_;
 
   const StringId pages_per_slab_id_;
   const StringId num_slabs_id_;

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -167,6 +167,10 @@ namespace perfetto::trace_processor::stats {
   F(app_wakelock_unknown_id,              kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
        "Interning ID not found. Should never happen."),                        \
   F(meminfo_unknown_keys,                 kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
+  F(cpu_info_unknown_cpu_features,        kSingle,  kInfo,     kAnalysis, Scope::kMachineAndTrace,      \
+       "CpuInfo contained CPU feature bits not known to this version of "      \
+       "trace_processor. The full bitmap is still preserved in the cpu "       \
+       "table args as cpu_features.raw_bitmap."),                              \
   F(missing_disk_io_event_name,           kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
        "ETW Disk IO tracker encountered an event with an opcode for which it " \
         "didn't have a name."),                                                \

--- a/test/trace_processor/diff_tests/parser/parsing/cpu_info.textproto
+++ b/test/trace_processor/diff_tests/parser/parsing/cpu_info.textproto
@@ -72,6 +72,7 @@ packet {
       frequencies: 1516800
       frequencies: 1612800
       frequencies: 1708800
+      features: 1
     }
     cpus {
       processor: "AArch64 Processor rev 13 (aarch64)"
@@ -85,6 +86,7 @@ packet {
       frequencies: 1747200
       frequencies: 1843200
       frequencies: 1996800
+      features: 3
     }
     cpus {
       processor: "AArch64 Processor rev 13 (aarch64)"
@@ -98,6 +100,16 @@ packet {
       frequencies: 1747200
       frequencies: 1843200
       frequencies: 1996800
+      arm_identifier {
+        implementer: 65
+        architecture: 8
+        variant: 0
+        part: 3336
+        revision: 13
+      }
+      # Bits 0, 1 (mte, mte3) plus bit 62, which is not in the allowlist and
+      # exercises the unknown-feature fallback (cpu_features.raw_bitmap).
+      features: 4611686018427387907
     }
   }
 }

--- a/test/trace_processor/diff_tests/parser/parsing/tests.py
+++ b/test/trace_processor/diff_tests/parser/parsing/tests.py
@@ -894,6 +894,41 @@ class Parsing(TestSuite):
         7,1,"AArch64 Processor rev 13 (aarch64)"
         """))
 
+  def test_cpu_features(self):
+    return DiffTestBlueprint(
+        trace=Path('cpu_info.textproto'),
+        query="""
+        SELECT
+          cpu,
+          EXTRACT_ARG(arg_set_id, 'cpu_features.mte') AS mte,
+          EXTRACT_ARG(arg_set_id, 'cpu_features.mte3') AS mte3,
+          EXTRACT_ARG(arg_set_id, 'cpu_features.raw_bitmap') AS raw_bitmap,
+          EXTRACT_ARG(arg_set_id, 'arm_cpu_part') AS arm_cpu_part
+        FROM cpu;
+        """,
+        out=Csv("""
+        "cpu","mte","mte3","raw_bitmap","arm_cpu_part"
+        0,"[NULL]","[NULL]","[NULL]","[NULL]"
+        1,"[NULL]","[NULL]","[NULL]","[NULL]"
+        2,"[NULL]","[NULL]","[NULL]","[NULL]"
+        3,"[NULL]","[NULL]","[NULL]","[NULL]"
+        4,"[NULL]","[NULL]","[NULL]","[NULL]"
+        5,1,"[NULL]",1,"[NULL]"
+        6,1,1,3,"[NULL]"
+        7,1,1,4611686018427387907,3336
+        """))
+
+  def test_cpu_features_unknown_stat(self):
+    return DiffTestBlueprint(
+        trace=Path('cpu_info.textproto'),
+        query="""
+        SELECT value FROM stats WHERE name = 'cpu_info_unknown_cpu_features';
+        """,
+        out=Csv("""
+        "value"
+        1
+        """))
+
   def test_cpu_freq(self):
     return DiffTestBlueprint(
         trace=Path('cpu_info.textproto'),


### PR DESCRIPTION
https://r.android.com/3464271 started recording a per-CPU features bitmap in CpuInfo.Cpu.features (bit i = base::kCpuInfoFeatures[i]) but trace_processor never parsed it.

- Decode the bitmap in SystemProbesParser::ParseCpuInfo into one boolean arg per known feature on the cpu table row, e.g. cpu_features.mte.
- Preserve the verbatim bitmap as cpu_features.raw_bitmap whenever it is non-zero, so nothing is lost on version skew.
- Bump the new cpu_info_unknown_cpu_features stat when the bitmap has bits beyond the allowlist (recorder newer than trace_processor).

Verified end to end on a trace from an MTE-enabled device:

```
  SELECT
    cpu,
    EXTRACT_ARG(arg_set_id, 'cpu_features.mte') AS mte,
    EXTRACT_ARG(arg_set_id, 'cpu_features.mte3') AS mte3,
    EXTRACT_ARG(arg_set_id, 'cpu_features.raw_bitmap') AS raw_bitmap
  FROM cpu;

  "cpu","mte","mte3","raw_bitmap"
  0,1,1,3
  1,1,1,3
  2,1,1,3
  3,1,1,3
  4,1,1,3
  5,1,1,3
  6,1,1,3
  7,1,1,3
```

Bug: 390666189
