### PR TITLE
tp: fix Python API startup timeout racing prebuilt download

### DIFF
--- a/python/perfetto/trace_processor/api.py
+++ b/python/perfetto/trace_processor/api.py
@@ -93,7 +93,7 @@ class TraceProcessorConfig:
 
   # The timeout in seconds for the trace processor binary starting up. If the
   # binary does not start within this time, an exception will be raised.
-  load_timeout: int = 2
+  load_timeout: int = 30
 
   # Any extra flags to pass to the trace processor binary.
   # Warning: this is a low-level option and should be used with caution.
@@ -114,7 +114,7 @@ class TraceProcessorConfig:
       ingest_ftrace_in_raw: bool = False,
       enable_dev_features=False,
       resolver_registry: Optional[ResolverRegistry] = None,
-      load_timeout: int = 2,
+      load_timeout: int = 30,
       extra_flags: Optional[List[str]] = None,
       add_sql_packages: Optional[List[Union[str, SqlPackage]]] = None,
       fetch_latest_trace_processor: bool = False,

--- a/python/perfetto/trace_processor/shell.py
+++ b/python/perfetto/trace_processor/shell.py
@@ -43,7 +43,7 @@ def load_shell(
     ingest_ftrace_in_raw: bool,
     enable_dev_features: bool,
     platform_delegate: PlatformDelegate,
-    load_timeout: int = 2,
+    load_timeout: int = 30,
     extra_flags: Optional[List[str]] = None,
     add_sql_packages: Optional[List[Union[str, 'SqlPackage']]] = None,
     fetch_latest_trace_processor: bool = False,
@@ -65,6 +65,11 @@ def load_shell(
     tp_exec = [python_executable_path, shell_path]
   else:
     tp_exec = [shell_path]
+
+  if fetch_latest_trace_processor and bin_path is None:
+    # The wrapper script downloads the real binary on first run. Do this
+    # here so it does not race the startup timeout below.
+    subprocess.check_call(tp_exec + ['--version'], stdout=subprocess.DEVNULL)
 
   args = ['-D', '--http-port', str(port)]
   if not ingest_ftrace_in_raw:
@@ -125,6 +130,8 @@ def load_shell(
     temp_stdout.close()
     temp_stderr.close()
     raise PerfettoException("Trace processor failed to start.\n"
-                            f"stdout: {stdout}\nstderr: {stderr}\n")
+                            f"stdout: {stdout}\nstderr: {stderr}\n"
+                            "If this is a slow machine or network, try "
+                            "increasing load_timeout in TraceProcessorConfig.")
 
   return url, p, temp_stdout, temp_stderr, job_handle


### PR DESCRIPTION
When TraceProcessorConfig(fetch_latest_trace_processor=True) is used,
the wrapper script fetched from get.perfetto.dev downloads the real
trace_processor binary on its first run. This download happened inside
the subprocess spawned by load_shell(), so on slow connections the 2s
startup timeout expired mid-download and the API raised "Trace
processor failed to start" with a truncated curl progress bar.

Fix this by running the wrapper once synchronously (--version) before
starting the server, so the download happens outside the timed window,
mirroring what the default pinned-prebuilt path already does. Also bump
the default load_timeout from 2s to 30s (the poll loop exits as soon as
the server responds or the process dies, so this does not slow down
either the common success path or the process-died failure path) and
mention load_timeout in the startup failure message.

Fixes #5433
