### PR TITLE
perfetto: fully reinitialize getopt state before cmdline parsing

### DIFF
--- a/src/perfetto_cmd/perfetto_cmd.cc
+++ b/src/perfetto_cmd/perfetto_cmd.cc
@@ -302,7 +302,16 @@ std::optional<int> PerfettoCmd::ParseCmdlineAndMaybeDaemonize(int argc,
   static base::NoDestructor<std::mutex> getopt_mutex;
   std::unique_lock<std::mutex> getopt_lock(getopt_mutex.ref());
 
-  optind = 1;  // Reset getopt state. It's reused by the snapshot thread.
+  // Reset getopt state. It's reused by the snapshot thread and by tests.
+  // Rescanning requires optind = 0 on glibc (see NOTES in `man 3 getopt`,
+  // https://man7.org/linux/man-pages/man3/getopt.3.html) and on our
+  // getopt_compat; macOS requires optind = 1 plus optreset instead.
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE)
+  optind = 1;
+  optreset = 1;
+#else
+  optind = 0;
+#endif
   for (;;) {
     int option =
         getopt_long(argc, argv, "hc:o:dDt:b:s:a:", long_options, nullptr);

--- a/src/perfetto_cmd/perfetto_cmd_unittest.cc
+++ b/src/perfetto_cmd/perfetto_cmd_unittest.cc
@@ -33,13 +33,15 @@ class PerfettoCmdlineUnitTest : public ::testing::Test {
  protected:
   static std::optional<int> ParseCmdline(PerfettoCmd* cmd,
                                          std::vector<std::string> args) {
+    // getopt() expects a null-terminated argv (argv[argc] == nullptr).
     std::vector<char*> argv;
-    argv.reserve(args.size());
+    argv.reserve(args.size() + 1);
     for (auto& arg : args)
       argv.push_back(arg.data());
+    argv.push_back(nullptr);
 
     std::optional<int> res = cmd->ParseCmdlineAndMaybeDaemonize(
-        static_cast<int>(argv.size()), argv.data());
+        static_cast<int>(argv.size()) - 1, argv.data());
     return res;
   }
 


### PR DESCRIPTION
ParseCmdlineAndMaybeDaemonize reset getopt with optind = 1, which on glibc does not reinitialize the parser's internal state (nextchar and the argv permutation markers); the documented way to rescan is optind = 0 (NOTES in `man 3 getopt`). 

Any earlier getopt user in the same process (the bugreport snapshot thread re-parse, or other tests in perfetto_unittests such as GetoptCompatTest, which drives the real glibc getopt) leaves state behind that can misparse the next cmdline. 


Reset optind = 0 on glibc and getopt_compat, and optind = 1 plus optreset on macOS, following the existing
https://crsrc.org/c/third_party/perfetto/src/base/getopt_compat_unittest.cc;l=73-79 Also null-terminate the argv built by the test helper, as getopt expects argv[argc] == nullptr.
