### PR TITLE
[dns] ui: video frame panel and per-layer buffer tracks

### DIFF
--- a/ui/src/plugins/dev.perfetto.VideoFrames/index.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/index.ts
@@ -15,14 +15,122 @@
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {NUM, STR_NULL} from '../../trace_processor/query_result';
+import {NUM, STR, STR_NULL} from '../../trace_processor/query_result';
+import {createPerfettoTable} from '../../trace_processor/sql_utils';
 import {VideoFramePlayer} from './video_frame_player';
 import {createVideoFramesTrack} from './video_frames_track';
+import {createLayerTrack} from './layer_track';
 
 interface StreamInfo {
   displayId: number;
   displayName: string;
 }
+
+// One row per (video frame, visible buffered layer): the buffer on screen for
+// that frame. track_idx groups rows into one track per layer; changed flags a
+// fresh buffer vs a held one.
+const LAYER_BUFFER_SLICES = `
+  with video_frame as (
+    select ts as video_ts,
+      lead(ts) over (order by ts) - ts as video_dur
+    from __intrinsic_video_frames where coalesce(is_config, 0) = 0
+  ),
+  -- SF composites (one per on-screen frame); the name holds the display frame
+  -- token. Resolved once here so the details panel is a cheap per-slice lookup.
+  composite as materialized (
+    select cast(str_split(c.name, ' ', 1) as int) as token,
+      c.ts + c.dur as present
+    from slice c
+    join thread_track tt on tt.id = c.track_id
+    join thread t on t.utid = tt.utid
+    join process p on p.upid = t.upid
+    where p.name glob '*surfaceflinger*' and c.name glob 'composite *'
+  ),
+  frame_snapshot as (
+    select video_ts, video_dur,
+      (select max(s.ts) from surfaceflinger_layers_snapshot s
+       where s.ts <= video_frame.video_ts) as snapshot_ts,
+      -- the composite on screen at this video frame (its display frame token)
+      (select c.token from composite c
+       where c.present <= video_frame.video_ts
+       order by c.present desc limit 1) as composite_token
+    from video_frame where video_dur is not null
+  ),
+  -- Each rendered layer's process, from its app frames. A layer is owned by one
+  -- process, so this is stable -- it gives the process even for a held frame.
+  track_process as (
+    select
+      str_split(_vf_strip_vri(
+        replace(extract_arg(sf.arg_set_id, 'Layer name'), 'TX - ', '')),
+        '#', 0) as track_name,
+      max((select p.name from process p
+           where p.upid = extract_arg(t.dimension_arg_set_id, 'upid'))) as process
+    from actual_frame_timeline_slice sf
+    join track t on t.id = sf.track_id
+    where extract_arg(sf.arg_set_id, 'Is Buffer?') = 'Yes'
+    group by 1
+  ),
+  raw_layer as (
+    select s.ts as snapshot_ts, l.layer_name, l.arg_set_id,
+      l.hwc_composition_type, l.is_visible,
+      -- track_name: the layer name without the ViewRootImpl wrapper or #id.
+      str_split(_vf_strip_vri(l.layer_name), '#', 0) as track_name
+    from surfaceflinger_layers_snapshot s
+    join surfaceflinger_layer l on l.snapshot_id = s.id
+    where l.is_visible = 1
+      and extract_arg(l.arg_set_id, 'active_buffer.width') is not null
+  ),
+  layer as (
+    select raw_layer.*,
+      -- The layer's process: its renderer, or -- for a layer that never renders
+      -- (snapshot, wallpaper) -- its surface owner (uid).
+      coalesce(
+        tp.process,
+        (select p.name from process p
+         where p.uid = extract_arg(raw_layer.arg_set_id, 'owner_uid') limit 1),
+        raw_layer.track_name) as process
+    from raw_layer
+    left join track_process tp on tp.track_name = raw_layer.track_name
+  ),
+  -- The app frame's vsync token per (layer, composite), matched on display frame
+  -- token + layer name. Used to label the slice.
+  surface_frame as materialized (
+    select
+      cast(extract_arg(sf.arg_set_id, 'Display frame token') as int) as token,
+      str_split(_vf_strip_vri(
+        replace(extract_arg(sf.arg_set_id, 'Layer name'), 'TX - ', '')),
+        '#', 0) as track_name,
+      cast(extract_arg(sf.arg_set_id, 'Surface frame token') as int) as vsync
+    from actual_frame_timeline_slice sf
+    where extract_arg(sf.arg_set_id, 'Is Buffer?') = 'Yes'
+  ),
+  buffer_slice as (
+    select f.video_ts as ts, f.video_dur as dur, f.composite_token,
+      layer.track_name, layer.process, layer.layer_name,
+      -- slice label: the app frame's vsync token, or 'NULL' if the layer did
+      -- not (re)draw this frame (a held buffer).
+      coalesce(cast(sfr.vsync as text), 'NULL') as name,
+      extract_arg(layer.arg_set_id, 'curr_frame') as buffer_frame,
+      extract_arg(layer.arg_set_id, 'active_buffer.width') as buffer_width,
+      extract_arg(layer.arg_set_id, 'active_buffer.height') as buffer_height,
+      extract_arg(layer.arg_set_id, 'active_buffer.format') as buffer_format,
+      coalesce(extract_arg(layer.arg_set_id, 'z'), 0) as z_order,
+      layer.hwc_composition_type, layer.is_visible
+    from frame_snapshot f
+    join layer on layer.snapshot_ts = f.snapshot_ts
+    left join surface_frame sfr
+      on sfr.token = f.composite_token and sfr.track_name = layer.track_name
+  )
+  select row_number() over (order by track_name, ts) as id,
+    ts, dur, name, track_name, process, composite_token,
+    layer_name, buffer_frame, buffer_width,
+    buffer_height, buffer_format, z_order, hwc_composition_type, is_visible,
+    dense_rank() over (order by track_name) as track_idx,
+    case when buffer_frame is distinct from
+         lag(buffer_frame) over (partition by track_name order by ts)
+         then 1 else 0 end as changed
+  from buffer_slice
+`;
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.VideoFrames';
@@ -66,6 +174,71 @@ export default class implements PerfettoPlugin {
       group.addChildInOrder(new TrackNode({uri, name: stream.displayName}));
     }
 
