### PR TITLE
Add cgroup statistics polling to sys_stats data source

### DIFF
--- a/docs/data-sources/cgroup-counters.md
+++ b/docs/data-sources/cgroup-counters.md
@@ -1,0 +1,102 @@
+# Cgroup Counters
+
+This document describes the cgroup statistics tracking feature in Perfetto, which enables monitoring of Linux cgroup subsystem resource usage for specific task groups.
+
+## Overview
+
+Cgroup tracking allows you to monitor resource usage for specific task groups, which is particularly useful for performance analysis in Android systems. By polling cgroup statistics, you can track:
+
+- **CPU Usage**: CPU time allocation between foreground/background apps
+- **Memory Usage**: Memory consumption patterns for different task groups  
+- **I/O Statistics**: Disk read/write activity categorized by task groups
+
+## Supported Cgroup Counters
+
+### CPU Statistics (cpu.stat)
+- `CGROUP_CPU_USAGE_USEC`: Total CPU usage time in microseconds
+- `CGROUP_CPU_USER_USEC`: User-mode CPU time in microseconds
+- `CGROUP_CPU_SYSTEM_USEC`: Kernel-mode CPU time in microseconds
+- `CGROUP_CPU_NR_PERIODS`: Number of CFS scheduling periods
+- `CGROUP_CPU_NR_THROTTLED`: Number of times throttled
+- `CGROUP_CPU_THROTTLED_USEC`: Time spent throttled in microseconds
+
+### Memory Statistics (memory.stat)
+- `CGROUP_MEMORY_ANON`: Anonymous memory pages
+- `CGROUP_MEMORY_FILE`: File cache pages
+- `CGROUP_MEMORY_ACTIVE_ANON`: Active anonymous memory
+- `CGROUP_MEMORY_INACTIVE_ANON`: Inactive anonymous memory
+- `CGROUP_MEMORY_ACTIVE_FILE`: Active file cache
+- `CGROUP_MEMORY_INACTIVE_FILE`: Inactive file cache
+- `CGROUP_MEMORY_PGFAULT`: Page fault count
+- `CGROUP_MEMORY_PGMAJFAULT`: Major page fault count
+
+### Memory Limits
+- `CGROUP_MEMORY_CURRENT`: Current memory usage
+- `CGROUP_MEMORY_MAX`: Memory usage limit
+- `CGROUP_MEMORY_SWAP_CURRENT`: Current swap usage
+- `CGROUP_MEMORY_SWAP_MAX`: Swap usage limit
+
+### I/O Statistics (io.stat)
+- `CGROUP_IO_RBYTES`: Bytes read
+- `CGROUP_IO_WBYTES`: Bytes written
+- `CGROUP_IO_RIOS`: Read operations count
+- `CGROUP_IO_WIOS`: Write operations count
+- `CGROUP_IO_DBYTES`: Discarded bytes
+- `CGROUP_IO_DIOS`: Discard operations count
+
+## Configuration
+
+Add the following to your trace config:
+
+```protobuf
+data_sources: {
+    config {
+        name: "linux.sys_stats"
+        sys_stats_config {
+            # Poll cgroup stats every 100ms
+            cgroup_period_ms: 100
+            
+            # Cgroup paths to monitor
+            cgroup_paths: "/sys/fs/cgroup/cpu/top-app"
+            cgroup_paths: "/sys/fs/cgroup/memory/foreground"
+            cgroup_paths: "/sys/fs/cgroup/cpu/background"
+            
+            # Counters to collect
+            cgroup_counters: CGROUP_CPU_USAGE_USEC
+            cgroup_counters: CGROUP_MEMORY_ANON
+            cgroup_counters: CGROUP_IO_RBYTES
+        }
+    }
+}
+```
+
+## Common Android Cgroup Paths
+
+- `/sys/fs/cgroup/cpu/top-app`: Foreground applications
+- `/sys/fs/cgroup/cpu/foreground`: Foreground services
+- `/sys/fs/cgroup/cpu/background`: Background tasks
+- `/sys/fs/cgroup/cpu/system-background`: System background tasks
+- `/sys/fs/cgroup/memory/top-app`: Foreground app memory group
+- `/sys/fs/cgroup/memory/foreground`: Foreground service memory group
+- `/sys/fs/cgroup/memory/background`: Background task memory group
+
+## Use Cases
+
+1. **App Performance Analysis**: Compare resource usage between foreground and background apps
+2. **System Optimization**: Identify task groups with highest resource consumption
+3. **Memory Leak Detection**: Monitor memory usage trends for specific app groups
+4. **I/O Performance Analysis**: Analyze disk activity patterns across different task groups
+
+## Implementation Details
+
+- All polling periods must be ≥ 10ms to avoid excessive CPU usage
+- If no cgroup paths are specified, Android default paths are used
+- Supports both cgroup v1 and v2 filesystem formats
+- Statistics include full cgroup paths for analysis-time differentiation
+
+## Performance Impact
+
+Cgroup polling overhead is minimal:
+- File reading: < 0.5ms per cgroup path
+- Parsing and injection: < 0.1ms per counter
+- Recommended polling interval: 100-1000ms depending on analysis needs

