### PR TITLE
ui: Don't attempt to render the timeline canvas when its size is 0

### DIFF
--- a/ui/src/widgets/virtual_overlay_canvas.ts
+++ b/ui/src/widgets/virtual_overlay_canvas.ts
@@ -304,6 +304,14 @@ export class VirtualOverlayCanvas
     const virtualCanvas = ensureExists(this.virtualCanvas);
     const attrs = ensureExists(this.attrs);
     const containerElement = ensureExists(this.dom);
+    const canvasSize = virtualCanvas.size;
+
+    // If the canavs size is 0, just don't render anything. This either means
+    // the canavs element is hidden (has no layout) or it genuinely is 0. Either
+    // way - there's nothing to be gained from rendering to it.
+    if (canvasSize.height <= 0 || canvasSize.width <= 0) {
+      return;
+    }
 
     // Create the appropriate renderer: WebGLRenderer if available, otherwise
     // Canvas2DRenderer as fallback.


### PR DESCRIPTION
When looking at another page after visiting the timeline page, we get a flurry of`GL_INVALID_VALUE : glScissor: width < 0` errors printed to the console. This might be hiding other errors or causing issues itself.

This patch adds an early exit from the render function if the canvas size is 0.

Fixes: b/534259857