+    ctx.defaultWorkspace.addChildInOrder(group);
+
+    await this.addLayerTracks(ctx);
+  }
+
+  // A "Layers" group, one track per layer, showing the buffer as slices aligned
+  // to the video frames (split into All / Changed). Absent without layers data.
+  private async addLayerTracks(ctx: Trace): Promise<void> {
+    const count = await ctx.engine.query(
+      `select count(*) as c from surfaceflinger_layers_snapshot`,
+    );
+    if (count.firstRow({c: NUM}).c === 0) return;
+
+    // Strip the ViewRootImpl wrapper ("VRI[<name>]" / "VRI-<name>") off a layer
+    // name, so the track name and the frame-timeline layer match are the app's.
+    await ctx.engine.query(`
+      create perfetto function _vf_strip_vri(name string) returns string as
+      select case
+        when $name glob 'VRI[[]*' then substr($name, 5, instr($name, ']') - 5)
+        when $name glob 'VRI-*' then substr($name, 5)
+        else $name
+      end
+    `);
+    await createPerfettoTable({
+      engine: ctx.engine,
+      name: '_video_frame_buffer_slices',
+      as: LAYER_BUFFER_SLICES,
+    });
+
+    const res = await ctx.engine.query(`
+      select track_idx as trackIdx, track_name as trackName
+      from _video_frame_buffer_slices group by 1, 2 order by 1
+    `);
+
+    const group = new TrackNode({
+      name: 'Layers',
+      isSummary: true,
+      sortOrder: -54,
+    });
+    const allGroup = new TrackNode({name: 'All', isSummary: true});
+    const changedGroup = new TrackNode({name: 'Changed', isSummary: true});
+
+    const it = res.iter({trackIdx: NUM, trackName: STR});
+    for (; it.valid(); it.next()) {
+      const {trackIdx, trackName} = it;
+
+      const allUri = `/video_frame_layers/all/${trackIdx}`;
+      ctx.tracks.registerTrack({
+        uri: allUri,
+        renderer: createLayerTrack(ctx, allUri, trackIdx, false),
+      });
+      allGroup.addChildInOrder(new TrackNode({uri: allUri, name: trackName}));
+
+      const changedUri = `/video_frame_layers/changed/${trackIdx}`;
+      ctx.tracks.registerTrack({
+        uri: changedUri,
+        renderer: createLayerTrack(ctx, changedUri, trackIdx, true),
+      });
+      changedGroup.addChildInOrder(
+        new TrackNode({uri: changedUri, name: trackName}),
+      );
+    }
+
+    group.addChildInOrder(allGroup);
+    group.addChildInOrder(changedGroup);
     ctx.defaultWorkspace.addChildInOrder(group);
   }
 }

