### PR TITLE
tp: set android_aflags_errors as kError

### DIFF
--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -24,8 +24,7 @@ namespace perfetto::trace_processor::stats {
 // Compile time list of parsing and processing stats.
 // clang-format off
 #define PERFETTO_TP_STATS(F)                                                   \
-  /* TODO(b/512786856): Restore severity to kError after flag rollout. */    \
-  F(android_aflags_errors,               kSingle,  kInfo,     kTrace, Scope::kMachineAndTrace,          \
+  F(android_aflags_errors,               kSingle,  kError,     kTrace, Scope::kMachineAndTrace,         \
        "Errors occurred during the collection of Android aconfig flags by the "\
        "android.aflags data source. This typically happens if the aflags tool "\
        "fails or its output is malformed."),                                   \

--- a/test/trace_processor/diff_tests/parser/android/tests_aflags.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_aflags.py
@@ -71,5 +71,5 @@ class AndroidAflags(TestSuite):
         """,
         out=Csv("""
         "ts","name","severity","display_value"
-        2000,"android_aflags_errors","info","Failed to read aflags"
+        2000,"android_aflags_errors","error","Failed to read aflags"
         """))


### PR DESCRIPTION
ag/40948436 removes the flag aflags_list_proto so going onwards safe to set it back as kError