### PR TITLE
[DNS] tp: Fast C++ interval self intersection + ui: Process State Change Breakdowns

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3096,6 +3096,7 @@ cc_test {
         ":perfetto_src_trace_processor_plugins_graph_traversal_graph_traversal",
         ":perfetto_src_trace_processor_plugins_import_import",
         ":perfetto_src_trace_processor_plugins_interval_intersect_interval_intersect",
+        ":perfetto_src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
         ":perfetto_src_trace_processor_plugins_layout_functions_layout_functions",
         ":perfetto_src_trace_processor_plugins_math_functions_math_functions",
         ":perfetto_src_trace_processor_plugins_metadata_metadata",
@@ -18559,6 +18560,7 @@ filegroup {
         "src/trace_processor/perfetto_sql/stdlib/intervals/intersect.sql",
         "src/trace_processor/perfetto_sql/stdlib/intervals/mipmap.sql",
         "src/trace_processor/perfetto_sql/stdlib/intervals/overlap.sql",
+        "src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql",
     ],
 }
 
@@ -19548,6 +19550,14 @@ filegroup {
     name: "perfetto_src_trace_processor_plugins_interval_intersect_interval_intersect",
     srcs: [
         "src/trace_processor/plugins/interval_intersect/interval_intersect.cc",
+    ],
+}
+
+// GN: //src/trace_processor/plugins/interval_self_intersect:interval_self_intersect
+filegroup {
+    name: "perfetto_src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
+    srcs: [
+        "src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc",
     ],
 }
 
@@ -20595,6 +20605,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_plugins_graph_traversal_graph_traversal",
         ":perfetto_src_trace_processor_plugins_import_import",
         ":perfetto_src_trace_processor_plugins_interval_intersect_interval_intersect",
+        ":perfetto_src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
         ":perfetto_src_trace_processor_plugins_layout_functions_layout_functions",
         ":perfetto_src_trace_processor_plugins_math_functions_math_functions",
         ":perfetto_src_trace_processor_plugins_metadata_metadata",