--- a/ui/src/plugins/dev.perfetto.VideoFrames/layer_track.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/layer_track.ts
@@ -1,0 +1,190 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {materialColorScheme} from '../../components/colorizer';
+import {SliceTrack} from '../../components/tracks/slice_track';
+import type {TrackEventDetailsPanel} from '../../public/details_panel';
+import type {TrackEventSelection} from '../../public/selection';
+import type {Trace} from '../../public/trace';
+import {SourceDataset} from '../../trace_processor/dataset';
+import {LONG, NUM, NUM_NULL, STR} from '../../trace_processor/query_result';
+import {Button} from '../../widgets/button';
+import {DetailsShell} from '../../widgets/details_shell';
+import {GridLayout} from '../../widgets/grid_layout';
+import {Section} from '../../widgets/section';
+import {Tree, TreeNode} from '../../widgets/tree';
+
+interface BufferSlice {
+  readonly vsync: number | null;
+  readonly process: string;
+  readonly layer: string;
+  readonly buffer: number;
+  readonly state: string;
+  readonly visible: string;
+  readonly size: string;
+  readonly format: number;
+  readonly z: number;
+  readonly hwc: string;
+  // The Choreographer#doFrame that produced this buffer, or null when there is
+  // none (a held buffer, or a non-app layer such as wallpaper).
+  readonly doFrameId: number | null;
+}
+
+// Details panel for a buffer slice: the full layer/buffer info at that frame.
+class BufferSliceDetailsPanel implements TrackEventDetailsPanel {
+  private slice?: BufferSlice;
+
+  constructor(private readonly trace: Trace) {}
+
+  async load(sel: TrackEventSelection) {
+    const result = await this.trace.engine.query(`
+      select
+        b.process,
+        extract_arg(sf.arg_set_id, 'Surface frame token') as vsync,
+        -- The doFrame that drew it: the Choreographer#doFrame with the surface
+        -- frame's vsync token, in the frame's process (the token repeats across
+        -- every process that rendered that vsync).
+        (select ds.id from slice ds
+         join thread_track dtt on dtt.id = ds.track_id
+         join thread dth on dth.utid = dtt.utid
+         where dth.upid = extract_arg(sft.dimension_arg_set_id, 'upid')
+           and ds.name = 'Choreographer#doFrame ' ||
+                         extract_arg(sf.arg_set_id, 'Surface frame token'))
+          as doFrameId,
+        b.layer_name as layer,
+        b.buffer_frame as buffer,
+        case when b.changed then 'updated' else 'reused' end as state,
+        case when b.is_visible then 'yes' else 'no' end as visible,
+        b.buffer_width || 'x' || b.buffer_height as size,
+        b.buffer_format as format,
+        b.z_order as z,
+        case b.hwc_composition_type
+          when 1 then 'Client (GPU)'
+          when 2 then 'Device (HWC)'
+          when 3 then 'Solid color'
+          when 4 then 'Cursor'
+          when 5 then 'Sideband'
+          when 6 then 'Display decoration'
+          else cast(b.hwc_composition_type as text) end as hwc
+      from _video_frame_buffer_slices b
+      -- This layer's buffer surface frame in its composite (Is Buffer? -- a
+      -- token can also carry animation frames), matched by layer name.
+      left join actual_frame_timeline_slice sf
+        on extract_arg(sf.arg_set_id, 'Is Buffer?') = 'Yes'
+       and cast(extract_arg(sf.arg_set_id, 'Display frame token') as int) =
+           b.composite_token
+       and _vf_strip_vri(
+             replace(extract_arg(sf.arg_set_id, 'Layer name'), 'TX - ', ''))
+           glob b.track_name || '#*'
+      left join track sft on sft.id = sf.track_id
+      where b.id = ${sel.eventId}
+    `);
+    if (result.numRows() === 0) {
+      this.slice = undefined;
+      return;
+    }
+    this.slice = result.firstRow({
+      vsync: NUM_NULL,
+      process: STR,
+      layer: STR,
+      buffer: NUM,
+      state: STR,
+      visible: STR,
+      size: STR,
+      format: NUM,
+      z: NUM,
+      hwc: STR,
+      doFrameId: NUM_NULL,
+    });
+  }
+
+  private jumpToDoFrame(id: number) {
+    this.trace.selection.selectSqlEvent('slice', id, {scrollToSelection: true});
+  }
+
+  render() {
+    const s = this.slice;
+    if (s === undefined) {
+      return m(DetailsShell, {title: 'Buffer'}, m('span', 'Loading…'));
+    }
+    return m(
+      DetailsShell,
+      {
+        title: 'Buffer',
+        description: s.process,
+        buttons:
+          s.doFrameId !== null &&
+          m(Button, {
+            label: 'Jump to doFrame',
+            icon: 'arrow_forward',
+            onclick: () => this.jumpToDoFrame(s.doFrameId!),
+          }),
+      },
+      m(
+        GridLayout,
+        m(
+          Section,
+          {title: 'Details'},
+          m(Tree, [
+            m(TreeNode, {left: 'Process', right: s.process}),
+            s.vsync !== null &&
+              m(TreeNode, {left: 'Vsync', right: `${s.vsync}`}),
+            m(TreeNode, {left: 'Layer', right: s.layer}),
+            m(TreeNode, {left: 'Buffer', right: `${s.buffer}`}),
+            m(TreeNode, {left: 'State', right: s.state}),
+            m(TreeNode, {left: 'Visible', right: s.visible}),
+            m(TreeNode, {left: 'Size', right: s.size}),
+            m(TreeNode, {left: 'Format', right: `${s.format}`}),
+            m(TreeNode, {left: 'HWC composition', right: s.hwc}),
+            m(TreeNode, {left: 'Z-order', right: `${s.z}`}),
+          ]),
+        ),
+      ),
+    );
+  }
+}
+
+// A track of one layer's buffer as slices aligned to the video frames it was on
+// screen for. With changedOnly, only frames with a fresh buffer become slices.
+export function createLayerTrack(
+  trace: Trace,
+  uri: string,
+  trackIdx: number,
+  changedOnly: boolean,
+) {
+  const src = `
+    SELECT id, ts, dur, 0 AS depth, name, track_name
+    FROM _video_frame_buffer_slices
+    WHERE track_idx = ${trackIdx}${changedOnly ? ' AND changed = 1' : ''}
+  `;
+  return SliceTrack.create({
+    trace,
+    uri,
+    dataset: new SourceDataset({
+      schema: {
+        id: NUM,
+        ts: LONG,
+        dur: LONG,
+        name: STR,
+        depth: NUM,
+        track_name: STR,
+      },
+      src,
+    }),
+    // Label by vsync (name), but colour by layer so one track stays one colour.
+    colorizer: (row) => materialColorScheme(row.track_name),
+    detailsPanel: () => new BufferSliceDetailsPanel(trace),
+  });
+}

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_details_panel.ts
@@ -16,26 +16,146 @@ import './video_frames.scss';
 import m from 'mithril';
 import {ensureIsInstance} from '../../base/assert';
 import {Time} from '../../base/time';
