### PR TITLE
tp: improve tar parsing and ignore . files in archives

### DIFF
--- a/docs/analysis/merging-traces.md
+++ b/docs/analysis/merging-traces.md
@@ -225,6 +225,14 @@ or, at a higher level, the `_metadata_by_trace` view in the
   to a single `TraceProcessor` instance.
 - Archives containing archives cannot be merged recursively; merge the leaf
   files directly.
+- **Hidden files are ignored**: any archive entry whose name has a path
+  component starting with a `.` is skipped and never parsed as a trace. This
+  covers the metadata that archiving tools add automatically — most notably the
+  AppleDouble resource-fork files (`._foo`) and `.DS_Store` entries that macOS
+  `tar` and Finder-created ZIPs sprinkle next to the real files. As a result a
+  `.tar`/`.zip` built on macOS loads without a spurious "unknown trace type"
+  error. If you deliberately want a dot-prefixed file to be parsed, rename it so
+  no path component starts with a `.`.
 
 ## Next steps
 

--- a/python/generators/diff_tests/testing.py
+++ b/python/generators/diff_tests/testing.py
@@ -118,8 +118,14 @@ class Tar:
   """A tar archive trace assembled from the given members.
 
   Member semantics are identical to Zip.
+
+  When `macos_style` is True the archive emulates one produced by macOS/BSD
+  `tar`: it uses PAX extended headers and terminates the numeric header fields
+  (e.g. size) with a trailing space rather than a NUL, exactly as libarchive
+  does. This exercises the parser's handling of such archives.
   """
   members: Dict[str, Union[str, bytes, 'TextProto', Path, DataPath]]
+  macos_style: bool = False
 
 
 @dataclass

--- a/python/generators/diff_tests/trace_generator.py
+++ b/python/generators/diff_tests/trace_generator.py
@@ -111,14 +111,44 @@ class TraceGenerator:
   def serialize_tar_trace(self, blueprint: Any, archive: Tar,
                           out_stream: IO[bytes]):
     buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode='w') as t:
+    tar_format = tarfile.PAX_FORMAT if archive.macos_style else (
+        tarfile.DEFAULT_FORMAT)
+    with tarfile.open(fileobj=buf, mode='w', format=tar_format) as t:
       for name, member in archive.members.items():
         data = self.serialize_member(blueprint, member)
         info = tarfile.TarInfo(name)
         info.size = len(data)
+        if archive.macos_style:
+          # Force emission of a PAX extended header ('x' typeflag) block, as
+          # macOS/BSD tar does for every member.
+          info.pax_headers = {'comment': 'perfetto-test'}
         t.addfile(info, io.BytesIO(data))
-    out_stream.write(buf.getvalue())
+    raw = buf.getvalue()
+    if archive.macos_style:
+      raw = self._space_terminate_tar_numeric_fields(raw)
+    out_stream.write(raw)
     out_stream.flush()
+
+  @staticmethod
+  def _space_terminate_tar_numeric_fields(raw: bytes) -> bytes:
+    """Rewrites the size field of every tar header from NUL- to space-
+    termination, matching what macOS/BSD tar emits (11 octal digits followed by
+    a space). Only 512-byte blocks that are ustar headers are touched; the
+    parser ignores the header checksum so it is left unchanged."""
+    ba = bytearray(raw)
+    for off in range(0, len(ba) - 512 + 1, 512):
+      if bytes(ba[off + 257:off + 262]) != b'ustar':
+        continue
+      field = bytes(ba[off + 124:off + 136])
+      digits = field.split(b'\x00')[0].split(b' ')[0]
+      if not digits:
+        continue
+      try:
+        value = int(digits, 8)
+      except ValueError:
+        continue
+      ba[off + 124:off + 136] = b'%011o ' % value
+    return bytes(ba)
 
   def serialize_simpleperf_proto_trace(self, simpleperf_trace: SimpleperfProto,
                                        out_stream: IO[bytes]):

--- a/src/trace_processor/importers/archive/archive_entry.cc
+++ b/src/trace_processor/importers/archive/archive_entry.cc
@@ -16,9 +16,33 @@
 
 #include "src/trace_processor/importers/archive/archive_entry.h"
 