--- a/docs/data-sources/cgroup-counters.md
+++ b/docs/data-sources/cgroup-counters.md
@@ -53,15 +53,17 @@ data_sources: {
     config {
         name: "linux.sys_stats"
         sys_stats_config {
-            # Poll cgroup stats every 100ms
+            # Poll cgroup stats every 100ms.
             cgroup_period_ms: 100
-            
-            # Cgroup paths to monitor
-            cgroup_paths: "/sys/fs/cgroup/cpu/top-app"
-            cgroup_paths: "/sys/fs/cgroup/memory/foreground"
-            cgroup_paths: "/sys/fs/cgroup/cpu/background"
-            
-            # Counters to collect
+
+            # Cgroup paths to monitor. These are cgroup v2 unified-hierarchy
+            # paths; on a cgroup v1 system use the per-controller paths such as
+            # "/sys/fs/cgroup/cpu/top-app".
+            cgroup_paths: "/sys/fs/cgroup/top-app"
+            cgroup_paths: "/sys/fs/cgroup/foreground"
+            cgroup_paths: "/sys/fs/cgroup/background"
+
+            # Counters to collect. If omitted, all known counters are reported.
             cgroup_counters: CGROUP_CPU_USAGE_USEC
             cgroup_counters: CGROUP_MEMORY_ANON
             cgroup_counters: CGROUP_IO_RBYTES
@@ -70,15 +72,27 @@ data_sources: {
 }
 ```
 
-## Common Android Cgroup Paths
+Under each configured path, the data source probes `cpu.stat`, `memory.stat`,
+`memory.current`, `memory.high`, `memory.max`, `memory.swap.current`,
+`memory.swap.max` and `io.stat`. Files that do not exist are skipped, so the
+same configuration works on both hierarchies: on cgroup v1 each controller has
+its own directory, while on cgroup v2 all files share one unified directory.
 
-- `/sys/fs/cgroup/cpu/top-app`: Foreground applications
-- `/sys/fs/cgroup/cpu/foreground`: Foreground services
-- `/sys/fs/cgroup/cpu/background`: Background tasks
-- `/sys/fs/cgroup/cpu/system-background`: System background tasks
-- `/sys/fs/cgroup/memory/top-app`: Foreground app memory group
-- `/sys/fs/cgroup/memory/foreground`: Foreground service memory group
-- `/sys/fs/cgroup/memory/background`: Background task memory group
+## Querying in Trace Processor
+
+Each counter becomes a counter track dimensioned by cgroup path, counter name
+and (for `io.stat`) block device:
+
+```sql
+SELECT
+  ts,
+  EXTRACT_ARG(t.dimension_arg_set_id, 'cgroup_path') AS path,
+  EXTRACT_ARG(t.dimension_arg_set_id, 'cgroup_name') AS name,
+  value
+FROM counter c
+JOIN track t ON c.track_id = t.id
+WHERE t.name GLOB 'cgroup *';
+```
 
 ## Use Cases
 
@@ -89,14 +103,7 @@ data_sources: {
 
 ## Implementation Details
 
-- All polling periods must be ≥ 10ms to avoid excessive CPU usage
-- If no cgroup paths are specified, Android default paths are used
-- Supports both cgroup v1 and v2 filesystem formats
-- Statistics include full cgroup paths for analysis-time differentiation
-
-## Performance Impact
-
-Cgroup polling overhead is minimal:
-- File reading: < 0.5ms per cgroup path
-- Parsing and injection: < 0.1ms per counter
-- Recommended polling interval: 100-1000ms depending on analysis needs
+- All polling periods must be ≥ 10ms to avoid excessive CPU usage.
+- `cgroup_paths` must be set explicitly; there are no default paths.
+- Works with both the cgroup v1 and v2 hierarchies.
+- A limit file reading the literal `max` (no limit) is reported as uint64 max.

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -72,6 +72,7 @@
     - [Memory](#)
 
       - [Memory Counters](data-sources/memory-counters.md) {.tag-android .tag-linux}
+      - [Cgroup Counters](data-sources/cgroup-counters.md) {.tag-android .tag-linux}
       - [Allocation Profiler](data-sources/native-heap-profiler.md) {.tag-android .tag-linux}
       - [ART Heap Dumps](data-sources/java-heap-profiler.md) {.tag-android}
 

--- a/include/perfetto/ext/traced/sys_stats_counters.h
+++ b/include/perfetto/ext/traced/sys_stats_counters.h
@@ -384,6 +384,88 @@ inline std::vector<const char*> BuildVmstatCounterNames() {
   return v;
 }
 
+constexpr KeyAndId kCgroupKeys[] = {
+    {"CgroupUnspecified", protos::pbzero::CgroupCounters::CGROUP_UNSPECIFIED},
+
+    // CPU stats from cpu.stat
+    {"usage_usec", protos::pbzero::CgroupCounters::CGROUP_CPU_USAGE_USEC},
+    {"user_usec", protos::pbzero::CgroupCounters::CGROUP_CPU_USER_USEC},
+    {"system_usec", protos::pbzero::CgroupCounters::CGROUP_CPU_SYSTEM_USEC},
+    {"nr_periods", protos::pbzero::CgroupCounters::CGROUP_CPU_NR_PERIODS},
+    {"nr_throttled", protos::pbzero::CgroupCounters::CGROUP_CPU_NR_THROTTLED},
+    {"throttled_usec",
+     protos::pbzero::CgroupCounters::CGROUP_CPU_THROTTLED_USEC},
+
+    // Memory stats from memory.stat
+    {"anon", protos::pbzero::CgroupCounters::CGROUP_MEMORY_ANON},
+    {"file", protos::pbzero::CgroupCounters::CGROUP_MEMORY_FILE},
+    {"kernel_stack",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_KERNEL_STACK},
+    {"pagetables", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PAGETABLES},
+    {"percpu", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PERCPU},
+    {"sock", protos::pbzero::CgroupCounters::CGROUP_MEMORY_SOCK},
+    {"shmem", protos::pbzero::CgroupCounters::CGROUP_MEMORY_SHMEM},
+    {"file_mapped", protos::pbzero::CgroupCounters::CGROUP_MEMORY_FILE_MAPPED},
+    {"file_dirty", protos::pbzero::CgroupCounters::CGROUP_MEMORY_FILE_DIRTY},
+    {"file_writeback",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_FILE_WRITEBACK},
+    {"swapcached", protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAPCACHED},
+    {"anon_thp", protos::pbzero::CgroupCounters::CGROUP_MEMORY_ANON_THPS},
+    {"file_thp", protos::pbzero::CgroupCounters::CGROUP_MEMORY_FILE_THPS},
+    {"shmem_thp", protos::pbzero::CgroupCounters::CGROUP_MEMORY_SHMEM_THPS},
+    {"inactive_anon",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_INACTIVE_ANON},
+    {"active_anon", protos::pbzero::CgroupCounters::CGROUP_MEMORY_ACTIVE_ANON},
+    {"inactive_file",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_INACTIVE_FILE},
+    {"active_file", protos::pbzero::CgroupCounters::CGROUP_MEMORY_ACTIVE_FILE},
+    {"unevictable", protos::pbzero::CgroupCounters::CGROUP_MEMORY_UNEVICTABLE},
+    {"slab_reclaimable",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_SLAB_RECLAIMABLE},
+    {"slab_unreclaimable",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_SLAB_UNRECLAIMABLE},
+    {"slab", protos::pbzero::CgroupCounters::CGROUP_MEMORY_SLAB},
+    {"workingset_refault_anon",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_WORKINGSET_REFAULT_ANON},
+    {"workingset_refault_file",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_WORKINGSET_REFAULT_FILE},
+    {"workingset_activate_anon",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_WORKINGSET_ACTIVATE_ANON},
+    {"workingset_activate_file",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_WORKINGSET_ACTIVATE_FILE},
+    {"workingset_restore_anon",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_WORKINGSET_RESTORE_ANON},
+    {"workingset_restore_file",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_WORKINGSET_RESTORE_FILE},
+    {"workingset_nodereclaim",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_WORKINGSET_NODERECLAIM},
+    {"pgfault", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PGFAULT},
+    {"pgmajfault", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PGMAJFAULT},
+    {"pgrefill", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PGREFILL},
+    {"pgscan", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PGSCAN},
+    {"pgsteal", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PGSTEAL},
+    {"pgactivate", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PGACTIVATE},
+    {"pgdeactivate",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_PGDEACTIVATE},
+    {"pglazyfree", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PGLAZYFREE},
+    {"pglazyfreed", protos::pbzero::CgroupCounters::CGROUP_MEMORY_PGLAZYFREED},
+    {"thp_fault_alloc",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_THP_FAULT_ALLOC},
+    {"thp_collapse_alloc",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_THP_COLLAPSE_ALLOC},
+};
+
+inline std::vector<const char*> BuildCgroupCounterNames() {
+  int max_id = 0;
+  for (size_t i = 0; i < base::ArraySize(kCgroupKeys); i++)
+    max_id = std::max(max_id, kCgroupKeys[i].id);
+  std::vector<const char*> v;
+  v.resize(static_cast<size_t>(max_id) + 1);
+  for (size_t i = 0; i < base::ArraySize(kCgroupKeys); i++)
+    v[static_cast<size_t>(kCgroupKeys[i].id)] = kCgroupKeys[i].str;
+  return v;
+}
+
 }  // namespace perfetto
 
 #endif  // INCLUDE_PERFETTO_EXT_TRACED_SYS_STATS_COUNTERS_H_

--- a/include/perfetto/ext/traced/sys_stats_counters.h
+++ b/include/perfetto/ext/traced/sys_stats_counters.h
@@ -410,9 +410,9 @@ constexpr KeyAndId kCgroupKeys[] = {
     {"file_writeback",
      protos::pbzero::CgroupCounters::CGROUP_MEMORY_FILE_WRITEBACK},
     {"swapcached", protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAPCACHED},
-    {"anon_thp", protos::pbzero::CgroupCounters::CGROUP_MEMORY_ANON_THPS},
-    {"file_thp", protos::pbzero::CgroupCounters::CGROUP_MEMORY_FILE_THPS},
-    {"shmem_thp", protos::pbzero::CgroupCounters::CGROUP_MEMORY_SHMEM_THPS},
+    {"anon_thp", protos::pbzero::CgroupCounters::CGROUP_MEMORY_ANON_THP},
+    {"file_thp", protos::pbzero::CgroupCounters::CGROUP_MEMORY_FILE_THP},
+    {"shmem_thp", protos::pbzero::CgroupCounters::CGROUP_MEMORY_SHMEM_THP},
     {"inactive_anon",
      protos::pbzero::CgroupCounters::CGROUP_MEMORY_INACTIVE_ANON},
     {"active_anon", protos::pbzero::CgroupCounters::CGROUP_MEMORY_ACTIVE_ANON},
@@ -453,6 +453,24 @@ constexpr KeyAndId kCgroupKeys[] = {
      protos::pbzero::CgroupCounters::CGROUP_MEMORY_THP_FAULT_ALLOC},
     {"thp_collapse_alloc",
      protos::pbzero::CgroupCounters::CGROUP_MEMORY_THP_COLLAPSE_ALLOC},
+
+    // Single-value memory files. These strings are not matched against any
+    // file contents; they are used only to name the counter at parse time in
+    // trace_processor. The enum is chosen from the file name instead.
+    {"memory.current", protos::pbzero::CgroupCounters::CGROUP_MEMORY_CURRENT},
+    {"memory.high", protos::pbzero::CgroupCounters::CGROUP_MEMORY_HIGH},
+    {"memory.max", protos::pbzero::CgroupCounters::CGROUP_MEMORY_MAX},
+    {"memory.swap.current",
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAP_CURRENT},
+    {"memory.swap.max", protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAP_MAX},
+
+    // IO stats from io.stat. The strings match the per-device tokens.
+    {"rbytes", protos::pbzero::CgroupCounters::CGROUP_IO_RBYTES},
+    {"wbytes", protos::pbzero::CgroupCounters::CGROUP_IO_WBYTES},
+    {"rios", protos::pbzero::CgroupCounters::CGROUP_IO_RIOS},
+    {"wios", protos::pbzero::CgroupCounters::CGROUP_IO_WIOS},
+    {"dbytes", protos::pbzero::CgroupCounters::CGROUP_IO_DBYTES},
+    {"dios", protos::pbzero::CgroupCounters::CGROUP_IO_DIOS},
 };
 
 inline std::vector<const char*> BuildCgroupCounterNames() {

--- a/protos/perfetto/common/sys_stats_counters.proto
+++ b/protos/perfetto/common/sys_stats_counters.proto
@@ -256,3 +256,100 @@ enum VmstatCounters {
   VMSTAT_WORKINGSET_RESTORE_ANON = 187;
   VMSTAT_WORKINGSET_RESTORE_FILE = 188;
 }
+
+// Cgroup counter definitions for Linux's /sys/fs/cgroup.
+// These counters track resource usage for specific task groups such as
+// foreground/background apps and system services in Android.
+enum CgroupCounters {
+  // Unspecified cgroup counter.
+  CGROUP_UNSPECIFIED = 0;
+
+  // CPU stats from cpu.stat
+  // Total CPU usage time in microseconds.
+  CGROUP_CPU_USAGE_USEC = 1;
+  // User-mode CPU time in microseconds.
+  CGROUP_CPU_USER_USEC = 2;
+  // Kernel-mode CPU time in microseconds.
+  CGROUP_CPU_SYSTEM_USEC = 3;
+  // Number of CFS scheduling periods.
+  CGROUP_CPU_NR_PERIODS = 4;
+  // Number of times throttled.
+  CGROUP_CPU_NR_THROTTLED = 5;
+  // Time spent throttled in microseconds.
+  CGROUP_CPU_THROTTLED_USEC = 6;
+
+  // Memory stats from memory.stat
+  // Anonymous memory pages.
+  CGROUP_MEMORY_ANON = 7;
+  // File cache pages.
+  CGROUP_MEMORY_FILE = 8;
+  // Kernel stack memory.
+  CGROUP_MEMORY_KERNEL_STACK = 9;
+  // Page table memory.
+  CGROUP_MEMORY_PAGETABLES = 10;
+  // Per-CPU memory.
+  CGROUP_MEMORY_PERCPU = 11;
+  // Socket buffer memory.
+  CGROUP_MEMORY_SOCK = 12;
+  // Shared memory pages.
+  CGROUP_MEMORY_SHMEM = 13;
+  // Memory-mapped file pages.
+  CGROUP_MEMORY_FILE_MAPPED = 14;
+  // Dirty file pages.
+  CGROUP_MEMORY_FILE_DIRTY = 15;
+  // File pages being written back.
+  CGROUP_MEMORY_FILE_WRITEBACK = 16;
+  // Swap-cached pages.
+  CGROUP_MEMORY_SWAPCACHED = 17;
+  // Anonymous transparent huge pages.
+  CGROUP_MEMORY_ANON_THPS = 18;
+  // File transparent huge pages.
+  CGROUP_MEMORY_FILE_THPS = 19;
+  // Shared memory transparent huge pages.
+  CGROUP_MEMORY_SHMEM_THPS = 20;
+  // Inactive anonymous memory.
+  CGROUP_MEMORY_INACTIVE_ANON = 21;
+  // Active anonymous memory.
+  CGROUP_MEMORY_ACTIVE_ANON = 22;
+  // Inactive file cache.
+  CGROUP_MEMORY_INACTIVE_FILE = 23;
+  // Active file cache.
+  CGROUP_MEMORY_ACTIVE_FILE = 24;
+  CGROUP_MEMORY_UNEVICTABLE = 25;
+  CGROUP_MEMORY_SLAB_RECLAIMABLE = 26;
+  CGROUP_MEMORY_SLAB_UNRECLAIMABLE = 27;
+  CGROUP_MEMORY_SLAB = 28;
+  CGROUP_MEMORY_WORKINGSET_REFAULT_ANON = 29;
+  CGROUP_MEMORY_WORKINGSET_REFAULT_FILE = 30;
+  CGROUP_MEMORY_WORKINGSET_ACTIVATE_ANON = 31;
+  CGROUP_MEMORY_WORKINGSET_ACTIVATE_FILE = 32;
+  CGROUP_MEMORY_WORKINGSET_RESTORE_ANON = 33;
+  CGROUP_MEMORY_WORKINGSET_RESTORE_FILE = 34;
+  CGROUP_MEMORY_WORKINGSET_NODERECLAIM = 35;
+  CGROUP_MEMORY_PGFAULT = 36;
+  CGROUP_MEMORY_PGMAJFAULT = 37;
+  CGROUP_MEMORY_PGREFILL = 38;
+  CGROUP_MEMORY_PGSCAN = 39;
+  CGROUP_MEMORY_PGSTEAL = 40;
+  CGROUP_MEMORY_PGACTIVATE = 41;
+  CGROUP_MEMORY_PGDEACTIVATE = 42;
+  CGROUP_MEMORY_PGLAZYFREE = 43;
+  CGROUP_MEMORY_PGLAZYFREED = 44;
+  CGROUP_MEMORY_THP_FAULT_ALLOC = 45;
+  CGROUP_MEMORY_THP_COLLAPSE_ALLOC = 46;
+
+  // Memory limits and usage from memory.current, memory.max, etc.
+  CGROUP_MEMORY_CURRENT = 47;
+  CGROUP_MEMORY_HIGH = 48;
+  CGROUP_MEMORY_MAX = 49;
+  CGROUP_MEMORY_SWAP_CURRENT = 50;
+  CGROUP_MEMORY_SWAP_MAX = 51;
+
+  // IO stats from io.stat (for devices)
+  CGROUP_IO_RBYTES = 52;
+  CGROUP_IO_WBYTES = 53;
+  CGROUP_IO_RIOS = 54;
+  CGROUP_IO_WIOS = 55;
+  CGROUP_IO_DBYTES = 56;
+  CGROUP_IO_DIOS = 57;
+}

--- a/protos/perfetto/common/sys_stats_counters.proto
+++ b/protos/perfetto/common/sys_stats_counters.proto
@@ -302,11 +302,11 @@ enum CgroupCounters {
   // Swap-cached pages.
   CGROUP_MEMORY_SWAPCACHED = 17;
   // Anonymous transparent huge pages.
-  CGROUP_MEMORY_ANON_THPS = 18;
+  CGROUP_MEMORY_ANON_THP = 18;
   // File transparent huge pages.
-  CGROUP_MEMORY_FILE_THPS = 19;
+  CGROUP_MEMORY_FILE_THP = 19;
   // Shared memory transparent huge pages.
-  CGROUP_MEMORY_SHMEM_THPS = 20;
+  CGROUP_MEMORY_SHMEM_THP = 20;
   // Inactive anonymous memory.
   CGROUP_MEMORY_INACTIVE_ANON = 21;
   // Active anonymous memory.

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -4496,11 +4496,11 @@ enum CgroupCounters {
   // Swap-cached pages.
   CGROUP_MEMORY_SWAPCACHED = 17;
   // Anonymous transparent huge pages.
-  CGROUP_MEMORY_ANON_THPS = 18;
+  CGROUP_MEMORY_ANON_THP = 18;
   // File transparent huge pages.
-  CGROUP_MEMORY_FILE_THPS = 19;
+  CGROUP_MEMORY_FILE_THP = 19;
   // Shared memory transparent huge pages.
-  CGROUP_MEMORY_SHMEM_THPS = 20;
+  CGROUP_MEMORY_SHMEM_THP = 20;
   // Inactive anonymous memory.
   CGROUP_MEMORY_INACTIVE_ANON = 21;
   // Active anonymous memory.

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -4451,6 +4451,103 @@ enum VmstatCounters {
   VMSTAT_WORKINGSET_RESTORE_FILE = 188;
 }
 
+// Cgroup counter definitions for Linux's /sys/fs/cgroup.
+// These counters track resource usage for specific task groups such as
+// foreground/background apps and system services in Android.
+enum CgroupCounters {
+  // Unspecified cgroup counter.
+  CGROUP_UNSPECIFIED = 0;
+
+  // CPU stats from cpu.stat
+  // Total CPU usage time in microseconds.
+  CGROUP_CPU_USAGE_USEC = 1;
+  // User-mode CPU time in microseconds.
+  CGROUP_CPU_USER_USEC = 2;
+  // Kernel-mode CPU time in microseconds.
+  CGROUP_CPU_SYSTEM_USEC = 3;
+  // Number of CFS scheduling periods.
+  CGROUP_CPU_NR_PERIODS = 4;
+  // Number of times throttled.
+  CGROUP_CPU_NR_THROTTLED = 5;
+  // Time spent throttled in microseconds.
+  CGROUP_CPU_THROTTLED_USEC = 6;
+
+  // Memory stats from memory.stat
+  // Anonymous memory pages.
+  CGROUP_MEMORY_ANON = 7;
+  // File cache pages.
+  CGROUP_MEMORY_FILE = 8;
+  // Kernel stack memory.
+  CGROUP_MEMORY_KERNEL_STACK = 9;
+  // Page table memory.
+  CGROUP_MEMORY_PAGETABLES = 10;
+  // Per-CPU memory.
+  CGROUP_MEMORY_PERCPU = 11;
+  // Socket buffer memory.
+  CGROUP_MEMORY_SOCK = 12;
+  // Shared memory pages.
+  CGROUP_MEMORY_SHMEM = 13;
+  // Memory-mapped file pages.
+  CGROUP_MEMORY_FILE_MAPPED = 14;
+  // Dirty file pages.
+  CGROUP_MEMORY_FILE_DIRTY = 15;
+  // File pages being written back.
+  CGROUP_MEMORY_FILE_WRITEBACK = 16;
+  // Swap-cached pages.
+  CGROUP_MEMORY_SWAPCACHED = 17;
+  // Anonymous transparent huge pages.
+  CGROUP_MEMORY_ANON_THPS = 18;
+  // File transparent huge pages.
+  CGROUP_MEMORY_FILE_THPS = 19;
+  // Shared memory transparent huge pages.
+  CGROUP_MEMORY_SHMEM_THPS = 20;
+  // Inactive anonymous memory.
+  CGROUP_MEMORY_INACTIVE_ANON = 21;
+  // Active anonymous memory.
+  CGROUP_MEMORY_ACTIVE_ANON = 22;
+  // Inactive file cache.
+  CGROUP_MEMORY_INACTIVE_FILE = 23;
+  // Active file cache.
+  CGROUP_MEMORY_ACTIVE_FILE = 24;
+  CGROUP_MEMORY_UNEVICTABLE = 25;
+  CGROUP_MEMORY_SLAB_RECLAIMABLE = 26;
+  CGROUP_MEMORY_SLAB_UNRECLAIMABLE = 27;
+  CGROUP_MEMORY_SLAB = 28;
+  CGROUP_MEMORY_WORKINGSET_REFAULT_ANON = 29;
+  CGROUP_MEMORY_WORKINGSET_REFAULT_FILE = 30;
+  CGROUP_MEMORY_WORKINGSET_ACTIVATE_ANON = 31;
+  CGROUP_MEMORY_WORKINGSET_ACTIVATE_FILE = 32;
+  CGROUP_MEMORY_WORKINGSET_RESTORE_ANON = 33;
+  CGROUP_MEMORY_WORKINGSET_RESTORE_FILE = 34;
+  CGROUP_MEMORY_WORKINGSET_NODERECLAIM = 35;
+  CGROUP_MEMORY_PGFAULT = 36;
+  CGROUP_MEMORY_PGMAJFAULT = 37;
+  CGROUP_MEMORY_PGREFILL = 38;
+  CGROUP_MEMORY_PGSCAN = 39;
+  CGROUP_MEMORY_PGSTEAL = 40;
+  CGROUP_MEMORY_PGACTIVATE = 41;
+  CGROUP_MEMORY_PGDEACTIVATE = 42;
+  CGROUP_MEMORY_PGLAZYFREE = 43;
+  CGROUP_MEMORY_PGLAZYFREED = 44;
+  CGROUP_MEMORY_THP_FAULT_ALLOC = 45;
+  CGROUP_MEMORY_THP_COLLAPSE_ALLOC = 46;
+
+  // Memory limits and usage from memory.current, memory.max, etc.
+  CGROUP_MEMORY_CURRENT = 47;
+  CGROUP_MEMORY_HIGH = 48;
+  CGROUP_MEMORY_MAX = 49;
+  CGROUP_MEMORY_SWAP_CURRENT = 50;
+  CGROUP_MEMORY_SWAP_MAX = 51;
+
+  // IO stats from io.stat (for devices)
+  CGROUP_IO_RBYTES = 52;
+  CGROUP_IO_WBYTES = 53;
+  CGROUP_IO_RIOS = 54;
+  CGROUP_IO_WIOS = 55;
+  CGROUP_IO_DBYTES = 56;
+  CGROUP_IO_DIOS = 57;
+}
+
 // End of protos/perfetto/common/sys_stats_counters.proto
 
 // Begin of protos/perfetto/config/sys_stats/sys_stats_config.proto
@@ -4530,6 +4627,20 @@ message SysStatsConfig {
   // Polls /proc/slabinfo every X ms, if non-zero.
   // This is required to be > 10ms to avoid excessive CPU usage.
   optional uint32 slab_period_ms = 15;
+
+  // Polls cgroup stats every X ms, if non-zero.
+  // This is required to be > 10ms to avoid excessive CPU usage.
+  // Cost: ~0.5ms per cgroup path for file reading and parsing.
+  optional uint32 cgroup_period_ms = 16;
+
+  // Cgroup counters to collect. If empty, all known counters are reported.
+  // Otherwise, only the specified counters are collected to reduce overhead.
+  repeated CgroupCounters cgroup_counters = 17;
+
+  // Cgroup paths to monitor. If empty, monitors common Android cgroups
+  // like top-app, foreground, and background task groups.
+  // Examples: "/sys/fs/cgroup/cpu/top-app", "/sys/fs/cgroup/memory/background"
+  repeated string cgroup_paths = 18;
 }
 
 // End of protos/perfetto/config/sys_stats/sys_stats_config.proto

--- a/protos/perfetto/config/sys_stats/sys_stats_config.proto
+++ b/protos/perfetto/config/sys_stats/sys_stats_config.proto
@@ -95,4 +95,18 @@ message SysStatsConfig {
   // Polls /proc/slabinfo every X ms, if non-zero.
   // This is required to be > 10ms to avoid excessive CPU usage.
   optional uint32 slab_period_ms = 15;
+
+  // Polls cgroup stats every X ms, if non-zero.
+  // This is required to be > 10ms to avoid excessive CPU usage.
+  // Cost: ~0.5ms per cgroup path for file reading and parsing.
+  optional uint32 cgroup_period_ms = 16;
+
+  // Cgroup counters to collect. If empty, all known counters are reported.
+  // Otherwise, only the specified counters are collected to reduce overhead.
+  repeated CgroupCounters cgroup_counters = 17;
+
+  // Cgroup paths to monitor. If empty, monitors common Android cgroups
+  // like top-app, foreground, and background task groups.
+  // Examples: "/sys/fs/cgroup/cpu/top-app", "/sys/fs/cgroup/memory/background"
+  repeated string cgroup_paths = 18;
 }

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -4496,11 +4496,11 @@ enum CgroupCounters {
   // Swap-cached pages.
   CGROUP_MEMORY_SWAPCACHED = 17;
   // Anonymous transparent huge pages.
-  CGROUP_MEMORY_ANON_THPS = 18;
+  CGROUP_MEMORY_ANON_THP = 18;
   // File transparent huge pages.
-  CGROUP_MEMORY_FILE_THPS = 19;
+  CGROUP_MEMORY_FILE_THP = 19;
   // Shared memory transparent huge pages.
-  CGROUP_MEMORY_SHMEM_THPS = 20;
+  CGROUP_MEMORY_SHMEM_THP = 20;
   // Inactive anonymous memory.
   CGROUP_MEMORY_INACTIVE_ANON = 21;
   // Active anonymous memory.
@@ -16814,19 +16814,23 @@ message SysStats {
   }
   repeated SlabInfo slab_info = 18;
 
-  // Counters from cgroup subsystems for tracking task group resource usage.
-  message CgroupValue {
-    // The type of cgroup counter (CPU, memory, or I/O metric).
-    optional CgroupCounters key = 1;
-    // The counter value (usage in bytes, microseconds, or count).
-    optional uint64 value = 2;
-    // The cgroup path this value belongs to (e.g.,
-    // "/sys/fs/cgroup/cpu/top-app").
-    optional string cgroup_path = 3;
-    // For I/O stats, the device identifier (e.g., "8:0" for /dev/sda).
-    optional string device = 4;
+  // Per-cgroup resource counters polled from /sys/fs/cgroup. Works with both
+  // the cgroup v1 (per-controller) and v2 (unified) hierarchies.
+  message Cgroup {
+    // Absolute cgroup path, e.g. "/sys/fs/cgroup/top-app".
+    optional string path = 1;
+    message Counter {
+      // The counter type (a CPU, memory, or IO metric).
+      optional CgroupCounters key = 1;
+      // The counter value in bytes, microseconds, or a raw count. For "max"
+      // limits with no bound set, this is uint64 max.
+      optional uint64 value = 2;
+      // For io.stat counters, the block device, e.g. "8:0".
+      optional string device = 3;
+    }
+    repeated Counter counter = 2;
   }
-  repeated CgroupValue cgroup = 19;
+  repeated Cgroup cgroup = 19;
 }
 
 // End of protos/perfetto/trace/sys_stats/sys_stats.proto

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -4451,6 +4451,103 @@ enum VmstatCounters {
   VMSTAT_WORKINGSET_RESTORE_FILE = 188;
 }
 
+// Cgroup counter definitions for Linux's /sys/fs/cgroup.
+// These counters track resource usage for specific task groups such as
+// foreground/background apps and system services in Android.
+enum CgroupCounters {
+  // Unspecified cgroup counter.
+  CGROUP_UNSPECIFIED = 0;
+
+  // CPU stats from cpu.stat
+  // Total CPU usage time in microseconds.
+  CGROUP_CPU_USAGE_USEC = 1;
+  // User-mode CPU time in microseconds.
+  CGROUP_CPU_USER_USEC = 2;
+  // Kernel-mode CPU time in microseconds.
+  CGROUP_CPU_SYSTEM_USEC = 3;
+  // Number of CFS scheduling periods.
+  CGROUP_CPU_NR_PERIODS = 4;
+  // Number of times throttled.
+  CGROUP_CPU_NR_THROTTLED = 5;
+  // Time spent throttled in microseconds.
+  CGROUP_CPU_THROTTLED_USEC = 6;
+
+  // Memory stats from memory.stat
+  // Anonymous memory pages.
+  CGROUP_MEMORY_ANON = 7;
+  // File cache pages.
+  CGROUP_MEMORY_FILE = 8;
+  // Kernel stack memory.
+  CGROUP_MEMORY_KERNEL_STACK = 9;
+  // Page table memory.
+  CGROUP_MEMORY_PAGETABLES = 10;
+  // Per-CPU memory.
+  CGROUP_MEMORY_PERCPU = 11;
+  // Socket buffer memory.
+  CGROUP_MEMORY_SOCK = 12;
+  // Shared memory pages.
+  CGROUP_MEMORY_SHMEM = 13;
+  // Memory-mapped file pages.
+  CGROUP_MEMORY_FILE_MAPPED = 14;
+  // Dirty file pages.
+  CGROUP_MEMORY_FILE_DIRTY = 15;
+  // File pages being written back.
+  CGROUP_MEMORY_FILE_WRITEBACK = 16;
+  // Swap-cached pages.
+  CGROUP_MEMORY_SWAPCACHED = 17;
+  // Anonymous transparent huge pages.
+  CGROUP_MEMORY_ANON_THPS = 18;
+  // File transparent huge pages.
+  CGROUP_MEMORY_FILE_THPS = 19;
+  // Shared memory transparent huge pages.
+  CGROUP_MEMORY_SHMEM_THPS = 20;
+  // Inactive anonymous memory.
+  CGROUP_MEMORY_INACTIVE_ANON = 21;
+  // Active anonymous memory.
+  CGROUP_MEMORY_ACTIVE_ANON = 22;
+  // Inactive file cache.
+  CGROUP_MEMORY_INACTIVE_FILE = 23;
+  // Active file cache.
+  CGROUP_MEMORY_ACTIVE_FILE = 24;
+  CGROUP_MEMORY_UNEVICTABLE = 25;
+  CGROUP_MEMORY_SLAB_RECLAIMABLE = 26;
+  CGROUP_MEMORY_SLAB_UNRECLAIMABLE = 27;
+  CGROUP_MEMORY_SLAB = 28;
+  CGROUP_MEMORY_WORKINGSET_REFAULT_ANON = 29;
+  CGROUP_MEMORY_WORKINGSET_REFAULT_FILE = 30;
+  CGROUP_MEMORY_WORKINGSET_ACTIVATE_ANON = 31;
+  CGROUP_MEMORY_WORKINGSET_ACTIVATE_FILE = 32;
+  CGROUP_MEMORY_WORKINGSET_RESTORE_ANON = 33;
+  CGROUP_MEMORY_WORKINGSET_RESTORE_FILE = 34;
+  CGROUP_MEMORY_WORKINGSET_NODERECLAIM = 35;
+  CGROUP_MEMORY_PGFAULT = 36;
+  CGROUP_MEMORY_PGMAJFAULT = 37;
+  CGROUP_MEMORY_PGREFILL = 38;
+  CGROUP_MEMORY_PGSCAN = 39;
+  CGROUP_MEMORY_PGSTEAL = 40;
+  CGROUP_MEMORY_PGACTIVATE = 41;
+  CGROUP_MEMORY_PGDEACTIVATE = 42;
+  CGROUP_MEMORY_PGLAZYFREE = 43;
+  CGROUP_MEMORY_PGLAZYFREED = 44;
+  CGROUP_MEMORY_THP_FAULT_ALLOC = 45;
+  CGROUP_MEMORY_THP_COLLAPSE_ALLOC = 46;
+
+  // Memory limits and usage from memory.current, memory.max, etc.
+  CGROUP_MEMORY_CURRENT = 47;
+  CGROUP_MEMORY_HIGH = 48;
+  CGROUP_MEMORY_MAX = 49;
+  CGROUP_MEMORY_SWAP_CURRENT = 50;
+  CGROUP_MEMORY_SWAP_MAX = 51;
+
+  // IO stats from io.stat (for devices)
+  CGROUP_IO_RBYTES = 52;
+  CGROUP_IO_WBYTES = 53;
+  CGROUP_IO_RIOS = 54;
+  CGROUP_IO_WIOS = 55;
+  CGROUP_IO_DBYTES = 56;
+  CGROUP_IO_DIOS = 57;
+}
+
 // End of protos/perfetto/common/sys_stats_counters.proto
 
 // Begin of protos/perfetto/config/sys_stats/sys_stats_config.proto
@@ -4530,6 +4627,20 @@ message SysStatsConfig {
   // Polls /proc/slabinfo every X ms, if non-zero.
   // This is required to be > 10ms to avoid excessive CPU usage.
   optional uint32 slab_period_ms = 15;
+
+  // Polls cgroup stats every X ms, if non-zero.
+  // This is required to be > 10ms to avoid excessive CPU usage.
+  // Cost: ~0.5ms per cgroup path for file reading and parsing.
+  optional uint32 cgroup_period_ms = 16;
+
+  // Cgroup counters to collect. If empty, all known counters are reported.
+  // Otherwise, only the specified counters are collected to reduce overhead.
+  repeated CgroupCounters cgroup_counters = 17;
+
+  // Cgroup paths to monitor. If empty, monitors common Android cgroups
+  // like top-app, foreground, and background task groups.
+  // Examples: "/sys/fs/cgroup/cpu/top-app", "/sys/fs/cgroup/memory/background"
+  repeated string cgroup_paths = 18;
 }
 
 // End of protos/perfetto/config/sys_stats/sys_stats_config.proto
@@ -16702,6 +16813,20 @@ message SysStats {
     optional uint32 num_slabs = 3;
   }
   repeated SlabInfo slab_info = 18;
+
+  // Counters from cgroup subsystems for tracking task group resource usage.
+  message CgroupValue {
+    // The type of cgroup counter (CPU, memory, or I/O metric).
+    optional CgroupCounters key = 1;
+    // The counter value (usage in bytes, microseconds, or count).
+    optional uint64 value = 2;
+    // The cgroup path this value belongs to (e.g.,
+    // "/sys/fs/cgroup/cpu/top-app").
+    optional string cgroup_path = 3;
+    // For I/O stats, the device identifier (e.g., "8:0" for /dev/sda).
+    optional string device = 4;
+  }
+  repeated CgroupValue cgroup = 19;
 }
 
 // End of protos/perfetto/trace/sys_stats/sys_stats.proto

--- a/protos/perfetto/trace/sys_stats/sys_stats.proto
+++ b/protos/perfetto/trace/sys_stats/sys_stats.proto
@@ -194,17 +194,21 @@ message SysStats {
   }
   repeated SlabInfo slab_info = 18;
 
-  // Counters from cgroup subsystems for tracking task group resource usage.
-  message CgroupValue {
-    // The type of cgroup counter (CPU, memory, or I/O metric).
-    optional CgroupCounters key = 1;
-    // The counter value (usage in bytes, microseconds, or count).
-    optional uint64 value = 2;
-    // The cgroup path this value belongs to (e.g.,
-    // "/sys/fs/cgroup/cpu/top-app").
-    optional string cgroup_path = 3;
-    // For I/O stats, the device identifier (e.g., "8:0" for /dev/sda).
-    optional string device = 4;
+  // Per-cgroup resource counters polled from /sys/fs/cgroup. Works with both
+  // the cgroup v1 (per-controller) and v2 (unified) hierarchies.
+  message Cgroup {
+    // Absolute cgroup path, e.g. "/sys/fs/cgroup/top-app".
+    optional string path = 1;
+    message Counter {
+      // The counter type (a CPU, memory, or IO metric).
+      optional CgroupCounters key = 1;
+      // The counter value in bytes, microseconds, or a raw count. For "max"
+      // limits with no bound set, this is uint64 max.
+      optional uint64 value = 2;
+      // For io.stat counters, the block device, e.g. "8:0".
+      optional string device = 3;
+    }
+    repeated Counter counter = 2;
   }
-  repeated CgroupValue cgroup = 19;
+  repeated Cgroup cgroup = 19;
 }

--- a/protos/perfetto/trace/sys_stats/sys_stats.proto
+++ b/protos/perfetto/trace/sys_stats/sys_stats.proto
@@ -193,4 +193,18 @@ message SysStats {
     optional uint32 num_slabs = 3;
   }
   repeated SlabInfo slab_info = 18;
+
+  // Counters from cgroup subsystems for tracking task group resource usage.
+  message CgroupValue {
+    // The type of cgroup counter (CPU, memory, or I/O metric).
+    optional CgroupCounters key = 1;
+    // The counter value (usage in bytes, microseconds, or count).
+    optional uint64 value = 2;
+    // The cgroup path this value belongs to (e.g.,
+    // "/sys/fs/cgroup/cpu/top-app").
+    optional string cgroup_path = 3;
+    // For I/O stats, the device identifier (e.g., "8:0" for /dev/sda).
+    optional string device = 4;
+  }
+  repeated CgroupValue cgroup = 19;
 }

--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -280,7 +280,8 @@ SystemProbesParser::SystemProbesParser(TraceProcessorContext* context)
       pages_per_slab_id_(context->storage->InternString("pages_per_slab")),
       num_slabs_id_(context->storage->InternString("num_slabs")),
       meminfo_strs_(BuildMeminfoCounterNames()),
-      vmstat_strs_(BuildVmstatCounterNames()) {
+      vmstat_strs_(BuildVmstatCounterNames()),
+      cgroup_strs_(BuildCgroupCounterNames()) {
   for (size_t i = 0; i < base::ArraySize(base::kCpuInfoFeatures); ++i) {
     base::StackString<1024> key("cpu_features.%s", base::kCpuInfoFeatures[i]);
     cpu_features_ids_[i] = context->storage->InternString(key.string_view());
@@ -621,6 +622,50 @@ void SystemProbesParser::ParseSysStats(int64_t ts, ConstBytes blob) {
 
   for (auto it = sys_stats.slab_info(); it; ++it) {
     ParseSlabInfo(ts, *it);
+  }
+
+  for (auto it = sys_stats.cgroup(); it; ++it) {
+    ParseCgroup(ts, *it);
+  }
+}
+
+void SystemProbesParser::ParseCgroup(int64_t ts, ConstBytes blob) {
+  protos::pbzero::SysStats::Cgroup::Decoder cgroup(blob);
+  base::StringView path = cgroup.path();
+
+  static constexpr auto kBlueprint = tracks::CounterBlueprint(
+      "cgroup", tracks::UnknownUnitBlueprint(),
+      tracks::DimensionBlueprints(
+          tracks::StringDimensionBlueprint("cgroup_path"),
+          tracks::StringDimensionBlueprint("cgroup_name"),
+          tracks::StringDimensionBlueprint("cgroup_device")),
+      tracks::FnNameBlueprint([](base::StringView cgroup_path,
+                                 base::StringView name,
+                                 base::StringView device) {
+        if (device.empty()) {
+          return base::StackString<1024>(
+              "cgroup %.*s %.*s", int(cgroup_path.size()), cgroup_path.data(),
+              int(name.size()), name.data());
+        }
+        return base::StackString<1024>(
+            "cgroup %.*s %.*s %.*s", int(cgroup_path.size()),
+            cgroup_path.data(), int(name.size()), name.data(),
+            int(device.size()), device.data());
+      }));
+
+  for (auto it = cgroup.counter(); it; ++it) {
+    protos::pbzero::SysStats::Cgroup::Counter::Decoder counter(*it);
+    auto key = static_cast<size_t>(counter.key());
+    if (PERFETTO_UNLIKELY(key == 0 || key >= cgroup_strs_.size() ||
+                          !cgroup_strs_[key])) {
+      PERFETTO_ELOG("Cgroup counter key %zu is not recognized.", key);
+      continue;
+    }
+    TrackId track = context_->track_tracker->InternTrack(
+        kBlueprint,
+        tracks::Dimensions(path, cgroup_strs_[key], counter.device()));
+    context_->event_tracker->PushCounter(
+        ts, static_cast<double>(counter.value()), track);
   }
 }
 

--- a/src/trace_processor/importers/proto/system_probes_parser.h
+++ b/src/trace_processor/importers/proto/system_probes_parser.h
@@ -53,6 +53,7 @@ class SystemProbesParser {
   void ParseProcessFds(int64_t ts, uint32_t pid, ConstBytes);
   void ParseCpuIdleStats(int64_t ts, ConstBytes);
   void ParseSlabInfo(int64_t ts, ConstBytes);
+  void ParseCgroup(int64_t ts, ConstBytes);
 
   TraceProcessorContext* const context_;
 
@@ -79,6 +80,7 @@ class SystemProbesParser {
 
   std::vector<const char*> meminfo_strs_;
   std::vector<const char*> vmstat_strs_;
+  std::vector<const char*> cgroup_strs_;
 
   uint32_t page_size_ = 0;
 

--- a/src/traced/probes/sys_stats/sys_stats_data_source.cc
+++ b/src/traced/probes/sys_stats/sys_stats_data_source.cc
@@ -88,19 +88,18 @@ SysStatsDataSource::SysStatsDataSource(
       task_runner_(task_runner),
       writer_(std::move(writer)),
       cpu_freq_info_(std::move(cpu_freq_info)),
+      open_fn_(open_fn ? open_fn : OpenReadOnly),
       weak_factory_(this) {
   ns_per_user_hz_ = 1000000000ull / static_cast<uint64_t>(sysconf(_SC_CLK_TCK));
-
-  open_fn = open_fn ? open_fn : OpenReadOnly;
-  meminfo_fd_ = open_fn("/proc/meminfo");
-  vmstat_fd_ = open_fn("/proc/vmstat");
-  stat_fd_ = open_fn("/proc/stat");
-  buddy_fd_ = open_fn("/proc/buddyinfo");
-  diskstat_fd_ = open_fn("/proc/diskstats");
-  psi_cpu_fd_ = open_fn("/proc/pressure/cpu");
-  psi_io_fd_ = open_fn("/proc/pressure/io");
-  psi_memory_fd_ = open_fn("/proc/pressure/memory");
-  slab_fd_ = open_fn("/proc/slabinfo");
+  meminfo_fd_ = open_fn_("/proc/meminfo");
+  vmstat_fd_ = open_fn_("/proc/vmstat");
+  stat_fd_ = open_fn_("/proc/stat");
+  buddy_fd_ = open_fn_("/proc/buddyinfo");
+  diskstat_fd_ = open_fn_("/proc/diskstats");
+  psi_cpu_fd_ = open_fn_("/proc/pressure/cpu");
+  psi_io_fd_ = open_fn_("/proc/pressure/io");
+  psi_memory_fd_ = open_fn_("/proc/pressure/memory");
+  slab_fd_ = open_fn_("/proc/slabinfo");
   read_buf_ = base::PagedMemory::Allocate(kReadBufSize);
 
   // Build a lookup map that allows to quickly translate strings like "MemTotal"
@@ -152,8 +151,8 @@ SysStatsDataSource::SysStatsDataSource(
     stat_enabled_fields_ |= 1ul << static_cast<uint32_t>(*counter);
   }
 
-  std::array<uint32_t, 12> periods_ms{};
-  std::array<uint32_t, 12> ticks{};
+  std::array<uint32_t, 13> periods_ms{};
+  std::array<uint32_t, 13> ticks{};
   static_assert(periods_ms.size() == ticks.size(), "must have same size");
 
   periods_ms[0] =
@@ -179,6 +178,8 @@ SysStatsDataSource::SysStatsDataSource(
       ValidateAndClampPeriod(cfg.gpufreq_period_ms(), "gpufreq_period_ms");
   periods_ms[11] =
       ValidateAndClampPeriod(cfg.slab_period_ms(), "slab_period_ms");
+  periods_ms[12] =
+      ValidateAndClampPeriod(cfg.cgroup_period_ms(), "cgroup_period_ms");
 
   tick_period_ms_ = 0;
   for (uint32_t ms : periods_ms) {
@@ -209,6 +210,46 @@ SysStatsDataSource::SysStatsDataSource(
   cpuidle_ticks_ = ticks[9];
   gpufreq_ticks_ = ticks[10];
   slab_ticks_ = ticks[11];
+  cgroup_ticks_ = ticks[12];
+
+  // Build cgroup counters lookup map for enabled counters
+  constexpr size_t kMaxCgroupEnum = protos::pbzero::CgroupCounters_MAX;
+  std::bitset<kMaxCgroupEnum + 1> cgroup_counters_enabled{};
+  if (!cfg.has_cgroup_counters())
+    cgroup_counters_enabled.set();
+  for (auto it = cfg.cgroup_counters(); it; ++it) {
+    uint32_t counter = static_cast<uint32_t>(*it);
+    if (counter > 0 && counter <= kMaxCgroupEnum) {
+      cgroup_counters_enabled.set(counter);
+    } else {
+      PERFETTO_DFATAL("Cgroup counter out of bounds %u", counter);
+    }
+  }
+  for (size_t i = 0; i < base::ArraySize(kCgroupKeys); i++) {
+    const auto& k = kCgroupKeys[i];
+    if (cgroup_counters_enabled[static_cast<size_t>(k.id)])
+      cgroup_counters_.emplace(k.str, k.id);
+  }
+
+  // Configure cgroup paths to monitor
+  for (auto it = cfg.cgroup_paths(); it; ++it) {
+    cgroup_paths_.emplace_back(reinterpret_cast<const char*>(it->data()),
+                               it->size());
+  }
+
+  // Use default Android cgroup paths if none specified
+  if (cgroup_paths_.empty()) {
+    cgroup_paths_ = {
+        "/sys/fs/cgroup/cpu/top-app",
+        "/sys/fs/cgroup/cpu/foreground",
+        "/sys/fs/cgroup/cpu/background",
+        "/sys/fs/cgroup/cpu/system-background",
+        "/sys/fs/cgroup/memory/top-app",
+        "/sys/fs/cgroup/memory/foreground",
+        "/sys/fs/cgroup/memory/background",
+        "/sys/fs/cgroup/memory/system-background",
+    };
+  }
 }
 
 void SysStatsDataSource::Start() {
@@ -277,6 +318,9 @@ void SysStatsDataSource::ReadSysStats() {
 
   if (slab_ticks_ && tick_ % slab_ticks_ == 0)
     ReadSlabInfo(sys_stats);
+
+  if (cgroup_ticks_ && tick_ % cgroup_ticks_ == 0)
+    ReadCgroup(sys_stats);
 
   sys_stats->set_collection_end_timestamp(
       static_cast<uint64_t>(base::GetBootTimeNs().count()));
@@ -785,6 +829,220 @@ base::WeakPtr<SysStatsDataSource> SysStatsDataSource::GetWeakPtr() const {
 
 void SysStatsDataSource::Flush(FlushRequestID, std::function<void()> callback) {
   writer_->Flush(callback);
+}
+
+void SysStatsDataSource::ReadCgroup(protos::pbzero::SysStats* sys_stats) {
+  for (const auto& cgroup_path : cgroup_paths_) {
+    // Determine which files to read based on cgroup type
+    if (cgroup_path.find("/cpu/") != std::string::npos ||
+        cgroup_path.find("/cpu") == cgroup_path.length() - 4) {
+      ReadCgroupFile(sys_stats, cgroup_path, "cpu.stat", true);
+    }
+
+    if (cgroup_path.find("/memory/") != std::string::npos ||
+        cgroup_path.find("/memory") == cgroup_path.length() - 7) {
+      ReadCgroupFile(sys_stats, cgroup_path, "memory.stat", true);
+      ReadCgroupFile(sys_stats, cgroup_path, "memory.current", false);
+      ReadCgroupFile(sys_stats, cgroup_path, "memory.max", false);
+      ReadCgroupFile(sys_stats, cgroup_path, "memory.swap.current", false);
+      ReadCgroupFile(sys_stats, cgroup_path, "memory.swap.max", false);
+    }
+
+    // IO stats can be in various cgroup types
+    ReadCgroupFile(sys_stats, cgroup_path, "io.stat", false);
+  }
+}
+
+void SysStatsDataSource::ReadCgroupFile(protos::pbzero::SysStats* sys_stats,
+                                        const std::string& cgroup_path,
+                                        const std::string& file_name,
+                                        bool log_errors) {
+  std::string full_path = cgroup_path + "/" + file_name;
+  base::ScopedFile fd = open_fn_(full_path.c_str());
+  if (!fd) {
+    if (log_errors && !cgroup_error_logged_) {
+      PERFETTO_PLOG("Failed to open %s", full_path.c_str());
+      cgroup_error_logged_ = true;
+    }
+    return;
+  }
+
+  size_t rsize = ReadFile(&fd, full_path.c_str());
+  if (!rsize)
+    return;
+
+  char* buf = static_cast<char*>(read_buf_.Get());
+
+  if (file_name == "cpu.stat") {
+    ParseCgroupCpuStat(sys_stats, buf, rsize, cgroup_path);
+  } else if (file_name == "memory.stat") {
+    ParseCgroupMemoryStat(sys_stats, buf, rsize, cgroup_path);
+  } else if (file_name == "memory.current" || file_name == "memory.max" ||
+             file_name == "memory.swap.current" ||
+             file_name == "memory.swap.max") {
+    ParseCgroupSingleValue(sys_stats, buf, file_name, cgroup_path);
+  } else if (file_name == "io.stat") {
+    ParseCgroupIoStat(sys_stats, buf, rsize, cgroup_path);
+  }
+}
+
+void SysStatsDataSource::ParseCgroupCpuStat(protos::pbzero::SysStats* sys_stats,
+                                            char* buf,
+                                            size_t rsize,
+                                            const std::string& cgroup_path) {
+  for (base::StringSplitter lines(buf, rsize, '\n'); lines.Next();) {
+    base::StringSplitter words(&lines, ' ');
+    if (!words.Next())
+      continue;
+
+    auto it = cgroup_counters_.find(words.cur_token());
+    if (it == cgroup_counters_.end())
+      continue;
+
+    int counter_id = it->second;
+    if (!words.Next())
+      continue;
+
+    auto value = static_cast<uint64_t>(strtoll(words.cur_token(), nullptr, 10));
+    auto* cgroup_value = sys_stats->add_cgroup();
+    cgroup_value->set_key(
+        static_cast<protos::pbzero::CgroupCounters>(counter_id));
+    cgroup_value->set_value(value);
+    cgroup_value->set_cgroup_path(cgroup_path);
+  }
+}
+
+void SysStatsDataSource::ParseCgroupMemoryStat(
+    protos::pbzero::SysStats* sys_stats,
+    char* buf,
+    size_t rsize,
+    const std::string& cgroup_path) {
+  for (base::StringSplitter lines(buf, rsize, '\n'); lines.Next();) {
+    base::StringSplitter words(&lines, ' ');
+    if (!words.Next())
+      continue;
+
+    auto it = cgroup_counters_.find(words.cur_token());
+    if (it == cgroup_counters_.end())
+      continue;
+
+    int counter_id = it->second;
+    if (!words.Next())
+      continue;
+
+    auto value = static_cast<uint64_t>(strtoll(words.cur_token(), nullptr, 10));
+    auto* cgroup_value = sys_stats->add_cgroup();
+    cgroup_value->set_key(
+        static_cast<protos::pbzero::CgroupCounters>(counter_id));
+    cgroup_value->set_value(value);
+    cgroup_value->set_cgroup_path(cgroup_path);
+  }
+}
+
+void SysStatsDataSource::ParseCgroupSingleValue(
+    protos::pbzero::SysStats* sys_stats,
+    char* buf,
+    const std::string& file_name,
+    const std::string& cgroup_path) {
+  // Map filename to counter enum
+  protos::pbzero::CgroupCounters counter_enum;
+  int counter_id;
+
+  if (file_name == "memory.current") {
+    counter_enum = protos::pbzero::CgroupCounters::CGROUP_MEMORY_CURRENT;
+    counter_id = static_cast<int>(counter_enum);
+  } else if (file_name == "memory.max") {
+    counter_enum = protos::pbzero::CgroupCounters::CGROUP_MEMORY_MAX;
+    counter_id = static_cast<int>(counter_enum);
+  } else if (file_name == "memory.swap.current") {
+    counter_enum = protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAP_CURRENT;
+    counter_id = static_cast<int>(counter_enum);
+  } else if (file_name == "memory.swap.max") {
+    counter_enum = protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAP_MAX;
+    counter_id = static_cast<int>(counter_enum);
+  } else {
+    return;
+  }
+
+  // Check if this counter is enabled by looking for its ID
+  bool enabled = false;
+  for (const auto& pair : cgroup_counters_) {
+    if (pair.second == counter_id) {
+      enabled = true;
+      break;
+    }
+  }
+
+  if (!enabled)
+    return;
+
+  auto value = static_cast<uint64_t>(strtoll(buf, nullptr, 10));
+  auto* cgroup_value = sys_stats->add_cgroup();
+  cgroup_value->set_key(counter_enum);
+  cgroup_value->set_value(value);
+  cgroup_value->set_cgroup_path(cgroup_path);
+}
+
+void SysStatsDataSource::ParseCgroupIoStat(protos::pbzero::SysStats* sys_stats,
+                                           char* buf,
+                                           size_t rsize,
+                                           const std::string& cgroup_path) {
+  for (base::StringSplitter lines(buf, rsize, '\n'); lines.Next();) {
+    base::StringSplitter words(&lines, ' ');
+    if (!words.Next())
+      continue;
+
+    std::string device = words.cur_token();
+
+    // Parse IO stats: device rbytes=X wbytes=Y rios=Z wios=A dbytes=B dios=C
+    while (words.Next()) {
+      std::string token = words.cur_token();
+      size_t eq_pos = token.find('=');
+      if (eq_pos == std::string::npos)
+        continue;
+
+      std::string key = token.substr(0, eq_pos);
+      std::string value_str = token.substr(eq_pos + 1);
+      uint64_t value =
+          static_cast<uint64_t>(strtoll(value_str.c_str(), nullptr, 10));
+
+      protos::pbzero::CgroupCounters counter_enum;
+      if (key == "rbytes") {
+        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_RBYTES;
+      } else if (key == "wbytes") {
+        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_WBYTES;
+      } else if (key == "rios") {
+        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_RIOS;
+      } else if (key == "wios") {
+        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_WIOS;
+      } else if (key == "dbytes") {
+        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_DBYTES;
+      } else if (key == "dios") {
+        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_DIOS;
+      } else {
+        continue;
+      }
+
+      // Check if this counter is enabled by looking for its ID
+      bool enabled = false;
+      int counter_id = static_cast<int>(counter_enum);
+      for (const auto& pair : cgroup_counters_) {
+        if (pair.second == counter_id) {
+          enabled = true;
+          break;
+        }
+      }
+
+      if (!enabled)
+        continue;
+
+      auto* cgroup_value = sys_stats->add_cgroup();
+      cgroup_value->set_key(counter_enum);
+      cgroup_value->set_value(value);
+      cgroup_value->set_cgroup_path(cgroup_path);
+      cgroup_value->set_device(device);
+    }
+  }
 }
 
 size_t SysStatsDataSource::ReadFile(base::ScopedFile* fd, const char* path) {

--- a/src/traced/probes/sys_stats/sys_stats_data_source.cc
+++ b/src/traced/probes/sys_stats/sys_stats_data_source.cc
@@ -212,43 +212,25 @@ SysStatsDataSource::SysStatsDataSource(
   slab_ticks_ = ticks[11];
   cgroup_ticks_ = ticks[12];
 
-  // Build cgroup counters lookup map for enabled counters
   constexpr size_t kMaxCgroupEnum = protos::pbzero::CgroupCounters_MAX;
-  std::bitset<kMaxCgroupEnum + 1> cgroup_counters_enabled{};
-  if (!cfg.has_cgroup_counters())
-    cgroup_counters_enabled.set();
-  for (auto it = cfg.cgroup_counters(); it; ++it) {
-    uint32_t counter = static_cast<uint32_t>(*it);
-    if (counter > 0 && counter <= kMaxCgroupEnum) {
-      cgroup_counters_enabled.set(counter);
-    } else {
-      PERFETTO_DFATAL("Cgroup counter out of bounds %u", counter);
+  if (!cfg.has_cgroup_counters()) {
+    cgroup_counters_enabled_.set();
+  } else {
+    for (auto it = cfg.cgroup_counters(); it; ++it) {
+      uint32_t counter = static_cast<uint32_t>(*it);
+      if (counter > 0 && counter <= kMaxCgroupEnum) {
+        cgroup_counters_enabled_.set(counter);
+      } else {
+        PERFETTO_DFATAL("Cgroup counter out of bounds %u", counter);
+      }
     }
   }
-  for (size_t i = 0; i < base::ArraySize(kCgroupKeys); i++) {
-    const auto& k = kCgroupKeys[i];
-    if (cgroup_counters_enabled[static_cast<size_t>(k.id)])
-      cgroup_counters_.emplace(k.str, k.id);
-  }
+  for (const auto& k : kCgroupKeys)
+    cgroup_name_to_id_.emplace(k.str, k.id);
 
-  // Configure cgroup paths to monitor
   for (auto it = cfg.cgroup_paths(); it; ++it) {
     cgroup_paths_.emplace_back(reinterpret_cast<const char*>(it->data()),
                                it->size());
-  }
-
-  // Use default Android cgroup paths if none specified
-  if (cgroup_paths_.empty()) {
-    cgroup_paths_ = {
-        "/sys/fs/cgroup/cpu/top-app",
-        "/sys/fs/cgroup/cpu/foreground",
-        "/sys/fs/cgroup/cpu/background",
-        "/sys/fs/cgroup/cpu/system-background",
-        "/sys/fs/cgroup/memory/top-app",
-        "/sys/fs/cgroup/memory/foreground",
-        "/sys/fs/cgroup/memory/background",
-        "/sys/fs/cgroup/memory/system-background",
-    };
   }
 }
 
@@ -831,216 +813,136 @@ void SysStatsDataSource::Flush(FlushRequestID, std::function<void()> callback) {
   writer_->Flush(callback);
 }
 
+namespace {
+// The files probed under each configured cgroup path. Missing files are
+// skipped, so the same list works for both the cgroup v1 (per-controller) and
+// v2 (unified) hierarchies.
+struct CgroupFile {
+  const char* name;
+  enum Kind { kKeyValue, kSingleValue, kIoStat } kind;
+  // Only used for kSingleValue files, whose counter is fixed by the file name.
+  protos::pbzero::CgroupCounters single_value_key;
+};
+constexpr CgroupFile kCgroupFiles[] = {
+    {"cpu.stat", CgroupFile::kKeyValue,
+     protos::pbzero::CgroupCounters::CGROUP_UNSPECIFIED},
+    {"memory.stat", CgroupFile::kKeyValue,
+     protos::pbzero::CgroupCounters::CGROUP_UNSPECIFIED},
+    {"memory.current", CgroupFile::kSingleValue,
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_CURRENT},
+    {"memory.high", CgroupFile::kSingleValue,
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_HIGH},
+    {"memory.max", CgroupFile::kSingleValue,
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_MAX},
+    {"memory.swap.current", CgroupFile::kSingleValue,
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAP_CURRENT},
+    {"memory.swap.max", CgroupFile::kSingleValue,
+     protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAP_MAX},
+    {"io.stat", CgroupFile::kIoStat,
+     protos::pbzero::CgroupCounters::CGROUP_UNSPECIFIED},
+};
+}  // namespace
+
 void SysStatsDataSource::ReadCgroup(protos::pbzero::SysStats* sys_stats) {
-  for (const auto& cgroup_path : cgroup_paths_) {
-    // Determine which files to read based on cgroup type
-    if (cgroup_path.find("/cpu/") != std::string::npos ||
-        cgroup_path.find("/cpu") == cgroup_path.length() - 4) {
-      ReadCgroupFile(sys_stats, cgroup_path, "cpu.stat", true);
+  for (const auto& path : cgroup_paths_) {
+    auto* cgroup = sys_stats->add_cgroup();
+    cgroup->set_path(path);
+    for (const auto& file : kCgroupFiles) {
+      std::string full_path = path + "/" + file.name;
+      base::ScopedFile fd = open_fn_(full_path.c_str());
+      if (!fd)
+        continue;
+      size_t rsize = ReadFile(&fd, full_path.c_str());
+      if (!rsize)
+        continue;
+      char* buf = static_cast<char*>(read_buf_.Get());
+      switch (file.kind) {
+        case CgroupFile::kKeyValue:
+          ParseCgroupKeyValueStat(cgroup, buf, rsize);
+          break;
+        case CgroupFile::kSingleValue:
+          ParseCgroupSingleValue(cgroup, buf, file.single_value_key);
+          break;
+        case CgroupFile::kIoStat:
+          ParseCgroupIoStat(cgroup, buf, rsize);
+          break;
+      }
     }
-
-    if (cgroup_path.find("/memory/") != std::string::npos ||
-        cgroup_path.find("/memory") == cgroup_path.length() - 7) {
-      ReadCgroupFile(sys_stats, cgroup_path, "memory.stat", true);
-      ReadCgroupFile(sys_stats, cgroup_path, "memory.current", false);
-      ReadCgroupFile(sys_stats, cgroup_path, "memory.max", false);
-      ReadCgroupFile(sys_stats, cgroup_path, "memory.swap.current", false);
-      ReadCgroupFile(sys_stats, cgroup_path, "memory.swap.max", false);
-    }
-
-    // IO stats can be in various cgroup types
-    ReadCgroupFile(sys_stats, cgroup_path, "io.stat", false);
   }
 }
 
-void SysStatsDataSource::ReadCgroupFile(protos::pbzero::SysStats* sys_stats,
-                                        const std::string& cgroup_path,
-                                        const std::string& file_name,
-                                        bool log_errors) {
-  std::string full_path = cgroup_path + "/" + file_name;
-  base::ScopedFile fd = open_fn_(full_path.c_str());
-  if (!fd) {
-    if (log_errors && !cgroup_error_logged_) {
-      PERFETTO_PLOG("Failed to open %s", full_path.c_str());
-      cgroup_error_logged_ = true;
-    }
+void SysStatsDataSource::MaybeEmitCgroupCounter(
+    protos::pbzero::SysStats::Cgroup* cgroup,
+    protos::pbzero::CgroupCounters key,
+    uint64_t value,
+    const char* device,
+    size_t device_size) {
+  auto id = static_cast<size_t>(key);
+  if (id >= cgroup_counters_enabled_.size() || !cgroup_counters_enabled_[id])
     return;
-  }
-
-  size_t rsize = ReadFile(&fd, full_path.c_str());
-  if (!rsize)
-    return;
-
-  char* buf = static_cast<char*>(read_buf_.Get());
-
-  if (file_name == "cpu.stat") {
-    ParseCgroupCpuStat(sys_stats, buf, rsize, cgroup_path);
-  } else if (file_name == "memory.stat") {
-    ParseCgroupMemoryStat(sys_stats, buf, rsize, cgroup_path);
-  } else if (file_name == "memory.current" || file_name == "memory.max" ||
-             file_name == "memory.swap.current" ||
-             file_name == "memory.swap.max") {
-    ParseCgroupSingleValue(sys_stats, buf, file_name, cgroup_path);
-  } else if (file_name == "io.stat") {
-    ParseCgroupIoStat(sys_stats, buf, rsize, cgroup_path);
-  }
+  auto* counter = cgroup->add_counter();
+  counter->set_key(key);
+  counter->set_value(value);
+  if (device && device_size)
+    counter->set_device(device, device_size);
 }
 
-void SysStatsDataSource::ParseCgroupCpuStat(protos::pbzero::SysStats* sys_stats,
-                                            char* buf,
-                                            size_t rsize,
-                                            const std::string& cgroup_path) {
-  for (base::StringSplitter lines(buf, rsize, '\n'); lines.Next();) {
-    base::StringSplitter words(&lines, ' ');
-    if (!words.Next())
-      continue;
-
-    auto it = cgroup_counters_.find(words.cur_token());
-    if (it == cgroup_counters_.end())
-      continue;
-
-    int counter_id = it->second;
-    if (!words.Next())
-      continue;
-
-    auto value = static_cast<uint64_t>(strtoll(words.cur_token(), nullptr, 10));
-    auto* cgroup_value = sys_stats->add_cgroup();
-    cgroup_value->set_key(
-        static_cast<protos::pbzero::CgroupCounters>(counter_id));
-    cgroup_value->set_value(value);
-    cgroup_value->set_cgroup_path(cgroup_path);
-  }
-}
-
-void SysStatsDataSource::ParseCgroupMemoryStat(
-    protos::pbzero::SysStats* sys_stats,
+// Parses files whose lines are "key value", e.g. cpu.stat and memory.stat.
+void SysStatsDataSource::ParseCgroupKeyValueStat(
+    protos::pbzero::SysStats::Cgroup* cgroup,
     char* buf,
-    size_t rsize,
-    const std::string& cgroup_path) {
+    size_t rsize) {
   for (base::StringSplitter lines(buf, rsize, '\n'); lines.Next();) {
     base::StringSplitter words(&lines, ' ');
     if (!words.Next())
       continue;
-
-    auto it = cgroup_counters_.find(words.cur_token());
-    if (it == cgroup_counters_.end())
+    auto it = cgroup_name_to_id_.find(words.cur_token());
+    if (it == cgroup_name_to_id_.end())
       continue;
-
-    int counter_id = it->second;
     if (!words.Next())
       continue;
-
-    auto value = static_cast<uint64_t>(strtoll(words.cur_token(), nullptr, 10));
-    auto* cgroup_value = sys_stats->add_cgroup();
-    cgroup_value->set_key(
-        static_cast<protos::pbzero::CgroupCounters>(counter_id));
-    cgroup_value->set_value(value);
-    cgroup_value->set_cgroup_path(cgroup_path);
+    auto value =
+        static_cast<uint64_t>(strtoull(words.cur_token(), nullptr, 10));
+    MaybeEmitCgroupCounter(
+        cgroup, static_cast<protos::pbzero::CgroupCounters>(it->second), value);
   }
 }
 
 void SysStatsDataSource::ParseCgroupSingleValue(
-    protos::pbzero::SysStats* sys_stats,
+    protos::pbzero::SysStats::Cgroup* cgroup,
     char* buf,
-    const std::string& file_name,
-    const std::string& cgroup_path) {
-  // Map filename to counter enum
-  protos::pbzero::CgroupCounters counter_enum;
-  int counter_id;
-
-  if (file_name == "memory.current") {
-    counter_enum = protos::pbzero::CgroupCounters::CGROUP_MEMORY_CURRENT;
-    counter_id = static_cast<int>(counter_enum);
-  } else if (file_name == "memory.max") {
-    counter_enum = protos::pbzero::CgroupCounters::CGROUP_MEMORY_MAX;
-    counter_id = static_cast<int>(counter_enum);
-  } else if (file_name == "memory.swap.current") {
-    counter_enum = protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAP_CURRENT;
-    counter_id = static_cast<int>(counter_enum);
-  } else if (file_name == "memory.swap.max") {
-    counter_enum = protos::pbzero::CgroupCounters::CGROUP_MEMORY_SWAP_MAX;
-    counter_id = static_cast<int>(counter_enum);
-  } else {
-    return;
-  }
-
-  // Check if this counter is enabled by looking for its ID
-  bool enabled = false;
-  for (const auto& pair : cgroup_counters_) {
-    if (pair.second == counter_id) {
-      enabled = true;
-      break;
-    }
-  }
-
-  if (!enabled)
-    return;
-
-  auto value = static_cast<uint64_t>(strtoll(buf, nullptr, 10));
-  auto* cgroup_value = sys_stats->add_cgroup();
-  cgroup_value->set_key(counter_enum);
-  cgroup_value->set_value(value);
-  cgroup_value->set_cgroup_path(cgroup_path);
+    protos::pbzero::CgroupCounters key) {
+  // A literal "max" means the limit is unset; report it as uint64 max.
+  uint64_t value = !strncmp(buf, "max", 3)
+                       ? std::numeric_limits<uint64_t>::max()
+                       : static_cast<uint64_t>(strtoull(buf, nullptr, 10));
+  MaybeEmitCgroupCounter(cgroup, key, value);
 }
 
-void SysStatsDataSource::ParseCgroupIoStat(protos::pbzero::SysStats* sys_stats,
-                                           char* buf,
-                                           size_t rsize,
-                                           const std::string& cgroup_path) {
+// Parses io.stat: "<device> rbytes=X wbytes=Y rios=Z wios=A dbytes=B dios=C".
+void SysStatsDataSource::ParseCgroupIoStat(
+    protos::pbzero::SysStats::Cgroup* cgroup,
+    char* buf,
+    size_t rsize) {
   for (base::StringSplitter lines(buf, rsize, '\n'); lines.Next();) {
     base::StringSplitter words(&lines, ' ');
     if (!words.Next())
       continue;
-
-    std::string device = words.cur_token();
-
-    // Parse IO stats: device rbytes=X wbytes=Y rios=Z wios=A dbytes=B dios=C
+    const char* device = words.cur_token();
+    size_t device_size = words.cur_token_size();
     while (words.Next()) {
-      std::string token = words.cur_token();
-      size_t eq_pos = token.find('=');
-      if (eq_pos == std::string::npos)
+      char* token = words.cur_token();
+      char* eq = strchr(token, '=');
+      if (!eq)
         continue;
-
-      std::string key = token.substr(0, eq_pos);
-      std::string value_str = token.substr(eq_pos + 1);
-      uint64_t value =
-          static_cast<uint64_t>(strtoll(value_str.c_str(), nullptr, 10));
-
-      protos::pbzero::CgroupCounters counter_enum;
-      if (key == "rbytes") {
-        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_RBYTES;
-      } else if (key == "wbytes") {
-        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_WBYTES;
-      } else if (key == "rios") {
-        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_RIOS;
-      } else if (key == "wios") {
-        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_WIOS;
-      } else if (key == "dbytes") {
-        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_DBYTES;
-      } else if (key == "dios") {
-        counter_enum = protos::pbzero::CgroupCounters::CGROUP_IO_DIOS;
-      } else {
+      *eq = '\0';
+      auto it = cgroup_name_to_id_.find(token);
+      if (it == cgroup_name_to_id_.end())
         continue;
-      }
-
-      // Check if this counter is enabled by looking for its ID
-      bool enabled = false;
-      int counter_id = static_cast<int>(counter_enum);
-      for (const auto& pair : cgroup_counters_) {
-        if (pair.second == counter_id) {
-          enabled = true;
-          break;
-        }
-      }
-
-      if (!enabled)
-        continue;
-
-      auto* cgroup_value = sys_stats->add_cgroup();
-      cgroup_value->set_key(counter_enum);
-      cgroup_value->set_value(value);
-      cgroup_value->set_cgroup_path(cgroup_path);
-      cgroup_value->set_device(device);
+      auto value = static_cast<uint64_t>(strtoull(eq + 1, nullptr, 10));
+      MaybeEmitCgroupCounter(
+          cgroup, static_cast<protos::pbzero::CgroupCounters>(it->second),
+          value, device, device_size);
     }
   }
 }

--- a/src/traced/probes/sys_stats/sys_stats_data_source.h
+++ b/src/traced/probes/sys_stats/sys_stats_data_source.h
@@ -104,7 +104,30 @@ class SysStatsDataSource : public ProbesDataSource {
   void ReadCpuIdleStates(protos::pbzero::SysStats* sys_stats);
   void ReadGpuFrequency(protos::pbzero::SysStats* sys_stats);
   void ReadSlabInfo(protos::pbzero::SysStats* sys_stats);
+  void ReadCgroup(protos::pbzero::SysStats* sys_stats);
   std::optional<uint64_t> ReadAMDGpuFreq();
+
+  // Cgroup parsing and processing helper methods
+  void ReadCgroupFile(protos::pbzero::SysStats* sys_stats,
+                      const std::string& cgroup_path,
+                      const std::string& file_name,
+                      bool log_errors);
+  void ParseCgroupCpuStat(protos::pbzero::SysStats* sys_stats,
+                          char* buf,
+                          size_t rsize,
+                          const std::string& cgroup_path);
+  void ParseCgroupMemoryStat(protos::pbzero::SysStats* sys_stats,
+                             char* buf,
+                             size_t rsize,
+                             const std::string& cgroup_path);
+  void ParseCgroupSingleValue(protos::pbzero::SysStats* sys_stats,
+                              char* buf,
+                              const std::string& file_name,
+                              const std::string& cgroup_path);
+  void ParseCgroupIoStat(protos::pbzero::SysStats* sys_stats,
+                         char* buf,
+                         size_t rsize,
+                         const std::string& cgroup_path);
 
   size_t ReadFile(base::ScopedFile*, const char* path);
 
@@ -139,8 +162,15 @@ class SysStatsDataSource : public ProbesDataSource {
   uint32_t cpuidle_ticks_ = 0;
   uint32_t gpufreq_ticks_ = 0;
   uint32_t slab_ticks_ = 0;
+  uint32_t cgroup_ticks_ = 0;
 
   std::unique_ptr<CpuFreqInfo> cpu_freq_info_;
+
+  // Cgroup monitoring state and configuration
+  std::map<const char*, int, CStrCmp> cgroup_counters_;
+  std::vector<std::string> cgroup_paths_;
+  bool cgroup_error_logged_ = false;
+  OpenFunction open_fn_;
 
   base::WeakPtrFactory<SysStatsDataSource> weak_factory_;  // Keep last.
 };

--- a/src/traced/probes/sys_stats/sys_stats_data_source.h
+++ b/src/traced/probes/sys_stats/sys_stats_data_source.h
@@ -19,10 +19,12 @@
 
 #include <string.h>
 
+#include <bitset>
 #include <map>
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "perfetto/ext/base/paged_memory.h"
 #include "perfetto/ext/base/scoped_file.h"
@@ -30,6 +32,7 @@
 #include "perfetto/ext/tracing/core/basic_types.h"
 #include "perfetto/ext/tracing/core/trace_writer.h"
 #include "perfetto/tracing/core/data_source_config.h"
+#include "protos/perfetto/common/sys_stats_counters.pbzero.h"
 #include "protos/perfetto/trace/sys_stats/sys_stats.pbzero.h"
 #include "src/traced/probes/common/cpu_freq_info.h"
 #include "src/traced/probes/probes_data_source.h"
@@ -107,27 +110,20 @@ class SysStatsDataSource : public ProbesDataSource {
   void ReadCgroup(protos::pbzero::SysStats* sys_stats);
   std::optional<uint64_t> ReadAMDGpuFreq();
 
-  // Cgroup parsing and processing helper methods
-  void ReadCgroupFile(protos::pbzero::SysStats* sys_stats,
-                      const std::string& cgroup_path,
-                      const std::string& file_name,
-                      bool log_errors);
-  void ParseCgroupCpuStat(protos::pbzero::SysStats* sys_stats,
-                          char* buf,
-                          size_t rsize,
-                          const std::string& cgroup_path);
-  void ParseCgroupMemoryStat(protos::pbzero::SysStats* sys_stats,
-                             char* buf,
-                             size_t rsize,
-                             const std::string& cgroup_path);
-  void ParseCgroupSingleValue(protos::pbzero::SysStats* sys_stats,
+  void ParseCgroupKeyValueStat(protos::pbzero::SysStats::Cgroup* cgroup,
+                               char* buf,
+                               size_t rsize);
+  void ParseCgroupSingleValue(protos::pbzero::SysStats::Cgroup* cgroup,
                               char* buf,
-                              const std::string& file_name,
-                              const std::string& cgroup_path);
-  void ParseCgroupIoStat(protos::pbzero::SysStats* sys_stats,
+                              protos::pbzero::CgroupCounters key);
+  void ParseCgroupIoStat(protos::pbzero::SysStats::Cgroup* cgroup,
                          char* buf,
-                         size_t rsize,
-                         const std::string& cgroup_path);
+                         size_t rsize);
+  void MaybeEmitCgroupCounter(protos::pbzero::SysStats::Cgroup* cgroup,
+                              protos::pbzero::CgroupCounters key,
+                              uint64_t value,
+                              const char* device = nullptr,
+                              size_t device_size = 0);
 
   size_t ReadFile(base::ScopedFile*, const char* path);
 
@@ -166,10 +162,9 @@ class SysStatsDataSource : public ProbesDataSource {
 
   std::unique_ptr<CpuFreqInfo> cpu_freq_info_;
 
-  // Cgroup monitoring state and configuration
-  std::map<const char*, int, CStrCmp> cgroup_counters_;
+  std::map<const char*, int, CStrCmp> cgroup_name_to_id_;
+  std::bitset<protos::pbzero::CgroupCounters_MAX + 1> cgroup_counters_enabled_;
   std::vector<std::string> cgroup_paths_;
-  bool cgroup_error_logged_ = false;
   OpenFunction open_fn_;
 
   base::WeakPtrFactory<SysStatsDataSource> weak_factory_;  // Keep last.

--- a/src/traced/probes/sys_stats/sys_stats_data_source_unittest.cc
+++ b/src/traced/probes/sys_stats/sys_stats_data_source_unittest.cc
@@ -228,6 +228,61 @@ const char kMockAMDGpuFreq[] = R"(
 1: 400Mhz *
 2: 2000Mhz 
 )";
+
+const char kMockCgroupCpuStat[] = R"(usage_usec 123456789
+user_usec 87654321
+system_usec 35802468
+nr_periods 1000
+nr_throttled 50
+throttled_usec 123456)";
+
+const char kMockCgroupMemoryStat[] = R"(anon 1048576
+file 2097152
+kernel_stack 32768
+pagetables 65536
+percpu 16384
+sock 8192
+shmem 524288
+file_mapped 1572864
+file_dirty 131072
+file_writeback 65536
+swapcached 0
+anon_thp 0
+file_thp 0
+shmem_thp 0
+inactive_anon 524288
+active_anon 524288
+inactive_file 1048576
+active_file 1048576
+unevictable 0
+slab_reclaimable 262144
+slab_unreclaimable 131072
+slab 393216
+workingset_refault_anon 0
+workingset_refault_file 100
+workingset_activate_anon 0
+workingset_activate_file 50
+workingset_restore_anon 0
+workingset_restore_file 25
+workingset_nodereclaim 0
+pgfault 10000
+pgmajfault 100
+pgrefill 500
+pgscan 1000
+pgsteal 750
+pgactivate 250
+pgdeactivate 200
+pglazyfree 10
+pglazyfreed 5
+thp_fault_alloc 0
+thp_collapse_alloc 0)";
+
+const char kMockCgroupMemoryCurrent[] = "104857600";
+const char kMockCgroupMemoryMax[] = "268435456";
+
+const char kMockCgroupIoStat[] = R"(8:0 rbytes=1048576 wbytes=524288 rios=100 wios=50 dbytes=0 dios=0
+8:16 rbytes=2097152 wbytes=1048576 rios=200 wios=100 dbytes=0 dios=0)";
+
 // clang-format on
 class TestSysStatsDataSource : public SysStatsDataSource {
  public:
@@ -281,6 +336,33 @@ base::ScopedFile MockOpenReadOnly(const char* path) {
     EXPECT_GT(pwrite(tmp_.fd(), kMockPsi, strlen(kMockPsi), 0), 0);
   } else if (!strcmp(path, "/proc/slabinfo")) {
     EXPECT_GT(pwrite(tmp_.fd(), kMockSlabinfo, strlen(kMockSlabinfo), 0), 0);
+  } else if (!strcmp(path, "/sys/fs/cgroup/cpu/top-app/cpu.stat")) {
+    EXPECT_GT(
+        pwrite(tmp_.fd(), kMockCgroupCpuStat, strlen(kMockCgroupCpuStat), 0),
+        0);
+  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/memory.stat")) {
+    EXPECT_GT(pwrite(tmp_.fd(), kMockCgroupMemoryStat,
+                     strlen(kMockCgroupMemoryStat), 0),
+              0);
+  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/memory.current")) {
+    EXPECT_GT(pwrite(tmp_.fd(), kMockCgroupMemoryCurrent,
+                     strlen(kMockCgroupMemoryCurrent), 0),
+              0);
+  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/memory.max")) {
+    EXPECT_GT(pwrite(tmp_.fd(), kMockCgroupMemoryMax,
+                     strlen(kMockCgroupMemoryMax), 0),
+              0);
+  } else if (!strcmp(path, "/sys/fs/cgroup/cpu/top-app/io.stat")) {
+    EXPECT_GT(
+        pwrite(tmp_.fd(), kMockCgroupIoStat, strlen(kMockCgroupIoStat), 0), 0);
+  } else if (!strcmp(path,
+                     "/sys/fs/cgroup/memory/top-app/memory.swap.current")) {
+    EXPECT_GT(pwrite(tmp_.fd(), "0", 1, 0), 0);
+  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/memory.swap.max")) {
+    EXPECT_GT(pwrite(tmp_.fd(), "max", 3, 0), 0);
+  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/io.stat")) {
+    EXPECT_GT(
+        pwrite(tmp_.fd(), kMockCgroupIoStat, strlen(kMockCgroupIoStat), 0), 0);
   } else {
     PERFETTO_FATAL("Unexpected file opened %s", path);
   }
@@ -958,6 +1040,72 @@ TEST_F(SysStatsDataSourceTest, Slabinfo) {
   EXPECT_EQ(sys_stats.slab_info()[1].name(), "kmalloc-64");
   EXPECT_EQ(sys_stats.slab_info()[1].pages_per_slab(), 1u);
   EXPECT_EQ(sys_stats.slab_info()[1].num_slabs(), 2u);
+}
+
+TEST_F(SysStatsDataSourceTest, CgroupStatsWork) {
+  protos::gen::DataSourceConfig cfg;
+  protos::gen::SysStatsConfig sys_cfg;
+  sys_cfg.set_cgroup_period_ms(1);
+  sys_cfg.add_cgroup_paths("/sys/fs/cgroup/cpu/top-app");
+  sys_cfg.add_cgroup_paths("/sys/fs/cgroup/memory/top-app");
+
+  // Add basic cgroup counters to monitor
+  sys_cfg.add_cgroup_counters(
+      protos::gen::CgroupCounters::CGROUP_CPU_USAGE_USEC);
+  sys_cfg.add_cgroup_counters(
+      protos::gen::CgroupCounters::CGROUP_CPU_USER_USEC);
+  sys_cfg.add_cgroup_counters(protos::gen::CgroupCounters::CGROUP_MEMORY_ANON);
+  sys_cfg.add_cgroup_counters(protos::gen::CgroupCounters::CGROUP_MEMORY_FILE);
+
+  cfg.set_sys_stats_config_raw(sys_cfg.SerializeAsString());
+
+  auto data_source = GetSysStatsDataSource(cfg);
+  WaitTick(data_source.get());
+
+  protos::gen::TracePacket packet = writer_raw_->GetOnlyTracePacket();
+  ASSERT_TRUE(packet.has_sys_stats());
+
+  const auto& sys_stats = packet.sys_stats();
+  ASSERT_GT(sys_stats.cgroup_size(), 0);
+
+  // Check basic cgroup stats
+  bool found_cpu_usage = false;
+  bool found_cpu_user = false;
+  bool found_memory_anon = false;
+  bool found_memory_file = false;
+
+  for (const auto& cgroup_value : sys_stats.cgroup()) {
+    EXPECT_TRUE(cgroup_value.has_cgroup_path());
+
+    // Check each cgroup counter type
+
+    if (cgroup_value.key() ==
+        protos::gen::CgroupCounters::CGROUP_CPU_USAGE_USEC) {
+      EXPECT_EQ(cgroup_value.value(), 123456789UL);
+      EXPECT_TRUE(
+          base::StartsWith(cgroup_value.cgroup_path(), "/sys/fs/cgroup/cpu/"));
+      found_cpu_usage = true;
+    } else if (cgroup_value.key() ==
+               protos::gen::CgroupCounters::CGROUP_CPU_USER_USEC) {
+      EXPECT_EQ(cgroup_value.value(), 87654321UL);
+      found_cpu_user = true;
+    } else if (cgroup_value.key() ==
+               protos::gen::CgroupCounters::CGROUP_MEMORY_ANON) {
+      EXPECT_EQ(cgroup_value.value(), 1048576UL);
+      EXPECT_TRUE(base::StartsWith(cgroup_value.cgroup_path(),
+                                   "/sys/fs/cgroup/memory/"));
+      found_memory_anon = true;
+    } else if (cgroup_value.key() ==
+               protos::gen::CgroupCounters::CGROUP_MEMORY_FILE) {
+      EXPECT_EQ(cgroup_value.value(), 2097152UL);
+      found_memory_file = true;
+    }
+  }
+
+  EXPECT_TRUE(found_cpu_usage);
+  EXPECT_TRUE(found_cpu_user);
+  EXPECT_TRUE(found_memory_anon);
+  EXPECT_TRUE(found_memory_file);
 }
 
 }  // namespace

--- a/src/traced/probes/sys_stats/sys_stats_data_source_unittest.cc
+++ b/src/traced/probes/sys_stats/sys_stats_data_source_unittest.cc
@@ -17,6 +17,8 @@
 #include <unistd.h>
 
 #include <limits>
+#include <map>
+#include <utility>
 
 #include "perfetto/base/compiler.h"
 #include "perfetto/ext/base/file_utils.h"
@@ -336,33 +338,32 @@ base::ScopedFile MockOpenReadOnly(const char* path) {
     EXPECT_GT(pwrite(tmp_.fd(), kMockPsi, strlen(kMockPsi), 0), 0);
   } else if (!strcmp(path, "/proc/slabinfo")) {
     EXPECT_GT(pwrite(tmp_.fd(), kMockSlabinfo, strlen(kMockSlabinfo), 0), 0);
-  } else if (!strcmp(path, "/sys/fs/cgroup/cpu/top-app/cpu.stat")) {
+  } else if (!strcmp(path, "/sys/fs/cgroup/top-app/cpu.stat")) {
     EXPECT_GT(
         pwrite(tmp_.fd(), kMockCgroupCpuStat, strlen(kMockCgroupCpuStat), 0),
         0);
-  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/memory.stat")) {
+  } else if (!strcmp(path, "/sys/fs/cgroup/top-app/memory.stat")) {
     EXPECT_GT(pwrite(tmp_.fd(), kMockCgroupMemoryStat,
                      strlen(kMockCgroupMemoryStat), 0),
               0);
-  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/memory.current")) {
+  } else if (!strcmp(path, "/sys/fs/cgroup/top-app/memory.current")) {
     EXPECT_GT(pwrite(tmp_.fd(), kMockCgroupMemoryCurrent,
                      strlen(kMockCgroupMemoryCurrent), 0),
               0);
-  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/memory.max")) {
+  } else if (!strcmp(path, "/sys/fs/cgroup/top-app/memory.max")) {
     EXPECT_GT(pwrite(tmp_.fd(), kMockCgroupMemoryMax,
                      strlen(kMockCgroupMemoryMax), 0),
               0);
-  } else if (!strcmp(path, "/sys/fs/cgroup/cpu/top-app/io.stat")) {
-    EXPECT_GT(
-        pwrite(tmp_.fd(), kMockCgroupIoStat, strlen(kMockCgroupIoStat), 0), 0);
-  } else if (!strcmp(path,
-                     "/sys/fs/cgroup/memory/top-app/memory.swap.current")) {
+  } else if (!strcmp(path, "/sys/fs/cgroup/top-app/memory.swap.current")) {
     EXPECT_GT(pwrite(tmp_.fd(), "0", 1, 0), 0);
-  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/memory.swap.max")) {
+  } else if (!strcmp(path, "/sys/fs/cgroup/top-app/memory.swap.max")) {
     EXPECT_GT(pwrite(tmp_.fd(), "max", 3, 0), 0);
-  } else if (!strcmp(path, "/sys/fs/cgroup/memory/top-app/io.stat")) {
+  } else if (!strcmp(path, "/sys/fs/cgroup/top-app/io.stat")) {
     EXPECT_GT(
         pwrite(tmp_.fd(), kMockCgroupIoStat, strlen(kMockCgroupIoStat), 0), 0);
+  } else if (base::StartsWith(path, "/sys/fs/cgroup/")) {
+    // Any other cgroup file (e.g. memory.high) is treated as absent.
+    return base::ScopedFile();
   } else {
     PERFETTO_FATAL("Unexpected file opened %s", path);
   }
@@ -1042,21 +1043,24 @@ TEST_F(SysStatsDataSourceTest, Slabinfo) {
   EXPECT_EQ(sys_stats.slab_info()[1].num_slabs(), 2u);
 }
 
+// Collects all cgroup counters from the single Cgroup entry into a map keyed
+// by (counter key, device).
+std::map<std::pair<int, std::string>, uint64_t> CollectCgroupCounters(
+    const protos::gen::SysStats::Cgroup& cgroup) {
+  std::map<std::pair<int, std::string>, uint64_t> values;
+  for (const auto& c : cgroup.counter())
+    values[{static_cast<int>(c.key()), c.device()}] = c.value();
+  return values;
+}
+
 TEST_F(SysStatsDataSourceTest, CgroupStatsWork) {
-  protos::gen::DataSourceConfig cfg;
+  using C = protos::gen::CgroupCounters;
+  DataSourceConfig cfg;
   protos::gen::SysStatsConfig sys_cfg;
-  sys_cfg.set_cgroup_period_ms(1);
-  sys_cfg.add_cgroup_paths("/sys/fs/cgroup/cpu/top-app");
-  sys_cfg.add_cgroup_paths("/sys/fs/cgroup/memory/top-app");
-
-  // Add basic cgroup counters to monitor
-  sys_cfg.add_cgroup_counters(
-      protos::gen::CgroupCounters::CGROUP_CPU_USAGE_USEC);
-  sys_cfg.add_cgroup_counters(
-      protos::gen::CgroupCounters::CGROUP_CPU_USER_USEC);
-  sys_cfg.add_cgroup_counters(protos::gen::CgroupCounters::CGROUP_MEMORY_ANON);
-  sys_cfg.add_cgroup_counters(protos::gen::CgroupCounters::CGROUP_MEMORY_FILE);
-
+  sys_cfg.set_cgroup_period_ms(10);
+  // A cgroup v2 unified path: cpu.stat, memory.stat and io.stat all live in the
+  // same directory.
+  sys_cfg.add_cgroup_paths("/sys/fs/cgroup/top-app");
   cfg.set_sys_stats_config_raw(sys_cfg.SerializeAsString());
 
   auto data_source = GetSysStatsDataSource(cfg);
@@ -1064,48 +1068,77 @@ TEST_F(SysStatsDataSourceTest, CgroupStatsWork) {
 
   protos::gen::TracePacket packet = writer_raw_->GetOnlyTracePacket();
   ASSERT_TRUE(packet.has_sys_stats());
-
   const auto& sys_stats = packet.sys_stats();
-  ASSERT_GT(sys_stats.cgroup_size(), 0);
+  ASSERT_EQ(sys_stats.cgroup_size(), 1);
+  const auto& cgroup = sys_stats.cgroup()[0];
+  EXPECT_EQ(cgroup.path(), "/sys/fs/cgroup/top-app");
 
-  // Check basic cgroup stats
-  bool found_cpu_usage = false;
-  bool found_cpu_user = false;
-  bool found_memory_anon = false;
-  bool found_memory_file = false;
+  auto values = CollectCgroupCounters(cgroup);
+  auto get = [&](C key, const char* dev) -> uint64_t {
+    auto it = values.find({static_cast<int>(key), dev});
+    return it == values.end() ? 0u : it->second;
+  };
+  auto has = [&](C key, const char* dev) {
+    return values.count({static_cast<int>(key), dev}) > 0;
+  };
 
-  for (const auto& cgroup_value : sys_stats.cgroup()) {
-    EXPECT_TRUE(cgroup_value.has_cgroup_path());
+  // cpu.stat
+  EXPECT_EQ(get(C::CGROUP_CPU_USAGE_USEC, ""), 123456789u);
+  EXPECT_EQ(get(C::CGROUP_CPU_USER_USEC, ""), 87654321u);
+  EXPECT_EQ(get(C::CGROUP_CPU_THROTTLED_USEC, ""), 123456u);
+  // memory.stat, including a transparent-huge-page counter (THP name fix).
+  EXPECT_EQ(get(C::CGROUP_MEMORY_ANON, ""), 1048576u);
+  EXPECT_EQ(get(C::CGROUP_MEMORY_FILE, ""), 2097152u);
+  EXPECT_TRUE(has(C::CGROUP_MEMORY_ANON_THP, ""));
+  // Single-value memory files (previously never emitted).
+  EXPECT_EQ(get(C::CGROUP_MEMORY_CURRENT, ""), 104857600u);
+  EXPECT_EQ(get(C::CGROUP_MEMORY_MAX, ""), 268435456u);
+  EXPECT_TRUE(has(C::CGROUP_MEMORY_SWAP_CURRENT, ""));
+  // A literal "max" limit maps to uint64 max.
+  EXPECT_EQ(get(C::CGROUP_MEMORY_SWAP_MAX, ""),
+            std::numeric_limits<uint64_t>::max());
+  // memory.high is absent in the mock, so it is not emitted.
+  EXPECT_FALSE(has(C::CGROUP_MEMORY_HIGH, ""));
+  // io.stat, per block device (previously never emitted).
+  EXPECT_EQ(get(C::CGROUP_IO_RBYTES, "8:0"), 1048576u);
+  EXPECT_EQ(get(C::CGROUP_IO_WBYTES, "8:0"), 524288u);
+  EXPECT_EQ(get(C::CGROUP_IO_RBYTES, "8:16"), 2097152u);
+  EXPECT_TRUE(has(C::CGROUP_IO_DIOS, "8:16"));
+}
 
-    // Check each cgroup counter type
+TEST_F(SysStatsDataSourceTest, CgroupStatsRespectCounterFilter) {
+  using C = protos::gen::CgroupCounters;
+  DataSourceConfig cfg;
+  protos::gen::SysStatsConfig sys_cfg;
+  sys_cfg.set_cgroup_period_ms(10);
+  sys_cfg.add_cgroup_paths("/sys/fs/cgroup/top-app");
+  // Only two counters requested: one key-value stat and one io.stat field.
+  sys_cfg.add_cgroup_counters(C::CGROUP_CPU_USAGE_USEC);
+  sys_cfg.add_cgroup_counters(C::CGROUP_IO_RBYTES);
+  cfg.set_sys_stats_config_raw(sys_cfg.SerializeAsString());
 
-    if (cgroup_value.key() ==
-        protos::gen::CgroupCounters::CGROUP_CPU_USAGE_USEC) {
-      EXPECT_EQ(cgroup_value.value(), 123456789UL);
-      EXPECT_TRUE(
-          base::StartsWith(cgroup_value.cgroup_path(), "/sys/fs/cgroup/cpu/"));
-      found_cpu_usage = true;
-    } else if (cgroup_value.key() ==
-               protos::gen::CgroupCounters::CGROUP_CPU_USER_USEC) {
-      EXPECT_EQ(cgroup_value.value(), 87654321UL);
-      found_cpu_user = true;
-    } else if (cgroup_value.key() ==
-               protos::gen::CgroupCounters::CGROUP_MEMORY_ANON) {
-      EXPECT_EQ(cgroup_value.value(), 1048576UL);
-      EXPECT_TRUE(base::StartsWith(cgroup_value.cgroup_path(),
-                                   "/sys/fs/cgroup/memory/"));
-      found_memory_anon = true;
-    } else if (cgroup_value.key() ==
-               protos::gen::CgroupCounters::CGROUP_MEMORY_FILE) {
-      EXPECT_EQ(cgroup_value.value(), 2097152UL);
-      found_memory_file = true;
-    }
-  }
+  auto data_source = GetSysStatsDataSource(cfg);
+  WaitTick(data_source.get());
 
-  EXPECT_TRUE(found_cpu_usage);
-  EXPECT_TRUE(found_cpu_user);
-  EXPECT_TRUE(found_memory_anon);
-  EXPECT_TRUE(found_memory_file);
+  protos::gen::TracePacket packet = writer_raw_->GetOnlyTracePacket();
+  ASSERT_TRUE(packet.has_sys_stats());
+  ASSERT_EQ(packet.sys_stats().cgroup_size(), 1);
+  auto values = CollectCgroupCounters(packet.sys_stats().cgroup()[0]);
+  auto get = [&](C key, const char* dev) -> uint64_t {
+    auto it = values.find({static_cast<int>(key), dev});
+    return it == values.end() ? 0u : it->second;
+  };
+  auto has = [&](C key, const char* dev) {
+    return values.count({static_cast<int>(key), dev}) > 0;
+  };
+
+  // Only the two requested counters are present (io.rbytes for both devices).
+  EXPECT_EQ(get(C::CGROUP_CPU_USAGE_USEC, ""), 123456789u);
+  EXPECT_EQ(get(C::CGROUP_IO_RBYTES, "8:0"), 1048576u);
+  EXPECT_EQ(get(C::CGROUP_IO_RBYTES, "8:16"), 2097152u);
+  EXPECT_FALSE(has(C::CGROUP_CPU_USER_USEC, ""));
+  EXPECT_FALSE(has(C::CGROUP_MEMORY_ANON, ""));
+  EXPECT_FALSE(has(C::CGROUP_IO_WBYTES, "8:0"));
 }
 
 }  // namespace

--- a/test/configs/cgroup_stats.cfg
+++ b/test/configs/cgroup_stats.cfg
@@ -1,0 +1,46 @@
+data_sources: {
+    config {
+        name: "linux.sys_stats"
+        sys_stats_config {
+            # Cgroup polling period - collect cgroup stats every 100ms
+            cgroup_period_ms: 100
+            
+            # Monitor specific Android cgroup paths for foreground/background apps
+            cgroup_paths: "/sys/fs/cgroup/cpu/top-app"
+            cgroup_paths: "/sys/fs/cgroup/cpu/foreground"
+            cgroup_paths: "/sys/fs/cgroup/cpu/background"
+            cgroup_paths: "/sys/fs/cgroup/memory/top-app"
+            cgroup_paths: "/sys/fs/cgroup/memory/foreground"
+            cgroup_paths: "/sys/fs/cgroup/memory/background"
+            
+            # CPU usage and scheduling metrics
+            cgroup_counters: CGROUP_CPU_USAGE_USEC
+            cgroup_counters: CGROUP_CPU_USER_USEC
+            cgroup_counters: CGROUP_CPU_SYSTEM_USEC
+            cgroup_counters: CGROUP_CPU_NR_PERIODS
+            cgroup_counters: CGROUP_CPU_NR_THROTTLED
+            cgroup_counters: CGROUP_CPU_THROTTLED_USEC
+            
+            # Memory usage and allocation metrics
+            cgroup_counters: CGROUP_MEMORY_ANON
+            cgroup_counters: CGROUP_MEMORY_FILE
+            cgroup_counters: CGROUP_MEMORY_CURRENT
+            cgroup_counters: CGROUP_MEMORY_MAX
+            cgroup_counters: CGROUP_MEMORY_ACTIVE_ANON
+            cgroup_counters: CGROUP_MEMORY_INACTIVE_ANON
+            cgroup_counters: CGROUP_MEMORY_ACTIVE_FILE
+            cgroup_counters: CGROUP_MEMORY_INACTIVE_FILE
+            cgroup_counters: CGROUP_MEMORY_PGFAULT
+            cgroup_counters: CGROUP_MEMORY_PGMAJFAULT
+            
+            # Disk I/O activity metrics
+            cgroup_counters: CGROUP_IO_RBYTES
+            cgroup_counters: CGROUP_IO_WBYTES
+            cgroup_counters: CGROUP_IO_RIOS
+            cgroup_counters: CGROUP_IO_WIOS
+        }
+    }
+}
+
+# Trace duration: 10 seconds
+duration_ms: 10000

--- a/test/configs/cgroup_stats.cfg
+++ b/test/configs/cgroup_stats.cfg
@@ -2,26 +2,25 @@ data_sources: {
     config {
         name: "linux.sys_stats"
         sys_stats_config {
-            # Cgroup polling period - collect cgroup stats every 100ms
+            # Collect cgroup stats every 100ms.
             cgroup_period_ms: 100
-            
-            # Monitor specific Android cgroup paths for foreground/background apps
-            cgroup_paths: "/sys/fs/cgroup/cpu/top-app"
-            cgroup_paths: "/sys/fs/cgroup/cpu/foreground"
-            cgroup_paths: "/sys/fs/cgroup/cpu/background"
-            cgroup_paths: "/sys/fs/cgroup/memory/top-app"
-            cgroup_paths: "/sys/fs/cgroup/memory/foreground"
-            cgroup_paths: "/sys/fs/cgroup/memory/background"
-            
-            # CPU usage and scheduling metrics
+
+            # Cgroups to monitor. These are cgroup v2 unified-hierarchy paths;
+            # on a cgroup v1 system use the per-controller paths instead, e.g.
+            # "/sys/fs/cgroup/cpu/top-app" and "/sys/fs/cgroup/memory/top-app".
+            cgroup_paths: "/sys/fs/cgroup/top-app"
+            cgroup_paths: "/sys/fs/cgroup/foreground"
+            cgroup_paths: "/sys/fs/cgroup/background"
+
+            # CPU usage and scheduling metrics.
             cgroup_counters: CGROUP_CPU_USAGE_USEC
             cgroup_counters: CGROUP_CPU_USER_USEC
             cgroup_counters: CGROUP_CPU_SYSTEM_USEC
             cgroup_counters: CGROUP_CPU_NR_PERIODS
             cgroup_counters: CGROUP_CPU_NR_THROTTLED
             cgroup_counters: CGROUP_CPU_THROTTLED_USEC
-            
-            # Memory usage and allocation metrics
+
+            # Memory usage and allocation metrics.
             cgroup_counters: CGROUP_MEMORY_ANON
             cgroup_counters: CGROUP_MEMORY_FILE
             cgroup_counters: CGROUP_MEMORY_CURRENT
@@ -32,8 +31,8 @@ data_sources: {
             cgroup_counters: CGROUP_MEMORY_INACTIVE_FILE
             cgroup_counters: CGROUP_MEMORY_PGFAULT
             cgroup_counters: CGROUP_MEMORY_PGMAJFAULT
-            
-            # Disk I/O activity metrics
+
+            # Disk I/O activity metrics.
             cgroup_counters: CGROUP_IO_RBYTES
             cgroup_counters: CGROUP_IO_WBYTES
             cgroup_counters: CGROUP_IO_RIOS

--- a/test/trace_processor/diff_tests/parser/parsing/tests_sys_stats.py
+++ b/test/trace_processor/diff_tests/parser/parsing/tests_sys_stats.py
@@ -66,6 +66,51 @@ class ParsingSysStats(TestSuite):
         71626000387166,"C8",486636254.000000,0
         """))
 
+  def test_cgroup(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          sys_stats {
+            cgroup {
+              path: "/sys/fs/cgroup/top-app"
+              counter { key: CGROUP_CPU_USAGE_USEC value: 123456789 }
+              counter { key: CGROUP_MEMORY_ANON value: 1048576 }
+              counter { key: CGROUP_IO_RBYTES value: 4096 device: "8:0" }
+            }
+          }
+          timestamp: 100
+          trusted_packet_sequence_id: 2
+        }
+        packet {
+          sys_stats {
+            cgroup {
+              path: "/sys/fs/cgroup/top-app"
+              counter { key: CGROUP_CPU_USAGE_USEC value: 223456789 }
+            }
+          }
+          timestamp: 200
+          trusted_packet_sequence_id: 2
+        }
+        """),
+        query="""
+        SELECT
+          ts,
+          EXTRACT_ARG(t.dimension_arg_set_id, 'cgroup_path') AS path,
+          EXTRACT_ARG(t.dimension_arg_set_id, 'cgroup_name') AS name,
+          EXTRACT_ARG(t.dimension_arg_set_id, 'cgroup_device') AS device,
+          value
+        FROM counter c
+        JOIN track t ON c.track_id = t.id
+        ORDER BY ts, name, device;
+        """,
+        out=Csv("""
+        "ts","path","name","device","value"
+        100,"/sys/fs/cgroup/top-app","anon","[NULL]",1048576.000000
+        100,"/sys/fs/cgroup/top-app","rbytes","8:0",4096.000000
+        100,"/sys/fs/cgroup/top-app","usage_usec","[NULL]",123456789.000000
+        200,"/sys/fs/cgroup/top-app","usage_usec","[NULL]",223456789.000000
+        """))
+
   def test_thermal_zones(self):
     return DiffTestBlueprint(
         trace=TextProto(r"""


### PR DESCRIPTION
Adds per-cgroup resource counters to the `linux.sys_stats` data source and
wires them through trace_processor.

This is a rebased and fixed version of #3061 by @lvy010. The original
authorship is preserved: the first commit is @lvy010's, the second commit
contains the correctness fixes and trace_processor integration.

The original PR was producer-only and had a few correctness gaps that are
fixed here:

- **Emit all counters.** `memory.current/high/max`, swap, and every
  `io.stat` counter were unreachable because their enum ids were missing
  from the name table and enablement was checked against it. Enablement now
  uses a bitset over all `CgroupCounters`.
- **cgroup v2 support.** File selection no longer keys off `/cpu/` or
  `/memory/` path segments, which do not exist in the v2 unified hierarchy.
  Each path probes a fixed file list and skips absent files, so one config
  works on both v1 and v2. The hardcoded v1-only default paths were removed;
  `cgroup_paths` must be set explicitly.
- **`memory.max` = `max`** is reported as uint64 max (unlimited) instead of 0.
- **trace_processor ingestion** of `SysStats.cgroup`, previously absent, so
  the data is now queryable. Covered by a diff test.
- Grouped counters under one `Cgroup` message instead of repeating the path
  per value; collapsed the duplicate stat parsers; parse `io.stat` without
  per-token allocation; renamed `CGROUP_MEMORY_*_THPS` to `*_THP` to match
  the kernel field names; wired the doc into `docs/toc.md`.
