### PR TITLE
tp: support metatrace capture against --remote sessions

### DIFF
--- a/src/trace_processor/rpc/remote_trace_processor.cc
+++ b/src/trace_processor/rpc/remote_trace_processor.cc
@@ -32,10 +32,12 @@
 #include "perfetto/protozero/scattered_heap_buffer.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "perfetto/trace_processor/iterator.h"
+#include "perfetto/trace_processor/metatrace_config.h"
 #include "src/trace_processor/iterator_impl.h"
 #include "src/trace_processor/rpc/query_result_deserializer.h"
 #include "src/trace_processor/rpc/rpc_transport.h"
 
+#include "protos/perfetto/trace_processor/metatrace_categories.pbzero.h"
 #include "protos/perfetto/trace_processor/trace_processor.pbzero.h"
 #include "protos/perfetto/trace_summary/file.pbzero.h"
 
@@ -401,10 +403,25 @@ base::Status RemoteTraceProcessor::Summarize(
       });
 }
 
-void RemoteTraceProcessor::EnableMetatrace(MetatraceConfig) {
+void RemoteTraceProcessor::EnableMetatrace(MetatraceConfig config) {
+  using ProtoEnum = protos::pbzero::MetatraceCategories;
+  int32_t proto_categories = 0;
+  if (config.categories & metatrace::MetatraceCategories::QUERY_TIMELINE)
+    proto_categories |= ProtoEnum::QUERY_TIMELINE;
+  if (config.categories & metatrace::MetatraceCategories::QUERY_DETAILED)
+    proto_categories |= ProtoEnum::QUERY_DETAILED;
+  if (config.categories & metatrace::MetatraceCategories::FUNCTION_CALL)
+    proto_categories |= ProtoEnum::FUNCTION_CALL;
+  if (config.categories & metatrace::MetatraceCategories::DB)
+    proto_categories |= ProtoEnum::DB;
+  if (config.categories & metatrace::MetatraceCategories::API_TIMELINE)
+    proto_categories |= ProtoEnum::API_TIMELINE;
   base::ignore_result(RoundTrip(
       RpcProto::TPM_ENABLE_METATRACE,
-      [](RpcProto* rpc) { rpc->set_enable_metatrace_args(); },
+      [&](RpcProto* rpc) {
+        rpc->set_enable_metatrace_args()->set_categories(
+            static_cast<ProtoEnum>(proto_categories));
+      },
       [](RpcProto::Decoder&) { return base::OkStatus(); }));
 }
 

--- a/src/trace_processor/shell/common_flags.cc
+++ b/src/trace_processor/shell/common_flags.cc
@@ -524,7 +524,6 @@ static base::Status CheckRemoteFlagCompatibility(const GlobalOptions& opts) {
       {!opts.override_stdlib_path.empty(), "--override-stdlib"},
       {!opts.register_files_dir.empty(), "--register-files-dir"},
       {!opts.raw_metric_v1_extensions.empty(), "--metric-extension"},
-      {!opts.metatrace_path.empty(), "--metatrace"},
   };
   for (const auto& f : incompatible) {
     if (f.is_set) {
@@ -549,6 +548,14 @@ base::StatusOr<std::unique_ptr<TraceProcessor>> CreateTraceProcessor(
     RETURN_IF_ERROR(CheckRemoteFlagCompatibility(opts));
     ASSIGN_OR_RETURN(auto remote,
                      RemoteTraceProcessor::Connect(opts.remote_addr));
+    // Metatracing is scoped to this client's queries: enabled here, then
+    // collected by MaybeWriteMetatrace. Note the buffer capacity override is
+    // not forwarded over the RPC, only the categories.
+    if (!opts.metatrace_path.empty()) {
+      metatrace::MetatraceConfig metatrace_config;
+      metatrace_config.categories = opts.metatrace_categories;
+      remote->EnableMetatrace(metatrace_config);
+    }
     if (t_load_out)
       *t_load_out = base::TimeNanos(0);
     return std::unique_ptr<TraceProcessor>(std::move(remote));

--- a/test/trace_processor_shell_integrationtest.cc
+++ b/test/trace_processor_shell_integrationtest.cc
@@ -526,6 +526,16 @@ TEST(TraceProcessorShellIntegrationTest, RemoteQueryRoundTrip) {
       RunShell({"query", "--remote", sock, "SELECT * FROM no_such_table"});
   EXPECT_NE(r3.exit_code, 0);
 
+  // -m against a remote session enables metatracing server-side and collects
+  // the resulting trace client-side.
+  base::TempFile mt = base::TempFile::Create();
+  auto r4 = RunShell({"query", "--remote", sock, "-m", mt.path(),
+                      "SELECT count(*) FROM slice"});
+  EXPECT_EQ(r4.exit_code, 0) << r4.out;
+  std::string mt_data;
+  EXPECT_TRUE(base::ReadFile(mt.path(), &mt_data));
+  EXPECT_GT(mt_data.size(), 0u);
+
   server.KillAndWaitForTermination(SIGTERM);
   EXPECT_TRUE(WaitForFileState(sock, /*want_exists=*/false));
 }
@@ -611,10 +621,10 @@ TEST(TraceProcessorShellIntegrationTest, RemoteRejectsIncompatibleFlags) {
   EXPECT_THAT(r1.out, HasSubstr("--add-sql-package"));
   EXPECT_THAT(r1.out, HasSubstr("cannot be combined with --remote"));
 
-  auto r2 = RunShell({"query", "--remote", "some-session", "--metatrace",
-                      "/tmp/m.pb", "SELECT 1"});
+  auto r2 = RunShell(
+      {"query", "--remote", "some-session", "--full-sort", "SELECT 1"});
   EXPECT_NE(r2.exit_code, 0);
-  EXPECT_THAT(r2.out, HasSubstr("--metatrace"));
+  EXPECT_THAT(r2.out, HasSubstr("--full-sort"));
   EXPECT_THAT(r2.out, HasSubstr("cannot be combined with --remote"));
 }
 


### PR DESCRIPTION
Allow combining -m/--metatrace with query --remote: forward the
requested categories through EnableMetatraceArgs (previously dropped by
RemoteTraceProcessor) and enable metatracing on the remote handle right
after connecting. The metatrace is collected client-side on completion
as in local mode.

This gives a per-query window into the planner (DATAFRAME_BEST_INDEX,
DATAFRAME_FILTER_PREPARE) against a warm session without paying a trace
reload per query. The buffer capacity override is not forwarded, only
the categories.
