### PR TITLE
docs: fix slow docs-site search and restore compression

### DIFF
--- a/infra/perfetto.dev/appengine/app.yaml
+++ b/infra/perfetto.dev/appengine/app.yaml
@@ -1,4 +1,4 @@
-runtime: python38
+runtime: python313
 instance_class: B1
 basic_scaling:
   max_instances: 4

--- a/infra/perfetto.dev/appengine/main.py
+++ b/infra/perfetto.dev/appengine/main.py
@@ -57,12 +57,19 @@ def main(path=''):
   blob = bucket.get_blob(path[1:])
   if blob is None:
     return flask.abort(404)
+  # download_as_bytes() always returns the decompressed content, so don't copy
+  # the blob's content_encoding onto the response: claiming the plain body is
+  # gzip stopped App Engine from compressing anything on the site.
   data = blob.download_as_bytes()
   resp = flask.Response(data)
   resp.headers['Content-Type'] = blob.content_type
   resp.headers['Content-Length'] = len(data)
-  resp.headers['Content-Encoding'] = blob.content_encoding
-  if os.path.splitext(path)[1] in ('.png', '.svg'):
+  if path == '/assets/search_index.json':
+    # The index only changes on a docs push and being a bit stale is fine, so
+    # cache it for an hour to avoid re-fetching ~0.5MB as the user reads.
+    resp.headers['Cache-Control'] = (
+        'public, max-age=3600, stale-while-revalidate=86400')
+  elif os.path.splitext(path)[1] in ('.png', '.svg'):
     resp.headers['Cache-Control'] = 'public, max-age=86400'  # 1 Day
   else:
     resp.headers['Cache-Control'] = 'public, max-age=600'  # 10 min

--- a/infra/perfetto.dev/deploy
+++ b/infra/perfetto.dev/deploy
@@ -62,6 +62,7 @@ EOF
 [ "$(file $OUT_DIR/docs/images/perfetto-stack.svg)" == "image/svg+xml" ]
 [ "$(file $OUT_DIR/docs/images/perfetto-stack.svg)" == "image/svg+xml" ]
 [ "$(file $OUT_DIR/docs/analysis/sql-tables)" == "text/html" ]
+[ "$(file $OUT_DIR/assets/search_index.json)" == "application/json" ]
 
 # -j: apply 'Content-Encoding: gzip' compression to passed extensions.
 # -d: mirror also deletetions.
@@ -69,5 +70,5 @@ EOF
 # -r: recursive.
 # The trailing slash appended to $OUT_DIR is to prevent that gsutil creates a
 # nested sub-directory inside gs://perfetto.dev/.
-gsutil -m rsync -j html,js,css,svg -d -c -r \
+gsutil -m rsync -j html,js,css,svg,json -d -c -r \
   "$OUT_DIR/" gs://perfetto.dev/

--- a/infra/perfetto.dev/mime_util/file
+++ b/infra/perfetto.dev/mime_util/file
@@ -22,6 +22,7 @@ def main():
       '.css': 'text/css',
       '.js': 'text/javascript',
       '.jpg': 'image/jpeg',
+      '.json': 'application/json',
       '.png': 'image/png',
       '.svg': 'image/svg+xml',
   }

--- a/infra/perfetto.dev/src/assets/script.js
+++ b/infra/perfetto.dev/src/assets/script.js
@@ -373,179 +373,12 @@ function initMermaid() {
 }
 
 // ---------------------------------------------------------------------------
-// Client-side docs search. We ship a build-time full-text index
-// (assets/search_index.json, built by src/gen_search_index.js) and rank it
-// locally with BM25. The old Google Custom Search Engine couldn't see a doc
-// until Googlebot crawled it, often weeks after it shipped.
+// Client-side docs search. A build-time full-text index (assets/
+// search_index.json, built by src/gen_search_index.js) is fetched and ranked
+// with BM25 in a web worker (assets/search_worker.js); this file only sends the
+// query and renders the results the worker posts back. The old Google Custom
+// Search Engine couldn't see a doc until Googlebot crawled it, weeks later.
 // ---------------------------------------------------------------------------
