### PR TITLE
tp: model IN-filter selectivity as a union of equalities

### DIFF
--- a/src/trace_processor/core/dataframe/query_plan.cc
+++ b/src/trace_processor/core/dataframe/query_plan.cc
@@ -57,6 +57,22 @@ namespace {
 
 namespace i = interpreter;
 
+// Assumed number of distinct values matched by an IN filter when the list size
+// is not known at plan time. Scales the single-value equality estimate. Matches
+// SQLite's own tuning constant for "x IN (SELECT ...)" (see whereLoopAddBtree).
+constexpr double kAssumedInListSize = 25;
+
+// Rows surviving a scalar equality filter on a HasDuplicates column with
+// `estimated_distinct` distinct values (0 = unknown). With a known count, a
+// uniform column keeps ~1/estimated_distinct of the rows; otherwise fall back
+// to the data-blind heuristic.
+double EqualityFilterRows(uint32_t row_count, uint32_t estimated_distinct) {
+  if (estimated_distinct > 0) {
+    return static_cast<double>(row_count) / estimated_distinct;
+  }
+  return row_count / (2 * log2(row_count));
+}
+
 // Register type identifiers for cache key encoding.
 // Used with DataframeRegisterCache::GetOrAllocate(reg_type, ptr)
 // to cache column/index-specific registers.
@@ -900,8 +916,8 @@ void QueryPlanBuilder::IndexConstraints(
             i::Index<i::FilterIn>(non_id->Upcast<StorageType>(),
                                   NullabilityToSparseNullCollapsedNullability(
                                       column.null_storage.nullability())),
-            RowCountModifier{EqualityFilterRowCount{column.duplicate_state,
-                                                    column.estimated_distinct}},
+            RowCountModifier{InFilterRowCount{column.duplicate_state,
+                                              column.estimated_distinct}},
             i::LogPerRowCost{10});
         bc.arg<B::storage_register>() =
             StorageRegisterFor(fs.col, non_id->Upcast<StorageType>());
@@ -1155,20 +1171,10 @@ PERFETTO_NO_INLINE i::Bytecode& QueryPlanBuilder::AddRawOpcode(
       const auto& eq = base::unchecked_get<EqualityFilterRowCount>(rc);
       if (eq.duplicate_state.Is<HasDuplicates>()) {
         if (plan_.params.estimated_row_count > 1) {
-          double new_count;
-          if (eq.estimated_distinct > 0) {
-            // Known distinct-value count: an equality filter on a column with
-            // `estimated_distinct` distinct values keeps ~1/estimated_distinct
-            // of the rows under a uniformity assumption.
-            new_count = static_cast<double>(plan_.params.estimated_row_count) /
-                        eq.estimated_distinct;
-          } else {
-            // Unknown selectivity: fall back to the data-blind heuristic.
-            new_count = plan_.params.estimated_row_count /
-                        (2 * log2(plan_.params.estimated_row_count));
-          }
           plan_.params.estimated_row_count =
-              std::max(1u, static_cast<uint32_t>(new_count));
+              std::max(1u, static_cast<uint32_t>(EqualityFilterRows(
+                               plan_.params.estimated_row_count,
+                               eq.estimated_distinct)));
         } else {
           // Leave the estimated row count as is if it is already 1 or less.
         }
@@ -1177,6 +1183,23 @@ PERFETTO_NO_INLINE i::Bytecode& QueryPlanBuilder::AddRawOpcode(
         plan_.params.estimated_row_count =
             std::min(1u, plan_.params.estimated_row_count);
         plan_.params.max_row_count = std::min(1u, plan_.params.max_row_count);
+      }
+      break;
+    }
+    case base::variant_index<RowCountModifier, InFilterRowCount>(): {
+      const auto& in = base::unchecked_get<InFilterRowCount>(rc);
+      if (in.duplicate_state.Is<HasDuplicates>() &&
+          plan_.params.estimated_row_count > 1) {
+        // An IN is a union of equalities over the list values. The list size
+        // is unknown at plan time, so scale the single-value estimate by an
+        // assumed distinct-value count, capped at the current row count.
+        double per_value = EqualityFilterRows(plan_.params.estimated_row_count,
+                                              in.estimated_distinct);
+        double new_count =
+            std::min(static_cast<double>(plan_.params.estimated_row_count),
+                     per_value * kAssumedInListSize);
+        plan_.params.estimated_row_count =
+            std::max(1u, static_cast<uint32_t>(new_count));
       }
       break;
     }

--- a/src/trace_processor/core/dataframe/query_plan.cc
+++ b/src/trace_processor/core/dataframe/query_plan.cc
@@ -1171,10 +1171,10 @@ PERFETTO_NO_INLINE i::Bytecode& QueryPlanBuilder::AddRawOpcode(
       const auto& eq = base::unchecked_get<EqualityFilterRowCount>(rc);
       if (eq.duplicate_state.Is<HasDuplicates>()) {
         if (plan_.params.estimated_row_count > 1) {
-          plan_.params.estimated_row_count =
-              std::max(1u, static_cast<uint32_t>(EqualityFilterRows(
-                               plan_.params.estimated_row_count,
-                               eq.estimated_distinct)));
+          plan_.params.estimated_row_count = std::max(
+              1u,
+              static_cast<uint32_t>(EqualityFilterRows(
+                  plan_.params.estimated_row_count, eq.estimated_distinct)));
         } else {
           // Leave the estimated row count as is if it is already 1 or less.
         }

--- a/src/trace_processor/core/dataframe/query_plan.h
+++ b/src/trace_processor/core/dataframe/query_plan.h
@@ -263,6 +263,16 @@ class QueryPlanBuilder {
     uint32_t estimated_distinct = 0;
   };
 
+  // Indicates that the bytecode is an IN filter over a value list. Unlike a
+  // scalar equality, an IN matches multiple distinct values; since the list
+  // size is not known at plan time (the RHS may be a subquery), we assume it
+  // selects a fixed number of distinct values. `estimated_distinct` is the
+  // per-column distinct-value count (0 = unknown).
+  struct InFilterRowCount {
+    DuplicateState duplicate_state;
+    uint32_t estimated_distinct = 0;
+  };
+
   // Indicates that the bytecode produces *exactly* one row and the estimated
   // and maximum should be set to 1.
   struct OneRowCount {};
@@ -279,6 +289,7 @@ class QueryPlanBuilder {
   using RowCountModifier = std::variant<UnchangedRowCount,
                                         NonEqualityFilterRowCount,
                                         EqualityFilterRowCount,
+                                        InFilterRowCount,
                                         OneRowCount,
                                         ZeroRowCount,
                                         LimitOffsetRowCount>;


### PR DESCRIPTION
The IN-list size is not known at plan time: the RHS may be a subquery
and the vtab xBestIndex API does not expose the list length. Model an
IN as an assumed fixed number of matched distinct values, scaling the
single-value estimate. Use 25 to match SQLite's own tuning constant for
"x IN (SELECT ...)" in whereLoopAddBtree. Add a dedicated
InFilterRowCount cost modifier rather than overloading the scalar
equality path.

Restores android_monitor_contention to its pre-#6619 cost and leaves
the scalar-equality NDV estimates untouched. Full stdlib diff-test
suite and dataframe unit tests pass unchanged.
