### PR TITLE
tp: add transport-neutral stack sampling protos and parsing

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -2928,6 +2928,7 @@ cc_test {
         ":perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen",
         ":perfetto_protos_perfetto_trace_processor_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_cpp_gen",
+        ":perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_cpp_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -3107,6 +3108,7 @@ cc_test {
         ":perfetto_src_trace_processor_plugins_span_join_operator_span_join_operator",
         ":perfetto_src_trace_processor_plugins_sql_stats_table_sql_stats_table",
         ":perfetto_src_trace_processor_plugins_stack_functions_stack_functions",
+        ":perfetto_src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
         ":perfetto_src_trace_processor_plugins_stdlib_docs_stdlib_docs",
         ":perfetto_src_trace_processor_plugins_storage_tables_storage_tables",
         ":perfetto_src_trace_processor_plugins_string_functions_string_functions",
@@ -3317,6 +3319,7 @@ cc_test {
         "perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_cpp_gen_headers",
+        "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -3371,6 +3374,7 @@ cc_test {
         "perfetto_src_trace_processor_plugins_experimental_flat_slice_tables",
         "perfetto_src_trace_processor_plugins_experimental_slice_layout_tables",
         "perfetto_src_trace_processor_plugins_graph_traversal_tables",
+        "perfetto_src_trace_processor_plugins_stack_sample_importer_tables",
         "perfetto_src_trace_processor_plugins_stdlib_docs_tables",
         "perfetto_src_trace_processor_plugins_structural_tree_partition_tables",
         "perfetto_src_trace_processor_plugins_table_info_tables",
@@ -3654,6 +3658,7 @@ filegroup {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
         "protos/perfetto/trace/ps/process_stats.proto",
         "protos/perfetto/trace/ps/process_tree.proto",
         "protos/perfetto/trace/remote_clock_sync.proto",
@@ -8486,6 +8491,7 @@ genrule {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
         "protos/perfetto/trace/ps/process_stats.proto",
         "protos/perfetto/trace/ps/process_tree.proto",
         "protos/perfetto/trace/remote_clock_sync.proto",
@@ -9959,6 +9965,7 @@ genrule {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
         "protos/perfetto/trace/track_event/chrome_active_processes.proto",
         "protos/perfetto/trace/track_event/chrome_application_state_info.proto",
         "protos/perfetto/trace/track_event/chrome_compositor_scheduler_state.proto",
@@ -11338,6 +11345,7 @@ filegroup {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
         "protos/perfetto/trace/ps/process_stats.proto",
         "protos/perfetto/trace/ps/process_tree.proto",
         "protos/perfetto/trace/remote_clock_sync.proto",
@@ -11972,6 +11980,7 @@ filegroup {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
     ],
 }
 
@@ -11994,6 +12003,7 @@ genrule {
         "external/perfetto/protos/perfetto/trace/profiling/profile_common.gen.cc",
         "external/perfetto/protos/perfetto/trace/profiling/profile_packet.gen.cc",
         "external/perfetto/protos/perfetto/trace/profiling/smaps.gen.cc",
+        "external/perfetto/protos/perfetto/trace/profiling/stack_sample.gen.cc",
     ],
 }
 
@@ -12016,6 +12026,7 @@ genrule {
         "external/perfetto/protos/perfetto/trace/profiling/profile_common.gen.h",
         "external/perfetto/protos/perfetto/trace/profiling/profile_packet.gen.h",
         "external/perfetto/protos/perfetto/trace/profiling/smaps.gen.h",
+        "external/perfetto/protos/perfetto/trace/profiling/stack_sample.gen.h",
     ],
     export_include_dirs: [
         ".",
@@ -12032,6 +12043,7 @@ filegroup {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
     ],
 }
 
@@ -12053,6 +12065,7 @@ genrule {
         "external/perfetto/protos/perfetto/trace/profiling/profile_common.pb.cc",
         "external/perfetto/protos/perfetto/trace/profiling/profile_packet.pb.cc",
         "external/perfetto/protos/perfetto/trace/profiling/smaps.pb.cc",
+        "external/perfetto/protos/perfetto/trace/profiling/stack_sample.pb.cc",
     ],
 }
 
@@ -12074,6 +12087,67 @@ genrule {
         "external/perfetto/protos/perfetto/trace/profiling/profile_common.pb.h",
         "external/perfetto/protos/perfetto/trace/profiling/profile_packet.pb.h",
         "external/perfetto/protos/perfetto/trace/profiling/smaps.pb.h",
+        "external/perfetto/protos/perfetto/trace/profiling/stack_sample.pb.h",
+    ],
+    export_include_dirs: [
+        ".",
+        "protos",
+    ],
+}
+
+// GN: //protos/perfetto/trace/profiling:stack_sample_interned_data_zero
+filegroup {
+    name: "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero",
+    srcs: [
+        "protos/perfetto/trace/profiling/stack_sample_interned_data.proto",
+    ],
+}
+
+// GN: //protos/perfetto/trace/profiling:stack_sample_interned_data_zero
+genrule {
+    name: "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen",
+    srcs: [
+        ":perfetto_protos_perfetto_common_zero",
+        ":perfetto_protos_perfetto_protovm_zero",
+        ":perfetto_protos_perfetto_trace_android_zero",
+        ":perfetto_protos_perfetto_trace_chrome_zero",
+        ":perfetto_protos_perfetto_trace_gpu_zero",
+        ":perfetto_protos_perfetto_trace_interned_data_zero",
+        ":perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero",
+        ":perfetto_protos_perfetto_trace_profiling_zero",
+        ":perfetto_protos_perfetto_trace_track_event_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero)",
+    out: [
+        "external/perfetto/protos/perfetto/trace/profiling/stack_sample_interned_data.pbzero.cc",
+    ],
+}
+
+// GN: //protos/perfetto/trace/profiling:stack_sample_interned_data_zero
+genrule {
+    name: "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen_headers",
+    srcs: [
+        ":perfetto_protos_perfetto_common_zero",
+        ":perfetto_protos_perfetto_protovm_zero",
+        ":perfetto_protos_perfetto_trace_android_zero",
+        ":perfetto_protos_perfetto_trace_chrome_zero",
+        ":perfetto_protos_perfetto_trace_gpu_zero",
+        ":perfetto_protos_perfetto_trace_interned_data_zero",
+        ":perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero",
+        ":perfetto_protos_perfetto_trace_profiling_zero",
+        ":perfetto_protos_perfetto_trace_track_event_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero)",
+    out: [
+        "external/perfetto/protos/perfetto/trace/profiling/stack_sample_interned_data.pbzero.h",
     ],
     export_include_dirs: [
         ".",
@@ -12090,6 +12164,7 @@ filegroup {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
     ],
 }
 
@@ -12112,6 +12187,7 @@ genrule {
         "external/perfetto/protos/perfetto/trace/profiling/profile_common.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/profiling/profile_packet.pbzero.cc",
         "external/perfetto/protos/perfetto/trace/profiling/smaps.pbzero.cc",
+        "external/perfetto/protos/perfetto/trace/profiling/stack_sample.pbzero.cc",
     ],
 }
 
@@ -12134,6 +12210,7 @@ genrule {
         "external/perfetto/protos/perfetto/trace/profiling/profile_common.pbzero.h",
         "external/perfetto/protos/perfetto/trace/profiling/profile_packet.pbzero.h",
         "external/perfetto/protos/perfetto/trace/profiling/smaps.pbzero.h",
+        "external/perfetto/protos/perfetto/trace/profiling/stack_sample.pbzero.h",
     ],
     export_include_dirs: [
         ".",
@@ -13581,6 +13658,7 @@ genrule {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
         "protos/perfetto/trace/ps/process_stats.proto",
         "protos/perfetto/trace/ps/process_tree.proto",
         "protos/perfetto/trace/remote_clock_sync.proto",
@@ -19710,6 +19788,61 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/plugins/stack_sample_importer:stack_sample_importer
+filegroup {
+    name: "perfetto_src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
+    srcs: [
+        "src/trace_processor/plugins/stack_sample_importer/plugin.cc",
+    ],
+}
+
+// GN: //src/trace_processor/plugins/stack_sample_importer:tables
+genrule {
+    name: "perfetto_src_trace_processor_plugins_stack_sample_importer_tables",
+    srcs: [
+        "src/trace_processor/plugins/stack_sample_importer/tables.py",
+    ],
+    tools: [
+        "perfetto_src_trace_processor_plugins_stack_sample_importer_tables_binary",
+    ],
+    cmd: "$(location perfetto_src_trace_processor_plugins_stack_sample_importer_tables_binary) --gen-dir=$(genDir) --relative-input-dir=external/perfetto --inputs $(in)",
+    out: [
+        "src/trace_processor/plugins/stack_sample_importer/all_tables_fwd.h",
+        "src/trace_processor/plugins/stack_sample_importer/tables_fwd.h",
+        "src/trace_processor/plugins/stack_sample_importer/tables_py.h",
+    ],
+}
+
+// GN: //src/trace_processor/plugins/stack_sample_importer:tables
+python_binary_host {
+    name: "perfetto_src_trace_processor_plugins_stack_sample_importer_tables_binary",
+    srcs: [
+        "python/generators/trace_processor_table/public.py",
+        "python/generators/trace_processor_table/serialize.py",
+        "python/generators/trace_processor_table/util.py",
+        "src/trace_processor/plugins/stack_sample_importer/tables.py",
+        "src/trace_processor/tables/android_tables.py",
+        "src/trace_processor/tables/counter_tables.py",
+        "src/trace_processor/tables/etm_tables.py",
+        "src/trace_processor/tables/flow_tables.py",
+        "src/trace_processor/tables/jit_tables.py",
+        "src/trace_processor/tables/log_tables.py",
+        "src/trace_processor/tables/memory_tables.py",
+        "src/trace_processor/tables/metadata_tables.py",
+        "src/trace_processor/tables/perf_tables.py",
+        "src/trace_processor/tables/profiler_tables.py",
+        "src/trace_processor/tables/sched_tables.py",
+        "src/trace_processor/tables/slice_tables.py",
+        "src/trace_processor/tables/state_tables.py",
+        "src/trace_processor/tables/trace_proto_tables.py",
+        "src/trace_processor/tables/track_tables.py",
+        "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/winscope_tables.py",
+        "tools/gen_tp_table_headers.py",
+    ],
+    main: "tools/gen_tp_table_headers.py",
+}
+
 // GN: //src/trace_processor/plugins/stdlib_docs:stdlib_docs
 filegroup {
     name: "perfetto_src_trace_processor_plugins_stdlib_docs_stdlib_docs",
@@ -20533,6 +20666,7 @@ cc_library_static {
         ":perfetto_protos_perfetto_trace_power_zero_gen",
         ":perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen",
         ":perfetto_protos_perfetto_trace_processor_zero_gen",
+        ":perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
         ":perfetto_protos_perfetto_trace_statsd_zero_gen",
@@ -20668,6 +20802,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_plugins_span_join_operator_span_join_operator",
         ":perfetto_src_trace_processor_plugins_sql_stats_table_sql_stats_table",
         ":perfetto_src_trace_processor_plugins_stack_functions_stack_functions",
+        ":perfetto_src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
         ":perfetto_src_trace_processor_plugins_stdlib_docs_stdlib_docs",
         ":perfetto_src_trace_processor_plugins_storage_tables_storage_tables",
         ":perfetto_src_trace_processor_plugins_string_functions_string_functions",
@@ -20790,6 +20925,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
         "perfetto_protos_perfetto_trace_statsd_zero_gen_headers",
@@ -20837,6 +20973,7 @@ cc_library_static {
         "perfetto_src_trace_processor_plugins_experimental_flat_slice_tables",
         "perfetto_src_trace_processor_plugins_experimental_slice_layout_tables",
         "perfetto_src_trace_processor_plugins_graph_traversal_tables",
+        "perfetto_src_trace_processor_plugins_stack_sample_importer_tables",
         "perfetto_src_trace_processor_plugins_stdlib_docs_tables",
         "perfetto_src_trace_processor_plugins_structural_tree_partition_tables",
         "perfetto_src_trace_processor_plugins_table_info_tables",
@@ -20894,6 +21031,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
         "perfetto_protos_perfetto_trace_statsd_zero_gen_headers",
@@ -20941,6 +21079,7 @@ cc_library_static {
         "perfetto_src_trace_processor_plugins_experimental_flat_slice_tables",
         "perfetto_src_trace_processor_plugins_experimental_slice_layout_tables",
         "perfetto_src_trace_processor_plugins_graph_traversal_tables",
+        "perfetto_src_trace_processor_plugins_stack_sample_importer_tables",
         "perfetto_src_trace_processor_plugins_stdlib_docs_tables",
         "perfetto_src_trace_processor_plugins_structural_tree_partition_tables",
         "perfetto_src_trace_processor_plugins_table_info_tables",
@@ -22616,6 +22755,7 @@ java_library {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
         "protos/perfetto/trace/ps/process_stats.proto",
         "protos/perfetto/trace/ps/process_tree.proto",
         "protos/perfetto/trace/remote_clock_sync.proto",
@@ -23084,6 +23224,7 @@ python_library_host {
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
         "protos/perfetto/trace/ps/process_stats.proto",
         "protos/perfetto/trace/ps/process_tree.proto",
         "protos/perfetto/trace/remote_clock_sync.proto",
@@ -23296,6 +23437,7 @@ cc_test {
         ":perfetto_protos_perfetto_trace_processor_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_lite_gen",
+        ":perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_cpp_gen",
         ":perfetto_protos_perfetto_trace_ps_lite_gen",
@@ -23560,6 +23702,7 @@ cc_test {
         ":perfetto_src_trace_processor_plugins_span_join_operator_unittests",
         ":perfetto_src_trace_processor_plugins_sql_stats_table_sql_stats_table",
         ":perfetto_src_trace_processor_plugins_stack_functions_stack_functions",
+        ":perfetto_src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
         ":perfetto_src_trace_processor_plugins_stdlib_docs_stdlib_docs",
         ":perfetto_src_trace_processor_plugins_storage_tables_storage_tables",
         ":perfetto_src_trace_processor_plugins_string_functions_string_functions",
@@ -23862,6 +24005,7 @@ cc_test {
         "perfetto_protos_perfetto_trace_processor_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_lite_gen_headers",
+        "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_ps_lite_gen_headers",
@@ -23945,6 +24089,7 @@ cc_test {
         "perfetto_src_trace_processor_plugins_experimental_flat_slice_tables",
         "perfetto_src_trace_processor_plugins_experimental_slice_layout_tables",
         "perfetto_src_trace_processor_plugins_graph_traversal_tables",
+        "perfetto_src_trace_processor_plugins_stack_sample_importer_tables",
         "perfetto_src_trace_processor_plugins_stdlib_docs_tables",
         "perfetto_src_trace_processor_plugins_structural_tree_partition_tables",
         "perfetto_src_trace_processor_plugins_table_info_tables",
@@ -24527,6 +24672,7 @@ cc_library_static {
         ":perfetto_protos_perfetto_trace_power_zero_gen",
         ":perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen",
         ":perfetto_protos_perfetto_trace_processor_zero_gen",
+        ":perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
         ":perfetto_protos_perfetto_trace_statsd_zero_gen",
@@ -24658,6 +24804,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_plugins_span_join_operator_span_join_operator",
         ":perfetto_src_trace_processor_plugins_sql_stats_table_sql_stats_table",
         ":perfetto_src_trace_processor_plugins_stack_functions_stack_functions",
+        ":perfetto_src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
         ":perfetto_src_trace_processor_plugins_stdlib_docs_stdlib_docs",
         ":perfetto_src_trace_processor_plugins_storage_tables_storage_tables",
         ":perfetto_src_trace_processor_plugins_string_functions_string_functions",
@@ -24765,6 +24912,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
         "perfetto_protos_perfetto_trace_statsd_zero_gen_headers",
@@ -24811,6 +24959,7 @@ cc_library_static {
         "perfetto_src_trace_processor_plugins_experimental_flat_slice_tables",
         "perfetto_src_trace_processor_plugins_experimental_slice_layout_tables",
         "perfetto_src_trace_processor_plugins_graph_traversal_tables",
+        "perfetto_src_trace_processor_plugins_stack_sample_importer_tables",
         "perfetto_src_trace_processor_plugins_stdlib_docs_tables",
         "perfetto_src_trace_processor_plugins_structural_tree_partition_tables",
         "perfetto_src_trace_processor_plugins_table_info_tables",
@@ -24866,6 +25015,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
         "perfetto_protos_perfetto_trace_statsd_zero_gen_headers",
@@ -24912,6 +25062,7 @@ cc_library_static {
         "perfetto_src_trace_processor_plugins_experimental_flat_slice_tables",
         "perfetto_src_trace_processor_plugins_experimental_slice_layout_tables",
         "perfetto_src_trace_processor_plugins_graph_traversal_tables",
+        "perfetto_src_trace_processor_plugins_stack_sample_importer_tables",
         "perfetto_src_trace_processor_plugins_stdlib_docs_tables",
         "perfetto_src_trace_processor_plugins_structural_tree_partition_tables",
         "perfetto_src_trace_processor_plugins_table_info_tables",
@@ -25204,6 +25355,7 @@ cc_binary_host {
         ":perfetto_protos_perfetto_trace_power_zero_gen",
         ":perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen",
         ":perfetto_protos_perfetto_trace_processor_zero_gen",
+        ":perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
         ":perfetto_protos_perfetto_trace_statsd_zero_gen",
@@ -25337,6 +25489,7 @@ cc_binary_host {
         ":perfetto_src_trace_processor_plugins_span_join_operator_span_join_operator",
         ":perfetto_src_trace_processor_plugins_sql_stats_table_sql_stats_table",
         ":perfetto_src_trace_processor_plugins_stack_functions_stack_functions",
+        ":perfetto_src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
         ":perfetto_src_trace_processor_plugins_stdlib_docs_stdlib_docs",
         ":perfetto_src_trace_processor_plugins_storage_tables_storage_tables",
         ":perfetto_src_trace_processor_plugins_string_functions_string_functions",
@@ -25454,6 +25607,7 @@ cc_binary_host {
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_metrics_impl_zero_gen_headers",
         "perfetto_protos_perfetto_trace_processor_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_profiling_stack_sample_interned_data_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
         "perfetto_protos_perfetto_trace_statsd_zero_gen_headers",
@@ -25501,6 +25655,7 @@ cc_binary_host {
         "perfetto_src_trace_processor_plugins_experimental_flat_slice_tables",
         "perfetto_src_trace_processor_plugins_experimental_slice_layout_tables",
         "perfetto_src_trace_processor_plugins_graph_traversal_tables",
+        "perfetto_src_trace_processor_plugins_stack_sample_importer_tables",
         "perfetto_src_trace_processor_plugins_stdlib_docs_tables",
         "perfetto_src_trace_processor_plugins_structural_tree_partition_tables",
         "perfetto_src_trace_processor_plugins_table_info_tables",

--- a/BUILD
+++ b/BUILD
@@ -506,6 +506,8 @@ perfetto_cc_library(
         ":src_trace_processor_plugins_span_join_operator_span_join_operator",
         ":src_trace_processor_plugins_sql_stats_table_sql_stats_table",
         ":src_trace_processor_plugins_stack_functions_stack_functions",
+        ":src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
+        ":src_trace_processor_plugins_stack_sample_importer_tables",
         ":src_trace_processor_plugins_stdlib_docs_stdlib_docs",
         ":src_trace_processor_plugins_stdlib_docs_tables",
         ":src_trace_processor_plugins_storage_tables_storage_tables",
@@ -630,6 +632,7 @@ perfetto_cc_library(
                ":protos_perfetto_trace_power_zero",
                ":protos_perfetto_trace_processor_metrics_impl_zero",
                ":protos_perfetto_trace_processor_zero",
+               ":protos_perfetto_trace_profiling_stack_sample_interned_data_zero",
                ":protos_perfetto_trace_profiling_zero",
                ":protos_perfetto_trace_ps_zero",
                ":protos_perfetto_trace_statsd_zero",
@@ -804,6 +807,8 @@ perfetto_cc_library(
         ":src_trace_processor_plugins_span_join_operator_span_join_operator",
         ":src_trace_processor_plugins_sql_stats_table_sql_stats_table",
         ":src_trace_processor_plugins_stack_functions_stack_functions",
+        ":src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
+        ":src_trace_processor_plugins_stack_sample_importer_tables",
         ":src_trace_processor_plugins_stdlib_docs_stdlib_docs",
         ":src_trace_processor_plugins_stdlib_docs_tables",
         ":src_trace_processor_plugins_storage_tables_storage_tables",
@@ -945,6 +950,7 @@ perfetto_cc_library(
                ":protos_perfetto_trace_power_zero",
                ":protos_perfetto_trace_processor_metrics_impl_zero",
                ":protos_perfetto_trace_processor_zero",
+               ":protos_perfetto_trace_profiling_stack_sample_interned_data_zero",
                ":protos_perfetto_trace_profiling_zero",
                ":protos_perfetto_trace_ps_zero",
                ":protos_perfetto_trace_statsd_zero",
@@ -4867,6 +4873,31 @@ perfetto_filegroup(
     srcs = [
         "src/trace_processor/plugins/stack_functions/stack_functions.cc",
         "src/trace_processor/plugins/stack_functions/stack_functions.h",
+    ],
+)
+
+# GN target: //src/trace_processor/plugins/stack_sample_importer:stack_sample_importer
+perfetto_filegroup(
+    name = "src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
+    srcs = [
+        "src/trace_processor/plugins/stack_sample_importer/plugin.cc",
+        "src/trace_processor/plugins/stack_sample_importer/plugin.h",
+    ],
+)
+
+# GN target: //src/trace_processor/plugins/stack_sample_importer:tables
+perfetto_cc_tp_tables(
+    name = "src_trace_processor_plugins_stack_sample_importer_tables",
+    srcs = [
+        "src/trace_processor/plugins/stack_sample_importer/tables.py",
+    ],
+    deps = [
+        ":src_trace_processor_tables_tables_python",
+    ],
+    outs = [
+        "src/trace_processor/plugins/stack_sample_importer/all_tables_fwd.h",
+        "src/trace_processor/plugins/stack_sample_importer/tables_fwd.h",
+        "src/trace_processor/plugins/stack_sample_importer/tables_py.h",
     ],
 )
 
@@ -9466,6 +9497,7 @@ perfetto_proto_library(
         "protos/perfetto/trace/profiling/profile_common.proto",
         "protos/perfetto/trace/profiling/profile_packet.proto",
         "protos/perfetto/trace/profiling/smaps.proto",
+        "protos/perfetto/trace/profiling/stack_sample.proto",
     ],
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
@@ -9473,6 +9505,46 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_common_protos",
         ":protos_perfetto_protovm_protos",
+    ],
+)
+
+# GN target: //protos/perfetto/trace/profiling:stack_sample_interned_data_source_set
+perfetto_proto_library(
+    name = "protos_perfetto_trace_profiling_stack_sample_interned_data_protos",
+    srcs = [
+        "protos/perfetto/trace/profiling/stack_sample_interned_data.proto",
+    ],
+    visibility = [
+        PERFETTO_CONFIG.proto_library_visibility,
+    ],
+    deps = [
+        ":protos_perfetto_common_protos",
+        ":protos_perfetto_protovm_protos",
+        ":protos_perfetto_trace_android_protos",
+        ":protos_perfetto_trace_chrome_protos",
+        ":protos_perfetto_trace_gpu_protos",
+        ":protos_perfetto_trace_interned_data_protos",
+        ":protos_perfetto_trace_profiling_protos",
+        ":protos_perfetto_trace_track_event_protos",
+    ],
+    exports = [
+        ":protos_perfetto_trace_interned_data_protos",
+    ],
+)
+
+# GN target: //protos/perfetto/trace/profiling:stack_sample_interned_data_zero
+perfetto_cc_protozero_library(
+    name = "protos_perfetto_trace_profiling_stack_sample_interned_data_zero",
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_protovm_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_chrome_zero",
+        ":protos_perfetto_trace_gpu_zero",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_profiling_stack_sample_interned_data_protos",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protos_perfetto_trace_track_event_zero",
     ],
 )
 
@@ -11376,6 +11448,8 @@ perfetto_cc_library(
         ":src_trace_processor_plugins_span_join_operator_span_join_operator",
         ":src_trace_processor_plugins_sql_stats_table_sql_stats_table",
         ":src_trace_processor_plugins_stack_functions_stack_functions",
+        ":src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
+        ":src_trace_processor_plugins_stack_sample_importer_tables",
         ":src_trace_processor_plugins_stdlib_docs_stdlib_docs",
         ":src_trace_processor_plugins_stdlib_docs_tables",
         ":src_trace_processor_plugins_storage_tables_storage_tables",
@@ -11500,6 +11574,7 @@ perfetto_cc_library(
                ":protos_perfetto_trace_power_zero",
                ":protos_perfetto_trace_processor_metrics_impl_zero",
                ":protos_perfetto_trace_processor_zero",
+               ":protos_perfetto_trace_profiling_stack_sample_interned_data_zero",
                ":protos_perfetto_trace_profiling_zero",
                ":protos_perfetto_trace_ps_zero",
                ":protos_perfetto_trace_statsd_zero",
@@ -11704,6 +11779,8 @@ perfetto_cc_binary(
         ":src_trace_processor_plugins_span_join_operator_span_join_operator",
         ":src_trace_processor_plugins_sql_stats_table_sql_stats_table",
         ":src_trace_processor_plugins_stack_functions_stack_functions",
+        ":src_trace_processor_plugins_stack_sample_importer_stack_sample_importer",
+        ":src_trace_processor_plugins_stack_sample_importer_tables",
         ":src_trace_processor_plugins_stdlib_docs_stdlib_docs",
         ":src_trace_processor_plugins_stdlib_docs_tables",
         ":src_trace_processor_plugins_storage_tables_storage_tables",
@@ -11819,6 +11896,7 @@ perfetto_cc_binary(
                ":protos_perfetto_trace_power_zero",
                ":protos_perfetto_trace_processor_metrics_impl_zero",
                ":protos_perfetto_trace_processor_zero",
+               ":protos_perfetto_trace_profiling_stack_sample_interned_data_zero",
                ":protos_perfetto_trace_profiling_zero",
                ":protos_perfetto_trace_ps_zero",
                ":protos_perfetto_trace_statsd_zero",

--- a/protos/perfetto/trace/extensions.json
+++ b/protos/perfetto/trace/extensions.json
@@ -176,11 +176,18 @@
           "proto": "protos/perfetto/trace/gpu/gpu_interned_data.proto"
         },
         {
+          "name": "perfetto_profiling",
+          "range": [2000, 2099],
+          "contact": "perfetto-dev@googlegroups.com",
+          "description": "Reserved for Perfetto transport-neutral profiling (StackSample)",
+          "proto": "protos/perfetto/trace/profiling/stack_sample_interned_data.proto"
+        },
+        {
           "name": "unallocated",
           "comment": [
             "The next allocation goes here. Shrink and take from here."
           ],
-          "range": [2000, 9999]
+          "range": [2100, 9999]
         }
       ]
     }

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -13805,6 +13805,25 @@ message Frame {
   // is available at trace collection time. If not set, line numbers may be
   // added later via offline symbolization (see ModuleSymbols).
   optional uint32 line_number = 6;
+
+  // The kind of code this frame represents, for categorization (e.g. coloring
+  // a flamegraph, or telling interpreted Python frames apart from native and
+  // GC frames in one mixed stack). Set the well-known `kind` when one fits,
+  // otherwise set `kind_str` to a custom label. The well-known enum is
+  // append-only and language-neutral; language-specific labels go in kind_str.
+  enum Kind {
+    KIND_UNKNOWN = 0;
+    KIND_NATIVE = 1;
+    KIND_KERNEL = 2;
+    KIND_INTERPRETED = 3;
+    KIND_JIT = 4;
+    KIND_GC = 5;
+    KIND_RUNTIME = 6;
+  }
+  oneof kind_field {
+    Kind kind = 7;
+    string kind_str = 8;
+  }
 }
 
 message Callstack {
@@ -16421,6 +16440,142 @@ message SmapsPacket {
 
 // End of protos/perfetto/trace/profiling/smaps.proto
 
+// Begin of protos/perfetto/trace/profiling/stack_sample.proto
+
+// A single stack sample: a callstack captured for a task, measured against a
+// counter timebase. This is transport-neutral and timebase-neutral. The
+// timebase can be CPU cycles, wall-clock nanoseconds, allocated bytes, page
+// faults, etc.; the primary CounterDescriptor says which. It is not specific to
+// CPU profiling.
+//
+// Each context/callstack/descriptor can be given inline or as an `iid`
+// referencing an InternedData entry. Producers that reuse a context across
+// samples should intern it so the per-sample cost is a single varint.
+message StackSample {
+  // The privilege level a sample was taken at. Append-only: never renumber or
+  // repurpose an existing value.
+  enum Mode {
+    MODE_UNKNOWN = 0;
+    MODE_USER = 1;
+    MODE_KERNEL = 2;
+    MODE_HYPERVISOR = 3;
+    MODE_GUEST_USER = 4;
+    MODE_GUEST_KERNEL = 5;
+  }
+
+  // The unit a CounterDescriptor's values are expressed in. Append-only: new
+  // units may be added, but existing values are never renumbered or
+  // repurposed. If none of these fit, set CounterDescriptor.unit_str instead.
+  enum Unit {
+    UNIT_UNSPECIFIED = 0;
+    UNIT_NANOSECONDS = 1;
+    UNIT_CPU_CYCLES = 2;
+    UNIT_INSTRUCTIONS = 3;
+    UNIT_BYTES = 4;
+    UNIT_PAGE_FAULTS = 5;
+    UNIT_CACHE_MISSES = 6;
+    UNIT_CACHE_REFERENCES = 7;
+    UNIT_BRANCH_MISSES = 8;
+    UNIT_COUNT = 9;
+  }
+
+  // The task an observation is attributed to. At least one of pid / tid should
+  // be set.
+  message TaskContext {
+    // Interning key. Starts from 1, 0 is the same as "not set".
+    optional uint64 iid = 1;
+
+    optional uint32 pid = 2;
+    optional uint32 tid = 3;
+  }
+
+  // The execution state a sample was taken in. All fields are optional: an
+  // off-CPU sample (e.g. a wall-clock sampler catching a sleeping thread) has
+  // no meaningful cpu or mode.
+  message ExecutionContext {
+    // Interning key. Starts from 1, 0 is the same as "not set".
+    optional uint64 iid = 1;
+
+    optional uint32 cpu = 2;
+    optional Mode mode = 3;
+  }
+
+  // Describes a counter: a named, typed quantity a sample is measured against
+  // (the sampling timebase) or observed alongside (a follower). Values live on
+  // the sample as weights; this only describes their meaning.
+  message CounterDescriptor {
+    // Interning key. Starts from 1, 0 is the same as "not set".
+    optional uint64 iid = 1;
+
+    // E.g. "cycles", "wall-time", "cache-misses".
+    optional string name = 2;
+
+    // The unit weights are expressed in. Set the well-known `unit` when one
+    // fits, otherwise set `unit_str` to a custom label.
+    oneof unit_field {
+      Unit unit = 3;
+      string unit_str = 4;
+    }
+
+    // Scales raw weights to `unit`. E.g. unit=UNIT_BYTES, unit_multiplier=1024
+    // means weights are in KiB. Absent means 1.
+    optional uint64 unit_multiplier = 5;
+
+    optional string description = 6;
+  }
+
+  // The task (thread / process / async context) this sample is attributed to.
+  oneof task_context_field {
+    TaskContext task_context = 1;
+    uint64 task_context_iid = 2;
+  }
+
+  // The execution state (cpu, privilege mode) at sample time. Absent for
+  // samplers that observe off-CPU tasks.
+  oneof execution_context_field {
+    ExecutionContext execution_context = 3;
+    uint64 execution_context_iid = 4;
+  }
+
+  // The captured callstack, bottom frame first. Inline only for now; an
+  // interned callstack_iid variant may be added later.
+  oneof callstack_field {
+    Callstack callstack = 5;
+    // uint64 callstack_iid = 6;
+  }
+
+  // Set if stack unwinding was incomplete; describes the data, not producer
+  // internal state.
+  oneof unwind_error_field {
+    string unwind_error = 7;
+    uint64 unwind_error_iid = 8;
+  }
+
+  // The sampling timebase. Set one of the two; may be omitted if declared in
+  // StackSampleDefaults.
+  oneof primary_descriptor_field {
+    CounterDescriptor primary_descriptor = 9;
+    uint64 primary_descriptor_iid = 10;
+  }
+
+  // The value attributed to this sample for the primary counter (e.g. the
+  // number of cycles or nanoseconds this sample represents).
+  optional uint64 primary_weight = 11;
+}
+
+// Per-sequence defaults for StackSample. Lets a producer declare the source and
+// the common timebase once instead of on every sample.
+message StackSampleDefaults {
+  // Identifies the profiler that produced these samples, e.g. "linux.perf",
+  // "python.wall". Recorded once per sampling stream.
+  optional string source = 1;
+
+  // Default primary timebase for samples that omit their own.
+  optional StackSample.CounterDescriptor primary_descriptor = 2;
+}
+
+// End of protos/perfetto/trace/profiling/stack_sample.proto
+
 // Begin of protos/perfetto/trace/ps/process_stats.proto
 
 // Per-process periodically sampled stats. These samples are wrapped in a
@@ -17014,6 +17169,9 @@ message TracePacketDefaults {
 
   // Defaults for perf profiler packets (PerfSample).
   optional PerfSampleDefaults perf_sample_defaults = 12;
+
+  // Defaults for transport-neutral stack sampling packets (StackSample).
+  optional StackSampleDefaults stack_sample_defaults = 100;
 
   // Defaults for V8 code packets (V8JsCode, V8InternalCode, V8WasmCode,
   // V8RegexpCode)
@@ -17802,7 +17960,7 @@ message UiState {
 // See the [Buffers and Dataflow](/docs/concepts/buffers.md) doc for details.
 //
 // Next reserved id: 14 (up to 15).
-// Next id: 135.
+// Next id: 136.
 message TracePacket {
   // Encapsulates the state and configuration of the ProtoVM instances running
   // when the trace was snapshotted. This allows TP to re-instantiate the VMs
@@ -17901,6 +18059,11 @@ message TracePacket {
     SmapsPacket smaps_packet = 68;
     TracingServiceEvent service_event = 69;
     ConcurrentSessionEvent concurrent_session_event = 134;
+
+    // Transport-neutral stack sampling (see profiling/stack_sample.proto).
+    // Independent of PerfSample.
+    StackSample stack_sample = 135;
+
     InitialDisplayState initial_display_state = 70;
     GpuMemTotalEvent gpu_mem_total_event = 71;
     MemoryTrackerSnapshot memory_tracker_snapshot = 73;

--- a/protos/perfetto/trace/profiling/BUILD.gn
+++ b/protos/perfetto/trace/profiling/BUILD.gn
@@ -22,5 +22,14 @@ perfetto_proto_library("@TYPE@") {
     "profile_common.proto",
     "profile_packet.proto",
     "smaps.proto",
+    "stack_sample.proto",
   ]
+}
+
+# StackSample interned_data extension. Kept in its own target so InternedData,
+# which depends on this directory's protos, does not form a dependency cycle.
+perfetto_proto_library("stack_sample_interned_data_@TYPE@") {
+  sources = [ "stack_sample_interned_data.proto" ]
+  deps = [ ":@TYPE@" ]
+  public_deps = [ "../interned_data:@TYPE@" ]
 }

--- a/protos/perfetto/trace/profiling/profile_common.proto
+++ b/protos/perfetto/trace/profiling/profile_common.proto
@@ -164,6 +164,25 @@ message Frame {
   // is available at trace collection time. If not set, line numbers may be
   // added later via offline symbolization (see ModuleSymbols).
   optional uint32 line_number = 6;
+
+  // The kind of code this frame represents, for categorization (e.g. coloring
+  // a flamegraph, or telling interpreted Python frames apart from native and
+  // GC frames in one mixed stack). Set the well-known `kind` when one fits,
+  // otherwise set `kind_str` to a custom label. The well-known enum is
+  // append-only and language-neutral; language-specific labels go in kind_str.
+  enum Kind {
+    KIND_UNKNOWN = 0;
+    KIND_NATIVE = 1;
+    KIND_KERNEL = 2;
+    KIND_INTERPRETED = 3;
+    KIND_JIT = 4;
+    KIND_GC = 5;
+    KIND_RUNTIME = 6;
+  }
+  oneof kind_field {
+    Kind kind = 7;
+    string kind_str = 8;
+  }
 }
 
 message Callstack {

--- a/protos/perfetto/trace/profiling/stack_sample.proto
+++ b/protos/perfetto/trace/profiling/stack_sample.proto
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+
+import "protos/perfetto/trace/profiling/profile_common.proto";
+
+package perfetto.protos;
+
+// A single stack sample: a callstack captured for a task, measured against a
+// counter timebase. This is transport-neutral and timebase-neutral. The
+// timebase can be CPU cycles, wall-clock nanoseconds, allocated bytes, page
+// faults, etc.; the primary CounterDescriptor says which. It is not specific to
+// CPU profiling.
+//
+// Each context/callstack/descriptor can be given inline or as an `iid`
+// referencing an InternedData entry. Producers that reuse a context across
+// samples should intern it so the per-sample cost is a single varint.
+message StackSample {
+  // The privilege level a sample was taken at. Append-only: never renumber or
+  // repurpose an existing value.
+  enum Mode {
+    MODE_UNKNOWN = 0;
+    MODE_USER = 1;
+    MODE_KERNEL = 2;
+    MODE_HYPERVISOR = 3;
+    MODE_GUEST_USER = 4;
+    MODE_GUEST_KERNEL = 5;
+  }
+
+  // The unit a CounterDescriptor's values are expressed in. Append-only: new
+  // units may be added, but existing values are never renumbered or
+  // repurposed. If none of these fit, set CounterDescriptor.unit_str instead.
+  enum Unit {
+    UNIT_UNSPECIFIED = 0;
+    UNIT_NANOSECONDS = 1;
+    UNIT_CPU_CYCLES = 2;
+    UNIT_INSTRUCTIONS = 3;
+    UNIT_BYTES = 4;
+    UNIT_PAGE_FAULTS = 5;
+    UNIT_CACHE_MISSES = 6;
+    UNIT_CACHE_REFERENCES = 7;
+    UNIT_BRANCH_MISSES = 8;
+    UNIT_COUNT = 9;
+  }
+
+  // The task an observation is attributed to. At least one of pid / tid should
+  // be set.
+  message TaskContext {
+    // Interning key, used when this context is emitted via
+    // StackSampleInternedData.task_contexts and referenced by
+    // StackSample.task_context_iid. Starts from 1; 0 is the same as "not set".
+    optional uint64 iid = 1;
+
+    // OS process id the sample belongs to.
+    optional uint32 pid = 2;
+
+    // OS thread id the sample belongs to. If only tid is set, the process is
+    // inferred from thread association elsewhere in the trace.
+    optional uint32 tid = 3;
+  }
+
+  // The execution state a sample was taken in. All fields are optional: an
+  // off-CPU sample (e.g. a wall-clock sampler catching a sleeping thread) has
+  // no meaningful cpu or mode.
+  message ExecutionContext {
+    // Interning key, used when this context is emitted via
+    // StackSampleInternedData.execution_contexts and referenced by
+    // StackSample.execution_context_iid. Starts from 1; 0 is the same as "not
+    // set".
+    optional uint64 iid = 1;
+
+    // The cpu the sample was taken on.
+    optional uint32 cpu = 2;
+
+    // The privilege level the sampled code was running at.
+    optional Mode mode = 3;
+  }
+
+  // Describes a counter: a named, typed quantity a sample is measured against
+  // (the sampling timebase) or observed alongside (a follower). Values live on
+  // the sample as weights; this only describes their meaning.
+  message CounterDescriptor {
+    // Interning key, used when this descriptor is emitted via
+    // StackSampleInternedData.counter_descriptors and referenced by
+    // StackSample.primary_descriptor_iid. Starts from 1; 0 is the same as "not
+    // set".
+    optional uint64 iid = 1;
+
+    // Human-readable counter name, e.g. "cycles", "wall-time", "cache-misses".
+    optional string name = 2;
+
+    // The unit weights are expressed in. Set the well-known `unit` when one
+    // fits, otherwise set `unit_str` to a custom label.
+    oneof unit_field {
+      // A well-known unit from the Unit enum.
+      Unit unit = 3;
+
+      // A custom unit label, used when no Unit enum value fits.
+      string unit_str = 4;
+    }
+
+    // Scales raw weights to `unit`. E.g. unit=UNIT_BYTES, unit_multiplier=1024
+    // means weights are in KiB. Absent means 1.
+    optional uint64 unit_multiplier = 5;
+
+    // Free-form description of what the counter measures.
+    optional string description = 6;
+  }
+
+  // The task (thread / process / async context) this sample is attributed to.
+  // Give it inline via `task_context` or reference an interned TaskContext via
+  // `task_context_iid`.
+  oneof task_context_field {
+    // Inline task context.
+    TaskContext task_context = 1;
+
+    // Interned task context, referencing StackSampleInternedData.task_contexts.
+    uint64 task_context_iid = 2;
+  }
+
+  // The execution state (cpu, privilege mode) at sample time. Absent for
+  // samplers that observe off-CPU tasks. Give it inline via `execution_context`
+  // or reference an interned ExecutionContext via `execution_context_iid`.
+  oneof execution_context_field {
+    // Inline execution context.
+    ExecutionContext execution_context = 3;
+
+    // Interned execution context, referencing
+    // StackSampleInternedData.execution_contexts.
+    uint64 execution_context_iid = 4;
+  }
+
+  // The captured callstack, bottom frame first.
+  oneof callstack_field {
+    // Inline callstack. The only supported form for now.
+    Callstack callstack = 5;
+
+    // Reserved: an interned callstack variant may be added later.
+    // uint64 callstack_iid = 6;
+  }
+
+  // Set if stack unwinding was incomplete; describes the data, not producer
+  // internal state. Give it inline via `unwind_error` or reference an interned
+  // string via `unwind_error_iid`.
+  //
+  // TODO(lalitm): not yet parsed by trace_processor. Defined now to lock the
+  // wire layout; a table column will surface it later.
+  oneof unwind_error_field {
+    // Inline unwind error string.
+    string unwind_error = 7;
+
+    // Interned unwind error string, referencing an InternedData string entry.
+    uint64 unwind_error_iid = 8;
+  }
+
+  // The sampling timebase: the counter this sample's weight is measured
+  // against. Set one of the two; may be omitted entirely if declared in
+  // StackSampleDefaults.primary_descriptor.
+  oneof primary_descriptor_field {
+    // Inline timebase descriptor.
+    CounterDescriptor primary_descriptor = 9;
+
+    // Interned timebase descriptor, referencing
+    // StackSampleInternedData.counter_descriptors.
+    uint64 primary_descriptor_iid = 10;
+  }
+
+  // The value attributed to this sample for the primary counter (e.g. the
+  // number of cycles or nanoseconds this sample represents).
+  optional uint64 primary_weight = 11;
+}
+
+// Per-sequence defaults for StackSample. Lets a producer declare the source and
+// the common timebase once instead of on every sample.
+message StackSampleDefaults {
+  // Identifies the profiler that produced these samples, e.g. "linux.perf",
+  // "python.wall". Recorded once per sampling stream.
+  optional string source = 1;
+
+  // Default primary timebase for samples that omit their own.
+  optional StackSample.CounterDescriptor primary_descriptor = 2;
+}

--- a/protos/perfetto/trace/profiling/stack_sample_interned_data.proto
+++ b/protos/perfetto/trace/profiling/stack_sample_interned_data.proto
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+
+package perfetto.protos;
+
+import public "protos/perfetto/trace/interned_data/interned_data.proto";
+import "protos/perfetto/trace/profiling/stack_sample.proto";
+
+// StackSample context and descriptors interned into InternedData. Field numbers
+// are allocated from the perfetto_profiling range in
+// protos/perfetto/trace/extensions.json. Kept in its own file (not
+// stack_sample.proto) so InternedData, which already depends on the profiling
+// protos, does not gain a circular dependency.
+message StackSampleInternedData {
+  extend InternedData {
+    repeated StackSample.TaskContext task_contexts = 2000;
+    repeated StackSample.ExecutionContext execution_contexts = 2001;
+    repeated StackSample.CounterDescriptor counter_descriptors = 2002;
+  }
+}

--- a/protos/perfetto/trace/trace_packet.proto
+++ b/protos/perfetto/trace/trace_packet.proto
@@ -69,6 +69,7 @@ import "protos/perfetto/trace/profiling/deobfuscation.proto";
 import "protos/perfetto/trace/profiling/profile_common.proto";
 import "protos/perfetto/trace/profiling/profile_packet.proto";
 import "protos/perfetto/trace/profiling/smaps.proto";
+import "protos/perfetto/trace/profiling/stack_sample.proto";
 import "protos/perfetto/trace/ps/process_stats.proto";
 import "protos/perfetto/trace/ps/process_tree.proto";
 import "protos/perfetto/trace/remote_clock_sync.proto";
@@ -110,7 +111,7 @@ package perfetto.protos;
 // See the [Buffers and Dataflow](/docs/concepts/buffers.md) doc for details.
 //
 // Next reserved id: 14 (up to 15).
-// Next id: 135.
+// Next id: 136.
 message TracePacket {
   // Encapsulates the state and configuration of the ProtoVM instances running
   // when the trace was snapshotted. This allows TP to re-instantiate the VMs
@@ -209,6 +210,11 @@ message TracePacket {
     SmapsPacket smaps_packet = 68;
     TracingServiceEvent service_event = 69;
     ConcurrentSessionEvent concurrent_session_event = 134;
+
+    // Transport-neutral stack sampling (see profiling/stack_sample.proto).
+    // Independent of PerfSample.
+    StackSample stack_sample = 135;
+
     InitialDisplayState initial_display_state = 70;
     GpuMemTotalEvent gpu_mem_total_event = 71;
     MemoryTrackerSnapshot memory_tracker_snapshot = 73;

--- a/protos/perfetto/trace/trace_packet_defaults.proto
+++ b/protos/perfetto/trace/trace_packet_defaults.proto
@@ -18,6 +18,7 @@ syntax = "proto2";
 
 import "protos/perfetto/trace/chrome/v8.proto";
 import "protos/perfetto/trace/profiling/profile_packet.proto";
+import "protos/perfetto/trace/profiling/stack_sample.proto";
 import "protos/perfetto/trace/track_event/track_event.proto";
 
 package perfetto.protos;
@@ -37,6 +38,9 @@ message TracePacketDefaults {
 
   // Defaults for perf profiler packets (PerfSample).
   optional PerfSampleDefaults perf_sample_defaults = 12;
+
+  // Defaults for transport-neutral stack sampling packets (StackSample).
+  optional StackSampleDefaults stack_sample_defaults = 100;
 
   // Defaults for V8 code packets (V8JsCode, V8InternalCode, V8WasmCode,
   // V8RegexpCode)

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -243,6 +243,7 @@ if (enable_perfetto_trace_processor_sqlite) {
       "plugins/span_join_operator",
       "plugins/sql_stats_table",
       "plugins/stack_functions",
+      "plugins/stack_sample_importer",
       "plugins/stdlib_docs",
       "plugins/storage_tables",
       "plugins/string_functions",

--- a/src/trace_processor/importers/proto/stack_profile_sequence_state.cc
+++ b/src/trace_processor/importers/proto/stack_profile_sequence_state.cc
@@ -51,6 +51,29 @@ bool IsMagicalKernelMapping(const CreateMappingParams& params) {
          !params.build_id.has_value() && (params.name == "/kernel");
 }
 
+// Maps a well-known Frame.Kind to the canonical lowercase label stored in
+// stack_profile_frame.type. Returns nullptr for KIND_UNKNOWN / unrecognized.
+const char* StringifyFrameKind(protos::pbzero::Frame::Kind kind) {
+  using protos::pbzero::Frame;
+  switch (kind) {
+    case Frame::Kind::KIND_UNKNOWN:
+      return nullptr;
+    case Frame::Kind::KIND_NATIVE:
+      return "native";
+    case Frame::Kind::KIND_KERNEL:
+      return "kernel";
+    case Frame::Kind::KIND_INTERPRETED:
+      return "interpreted";
+    case Frame::Kind::KIND_JIT:
+      return "jit";
+    case Frame::Kind::KIND_GC:
+      return "gc";
+    case Frame::Kind::KIND_RUNTIME:
+      return "runtime";
+  }
+  return nullptr;
+}
+
 }  // namespace
 
 StackProfileSequenceState::StackProfileSequenceState(
@@ -188,9 +211,25 @@ std::optional<CallsiteId> StackProfileSequenceState::FindOrInsertCallstack(
     return std::nullopt;
   }
 
+  std::optional<CallsiteId> callsite_id =
+      FindOrInsertCallstackFromFrames(state, upid, *decoder);
+  if (!callsite_id) {
+    return std::nullopt;
+  }
+
+  cached_callstacks_.Insert({upid, iid}, *callsite_id);
+
+  return callsite_id;
+}
+
+std::optional<CallsiteId>
+StackProfileSequenceState::FindOrInsertCallstackFromFrames(
+    PacketSequenceStateGeneration* state,
+    std::optional<UniquePid> upid,
+    const protos::pbzero::Callstack_Decoder& callstack) {
   std::optional<CallsiteId> parent_callsite_id;
   uint32_t depth = 0;
-  for (auto it = decoder->frame_ids(); it; ++it) {
+  for (auto it = callstack.frame_ids(); it; ++it) {
     std::optional<FrameId> frame_id = FindOrInsertFrame(state, upid, *it);
     if (!frame_id) {
       return std::nullopt;
@@ -205,8 +244,6 @@ std::optional<CallsiteId> StackProfileSequenceState::FindOrInsertCallstack(
         stats::stackprofile_empty_callstack);
     return std::nullopt;
   }
-
-  cached_callstacks_.Insert({upid, iid}, *parent_callsite_id);
 
   return parent_callsite_id;
 }
@@ -251,38 +288,52 @@ std::optional<FrameId> StackProfileSequenceState::FindOrInsertFrame(
     line_number = decoder->line_number();
   }
 
-  // Check if mapping_id is 0, which means this is a "dummy" frame (no real
-  // mapping) In this case, we should use the dummy mapping API with source file
-  // and line number
+  // mapping_id == 0 means a "dummy" frame (no real mapping): use the dummy
+  // mapping API with source file and line number. Otherwise it's a regular
+  // frame in a real mapping. Both paths land in `frame_id`.
+  FrameId frame_id;
+  bool cache = true;
   if (decoder->mapping_id() == 0) {
     // Get or create the dummy mapping for interned frames with mapping_id = 0
     if (!dummy_mapping_for_interned_frames_) {
       dummy_mapping_for_interned_frames_ =
           &context_->mapping_tracker->CreateDummyMapping("");
     }
-
-    FrameId frame_id = dummy_mapping_for_interned_frames_->InternDummyFrame(
+    frame_id = dummy_mapping_for_interned_frames_->InternDummyFrame(
         function_name, source_file, line_number);
+  } else {
+    VirtualMemoryMapping* mapping =
+        FindOrInsertMappingImpl(state, upid, decoder->mapping_id());
+    if (!mapping) {
+      return std::nullopt;
+    }
+    // InternFrame will create the symbol entry if source_file or line_number is
+    // provided
+    frame_id = mapping->InternFrame(decoder->rel_pc(), function_name,
+                                    source_file, line_number);
+    cache = !mapping->is_jitted();
+  }
+
+  // Back-patch the frame kind (type) if the producer reported one.
+  std::optional<StringId> type_id;
+  if (decoder->has_kind()) {
+    const char* kind = StringifyFrameKind(
+        static_cast<protos::pbzero::Frame::Kind>(decoder->kind()));
+    if (kind) {
+      type_id = context_->storage->InternString(kind);
+    }
+  } else if (decoder->has_kind_str()) {
+    type_id = context_->storage->InternString(decoder->kind_str());
+  }
+  if (type_id) {
+    auto* frames = context_->storage->mutable_stack_profile_frame_table();
+    auto rr = (*frames)[frame_id];
+    rr.set_type(*type_id);
+  }
+
+  if (cache) {
     cached_frames_.Insert({upid, iid}, frame_id);
-    return frame_id;
   }
-
-  // Regular frame with a real mapping
-  VirtualMemoryMapping* mapping =
-      FindOrInsertMappingImpl(state, upid, decoder->mapping_id());
-  if (!mapping) {
-    return std::nullopt;
-  }
-
-  // InternFrame will create the symbol entry if source_file or line_number is
-  // provided
-  FrameId frame_id = mapping->InternFrame(decoder->rel_pc(), function_name,
-                                          source_file, line_number);
-
-  if (!mapping->is_jitted()) {
-    cached_frames_.Insert({upid, iid}, frame_id);
-  }
-
   return frame_id;
 }
 

--- a/src/trace_processor/importers/proto/stack_profile_sequence_state.h
+++ b/src/trace_processor/importers/proto/stack_profile_sequence_state.h
@@ -28,6 +28,10 @@
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
+namespace perfetto::protos::pbzero {
+class Callstack_Decoder;
+}  // namespace perfetto::protos::pbzero
+
 namespace perfetto::trace_processor {
 
 class DummyMemoryMapping;
@@ -51,6 +55,14 @@ class StackProfileSequenceState final
       PacketSequenceStateGeneration* state,
       std::optional<UniquePid> upid,
       uint64_t iid);
+
+  // Walks a Callstack's frame_ids (interned frame iids, bottom frame first),
+  // interning each frame and building the callsite chain. Used for both the
+  // interned callstack path and inline callstacks.
+  std::optional<CallsiteId> FindOrInsertCallstackFromFrames(
+      PacketSequenceStateGeneration* state,
+      std::optional<UniquePid> upid,
+      const protos::pbzero::Callstack_Decoder& callstack);
 
  private:
   std::optional<base::StringView> LookupInternedBuildId(

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -569,7 +569,10 @@ CREATE PERFETTO VIEW stack_profile_frame(
   -- If the profile was offline symbolized, the offline symbol information.
   symbol_set_id LONG,
   -- Deobfuscated name of the function this location is in.
-  deobfuscated_name STRING
+  deobfuscated_name STRING,
+  -- The kind of frame (e.g. "native", "kernel", "interpreted", "jit", "gc",
+  -- "runtime") if reported by the producer, else NULL.
+  type STRING
 )
 AS
 SELECT * FROM __intrinsic_stack_profile_frame;

--- a/src/trace_processor/plugins/stack_sample_importer/BUILD.gn
+++ b/src/trace_processor/plugins/stack_sample_importer/BUILD.gn
@@ -1,0 +1,53 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/perfetto.gni")
+import("../../../../gn/perfetto_tp_tables.gni")
+
+assert(enable_perfetto_trace_processor_sqlite)
+
+perfetto_tp_tables("tables") {
+  sources = [ "tables.py" ]
+  deps = [ "../../tables:tables_python" ]
+}
+
+source_set("stack_sample_importer") {
+  sources = [
+    "module.cc",
+    "module.h",
+    "plugin.cc",
+    "plugin.h",
+  ]
+  deps = [
+    ":tables",
+    "../../../../gn:default_deps",
+    "../../../../include/perfetto/trace_processor:basic_types",
+    "../../../../protos/perfetto/trace:zero",
+    "../../../../protos/perfetto/trace/interned_data:zero",
+    "../../../../protos/perfetto/trace/profiling:stack_sample_interned_data_zero",
+    "../../../../protos/perfetto/trace/profiling:zero",
+    "../../../base",
+    "../../../protozero",
+    "../../core/dataframe",
+    "../../core/plugin",
+    "../../importers/common",
+    "../../importers/common:parser_types",
+    "../../importers/proto:minimal",
+    "../../importers/proto:packet_sequence_state_generation_hdr",
+    "../../importers/proto:proto_importer_module",
+    "../../storage",
+    "../../tables",
+    "../../types",
+  ]
+}

--- a/src/trace_processor/plugins/stack_sample_importer/module.cc
+++ b/src/trace_processor/plugins/stack_sample_importer/module.cc
@@ -1,0 +1,338 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/plugins/stack_sample_importer/module.h"
+
+#include <cstdint>
+#include <optional>
+
+#include "perfetto/ext/base/fnv_hash.h"
+#include "src/trace_processor/importers/common/process_tracker.h"
+#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/importers/proto/stack_profile_sequence_state.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+#include "protos/perfetto/trace/interned_data/interned_data.pbzero.h"
+#include "protos/perfetto/trace/profiling/profile_common.pbzero.h"
+#include "protos/perfetto/trace/profiling/stack_sample.pbzero.h"
+#include "protos/perfetto/trace/profiling/stack_sample_interned_data.pbzero.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "protos/perfetto/trace/trace_packet_defaults.pbzero.h"
+
+namespace perfetto::trace_processor::stack_sample_importer {
+namespace {
+
+using perfetto::protos::pbzero::TracePacket;
+
+const char* StringifyStackSampleMode(protos::pbzero::StackSample::Mode mode) {
+  using StackSample = protos::pbzero::StackSample;
+  switch (mode) {
+    case StackSample::Mode::MODE_UNKNOWN:
+      return "";
+    case StackSample::Mode::MODE_USER:
+      return "user";
+    case StackSample::Mode::MODE_KERNEL:
+      return "kernel";
+    case StackSample::Mode::MODE_HYPERVISOR:
+      return "hypervisor";
+    case StackSample::Mode::MODE_GUEST_USER:
+      return "guest_user";
+    case StackSample::Mode::MODE_GUEST_KERNEL:
+      return "guest_kernel";
+  }
+  return "";
+}
+
+const char* StringifyProfileUnit(protos::pbzero::StackSample::Unit unit) {
+  using StackSample = protos::pbzero::StackSample;
+  switch (unit) {
+    case StackSample::Unit::UNIT_UNSPECIFIED:
+      return "";
+    case StackSample::Unit::UNIT_NANOSECONDS:
+      return "ns";
+    case StackSample::Unit::UNIT_CPU_CYCLES:
+      return "cycles";
+    case StackSample::Unit::UNIT_INSTRUCTIONS:
+      return "instructions";
+    case StackSample::Unit::UNIT_BYTES:
+      return "bytes";
+    case StackSample::Unit::UNIT_PAGE_FAULTS:
+      return "page-faults";
+    case StackSample::Unit::UNIT_CACHE_MISSES:
+      return "cache-misses";
+    case StackSample::Unit::UNIT_CACHE_REFERENCES:
+      return "cache-references";
+    case StackSample::Unit::UNIT_BRANCH_MISSES:
+      return "branch-misses";
+    case StackSample::Unit::UNIT_COUNT:
+      return "count";
+  }
+  return "";
+}
+
+uint64_t OptStringKey(std::optional<StringId> id) {
+  return id ? (uint64_t{1} << 32) | id->raw_id() : 0;
+}
+
+uint64_t OptUintKey(std::optional<uint32_t> v) {
+  return v ? (uint64_t{1} << 32) | *v : 0;
+}
+
+ResolvedCounterDescriptor ResolveCounterDescriptor(
+    TraceProcessorContext* context,
+    const protos::pbzero::StackSample::CounterDescriptor::Decoder& desc) {
+  using StackSample = protos::pbzero::StackSample;
+  ResolvedCounterDescriptor out;
+  out.name = context->storage->InternString(desc.name());
+  if (desc.has_unit() && desc.unit() != StackSample::Unit::UNIT_UNSPECIFIED) {
+    out.unit = context->storage->InternString(
+        StringifyProfileUnit(static_cast<StackSample::Unit>(desc.unit())));
+  } else if (desc.unit_str().size > 0) {
+    out.unit = context->storage->InternString(desc.unit_str());
+  }
+  if (desc.has_unit_multiplier()) {
+    out.unit_multiplier = static_cast<int64_t>(desc.unit_multiplier());
+  }
+  if (desc.description().size > 0) {
+    out.description = context->storage->InternString(desc.description());
+  }
+  return out;
+}
+
+// Resolves an inline callstack (a profile_common Callstack whose frame_ids are
+// interned frame iids).
+std::optional<CallsiteId> ResolveCallstack(
+    PacketSequenceStateGeneration* sequence_state,
+    std::optional<UniquePid> upid,
+    const protos::pbzero::StackSample::Decoder& sample) {
+  if (!sample.has_callstack()) {
+    return std::nullopt;
+  }
+  auto* state = sequence_state->GetCustomState<StackProfileSequenceState>();
+  protos::pbzero::Callstack::Decoder callstack(sample.callstack());
+  return state->FindOrInsertCallstackFromFrames(sequence_state, upid,
+                                                callstack);
+}
+
+}  // namespace
+
+StackSampleModule::StackSampleModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context,
+    tables::StackSampleTable* table,
+    tables::StackSampleTaskContextTable* task_context_table,
+    tables::StackSampleExecutionContextTable* exec_context_table,
+    tables::StackSampleTimebaseTable* timebase_table)
+    : ProtoImporterModule(module_context),
+      context_(context),
+      table_(table),
+      task_context_table_(task_context_table),
+      exec_context_table_(exec_context_table),
+      timebase_table_(timebase_table) {
+  RegisterForField(TracePacket::kStackSampleFieldNumber);
+}
+
+void StackSampleModule::ParseField(const ParseFieldArgs& args) {
+  if (args.field.id() == TracePacket::kStackSampleFieldNumber) {
+    ParseStackSample(args.ts, args.data.sequence_state.get(),
+                     args.field.Cast<TracePacket::kStackSample>());
+  }
+}
+
+tables::StackSampleTaskContextTable::Id StackSampleModule::InternTaskContext(
+    std::optional<uint32_t> utid,
+    std::optional<uint32_t> upid) {
+  uint64_t key = base::FnvHasher::Combine(OptUintKey(utid), OptUintKey(upid));
+  if (auto* id = task_contexts_.Find(key)) {
+    return *id;
+  }
+  tables::StackSampleTaskContextTable::Row row;
+  row.utid = utid;
+  row.upid = upid;
+  auto id = task_context_table_->Insert(row).id;
+  task_contexts_.Insert(key, id);
+  return id;
+}
+
+tables::StackSampleExecutionContextTable::Id
+StackSampleModule::InternExecutionContext(std::optional<uint32_t> cpu,
+                                          StringId mode) {
+  uint64_t key = base::FnvHasher::Combine(OptUintKey(cpu), mode.raw_id());
+  if (auto* id = exec_contexts_.Find(key)) {
+    return *id;
+  }
+  tables::StackSampleExecutionContextTable::Row row;
+  row.cpu = cpu;
+  row.mode = mode;
+  auto id = exec_context_table_->Insert(row).id;
+  exec_contexts_.Insert(key, id);
+  return id;
+}
+
+tables::StackSampleTimebaseTable::Id StackSampleModule::InternTimebase(
+    StringId source,
+    const ResolvedCounterDescriptor& desc) {
+  uint64_t key = base::FnvHasher::Combine(
+      source.raw_id(), desc.name.raw_id(), OptStringKey(desc.unit),
+      desc.unit_multiplier ? static_cast<uint64_t>(*desc.unit_multiplier) : 0,
+      OptStringKey(desc.description));
+  if (auto* id = timebases_.Find(key)) {
+    return *id;
+  }
+  tables::StackSampleTimebaseTable::Row row;
+  row.source = source;
+  row.name = desc.name;
+  row.unit = desc.unit;
+  row.unit_multiplier = desc.unit_multiplier;
+  row.description = desc.description;
+  auto id = timebase_table_->Insert(row).id;
+  timebases_.Insert(key, id);
+  return id;
+}
+
+void StackSampleModule::ParseStackSample(
+    int64_t ts,
+    PacketSequenceStateGeneration* sequence_state,
+    protozero::ConstBytes blob) {
+  using protos::pbzero::StackSample;
+  using protos::pbzero::StackSampleDefaults;
+  using protos::pbzero::StackSampleInternedData;
+  using CounterDescriptor = StackSample::CounterDescriptor;
+  using ExecutionContext = StackSample::ExecutionContext;
+  using Mode = StackSample::Mode;
+  using TaskContext = StackSample::TaskContext;
+
+  StackSample::Decoder sample(blob.data, blob.size);
+
+  // Defaults carry the source and the fallback primary descriptor.
+  std::optional<StackSampleDefaults::Decoder> defaults;
+  if (auto* d = sequence_state->GetTracePacketDefaults();
+      d && d->has_stack_sample_defaults()) {
+    defaults.emplace(d->stack_sample_defaults());
+  }
+  StringId source_id = kNullStringId;
+  if (defaults && defaults->source().size > 0) {
+    source_id = context_->storage->InternString(defaults->source());
+  }
+
+  // Task context: attributes the sample to a thread / process.
+  std::optional<uint32_t> pid;
+  std::optional<uint32_t> tid;
+  bool has_task = false;
+  auto extract_task = [&](const TaskContext::Decoder& t) {
+    has_task = true;
+    if (t.has_pid()) {
+      pid = t.pid();
+    }
+    if (t.has_tid()) {
+      tid = t.tid();
+    }
+  };
+  if (sample.has_task_context()) {
+    TaskContext::Decoder t(sample.task_context());
+    extract_task(t);
+  } else if (sample.has_task_context_iid()) {
+    if (auto* t = sequence_state->LookupInternedMessage<
+            StackSampleInternedData::kTaskContextsFieldNumber, TaskContext>(
+            sample.task_context_iid())) {
+      extract_task(*t);
+    }
+  }
+
+  ProcessTracker* procs = context_->process_tracker.get();
+  std::optional<UniquePid> upid;
+  std::optional<uint32_t> utid;
+  if (pid) {
+    upid = procs->GetOrCreateProcess(*pid);
+  }
+  if (tid) {
+    utid = pid ? procs->UpdateThread(*tid, *pid)
+               : procs->GetOrCreateThread(*tid);
+  }
+  std::optional<tables::StackSampleTaskContextTable::Id> task_context_id;
+  if (has_task && (utid || upid)) {
+    task_context_id = InternTaskContext(utid, upid);
+  }
+
+  // Execution context: cpu + privilege mode at sample time.
+  std::optional<uint32_t> cpu;
+  Mode mode = StackSample::Mode::MODE_UNKNOWN;
+  bool has_exec = false;
+  auto extract_exec = [&](const ExecutionContext::Decoder& e) {
+    has_exec = true;
+    if (e.has_cpu()) {
+      cpu = e.cpu();
+    }
+    if (e.has_mode()) {
+      mode = static_cast<Mode>(e.mode());
+    }
+  };
+  if (sample.has_execution_context()) {
+    ExecutionContext::Decoder e(sample.execution_context());
+    extract_exec(e);
+  } else if (sample.has_execution_context_iid()) {
+    if (auto* e = sequence_state->LookupInternedMessage<
+            StackSampleInternedData::kExecutionContextsFieldNumber,
+            ExecutionContext>(sample.execution_context_iid())) {
+      extract_exec(*e);
+    }
+  }
+  std::optional<tables::StackSampleExecutionContextTable::Id>
+      execution_context_id;
+  if (has_exec) {
+    StringId mode_id =
+        context_->storage->InternString(StringifyStackSampleMode(mode));
+    execution_context_id = InternExecutionContext(cpu, mode_id);
+  }
+
+  // Primary (timebase) descriptor: inline, interned, or from defaults.
+  ResolvedCounterDescriptor primary;
+  if (sample.has_primary_descriptor()) {
+    CounterDescriptor::Decoder d(sample.primary_descriptor());
+    primary = ResolveCounterDescriptor(context_, d);
+  } else if (sample.has_primary_descriptor_iid()) {
+    if (auto* d = sequence_state->LookupInternedMessage<
+            StackSampleInternedData::kCounterDescriptorsFieldNumber,
+            CounterDescriptor>(sample.primary_descriptor_iid())) {
+      primary = ResolveCounterDescriptor(context_, *d);
+    }
+  } else if (defaults && defaults->has_primary_descriptor()) {
+    CounterDescriptor::Decoder d(defaults->primary_descriptor());
+    primary = ResolveCounterDescriptor(context_, d);
+  }
+  tables::StackSampleTimebaseTable::Id timebase_id =
+      InternTimebase(source_id, primary);
+
+  std::optional<CallsiteId> cs_id =
+      ResolveCallstack(sequence_state, upid, sample);
+
+  std::optional<int64_t> weight;
+  if (sample.has_primary_weight()) {
+    weight = static_cast<int64_t>(sample.primary_weight());
+  }
+
+  tables::StackSampleTable::Row row;
+  row.ts = ts;
+  row.task_context_id = task_context_id;
+  row.execution_context_id = execution_context_id;
+  row.timebase_id = timebase_id;
+  row.callsite_id = cs_id;
+  row.weight = weight;
+  table_->Insert(row);
+}
+
+}  // namespace perfetto::trace_processor::stack_sample_importer

--- a/src/trace_processor/plugins/stack_sample_importer/module.h
+++ b/src/trace_processor/plugins/stack_sample_importer/module.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PLUGINS_STACK_SAMPLE_IMPORTER_MODULE_H_
+#define SRC_TRACE_PROCESSOR_PLUGINS_STACK_SAMPLE_IMPORTER_MODULE_H_
+
+#include <cstdint>
+#include <optional>
+
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/protozero/field.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/plugins/stack_sample_importer/tables_py.h"
+#include "src/trace_processor/storage/trace_storage.h"
+
+namespace perfetto::trace_processor {
+class PacketSequenceStateGeneration;
+class TraceProcessorContext;
+}  // namespace perfetto::trace_processor
+
+namespace perfetto::trace_processor::stack_sample_importer {
+
+// A resolved StackSample.CounterDescriptor: all strings already interned.
+struct ResolvedCounterDescriptor {
+  StringId name = kNullStringId;
+  std::optional<StringId> unit;
+  std::optional<int64_t> unit_multiplier;
+  std::optional<StringId> description;
+};
+
+// Parses the transport-neutral StackSample packets (see
+// profiling/stack_sample.proto) into the plugin-owned tables, passed in by the
+// owning plugin. The task, execution and timebase contexts are deduplicated
+// into their own tables; the sample rows reference them by id.
+class StackSampleModule : public ProtoImporterModule {
+ public:
+  StackSampleModule(ProtoImporterModuleContext* module_context,
+                    TraceProcessorContext* context,
+                    tables::StackSampleTable* table,
+                    tables::StackSampleTaskContextTable* task_context_table,
+                    tables::StackSampleExecutionContextTable* exec_context_table,
+                    tables::StackSampleTimebaseTable* timebase_table);
+
+  void ParseField(const ParseFieldArgs& args) override;
+
+ private:
+  tables::StackSampleTaskContextTable::Id InternTaskContext(
+      std::optional<uint32_t> utid,
+      std::optional<uint32_t> upid);
+  tables::StackSampleExecutionContextTable::Id InternExecutionContext(
+      std::optional<uint32_t> cpu,
+      StringId mode);
+  tables::StackSampleTimebaseTable::Id InternTimebase(
+      StringId source,
+      const ResolvedCounterDescriptor& desc);
+
+  void ParseStackSample(int64_t ts,
+                        PacketSequenceStateGeneration* sequence_state,
+                        protozero::ConstBytes blob);
+
+  TraceProcessorContext* const context_;
+  tables::StackSampleTable* const table_;
+  tables::StackSampleTaskContextTable* const task_context_table_;
+  tables::StackSampleExecutionContextTable* const exec_context_table_;
+  tables::StackSampleTimebaseTable* const timebase_table_;
+
+  // Content-dedup maps: fingerprint of the context fields -> interned row id.
+  base::FlatHashMap<uint64_t, tables::StackSampleTaskContextTable::Id>
+      task_contexts_;
+  base::FlatHashMap<uint64_t, tables::StackSampleExecutionContextTable::Id>
+      exec_contexts_;
+  base::FlatHashMap<uint64_t, tables::StackSampleTimebaseTable::Id> timebases_;
+};
+
+}  // namespace perfetto::trace_processor::stack_sample_importer
+
+#endif  // SRC_TRACE_PROCESSOR_PLUGINS_STACK_SAMPLE_IMPORTER_MODULE_H_

--- a/src/trace_processor/plugins/stack_sample_importer/plugin.cc
+++ b/src/trace_processor/plugins/stack_sample_importer/plugin.cc
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/plugins/stack_sample_importer/plugin.h"
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/compiler.h"
+#include "src/trace_processor/core/plugin/plugin.h"
+#include "src/trace_processor/core/plugin/registration.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/plugins/stack_sample_importer/module.h"
+#include "src/trace_processor/plugins/stack_sample_importer/tables_py.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor::stack_sample_importer {
+namespace {
+
+// The plugin owns the __intrinsic_stack_sample table and its three context
+// tables, populated by StackSampleModule during parsing and living for the
+// whole session.
+class StackSampleImporter : public Plugin<StackSampleImporter> {
+ public:
+  ~StackSampleImporter() override;
+
+  void RegisterDataframes(std::vector<PluginDataframe>& out) override {
+    EnsureTables();
+    out.push_back({&table_->dataframe(), tables::StackSampleTable::Name(), {}});
+    out.push_back({&task_context_table_->dataframe(),
+                   tables::StackSampleTaskContextTable::Name(), {}});
+    out.push_back({&exec_context_table_->dataframe(),
+                   tables::StackSampleExecutionContextTable::Name(), {}});
+    out.push_back({&timebase_table_->dataframe(),
+                   tables::StackSampleTimebaseTable::Name(), {}});
+  }
+
+  void RegisterProtoImporterModules(
+      ProtoImporterModuleContext* module_context,
+      TraceProcessorContext* trace_context) override {
+    EnsureTables();
+    module_context->modules.emplace_back(new StackSampleModule(
+        module_context, trace_context, table_.get(), task_context_table_.get(),
+        exec_context_table_.get(), timebase_table_.get()));
+  }
+
+  uint64_t GetBoundsMutationCount() override {
+    return table_ ? table_->mutations() : 0;
+  }
+
+  std::pair<int64_t, int64_t> GetTimestampBounds() override {
+    if (!table_ || table_->row_count() == 0) {
+      return {std::numeric_limits<int64_t>::max(), 0};
+    }
+    // ts is ColumnFlag.SORTED: the first row holds the min, the last the max.
+    uint32_t last = table_->row_count() - 1;
+    return {(*table_)[0].ts(), (*table_)[last].ts()};
+  }
+
+ private:
+  void EnsureTables() {
+    if (table_) {
+      return;
+    }
+    auto* pool = trace_context_->storage->mutable_string_pool();
+    table_ = std::make_unique<tables::StackSampleTable>(pool);
+    task_context_table_ =
+        std::make_unique<tables::StackSampleTaskContextTable>(pool);
+    exec_context_table_ =
+        std::make_unique<tables::StackSampleExecutionContextTable>(pool);
+    timebase_table_ =
+        std::make_unique<tables::StackSampleTimebaseTable>(pool);
+  }
+
+  std::unique_ptr<tables::StackSampleTable> table_;
+  std::unique_ptr<tables::StackSampleTaskContextTable> task_context_table_;
+  std::unique_ptr<tables::StackSampleExecutionContextTable> exec_context_table_;
+  std::unique_ptr<tables::StackSampleTimebaseTable> timebase_table_;
+};
+
+StackSampleImporter::~StackSampleImporter() = default;
+
+}  // namespace
+
+void RegisterPlugin() {
+  static PluginRegistration reg(
+      []() -> std::unique_ptr<PluginBase> {
+        return std::make_unique<StackSampleImporter>();
+      },
+      StackSampleImporter::kPluginId, StackSampleImporter::kDepIds.data(),
+      StackSampleImporter::kDepIds.size());
+  base::ignore_result(reg);
+}
+
+}  // namespace perfetto::trace_processor::stack_sample_importer

--- a/src/trace_processor/plugins/stack_sample_importer/plugin.h
+++ b/src/trace_processor/plugins/stack_sample_importer/plugin.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PLUGINS_STACK_SAMPLE_IMPORTER_PLUGIN_H_
+#define SRC_TRACE_PROCESSOR_PLUGINS_STACK_SAMPLE_IMPORTER_PLUGIN_H_
+
+namespace perfetto::trace_processor::stack_sample_importer {
+
+void RegisterPlugin();
+
+}  // namespace perfetto::trace_processor::stack_sample_importer
+
+#endif  // SRC_TRACE_PROCESSOR_PLUGINS_STACK_SAMPLE_IMPORTER_PLUGIN_H_

--- a/src/trace_processor/plugins/stack_sample_importer/tables.py
+++ b/src/trace_processor/plugins/stack_sample_importer/tables.py
@@ -1,0 +1,156 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tables owned by the transport-neutral stack sampling importer plugin."""
+
+from python.generators.trace_processor_table.public import Column as C
+from python.generators.trace_processor_table.public import ColumnFlag
+from python.generators.trace_processor_table.public import CppAccess
+from python.generators.trace_processor_table.public import CppAccessDuration
+from python.generators.trace_processor_table.public import CppInt64
+from python.generators.trace_processor_table.public import CppOptional
+from python.generators.trace_processor_table.public import CppString
+from python.generators.trace_processor_table.public import CppTableId
+from python.generators.trace_processor_table.public import CppUint32
+from python.generators.trace_processor_table.public import Table
+from python.generators.trace_processor_table.public import TableDoc
+
+from src.trace_processor.tables.profiler_tables import STACK_PROFILE_CALLSITE_TABLE
+
+STACK_SAMPLE_TASK_CONTEXT_TABLE = Table(
+    python_module=__file__,
+    class_name='StackSampleTaskContextTable',
+    sql_name='__intrinsic_stack_sample_task_context',
+    columns=[
+        C('utid', CppOptional(CppUint32())),
+        C('upid', CppOptional(CppUint32())),
+    ],
+    tabledoc=TableDoc(
+        doc='''
+          The task a stack sample is attributed to: a thread, a process, or (in
+          future) an async context. Deduplicated, one row per distinct task.
+        ''',
+        group='Callstack profilers',
+        columns={
+            'utid':
+                '''The sampled thread, if the task is a thread. Joinable with
+                   thread.utid.''',
+            'upid':
+                '''The sampled process, if known. Joinable with
+                   process.upid.''',
+        }))
+
+STACK_SAMPLE_EXECUTION_CONTEXT_TABLE = Table(
+    python_module=__file__,
+    class_name='StackSampleExecutionContextTable',
+    sql_name='__intrinsic_stack_sample_execution_context',
+    columns=[
+        C('cpu', CppOptional(CppUint32())),
+        C('mode', CppString()),
+    ],
+    tabledoc=TableDoc(
+        doc='''
+          The execution state a stack sample was taken in. Deduplicated, one row
+          per distinct state.
+        ''',
+        group='Callstack profilers',
+        columns={
+            'cpu':
+                '''Core the sample was taken on, if known.''',
+            'mode':
+                '''Privilege mode the sample was taken in (e.g. "user",
+                   "kernel"). Empty if unknown.''',
+        }))
+
+STACK_SAMPLE_TIMEBASE_TABLE = Table(
+    python_module=__file__,
+    class_name='StackSampleTimebaseTable',
+    sql_name='__intrinsic_stack_sample_timebase',
+    columns=[
+        C('source', CppString()),
+        C('name', CppString()),
+        C('unit', CppOptional(CppString())),
+        C('unit_multiplier', CppOptional(CppInt64())),
+        C('description', CppOptional(CppString())),
+    ],
+    tabledoc=TableDoc(
+        doc='''
+          The counter timebase a stack sample is measured against: the profiler
+          source and the primary CounterDescriptor. Deduplicated, one row per
+          distinct timebase.
+        ''',
+        group='Callstack profilers',
+        columns={
+            'source':
+                '''The profiler that produced the samples (from
+                   StackSampleDefaults.source, e.g. "linux.perf").''',
+            'name':
+                '''The counter name (e.g. "wall-time", "cycles").''',
+            'unit':
+                '''The unit weights are expressed in, if known.''',
+            'unit_multiplier':
+                '''Scales raw weights to `unit`, if set.''',
+            'description':
+                '''Human-readable description of the counter, if provided.''',
+        }))
+
+STACK_SAMPLE_TABLE = Table(
+    python_module=__file__,
+    class_name='StackSampleTable',
+    sql_name='__intrinsic_stack_sample',
+    columns=[
+        C(
+            'ts',
+            CppInt64(),
+            flags=ColumnFlag.SORTED,
+            cpp_access=CppAccess.READ,
+            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
+        ),
+        C('task_context_id',
+          CppOptional(CppTableId(STACK_SAMPLE_TASK_CONTEXT_TABLE))),
+        C('execution_context_id',
+          CppOptional(CppTableId(STACK_SAMPLE_EXECUTION_CONTEXT_TABLE))),
+        C('timebase_id', CppTableId(STACK_SAMPLE_TIMEBASE_TABLE)),
+        C('callsite_id',
+          CppOptional(CppTableId(STACK_PROFILE_CALLSITE_TABLE))),
+        C('weight', CppOptional(CppInt64())),
+    ],
+    tabledoc=TableDoc(
+        doc='''Transport-neutral, timebase-neutral stack samples (StackSample).
+               Each row is a callstack captured for a task and measured against
+               a primary counter timebase.''',
+        group='Callstack profilers',
+        columns={
+            'ts':
+                '''Timestamp of the sample.''',
+            'task_context_id':
+                '''The task this sample is attributed to, if any.''',
+            'execution_context_id':
+                '''The execution state (cpu, privilege mode) at sample time, if
+                   known.''',
+            'timebase_id':
+                '''The counter timebase this sample is measured against.''',
+            'callsite_id':
+                '''If set, the captured callstack.''',
+            'weight':
+                '''Value attributed to this sample for the timebase counter, if
+                   set.''',
+        }))
+
+# Keep this list sorted.
+ALL_TABLES = [
+    STACK_SAMPLE_EXECUTION_CONTEXT_TABLE,
+    STACK_SAMPLE_TABLE,
+    STACK_SAMPLE_TASK_CONTEXT_TABLE,
+    STACK_SAMPLE_TIMEBASE_TABLE,
+]

--- a/src/trace_processor/tables/profiler_tables.py
+++ b/src/trace_processor/tables/profiler_tables.py
@@ -371,6 +371,12 @@ STACK_PROFILE_FRAME_TABLE = Table(
             cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
             cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
         ),
+        C(
+            'type',
+            CppOptional(CppString()),
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
+            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
+        ),
     ],
     tabledoc=TableDoc(
         doc='''
@@ -389,7 +395,10 @@ STACK_PROFILE_FRAME_TABLE = Table(
                 '''If the profile was offline symbolized, the offline
                 symbol information of this frame.''',
             'deobfuscated_name':
-                '''Deobfuscated name of the function this location is in.'''
+                '''Deobfuscated name of the function this location is in.''',
+            'type':
+                '''The kind of frame (e.g. "native", "kernel", "interpreted",
+                "jit", "gc", "runtime") if reported by the producer, else NULL.'''
         }))
 
 STACK_PROFILE_CALLSITE_TABLE = Table(

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -126,6 +126,7 @@
 #include "src/trace_processor/plugins/span_join_operator/span_join_operator.h"
 #include "src/trace_processor/plugins/sql_stats_table/sql_stats_table.h"
 #include "src/trace_processor/plugins/stack_functions/stack_functions.h"
+#include "src/trace_processor/plugins/stack_sample_importer/plugin.h"
 #include "src/trace_processor/plugins/stdlib_docs/stdlib_docs.h"
 #include "src/trace_processor/plugins/storage_tables/storage_tables.h"
 #include "src/trace_processor/plugins/string_functions/string_functions.h"
@@ -361,6 +362,7 @@ TraceProcessorImpl::TraceProcessorImpl(const Config& cfg)
   span_join_operator::RegisterPlugin();
   sql_stats_table::RegisterPlugin();
   stack_functions::RegisterPlugin();
+  stack_sample_importer::RegisterPlugin();
   stdlib_docs::RegisterPlugin();
   storage_tables::RegisterPlugin();
   string_functions::RegisterPlugin();

--- a/test/trace_processor/diff_tests/parser/profiling/frame_types.textproto
+++ b/test/trace_processor/diff_tests/parser/profiling/frame_types.textproto
@@ -1,0 +1,92 @@
+packet {
+  process_tree {
+    processes {
+      pid: 100
+      ppid: 1
+      cmdline: "myproc"
+      uid: 0
+    }
+  }
+}
+
+packet {
+  previous_packet_dropped: 1
+  incremental_state_cleared: true
+  trusted_packet_sequence_id: 1
+  timestamp: 500
+  trace_packet_defaults {
+    stack_sample_defaults {
+      source: "python.wall"
+      primary_descriptor {
+        name: "wall-time"
+        unit: UNIT_NANOSECONDS
+      }
+    }
+  }
+  interned_data {
+    mappings {
+      iid: 1
+    }
+    function_names {
+      iid: 1
+      str: "interp_fn"
+    }
+    function_names {
+      iid: 2
+      str: "custom_fn"
+    }
+    function_names {
+      iid: 3
+      str: "gc_fn"
+    }
+    function_names {
+      iid: 4
+      str: "plain_fn"
+    }
+    frames {
+      iid: 1
+      mapping_id: 1
+      rel_pc: 0x100
+      function_name_id: 1
+      kind: KIND_INTERPRETED
+    }
+    frames {
+      iid: 2
+      mapping_id: 1
+      rel_pc: 0x200
+      function_name_id: 2
+      kind_str: "custom"
+    }
+    frames {
+      iid: 3
+      mapping_id: 1
+      rel_pc: 0x300
+      function_name_id: 3
+      kind: KIND_GC
+    }
+    frames {
+      iid: 4
+      mapping_id: 1
+      rel_pc: 0x400
+      function_name_id: 4
+    }
+  }
+}
+
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 1000
+  stack_sample {
+    task_context {
+      pid: 100
+      tid: 101
+    }
+    callstack {
+      frame_ids: 1
+      frame_ids: 2
+      frame_ids: 3
+      frame_ids: 4
+    }
+    primary_weight: 1000000
+  }
+}

--- a/test/trace_processor/diff_tests/parser/profiling/stack_sample.textproto
+++ b/test/trace_processor/diff_tests/parser/profiling/stack_sample.textproto
@@ -1,0 +1,71 @@
+packet {
+  process_tree {
+    processes {
+      pid: 100
+      ppid: 1
+      cmdline: "myproc"
+      uid: 0
+    }
+  }
+}
+
+packet {
+  previous_packet_dropped: 1
+  incremental_state_cleared: true
+  trusted_packet_sequence_id: 1
+  timestamp: 500
+  trace_packet_defaults {
+    stack_sample_defaults {
+      source: "python.wall"
+      primary_descriptor {
+        name: "wall-time"
+        unit: UNIT_NANOSECONDS
+      }
+    }
+  }
+  interned_data {
+    mappings {
+      iid: 1
+    }
+    function_names {
+      iid: 1
+      str: "foo"
+    }
+    frames {
+      iid: 1
+      mapping_id: 1
+      rel_pc: 0x100
+      function_name_id: 1
+    }
+  }
+}
+
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 1000
+  stack_sample {
+    task_context {
+      pid: 100
+      tid: 101
+    }
+    execution_context {
+      cpu: 2
+      mode: MODE_USER
+    }
+    callstack {
+      frame_ids: 1
+    }
+    primary_weight: 1000000
+  }
+}
+
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 7000
+  stack_sample {
+    callstack {
+      frame_ids: 1
+    }
+    primary_weight: 7000000
+  }
+}

--- a/test/trace_processor/diff_tests/parser/profiling/tests.py
+++ b/test/trace_processor/diff_tests/parser/profiling/tests.py
@@ -642,6 +642,76 @@ class Profiling(TestSuite):
         0,0,2,1144537.000000
         """))
 
+  def test_stack_sample(self):
+    return DiffTestBlueprint(
+        trace=Path('stack_sample.textproto'),
+        query="""
+        SELECT
+          ss.ts,
+          ec.cpu,
+          ec.mode,
+          ss.weight,
+          tb.source,
+          tb.name AS timebase_name,
+          tb.unit,
+          spf.name AS frame_name
+        FROM __intrinsic_stack_sample ss
+        JOIN __intrinsic_stack_sample_timebase tb ON ss.timebase_id = tb.id
+        LEFT JOIN __intrinsic_stack_sample_execution_context ec
+          ON ss.execution_context_id = ec.id
+        JOIN stack_profile_callsite spc ON ss.callsite_id = spc.id
+        JOIN stack_profile_frame spf ON spc.frame_id = spf.id
+        ORDER BY ss.ts;
+        """,
+        out=Csv("""
+        "ts","cpu","mode","weight","source","timebase_name","unit","frame_name"
+        1000,2,"user",1000000,"python.wall","wall-time","ns","foo"
+        7000,"[NULL]","[NULL]",7000000,"python.wall","wall-time","ns","foo"
+        """))
+
+  def test_stack_sample_contexts(self):
+    return DiffTestBlueprint(
+        trace=Path('stack_sample.textproto'),
+        query="""
+        -- The ts=1000 sample is attributed to a task and execution context; the
+        -- ts=7000 sample has neither, so both context ids are NULL.
+        SELECT
+          ss.ts,
+          p.name AS process_name,
+          ec.cpu,
+          ec.mode
+        FROM __intrinsic_stack_sample ss
+        LEFT JOIN __intrinsic_stack_sample_task_context tc
+          ON ss.task_context_id = tc.id
+        LEFT JOIN process p ON tc.upid = p.upid
+        LEFT JOIN __intrinsic_stack_sample_execution_context ec
+          ON ss.execution_context_id = ec.id
+        ORDER BY ss.ts;
+        """,
+        out=Csv("""
+        "ts","process_name","cpu","mode"
+        1000,"myproc",2,"user"
+        7000,"[NULL]","[NULL]","[NULL]"
+        """))
+
+  def test_frame_types(self):
+    return DiffTestBlueprint(
+        trace=Path('frame_types.textproto'),
+        query="""
+        -- Frame.kind (well-known enum) and Frame.kind_str (custom label) are
+        -- parsed into stack_profile_frame.type; frames with no kind are NULL.
+        SELECT name, type
+        FROM stack_profile_frame
+        ORDER BY name;
+        """,
+        out=Csv("""
+        "name","type"
+        "custom_fn","custom"
+        "gc_fn","gc"
+        "interp_fn","interpreted"
+        "plain_fn","[NULL]"
+        """))
+
   def test_art_oome_stack_sample(self):
     return DiffTestBlueprint(
         trace=TextProto(r"""


### PR DESCRIPTION
Add StackSample: a callstack captured for a thread, process, or cpu,
measured against a primary counter timebase, emitted as
TracePacket.stack_sample. Contexts and the primary descriptor can be
inline or interned; interned context hangs off InternedData through the
StackSampleInternedData extension.

Parse into __intrinsic_stack_sample plus deduplicated task_context,
execution_context, and timebase tables; each sample references its
contexts by id. No tracks are minted.

Frame in profile_common.proto gains a frame-kind field, parsed into a
nullable stack_profile_frame.type column.