-
-// The parsed index, loaded lazily on first interaction (see loadSearchIndex).
-let searchIndex = null;
-let searchIndexPromise = null;
-
-// Lowercase alphanumeric tokens, keeping a trailing "++"/"#" so "c++" and "c#"
-// stay searchable. Tokens shorter than 2 chars are dropped as noise.
-function searchTokenize(str) {
-  const out = [];
-  const re = /[a-z0-9]+(\+\+|#)?/g;
-  let m;
-  while ((m = re.exec(str.toLowerCase())) !== null) {
-    if (m[0].length >= 2) out.push(m[0]);
-  }
-  return out;
-}
-
-async function loadSearchIndex() {
-  const resp = await fetch("/assets/search_index.json");
-  if (!resp.ok) throw new Error(`search index HTTP ${resp.status}`);
-  const docs = (await resp.json()).docs;
-
-  // Field boosts: a hit in the title matters far more than one in the body.
-  const FIELD_BOOST = {title: 8, heading: 4, body: 1};
-  const postings = new Map();
-  const docLen = new Array(docs.length).fill(0);
-  const titleTokens = new Array(docs.length);
-  const navTokens = new Array(docs.length);
-  const addTokens = (docIdx, tokens, boost) => {
-    for (const tok of tokens) {
-      let postingList = postings.get(tok);
-      if (postingList === undefined) {
-        postingList = new Map();
-        postings.set(tok, postingList);
-      }
-      postingList.set(docIdx, (postingList.get(docIdx) || 0) + boost);
-      docLen[docIdx] += boost;
-    }
-  };
-  for (let i = 0; i < docs.length; i++) {
-    const d = docs[i];
-    const tt = searchTokenize(d.t || "");
-    titleTokens[i] = tt;
-    addTokens(i, tt, FIELD_BOOST.title);
-    // The toc.md nav label (d.n), when it differs from the title, is a curated
-    // keyword alias -- index it at title weight too.
-    if (d.n) {
-      navTokens[i] = searchTokenize(d.n);
-      addTokens(i, navTokens[i], FIELD_BOOST.title);
-    }
-    // The URL slug (last path segment, e.g. "perfetto-cli", "stdlib-docs") is a
-    // curated keyword, often searched even when the word never appears in the
-    // prose. searchTokenize splits it on the "-"/"_"; index it at title weight.
-    const slug = d.u.split("/").filter(Boolean).pop() || "";
-    addTokens(i, searchTokenize(slug), FIELD_BOOST.title);
-    for (const h of d.h || []) addTokens(i, searchTokenize(h.t), FIELD_BOOST.heading);
-    if (d.b) addTokens(i, searchTokenize(d.b), FIELD_BOOST.body);
-  }
-  let total = 0;
-  for (const l of docLen) total += l;
-  searchIndex = {
-    docs,
-    postings,
-    // Sorted so searchPostings() can binary-search the prefix range.
-    sortedTerms: [...postings.keys()].sort(),
-    docLen,
-    titleTokens,
-    navTokens,
-    avgdl: docLen.length ? total / docLen.length : 1,
-    N: docs.length,
-  };
-  return searchIndex;
-}
-
-// Index of the first element of the sorted array `arr` that is >= `key`.
-function lowerBound(arr, key) {
-  let lo = 0;
-  let hi = arr.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1;
-    if (arr[mid] < key) lo = mid + 1;
-    else hi = mid;
-  }
-  return lo;
-}
-
-function ensureSearchIndex() {
-  if (searchIndexPromise === null) {
-    searchIndexPromise = loadSearchIndex().catch((e) => {
-      searchIndexPromise = null;  // Allow a retry on the next keystroke.
-      throw e;
-    });
-  }
-  return searchIndexPromise;
-}
-
-// Returns {df, tf: Map(docIdx -> weightedTf)} for a query term. The final,
-// still-being-typed term also matches everything it prefixes, so "trace"
-// surfaces "traceconv" and "tracing"; earlier terms match exactly.
-function searchPostings(idx, term, allowPrefix) {
-  const exact = idx.postings.get(term);
-  if (!allowPrefix) return exact === undefined ? null : {df: exact.size, tf: exact};
-  const merged = new Map();
-  const union = (postingList) => {
-    for (const [docIdx, w] of postingList) merged.set(docIdx, (merged.get(docIdx) || 0) + w);
-  };
-  if (exact !== undefined) union(exact);
-  // Prefix matches are a contiguous run in sortedTerms: walk from the first
-  // term >= `term` and stop at the first miss.
-  let matched = 0;
-  for (let i = lowerBound(idx.sortedTerms, term); i < idx.sortedTerms.length; i++) {
-    const t = idx.sortedTerms[i];
-    if (!t.startsWith(term)) break;
-    if (t === term) continue;
-    union(idx.postings.get(t));
-    if (++matched >= 200) break;  // Cap fan-out on very short prefixes.
-  }
-  return merged.size ? {df: merged.size, tf: merged} : null;
-}
-
-// Ranks docs against the query with BM25. Returns up to `limit` doc objects.
-function searchRank(idx, query, limit) {
-  const terms = searchTokenize(query);
-  if (terms.length === 0) return [];
-  const k1 = 1.2;
-  const b = 0.75;
-  const scores = new Map();
-  for (let ti = 0; ti < terms.length; ti++) {
-    const p = searchPostings(idx, terms[ti], ti === terms.length - 1);
-    if (p === null) continue;
-    // BM25, the standard ranking function: https://en.wikipedia.org/wiki/Okapi_BM25
-    //   idf  -- rarer terms (matching fewer docs, `df`) count for more.
-    //   score -- rises with term frequency `tf` but saturates (`k1`), and is
-    //            penalised for long docs (`b`, via dl/avgdl) so a short focused
-    //            page outranks a long one that just repeats the word.
-    const idf = Math.log(1 + (idx.N - p.df + 0.5) / (p.df + 0.5));
-    for (const [docIdx, tf] of p.tf) {
-      // Floor the length used for normalization so near-empty pages (e.g. the
-      // body-less generated reference pages) don't win on BM25's short-doc bonus.
-      const dl = Math.max(idx.docLen[docIdx], 0.5 * idx.avgdl);
-      const s = idf * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl / idx.avgdl));
-      scores.set(docIdx, (scores.get(docIdx) || 0) + s);  // sum over query terms
-    }
-  }
-  // Boost title matches. Past an exact title, reward how much of the title the
-  // query covers -- so a short "Perfetto UI" beats a long "...Perfetto UI..." --
-  // with a small extra bump when the query leads the title, which keeps "Batch
-  // Trace Processor" below "Trace Processor (C++)". Tokenized so title
-  // punctuation can't block a match; the nav label counts as a title too, so
-  // "boot tracing" finds the page labelled "Boot Tracing".
-  const phrase = terms.join(" ");
-  const titleBoost = (toks) => {
-    const norm = toks.join(" ");
-    if (norm === phrase) return 12;
-    if (!terms.every((t) => toks.includes(t))) return norm.includes(phrase) ? 3 : 0;
-    return 3 + 6 * (terms.length / toks.length) + (norm.startsWith(phrase + " ") ? 3 : 0);
-  };
-  for (const docIdx of scores.keys()) {
-    let boost = titleBoost(idx.titleTokens[docIdx]);
-    const nav = idx.navTokens[docIdx];
-    if (nav) boost = Math.max(boost, titleBoost(nav));
-    if (boost) scores.set(docIdx, scores.get(docIdx) + boost);
-  }
-  return [...scores.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, limit)
-    .map(([docIdx]) => idx.docs[docIdx]);
-}
 
 function escapeRegExp(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -574,31 +407,6 @@ function appendHighlighted(el, text, terms) {
   if (last < text.length) el.appendChild(document.createTextNode(text.slice(last)));
 }
 
-// Extracts a ~180 char window of body text centred on the first term match.
-function searchSnippet(doc, terms) {
-  const text = doc.b || (doc.h || []).map((h) => h.t).join(" · ") || doc.t || "";
-  const lower = text.toLowerCase();
-  let pos = -1;
-  for (const t of terms) {
-    const i = lower.indexOf(t);
-    if (i !== -1 && (pos === -1 || i < pos)) pos = i;
-  }
-  if (pos === -1) pos = 0;
-  const start = Math.max(0, pos - 40);
-  let out = text.slice(start, start + 180);
-  if (start > 0) out = "…" + out;
-  if (start + 180 < text.length) out += "…";
-  return out;
-}
-
-// If a query term matches a heading with an anchor, deep-link to it.
-function searchAnchor(doc, terms) {
-  for (const h of doc.h || []) {
-    if (h.a && terms.some((t) => h.t.toLowerCase().includes(t))) return h.a;
-  }
-  return "";
-}
-
 function setupSearch() {
   const searchContainer = document.getElementById("search");
   const searchBox = document.getElementById("search-box");
@@ -618,8 +426,34 @@ function setupSearch() {
     }
   });
 
