### PR TITLE
docs: document trace compression (zstd/deflate) config

### DIFF
--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -267,6 +267,98 @@ For a complete example of a working trace config in long-tracing mode see
 Summary: to capture a long trace just set `write_into_file:true`, set a long
 `duration_ms` and use an in-memory buffer size of 32MB or more.
 
+## {#compression} Compressing the trace
+
+The tracing service can compress the trace as it is written out. This
+substantially reduces the size of the file on disk (and of the data pulled off a
+device), at the cost of some extra CPU while tracing. Compression is off by
+default and is opted into from the TraceConfig.
+
+Perfetto readers decompress transparently: a compressed trace opens directly in
+the [Perfetto UI](/docs/visualization/perfetto-ui.md) and Trace Processor, no
+manual step required.
+
+### Selecting a codec
+
+Set the `compression` field, choosing a codec by which sub-message you fill in:
+
+- **zstd** — recommended. Smaller traces than deflate at a similar speed.
+- **deflate** (zlib) — the older codec, kept for compatibility.
+
+<?tabs>
+
+TAB: zstd (recommended)
+
+```protobuf
+# Rest of the trace config (buffers, data_sources, ...) omitted.
+
+compression {
+  zstd {}
+}
+```
+
+TAB: deflate
+
+```protobuf
+# Rest of the trace config (buffers, data_sources, ...) omitted.
+
+compression {
+  deflate {}
+}
+```
+
+</tabs?>
+
+### Tuning the zstd level
+
+zstd exposes a compression level, trading CPU for a smaller file:
+
+```protobuf
+compression {
+  zstd {
+    level: 9
+  }
+}
+```
+
+- The range is `1` (fastest) to `22` (smallest). Levels above the maximum are
+  clamped.
+- `0` or unset uses zstd's default (`3`), a good balance for most traces.
+- Negative levels are valid and select faster, lower-ratio modes.
+
+### Compatibility across service versions
+
+`compression` was added in Perfetto v58 (Android 26Q3+). A service reads only the
+codecs it knows and picks the one with the **highest field number**, so a single
+config can target old and new services: set both, and v58+ uses `zstd` (field 2)
+while older services fall back to `deflate` (field 1).
+
+```protobuf
+compression {
+  deflate {}
+  zstd {}
+}
+```
+
+Services predating `compression` used the now-deprecated `compression_type`
+(deflate only). It is still honored, but `compression` takes precedence when both
+are set.
+
+NOTE: A codec is only compiled in when its build flag is enabled
+(`enable_perfetto_zlib`, `enable_perfetto_zstd`). Builds without it — notably the
+in-process SDK backend — ignore the request and emit an uncompressed trace. See
+[the SDK build flags](/docs/instrumentation/tracing-sdk.md) to enable compression
+when writing traces directly from an app.
+
+### Reading a compressed trace outside Perfetto
+
+If you need the raw, uncompressed protobuf (e.g. for a non-Perfetto tool), use
+`traceconv` to expand the compressed packets:
+
+```bash
+./traceconv decompress_packets trace.perfetto-trace trace.decompressed
+```
+
 ## Data-source specific config
 
 Alongside the trace-wide configuration parameters, the trace config also defines

--- a/docs/instrumentation/tracing-sdk.md
+++ b/docs/instrumentation/tracing-sdk.md
@@ -106,28 +106,33 @@ You are now ready to instrument your app with trace events.
 
 ## Optional features
 
-The amalgamated SDK ships two optional features. They are off by default;
+The amalgamated SDK ships three optional features. They are off by default;
 opt in by dropping a header named `perfetto_sdk_config.h` on the SDK's
 include path and defining the matching macro inside it:
 
 ```C++
 // perfetto_sdk_config.h
 #define PERFETTO_SDK_ENABLE_ZLIB 1   // optional
+#define PERFETTO_SDK_ENABLE_ZSTD 1   // optional
 #define PERFETTO_SDK_ENABLE_RE2  1   // optional
 ```
 
 `build_config.h` detects the file via `__has_include` and reads the macros
-from there; no cflag plumbing is required. The two features are
-independent — set either, both, or neither.
+from there; no cflag plumbing is required. The features are
+independent — set any combination, or none.
 
 | Macro | Link | System header | What it does |
 | --- | --- | --- | --- |
-| `PERFETTO_SDK_ENABLE_ZLIB` | `-lz` | `zlib.h` | Honors `TraceConfig.compression_type = COMPRESSION_TYPE_DEFLATE` on the in-process backend so `.pftrace` files written via `TracingSession::Setup(cfg, fd)` are zlib-compressed. Without the macro the field is silently ignored. |
+| `PERFETTO_SDK_ENABLE_ZLIB` | `-lz` | `zlib.h` | Enables the deflate (zlib) codec on the in-process backend, honoring `TraceConfig.compression { deflate {} }` (and the legacy `compression_type = COMPRESSION_TYPE_DEFLATE`) so `.pftrace` files written via `TracingSession::Setup(cfg, fd)` are compressed. Without the macro the field is silently ignored. |
+| `PERFETTO_SDK_ENABLE_ZSTD` | `-lzstd` | `zstd.h` | Enables the zstd codec on the in-process backend, honoring `TraceConfig.compression { zstd { level: N } }`. zstd produces smaller traces than deflate at a similar speed. Without the macro the field is silently ignored. |
 | `PERFETTO_SDK_ENABLE_RE2` | `-lre2` | `re2/re2.h` | Replaces the default `std::regex` backend used by `base::Regex` (e.g. for `TraceConfig` data-source/producer name filtering) with [RE2](https://github.com/google/re2), which is significantly faster on large input. |
 
+See [Compressing the trace](/docs/concepts/config.md#compression) for how to
+select and tune a codec in the `TraceConfig`.
+
 When opting in, the matching system header must also be reachable from the
-include path; on Debian/Ubuntu that's `zlib1g-dev` / `libre2-dev`, on
-Fedora `zlib-devel` / `re2-devel`.
+include path; on Debian/Ubuntu that's `zlib1g-dev` / `libzstd-dev` /
+`libre2-dev`, on Fedora `zlib-devel` / `libzstd-devel` / `re2-devel`.
 
 ## Custom data sources vs Track events
 


### PR DESCRIPTION
Add a 'Compressing the trace' section to the Trace Configuration concept page covering the new TraceConfig.compression field: selecting the zstd or deflate codec, tuning the zstd level, targeting old and new services with one config, the deprecated compression_type fallback, and reading compressed traces.

Cross-link the SDK optional-features table, adding a PERFETTO_SDK_ENABLE_ZSTD row and a forward-link to the new section.