### PR TITLE
tp+ui: show concurrent tracing sessions as state tracks

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17931,6 +17931,7 @@ filegroup {
         "src/trace_processor/importers/proto/chrome_string_lookup.cc",
         "src/trace_processor/importers/proto/chrome_system_probes_module.cc",
         "src/trace_processor/importers/proto/chrome_system_probes_parser.cc",
+        "src/trace_processor/importers/proto/concurrent_sessions_module.cc",
         "src/trace_processor/importers/proto/default_modules.cc",
         "src/trace_processor/importers/proto/incremental_state.cc",
         "src/trace_processor/importers/proto/memory_tracker_snapshot_module.cc",

--- a/BUILD
+++ b/BUILD
@@ -3207,6 +3207,8 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/chrome_system_probes_module.h",
         "src/trace_processor/importers/proto/chrome_system_probes_parser.cc",
         "src/trace_processor/importers/proto/chrome_system_probes_parser.h",
+        "src/trace_processor/importers/proto/concurrent_sessions_module.cc",
+        "src/trace_processor/importers/proto/concurrent_sessions_module.h",
         "src/trace_processor/importers/proto/default_modules.cc",
         "src/trace_processor/importers/proto/default_modules.h",
         "src/trace_processor/importers/proto/incremental_state.cc",

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -30,6 +30,8 @@ source_set("minimal") {
     "chrome_system_probes_module.h",
     "chrome_system_probes_parser.cc",
     "chrome_system_probes_parser.h",
+    "concurrent_sessions_module.cc",
+    "concurrent_sessions_module.h",
     "default_modules.cc",
     "default_modules.h",
     "incremental_state.cc",

--- a/src/trace_processor/importers/proto/additional_modules.cc
+++ b/src/trace_processor/importers/proto/additional_modules.cc
@@ -28,6 +28,7 @@
 #include "src/trace_processor/importers/proto/android_kernel_wakelocks_module.h"
 #include "src/trace_processor/importers/proto/android_probes_module.h"
 #include "src/trace_processor/importers/proto/app_wakelock_module.h"
+#include "src/trace_processor/importers/proto/concurrent_sessions_module.h"
 #include "src/trace_processor/importers/proto/content_analyzer.h"
 #include "src/trace_processor/importers/proto/deobfuscation_module.h"
 #include "src/trace_processor/importers/proto/graphics_event_module.h"
@@ -85,6 +86,8 @@ void RegisterAdditionalModules(ProtoImporterModuleContext* module_context,
       new ProfileModule(module_context, context));
   module_context->modules.emplace_back(
       new AppWakelockModule(module_context, context));
+  module_context->modules.emplace_back(
+      new ConcurrentSessionsModule(module_context, context));
   module_context->modules.emplace_back(
       new GenericKernelModule(module_context, context));
 

--- a/src/trace_processor/importers/proto/concurrent_sessions_module.cc
+++ b/src/trace_processor/importers/proto/concurrent_sessions_module.cc
@@ -55,6 +55,7 @@ ConcurrentSessionsModule::ConcurrentSessionsModule(
       context_(context),
       arg_consumer_uid_(context->storage->InternString("consumer_uid")),
       arg_num_data_sources_(context->storage->InternString("num_data_sources")),
+      state_disabled_(context->storage->InternString("DISABLED")),
       state_configured_(context->storage->InternString("CONFIGURED")),
       state_started_(context->storage->InternString("STARTED")),
       state_disabling_waiting_stop_acks_(
@@ -79,9 +80,7 @@ void ConcurrentSessionsModule::ParseConcurrentSessionEvent(
   StringId state_name = kNullStringId;
   switch (event.state()) {
     case ConcurrentSessionEvent::STATE_DISABLED:
-      // DISABLED is terminal: close the track instead of drawing an
-      // open-ended DISABLED state.
-      state_name = kNullStringId;
+      state_name = state_disabled_;
       break;
     case ConcurrentSessionEvent::STATE_CONFIGURED:
       state_name = state_configured_;
@@ -120,12 +119,6 @@ void ConcurrentSessionsModule::ParseConcurrentSessionEvent(
       tracks::Dimensions(static_cast<int64_t>(event.session_id())),
       tracks::DynamicName(track_name));
 
-  // A null state name only ends the active state; no new args to add.
-  if (state_name.is_null()) {
-    context_->state_tracker->UpdateState(ts, track_id, kNullStringId);
-    return;
-  }
-
   context_->state_tracker->UpdateState(
       ts, track_id, state_name, kNullStringId,
       [this, &event](ArgsTracker::BoundInserter* args) {
@@ -134,6 +127,11 @@ void ConcurrentSessionsModule::ParseConcurrentSessionEvent(
         args->AddArg(arg_num_data_sources_,
                      Variadic::Integer(event.num_data_sources()));
       });
+
+  // DISABLED is terminal: close it at the same timestamp, so it renders as a
+  // zero-width marker rather than an open-ended state.
+  if (event.state() == ConcurrentSessionEvent::STATE_DISABLED)
+    context_->state_tracker->UpdateState(ts, track_id, kNullStringId);
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/concurrent_sessions_module.cc
+++ b/src/trace_processor/importers/proto/concurrent_sessions_module.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/concurrent_sessions_module.h"
+
+#include <cstdint>
+#include <string>
+
+#include "perfetto/ext/base/string_view.h"
+#include "perfetto/protozero/field.h"
+#include "protos/perfetto/trace/perfetto/concurrent_session_event.pbzero.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
+#include "src/trace_processor/importers/common/state_tracker.h"
+#include "src/trace_processor/importers/common/track_tracker.h"
+#include "src/trace_processor/importers/common/tracks.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/storage/stats.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/variadic.h"
+
+namespace perfetto::trace_processor {
+
+using ::perfetto::protos::pbzero::ConcurrentSessionEvent;
+using ::perfetto::protos::pbzero::TracePacket;
+
+namespace {
+
+// One state track per session. The UI groups tracks of this type under
+// System > Concurrent tracing sessions (see state_tracks.ts).
+constexpr auto kSessionTrackBlueprint = tracks::StateBlueprint(
+    "concurrent_tracing_sessions",
+    tracks::DimensionBlueprints(tracks::LongDimensionBlueprint("session_id")),
+    tracks::DynamicNameBlueprint());
+
+}  // namespace
+
+ConcurrentSessionsModule::ConcurrentSessionsModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context),
+      context_(context),
+      arg_consumer_uid_(context->storage->InternString("consumer_uid")),
+      arg_num_data_sources_(context->storage->InternString("num_data_sources")),
+      state_configured_(context->storage->InternString("CONFIGURED")),
+      state_started_(context->storage->InternString("STARTED")),
+      state_disabling_waiting_stop_acks_(
+          context->storage->InternString("DISABLING_WAITING_STOP_ACKS")),
+      state_cloned_read_only_(
+          context->storage->InternString("CLONED_READ_ONLY")) {
+  RegisterForField(TracePacket::kConcurrentSessionEventFieldNumber);
+}
+
+void ConcurrentSessionsModule::ParseField(const ParseFieldArgs& args) {
+  if (args.field.id() == TracePacket::kConcurrentSessionEventFieldNumber) {
+    ParseConcurrentSessionEvent(
+        args.ts, args.field.Cast<TracePacket::kConcurrentSessionEvent>());
+  }
+}
+
+void ConcurrentSessionsModule::ParseConcurrentSessionEvent(
+    int64_t ts,
+    protozero::ConstBytes blob) {
+  ConcurrentSessionEvent::Decoder event(blob);
+
+  StringId state_name = kNullStringId;
+  switch (event.state()) {
+    case ConcurrentSessionEvent::STATE_DISABLED:
+      // DISABLED is terminal: close the track instead of drawing an
+      // open-ended DISABLED state.
+      state_name = kNullStringId;
+      break;
+    case ConcurrentSessionEvent::STATE_CONFIGURED:
+      state_name = state_configured_;
+      break;
+    case ConcurrentSessionEvent::STATE_STARTED:
+      state_name = state_started_;
+      break;
+    case ConcurrentSessionEvent::STATE_DISABLING_WAITING_STOP_ACKS:
+      state_name = state_disabling_waiting_stop_acks_;
+      break;
+    case ConcurrentSessionEvent::STATE_CLONED_READ_ONLY:
+      state_name = state_cloned_read_only_;
+      break;
+    default:
+      // STATE_UNSPECIFIED or a state added by a newer version of the proto.
+      context_->import_logs_tracker->RecordParserError(
+          stats::concurrent_session_event_unknown_state, ts,
+          [&](ArgsTracker::BoundInserter& inserter) {
+            inserter.AddArg(context_->storage->InternString("state"),
+                            Variadic::Integer(event.state()));
+          });
+      return;
+  }
+
+  // Clones share their parent's name: suffix them to tell the tracks apart.
+  // A clone's first event, which fixes the track name, is CLONED_READ_ONLY.
+  std::string name = event.session_name().ToStdString();
+  if (name.empty())
+    name = "Session " + std::to_string(event.session_id());
+  if (event.state() == ConcurrentSessionEvent::STATE_CLONED_READ_ONLY)
+    name += " (clone)";
+  StringId track_name = context_->storage->InternString(base::StringView(name));
+
+  TrackId track_id = context_->track_tracker->InternTrack(
+      kSessionTrackBlueprint,
+      tracks::Dimensions(static_cast<int64_t>(event.session_id())),
+      tracks::DynamicName(track_name));
+
+  // A null state name only ends the active state; no new args to add.
+  if (state_name.is_null()) {
+    context_->state_tracker->UpdateState(ts, track_id, kNullStringId);
+    return;
+  }
+
+  context_->state_tracker->UpdateState(
+      ts, track_id, state_name, kNullStringId,
+      [this, &event](ArgsTracker::BoundInserter* args) {
+        args->AddArg(arg_consumer_uid_,
+                     Variadic::Integer(event.consumer_uid()));
+        args->AddArg(arg_num_data_sources_,
+                     Variadic::Integer(event.num_data_sources()));
+      });
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/concurrent_sessions_module.h
+++ b/src/trace_processor/importers/proto/concurrent_sessions_module.h
@@ -46,6 +46,7 @@ class ConcurrentSessionsModule : public ProtoImporterModule {
   const StringId arg_num_data_sources_;
 
   // State names, same strings as TracingServiceState.TracingSession.state.
+  const StringId state_disabled_;
   const StringId state_configured_;
   const StringId state_started_;
   const StringId state_disabling_waiting_stop_acks_;

--- a/src/trace_processor/importers/proto/concurrent_sessions_module.h
+++ b/src/trace_processor/importers/proto/concurrent_sessions_module.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_CONCURRENT_SESSIONS_MODULE_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_CONCURRENT_SESSIONS_MODULE_H_
+
+#include <cstdint>
+
+#include "perfetto/protozero/field.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor {
+
+// Turns ConcurrentSessionEvent packets (emitted by traced to record the state
+// changes of other concurrently active tracing sessions) into one state track
+// per session.
+class ConcurrentSessionsModule : public ProtoImporterModule {
+ public:
+  ConcurrentSessionsModule(ProtoImporterModuleContext* module_context,
+                           TraceProcessorContext* context);
+  ~ConcurrentSessionsModule() override = default;
+
+  void ParseField(const ParseFieldArgs& args) override;
+
+ private:
+  void ParseConcurrentSessionEvent(int64_t ts, protozero::ConstBytes blob);
+
+  TraceProcessorContext* const context_;
+
+  const StringId arg_consumer_uid_;
+  const StringId arg_num_data_sources_;
+
+  // State names, same strings as TracingServiceState.TracingSession.state.
+  const StringId state_configured_;
+  const StringId state_started_;
+  const StringId state_disabling_waiting_stop_acks_;
+  const StringId state_cloned_read_only_;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_CONCURRENT_SESSIONS_MODULE_H_

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -178,6 +178,14 @@ namespace perfetto::trace_processor::stats {
        "Parsing packed repeated field. Should never happen."),                 \
   F(app_wakelock_unknown_id,              kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
        "Interning ID not found. Should never happen."),                        \
+  F(concurrent_session_event_unknown_state,                                    \
+                                          kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace,      \
+       "ConcurrentSessionEvent packet with an unspecified or unknown "         \
+       "state, likely emitted by a newer version of the tracing service. "     \
+       "The event was dropped, so the session's state track is missing a "     \
+       "transition. Retry with a trace_processor version at least as new as "  \
+       "the traced that recorded the trace; the raw state value is in the "    \
+       "trace import logs."),                                                  \
   F(meminfo_unknown_keys,                 kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
   F(cpu_info_unknown_cpu_features,        kSingle,  kInfo,     kAnalysis, Scope::kMachineAndTrace,      \
        "CpuInfo contained CPU feature bits not known to this version of "      \

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -95,6 +95,7 @@ from diff_tests.parser.linux.tests import Linux
 from diff_tests.parser.memory.tests import MemoryParser
 from diff_tests.parser.network.tests import NetworkParser
 from diff_tests.parser.parsing.tests import Parsing
+from diff_tests.parser.parsing.tests_concurrent_sessions import ParsingConcurrentSessions
 from diff_tests.parser.parsing.tests_debug_annotation import ParsingDebugAnnotation
 from diff_tests.parser.parsing.tests_memory_counters import ParsingMemoryCounters
 from diff_tests.parser.parsing.tests_rss_stats import ParsingRssStats
@@ -271,6 +272,7 @@ def fetch_all_diff_tests(
       TranslatedArgs,
       Ufs,
       Parsing,
+      ParsingConcurrentSessions,
       ParsingDebugAnnotation,
       ParsingRssStats,
       ParsingSysStats,

--- a/test/trace_processor/diff_tests/parser/parsing/tests_concurrent_sessions.py
+++ b/test/trace_processor/diff_tests/parser/parsing/tests_concurrent_sessions.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import Csv, TextProto
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class ParsingConcurrentSessions(TestSuite):
+  # ConcurrentSessionEvent packets become one state track per session (shown
+  # by the UI under System > Concurrent tracing sessions). STATE_DISABLED
+  # closes the track (a disabled session never becomes active again).
+  # consumer_uid and num_data_sources become args.
+  def test_concurrent_session_events_become_state_tracks(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 400
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_CONFIGURED
+            session_name: "session_a"
+            session_id: 1
+            consumer_uid: 10000
+            num_data_sources: 3
+          }
+        }
+        packet {
+          timestamp: 500
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_STARTED
+            session_name: "session_a"
+            session_id: 1
+            consumer_uid: 10000
+            num_data_sources: 3
+          }
+        }
+        packet {
+          timestamp: 1000
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_STARTED
+            session_name: "session_b"
+            session_id: 2
+            consumer_uid: 10001
+            num_data_sources: 1
+          }
+        }
+        packet {
+          timestamp: 3000
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_DISABLED
+            session_name: "session_b"
+            session_id: 2
+            consumer_uid: 10001
+            num_data_sources: 1
+          }
+        }
+        packet {
+          timestamp: 4000
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_DISABLED
+            session_name: "session_a"
+            session_id: 1
+            consumer_uid: 10000
+            num_data_sources: 3
+          }
+        }
+        """),
+        query="""
+          SELECT
+            t.name AS track_name,
+            s.ts,
+            s.dur,
+            s.value,
+            extract_arg(s.arg_set_id, 'consumer_uid') AS consumer_uid,
+            extract_arg(s.arg_set_id, 'num_data_sources') AS num_data_sources
+          FROM state s
+          JOIN track t ON s.track_id = t.id
+          WHERE t.type = 'concurrent_tracing_sessions'
+          ORDER BY t.name, s.ts;
+        """,
+        out=Csv("""
+        "track_name","ts","dur","value","consumer_uid","num_data_sources"
+        "session_a",400,100,"CONFIGURED",10000,3
+        "session_a",500,3500,"STARTED",10000,3
+        "session_b",1000,2000,"STARTED",10001,1
+        """))
+
+  # Tracks are keyed by session_id, so overlapping unnamed sessions get their
+  # own track, named "Session <id>". Cloned sessions (born in
+  # CLONED_READ_ONLY) get a " (clone)" suffix. STATE_DISABLED closes each
+  # track.
+  def test_concurrent_unnamed_sessions_paired_by_id(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 1000
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_STARTED
+            session_id: 1
+          }
+        }
+        packet {
+          timestamp: 2000
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_STARTED
+            session_id: 2
+          }
+        }
+        packet {
+          timestamp: 3000
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_DISABLING_WAITING_STOP_ACKS
+            session_id: 1
+          }
+        }
+        packet {
+          timestamp: 3500
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_DISABLED
+            session_id: 1
+          }
+        }
+        packet {
+          timestamp: 4000
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_CLONED_READ_ONLY
+            session_name: "snapshot"
+            session_id: 3
+          }
+        }
+        packet {
+          timestamp: 4500
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_DISABLED
+            session_name: "snapshot"
+            session_id: 3
+          }
+        }
+        packet {
+          timestamp: 5000
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_DISABLED
+            session_id: 2
+          }
+        }
+        """),
+        query="""
+          SELECT t.name AS track_name, s.ts, s.dur, s.value
+          FROM state s
+          JOIN track t ON s.track_id = t.id
+          WHERE t.type = 'concurrent_tracing_sessions'
+          ORDER BY t.name, s.ts;
+        """,
+        out=Csv("""
+        "track_name","ts","dur","value"
+        "Session 1",1000,2000,"STARTED"
+        "Session 1",3000,500,"DISABLING_WAITING_STOP_ACKS"
+        "Session 2",2000,3000,"STARTED"
+        "snapshot (clone)",4000,500,"CLONED_READ_ONLY"
+        """))

--- a/test/trace_processor/diff_tests/parser/parsing/tests_concurrent_sessions.py
+++ b/test/trace_processor/diff_tests/parser/parsing/tests_concurrent_sessions.py
@@ -20,8 +20,8 @@ from python.generators.diff_tests.testing import TestSuite
 
 class ParsingConcurrentSessions(TestSuite):
   # ConcurrentSessionEvent packets become one state track per session (shown
-  # by the UI under System > Concurrent tracing sessions). STATE_DISABLED
-  # closes the track (a disabled session never becomes active again).
+  # by the UI under System > Concurrent tracing sessions). STATE_DISABLED is
+  # terminal: it closes the track and renders as a zero-width marker.
   # consumer_uid and num_data_sources become args.
   def test_concurrent_session_events_become_state_tracks(self):
     return DiffTestBlueprint(
@@ -99,13 +99,14 @@ class ParsingConcurrentSessions(TestSuite):
         "track_name","ts","dur","value","consumer_uid","num_data_sources"
         "session_a",400,100,"CONFIGURED",10000,3
         "session_a",500,3500,"STARTED",10000,3
+        "session_a",4000,0,"DISABLED",10000,3
         "session_b",1000,2000,"STARTED",10001,1
+        "session_b",3000,0,"DISABLED",10001,1
         """))
 
   # Tracks are keyed by session_id, so overlapping unnamed sessions get their
   # own track, named "Session <id>". Cloned sessions (born in
-  # CLONED_READ_ONLY) get a " (clone)" suffix. STATE_DISABLED closes each
-  # track.
+  # CLONED_READ_ONLY) get a " (clone)" suffix.
   def test_concurrent_unnamed_sessions_paired_by_id(self):
     return DiffTestBlueprint(
         trace=TextProto(r"""
@@ -179,6 +180,36 @@ class ParsingConcurrentSessions(TestSuite):
         "track_name","ts","dur","value"
         "Session 1",1000,2000,"STARTED"
         "Session 1",3000,500,"DISABLING_WAITING_STOP_ACKS"
+        "Session 1",3500,0,"DISABLED"
         "Session 2",2000,3000,"STARTED"
+        "Session 2",5000,0,"DISABLED"
         "snapshot (clone)",4000,500,"CLONED_READ_ONLY"
+        "snapshot (clone)",4500,0,"DISABLED"
+        """))
+
+  # A session observed only through its terminal DISABLED event still gets a
+  # track, carrying just the zero-width DISABLED marker.
+  def test_disabled_only_session_gets_marker_track(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 1000
+          trusted_packet_sequence_id: 1
+          concurrent_session_event {
+            state: STATE_DISABLED
+            session_name: "ghost"
+            session_id: 7
+          }
+        }
+        """),
+        query="""
+          SELECT t.name AS track_name, s.ts, s.dur, s.value
+          FROM state s
+          JOIN track t ON s.track_id = t.id
+          WHERE t.type = 'concurrent_tracing_sessions'
+          ORDER BY t.name, s.ts;
+        """,
+        out=Csv("""
+        "track_name","ts","dur","value"
+        "ghost",1000,0,"DISABLED"
         """))

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -53,8 +53,10 @@ import {COUNTER_TRACK_SCHEMAS} from './counter_tracks';
 import {PivotTableTab} from './pivot_table_tab';
 import {SliceSelectionAggregator} from './slice_selection_aggregator';
 import {SLICE_TRACK_SCHEMAS} from './slice_tracks';
+import {STATE_TRACK_SCHEMAS} from './state_tracks';
 import {TraceProcessorCounterTrack} from './trace_processor_counter_track';
 import {createTraceProcessorSliceTrack} from './trace_processor_slice_track';
+import {createTraceProcessorStateTrack} from './trace_processor_state_track';
 import type {TopLevelTrackGroup, TrackGroupSchema} from './types';
 import type {Store} from '../../base/store';
 import {z} from 'zod';
@@ -110,6 +112,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
 
     await this.addCounters(ctx);
     await this.addSlices(ctx);
+    await this.addStates(ctx);
     this.addAggregations(ctx);
     this.addMinimapContentProvider(ctx);
     this.addSearchProviders(ctx);
@@ -460,6 +463,51 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
             isKernelThread === 0 && isMainThread === 1 && 'main thread',
           ]),
         }),
+      );
+    }
+  }
+
+  private async addStates(ctx: Trace) {
+    const schemas = new Map(STATE_TRACK_SCHEMAS.map((x) => [x.type, x]));
+    const types = STATE_TRACK_SCHEMAS.map((x) => `'${x.type}'`).join(',');
+    const result = await ctx.engine.query(`
+      select t.id, t.type, t.name
+      from track t
+      where t.type in (${types})
+        and exists (select 1 from state s where s.track_id = t.id)
+      order by lower(t.name)
+    `);
+    const it = result.iter({id: NUM, type: STR, name: STR_NULL});
+    for (; it.valid(); it.next()) {
+      const {id: trackId, type, name} = it;
+      const schema = schemas.get(type);
+      if (schema === undefined) {
+        continue;
+      }
+      const {group, topLevelGroup} = schema;
+      const trackName = name ?? `${type} ${trackId}`;
+      const uri = `/state_${trackId}`;
+      ctx.tracks.registerTrack({
+        uri,
+        tags: {
+          kinds: [SLICE_TRACK_KIND],
+          trackIds: [trackId],
+          type,
+        },
+        renderer: await createTraceProcessorStateTrack({
+          trace: ctx,
+          uri,
+          trackId,
+          trackName,
+        }),
+      });
+      this.addTrack(
+        ctx,
+        topLevelGroup,
+        group,
+        null,
+        null,
+        new TrackNode({uri, name: trackName}),
       );
     }
   }

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/state_tracks.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/state_tracks.ts
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {TopLevelTrackGroup, TrackGroupSchema} from './types';
+
+export interface StateTrackTypeSchema {
+  readonly type: string;
+  readonly group: string | TrackGroupSchema | undefined;
+  readonly topLevelGroup: TopLevelTrackGroup;
+}
+
+export const STATE_TRACK_SCHEMAS: ReadonlyArray<StateTrackTypeSchema> = [
+  {
+    type: 'concurrent_tracing_sessions',
+    topLevelGroup: 'SYSTEM',
+    group: 'Concurrent tracing sessions',
+  },
+];


### PR DESCRIPTION
Turn the ConcurrentSessionEvent packets emitted by traced into one state track per concurrent session.

- Add ConcurrentSessionsModule: tracks are keyed by session id and named by unique_session_name ("Session <id>" when unnamed, a " (clone)" suffix for cloned sessions). STATE_DISABLED closes the track instead of drawing an open-ended state. consumer_uid and num_data_sources become args; unknown states are recorded in the trace import logs.
- UI: register the tracks as state tracks, grouped under System > Concurrent tracing sessions.
- Add TP diff tests.
