### PR TITLE
ui: Add recently opened traces section to the home page

### DIFF
--- a/ui/src/core/cache_manager.ts
+++ b/ui/src/core/cache_manager.ts
@@ -38,7 +38,7 @@ async function getCache(): Promise<Cache | undefined> {
   return LAZY_CACHE;
 }
 
-async function cacheDelete(key: Request): Promise<boolean> {
+async function cacheDelete(key: Request | string): Promise<boolean> {
   try {
     const cache = await getCache();
     if (cache === undefined) return false; // Cache storage not supported.
@@ -205,4 +205,53 @@ async function deleteStaleEntries() {
   // TODO(hjd): Wrong Promise.all here, should use the one that
   // ignores failures but need to upgrade TypeScript for that.
   await Promise.all(deletions);
+}
+
+export interface CachedTraceEntry {
+  readonly uuid: string;
+  readonly title: string;
+  readonly fileName?: string;
+  readonly url?: string;
+  readonly sizeBytes?: number;
+  readonly expires?: string;
+}
+
+export async function getRecentCachedTraces(): Promise<
+  ReadonlyArray<CachedTraceEntry>
+> {
+  await deleteStaleEntries();
+  const keys = await cacheKeys();
+  const entries: CachedTraceEntry[] = [];
+
+  for (const key of keys) {
+    const response = await cacheMatch(key);
+    if (!response) continue;
+
+    // Key URL format: /_cached_traces/${uuid}
+    const uuid = key.url.split('/').pop() ?? '';
+    const rawTitle = response.headers.get('x-trace-title');
+    const title = rawTitle ? decodeURI(rawTitle) : 'Untitled trace';
+    const fileName = response.headers.get('x-trace-filename') ?? undefined;
+    const url = response.headers.get('x-trace-url') ?? undefined;
+    const contentLength = response.headers.get('content-length');
+    const sizeBytes = contentLength ? parseInt(contentLength, 10) : undefined;
+    const expires = response.headers.get('expires') ?? undefined;
+
+    entries.push({
+      uuid,
+      title,
+      fileName,
+      url,
+      sizeBytes,
+      expires,
+    });
+  }
+
+  // Sort descending by expires string
+  entries.sort((a, b) => (b.expires ?? '').localeCompare(a.expires ?? ''));
+  return entries;
+}
+
+export async function deleteCachedTrace(uuid: string): Promise<boolean> {
+  return await cacheDelete(`/_${TRACE_CACHE_NAME}/${uuid}`);
 }

--- a/ui/src/frontend/home_page.scss
+++ b/ui/src/frontend/home_page.scss
@@ -139,6 +139,57 @@
       }
     }
 
+    .pf-home-page__item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      border-radius: $border-radius;
+      padding: 4px 8px;
+      margin: 0 -8px;
+      cursor: pointer;
+      user-select: none;
+      gap: 12px;
+
+      .pf-visible-on-hover {
+        visibility: hidden;
+      }
+
+      &:hover {
+        background: color_hover(transparent);
+
+        .pf-visible-on-hover {
+          visibility: visible;
+        }
+      }
+
+      &:active {
+        background: color_active(transparent);
+      }
+
+      & > .pf-left-icon {
+        color: var(--pf-color-text-muted);
+      }
+
+      &-info {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+      }
+
+      &-title {
+        color: var(--pf-color-text);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      &-details {
+        font-size: 0.85em;
+        color: var(--pf-color-text-muted);
+      }
+    }
+
     .pf-home-page__shortcut {
       display: flex;
       align-items: center;

--- a/ui/src/frontend/home_page.scss
+++ b/ui/src/frontend/home_page.scss
@@ -85,6 +85,7 @@
       flex: 1;
       display: flex;
       flex-direction: column;
+      max-width: 400px;
 
       &-title {
         font-size: 12px;
@@ -144,7 +145,7 @@
       align-items: center;
       justify-content: space-between;
       border-radius: $border-radius;
-      padding: 4px 8px;
+      padding: 5px 8px;
       margin: 0 -8px;
       cursor: pointer;
       user-select: none;

--- a/ui/src/frontend/home_page.ts
+++ b/ui/src/frontend/home_page.ts
@@ -39,6 +39,12 @@ import {
 } from '../base/keyboard_layout_map';
 import {Spinner} from '../widgets/spinner';
 import {KeyMapping} from '../base/wasd_key_mapping';
+import {
+  deleteCachedTrace,
+  getRecentCachedTraces,
+  type CachedTraceEntry,
+} from '../core/cache_manager';
+import {formatBytesSi} from '../base/bytes_format';
 
 export class HomePage implements m.ClassComponent {
   view() {
@@ -177,32 +183,37 @@ class Hints implements m.ClassComponent {
         m(
           '.pf-home-page__section-content',
           m(
-            '.pf-home-page__getting-started-buttons',
+            Stack,
             m(
-              '.pf-home-page__button',
+              '.pf-home-page__item',
               {
                 onclick: () => {
-                  AppImpl.instance.commands.runCommand(
-                    'dev.perfetto.OpenTrace',
-                  );
+                  app.commands.runCommand('dev.perfetto.OpenTrace');
                 },
               },
               m(Icon, {icon: 'folder_open', className: 'pf-left-icon'}),
-              m('span.pf-button__label', 'Open trace'),
+              m(
+                '.pf-home-page__item-info',
+                m('.pf-home-page__item-title', 'Open trace'),
+              ),
             ),
             m(
-              '.pf-home-page__button',
+              '.pf-home-page__item',
               {
                 onclick: () => {
                   Router.navigate('#!/record');
                 },
               },
               m(Icon, {icon: 'fiber_smart_record', className: 'pf-left-icon'}),
-              m('span.pf-button__label', 'Record new trace'),
+              m(
+                '.pf-home-page__item-info',
+                m('.pf-home-page__item-title', 'Record new trace'),
+              ),
             ),
           ),
         ),
       ),
+      m(RecentTraces),
       // Keyboard shortcuts section
       m(
         '.pf-home-page__section',
@@ -260,4 +271,76 @@ class Hints implements m.ClassComponent {
       ),
     );
   }
+}
+
+function RecentTraces(): m.Component {
+  let recentTraces: ReadonlyArray<CachedTraceEntry> = [];
+  let loading = true;
+  const MAX_RECENT_TRACES = 5;
+
+  function reloadTraces() {
+    getRecentCachedTraces().then((traces) => {
+      recentTraces = traces.slice(0, MAX_RECENT_TRACES);
+      loading = false;
+      m.redraw();
+    });
+  }
+
+  reloadTraces();
+
+  return {
+    view() {
+      if (loading || recentTraces.length === 0) {
+        return null;
+      }
+
+      return m(
+        '.pf-home-page__section',
+        m('.pf-home-page__section-title', 'Recently opened traces'),
+        m(
+          '.pf-home-page__section-content',
+          m(
+            Stack,
+            recentTraces.map((trace) => {
+              return m(
+                '.pf-home-page__item',
+                {
+                  onclick: () => {
+                    Router.navigate(`#!/?local_cache_key=${trace.uuid}`);
+                  },
+                },
+                m(Icon, {icon: 'description', className: 'pf-left-icon'}),
+                m(
+                  '.pf-home-page__item-info',
+                  m('.pf-home-page__item-title', trace.title),
+                  m(
+                    '.pf-home-page__item-details',
+                    trace.sizeBytes !== undefined &&
+                      formatBytesSi(trace.sizeBytes),
+                  ),
+                ),
+                m(Button, {
+                  className: 'pf-visible-on-hover',
+                  icon: 'close',
+                  variant: ButtonVariant.Minimal,
+                  title: 'Remove from cache',
+                  onclick: async (e: Event) => {
+                    e.stopPropagation();
+                    if (
+                      window.confirm(
+                        'Are you sure you want to remove this trace?',
+                      )
+                    ) {
+                      await deleteCachedTrace(trace.uuid);
+                      reloadTraces();
+                    }
+                  },
+                }),
+              );
+            }),
+          ),
+        ),
+      );
+    },
+  };
 }

--- a/ui/src/frontend/home_page.ts
+++ b/ui/src/frontend/home_page.ts
@@ -28,6 +28,7 @@ import {HotkeyGlyphs, Keycap} from '../widgets/hotkey_glyphs';
 import {Switch} from '../widgets/switch';
 import {assetSrc} from '../base/assets';
 import {Stack} from '../widgets/stack';
+import {MiddleEllipsis} from '../widgets/middle_ellipsis';
 import {Icons} from '../base/semantic_icons';
 import {Icon} from '../widgets/icon';
 import {classNames} from '../base/classnames';
@@ -188,7 +189,9 @@ class Hints implements m.ClassComponent {
               '.pf-home-page__item',
               {
                 onclick: () => {
-                  app.commands.runCommand('dev.perfetto.OpenTrace');
+                  AppImpl.instance.commands.runCommand(
+                    'dev.perfetto.OpenTrace',
+                  );
                 },
               },
               m(Icon, {icon: 'folder_open', className: 'pf-left-icon'}),
@@ -312,7 +315,11 @@ function RecentTraces(): m.Component {
                 m(Icon, {icon: 'description', className: 'pf-left-icon'}),
                 m(
                   '.pf-home-page__item-info',
-                  m('.pf-home-page__item-title', trace.title),
+                  m(MiddleEllipsis, {
+                    text: trace.title,
+                    endChars: 16,
+                    className: 'pf-home-page__item-title',
+                  }),
                   m(
                     '.pf-home-page__item-details',
                     trace.sizeBytes !== undefined &&


### PR DESCRIPTION
This is a first attempt based purely on what data we have available in the cache. Thus, it only applies to traces that actually get cached (e.g. traces loaded from a url don't get cached).

Features:
- Show up to the 5 most recently cached traces.
- Click to open that trace.
- Click the x button to delete it from the cache.
- Use MiddleEllipsis widget to handle long titles.

Fixes: b/531725088

<img width="435" height="575" alt="image" src="https://github.com/user-attachments/assets/8581abdf-5ead-4ff9-88e7-2d2f5864b734" />