### PR TITLE
ui: fix pprof download for traces with multiple profile types

### DIFF
--- a/ui/src/frontend/trace_converter.ts
+++ b/ui/src/frontend/trace_converter.ts
@@ -123,14 +123,21 @@ export function convertToJson(
   );
 }
 
+// Maps to traceconv's --alloc/--perf/--java-heap disambiguation flags:
+// traces can contain more than one profile type and traceconv refuses to
+// guess in that case.
+export type PprofProfileType = 'alloc' | 'perf' | 'java-heap';
+
 export function convertTraceToPprofAndDownload(
   trace: Blob,
+  profileType: PprofProfileType,
   pid: number,
   ts: time,
 ): Promise<void> {
   return makeWorkerAndPost({
     kind: 'ConvertTraceToPprof',
     trace,
+    profileType,
     pid,
     ts,
   });

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -646,7 +646,14 @@ async function downloadPprof(trace: Trace, upid: number, ts: time) {
     return;
   }
   const blob = await trace.getTraceFile();
-  convertTraceToPprofAndDownload(blob, pid.firstRow({pid: NUM}).pid, ts);
+  // This is only reachable for heapprofd-based profiles (native heap and
+  // Java heap samples), which are both allocator profiles for traceconv.
+  convertTraceToPprofAndDownload(
+    blob,
+    'alloc',
+    pid.firstRow({pid: NUM}).pid,
+    ts,
+  );
 }
 
 function getHeapGraphDuplicateObjectsView(

--- a/ui/src/traceconv/index.ts
+++ b/ui/src/traceconv/index.ts
@@ -170,9 +170,12 @@ async function ConvertTraceAndOpenInLegacy(
   }
 }
 
+type PprofProfileType = 'alloc' | 'perf' | 'java-heap';
+
 interface ConvertTraceToPprofArgs {
   kind: 'ConvertTraceToPprof';
   trace: Blob;
+  profileType: PprofProfileType;
   pid: number;
   ts: time;
 }
@@ -184,9 +187,15 @@ function isConvertTraceToPprof(msg: Args): msg is ConvertTraceToPprofArgs {
   return true;
 }
 
-async function ConvertTraceToPprof(trace: Blob, pid: number, ts: time) {
+async function ConvertTraceToPprof(
+  trace: Blob,
+  profileType: PprofProfileType,
+  pid: number,
+  ts: time,
+) {
   const args = [
     'profile',
+    `--${profileType}`,
     `--pid`,
     `${pid}`,
     `--timestamps`,
@@ -199,6 +208,12 @@ async function ConvertTraceToPprof(trace: Blob, pid: number, ts: time) {
     const heapDirName = Object.keys(
       module.FS.lookupPath('/tmp/').node.contents,
     )[0];
+    if (heapDirName === undefined) {
+      throw new Error(
+        'No profiles generated; the trace has no profile matching ' +
+          `type=${profileType} pid=${pid} ts=${ts}`,
+      );
+    }
     const heapDirContents = module.FS.lookupPath(`/tmp/${heapDirName}`).node
       .contents;
     const heapDumpFiles = Object.keys(heapDirContents);
@@ -225,7 +240,7 @@ selfWorker.onmessage = (msg: MessageEvent) => {
   } else if (isConvertTraceAndOpenInLegacy(args)) {
     ConvertTraceAndOpenInLegacy(args.trace, args.truncate);
   } else if (isConvertTraceToPprof(args)) {
-    ConvertTraceToPprof(args.trace, args.pid, args.ts);
+    ConvertTraceToPprof(args.trace, args.profileType, args.pid, args.ts);
   } else {
     throw new Error(`Unknown method call ${JSON.stringify(args)}`);
   }


### PR DESCRIPTION
The "download pprof" button in the heap profile details panel invoked
traceconv's profile mode without a profile type flag, relying on
auto-detection. On traces containing more than one profile type (e.g.
heapprofd allocations plus perf samples), traceconv refuses to guess,
exits without writing any output and the worker then crashed with an
opaque ErrnoError when looking up the output directory in /tmp.

Since the button is only shown for heapprofd-based profiles, pass
--alloc explicitly through the conversion pipeline. Also surface a
real error message instead of the ErrnoError if traceconv produces
no profiles.
