### PR TITLE
ui: fix circular dependency build error printing

### DIFF
--- a/ui/vite.config.mjs
+++ b/ui/vite.config.mjs
@@ -354,8 +354,13 @@ export default defineConfig(({command}) => {
             onwarn(warning, warn) {
               if (warning.code === 'CIRCULAR_DEPENDENCY') {
                 if ((warning.message || '').includes('node_modules')) return;
+                // Rollup >=4 reports the cycle in `warning.ids` (older versions
+                // used `warning.importer`/`warning.cycle`, which are now
+                // undefined). `warning.message` already contains a formatted
+                // "a -> b -> a" chain, so prefer it and fall back to `ids`.
+                const cycle = warning.ids ?? warning.cycle ?? [];
                 throw new Error(
-                  `Circular dependency: ${warning.importer}\n  ${(warning.cycle || []).join('\n  ')}`,
+                  `${warning.message ?? 'Circular dependency'}\n  ${cycle.join('\n  ')}`,
                 );
               }
               warn(warning);


### PR DESCRIPTION
The Rollup onwarn handler that turns circular-dependency warnings into
build errors read `warning.importer` and `warning.cycle`. Those fields
existed in older Rollup, but Rollup 4.x emits the CIRCULAR_DEPENDENCY
warning with `warning.ids` (the cycle path) and a pre-formatted
`warning.message` instead. As a result the error printed as:

    Circular dependency: undefined

The detection itself worked; only the message construction referenced
the now-undefined fields. Use `warning.message` (which already contains
the "a -> b -> a" chain) and read the cycle from `warning.ids`, keeping
`warning.cycle` as a fallback for older Rollup.

Bug: b/533388309