### PR TITLE
Collapse isolated UIDs into one CPU per UID track

### DIFF
--- a/src/trace_processor/importers/proto/android_cpu_per_uid_module.cc
+++ b/src/trace_processor/importers/proto/android_cpu_per_uid_module.cc
@@ -45,6 +45,34 @@ uint64_t MakeKey(uint32_t uid, uint32_t cluster) {
   return ((uint64_t(uid)) << 32) | cluster;
 }
 
+std::pair<uint32_t, uint32_t> SplitKey(uint64_t key) {
+  uint32_t uid = key >> 32;
+  uint32_t cluster = key & 0xffffffff;
+  return std::make_pair(uid, cluster);
+}
+
+// Returns the package ID for a uid (the uid minus the user portion).
+uint32_t PkgId(uint32_t uid) {
+  return uid % 100000;
+}
+
+// Returns whether the UID is part of an anonymous UID range, such as the shared
+// uid range, or isolated UID range.
+bool IsGroupedUid(uint32_t uid) {
+  uint32_t pkgid = PkgId(uid);
+  return (50000 <= pkgid && pkgid < 60000) ||
+         (90000 <= pkgid && pkgid < 100000);
+}
+
+// Returns the canonical grouped UID for UIDs within anonymous ranges. For
+// example 1090123 is mapped to 1090000.
+uint32_t GetGroupedUid(uint32_t uid) {
+  if (IsGroupedUid(uid)) {
+    return uid - (uid % 10000);
+  }
+  return uid;
+}
+
 constexpr auto kCpuPerUidBlueprint = tracks::CounterBlueprint(
     "android_cpu_per_uid",
     tracks::StaticUnitBlueprint("ms"),
@@ -94,27 +122,20 @@ void AndroidCpuPerUidModule::ParseField(const ParseFieldArgs& args) {
     state->cluster_count = evt.cluster_count();
   }
 
-  std::unordered_set<uint32_t> uid_with_value_this_packet;
-
   bool parse_error = false;
   uint32_t cluster = 0;
   auto uid_it = evt.uid(&parse_error);
   for (auto time_it = evt.total_time_ms(&parse_error); uid_it && time_it;
        ++time_it) {
-    uid_with_value_this_packet.insert(*uid_it);
-    uint64_t key = MakeKey(*uid_it, cluster);
-    uint64_t* previous = state->last_values.Find(key);
-    uint64_t time_ms;
-    if (previous) {
-      time_ms = *time_it + *previous;
-      *previous = time_ms;
-    } else {
-      time_ms = *time_it;
-      state->last_values.Insert(key, time_ms);
-    }
+    auto [time_ms, delta_ms] =
+        IncrementalStateUpdate(*uid_it, cluster, *time_it, state);
 
-    ComputeTotals(*uid_it, cluster, time_ms);
-    UpdateCounter(args.ts, *uid_it, cluster, time_ms);
+    // Totals are computed using grouped IDs, because totals correspond 1:1 with
+    // real tracks. Grouped UIDs (such as isolated UIDs) are consolidated onto
+    // a single track for the group.
+    uint32_t grouped_uid = GetGroupedUid(*uit_it);
+    ComputeTotals(grouped_uid, cluster, delta_ms);
+
     cluster++;
     if (cluster >= state->cluster_count) {
       cluster = 0;
@@ -128,17 +149,17 @@ void AndroidCpuPerUidModule::ParseField(const ParseFieldArgs& args) {
   for (auto it = app_totals_.GetIterator(); it; ++it) {
     UpdateTotals(args.ts, "Apps", it.key(), it.value());
   }
-
-  // Anything we knew about but didn't see in this packet must not have
-  // incremented.
-  for (auto it = state->last_values.GetIterator(); it; ++it) {
-    uint32_t uid = it.key() >> 32;
-    if (uid_with_value_this_packet.count(uid)) {
-      continue;
+  for (auto it = cumulative_.GetIterator(); it; ++it) {
+    auto [uid, cluster_id] = SplitKey(it.key());
+    if (IsGroupedUid(uid)) {
+      UpdateCounter(args.ts, uid, cluster_id, it.value());
     }
-    uint32_t cluster_id = it.key() & 0xffffffff;
-
-    UpdateCounter(args.ts, uid, cluster_id, it.value());
+  }
+  for (auto it = state->last_values.GetIterator(); it; ++it) {
+    auto [uid, cluster_id] = SplitKey(it.key());
+    if (!IsGroupedUid(uid)) {
+      UpdateCounter(args.ts, uid, cluster_id, it.value());
+    }
   }
 }
 
@@ -165,20 +186,10 @@ void AndroidCpuPerUidModule::OnEventsFullyExtracted() {
 
 void AndroidCpuPerUidModule::ComputeTotals(uint32_t uid,
                                            uint32_t cluster,
-                                           uint64_t time_ms) {
-  // Note: in ParseField, previous is computed per intern sequence,
-  // whereas here it's computed globally post-interning.
+                                           uint64_t delta_ms) {
   uint64_t key = MakeKey(uid, cluster);
-  auto [previous, inserted] = last_value_.Insert(key, time_ms);
-
-  uint64_t delta_ms = 0;
-  if (time_ms > *previous && !inserted) {
-    delta_ms = time_ms - *previous;
-  }
-  *previous = time_ms;
-
   cumulative_[key] += delta_ms;
-  if ((uid % 100000) < 10000) {
+  if (PkgId(uid) < 10000) {
     system_totals_[cluster] += delta_ms;
   } else {
     app_totals_[cluster] += delta_ms;
@@ -201,6 +212,33 @@ void AndroidCpuPerUidModule::UpdateTotals(int64_t ts,
   TrackId track = context_->track_tracker->InternTrack(
       kCpuTotalsBlueprint, tracks::Dimensions(name, cluster));
   context_->event_tracker->PushCounter(ts, double(value), track);
+}
+
+std::pair<uint64_t, uint64_t> AndroidCpuPerUidModule::IncrementalStateUpdate(
+    uint32_t uid,
+    uint32_t cluster,
+    uint64_t raw_time,
+    AndroidCpuPerUidState* state) {
+  uint64_t key = MakeKey(uid, cluster);
+  uint64_t delta_ms = 0;
+
+  // The meaning of the raw_time depends on incremental state. The first time
+  // we see a key, it's the absolute value of the counter since boot. For all
+  // subsequent times, it's the difference from the last.
+  auto [incr_value, incr_inserted] = state->last_values.Insert(key, raw_time);
+  if (!incr_inserted) {
+    *incr_value += raw_time;
+  }
+
+  // The last value irregardless of incremental state is stored on the importer.
+  // We use this to compute the non-negative delta since the last value.
+  auto [local_value, local_inserted] = last_value_.Insert(key, *incr_value);
+  if (*incr_value > *local_value) {
+    delta_ms = *incr_value - *local_value;
+  }
+
+  *local_value = *incr_value;
+  return std::make_pair(*incr_value, delta_ms);
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/android_cpu_per_uid_module.h
+++ b/src/trace_processor/importers/proto/android_cpu_per_uid_module.h
@@ -41,12 +41,21 @@ class AndroidCpuPerUidModule : public ProtoImporterModule {
   void OnEventsFullyExtracted() override;
 
  private:
+  // Takes in a raw time reading from the proto and handles the incremental
+  // state and internal state (last_value_). Returns the value of the counter
+  // currently, and the difference from the last value (if any).
+  std::pair<uint64_t, uint64_t> IncrementalStateUpdate(
+      uint32_t uid,
+      uint32_t cluster,
+      uint64_t raw_time,
+      AndroidCpuPerUidState* state);
+
   void UpdateCounter(int64_t ts,
                      uint32_t uid,
                      uint32_t cluster,
                      uint64_t value);
 
-  void ComputeTotals(uint32_t uid, uint32_t cluster, uint64_t time_ms);
+  void ComputeTotals(uint32_t uid, uint32_t cluster, uint64_t delta_ms);
   void UpdateTotals(int64_t ts,
                     base::StringView name,
                     uint32_t cluster,

--- a/test/trace_processor/diff_tests/parser/android/tests_cpu_per_uid.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_cpu_per_uid.py
@@ -60,7 +60,8 @@ class AndroidCpuPerUid(TestSuite):
         query="""
         SELECT t.name, c.ts, c.value
         FROM counter_track t JOIN counter c ON t.id = c.track_id
-        WHERE type = 'android_cpu_per_uid';
+        WHERE type = 'android_cpu_per_uid'
+        ORDER BY 1, 2;
         """,
         out=Csv("""
         "name","ts","value"
@@ -116,7 +117,8 @@ class AndroidCpuPerUid(TestSuite):
         query="""
         SELECT t.name, c.ts, c.value
         FROM counter_track t JOIN counter c ON t.id = c.track_id
-        WHERE type = 'android_cpu_per_uid';
+        WHERE type = 'android_cpu_per_uid'
+        ORDER BY 1, 2;
         """,
         out=Csv("""
         "name","ts","value"
@@ -130,4 +132,156 @@ class AndroidCpuPerUid(TestSuite):
         "CPU for UID 1000 CL0",12000,1000000.000000
         "CPU for UID 1000 CL1",10000,1000000.000000
         "CPU for UID 1000 CL1",12000,1000000.000000
+        """))
+
+  def test_android_cpu_per_uid_isolated_uids(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 10000
+          cpu_per_uid_data {
+            cluster_count: 1
+            uid: 90000
+            uid: 90001
+            uid: 91000
+            total_time_ms: 1000000
+            total_time_ms: 100000
+            total_time_ms: 10000
+          }
+        }
+        packet {
+          timestamp: 12000
+          cpu_per_uid_data {
+            uid: 91000
+            total_time_ms: 50
+          }
+        }
+        packet {
+          timestamp: 14000
+          cpu_per_uid_data {
+            uid: 90001
+            total_time_ms: 60
+          }
+        }
+        """),
+        query="""
+        SELECT t.name, c.ts, c.value
+        FROM counter_track t JOIN counter c ON t.id = c.track_id
+        WHERE type = 'android_cpu_per_uid'
+        ORDER BY 1, 2;
+        """,
+        out=Csv("""
+        "name","ts","value"
+        "CPU for UID 90000 CL0",10000,0.000000
+        "CPU for UID 90000 CL0",12000,50.000000
+        "CPU for UID 90000 CL0",14000,110.000000
+        """))
+
+  def test_android_cpu_per_uid_cumulative_tracks(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 10000
+          cpu_per_uid_data {
+            cluster_count: 3
+            uid: 0
+            uid: 1000
+            uid: 1001
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+          }
+        }
+        packet {
+          timestamp: 12000
+          cpu_per_uid_data {
+            uid: 0
+            uid: 1000
+            total_time_ms: 100
+            total_time_ms: 0
+            total_time_ms: 0
+            total_time_ms: 2000
+            total_time_ms: 200
+            total_time_ms: 20
+          }
+        }
+        """),
+        query="""
+        SELECT t.name, c.ts, c.value
+        FROM counter_track t JOIN counter c ON t.id = c.track_id
+        WHERE type = 'android_cpu_per_uid_totals'
+        ORDER BY 1, 2;
+        """,
+        out=Csv("""
+        "name","ts","value"
+        "CPU for System CL0",10000,0.000000
+        "CPU for System CL0",12000,2100.000000
+        "CPU for System CL1",10000,0.000000
+        "CPU for System CL1",12000,200.000000
+        "CPU for System CL2",10000,0.000000
+        "CPU for System CL2",12000,20.000000
+        """))
+
+  def test_android_cpu_per_uid_track_summaries(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 10000
+          cpu_per_uid_data {
+            cluster_count: 2
+            uid: 0
+            uid: 1000
+            uid: 1001
+            uid: 1090001
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+            total_time_ms: 1000000
+          }
+        }
+        packet {
+          timestamp: 12000
+          cpu_per_uid_data {
+            uid: 0
+            uid: 1000
+            total_time_ms: 100
+            total_time_ms: 0
+            total_time_ms: 2000
+            total_time_ms: 200
+          }
+        }
+        packet {
+          timestamp: 14000
+          cpu_per_uid_data {
+            uid: 1090001
+            total_time_ms: 60
+            total_time_ms: 80
+          }
+        }
+        """),
+        query="""
+        SELECT uid, cluster, total_cpu_millis
+        FROM __intrinsic_android_cpu_per_uid_track
+        ORDER BY uid, cluster;
+        """,
+        out=Csv("""
+        "uid","cluster","total_cpu_millis"
+        0,0,100
+        0,1,0
+        1000,0,2000
+        1000,1,200
+        1001,0,0
+        1001,1,0
+        1090000,0,60
+        1090000,1,80
         """))


### PR DESCRIPTION
There can be many thousand isolated UIDs in a trace which is not particularly helpful to a user and is expensive for queries. This change treats isolated UIDs and shared UIDs similar to the totals tracks, where the delta is accumulated and written at the end of packet handling.

One subtle point: the last_value_ and delta_ms calculation is moved out of ComputeTotals, since we're now passing the canonicalized UID in which would break the delta calculation. This also puts the incremental and global last_value calculation in one function and tries to explain why they both exist.
