### PR TITLE
tp: show address @ mapping for unsymbolized callstack frames

### DIFF
--- a/src/trace_processor/importers/pprof/pprof_trace_reader.cc
+++ b/src/trace_processor/importers/pprof/pprof_trace_reader.cc
@@ -65,7 +65,6 @@ struct FunctionInfo {
 
 PprofTraceReader::PprofTraceReader(TraceProcessorContext* context)
     : context_(context),
-      unknown_string_id_(context->storage->InternString("[unknown]")),
       unknown_no_brackets_string_id_(context->storage->InternString("unknown")),
       count_string_id_(context->storage->InternString("count")),
       pprof_file_string_id_(context->storage->InternString("pprof_file")) {}
@@ -129,7 +128,7 @@ base::Status PprofTraceReader::ParseProfile() {
 
     StringId filename_id = mapping_decoder.has_filename()
                                ? lookup_string_id(mapping_decoder.filename())
-                               : unknown_string_id_;
+                               : kNullStringId;
     StringId build_id_id = mapping_decoder.has_build_id()
                                ? lookup_string_id(mapping_decoder.build_id())
                                : kNullStringId;
@@ -160,7 +159,7 @@ base::Status PprofTraceReader::ParseProfile() {
 
     functions[func_decoder.id()] = {
         func_decoder.has_name() ? lookup_string_id(func_decoder.name())
-                                : unknown_string_id_,
+                                : kNullStringId,
         func_decoder.has_filename() ? lookup_string_id(func_decoder.filename())
                                     : kNullStringId,
         func_decoder.has_start_line() ? func_decoder.start_line() : 0};
@@ -182,11 +181,12 @@ base::Status PprofTraceReader::ParseProfile() {
       }
     }
     if (!mapping) {
-      mapping = &context_->mapping_tracker->CreateDummyMapping("[unknown]");
+      mapping = &context_->mapping_tracker->CreateDummyMapping("");
     }
 
-    // Extract function information from the first line for frame name
-    StringId frame_name_id = unknown_string_id_;
+    // Extract function information from the first line for frame name. Leave it
+    // empty when unsymbolized so downstream renders the address and mapping.
+    StringId frame_name_id = kNullStringId;
     for (auto line_it = loc_decoder.line(); line_it; ++line_it) {
       const Line::Decoder line_decoder(*line_it);
       if (!line_decoder.has_function_id()) {

--- a/src/trace_processor/importers/pprof/pprof_trace_reader.h
+++ b/src/trace_processor/importers/pprof/pprof_trace_reader.h
@@ -46,7 +46,6 @@ class PprofTraceReader : public ChunkedTraceReader {
   bool parsed_any_data_ = false;
 
   // Constant strings interned at construction time
-  const StringId unknown_string_id_;
   const StringId unknown_no_brackets_string_id_;
   const StringId count_string_id_;
   const StringId pprof_file_string_id_;

--- a/src/trace_processor/perfetto_sql/stdlib/callstacks/stack_profile.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/callstacks/stack_profile.sql
@@ -81,10 +81,17 @@ SELECT
     'REGEXP: ' || rc.pattern,
     'V8: ' || v8c.function_name,
     'JIT: ' || jc.function_name,
-    demangle(coalesce(s.name, f.deobfuscated_name, f.name)),
-    coalesce(s.name, f.deobfuscated_name, f.name, '[Unknown]')
+    __intrinsic_frame_name(
+      s.name,
+      f.deobfuscated_name,
+      f.name,
+      s.source_file,
+      f.rel_pc,
+      m.name
+    )
   ) AS name,
   f.mapping AS mapping_id,
+  m.name AS mapping_name,
   s.source_file,
   coalesce(jsf.line, s.line_number) AS line_number,
   coalesce(jsf.col, 0) AS column_number,
@@ -94,6 +101,8 @@ SELECT
 FROM _callstack_spc_raw_forest AS c
 JOIN stack_profile_frame AS f
   ON c.frame_id = f.id
+JOIN stack_profile_mapping AS m
+  ON f.mapping = m.id
 LEFT JOIN _v8_js_code AS jsc USING (jit_code_id)
 LEFT JOIN v8_js_function AS jsf USING (v8_js_function_id)
 LEFT JOIN _v8_internal_code AS v8c USING (jit_code_id)
@@ -131,7 +140,7 @@ AS (
     f.parent_id,
     f.callsite_id,
     f.name,
-    m.name AS mapping_name,
+    f.mapping_name,
     f.source_file,
     f.line_number,
     f.inlined,
@@ -147,8 +156,6 @@ AS (
   ) AS g
   JOIN _callstack_spc_forest AS f
     USING (id)
-  JOIN stack_profile_mapping AS m
-    ON f.mapping_id = m.id
 );
 
 CREATE PERFETTO MACRO _callstacks_for_callsites(samples TableOrSubquery)

--- a/src/trace_processor/plugins/utils_functions/utils_functions.cc
+++ b/src/trace_processor/plugins/utils_functions/utils_functions.cc
@@ -17,6 +17,7 @@
 #include "src/trace_processor/plugins/utils_functions/utils_functions.h"
 
 #include <cerrno>
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -229,6 +230,92 @@ void Demangle::Step(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
           ctx, "Unsupported type of arg passed to DEMANGLE");
   }
 }
+
+// Resolves the display name of a callstack frame. Args (all nullable):
+//   0: symbol name, 1: deobfuscated name, 2: frame name,
+//   3: source file, 4: rel_pc, 5: mapping name.
+// The first non-empty of the three names is demangled if possible, else used
+// as-is. If there is no name but there is source info (e.g. an anonymous JS
+// function), the empty string is returned. Otherwise the frame is treated as an
+// unsymbolized native frame and rendered as '0x<rel_pc>' optionally followed by
+// ' @ <mapping basename>', e.g. '0x1a2b @ libfoo.so'.
+struct FrameName : public sqlite::Function<FrameName> {
+  static constexpr char kName[] = "__intrinsic_frame_name";
+  static constexpr int kArgCount = 6;
+
+  static void Step(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
+    PERFETTO_DCHECK(argc == 6);
+
+    // Prefer the first non-empty of symbol / deobfuscated / frame name.
+    for (int i = 0; i < 3; ++i) {
+      if (sqlite::value::Type(argv[i]) != sqlite::Type::kText) {
+        continue;
+      }
+      const char* name = sqlite::value::Text(argv[i]);
+      if (!name || name[0] == '\0') {
+        continue;
+      }
+      // Demangling dominates runtime on big traces, so only attempt it for
+      // names that could plausibly be mangled: every scheme the demangler
+      // understands (Itanium '_Z', Rust '_R', D '_D', MSVC '?') starts with
+      // '_' or '?'. On success we hand off the malloc'd buffer, so SQLite does
+      // not copy it.
+      if (name[0] == '_' || name[0] == '?') {
+        if (std::unique_ptr<char, base::FreeDeleter> demangled =
+                demangle::Demangle(name)) {
+          int len = static_cast<int>(strlen(demangled.get()));
+          return sqlite::result::RawString(ctx, demangled.release(), len, free);
+        }
+      }
+      // Not mangled: return the text as-is. A transient copy is unavoidable
+      // (the pointer is only valid for this call) but is cheaper than dup'ing
+      // the whole sqlite3_value.
+      return sqlite::result::TransientString(ctx, name,
+                                             sqlite::value::Bytes(argv[i]));
+    }
+
+    // No name. Keep symbolized-but-anonymous frames (those with source info)
+    // empty rather than synthesizing a meaningless address.
+    if (sqlite::value::Type(argv[3]) == sqlite::Type::kText) {
+      return sqlite::result::StaticString(ctx, "", 0);
+    }
+
+    // Unsymbolized native frame: '0x<rel_pc>' optionally followed by
+    // ' @ <mapping basename>'. Assemble it into a single owned buffer that is
+    // handed off to SQLite, avoiding both a std::string and a result copy.
+    int64_t rel_pc = sqlite::value::Type(argv[4]) == sqlite::Type::kInteger
+                         ? sqlite::value::Int64(argv[4])
+                         : 0;
+    base::StackString<20> addr("0x%" PRIx64, rel_pc);
+
+    std::string_view base;
+    if (sqlite::value::Type(argv[5]) == sqlite::Type::kText) {
+      std::string_view mapping = sqlite::value::Text(argv[5]);
+      if (!mapping.empty()) {
+        size_t slash = mapping.find_last_of('/');
+        base = slash == std::string_view::npos ? mapping
+                                               : mapping.substr(slash + 1);
+      }
+    }
+
+    static constexpr std::string_view kSep = " @ ";
+    size_t suffix_len = base.empty() ? 0 : kSep.size() + base.size();
+    char* buf = static_cast<char*>(malloc(addr.len() + suffix_len + 1));
+    if (!buf) {
+      return sqlite::utils::SetError(ctx, "FRAME_NAME: out of memory");
+    }
+    memcpy(buf, addr.c_str(), addr.len());
+    size_t len = addr.len();
+    if (!base.empty()) {
+      memcpy(buf + len, kSep.data(), kSep.size());
+      len += kSep.size();
+      memcpy(buf + len, base.data(), base.size());
+      len += base.size();
+    }
+    buf[len] = '\0';
+    return sqlite::result::RawString(ctx, buf, static_cast<int>(len), free);
+  }
+};
 
 struct WriteFile : public sqlite::Function<WriteFile> {
   static constexpr char kName[] = "write_file";
@@ -485,6 +572,7 @@ class UtilsFunctionsPlugin : public Plugin<UtilsFunctionsPlugin> {
     out.push_back(MakeFunctionRegistration<Reverse>(nullptr));
     out.push_back(MakeFunctionRegistration<Base64Encode>(nullptr));
     out.push_back(MakeFunctionRegistration<Demangle>(nullptr));
+    out.push_back(MakeFunctionRegistration<FrameName>(nullptr));
     out.push_back(MakeFunctionRegistration<TablePtrBind>(nullptr));
     out.push_back(MakeFunctionRegistration<Glob>(nullptr));
     out.push_back(MakeFunctionRegistration<Regexp>(nullptr));

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -166,6 +166,7 @@ from diff_tests.stdlib.prelude.args_functions_tests import ArgsFunctions
 from diff_tests.stdlib.prelude.math_functions_tests import PreludeMathFunctions
 from diff_tests.stdlib.prelude.package_lookup_tests import PackageLookup
 from diff_tests.stdlib.prelude.pprof_functions_tests import PreludePprofFunctions
+from diff_tests.stdlib.prelude.frame_name import FrameName
 from diff_tests.stdlib.prelude.regexp_extract import RegexpExtract
 from diff_tests.stdlib.prelude.regexp_replace_simple import RegexpReplaceSimple
 from diff_tests.stdlib.prelude.slices_tests import PreludeSlices
@@ -350,6 +351,7 @@ def fetch_all_diff_tests(
       UnHex,
       PreludePprofFunctions,
       PreludeWindowFunctions,
+      FrameName,
       RegexpExtract,
       RegexpReplaceSimple,
       Pkvm,

--- a/test/trace_processor/diff_tests/parser/simpleperf/tests.py
+++ b/test/trace_processor/diff_tests/parser/simpleperf/tests.py
@@ -368,16 +368,16 @@ class Simpleperf(TestSuite):
         ''',
         out=Csv('''
           "id","parent_id","name","mapping_name","source_file","line_number","self_count","cumulative_count"
-          0,"[NULL]","","/elf","[NULL]","[NULL]",84,84
-          1,"[NULL]","","/elf","[NULL]","[NULL]",69,69
-          2,"[NULL]","","/elf","[NULL]","[NULL]",177,177
-          3,"[NULL]","","/elf","[NULL]","[NULL]",89,89
-          4,"[NULL]","","/t1","[NULL]","[NULL]",70,70
-          5,"[NULL]","","/elf","[NULL]","[NULL]",218,218
-          6,"[NULL]","","/elf","[NULL]","[NULL]",65,65
-          7,"[NULL]","","/elf","[NULL]","[NULL]",70,70
-          8,"[NULL]","","/t1","[NULL]","[NULL]",87,87
-          9,"[NULL]","","/elf","[NULL]","[NULL]",64,64
+          0,"[NULL]","0x513 @ elf","/elf","[NULL]","[NULL]",84,84
+          1,"[NULL]","0x4f7 @ elf","/elf","[NULL]","[NULL]",69,69
+          2,"[NULL]","0x51c @ elf","/elf","[NULL]","[NULL]",177,177
+          3,"[NULL]","0x513 @ elf","/elf","[NULL]","[NULL]",89,89
+          4,"[NULL]","0x4f7 @ t1","/t1","[NULL]","[NULL]",70,70
+          5,"[NULL]","0x51c @ elf","/elf","[NULL]","[NULL]",218,218
+          6,"[NULL]","0x518 @ elf","/elf","[NULL]","[NULL]",65,65
+          7,"[NULL]","0x4ed @ elf","/elf","[NULL]","[NULL]",70,70
+          8,"[NULL]","0x518 @ t1","/t1","[NULL]","[NULL]",87,87
+          9,"[NULL]","0x523 @ elf","/elf","[NULL]","[NULL]",64,64
         '''))
 
   def test_global_counters(self):

--- a/test/trace_processor/diff_tests/stdlib/prelude/frame_name.py
+++ b/test/trace_processor/diff_tests/stdlib/prelude/frame_name.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import Path, DataPath, Metric
+from python.generators.diff_tests.testing import Csv, Json, TextProto
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class FrameName(TestSuite):
+
+  def test_frame_name(self):
+    return DiffTestBlueprint(
+        trace=TextProto(''),
+        query="""
+        SELECT
+          -- A symbol name is preferred and demangled.
+          __intrinsic_frame_name('_Z3foov', NULL, 'raw', NULL, 100,
+            '/a/b/libx.so') AS symbol,
+          -- A non-mangled name is kept as-is.
+          __intrinsic_frame_name(NULL, NULL, 'my_func', NULL, 100,
+            '/a/b/libx.so') AS raw_name,
+          -- The deobfuscated name wins over an empty frame name.
+          __intrinsic_frame_name(NULL, 'com.Foo.bar', '', NULL, 100,
+            '/a/b/libx.so') AS deobfuscated,
+          -- Unsymbolized native frame: address plus the mapping basename.
+          __intrinsic_frame_name(NULL, NULL, '', NULL, 6699,
+            '/apex/x/lib64/libart.so') AS unsym_mapping,
+          -- Unsymbolized native frame with no mapping name: just the address.
+          __intrinsic_frame_name(NULL, NULL, '', NULL, 4660, '') AS unsym_empty,
+          __intrinsic_frame_name(NULL, NULL, NULL, NULL, 4660, NULL)
+            AS unsym_null,
+          -- No name but source info present (e.g. anonymous JS): kept empty.
+          __intrinsic_frame_name(NULL, NULL, '', 'http://x/y.js', 0, NULL)
+            AS anonymous
+        """,
+        out=Csv("""
+        "symbol","raw_name","deobfuscated","unsym_mapping","unsym_empty","unsym_null","anonymous"
+        "foo()","my_func","com.Foo.bar","0x1a2b @ libart.so","0x1234","0x1234",""
+        """))

--- a/ui/src/plugins/dev.perfetto.HeapProfile/oome_callstack_common.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/oome_callstack_common.ts
@@ -45,11 +45,14 @@ export function buildOomeCallstackMetrics(
         SELECT
           cs.id,
           cs.parentId,
-          coalesce(f.deobfuscated_name, f.name) as name,
+          __intrinsic_frame_name(
+            s.name, f.deobfuscated_name, f.name, s.source_file, f.rel_pc, m.name
+          ) as name,
           iif(cs.depth = (select max(depth) from callstack), 1, 0) as value,
           s.source_file || ':' || cast(s.line_number as text) as source_location
         FROM callstack cs
         JOIN stack_profile_frame f ON cs.frame_id = f.id
+        JOIN stack_profile_mapping m ON f.mapping = m.id
         LEFT JOIN stack_profile_symbol s ON f.symbol_set_id = s.symbol_set_id
       `,
       unaggregatableProperties: [],

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/native_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/native_section.ts
@@ -243,7 +243,9 @@ async function loadNativeStacks(
       CAST(c.unreleased AS INT) AS unreleased,
       CAST(c.allocs AS INT) AS allocs,
       c.depth AS depth,
-      coalesce(f.deobfuscated_name, f.name, '<unknown>') AS frame_name,
+      __intrinsic_frame_name(
+        NULL, f.deobfuscated_name, f.name, NULL, f.rel_pc, mp.name
+      ) AS frame_name,
       mp.name AS mapping_name
     FROM chain c
     JOIN stack_profile_callsite sc ON sc.id = c.callsite_id

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/callstack_details_section.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/callstack_details_section.ts
@@ -18,7 +18,7 @@ import type {TrackEventSelection} from '../../public/selection';
 import type {TrackEventDetailsPanelSection} from '../../components/details/thread_slice_details_tab';
 import {Section} from '../../widgets/section';
 import {Tree, TreeNode} from '../../widgets/tree';
-import {STR_NULL, NUM_NULL} from '../../trace_processor/query_result';
+import {STR, STR_NULL, NUM_NULL} from '../../trace_processor/query_result';
 
 interface CallstackFrame {
   name: string;
@@ -96,13 +96,13 @@ export class CallstackDetailsSection implements TrackEventDetailsPanelSection {
     `);
     const frames: CallstackFrame[] = [];
     const it = result.iter({
-      name: STR_NULL,
+      name: STR,
       sourceFile: STR_NULL,
       lineNumber: NUM_NULL,
     });
     for (; it.valid(); it.next()) {
       frames.push({
-        name: it.name ?? '<unknown>',
+        name: it.name,
         sourceFile: it.sourceFile ?? undefined,
         lineNumber: it.lineNumber ?? undefined,
       });


### PR DESCRIPTION
Previously an unsymbolized callstack frame was rendered as the placeholder
'[Unknown]' (or an empty name). Instead, resolve such frames to
'0x<rel_pc> @ <mapping basename>', e.g. '0x1a2b @ libart.so', so
unsymbolized native traces still convey the address and library.

Name resolution now lives in a single __intrinsic_frame_name C++ function
called from the callstacks.stack_profile forest, replacing the nested
coalesce/demangle/iif SQL. This flows to every flamegraph built on the
module (CPU profile, heap profile, perf, track event callstacks). Frames
that have source info but no name (e.g. anonymous JS functions) are kept
as-is rather than given a meaningless address. The intrinsic only attempts
demangling for names that can actually be mangled and hands owned buffers
to SQLite to avoid result copies.

The remaining paths are routed through the same intrinsic for consistency:
the pprof importer now stores an empty frame name (and empty dummy mapping
name) instead of '[unknown]', so its already-imported addresses and
mappings surface; and the OOME, Memscope native, and track-event callstack
UI paths call the intrinsic instead of their own name fallbacks.
