### PR TITLE
tp: DecompressTraceSlowly -> DecompressTrace

### DIFF
--- a/include/perfetto/trace_processor/read_trace.h
+++ b/include/perfetto/trace_processor/read_trace.h
@@ -72,13 +72,10 @@ base::Status PERFETTO_EXPORT_COMPONENT ReadTrace(
     bool call_notify_end_of_file = true,
     const ReadTraceArgs& args = {});
 
-// Decompresses `data` into `output`. "Slowly" because it copies the whole input
-// and buffers the whole output, so it is only for offline/one-shot paths. A hot
-// path should add a streaming entry point rather than call this.
+// Decompresses a gzip/zstd trace, or a proto trace containing
+// compressed_packets, into `output` as a plain proto trace.
 base::Status PERFETTO_EXPORT_COMPONENT
-DecompressTraceSlowly(const uint8_t* data,
-                      size_t size,
-                      std::vector<uint8_t>* output);
+DecompressTrace(const uint8_t* data, size_t size, std::vector<uint8_t>* output);
 
 }  // namespace trace_processor
 }  // namespace perfetto

--- a/src/trace_processor/read_trace.cc
+++ b/src/trace_processor/read_trace.cc
@@ -18,12 +18,14 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_macros.h"
+#include "perfetto/protozero/field.h"
 #include "perfetto/protozero/proto_utils.h"
 #include "perfetto/trace_processor/trace_blob.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
@@ -32,6 +34,7 @@
 #include "src/trace_processor/importers/common/chunked_trace_reader.h"
 #include "src/trace_processor/importers/proto/proto_trace_tokenizer.h"
 #include "src/trace_processor/read_trace_internal.h"
+#include "src/trace_processor/util/decompressor.h"
 #include "src/trace_processor/util/trace_type.h"
 
 #include "protos/perfetto/trace/trace.pbzero.h"
@@ -87,15 +90,15 @@ base::Status ReadTrace(
   return base::OkStatus();
 }
 
