### PR TITLE
ui: Fix circular dependency crash in Data Explorer Smart Graph

### DIFF
--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
@@ -333,8 +333,8 @@ export function serializeState(state: DataExplorerState): string {
   };
 
   const replacer = (key: string, value: unknown) => {
-    // Only strip _trace to avoid including large trace objects
-    if (key === '_trace') {
+    // strip _trace / trace to avoid including large trace objects
+    if (key === '_trace' || key === 'trace') {
       return undefined;
     }
     // Connection info is stored in node-specific state (primaryInputId, inputNodeIds, etc.)

--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
@@ -119,6 +119,40 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedNode).toBeInstanceOf(SlicesSourceNode);
   });
 
+  test('does not crash when serializeState is called with circular references in trace', () => {
+    // Create a mock Trace object with circular references resembling the actual TraceImpl structure.
+    const circularTrace: Record<string, unknown> = {};
+    const searchManager: Record<string, unknown> = {_trackManager: {}};
+    const trackManager: Record<string, unknown> = {_overlays: []};
+    const overlay: Record<string, unknown> = {trace: circularTrace};
+
+    (trackManager._overlays as unknown[]).push(overlay);
+    searchManager._trackManager = trackManager;
+    circularTrace.search = searchManager;
+
+    // Create a node with attrs referencing the trace.
+    const node = new SlicesSourceNode({}, {});
+    (node.attrs as Record<string, unknown>).trace = circularTrace;
+
+    const initialState: DataExplorerState = {
+      rootNodes: [node],
+      selectedNodes: new Set(),
+      nodeLayouts: new Map(),
+      labels: [],
+    };
+
+    // This should not throw 'TypeError: Converting circular structure to JSON'.
+    let json: string | undefined;
+    expect(() => {
+      json = serializeState(initialState);
+    }).not.toThrow();
+
+    // Verify that the serialized JSON doesn't contain the trace object
+    expect(json).toBeDefined();
+    const parsed = JSON.parse(json!);
+    expect(parsed.nodes[0].state.trace).toBeUndefined();
+  });
+
   test('handles multiple nodes and connections', () => {
     const tableNode = new TableSourceNode(
       {sqlTable: 'slice'},


### PR DESCRIPTION
Exclude the 'trace' property from JSON serialization in the Data Explorer plugin. When saving history or exporting states, JSON.stringify was attempting to serialize the Trace object, which contains circular references and causes a UI crash. Also added a unit test to verify circular reference handling during serialization.