### PR TITLE
docs: speed up docs-site search

### DIFF
--- a/infra/perfetto.dev/BUILD.gn
+++ b/infra/perfetto.dev/BUILD.gn
@@ -399,11 +399,11 @@ group("all_mdfiles") {
   deps = mdtargets
 }
 
-# Builds assets/search_index.json, the client-side full-text search index
+# Builds assets/search_index.json.gz, the client-side full-text search index
 # consumed by setupSearch() in src/assets/script.js. Hand-written docs are
 # indexed in full; the huge auto-generated reference pages (SQL tables, stdlib,
 # protos) are indexed by title + headings only to keep the shipped index small.
-gen_search_index_out = "${perfetto_website_out_dir}/assets/search_index.json"
+gen_search_index_out = "${perfetto_website_out_dir}/assets/search_index.json.gz"
 
 nodejs_script("gen_search_index") {
   script = "src/gen_search_index.js"

--- a/infra/perfetto.dev/mime_util/file
+++ b/infra/perfetto.dev/mime_util/file
@@ -21,6 +21,7 @@ def main():
       '.html': 'text/html',
       '.css': 'text/css',
       '.js': 'text/javascript',
+      '.gz': 'application/gzip',
       '.jpg': 'image/jpeg',
       '.png': 'image/png',
       '.svg': 'image/svg+xml',

--- a/infra/perfetto.dev/src/assets/script.js
+++ b/infra/perfetto.dev/src/assets/script.js
@@ -374,7 +374,7 @@ function initMermaid() {
 
 // ---------------------------------------------------------------------------
 // Client-side docs search. We ship a build-time full-text index
-// (assets/search_index.json, built by src/gen_search_index.js) and rank it
+// (assets/search_index.json.gz, built by src/gen_search_index.js) and rank it
 // locally with BM25. The old Google Custom Search Engine couldn't see a doc
 // until Googlebot crawled it, often weeks after it shipped.
 // ---------------------------------------------------------------------------
@@ -396,58 +396,36 @@ function searchTokenize(str) {
 }
 
 async function loadSearchIndex() {
-  const resp = await fetch("/assets/search_index.json");
+  const resp = await fetch("/assets/search_index.json.gz");
   if (!resp.ok) throw new Error(`search index HTTP ${resp.status}`);
-  const docs = (await resp.json()).docs;
+  // The server doesn't gzip this file, so it's gzipped at build time and
+  // decompressed here.
+  const stream = resp.body.pipeThrough(new DecompressionStream("gzip"));
+  const data = await new Response(stream).json();
 
-  // Field boosts: a hit in the title matters far more than one in the body.
-  const FIELD_BOOST = {title: 8, heading: 4, body: 1};
-  const postings = new Map();
-  const docLen = new Array(docs.length).fill(0);
-  const titleTokens = new Array(docs.length);
-  const navTokens = new Array(docs.length);
-  const addTokens = (docIdx, tokens, boost) => {
-    for (const tok of tokens) {
-      let postingList = postings.get(tok);
-      if (postingList === undefined) {
-        postingList = new Map();
-        postings.set(tok, postingList);
-      }
-      postingList.set(docIdx, (postingList.get(docIdx) || 0) + boost);
-      docLen[docIdx] += boost;
+  const postings = new Map();  // token -> Map(docIdx -> weight)
+  for (let i = 0; i < data.terms.length; i++) {
+    const flat = data.post[i];
+    const postingList = new Map();
+    for (let j = 0; j < flat.length; j += 2) {
+      const docIdx = flat[j];
+      const weight = flat[j + 1];
+      postingList.set(docIdx, weight);
     }
-  };
-  for (let i = 0; i < docs.length; i++) {
-    const d = docs[i];
-    const tt = searchTokenize(d.t || "");
-    titleTokens[i] = tt;
-    addTokens(i, tt, FIELD_BOOST.title);
-    // The toc.md nav label (d.n), when it differs from the title, is a curated
-    // keyword alias -- index it at title weight too.
-    if (d.n) {
-      navTokens[i] = searchTokenize(d.n);
-      addTokens(i, navTokens[i], FIELD_BOOST.title);
-    }
-    // The URL slug (last path segment, e.g. "perfetto-cli", "stdlib-docs") is a
-    // curated keyword, often searched even when the word never appears in the
-    // prose. searchTokenize splits it on the "-"/"_"; index it at title weight.
-    const slug = d.u.split("/").filter(Boolean).pop() || "";
-    addTokens(i, searchTokenize(slug), FIELD_BOOST.title);
-    for (const h of d.h || []) addTokens(i, searchTokenize(h.t), FIELD_BOOST.heading);
-    if (d.b) addTokens(i, searchTokenize(d.b), FIELD_BOOST.body);
+    postings.set(data.terms[i], postingList);
   }
+
   let total = 0;
-  for (const l of docLen) total += l;
+  for (const l of data.docLen) total += l;
   searchIndex = {
-    docs,
+    docs: data.docs,
     postings,
-    // Sorted so searchPostings() can binary-search the prefix range.
-    sortedTerms: [...postings.keys()].sort(),
-    docLen,
-    titleTokens,
-    navTokens,
-    avgdl: docLen.length ? total / docLen.length : 1,
-    N: docs.length,
+    sortedTerms: data.terms,  // Already sorted at build time.
+    docLen: data.docLen,
+    titleTokens: data.titleTokens,
+    navTokens: data.navTokens,
+    avgdl: data.docLen.length ? total / data.docLen.length : 1,
+    N: data.docs.length,
   };
   return searchIndex;
 }
@@ -664,20 +642,28 @@ function setupSearch() {
       searchRes.innerHTML = "";
       return;
     }
+    // Show a placeholder while the index loads, so a slow first search looks
+    // like it's working rather than broken.
+    if (searchIndex === null) {
+      searchRes.style.width = `${searchBox.offsetWidth}px`;
+      searchRes.innerHTML = '<div class="sr-loading">Loading search index…</div>';
+    }
     let idx;
     try {
       idx = await ensureSearchIndex();
     } catch (e) {
-      return;  // Index failed to load; leave the box empty rather than error.
+      console.error("Docs search: could not load the index.", e);
+      searchRes.innerHTML = "";  // Clear the placeholder if loading failed.
+      return;
     }
     if (searchBox.value.trim() !== query) return;  // A newer query superseded us.
     results = searchRank(idx, query, 8);
     render(query);
   };
 
-  // Start fetching the index as soon as the user engages with the box.
-  searchBox.addEventListener("focus", () => { ensureSearchIndex().catch(() => {}); },
-                             {once: true});
+  // Start loading the index now, so the first search doesn't wait on the
+  // download. runSearch() shows a placeholder if the user types before it lands.
+  ensureSearchIndex().catch(() => {});
 
   let timerId = -1;
   searchBox.addEventListener("input", () => {

--- a/infra/perfetto.dev/src/assets/style.scss
+++ b/infra/perfetto.dev/src/assets/style.scss
@@ -271,6 +271,11 @@ h3 {
       color: var(--color-text-secondary);
       font-size: 0.9rem;
     }
+    .sr-loading {
+      color: var(--color-text-secondary);
+      font-size: 0.9rem;
+      font-style: italic;
+    }
     mark {
       background-color: rgba(255, 210, 0, 0.35);
       color: inherit;

--- a/infra/perfetto.dev/src/gen_search_index.js
+++ b/infra/perfetto.dev/src/gen_search_index.js
@@ -14,8 +14,8 @@
 
 "use strict";
 
-// Builds the client-side full-text search index (search_index.json) consumed by
-// setupSearch() in assets/script.js.
+// Builds the client-side full-text search index (search_index.json.gz) consumed
+// by setupSearch() in assets/script.js.
 //
 // Inputs (wired up in BUILD.gn):
 //   --full     <md>   Hand-written docs: title, headings and body are indexed.
@@ -28,6 +28,7 @@
 // README.md -> /docs/).
 
 const fs = require("fs");
+const zlib = require("zlib");
 const path = require("path");
 const marked = require("marked");
 const argv = require("yargs").argv;
@@ -150,6 +151,73 @@ function genFileSlug(file) {
   return file.replace(/\.md$/, "").replace(/^gen_/, "").replace(/_/g, "-");
 }
 
+// Lowercase alphanumeric tokens, keeping a trailing "++"/"#" so "c++" and "c#"
+// stay searchable. Tokens shorter than 2 chars are dropped as noise.
+function searchTokenize(str) {
+  const out = [];
+  const re = /[a-z0-9]+(\+\+|#)?/g;
+  let m;
+  while ((m = re.exec(str.toLowerCase())) !== null) {
+    if (m[0].length >= 2) out.push(m[0]);
+  }
+  return out;
+}
+
+// Builds the BM25 inverted index here rather than in the browser, which would
+// otherwise tokenize every doc on load. Field boosts: a hit in the title matters
+// far more than one in the body. Returns:
+//   terms       -- sorted unique tokens
+//   post        -- parallel to terms; each a flat [docIdx, weight, ...] array
+//   docLen      -- per-doc total weighted token count (BM25 length normalization)
+//   titleTokens -- per-doc tokenized title, for the title boost
+//   navTokens   -- per-doc tokenized nav label, or null; also for the title boost
+function buildInvertedIndex(docs) {
+  const FIELD_BOOST = {title: 8, heading: 4, body: 1};
+  const postings = new Map();  // token -> Map(docIdx -> weight)
+  const docLen = new Array(docs.length).fill(0);
+  const titleTokens = new Array(docs.length);
+  const navTokens = new Array(docs.length).fill(null);
+  const addTokens = (i, tokens, boost) => {
+    for (const tok of tokens) {
+      let postingList = postings.get(tok);
+      if (postingList === undefined) {
+        postingList = new Map();
+        postings.set(tok, postingList);
+      }
+      postingList.set(i, (postingList.get(i) || 0) + boost);
+      docLen[i] += boost;
+    }
+  };
+  for (let i = 0; i < docs.length; i++) {
+    const d = docs[i];
+    titleTokens[i] = searchTokenize(d.t || "");
+    addTokens(i, titleTokens[i], FIELD_BOOST.title);
+    // The toc.md nav label (d.n) is a curated keyword alias -- index at title
+    // weight. Same for the URL slug (last path segment, e.g. "perfetto-cli").
+    if (d.n) {
+      navTokens[i] = searchTokenize(d.n);
+      addTokens(i, navTokens[i], FIELD_BOOST.title);
+    }
+    const slug = d.u.split("/").filter(Boolean).pop() || "";
+    addTokens(i, searchTokenize(slug), FIELD_BOOST.title);
+    for (const h of d.h || []) {
+      addTokens(i, searchTokenize(h.t), FIELD_BOOST.heading);
+    }
+    if (d.b) {
+      addTokens(i, searchTokenize(d.b), FIELD_BOOST.body);
+    }
+  }
+  const terms = [...postings.keys()].sort();
+  const post = terms.map((t) => {
+    const flat = [];
+    for (const [docIdx, weight] of postings.get(t)) {
+      flat.push(docIdx, weight);
+    }
+    return flat;
+  });
+  return {terms, post, docLen, titleTokens, navTokens};
+}
+
 function main() {
   const outFile = argv["out"];
   const docRoot = argv["doc-root"];
@@ -191,8 +259,12 @@ function main() {
   }
 
   docs.sort((a, b) => a.u.localeCompare(b.u)); // Deterministic output.
+  const index = buildInvertedIndex(docs);
+  // The docs-site proxy serves this file uncompressed, so gzip it here and let
+  // script.js inflate it. Level 9: built once, so size wins over speed.
+  const json = JSON.stringify({docs, ...index});
   fs.mkdirSync(path.dirname(outFile), {recursive: true});
-  fs.writeFileSync(outFile, JSON.stringify({docs}));
+  fs.writeFileSync(outFile, zlib.gzipSync(json, {level: 9}));
 }
 
 main();


### PR DESCRIPTION
The client-side search downloaded a ~1.5MB uncompressed search_index.json and rebuilt the whole BM25 index on the main thread on first use, which froze the search box for seconds on the first keystroke (#6654). Fixed on the build/client side:

1. Precompute the inverted index (gen_search_index.js, script.js): build the postings at build time and ship them, so the browser rebuilds the map from flat arrays (~10ms) instead of re-tokenizing ~1.2MB of body text.

2. Ship the index gzipped (gen_search_index.js, BUILD.gn, mime_util, script.js): the docs-site proxy serves this file uncompressed, so gzip it at build time (search_index.json.gz) and inflate it in the browser with DecompressionStream. The download is ~540KB even though precomputing grows the index to ~1.8MB uncompressed.

3. Warm and show progress (script.js, style.scss): load the index at idle so it's usually ready before the first search, and show a loading row if the user types before it arrives, instead of a frozen box.
