### PR TITLE
ui: thread_state_track: disable same-title slice highlighting

### DIFF
--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
@@ -14,7 +14,7 @@
 
 import {HSLColor} from '../../base/color';
 import type {ColorScheme} from '../../base/color_scheme';
-import {SliceTrack} from '../../components/tracks/slice_track';
+import {ColorVariant, SliceTrack} from '../../components/tracks/slice_track';
 import type {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, NUM, NUM_NULL, STR} from '../../trace_processor/query_result';
@@ -36,6 +36,7 @@ export function createThreadStateTrack(
   uri: string,
   utid: number,
 ) {
+  let hoveredSliceId: number | undefined;
   return SliceTrack.create({
     trace,
     uri,
@@ -72,6 +73,23 @@ export function createThreadStateTrack(
       sliceHeight: 12,
       titleSizePx: 10,
     },
+    // The following set of callbacks work around base slice_track's behaviour
+    // of globally highlighting all slices with the same title. Highlighting
+    // all "running" or "sleeping" slices across all visible thread tracks is
+    // both visually noisy, and distracts from the actual slice being hovered.
+    // Corner case: different tracks still see the published title for
+    // highlighting, but the alternative is polluting SliceTrackAttrs for a
+    // case that only this track currently cares about.
+    onSliceOver: ({slice}) => {
+      hoveredSliceId = slice.id;
+    },
+    onSliceOut: () => {
+      hoveredSliceId = undefined;
+    },
+    onUpdatedSlices: (slices) =>
+      slices.map((s) =>
+        s.id === hoveredSliceId ? ColorVariant.VARIANT : ColorVariant.BASE,
+      ),
     sliceName: (row) => row.state || '[Unknown]',
     colorizer: (row): ColorScheme => {
       const colorForState = colorForThreadState(row.state || '[Unknown]');


### PR DESCRIPTION
Highlighting all slices with the same name (across all tracks) is undesirable for thread state tracks, since there's a small set of possible names and too many slices end up being highlighted. This both adds visual noise, and distracts from the actual slice being hovered.

I've chosen to hack around this within the plugin, but can add a boolean to suppress global highlighting to SliceTrackAttrs instead if that's preferable. I also don't know how to accurately measure the overhead of the additional onUpdatedSlices(), but I could not perceive a difference on my machines.