@@ -23483,6 +23494,7 @@ cc_test {
         ":perfetto_src_trace_processor_plugins_graph_traversal_graph_traversal",
         ":perfetto_src_trace_processor_plugins_import_import",
         ":perfetto_src_trace_processor_plugins_interval_intersect_interval_intersect",
+        ":perfetto_src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
         ":perfetto_src_trace_processor_plugins_layout_functions_layout_functions",
         ":perfetto_src_trace_processor_plugins_math_functions_math_functions",
         ":perfetto_src_trace_processor_plugins_metadata_metadata",
@@ -24581,6 +24593,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_plugins_graph_traversal_graph_traversal",
         ":perfetto_src_trace_processor_plugins_import_import",
         ":perfetto_src_trace_processor_plugins_interval_intersect_interval_intersect",
+        ":perfetto_src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
         ":perfetto_src_trace_processor_plugins_layout_functions_layout_functions",
         ":perfetto_src_trace_processor_plugins_math_functions_math_functions",
         ":perfetto_src_trace_processor_plugins_metadata_metadata",
@@ -25260,6 +25273,7 @@ cc_binary_host {
         ":perfetto_src_trace_processor_plugins_graph_traversal_graph_traversal",
         ":perfetto_src_trace_processor_plugins_import_import",
         ":perfetto_src_trace_processor_plugins_interval_intersect_interval_intersect",
+        ":perfetto_src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
         ":perfetto_src_trace_processor_plugins_layout_functions_layout_functions",
         ":perfetto_src_trace_processor_plugins_math_functions_math_functions",
         ":perfetto_src_trace_processor_plugins_metadata_metadata",

--- a/BUILD
+++ b/BUILD
@@ -493,6 +493,7 @@ perfetto_cc_library(
         ":src_trace_processor_plugins_graph_traversal_tables",
         ":src_trace_processor_plugins_import_import",
         ":src_trace_processor_plugins_interval_intersect_interval_intersect",
+        ":src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
         ":src_trace_processor_plugins_layout_functions_layout_functions",
         ":src_trace_processor_plugins_math_functions_math_functions",
         ":src_trace_processor_plugins_metadata_metadata",
@@ -791,6 +792,7 @@ perfetto_cc_library(
         ":src_trace_processor_plugins_graph_traversal_tables",
         ":src_trace_processor_plugins_import_import",
         ":src_trace_processor_plugins_interval_intersect_interval_intersect",
+        ":src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
         ":src_trace_processor_plugins_layout_functions_layout_functions",
         ":src_trace_processor_plugins_math_functions_math_functions",
         ":src_trace_processor_plugins_metadata_metadata",
@@ -3990,6 +3992,7 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/stdlib/intervals/intersect.sql",
         "src/trace_processor/perfetto_sql/stdlib/intervals/mipmap.sql",
         "src/trace_processor/perfetto_sql/stdlib/intervals/overlap.sql",
+        "src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql",
     ],
 )
 
@@ -4758,6 +4761,15 @@ perfetto_filegroup(
     srcs = [
         "src/trace_processor/plugins/interval_intersect/interval_intersect.cc",
         "src/trace_processor/plugins/interval_intersect/interval_intersect.h",
+    ],
+)
+
+# GN target: //src/trace_processor/plugins/interval_self_intersect:interval_self_intersect
+perfetto_filegroup(
+    name = "src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
+    srcs = [
+        "src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc",
+        "src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.h",
     ],
 )
 
@@ -11287,6 +11299,7 @@ perfetto_cc_library(
         ":src_trace_processor_plugins_graph_traversal_tables",
         ":src_trace_processor_plugins_import_import",
         ":src_trace_processor_plugins_interval_intersect_interval_intersect",
+        ":src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
         ":src_trace_processor_plugins_layout_functions_layout_functions",
         ":src_trace_processor_plugins_math_functions_math_functions",
         ":src_trace_processor_plugins_metadata_metadata",
@@ -11615,6 +11628,7 @@ perfetto_cc_binary(
         ":src_trace_processor_plugins_graph_traversal_tables",
         ":src_trace_processor_plugins_import_import",
         ":src_trace_processor_plugins_interval_intersect_interval_intersect",
+        ":src_trace_processor_plugins_interval_self_intersect_interval_self_intersect",
         ":src_trace_processor_plugins_layout_functions_layout_functions",
         ":src_trace_processor_plugins_math_functions_math_functions",
         ":src_trace_processor_plugins_metadata_metadata",

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -232,6 +232,7 @@ if (enable_perfetto_trace_processor_sqlite) {
       "plugins/graph_traversal",
       "plugins/import",
       "plugins/interval_intersect",
+      "plugins/interval_self_intersect",
       "plugins/layout_functions",
       "plugins/math_functions",
       "plugins/metadata",

--- a/src/trace_processor/perfetto_sql/stdlib/intervals/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/BUILD.gn
@@ -21,5 +21,6 @@ perfetto_sql_source_set("intervals") {
     "intersect.sql",
     "mipmap.sql",
     "overlap.sql",
+    "self_intersect.sql",
   ]
 }

--- a/src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql
@@ -1,0 +1,64 @@
+--
+-- Copyright 2026 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- sqlformat file off
+
+-- Self-intersection of an interval table. Identical output contract to the
+-- existing intervals.intersect.interval_self_intersect SQL macro — drop-in
+-- replacement, implemented via the C++ plugin
+-- plugins/interval_self_intersect (single-pass O(n log n) sweep).
+--
+-- For each atomic time segment defined by the endpoints of |intervals| and
+-- for every interval active in that segment, emits one row with the
+-- interval's id and interval_ends_at_ts = 0. For each interval, also emits
+-- one "end marker" row at the segment that begins at the interval's end ts
+-- with interval_ends_at_ts = 1; the final endpoint produces a dur=0
+-- segment containing only end markers (matching the SQL macro's quirk).
+--
+-- |intervals| must expose `id INT64`, `ts INT64`, `dur INT64`.
+-- Output:
+--   ts INT64                start of the atomic segment
+--   dur INT64               duration to the next endpoint (0 at the final)
+--   group_id INT64          1-indexed stable per-segment id
+--   id INT64                original interval id
+--   interval_ends_at_ts INT64    0 = active in segment, 1 = end marker
+CREATE PERFETTO MACRO _interval_self_intersect(
+  intervals TableOrSubquery
+)
+RETURNS TableOrSubquery AS
+(
+  SELECT
+    c0 AS ts,
+    c1 AS dur,
+    c2 AS group_id,
+    c3 AS id,
+    c4 AS interval_ends_at_ts
+  FROM __intrinsic_table_ptr(
+    __intrinsic_interval_self_intersect(
+      (
+        SELECT
+          __intrinsic_interval_tree_intervals_agg(
+            input.id, input.ts, input.dur
+          )
+        FROM (SELECT * FROM $intervals ORDER BY ts) input
+      )
+    )
+  )
+  WHERE __intrinsic_table_ptr_bind(c0, 'ts')
+    AND __intrinsic_table_ptr_bind(c1, 'dur')
+    AND __intrinsic_table_ptr_bind(c2, 'group_id')
+    AND __intrinsic_table_ptr_bind(c3, 'id')
+    AND __intrinsic_table_ptr_bind(c4, 'interval_ends_at_ts')
+);

--- a/src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql
@@ -62,3 +62,135 @@ RETURNS TableOrSubquery AS
     AND __intrinsic_table_ptr_bind(c3, 'id')
     AND __intrinsic_table_ptr_bind(c4, 'interval_ends_at_ts')
 );
+
+-- Helper macros for the aggregated variant below.
+CREATE PERFETTO MACRO _isi_agg_pair(x ColumnName, y ColumnName)
+RETURNS _ProjectionFragment AS __intrinsic_stringify!($x), input.$y;
+
+CREATE PERFETTO MACRO _isi_select(x ColumnName, y Expr)
+RETURNS _ProjectionFragment AS $x AS $y;
+
+CREATE PERFETTO MACRO _isi_bind(x Expr, y Expr)
+RETURNS Expr AS __intrinsic_table_ptr_bind($x, __intrinsic_stringify!($y));
+
+-- Partitioned self-intersect with aggregation done during the sweep.
+--
+-- Splits the timeline of each partition (tuple of $partition_cols values,
+-- NULL keys form their own partition) into atomic segments at every interval
+-- endpoint and emits exactly ONE row per segment — including zero-active gap
+-- segments and a final dur=0 segment at the partition's last endpoint, so a
+-- counter sourced from this output drops to zero where cover ends. Output
+-- size is at most 2x the input rows (per partition), regardless of overlap
+-- depth.
+--
+-- |intervals| must expose `ts INT64`, `dur INT64` (>= 0), $value_col
+-- (numeric or NULL), and the $partition_cols. Input need not be sorted.
+--
+-- Output:
+--   ts INT64          start of the atomic segment
+--   dur INT64         duration to the next endpoint in the partition
+--                     (0 at the final segment)
+--   group_id INT64    globally unique 1-indexed segment id
+--   cnt INT64         number of intervals active in the segment
+--   sum_value DOUBLE  sum of $value_col over active intervals (0 when none)
+--   min_value DOUBLE  min of $value_col over active intervals (NULL when none)
+--   max_value DOUBLE  max of $value_col over active intervals (NULL when none)
+--   <partition cols>  the partition tuple, with their original names
+CREATE PERFETTO MACRO _interval_self_intersect_agg(
+  intervals TableOrSubquery,
+  value_col ColumnName,
+  partition_cols ColumnNameList
+)
+RETURNS TableOrSubquery AS
+(
+  SELECT
+    c0 AS ts,
+    c1 AS dur,
+    c2 AS group_id,
+    c3 AS cnt,
+    c4 AS sum_value,
+    c5 AS min_value,
+    c6 AS max_value
+    __intrinsic_token_apply_prefix!(
+      _isi_select,
+      (c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21),
+      $partition_cols
+    )
+  FROM __intrinsic_table_ptr(
+    __intrinsic_interval_self_intersect_agg(
+      (
+        SELECT __intrinsic_isi_intervals_agg(
+          input.ts, input.dur, input.$value_col
+          __intrinsic_token_apply_prefix!(
+            _isi_agg_pair,
+            $partition_cols,
+            $partition_cols
+          )
+        )
+        FROM $intervals input
+      ),
+      __intrinsic_stringify!($partition_cols)
+    )
+  )
+  WHERE __intrinsic_table_ptr_bind(c0, 'ts')
+    AND __intrinsic_table_ptr_bind(c1, 'dur')
+    AND __intrinsic_table_ptr_bind(c2, 'group_id')
+    AND __intrinsic_table_ptr_bind(c3, 'cnt')
+    AND __intrinsic_table_ptr_bind(c4, 'sum_value')
+    AND __intrinsic_table_ptr_bind(c5, 'min_value')
+    AND __intrinsic_table_ptr_bind(c6, 'max_value')
+    __intrinsic_token_apply_and_prefix!(
+      _isi_bind,
+      (c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21),
+      $partition_cols
+    )
+);
+
+-- Count-only variant of _interval_self_intersect_agg for callers with no
+-- value column: sum_value/min_value/max_value are emitted but carry no
+-- information (0/NULL/NULL). Same output contract otherwise.
+CREATE PERFETTO MACRO _interval_self_intersect_count(
+  intervals TableOrSubquery,
+  partition_cols ColumnNameList
+)
+RETURNS TableOrSubquery AS
+(
+  SELECT
+    c0 AS ts,
+    c1 AS dur,
+    c2 AS group_id,
+    c3 AS cnt
+    __intrinsic_token_apply_prefix!(
+      _isi_select,
+      (c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21),
+      $partition_cols
+    )
+  FROM __intrinsic_table_ptr(
+    __intrinsic_interval_self_intersect_agg(
+      (
+        SELECT __intrinsic_isi_intervals_agg(
+          input.ts, input.dur, NULL
+          __intrinsic_token_apply_prefix!(
+            _isi_agg_pair,
+            $partition_cols,
+            $partition_cols
+          )
+        )
+        FROM $intervals input
+      ),
+      __intrinsic_stringify!($partition_cols)
+    )
+  )
+  WHERE __intrinsic_table_ptr_bind(c0, 'ts')
+    AND __intrinsic_table_ptr_bind(c1, 'dur')
+    AND __intrinsic_table_ptr_bind(c2, 'group_id')
+    AND __intrinsic_table_ptr_bind(c3, 'cnt')
+    AND __intrinsic_table_ptr_bind(c4, 'sum_value')
+    AND __intrinsic_table_ptr_bind(c5, 'min_value')
+    AND __intrinsic_table_ptr_bind(c6, 'max_value')
+    __intrinsic_token_apply_and_prefix!(
+      _isi_bind,
+      (c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21),
+      $partition_cols
+    )
+);

--- a/src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql
@@ -34,11 +34,9 @@
 --   group_id INT64          1-indexed stable per-segment id
 --   id INT64                original interval id
 --   interval_ends_at_ts INT64    0 = active in segment, 1 = end marker
-CREATE PERFETTO MACRO _interval_self_intersect(
-  intervals TableOrSubquery
-)
-RETURNS TableOrSubquery AS
-(
+CREATE PERFETTO MACRO _interval_self_intersect(intervals TableOrSubquery)
+RETURNS TableOrSubquery
+AS (
   SELECT
     c0 AS ts,
     c1 AS dur,
@@ -65,13 +63,16 @@ RETURNS TableOrSubquery AS
 
 -- Helper macros for the aggregated variant below.
 CREATE PERFETTO MACRO _isi_agg_pair(x ColumnName, y ColumnName)
-RETURNS _ProjectionFragment AS __intrinsic_stringify!($x), input.$y;
+RETURNS _ProjectionFragment
+AS __intrinsic_stringify!($x), input.$y;
 
 CREATE PERFETTO MACRO _isi_select(x ColumnName, y Expr)
-RETURNS _ProjectionFragment AS $x AS $y;
+RETURNS _ProjectionFragment
+AS $x AS $y;
 
 CREATE PERFETTO MACRO _isi_bind(x Expr, y Expr)
-RETURNS Expr AS __intrinsic_table_ptr_bind($x, __intrinsic_stringify!($y));
+RETURNS Expr
+AS __intrinsic_table_ptr_bind($x, __intrinsic_stringify!($y));
 
 -- Partitioned self-intersect with aggregation done during the sweep.
 --
@@ -103,8 +104,8 @@ CREATE PERFETTO MACRO _interval_self_intersect_agg(
   value_col ColumnName,
   partition_cols ColumnNameList
 )
-RETURNS TableOrSubquery AS
-(
+RETURNS TableOrSubquery
+AS (
   SELECT
     c0 AS ts,
     c1 AS dur,
@@ -155,8 +156,8 @@ CREATE PERFETTO MACRO _interval_self_intersect_count(
   intervals TableOrSubquery,
   partition_cols ColumnNameList
 )
-RETURNS TableOrSubquery AS
-(
+RETURNS TableOrSubquery
+AS (
   SELECT
     c0 AS ts,
     c1 AS dur,

--- a/src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/self_intersect.sql
@@ -77,19 +77,21 @@ RETURNS Expr AS __intrinsic_table_ptr_bind($x, __intrinsic_stringify!($y));
 --
 -- Splits the timeline of each partition (tuple of $partition_cols values,
 -- NULL keys form their own partition) into atomic segments at every interval
--- endpoint and emits exactly ONE row per segment — including zero-active gap
--- segments and a final dur=0 segment at the partition's last endpoint, so a
--- counter sourced from this output drops to zero where cover ends. Output
--- size is at most 2x the input rows (per partition), regardless of overlap
--- depth.
+-- endpoint and emits ONE row per run of adjacent segments with identical
+-- aggregates — a boundary where as many intervals start as end (e.g.
+-- back-to-back slices with equal values) does not emit a row. Zero-active
+-- gap segments are emitted too, as is a trailing segment ending at the
+-- partition's last endpoint, so a counter sourced from this output drops to
+-- zero where cover ends. Output size is at most 2x the input rows (per
+-- partition), regardless of overlap depth.
 --
 -- |intervals| must expose `ts INT64`, `dur INT64` (>= 0), $value_col
 -- (numeric or NULL), and the $partition_cols. Input need not be sorted.
 --
 -- Output:
---   ts INT64          start of the atomic segment
---   dur INT64         duration to the next endpoint in the partition
---                     (0 at the final segment)
+--   ts INT64          start of the (merged) segment
+--   dur INT64         duration until the aggregates next change in the
+--                     partition (0 at the trailing segment)
 --   group_id INT64    globally unique 1-indexed segment id
 --   cnt INT64         number of intervals active in the segment
 --   sum_value DOUBLE  sum of $value_col over active intervals (0 when none)

--- a/src/trace_processor/plugins/interval_self_intersect/BUILD.gn
+++ b/src/trace_processor/plugins/interval_self_intersect/BUILD.gn
@@ -1,0 +1,38 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/perfetto.gni")
+
+assert(enable_perfetto_trace_processor_sqlite)
+
+source_set("interval_self_intersect") {
+  sources = [
+    "interval_self_intersect.cc",
+    "interval_self_intersect.h",
+  ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../../gn:sqlite",
+    "../../../../include/perfetto/trace_processor:basic_types",
+    "../../../base",
+    "../../containers",
+    "../../core/dataframe",
+    "../../core/plugin",
+    "../../perfetto_sql/engine",
+    "../../perfetto_sql/intrinsics/types",
+    "../../sqlite",
+    "../../storage",
+    "../../types",
+  ]
+}

--- a/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc
+++ b/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <set>
@@ -404,6 +405,18 @@ struct IsiIntervalsAgg : public sqlite::AggregateFunction<IsiIntervalsAgg> {
   }
 };
 
+// Bit-level double equality for the segment-merge check: merging must only
+// happen when the emitted value would be byte-identical, and bit comparison
+// sidesteps float-equality pitfalls (NaN never equals itself with ==; a
+// missed merge just emits an extra, still-correct row).
+inline bool BitEqual(double a, double b) {
+  uint64_t ia;
+  uint64_t ib;
+  memcpy(&ia, &a, sizeof(ia));
+  memcpy(&ib, &b, sizeof(ib));
+  return ia == ib;
+}
+
 // Output column layout; must match the c0..c6 binds in
 // stdlib/intervals/self_intersect.sql.
 constexpr uint32_t kOutTs = 0;
@@ -451,30 +464,73 @@ uint32_t SweepPartition(dataframe::AdhocDataframeBuilder& builder,
   double sum = 0;
   std::multiset<double> values;
 
+  // Adjacent atomic segments with identical aggregates are merged into one
+  // row: a boundary where as many intervals start as end (e.g. back-to-back
+  // slices) changes nothing a step-function consumer can observe, so emitting
+  // it would only inflate the output. The pending row is extended until the
+  // aggregates change, then flushed. Merging on the exact double `sum` is
+  // conservative: a bit-level difference just emits an extra (still correct)
+  // row.
+  bool pending = false;
+  int64_t pend_ts = 0;
+  int64_t pend_end = 0;
+  int64_t pend_cnt = 0;
+  double pend_sum = 0;
+  bool pend_has_minmax = false;
+  double pend_min = 0;
+  double pend_max = 0;
+
   uint32_t rows = 0;
-  auto emit = [&](int64_t seg_ts, int64_t seg_dur) {
-    builder.PushNonNullUnchecked(kOutTs, seg_ts);
-    builder.PushNonNullUnchecked(kOutDur, seg_dur);
+  auto flush = [&]() {
+    if (!pending) {
+      return;
+    }
+    builder.PushNonNullUnchecked(kOutTs, pend_ts);
+    builder.PushNonNullUnchecked(kOutDur, pend_end - pend_ts);
     builder.PushNonNullUnchecked(kOutGroupId, group_id);
-    builder.PushNonNullUnchecked(kOutCnt, cnt);
-    builder.PushNonNullUnchecked(kOutSum, sum);
-    if (values.empty()) {
+    builder.PushNonNullUnchecked(kOutCnt, pend_cnt);
+    builder.PushNonNullUnchecked(kOutSum, pend_sum);
+    if (pend_has_minmax) {
+      builder.PushNonNullUnchecked(kOutMin, pend_min);
+      builder.PushNonNullUnchecked(kOutMax, pend_max);
+    } else {
       builder.PushNull(kOutMin, 1);
       builder.PushNull(kOutMax, 1);
-    } else {
-      builder.PushNonNullUnchecked(kOutMin, *values.begin());
-      builder.PushNonNullUnchecked(kOutMax, *values.rbegin());
     }
     ++group_id;
     ++rows;
+    pending = false;
+  };
+
+  auto add_segment = [&](int64_t seg_ts, int64_t seg_end) {
+    bool has_minmax = !values.empty();
+    double mn = has_minmax ? *values.begin() : 0;
+    double mx = has_minmax ? *values.rbegin() : 0;
+    // Segments within a partition are contiguous (pend_end == seg_ts always
+    // holds); the check documents the merge invariant.
+    if (pending && pend_end == seg_ts && pend_cnt == cnt &&
+        BitEqual(pend_sum, sum) && pend_has_minmax == has_minmax &&
+        (!has_minmax || (BitEqual(pend_min, mn) && BitEqual(pend_max, mx)))) {
+      pend_end = seg_end;
+      return;
+    }
+    flush();
+    pending = true;
+    pend_ts = seg_ts;
+    pend_end = seg_end;
+    pend_cnt = cnt;
+    pend_sum = sum;
+    pend_has_minmax = has_minmax;
+    pend_min = mn;
+    pend_max = mx;
   };
 
   int64_t prev_ts = events.front().ts;
   for (const auto& ev : events) {
     if (ev.ts > prev_ts) {
-      // Emit the segment [prev_ts, ev.ts) with the state accumulated from
-      // all events at prev_ts and earlier. Zero-active gaps emit too.
-      emit(prev_ts, ev.ts - prev_ts);
+      // Add the segment [prev_ts, ev.ts) with the state accumulated from
+      // all events at prev_ts and earlier. Zero-active gaps count too.
+      add_segment(prev_ts, ev.ts);
       prev_ts = ev.ts;
     }
     if (ev.delta > 0) {
@@ -492,10 +548,12 @@ uint32_t SweepPartition(dataframe::AdhocDataframeBuilder& builder,
     }
   }
   // Every start has a matching end, so the active set is empty here; the
-  // final dur=0 segment is the counter's drop-to-zero point at the
-  // partition's last endpoint.
+  // trailing zero-width segment is the counter's drop-to-zero point at the
+  // partition's last endpoint (it merges into a preceding zero-count gap
+  // row when one exists).
   PERFETTO_DCHECK(cnt == 0);
-  emit(prev_ts, 0);
+  add_segment(prev_ts, prev_ts);
+  flush();
   return rows;
 }
 

--- a/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc
+++ b/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc
@@ -18,14 +18,22 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/murmur_hash.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/string_view.h"
+#include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_aggregate_function.h"
 #include "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
 #include "src/trace_processor/core/plugin/plugin.h"
@@ -214,6 +222,424 @@ struct IntervalSelfIntersect
   }
 };
 
+// ---------------------------------------------------------------------------
+// Partitioned self-intersect with direct aggregation.
+//
+// Unlike the drop-in variant above (which mirrors the SQL macro's
+// per-(segment x active interval) output), this pipeline aggregates DURING
+// the sweep and emits exactly one row per atomic segment per partition:
+//
+//   ts, dur, group_id, cnt, sum_value, min_value, max_value, <partitions...>
+//
+// so the output size is bounded by 2x the input row count per partition set,
+// independent of how many intervals overlap. Zero-active gap segments are
+// emitted too (cnt = 0), including a final dur=0 segment at each partition's
+// last endpoint, so a counter track sourced from this table drops to zero
+// exactly where the old end-marker rows made it drop.
+// ---------------------------------------------------------------------------
+
+// Max partition columns; must match the c7..c21 binds in
+// stdlib/intervals/self_intersect.sql.
+constexpr uint32_t kMaxPartitionCols = 15;
+
+// Input blob built by __intrinsic_isi_intervals_agg and consumed by
+// __intrinsic_interval_self_intersect_agg. Self-contained (not shared with
+// the interval_intersect machinery): intervals are stored in insertion order
+// per partition, never indexed by any caller-supplied id.
+struct IsiIntervals {
+  static constexpr char kName[] = "ISI_INTERVALS";
+
+  struct Interval {
+    int64_t start;
+    int64_t end;
+    double value;     // Meaningless when !has_value.
+    bool has_value;
+  };
+
+  struct Part {
+    // Partition column values; strings interned in the StringPool.
+    std::vector<SqlValue> key;
+    std::vector<Interval> intervals;
+  };
+
+  std::vector<std::string> partition_col_names;
+  // Keyed by murmur hash of the partition tuple. NULL hashes like a regular
+  // value, so NULL partition keys form their own partition (no rows are ever
+  // dropped on NULL, unlike SQL equality joins).
+  base::FlatHashMap<uint64_t, Part> parts;
+};
+
+inline void HashSqlValue(base::MurmurHashCombiner& h, const SqlValue& v) {
+  h.Combine(v.type);
+  switch (v.type) {
+    case SqlValue::Type::kString:
+      h.Combine(base::StringView(v.AsString()));
+      break;
+    case SqlValue::Type::kDouble:
+      h.Combine(v.AsDouble());
+      break;
+    case SqlValue::Type::kLong:
+      h.Combine(v.AsLong());
+      break;
+    case SqlValue::Type::kNull:
+      h.Combine(0);
+      break;
+    case SqlValue::Type::kBytes:
+      PERFETTO_FATAL("Wrong type");
+  }
+}
+
+// __intrinsic_isi_intervals_agg(ts, dur, value, [part_name, part_val]*)
+//
+// Collects intervals into an IsiIntervals blob. Every input row is one
+// interval; `value` is the aggregation value (NULL for callers that only
+// need counts). Input does NOT need to be sorted — the sweep sorts events
+// itself.
+struct IsiIntervalsAgg : public sqlite::AggregateFunction<IsiIntervalsAgg> {
+  static constexpr char kName[] = "__intrinsic_isi_intervals_agg";
+  static constexpr int kArgCount = -1;
+  static constexpr uint32_t kMinArgCount = 3;
+
+  struct UserData {
+    StringPool* pool;
+  };
+
+  struct AggCtx : sqlite::AggregateContext<AggCtx> {
+    IsiIntervals intervals;
+    std::vector<SqlValue> tmp_key;
+    bool cols_initialized = false;
+  };
+
+  static void Step(sqlite3_context* ctx, int rargc, sqlite3_value** argv) {
+    auto argc = static_cast<uint32_t>(rargc);
+    if (argc < kMinArgCount || (argc - kMinArgCount) % 2 != 0) {
+      return sqlite::result::Error(
+          ctx,
+          "isi_intervals_agg: expected (ts, dur, value, [part_name, "
+          "part_val]*)");
+    }
+    auto& agg_ctx = AggCtx::GetOrCreateContextForStep(ctx);
+
+    if (!agg_ctx.cols_initialized) {
+      uint32_t part_count = (argc - kMinArgCount) / 2;
+      if (part_count > kMaxPartitionCols) {
+        return sqlite::result::Error(
+            ctx, "isi_intervals_agg: at most 15 partition columns supported");
+      }
+      for (uint32_t i = kMinArgCount; i < argc; i += 2) {
+        agg_ctx.intervals.partition_col_names.push_back(
+            sqlite::utils::SqliteValueToSqlValue(argv[i]).AsString());
+      }
+      agg_ctx.tmp_key.resize(part_count);
+      agg_ctx.cols_initialized = true;
+    }
+
+    int64_t ts = sqlite::value::Int64(argv[0]);
+    int64_t dur = sqlite::value::Int64(argv[1]);
+    if (dur < 0) {
+      return sqlite::result::Error(
+          ctx, "isi_intervals_agg: negative durations are not supported");
+    }
+    if (ts > std::numeric_limits<int64_t>::max() - dur) {
+      return sqlite::result::Error(ctx,
+                                   "isi_intervals_agg: ts + dur overflows");
+    }
+
+    IsiIntervals::Interval interval;
+    interval.start = ts;
+    interval.end = ts + dur;
+    SqlValue value = sqlite::utils::SqliteValueToSqlValue(argv[2]);
+    switch (value.type) {
+      case SqlValue::Type::kLong:
+        interval.value = static_cast<double>(value.long_value);
+        interval.has_value = true;
+        break;
+      case SqlValue::Type::kDouble:
+        interval.value = value.double_value;
+        interval.has_value = true;
+        break;
+      case SqlValue::Type::kNull:
+        interval.value = 0;
+        interval.has_value = false;
+        break;
+      case SqlValue::Type::kString:
+      case SqlValue::Type::kBytes:
+        return sqlite::result::Error(
+            ctx, "isi_intervals_agg: value must be numeric or NULL");
+    }
+
+    base::MurmurHashCombiner h;
+    StringPool* pool = GetUserData(ctx)->pool;
+    for (uint32_t i = 0; i < agg_ctx.tmp_key.size(); ++i) {
+      SqlValue v =
+          sqlite::utils::SqliteValueToSqlValue(argv[kMinArgCount + i * 2 + 1]);
+      if (v.type == SqlValue::kString) {
+        // Intern so the pointer outlives this Step call and duplicates share
+        // storage.
+        v.string_value = pool->Get(pool->InternString(v.AsString())).c_str();
+      }
+      agg_ctx.tmp_key[i] = v;
+      HashSqlValue(h, v);
+    }
+
+    auto& parts = agg_ctx.intervals.parts;
+    IsiIntervals::Part* part = parts.Find(h.digest());
+    if (!part) {
+      IsiIntervals::Part new_part;
+      new_part.key = agg_ctx.tmp_key;
+      part = parts.Insert(h.digest(), std::move(new_part)).first;
+    }
+    part->intervals.push_back(interval);
+  }
+
+  static void Final(sqlite3_context* ctx) {
+    auto raw = AggCtx::GetContextOrNullForFinal(ctx);
+    if (!raw) {
+      return sqlite::result::Null(ctx);
+    }
+    return sqlite::result::UniquePointer(
+        ctx,
+        std::make_unique<IsiIntervals>(std::move(raw.get()->intervals)),
+        IsiIntervals::kName);
+  }
+};
+
+// Output column layout; must match the c0..c6 binds in
+// stdlib/intervals/self_intersect.sql.
+constexpr uint32_t kOutTs = 0;
+constexpr uint32_t kOutDur = 1;
+constexpr uint32_t kOutGroupId = 2;
+constexpr uint32_t kOutCnt = 3;
+constexpr uint32_t kOutSum = 4;
+constexpr uint32_t kOutMin = 5;
+constexpr uint32_t kOutMax = 6;
+constexpr uint32_t kOutPartitionOffset = 7;
+
+// Runs the aggregating sweep for one partition, appending one row per atomic
+// segment. Returns the number of rows emitted.
+uint32_t SweepPartition(dataframe::AdhocDataframeBuilder& builder,
+                        const IsiIntervals::Part& part,
+                        int64_t& group_id) {
+  struct AggEvent {
+    int64_t ts;
+    int8_t delta;  // +1 = start, -1 = end
+    double value;
+    bool has_value;
+
+    // Starts sort before ends at the same ts so a zero-duration interval's
+    // value is inserted into the aggregation state before it is erased.
+    bool operator<(const AggEvent& other) const {
+      if (ts != other.ts) {
+        return ts < other.ts;
+      }
+      return delta > other.delta;
+    }
+  };
+
+  std::vector<AggEvent> events;
+  events.reserve(part.intervals.size() * 2);
+  for (const auto& iv : part.intervals) {
+    events.push_back(AggEvent{iv.start, 1, iv.value, iv.has_value});
+    events.push_back(AggEvent{iv.end, -1, iv.value, iv.has_value});
+  }
+  std::sort(events.begin(), events.end());
+
+  // Incremental aggregation state. cnt/sum are O(1) per event; min/max use a
+  // multiset for O(log n) insert/erase, keeping the whole sweep O(n log n)
+  // with no per-segment rescan of the active set.
+  int64_t cnt = 0;
+  double sum = 0;
+  std::multiset<double> values;
+
+  uint32_t rows = 0;
+  auto emit = [&](int64_t seg_ts, int64_t seg_dur) {
+    builder.PushNonNullUnchecked(kOutTs, seg_ts);
+    builder.PushNonNullUnchecked(kOutDur, seg_dur);
+    builder.PushNonNullUnchecked(kOutGroupId, group_id);
+    builder.PushNonNullUnchecked(kOutCnt, cnt);
+    builder.PushNonNullUnchecked(kOutSum, sum);
+    if (values.empty()) {
+      builder.PushNull(kOutMin, 1);
+      builder.PushNull(kOutMax, 1);
+    } else {
+      builder.PushNonNullUnchecked(kOutMin, *values.begin());
+      builder.PushNonNullUnchecked(kOutMax, *values.rbegin());
+    }
+    ++group_id;
+    ++rows;
+  };
+
+  int64_t prev_ts = events.front().ts;
+  for (const auto& ev : events) {
+    if (ev.ts > prev_ts) {
+      // Emit the segment [prev_ts, ev.ts) with the state accumulated from
+      // all events at prev_ts and earlier. Zero-active gaps emit too.
+      emit(prev_ts, ev.ts - prev_ts);
+      prev_ts = ev.ts;
+    }
+    if (ev.delta > 0) {
+      ++cnt;
+      if (ev.has_value) {
+        sum += ev.value;
+        values.insert(ev.value);
+      }
+    } else {
+      --cnt;
+      if (ev.has_value) {
+        sum -= ev.value;
+        values.erase(values.find(ev.value));
+      }
+    }
+  }
+  // Every start has a matching end, so the active set is empty here; the
+  // final dur=0 segment is the counter's drop-to-zero point at the
+  // partition's last endpoint.
+  PERFETTO_DCHECK(cnt == 0);
+  emit(prev_ts, 0);
+  return rows;
+}
+
+// __intrinsic_interval_self_intersect_agg(intervals_ptr, partition_list)
+//
+// Consumes an IsiIntervals blob and emits the aggregated atomic segments as
+// a dataframe. `partition_list` is the stringified partition column list
+// (e.g. '(k0, k1)'); it names the output columns so the schema is stable
+// even when the input is empty, and it is validated against the blob.
+struct IntervalSelfIntersectAgg
+    : public sqlite::Function<IntervalSelfIntersectAgg> {
+  static constexpr char kName[] = "__intrinsic_interval_self_intersect_agg";
+  static constexpr int kArgCount = 2;
+
+  struct UserData {
+    StringPool* pool;
+  };
+
+  static void Step(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
+    PERFETTO_DCHECK(argc == kArgCount);
+
+    const char* partition_list = sqlite::value::Text(argv[1]);
+    if (!partition_list) {
+      return sqlite::result::Error(
+          ctx, "interval_self_intersect_agg: column list cannot be null");
+    }
+    std::vector<std::string> ret_col_names{"ts",  "dur",       "group_id",
+                                           "cnt", "sum_value", "min_value",
+                                           "max_value"};
+    std::vector<ColType> col_types{ColType::kInt64,  ColType::kInt64,
+                                   ColType::kInt64,  ColType::kInt64,
+                                   ColType::kDouble, ColType::kDouble,
+                                   ColType::kDouble};
+    uint32_t num_partition_cols = 0;
+    for (const auto& c :
+         base::SplitString(base::StripChars(partition_list, "()", ' '), ",")) {
+      std::string name = base::TrimWhitespace(c);
+      if (!name.empty()) {
+        ret_col_names.push_back(name);
+        ++num_partition_cols;
+      }
+    }
+    if (num_partition_cols > kMaxPartitionCols) {
+      return sqlite::result::Error(
+          ctx,
+          "interval_self_intersect_agg: at most 15 partition columns "
+          "supported");
+    }
+
+    auto* intervals =
+        sqlite::value::Pointer<IsiIntervals>(argv[0], IsiIntervals::kName);
+    if (intervals &&
+        intervals->partition_col_names.size() != num_partition_cols) {
+      return sqlite::result::Error(
+          ctx,
+          "interval_self_intersect_agg: partition list does not match the "
+          "columns the intervals were collected with");
+    }
+
+    // Partition column types: from the first non-NULL value per column
+    // across partitions; a column that is NULL everywhere defaults to int64
+    // (only nulls are ever pushed into it).
+    StringPool* pool = GetUserData(ctx)->pool;
+    std::vector<ColType> part_types(num_partition_cols, ColType::kInt64);
+    if (intervals) {
+      std::vector<bool> known(num_partition_cols, false);
+      uint32_t remaining = num_partition_cols;
+      for (auto it = intervals->parts.GetIterator(); it && remaining; ++it) {
+        for (uint32_t i = 0; i < num_partition_cols; ++i) {
+          if (known[i] || it.value().key[i].is_null()) {
+            continue;
+          }
+          switch (it.value().key[i].type) {
+            case SqlValue::kLong:
+              part_types[i] = ColType::kInt64;
+              break;
+            case SqlValue::kDouble:
+              part_types[i] = ColType::kDouble;
+              break;
+            case SqlValue::kString:
+              part_types[i] = ColType::kString;
+              break;
+            case SqlValue::kNull:
+            case SqlValue::kBytes:
+              PERFETTO_FATAL("Unreachable");
+          }
+          known[i] = true;
+          --remaining;
+        }
+      }
+    }
+    col_types.insert(col_types.end(), part_types.begin(), part_types.end());
+
+    dataframe::AdhocDataframeBuilder builder(
+        ret_col_names, pool,
+        dataframe::AdhocDataframeBuilder::Options{
+            col_types, dataframe::NullabilityType::kDenseNull});
+
+    int64_t group_id = 1;
+    if (intervals) {
+      for (auto it = intervals->parts.GetIterator(); it; ++it) {
+        const IsiIntervals::Part& part = it.value();
+        if (part.intervals.empty()) {
+          continue;
+        }
+        uint32_t rows = SweepPartition(builder, part, group_id);
+        for (uint32_t i = 0; i < num_partition_cols; ++i) {
+          const SqlValue& v = part.key[i];
+          bool ok = true;
+          switch (v.type) {
+            case SqlValue::kLong:
+              ok = builder.PushNonNull(kOutPartitionOffset + i, v.long_value,
+                                       rows);
+              break;
+            case SqlValue::kDouble:
+              ok = builder.PushNonNull(kOutPartitionOffset + i, v.double_value,
+                                       rows);
+              break;
+            case SqlValue::kString:
+              ok = builder.PushNonNull(kOutPartitionOffset + i,
+                                       pool->InternString(v.string_value),
+                                       rows);
+              break;
+            case SqlValue::kNull:
+              builder.PushNull(kOutPartitionOffset + i, rows);
+              break;
+            case SqlValue::kBytes:
+              PERFETTO_FATAL("Unreachable");
+          }
+          if (!ok) {
+            return sqlite::result::Error(ctx, builder.status().c_message());
+          }
+        }
+      }
+    }
+
+    SQLITE_ASSIGN_OR_RETURN(ctx, dataframe::Dataframe ret_tab,
+                            std::move(builder).Build());
+    return sqlite::result::UniquePointer(
+        ctx, std::make_unique<dataframe::Dataframe>(std::move(ret_tab)),
+        "TABLE");
+  }
+};
+
 class IntervalSelfIntersectPlugin
     : public Plugin<IntervalSelfIntersectPlugin> {
  public:
@@ -225,7 +651,25 @@ class IntervalSelfIntersectPlugin
     out.push_back(MakeFunctionRegistration<IntervalSelfIntersect>(
         std::make_unique<IntervalSelfIntersect::UserData>(
             IntervalSelfIntersect::UserData{pool})));
+    out.push_back(MakeFunctionRegistration<IntervalSelfIntersectAgg>(
+        std::make_unique<IntervalSelfIntersectAgg::UserData>(
+            IntervalSelfIntersectAgg::UserData{pool})));
   }
+
+  void RegisterAggregateFunctions(
+      PerfettoSqlConnection*,
+      std::vector<AggregateFunctionRegistration>& out) override {
+    StringPool* pool = trace_context_->storage->mutable_string_pool();
+    isi_agg_user_data_ = std::make_unique<IsiIntervalsAgg::UserData>(
+        IsiIntervalsAgg::UserData{pool});
+    out.push_back(
+        MakeAggregateRegistration<IsiIntervalsAgg>(isi_agg_user_data_.get()));
+  }
+
+ private:
+  // MakeAggregateRegistration takes a non-owning pointer; the plugin instance
+  // owns the user data for the lifetime of the connection.
+  std::unique_ptr<IsiIntervalsAgg::UserData> isi_agg_user_data_;
 };
 
 IntervalSelfIntersectPlugin::~IntervalSelfIntersectPlugin() = default;

--- a/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc
+++ b/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc
@@ -34,12 +34,12 @@
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/containers/string_pool.h"
-#include "src/trace_processor/sqlite/bindings/sqlite_aggregate_function.h"
 #include "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
 #include "src/trace_processor/core/plugin/plugin.h"
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
 #include "src/trace_processor/perfetto_sql/intrinsics/types/partitioned_intervals.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_aggregate_function.h"
 #include "src/trace_processor/sqlite/bindings/sqlite_function.h"
 #include "src/trace_processor/sqlite/bindings/sqlite_result.h"
 #include "src/trace_processor/sqlite/bindings/sqlite_value.h"
@@ -96,9 +96,9 @@ void RunSelfIntersect(dataframe::AdhocDataframeBuilder& builder,
   uint32_t max_id = 0;
   for (auto p_it = table.partitions_map.GetIterator(); p_it; ++p_it) {
     for (const auto& iv : p_it.value().intervals) {
-      events.push_back(
-          Event{static_cast<int64_t>(iv.start), static_cast<uint32_t>(iv.id),
-                static_cast<int8_t>(1)});
+      events.push_back(Event{static_cast<int64_t>(iv.start),
+                             static_cast<uint32_t>(iv.id),
+                             static_cast<int8_t>(1)});
       events.push_back(Event{static_cast<int64_t>(iv.end),
                              static_cast<uint32_t>(iv.id),
                              static_cast<int8_t>(-1)});
@@ -185,8 +185,7 @@ void RunSelfIntersect(dataframe::AdhocDataframeBuilder& builder,
   emit_segment(prev_ts, prev_ts);
 }
 
-struct IntervalSelfIntersect
-    : public sqlite::Function<IntervalSelfIntersect> {
+struct IntervalSelfIntersect : public sqlite::Function<IntervalSelfIntersect> {
   static constexpr char kName[] = "__intrinsic_interval_self_intersect";
   static constexpr int kArgCount = 1;
 
@@ -253,7 +252,7 @@ struct IsiIntervals {
   struct Interval {
     int64_t start;
     int64_t end;
-    double value;     // Meaningless when !has_value.
+    double value;  // Meaningless when !has_value.
     bool has_value;
   };
 
@@ -399,8 +398,7 @@ struct IsiIntervalsAgg : public sqlite::AggregateFunction<IsiIntervalsAgg> {
       return sqlite::result::Null(ctx);
     }
     return sqlite::result::UniquePointer(
-        ctx,
-        std::make_unique<IsiIntervals>(std::move(raw.get()->intervals)),
+        ctx, std::make_unique<IsiIntervals>(std::move(raw.get()->intervals)),
         IsiIntervals::kName);
   }
 };
@@ -580,13 +578,11 @@ struct IntervalSelfIntersectAgg
       return sqlite::result::Error(
           ctx, "interval_self_intersect_agg: column list cannot be null");
     }
-    std::vector<std::string> ret_col_names{"ts",  "dur",       "group_id",
-                                           "cnt", "sum_value", "min_value",
-                                           "max_value"};
-    std::vector<ColType> col_types{ColType::kInt64,  ColType::kInt64,
-                                   ColType::kInt64,  ColType::kInt64,
-                                   ColType::kDouble, ColType::kDouble,
-                                   ColType::kDouble};
+    std::vector<std::string> ret_col_names{
+        "ts", "dur", "group_id", "cnt", "sum_value", "min_value", "max_value"};
+    std::vector<ColType> col_types{
+        ColType::kInt64,  ColType::kInt64,  ColType::kInt64, ColType::kInt64,
+        ColType::kDouble, ColType::kDouble, ColType::kDouble};
     uint32_t num_partition_cols = 0;
     for (const auto& c :
          base::SplitString(base::StripChars(partition_list, "()", ' '), ",")) {
@@ -673,9 +669,9 @@ struct IntervalSelfIntersectAgg
                                        rows);
               break;
             case SqlValue::kString:
-              ok = builder.PushNonNull(kOutPartitionOffset + i,
-                                       pool->InternString(v.string_value),
-                                       rows);
+              ok =
+                  builder.PushNonNull(kOutPartitionOffset + i,
+                                      pool->InternString(v.string_value), rows);
               break;
             case SqlValue::kNull:
               builder.PushNull(kOutPartitionOffset + i, rows);
@@ -698,8 +694,7 @@ struct IntervalSelfIntersectAgg
   }
 };
 
-class IntervalSelfIntersectPlugin
-    : public Plugin<IntervalSelfIntersectPlugin> {
+class IntervalSelfIntersectPlugin : public Plugin<IntervalSelfIntersectPlugin> {
  public:
   ~IntervalSelfIntersectPlugin() override;
 

--- a/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc
+++ b/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.cc
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h"
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/plugin/plugin.h"
+#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
+#include "src/trace_processor/perfetto_sql/intrinsics/types/partitioned_intervals.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_function.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_result.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_value.h"
+#include "src/trace_processor/sqlite/sqlite_utils.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor::interval_self_intersect {
+namespace {
+
+using ColType = dataframe::AdhocDataframeBuilder::ColumnType;
+using perfetto_sql::PartitionedTable;
+
+// Sweep-line event: an interval start or end at a given timestamp.
+// Tie-break: starts before ends at identical ts so an interval that ends
+// exactly when another starts doesn't briefly drop the active set.
+struct Event {
+  int64_t ts;
+  uint32_t id;
+  int8_t delta;  // +1 = start, -1 = end
+
+  bool operator<(const Event& other) const {
+    if (ts != other.ts) {
+      return ts < other.ts;
+    }
+    return delta > other.delta;
+  }
+};
+
+constexpr uint32_t kMaxDenseBitsetSize = 100000;
+
+// Mirror the old SQL intervals.intersect.interval_self_intersect macro's
+// output exactly: one row per (atomic segment × active interval), plus one
+// "end marker" row per interval at the segment that begins at the interval's
+// end ts (dur taken from that segment, so the last interval emits a dur=0
+// end marker at the final endpoint).
+//
+// Implementation: single O(n log n) sweep over all events from the input.
+// Partition columns on the input (if any) are ignored — the macro contract
+// matches the partitionless SQL macro, callers can JOIN back to the source
+// to recover any per-interval attributes.
+void RunSelfIntersect(dataframe::AdhocDataframeBuilder& builder,
+                      const PartitionedTable& table) {
+  size_t total_intervals = 0;
+  for (auto p_it = table.partitions_map.GetIterator(); p_it; ++p_it) {
+    total_intervals += p_it.value().intervals.size();
+  }
+  if (total_intervals == 0) {
+    return;
+  }
+
+  std::vector<Event> events;
+  events.reserve(total_intervals * 2);
+  uint32_t max_id = 0;
+  for (auto p_it = table.partitions_map.GetIterator(); p_it; ++p_it) {
+    for (const auto& iv : p_it.value().intervals) {
+      events.push_back(
+          Event{static_cast<int64_t>(iv.start), static_cast<uint32_t>(iv.id),
+                static_cast<int8_t>(1)});
+      events.push_back(Event{static_cast<int64_t>(iv.end),
+                             static_cast<uint32_t>(iv.id),
+                             static_cast<int8_t>(-1)});
+      max_id = std::max(max_id, static_cast<uint32_t>(iv.id));
+    }
+  }
+  std::sort(events.begin(), events.end());
+
+  // Active set: bitset for dense ids, FlatHashMap fallback. active_ids holds
+  // ids in insertion order so emit_segment can iterate without re-scanning.
+  const bool use_bitset = max_id < kMaxDenseBitsetSize;
+  std::vector<bool> active_bitset;
+  base::FlatHashMap<uint32_t, bool> active_map;
+  if (use_bitset) {
+    active_bitset.resize(max_id + 1, false);
+  }
+  std::vector<uint32_t> active_ids;
+
+  // End ids seen at prev_ts — emitted into the next segment (the one that
+  // begins at their end ts), matching the old SQL macro's "end marker"
+  // attribution.
+  std::vector<uint32_t> ends_at_current;
+
+  uint32_t group_id = 1;
+  int64_t prev_ts = events.front().ts;
+
+  auto emit_segment = [&](int64_t seg_ts, int64_t next_ts) {
+    int64_t seg_dur = next_ts - seg_ts;
+    for (uint32_t id : active_ids) {
+      builder.PushNonNullUnchecked(0, seg_ts);
+      builder.PushNonNullUnchecked(1, seg_dur);
+      builder.PushNonNullUnchecked(2, static_cast<int64_t>(group_id));
+      builder.PushNonNullUnchecked(3, static_cast<int64_t>(id));
+      builder.PushNonNullUnchecked(4, static_cast<int64_t>(0));
+    }
+    for (uint32_t id : ends_at_current) {
+      builder.PushNonNullUnchecked(0, seg_ts);
+      builder.PushNonNullUnchecked(1, seg_dur);
+      builder.PushNonNullUnchecked(2, static_cast<int64_t>(group_id));
+      builder.PushNonNullUnchecked(3, static_cast<int64_t>(id));
+      builder.PushNonNullUnchecked(4, static_cast<int64_t>(1));
+    }
+  };
+
+  for (const auto& ev : events) {
+    if (ev.ts > prev_ts) {
+      emit_segment(prev_ts, ev.ts);
+      ends_at_current.clear();
+      ++group_id;
+      prev_ts = ev.ts;
+    }
+    if (ev.delta > 0) {
+      bool already;
+      if (use_bitset) {
+        already = active_bitset[ev.id];
+        if (!already) {
+          active_bitset[ev.id] = true;
+        }
+      } else {
+        already = active_map.Find(ev.id) != nullptr;
+        if (!already) {
+          active_map[ev.id] = true;
+        }
+      }
+      if (!already) {
+        active_ids.push_back(ev.id);
+      }
+    } else {
+      if (use_bitset) {
+        active_bitset[ev.id] = false;
+      } else {
+        active_map.Erase(ev.id);
+      }
+      auto it = std::find(active_ids.begin(), active_ids.end(), ev.id);
+      if (it != active_ids.end()) {
+        active_ids.erase(it);
+      }
+      ends_at_current.push_back(ev.id);
+    }
+  }
+
+  // Final segment at the last endpoint: dur=0, no active rows, end markers
+  // for the intervals that closed at this ts.
+  emit_segment(prev_ts, prev_ts);
+}
+
+struct IntervalSelfIntersect
+    : public sqlite::Function<IntervalSelfIntersect> {
+  static constexpr char kName[] = "__intrinsic_interval_self_intersect";
+  static constexpr int kArgCount = 1;
+
+  struct UserData {
+    StringPool* pool;
+  };
+
+  static void Step(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
+    PERFETTO_DCHECK(argc == kArgCount);
+
+    std::vector<std::string> ret_col_names{"ts", "dur", "group_id", "id",
+                                           "interval_ends_at_ts"};
+    std::vector<ColType> col_types{ColType::kInt64, ColType::kInt64,
+                                   ColType::kInt64, ColType::kInt64,
+                                   ColType::kInt64};
+
+    PartitionedTable* table = sqlite::value::Pointer<PartitionedTable>(
+        argv[0], PartitionedTable::kName);
+
+    dataframe::AdhocDataframeBuilder builder(
+        ret_col_names, GetUserData(ctx)->pool,
+        dataframe::AdhocDataframeBuilder::Options{
+            col_types, dataframe::NullabilityType::kDenseNull});
+
+    if (table && table->partitions_map.size() != 0) {
+      RunSelfIntersect(builder, *table);
+    }
+
+    SQLITE_ASSIGN_OR_RETURN(ctx, dataframe::Dataframe ret_tab,
+                            std::move(builder).Build());
+    return sqlite::result::UniquePointer(
+        ctx, std::make_unique<dataframe::Dataframe>(std::move(ret_tab)),
+        "TABLE");
+  }
+};
+
+class IntervalSelfIntersectPlugin
+    : public Plugin<IntervalSelfIntersectPlugin> {
+ public:
+  ~IntervalSelfIntersectPlugin() override;
+
+  void RegisterFunctions(PerfettoSqlConnection*,
+                         std::vector<FunctionRegistration>& out) override {
+    StringPool* pool = trace_context_->storage->mutable_string_pool();
+    out.push_back(MakeFunctionRegistration<IntervalSelfIntersect>(
+        std::make_unique<IntervalSelfIntersect::UserData>(
+            IntervalSelfIntersect::UserData{pool})));
+  }
+};
+
+IntervalSelfIntersectPlugin::~IntervalSelfIntersectPlugin() = default;
+
+}  // namespace
+
+void RegisterPlugin() {
+  static PluginRegistration reg(
+      []() -> std::unique_ptr<PluginBase> {
+        return std::make_unique<IntervalSelfIntersectPlugin>();
+      },
+      IntervalSelfIntersectPlugin::kPluginId,
+      IntervalSelfIntersectPlugin::kDepIds.data(),
+      IntervalSelfIntersectPlugin::kDepIds.size());
+  base::ignore_result(reg);
+}
+
+}  // namespace perfetto::trace_processor::interval_self_intersect

--- a/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.h
+++ b/src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PLUGINS_INTERVAL_SELF_INTERSECT_INTERVAL_SELF_INTERSECT_H_
+#define SRC_TRACE_PROCESSOR_PLUGINS_INTERVAL_SELF_INTERSECT_INTERVAL_SELF_INTERSECT_H_
+
+namespace perfetto::trace_processor::interval_self_intersect {
+
+// Registers the __intrinsic_interval_self_intersect SQL function: an O(n log n)
+// sweep-line implementation that, for every atomic time segment defined by the
+// endpoints of the input intervals and for every distinct partition tuple
+// active in that segment, emits one row carrying (ts, dur, group_id, count,
+// partition_cols...).
+//
+// Drop-in faster replacement for the SQL-stdlib `interval_self_intersect!`
+// macro that routes through the general two-table `interval_intersect`.
+// Algorithm inspired by dev/zezeozue/self_intersect; this build narrows the
+// scope to COUNT (active intervals per partition per segment) — sum/min/max/avg
+// can be layered on later if a caller needs them.
+void RegisterPlugin();
+
+}  // namespace perfetto::trace_processor::interval_self_intersect
+
+#endif  // SRC_TRACE_PROCESSOR_PLUGINS_INTERVAL_SELF_INTERSECT_INTERVAL_SELF_INTERSECT_H_

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -114,6 +114,7 @@
 #include "src/trace_processor/plugins/graph_traversal/graph_traversal.h"
 #include "src/trace_processor/plugins/import/import.h"
 #include "src/trace_processor/plugins/interval_intersect/interval_intersect.h"
+#include "src/trace_processor/plugins/interval_self_intersect/interval_self_intersect.h"
 #include "src/trace_processor/plugins/layout_functions/layout_functions.h"
 #include "src/trace_processor/plugins/math_functions/math_functions.h"
 #include "src/trace_processor/plugins/metadata/metadata.h"
@@ -348,6 +349,7 @@ TraceProcessorImpl::TraceProcessorImpl(const Config& cfg)
   graph_traversal::RegisterPlugin();
   import::RegisterPlugin();
   interval_intersect::RegisterPlugin();
+  interval_self_intersect::RegisterPlugin();
   layout_functions::RegisterPlugin();
   math_functions::RegisterPlugin();
   metadata::RegisterPlugin();

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -154,6 +154,7 @@ from diff_tests.stdlib.graphs.search_tests import GraphSearchTests
 from diff_tests.stdlib.intervals.create_intervals_tests import CreateIntervals
 from diff_tests.stdlib.intervals.fill_gaps_tests import IntervalsFillGaps
 from diff_tests.stdlib.intervals.intersect_tests import IntervalsIntersect
+from diff_tests.stdlib.intervals.self_intersect_tests import IntervalsSelfIntersect
 from diff_tests.stdlib.intervals.tests import StdlibIntervals
 from diff_tests.stdlib.linux.cpu import LinuxCpu
 from diff_tests.stdlib.linux.memory import Memory
@@ -363,6 +364,7 @@ def fetch_all_diff_tests(
       CreateIntervals,
       IntervalsFillGaps,
       IntervalsIntersect,
+      IntervalsSelfIntersect,
       StdlibIntervals,
       StdlibMetasql,
       SystemUICujs,

--- a/test/trace_processor/diff_tests/stdlib/intervals/self_intersect_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/intervals/self_intersect_tests.py
@@ -257,6 +257,9 @@ class IntervalsSelfIntersect(TestSuite):
         """))
 
   def test_self_intersect_count_zero_dur_intervals(self):
+    # The zero-dur interval at ts=5 is never active in any segment, so the
+    # boundary it creates changes no aggregate and the [0,5) and [5,10)
+    # segments merge into one row.
     return DiffTestBlueprint(
         trace=TextProto(""),
         query="""
@@ -275,10 +278,45 @@ class IntervalsSelfIntersect(TestSuite):
         """,
         out=Csv("""
         "ts","dur","cnt","k0"
-        0,5,1,"Y"
-        5,5,1,"Y"
+        0,10,1,"Y"
         10,0,0,"Y"
         7,0,0,"Z"
+        """))
+
+  def test_self_intersect_agg_merges_touching_intervals(self):
+    # T: back-to-back intervals with equal values keep every aggregate
+    # constant across the ts=10 boundary, so a single merged row spans both.
+    # W: the boundary changes sum/min/max (1 vs 2) even though cnt stays 1,
+    # so no merge happens there.
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur, v, k0) AS (
+            VALUES
+              (0, 10, 5, 'T'),
+              (10, 10, 5, 'T'),
+              (0, 10, 1, 'W'),
+              (10, 10, 2, 'W')
+          )
+        SELECT
+          ts, dur, cnt,
+          CAST(sum_value AS INT64) AS sum_v,
+          CAST(min_value AS INT64) AS min_v,
+          CAST(max_value AS INT64) AS max_v,
+          k0
+        FROM _interval_self_intersect_agg!(data, v, (k0))
+        ORDER BY k0 ASC, ts ASC;
+        """,
+        out=Csv("""
+        "ts","dur","cnt","sum_v","min_v","max_v","k0"
+        0,20,1,5,5,5,"T"
+        20,0,0,0,"[NULL]","[NULL]","T"
+        0,10,1,1,1,1,"W"
+        10,10,1,2,2,2,"W"
+        20,0,0,0,"[NULL]","[NULL]","W"
         """))
 
   def test_self_intersect_count_global(self):

--- a/test/trace_processor/diff_tests/stdlib/intervals/self_intersect_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/intervals/self_intersect_tests.py
@@ -107,3 +107,214 @@ class IntervalsSelfIntersect(TestSuite):
         out=Csv("""
         "ts","dur","group_id","id","interval_ends_at_ts"
         """))
+
+  # --- _interval_self_intersect_count / _interval_self_intersect_agg ---
+  # group_id is hash-map iteration order across partitions (stable only
+  # within a partition), so tests exclude it except where a single
+  # partition makes it deterministic.
+
+  def test_self_intersect_count_partitioned(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur, k0) AS (
+            VALUES
+              (0, 100, 'A'),
+              (10, 50, 'A'),
+              (20, 100, 'B'),
+              (30, 20, 'B')
+          )
+        SELECT ts, dur, cnt, k0
+        FROM _interval_self_intersect_count!(data, (k0))
+        ORDER BY k0 ASC, ts ASC;
+        """,
+        out=Csv("""
+        "ts","dur","cnt","k0"
+        0,10,1,"A"
+        10,50,2,"A"
+        60,40,1,"A"
+        100,0,0,"A"
+        20,10,1,"B"
+        30,20,2,"B"
+        50,70,1,"B"
+        120,0,0,"B"
+        """))
+
+  def test_self_intersect_count_gap_drops_to_zero(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur, k0) AS (
+            VALUES
+              (0, 10, 'X'),
+              (20, 10, 'X')
+          )
+        SELECT ts, dur, group_id, cnt, k0
+        FROM _interval_self_intersect_count!(data, (k0))
+        ORDER BY ts ASC;
+        """,
+        out=Csv("""
+        "ts","dur","group_id","cnt","k0"
+        0,10,1,1,"X"
+        10,10,2,0,"X"
+        20,10,3,1,"X"
+        30,0,4,0,"X"
+        """))
+
+  def test_self_intersect_agg_values(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur, v, k0) AS (
+            VALUES
+              (0, 10, 10, 'P'),
+              (5, 10, NULL, 'P'),
+              (8, 4, 2, 'P')
+          )
+        SELECT
+          ts, dur, cnt,
+          CAST(sum_value AS INT64) AS sum_v,
+          CAST(min_value AS INT64) AS min_v,
+          CAST(max_value AS INT64) AS max_v,
+          k0
+        FROM _interval_self_intersect_agg!(data, v, (k0))
+        ORDER BY ts ASC;
+        """,
+        out=Csv("""
+        "ts","dur","cnt","sum_v","min_v","max_v","k0"
+        0,5,1,10,10,10,"P"
+        5,3,2,10,10,10,"P"
+        8,2,3,12,2,10,"P"
+        10,2,2,2,2,2,"P"
+        12,3,1,0,"[NULL]","[NULL]","P"
+        15,0,0,0,"[NULL]","[NULL]","P"
+        """))
+
+  def test_self_intersect_count_null_partition_key(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur, k0) AS (
+            VALUES
+              (0, 10, NULL),
+              (5, 10, NULL),
+              (2, 6, 'X')
+          )
+        SELECT ts, dur, cnt, k0
+        FROM _interval_self_intersect_count!(data, (k0))
+        ORDER BY k0 ASC, ts ASC;
+        """,
+        out=Csv("""
+        "ts","dur","cnt","k0"
+        0,5,1,"[NULL]"
+        5,5,2,"[NULL]"
+        10,5,1,"[NULL]"
+        15,0,0,"[NULL]"
+        2,6,1,"X"
+        8,0,0,"X"
+        """))
+
+  def test_self_intersect_count_multi_key(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur, p, q) AS (
+            VALUES
+              (0, 10, 'A', 1),
+              (5, 10, 'A', 1),
+              (5, 10, 'B', 1),
+              (10, 5, 'B', 2)
+          )
+        SELECT ts, dur, cnt, p, q
+        FROM _interval_self_intersect_count!(data, (p, q))
+        ORDER BY p ASC, q ASC, ts ASC;
+        """,
+        out=Csv("""
+        "ts","dur","cnt","p","q"
+        0,5,1,"A",1
+        5,5,2,"A",1
+        10,5,1,"A",1
+        15,0,0,"A",1
+        5,10,1,"B",1
+        15,0,0,"B",1
+        10,5,1,"B",2
+        15,0,0,"B",2
+        """))
+
+  def test_self_intersect_count_zero_dur_intervals(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur, k0) AS (
+            VALUES
+              (0, 10, 'Y'),
+              (5, 0, 'Y'),
+              (7, 0, 'Z')
+          )
+        SELECT ts, dur, cnt, k0
+        FROM _interval_self_intersect_count!(data, (k0))
+        ORDER BY k0 ASC, ts ASC;
+        """,
+        out=Csv("""
+        "ts","dur","cnt","k0"
+        0,5,1,"Y"
+        5,5,1,"Y"
+        10,0,0,"Y"
+        7,0,0,"Z"
+        """))
+
+  def test_self_intersect_count_global(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur) AS (
+            VALUES
+              (0, 10),
+              (5, 10)
+          )
+        SELECT ts, dur, group_id, cnt
+        FROM _interval_self_intersect_count!(data, ())
+        ORDER BY ts ASC;
+        """,
+        out=Csv("""
+        "ts","dur","group_id","cnt"
+        0,5,1,1
+        5,5,2,2
+        10,5,3,1
+        15,0,4,0
+        """))
+
+  def test_self_intersect_count_empty_input(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        SELECT ts, dur, cnt, k0
+        FROM _interval_self_intersect_count!(
+          (SELECT 0 AS ts, 0 AS dur, '' AS k0 WHERE FALSE), (k0));
+        """,
+        out=Csv("""
+        "ts","dur","cnt","k0"
+        """))

--- a/test/trace_processor/diff_tests/stdlib/intervals/self_intersect_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/intervals/self_intersect_tests.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import Csv, TextProto
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class IntervalsSelfIntersect(TestSuite):
+
+  # Mirrors test_intersect_list in intervals/tests.py: same input, same
+  # expected output. Confirms the C++ _interval_self_intersect in
+  # intervals.self_intersect is a drop-in for the SQL stdlib's
+  # intervals.intersect.interval_self_intersect.
+  def test_self_intersect_list(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur, id) AS (
+            VALUES
+              (10, 100, 0),
+              (20, 40, 1),
+              (30, 120, 2),
+              (200, 10, 3),
+              (200, 20, 4),
+              (300, 10, 5)
+          )
+        SELECT *
+        FROM _interval_self_intersect!(data)
+        ORDER BY ts ASC, id ASC;
+        """,
+        out=Csv("""
+        "ts","dur","group_id","id","interval_ends_at_ts"
+        10,10,1,0,0
+        20,10,2,0,0
+        20,10,2,1,0
+        30,30,3,0,0
+        30,30,3,1,0
+        30,30,3,2,0
+        60,50,4,0,0
+        60,50,4,1,1
+        60,50,4,2,0
+        110,40,5,0,1
+        110,40,5,2,0
+        150,50,6,2,1
+        200,10,7,3,0
+        200,10,7,4,0
+        210,10,8,3,1
+        210,10,8,4,0
+        220,80,9,4,1
+        300,10,10,5,0
+        310,0,11,5,1
+        """))
+
+  # Adjacent intervals: end of one coincides with start of the next.
+  # Active set should not include the ending interval in segments at/after
+  # its end ts; the end marker fires at the segment beginning at the end ts.
+  def test_adjacent_intervals(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH
+          data(ts, dur, id) AS (
+            VALUES
+              (0, 10, 0),
+              (10, 10, 1)
+          )
+        SELECT *
+        FROM _interval_self_intersect!(data)
+        ORDER BY ts ASC, id ASC;
+        """,
+        out=Csv("""
+        "ts","dur","group_id","id","interval_ends_at_ts"
+        0,10,1,0,0
+        10,10,2,0,1
+        10,10,2,1,0
+        20,0,3,1,1
+        """))
+
+  # Empty input table: zero rows out, no error.
+  def test_empty_input(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+        WITH data(ts, dur, id) AS (SELECT 0, 0, 0 WHERE FALSE)
+        SELECT * FROM _interval_self_intersect!(data);
+        """,
+        out=Csv("""
+        "ts","dur","group_id","id","interval_ends_at_ts"
+        """))

--- a/ui/src/components/tracks/breakdown_tracks.ts
+++ b/ui/src/components/tracks/breakdown_tracks.ts
@@ -162,12 +162,16 @@ interface Filter {
  *   slice columns        -> slice tracks
  *   pivot columns        -> slice tracks (sourced via an optional join)
  *
- * All counters are driven by ONE shared `interval_self_intersect` segments
- * table built once per instance, so the expensive overlap computation is paid
- * a single time instead of once per node. The per-node counter query is then a
- * cheap GROUP BY over those segments, and the counter renderers are lazy
- * (CounterTrack.create), so the work scales with what the user views rather
- * than with the size of the hierarchy.
+ * All counters are driven by a small set of per-level segments tables built
+ * once per instance by the C++ `_interval_self_intersect_count` /
+ * `_interval_self_intersect_agg` macros: the table for hierarchy depth d
+ * partitions the intervals by (k0..k{d-1}) and carries the COUNT / SUM / MAX
+ * over each partition's atomic overlap segments, pre-aggregated during the
+ * sweep. A node at depth d pins all of its level's partition columns, so its
+ * counter query is a plain filter over its own partition's rows — no JOIN, no
+ * GROUP BY, and an output size bounded by 2x the interval count per level
+ * regardless of overlap depth. Counter renderers stay lazy
+ * (CounterTrack.create), so render work scales with what the user views.
  */
 export class BreakdownTracks {
   private readonly props: BreakdownTrackProps;
@@ -180,14 +184,17 @@ export class BreakdownTracks {
   private readonly sliceJoinClause: string;
   private readonly pivotJoinClause: string;
 
-  // The three tables built once per BreakdownTracks instance (see buildTables);
+  // The tables built once per BreakdownTracks instance (see buildTables);
   // each name gets a UUID suffix so independent grids — e.g. the binder server
   // and client trees — never collide on a table name:
-  //   intervals  one row per source interval (no joins).
-  //   segments   interval_self_intersect output: the atomic overlap segments.
-  //   projected  source rows + slice/pivot joins (may fan out 1:N) + ts/dur.
+  //   intervals       one row per source interval (no joins).
+  //   segments (per level d in 0..aggColNames.length)  pre-aggregated atomic
+  //                   overlap segments partitioned by (k0..k{d-1}); see
+  //                   segmentsTable().
+  //   projected       source rows + slice/pivot joins (may fan out 1:N) +
+  //                   ts/dur.
   private readonly intervalsTableName: string;
-  private readonly segmentsTableName: string;
+  private readonly segmentsTableBaseName: string;
   private readonly projectedTableName: string;
 
   // The breakdown / slice / pivot columns the caller supplies are arbitrary SQL
@@ -216,7 +223,7 @@ export class BreakdownTracks {
 
     const unique = uuidv4().replace(/-/g, '_');
     this.intervalsTableName = `_breakdown_intervals_${unique}`;
-    this.segmentsTableName = `_breakdown_segments_${unique}`;
+    this.segmentsTableBaseName = `_breakdown_segments_${unique}`;
     this.projectedTableName = `_breakdown_projected_${unique}`;
 
     this.aggColNames = props.aggregation.columns.map((_, i) => `k${i}`);
@@ -225,7 +232,7 @@ export class BreakdownTracks {
 
     this.modulesClause = [
       ...(props.modules ?? []).map((m) => `INCLUDE PERFETTO MODULE ${m};`),
-      'INCLUDE PERFETTO MODULE intervals.intersect;',
+      'INCLUDE PERFETTO MODULE intervals.self_intersect;',
     ].join('\n');
 
     this.sliceJoinClause = props.slice?.joins
@@ -236,33 +243,41 @@ export class BreakdownTracks {
       : '';
   }
 
-  // The aggregate evaluated over each atomic segment's active (non-end-marker)
-  // intervals. COUNT counts them; MAX/SUM reduce the denormalized agg_value.
-  // End-markers map to NULL / 0 so they contribute nothing and the counter
-  // naturally drops where intervals end. MAX maps end-markers to NULL (rather
-  // than a sentinel like 0) precisely because SQL aggregates skip NULL: a
-  // numeric sentinel could wrongly win the MAX when every active value is lower
-  // (e.g. all negative).
-  private aggValueExpr(): string {
+  // The segments table serving hierarchy depth `depth`: its rows are the
+  // atomic overlap segments of the intervals partitioned by the first `depth`
+  // breakdown columns, with cnt / sum_value / max_value pre-aggregated over
+  // each segment's active intervals by the C++ sweep. Depth 0 (the root) is a
+  // single unpartitioned series.
+  private segmentsTable(depth: number): string {
+    return `${this.segmentsTableBaseName}_l${depth}`;
+  }
+
+  // The pre-aggregated column matching this instance's aggregation type.
+  // Segments with no active interval carry cnt = 0 / sum_value = 0 /
+  // max_value = NULL, so the counter naturally drops where cover ends (MAX
+  // uses NULL rather than a sentinel like 0 because a numeric sentinel could
+  // wrongly render above genuinely low values, e.g. when all are negative).
+  private aggValueColumn(): string {
     switch (this.props.aggregationType) {
       case BreakdownTrackAggType.MAX:
-        return 'MAX(IIF(interval_ends_at_ts = FALSE, agg_value, NULL))';
+        return 'max_value';
       case BreakdownTrackAggType.SUM:
-        return 'SUM(IIF(interval_ends_at_ts = FALSE, agg_value, 0))';
+        return 'sum_value';
       case BreakdownTrackAggType.COUNT:
-        return 'SUM(IIF(interval_ends_at_ts = FALSE, 1, 0))';
+        return 'cnt';
     }
     assertUnreachable(this.props.aggregationType);
   }
 
-  private getAggregationQuery(filtersClause: string): string {
-    // One row per atomic segment, aggregating that segment's active intervals.
-    // Filters are raw equality on the pre-projected k* columns.
+  private getAggregationQuery(filtersClause: string, depth: number): string {
+    // A node at depth `depth` pins every partition column of its level's
+    // segments table (k0..k{depth-1}), so the filter selects exactly one
+    // partition's pre-aggregated rows. Filters are raw equality on the
+    // pre-projected k* columns.
     return `
-      SELECT MIN(ts) AS ts, ${this.aggValueExpr()} AS value
-      FROM ${this.segmentsTableName}
+      SELECT ts, ${this.aggValueColumn()} AS value
+      FROM ${this.segmentsTable(depth)}
       ${filtersClause}
-      GROUP BY group_id
       ORDER BY ts
     `;
   }
@@ -297,14 +312,15 @@ export class BreakdownTracks {
     ];
   }
 
-  // Builds the three tables that drive every track:
-  //   _breakdown_intervals: one row per source interval (id, ts, dur, the
+  // Builds the tables that drive every track:
+  //   _breakdown_intervals: one row per source interval (ts, dur, the
   //     breakdown columns, [agg_value]) from the aggregation table ONLY — no
   //     slice/pivot joins, so the overlap count is never inflated by a 1:N join.
-  //   _breakdown_segments: per-(atomic segment, active interval) rows from
-  //     interval_self_intersect over the intervals, with the breakdown columns
-  //     and agg_value inline so per-node counter queries are a plain GROUP BY
-  //     with no JOIN back.
+  //   _breakdown_segments_l<d> (one per hierarchy depth d): pre-aggregated
+  //     atomic overlap segments from _interval_self_intersect_count/_agg over
+  //     the intervals, partitioned by (k0..k{d-1}). Each table is at most
+  //     ~2x the interval count regardless of overlap depth, and per-node
+  //     counter queries are a plain filter — no JOIN back, no GROUP BY.
   //   _breakdown_projected: one row per source row WITH the slice/pivot joins
   //     applied (so it may fan out 1:N) plus the slice/pivot ts/dur. Drives the
   //     hierarchy enumeration and the slice/pivot tracks.
@@ -312,29 +328,47 @@ export class BreakdownTracks {
     const agg = this.props.aggregation;
     const aggTs = agg.tsCol ?? 'ts';
     const aggDur = agg.durCol ?? 'dur';
-    const idExpr = this.props.sliceIdColumn ?? 'ROW_NUMBER() OVER ()';
     const hasValue = agg.valueCol !== undefined;
 
     const intervalCols = [
-      `${idExpr} AS id`,
       `${aggTs} AS ts`,
       `${aggDur} AS dur`,
       ...agg.columns.map((col, i) => `${col} AS k${i}`),
       ...(hasValue ? [`${agg.valueCol} AS agg_value`] : []),
     ].join(', ');
 
-    const denormCols = [
-      ...this.aggColNames.map((n) => `i.${n}`),
-      ...(hasValue ? ['i.agg_value'] : []),
-    ].join(', ');
-
     // Drop intervals that can't carry a count: a NULL id (e.g. binder_reply_id
     // on oneway transactions) or a negative dur (dur = -1 marks an incomplete
-    // slice). ROW_NUMBER ids are never NULL, so the id check is only emitted
-    // when a real id column was supplied.
+    // slice). The id itself is not projected — the self-intersect macros
+    // treat every row as one interval — so the check reads the raw column.
     const idCheck = this.props.sliceIdColumn
       ? `${this.props.sliceIdColumn} IS NOT NULL AND `
       : '';
+
+    // One segments table per hierarchy depth: depth d partitions by the
+    // first d breakdown columns (depth 0 = the unpartitioned root series).
+    // The COUNT flavor skips the value plumbing entirely; MAX/SUM ship
+    // agg_value through the sweep.
+    const segmentTables = this.aggColNames.map((_, i) => i + 1);
+    segmentTables.unshift(0);
+    const segmentsDdl = segmentTables
+      .map((depth) => {
+        const keys = this.aggColNames.slice(0, depth).join(', ');
+        const keyCols = keys.length > 0 ? `, ${keys}` : '';
+        const src =
+          this.props.aggregationType === BreakdownTrackAggType.COUNT
+            ? `_interval_self_intersect_count!((
+                 SELECT ts, dur${keyCols} FROM ${this.intervalsTableName}
+               ), (${keys}))`
+            : `_interval_self_intersect_agg!((
+                 SELECT ts, dur, agg_value${keyCols}
+                 FROM ${this.intervalsTableName}
+               ), agg_value, (${keys}))`;
+        return `
+          CREATE PERFETTO TABLE ${this.segmentsTable(depth)} AS
+          SELECT * FROM ${src};`;
+      })
+      .join('\n');
 
     // The projection applies the slice/pivot joins, so a plain id column would
     // be ambiguous if a join table shares the name — e.g. the binder breakdown
@@ -358,13 +392,7 @@ export class BreakdownTracks {
       SELECT ${intervalCols}
       FROM ${agg.tableName}
       WHERE ${idCheck}${aggTs} IS NOT NULL AND ${aggDur} >= 0;
-
-      CREATE PERFETTO TABLE ${this.segmentsTableName} AS
-      SELECT iss.ts, iss.group_id, iss.interval_ends_at_ts, ${denormCols}
-      FROM interval_self_intersect!((
-        SELECT id, ts, dur FROM ${this.intervalsTableName}
-      )) iss
-      JOIN ${this.intervalsTableName} i USING(id);
+      ${segmentsDdl}
 
       CREATE PERFETTO TABLE ${this.projectedTableName} AS
       SELECT ${projectedCols}
@@ -555,8 +583,9 @@ export class BreakdownTracks {
 
   private async getCounterTrackSortOrder(
     filtersClause: string,
+    depth: number,
   ): Promise<number> {
-    const aggregationQuery = this.getAggregationQuery(filtersClause);
+    const aggregationQuery = this.getAggregationQuery(filtersClause, depth);
     const result = await this.props.trace.engine.query(`
       SELECT MAX(value) as max_value FROM (${aggregationQuery})
     `);
@@ -568,22 +597,26 @@ export class BreakdownTracks {
     name: string,
     newFilters: Filter[],
   ): Promise<TrackNode> {
+    // Counter nodes only ever filter on breakdown (k*) columns, so the
+    // filter count IS the hierarchy depth, which picks the segments table
+    // partitioned by exactly those columns.
+    const depth = newFilters.length;
     return this.createTrackNode(
       name,
       newFilters,
       (uri, filtersClause) =>
-        // Lazy: getAggregationQuery is a cheap GROUP BY over the shared segments
-        // table, and CounterTrack's useData fires it only on render — nothing is
-        // materialized per node at trace load.
+        // Lazy: getAggregationQuery is a plain filter over this depth's
+        // pre-aggregated segments table, and CounterTrack's useData fires it
+        // only on render — nothing is materialized per node at trace load.
         CounterTrack.create({
           trace: this.props.trace,
           uri,
           sqlSource: `
             SELECT ts, value
-            FROM (${this.getAggregationQuery(filtersClause)})
+            FROM (${this.getAggregationQuery(filtersClause, depth)})
           `,
         }),
-      (filtersClause) => this.getCounterTrackSortOrder(filtersClause),
+      (filtersClause) => this.getCounterTrackSortOrder(filtersClause, depth),
     );
   }
 

--- a/ui/src/plugins/com.android.ProcessStateBreakdowns/index.ts
+++ b/ui/src/plugins/com.android.ProcessStateBreakdowns/index.ts
@@ -1,0 +1,114 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {sqliteString} from '../../base/string_utils';
+import {
+  BreakdownTrackAggType,
+  BreakdownTracks,
+} from '../../components/tracks/breakdown_tracks';
+import type {PerfettoPlugin} from '../../public/plugin';
+import type {Trace} from '../../public/trace';
+import {TrackNode} from '../../public/workspace';
+import {NUM, STR} from '../../trace_processor/query_result';
+import {PROCESS_STATE_SQL} from './sql';
+
+/**
+ * Visualizes framework process-state transitions (the `process_state_changed`
+ * track events emitted by system_server) as one breakdown tree per proc
+ * state, ordered by perceptibility: each state gets a concurrency counter
+ * broken down package -> uid -> process, with the raw state intervals as
+ * slices at the leaves.
+ */
+export default class implements PerfettoPlugin {
+  static readonly id = 'com.android.ProcessStateBreakdowns';
+
+  async onTraceLoad(ctx: Trace): Promise<void> {
+    await ctx.engine.query(PROCESS_STATE_SQL);
+
+    // One row per state present in the trace, in perceptibility order.
+    // States missing from the rank table (future enum additions) sort
+    // between the real states and the UNKNOWN family.
+    const states = await ctx.engine.query(`
+      SELECT
+        i.state AS state,
+        IFNULL(r.rank, 500) AS rank,
+        IFNULL(r.display_name, REPLACE(i.state, 'PROCESS_STATE_', ''))
+          AS displayName
+      FROM (
+        SELECT DISTINCT state FROM _psb_process_state_intervals
+        WHERE state IS NOT NULL
+      ) i
+      LEFT JOIN _psb_state_rank r USING (state)
+      ORDER BY rank
+    `);
+
+    const stateRows: Array<{state: string; rank: number; displayName: string}> =
+      [];
+    for (
+      const it = states.iter({state: STR, rank: NUM, displayName: STR});
+      it.valid();
+      it.next()
+    ) {
+      stateRows.push({
+        state: it.state,
+        rank: it.rank,
+        displayName: it.displayName,
+      });
+    }
+    // Trace has no process state events: don't add an empty group.
+    if (stateRows.length === 0) return;
+
+    const group = new TrackNode({name: 'Process States', isSummary: true});
+
+    await Promise.all(
+      stateRows.map(async ({state, rank, displayName}) => {
+        // Rank-keyed name: unique per state and safe as an identifier
+        // (state strings come from trace data, so they never reach SQL
+        // unquoted).
+        const stateTable = `_psb_state_intervals_r${rank}`;
+        await ctx.engine.query(`
+          CREATE OR REPLACE PERFETTO VIEW ${stateTable} AS
+          SELECT * FROM _psb_process_state_intervals
+          WHERE state = ${sqliteString(state)}
+        `);
+
+        const breakdowns = new BreakdownTracks({
+          trace: ctx,
+          trackTitle: displayName,
+          description:
+            `Processes in ${state}, broken down by package, uid and ` +
+            `process. The counters show how many matching processes are ` +
+            `in this state over time.`,
+          aggregationType: BreakdownTrackAggType.COUNT,
+          aggregation: {
+            columns: ['package_name', 'uid', 'process_name'],
+            tableName: stateTable,
+          },
+          slice: {
+            columns: [sqliteString(displayName)],
+            tableName: stateTable,
+          },
+          sliceIdColumn: 'id',
+          sortTracks: true,
+        });
+
+        const node = await breakdowns.createTracks();
+        node.sortOrder = rank;
+        group.addChildInOrder(node);
+      }),
+    );
+
+    ctx.defaultWorkspace.addChildInOrder(group);
+  }
+}

--- a/ui/src/plugins/com.android.ProcessStateBreakdowns/index.ts
+++ b/ui/src/plugins/com.android.ProcessStateBreakdowns/index.ts
@@ -17,11 +17,13 @@ import {
   BreakdownTrackAggType,
   BreakdownTracks,
 } from '../../components/tracks/breakdown_tracks';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {NUM, STR} from '../../trace_processor/query_result';
-import {PROCESS_STATE_SQL} from './sql';
+import {SourceDataset} from '../../trace_processor/dataset';
+import {LONG, NUM, STR} from '../../trace_processor/query_result';
+import {PERCEPTIBLE_STATE_SQL, PROCESS_STATE_SQL} from './sql';
 
 /**
  * Visualizes framework process-state transitions (the `process_state_changed`
@@ -70,6 +72,7 @@ export default class implements PerfettoPlugin {
     if (stateRows.length === 0) return;
 
     const group = new TrackNode({name: 'Process States', isSummary: true});
+    group.uri = await this.createPerceptibleStateTrack(ctx);
 
     await Promise.all(
       stateRows.map(async ({state, rank, displayName}) => {
@@ -110,5 +113,40 @@ export default class implements PerfettoPlugin {
     );
 
     ctx.defaultWorkspace.addChildInOrder(group);
+  }
+
+  // The group's own track: at every instant, the most perceptible (best
+  // ranked) state any tracked process is in, rendered as slices named after
+  // the state. This is what shows when the group is collapsed, replacing the
+  // "root counter" a plain BreakdownTracks tree would put there.
+  private async createPerceptibleStateTrack(ctx: Trace): Promise<string> {
+    await ctx.engine.query(PERCEPTIBLE_STATE_SQL);
+
+    const uri = `/process_state_breakdowns_perceptible`;
+    ctx.tracks.registerTrack({
+      uri,
+      description:
+        'The most perceptible process state any tracked process is in, ' +
+        'at every point in time.',
+      renderer: SliceTrack.create({
+        trace: ctx,
+        uri,
+        dataset: new SourceDataset({
+          schema: {
+            id: NUM,
+            ts: LONG,
+            dur: LONG,
+            name: STR,
+          },
+          src: `
+            SELECT s.id, s.ts, s.dur,
+                   IFNULL(r.display_name, 'UNKNOWN') AS name
+            FROM _psb_perceptible_slices s
+            LEFT JOIN _psb_state_rank r USING (rank)
+          `,
+        }),
+      }),
+    });
+    return uri;
   }
 }

--- a/ui/src/plugins/com.android.ProcessStateBreakdowns/index.ts
+++ b/ui/src/plugins/com.android.ProcessStateBreakdowns/index.ts
@@ -71,7 +71,10 @@ export default class implements PerfettoPlugin {
     // Trace has no process state events: don't add an empty group.
     if (stateRows.length === 0) return;
 
-    const group = new TrackNode({name: 'Process States', isSummary: true});
+    // Deliberately NOT isSummary: a summary node's track content is omitted
+    // while the group is expanded, but the perceptible-state timeline is the
+    // headline content of this group and should stay visible in both states.
+    const group = new TrackNode({name: 'Process States'});
     group.uri = await this.createPerceptibleStateTrack(ctx);
 
     await Promise.all(

--- a/ui/src/plugins/com.android.ProcessStateBreakdowns/sql.ts
+++ b/ui/src/plugins/com.android.ProcessStateBreakdowns/sql.ts
@@ -1,0 +1,263 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SQL pipeline turning framework `process_state_changed` track events into
+// per-process proc-state intervals. Everything is prefixed `_psb_` so this
+// plugin never collides with stdlib or other plugins in the global table
+// namespace. Only the chain feeding the state timeline is materialized here;
+// the wider event families (freezer, broadcast, service/fgs/provider state)
+// can be added alongside when tracks exist for them.
+export const PROCESS_STATE_SQL = `
+-- Raw framework events. proc-state enum args arrive as their string names
+-- (e.g. 'PROCESS_STATE_TOP') because trace processor resolves enum-typed
+-- track event fields via the descriptor.
+CREATE OR REPLACE PERFETTO TABLE _psb_process_state_changed AS
+SELECT
+  ts,
+  extract_arg(arg_set_id, 'process_state_changed_event.uid') AS uid,
+  extract_arg(arg_set_id, 'process_state_changed_event.pid') AS pid,
+  extract_arg(arg_set_id, 'process_state_changed_event.cur_proc_state')
+    AS cur_proc_state
+FROM slice
+WHERE name = 'process_state_changed';
+
+CREATE OR REPLACE PERFETTO TABLE _psb_process_bound AS
+SELECT
+  ts,
+  extract_arg(arg_set_id, 'process_start_event.uid') AS uid,
+  extract_arg(arg_set_id, 'process_start_event.pid') AS pid,
+  extract_arg(arg_set_id, 'process_start_event.process_name') AS process_name
+FROM slice
+WHERE name = 'process_bound';
+
+CREATE OR REPLACE PERFETTO TABLE _psb_process_died AS
+SELECT
+  ts,
+  extract_arg(arg_set_id, 'process_died_event.pid') AS pid,
+  extract_arg(arg_set_id, 'process_died_event.reason') AS reason,
+  extract_arg(arg_set_id, 'process_died_event.sub_reason') AS sub_reason
+FROM slice
+WHERE name = 'process_died';
+
+CREATE OR REPLACE PERFETTO TABLE _psb_binder_died AS
+SELECT
+  ts,
+  extract_arg(arg_set_id, 'binder_died_event.pid') AS pid
+FROM slice
+WHERE name = 'binder_died';
+
+-- Framework-emitted process lifecycle, keyed by upid (one row per process):
+-- fw_start_ts from AndroidProcessStartEvent, fw_end_ts from
+-- AndroidBinderDiedEvent. Fused below with whatever the process table
+-- already has (e.g. from ftrace sched).
+CREATE OR REPLACE PERFETTO TABLE _psb_fw_process_lifecycle AS
+SELECT upid, fw_start_ts, fw_end_ts
+FROM __intrinsic_android_track_event_process;
+
+-- Perceptibility ranking of proc states, mirroring ActivityManager's
+-- importance order (NOT the wire enum values: PROCESS_STATE_BOUND_TOP was
+-- appended to the proto as 1020 and would sort below the cached states).
+-- Lower rank = more perceptible. Unknown/unspecified sort last; states
+-- missing from this table (a future enum addition) default to rank 500 at
+-- the query sites.
+CREATE OR REPLACE PERFETTO TABLE _psb_state_rank AS
+WITH r(state, rank) AS (
+  VALUES
+    ('PROCESS_STATE_PERSISTENT', 0),
+    ('PROCESS_STATE_PERSISTENT_UI', 1),
+    ('PROCESS_STATE_TOP', 2),
+    ('PROCESS_STATE_BOUND_TOP', 3),
+    ('PROCESS_STATE_FOREGROUND_SERVICE', 4),
+    ('PROCESS_STATE_BOUND_FOREGROUND_SERVICE', 5),
+    ('PROCESS_STATE_IMPORTANT_FOREGROUND', 6),
+    ('PROCESS_STATE_IMPORTANT_BACKGROUND', 7),
+    ('PROCESS_STATE_TRANSIENT_BACKGROUND', 8),
+    ('PROCESS_STATE_BACKUP', 9),
+    ('PROCESS_STATE_SERVICE', 10),
+    ('PROCESS_STATE_RECEIVER', 11),
+    ('PROCESS_STATE_TOP_SLEEPING', 12),
+    ('PROCESS_STATE_HEAVY_WEIGHT', 13),
+    ('PROCESS_STATE_HOME', 14),
+    ('PROCESS_STATE_LAST_ACTIVITY', 15),
+    ('PROCESS_STATE_CACHED_ACTIVITY', 16),
+    ('PROCESS_STATE_CACHED_ACTIVITY_CLIENT', 17),
+    ('PROCESS_STATE_CACHED_RECENT', 18),
+    ('PROCESS_STATE_CACHED_EMPTY', 19),
+    ('PROCESS_STATE_NONEXISTENT', 20),
+    ('PROCESS_STATE_UNSPECIFIED', 997),
+    ('PROCESS_STATE_UNKNOWN_TO_PROTO', 998),
+    ('PROCESS_STATE_UNKNOWN', 999)
+)
+SELECT
+  state,
+  rank,
+  REPLACE(state, 'PROCESS_STATE_', '') AS display_name
+FROM r;
+
+-- Multi-user package mapping: uid % 100000 folds per-user uids (u10 app has
+-- uid 1010123) onto the owning package's appid.
+CREATE OR REPLACE PERFETTO TABLE _psb_multi_user_mapping AS
+WITH all_uids AS (
+  SELECT DISTINCT uid FROM process WHERE uid IS NOT NULL
+),
+collapsed_packages AS (
+  SELECT
+    uid,
+    MIN(package_name) AS package_name,
+    MAX(debuggable) AS debuggable,
+    MAX(version_code) AS version_code
+  FROM package_list
+  GROUP BY uid
+)
+SELECT
+  au.uid,
+  CASE
+    WHEN (au.uid % 100000) = 1000 THEN 'system'
+    ELSE pl.package_name
+  END AS package_name,
+  pl.debuggable,
+  pl.version_code
+FROM all_uids au
+LEFT JOIN collapsed_packages pl ON (au.uid % 100000) = pl.uid;
+
+-- Master process map: one row per process lifecycle (pid can be reused), with
+-- start/end fused from the framework lifecycle events, the process table, and
+-- binder_died, falling back to the trace bounds.
+CREATE OR REPLACE PERFETTO TABLE _psb_process_map AS
+WITH _all_starts AS (
+  SELECT
+    p.pid,
+    COALESCE(fw.fw_start_ts, p.start_ts, trace_start()) AS ts,
+    p.name AS process_name,
+    p.uid,
+    p.upid
+  FROM process p
+  LEFT JOIN _psb_fw_process_lifecycle fw USING (upid)
+  WHERE p.pid > 0
+  UNION ALL
+  SELECT pid, ts, process_name, uid, CAST(NULL AS INT) AS upid
+  FROM _psb_process_bound
+),
+_all_deaths AS (
+  SELECT
+    p.pid,
+    COALESCE(fw.fw_end_ts, p.end_ts) AS ts
+  FROM process p
+  LEFT JOIN _psb_fw_process_lifecycle fw USING (upid)
+  WHERE p.pid > 0 AND COALESCE(fw.fw_end_ts, p.end_ts) IS NOT NULL
+  UNION ALL
+  SELECT pid, ts FROM _psb_binder_died
+),
+_starts_with_next_death AS (
+  SELECT
+    s.pid, s.ts AS start_ts, s.process_name, s.uid, s.upid,
+    MIN(d.ts) AS next_death_ts
+  FROM _all_starts s
+  LEFT JOIN _all_deaths d ON s.pid = d.pid AND d.ts >= s.ts
+  GROUP BY s.pid, s.ts, s.process_name, s.uid, s.upid
+),
+_lifecycles AS (
+  SELECT
+    pid,
+    MIN(start_ts) AS start_ts,
+    next_death_ts,
+    MAX(upid) AS upid,
+    MAX(process_name) AS process_name,
+    -- Prefer UID from the process table (has upid) over slice-only entries
+    -- to avoid PID-reuse artifacts (e.g. kworker inheriting an app PID).
+    COALESCE(MAX(CASE WHEN upid IS NOT NULL THEN uid END), MAX(uid)) AS uid
+  FROM _starts_with_next_death
+  GROUP BY pid, next_death_ts
+)
+SELECT
+  COALESCE(
+    l.upid,
+    CAST((ROW_NUMBER() OVER (ORDER BY l.start_ts, l.pid)) + 1000000 AS INT)
+  ) AS upid,
+  l.pid,
+  l.uid,
+  mum.package_name,
+  mum.debuggable,
+  mum.version_code,
+  l.process_name,
+  l.start_ts,
+  COALESCE(l.next_death_ts, trace_end()) AS end_ts,
+  (
+    SELECT reason FROM _psb_process_died pd
+    WHERE pd.pid = l.pid AND pd.ts >= l.start_ts
+      AND pd.ts <= COALESCE(l.next_death_ts, trace_end())
+    ORDER BY ts ASC LIMIT 1
+  ) AS death_reason,
+  (
+    SELECT sub_reason FROM _psb_process_died pd
+    WHERE pd.pid = l.pid AND pd.ts >= l.start_ts
+      AND pd.ts <= COALESCE(l.next_death_ts, trace_end())
+    ORDER BY ts ASC LIMIT 1
+  ) AS death_sub_reason
+FROM _lifecycles l
+LEFT JOIN _psb_multi_user_mapping mum ON l.uid = mum.uid
+WHERE mum.package_name IS NOT NULL;
+
+CREATE OR REPLACE PERFETTO TABLE _psb_process_state_enriched AS
+SELECT
+  ps.*,
+  ap.upid,
+  ap.process_name,
+  ap.package_name,
+  ap.debuggable,
+  ap.version_code,
+  ap.death_reason,
+  ap.death_sub_reason,
+  ap.end_ts AS process_end_ts
+FROM _psb_process_state_changed ps
+JOIN _psb_process_map ap
+  ON ps.pid = ap.pid AND ps.ts >= ap.start_ts AND ps.ts < ap.end_ts;
+
+-- The state timeline: one interval per (process lifecycle, run of a state).
+-- id is required by BreakdownTracks' sliceIdColumn.
+CREATE OR REPLACE PERFETTO TABLE _psb_process_state_intervals AS
+WITH state_with_lag AS (
+  SELECT
+    ts, uid, package_name, debuggable, version_code, pid, process_name,
+    death_reason,
+    cur_proc_state AS state,
+    LAG(cur_proc_state) OVER (PARTITION BY upid ORDER BY ts) AS prev_state,
+    process_end_ts, upid
+  FROM _psb_process_state_enriched
+),
+raw_transitions AS (
+  SELECT
+    ts, uid, package_name, debuggable, version_code, pid, process_name,
+    death_reason, state,
+    LEAD(ts) OVER (PARTITION BY upid ORDER BY ts) AS next_ts,
+    process_end_ts
+  FROM state_with_lag
+  WHERE prev_state IS NULL OR state != prev_state
+),
+calculated_durations AS (
+  SELECT
+    ts,
+    COALESCE(next_ts, process_end_ts) - ts AS dur,
+    uid, pid, process_name, package_name, debuggable, version_code,
+    death_reason, state
+  FROM raw_transitions
+  WHERE state IS NOT NULL
+)
+SELECT
+  ROW_NUMBER() OVER (ORDER BY ts) AS id,
+  *,
+  COALESCE(package_name, process_name) || ': ' || uid AS name
+FROM calculated_durations
+WHERE dur > 0;
+`;

--- a/ui/src/plugins/com.android.ProcessStateBreakdowns/sql.ts
+++ b/ui/src/plugins/com.android.ProcessStateBreakdowns/sql.ts
@@ -261,3 +261,49 @@ SELECT
 FROM calculated_durations
 WHERE dur > 0;
 `;
+
+// The "most perceptible state" timeline: at every instant, the best (lowest)
+// perceptibility rank across ALL tracked processes, as one slice per run.
+// _interval_self_intersect_agg computes MIN(rank) over each atomic overlap
+// segment in C++ (one pre-aggregated row per segment); the islands pass then
+// merges contiguous same-rank segments — the C++ merge alone can't fuse them
+// because the process count changing splits segments even when the min
+// doesn't. Time with no tracked process alive produces no slice (cnt = 0
+// rows are dropped), so gaps stay visibly empty.
+export const PERCEPTIBLE_STATE_SQL = `
+INCLUDE PERFETTO MODULE intervals.self_intersect;
+
+CREATE OR REPLACE PERFETTO TABLE _psb_perceptible_slices AS
+WITH ranked AS (
+  SELECT i.ts, i.dur, IFNULL(r.rank, 500) AS v
+  FROM _psb_process_state_intervals i
+  LEFT JOIN _psb_state_rank r USING (state)
+),
+covered AS (
+  SELECT ts, dur, CAST(min_value AS INT64) AS rank
+  FROM _interval_self_intersect_agg!(ranked, v, ())
+  WHERE cnt > 0
+),
+marked AS (
+  SELECT
+    ts, dur, rank,
+    IIF(
+      LAG(rank) OVER (ORDER BY ts) = rank
+        AND LAG(ts + dur) OVER (ORDER BY ts) = ts,
+      0,
+      1
+    ) AS is_break
+  FROM covered
+),
+runs AS (
+  SELECT ts, dur, rank, SUM(is_break) OVER (ORDER BY ts) AS run_id
+  FROM marked
+)
+SELECT
+  run_id AS id,
+  MIN(ts) AS ts,
+  MAX(ts + dur) - MIN(ts) AS dur,
+  MIN(rank) AS rank
+FROM runs
+GROUP BY run_id;
+`;


### PR DESCRIPTION
This change introduces a highly optimized C++ interval intersection plugin and uses it to power a new Process State Breakdowns UI plugin, solving performance bottlenecks in deep interval overlaps.

Trace Processor (tp) changes:
- Adds a C++ `interval_self_intersect` plugin, replacing the SQL
  stdlib macro with an O(n log n) sweep that processes overlaps in
  memory.
- Extends the C++ plugin with partitioned in-sweep aggregation
  (cnt/sum/min/max) and merges adjacent equal-aggregate segments. This
  avoids the O(N * depth) row explosion of heavily overlapping
  intervals, bounding the output to 2x the input rows.

UI (ui) changes:
- Updates `BreakdownTracks` to use the new partitioned in-sweep
  aggregation, computing one pre-aggregated table per hierarchy level.
  This removes expensive JOINs and GROUP BYs, resolving OOMs and lag
  during trace load.
- Adds the `ProcessStateBreakdowns` plugin, which fuses Android
  framework lifecycle events to visualize process states and OOM adj
  scores.
- Includes a top-level summary track that highlights the most
  perceptible state across all processes, which remains visible when
  expanded.