### PR TITLE
GpuCompute: fix summary stack overflow for large kernel counts

### DIFF
--- a/ui/src/plugins/com.meta.GpuCompute/summary.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/summary.ts
@@ -287,7 +287,8 @@ export const KernelSummarySection: m.Component<
       if (nums.length === 0) {
         return undefined;
       }
-      return Math.max(...nums);
+      // Reduce, not `Math.max(...nums)`, which overflows the stack for large arrays.
+      return nums.reduce((a, b) => Math.max(a, b));
     };
 
     state.rows = rows;


### PR DESCRIPTION
finiteMax used Math.max(...nums), which spreads the array as function arguments; for traces with many kernels this exceeds the argument/call-stack limit and throws 'RangeError: Maximum call stack size exceeded' when the summary section mounts. Fold with reduce instead so it scales to any array size.