### PR TITLE
config: add DisplayVideoConfig.repeat_codec_config

### DIFF
--- a/protos/perfetto/config/android/display_video_config.proto
+++ b/protos/perfetto/config/android/display_video_config.proto
@@ -40,4 +40,11 @@ message DisplayVideoConfig {
   // Per-display cap on emitted bytes. On reaching it the stream is torn
   // down with a VideoFrameError (SIZE_CAP_HIT).
   optional uint64 max_stream_size_bytes = 4;
+
+  // Re-emit the codec config before every keyframe instead of only once at
+  // the start of the stream. This keeps the stream decodable from any
+  // retained window, which is required for ring-buffer capture (where the
+  // initial config would otherwise be overwritten). Costs a few extra bytes
+  // per keyframe; off by default.
+  optional bool repeat_codec_config = 5;
 }

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -983,6 +983,13 @@ message DisplayVideoConfig {
   // Per-display cap on emitted bytes. On reaching it the stream is torn
   // down with a VideoFrameError (SIZE_CAP_HIT).
   optional uint64 max_stream_size_bytes = 4;
+
+  // Re-emit the codec config before every keyframe instead of only once at
+  // the start of the stream. This keeps the stream decodable from any
+  // retained window, which is required for ring-buffer capture (where the
+  // initial config would otherwise be overwritten). Costs a few extra bytes
+  // per keyframe; off by default.
+  optional bool repeat_codec_config = 5;
 }
 
 // End of protos/perfetto/config/android/display_video_config.proto

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -983,6 +983,13 @@ message DisplayVideoConfig {
   // Per-display cap on emitted bytes. On reaching it the stream is torn
   // down with a VideoFrameError (SIZE_CAP_HIT).
   optional uint64 max_stream_size_bytes = 4;
+
+  // Re-emit the codec config before every keyframe instead of only once at
+  // the start of the stream. This keeps the stream decodable from any
+  // retained window, which is required for ring-buffer capture (where the
+  // initial config would otherwise be overwritten). Costs a few extra bytes
+  // per keyframe; off by default.
+  optional bool repeat_codec_config = 5;
 }
 
 // End of protos/perfetto/config/android/display_video_config.proto


### PR DESCRIPTION
Adds an opt-in flag to re-emit the codec config before every keyframe instead of only once at the start of the stream. This keeps the encoded stream decodable from any retained window, which ring-buffer capture needs (the single start-of-stream config would otherwise be overwritten once the buffer wraps). Off by default; costs a few bytes per keyframe.
