### PR TITLE
perfetto: roll zstd to 1.5.7

### DIFF
--- a/buildtools/BUILD.gn
+++ b/buildtools/BUILD.gn
@@ -1883,6 +1883,8 @@ source_set("zstd") {
     "zstd/lib/compress/zstd_ldm_geartab.h",
     "zstd/lib/compress/zstd_opt.c",
     "zstd/lib/compress/zstd_opt.h",
+    "zstd/lib/compress/zstd_preSplit.c",
+    "zstd/lib/compress/zstd_preSplit.h",
     "zstd/lib/compress/zstdmt_compress.c",
     "zstd/lib/compress/zstdmt_compress.h",
     "zstd/lib/decompress/huf_decompress.c",

--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -392,6 +392,12 @@ declare_args() {
   # Enables Zstd support. This is used to compress traces (by the tracing
   # service) and to decompress traces (by trace_processor), as an alternative
   # to Zlib/deflate.
+  #
+  # Off in Chromium builds: enabling it makes the tracing service the first
+  # thing to pull Chromium's //third_party/zstd:compress (the zstd *encoder*)
+  # into size-optimized Android. Chrome only ever linked the decoder there, so
+  # this added ~235 KB to Trichrome, which is too much to justify. See the
+  # size increase on the Chromium roll: https://crrev.com/c/8065805
   enable_perfetto_zstd =
       !build_with_chromium &&
       (enable_perfetto_trace_processor || enable_perfetto_platform_services)

--- a/tools/install-build-deps
+++ b/tools/install-build-deps
@@ -293,20 +293,21 @@ BUILD_DEPS_HOST = [
     Dependency('buildtools/lzma',
                'https://android.googlesource.com/platform/external/lzma.git',
                '7851dce6f4ca17f5caa1c93a4e0a45686b1d56c3', 'all', 'all'),
-    Dependency('buildtools/zstd',
-               'https://android.googlesource.com/platform/external/zstd.git',
-               '77211fcc5e08c781734a386402ada93d0d18d093', 'all', 'all'),
     Dependency('buildtools/bionic',
                'https://android.googlesource.com/platform/bionic.git',
                'a0d0355105cb9d4a4b5384897448676133d7b8e2', 'all', 'all'),
 
-    # Zlib used both in the tracing binaries, as well as the trace processor and
-    # assorted tools.
-    # If updating the version, also update bazel/deps.bzl.
+    # Zlib and Zstd, the compression libraries used both in the tracing binaries
+    # and in the trace processor and assorted tools.
+    # If updating either version, also update bazel/deps.bzl.
     Dependency(
         'buildtools/zlib',
         'https://chromium.googlesource.com/chromium/src/third_party/zlib.git',
         '6f9b4e61924021237d474569027cfb8ac7933ee6', 'all', 'all'),
+    Dependency(
+        'buildtools/zstd',
+        'https://chromium.googlesource.com/external/github.com/facebook/zstd.git',
+        'f8745da6ff1ad1e7bab384bd1f9d742439278e99', 'all', 'all'),
 
     # Linenoise, used only by trace_processor in standalone builds.
     # If updating the version, also update bazel/deps.bzl.


### PR DESCRIPTION
- Bump buildtools/zstd to v1.5.7 (Chromium mirror, matches bazel/deps.bzl).
- Add zstd_preSplit.c/.h sources, needed to link 1.5.7.
- Document why zstd is off for Chromium builds.