+import {NUM, STR} from '../../trace_processor/query_result';
 import {Timestamp} from '../../components/widgets/timestamp';
 import type {TrackEventDetailsPanel} from '../../public/details_panel';
 import type {TrackEventSelection} from '../../public/selection';
 import {Button, ButtonBar} from '../../widgets/button';
 import {Intent} from '../../widgets/common';
 import {DetailsShell} from '../../widgets/details_shell';
-import {GridLayout} from '../../widgets/grid_layout';
+import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
 import {Section} from '../../widgets/section';
 import {Select} from '../../widgets/select';
 import {Tree, TreeNode} from '../../widgets/tree';
+import {DataGrid} from '../../components/widgets/datagrid/datagrid';
+import {InMemoryDataSource} from '../../components/widgets/datagrid/in_memory_data_source';
+import type {SchemaRegistry} from '../../components/widgets/datagrid/datagrid_schema';
+import type {Row} from '../../trace_processor/query_result';
 import type {VideoFramePlayer} from './video_frame_player';
 
 // Playback speed options, in real-time multiples.
 const PLAYBACK_RATES = [0.1, 0.2, 0.5, 1, 1.5, 2];
+
+interface BufferRow {
+  readonly layer: string;
+  readonly visible: string; // 'yes' | 'no'
+  readonly bufferFrame: number;
+  readonly state: string; // 'updated' | 'reused'
+  readonly size: string;
+  readonly z: number;
+}
+
+const BUFFER_SCHEMA: SchemaRegistry = {
+  root: {
+    layer: {title: 'Layer'},
+    visible: {title: 'Visible'},
+    bufferFrame: {title: 'Buffer'},
+    state: {title: 'State'},
+    size: {title: 'Size'},
+    z: {title: 'Z'},
+  },
+};
 
 export class VideoFrameDetailsPanel implements TrackEventDetailsPanel {
   private readonly player: VideoFramePlayer;
 
   constructor(player: VideoFramePlayer) {
     this.player = player;
+  }
+
+  private buffers?: ReadonlyArray<BufferRow>;
+  private buffersDataSource?: InMemoryDataSource;
+  private buffersTs?: bigint;
+
+  // Layers holding a buffer in the SurfaceFlinger snapshot nearest the frame,
+  // flagged reused when the buffer is unchanged from the prior snapshot.
+  private async loadBuffers(
+    frameTs: bigint,
+  ): Promise<ReadonlyArray<BufferRow>> {
+    try {
+      const result = await this.player.trace.engine.query(`
+        with snap as (
+          select id, ts from surfaceflinger_layers_snapshot
+          where ts <= ${frameTs} order by ts desc limit 1
+        ),
+        prev as (
+          select id from surfaceflinger_layers_snapshot
+          where ts < (select ts from snap) order by ts desc limit 1
+        )
+        select
+          l.layer_name as layer,
+          case when l.is_visible then 'yes' else 'no' end as visible,
+          extract_arg(l.arg_set_id, 'curr_frame') as bufferFrame,
+          case when extract_arg(l.arg_set_id, 'curr_frame') = (
+            select extract_arg(pl.arg_set_id, 'curr_frame')
+            from surfaceflinger_layer pl
+            where pl.snapshot_id = (select id from prev)
+              and pl.layer_name = l.layer_name)
+          then 'reused' else 'updated' end as state,
+          extract_arg(l.arg_set_id, 'active_buffer.width') || 'x' ||
+            extract_arg(l.arg_set_id, 'active_buffer.height') as size,
+          coalesce(extract_arg(l.arg_set_id, 'z'), 0) as z
+        from surfaceflinger_layer l
+        where l.snapshot_id = (select id from snap)
+          and extract_arg(l.arg_set_id, 'active_buffer.width') is not null
+        order by l.is_visible desc, z
+      `);
+      const rows: BufferRow[] = [];
+      const it = result.iter({
+        layer: STR,
+        visible: STR,
+        bufferFrame: NUM,
+        state: STR,
+        size: STR,
+        z: NUM,
+      });
+      for (; it.valid(); it.next()) {
+        rows.push({
+          layer: it.layer,
+          visible: it.visible,
+          bufferFrame: it.bufferFrame,
+          state: it.state,
+          size: it.size,
+          z: it.z,
+        });
+      }
+      return rows;
+    } catch {
+      // Trace has no android.surfaceflinger.layers data source.
+      return [];
+    }
+  }
+
+  private renderBuffers(frameTs: bigint): m.Children {
+    if (this.buffersTs !== frameTs) {
+      this.buffersTs = frameTs;
+      this.buffers = undefined;
+      this.buffersDataSource = undefined;
+      void this.loadBuffers(frameTs).then((rows) => {
+        if (this.buffersTs === frameTs) {
+          this.buffers = rows;
+          m.redraw();
+        }
+      });
+    }
+    if (this.buffers === undefined) return m('span', 'Loading…');
+    if (this.buffers.length === 0) {
+      return m(
+        'span',
+        'No buffers for this frame (the trace may lack the ' +
+          'android.surfaceflinger.layers data source).',
+      );
+    }
+    // Cached so the grid keeps its sort/filter state; reset on frame change.
+    this.buffersDataSource ??= new InMemoryDataSource(
+      this.buffers as unknown as ReadonlyArray<Row>,
+    );
+    return m(DataGrid, {
+      schema: BUFFER_SCHEMA,
+      rootSchema: 'root',
+      data: this.buffersDataSource,
+      fillHeight: false,
+    });
   }
 
   async load(sel: TrackEventSelection) {
@@ -74,7 +194,11 @@ export class VideoFrameDetailsPanel implements TrackEventDetailsPanel {
       },
       m(
         GridLayout,
-        m(Section, {title: 'Details'}, m(Tree, detailRows)),
+        m(
+          GridLayoutColumn,
+          m(Section, {title: 'Details'}, m(Tree, detailRows)),
+          m(Section, {title: 'Buffers'}, this.renderBuffers(frame.ts)),
+        ),
         m(
           Section,
           {title: 'Preview', className: 'pf-video-frame-preview-section'},
@@ -95,12 +219,46 @@ export class VideoFrameDetailsPanel implements TrackEventDetailsPanel {
     );
   }
 
+  private async jumpToSurfaceFlingerFrame() {
+    const frame = this.player.currentFrame;
+    if (frame === undefined) return;
+    const trace = this.player.trace;
+    // A video frame shows the last presented composition: the latest presented
+    // display frame (surface-token-null) at/before it, skipping dropped frames
+    // (named "0"), which were never on screen.
+    const result = await trace.engine.query(`
+      select id, track_id as trackId
+      from actual_frame_timeline_slice
+      where extract_arg(arg_set_id, 'Surface frame token') is null
+        and extract_arg(arg_set_id, 'Present type') != 'Dropped Frame'
+        and name != '0'
+        and ts + dur <= ${frame.ts}
+      order by ts + dur desc
+      limit 1
+    `);
+    if (result.numRows() === 0) return;
+    const {id, trackId} = result.firstRow({id: NUM, trackId: NUM});
+    // These slices live on the Frames plugin's "Actual Timeline" track, keyed
+    // by actual_frame_timeline_slice.id; find that track and select there.
+    const track = trace.tracks
+      .getAllTracks()
+      .find((t) => t.tags?.trackIds?.includes(trackId));
+    if (track === undefined) return;
+    trace.selection.selectTrackEvent(track.uri, id, {scrollToSelection: true});
+  }
+
   private renderControls(): m.Children {
     const p = this.player;
     const idx = p.currentIdx;
     const total = p.frames.length;
     return m(
       ButtonBar,
+      m(Button, {
+        label: 'Jump to SF frame',
+        icon: 'arrow_forward',
+        compact: true,
+        onclick: () => this.jumpToSurfaceFlingerFrame(),
+      }),
       m(Button, {
         icon: 'skip_previous',
         compact: true,


### PR DESCRIPTION
Video Frames details panel:
- "Jump to SF frame" selects the SurfaceFlinger display frame last presented at/before the video frame (skipping dropped frames).
- A "Buffers" grid beside Details listing the layer buffers at the frame (process, package, uid, layer, visible, buffer id, updated/reused, size, z-order) from the android.surfaceflinger.layers snapshot.

A "Layers" group (sibling to Video Frames, when the trace has android.surfaceflinger.layers) built with BreakdownTracks: a "buffers on screen" count broken down into one track per layer, the layer's buffer shown as slices aligned to the video frames it was on screen for and labelled with the owning process/package. Split into "Changed" (a fresh buffer was rendered) and "All". Clicking a slice opens a details panel with the full buffer info.