-  let results = [];
+  let results = [];  // From the worker: {u, t, snippet, anchor}.
+  let terms = [];    // Query terms to highlight, tokenized by the worker.
   let selected = -1;
+
+  // The worker (assets/search_worker.js) holds the index and does the ranking;
+  // it's spawned lazily and only once. `workerReady` gates the loading row.
+  let worker = null;
+  let workerReady = false;
+  const ensureWorker = () => {
+    if (worker !== null) return worker;
+    try {
+      worker = new Worker("/assets/search_worker.js");
+    } catch (e) {
+      worker = null;  // No worker support; search stays inert rather than error.
+      return null;
+    }
+    worker.addEventListener("message", (e) => {
+      const msg = e.data;
+      if (msg.type === "ready") {
+        workerReady = true;
+      } else if (msg.type === "results" && searchBox.value.trim() === msg.query) {
+        results = msg.results;  // Ignore stale replies superseded by newer typing.
+        terms = msg.terms;
+        render();
+      }
+    });
+    return worker;
+  };
 
   const highlightSelected = () => {
     const items = searchRes.children;
@@ -631,15 +465,13 @@ function setupSearch() {
     }
   };
 
-  const render = (query) => {
-    const terms = searchTokenize(query);
+  const render = () => {
     searchRes.style.width = `${searchBox.offsetWidth}px`;
     searchRes.innerHTML = "";
     selected = -1;
     for (const doc of results) {
-      const anchor = searchAnchor(doc, terms);
       const link = document.createElement("a");
-      link.href = doc.u + (anchor ? "#" + anchor : "");
+      link.href = doc.u + (doc.anchor ? "#" + doc.anchor : "");
 
       const title = document.createElement("div");
       title.className = "sr-title";
@@ -648,7 +480,7 @@ function setupSearch() {
 
       const snippet = document.createElement("div");
       snippet.className = "sr-snippet";
-      appendHighlighted(snippet, searchSnippet(doc, terms), terms);
+      appendHighlighted(snippet, doc.snippet, terms);
       link.appendChild(snippet);
 
       const div = document.createElement("div");
@@ -657,27 +489,38 @@ function setupSearch() {
     }
   };
 
-  const runSearch = async () => {
+  const runSearch = () => {
     const query = searchBox.value.trim();
     if (query === "") {
       results = [];
       searchRes.innerHTML = "";
       return;
     }
-    let idx;
-    try {
-      idx = await ensureSearchIndex();
-    } catch (e) {
-      return;  // Index failed to load; leave the box empty rather than error.
+    const w = ensureWorker();
+    if (w === null) return;
+    // Show a placeholder while the index is still building, so a slow first
+    // load looks like it's working instead of a frozen box (issue #6654).
+    if (!workerReady) {
+      searchRes.style.width = `${searchBox.offsetWidth}px`;
+      searchRes.innerHTML = "";
+      const loading = document.createElement("div");
+      loading.className = "sr-loading";
+      loading.textContent = "Loading search index…";
+      searchRes.appendChild(loading);
     }
-    if (searchBox.value.trim() !== query) return;  // A newer query superseded us.
-    results = searchRank(idx, query, 8);
-    render(query);
+    w.postMessage({query, limit: 8});
   };
 
-  // Start fetching the index as soon as the user engages with the box.
-  searchBox.addEventListener("focus", () => { ensureSearchIndex().catch(() => {}); },
-                             {once: true});
+  // Spawn the worker once the page is idle so it fetches and builds the index in
+  // the background, making the first search instant. It builds off the main
+  // thread, so this never blocks the page.
+  const scheduleIdle = window.requestIdleCallback
+      ? (cb) => window.requestIdleCallback(cb, {timeout: 2000})
+      : (cb) => setTimeout(cb, 200);
+  scheduleIdle(() => { ensureWorker(); });
+
+  // In case the idle spawn hasn't run yet, also start on first focus.
+  searchBox.addEventListener("focus", () => { ensureWorker(); }, {once: true});
 
   let timerId = -1;
   searchBox.addEventListener("input", () => {

--- a/infra/perfetto.dev/src/assets/search_worker.js
+++ b/infra/perfetto.dev/src/assets/search_worker.js
@@ -1,0 +1,245 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+// Web worker backing the docs search box (see setupSearch() in script.js).
+// Fetching search_index.json and building the BM25 index tokenizes ~1.2MB of
+// text, which is too slow to run on the main thread (it froze the box on the
+// first keystroke, issue #6654). Doing it here keeps the page responsive: the
+// main thread only sends a query string and renders the small result list we
+// post back.
+
+// Lowercase alphanumeric tokens, keeping a trailing "++"/"#" so "c++" and "c#"
+// stay searchable. Tokens shorter than 2 chars are dropped as noise.
+function searchTokenize(str) {
+  const out = [];
+  const re = /[a-z0-9]+(\+\+|#)?/g;
+  let m;
+  while ((m = re.exec(str.toLowerCase())) !== null) {
+    if (m[0].length >= 2) out.push(m[0]);
+  }
+  return out;
+}
+
+function buildSearchIndex(docs) {
+  // Field boosts: a hit in the title matters far more than one in the body.
+  const FIELD_BOOST = {title: 8, heading: 4, body: 1};
+  const postings = new Map();
+  const docLen = new Array(docs.length).fill(0);
+  const titleTokens = new Array(docs.length);
+  const navTokens = new Array(docs.length);
+  const addTokens = (docIdx, tokens, boost) => {
+    for (const tok of tokens) {
+      let postingList = postings.get(tok);
+      if (postingList === undefined) {
+        postingList = new Map();
+        postings.set(tok, postingList);
+      }
+      postingList.set(docIdx, (postingList.get(docIdx) || 0) + boost);
+      docLen[docIdx] += boost;
+    }
+  };
+  for (let i = 0; i < docs.length; i++) {
+    const d = docs[i];
+    const tt = searchTokenize(d.t || "");
+    titleTokens[i] = tt;
+    addTokens(i, tt, FIELD_BOOST.title);
+    // The toc.md nav label (d.n), when it differs from the title, is a curated
+    // keyword alias -- index it at title weight too.
+    if (d.n) {
+      navTokens[i] = searchTokenize(d.n);
+      addTokens(i, navTokens[i], FIELD_BOOST.title);
+    }
+    // The URL slug (last path segment, e.g. "perfetto-cli", "stdlib-docs") is a
+    // curated keyword, often searched even when the word never appears in the
+    // prose. searchTokenize splits it on the "-"/"_"; index it at title weight.
+    const slug = d.u.split("/").filter(Boolean).pop() || "";
+    addTokens(i, searchTokenize(slug), FIELD_BOOST.title);
+    for (const h of d.h || []) addTokens(i, searchTokenize(h.t), FIELD_BOOST.heading);
+    if (d.b) addTokens(i, searchTokenize(d.b), FIELD_BOOST.body);
+  }
+  let total = 0;
+  for (const l of docLen) total += l;
+  return {
+    docs,
+    postings,
+    // Sorted so searchPostings() can binary-search the prefix range.
+    sortedTerms: [...postings.keys()].sort(),
+    docLen,
+    titleTokens,
+    navTokens,
+    avgdl: docLen.length ? total / docLen.length : 1,
+    N: docs.length,
+  };
+}
+
+// Index of the first element of the sorted array `arr` that is >= `key`.
+function lowerBound(arr, key) {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid] < key) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+// Returns {df, tf: Map(docIdx -> weightedTf)} for a query term. The final,
+// still-being-typed term also matches everything it prefixes, so "trace"
+// surfaces "traceconv" and "tracing"; earlier terms match exactly.
+function searchPostings(idx, term, allowPrefix) {
+  const exact = idx.postings.get(term);
+  if (!allowPrefix) return exact === undefined ? null : {df: exact.size, tf: exact};
+  const merged = new Map();
+  const union = (postingList) => {
+    for (const [docIdx, w] of postingList) merged.set(docIdx, (merged.get(docIdx) || 0) + w);
+  };
+  if (exact !== undefined) union(exact);
+  // Prefix matches are a contiguous run in sortedTerms: walk from the first
+  // term >= `term` and stop at the first miss.
+  let matched = 0;
+  for (let i = lowerBound(idx.sortedTerms, term); i < idx.sortedTerms.length; i++) {
+    const t = idx.sortedTerms[i];
+    if (!t.startsWith(term)) break;
+    if (t === term) continue;
+    union(idx.postings.get(t));
+    if (++matched >= 200) break;  // Cap fan-out on very short prefixes.
+  }
+  return merged.size ? {df: merged.size, tf: merged} : null;
+}
+
+// Ranks docs against the query with BM25. Returns up to `limit` doc objects.
+function searchRank(idx, query, limit) {
+  const terms = searchTokenize(query);
+  if (terms.length === 0) return [];
+  const k1 = 1.2;
+  const b = 0.75;
+  const scores = new Map();
+  for (let ti = 0; ti < terms.length; ti++) {
+    const p = searchPostings(idx, terms[ti], ti === terms.length - 1);
+    if (p === null) continue;
+    // BM25, the standard ranking function: https://en.wikipedia.org/wiki/Okapi_BM25
+    //   idf  -- rarer terms (matching fewer docs, `df`) count for more.
+    //   score -- rises with term frequency `tf` but saturates (`k1`), and is
+    //            penalised for long docs (`b`, via dl/avgdl) so a short focused
+    //            page outranks a long one that just repeats the word.
+    const idf = Math.log(1 + (idx.N - p.df + 0.5) / (p.df + 0.5));
+    for (const [docIdx, tf] of p.tf) {
+      // Floor the length used for normalization so near-empty pages (e.g. the
+      // body-less generated reference pages) don't win on BM25's short-doc bonus.
+      const dl = Math.max(idx.docLen[docIdx], 0.5 * idx.avgdl);
+      const s = idf * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl / idx.avgdl));
+      scores.set(docIdx, (scores.get(docIdx) || 0) + s);  // sum over query terms
+    }
+  }
+  // Boost title matches. Past an exact title, reward how much of the title the
+  // query covers -- so a short "Perfetto UI" beats a long "...Perfetto UI..." --
+  // with a small extra bump when the query leads the title, which keeps "Batch
+  // Trace Processor" below "Trace Processor (C++)". Tokenized so title
+  // punctuation can't block a match; the nav label counts as a title too, so
+  // "boot tracing" finds the page labelled "Boot Tracing".
+  const phrase = terms.join(" ");
+  const titleBoost = (toks) => {
+    const norm = toks.join(" ");
+    if (norm === phrase) return 12;
+    if (!terms.every((t) => toks.includes(t))) return norm.includes(phrase) ? 3 : 0;
+    return 3 + 6 * (terms.length / toks.length) + (norm.startsWith(phrase + " ") ? 3 : 0);
+  };
+  for (const docIdx of scores.keys()) {
+    let boost = titleBoost(idx.titleTokens[docIdx]);
+    const nav = idx.navTokens[docIdx];
+    if (nav) boost = Math.max(boost, titleBoost(nav));
+    if (boost) scores.set(docIdx, scores.get(docIdx) + boost);
+  }
+  return [...scores.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([docIdx]) => idx.docs[docIdx]);
+}
+
+// Extracts a ~180 char window of body text centred on the first term match.
+function searchSnippet(doc, terms) {
+  const text = doc.b || (doc.h || []).map((h) => h.t).join(" · ") || doc.t || "";
+  const lower = text.toLowerCase();
+  let pos = -1;
+  for (const t of terms) {
+    const i = lower.indexOf(t);
+    if (i !== -1 && (pos === -1 || i < pos)) pos = i;
+  }
+  if (pos === -1) pos = 0;
+  const start = Math.max(0, pos - 40);
+  let out = text.slice(start, start + 180);
+  if (start > 0) out = "…" + out;
+  if (start + 180 < text.length) out += "…";
+  return out;
+}
+
+// If a query term matches a heading with an anchor, deep-link to it.
+function searchAnchor(doc, terms) {
+  for (const h of doc.h || []) {
+    if (h.a && terms.some((t) => h.t.toLowerCase().includes(t))) return h.a;
+  }
+  return "";
+}
+
+// The built index, and the in-flight build promise (mirrors the singleton in
+// the old main-thread loader: a failed build clears it so the next query
+// retries).
+let searchIndex = null;
+let searchIndexPromise = null;
+
+function ensureSearchIndex() {
+  if (searchIndexPromise === null) {
+    searchIndexPromise = fetch("/assets/search_index.json")
+      .then((resp) => {
+        if (!resp.ok) throw new Error(`search index HTTP ${resp.status}`);
+        return resp.json();
+      })
+      .then((data) => {
+        searchIndex = buildSearchIndex(data.docs);
+        return searchIndex;
+      })
+      .catch((e) => {
+        searchIndexPromise = null;  // Allow a retry on the next query.
+        throw e;
+      });
+  }
+  return searchIndexPromise;
+}
+
+self.addEventListener("message", (e) => {
+  const {query, limit} = e.data;
+  ensureSearchIndex()
+    .then((idx) => {
+      const terms = searchTokenize(query);
+      // Return only what the main thread renders -- title, a body snippet and a
+      // deep-link anchor -- not the full (large) doc bodies.
+      const results = searchRank(idx, query, limit).map((doc) => ({
+        u: doc.u,
+        t: doc.t,
+        snippet: searchSnippet(doc, terms),
+        anchor: searchAnchor(doc, terms),
+      }));
+      self.postMessage({type: "results", query, terms, results});
+    })
+    .catch(() => {});  // Index failed to load; a later query retries.
+});
+
+// Start building as soon as the worker spawns, and tell the main thread when
+// the index is ready so it can decide whether to show a "loading" placeholder.
+ensureSearchIndex()
+  .then(() => self.postMessage({type: "ready"}))
+  .catch(() => {});

--- a/infra/perfetto.dev/src/assets/style.scss
+++ b/infra/perfetto.dev/src/assets/style.scss
@@ -271,6 +271,11 @@ h3 {
       color: var(--color-text-secondary);
       font-size: 0.9rem;
     }
+    .sr-loading {
+      color: var(--color-text-secondary);
+      font-size: 0.9rem;
+      font-style: italic;
+    }
     mark {
       background-color: rgba(255, 210, 0, 0.35);
       color: inherit;


### PR DESCRIPTION
The new client-side search shipped a 1.46MB search_index.json, which froze the search box for seconds on the first keystroke (#6654). Two separate causes: a pre-existing bug disabled compression site-wide (made painful only once search added a large asset), and the index was fetched and built on the main thread. Fixes, each independent:

1. Re-enable compression (main.py): stop copying the blob's content_encoding onto the response. It falsely marked plain bodies as gzip, which made App Engine skip its own compression for every asset. Removing it takes search_index.json from 1,455,885 -> ~531KB (2.7x) and shrinks all JS/CSS/HTML too (e.g. script.js 30KB -> 12KB).

2. Store the index gzipped and typed (deploy, mime_util/file): add json to the rsync -j list and map .json -> application/json (was defaulting to text/html).

3. Build the index in a web worker (script.js, search_worker.js): tokenizing ~1.2MB of text took seconds on some browsers and froze the page. Moving fetch + build + ranking into a worker keeps the main thread responsive (measured main-thread stall dropped from ~5s to ~17ms); script.js only sends the query and renders the results posted back. Warm queries return in ~125ms (just the debounce). The download is unchanged at ~531KB. Follows the worker pattern already used for the trace_processor engine in ui/.

4. Warm and show progress (script.js, style.scss): spawn the worker at idle so the index is usually built before the first search, and show a loading row if the user types before it's ready, instead of a frozen box.

5. Cache the index for an hour (main.py): was 10 min; avoids re-fetching ~0.5MB on every page navigation during a reading session.

Also bumps the App Engine runtime python38 -> python313, which is unrelated but required as python38 is no longer accepted for deploys.
