### PR TITLE
tp: signifcantly improve performance of blocking calls in CUJ

### DIFF
--- a/src/trace_processor/metrics/sql/android/android_blocking_calls_cuj_per_frame_metric.sql
+++ b/src/trace_processor/metrics/sql/android/android_blocking_calls_cuj_per_frame_metric.sql
@@ -26,6 +26,49 @@ INCLUDE PERFETTO MODULE android.critical_blocking_calls;
 INCLUDE PERFETTO MODULE android.frames.timeline;
 INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
 
+-- The `DrawFrames` slices (one per drawn layer) for each frame within a CUJ,
+-- with their render thread timing.
+--
+-- This is materialized into its own table (rather than left as a CTE) for two
+-- reasons:
+--   1. It avoids the query planner re-evaluating it multiple times when it is
+--      consumed downstream.
+--   2. It lets us join against the pre-parsed `android_frames_draw_frame` table
+--      (integer equality on frame_id) instead of re-parsing the slice name with
+--      `STR_SPLIT` on every row of a `thread_slice` scan.
+DROP TABLE IF EXISTS android_blocking_calls_cuj_per_frame_draw_frames;
+CREATE PERFETTO TABLE android_blocking_calls_cuj_per_frame_draw_frames AS
+SELECT
+  frame.frame_id,
+  frame.cuj_name,
+  df.upid,
+  p.name AS process_name,
+  s.ts,
+  s.ts + s.dur AS ts_end
+FROM _extended_frame_boundary frame
+JOIN android_frames_draw_frame df
+  ON df.frame_id = frame.frame_id
+  AND df.render_thread_utid = frame.render_thread_utid
+JOIN slice s ON s.id = df.id
+JOIN process p ON p.upid = df.upid;
+
+-- The `hwuiTask` running time overlapping each frame within a CUJ. Materialized
+-- for the same reasons as above: the interval-overlap join against
+-- `thread_state` is expensive and must only run once.
+DROP TABLE IF EXISTS android_blocking_calls_cuj_per_frame_hwui_tasks;
+CREATE PERFETTO TABLE android_blocking_calls_cuj_per_frame_hwui_tasks AS
+SELECT
+  df.frame_id,
+  df.cuj_name,
+  df.upid,
+  df.process_name,
+  'hwuiTask' AS name,
+  MIN(ts.ts + ts.dur, df.ts_end) - MAX(ts.ts, df.ts) AS dur
+FROM android_blocking_calls_cuj_per_frame_draw_frames df
+JOIN thread t ON t.upid = df.upid AND t.name GLOB 'hwuiTask*'
+JOIN thread_state ts ON ts.utid = t.utid AND ts.state = 'Running'
+WHERE ts.ts < df.ts_end AND ts.ts + ts.dur > df.ts;
+
 -- Calculate the mean/max values for duration and count for blocking calls per frame.
 DROP TABLE IF EXISTS android_blocking_calls_cuj_per_frame_calls;
 CREATE PERFETTO TABLE android_blocking_calls_cuj_per_frame_calls AS
@@ -42,34 +85,6 @@ WITH blocking_calls_aggregate_values AS (
   FROM _blocking_calls_frame_cuj
   GROUP BY cuj_name, name, frame_id
 ),
