### PR TITLE
tp: fix flaky TempDir teardown crash in integration tests

### DIFF
--- a/src/trace_processor/rpc/unixd.cc
+++ b/src/trace_processor/rpc/unixd.cc
@@ -171,7 +171,8 @@ base::Status UnixRpcServer::Run() {
 #if PERFETTO_TP_UNIXD_CTRL_C()
   // Install *before* binding: a SIGTERM/SIGINT in the window after the socket
   // exists would otherwise terminate us without unlinking it, leaking the file.
-  // Unlinking a not-yet-bound path is harmless; the pid path is wired up later.
+  // Unlinking a not-yet-bound path is harmless; the pid path is registered the
+  // same way below.
   g_socket_path_for_signal = args_.socket_path.c_str();
   base::InstallCtrlCHandler(&HandleTermSignal);
 #endif
@@ -232,6 +233,11 @@ base::Status UnixRpcServer::Run() {
   // runs in the serving process (the child, when daemonized), so the pid
   // matches the one printed in the startup record.
   pid_path_ = args_.socket_path + session::kPidFileSuffix;
+#if PERFETTO_TP_UNIXD_CTRL_C()
+  // Register the pid path before creating the file, like the socket above, so
+  // a SIGTERM in the gap still unlinks it instead of leaking it.
+  g_pid_path_for_signal = pid_path_.c_str();
+#endif
   WritePidFile(pid_path_, static_cast<int>(base::GetProcessId()));
 
   listen_sock_ = base::UnixSocket::Listen(raw.ReleaseFd(), this, &task_runner_,
@@ -246,11 +252,6 @@ base::Status UnixRpcServer::Run() {
       std::make_unique<IdleReaper>(&task_runner_, args_.idle_timeout_ms,
                                    args_.idle_start, [this] { Shutdown(); });
   reaper_->Start();
-
-#if PERFETTO_TP_UNIXD_CTRL_C()
-  // Now that the pid-file path is known, let the handler unlink it too.
-  g_pid_path_for_signal = pid_path_.c_str();
-#endif
 
   task_runner_.Run();
   remove(args_.socket_path.c_str());

--- a/test/trace_processor_shell_integrationtest.cc
+++ b/test/trace_processor_shell_integrationtest.cc
@@ -970,6 +970,9 @@ TEST(TraceProcessorShellIntegrationTest, ClassicBadTraceFileShowsOnlyError) {
 TEST(TraceProcessorShellIntegrationTest, ConvertBundleWithDebugOnlyLibraries) {
   auto out_dir = base::TempDir::Create();
   std::string out_path = out_dir.path() + "/bundle.tar";
+  // Clean up on every exit path (an early ASSERT included): TempDir's
+  // destructor aborts the binary if the dir isn't empty.
+  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
 
   auto symbolize = [&](const std::string& in_file,
                        const std::string& symbol_path) {
@@ -1091,8 +1094,6 @@ TEST(TraceProcessorShellIntegrationTest, ConvertBundleWithDebugOnlyLibraries) {
       "(anonymous namespace)::C()",
   };
   EXPECT_THAT(query_result.out, HasSubstr(base::Join(expected_frames, ",")));
-
-  unlink(out_path.c_str());
 }
 
 #endif
@@ -1291,6 +1292,7 @@ TEST(TraceProcessorShellIntegrationTest, BundleWithProguardMap) {
       "    void bar() -> b\n");
   auto out_dir = base::TempDir::Create();
   std::string out_path = out_dir.path() + "/bundle.tar";
+  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
 
   auto result = RunShell({"bundle", "--no-auto-symbol-paths", "--proguard-map",
                           "com.example=" + mapping.path(), HeapprofdTracePath(),
@@ -1318,7 +1320,6 @@ TEST(TraceProcessorShellIntegrationTest, BundleWithProguardMap) {
   EXPECT_EQ(
       dm.obfuscated_classes()[0].obfuscated_methods()[0].obfuscated_name(),
       "b");
-  unlink(out_path.c_str());
 }
 
 // Repeated --proguard-map should emit one DeobfuscationMapping per input map,
@@ -1328,6 +1329,7 @@ TEST(TraceProcessorShellIntegrationTest, BundleRepeatedProguardMap) {
   auto m2 = WriteTempFile("com.example.Bar -> b.b:\n");
   auto out_dir = base::TempDir::Create();
   std::string out_path = out_dir.path() + "/bundle.tar";
+  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
 
   auto result = RunShell({"bundle", "--no-auto-symbol-paths", "--proguard-map",
                           "com.example.one=" + m1.path(), "--proguard-map",
@@ -1340,18 +1342,17 @@ TEST(TraceProcessorShellIntegrationTest, BundleRepeatedProguardMap) {
   EXPECT_THAT(
       DeobfuscationPackages(members["deobfuscation.pb"]),
       testing::UnorderedElementsAre("com.example.one", "com.example.two"));
-  unlink(out_path.c_str());
 }
 
 TEST(TraceProcessorShellIntegrationTest, BundleMissingProguardMapFails) {
   auto out_dir = base::TempDir::Create();
   std::string out_path = out_dir.path() + "/bundle.tar";
+  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
 
   auto result = RunShell({"bundle", "--no-auto-symbol-paths", "--proguard-map",
                           "com.example=/nonexistent/mapping.txt",
                           HeapprofdTracePath(), out_path});
   EXPECT_NE(result.exit_code, 0);
-  unlink(out_path.c_str());
 }
 
 TEST(TraceProcessorShellIntegrationTest, BundleHelpShowsProguardMap) {
@@ -1368,6 +1369,7 @@ TEST(TraceProcessorShellIntegrationTest, BundleNoAutoProguardMaps) {
   auto mapping = WriteTempFile("com.example.Foo -> a.a:\n");
   auto out_dir = base::TempDir::Create();
   std::string out_path = out_dir.path() + "/bundle.tar";
+  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
 
   auto result =
       RunShell({"bundle", "--no-auto-symbol-paths", "--no-auto-proguard-maps",
@@ -1379,7 +1381,6 @@ TEST(TraceProcessorShellIntegrationTest, BundleNoAutoProguardMaps) {
   ASSERT_TRUE(members.count("deobfuscation.pb"));
   EXPECT_THAT(DeobfuscationPackages(members["deobfuscation.pb"]),
               testing::UnorderedElementsAre("com.example"));
-  unlink(out_path.c_str());
 }
 
 // ---------------------------------------------------------------------------

--- a/test/traced_integrationtest.cc
+++ b/test/traced_integrationtest.cc
@@ -474,6 +474,14 @@ TEST(PerfettoTracedIntegrationTest, TestMultipleProducerSockets) {
       temp_dir.path() + "/producer2.sock",
   };
   auto producer_sock_name = base::Join(producer_socket_names, ",");
+
+  // Clean up on every exit path (an early ASSERT included): TempDir's
+  // destructor aborts the binary if the dir isn't empty.
+  auto remove_sockets = base::OnScopeExit([&] {
+    for (const auto& sock_name : producer_socket_names)
+      remove(sock_name.c_str());
+  });
+
   // We need to start the service thread for multiple producer sockets.
   TestHelper helper(&task_runner, TestHelper::Mode::kStartDaemons,
                     producer_sock_name.c_str());
@@ -518,14 +526,10 @@ TEST(PerfettoTracedIntegrationTest, TestMultipleProducerSockets) {
   for (const auto& packet : packets) {
     ASSERT_TRUE(packet.has_for_testing());
   }
-
-  for (const auto& sock_name : producer_socket_names)
-    remove(sock_name.c_str());
 }
 
 TEST(PerfettoTracedIntegrationTest, TestShmemEmulation) {
   base::TestTaskRunner task_runner;
-  auto temp_dir = base::TempDir::Create();
 
   std::string sock_name;
   {


### PR DESCRIPTION
The perfetto_integrationtests binary was flakily aborting (SIGILL, exit
132) on sanitizer builds with:
  temp_file.cc:154 PERFETTO_CHECK(Rmdir(path_)) (errno: 39, Directory not empty)

TempDir's destructor CHECKs that its directory is empty, so any leftover
file there takes down the whole binary. Two independent leaks caused this:

1. `server unix` registered its "<socket>.pid" path with the SIGTERM
   handler only after creating the file and setting up the listen socket
   and idle reaper. A SIGTERM in that window unlinked the socket but left
   the pid file behind, and ServerUnixBindAndCleanup then aborted on the
   non-empty TempDir. The socket is still removed, so the test's
   WaitForFileState guard passes and nothing looks wrong until teardown.
   The window is tiny normally but widens under ASan/MSan. Register the
   pid path before creating the file, mirroring the socket path.

2. Several tests removed a file from a TempDir only at the end of the test
   body, which is skipped if an ASSERT above returns early. Move those to
   OnScopeExit so cleanup always runs (traced multi-producer-socket test
   and the trace_processor `bundle` tests).

https://github.com/google/perfetto/actions/runs/28811487303/job/85440268082?pr=6547

Bug: 530236105