### PR TITLE
Add proto events for capability update in ProcessStateController

### DIFF
--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
@@ -230,6 +230,18 @@ enum AppExitReasonCode {
   APP_EXIT_REASON_MEMORY_LIMITER = 17;
 }
 
+// Bitfield flags for AndroidCapabilityUpdateEvent.flags.
+// Multiple flags may be bitwise-ORed together.
+enum CapabilityUpdateFlag {
+  CAPABILITY_UPDATE_FLAG_UNKNOWN = 0;
+  CAPABILITY_UPDATE_FLAG_ACTIVE_INSTRUMENTATION = 0x1;    // 1 << 0
+  CAPABILITY_UPDATE_FLAG_RUNNING_REMOTE_ANIMATION = 0x2;  // 1 << 1
+  CAPABILITY_UPDATE_FLAG_FOREGROUND_SERVICES = 0x4;       // 1 << 2
+  CAPABILITY_UPDATE_FLAG_NON_SHORT_FGS = 0x8;             // 1 << 3
+  CAPABILITY_UPDATE_FLAG_PENDING_FINISH_ATTACH = 0x10;    // 1 << 4
+  CAPABILITY_UPDATE_FLAG_FOREGROUND_ACTIVITIES = 0x20;    // 1 << 5
+}
+
 enum AppExitSubReasonCode {
   APP_EXIT_SUBREASON_UNKNOWN = 0;
   APP_EXIT_SUBREASON_WAIT_FOR_DEBUGGER = 1;
@@ -659,9 +671,62 @@ message AndroidProviderStateChangedEvent {
   optional int32 is_stable = 6;
 }
 
+message AndroidCapabilitySummaryEvent {
+  // Whether the update is a full update.
+  optional bool is_full_update = 1;
+
+  // Reason for the OOM adjustment.
+  optional OomChangeReasonEnum reason = 2;
+
+  // The total number of processes evaluated during the update.
+  optional int32 total_processes = 3;
+
+  // The number of processes with discrepancies.
+  optional int32 discrepant_processes = 4;
+}
+
+message AndroidCapabilityUpdateEvent {
+  // Whether the update is a full update.
+  optional bool is_full_update = 1;
+
+  // Reason for the OOM adjustment.
+  optional OomChangeReasonEnum reason = 2;
+
+  // Pid of the process.
+  optional int32 pid = 3;
+
+  // The capabilities computed by CapabilityController.
+  optional int32 capability = 4;
+
+  // Bitmask of reasons for granting PROCESS_CAPABILITY_CPU_TIME.
+  optional int32 cpu_reasons = 5;
+
+  // Bitmask of reasons for granting PROCESS_CAPABILITY_IMPLICIT_CPU_TIME.
+  optional int32 implicit_cpu_reasons = 6;
+
+  // The capabilities computed by the legacy OomAdjuster.
+  optional int32 legacy_capability = 7;
+
+  // The CPU time reasons computed by the legacy OomAdjuster.
+  optional int32 legacy_cpu_reasons = 8;
+
+  // The implicit CPU time reasons computed by the legacy OomAdjuster.
+  optional int32 legacy_implicit_cpu_reasons = 9;
+
+  // The OOM adjustment score.
+  optional int32 oom_adj = 10;
+
+  // The process state.
+  optional ProcessStateEnum proc_state = 11;
+
+  // Bitfield representing various process state flags (see
+  // CapabilityUpdateFlag).
+  optional int32 flags = 12;
+}
+
 message FrameworksBaseTrackEvent {
   // Usable range: [2004, 2006], [2008, 2099].
-  // Next id: 2017.
+  // Next id: 2019.
   extend perfetto.protos.TrackEvent {
     // MessageQueue messages.
     optional AndroidMessageQueue message_queue = 2004;
@@ -692,5 +757,9 @@ message FrameworksBaseTrackEvent {
     // Foreground service state changed event.
     optional AndroidServiceStateChangedEvent fg_service_state_changed_event =
         2016;
+    // Capability summary event.
+    optional AndroidCapabilitySummaryEvent capability_summary_event = 2017;
+    // Capability update event.
+    optional AndroidCapabilityUpdateEvent capability_update_event = 2018;
   }
 }


### PR DESCRIPTION
The proto events are needed to validate the correctness of capability computation in ProcessStateController.

Bug - b/500538435
