### PR TITLE
perfetto: list other tracing sessions in trace

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3641,6 +3641,7 @@ filegroup {
         "protos/perfetto/trace/interned_data/interned_data.proto",
         "protos/perfetto/trace/linux/journald_event.proto",
         "protos/perfetto/trace/memory_graph.proto",
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",
@@ -8472,6 +8473,7 @@ genrule {
         "protos/perfetto/trace/interned_data/interned_data.proto",
         "protos/perfetto/trace/linux/journald_event.proto",
         "protos/perfetto/trace/memory_graph.proto",
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",
@@ -11323,6 +11325,7 @@ filegroup {
         "protos/perfetto/trace/interned_data/interned_data.proto",
         "protos/perfetto/trace/linux/journald_event.proto",
         "protos/perfetto/trace/memory_graph.proto",
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",
@@ -11533,6 +11536,7 @@ genrule {
 filegroup {
     name: "perfetto_protos_perfetto_trace_perfetto_cpp",
     srcs: [
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",
@@ -11551,6 +11555,7 @@ genrule {
     ],
     cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_cpp)",
     out: [
+        "external/perfetto/protos/perfetto/trace/perfetto/concurrent_session_event.gen.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.gen.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.gen.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/tracing_service_event.gen.cc",
@@ -11569,6 +11574,7 @@ genrule {
     ],
     cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_cpp)",
     out: [
+        "external/perfetto/protos/perfetto/trace/perfetto/concurrent_session_event.gen.h",
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.gen.h",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.gen.h",
         "external/perfetto/protos/perfetto/trace/perfetto/tracing_service_event.gen.h",
@@ -11583,6 +11589,7 @@ genrule {
 filegroup {
     name: "perfetto_protos_perfetto_trace_perfetto_lite",
     srcs: [
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",
@@ -11600,6 +11607,7 @@ genrule {
     ],
     cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_lite)",
     out: [
+        "external/perfetto/protos/perfetto/trace/perfetto/concurrent_session_event.pb.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.pb.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.pb.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/tracing_service_event.pb.cc",
@@ -11617,6 +11625,7 @@ genrule {
     ],
     cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_lite)",
     out: [
+        "external/perfetto/protos/perfetto/trace/perfetto/concurrent_session_event.pb.h",
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.pb.h",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.pb.h",
         "external/perfetto/protos/perfetto/trace/perfetto/tracing_service_event.pb.h",
@@ -11631,6 +11640,7 @@ genrule {
 filegroup {
     name: "perfetto_protos_perfetto_trace_perfetto_zero",
     srcs: [
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",
@@ -11649,6 +11659,7 @@ genrule {
     ],
     cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_zero)",
     out: [
+        "external/perfetto/protos/perfetto/trace/perfetto/concurrent_session_event.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/perfetto/tracing_service_event.pbzero.cc",
@@ -11667,6 +11678,7 @@ genrule {
     ],
     cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_perfetto_zero)",
     out: [
+        "external/perfetto/protos/perfetto/trace/perfetto/concurrent_session_event.pbzero.h",
         "external/perfetto/protos/perfetto/trace/perfetto/perfetto_metatrace.pbzero.h",
         "external/perfetto/protos/perfetto/trace/perfetto/trace_provenance.pbzero.h",
         "external/perfetto/protos/perfetto/trace/perfetto/tracing_service_event.pbzero.h",
@@ -13556,6 +13568,7 @@ genrule {
         "protos/perfetto/trace/interned_data/interned_data.proto",
         "protos/perfetto/trace/linux/journald_event.proto",
         "protos/perfetto/trace/memory_graph.proto",
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",
@@ -22587,6 +22600,7 @@ java_library {
         "protos/perfetto/trace/interned_data/interned_data.proto",
         "protos/perfetto/trace/linux/journald_event.proto",
         "protos/perfetto/trace/memory_graph.proto",
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",
@@ -23054,6 +23068,7 @@ python_library_host {
         "protos/perfetto/trace/interned_data/interned_data.proto",
         "protos/perfetto/trace/linux/journald_event.proto",
         "protos/perfetto/trace/memory_graph.proto",
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",

--- a/BUILD
+++ b/BUILD
@@ -9308,6 +9308,7 @@ perfetto_cc_protozero_library(
 perfetto_proto_library(
     name = "protos_perfetto_trace_perfetto_protos",
     srcs = [
+        "protos/perfetto/trace/perfetto/concurrent_session_event.proto",
         "protos/perfetto/trace/perfetto/perfetto_metatrace.proto",
         "protos/perfetto/trace/perfetto/trace_provenance.proto",
         "protos/perfetto/trace/perfetto/tracing_service_event.proto",

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 Unreleased:
   Tracing service and probes:
+    * Added optional recording of the state changes of other concurrent
+      tracing sessions, as ConcurrentSessionEvent packets. Opt-in via
+      TraceConfig.BuiltinDataSource.enable_concurrent_session_events. Trace
+      Processor and the UI show them as one state track per session.
     * Added Zstd as a trace compression option alongside deflate, selected via
       the new TraceConfig.compression field (which supersedes compression_type).
     * The procfs scraper (process_stats data source) now writes an explicit

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -5153,6 +5153,12 @@ message TraceConfig {
 
     // Disable emitting extension descriptors into the trace.
     optional bool disable_extension_descriptors = 9;
+
+    // Emit state changes of other tracing sessions running concurrently
+    // with this one (see ConcurrentSessionEvent).
+    //
+    // Introduced in v58 / Android 26Q3+.
+    optional bool enable_concurrent_session_events = 10;
   }
   optional BuiltinDataSource builtin_data_sources = 20;
 

--- a/protos/perfetto/config/trace_config.proto
+++ b/protos/perfetto/config/trace_config.proto
@@ -175,6 +175,12 @@ message TraceConfig {
 
     // Disable emitting extension descriptors into the trace.
     optional bool disable_extension_descriptors = 9;
+
+    // Emit state changes of other tracing sessions running concurrently
+    // with this one (see ConcurrentSessionEvent).
+    //
+    // Introduced in v58 / Android 26Q3+.
+    optional bool enable_concurrent_session_events = 10;
   }
   optional BuiltinDataSource builtin_data_sources = 20;
 

--- a/protos/perfetto/trace/perfetto/BUILD.gn
+++ b/protos/perfetto/trace/perfetto/BUILD.gn
@@ -16,6 +16,7 @@ import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
   sources = [
+    "concurrent_session_event.proto",
     "perfetto_metatrace.proto",
     "trace_provenance.proto",
     "tracing_service_event.proto",

--- a/protos/perfetto/trace/perfetto/concurrent_session_event.proto
+++ b/protos/perfetto/trace/perfetto/concurrent_session_event.proto
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+
+package perfetto.protos;
+
+// Emitted by the tracing service to record a state change of another tracing
+// session that was active while this trace was being recorded. Opt-in via
+// TraceConfig.BuiltinDataSource.enable_concurrent_session_events.
+//
+// One packet per state change; its time is carried by the enclosing
+// TracePacket's timestamp (CLOCK_BOOTTIME). Events of the same session share
+// the same |session_id|. The trace UUID is deliberately not included.
+//
+// Introduced in v58 / Android 26Q3+.
+message ConcurrentSessionEvent {
+  // Mirrors the tracing service's internal session state machine
+  // (TracingSession::State in the service): keep these two enums in sync.
+  // These values are part of the trace wire format and must stay stable: never
+  // renumber or reuse an existing value, only append new ones at the end.
+  enum State {
+    STATE_UNSPECIFIED = 0;
+    // Not recording (initial and final state).
+    STATE_DISABLED = 1;
+    // Configured but waiting for a start signal (e.g. a trigger).
+    STATE_CONFIGURED = 2;
+    // Actively recording data.
+    STATE_STARTED = 3;
+    // Stopping, waiting for data sources to ack and drain their final data.
+    STATE_DISABLING_WAITING_STOP_ACKS = 4;
+    // A read-only snapshot of another session, created by a clone operation.
+    STATE_CLONED_READ_ONLY = 5;
+  }
+  // The state the session transitioned to at this timestamp.
+  optional State state = 1;
+
+  // unique_session_name from the session's TraceConfig. May be empty.
+  optional string session_name = 2;
+
+  // Service-local monotonic counter identifying the session. Shared by all
+  // state changes of one session, never reused within a service instance.
+  optional uint64 session_id = 3;
+
+  // Unix uid of the consumer that started the session.
+  optional int32 consumer_uid = 4;
+
+  // Number of data sources in the session at the time of the state change.
+  optional uint32 num_data_sources = 5;
+}

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -5153,6 +5153,12 @@ message TraceConfig {
 
     // Disable emitting extension descriptors into the trace.
     optional bool disable_extension_descriptors = 9;
+
+    // Emit state changes of other tracing sessions running concurrently
+    // with this one (see ConcurrentSessionEvent).
+    //
+    // Introduced in v58 / Android 26Q3+.
+    optional bool enable_concurrent_session_events = 10;
   }
   optional BuiltinDataSource builtin_data_sources = 20;
 
@@ -15453,6 +15459,54 @@ message MemoryTrackerSnapshot {
 
 // End of protos/perfetto/trace/memory_graph.proto
 
+// Begin of protos/perfetto/trace/perfetto/concurrent_session_event.proto
+
+// Emitted by the tracing service to record a state change of another tracing
+// session that was active while this trace was being recorded. Opt-in via
+// TraceConfig.BuiltinDataSource.enable_concurrent_session_events.
+//
+// One packet per state change; its time is carried by the enclosing
+// TracePacket's timestamp (CLOCK_BOOTTIME). Events of the same session share
+// the same |session_id|. The trace UUID is deliberately not included.
+//
+// Introduced in v58 / Android 26Q3+.
+message ConcurrentSessionEvent {
+  // Mirrors the tracing service's internal session state machine
+  // (TracingSession::State in the service): keep these two enums in sync.
+  // These values are part of the trace wire format and must stay stable: never
+  // renumber or reuse an existing value, only append new ones at the end.
+  enum State {
+    STATE_UNSPECIFIED = 0;
+    // Not recording (initial and final state).
+    STATE_DISABLED = 1;
+    // Configured but waiting for a start signal (e.g. a trigger).
+    STATE_CONFIGURED = 2;
+    // Actively recording data.
+    STATE_STARTED = 3;
+    // Stopping, waiting for data sources to ack and drain their final data.
+    STATE_DISABLING_WAITING_STOP_ACKS = 4;
+    // A read-only snapshot of another session, created by a clone operation.
+    STATE_CLONED_READ_ONLY = 5;
+  }
+  // The state the session transitioned to at this timestamp.
+  optional State state = 1;
+
+  // unique_session_name from the session's TraceConfig. May be empty.
+  optional string session_name = 2;
+
+  // Service-local monotonic counter identifying the session. Shared by all
+  // state changes of one session, never reused within a service instance.
+  optional uint64 session_id = 3;
+
+  // Unix uid of the consumer that started the session.
+  optional int32 consumer_uid = 4;
+
+  // Number of data sources in the session at the time of the state change.
+  optional uint32 num_data_sources = 5;
+}
+
+// End of protos/perfetto/trace/perfetto/concurrent_session_event.proto
+
 // Begin of protos/perfetto/trace/perfetto/perfetto_metatrace.proto
 
 // Used to trace the execution of perfetto itself.
@@ -17693,7 +17747,7 @@ message UiState {
 // See the [Buffers and Dataflow](/docs/concepts/buffers.md) doc for details.
 //
 // Next reserved id: 14 (up to 15).
-// Next id: 134.
+// Next id: 135.
 message TracePacket {
   // Encapsulates the state and configuration of the ProtoVM instances running
   // when the trace was snapshotted. This allows TP to re-instantiate the VMs
@@ -17791,6 +17845,7 @@ message TracePacket {
     CpuInfo cpu_info = 67;
     SmapsPacket smaps_packet = 68;
     TracingServiceEvent service_event = 69;
+    ConcurrentSessionEvent concurrent_session_event = 134;
     InitialDisplayState initial_display_state = 70;
     GpuMemTotalEvent gpu_mem_total_event = 71;
     MemoryTrackerSnapshot memory_tracker_snapshot = 73;

--- a/protos/perfetto/trace/trace_packet.proto
+++ b/protos/perfetto/trace/trace_packet.proto
@@ -55,6 +55,7 @@ import "protos/perfetto/trace/gpu/vulkan_memory_event.proto";
 import "protos/perfetto/trace/gpu/vulkan_api_event.proto";
 import "protos/perfetto/trace/interned_data/interned_data.proto";
 import "protos/perfetto/trace/memory_graph.proto";
+import "protos/perfetto/trace/perfetto/concurrent_session_event.proto";
 import "protos/perfetto/trace/perfetto/perfetto_metatrace.proto";
 import "protos/perfetto/trace/perfetto/trace_provenance.proto";
 import "protos/perfetto/trace/perfetto/tracing_service_event.proto";
@@ -109,7 +110,7 @@ package perfetto.protos;
 // See the [Buffers and Dataflow](/docs/concepts/buffers.md) doc for details.
 //
 // Next reserved id: 14 (up to 15).
-// Next id: 134.
+// Next id: 135.
 message TracePacket {
   // Encapsulates the state and configuration of the ProtoVM instances running
   // when the trace was snapshotted. This allows TP to re-instantiate the VMs
@@ -207,6 +208,7 @@ message TracePacket {
     CpuInfo cpu_info = 67;
     SmapsPacket smaps_packet = 68;
     TracingServiceEvent service_event = 69;
+    ConcurrentSessionEvent concurrent_session_event = 134;
     InitialDisplayState initial_display_state = 70;
     GpuMemTotalEvent gpu_mem_total_event = 71;
     MemoryTrackerSnapshot memory_tracker_snapshot = 73;

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -1093,7 +1093,17 @@ base::Status TracingServiceImpl::EnableTracing(ConsumerEndpointImpl* consumer,
                                           weak_runner_.task_runner()))
            .first->second;
 
-  PopulateConcurrentTracingSessions(tracing_session);
+  // Snapshot the current state of every other session into the newly created
+  // one, so its trace records which sessions were already active when it
+  // started. Each snapshot is timestamped with when that session entered its
+  // current state.
+  if (cfg.builtin_data_sources().enable_concurrent_session_events()) {
+    for (auto& [src_id, src] : tracing_sessions_) {
+      if (src_id == tsid)
+        continue;
+      tracing_session->AddConcurrentSessionEventWithLimit(src);
+    }
+  }
 
   tracing_session->trace_uuid = uuid;
 
@@ -4296,7 +4306,6 @@ void TracingServiceImpl::SetSessionState(TracingSession* session,
   // Broadcast this state change into every other session that opted into
   // concurrent session events, so their trace logs that this session changed
   // state while they were running.
-  std::optional<TracingSession::ConcurrentSessionEvent> event;
   for (auto& [dst_id, dst] : tracing_sessions_) {
     if (!dst.config.builtin_data_sources().enable_concurrent_session_events())
       continue;
@@ -4312,49 +4321,7 @@ void TracingServiceImpl::SetSessionState(TracingSession* session,
       continue;
     }
 
-    if (!event) {
-      event.emplace();
-      event->timestamp = session->current_state_start_ns;
-      event->session_id = session->id;
-      event->state = session->state;
-      event->consumer_uid = session->consumer_uid;
-      event->num_data_sources =
-          static_cast<uint32_t>(session->data_source_instances.size());
-      event->name = session->config.unique_session_name();
-    }
-    dst.AddConcurrentSessionEventWithLimit(*event);
-  }
-}
-
-void TracingServiceImpl::PopulateConcurrentTracingSessions(
-    TracingSession* dst) {
-  if (!dst->config.builtin_data_sources().enable_concurrent_session_events())
-    return;
-
-  // Snapshot the current state of every other session into the newly created
-  // |dst|, so its trace records which sessions were already active when it
-  // started. Each snapshot is timestamped with when |src| entered its current
-  // state.
-  for (auto& [src_id, src] : tracing_sessions_) {
-    if (src_id == dst->id)
-      continue;
-
-    // Skip DISABLED sessions: they've already finished (a DISABLED session
-    // lingers in the map until the consumer calls FreeBuffers) and won't emit a
-    // follow-up transition, so snapshotting one would leave a dangling terminal
-    // event for a session |dst| never really overlapped with.
-    if (src.state == TracingSession::DISABLED)
-      continue;
-
-    TracingSession::ConcurrentSessionEvent event{};
-    event.timestamp = src.current_state_start_ns;
-    event.session_id = src.id;
-    event.state = src.state;
-    event.consumer_uid = src.consumer_uid;
-    event.num_data_sources =
-        static_cast<uint32_t>(src.data_source_instances.size());
-    event.name = src.config.unique_session_name();
-    dst->AddConcurrentSessionEventWithLimit(std::move(event));
+    dst.AddConcurrentSessionEventWithLimit(*session);
   }
 }
 

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -132,6 +132,7 @@
 #include "protos/perfetto/protovm/vm_program.gen.h"
 #include "protos/perfetto/trace/clock_snapshot.pbzero.h"
 #include "protos/perfetto/trace/extension_descriptor.pbzero.h"
+#include "protos/perfetto/trace/perfetto/concurrent_session_event.pbzero.h"
 #include "protos/perfetto/trace/perfetto/trace_provenance.pbzero.h"
 #include "protos/perfetto/trace/perfetto/tracing_service_event.pbzero.h"
 #include "protos/perfetto/trace/remote_clock_sync.pbzero.h"
@@ -1092,6 +1093,8 @@ base::Status TracingServiceImpl::EnableTracing(ConsumerEndpointImpl* consumer,
                                           weak_runner_.task_runner()))
            .first->second;
 
+  PopulateConcurrentTracingSessions(tracing_session);
+
   tracing_session->trace_uuid = uuid;
 
   if (trace_filter)
@@ -1305,7 +1308,7 @@ base::Status TracingServiceImpl::EnableTracing(ConsumerEndpointImpl* consumer,
       // is handled few lines above (search for TriggerMode_MAX).
   }
 
-  tracing_session->state = TracingSession::CONFIGURED;
+  SetSessionState(tracing_session, TracingSession::CONFIGURED);
   PERFETTO_LOG(
       "Configured tracing session %" PRIu64
       ", #sources:%zu, duration:%u ms%s, #buffers:%d, total "
@@ -1475,7 +1478,7 @@ void TracingServiceImpl::StartTracing(TracingSessionID tsid) {
     return;
   }
 
-  tracing_session->state = TracingSession::STARTED;
+  SetSessionState(tracing_session, TracingSession::STARTED);
 
   // We store the start of trace snapshot separately as it's important to make
   // sure we can interpret all the data in the trace and storing it in the ring
@@ -1714,7 +1717,7 @@ void TracingServiceImpl::DisableTracing(TracingSessionID tsid,
   if (tracing_session->AllDataSourceInstancesStopped())
     return DisableTracingNotifyConsumerAndFlushFile(tracing_session, error);
 
-  tracing_session->state = TracingSession::DISABLING_WAITING_STOP_ACKS;
+  SetSessionState(tracing_session, TracingSession::DISABLING_WAITING_STOP_ACKS);
   weak_runner_.PostDelayedTask([this, tsid] { OnDisableTracingTimeout(tsid); },
                                tracing_session->data_source_stop_timeout_ms());
 
@@ -2075,7 +2078,7 @@ void TracingServiceImpl::DisableTracingNotifyConsumerAndFlushFile(
           *producer, inst_kv.second);
     }
   }
-  tracing_session->state = TracingSession::DISABLED;
+  SetSessionState(tracing_session, TracingSession::DISABLED);
 
   // Scrape any remaining chunks that weren't flushed by the producers.
   for (auto& producer_id_and_producer : producers_)
@@ -2717,6 +2720,11 @@ std::vector<TracePacket> TracingServiceImpl::ReadBuffers(
   if (!tracing_session->config.builtin_data_sources().disable_service_events())
     EmitLifecycleEvents(tracing_session, &packets);
 
+  if (tracing_session->config.builtin_data_sources()
+          .enable_concurrent_session_events()) {
+    EmitConcurrentSessionEvents(tracing_session, &packets);
+  }
+
   // In a multi-machine tracing session, emit clock synchronization messages for
   // remote machines.
   if (!tracing_session->config.builtin_data_sources()
@@ -3048,6 +3056,12 @@ void TracingServiceImpl::FreeBuffers(TracingSessionID tsid,
   bool is_long_trace =
       (tracing_session->config.write_into_file() &&
        tracing_session->config.file_write_period_ms() < kMillisPerDay);
+
+  // DisableTracing() above ignores cloned sessions: record their teardown
+  // here so other sessions observing this one see a terminal DISABLED state.
+  if (tracing_session->state == TracingSession::CLONED_READ_ONLY)
+    SetSessionState(tracing_session, TracingSession::DISABLED);
+
   auto pending_clones = std::move(tracing_session->pending_clones);
   tracing_sessions_.erase(tsid);
   tracing_session = nullptr;
@@ -4269,6 +4283,131 @@ void TracingServiceImpl::EmitLifecycleEvents(
     SerializeAndAppendPacket(packets, std::move(pair.second));
 }
 
+void TracingServiceImpl::SetSessionState(TracingSession* session,
+                                         TracingSession::State new_state) {
+  PERFETTO_DCHECK_THREAD(thread_checker_);
+
+  if (session->state == new_state)
+    return;
+
+  session->state = new_state;
+  session->current_state_start_ns = clock_->GetBootTimeNs().count();
+
+  // Broadcast this state change into every other session that opted into
+  // concurrent session events, so their trace logs that this session changed
+  // state while they were running.
+  std::optional<TracingSession::ConcurrentSessionEvent> event;
+  for (auto& [dst_id, dst] : tracing_sessions_) {
+    if (!dst.config.builtin_data_sources().enable_concurrent_session_events())
+      continue;
+    if (dst_id == session->id)
+      continue;
+
+    // Skip CLONED_READ_ONLY sessions, whose buffers are a frozen snapshot and
+    // must never change, and DISABLED ones (terminal, or not yet configured).
+    // Every other state (CONFIGURED, STARTED, DISABLING_WAITING_STOP_ACKS) is a
+    // live trace still being recorded or finalized, and will be read.
+    if (dst.state == TracingSession::CLONED_READ_ONLY ||
+        dst.state == TracingSession::DISABLED) {
+      continue;
+    }
+
+    if (!event) {
+      event.emplace();
+      event->timestamp = session->current_state_start_ns;
+      event->session_id = session->id;
+      event->state = session->state;
+      event->consumer_uid = session->consumer_uid;
+      event->num_data_sources =
+          static_cast<uint32_t>(session->data_source_instances.size());
+      event->name = session->config.unique_session_name();
+    }
+    dst.AddConcurrentSessionEventWithLimit(*event);
+  }
+}
+
+void TracingServiceImpl::PopulateConcurrentTracingSessions(
+    TracingSession* dst) {
+  if (!dst->config.builtin_data_sources().enable_concurrent_session_events())
+    return;
+
+  // Snapshot the current state of every other session into the newly created
+  // |dst|, so its trace records which sessions were already active when it
+  // started. Each snapshot is timestamped with when |src| entered its current
+  // state.
+  for (auto& [src_id, src] : tracing_sessions_) {
+    if (src_id == dst->id)
+      continue;
+
+    // Skip DISABLED sessions: they've already finished (a DISABLED session
+    // lingers in the map until the consumer calls FreeBuffers) and won't emit a
+    // follow-up transition, so snapshotting one would leave a dangling terminal
+    // event for a session |dst| never really overlapped with.
+    if (src.state == TracingSession::DISABLED)
+      continue;
+
+    TracingSession::ConcurrentSessionEvent event{};
+    event.timestamp = src.current_state_start_ns;
+    event.session_id = src.id;
+    event.state = src.state;
+    event.consumer_uid = src.consumer_uid;
+    event.num_data_sources =
+        static_cast<uint32_t>(src.data_source_instances.size());
+    event.name = src.config.unique_session_name();
+    dst->AddConcurrentSessionEventWithLimit(std::move(event));
+  }
+}
+
+void TracingServiceImpl::EmitConcurrentSessionEvents(
+    TracingSession* tracing_session,
+    std::vector<TracePacket>* packets) {
+  auto& events = tracing_session->concurrent_session_events;
+  if (events.empty())
+    return;
+
+  // Sort by timestamp so this sequence has monotonic timestamps, like the
+  // other service-emitted sequences.
+  std::sort(events.begin(), events.end(),
+            [](const TracingSession::ConcurrentSessionEvent& a,
+               const TracingSession::ConcurrentSessionEvent& b) {
+              return a.timestamp < b.timestamp;
+            });
+
+  auto to_proto_state = [](TracingSession::State state) {
+    using protos::pbzero::ConcurrentSessionEvent;
+    switch (state) {
+      case TracingSession::DISABLED:
+        return ConcurrentSessionEvent::STATE_DISABLED;
+      case TracingSession::CONFIGURED:
+        return ConcurrentSessionEvent::STATE_CONFIGURED;
+      case TracingSession::STARTED:
+        return ConcurrentSessionEvent::STATE_STARTED;
+      case TracingSession::DISABLING_WAITING_STOP_ACKS:
+        return ConcurrentSessionEvent::STATE_DISABLING_WAITING_STOP_ACKS;
+      case TracingSession::CLONED_READ_ONLY:
+        return ConcurrentSessionEvent::STATE_CLONED_READ_ONLY;
+    }
+    PERFETTO_FATAL("For GCC");
+  };
+
+  for (const auto& event : events) {
+    protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
+    packet->set_timestamp(static_cast<uint64_t>(event.timestamp));
+    SetServiceTracePacketHeader(packet.get());
+    auto* session_event = packet->set_concurrent_session_event();
+    session_event->set_state(to_proto_state(event.state));
+    if (!event.name.empty()) {
+      session_event->set_session_name(event.name);
+    }
+    session_event->set_session_id(event.session_id);
+    session_event->set_consumer_uid(static_cast<int32_t>(event.consumer_uid));
+    session_event->set_num_data_sources(event.num_data_sources);
+    SerializeAndAppendPacket(packets, packet.SerializeAsArray());
+  }
+
+  events.clear();
+}
+
 void TracingServiceImpl::MaybeEmitRemoteClockSync(
     TracingSession* tracing_session,
     std::vector<TracePacket>* packets) {
@@ -4829,7 +4968,7 @@ base::Status TracingServiceImpl::FinishCloneSession(
   // that triggered it. See the corresponding code in perfetto_cmd.cc which
   // reads at triggering_subscription_id().
   const int64_t orig_uuid_lsb = src->trace_uuid.lsb();
-  cloned_session->state = TracingSession::CLONED_READ_ONLY;
+  SetSessionState(cloned_session, TracingSession::CLONED_READ_ONLY);
   cloned_session->trace_uuid = base::Uuidv4();
   cloned_session->trace_uuid.set_lsb(orig_uuid_lsb);
   *new_uuid = cloned_session->trace_uuid;
@@ -4864,6 +5003,7 @@ base::Status TracingServiceImpl::FinishCloneSession(
       std::vector<TracingSession::LifecycleEvent>(src->lifecycle_events);
   cloned_session->slow_start_event = src->slow_start_event;
   cloned_session->last_flush_events = src->last_flush_events;
+  cloned_session->concurrent_session_events = src->concurrent_session_events;
   cloned_session->initial_clock_snapshot = src->initial_clock_snapshot;
   cloned_session->clock_snapshot_ring_buffer = src->clock_snapshot_ring_buffer;
   cloned_session->invalid_packets = src->invalid_packets;

--- a/src/tracing/service/tracing_service_impl.h
+++ b/src/tracing/service/tracing_service_impl.h
@@ -268,8 +268,6 @@ class TracingServiceImpl : public TracingService {
   // The only way to change a session's state. Broadcasts the change into the
   // other opted-in sessions' concurrent_session_events.
   void SetSessionState(TracingSession*, TracingSession::State);
-  // Snapshots the sessions already active into a newly created session.
-  void PopulateConcurrentTracingSessions(TracingSession*);
   void EmitConcurrentSessionEvents(TracingSession*, std::vector<TracePacket>*);
   void EmitUuid(TracingSession*, std::vector<TracePacket>*);
   void MaybeEmitTraceConfig(TracingSession*, std::vector<TracePacket>*);

--- a/src/tracing/service/tracing_service_impl.h
+++ b/src/tracing/service/tracing_service_impl.h
@@ -265,6 +265,12 @@ class TracingServiceImpl : public TracingService {
   void EmitStats(TracingSession*, std::vector<TracePacket>*);
   TraceStats GetTraceStats(TracingSession*);
   void EmitLifecycleEvents(TracingSession*, std::vector<TracePacket>*);
+  // The only way to change a session's state. Broadcasts the change into the
+  // other opted-in sessions' concurrent_session_events.
+  void SetSessionState(TracingSession*, TracingSession::State);
+  // Snapshots the sessions already active into a newly created session.
+  void PopulateConcurrentTracingSessions(TracingSession*);
+  void EmitConcurrentSessionEvents(TracingSession*, std::vector<TracePacket>*);
   void EmitUuid(TracingSession*, std::vector<TracePacket>*);
   void MaybeEmitTraceConfig(TracingSession*, std::vector<TracePacket>*);
   void EmitSystemInfo(std::vector<TracePacket>*);

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -629,7 +629,10 @@ CollectConcurrentSessionEvents(
 }
 
 // Checks that each tracing session records the state changes of the *other*
-// tracing sessions that overlapped with it, as ConcurrentSessionEvent packets.
+// tracing sessions that overlapped with it, as ConcurrentSessionEvent packets:
+// sessions already in the service when one starts are snapshotted in their
+// current state (including ended-but-not-yet-freed ones, as DISABLED), and
+// later state changes are recorded as they happen.
 TEST_F(TracingServiceImplTest, ConcurrentSessionEvents) {
   auto make_config = [](const char* name) {
     TraceConfig cfg;
@@ -661,11 +664,29 @@ TEST_F(TracingServiceImplTest, ConcurrentSessionEvents) {
                   protos::gen::ConcurrentSessionEvent::STATE_STARTED,
                   "session_a", 1u)));
 
+  // |session_b| has ended but its consumer hasn't freed it yet, so it lingers
+  // in the DISABLED state. |session_c| starts now: its snapshot contains both
+  // the running |session_a| and the lingering |session_b|.
+  constexpr uid_t kConsumerCUid = 2002;
+  std::unique_ptr<MockConsumer> consumer_c = CreateMockConsumer();
+  consumer_c->Connect(svc.get(), kConsumerCUid);
+  consumer_c->EnableTracing(make_config("session_c"));
+  consumer_c->DisableTracing();
+  consumer_c->WaitForTracingDisabled();
+  EXPECT_THAT(
+      CollectConcurrentSessionEvents(consumer_c->ReadBuffers()),
+      ElementsAre(
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_STARTED,
+                          "session_a", 1u),
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_DISABLED,
+                          "session_b", 2u)));
+
   consumer_a->DisableTracing();
   consumer_a->WaitForTracingDisabled();
 
-  // |session_a| observed |session_b|'s full lifecycle. With no data sources
-  // to wait for, DISABLING_WAITING_STOP_ACKS is skipped.
+  // |session_a| observed the full lifecycle of both |session_b| and
+  // |session_c|. With no data sources to wait for,
+  // DISABLING_WAITING_STOP_ACKS is skipped.
   auto packets_a = consumer_a->ReadBuffers();
   EXPECT_THAT(
       CollectConcurrentSessionEvents(packets_a),
@@ -675,14 +696,22 @@ TEST_F(TracingServiceImplTest, ConcurrentSessionEvents) {
           std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_STARTED,
                           "session_b", 2u),
           std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_DISABLED,
-                          "session_b", 2u)));
+                          "session_b", 2u),
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_CONFIGURED,
+                          "session_c", 3u),
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_STARTED,
+                          "session_c", 3u),
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_DISABLED,
+                          "session_c", 3u)));
 
   // Events carry the source session's consumer uid and data source count.
   for (const auto& packet : packets_a) {
     if (!packet.has_concurrent_session_event())
       continue;
     const auto& ev = packet.concurrent_session_event();
-    EXPECT_EQ(ev.consumer_uid(), static_cast<int32_t>(kConsumerBUid));
+    EXPECT_EQ(ev.consumer_uid(),
+              static_cast<int32_t>(ev.session_id() == 2u ? kConsumerBUid
+                                                         : kConsumerCUid));
     EXPECT_EQ(ev.num_data_sources(), 0u);
   }
 }
@@ -730,51 +759,6 @@ TEST_F(TracingServiceImplTest, ConcurrentSessionEventsAreOptIn) {
                           "session_b", 2u),
           std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_DISABLED,
                           "session_b", 2u)));
-}
-
-// A session that has already ended but not yet been freed lingers in the
-// service in the DISABLED state. It must not be snapshotted into a session that
-// starts afterwards: it isn't concurrently active and would produce a dangling
-// terminal event with no matching lifecycle.
-TEST_F(TracingServiceImplTest, ConcurrentSessionEventsSkipDisabled) {
-  auto make_config = [](const char* name) {
-    TraceConfig cfg;
-    cfg.add_buffers()->set_size_kb(128);
-    cfg.set_unique_session_name(name);
-    cfg.mutable_builtin_data_sources()->set_enable_concurrent_session_events(
-        true);
-    return cfg;
-  };
-
-  // |session_a| (id 1) stays running throughout.
-  std::unique_ptr<MockConsumer> consumer_a = CreateMockConsumer();
-  consumer_a->Connect(svc.get());
-  consumer_a->EnableTracing(make_config("session_a"));
-
-  // |session_b| (id 2) starts and fully stops, but is not freed (its consumer
-  // stays connected), so it lingers in the DISABLED state.
-  std::unique_ptr<MockConsumer> consumer_b = CreateMockConsumer();
-  consumer_b->Connect(svc.get());
-  consumer_b->EnableTracing(make_config("session_b"));
-  consumer_b->DisableTracing();
-  consumer_b->WaitForTracingDisabled();
-
-  // |session_c| (id 3) starts while |session_b| is lingering DISABLED.
-  std::unique_ptr<MockConsumer> consumer_c = CreateMockConsumer();
-  consumer_c->Connect(svc.get());
-  consumer_c->EnableTracing(make_config("session_c"));
-  consumer_c->DisableTracing();
-  consumer_c->WaitForTracingDisabled();
-
-  // |session_c|'s snapshot contains the running |session_a| but not the
-  // already-DISABLED |session_b|.
-  EXPECT_THAT(CollectConcurrentSessionEvents(consumer_c->ReadBuffers()),
-              ElementsAre(std::make_tuple(
-                  protos::gen::ConcurrentSessionEvent::STATE_STARTED,
-                  "session_a", 1u)));
-
-  consumer_a->DisableTracing();
-  consumer_a->WaitForTracingDisabled();
 }
 
 // Creates a tracing session with a START_TRACING trigger and checks that data

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -73,6 +73,7 @@
 #include "protos/perfetto/common/semantic_type.gen.h"
 #include "protos/perfetto/common/track_event_descriptor.gen.h"
 #include "protos/perfetto/trace/extension_descriptor.gen.h"
+#include "protos/perfetto/trace/perfetto/concurrent_session_event.gen.h"
 #include "protos/perfetto/trace/perfetto/trace_provenance.gen.h"
 #include "protos/perfetto/trace/perfetto/tracing_service_event.gen.h"
 #include "protos/perfetto/trace/test_event.gen.h"
@@ -610,6 +611,170 @@ TEST_F(TracingServiceImplTest, EnableAndDisableTracing) {
   consumer->DisableTracing();
   producer->WaitForDataSourceStop("data_source");
   consumer->WaitForTracingDisabled();
+}
+
+// Collects (state, session_name, session_id) tuples from
+// ConcurrentSessionEvent packets.
+std::vector<std::tuple<int, std::string, uint64_t>>
+CollectConcurrentSessionEvents(
+    const std::vector<protos::gen::TracePacket>& packets) {
+  std::vector<std::tuple<int, std::string, uint64_t>> events;
+  for (const auto& packet : packets) {
+    if (!packet.has_concurrent_session_event())
+      continue;
+    const auto& ev = packet.concurrent_session_event();
+    events.emplace_back(ev.state(), ev.session_name(), ev.session_id());
+  }
+  return events;
+}
+
+// Checks that each tracing session records the state changes of the *other*
+// tracing sessions that overlapped with it, as ConcurrentSessionEvent packets.
+TEST_F(TracingServiceImplTest, ConcurrentSessionEvents) {
+  auto make_config = [](const char* name) {
+    TraceConfig cfg;
+    cfg.add_buffers()->set_size_kb(128);
+    cfg.set_unique_session_name(name);
+    cfg.mutable_builtin_data_sources()->set_enable_concurrent_session_events(
+        true);
+    return cfg;
+  };
+
+  std::unique_ptr<MockConsumer> consumer_a = CreateMockConsumer();
+  consumer_a->Connect(svc.get());
+  consumer_a->EnableTracing(make_config("session_a"));
+
+  // While |session_a| is running, |session_b| starts and then stops.
+  constexpr uid_t kConsumerBUid = 2001;
+  std::unique_ptr<MockConsumer> consumer_b = CreateMockConsumer();
+  consumer_b->Connect(svc.get(), kConsumerBUid);
+  consumer_b->EnableTracing(make_config("session_b"));
+
+  consumer_b->DisableTracing();
+  consumer_b->WaitForTracingDisabled();
+
+  // |session_b| only sees |session_a| as an already-running session,
+  // snapshotted as a STARTED event at |session_b|'s creation. Session ids are
+  // assigned incrementally from 1.
+  EXPECT_THAT(CollectConcurrentSessionEvents(consumer_b->ReadBuffers()),
+              ElementsAre(std::make_tuple(
+                  protos::gen::ConcurrentSessionEvent::STATE_STARTED,
+                  "session_a", 1u)));
+
+  consumer_a->DisableTracing();
+  consumer_a->WaitForTracingDisabled();
+
+  // |session_a| observed |session_b|'s full lifecycle. With no data sources
+  // to wait for, DISABLING_WAITING_STOP_ACKS is skipped.
+  auto packets_a = consumer_a->ReadBuffers();
+  EXPECT_THAT(
+      CollectConcurrentSessionEvents(packets_a),
+      ElementsAre(
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_CONFIGURED,
+                          "session_b", 2u),
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_STARTED,
+                          "session_b", 2u),
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_DISABLED,
+                          "session_b", 2u)));
+
+  // Events carry the source session's consumer uid and data source count.
+  for (const auto& packet : packets_a) {
+    if (!packet.has_concurrent_session_event())
+      continue;
+    const auto& ev = packet.concurrent_session_event();
+    EXPECT_EQ(ev.consumer_uid(), static_cast<int32_t>(kConsumerBUid));
+    EXPECT_EQ(ev.num_data_sources(), 0u);
+  }
+}
+
+// Concurrent session events are opt-in and applied per-session: a session that
+// doesn't enable them records nothing, even if another session that enabled
+// them does.
+TEST_F(TracingServiceImplTest, ConcurrentSessionEventsAreOptIn) {
+  // |session_a| opts in, |session_b| does not.
+  TraceConfig cfg_a;
+  cfg_a.add_buffers()->set_size_kb(128);
+  cfg_a.set_unique_session_name("session_a");
+  cfg_a.mutable_builtin_data_sources()->set_enable_concurrent_session_events(
+      true);
+
+  TraceConfig cfg_b;
+  cfg_b.add_buffers()->set_size_kb(128);
+  cfg_b.set_unique_session_name("session_b");
+
+  std::unique_ptr<MockConsumer> consumer_a = CreateMockConsumer();
+  consumer_a->Connect(svc.get());
+  consumer_a->EnableTracing(cfg_a);
+
+  std::unique_ptr<MockConsumer> consumer_b = CreateMockConsumer();
+  consumer_b->Connect(svc.get());
+  consumer_b->EnableTracing(cfg_b);
+
+  consumer_b->DisableTracing();
+  consumer_b->WaitForTracingDisabled();
+
+  // |session_b| opted out: its trace contains no events.
+  EXPECT_THAT(CollectConcurrentSessionEvents(consumer_b->ReadBuffers()),
+              IsEmpty());
+
+  consumer_a->DisableTracing();
+  consumer_a->WaitForTracingDisabled();
+
+  // |session_a| opted in, so it still observes |session_b|'s state changes.
+  EXPECT_THAT(
+      CollectConcurrentSessionEvents(consumer_a->ReadBuffers()),
+      ElementsAre(
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_CONFIGURED,
+                          "session_b", 2u),
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_STARTED,
+                          "session_b", 2u),
+          std::make_tuple(protos::gen::ConcurrentSessionEvent::STATE_DISABLED,
+                          "session_b", 2u)));
+}
+
+// A session that has already ended but not yet been freed lingers in the
+// service in the DISABLED state. It must not be snapshotted into a session that
+// starts afterwards: it isn't concurrently active and would produce a dangling
+// terminal event with no matching lifecycle.
+TEST_F(TracingServiceImplTest, ConcurrentSessionEventsSkipDisabled) {
+  auto make_config = [](const char* name) {
+    TraceConfig cfg;
+    cfg.add_buffers()->set_size_kb(128);
+    cfg.set_unique_session_name(name);
+    cfg.mutable_builtin_data_sources()->set_enable_concurrent_session_events(
+        true);
+    return cfg;
+  };
+
+  // |session_a| (id 1) stays running throughout.
+  std::unique_ptr<MockConsumer> consumer_a = CreateMockConsumer();
+  consumer_a->Connect(svc.get());
+  consumer_a->EnableTracing(make_config("session_a"));
+
+  // |session_b| (id 2) starts and fully stops, but is not freed (its consumer
+  // stays connected), so it lingers in the DISABLED state.
+  std::unique_ptr<MockConsumer> consumer_b = CreateMockConsumer();
+  consumer_b->Connect(svc.get());
+  consumer_b->EnableTracing(make_config("session_b"));
+  consumer_b->DisableTracing();
+  consumer_b->WaitForTracingDisabled();
+
+  // |session_c| (id 3) starts while |session_b| is lingering DISABLED.
+  std::unique_ptr<MockConsumer> consumer_c = CreateMockConsumer();
+  consumer_c->Connect(svc.get());
+  consumer_c->EnableTracing(make_config("session_c"));
+  consumer_c->DisableTracing();
+  consumer_c->WaitForTracingDisabled();
+
+  // |session_c|'s snapshot contains the running |session_a| but not the
+  // already-DISABLED |session_b|.
+  EXPECT_THAT(CollectConcurrentSessionEvents(consumer_c->ReadBuffers()),
+              ElementsAre(std::make_tuple(
+                  protos::gen::ConcurrentSessionEvent::STATE_STARTED,
+                  "session_a", 1u)));
+
+  consumer_a->DisableTracing();
+  consumer_a->WaitForTracingDisabled();
 }
 
 // Creates a tracing session with a START_TRACING trigger and checks that data

--- a/src/tracing/service/tracing_service_session.cc
+++ b/src/tracing/service/tracing_service_session.cc
@@ -102,4 +102,22 @@ bool TracingSession::AllDataSourceInstancesStopped() {
                      });
 }
 
+void TracingSession::AddConcurrentSessionEventWithLimit(
+    const TracingSession& src) {
+  static constexpr size_t kMaxConcurrentSessionEvents = 4096;
+
+  if (concurrent_session_events.size() >= kMaxConcurrentSessionEvents)
+    return;
+
+  ConcurrentSessionEvent event{};
+  event.timestamp = src.current_state_start_ns;
+  event.session_id = src.id;
+  event.state = src.state;
+  event.consumer_uid = src.consumer_uid;
+  event.num_data_sources =
+      static_cast<uint32_t>(src.data_source_instances.size());
+  event.name = src.config.unique_session_name();
+  concurrent_session_events.emplace_back(std::move(event));
+}
+
 }  // namespace perfetto::tracing_service

--- a/src/tracing/service/tracing_service_session.h
+++ b/src/tracing/service/tracing_service_session.h
@@ -227,6 +227,34 @@ struct TracingSession {
 
   State state = DISABLED;
 
+  // BOOTTIME (ns) when this session entered its current state. Maintained
+  // solely by SetSessionState(), which every state transition goes through.
+  // Used as the timestamp when this session is snapshotted into another
+  // session's concurrent_session_events.
+  int64_t current_state_start_ns = 0;
+
+  // State changes of other concurrently active sessions. Emitted as
+  // ConcurrentSessionEvent packets and cleared on ReadBuffers(), like
+  // lifecycle_events.
+  struct ConcurrentSessionEvent {
+    int64_t timestamp = 0;            // BOOTTIME (ns) of the state change.
+    TracingSessionID session_id = 0;  // Id of the session that changed state.
+    State state = DISABLED;           // The state it transitioned to.
+    uid_t consumer_uid = 0;           // Uid of its consumer.
+    uint32_t num_data_sources = 0;    // Its data source count.
+    std::string name;                 // Its unique_session_name (or empty).
+  };
+
+  // Appends |event|, dropping it once the buffer hits the limit. The cap
+  // bounds memory, as the buffer is drained only on ReadBuffers().
+  void AddConcurrentSessionEventWithLimit(ConcurrentSessionEvent event) {
+    static constexpr size_t kMaxConcurrentSessionEvents = 4096;
+    if (concurrent_session_events.size() >= kMaxConcurrentSessionEvents)
+      return;
+    concurrent_session_events.emplace_back(std::move(event));
+  }
+  std::vector<ConcurrentSessionEvent> concurrent_session_events;
+
   // If the consumer detached the session, this variable defines the key used
   // for identifying the session later when reattaching.
   std::string detach_key;

--- a/src/tracing/service/tracing_service_session.h
+++ b/src/tracing/service/tracing_service_session.h
@@ -97,6 +97,11 @@ struct TracingSession {
   // session.
   bool IsCloneAllowed(uid_t clone_uid) const;
 
+  // Records |src|'s current state into concurrent_session_events, dropping the
+  // event once the buffer hits the limit. The cap bounds memory, as the buffer
+  // is drained only on ReadBuffers().
+  void AddConcurrentSessionEventWithLimit(const TracingSession& src);
+
   const TracingSessionID id;
 
   // The consumer that started the session.
@@ -245,14 +250,6 @@ struct TracingSession {
     std::string name;                 // Its unique_session_name (or empty).
   };
 
-  // Appends |event|, dropping it once the buffer hits the limit. The cap
-  // bounds memory, as the buffer is drained only on ReadBuffers().
-  void AddConcurrentSessionEventWithLimit(ConcurrentSessionEvent event) {
-    static constexpr size_t kMaxConcurrentSessionEvents = 4096;
-    if (concurrent_session_events.size() >= kMaxConcurrentSessionEvents)
-      return;
-    concurrent_session_events.emplace_back(std::move(event));
-  }
   std::vector<ConcurrentSessionEvent> concurrent_session_events;
 
   // If the consumer detached the session, this variable defines the key used


### PR DESCRIPTION
Optionally record the lifecycle state changes of *other* tracing
sessions active while a trace is being recorded, to help diagnose
field issues caused by unexpected concurrent sessions.

- Add the ConcurrentSessionEvent packet: state (mirrors the service's
  session state machine), unique_session_name, service-local session
  id (deliberately not the trace UUID), consumer uid and number of
  data sources.
- Route every session state change through a single SetSessionState()
  helper. It broadcasts the change into the other opted-in sessions
  that are still recording (i.e. CONFIGURED, STARTED or
  DISABLING_WAITING_STOP_ACKS; read-only clones and already-disabled
  sessions are skipped), appending to a bounded per-session buffer
  that is drained on ReadBuffers().
- On creation, a session snapshots the current state of the other
  active sessions, so its trace records what was already running when
  it started. Each event is timestamped with when that session entered
  its current state.
- Cloned sessions inherit the source's events and record a terminal
  DISABLED on teardown.
- Opt-in via
  TraceConfig.BuiltinDataSource.enable_concurrent_session_events.
- Add service unittests.