### PR TITLE
tp: annotate frameworks_base flag fields with flags_enum

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14222,6 +14222,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     ],
@@ -14229,7 +14230,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.pbzero.cc",
     ],
@@ -14239,6 +14240,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     ],
@@ -14246,7 +14248,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.pbzero.h",
     ],

--- a/Android.bp
+++ b/Android.bp
@@ -2903,6 +2903,7 @@ cc_test {
         ":perfetto_protos_perfetto_trace_chrome_zero_gen",
         ":perfetto_protos_perfetto_trace_etw_cpp_gen",
         ":perfetto_protos_perfetto_trace_etw_zero_gen",
+        ":perfetto_protos_perfetto_trace_field_options_zero_gen",
         ":perfetto_protos_perfetto_trace_filesystem_cpp_gen",
         ":perfetto_protos_perfetto_trace_filesystem_zero_gen",
         ":perfetto_protos_perfetto_trace_ftrace_cpp_gen",
@@ -3292,6 +3293,7 @@ cc_test {
         "perfetto_protos_perfetto_trace_chrome_zero_gen_headers",
         "perfetto_protos_perfetto_trace_etw_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_etw_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_field_options_zero_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ftrace_cpp_gen_headers",
@@ -8689,6 +8691,52 @@ genrule {
     ],
 }
 
+// GN: //protos/perfetto/trace:field_options_zero
+filegroup {
+    name: "perfetto_protos_perfetto_trace_field_options_zero",
+    srcs: [
+        "protos/perfetto/trace/field_options.proto",
+    ],
+}
+
+// GN: //protos/perfetto/trace:field_options_zero
+genrule {
+    name: "perfetto_protos_perfetto_trace_field_options_zero_gen",
+    srcs: [
+        ":libprotobuf-internal-descriptor-proto",
+        ":perfetto_protos_perfetto_trace_field_options_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_field_options_zero)",
+    out: [
+        "external/perfetto/protos/perfetto/trace/field_options.pbzero.cc",
+    ],
+}
+
+// GN: //protos/perfetto/trace:field_options_zero
+genrule {
+    name: "perfetto_protos_perfetto_trace_field_options_zero_gen_headers",
+    srcs: [
+        ":libprotobuf-internal-descriptor-proto",
+        ":perfetto_protos_perfetto_trace_field_options_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_trace_field_options_zero)",
+    out: [
+        "external/perfetto/protos/perfetto/trace/field_options.pbzero.h",
+    ],
+    export_include_dirs: [
+        ".",
+        "protos",
+    ],
+}
+
 // GN: //protos/perfetto/trace/filesystem:cpp
 filegroup {
     name: "perfetto_protos_perfetto_trace_filesystem_cpp",
@@ -13471,6 +13519,7 @@ genrule {
         "protos/perfetto/trace/etw/etw_event.proto",
         "protos/perfetto/trace/etw/etw_event_bundle.proto",
         "protos/perfetto/trace/extension_descriptor.proto",
+        "protos/perfetto/trace/field_options.proto",
         "protos/perfetto/trace/filesystem/inode_file_map.proto",
         "protos/perfetto/trace/ftrace/android_fs.proto",
         "protos/perfetto/trace/ftrace/bcl_exynos.proto",
@@ -14223,6 +14272,7 @@ genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
     srcs: [
         ":libprotobuf-internal-descriptor-proto",
+        ":perfetto_protos_perfetto_trace_field_options_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     ],
@@ -14241,6 +14291,7 @@ genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
     srcs: [
         ":libprotobuf-internal-descriptor-proto",
+        ":perfetto_protos_perfetto_trace_field_options_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     ],
@@ -20521,6 +20572,7 @@ cc_library_static {
         ":perfetto_protos_perfetto_trace_android_zero_gen",
         ":perfetto_protos_perfetto_trace_chrome_zero_gen",
         ":perfetto_protos_perfetto_trace_etw_zero_gen",
+        ":perfetto_protos_perfetto_trace_field_options_zero_gen",
         ":perfetto_protos_perfetto_trace_filesystem_zero_gen",
         ":perfetto_protos_perfetto_trace_ftrace_zero_gen",
         ":perfetto_protos_perfetto_trace_generic_kernel_zero_gen",
@@ -20778,6 +20830,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_android_zero_gen_headers",
         "perfetto_protos_perfetto_trace_chrome_zero_gen_headers",
         "perfetto_protos_perfetto_trace_etw_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_field_options_zero_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ftrace_zero_gen_headers",
         "perfetto_protos_perfetto_trace_generic_kernel_zero_gen_headers",
@@ -20882,6 +20935,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_android_zero_gen_headers",
         "perfetto_protos_perfetto_trace_chrome_zero_gen_headers",
         "perfetto_protos_perfetto_trace_etw_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_field_options_zero_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ftrace_zero_gen_headers",
         "perfetto_protos_perfetto_trace_generic_kernel_zero_gen_headers",
@@ -23262,6 +23316,7 @@ cc_test {
         ":perfetto_protos_perfetto_trace_etw_cpp_gen",
         ":perfetto_protos_perfetto_trace_etw_lite_gen",
         ":perfetto_protos_perfetto_trace_etw_zero_gen",
+        ":perfetto_protos_perfetto_trace_field_options_zero_gen",
         ":perfetto_protos_perfetto_trace_filesystem_cpp_gen",
         ":perfetto_protos_perfetto_trace_filesystem_lite_gen",
         ":perfetto_protos_perfetto_trace_filesystem_zero_gen",
@@ -23828,6 +23883,7 @@ cc_test {
         "perfetto_protos_perfetto_trace_etw_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_etw_lite_gen_headers",
         "perfetto_protos_perfetto_trace_etw_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_field_options_zero_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_lite_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_zero_gen_headers",
@@ -24515,6 +24571,7 @@ cc_library_static {
         ":perfetto_protos_perfetto_trace_android_zero_gen",
         ":perfetto_protos_perfetto_trace_chrome_zero_gen",
         ":perfetto_protos_perfetto_trace_etw_zero_gen",
+        ":perfetto_protos_perfetto_trace_field_options_zero_gen",
         ":perfetto_protos_perfetto_trace_filesystem_zero_gen",
         ":perfetto_protos_perfetto_trace_ftrace_zero_gen",
         ":perfetto_protos_perfetto_trace_generic_kernel_zero_gen",
@@ -24753,6 +24810,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_android_zero_gen_headers",
         "perfetto_protos_perfetto_trace_chrome_zero_gen_headers",
         "perfetto_protos_perfetto_trace_etw_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_field_options_zero_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ftrace_zero_gen_headers",
         "perfetto_protos_perfetto_trace_generic_kernel_zero_gen_headers",
@@ -24854,6 +24912,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_android_zero_gen_headers",
         "perfetto_protos_perfetto_trace_chrome_zero_gen_headers",
         "perfetto_protos_perfetto_trace_etw_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_field_options_zero_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ftrace_zero_gen_headers",
         "perfetto_protos_perfetto_trace_generic_kernel_zero_gen_headers",
@@ -25192,6 +25251,7 @@ cc_binary_host {
         ":perfetto_protos_perfetto_trace_android_zero_gen",
         ":perfetto_protos_perfetto_trace_chrome_zero_gen",
         ":perfetto_protos_perfetto_trace_etw_zero_gen",
+        ":perfetto_protos_perfetto_trace_field_options_zero_gen",
         ":perfetto_protos_perfetto_trace_filesystem_zero_gen",
         ":perfetto_protos_perfetto_trace_ftrace_zero_gen",
         ":perfetto_protos_perfetto_trace_generic_kernel_zero_gen",
@@ -25442,6 +25502,7 @@ cc_binary_host {
         "perfetto_protos_perfetto_trace_android_zero_gen_headers",
         "perfetto_protos_perfetto_trace_chrome_zero_gen_headers",
         "perfetto_protos_perfetto_trace_etw_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_field_options_zero_gen_headers",
         "perfetto_protos_perfetto_trace_filesystem_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ftrace_zero_gen_headers",
         "perfetto_protos_perfetto_trace_generic_kernel_zero_gen_headers",

--- a/BUILD
+++ b/BUILD
@@ -616,6 +616,7 @@ perfetto_cc_library(
                ":protos_perfetto_trace_android_zero",
                ":protos_perfetto_trace_chrome_zero",
                ":protos_perfetto_trace_etw_zero",
+               ":protos_perfetto_trace_field_options_zero",
                ":protos_perfetto_trace_filesystem_zero",
                ":protos_perfetto_trace_ftrace_zero",
                ":protos_perfetto_trace_generic_kernel_zero",
@@ -931,6 +932,7 @@ perfetto_cc_library(
                ":protos_perfetto_trace_android_zero",
                ":protos_perfetto_trace_chrome_zero",
                ":protos_perfetto_trace_etw_zero",
+               ":protos_perfetto_trace_field_options_zero",
                ":protos_perfetto_trace_filesystem_zero",
                ":protos_perfetto_trace_ftrace_zero",
                ":protos_perfetto_trace_generic_kernel_zero",
@@ -7246,6 +7248,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_android_protos",
         ":protos_perfetto_trace_chrome_protos",
         ":protos_perfetto_trace_etw_protos",
+        ":protos_perfetto_trace_field_options_protos",
         ":protos_perfetto_trace_filesystem_protos",
         ":protos_perfetto_trace_ftrace_protos",
         ":protos_perfetto_trace_generic_kernel_protos",
@@ -8869,6 +8872,27 @@ perfetto_cc_protozero_library(
     ],
 )
 
+# GN target: //protos/perfetto/trace:field_options_source_set
+perfetto_proto_library(
+    name = "protos_perfetto_trace_field_options_protos",
+    srcs = [
+        "protos/perfetto/trace/field_options.proto",
+    ],
+    visibility = [
+        PERFETTO_CONFIG.proto_library_visibility,
+    ],
+    deps = [
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
+)
+
+# GN target: //protos/perfetto/trace:field_options_zero
+perfetto_cc_protozero_library(
+    name = "protos_perfetto_trace_field_options_zero",
+    deps = [
+        ":protos_perfetto_trace_field_options_protos",
+    ],
+)
+
 # GN target: //protos/perfetto/trace/filesystem:source_set
 perfetto_proto_library(
     name = "protos_perfetto_trace_filesystem_protos",
@@ -9800,6 +9824,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_android_protos",
         ":protos_perfetto_trace_chrome_protos",
         ":protos_perfetto_trace_etw_protos",
+        ":protos_perfetto_trace_field_options_protos",
         ":protos_perfetto_trace_filesystem_protos",
         ":protos_perfetto_trace_ftrace_protos",
         ":protos_perfetto_trace_generic_kernel_protos",
@@ -10276,9 +10301,11 @@ perfetto_proto_library(
         PERFETTO_CONFIG.proto_library_visibility,
     ],
     deps = [
+        ":protos_perfetto_trace_field_options_protos",
         ":protos_perfetto_trace_track_event_protos",
     ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
+        ":protos_perfetto_trace_field_options_protos",
         ":protos_perfetto_trace_track_event_protos",
     ],
 )
@@ -10287,6 +10314,7 @@ perfetto_proto_library(
 perfetto_cc_protozero_library(
     name = "protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     deps = [
+        ":protos_perfetto_trace_field_options_zero",
         ":protos_perfetto_trace_track_event_zero",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_protos",
     ],
@@ -11486,6 +11514,7 @@ perfetto_cc_library(
                ":protos_perfetto_trace_android_zero",
                ":protos_perfetto_trace_chrome_zero",
                ":protos_perfetto_trace_etw_zero",
+               ":protos_perfetto_trace_field_options_zero",
                ":protos_perfetto_trace_filesystem_zero",
                ":protos_perfetto_trace_ftrace_zero",
                ":protos_perfetto_trace_generic_kernel_zero",
@@ -11805,6 +11834,7 @@ perfetto_cc_binary(
                ":protos_perfetto_trace_android_zero",
                ":protos_perfetto_trace_chrome_zero",
                ":protos_perfetto_trace_etw_zero",
+               ":protos_perfetto_trace_field_options_zero",
                ":protos_perfetto_trace_filesystem_zero",
                ":protos_perfetto_trace_ftrace_zero",
                ":protos_perfetto_trace_generic_kernel_zero",

--- a/BUILD
+++ b/BUILD
@@ -10277,7 +10277,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_trace_track_event_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_track_event_protos",
     ],

--- a/protos/third_party/android/frameworks/base/proto/tracing/BUILD.gn
+++ b/protos/third_party/android/frameworks/base/proto/tracing/BUILD.gn
@@ -14,9 +14,14 @@
 
 import("../../../../../../../gn/proto_library.gni")
 
+# Imports field_options.proto (a custom option), so it is protozero-only.
 perfetto_proto_library("frameworks_base_track_event_@TYPE@") {
+  proto_generators = [ "zero" ]
   sources = [ "frameworks_base_track_event.proto" ]
-  public_deps = [ "../../../../../../perfetto/trace/track_event:@TYPE@" ]
+  public_deps = [
+    "../../../../../../perfetto/trace:field_options_@TYPE@",
+    "../../../../../../perfetto/trace/track_event:@TYPE@",
+  ]
   import_dirs = [ "${perfetto_protobuf_src_dir}" ]
 }
 

--- a/protos/third_party/android/frameworks/base/proto/tracing/BUILD.gn
+++ b/protos/third_party/android/frameworks/base/proto/tracing/BUILD.gn
@@ -17,6 +17,7 @@ import("../../../../../../../gn/proto_library.gni")
 perfetto_proto_library("frameworks_base_track_event_@TYPE@") {
   sources = [ "frameworks_base_track_event.proto" ]
   public_deps = [ "../../../../../../perfetto/trace/track_event:@TYPE@" ]
+  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
 }
 
 perfetto_proto_library("frameworks_base_interned_data_@TYPE@") {

--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
@@ -21,6 +21,7 @@
 syntax = "proto2";
 
 import public "protos/perfetto/trace/track_event/track_event.proto";
+import "protos/perfetto/trace/field_options.proto";
 
 package com.android.internal;
 
@@ -568,7 +569,9 @@ message AndroidBroadcastEvent {
   optional BroadcastDeliveryGroupPolicy delivery_group_policy = 13;
 
   // Flags set in the broadcast intent.
-  optional int32 intent_flags = 14;
+  optional int32 intent_flags = 14
+      [(perfetto.protos.flags_enum) =
+           ".com.android.internal.BroadcastIntentFlag"];
 
   // The intent filter priority of the broadcast receiver.
   optional int32 filter_priority = 15;
@@ -684,10 +687,14 @@ message AndroidProcessStateChangedEvent {
   optional ProcessStateEnum cur_proc_state = 4;
 
   // Previous capability flags.
-  optional int32 prev_capability_flags = 5;
+  optional int32 prev_capability_flags = 5
+      [(perfetto.protos.flags_enum) =
+           ".com.android.internal.ProcessCapabilityEnum"];
 
   // Current capability flags.
-  optional int32 cur_capability_flags = 6;
+  optional int32 cur_capability_flags = 6
+      [(perfetto.protos.flags_enum) =
+           ".com.android.internal.ProcessCapabilityEnum"];
 
   // Previous oom score.
   optional int32 prev_oom_score = 7;
@@ -704,13 +711,17 @@ message AndroidProcessStateChangedEvent {
   optional int64 seq_id = 10;
 
   // Bitmask of reasons for granting PROCESS_CAPABILITY_CPU_TIME.
-  optional int32 cpu_time_reasons = 11;
+  optional int32 cpu_time_reasons = 11
+      [(perfetto.protos.flags_enum) = ".com.android.internal.CpuTimeReason"];
 
   // Bitmask of reasons for granting PROCESS_CAPABILITY_IMPLICIT_CPU_TIME.
-  optional int32 implicit_cpu_time_reasons = 12;
+  optional int32 implicit_cpu_time_reasons = 12
+      [(perfetto.protos.flags_enum) = ".com.android.internal.CpuTimeReason"];
 
   // Bitfield to represent boolean freeze policy states.
-  optional int32 freeze_policy_flags = 13;
+  optional int32 freeze_policy_flags = 13
+      [(perfetto.protos.flags_enum) =
+           ".com.android.internal.FreezerPolicyFlag"];
 }
 
 message AndroidServiceStateChangedEvent {
@@ -732,7 +743,8 @@ message AndroidServiceStateChangedEvent {
   optional int32 caller_pid = 8;
   optional ServiceRestartReason reason_enum = 9;
   // Bitmask of flags used in the service binding.
-  optional int32 bind_flags = 10;
+  optional int32 bind_flags = 10
+      [(perfetto.protos.flags_enum) = ".com.android.internal.ServiceBindFlag"];
 }
 
 message AndroidProviderStateChangedEvent {
@@ -800,7 +812,8 @@ message AndroidCapabilityUpdateEvent {
 
   // Bitfield representing various process state flags (see
   // CapabilityUpdateFlag).
-  optional int32 flags = 12;
+  optional int32 flags = 12 [(perfetto.protos.flags_enum) =
+                                 ".com.android.internal.CapabilityUpdateFlag"];
 }
 
 message FrameworksBaseTrackEvent {


### PR DESCRIPTION
Mark the bitmask int fields in frameworks_base_track_event.proto with the flags_enum field option so trace_processor expands each mask into one arg per set flag.
