### PR TITLE
Fix bug in Flow::ProcessScoped() with named scope

### DIFF
--- a/include/perfetto/tracing/track_event_args.h
+++ b/include/perfetto/tracing/track_event_args.h
@@ -40,7 +40,7 @@ class FlowImpl {
   static PERFETTO_ALWAYS_INLINE inline FlowImpl ProcessScoped(
       uint64_t flow_id,
       const char* named_scope) {
-    return Global(flow_id, named_scope);
+    return Global(flow_id ^ Track::process_uuid, named_scope);
   }
 
   // Same as above, but construct an id from a pointer.


### PR DESCRIPTION
`Flow::ProcessScoped(flow_id, named_scope)` currently fails to xor the process track ID with the flow ID and instead is acting a pass-through wrapper on `Flow::Global(flow_id, named_scope)`.  Users of `Flow::ProcessScoped(flow_id, named_scope)` will currently get collisions if the same flow ID and named scope are used simultaneously across different processes.