-draw_frames_in_cuj AS (
-  SELECT
-    frame.frame_id,
-    frame.cuj_name,
-    t.upid,
-    p.name AS process_name,
-    s.ts,
-    s.ts + s.dur AS ts_end
-  FROM _extended_frame_boundary frame
-  JOIN thread t ON t.utid = frame.render_thread_utid
-  JOIN process p ON p.upid = t.upid
-  JOIN thread_slice s ON s.utid = frame.render_thread_utid
-                      AND s.name GLOB 'DrawFrames*'
-                      AND CAST(STR_SPLIT(s.name, ' ', 1) AS INT) = frame.frame_id
-),
-hwui_tasks_in_cuj AS (
-  SELECT
-    df.frame_id,
-    df.cuj_name,
-    df.upid,
-    df.process_name,
-    'hwuiTask' AS name,
-    MIN(ts.ts + ts.dur, df.ts_end) - MAX(ts.ts, df.ts) AS dur
-  FROM draw_frames_in_cuj df
-  JOIN thread t ON t.upid = df.upid AND t.name GLOB 'hwuiTask*'
-  JOIN thread_state ts ON ts.utid = t.utid AND ts.state = 'Running'
-  WHERE ts.ts < df.ts_end AND ts.ts + ts.dur > df.ts
-),
 hwui_tasks_aggregate_values AS (
   SELECT
     1 AS cnt,
@@ -78,7 +93,7 @@ hwui_tasks_aggregate_values AS (
     upid,
     process_name,
     name
-  FROM hwui_tasks_in_cuj
+  FROM android_blocking_calls_cuj_per_frame_hwui_tasks
   GROUP BY cuj_name, name, frame_id
 ),
 all_blocking_calls_aggregate_values AS (

--- a/src/trace_processor/perfetto_sql/stdlib/android/critical_blocking_calls.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/critical_blocking_calls.sql
@@ -19,49 +19,73 @@ INCLUDE PERFETTO MODULE android.binder;
 
 INCLUDE PERFETTO MODULE slices.with_context;
 
+-- Internal implementation detail. Expands to a boolean expression that is true
+-- when `slice_name` refers to a relevant blocking call.
+--
+-- This is a macro (rather than a `PERFETTO FUNCTION`) purely for performance:
+-- trace_processor does not inline SQL functions, so calling one per row across
+-- the whole `thread_slice` table (millions of rows) adds several seconds of
+-- per-call dispatch overhead. A macro is expanded textually into the query, so
+-- the predicate is evaluated directly with no call overhead.
+CREATE PERFETTO MACRO _is_relevant_blocking_call_expr(
+  -- Expression evaluating to the slice name to test.
+  slice_name Expr
+)
+-- Boolean expression: true if the slice is a relevant blocking call.
+RETURNS Expr
+AS (
+  $slice_name IN (
+    'measure',
+    'layout',
+    'configChanged',
+    'animation',
+    'input',
+    'traversal',
+    'Contending for pthread mutex',
+    'postAndWait',
+    'CreateGraphicsPipeline',
+    'flush layers',
+    'flush commands',
+    'queueBuffer'
+  )
+  OR $slice_name GLOB 'monitor contention with*'
+  OR $slice_name GLOB 'SuspendThreadByThreadId*'
+  OR $slice_name GLOB 'LoadApkAssetsFd*'
+  OR $slice_name GLOB '*binder transaction*'
+  OR $slice_name GLOB 'inflate*'
+  OR $slice_name GLOB 'Lock contention on*'
+  OR $slice_name GLOB 'android.os.Handler: kotlinx.coroutines*'
+  OR $slice_name GLOB 'relayoutWindow*'
+  OR $slice_name GLOB 'ImageDecoder#decode*'
+  OR $slice_name GLOB 'NotificationStackScrollLayout#onMeasure'
+  OR $slice_name GLOB 'ExpNotRow#*'
+  OR $slice_name GLOB 'GC: Wait For*'
+  OR $slice_name GLOB 'Recomposer:*'
+  OR $slice_name GLOB 'Compose:*'
+  OR $slice_name GLOB 'draw-VRI*'
+  OR $slice_name GLOB 'drawLayer *'
+  OR $slice_name GLOB 'DrawFrames*'
+  OR $slice_name GLOB 'Texture upload*'
+  OR (
+    NOT ($slice_name GLOB '*Choreographer*')
+    AND NOT ($slice_name GLOB '*Input*')
+    AND NOT ($slice_name GLOB '*input*')
+    AND NOT ($slice_name GLOB 'android.os.Handler: #*')
+    AND (
+      -- Handler pattern heuristics
+      $slice_name GLOB '*Handler: *$*'
+      OR $slice_name GLOB '*.*.*: *$*'
+      OR $slice_name GLOB '*.*$*: #*'
+    )
+  )
+);
+
+-- Retained for backwards compatibility with any external callers. The `depth`
+-- argument is unused.
 CREATE PERFETTO FUNCTION _is_relevant_blocking_call(name STRING, depth LONG)
 RETURNS BOOL
 AS
-SELECT
-  $name = 'measure'
-  OR $name = 'layout'
-  OR $name = 'configChanged'
-  OR $name = 'animation'
-  OR $name = 'input'
-  OR $name = 'traversal'
-  OR $name = 'Contending for pthread mutex'
-  OR $name = 'postAndWait'
-  OR $name GLOB 'monitor contention with*'
-  OR $name GLOB 'SuspendThreadByThreadId*'
-  OR $name GLOB 'LoadApkAssetsFd*'
-  OR $name GLOB '*binder transaction*'
-  OR $name GLOB 'inflate*'
-  OR $name GLOB 'Lock contention on*'
-  OR $name GLOB 'android.os.Handler: kotlinx.coroutines*'
-  OR $name GLOB 'relayoutWindow*'
-  OR $name GLOB 'ImageDecoder#decode*'
-  OR $name GLOB 'NotificationStackScrollLayout#onMeasure'
-  OR $name GLOB 'ExpNotRow#*'
-  OR $name GLOB 'GC: Wait For*'
-  OR $name GLOB 'Recomposer:*'
-  OR $name GLOB 'Compose:*'
-  OR $name GLOB 'draw-VRI*'
-  OR $name = 'CreateGraphicsPipeline'
-  OR $name GLOB 'drawLayer *'
-  OR $name GLOB 'DrawFrames*'
-  OR $name = 'flush layers'
-  OR $name = 'flush commands'
-  OR $name = 'queueBuffer'
-  OR $name GLOB 'Texture upload*'
-  OR (NOT ($name GLOB '*Choreographer*')
-  AND NOT ($name GLOB '*Input*')
-  AND NOT ($name GLOB '*input*')
-  AND NOT ($name GLOB 'android.os.Handler: #*')
-  AND (
-  -- Handler pattern heuristics
-  $name GLOB '*Handler: *$*'
-  OR $name GLOB '*.*.*: *$*'
-  OR $name GLOB '*.*$*: #*'));
+SELECT _is_relevant_blocking_call_expr!($name);
 
 --Extract critical blocking calls from all processes.
 CREATE PERFETTO TABLE _android_critical_blocking_calls AS
@@ -77,7 +101,7 @@ SELECT
 FROM thread_slice AS s
 JOIN thread USING (utid)
 WHERE
-  _is_relevant_blocking_call(s.name, s.depth)
+  _is_relevant_blocking_call_expr!(s.name)
 UNION ALL
 -- Add a summation of all drawLayer slices without the individual layer name
 SELECT

--- a/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
@@ -79,6 +79,16 @@ ORDER BY
   frame_id;
 
 -- Capture blocking call duration within frames within a CUJ.
+--
+-- The join between blocking calls and frames is split into two branches (one
+-- for the UI thread, one for the render thread) that are `UNION ALL`-ed
+-- together, rather than joining on `bc.utid = frame.ui_thread_utid OR bc.utid =
+-- frame.render_thread_utid`. An `OR` in a join condition forces a nested loop
+-- over the full cross product; two separate equality joins can each be executed
+-- efficiently. The `bc.utid != frame.ui_thread_utid` guard on the render branch
+-- keeps the two branches disjoint (so no row is double counted in the rare case
+-- where a frame's UI and render threads are the same), making this exactly
+-- equivalent to the original `OR` join.
 CREATE PERFETTO TABLE _blocking_calls_frame_cuj AS
 SELECT
   min(bc.dur, frame.ts_end - bc.ts, bc.ts_end - frame.ts) AS dur,
@@ -93,12 +103,32 @@ SELECT
   cuj_name
 FROM _android_critical_blocking_calls AS bc
 JOIN _extended_frame_boundary AS frame
-  ON (bc.utid = frame.ui_thread_utid OR bc.utid = frame.render_thread_utid)
+  ON bc.utid = frame.ui_thread_utid
 -- The following condition to accommodate blocking call crossing frame boundary. The blocking
 -- call starts in a frame or ends in a frame. It can either be the same frame or a different
 -- frame.
 WHERE
   (
   -- Blocking call starts within the frame.
+  (bc.ts >= frame.ts AND bc.ts <= frame.ts_end)
+  OR (bc.ts_end >= frame.ts AND bc.ts_end <= frame.ts_end))
+UNION ALL
+SELECT
+  min(bc.dur, frame.ts_end - bc.ts, bc.ts_end - frame.ts) AS dur,
+  max(frame.ts, bc.ts) AS ts,
+  bc.upid,
+  bc.name,
+  bc.process_name,
+  bc.utid,
+  frame.frame_id,
+  frame.layer_id,
+  cuj_id,
+  cuj_name
+FROM _android_critical_blocking_calls AS bc
+JOIN _extended_frame_boundary AS frame
+  ON bc.utid = frame.render_thread_utid
+  AND bc.utid != frame.ui_thread_utid
+WHERE
+  (
   (bc.ts >= frame.ts AND bc.ts <= frame.ts_end)
   OR (bc.ts_end >= frame.ts AND bc.ts_end <= frame.ts_end));

--- a/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
@@ -129,6 +129,5 @@ JOIN _extended_frame_boundary AS frame
   ON bc.utid = frame.render_thread_utid
   AND bc.utid != frame.ui_thread_utid
 WHERE
-  (
-  (bc.ts >= frame.ts AND bc.ts <= frame.ts_end)
+  ((bc.ts >= frame.ts AND bc.ts <= frame.ts_end)
   OR (bc.ts_end >= frame.ts AND bc.ts_end <= frame.ts_end));


### PR DESCRIPTION
* materialize CTEs as PERFETTO tables significantly imporving
  performance
* instead of joining on an STR_SPLIT (which has atrocious performance
  characteristics), join on the pre materialized draw frames instead
* extract out complex fuction -> macro to allow for inlining, speeding
  up perf
* change or condition in join to instead implement two independent
  queries with a union all, speeding up performance quite a bit
