### PR TITLE
Remove debugfs tracing fallback for Android

### DIFF
--- a/docs/data-sources/atrace.md
+++ b/docs/data-sources/atrace.md
@@ -39,7 +39,7 @@ enable both system and app events.
 ATrace instrumentation a non-negligible cost of 1-10us per event.
 This is because each event involves a stringification, a JNI call if coming from
 a managed execution environment, and a user-space <-> kernel-space roundtrip to
-write the marker into `/sys/kernel/debug/tracing/trace_marker` (which is the
+write the marker into `/sys/kernel/tracing/trace_marker` (which is the
 most expensive part).
 
 Our team is looking into a migration path for Android, in light of the newly

--- a/perfetto.rc
+++ b/perfetto.rc
@@ -147,7 +147,6 @@ on late-init && property:ro.boot.fastboot.boottrace=enabled
 # disable on boot complete when using textual ftrace tracing without perfetto.
 on property:sys.boot_completed=1 && property:ro.boot.fastboot.boottrace=enabled && property:init.svc.perfetto_trace_on_boot=
     setprop debug.atrace.tags.enableflags 0
-    write /sys/kernel/debug/tracing/tracing_on 0
     write /sys/kernel/tracing/tracing_on 0
 
 # These must be set as soon as possible for processes guarded by

--- a/tools/run_android_test
+++ b/tools/run_android_test
@@ -157,9 +157,6 @@ def Main():
   AdbCall(
       'shell', 'test -f /sys/kernel/tracing/tracing_on ' +
       '&& echo 0 > /sys/kernel/tracing/tracing_on || true')
-  AdbCall(
-      'shell', 'test -f /sys/kernel/debug/tracing/tracing_on ' +
-      '&& echo 0 > /sys/kernel/debug/tracing/tracing_on || true')
 
   # This needs to go into /data/nativetest in order to have the system linker
   # namespace applied, which we need in order to link libdexfile.so.


### PR DESCRIPTION
Remove legacy debugfs tracing references (/sys/kernel/debug/tracing) from Android-specific files as Android devices since Android Q mount tracefs at /sys/kernel/tracing, and release builds since Android R forbid mounting debugfs (b/31856701#comment72).

Updated files:
- perfetto.rc: Removed write to /sys/kernel/debug/tracing/tracing_on. Safe because tracing_on is written at /sys/kernel/tracing, and debugfs is disabled/unmounted on release builds.
- tools/run_android_test: Removed adb fallback for debugfs tracing. Safe because supported Android test devices run Android Q+.
- docs/data-sources/atrace.md: Updated ATrace documentation to point to /sys/kernel/tracing/trace_marker.

Files retained for backward compatibility:
- src/traced/probes/ftrace/tracefs.cc: Retained fallback path "/sys/kernel/debug/tracing/" in Tracefs::kTracingPaths to preserve compatibility for non-Android Linux and embedded systems where tracefs may still be mounted under debugfs.
- docs/contributing/*.md: Retained general Linux host documentation.

Bug: 303590268
Test: tools/run_android_test
Flag: EXEMPT PURE_REFACTOR