### PR TITLE
Emit CPU per UID counters only when the value changes.

### DIFF
--- a/src/trace_processor/importers/proto/android_cpu_per_uid_module.cc
+++ b/src/trace_processor/importers/proto/android_cpu_per_uid_module.cc
@@ -94,14 +94,11 @@ void AndroidCpuPerUidModule::ParseField(const ParseFieldArgs& args) {
     state->cluster_count = evt.cluster_count();
   }
 
-  std::unordered_set<uint32_t> uid_with_value_this_packet;
-
   bool parse_error = false;
   uint32_t cluster = 0;
   auto uid_it = evt.uid(&parse_error);
   for (auto time_it = evt.total_time_ms(&parse_error); uid_it && time_it;
        ++time_it) {
-    uid_with_value_this_packet.insert(*uid_it);
     uint64_t key = MakeKey(*uid_it, cluster);
     uint64_t* previous = state->last_values.Find(key);
     uint64_t time_ms;
@@ -129,17 +126,7 @@ void AndroidCpuPerUidModule::ParseField(const ParseFieldArgs& args) {
     UpdateTotals(args.ts, "Apps", it.key(), it.value());
   }
 
-  // Anything we knew about but didn't see in this packet must not have
-  // incremented.
-  for (auto it = state->last_values.GetIterator(); it; ++it) {
-    uint32_t uid = it.key() >> 32;
-    if (uid_with_value_this_packet.count(uid)) {
-      continue;
-    }
-    uint32_t cluster_id = it.key() & 0xffffffff;
-
-    UpdateCounter(args.ts, uid, cluster_id, it.value());
-  }
+  last_packet_ts_ = args.ts;
 }
 
 void AndroidCpuPerUidModule::OnEventsFullyExtracted() {
@@ -191,7 +178,7 @@ void AndroidCpuPerUidModule::UpdateCounter(int64_t ts,
                                            uint64_t value) {
   TrackId track = context_->track_tracker->InternTrack(
       kCpuPerUidBlueprint, tracks::Dimensions(uid, cluster));
-  context_->event_tracker->PushCounter(ts, double(value), track);
+  PushCounter(ts, track, value);
 }
 
 void AndroidCpuPerUidModule::UpdateTotals(int64_t ts,
@@ -200,7 +187,29 @@ void AndroidCpuPerUidModule::UpdateTotals(int64_t ts,
                                           uint64_t value) {
   TrackId track = context_->track_tracker->InternTrack(
       kCpuTotalsBlueprint, tracks::Dimensions(name, cluster));
-  context_->event_tracker->PushCounter(ts, double(value), track);
+  PushCounter(ts, track, value);
+}
+
+void AndroidCpuPerUidModule::PushCounter(int64_t ts,
+                                         TrackId track,
+                                         uint64_t value) {
+  auto [state, inserted] = track_state_.Insert(track, TrackState{});
+  if (state->last_value == value) {
+    return;
+  }
+
+  // If the last value written wasn't from the last packet, there must have been
+  // a period where the counter held the same value. To cap off that period, we
+  // re-write the last value at the last global packet ts.
+  if (state->last_time != last_packet_ts_ && !inserted) {
+    context_->event_tracker->PushCounter(
+        last_packet_ts_, static_cast<double>(state->last_value), track);
+  }
+
+  context_->event_tracker->PushCounter(ts, static_cast<double>(value), track);
+
+  state->last_value = value;
+  state->last_time = ts;
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/android_cpu_per_uid_module.h
+++ b/src/trace_processor/importers/proto/android_cpu_per_uid_module.h
@@ -41,6 +41,7 @@ class AndroidCpuPerUidModule : public ProtoImporterModule {
   void OnEventsFullyExtracted() override;
 
  private:
+  void PushCounter(int64_t ts, TrackId track, uint64_t value);
   void UpdateCounter(int64_t ts,
                      uint32_t uid,
                      uint32_t cluster,
@@ -52,7 +53,19 @@ class AndroidCpuPerUidModule : public ProtoImporterModule {
                     uint32_t cluster,
                     uint64_t value);
 
+  struct TrackState {
+    uint64_t last_value = 0;
+    int64_t last_time = 0;
+  };
+
   TraceProcessorContext* context_;
+
+  // The last packet's timestamp.
+  int64_t last_packet_ts_ = 0;
+
+  // The last value and time pushed per track. Using PushCounter, this allows
+  // writing only changed valued and backfilling the last data point.
+  base::FlatHashMap<TrackId, TrackState> track_state_;
 
   // Last cpu duration per uid/cluster (key is uid << 32 | cluster).
   base::FlatHashMap<uint64_t, uint64_t> last_value_;

--- a/test/trace_processor/diff_tests/parser/android/tests_cpu_per_uid.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_cpu_per_uid.py
@@ -67,9 +67,7 @@ class AndroidCpuPerUid(TestSuite):
         "CPU for UID 0 CL0",10000,1000000.000000
         "CPU for UID 0 CL0",12000,1000100.000000
         "CPU for UID 0 CL1",10000,1000000.000000
-        "CPU for UID 0 CL1",12000,1000000.000000
         "CPU for UID 0 CL2",10000,1000000.000000
-        "CPU for UID 0 CL2",12000,1000000.000000
         "CPU for UID 1000 CL0",10000,1000000.000000
         "CPU for UID 1000 CL0",12000,1002000.000000
         "CPU for UID 1000 CL1",10000,1000000.000000
@@ -77,11 +75,8 @@ class AndroidCpuPerUid(TestSuite):
         "CPU for UID 1000 CL2",10000,1000000.000000
         "CPU for UID 1000 CL2",12000,1000020.000000
         "CPU for UID 1001 CL0",10000,1000000.000000
-        "CPU for UID 1001 CL0",12000,1000000.000000
         "CPU for UID 1001 CL1",10000,1000000.000000
-        "CPU for UID 1001 CL1",12000,1000000.000000
         "CPU for UID 1001 CL2",10000,1000000.000000
-        "CPU for UID 1001 CL2",12000,1000000.000000
         """))
 
   def test_android_cpu_per_uid_malformed(self):
@@ -127,7 +122,59 @@ class AndroidCpuPerUid(TestSuite):
         "CPU for UID 0 CL2",10000,1000000.000000
         "CPU for UID 0 CL2",12000,2000000.000000
         "CPU for UID 1000 CL0",10000,1000000.000000
-        "CPU for UID 1000 CL0",12000,1000000.000000
         "CPU for UID 1000 CL1",10000,1000000.000000
-        "CPU for UID 1000 CL1",12000,1000000.000000
+        """))
+
+  def test_android_cpu_per_uid_sparse(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 10000
+          cpu_per_uid_data {
+            cluster_count: 1
+            uid: 100
+            uid: 200
+            uid: 300
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+          }
+        }
+        packet {
+          timestamp: 12000
+          cpu_per_uid_data {
+            uid: 100
+            total_time_ms: 50
+          }
+        }
+        packet {
+          timestamp: 14000
+          cpu_per_uid_data {
+            uid: 200
+            total_time_ms: 60
+          }
+        }
+        packet {
+          timestamp: 16000
+          cpu_per_uid_data {
+            uid: 300
+            total_time_ms: 70
+          }
+        }
+        """),
+        query="""
+        SELECT t.name, c.ts, c.value
+        FROM counter_track t JOIN counter c ON t.id = c.track_id
+        WHERE type = 'android_cpu_per_uid';
+        """,
+        out=Csv("""
+        "name","ts","value"
+        "CPU for UID 100 CL0",10000,1000000.000000
+        "CPU for UID 100 CL0",12000,1000050.000000
+        "CPU for UID 200 CL0",10000,1000000.000000
+        "CPU for UID 200 CL0",12000,1000000.000000
+        "CPU for UID 200 CL0",14000,1000060.000000
+        "CPU for UID 300 CL0",10000,1000000.000000
+        "CPU for UID 300 CL0",14000,1000000.000000
+        "CPU for UID 300 CL0",16000,1000070.000000
         """))


### PR DESCRIPTION
This emits the value only when the counter changes with special logic to handle the previous point. Consider the following:

```
A     B     C     D     E
^-----^-----^-----^-----^
1     2     2     2     3
```

To fully represent this without loss, the only data point that can be skipped is `C`. While the value at `D` is unchanged, if we don't emit a point at `D`, it will look like there was a difference of 1 between `B` and `E` which is untrue - that delta occurred specifically between `D` and `E`.

This is generalized at the TrackId level so that it can be re-used with both the UID and aggregate tracks (though zeros are more rare in the aggregated tracks).