+#include <cstddef>
+#include <string>
 #include <tuple>
 
 namespace perfetto::trace_processor {
+
+bool IsHiddenArchivePath(const std::string& path) {
+  size_t start = 0;
+  while (start <= path.size()) {
+    size_t slash = path.find('/', start);
+    size_t end = slash == std::string::npos ? path.size() : slash;
+    // Inspect the component [start, end).
+    if (end > start && path[start] == '.') {
+      // "." and ".." are current/parent directory segments, not hidden files.
+      bool is_dot = (end - start) == 1;
+      bool is_dot_dot = (end - start) == 2 && path[start + 1] == '.';
+      if (!is_dot && !is_dot_dot) {
+        return true;
+      }
+    }
+    if (slash == std::string::npos) {
+      break;
+    }
+    start = slash + 1;
+  }
+  return false;
+}
 
 int ArchiveEntry::ComputePriority(TraceImporterId type,
                                   const TraceImporterRegistry& registry) {

--- a/src/trace_processor/importers/archive/archive_entry.h
+++ b/src/trace_processor/importers/archive/archive_entry.h
@@ -24,6 +24,15 @@
 
 namespace perfetto::trace_processor {
 
+// Returns true if `path` should be ignored when reading an archive (tar/zip),
+// i.e. if any of its path components starts with a '.' (other than the "." and
+// ".." path segments). Such entries are hidden files and directories which are
+// never traces: the most common cases are the AppleDouble resource-fork files
+// ("._foo") and ".DS_Store" entries that macOS/BSD tar and Finder-created zips
+// sprinkle alongside the real files. Ignoring them lets archives created on
+// macOS load without spurious "unknown trace type" failures.
+bool IsHiddenArchivePath(const std::string& path);
+
 // Helper class to determine a proper tokenization. This class can be used as
 // a key of a std::map to automatically sort files before sending them in proper
 // order for tokenization.

--- a/src/trace_processor/importers/archive/tar_trace_reader.cc
+++ b/src/trace_processor/importers/archive/tar_trace_reader.cc
@@ -51,6 +51,11 @@ constexpr char TYPE_FLAG_REGULAR = '0';
 constexpr char TYPE_FLAG_AREGULAR = '\0';
 constexpr char TYPE_FLAG_GNU_LONG_NAME = 'L';
 constexpr char TYPE_FLAG_DIR = '5';
+// PAX extended headers ('x' applies to the next entry, 'g' to the whole
+// archive). Emitted by e.g. macOS/BSD tar. We rely on the plain ustar header
+// fields, so the PAX payload is consumed and ignored.
+constexpr char TYPE_FLAG_PAX_EXTENDED = 'x';
+constexpr char TYPE_FLAG_PAX_GLOBAL = 'g';
 
 template <size_t Size>
 base::StatusOr<uint64_t> ParseBase256(const char (&ptr)[Size]) {
@@ -82,8 +87,15 @@ base::StatusOr<uint64_t> ParseBase256(const char (&ptr)[Size]) {
 
 template <size_t Size>
 base::StatusOr<uint64_t> ParseOctal(const char (&ptr)[Size]) {
+  // POSIX allows numeric fields to be padded with leading spaces and to be
+  // terminated by either a NUL or a space. GNU tar NUL-terminates, but
+  // macOS/BSD tar terminates with a trailing space, so both must be tolerated.
+  size_t i = 0;
+  while (i < Size && ptr[i] == ' ') {
+    ++i;
+  }
   uint64_t value = 0;
-  for (size_t i = 0; i < Size && ptr[i] != 0; ++i) {
+  for (; i < Size && ptr[i] != 0 && ptr[i] != ' '; ++i) {
     if (ptr[i] > '7' || ptr[i] < '0') {
       return base::ErrStatus("Invalid octal digit in size field.");
     }
@@ -300,6 +312,8 @@ base::StatusOr<TarTraceReader::ParseResult> TarTraceReader::ParseMetadata() {
     case TYPE_FLAG_REGULAR:
     case TYPE_FLAG_AREGULAR:
     case TYPE_FLAG_GNU_LONG_NAME:
+    case TYPE_FLAG_PAX_EXTENDED:
+    case TYPE_FLAG_PAX_GLOBAL:
       state_ = State::kContent;
       break;
 
@@ -323,11 +337,21 @@ base::StatusOr<TarTraceReader::ParseResult> TarTraceReader::ParseContent() {
     return ParseResult::kNeedsMoreData;
   }
 
-  if (metadata_->type_flag == TYPE_FLAG_GNU_LONG_NAME) {
+  if (metadata_->type_flag == TYPE_FLAG_PAX_EXTENDED ||
+      metadata_->type_flag == TYPE_FLAG_PAX_GLOBAL) {
+    // PAX extended headers carry metadata (long names, large sizes, ...) for
+    // the following entry, or the whole archive for the global variant. We
+    // read names and sizes from the plain ustar header of each entry, so the
+    // PAX payload is skipped by falling through to the PopFrontBytes below.
+  } else if (metadata_->type_flag == TYPE_FLAG_GNU_LONG_NAME) {
     TraceBlobView data =
         *buffer_.SliceOff(buffer_.start_offset(), metadata_->size);
     long_name_ = std::string(reinterpret_cast<const char*>(data.data()),
                              metadata_->size);
+  } else if (IsHiddenArchivePath(metadata_->name)) {
+    // Ignore hidden files/directories (e.g. macOS "._" resource forks and
+    // ".DS_Store"). The content bytes are still consumed via PopFrontBytes
+    // below so parsing stays aligned to the next header.
   } else {
     AddFile(*metadata_,
             *buffer_.SliceOff(

--- a/src/trace_processor/importers/archive/zip_trace_reader.cc
+++ b/src/trace_processor/importers/archive/zip_trace_reader.cc
@@ -76,6 +76,12 @@ base::Status ZipTraceReader::OnPushDataToSorter() {
   std::map<ArchiveEntry, File> ordered_files;
   for (size_t i = 0; i < files.size(); ++i) {
     util::ZipFile& zip_file = files[i];
+    // Ignore hidden files/directories (e.g. macOS "__MACOSX/._" resource forks
+    // and ".DS_Store"). They are never traces and would otherwise fail the
+    // whole archive with an "unknown trace type" error.
+    if (IsHiddenArchivePath(zip_file.name())) {
+      continue;
+    }
     auto id = context_->trace_file_tracker->AddFile(zip_file.name());
     context_->trace_file_tracker->SetSize(id, zip_file.compressed_size());
     RETURN_IF_ERROR(files[i].Decompress(&buffer));

--- a/test/trace_processor/diff_tests/parser/zip/tests.py
+++ b/test/trace_processor/diff_tests/parser/zip/tests.py
@@ -209,6 +209,34 @@ class Zip(TestSuite):
         8,1
         '''))
 
+  # A tar archive as produced by macOS/BSD `tar`: PAX extended headers,
+  # space-terminated numeric fields, and AppleDouble ("._foo") / ".DS_Store"
+  # metadata files sprinkled next to the real trace. The real trace must load
+  # and every hidden (dot-prefixed) entry must be ignored, including one nested
+  # under a subdirectory.
+  def test_macos_tar(self):
+    return DiffTestBlueprint(
+        trace=Tar(
+            {
+                'sched.pb': DataPath('synth_1.pb'),
+                '._sched.pb': b'Mac OS X AppleDouble junk\x00\x01\x02',
+                '.DS_Store': b'Bud1\x00\x00\x00\x00junk',
+                'sub/._nested.pb': b'more junk',
+            },
+            macos_style=True,
+        ),
+        query='''
+          SELECT
+            (SELECT count(*) FROM sched) AS sched_count,
+            (SELECT count(*) FROM __intrinsic_trace_file) AS file_count,
+            (SELECT count(*) FROM __intrinsic_trace_file
+             WHERE name GLOB '*._*' OR name GLOB '*.DS_Store') AS hidden_count;
+        ''',
+        out=Csv('''
+        "sched_count","file_count","hidden_count"
+        8,2,0
+        '''))
+
   def test_multi_trace_single_machine_clock(self):
     return DiffTestBlueprint(
         trace=DataPath('multi_trace_single_machine_clock.zip'),


### PR DESCRIPTION
* allow for ' ' to pad sizes in tar
* allow for unknown PAX headers which are silently ignored
* ignore any . prefixed files inside archives
