### PR TITLE
tp: add `report` subcommand with streaming packet protocol

### DIFF
--- a/protos/perfetto/trace_processor/BUILD.gn
+++ b/protos/perfetto/trace_processor/BUILD.gn
@@ -45,3 +45,12 @@ perfetto_proto_library("metrics_impl_@TYPE@") {
   proto_generators = [ "zero" ]
   sources = [ "metrics_impl.proto" ]
 }
+
+perfetto_proto_library("report_@TYPE@") {
+  proto_generators = [ "zero" ]
+  sources = [ "report.proto" ]
+  generate_descriptor = "report.descriptor"
+  generator_visibility =
+      [ "../../../src/trace_processor/shell:gen_cc_report_descriptor" ]
+  descriptor_root_source = "report.proto"
+}

--- a/protos/perfetto/trace_processor/report.proto
+++ b/protos/perfetto/trace_processor/report.proto
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+
+package perfetto.protos;
+
+// Schema for the output of `trace_processor_shell report`.
+//
+// A Report is a stream of self-delimited packets, modeled on the Perfetto Trace
+// format (`Trace` = repeated `TracePacket`). The stream can be truncated at any
+// packet boundary and the prefix remains parseable, and consumers can process
+// packets incrementally without buffering the whole report. The same schema is
+// emitted in three encodings: length-delimited binary (this message), JSONL
+// (one `ReportPacket` per line), and a human-readable text rendering.
+message Report {
+  repeated ReportPacket packet = 1;
+}
+
+// A single unit in the report stream. Exactly one field is set.
+//
+// Interned definitions (Function, Frame, Callstack) are always emitted before
+// any packet that references them by id, so a truncated prefix stays internally
+// consistent. Each interned type has its own id space.
+message ReportPacket {
+  oneof data {
+    // Stream framing and trace-level context.
+    ReportHeader header = 1;
+    SectionInfo section_info = 2;
+
+    // Interned tables, pprof-oriented but Perfetto-native. A Function is a
+    // symbol; a Frame is a physical location (PC/line) pointing at a Function;
+    // a Callstack is a prefix-shared tree node. Many frames can share one
+    // function (inlining, multiple call sites), which is why they are distinct.
+    Function function = 3;
+    Frame frame = 4;
+    Callstack callstack = 5;
+
+    // Typed data rows: one arm per trace data type. Extended per increment.
+    SliceAggregate slice_aggregate = 6;
+    CounterAggregate counter_aggregate = 7;
+    Track track = 8;
+    Process process = 9;
+    // Stack samples / heap profiles aggregated BY FUNCTION (functions view)
+    // versus BY CALLSTACK (top-down / bottom-up tree views) are deliberately
+    // separate packet types.
+    FunctionStat function_stat = 10;
+    CallstackStat callstack_stat = 11;
+    HeapObject heap_object = 12;
+  }
+}
+
+// Trace-level context, emitted once at the start of the stream.
+message ReportHeader {
+  optional string trace_file = 1;
+  optional int64 trace_start_ns = 2;
+  optional int64 trace_end_ns = 3;
+  optional int64 trace_dur_ns = 4;
+  optional int64 process_count = 5;
+  // Device / OS metadata deferred to a later increment.
+}
+
+// Marks the start of a view section and carries the totals needed to render a
+// truncation footnote. Emitted before the section's data rows; the totals are
+// known up-front because the builder counts before selecting the top rows.
+message SectionInfo {
+  optional string title = 1;  // e.g. "Slices"
+  optional string noun = 2;   // e.g. "slices"
+  optional string view = 3;   // e.g. "table"
+  // Distinct rows available in scope vs rows actually emitted (bounded by
+  // --top). shown_rows < total_rows means the section was truncated.
+  optional int64 total_rows = 4;
+  optional int64 shown_rows = 5;
+  // Total underlying items in scope and their noun, for headline counts like
+  // "Slices (12.3M total)".
+  optional int64 total_items = 6;
+  optional string item_noun = 7;
+  // Plural noun for the aggregated rows, used in the truncation footnote
+  // ("N more <row_noun> below --top T"), e.g. "slice names" or "processes".
+  optional string row_noun = 8;
+
+  // How a column's values should be rendered. The typed row packets carry raw
+  // values; the format tells a renderer how to turn each into a display string.
+  enum ColumnFormat {
+    CF_STRING = 0;    // as-is
+    CF_INT = 1;       // plain integer
+    CF_COUNT = 2;     // integer, abbreviated (12.3k, 4.1M)
+    CF_DURATION = 3;  // nanoseconds as 4.1s / 128ms / 33us
+    CF_PERCENT = 4;   // 33.2%
+    CF_NUMBER = 5;    // arbitrary magnitude (33.2k, 1.2G, 4.20)
+  }
+  // The section's columns, in order, declared by the view. A renderer takes its
+  // headers and per-column formatting from here rather than from the noun.
+  message Column {
+    optional string name = 1;
+    optional ColumnFormat format = 2;
+  }
+  repeated Column columns = 10;
+}
+
+// -------------------------------------------------------------------------
+// Interned tables.
+// -------------------------------------------------------------------------
+
+// An interned symbol.
+message Function {
+  optional uint32 id = 1;
+  optional string name = 2;
+  optional string module = 3;  // mapping / shared object name
+  optional string file = 4;
+}
+
+// An interned physical location, referencing a Function by id.
+message Frame {
+  optional uint32 id = 1;
+  optional uint32 function_id = 2;  // -> Function.id
+  optional int64 rel_pc = 3;
+  optional uint32 line = 4;
+}
+
+// An interned callstack tree node: a leaf Frame plus a parent node, giving
+// prefix sharing across callstacks (as in stack_profile_callsite).
+message Callstack {
+  optional uint32 id = 1;
+  optional uint32 parent_id = 2;  // -> Callstack.id; unset at the root
+  optional uint32 frame_id = 3;   // -> Frame.id
+}
+
+// -------------------------------------------------------------------------
+// Typed data rows.
+// -------------------------------------------------------------------------
+
+// Slices grouped by name.
+message SliceAggregate {
+  optional string name = 1;
+  optional int64 count = 2;
+  optional int64 total_dur_ns = 3;
+  optional double pct_of_trace = 4;
+  optional int64 max_dur_ns = 5;
+  // Coordinates (ts / thread) of the max-duration instance deferred.
+}
+
+// Counters grouped by name.
+message CounterAggregate {
+  optional string name = 1;
+  optional int64 count = 2;
+  optional double min = 3;
+  optional double max = 4;
+  optional double avg = 5;
+  optional double last = 6;
+}
+
+// A track, for structural discovery.
+message Track {
+  optional string name = 1;
+  optional string type = 2;
+  optional int64 event_count = 3;
+  optional string context = 4;  // owning process / thread
+}
+
+// A process, for structural discovery.
+message Process {
+  optional int64 pid = 1;
+  optional string name = 2;
+  optional int64 cpu_time_ns = 3;
+  optional double pct_of_trace = 4;
+  optional int64 thread_count = 5;
+}
+
+// Stack samples / heap profile aggregated by function.
+message FunctionStat {
+  optional uint32 function_id = 1;  // -> Function.id
+  optional int64 self_value = 2;
+  optional int64 total_value = 3;
+  optional double self_percent = 4;
+  optional double total_percent = 5;
+  optional int64 sample_count = 6;
+}
+
+// Stack samples / heap profile aggregated by callstack (one per tree node).
+message CallstackStat {
+  optional uint32 callstack_id = 1;  // -> Callstack.id
+  optional int64 self_value = 2;
+  optional int64 total_value = 3;
+  optional double self_percent = 4;
+  optional double total_percent = 5;
+}
+
+// A heap-dump type / object row.
+message HeapObject {
+  optional string type_name = 1;
+  optional int64 retained_size = 2;
+  optional int64 live_count = 3;
+}

