### PR TITLE
[chrome] Update reliable_range to 

### DIFF
--- a/src/trace_processor/metrics/sql/chrome/chrome_reliable_range.sql
+++ b/src/trace_processor/metrics/sql/chrome/chrome_reliable_range.sql
@@ -17,8 +17,8 @@
 --    entire duration of the trace.
 -- 2. Otherwise, the thread data is reliable from the first thread event till the end of the trace.
 -- 3. The "reliable range" is an intersection of reliable thread ranges for all threads such that:
---   a. The number of events on the thread is at or above 25p.
---   b. The event rate for the thread is at or above 75p.
+--   a. The number of events on the thread is at or above 50p.
+--   b. The event rate for the thread is at or above 95p.
 -- Note: this metric considers only chrome processes and their threads, i.e. the ones coming
 -- from track_event's.
 
@@ -30,12 +30,21 @@ CREATE OR REPLACE PERFETTO FUNCTION _extract_int_metadata(
 RETURNS LONG AS
 SELECT int_value FROM metadata WHERE name = ($name) LIMIT 1;
 
+SELECT RUN_METRIC('chrome/chrome_browser_main_thread_duration.sql');
+
 DROP VIEW IF EXISTS chrome_event_stats_per_thread;
 
 CREATE PERFETTO VIEW chrome_event_stats_per_thread
 AS
 SELECT
-  COUNT(*) AS cnt, CAST(COUNT(*) AS DOUBLE) / (MAX(ts + dur) - MIN(ts)) AS rate, utid
+  COUNT(*) AS cnt,
+  COALESCE(
+    CAST(COUNT(*) AS DOUBLE) / (
+      SELECT duration_ms FROM chrome_browser_main_thread_duration
+    ),
+    0
+  ) AS rate,
+  utid
 FROM thread_track
 JOIN slice
   ON thread_track.id = slice.track_id
@@ -44,7 +53,7 @@ GROUP BY utid;
 
 DROP VIEW IF EXISTS chrome_event_cnt_cutoff;
 
--- Ignore the bottom 25% of threads by event count. 25% is a somewhat arbitrary number. It creates a
+-- Ignore the bottom 50% of threads by event count. 50% is a somewhat arbitrary number. It creates a
 -- cutoff at around 10 events for a typical trace, and threads with fewer events are usually:
 -- 1. Not particularly interesting for the reliable range definition.
 -- 2. Create a lot of noise for other metrics, such as event rate.
@@ -58,11 +67,11 @@ ORDER BY
 LIMIT
   1
   OFFSET(
-    (SELECT COUNT(*) FROM chrome_event_stats_per_thread) / 4);
+    (SELECT COUNT(*) FROM chrome_event_stats_per_thread) * 50 / 100);
 
 DROP VIEW IF EXISTS chrome_event_rate_cutoff;
 
--- Choose the top 25% event rate. 25% is a somewhat arbitrary number. The goal is to strike
+-- Choose the top 5% event rate. 95% is a somewhat arbitrary number. The goal is to strike
 -- balance between not cropping too many events and making sure that the chance of data loss in the
 -- range declared "reliable" is low.
 CREATE PERFETTO VIEW chrome_event_rate_cutoff
@@ -75,7 +84,7 @@ ORDER BY
 LIMIT
   1
   OFFSET(
-    (SELECT COUNT(*) FROM chrome_event_stats_per_thread) * 3 / 4);
+    (SELECT COUNT(*) FROM chrome_event_stats_per_thread) * 95 / 100);
 
 DROP VIEW IF EXISTS chrome_reliable_range_per_thread;
 
@@ -149,8 +158,12 @@ FROM
     -- entire duration of the trace.
     SELECT upid, NULL AS reliable_from
     FROM chrome_processes_with_missing_main
+    UNION ALL
+    -- If the browser main thread duration is null or 0, the entire trace is unreliable.
+    SELECT NULL AS upid, NULL AS reliable_from
+    WHERE (SELECT duration_ms FROM chrome_browser_main_thread_duration) IS NULL
   )
-ORDER BY start DESC, upid
+ORDER BY start DESC, upid IS NOT NULL DESC, upid
 LIMIT 1;
 
 DROP VIEW IF EXISTS chrome_reliable_range;

--- a/src/trace_processor/metrics/sql/chrome/chrome_reliable_range.sql
+++ b/src/trace_processor/metrics/sql/chrome/chrome_reliable_range.sql
@@ -54,7 +54,7 @@ GROUP BY utid;
 DROP VIEW IF EXISTS chrome_event_cnt_cutoff;
 
 -- Ignore the bottom 50% of threads by event count. 50% is a somewhat arbitrary number. It creates a
