### PR TITLE
ui: roll syntaqlite to v0.7.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,7 @@
     "noice-json-rpc": "^1.2.0",
     "pako": "^2.1.0",
     "protobufjs": "^7.6.2",
-    "syntaqlite": "^0.5.9",
+    "syntaqlite": "^0.7.0",
     "uuid": "^14.0.0",
     "zod": "^4.3.5"
   },

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -81,8 +81,8 @@ dependencies:
     specifier: ^7.6.2
     version: 7.6.2
   syntaqlite:
-    specifier: ^0.5.9
-    version: 0.5.9
+    specifier: ^0.7.0
+    version: 0.7.0
   uuid:
     specifier: ^14.0.0
     version: 14.0.0
@@ -3094,8 +3094,8 @@ packages:
       tslib: 2.6.3
     dev: true
 
-  /syntaqlite@0.5.9:
-    resolution: {integrity: sha512-hCJ58Nd+QVPv2UXQmMsd3BGikmoYIl4yynC6l9MSEoQ/m6Y2QbN1WipfM/C/6viyfSpdKsC1JwvmPdlmQ8prWw==}
+  /syntaqlite@0.7.0:
+    resolution: {integrity: sha512-orcBtx1ikMO7lDIomV/tKHTD0WvZNtTkfSvqWXRS8BGilpMj9L3Gx1o00pAKKUr/Bzwp9JyVwqRgrJd/pYq5Gg==}
     dev: false
 
   /tinybench@2.9.0:

--- a/ui/src/bigtrace/query/sql_formatter.ts
+++ b/ui/src/bigtrace/query/sql_formatter.ts
@@ -44,14 +44,12 @@ export async function formatPerfettoSql(
 ): Promise<string | undefined> {
   try {
     const engine = await getFormatterEngine();
-    const result = engine.runFmt(text, {
+    return engine.format(text, {
       lineWidth: 80,
       indentWidth: 2,
-      keywordCase: 1,
+      keywordCase: 'upper',
       semicolons: true,
     });
-    if (result.ok) return result.text;
-    console.error('SQL formatting failed', result.text);
   } catch (e) {
     console.error('SQL formatting failed', e);
   }

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -385,18 +385,14 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
   private async formatSql(attrs: QueryPageAttrs, tabId: string, text: string) {
     try {
       const engine = await this.getFormatterEngine();
-      const result = engine.runFmt(text, {
+      const formatted = engine.format(text, {
         lineWidth: 80,
         indentWidth: 2,
-        keywordCase: 1,
+        keywordCase: 'upper',
         semicolons: true,
       });
-      if (result.ok) {
-        attrs.onEditorContentUpdate?.(tabId, result.text);
-        m.redraw();
-      } else {
-        console.error('SQL formatting failed', result.text);
-      }
+      attrs.onEditorContentUpdate?.(tabId, formatted);
+      m.redraw();
     } catch (e) {
       console.error('SQL formatting failed', e);
     }


### PR DESCRIPTION
Completes the trace_processor-side syntaqlite roll for the UI, which was still pinned to ^0.5.9 and so loaded a v0.5.x runtime against the freshly re-vendored v0.7.0 perfetto dialect.

syntaqlite 0.7.0 reworks the one-shot JS API: runFmt() is replaced by format(), which returns the formatted string directly and throws on failure, and keywordCase moved from a numeric enum to 'upper'|'lower' (1 mapped to Upper in the old wasm decoder). Migrate the two call sites (query page and bigtrace SQL formatters) accordingly.

