### PR TITLE
tools/record_android_trace: fix reconnects and "sh" spam

### DIFF
--- a/python/tools/record_android_trace.py
+++ b/python/tools/record_android_trace.py
@@ -383,7 +383,8 @@ def start_trace(args, print_log=True):
   #   something to block on
   # * poll the existence of /proc/pid to check that the process has exited
   #
-  # The following command prints RUN once, and TERM when the process finishes.
+  # On older Android devices adbd doesn't propagate the exit code. Hence
+  # the following command prints RUN once, and TERM when the process finishes.
   # On an error/disconnect the pipe closes without TERM.
   wait_cmd = (
       'echo RUN; while [ -d /proc/%s ]; do read -t 1 scratch_var; done; echo TERM'

--- a/python/tools/record_android_trace.py
+++ b/python/tools/record_android_trace.py
@@ -46,7 +46,9 @@ ABI_TO_ARCH = {
     'x86_64': 'x64',
 }
 
-MAX_ADB_FAILURES = 15  # 2 seconds between retries, 30 seconds total.
+# We support disconnecting a device after starting a trace, and proceeding after
+# reconnection if this script keeps running. Put a 24h timeout on the wait.
+MAX_ADB_FAILURE_TIME_SEC = 24 * 60 * 60  # 24h
 
 devnull = open(os.devnull, 'rb')
 adb_path = None
@@ -370,38 +372,84 @@ def start_trace(args, print_log=True):
   logcat = adb('logcat', log_level, 'brief', '-s', 'perfetto', '-b', 'main',
                '-T', '1')
 
+  # We want to wait until the "perfetto" process terminates. However it
+  # daemonized and therefore cannot be "wait"ed on (as it's not a child of the
+  # adbd's shell). We also want to avoid spawning new processes (including
+  # subshells for e.g. "sleep") as that pollutes the trace.
+  #
+  # Given the limitation's of android's mksh and toybox, we:
+  # * use the "read -t" builtin as a sleeping mechanism
+  # * use a never-written-to stdin pipe (forwarded by adbd) to give "read"
+  #   something to block on
+  # * poll the existence of /proc/pid to check that the process has exited
+  #
+  # The following command prints RUN once, and TERM when the process finishes.
+  # On an error/disconnect the pipe closes without TERM.
+  wait_cmd = (
+      'echo RUN; while [ -d /proc/%s ]; do read -t 1 scratch_var; done; echo TERM'
+      % bg_pid)
+
   ctrl_c_count = 0
   adb_failure_count = 0
+  adb_failure_time = 0
+  last_adb_error = None
   while ctrl_c_count < 2:
+    poll = None
     try:
-      # On older Android devices adbd doesn't propagate the exit code. Hence
-      # the RUN/TERM parts.
+      # stderr is merged into stdout so that adb/shell diagnostics are drained
+      # by the readline() loop below. If stderr had its own pipe it would go
+      # undrained while we block on stdout for the whole trace, and enough
+      # output (e.g. a per-iteration shell warning) would fill it and deadlock.
       poll = adb(
           'shell',
-          'test -d /proc/%s && echo RUN || echo TERM' % bg_pid,
-          stdout=subprocess.PIPE)
-      poll_res = poll.communicate()[0].decode().strip()
-      if poll_res == 'TERM':
-        break  # Process terminated
-      if poll_res == 'RUN':
-        # The 'perfetto' cmdline client is still running. If previously we had
-        # an ADB error, tell the user now it's all right again.
-        if adb_failure_count > 0:
-          adb_failure_count = 0
-          prt('ADB connection re-established, the trace is still ongoing',
-              ANSI.BLUE)
-        time.sleep(0.5)
-        continue
-      # Some ADB error happened. This can happen when tracing soon after boot,
-      # before logging in, when adb gets restarted.
+          wait_cmd,
+          stdin=subprocess.PIPE,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.STDOUT)
+      terminated = False
+      while True:
+        line = poll.stdout.readline()
+        if not line:
+          break  # EOF: the shell exited, i.e. some adb error/disconnect.
+        token = line.decode().strip()
+        if token == 'TERM':
+          terminated = True
+          break
+        if token == 'RUN':
+          if adb_failure_count > 0:
+            # We had lost the connection and just got it back.
+            adb_failure_count = 0
+            last_adb_error = None
+            prt('ADB connection re-established, the trace is still ongoing',
+                ANSI.BLUE)
+          continue
+        # Anything else is an adb/shell diagnostic; forward it live, deduping
+        # the same error repeated across retries.
+        if token and token != last_adb_error:
+          last_adb_error = token
+          sys.stderr.write(token + '\n')
+          sys.stderr.flush()
+      poll.stdout.close()
+      if poll.stdin:
+        poll.stdin.close()
+      poll.wait()
+      if terminated:
+        break
+      # adb error, possibly disconnect.
       adb_failure_count += 1