--- cutoff at around 10 events for a typical trace, and threads with fewer events are usually:
+-- cutoff at around 100 events for a typical trace, and threads with fewer events are usually:
 -- 1. Not particularly interesting for the reliable range definition.
 -- 2. Create a lot of noise for other metrics, such as event rate.
 CREATE PERFETTO VIEW chrome_event_cnt_cutoff

--- a/test/trace_processor/diff_tests/metrics/chrome/chrome_reliable_range.textproto
+++ b/test/trace_processor/diff_tests/metrics/chrome/chrome_reliable_range.textproto
@@ -130,10 +130,9 @@ packet {
     type: 2
   }
 }
-# Browser Main slice ends at 1000012 to make duration_ms = 1 (> 0).
 packet {
   trusted_packet_sequence_id: 2
-  timestamp: 1000012
+  timestamp: 1012
   track_event {
     track_uuid: 2
     categories: "cat"

--- a/test/trace_processor/diff_tests/metrics/chrome/chrome_reliable_range.textproto
+++ b/test/trace_processor/diff_tests/metrics/chrome/chrome_reliable_range.textproto
@@ -2,6 +2,47 @@
 # 12, and 13. The third thread has first_packet_on_sequence, so it should be
 # ignored for the reliable range computation.
 
+# Process descriptors for each process.
+packet {
+  timestamp: 1
+  trusted_packet_sequence_id: 1
+  track_descriptor {
+    uuid: 5
+    process {
+      pid: 1
+    }
+    chrome_process {
+      process_type: 2 # Renderer
+    }
+  }
+}
+packet {
+  timestamp: 1
+  trusted_packet_sequence_id: 2
+  track_descriptor {
+    uuid: 4
+    process {
+      pid: 2
+    }
+    chrome_process {
+      process_type: 1 # Browser
+    }
+  }
+}
+packet {
+  timestamp: 1
+  trusted_packet_sequence_id: 3
+  track_descriptor {
+    uuid: 6
+    process {
+      pid: 3
+    }
+    chrome_process {
+      process_type: 2 # Renderer
+    }
+  }
+}
+
 # Track descriptors for each thread.
 packet {
   timestamp: 1
@@ -12,6 +53,7 @@ packet {
     thread {
       pid: 1
       tid: 1
+      thread_name: "CrRendererMain"
     }
     disallow_merging_with_system_tracks: true
   }
@@ -25,6 +67,7 @@ packet {
     thread {
       pid: 2
       tid: 2
+      thread_name: "CrBrowserMain"
     }
     disallow_merging_with_system_tracks: true
   }
@@ -39,6 +82,7 @@ packet {
     thread {
       pid: 3
       tid: 3
+      thread_name: "CrRendererMain"
     }
     parent_uuid: 0
   }
@@ -86,9 +130,10 @@ packet {
     type: 2
   }
 }
+# Browser Main slice ends at 1000012 to make duration_ms = 1 (> 0).
 packet {
   trusted_packet_sequence_id: 2
-  timestamp: 1012
+  timestamp: 1000012
   track_event {
     track_uuid: 2
     categories: "cat"

--- a/test/trace_processor/diff_tests/metrics/chrome/tests.py
+++ b/test/trace_processor/diff_tests/metrics/chrome/tests.py
@@ -234,7 +234,7 @@ class ChromeMetrics(TestSuite):
         query=Path('chrome_reliable_range_test.sql'),
         out=Csv("""
         "start","reason","debug_limiting_upid","debug_limiting_utid"
-        0,"[NULL]","[NULL]","[NULL]"
+        99069280596,"[NULL]","[NULL]","[NULL]"
         """))
 
   # Chrome slices


### PR DESCRIPTION
This PR fixes a few issues I've seen with chrome reliable_range computation:
- Thread rate is noisy: a thread doing bursty work over a short period will have very large event rate, leading to short reliable range. To work around this I'm using chrome browser main as the denominator to compute event rate.
- A trace with no browser main event should have a reliable range duration = 0
- 25%ile of event count and 75%ile of event rate include somewhat idle thread. An idle thread is likely to give a random reliable_range start. To work around this I'm updating to more strict cutoff 50%ile and 95%ile respectively, effectively only including very busy thread (browser, gpu, active renderer main threads)