### PR TITLE
ui: Remap Mod+Shift+P to F1 on firefox

### DIFF
--- a/ui/src/base/hotkeys.ts
+++ b/ui/src/base/hotkeys.ts
@@ -91,7 +91,20 @@ type Special =
   | ']'
   | ','
   | '.';
-export type Key = Alphabet | Number | Special;
+type FunctionsKeys =
+  | 'F1'
+  | 'F2'
+  | 'F3'
+  | 'F4'
+  | 'F5'
+  | 'F6'
+  | 'F7'
+  | 'F8'
+  | 'F9'
+  | 'F10'
+  | 'F11'
+  | 'F12';
+export type Key = Alphabet | Number | Special | FunctionsKeys;
 export type Modifier =
   | ''
   | 'Mod+'

--- a/ui/src/base/hotkeys_unittest.ts
+++ b/ui/src/base/hotkeys_unittest.ts
@@ -89,6 +89,13 @@ describe('checkHotkey', () => {
     expect(checkHotkey('X', {key: 'x', target: el})).toBe(false);
     expect(checkHotkey('!X', {key: 'x', target: el})).toBe(true);
   });
+
+  // Quick sanity check on function keys parsing.
+  test('function keys', () => {
+    expect(checkHotkey('F1', {key: 'F1'})).toBe(true);
+    expect(checkHotkey('!F1', {key: 'F1'})).toBe(true);
+    expect(checkHotkey('!F1', {key: 'F'})).toBe(false);
+  });
 });
 
 test('formatHotkey', () => {

--- a/ui/src/core/command_manager.ts
+++ b/ui/src/core/command_manager.ts
@@ -19,6 +19,58 @@ import {raf} from './raf_scheduler';
 import type {OmniboxManagerImpl} from './omnibox_manager';
 import {STARTUP_COMMAND_ALLOWLIST_SET} from './startup_command_allowlist';
 import {DisposableStack} from '../base/disposable_stack';
+import type {Hotkey} from '../base/hotkeys';
+
+// A map of command id -> hotkey.
+export type HotkeyOverlay = Record<string, Hotkey>;
+
+// A hotkey overlay for firefox browser.
+const firefoxOverlay: HotkeyOverlay = {
+  'dev.perfetto.OpenCommandPalette': '!F1', // Mod+Shift+P is not overridable in firefox
+};
+
+// Work out whether we are running inside firefox or not. Safe to evaluate this
+// at module scope because the browser cannot change.
+// TODO(stevegolton): We should move this to a common place.
+const isFirefox =
+  typeof navigator !== 'undefined' && navigator.userAgent.includes('Firefox');
+
+// The list of overlays for this environment.
+// For now - only firefox has mods, but this could include other browsers or
+// keyboard mappings in the future.
+const hotkeyOverlays = isFirefox ? [firefoxOverlay] : [];
+
+/**
+ * Remaps command hotkeys using one or more overlays. Overlays are a map of
+ * command id -> hotkey. Overlays are applied sequentially so the later overlays
+ * take precedence.
+ *
+ * @param cmds Commands to remap.
+ * @param overlays Overlays to apply.
+ * @returns Remapped commands - 'cmd.defaultHotkey's updated.
+ */
+export function remapHotkeys(
+  cmds: readonly Command[],
+  overlays: readonly HotkeyOverlay[],
+): readonly Command[] {
+  if (overlays.length === 0) {
+    return cmds;
+  }
+  return cmds.map((cmd) => {
+    const overriddenHotkey = overlays.reduce(
+      (hotkey: Hotkey | undefined, overlay: HotkeyOverlay) => {
+        const overriddenHotkey = overlay[cmd.id];
+        return overriddenHotkey ?? hotkey;
+      },
+      undefined,
+    );
+    if (!overriddenHotkey) return cmd;
+    return {
+      ...cmd,
+      defaultHotkey: overriddenHotkey,
+    };
+  });
+}
 
 /**
  * Zod schema for a single command invocation.
@@ -103,7 +155,9 @@ export class CommandManagerImpl implements CommandManager {
   constructor(private omnibox: OmniboxManagerImpl) {}
 
   getCommand(commandId: string): Command | undefined {
-    return this.registry.tryGet(commandId);
+    const cmd = this.registry.tryGet(commandId);
+    if (!cmd) return undefined;
+    return remapHotkeys([cmd], hotkeyOverlays)[0];
   }
 
   hasCommand(commandId: string): boolean {
@@ -111,7 +165,7 @@ export class CommandManagerImpl implements CommandManager {
   }
 
   getCommands(): readonly Command[] {
-    return this.registry.valuesAsArray();
+    return remapHotkeys(this.registry.valuesAsArray(), hotkeyOverlays);
   }
 
   registerCommand(cmd: Command): Disposable {

--- a/ui/src/core/command_manager_unittest.ts
+++ b/ui/src/core/command_manager_unittest.ts
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {Command} from '../public/commands';
+import {type HotkeyOverlay, remapHotkeys} from './command_manager';
+
+describe('remapHotkeys', () => {
+  test('single layer', () => {
+    const cmd: Command = {
+      id: 'cmd1',
+      name: '',
+      callback: () => {},
+      defaultHotkey: 'P',
+    };
+    const overlay: HotkeyOverlay = {
+      cmd1: 'X',
+    };
+    const remapped = remapHotkeys([cmd], [overlay]);
+
+    expect(remapped[0].defaultHotkey).toBe('X');
+  });
+
+  test('double layer', () => {
+    const cmd: Command = {
+      id: 'cmd1',
+      name: '',
+      callback: () => {},
+      defaultHotkey: 'P',
+    };
+    const overlay1: HotkeyOverlay = {
+      cmd1: 'X',
+    };
+    const overlay2: HotkeyOverlay = {
+      cmd1: 'Z',
+    };
+    const remapped = remapHotkeys([cmd], [overlay1, overlay2]);
+
+    expect(remapped[0].defaultHotkey).toBe('Z');
+  });
+
+  test('not defined in layer', () => {
+    const cmd: Command = {
+      id: 'cmd1',
+      name: '',
+      callback: () => {},
+      defaultHotkey: 'P',
+    };
+    const overlay1: HotkeyOverlay = {
+      anotherCmd: 'X',
+    };
+    const remapped = remapHotkeys([cmd], [overlay1]);
+
+    expect(remapped[0].defaultHotkey).toBe('P');
+  });
+
+  test('no overlays', () => {
+    const cmd: Command = {
+      id: 'cmd1',
+      name: '',
+      callback: () => {},
+      defaultHotkey: 'P',
+    };
+    const remapped = remapHotkeys([cmd], []);
+
+    expect(remapped[0].defaultHotkey).toBe('P');
+  });
+
+  test('cmd without default hotkey gets remapped', () => {
+    const cmd: Command = {
+      id: 'cmd1',
+      name: '',
+      callback: () => {},
+    };
+    const overlay: HotkeyOverlay = {
+      cmd1: 'X',
+    };
+    const remapped = remapHotkeys([cmd], [overlay]);
+
+    expect(remapped[0].defaultHotkey).toBe('X');
+  });
+});


### PR DESCRIPTION
The 'OpenCommandPalette' hotkey is currently bound to Mod+Shift+P which works fine in Chromium based browsers, but it's not overridable on Firefox - it always opens a new incognito window.

This patch introduces a a hotkey overlay subsystem. For now we simply define a single overlay if firefox is detected, which remaps the open palette command to F1 (similar to what the in-browser version of vscode does.

I.e.:

```js
const firefoxOverlay = {
  'dev.perfetto.OpenCommandPalette': '!F1',
};
```