-base::Status DecompressTraceSlowly(const uint8_t* data,
-                                   size_t size,
-                                   std::vector<uint8_t>* output) {
+base::Status DecompressTrace(const uint8_t* data,
+                             size_t size,
+                             std::vector<uint8_t>* output) {
   TraceType type = GuessTraceType(data, size);
   if (type != TraceType::kGzipTraceType && type != TraceType::kZstdTraceType &&
       type != TraceType::kProtoTraceType) {
     return base::ErrStatus(
         "Only GZIP, ZSTD and proto trace types are supported by "
-        "DecompressTraceSlowly");
+        "DecompressTrace");
   }
 
   if (type == TraceType::kGzipTraceType || type == TraceType::kZstdTraceType) {
@@ -111,12 +114,46 @@ base::Status DecompressTraceSlowly(const uint8_t* data,
 
   PERFETTO_CHECK(type == TraceType::kProtoTraceType);
 
-  // Run the trace through the tokenizer, which expands any compressed_packets /
-  // zstd_compressed_packets bundles and hands back plain packets that the
-  // reader re-serializes into `output`. Copying the whole input into an owned
-  // TraceBlob is fine on this offline path (see the header).
-  SerializingProtoTraceReader reader(output);
-  return reader.Parse(TraceBlobView(TraceBlob::CopyFrom(data, size)));
+  // Plain proto: expand each compressed_packets / zstd_compressed_packets
+  // bundle into `output`, and pass other packets through unchanged.
+  protos::pbzero::Trace::Decoder decoder(data, size);
+  if (size > 0 && !decoder.packet()) {
+    return base::ErrStatus("Trace does not contain valid packets");
+  }
+
+  for (auto it = decoder.packet(); it; ++it) {
+    protos::pbzero::TracePacket::Decoder packet(*it);
+
+    util::CompressionType codec;
+    protozero::ConstBytes bytes;
+    if (packet.has_compressed_packets()) {
+      codec = util::CompressionType::kGzip;
+      bytes = packet.compressed_packets();
+    } else if (packet.has_zstd_compressed_packets()) {
+      codec = util::CompressionType::kZstd;
+      bytes = packet.zstd_compressed_packets();
+    } else {
+      it->SerializeAndAppendTo(output);
+      continue;
+    }
+
+    if (!util::IsCompressionSupported(codec)) {
+      auto info = util::GetCompressionCodecInfo(codec);
+      return base::ErrStatus(
+          "Cannot decompress compressed_packets: %s is not enabled in this "
+          "build (rebuild with %s=true)",
+          info.name, info.gn_arg);
+    }
+
+    std::optional<util::DecompressedBuffer> buf =
+        util::DecompressToBuffer(codec, bytes.data, bytes.size);
+    if (!buf) {
+      return base::ErrStatus(
+          "Failed to decompress compressed_packets (ERR:tp-corrupt)");
+    }
+    output->insert(output->end(), buf->data.get(), buf->data.get() + buf->size);
+  }
+  return base::OkStatus();
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/read_trace_integrationtest.cc
+++ b/src/trace_processor/read_trace_integrationtest.cc
@@ -75,7 +75,7 @@ TEST_F(ReadTraceIntegrationTest, CompressedTrace) {
   std::vector<uint8_t> decompressed;
   decompressed.reserve(raw_trace.size());
 
-  base::Status status = trace_processor::DecompressTraceSlowly(
+  base::Status status = trace_processor::DecompressTrace(
       raw_trace.data(), raw_trace.size(), &decompressed);
   ASSERT_TRUE(status.ok());
 
@@ -95,7 +95,7 @@ TEST_F(ReadTraceIntegrationTest, NonProtobufShouldNotDecompress) {
   std::vector<uint8_t> raw_trace = ReadAllData(f);
 
   std::vector<uint8_t> decompressed;
-  base::Status status = trace_processor::DecompressTraceSlowly(
+  base::Status status = trace_processor::DecompressTrace(
       raw_trace.data(), raw_trace.size(), &decompressed);
   ASSERT_FALSE(status.ok());
 }
@@ -106,7 +106,7 @@ TEST_F(ReadTraceIntegrationTest, OuterGzipDecompressTrace) {
   std::vector<uint8_t> raw_compressed_trace = ReadAllData(f);
 
   std::vector<uint8_t> decompressed;
-  base::Status status = trace_processor::DecompressTraceSlowly(
+  base::Status status = trace_processor::DecompressTrace(
       raw_compressed_trace.data(), raw_compressed_trace.size(), &decompressed);
   ASSERT_TRUE(status.ok());
 
@@ -123,7 +123,7 @@ TEST_F(ReadTraceIntegrationTest, DoubleGzipDecompressTrace) {
   std::vector<uint8_t> raw_compressed_trace = ReadAllData(f);
 
   std::vector<uint8_t> decompressed;
-  base::Status status = trace_processor::DecompressTraceSlowly(
+  base::Status status = trace_processor::DecompressTrace(
       raw_compressed_trace.data(), raw_compressed_trace.size(), &decompressed);
   ASSERT_TRUE(status.ok()) << status.message();
 
@@ -141,7 +141,7 @@ TEST_F(ReadTraceIntegrationTest, DoubleGzipDecompressTrace) {
 #if PERFETTO_BUILDFLAG(PERFETTO_ZSTD)
 // End-to-end check of the zstd decode path: wrap a zstd-compressed packet
 // stream in TracePacket.zstd_compressed_packets (as the tracing service emits)
-// and assert DecompressTraceSlowly recovers the original packets.
+// and assert DecompressTrace recovers the original packets.
 TEST_F(ReadTraceIntegrationTest, ZstdCompressedPackets) {
   // The framed packet stream is itself a valid Trace proto.
   constexpr uint64_t kTimestamps[] = {1000, 2000, 3000};
@@ -163,7 +163,7 @@ TEST_F(ReadTraceIntegrationTest, ZstdCompressedPackets) {
   std::vector<uint8_t> outer_bytes = outer.SerializeAsArray();
 
   std::vector<uint8_t> decompressed;
-  base::Status status = trace_processor::DecompressTraceSlowly(
+  base::Status status = trace_processor::DecompressTrace(
       outer_bytes.data(), outer_bytes.size(), &decompressed);
   ASSERT_TRUE(status.ok()) << status.message();
 
@@ -187,7 +187,7 @@ TEST_F(ReadTraceIntegrationTest, ZstdCorruptCompressedPacketsFails) {
   std::vector<uint8_t> outer_bytes = outer.SerializeAsArray();
 
   std::vector<uint8_t> decompressed;
-  base::Status status = trace_processor::DecompressTraceSlowly(
+  base::Status status = trace_processor::DecompressTrace(
       outer_bytes.data(), outer_bytes.size(), &decompressed);
   ASSERT_FALSE(status.ok());
 }

--- a/src/traceconv/trace_unpack.cc
+++ b/src/traceconv/trace_unpack.cc
@@ -32,7 +32,7 @@ bool UnpackCompressedPackets(std::istream* input, std::ostream* output) {
   std::vector<char> packed(std::istreambuf_iterator<char>{*input},
                            std::istreambuf_iterator<char>{});
   std::vector<uint8_t> unpacked;
-  auto status = trace_processor::DecompressTraceSlowly(
+  auto status = trace_processor::DecompressTrace(
       reinterpret_cast<uint8_t*>(packed.data()), packed.size(), &unpacked);
   if (!status.ok())
     return false;


### PR DESCRIPTION
- "Slowly" assumed one caller; there are several now, so drop it. This also un-breaks the existing callers.
- The proto path now decodes in place via a protozero view instead of copying the whole input, and expands compressed_packets (gzip) and zstd_compressed_packets bundles straight into output.