### PR TITLE
docs: document track filtering in the Perfetto UI

### DIFF
--- a/docs/visualization/perfetto-ui.md
+++ b/docs/visualization/perfetto-ui.md
@@ -107,6 +107,19 @@ typing to fuzzy find tracks.
   <source src="https://storage.googleapis.com/perfetto-misc/finding-tracks.webm" type="video/webm">
 </video>
 
+## Filtering Tracks
+
+Click the filter icon in the timeline toolbar to filter which tracks are shown
+on the timeline. Type comma separated terms to filter tracks by name, or use
+the dropdowns to only show tracks belonging to specific processes or threads.
+
+Filters are non-destructive: press 'Clear All Filters' to show all tracks
+again. While filters are active, the filter icon appears filled.
+
+<video width="800" controls>
+  <source src="https://storage.googleapis.com/perfetto-misc/filtering-tracks.webm" type="video/webm">
+</video>
+
 ## Pinning Tracks
 
 Press the 'Pin' icon in the track shell to pin a track to the top of the


### PR DESCRIPTION
Add a 'Filtering Tracks' section to the Perfetto UI page covering the
track filter popup in the timeline toolbar: filtering tracks by name
and restricting the timeline to specific processes or threads, plus
the filled filter icon indicator and 'Clear All Filters'. Includes a
demo video recorded on the Android example trace.
