### PR TITLE
perfetto: fix zstd GN deps for Chromium builds

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -467,9 +467,25 @@ if (enable_perfetto_zstd) {
     if (perfetto_root_path == "//") {
       public_configs = [ "//buildtools:zstd_config" ]
       public_deps = [ "//buildtools:zstd" ]
+    } else if (build_with_chromium) {
+      # Chromium's //third_party/zstd exposes per-stage source_sets rather than
+      # a single :zstd target + :zstd_config, so map to those and supply the
+      # include path ourselves.
+      # https://crsrc.org/c/third_party/zstd/BUILD.gn
+      public_configs = [ ":zstd_chromium_include_path" ]
+      public_deps = [
+        "//third_party/zstd:compress",
+        "//third_party/zstd:decompress",
+      ]
     } else {
       public_configs = [ "//third_party/zstd:zstd_config" ]
       public_deps = [ "//third_party/zstd" ]
+    }
+  }
+
+  config("zstd_chromium_include_path") {
+    if (build_with_chromium) {
+      include_dirs = [ "//third_party/zstd/src/lib" ]
     }
   }
 }


### PR DESCRIPTION
Chromium's //third_party/zstd exposes per-stage source_sets (:compress, :decompress, :common, :headers) rather than a single :zstd target and a :zstd_config config.

Add a build_with_chromium branch to the zstd group that depends on Chromium's real :compress and :decompress targets (these pull in :common and :headers transitively) and supplies the <zstd.h> include path ourselves. This matches how in-tree consumers such as net depend on zstd.