### PR TITLE
sdk: enable SHLIB export in amalgamated output

### DIFF
--- a/include/perfetto/public/abi/export.h
+++ b/include/perfetto/public/abi/export.h
@@ -31,7 +31,7 @@
 // line):
 // * PERFETTO_SDK_DISABLE_SHLIB_EXPORT: If this is defined, no export
 //   annotations are added. This might be useful when static linking.
-// * PERFETTO_SDK_SHLIB_IMPLEMENTATION: This must be defined when compiling the
+// * PERFETTO_SHLIB_SDK_IMPLEMENTATION: This must be defined when compiling the
 //   shared library itself (in order to export the symbols), but must be
 //   undefined when compiling objects that use the shared library (in order to
 //   import the symbols).

--- a/tools/gen_amalgamated
+++ b/tools/gen_amalgamated
@@ -51,8 +51,12 @@ c_sdk_header_preamble = [
     '#define _GNU_SOURCE',
     '#endif',
     '',
-    '// Disable shared library export annotations for static linking.',
+    '// Disable shared library export annotations for static linking, unless we are',
+    '// building the SDK as a shared library (PERFETTO_SHLIB_SDK_IMPLEMENTATION is',
+    '// defined by the build when compiling the shared library itself).',
+    '#if !defined(PERFETTO_SHLIB_SDK_IMPLEMENTATION)',
     '#define PERFETTO_SDK_DISABLE_SHLIB_EXPORT',
+    '#endif',
     '',
 ]
 


### PR DESCRIPTION
gen_amalgamated is unconditionally prepending

#define PERFETTO_SDK_DISABLE_SHLIB_EXPORT

...assuming that the C SDK will be used only in a static linking
scenario. However, for the use case of building a shared library from
the amalgamated C SDK, this prevents to control symbol visibility via
PERFETTO_SDK_EXPORT.

Change this to only define PERFETTO_SDK_DISABLE_SHLIB_EXPORT when
PERFETTO_SHLIB_SDK_IMPLEMENTATION is not set, so the default static
linkage keeps PERFETTO_SDK_EXPORT empty while shared library builds
get proper export annotations.

Also attach a drive-by documentation fix.