### PR TITLE
ui: Fail loudly on webgl context loss

### DIFF
--- a/ui/src/widgets/virtual_overlay_canvas.ts
+++ b/ui/src/widgets/virtual_overlay_canvas.ts
@@ -221,6 +221,12 @@ export class VirtualOverlayCanvas
       });
       if (webglCtx) {
         this.webglRenderer = new WebGLRenderer(this.ctx, webglCtx);
+        // Fail loudly if we lose context
+        this.webglCanvas.addEventListener('webglcontextlost', (e) => {
+          const statusMessage =
+            (e as WebGLContextEvent).statusMessage || 'no status message';
+          throw new Error(`WebGL context lost: ${statusMessage}`);
+        });
       }
     }
 


### PR DESCRIPTION
Throw an error when any of the webgl contexts is lost in any of the virtual overlay canvases.

Fixes b/533369431