### PR TITLE
ui: make MemoryViz LMK events visible to area-selection aggregation

### DIFF
--- a/ui/src/plugins/com.android.MemoryViz/index.ts
+++ b/ui/src/plugins/com.android.MemoryViz/index.ts
@@ -268,7 +268,7 @@ export default class MemoryViz implements PerfettoPlugin {
           0 AS dur,
           upid,
           pid,
-          COALESCE(process_name, 'Unknown') AS process_name,
+          COALESCE(process_name, 'Unknown') AS name,
           oom_score_adj,
           android_oom_adj_score_to_bucket_name(oom_score_adj) AS oom_bucket,
           kill_reason
@@ -304,13 +304,12 @@ export default class MemoryViz implements PerfettoPlugin {
             dur: LONG,
             upid: NUM_NULL,
             pid: NUM_NULL,
-            process_name: STR,
+            name: STR,
             oom_score_adj: NUM,
             oom_bucket: STR,
             kill_reason: STR_NULL,
           },
         }),
-        sliceName: (row) => row.process_name,
       }),
     });
     const lmkGroup = new TrackNode({
@@ -337,14 +336,13 @@ export default class MemoryViz implements PerfettoPlugin {
               dur: LONG,
               upid: NUM_NULL,
               pid: NUM_NULL,
-              process_name: STR,
+              name: STR,
               oom_score_adj: NUM,
               oom_bucket: STR,
               kill_reason: STR_NULL,
             },
             filter: {col: 'oom_bucket', eq: bucket},
           }),
-          sliceName: (row) => row.process_name,
         }),
       });
       lmkGroup.addChildInOrder(new TrackNode({uri, name: bucket}));


### PR DESCRIPTION
Drag-selecting an area over the LMK tracks (parent or per-oom-bucket children) showed "No details available for the selection": the SliceSelectionAggregator only accepts tracks whose dataset implements {id, name, ts, dur}, and the LMK dataset exposed the process name as 'process_name' with no 'name' column, so probe() rejected every LMK track and no aggregation tab was created.

Rename the column to 'name' in the memory_viz_lmk_slices table and the dataset schemas. The explicit sliceName callbacks become redundant since SliceTrack defaults the slice title to the row's 'name' column, so drop them. Rendering is unchanged (same coalesced string feeds the title, tooltip and colorizer); area selection over the LMK tracks now yields the standard Slices aggregation, grouped by process name.
