### PR TITLE
gn: Disable Zstd when building with Chromium

### DIFF
--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -393,7 +393,8 @@ declare_args() {
   # service) and to decompress traces (by trace_processor), as an alternative
   # to Zlib/deflate.
   enable_perfetto_zstd =
-      enable_perfetto_trace_processor || enable_perfetto_platform_services
+      !build_with_chromium &&
+      (enable_perfetto_trace_processor || enable_perfetto_platform_services)
 
   # Enables PCRE2 support. Individual modules that should not pull libpcre2
   # in (e.g. libperfetto_client_experimental) can opt out by setting


### PR DESCRIPTION
Disables enable_perfetto_zstd when build_with_chromium is true to unblock auto-roller.