### PR TITLE
ui: Ensure Core settings are at the top

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.SettingsPage/settings_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.SettingsPage/settings_page.ts
@@ -38,6 +38,7 @@ import {GateDetector} from '../../base/mithril_utils';
 import {findRef} from '../../base/dom_utils';
 
 const SEARCH_BOX_REF = 'settings-search-box';
+const CORE_GROUP = 'Core';
 
 export interface SettingsPageAttrs {
   readonly subpage?: string;
@@ -59,10 +60,10 @@ export class SettingsPage implements m.ClassComponent<SettingsPageAttrs> {
       : this.getAllSettingsGrouped(settingsManager);
     const groupedSettings = this.groupSettingsByPlugin(settings);
 
-    // Sort plugin IDs: CORE_PLUGIN_ID first, then alphabetically
+    // Sort plugin IDs: CORE_GROUP first, then alphabetically
     const sortedPluginIds = Array.from(groupedSettings.keys()).sort((a, b) => {
-      if (!a) return -1;
-      if (!b) return 1;
+      if (a === CORE_GROUP) return -1;
+      if (b === CORE_GROUP) return 1;
       return a.localeCompare(b);
     });
 
@@ -187,7 +188,7 @@ export class SettingsPage implements m.ClassComponent<SettingsPageAttrs> {
       const isCore =
         setting.pluginId === undefined ||
         app.plugins.isCorePlugin(setting.pluginId);
-      const targetGroup = isCore ? 'Core' : setting.pluginId;
+      const targetGroup = isCore ? CORE_GROUP : setting.pluginId;
 
       const existing = grouped.get(targetGroup) ?? [];
       existing.push(result);


### PR DESCRIPTION
It seems like currently Core is not ordered at the top, as the sorting logic currently checks for falsy values as opposed to the CORE_PLUGIN_ID after some refactoring. This PR adds back the comparison except to the name 'Core' through a new constant CORE_GROUP.

Bug: #6666 