### PR TITLE
perfetto: document fresh Debian/Ubuntu build prerequisites

### DIFF
--- a/docs/contributing/build-instructions.md
+++ b/docs/contributing/build-instructions.md
@@ -34,6 +34,17 @@ git clone https://github.com/google/perfetto
 tools/install-build-deps [--android] [--ui] [--linux-arm] [--rust]
 ```
 
+On a fresh Debian/Ubuntu install (including WSL 2), install these system
+packages first. `install-build-deps` uses `curl` and `python3 -m venv`, and the
+hermetic clang toolchain compiles against the system libc headers provided by
+`build-essential` (without them the build fails with
+`fatal error: 'features.h' file not found`, see
+[#405](https://github.com/google/perfetto/issues/405)):
+
+```bash
+sudo apt install curl python3-venv build-essential
+```
+
 `--android` will pull the Android NDK, emulator and other deps required
 to build for `target_os = "android"`.
 
@@ -177,7 +188,9 @@ The following targets are supported on Windows:
 - `perfetto_unittests` / `perfetto_integrationtests`: although they support only
   the subset of code that is supported on Windows (e.g. no ftrace).
 
-It is NOT possible to build the Perfetto UI from Windows.
+It is NOT possible to build the Perfetto UI natively from Windows. You can,
+however, build it from Windows using [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/about)
+by following the Linux instructions inside the WSL environment.
 
 #### Prerequisites
 

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -8,6 +8,19 @@ Follow those steps if you are new to contributing to Perfetto.
 
 **Prerequisites:** git and python3.
 
+On a fresh Debian/Ubuntu install (including WSL 2) a few extra system packages
+are needed. `tools/install-build-deps` uses `curl` to download toolchains and
+`python3 -m venv` to set up its Python environment, and the hermetic clang
+toolchain compiles against the system libc headers:
+
+```sh
+sudo apt install curl python3-venv build-essential
+```
+
+Without `build-essential` (specifically `libc6-dev`) the build fails with
+`fatal error: 'features.h' file not found`
+(see [#405](https://github.com/google/perfetto/issues/405)).
+
 ```sh
 # Clone the Perfetto repo and enter the directory
 git clone https://github.com/google/perfetto.git

--- a/docs/contributing/ui-getting-started.md
+++ b/docs/contributing/ui-getting-started.md
@@ -9,6 +9,16 @@ and installs the `node_modules` in `ui/node_modules`:
 tools/install-build-deps --ui
 ```
 
+On a fresh Debian/Ubuntu install (including WSL 2), first install the system
+packages the build depends on:
+
+```bash
+sudo apt install curl python3-venv build-essential
+```
+
+Building the UI from Windows is not supported natively, but works from Windows
+via [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/about).
+
 ### Build the UI
 
 ```bash


### PR DESCRIPTION
A fresh Debian/Ubuntu install (including WSL 2) is missing a few system
packages the getting-started guide assumes are present, which trips up new
contributors.

Verified on a clean ubuntu:22.04 container:

- tools/install-build-deps downloads toolchains via curl and sets up its
  Python environment with `python3 -m venv`. Without curl it fails with
  FileNotFoundError; without python3-venv it fails because ensurepip is not
  available.
- The hermetic clang toolchain compiles against the system libc headers.
  Without them the build fails with "fatal error: 'features.h' file not
  found" (#405). libc6-dev from build-essential fixes this; g++-multilib is
  not required since the build is 64-bit.

lbzip2 is not needed: install-build-deps extracts .tbz2 archives via Python's
bz2 module, not an external binary.

Also note that the UI can be built from Windows via WSL 2, rather than only
stating that native Windows builds are unsupported.

Fixes #1255
