### PR TITLE
perfetto: drop deprecated pipes import, plug TraceProcessor fd leak

### DIFF
--- a/python/perfetto/trace_processor/api.py
+++ b/python/perfetto/trace_processor/api.py
@@ -353,6 +353,11 @@ class TraceProcessor:
     self.close()
     return False
 
+  def __del__(self):
+    # Fallback for callers that skip close()/the context manager, so temp files
+    # and the HTTP connection don't leak (as a "ResourceWarning: unclosed file").
+    self.close()
+
   def close(self):
     if getattr(self, 'subprocess', None):
       # Force-kill the whole process tree (the trace_processor subprocess and

--- a/tools/compat.py
+++ b/tools/compat.py
@@ -13,10 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-  from shlex import quote
-except ImportError:
-  from pipes import quote
+from shlex import quote
 
 try:
   from urllib.request import urlretrieve


### PR DESCRIPTION
Remove the dead Python 2 *from pipes import quote* fallback in tools/compat.py; shlex.quote exists on every supported Python 3, so the except ImportError branch was unreachable and only kept a reference to the deprecated (removed in 3.13) pipes module alive.

Add a __del__ safety net to TraceProcessor mirroring BatchTraceProcessor, so callers that skip close()/the context manager no longer leak the subprocess stdout/stderr temp files and the HTTP connection until GC (surfacing as "ResourceWarning: unclosed file").

Fixes: https://github.com/google/perfetto/issues/3589
