### PR TITLE
perfetto: fix leak of calling thread's TLS in Tracing::Shutdown()

### DIFF
--- a/src/tracing/internal/tracing_muxer_impl.cc
+++ b/src/tracing/internal/tracing_muxer_impl.cc
@@ -2790,6 +2790,7 @@ void TracingMuxerImpl::Shutdown() {
 
   std::unique_ptr<base::TaskRunner> owned_task_runner(
       muxer->task_runner_.get());
+  Platform* platform = muxer->platform_;
   base::WaitableEvent shutdown_done;
   owned_task_runner->PostTask([muxer, &shutdown_done] {
     // Check that no consumer session is currently active on any backend.
@@ -2807,13 +2808,17 @@ void TracingMuxerImpl::Shutdown() {
     // The task runner must be deleted outside the muxer thread. This is done by
     // `owned_task_runner` above.
     muxer->task_runner_.release();
-    auto* platform = muxer->platform_;
     delete muxer;
     instance_ = TracingMuxerFake::Get();
-    platform->Shutdown();
     shutdown_done.Notify();
   });
   shutdown_done.Wait();
+
+  // Join the muxer thread before the platform (and its TLS key) is destroyed.
+  owned_task_runner.reset();
+
+  // On the calling thread, so the platform can free this thread's TLS object.
+  platform->Shutdown();
 }
 
 void TracingMuxerImpl::AppendResetForTestingCallback(std::function<void()> cb) {

--- a/src/tracing/platform_windows.cc
+++ b/src/tracing/platform_windows.cc
@@ -71,6 +71,9 @@ PlatformWindows::PlatformWindows() {
 }
 
 PlatformWindows::~PlatformWindows() {
+  // TlsFree doesn't call destructors, so do it manually for the calling
+  // thread.
+  OnThreadExit();
   ::TlsFree(tls_key_);
   instance = nullptr;
 }


### PR DESCRIPTION
Tracing::Initialize() lazily creates a TracingTLS object for the
calling thread.

Tracing::Shutdown(), however, ran Platform::Shutdown() on the muxer
thread: the manual free of the TLS therefore freed the muxer thread's
object instead, and the subsequent pthread_key_delete() made the
calling thread's object unreachable forever.

Fix this by joining the muxer thread first, so that its TLS object is
reclaimed by the pthread key destructor at thread exit, and then
running Platform::Shutdown() on the calling thread, so the platform
dtor frees this thread's TLS object.

On Windows, ~PlatformWindows additionally never freed the calling
thread's TLS object at all: do it manually there too, mirroring the
posix platform.

Verified with a standalone LSan repro and the client API
integration tests.

Fixes #2831
