### PR TITLE
ui: video frame plugin fixes

### DIFF
--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_details_panel.ts
@@ -48,7 +48,7 @@ export class VideoFrameDetailsPanel implements TrackEventDetailsPanel {
     // Don't await: while load() is pending the panel sits in its loading
     // state, which remounts and blanks the <canvas>. seek() cancels stale
     // decodes itself.
-    void this.player.seek(sel.eventId);
+    this.player.seek(sel.eventId);
   }
 
   render() {

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_details_panel.ts
@@ -45,7 +45,10 @@ export class VideoFrameDetailsPanel implements TrackEventDetailsPanel {
     if (this.player.playing) return;
     await this.player.ensureFramesLoaded();
     if (this.player.frames[this.player.currentIdx]?.id === sel.eventId) return;
-    await this.player.seek(sel.eventId);
+    // Don't await: while load() is pending the panel sits in its loading
+    // state, which remounts and blanks the <canvas>. seek() cancels stale
+    // decodes itself.
+    void this.player.seek(sel.eventId);
   }
 
   render() {

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_player.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_player.ts
@@ -232,6 +232,9 @@ export class VideoFramePlayer {
     const setup = await this.loadSetup();
     if (setup === undefined) return undefined;
     const k = this.nearestKey(idx);
+    // No key frame precedes idx (ring buffer dropped the GOP start); the
+    // decoder can't be seeded, so this frame is undecodable.
+    if (k < 0) return undefined;
     const range = this.frames.slice(k, idx + 1);
     const datas = await this.fetchAuData(range.map((f) => f.id));
     const outs: VideoFrame[] = [];
@@ -303,6 +306,7 @@ export class VideoFramePlayer {
     // paint from fromIdx, so play() starts on the selected frame. Frames in
     // [k, fromIdx) are decoded only to prime the decoder, not painted.
     const k = this.nearestKey(fromIdx);
+    if (k < 0) return; // no key frame to seed from (ring buffer start)
     const session = await this.openPlaySession(token, k);
     if (session === undefined) return;
     this.startPlaybackLoop(token, session, fromIdx);
@@ -448,7 +452,9 @@ export class VideoFramePlayer {
   // frame to seed the reference list before any non-key frame.
   private nearestKey(idx: number): number {
     let k = idx;
-    while (k > 0 && !this.frames[k].isKey) k--;
+    while (k >= 0 && !this.frames[k].isKey) k--;
+    // -1 when no key frame precedes idx, e.g. a ring buffer whose start (and
+    // the GOP's key frame) was overwritten. Such frames can't be decoded.
     return k;
   }
 

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
@@ -30,7 +30,10 @@ export function createVideoFramesTrack(
   player: VideoFramePlayer,
 ) {
   // dur spans each frame to the next (last frame: 0). is_config rows are
-  // decoder setup, not displayable, so excluded.
+  // decoder setup, not displayable, so excluded. Frames before the first key
+  // frame can't be decoded (no key frame to seed the decoder, e.g. a ring
+  // buffer whose GOP start was overwritten), so start the track at the first
+  // key frame.
   const src = `
     SELECT
       id,
@@ -41,6 +44,10 @@ export function createVideoFramesTrack(
     FROM __intrinsic_video_frames
     WHERE display_id = ${displayId}
       AND COALESCE(is_config, 0) = 0
+      AND ts >= (
+        SELECT MIN(ts) FROM __intrinsic_video_frames
+        WHERE display_id = ${displayId} AND is_key_frame = 1
+      )
   `;
 
   // QuerySlot caches the decoded hover image per frame id.

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
@@ -15,6 +15,7 @@
 import './video_frames.scss';
 import m from 'mithril';
 import {QuerySlot} from '../../base/query_slot';
+import {materialColorScheme} from '../../components/colorizer';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import type {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
@@ -58,6 +59,7 @@ export function createVideoFramesTrack(
       src,
     }),
     detailsPanel: () => panel,
+    colorizer: (row) => materialColorScheme(row.name),
     tooltip: (data) => {
       const image = imageSlot.use({
         key: {id: data.id},

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
@@ -15,7 +15,6 @@
 import './video_frames.scss';
 import m from 'mithril';
 import {QuerySlot} from '../../base/query_slot';
-import {materialColorScheme} from '../../components/colorizer';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import type {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
@@ -29,15 +28,13 @@ export function createVideoFramesTrack(
   displayId: number,
   player: VideoFramePlayer,
 ) {
-  // dur = -1, depth = 0 renders each frame as an incomplete slice spanning
-  // to the next frame and fading out (same as the Screenshots track).
-  // is_config rows are decoder setup, not displayable, so excluded. The
-  // name doubles as the colorization seed.
+  // dur spans each frame to the next (last frame: 0). is_config rows are
+  // decoder setup, not displayable, so excluded.
   const src = `
     SELECT
       id,
       ts,
-      -1 AS dur,
+      COALESCE(LEAD(ts) OVER (ORDER BY ts) - ts, 0) AS dur,
       0 AS depth,
       'Frame ' || frame_number AS name
     FROM __intrinsic_video_frames
@@ -61,7 +58,6 @@ export function createVideoFramesTrack(
       src,
     }),
     detailsPanel: () => panel,
-    colorizer: (row) => materialColorScheme(row.name),
     tooltip: (data) => {
       const image = imageSlot.use({
         key: {id: data.id},


### PR DESCRIPTION
  - Details panel: don't await player.seek() in load(). Awaiting held the
    panel in its loading state, which remounts and blanks the <canvas>;
    seek() cancels superseded decodes itself, so the preview stays painted
    during keyboard nav.
  - Track: render each frame as a bounded slice (dur = LEAD(ts) - ts, and 0
    for the last frame) instead of an unbounded, fading dur = -1 slice.
  - Player: don't decode a frame with no preceding key frame. nearestKey
    walked back to index 0 even when it was a delta frame (e.g. a ring buffer
    whose GOP start was overwritten); feeding a delta chunk after configure()
    throws "A key frame is required after configure()". nearestKey now returns
    -1 and the decode/playback paths bail, leaving a blank preview instead of
    throwing.