### PR TITLE
tp: order context-join stdlib views fact-table-last

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/sched/with_context.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/sched/with_context.sql
@@ -61,6 +61,11 @@ SELECT
   sched.cpu,
   sched.end_state,
   sched.priority
-FROM sched
-JOIN thread USING (utid)
-LEFT JOIN process USING (upid);
+-- Join order matters: list the small dimensions first and the large fact table
+-- (sched) last. A `LEFT JOIN` pins its right table after everything to its
+-- left, so writing `sched ... LEFT JOIN process` forces `process` to be
+-- re-probed once per sched row; attaching `process` to `thread` and joining
+-- `sched` last lets the planner drive from whichever dimension is filtered.
+FROM thread
+LEFT JOIN process USING (upid)
+JOIN sched USING (utid);

--- a/src/trace_processor/perfetto_sql/stdlib/slices/with_context.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/slices/with_context.sql
@@ -75,11 +75,16 @@ SELECT
   slice.arg_set_id,
   slice.thread_ts,
   slice.thread_dur
-FROM slice
-JOIN thread_track
-  ON slice.track_id = thread_track.id
+-- Join order matters: dimensions first, the large fact table (slice) last. A
+-- `LEFT JOIN` pins its right table after everything to its left, so
+-- `slice ... LEFT JOIN process` re-probes `process` once per slice; attaching
+-- `process` to `thread` and joining `slice` last lets the planner drive from
+-- whichever dimension is filtered.
+FROM thread_track
 JOIN thread USING (utid)
-LEFT JOIN process USING (upid);
+LEFT JOIN process USING (upid)
+JOIN slice
+  ON slice.track_id = thread_track.id;
 
 -- All process slices with data about process track and process.
 CREATE PERFETTO VIEW process_slice(
@@ -190,11 +195,12 @@ SELECT
   slice.depth,
   slice.parent_id,
   slice.arg_set_id
-FROM slice
-JOIN thread_track
-  ON slice.track_id = thread_track.id
+-- Dimensions first, fact table (slice) last -- see thread_slice above.
+FROM thread_track
 JOIN thread USING (utid)
 LEFT JOIN process USING (upid)
+JOIN slice
+  ON slice.track_id = thread_track.id
 UNION ALL
 SELECT
   slice.id,


### PR DESCRIPTION
sched.with_context and slices.with_context wrote the large fact table
first and LEFT JOINed process last:

```
  FROM sched JOIN thread USING(utid) LEFT JOIN process USING(upid)
```

SQLite never plans the right side of a LEFT JOIN before any table in the
join's left operand, so process was pinned after the fact-table
expansion and re-probed once per fact row. Reordering so the dimensions
form a flat chain and the fact table joins last lets the planner drive
from whichever dimension is filtered, and is result-identical:

```
  FROM thread LEFT JOIN process USING(upid) JOIN sched USING(utid)
```

Applies to sched_with_thread_process, thread_slice and
thread_or_process_slice. On a 30s Android trace, filtering
sched_with_thread_process by thread_name drops 3ms to 1ms and
thread_slice 4ms to 0ms; the gap grows with the fact table's size.
