### PR TITLE
ui: add ring buffer size control to stack sampling record page

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/stack_sampling.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/stack_sampling.ts
@@ -39,6 +39,17 @@ function tracedPerf(): RecordProbe {
       values: [1, 10, 50, 100, 250, 500, 1000],
       unit: 'Hz',
     }),
+    ringBufSize: new Slider({
+      title: 'Kernel ring buffer size',
+      description:
+        'Size of each per-cpu ring buffer filled by the kernel. ' +
+        'Increase this if samples are being dropped. ' +
+        '0 = use the default (1 MiB).',
+      cssClass: '.thin',
+      values: [0, 512, 1024, 2048, 4096, 8192, 16384, 32768],
+      unit: 'KiB',
+      zeroIsDefault: true,
+    }),
     procs: new Textarea({
       placeholder:
         'Filters for processes to profile, one per line e.g.' +
@@ -58,6 +69,7 @@ function tracedPerf(): RecordProbe {
       const s = settings;
       const pkgs = splitLinesNonEmpty(s.procs.text);
       tc.addDataSource('linux.perf').perfEventConfig = {
+        ringBufferPages: ringBufferPagesFromKib(s.ringBufSize.value),
         timebase: {
           frequency: s.samplingFreq.value,
           timestampClock: protos.PerfEvents.PerfClock.PERF_CLOCK_MONOTONIC,
@@ -73,4 +85,12 @@ function tracedPerf(): RecordProbe {
       };
     },
   };
+}
+
+// The kernel requires the ring buffer size to be a power of two of the page
+// size (4 KiB), so round up whatever the user typed in.
+function ringBufferPagesFromKib(sizeKib: number): number | undefined {
+  if (sizeKib <= 0 || !Number.isFinite(sizeKib)) return undefined;
+  const pages = Math.max(1, Math.ceil(sizeKib / 4));
+  return Math.pow(2, Math.ceil(Math.log2(pages)));
 }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/styles.scss
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/styles.scss
@@ -510,7 +510,8 @@
       grid-area: descr;
       font-size: var(--pf-font-size-s);
       color: var(--pf-color-text-muted);
-      height: 20px;
+      height: auto;
+      min-height: 20px;
       line-height: 20px;
     }
 


### PR DESCRIPTION
traced_perf suggests increasing ring_buffer_pages when the kernel
drops samples, but until now the only way to set it was to hand-edit
the trace config proto. Expose it as a slider in the Record > Stack
sampling page.

The control is denominated in KiB for clarity and converted to 4 KiB
pages internally, rounding up to the power of two that the kernel
requires. Leaving it at 0 keeps the traced_perf default (1 MiB per
cpu).

Bug: 407406366
