### PR TITLE
DNS: ui: Allow pinning groups/processes

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.Timeline/track_view.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/track_view.ts
@@ -163,9 +163,7 @@ export class TrackView {
           (removable || node.removable) && this.renderCloseButton(),
           this.renderTrackMenuButton(),
           // Always-visible buttons last (pin button is visible when pinned)
-          // We don't want summary tracks to be pinned as they rarely have
-          // useful information.
-          !node.isSummary && this.renderPinButton(),
+          this.renderPinButton(),
           // Area seletion (when in area selection mode is always visible so put
           // it at the end)
           this.renderAreaSelectionCheckbox(),

--- a/ui/src/public/workspace.ts
+++ b/ui/src/public/workspace.ts
@@ -607,14 +607,9 @@ export class Workspace {
    * Adds a track node to this workspace's pinned area.
    */
   pinTrack(track: TrackNode): void {
-    // Make a lightweight clone of this track - just the uri and the title.
-    const cloned = new TrackNode({
-      uri: track.uri,
-      name: track.name,
-      subtitle: track.subtitle,
-      removable: track.removable,
-      chips: track.chips,
-    });
+    const cloned = track.clone(true);
+    // Replace the name with the full path to help with lineage tracking.
+    cloned.name = track.fullPath.join(' > ');
     this.pinnedTracksNode.addChildLast(cloned);
   }
 


### PR DESCRIPTION
Currently it's not possible to pin summary tracks (processes, most groups). This is an artificial restriction.

This patch simply adds the pin button back to these tracks and changes the pin algorithm to perform a full clone, copying the track and all its children.

Issues:
- The pin indicator is now messed up - pinning indicators appear on the both the original track and the pinned copy, but clicking these no longer un-pins the track.
- It should be possible to modify children within the pinned track section - e.g. unpinning.
- Expanding a group automatically scrolls down to last child in the group. This is because the pinned area always scrolls to the most recently created track element which makes sense when you have a flat list of tracks only as it simply scrolls to reveal the most recently pinned track, but is janky when we have groups.

Fixes: #3548
Fixes: https://b.corp.google.com/issues/458321702