--- a/src/trace_processor/shell/BUILD.gn
+++ b/src/trace_processor/shell/BUILD.gn
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 import("../../../gn/perfetto.gni")
+import("../../../gn/perfetto_cc_proto_descriptor.gni")
+
+perfetto_cc_proto_descriptor("gen_cc_report_descriptor") {
+  descriptor_name = "report.descriptor"
+  descriptor_target = "../../../protos/perfetto/trace_processor:report_descriptor"
+}
 
 source_set("shell") {
   sources = [
@@ -40,6 +46,17 @@ source_set("shell") {
     "query.h",
     "query_subcommand.cc",
     "query_subcommand.h",
+    "report/report_sink.cc",
+    "report/report_sink.h",
+    "report/report_view.cc",
+    "report/report_view.h",
+    "report/slices_view.cc",
+    "report/slices_view.h",
+    "report/text_renderer.cc",
+    "report/text_renderer.h",
+    "report/view_common.h",
+    "report_subcommand.cc",
+    "report_subcommand.h",
     "server_subcommand.cc",
     "server_subcommand.h",
     "shell_utils.cc",
@@ -52,10 +69,13 @@ source_set("shell") {
     "util_subcommand.h",
   ]
   deps = [
+    ":gen_cc_report_descriptor",
     ":subcommands",
     "../../../gn:default_deps",
     "../../../gn:protobuf_full",
     "../../../include/perfetto/ext/trace_processor:trace_processor_shell",
+    "../../../include/perfetto/protozero",
+    "../../../protos/perfetto/trace_processor:report_zero",
     "../../../protos/perfetto/trace_processor:zero",
     "../../base",
     "../../base:version",
@@ -70,7 +90,10 @@ source_set("shell") {
     "../rpc:stdiod",
     "../trace_summary",
     "../trace_summary:gen_cc_trace_summary_descriptor",
+    "../util:descriptors",
     "../util:json_value",
+    "../util:protozero_to_json",
+    "../util:simple_json_serializer",
     "../util:stdlib",
     "../util:tar_writer",
     "../util/deobfuscation:deobfuscator",
@@ -110,6 +133,8 @@ source_set("unittests") {
   sources = [
     "convert_helpers_unittest.cc",
     "find_subcommand_unittest.cc",
+    "report/report_render_unittest.cc",
+    "report_subcommand_unittest.cc",
     "subcommand_flags_unittest.cc",
   ]
   deps = [
@@ -118,6 +143,8 @@ source_set("unittests") {
     "../../../gn:default_deps",
     "../../../gn:gtest_and_gmock",
     "../../../gn:protobuf_full",
+    "../../../include/perfetto/protozero",
+    "../../../protos/perfetto/trace_processor:report_zero",
     "../../base",
   ]
 }

--- a/src/trace_processor/shell/report/report_render_unittest.cc
+++ b/src/trace_processor/shell/report/report_render_unittest.cc
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/report/report_sink.h"
+#include "src/trace_processor/shell/report/text_renderer.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/temp_file.h"
+#include "perfetto/protozero/scattered_heap_buffer.h"
+#include "protos/perfetto/trace_processor/report.pbzero.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::shell {
+namespace {
+
+using ::testing::HasSubstr;
+using protos::pbzero::ReportPacket;
+
+std::vector<uint8_t> HeaderPacket() {
+  protozero::HeapBuffered<ReportPacket> p;
+  auto* h = p->set_header();
+  h->set_trace_file("t.pb");
+  h->set_trace_dur_ns(12'300'000'000);
+  h->set_process_count(12);
+  return p.SerializeAsArray();
+}
+
+std::vector<uint8_t> SectionPacket() {
+  using SI = protos::pbzero::SectionInfo;
+  protozero::HeapBuffered<ReportPacket> p;
+  auto* s = p->set_section_info();
+  s->set_title("Slices");
+  s->set_total_rows(100);
+  s->set_shown_rows(2);
+  s->set_total_items(1'000'000);
+  s->set_item_noun("slice");
+  s->set_row_noun("slice names");
+  for (auto [name, fmt] : {std::pair<const char*, SI::ColumnFormat>
+                               {"Name", SI::CF_STRING},
+                           {"Count", SI::CF_COUNT},
+                           {"Total dur", SI::CF_DURATION},
+                           {"% of trace", SI::CF_PERCENT},
+                           {"Max dur", SI::CF_DURATION}}) {
+    auto* c = s->add_columns();
+    c->set_name(name);
+    c->set_format(fmt);
+  }
+  return p.SerializeAsArray();
+}
+
+std::vector<uint8_t> SlicePacket(const char* name,
+                                 int64_t count,
+                                 int64_t total_dur,
+                                 int64_t max_dur,
+                                 double pct) {
+  protozero::HeapBuffered<ReportPacket> p;
+  auto* s = p->set_slice_aggregate();
+  s->set_name(name);
+  s->set_count(count);
+  s->set_total_dur_ns(total_dur);
+  s->set_max_dur_ns(max_dur);
+  s->set_pct_of_trace(pct);
+  return p.SerializeAsArray();
+}
+
+// Reads a length-delimited varint. Returns false on truncation.
+bool ReadVarint(const std::string& b, size_t* i, uint64_t* out) {
+  uint64_t r = 0;
+  int s = 0;
+  while (*i < b.size()) {
+    uint8_t x = static_cast<uint8_t>(b[(*i)++]);
+    r |= static_cast<uint64_t>(x & 0x7f) << s;
+    if (!(x & 0x80)) {
+      *out = r;
+      return true;
+    }
+    s += 7;
+  }
+  return false;
+}
+
+// Counts the packets in a length-delimited ReportPacket stream.
+int CountPackets(const std::string& b) {
+  size_t i = 0;
+  int n = 0;
+  while (i < b.size()) {
+    uint64_t tag = 0;
+    uint64_t len = 0;
+    if (!ReadVarint(b, &i, &tag) || tag != 0x0A)
+      return -1;
+    if (!ReadVarint(b, &i, &len))
+      return -1;
+    if (i + len > b.size())
+      return -1;
+    i += len;
+    n++;
+  }
+  return n;
+}
+
+TEST(ReportBinarySinkTest, FramesPacketsLengthDelimited) {
+  base::TempFile tf = base::TempFile::Create();
+  FILE* f = fopen(tf.path().c_str(), "wb");
+  ASSERT_TRUE(f);
+  BinarySink sink(f);
+  auto h = HeaderPacket();
+  auto s = SectionPacket();
+  ASSERT_TRUE(sink.OnPacket({h.data(), h.size()}).ok());
+  ASSERT_TRUE(sink.OnPacket({s.data(), s.size()}).ok());
+  ASSERT_TRUE(sink.Finalize().ok());
+  fclose(f);
+
+  std::string out;
+  ASSERT_TRUE(base::ReadFile(tf.path(), &out));
+  EXPECT_EQ(CountPackets(out), 2);
+
+  // A prefix cut inside the last packet still parses the first.
+  EXPECT_EQ(CountPackets(out.substr(0, out.size() - 1)), -1)
+      << "cut stream should not validate as a clean multiple of packets";
+  size_t first_len = static_cast<uint8_t>(out[1]);
+  EXPECT_EQ(CountPackets(out.substr(0, 2 + first_len)), 1);
+}
+
+TEST(ReportTextSinkTest, RendersHeaderTableAndFootnote) {
+  base::TempFile tf = base::TempFile::Create();
+  FILE* f = fopen(tf.path().c_str(), "wb");
+  ASSERT_TRUE(f);
+  TextSink sink(f, /*overview=*/false);
+
+  auto emit = [&](const std::vector<uint8_t>& p) {
+    ASSERT_TRUE(sink.OnPacket({p.data(), p.size()}).ok());
+  };
+  emit(HeaderPacket());
+  emit(SectionPacket());
+  emit(SlicePacket("Foo", 2000, 4'100'000'000, 128'000'000, 33.2));
+  emit(SlicePacket("Bar", 500, 890'000'000, 42'000'000, 7.2));
+  ASSERT_TRUE(sink.Finalize().ok());
+  fclose(f);
+
+  std::string out;
+  ASSERT_TRUE(base::ReadFile(tf.path(), &out));
+
+  EXPECT_THAT(out, HasSubstr("[t.pb | full trace | 12.3s | 12 processes]"));
+  EXPECT_THAT(out, HasSubstr("Slices (1.0M total):"));
+  // Human-formatted cells.
+  EXPECT_THAT(out, HasSubstr("2.0k"));
+  EXPECT_THAT(out, HasSubstr("4.1s"));
+  EXPECT_THAT(out, HasSubstr("33.2%"));
+  EXPECT_THAT(out, HasSubstr("128ms"));
+  EXPECT_THAT(out, HasSubstr("890ms"));
+  // Truncation footnote: 100 total, 2 shown.
+  EXPECT_THAT(out, HasSubstr(
+                       "98 more slice names below --top 2; rerun with --top 50"));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/report/report_sink.cc
+++ b/src/trace_processor/shell/report/report_sink.cc
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/report/report_sink.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/protozero/proto_utils.h"
+#include "src/trace_processor/shell/report.descriptor.h"
+#include "src/trace_processor/util/descriptors.h"
+#include "src/trace_processor/util/protozero_to_json.h"
+
+namespace perfetto::trace_processor::shell {
+
+ReportSink::~ReportSink() = default;
+
+base::Status BinarySink::OnPacket(protozero::ConstBytes packet) {
+  // Frame the packet as field 1 (`Report.packet`, length-delimited).
+  uint8_t header[16];
+  uint8_t* p = header;
+  p = protozero::proto_utils::WriteVarInt(
+      protozero::proto_utils::MakeTagLengthDelimited(1), p);
+  p = protozero::proto_utils::WriteVarInt(packet.size, p);
+  auto header_size = static_cast<size_t>(p - header);
+  if (fwrite(header, 1, header_size, out_) != header_size ||
+      fwrite(packet.data, 1, packet.size, out_) != packet.size) {
+    return base::ErrStatus("Failed to write report packet");
+  }
+  return base::OkStatus();
+}
+
+base::Status BinarySink::Finalize() {
+  return base::OkStatus();
+}
+
+base::StatusOr<std::unique_ptr<JsonlSink>> JsonlSink::Create(FILE* out) {
+  auto pool = std::make_unique<DescriptorPool>();
+  RETURN_IF_ERROR(pool->AddFromFileDescriptorSet(kReportDescriptor.data(),
+                                                 kReportDescriptor.size()));
+  return std::unique_ptr<JsonlSink>(new JsonlSink(out, std::move(pool)));
+}
+
+JsonlSink::JsonlSink(FILE* out, std::unique_ptr<DescriptorPool> pool)
+    : out_(out), pool_(std::move(pool)) {}
+
+JsonlSink::~JsonlSink() = default;
+
+base::Status JsonlSink::OnPacket(protozero::ConstBytes packet) {
+  std::string json = protozero_to_json::ProtozeroToJson(
+      *pool_, ".perfetto.protos.ReportPacket", packet,
+      protozero_to_json::kNone);
+  if (fwrite(json.data(), 1, json.size(), out_) != json.size() ||
+      fputc('\n', out_) == EOF) {
+    return base::ErrStatus("Failed to write report packet");
+  }
+  return base::OkStatus();
+}
+
+base::Status JsonlSink::Finalize() {
+  return base::OkStatus();
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/report/report_sink.h
+++ b/src/trace_processor/shell/report/report_sink.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_REPORT_REPORT_SINK_H_
+#define SRC_TRACE_PROCESSOR_SHELL_REPORT_REPORT_SINK_H_
+
+#include <cstdio>
+#include <memory>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/protozero/field.h"
+
+namespace perfetto::trace_processor {
+class DescriptorPool;
+}  // namespace perfetto::trace_processor
+
+namespace perfetto::trace_processor::shell {
+
+// Consumes the report stream one serialized ReportPacket at a time. View
+// builders emit packets to a sink; the sink encodes them. Because every sink
+// sees the identical packet bytes, the binary, JSONL and text encodings cannot
+// drift from each other.
+class ReportSink {
+ public:
+  virtual ~ReportSink();
+
+  // Called once per packet, in emission order. |packet| is a serialized
+  // ReportPacket and is only valid for the duration of the call.
+  virtual base::Status OnPacket(protozero::ConstBytes packet) = 0;
+
+  // Flushes any buffered state. Called once after the last packet.
+  virtual base::Status Finalize() = 0;
+};
+
+// Writes the stream as length-delimited ReportPackets, i.e. the on-wire form of
+// `Report { repeated ReportPacket packet = 1; }`. Truncating the output at any
+// point still yields a parseable prefix.
+class BinarySink : public ReportSink {
+ public:
+  explicit BinarySink(FILE* out) : out_(out) {}
+  base::Status OnPacket(protozero::ConstBytes packet) override;
+  base::Status Finalize() override;
+
+ private:
+  FILE* out_;
+};
+
+// Writes one JSON object per packet, newline-delimited (JSONL). The JSON is the
+// proto3 JSON mapping of the same ReportPacket schema, so it is line-based,
+// streamable and incrementally parseable.
+class JsonlSink : public ReportSink {
+ public:
+  static base::StatusOr<std::unique_ptr<JsonlSink>> Create(FILE* out);
+  ~JsonlSink() override;
+  base::Status OnPacket(protozero::ConstBytes packet) override;
+  base::Status Finalize() override;
+
+ private:
+  JsonlSink(FILE* out, std::unique_ptr<DescriptorPool> pool);
+  FILE* out_;
+  std::unique_ptr<DescriptorPool> pool_;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_REPORT_REPORT_SINK_H_

--- a/src/trace_processor/shell/report/report_view.cc
+++ b/src/trace_processor/shell/report/report_view.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/report/report_view.h"
+
+#include <cstdint>
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/trace_processor/basic_types.h"
+#include "perfetto/trace_processor/iterator.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "protos/perfetto/trace_processor/report.pbzero.h"
+#include "src/trace_processor/shell/report/report_sink.h"
+#include "src/trace_processor/shell/report/view_common.h"
+
+namespace perfetto::trace_processor::shell {
+
+ReportView::~ReportView() = default;
+
+base::Status EmitHeader(TraceProcessor* tp,
+                        const std::string& trace_file,
+                        ReportSink* sink) {
+  int64_t start = 0;
+  int64_t end = 0;
+  {
+    auto it = tp->ExecuteQuery("SELECT start_ts, end_ts FROM trace_bounds");
+    if (it.Next()) {
+      start = AsI64(it.Get(0));
+      end = AsI64(it.Get(1));
+    }
+    RETURN_IF_ERROR(it.Status());
+  }
+  int64_t process_count = 0;
+  {
+    auto it = tp->ExecuteQuery("SELECT count() FROM process");
+    if (it.Next())
+      process_count = AsI64(it.Get(0));
+    RETURN_IF_ERROR(it.Status());
+  }
+
+  protozero::HeapBuffered<protos::pbzero::ReportPacket> packet;
+  auto* h = packet->set_header();
+  if (!trace_file.empty())
+    h->set_trace_file(trace_file);
+  h->set_trace_start_ns(start);
+  h->set_trace_end_ns(end);
+  h->set_trace_dur_ns(end - start);
+  h->set_process_count(process_count);
+  return EmitPacket(sink, &packet);
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/report/report_view.h
+++ b/src/trace_processor/shell/report/report_view.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_REPORT_REPORT_VIEW_H_
+#define SRC_TRACE_PROCESSOR_SHELL_REPORT_REPORT_VIEW_H_
+
+#include <string>
+
+#include "perfetto/base/status.h"
+
+namespace perfetto::trace_processor {
+class TraceProcessor;
+}  // namespace perfetto::trace_processor
+
+namespace perfetto::trace_processor::shell {
+
+class ReportSink;
+struct Scope;
+
+// A single opinionated view over one trace dimension (a noun/view pair). Every
+// view implements the same contract, so cross-cutting features -- running,
+// --format sql, and anything added later -- apply to all views uniformly. Add a
+// view by subclassing this and registering it in report_subcommand.cc; nothing
+// else needs to special-case it.
+class ReportView {
+ public:
+  virtual ~ReportView();
+
+  // The SQL that produces this view's rows. Surfaced verbatim by --format sql
+  // and used by Emit(), so the two never drift.
+  virtual std::string Sql(const Scope& scope) const = 0;
+
+  // Runs the view against |tp| and emits its packets (a SectionInfo followed by
+  // the row packets) to |sink|. If |omit_if_empty| the whole section is skipped
+  // when the trace has no matching data in scope (used by the overview).
+  virtual base::Status Emit(TraceProcessor* tp,
+                            const Scope& scope,
+                            ReportSink* sink,
+                            bool omit_if_empty) const = 0;
+};
+
+// Emits the trace-level ReportHeader packet (duration, process count) that opens
+// every report stream. Not a view: it is the stream preamble.
+base::Status EmitHeader(TraceProcessor* tp,
+                        const std::string& trace_file,
+                        ReportSink* sink);
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_REPORT_REPORT_VIEW_H_

--- a/src/trace_processor/shell/report/scope.h
+++ b/src/trace_processor/shell/report/scope.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_REPORT_SCOPE_H_
+#define SRC_TRACE_PROCESSOR_SHELL_REPORT_SCOPE_H_
+
+#include <cstdint>
+#include <string>
+
+namespace perfetto::trace_processor::shell {
+
+// The effective scope and aggregation controls for a report view, compiled
+// from the report subcommand's flags. Extended as new scope flags land.
+struct Scope {
+  // Maximum number of aggregated rows to emit (--top).
+  int64_t top = 10;
+  // If non-empty, a GLOB restricting rows by name (--name).
+  std::string name_glob;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_REPORT_SCOPE_H_

--- a/src/trace_processor/shell/report/slices_view.cc
+++ b/src/trace_processor/shell/report/slices_view.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/report/slices_view.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/trace_processor/basic_types.h"
+#include "perfetto/trace_processor/iterator.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "protos/perfetto/trace_processor/report.pbzero.h"
+#include "src/trace_processor/shell/report/report_sink.h"
+#include "src/trace_processor/shell/report/scope.h"
+#include "src/trace_processor/shell/report/view_common.h"
+
+namespace perfetto::trace_processor::shell {
+namespace {
+
+using protos::pbzero::ReportPacket;
+using protos::pbzero::SectionInfo;
+
+std::string WhereClause(const Scope& scope) {
+  // Exclude unfinished slices (dur < 0), which would skew duration ranking.
+  std::string where = "dur >= 0";
+  if (!scope.name_glob.empty())
+    where += " AND name GLOB '" + EscapeSqlLiteral(scope.name_glob) + "'";
+  return where;
+}
+
+}  // namespace
+
+std::string SlicesTableView::Sql(const Scope& scope) const {
+  return R"(SELECT name, count() AS cnt, sum(dur) AS total_dur,
+    max(dur) AS max_dur,
+    100.0 * sum(dur) / (SELECT end_ts - start_ts FROM trace_bounds) AS pct
+  FROM slice WHERE )" +
+         WhereClause(scope) + R"( GROUP BY name ORDER BY total_dur DESC
+  LIMIT )" +
+         std::to_string(scope.top);
+}
+
+base::Status SlicesTableView::Emit(TraceProcessor* tp,
+                                   const Scope& scope,
+                                   ReportSink* sink,
+                                   bool omit_if_empty) const {
+  int64_t total_names = 0;
+  int64_t total_slices = 0;
+  {
+    std::string sql =
+        "SELECT count(DISTINCT name) AS names, count() AS n FROM slice WHERE " +
+        WhereClause(scope);
+    auto it = tp->ExecuteQuery(sql);
+    if (it.Next()) {
+      total_names = AsI64(it.Get(0));
+      total_slices = AsI64(it.Get(1));
+    }
+    RETURN_IF_ERROR(it.Status());
+  }
+  if (omit_if_empty && total_slices == 0)
+    return base::OkStatus();
+
+  {
+    protozero::HeapBuffered<ReportPacket> packet;
+    auto* s = packet->set_section_info();
+    s->set_title("Slices");
+    s->set_noun("slices");
+    s->set_view("flat");
+    s->set_total_rows(total_names);
+    s->set_shown_rows(std::min(scope.top, total_names));
+    s->set_total_items(total_slices);
+    s->set_item_noun("slice");
+    s->set_row_noun("slice names");
+    SetColumns(s, {{"Name", SectionInfo::CF_STRING},
+                   {"Count", SectionInfo::CF_COUNT},
+                   {"Total dur", SectionInfo::CF_DURATION},
+                   {"% of trace", SectionInfo::CF_PERCENT},
+                   {"Max dur", SectionInfo::CF_DURATION}});
+    RETURN_IF_ERROR(EmitPacket(sink, &packet));
+  }
+
+  auto it = tp->ExecuteQuery(Sql(scope));
+  while (it.Next()) {
+    protozero::HeapBuffered<ReportPacket> packet;
+    auto* sa = packet->set_slice_aggregate();
+    SqlValue name = it.Get(0);
+    if (!name.is_null())
+      sa->set_name(name.AsString());
+    sa->set_count(AsI64(it.Get(1)));
+    sa->set_total_dur_ns(AsI64(it.Get(2)));
+    sa->set_max_dur_ns(AsI64(it.Get(3)));
+    sa->set_pct_of_trace(AsF64(it.Get(4)));
+    RETURN_IF_ERROR(EmitPacket(sink, &packet));
+  }
+  RETURN_IF_ERROR(it.Status());
+  return base::OkStatus();
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/report/slices_view.h
+++ b/src/trace_processor/shell/report/slices_view.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_REPORT_SLICES_VIEW_H_
+#define SRC_TRACE_PROCESSOR_SHELL_REPORT_SLICES_VIEW_H_
+
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/shell/report/report_view.h"
+
+namespace perfetto::trace_processor::shell {
+
+// Slices aggregated by name, ranked by total duration.
+class SlicesTableView : public ReportView {
+ public:
+  std::string Sql(const Scope& scope) const override;
+  base::Status Emit(TraceProcessor* tp,
+                    const Scope& scope,
+                    ReportSink* sink,
+                    bool omit_if_empty) const override;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_REPORT_SLICES_VIEW_H_

--- a/src/trace_processor/shell/report/text_renderer.cc
+++ b/src/trace_processor/shell/report/text_renderer.cc
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/report/text_renderer.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/protozero/field.h"
+#include "protos/perfetto/trace_processor/report.pbzero.h"
+
+namespace perfetto::trace_processor::shell {
+namespace {
+
+constexpr size_t kMaxNameWidth = 50;
+
+std::string FormatDuration(int64_t ns) {
+  double a = std::abs(static_cast<double>(ns));
+  if (a >= 1e9)
+    return base::StackString<32>("%.1fs", static_cast<double>(ns) / 1e9)
+        .ToStdString();
+  if (a >= 1e6)
+    return base::StackString<32>("%.0fms", static_cast<double>(ns) / 1e6)
+        .ToStdString();
+  if (a >= 1e3)
+    return base::StackString<32>("%.0fus", static_cast<double>(ns) / 1e3)
+        .ToStdString();
+  return base::StackString<32>("%" PRId64 "ns", ns).ToStdString();
+}
+
+std::string FormatCount(int64_t n) {
+  double a = std::abs(static_cast<double>(n));
+  if (a >= 1e6)
+    return base::StackString<32>("%.1fM", static_cast<double>(n) / 1e6)
+        .ToStdString();
+  if (a >= 1e3)
+    return base::StackString<32>("%.1fk", static_cast<double>(n) / 1e3)
+        .ToStdString();
+  return base::StackString<32>("%" PRId64, n).ToStdString();
+}
+
+std::string FormatPercent(double pct) {
+  return base::StackString<32>("%.1f%%", pct).ToStdString();
+}
+
+std::string CapName(const std::string& name) {
+  if (name.size() <= kMaxNameWidth)
+    return name;
+  return name.substr(0, kMaxNameWidth - 3) + "...";
+}
+
+// Renders a raw cell to a display string per its column's declared format.
+std::string FormatCell(const TextSink::Cell& c, int32_t format) {
+  using SI = protos::pbzero::SectionInfo;
+  switch (format) {
+    case SI::CF_INT:
+      return base::StackString<32>("%" PRId64, c.i).ToStdString();
+    case SI::CF_COUNT:
+      return FormatCount(c.i);
+    case SI::CF_DURATION:
+      return FormatDuration(c.i);
+    case SI::CF_PERCENT:
+      return FormatPercent(c.d);
+    case SI::CF_STRING:
+    default:
+      return c.str;
+  }
+}
+
+}  // namespace
+
+TextSink::TextSink(FILE* out, bool overview) : out_(out), overview_(overview) {}
+
+TextSink::~TextSink() = default;
+
+base::Status TextSink::OnPacket(protozero::ConstBytes packet) {
+  protos::pbzero::ReportPacket::Decoder p(packet.data, packet.size);
+  if (p.has_header()) {
+    auto hb = p.header();
+    protos::pbzero::ReportHeader::Decoder h(hb.data, hb.size);
+    trace_file_ = h.trace_file().ToStdString();
+    std::string name = trace_file_.empty() ? "trace" : trace_file_;
+    fprintf(out_, "[%s | full trace | %s | %" PRId64 " processes]\n",
+            name.c_str(), FormatDuration(h.trace_dur_ns()).c_str(),
+            h.process_count());
+    return base::OkStatus();
+  }
+  if (p.has_section_info()) {
+    FlushSection();
+    auto sb = p.section_info();
+    protos::pbzero::SectionInfo::Decoder s(sb.data, sb.size);
+    in_section_ = true;
+    section_title_ = s.title().ToStdString();
+    row_noun_ = s.row_noun().ToStdString();
+    total_rows_ = s.total_rows();
+    shown_rows_ = s.shown_rows();
+    total_items_ = s.total_items();
+    // The section declares its own columns; the renderer takes its headers and
+    // per-column formatting from the stream rather than from the noun.
+    columns_.clear();
+    column_formats_.clear();
+    for (auto it = s.columns(); it; ++it) {
+      protos::pbzero::SectionInfo::Column::Decoder col(*it);
+      columns_.push_back(col.name().ToStdString());
+      column_formats_.push_back(col.format());
+    }
+    rows_.clear();
+    return base::OkStatus();
+  }
+  if (p.has_slice_aggregate()) {
+    auto sb = p.slice_aggregate();
+    protos::pbzero::SliceAggregate::Decoder s(sb.data, sb.size);
+    rows_.push_back({Cell::Str(CapName(s.name().ToStdString())),
+                     Cell::Int(s.count()), Cell::Int(s.total_dur_ns()),
+                     Cell::Dbl(s.pct_of_trace()), Cell::Int(s.max_dur_ns())});
+    return base::OkStatus();
+  }
+  return base::OkStatus();
+}
+
+void TextSink::FlushSection() {
+  if (!in_section_)
+    return;
+  in_section_ = false;
+
+  std::string headline = section_title_;
+  if (total_items_ > 0)
+    headline += " (" + FormatCount(total_items_) + " total)";
+  fprintf(out_, "\n%s:\n", headline.c_str());
+
+  // Format the raw cells to strings up front, keyed by each column's format.
+  std::vector<std::vector<std::string>> cells;
+  cells.reserve(rows_.size());
+  for (const auto& row : rows_) {
+    std::vector<std::string> out;
+    out.reserve(row.size());
+    for (size_t c = 0; c < row.size(); ++c) {
+      int32_t fmt = c < column_formats_.size() ? column_formats_[c] : 0;
+      out.push_back(FormatCell(row[c], fmt));
+    }
+    cells.push_back(std::move(out));
+  }
+
+  std::vector<size_t> widths(columns_.size());
+  for (size_t c = 0; c < columns_.size(); ++c)
+    widths[c] = columns_[c].size();
+  for (const auto& row : cells) {
+    for (size_t c = 0; c < row.size(); ++c)
+      widths[c] = std::max(widths[c], row[c].size());
+  }
+
+  auto print_row = [&](const std::vector<std::string>& row) {
+    std::string line = "  ";
+    for (size_t c = 0; c < row.size(); ++c) {
+      line += row[c];
+      if (c + 1 < row.size())
+        line.append(widths[c] - row[c].size() + 3, ' ');
+    }
+    fprintf(out_, "%s\n", line.c_str());
+  };
+
+  print_row(columns_);
+  for (const auto& row : cells)
+    print_row(row);
+
+  if (total_rows_ > shown_rows_) {
+    int64_t hidden = total_rows_ - shown_rows_;
+    int64_t suggested = std::min<int64_t>(
+        total_rows_, shown_rows_ < 50 ? 50 : shown_rows_ * 5);
+    std::string noun = row_noun_.empty() ? "rows" : row_noun_;
+    fprintf(out_,
+            "  * %" PRId64 " more %s below --top %" PRId64
+            "; rerun with --top %" PRId64 "\n",
+            hidden, noun.c_str(), shown_rows_, suggested);
+  }
+}
+
+base::Status TextSink::Finalize() {
+  FlushSection();
+  if (overview_) {
+    std::string trace = trace_file_.empty() ? "<trace>" : trace_file_;
+    fprintf(out_, "\nNext: report slices %s --top 50\n", trace.c_str());
+  }
+  return base::OkStatus();
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/report/text_renderer.h
+++ b/src/trace_processor/shell/report/text_renderer.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_REPORT_TEXT_RENDERER_H_
+#define SRC_TRACE_PROCESSOR_SHELL_REPORT_TEXT_RENDERER_H_
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/protozero/field.h"
+#include "src/trace_processor/shell/report/report_sink.h"
+
+namespace perfetto::trace_processor::shell {
+
+// A ReportSink that decodes the packet stream and renders human-readable tables
+// (the default `report` output). Sections are bounded by --top, so it buffers a
+// section's rows to align columns, then prints on the next section boundary.
+class TextSink : public ReportSink {
+ public:
+  // |overview| controls whether "Next:" drill-down hints are printed at the end
+  // (shown for the overview, omitted for single-noun views).
+  TextSink(FILE* out, bool overview);
+  ~TextSink() override;
+
+  base::Status OnPacket(protozero::ConstBytes packet) override;
+  base::Status Finalize() override;
+
+  // A raw table cell. The value is stored untyped; the section's per-column
+  // format (from SectionInfo) decides how it is rendered to a string.
+  struct Cell {
+    enum Kind { kStr, kInt, kDbl } kind = kStr;
+    std::string str;
+    int64_t i = 0;
+    double d = 0;
+    static Cell Str(std::string v) {
+      Cell c;
+      c.kind = kStr;
+      c.str = std::move(v);
+      return c;
+    }
+    static Cell Int(int64_t v) {
+      Cell c;
+      c.kind = kInt;
+      c.i = v;
+      return c;
+    }
+    static Cell Dbl(double v) {
+      Cell c;
+      c.kind = kDbl;
+      c.d = v;
+      return c;
+    }
+  };
+
+ private:
+  void FlushSection();
+
+  FILE* out_;
+  bool overview_;
+  std::string trace_file_;
+
+  bool in_section_ = false;
+  std::string section_title_;
+  std::string row_noun_;
+  int64_t total_rows_ = 0;
+  int64_t shown_rows_ = 0;
+  int64_t total_items_ = 0;
+  std::vector<std::string> columns_;
+  // Per-column format (SectionInfo::ColumnFormat), parallel to columns_.
+  std::vector<int32_t> column_formats_;
+  std::vector<std::vector<Cell>> rows_;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_REPORT_TEXT_RENDERER_H_

--- a/src/trace_processor/shell/report/view_common.h
+++ b/src/trace_processor/shell/report/view_common.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_REPORT_VIEW_COMMON_H_
+#define SRC_TRACE_PROCESSOR_SHELL_REPORT_VIEW_COMMON_H_
+
+#include <cstdint>
+#include <initializer_list>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/trace_processor/basic_types.h"
+#include "protos/perfetto/trace_processor/report.pbzero.h"
+#include "src/trace_processor/shell/report/report_sink.h"
+
+namespace perfetto::trace_processor::shell {
+
+// Escapes a string for inclusion in a single-quoted SQL literal.
+inline std::string EscapeSqlLiteral(const std::string& s) {
+  return base::ReplaceAll(s, "'", "''");
+}
+
+// Declares a section's columns (name + format), in order. A view calls this on
+// its SectionInfo so the renderer takes headers and formatting from the stream
+// rather than from the noun.
+inline void SetColumns(
+    protos::pbzero::SectionInfo* s,
+    std::initializer_list<
+        std::pair<const char*, protos::pbzero::SectionInfo::ColumnFormat>>
+        cols) {
+  for (const auto& [name, format] : cols) {
+    auto* c = s->add_columns();
+    c->set_name(name);
+    c->set_format(format);
+  }
+}
+
+// Serializes |packet| and forwards the bytes to |sink|.
+inline base::Status EmitPacket(
+    ReportSink* sink,
+    protozero::HeapBuffered<protos::pbzero::ReportPacket>* packet) {
+  std::vector<uint8_t> bytes = packet->SerializeAsArray();
+  return sink->OnPacket({bytes.data(), bytes.size()});
+}
+
+// Reads a SqlValue as int64, tolerating null and double-typed results.
+inline int64_t AsI64(const SqlValue& v) {
+  if (v.is_null())
+    return 0;
+  if (v.type == SqlValue::kDouble)
+    return static_cast<int64_t>(v.AsDouble());
+  return v.AsLong();
+}
+
+// Reads a SqlValue as double, tolerating null and long-typed results.
+inline double AsF64(const SqlValue& v) {
+  if (v.is_null())
+    return 0.0;
+  if (v.type == SqlValue::kLong)
+    return static_cast<double>(v.AsLong());
+  return v.AsDouble();
+}
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_REPORT_VIEW_COMMON_H_

--- a/src/trace_processor/shell/report_subcommand.cc
+++ b/src/trace_processor/shell/report_subcommand.cc
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/report_subcommand.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/base/time.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "src/trace_processor/shell/common_flags.h"
+#include "src/trace_processor/shell/metatrace.h"
+#include "src/trace_processor/shell/report/report_sink.h"
+#include "src/trace_processor/shell/report/report_view.h"
+#include "src/trace_processor/shell/report/scope.h"
+#include "src/trace_processor/shell/report/slices_view.h"
+#include "src/trace_processor/shell/report/text_renderer.h"
+#include "src/trace_processor/shell/subcommand.h"
+#include "src/trace_processor/util/simple_json_serializer.h"
+
+namespace perfetto::trace_processor::shell {
+namespace {
+
+template <typename T>
+std::unique_ptr<ReportView> MakeView() {
+  return std::make_unique<T>();
+}
+
+struct ViewEntry {
+  const char* view;
+  std::unique_ptr<ReportView> (*make)();
+};
+
+struct NounSpec {
+  const char* noun;
+  const char* default_view;
+  std::vector<ViewEntry> views;  // empty for the overview, which fans out
+};
+
+// The closed set of nouns and the views implementing them. Registering a view
+// here is all that is needed: running, --format sql and the overview fan-out
+// pick it up automatically.
+const std::vector<NounSpec>& Nouns() {
+  static const auto* nouns = new std::vector<NounSpec>{
+      {"overview", "", {}},
+      {"slices", "flat", {{"flat", &MakeView<SlicesTableView>}}},
+  };
+  return *nouns;
+}
+
+const NounSpec* FindNoun(const std::string& noun) {
+  for (const auto& n : Nouns()) {
+    if (noun == n.noun)
+      return &n;
+  }
+  return nullptr;
+}
+
+std::string NounList() {
+  std::string out;
+  for (const auto& n : Nouns()) {
+    if (!out.empty())
+      out += ", ";
+    out += n.noun;
+  }
+  return out;
+}
+
+std::string ViewList(const NounSpec& spec) {
+  std::string out;
+  for (const auto& v : spec.views) {
+    if (!out.empty())
+      out += ", ";
+    out += v.view;
+  }
+  return out;
+}
+
+bool IsKnownView(const NounSpec& spec, const std::string& view) {
+  for (const auto& v : spec.views) {
+    if (view == v.view)
+      return true;
+  }
+  return false;
+}
+
+// The views to run for a resolved noun/view. For the overview this is every
+// other noun's default view; otherwise the single matching view.
+std::vector<std::unique_ptr<ReportView>> ViewsFor(const std::string& noun,
+                                                  const std::string& view) {
+  std::vector<std::unique_ptr<ReportView>> out;
+  if (noun == "overview") {
+    for (const auto& n : Nouns()) {
+      if (std::string(n.noun) == "overview")
+        continue;
+      for (const auto& e : n.views) {
+        if (std::string(e.view) == n.default_view)
+          out.push_back(e.make());
+      }
+    }
+    return out;
+  }
+  const NounSpec* spec = FindNoun(noun);
+  for (const auto& e : spec->views) {
+    if (view == e.view)
+      out.push_back(e.make());
+  }
+  return out;
+}
+
+}  // namespace
+
+base::StatusOr<ParsedReportArgs> ParseReportArgs(
+    const std::vector<std::string>& positional,
+    bool remote) {
+  // Grammar: report [noun [view]] <trace_file>. The noun and view are parsed
+  // from the front so a leading known noun (e.g. `report slices`) is always
+  // treated as the noun, never as the trace file. The trace file (local mode
+  // only) is whatever remains after the noun/view.
+  ParsedReportArgs args;
+  args.noun = "overview";
+
+  // In local mode one trailing positional is reserved for the trace file.
+  const size_t trace_slots = remote ? 0 : 1;
+
+  size_t i = 0;
+  if (!positional.empty() && FindNoun(positional[0])) {
+    args.noun = positional[i++];
+  } else if (positional.size() > trace_slots) {
+    // The leading token sits in the noun slot (a trace file still follows it)
+    // but is not a known noun.
+    return base::ErrStatus("report: unknown noun '%s'; valid nouns: %s",
+                           positional[0].c_str(), NounList().c_str());
+  }
+  const NounSpec* spec = FindNoun(args.noun);
+  size_t remaining = positional.size() - i;
+
+  // A view is present only if there is a token beyond the trace-file slot.
+  args.view = spec->default_view;
+  if (remaining > trace_slots) {
+    const std::string& view = positional[i];
+    if (!IsKnownView(*spec, view)) {
+      return base::ErrStatus(
+          "report: unknown view '%s' for '%s'; valid views: %s", view.c_str(),
+          args.noun.c_str(), ViewList(*spec).c_str());
+    }
+    args.view = view;
+    ++i;
+    remaining = positional.size() - i;
+  }
+
+  if (!remote) {
+    if (remaining == 0)
+      return base::ErrStatus("report: trace file is required");
+    args.trace_file = positional[i++];
+    remaining = positional.size() - i;
+  }
+  if (remaining > 0) {
+    return base::ErrStatus("report: unexpected argument '%s'",
+                           positional[i].c_str());
+  }
+  return args;
+}
+
+const char* ReportSubcommand::name() const {
+  return "report";
+}
+
+const char* ReportSubcommand::description() const {
+  return "Print opinionated, built-in summaries of a trace.";
+}
+
+const char* ReportSubcommand::usage_args() const {
+  return "[noun [view]] <trace_file>";
+}
+
+const char* ReportSubcommand::detailed_help() const {
+  return R"(Print zero-config summaries over common trace dimensions.
+
+With no noun, prints an overview of what is in the trace. Otherwise pass a
+noun (and optionally a view) to drill in:
+  report slices <trace>            slices aggregated by name
+
+Output is a stream of self-delimited packets. --format selects the encoding:
+text (default, human tables), jsonl (one packet per line), binary
+(length-delimited proto, truncatable), or sql (print the underlying queries
+instead of running them).)";
+}
+
+std::vector<FlagSpec> ReportSubcommand::GetFlags() {
+  return {
+      StringFlag("format", '\0', "FORMAT",
+                 "Output: text (default), jsonl, binary, sql.", &format_),
+      StringFlag("top", '\0', "N", "Max rows per view (default 10).", &top_),
+      StringFlag("name", '\0', "GLOB", "Filter rows by name (GLOB).",
+                 &name_glob_),
+  };
+}
+
+base::Status ReportSubcommand::Run(const SubcommandContext& ctx) {
+  base::Status status = RunInner(ctx);
+  if (status.ok())
+    return status;
+  // Under a JSON encoding, surface failures as a structured error object on
+  // stdout so machine consumers get one shape for success and failure.
+  if (base::CaseInsensitiveEqual(format_, "json") ||
+      base::CaseInsensitiveEqual(format_, "jsonl")) {
+    std::string out = json::SerializeJson([&](json::JsonValueSerializer&& w) {
+      std::move(w).WriteDict([&](json::JsonDictSerializer& d) {
+        d.AddDict("error", [&](json::JsonDictSerializer& e) {
+          e.AddString("message", status.message());
+        });
+      });
+    });
+    printf("%s\n", out.c_str());
+    return base::OkStatus();
+  }
+  return status;
+}
+
+base::Status ReportSubcommand::RunInner(const SubcommandContext& ctx) {
+  bool remote = !ctx.global->remote_addr.empty();
+  ASSIGN_OR_RETURN(ParsedReportArgs args,
+                   ParseReportArgs(ctx.positional_args, remote));
+  const std::string& noun = args.noun;
+  const std::string& trace_file = args.trace_file;
+
+  Scope scope;
+  if (!top_.empty()) {
+    auto parsed = base::StringToInt64(top_);
+    if (!parsed || *parsed <= 0)
+      return base::ErrStatus("report: --top must be a positive integer");
+    scope.top = *parsed;
+  }
+  scope.name_glob = name_glob_;
+
+  std::vector<std::unique_ptr<ReportView>> views = ViewsFor(noun, args.view);
+  const std::string& format = format_.empty() ? std::string("text") : format_;
+
+  // `sql` is a dry run: print each view's query without loading the trace.
+  if (base::CaseInsensitiveEqual(format, "sql")) {
+    for (const auto& v : views)
+      printf("%s;\n", v->Sql(scope).c_str());
+    return base::OkStatus();
+  }
+
+  base::TimeNanos t_load{};
+  ASSIGN_OR_RETURN(auto tp, CreateTraceProcessor(*ctx.global, ctx.platform,
+                                                 trace_file, &t_load));
+
+  bool overview = noun == "overview";
+  std::unique_ptr<ReportSink> sink;
+  if (base::CaseInsensitiveEqual(format, "text")) {
+    sink = std::make_unique<TextSink>(stdout, overview);
+  } else if (base::CaseInsensitiveEqual(format, "binary")) {
+    sink = std::make_unique<BinarySink>(stdout);
+  } else if (base::CaseInsensitiveEqual(format, "jsonl") ||
+             base::CaseInsensitiveEqual(format, "json")) {
+    ASSIGN_OR_RETURN(auto jsonl, JsonlSink::Create(stdout));
+    sink = std::move(jsonl);
+  } else {
+    return base::ErrStatus(
+        "report: unknown --format '%s'; valid formats: text, jsonl, binary, "
+        "sql",
+        format.c_str());
+  }
+
+  RETURN_IF_ERROR(EmitHeader(tp.get(), trace_file, sink.get()));
+  // Skip empty sections only in the overview fan-out.
+  for (const auto& v : views)
+    RETURN_IF_ERROR(v->Emit(tp.get(), scope, sink.get(), overview));
+  RETURN_IF_ERROR(sink->Finalize());
+
+  RETURN_IF_ERROR(MaybeWriteMetatrace(tp.get(), ctx.global->metatrace_path));
+  return base::OkStatus();
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/report_subcommand.h
+++ b/src/trace_processor/shell/report_subcommand.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_REPORT_SUBCOMMAND_H_
+#define SRC_TRACE_PROCESSOR_SHELL_REPORT_SUBCOMMAND_H_
+
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/trace_processor/shell/subcommand.h"
+
+namespace perfetto::trace_processor::shell {
+
+// The resolved noun/view/trace_file from a `report` invocation's positionals.
+struct ParsedReportArgs {
+  std::string noun;
+  std::string view;
+  std::string trace_file;  // empty in --remote mode
+};
+
+// Parses `report [noun [view]] <trace_file>` from |positional|. In local mode
+// (|remote| false) the trace file is the last positional; in --remote mode all
+// positionals are noun/view. Validates the noun/view against the closed set and
+// resolves the default view. Returns an error with the valid options on a bad
+// noun/view or a missing trace file.
+base::StatusOr<ParsedReportArgs> ParseReportArgs(
+    const std::vector<std::string>& positional,
+    bool remote);
+
+// `report`: opinionated, zero-config built-in trace summaries. Emits a stream
+// of self-delimited packets in one of three encodings (human text, JSONL,
+// length-delimited binary).
+class ReportSubcommand : public Subcommand {
+ public:
+  const char* name() const override;
+  const char* description() const override;
+  const char* usage_args() const override;
+  const char* detailed_help() const override;
+  std::vector<FlagSpec> GetFlags() override;
+  base::Status Run(const SubcommandContext& ctx) override;
+
+ private:
+  // The body of Run(); on error under --format json/jsonl, Run() turns its
+  // status into a structured JSON error object instead of a text message.
+  base::Status RunInner(const SubcommandContext& ctx);
+
+  std::string format_;
+  std::string top_;
+  std::string name_glob_;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_REPORT_SUBCOMMAND_H_

--- a/src/trace_processor/shell/report_subcommand_unittest.cc
+++ b/src/trace_processor/shell/report_subcommand_unittest.cc
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/report_subcommand.h"
+
+#include <string>
+#include <vector>
+
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::shell {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(ReportArgsTest, DefaultsToOverview) {
+  auto r = ParseReportArgs({"trace.pb"}, /*remote=*/false);
+  ASSERT_TRUE(r.ok()) << r.status().message();
+  EXPECT_EQ(r->noun, "overview");
+  EXPECT_EQ(r->view, "");
+  EXPECT_EQ(r->trace_file, "trace.pb");
+}
+
+TEST(ReportArgsTest, NounResolvesDefaultView) {
+  auto r = ParseReportArgs({"slices", "trace.pb"}, /*remote=*/false);
+  ASSERT_TRUE(r.ok()) << r.status().message();
+  EXPECT_EQ(r->noun, "slices");
+  EXPECT_EQ(r->view, "flat");
+  EXPECT_EQ(r->trace_file, "trace.pb");
+}
+
+TEST(ReportArgsTest, ExplicitView) {
+  auto r = ParseReportArgs({"slices", "flat", "trace.pb"}, /*remote=*/false);
+  ASSERT_TRUE(r.ok()) << r.status().message();
+  EXPECT_EQ(r->noun, "slices");
+  EXPECT_EQ(r->view, "flat");
+  EXPECT_EQ(r->trace_file, "trace.pb");
+}
+
+TEST(ReportArgsTest, UnknownNoun) {
+  auto r = ParseReportArgs({"bogus", "trace.pb"}, /*remote=*/false);
+  ASSERT_FALSE(r.ok());
+  EXPECT_THAT(r.status().message(), HasSubstr("unknown noun 'bogus'"));
+  EXPECT_THAT(r.status().message(), HasSubstr("slices"));
+}
+
+TEST(ReportArgsTest, UnknownView) {
+  auto r = ParseReportArgs({"slices", "bogus", "trace.pb"}, /*remote=*/false);
+  ASSERT_FALSE(r.ok());
+  EXPECT_THAT(r.status().message(), HasSubstr("unknown view 'bogus'"));
+}
+
+TEST(ReportArgsTest, TooManyArgs) {
+  auto r =
+      ParseReportArgs({"slices", "flat", "extra", "trace.pb"}, /*remote=*/false);
+  ASSERT_FALSE(r.ok());
+  EXPECT_THAT(r.status().message(), HasSubstr("unexpected argument"));
+}
+
+TEST(ReportArgsTest, MissingTraceFile) {
+  auto r = ParseReportArgs({}, /*remote=*/false);
+  ASSERT_FALSE(r.ok());
+  EXPECT_THAT(r.status().message(), HasSubstr("trace file is required"));
+}
+
+TEST(ReportArgsTest, NounWithoutTraceFileIsNotTreatedAsTrace) {
+  // `report slices` (no trace) must treat "slices" as the noun and report a
+  // missing trace file, not try to load a trace named "slices".
+  auto r = ParseReportArgs({"slices"}, /*remote=*/false);
+  ASSERT_FALSE(r.ok());
+  EXPECT_THAT(r.status().message(), HasSubstr("trace file is required"));
+}
+
+TEST(ReportArgsTest, TraceFileNamedLikeNounNeedsExplicitOverview) {
+  // Escape hatch: a trace file literally named "slices" is reachable via the
+  // explicit overview noun.
+  auto r = ParseReportArgs({"overview", "slices"}, /*remote=*/false);
+  ASSERT_TRUE(r.ok()) << r.status().message();
+  EXPECT_EQ(r->noun, "overview");
+  EXPECT_EQ(r->trace_file, "slices");
+}
+
+TEST(ReportArgsTest, RemoteConsumesNoTraceFile) {
+  auto r = ParseReportArgs({"slices"}, /*remote=*/true);
+  ASSERT_TRUE(r.ok()) << r.status().message();
+  EXPECT_EQ(r->noun, "slices");
+  EXPECT_EQ(r->view, "flat");
+  EXPECT_EQ(r->trace_file, "");
+}
+
+TEST(ReportArgsTest, RemoteOverview) {
+  auto r = ParseReportArgs({}, /*remote=*/true);
+  ASSERT_TRUE(r.ok()) << r.status().message();
+  EXPECT_EQ(r->noun, "overview");
+  EXPECT_EQ(r->trace_file, "");
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -60,6 +60,7 @@
 #include "src/trace_processor/shell/metatrace.h"
 #include "src/trace_processor/shell/metrics_subcommand.h"
 #include "src/trace_processor/shell/query_subcommand.h"
+#include "src/trace_processor/shell/report_subcommand.h"
 #include "src/trace_processor/shell/server_subcommand.h"
 #include "src/trace_processor/shell/subcommand.h"
 #include "src/trace_processor/shell/summarize_subcommand.h"
@@ -160,6 +161,7 @@ Commands:
   interactive   Interactive SQL shell (default if no command is given).
   convert       Convert trace format.
   summarize     Compute a trace summary from specs and/or built-in metrics.
+  report        Print opinionated, built-in summaries of a trace.
   bundle        Bundle a trace with symbols and deobfuscation data.
   util          Low-level trace utilities (symbolize, deobfuscate).
   server        Start an RPC server (http or stdio).
@@ -810,6 +812,7 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
     shell::InteractiveSubcommand interactive_subcommand;
     shell::ServerSubcommand server_subcommand;
     shell::SummarizeSubcommand summarize_subcommand;
+    shell::ReportSubcommand report_subcommand;
     shell::ExportSubcommand export_subcommand;
     shell::MetricsSubcommand metrics_subcommand;
     shell::ConvertSubcommand convert_subcommand;
@@ -817,8 +820,9 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
     shell::UtilSubcommand util_subcommand;
     std::vector<shell::Subcommand*> subcommands = {
         &query_subcommand,     &interactive_subcommand, &convert_subcommand,
-        &summarize_subcommand, &bundle_subcommand,      &util_subcommand,
-        &server_subcommand,    &export_subcommand,      &metrics_subcommand,
+        &summarize_subcommand, &report_subcommand,      &bundle_subcommand,
+        &util_subcommand,      &server_subcommand,       &export_subcommand,
+        &metrics_subcommand,
     };
 
     // Handle "help" pseudo-subcommand: `tp help <command>` or bare `tp help`.


### PR DESCRIPTION
Introduce `trace_processor_shell report`, an opinionated zero-config
summary tool alongside `summarize`. Output is a stream of self-delimited
ReportPacket protos (report.proto), modeled on the trace format so it is
truncatable and incrementally parseable. The single schema is emitted in
four encodings via --format: text (human tables), jsonl (one packet per
line), binary (length-delimited), and sql (print the underlying queries
without running them).

Views implement a small ReportView interface (Sql + Emit) and are
registered in a noun table, so running, --format sql and the overview
fan-out apply to every view uniformly. This adds the framework and the
first view: slices aggregated by name.
