### PR TITLE
perfetto: document that changes must land on GitHub upstream

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,6 +2,18 @@
 
 This document provides essential instructions and best practices for developing in the Perfetto codebase. Adhere to these guidelines to ensure consistency and quality.
 
+## Where to Land Changes
+
+All Perfetto changes must be landed in the upstream repository at
+https://github.com/google/perfetto.
+
+**Note for Google folks:** Pull requests or changelists raised against
+`third_party/perfetto/` in google3, or against `external/perfetto` in the
+internal Android repository, will NOT be accepted. To upstream your changes,
+follow the instructions at
+[go/perfetto-github-instructions](http://go/perfetto-github-instructions), or contact
+perfetto-team@google.com for help.
+
 ## Overview
 
 The perfetto repo contains several projects. These are the major ones


### PR DESCRIPTION
Add a "Where to Land Changes" section to docs/AGENTS.md directing all Perfetto changes to https://github.com/google/perfetto. 

Bug: 531621607