-      if adb_failure_count >= MAX_ADB_FAILURES:
+      if adb_failure_count == 1:
+        adb_failure_time = time.time()
+        prt('ADB connection lost, will keep retrying while the trace continues',
+            ANSI.BLUE)
+      if time.time() - adb_failure_time > MAX_ADB_FAILURE_TIME_SEC:
         prt('Too many unrecoverable ADB failures, bailing out', ANSI.RED)
         sys.exit(1)
       time.sleep(2)
     except (KeyboardInterrupt, SignalException):
       sig = 'TERM' if ctrl_c_count == 0 else 'KILL'
       ctrl_c_count += 1
+      if poll:
+        poll.kill()  # Tear down the blocking wait shell.
       if print_log:
         prt('Stopping the trace (SIG%s)' % sig, ANSI.BLACK + ANSI.BG_YELLOW)
       adb('shell', 'kill -%s %s' % (sig, bg_pid)).wait()

--- a/python/tools/record_android_trace.py
+++ b/python/tools/record_android_trace.py
@@ -396,10 +396,8 @@ def start_trace(args, print_log=True):
   while ctrl_c_count < 2:
     poll = None
     try:
-      # stderr is merged into stdout so that adb/shell diagnostics are drained
-      # by the readline() loop below. If stderr had its own pipe it would go
-      # undrained while we block on stdout for the whole trace, and enough
-      # output (e.g. a per-iteration shell warning) would fill it and deadlock.
+      # stderr is merged into stdout so that we can suppress identical adb
+      # error messages while waiting for reconnection.
       poll = adb(
           'shell',
           wait_cmd,
@@ -423,7 +421,7 @@ def start_trace(args, print_log=True):
             prt('ADB connection re-established, the trace is still ongoing',
                 ANSI.BLUE)
           continue
-        # Anything else is an adb/shell diagnostic; forward it live, deduping
+        # Anything else is an adb/shell message or error. Forward it, deduping
         # the same error repeated across retries.
         if token and token != last_adb_error:
           last_adb_error = token

--- a/tools/record_android_trace
+++ b/tools/record_android_trace
@@ -698,10 +698,8 @@ def start_trace(args, print_log=True):
   while ctrl_c_count < 2:
     poll = None
     try:
-      # stderr is merged into stdout so that adb/shell diagnostics are drained
-      # by the readline() loop below. If stderr had its own pipe it would go
-      # undrained while we block on stdout for the whole trace, and enough
-      # output (e.g. a per-iteration shell warning) would fill it and deadlock.
+      # stderr is merged into stdout so that we can suppress identical adb
+      # error messages while waiting for reconnection.
       poll = adb(
           'shell',
           wait_cmd,
@@ -725,7 +723,7 @@ def start_trace(args, print_log=True):
             prt('ADB connection re-established, the trace is still ongoing',
                 ANSI.BLUE)
           continue
-        # Anything else is an adb/shell diagnostic; forward it live, deduping
+        # Anything else is an adb/shell message or error. Forward it, deduping
         # the same error repeated across retries.
         if token and token != last_adb_error:
           last_adb_error = token

--- a/tools/record_android_trace
+++ b/tools/record_android_trace
@@ -685,7 +685,8 @@ def start_trace(args, print_log=True):
   #   something to block on
   # * poll the existence of /proc/pid to check that the process has exited
   #
-  # The following command prints RUN once, and TERM when the process finishes.
+  # On older Android devices adbd doesn't propagate the exit code. Hence
+  # the following command prints RUN once, and TERM when the process finishes.
   # On an error/disconnect the pipe closes without TERM.
   wait_cmd = (
       'echo RUN; while [ -d /proc/%s ]; do read -t 1 scratch_var; done; echo TERM'

--- a/tools/record_android_trace
+++ b/tools/record_android_trace
@@ -348,7 +348,9 @@ ABI_TO_ARCH = {
     'x86_64': 'x64',
 }
 
-MAX_ADB_FAILURES = 15  # 2 seconds between retries, 30 seconds total.
+# We support disconnecting a device after starting a trace, and proceeding after
+# reconnection if this script keeps running. Put a 24h timeout on the wait.
+MAX_ADB_FAILURE_TIME_SEC = 24 * 60 * 60  # 24h
 
 devnull = open(os.devnull, 'rb')
 adb_path = None
@@ -672,38 +674,84 @@ def start_trace(args, print_log=True):
   logcat = adb('logcat', log_level, 'brief', '-s', 'perfetto', '-b', 'main',
                '-T', '1')
 
+  # We want to wait until the "perfetto" process terminates. However it
+  # daemonized and therefore cannot be "wait"ed on (as it's not a child of the
+  # adbd's shell). We also want to avoid spawning new processes (including
+  # subshells for e.g. "sleep") as that pollutes the trace.
+  #
+  # Given the limitation's of android's mksh and toybox, we:
+  # * use the "read -t" builtin as a sleeping mechanism
+  # * use a never-written-to stdin pipe (forwarded by adbd) to give "read"
+  #   something to block on
+  # * poll the existence of /proc/pid to check that the process has exited
+  #
+  # The following command prints RUN once, and TERM when the process finishes.
+  # On an error/disconnect the pipe closes without TERM.
+  wait_cmd = (
+      'echo RUN; while [ -d /proc/%s ]; do read -t 1 scratch_var; done; echo TERM'
+      % bg_pid)
+
   ctrl_c_count = 0
   adb_failure_count = 0
+  adb_failure_time = 0
+  last_adb_error = None
   while ctrl_c_count < 2:
+    poll = None
     try:
-      # On older Android devices adbd doesn't propagate the exit code. Hence
-      # the RUN/TERM parts.
+      # stderr is merged into stdout so that adb/shell diagnostics are drained
+      # by the readline() loop below. If stderr had its own pipe it would go
+      # undrained while we block on stdout for the whole trace, and enough
+      # output (e.g. a per-iteration shell warning) would fill it and deadlock.
       poll = adb(
           'shell',
-          'test -d /proc/%s && echo RUN || echo TERM' % bg_pid,
-          stdout=subprocess.PIPE)
-      poll_res = poll.communicate()[0].decode().strip()
-      if poll_res == 'TERM':
-        break  # Process terminated
-      if poll_res == 'RUN':
-        # The 'perfetto' cmdline client is still running. If previously we had
-        # an ADB error, tell the user now it's all right again.
-        if adb_failure_count > 0:
-          adb_failure_count = 0
-          prt('ADB connection re-established, the trace is still ongoing',
-              ANSI.BLUE)
-        time.sleep(0.5)
-        continue
-      # Some ADB error happened. This can happen when tracing soon after boot,
-      # before logging in, when adb gets restarted.
+          wait_cmd,
+          stdin=subprocess.PIPE,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.STDOUT)
+      terminated = False
+      while True:
+        line = poll.stdout.readline()
+        if not line:
+          break  # EOF: the shell exited, i.e. some adb error/disconnect.
+        token = line.decode().strip()
+        if token == 'TERM':
+          terminated = True
+          break
+        if token == 'RUN':
+          if adb_failure_count > 0:
+            # We had lost the connection and just got it back.
+            adb_failure_count = 0
+            last_adb_error = None
+            prt('ADB connection re-established, the trace is still ongoing',
+                ANSI.BLUE)
+          continue
+        # Anything else is an adb/shell diagnostic; forward it live, deduping
+        # the same error repeated across retries.
+        if token and token != last_adb_error:
+          last_adb_error = token
+          sys.stderr.write(token + '\n')
+          sys.stderr.flush()
+      poll.stdout.close()
+      if poll.stdin:
+        poll.stdin.close()
+      poll.wait()
+      if terminated:
+        break
+      # adb error, possibly disconnect.
       adb_failure_count += 1
-      if adb_failure_count >= MAX_ADB_FAILURES:
+      if adb_failure_count == 1:
+        adb_failure_time = time.time()
+        prt('ADB connection lost, will keep retrying while the trace continues',
+            ANSI.BLUE)
+      if time.time() - adb_failure_time > MAX_ADB_FAILURE_TIME_SEC:
         prt('Too many unrecoverable ADB failures, bailing out', ANSI.RED)
         sys.exit(1)
       time.sleep(2)
     except (KeyboardInterrupt, SignalException):
       sig = 'TERM' if ctrl_c_count == 0 else 'KILL'
       ctrl_c_count += 1
+      if poll:
+        poll.kill()  # Tear down the blocking wait shell.
       if print_log:
         prt('Stopping the trace (SIG%s)' % sig, ANSI.BLACK + ANSI.BG_YELLOW)
       adb('shell', 'kill -%s %s' % (sig, bg_pid)).wait()


### PR DESCRIPTION
The script currently spawns a new adb shell every 0.5s, which pollutes
traces visually, and adds unnecessary noise to the system itself.
Additionally, the script advertises to support reconnects, but bails out
too early to be practical.

Address both points while working around mksh's limitations. I didn't
want to change the original perfetto invocation, so the changes are to
the waiting adb command. We now use "read -t" as a mksh-builtin sleeping
mechanism, with a pipe forwarded from adbd's stdin to give something for
the read to block on.

Tested on newest device and emulator64_x86_64:12/SE2A.230906.003.