### PR TITLE
ui: Add status field to allow plugins to be marked experimental

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.scss
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.scss
@@ -80,4 +80,9 @@
     text-decoration: none;
     color: inherit;
   }
+
+  &__warning {
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
 }

--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.ts
@@ -36,6 +36,7 @@ import {Icon} from '../../widgets/icon';
 import {Icons} from '../../base/semantic_icons';
 import {GateDetector} from '../../base/mithril_utils';
 import {findRef} from '../../base/dom_utils';
+import {Callout} from '../../widgets/callout';
 
 const SEARCH_BOX_REF = 'plugin-search-box';
 
@@ -300,16 +301,28 @@ export class PluginsPage implements m.ClassComponent<PluginsPageAttrs> {
       this.dependenciesByPluginId.get(plugin.desc.id) ?? [];
     const dependantPlugins =
       this.dependantsByPluginId.get(plugin.desc.id) ?? [];
+    const isExperimental = plugin.desc.status === 'experimental';
     return m(SettingsCard, {
       key: plugin.desc.id,
       id: plugin.desc.id,
       className: classNames(
         'pf-plugins-page__card',
         plugin.enableFlag.get() && 'pf-plugins-page__card--enabled',
+        isExperimental && 'pf-plugins-page__card--experimental',
       ),
       title: plugin.desc.id,
       linkHref: `#!/plugins/${encodeURIComponent(plugin.desc.id)}`,
       description: [
+        isExperimental &&
+          m(
+            Callout,
+            {
+              className: 'pf-plugins-page__warning',
+              icon: 'warning',
+              intent: Intent.Danger,
+            },
+            ' This plugin is experimental and may contain unstable features.',
+          ),
         plugin.desc.description?.trim(),
         this.renderPluginIdList(
           'Requires',

--- a/ui/src/plugins/dev.perfetto.Intelletto/index.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/index.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import type {ZodRawShape} from 'zod';
-import type {PerfettoPlugin} from '../../public/plugin';
+import type {PerfettoPlugin, PluginStatus} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import LlmPlugin from '../dev.perfetto.Llm';
 import QueryPagePlugin from '../dev.perfetto.QueryPage';
@@ -48,6 +48,7 @@ export default class IntellettoPlugin
     'it queries the trace and drives the UI. Requires the dev.perfetto.Llm ' +
     'gateway and an LLM protocol plugin. Other plugins can register their own ' +
     'tools via getPlugin(IntellettoPlugin).registerTool().';
+  static readonly status: PluginStatus = 'experimental';
   static readonly dependencies = [
     LlmPlugin,
     QueryPagePlugin,

--- a/ui/src/plugins/dev.perfetto.Memscope/index.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/index.ts
@@ -15,7 +15,7 @@
 import './styles.scss';
 import m from 'mithril';
 import type {App} from '../../public/app';
-import type {PerfettoPlugin} from '../../public/plugin';
+import type {PerfettoPlugin, PluginStatus} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import RecordPageV2 from '../dev.perfetto.RecordTraceV2';
 import {ConnectionPage} from './views/connection';
@@ -28,6 +28,7 @@ export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.Memscope';
   static readonly description =
     'Live memory profiler for Android/Linux devices';
+  static readonly status: PluginStatus = 'experimental';
   static readonly dependencies = [RecordPageV2];
 
   static onActivate(app: App) {

--- a/ui/src/public/plugin.ts
+++ b/ui/src/public/plugin.ts
@@ -17,6 +17,14 @@ import type {App} from './app';
 import type {RouteArgs} from './route_schema';
 
 /**
+ * Indicates the maturity/stability of a plugin.
+ *
+ * - 'experimental': The plugin is in development and may contain unstable or
+ *   incomplete features. Users will see a warning when enabling such plugins.
+ */
+export type PluginStatus = 'experimental';
+
+/**
  * This interface defines the shape of the plugins's class constructor (i.e. the
  * the constructor and all static members of the plugin's class.
  *
@@ -28,6 +36,13 @@ import type {RouteArgs} from './route_schema';
 export interface PerfettoPluginStatic<T extends PerfettoPlugin> {
   readonly id: string;
   readonly description?: string;
+  /**
+   * Optional status flag indicating the maturity of this plugin.
+   * When set to 'experimental', users will see a warning that enabling
+   * this plugin may expose experimental or unstable features.
+   * Defaults to stable (no warning) when not specified.
+   */
+  readonly status?: PluginStatus;
   readonly dependencies?: ReadonlyArray<PerfettoPluginStatic<PerfettoPlugin>>;
   onActivate?(app: App, args: RouteArgs): void;
   new (trace: Trace): T;


### PR DESCRIPTION
Add a status field to plugins to indicate maturity & add warning in the plugins page. Also apply the experimental status to the memscope and intelletto plugins.