### PR TITLE
ui: Simplify DataGrid schema models

### DIFF
--- a/ui/src/bigtrace/pages/results_grid.ts
+++ b/ui/src/bigtrace/pages/results_grid.ts
@@ -19,10 +19,7 @@ import {linkify} from '../../widgets/anchor';
 import {Spinner} from '../../widgets/spinner';
 import {DataGrid} from '../../components/widgets/datagrid/datagrid';
 import type {DataSource} from '../../components/widgets/datagrid/data_source';
-import type {
-  ColumnSchema,
-  SchemaRegistry,
-} from '../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
 import type {
   Column,
   SortDirection,
@@ -155,7 +152,6 @@ function renderDataGrid(
       columnSchema[column] = {cellRenderer: undefined};
     }
   }
-  const schema: SchemaRegistry = {data: columnSchema};
 
   // Per-tab visible subset (empty/unset → defaults); shipped as the
   // `:fetch_results` `columns` projection.
@@ -165,8 +161,7 @@ function renderDataGrid(
   const sortState = resultsSortByTab.get(tab);
 
   return m(DataGrid, {
-    schema,
-    rootSchema: 'data',
+    schema: columnSchema,
     disablePivotControls: true,
     // Splice per-tab sort onto its column so a header click survives redraws.
     columns: visible.map((col) => {

--- a/ui/src/bigtrace/pages/settings_page.ts
+++ b/ui/src/bigtrace/pages/settings_page.ts
@@ -51,10 +51,7 @@ import {TextInput} from '../../widgets/text_input';
 import {Stack, StackAuto} from '../../widgets/stack';
 
 import {DataGrid} from '../../components/widgets/datagrid/datagrid';
-import type {
-  ColumnSchema,
-  SchemaRegistry,
-} from '../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
 import type {
   Column,
   Filter,
@@ -179,13 +176,11 @@ class BigTraceSettingsCard
 // renderer can branch on it.
 const TRACE_ADDRESS_DISPLAY = 'Trace Address';
 
-const SCHEMA_ROOT = 'trace_list';
-
-// SchemaRegistry from /trace_metadata_schema: one entry per column, default
-// string renderer (every cell is a string per the always-strings contract).
-function buildSchemaRegistry(
+// Schema from /trace_metadata_schema: one entry per column, default string
+// renderer (every cell is a string per the always-strings contract).
+function columnSchema(
   schema: ReadonlyArray<TraceColumnDescriptor>,
-): SchemaRegistry {
+): ColumnSchema {
   const columnSchema: ColumnSchema = {};
   for (const c of schema) {
     // The `link` column renders as a clickable link; all others as strings.
@@ -199,7 +194,7 @@ function buildSchemaRegistry(
           }
         : {cellRenderer: undefined};
   }
-  return {[SCHEMA_ROOT]: columnSchema};
+  return columnSchema;
 }
 
 interface SchemaError {
@@ -708,7 +703,7 @@ export class SettingsPage implements m.ClassComponent<SettingsPageAttrs> {
 
     // Schema resolved: build the column list from the effective selection.
     const chosen = traceColumnsState.effective(schema!.columns);
-    const schemaRegistry = buildSchemaRegistry(schema!.columns);
+    const datagridSchema = columnSchema(schema!.columns);
 
     return m(
       Card,
@@ -737,8 +732,7 @@ export class SettingsPage implements m.ClassComponent<SettingsPageAttrs> {
             style: {height: '500px', marginTop: '16px'},
           },
           m(DataGrid, {
-            schema: schemaRegistry,
-            rootSchema: SCHEMA_ROOT,
+            schema: datagridSchema,
             data: ds,
             // Inner virtualized Grid uses the wrapper's 500px as its viewport.
             fillHeight: true,

--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -35,10 +35,7 @@ import {Spinner} from '../widgets/spinner';
 import {AggregationPanel} from './aggregation_panel';
 import type {Column, Filter, Pivot} from './widgets/datagrid/model';
 import {SQLDataSource} from './widgets/datagrid/sql_data_source';
-import {
-  createSimpleSchema,
-  type SQLSchemaRegistry,
-} from './widgets/datagrid/sql_schema';
+import type {SQLTableSchema} from './widgets/datagrid/sql_schema';
 import type {BarChartData} from './aggregation';
 import {
   createPerfettoTable,
@@ -76,10 +73,10 @@ export interface AggregatorGridConfig {
   readonly initialFilters?: readonly Filter[];
   /**
    * Optional override that produces the SQL schema used to resolve columns
-   * for the aggregation table. If undefined, a generic schema is created from
-   * the table name via `createSimpleSchema`.
+   * for the aggregation table. If undefined, a simple table-or-subquery
+   * schema is created from the table name.
    */
-  readonly sqlConfig?: (data: AggregationData) => SQLSchemaRegistry;
+  readonly sqlConfig?: (data: AggregationData) => SQLTableSchema;
 }
 
 /**
@@ -273,13 +270,13 @@ export function createAggregationTab(
           if (aggregation) {
             data = await aggregation?.prepareData(trace.engine);
             const gridConfig = aggregator.getGridConfig();
+            const sqlConfig = gridConfig.sqlConfig?.(data) ?? {
+              tableOrSubquery: data.tableName,
+            };
             dataSource = new SQLDataSource({
               queue,
               engine: trace.engine,
-              sqlSchema:
-                gridConfig.sqlConfig?.(data) ??
-                createSimpleSchema(data.tableName),
-              rootSchemaName: 'query',
+              ...sqlConfig,
             });
           }
         });

--- a/ui/src/components/aggregation_panel.ts
+++ b/ui/src/components/aggregation_panel.ts
@@ -28,7 +28,6 @@ import type {AggregatorGridConfig, DataGridState} from './aggregation_adapter';
 import type {
   CellRenderer,
   ColumnType,
-  SchemaRegistry,
 } from './widgets/datagrid/datagrid_schema';
 import type {DataSource} from './widgets/datagrid/data_source';
 import {Button} from '../widgets/button';
@@ -82,12 +81,9 @@ export class AggregationPanel
     dataGridState?: DataGridState,
     onClearGridState?: () => void,
   ) {
-    const schema: SchemaRegistry = {data: gridConfig.schema};
-
     return m(DataGrid, {
       fillHeight: true,
-      schema,
-      rootSchema: 'data',
+      schema: gridConfig.schema,
       data: dataSource,
       onReady,
       // Spread controlled state props (columns, filters, pivot and callbacks)

--- a/ui/src/components/distribution_panel.ts
+++ b/ui/src/components/distribution_panel.ts
@@ -42,15 +42,9 @@ import {
 } from './widgets/charts/histogram_loader';
 import {DataGrid, renderCell} from './widgets/datagrid/datagrid';
 import {SQLDataSource} from './widgets/datagrid/sql_data_source';
-import type {
-  ColumnSchema,
-  SchemaRegistry,
-} from './widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from './widgets/datagrid/datagrid_schema';
 import type {Column, Filter} from './widgets/datagrid/model';
-import type {
-  SQLSchemaRegistry,
-  SQLTableSchema,
-} from './widgets/datagrid/sql_schema';
+import type {SQLTableSchema} from './widgets/datagrid/sql_schema';
 import {formatDuration} from './time_utils';
 
 export function helpIcon(help: m.Children): m.Children {
@@ -505,7 +499,6 @@ export class DistributionPanel
     const dataSource = this.useDataSource(attrs, tableEntity.name);
     return m(DataGrid, {
       schema: buildGridSchema(attrs, this.renderIdCell.bind(this)),
-      rootSchema: 'root',
       data: dataSource,
       filters: brushFilters(attrs.valueColumn, this.brush),
       initialColumns: gridColumns(attrs),
@@ -523,8 +516,7 @@ export class DistributionPanel
       ds?.dispose();
       ds = new SQLDataSource({
         engine: attrs.trace.engine,
-        sqlSchema: buildSqlSchema(attrs, tableName),
-        rootSchemaName: 'root',
+        ...buildSqlSchema(attrs, tableName),
       });
       this.dataSource = ds;
       this.dataSourceTableName = tableName;
@@ -567,7 +559,7 @@ function buildGridSchema(
     attrs: DistributionPanelAttrs,
     value: Row[string],
   ) => m.Children,
-): SchemaRegistry {
+): ColumnSchema {
   const rootSchema: ColumnSchema = {};
   for (const col of [attrs.idColumn, ...attrs.displayColumns]) {
     const cellRenderer =
@@ -576,7 +568,7 @@ function buildGridSchema(
         : attrs.cellRenderers?.[col];
     rootSchema[col] = {title: col, cellRenderer};
   }
-  return {root: rootSchema};
+  return rootSchema;
 }
 
 function gridColumns(attrs: DistributionPanelAttrs): Column[] {
@@ -644,7 +636,7 @@ function requiredSchema(
 function buildSqlSchema(
   attrs: DistributionPanelAttrs,
   tableName: string,
-): SQLSchemaRegistry {
+): SQLTableSchema {
   const columns: SQLTableSchema['columns'] = {};
   columns[attrs.idColumn] = {};
   columns[attrs.valueColumn] = {};
@@ -652,11 +644,9 @@ function buildSqlSchema(
     columns[col] = {};
   }
   return {
-    root: {
-      table: tableName,
-      primaryKey: attrs.idColumn,
-      columns,
-    },
+    tableOrSubquery: tableName,
+    primaryKey: attrs.idColumn,
+    columns,
   };
 }
 

--- a/ui/src/components/widgets/charts/datagrid_chart.ts
+++ b/ui/src/components/widgets/charts/datagrid_chart.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import type {Row} from '../../../trace_processor/query_result';
 import {DataGrid} from '../datagrid/datagrid';
-import type {CellFormatter, SchemaRegistry} from '../datagrid/datagrid_schema';
+import type {CellFormatter, ColumnSchema} from '../datagrid/datagrid_schema';
 
 /**
  * Data provided to a DatagridChart.
@@ -71,7 +71,6 @@ export class DatagridChart implements m.ClassComponent<DatagridChartAttrs> {
 
     return m(DataGrid, {
       schema,
-      rootSchema: 'root',
       // DataGrid expects a mutable Row[] but our source is readonly Row[].
       // The cast is safe because DataGrid only reads from the array.
       data: data.rows as Row[],
@@ -84,23 +83,17 @@ export class DatagridChart implements m.ClassComponent<DatagridChartAttrs> {
 }
 
 /**
- * Build a minimal SchemaRegistry from column names.
+ * Build a minimal schema from column names.
  * Each column becomes a simple leaf ColumnDef.
  */
 function buildSchemaFromColumns(
   columns: readonly string[],
   cellFormatters?: Readonly<Record<string, CellFormatter>>,
-): SchemaRegistry {
-  const schema: SchemaRegistry = {
-    root: Object.fromEntries(
-      columns.map((col) => {
-        const formatter = cellFormatters?.[col];
-        return [
-          col,
-          {title: col, ...(formatter && {cellFormatter: formatter})},
-        ];
-      }),
-    ),
-  };
-  return schema;
+): ColumnSchema {
+  return Object.fromEntries(
+    columns.map((col) => {
+      const formatter = cellFormatters?.[col];
+      return [col, {title: col, ...(formatter && {cellFormatter: formatter})}];
+    }),
+  );
 }

--- a/ui/src/components/widgets/datagrid/add_column_menu.ts
+++ b/ui/src/components/widgets/datagrid/add_column_menu.ts
@@ -15,129 +15,147 @@
 import m from 'mithril';
 import {FuzzyFinder} from '../../../base/fuzzy';
 import {Icons} from '../../../base/semantic_icons';
-import {maybeUndefined} from '../../../base/utils';
 import {EmptyState} from '../../../widgets/empty_state';
 import {Icon} from '../../../widgets/icon';
 import {MenuItem} from '../../../widgets/menu';
 import {TextInput} from '../../../widgets/text_input';
 import type {DataSource} from './data_source';
-import {
-  type SchemaRegistry,
-  isColumnDef,
-  isParameterizedColumnDef,
-  isSchemaRef,
-} from './datagrid_schema';
+import type {ColumnSchema} from './datagrid_schema';
 import type {AggregateColumn, AggregateFunction} from './model';
 
-interface AddColumnMenuContext {
-  readonly dataSource: DataSource;
-}
-
-/**
- * Builds menu items for adding columns from a schema.
- * Recursively builds submenus for schema references.
- *
- * @param registry The schema registry
- * @param schemaName The name of the current schema to build from
- * @param pathPrefix The current path prefix (e.g., 'parent' or 'thread.process')
- * @param depth Current recursion depth (to prevent infinite menus)
- * @param columns Currently visible columns (to disable duplicates)
- * @param onSelect Callback when a column is selected
- * @param context Context containing dataSource and parameterKeyColumns for key discovery
- * @param maxDepth Maximum recursion depth (default 5)
- */
-function buildAddColumnMenuFromSchema(
-  registry: SchemaRegistry,
-  schemaName: string,
-  pathPrefix: string,
-  depth: number,
-  columns: ReadonlyArray<string>,
-  onSelect: (columnPath: string) => void,
-  context: AddColumnMenuContext,
-  maxDepth: number = 5,
-): m.Children[] {
-  const schema = maybeUndefined(registry[schemaName]);
-  if (!schema) return [];
-
-  // Stop if we've gone too deep (prevents infinite menus for self-referential schemas)
-  if (depth > maxDepth) {
-    return [m(MenuItem, {label: '(max depth reached)', disabled: true})];
-  }
-
-  const menuItems: m.Children[] = [];
-
-  for (const [columnName, entry] of Object.entries(schema)) {
-    const fullPath = pathPrefix ? `${pathPrefix}.${columnName}` : columnName;
-
-    if (isColumnDef(entry)) {
-      // Leaf column - clicking adds it (disabled if already visible)
-      const title = entry.title ?? columnName;
-      const isAlreadyVisible = columns.includes(fullPath);
-      menuItems.push(
-        m(MenuItem, {
-          label: title,
-          disabled: isAlreadyVisible,
-          onclick: () => onSelect(fullPath),
-        }),
-      );
-    } else if (isSchemaRef(entry)) {
-      // Reference to another schema - create a submenu
-      const refTitle = entry.title ?? columnName;
-      const childMenuItems = buildAddColumnMenuFromSchema(
-        registry,
-        entry.ref,
-        fullPath,
-        depth + 1,
-        columns,
-        onSelect,
-        context,
-        maxDepth,
-      );
-
-      if (childMenuItems.length > 0) {
-        menuItems.push(m(MenuItem, {label: refTitle}, childMenuItems));
-      }
-    } else if (isParameterizedColumnDef(entry)) {
-      // Parameterized column - show available keys from datasource
-      const title = typeof entry.title === 'string' ? entry.title : columnName;
-      menuItems.push(
-        m(
-          MenuItem,
-          {label: `${title}...`},
-          m(ParameterizedColumnSubmenu, {
-            pathPrefix: fullPath,
-            columns,
-            dataSource: context.dataSource,
-            onSelect,
-          }),
-        ),
-      );
-    }
-  }
-
-  return menuItems;
-}
-
-// Helper component for parameterized column input
-export interface ParameterizedColumnSubmenuAttrs {
+interface AddColumnSchemaMenuItemAttrs {
+  // Label shown on this submenu's own menu item.
+  readonly label: m.Children;
+  // Optional icon shown alongside the label.
+  readonly icon?: string;
+  // The schema whose columns are listed in this submenu.
+  readonly schema: ColumnSchema;
+  // Path prefix for columns at this level (e.g. 'parent' or 'thread.process').
   readonly pathPrefix: string;
-  readonly columns: ReadonlyArray<string>;
-  readonly dataSource: DataSource;
+  // Currently visible columns, used to disable already-added entries.
+  readonly existingColumns: readonly string[];
+  // Data source used to discover keys for parameterized columns.
+  readonly datasource: DataSource;
+  // Callback invoked with the full column path when a column is selected.
   readonly onSelect: (columnPath: string) => void;
 }
 
-export class ParameterizedColumnSubmenu
-  implements m.ClassComponent<ParameterizedColumnSubmenuAttrs>
-{
-  private searchQuery = '';
-  private static readonly MAX_VISIBLE_ITEMS = 100;
+/**
+ * A menu item that expands into a submenu of the columns available in a schema.
+ * Schema references recurse through nested instances of this component, so each
+ * level is only built when its submenu is opened - no depth limit needed.
+ */
+const AddColumnSchemaMenuItem: m.Component<AddColumnSchemaMenuItemAttrs> = {
+  view({attrs}) {
+    const {
+      label,
+      icon,
+      schema,
+      pathPrefix,
+      existingColumns,
+      onSelect,
+      datasource,
+    } = attrs;
+    const menuItems: m.Children[] = [];
 
-  view({attrs}: m.Vnode<ParameterizedColumnSubmenuAttrs>) {
-    const {pathPrefix, columns, dataSource, onSelect} = attrs;
+    for (const [columnName, entry] of Object.entries(schema)) {
+      const fullPath = pathPrefix ? `${pathPrefix}.${columnName}` : columnName;
+      const title = entry.title ?? columnName;
+
+      if ('parameterized' in entry) {
+        // Parameterized column - show available keys from datasource
+        menuItems.push(
+          m(AddColumnParamMenuItem, {
+            label: `${title}...`,
+            pathPrefix: fullPath,
+            existingColumns,
+            datasource,
+            onSelect,
+          }),
+        );
+      } else if ('schema' in entry) {
+        menuItems.push(
+          m(AddColumnSchemaMenuItem, {
+            label: title,
+            schema: entry.schema,
+            pathPrefix: fullPath,
+            existingColumns,
+            onSelect,
+            datasource,
+          }),
+        );
+      } else {
+        menuItems.push(
+          m(MenuItem, {
+            label: title,
+            disabled: existingColumns.includes(fullPath),
+            onclick: () => onSelect(fullPath),
+          }),
+        );
+      }
+    }
+
+    return m(
+      MenuItem,
+      {label, icon, disabled: menuItems.length === 0},
+      menuItems,
+    );
+  },
+};
+
+export interface AddColumnParamMenuItemAttrs {
+  // Label shown on this submenu's own menu item.
+  readonly label: m.Children;
+  // Optional icon shown alongside the label.
+  readonly icon?: string;
+  // Path prefix of the parameterized column (the key is appended to this).
+  readonly pathPrefix: string;
+  // Currently visible columns, used to disable already-added entries.
+  readonly existingColumns: ReadonlyArray<string>;
+  // Data source used to discover the available parameter keys.
+  readonly datasource: DataSource;
+  // Callback invoked with the full column path when a key is selected.
+  readonly onSelect: (columnPath: string) => void;
+}
+
+/**
+ * A menu item for a parameterized column that expands into a searchable list of
+ * the keys available in the data source. Keys are only fetched when the submenu
+ * is opened.
+ */
+export class AddColumnParamMenuItem
+  implements m.ClassComponent<AddColumnParamMenuItemAttrs>
+{
+  view({attrs}: m.Vnode<AddColumnParamMenuItemAttrs>) {
+    const {pathPrefix, existingColumns, datasource, onSelect, label, icon} =
+      attrs;
+    return m(MenuItem, {label, icon}, [
+      m(RecordPopup, {pathPrefix, existingColumns, datasource, onSelect}),
+    ]);
+  }
+}
+
+interface RecordPopupAttrs {
+  // Path prefix of the parameterized column (the key is appended to this).
+  readonly pathPrefix: string;
+  // Currently visible columns, used to disable already-added entries.
+  readonly existingColumns: ReadonlyArray<string>;
+  // Data source used to discover the available parameter keys.
+  readonly datasource: DataSource;
+  // Callback invoked with the full column path when a key is selected.
+  readonly onSelect: (columnPath: string) => void;
+}
+
+class RecordPopup implements m.ClassComponent<RecordPopupAttrs> {
+  private readonly MAX_VISIBLE_ITEMS = 100;
+  private searchQuery = '';
+
+  view({attrs}: m.Vnode<RecordPopupAttrs>): m.Children {
+    const {pathPrefix, existingColumns, datasource, onSelect} = attrs;
 
     // Fetch available keys - this is only called when the submenu is visible
     const {data: availableKeys, isPending} =
-      dataSource.useParameterKeys(pathPrefix);
+      datasource.useParameterKeys(pathPrefix);
 
     // Show loading state while fetching
     if (isPending || availableKeys === undefined) {
@@ -168,12 +186,8 @@ export class ParameterizedColumnSubmenu
     })();
 
     // Limit the number of items rendered
-    const visibleResults = fuzzyResults.slice(
-      0,
-      ParameterizedColumnSubmenu.MAX_VISIBLE_ITEMS,
-    );
-    const remainingCount =
-      fuzzyResults.length - ParameterizedColumnSubmenu.MAX_VISIBLE_ITEMS;
+    const visibleResults = fuzzyResults.slice(0, this.MAX_VISIBLE_ITEMS);
+    const remainingCount = fuzzyResults.length - this.MAX_VISIBLE_ITEMS;
 
     // Check if search query could be used as a custom key
     const customKeyPath =
@@ -181,7 +195,7 @@ export class ParameterizedColumnSubmenu
         ? `${pathPrefix}.${this.searchQuery.trim()}`
         : '';
     const isCustomKeyAlreadyVisible =
-      customKeyPath !== '' && columns.includes(customKeyPath);
+      customKeyPath !== '' && existingColumns.includes(customKeyPath);
     const isCustomKeyInResults =
       this.searchQuery.trim().length > 0 &&
       availableKeys.includes(this.searchQuery.trim());
@@ -221,7 +235,7 @@ export class ParameterizedColumnSubmenu
                   segments: {matching: boolean; value: string}[];
                 }) => {
                   const keyPath = `${pathPrefix}.${result.key}`;
-                  const isKeyAlreadyVisible = columns.includes(keyPath);
+                  const isKeyAlreadyVisible = existingColumns.includes(keyPath);
 
                   // Render highlighted label
                   const labelContent = result.segments.map(
@@ -285,11 +299,10 @@ export class ParameterizedColumnSubmenu
 }
 
 interface ColumnMenuAttrs {
-  readonly schema: SchemaRegistry;
-  readonly rootSchema: string;
+  readonly schema: ColumnSchema;
   readonly visibleColumns: ReadonlyArray<string>;
   readonly onAddColumn: (field: string) => void;
-  readonly dataSource: DataSource;
+  readonly datasource: DataSource;
 
   // Optional add column control - defaults to true
   readonly canAdd?: boolean;
@@ -315,31 +328,24 @@ export class ColumnMenu implements m.ClassComponent<ColumnMenuAttrs> {
       canRemove,
       onRemove,
       schema,
-      rootSchema,
       visibleColumns,
       onAddColumn,
-      dataSource,
+      datasource,
       removeLabel = 'Remove column',
       addLabel = 'Add column',
     } = attrs;
 
-    const addColumnSubmenu = buildAddColumnMenuFromSchema(
-      schema,
-      rootSchema,
-      '',
-      0,
-      visibleColumns,
-      onAddColumn,
-      {dataSource},
-    );
-
     return [
       canAdd &&
-        m(
-          MenuItem,
-          {label: addLabel, icon: Icons.AddColumnRight},
-          addColumnSubmenu,
-        ),
+        m(AddColumnSchemaMenuItem, {
+          label: addLabel,
+          icon: Icons.AddColumnRight,
+          schema,
+          pathPrefix: '',
+          existingColumns: visibleColumns,
+          onSelect: onAddColumn,
+          datasource,
+        }),
       onRemove &&
         m(MenuItem, {
           label: removeLabel,
@@ -401,87 +407,121 @@ function isAggregateExists(
 }
 
 /**
- * Builds menu items for adding aggregate columns from a schema.
- * Each column shows a submenu with aggregate function options.
+ * Builds the aggregate-function menu items (SUM, MIN, MAX, ...) for a single
+ * column, based on its type.
  */
-function buildAggregateColumnMenuFromSchema(
-  registry: SchemaRegistry,
-  schemaName: string,
-  pathPrefix: string,
-  depth: number,
-  onSelect: (func: AggregateFunction, field: string) => void,
+function buildAggFuncItems(
+  columnType: 'text' | 'quantitative' | 'identifier' | undefined,
+  field: string,
   existingAggregates: readonly AggregateColumn[] | undefined,
-  maxDepth: number = 5,
+  onSelect: (func: AggregateFunction, field: string) => void,
 ): m.Children[] {
-  const schema = maybeUndefined(registry[schemaName]);
-  if (!schema) return [];
-
-  if (depth > maxDepth) {
-    return [m(MenuItem, {label: '(max depth reached)', disabled: true})];
-  }
-
-  const menuItems: m.Children[] = [];
-
-  for (const [columnName, entry] of Object.entries(schema)) {
-    const fullPath = pathPrefix ? `${pathPrefix}.${columnName}` : columnName;
-
-    if (isColumnDef(entry)) {
-      const title = entry.title ?? columnName;
-      // Get available aggregate functions based on column type
-      const availableFuncs = getAggregateFunctionsForColumnType(
-        entry.columnType,
-      );
-      const aggFuncItems = availableFuncs.map((func) => {
-        const exists = isAggregateExists(existingAggregates, func, fullPath);
-        return m(MenuItem, {
-          label: func,
-          disabled: exists,
-          onclick: exists ? undefined : () => onSelect(func, fullPath),
-        });
-      });
-
-      menuItems.push(m(MenuItem, {label: title}, aggFuncItems));
-    } else if (isSchemaRef(entry)) {
-      const refTitle = entry.title ?? columnName;
-      const childMenuItems = buildAggregateColumnMenuFromSchema(
-        registry,
-        entry.ref,
-        fullPath,
-        depth + 1,
-        onSelect,
-        existingAggregates,
-        maxDepth,
-      );
-
-      if (childMenuItems.length > 0) {
-        menuItems.push(m(MenuItem, {label: refTitle}, childMenuItems));
-      }
-    } else if (isParameterizedColumnDef(entry)) {
-      // For parameterized columns, show just the base name with a note
-      const title = typeof entry.title === 'string' ? entry.title : columnName;
-      // Get available aggregate functions based on filter type
-      const availableFuncs = getAggregateFunctionsForColumnType(
-        entry.filterType,
-      );
-      const aggFuncItems = availableFuncs.map((func) => {
-        const exists = isAggregateExists(existingAggregates, func, fullPath);
-        return m(MenuItem, {
-          label: func,
-          disabled: exists,
-          onclick: exists ? undefined : () => onSelect(func, fullPath),
-        });
-      });
-
-      menuItems.push(m(MenuItem, {label: `${title} (base)`}, aggFuncItems));
-    }
-  }
-
-  return menuItems;
+  return getAggregateFunctionsForColumnType(columnType).map((func) => {
+    const exists = isAggregateExists(existingAggregates, func, field);
+    return m(MenuItem, {
+      label: func,
+      disabled: exists,
+      onclick: exists ? undefined : () => onSelect(func, field),
+    });
+  });
 }
 
+interface AggregateSchemaMenuItemAttrs {
+  // Label shown on this submenu's own menu item.
+  readonly label: m.Children;
+  // Optional icon shown alongside the label.
+  readonly icon?: string;
+  // The schema whose columns are listed in this submenu.
+  readonly schema: ColumnSchema;
+  // Path prefix for columns at this level (e.g. 'parent' or 'thread.process').
+  readonly pathPrefix: string;
+  // Callback invoked with the chosen aggregate function and full column path.
+  readonly onSelect: (func: AggregateFunction, field: string) => void;
+  // Existing aggregates, used to disable already-added function/column pairs.
+  readonly existingAggregates: readonly AggregateColumn[] | undefined;
+  // Extra items rendered before the column entries (e.g. the COUNT option at
+  // the root of the menu).
+  readonly leadingItems?: m.Children;
+}
+
+/**
+ * A menu item that expands into a submenu of columns, each exposing the
+ * aggregate functions valid for its type. Schema references recurse through
+ * nested instances of this component, so each level is only built when its
+ * submenu is opened - no depth limit needed.
+ */
+const AggregateSchemaMenuItem: m.Component<AggregateSchemaMenuItemAttrs> = {
+  view({attrs}) {
+    const {
+      label,
+      icon,
+      schema,
+      pathPrefix,
+      onSelect,
+      existingAggregates,
+      leadingItems,
+    } = attrs;
+    const menuItems: m.Children[] = [];
+
+    if (leadingItems !== undefined) {
+      menuItems.push(leadingItems);
+    }
+
+    for (const [columnName, entry] of Object.entries(schema)) {
+      const fullPath = pathPrefix ? `${pathPrefix}.${columnName}` : columnName;
+
+      if ('parameterized' in entry) {
+        // For parameterized columns, aggregate over the base column.
+        const title =
+          typeof entry.title === 'string' ? entry.title : columnName;
+        menuItems.push(
+          m(
+            MenuItem,
+            {label: `${title} (base)`},
+            buildAggFuncItems(
+              entry.filterType,
+              fullPath,
+              existingAggregates,
+              onSelect,
+            ),
+          ),
+        );
+      } else if ('schema' in entry) {
+        menuItems.push(
+          m(AggregateSchemaMenuItem, {
+            label: entry.title ?? columnName,
+            schema: entry.schema,
+            pathPrefix: fullPath,
+            onSelect,
+            existingAggregates,
+          }),
+        );
+      } else {
+        menuItems.push(
+          m(
+            MenuItem,
+            {label: entry.title ?? columnName},
+            buildAggFuncItems(
+              entry.columnType,
+              fullPath,
+              existingAggregates,
+              onSelect,
+            ),
+          ),
+        );
+      }
+    }
+
+    return m(
+      MenuItem,
+      {label, icon, disabled: menuItems.length === 0},
+      menuItems,
+    );
+  },
+};
+
 interface AggregateMenuAttrs {
-  readonly schema: SchemaRegistry;
-  readonly rootSchema: string;
+  readonly schema: ColumnSchema;
   readonly onAddAggregate: (
     func: AggregateFunction | 'COUNT',
     field: string | undefined,
@@ -503,20 +543,10 @@ export class AggregateMenu implements m.ClassComponent<AggregateMenuAttrs> {
   view({attrs}: m.Vnode<AggregateMenuAttrs>): m.Children {
     const {
       schema,
-      rootSchema,
       onAddAggregate,
       existingAggregates,
       label = 'Add column',
     } = attrs;
-
-    const columnAggSubmenu = buildAggregateColumnMenuFromSchema(
-      schema,
-      rootSchema,
-      '',
-      0,
-      (func, field) => onAddAggregate(func, field),
-      existingAggregates,
-    );
 
     const countExists = isAggregateExists(
       existingAggregates,
@@ -524,19 +554,21 @@ export class AggregateMenu implements m.ClassComponent<AggregateMenuAttrs> {
       undefined,
     );
 
-    return m(
-      MenuItem,
-      {label, icon: Icons.AddColumnRight},
+    return m(AggregateSchemaMenuItem, {
+      label,
+      icon: Icons.AddColumnRight,
+      schema,
+      pathPrefix: '',
+      onSelect: (func, field) => onAddAggregate(func, field),
+      existingAggregates,
       // COUNT option - doesn't need a field
-      m(MenuItem, {
+      leadingItems: m(MenuItem, {
         label: 'COUNT',
         disabled: countExists,
         onclick: countExists
           ? undefined
           : () => onAddAggregate('COUNT', undefined),
       }),
-      // Column-based aggregates
-      ...columnAggSubmenu,
-    );
+    } satisfies AggregateSchemaMenuItemAttrs);
   }
 }

--- a/ui/src/components/widgets/datagrid/column_info_menu.ts
+++ b/ui/src/components/widgets/datagrid/column_info_menu.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {MenuItem} from '../../../widgets/menu';
-import {type ColumnInfo, isParameterizedColumnDef} from './datagrid_schema';
+import type {ColumnInfo} from './datagrid_schema';
 
 interface ColumnInfoMenuAttrs {
   readonly id: string;
@@ -70,7 +70,7 @@ export class ColumnInfoMenu implements m.ClassComponent<ColumnInfoMenuAttrs> {
       }
 
       // Parameterized column info
-      if (isParameterizedColumnDef(colInfo.def)) {
+      if ('parameterized' in colInfo.def) {
         infoItems.push(
           m(MenuItem, {
             label: 'Parameterized: yes',

--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -54,7 +54,7 @@ import type {
   TreeModel,
 } from './data_source';
 import {
-  type SchemaRegistry,
+  type ColumnSchema,
   getColumnInfo,
   getDefaultVisibleColumns,
   isCellRenderResult,
@@ -168,12 +168,7 @@ export interface DataGridAttrs {
    * Schema registry defining the shape of available data.
    * Contains named schemas that can reference each other for nested relationships.
    */
-  readonly schema: SchemaRegistry;
-
-  /**
-   * The name of the root schema in the registry to use for this grid.
-   */
-  readonly rootSchema: string;
+  readonly schema: ColumnSchema;
 
   /**
    * The data source that provides rows to the grid. Responsible for fetching,
@@ -388,6 +383,13 @@ export interface DataGridApi {
    * @returns The total row count
    */
   getRowCount(): number | undefined;
+
+  /**
+   * Get the DataSourceModel (columns, filters, sort, pagination, mode) used
+   * for the grid's current render. Combine with a datasource's own
+   * introspection (e.g. SQLDataSource.getQuery) to see what's being run.
+   */
+  getModel(): DataSourceModel;
 }
 
 function getOrCreateDataSource(data: DataSource | readonly Row[]): DataSource {
@@ -403,8 +405,7 @@ function getOrCreateDataSource(data: DataSource | readonly Row[]): DataSource {
  */
 interface FlatGridBuildContext {
   readonly attrs: DataGridAttrs;
-  readonly schema: SchemaRegistry;
-  readonly rootSchema: string;
+  readonly schema: ColumnSchema;
   readonly datasource: DataSource;
   readonly rowsResult: DataSourceRows;
   readonly aggregateSummaries?: Row;
@@ -422,8 +423,7 @@ interface FlatGridBuildContext {
  */
 interface PivotGridBuildContext {
   readonly attrs: DataGridAttrs;
-  readonly schema: SchemaRegistry;
-  readonly rootSchema: string;
+  readonly schema: ColumnSchema;
   readonly datasource: DataSource;
   readonly rowsResult: DataSourceRows;
   readonly aggregateSummaries?: Row;
@@ -451,10 +451,10 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
     if (attrs.initialColumns) {
       this.columns = attrs.initialColumns;
     } else {
-      this.columns = getDefaultVisibleColumns(
-        attrs.schema,
-        attrs.rootSchema,
-      ).map((field) => ({id: shortUuid(), field}));
+      this.columns = getDefaultVisibleColumns(attrs.schema).map((field) => ({
+        id: shortUuid(),
+        field,
+      }));
     }
 
     if (attrs.initialFilters) {
@@ -480,7 +480,6 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       pivot,
       tree,
       schema,
-      rootSchema,
       structuredQueryCompatMode = false,
       toolbarItemsLeft,
       toolbarItemsRight,
@@ -551,13 +550,15 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           datasource,
           model,
           schema,
-          rootSchema,
           this.pivot,
           format,
         );
       },
       getRowCount: () => {
         return rowsResult.totalRows;
+      },
+      getModel: () => {
+        return model;
       },
     });
 
@@ -570,7 +571,6 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       const pivotContext: PivotGridBuildContext = {
         attrs,
         schema,
-        rootSchema,
         datasource,
         rowsResult,
         aggregateSummaries: aggregateSummariesResult.data,
@@ -587,7 +587,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       const columnInfoCache = new Map(
         this.columns.map((col) => [
           col.field,
-          getColumnInfo(schema, rootSchema, col.field),
+          getColumnInfo(schema, col.field),
         ]),
       );
 
@@ -595,7 +595,6 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       const flatContext: FlatGridBuildContext = {
         attrs,
         schema,
-        rootSchema,
         datasource,
         rowsResult,
         aggregateSummaries: aggregateSummariesResult.data,
@@ -630,19 +629,12 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           showExportButton &&
             m(ExportButton, {
               onExportData: (format) =>
-                this.formatData(
-                  datasource,
-                  model,
-                  schema,
-                  rootSchema,
-                  this.pivot,
-                  format,
-                ),
+                this.formatData(datasource, model, schema, this.pivot, format),
             }),
         ],
         filterChips: this.filters.map((filter, index) =>
           m(GridFilterChip, {
-            content: this.formatFilter(filter, schema, rootSchema),
+            content: this.formatFilter(filter, schema),
             onRemove: showFilterControls
               ? () => this.removeFilter(index, attrs)
               : undefined,
@@ -651,7 +643,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
         drillDownFields:
           this.pivot?.drillDown &&
           this.pivot.drillDown.map(({field, value}) => {
-            const colInfo = getColumnInfo(schema, rootSchema, field);
+            const colInfo = getColumnInfo(schema, field);
             const titleParts = colInfo?.titleParts ?? field.split('.');
             return {
               title: buildColumnTitle(titleParts),
@@ -1467,7 +1459,6 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
     const {
       attrs,
       schema,
-      rootSchema,
       datasource,
       aggregateSummaries,
       columnInfoCache,
@@ -1526,11 +1517,10 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
                 ? () => this.removeColumn(colId, attrs)
                 : undefined,
             schema,
-            rootSchema,
             visibleColumns: this.columns.map((c) => c.field),
             onAddColumn: (newField) =>
               this.addColumn(newField, attrs, colIndex),
-            dataSource: datasource,
+            datasource,
           }),
         attrs.addColumnMenuItems?.(field),
         m(MenuDivider),
@@ -1784,7 +1774,6 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
     const {
       attrs,
       schema,
-      rootSchema,
       datasource,
       aggregateSummaries,
       pivot,
@@ -1813,7 +1802,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       const isLastGroupBy = i === pivot.groupBy.length - 1;
 
       // Get column info from schema
-      const colInfo = getColumnInfo(schema, rootSchema, field);
+      const colInfo = getColumnInfo(schema, field);
       const titleParts = colInfo?.titleParts ?? field.split('.');
       const titleContent = buildColumnTitle(titleParts);
 
@@ -1838,11 +1827,10 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
         showPivotControls &&
           m(ColumnMenu, {
             schema,
-            rootSchema,
             visibleColumns: currentGroupByFields,
             onAddColumn: (newField) =>
               this.addGroupByColumn(newField, attrs, i),
-            dataSource: datasource,
+            datasource,
             canRemove: true,
             onRemove: () => this.removeGroupByColumn(i, attrs),
             removeLabel: 'Remove group by',
@@ -1897,7 +1885,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       if (agg.function === 'COUNT') {
         title = 'Count';
       } else {
-        colInfo = getColumnInfo(schema, rootSchema, agg.field);
+        colInfo = getColumnInfo(schema, agg.field);
         const fieldTitle = colInfo?.titleParts ?? [agg.field];
         title = buildColumnTitle(fieldTitle);
       }
@@ -1944,7 +1932,6 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           groupByThisMenuItem,
           m(AggregateMenu, {
             schema,
-            rootSchema,
             existingAggregates: pivot.aggregates,
             onAddAggregate: (func, aggField) =>
               this.addAggregateColumn(func, aggField, attrs, i),
@@ -2015,7 +2002,6 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
     const {
       attrs,
       schema,
-      rootSchema,
       rowsResult,
       pivot,
       showPivotControls,
@@ -2070,7 +2056,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           }
 
           // Get cell renderer from schema
-          const colInfo = getColumnInfo(schema, rootSchema, field);
+          const colInfo = getColumnInfo(schema, field);
           const cellRenderer =
             colInfo?.cellRenderer ?? ((v: SqlValue) => renderCell(v, field));
           const rendered = cellRenderer(value, row);
@@ -2191,7 +2177,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           // For aggregates with a field, we can use the field's cell renderer
           let cellRenderer =
             'field' in agg
-              ? getColumnInfo(schema, rootSchema, agg.field)?.cellRenderer
+              ? getColumnInfo(schema, agg.field)?.cellRenderer
               : undefined;
           cellRenderer ??= (v: SqlValue) => renderCell(v, alias);
 
@@ -2221,8 +2207,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
   private async formatData(
     dataSource: DataSource,
     model: DataSourceModel,
-    schema: SchemaRegistry | undefined,
-    rootSchema: string | undefined,
+    schema: ColumnSchema,
     pivot: Pivot | undefined,
     format: 'tsv' | 'json' | 'markdown' = 'tsv',
   ): Promise<string> {
@@ -2252,10 +2237,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       // Add groupBy column names (keyed by ID)
       for (const groupByCol of pivot.groupBy) {
         const {id, field} = groupByCol;
-        const colInfo =
-          schema && rootSchema
-            ? getColumnInfo(schema, rootSchema, field)
-            : undefined;
+        const colInfo = getColumnInfo(schema, field);
         columnNames[id] = colInfo?.def.titleString ?? field;
       }
 
@@ -2265,10 +2247,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
         if (agg.function === 'COUNT') {
           columnNames[alias] = 'COUNT';
         } else if ('field' in agg) {
-          const colInfo =
-            schema && rootSchema
-              ? getColumnInfo(schema, rootSchema, agg.field)
-              : undefined;
+          const colInfo = getColumnInfo(schema, agg.field);
           const fieldTitle = colInfo?.def.titleString ?? agg.field;
           columnNames[alias] = `${agg.function}(${fieldTitle})`;
         }
@@ -2280,7 +2259,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
 
       // Build column names using field paths for schema lookup
       const fieldPaths = this.columns.map((c) => c.field);
-      columnNames = buildColumnNames(schema, rootSchema, fieldPaths);
+      columnNames = buildColumnNames(schema, fieldPaths);
 
       // Map aliases to field paths for column name lookup
       for (let i = 0; i < columns.length; i++) {
@@ -2298,13 +2277,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       aliasToField[getColumnAlias(col)] = col.field;
     }
 
-    const formattedRows = formatRows(
-      rows,
-      schema,
-      rootSchema,
-      columns,
-      aliasToField,
-    );
+    const formattedRows = formatRows(rows, schema, columns, aliasToField);
 
     // Format the data based on the requested format
     switch (format) {
@@ -2317,13 +2290,9 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
     }
   }
 
-  private formatFilter(
-    filter: Filter,
-    schema: SchemaRegistry,
-    rootSchema: string,
-  ): m.Children {
+  private formatFilter(filter: Filter, schema: ColumnSchema): m.Children {
     // Resolve column info once for all properties
-    const colInfo = getColumnInfo(schema, rootSchema, filter.field);
+    const colInfo = getColumnInfo(schema, filter.field);
 
     // Build column title with chevron separators
     const titleParts = colInfo?.titleParts ?? filter.field.split('.');

--- a/ui/src/components/widgets/datagrid/datagrid_jsdomtest.ts
+++ b/ui/src/components/widgets/datagrid/datagrid_jsdomtest.ts
@@ -17,7 +17,7 @@ import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {prettyDOM, queryAllByRole} from '@testing-library/dom';
 import {DataGrid, type DataGridAttrs} from './datagrid';
 import {InMemoryDataSource} from './in_memory_data_source';
-import type {SchemaRegistry} from './datagrid_schema';
+import type {ColumnSchema} from './datagrid_schema';
 import type {Column, Filter} from './model';
 
 // These tests render a DataGrid into a jsdom element and query the DOM to
@@ -38,11 +38,9 @@ import type {Column, Filter} from './model';
 // same showFilterControls signal as the column-header one, so nothing goes
 // untested.
 
-const SCHEMA: SchemaRegistry = {
-  root: {
-    name: {title: 'Name', columnType: 'text'},
-    value: {title: 'Value', columnType: 'quantitative'},
-  },
+const SCHEMA: ColumnSchema = {
+  name: {title: 'Name', columnType: 'text'},
+  value: {title: 'Value', columnType: 'quantitative'},
 };
 
 const DATA = [
@@ -81,7 +79,6 @@ afterEach(() => {
 function renderDataGrid(attrs: Partial<DataGridAttrs>) {
   const fullAttrs = {
     schema: SCHEMA,
-    rootSchema: 'root',
     data: new InMemoryDataSource(DATA),
     ...attrs,
   };

--- a/ui/src/components/widgets/datagrid/datagrid_schema.ts
+++ b/ui/src/components/widgets/datagrid/datagrid_schema.ts
@@ -47,15 +47,6 @@ export type CellRenderer = (
 export type CellFormatter = (value: SqlValue, row: Row) => string;
 
 /**
- * A registry of named schemas that can reference each other.
- * This allows defining complex relational schemas with self-references
- * (e.g., parent.parent.parent.name) and cross-references between tables.
- */
-export interface SchemaRegistry {
-  [schemaName: string]: ColumnSchema;
-}
-
-/**
  * A schema defining the available columns in a data source.
  * Each key is a column name, and the value describes how to render it
  * or references another schema for nested data.
@@ -107,10 +98,10 @@ export interface ColumnDef {
  */
 export interface SchemaRef {
   // Name of the schema in the registry to reference
-  readonly ref: string;
+  readonly schema: ColumnSchema;
 
   // Override the title for this reference (e.g., "Parent Slice" instead of "Slice")
-  readonly title?: string;
+  readonly title?: m.Children;
 
   // Override filter type for all columns accessed through this reference
   readonly filterType?: 'quantitative' | 'text';
@@ -124,7 +115,7 @@ export interface ParameterizedColumnDef {
   readonly parameterized: true;
 
   // Title can be a static string or a function that takes the key
-  readonly title?: m.Children | ((key: string) => m.Children);
+  readonly title?: m.Children;
 
   // Plain string title for exports. Falls back to column path if not provided.
   readonly titleString?: string;
@@ -136,53 +127,21 @@ export interface ParameterizedColumnDef {
 }
 
 /**
- * Type guard to check if a schema entry is a leaf ColumnDef.
- */
-export function isColumnDef(
-  entry: ColumnDef | SchemaRef | ParameterizedColumnDef,
-): entry is ColumnDef {
-  return !('ref' in entry) && !('parameterized' in entry);
-}
-
-/**
- * Type guard to check if a schema entry is a SchemaRef.
- */
-export function isSchemaRef(
-  entry: ColumnDef | SchemaRef | ParameterizedColumnDef,
-): entry is SchemaRef {
-  return 'ref' in entry;
-}
-
-/**
- * Type guard to check if a schema entry is a ParameterizedColumnDef.
- */
-export function isParameterizedColumnDef(
-  entry: ColumnDef | SchemaRef | ParameterizedColumnDef,
-): entry is ParameterizedColumnDef {
-  return 'parameterized' in entry;
-}
-
-/**
  * Gets the default visible columns for a schema.
  * Returns all leaf columns (ColumnDef) at the root level.
  * Does not include schema references or parameterized columns by default.
  *
- * @param registry The schema registry
- * @param rootSchema The root schema name
+ * @param schema The datagrid schema.
  * @returns Array of column names that are leaf columns
  */
-export function getDefaultVisibleColumns(
-  registry: SchemaRegistry,
-  rootSchema: string,
-): string[] {
-  const schema = maybeUndefined(registry[rootSchema]);
-  if (!schema) return [];
-
+export function getDefaultVisibleColumns(schema: ColumnSchema): string[] {
   const columns: string[] = [];
   for (const [columnName, entry] of Object.entries(schema)) {
-    if (isColumnDef(entry)) {
-      columns.push(columnName);
+    if ('schema' in entry || 'parameterized' in entry) {
+      // Skip schema references and parameterized columns
+      continue;
     }
+    columns.push(columnName);
   }
   return columns;
 }
@@ -214,25 +173,18 @@ export interface ColumnInfo {
  * Resolves a column path and returns all information needed for rendering.
  * This consolidates multiple schema lookups into a single traversal.
  *
- * @param registry The schema registry
- * @param rootSchema The root schema name
+ * @param schema The schema
  * @param path The column path (e.g., "parent.parent.name")
  * @returns Complete column info, or undefined if path is invalid
  */
 export function getColumnInfo(
-  registry: SchemaRegistry,
-  rootSchema: string,
+  schema: ColumnSchema,
   path: string,
 ): ColumnInfo | undefined {
   const parts = path.split('.');
-  const initialSchema = maybeUndefined(registry[rootSchema]);
-
-  if (!initialSchema) {
-    return undefined;
-  }
 
   const titleParts: m.Children[] = [];
-  let currentSchema = initialSchema;
+  let currentSchema = schema;
 
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i];
@@ -242,34 +194,25 @@ export function getColumnInfo(
       return undefined;
     }
 
-    if (isSchemaRef(entry)) {
+    if ('schema' in entry) {
       // Add title for this ref
       titleParts.push(entry.title ?? part);
       // Follow the reference
-      const referencedSchema = maybeUndefined(registry[entry.ref]);
-      if (!referencedSchema) {
-        return undefined;
-      }
-      currentSchema = referencedSchema;
-    } else if (isParameterizedColumnDef(entry)) {
+      currentSchema = entry.schema;
+    } else if ('parameterized' in entry) {
       // For parameterized columns, remaining parts are the key
       const remainingParts = parts.slice(i + 1);
       const paramKey =
         remainingParts.length > 0 ? remainingParts.join('.') : undefined;
 
-      // Build title for parameterized column as "Name[key]" format
-      if (typeof entry.title === 'function' && paramKey) {
-        titleParts.push(entry.title(paramKey));
+      const baseName = typeof entry.title === 'string' ? entry.title : part;
+      if (paramKey) {
+        // Format as "Name[key]" - single element with index-style notation
+        titleParts.push(
+          m('span', [baseName, m('span.pf-param-key', `[${paramKey}]`)]),
+        );
       } else {
-        const baseName = typeof entry.title === 'string' ? entry.title : part;
-        if (paramKey) {
-          // Format as "Name[key]" - single element with index-style notation
-          titleParts.push(
-            m('span', [baseName, m('span.pf-param-key', `[${paramKey}]`)]),
-          );
-        } else {
-          titleParts.push(baseName);
-        }
+        titleParts.push(baseName);
       }
 
       return {
@@ -280,7 +223,7 @@ export function getColumnInfo(
         cellRenderer: entry.cellRenderer,
         cellFormatter: entry.cellFormatter,
       };
-    } else if (isColumnDef(entry)) {
+    } else {
       // Leaf column - should be the last part of the path
       if (i === parts.length - 1) {
         titleParts.push(entry.title ?? part);

--- a/ui/src/components/widgets/datagrid/export_utils.ts
+++ b/ui/src/components/widgets/datagrid/export_utils.ts
@@ -15,7 +15,7 @@
 import type {Row, SqlValue} from '../../../trace_processor/query_result';
 import {
   type CellFormatter,
-  type SchemaRegistry,
+  type ColumnSchema,
   getColumnInfo,
 } from './datagrid_schema';
 
@@ -47,15 +47,13 @@ export interface ExportOptions {
  * Apply cell formatters to all rows, converting SqlValues to strings.
  * @param rows The input rows to format.
  * @param schema Optional schema registry for looking up column info.
- * @param rootSchema Optional name of the root schema for lookup.
  * @param columns The list of column aliases to include in the output.
  * @param aliasToField Optional mapping from column aliases to field paths,
  *   used when column IDs differ from field paths for schema lookup.
  */
 export function formatRows(
   rows: readonly Row[],
-  schema: SchemaRegistry | undefined,
-  rootSchema: string | undefined,
+  schema: ColumnSchema | undefined,
   columns: ReadonlyArray<string>,
   aliasToField?: Record<string, string>,
 ): Array<Record<string, string>> {
@@ -65,11 +63,10 @@ export function formatRows(
       const value = row[colAlias];
       // Use field path for schema lookup if provided, otherwise use alias
       const fieldPath = aliasToField?.[colAlias] ?? colAlias;
-      const formatter =
-        schema && rootSchema
-          ? getColumnInfo(schema, rootSchema, fieldPath)?.cellFormatter ??
-            defaultValueFormatter
-          : defaultValueFormatter;
+      const formatter = schema
+        ? getColumnInfo(schema, fieldPath)?.cellFormatter ??
+          defaultValueFormatter
+        : defaultValueFormatter;
       formattedRow[colAlias] = formatter(value, row);
     }
     return formattedRow;
@@ -79,20 +76,17 @@ export function formatRows(
 /**
  * Build a mapping of column paths to display names.
  * @param schema Optional schema registry for looking up column info.
- * @param rootSchema Optional name of the root schema for lookup.
  * @param columns The list of column paths to get names for.
  */
 export function buildColumnNames(
-  schema: SchemaRegistry | undefined,
-  rootSchema: string | undefined,
+  schema: ColumnSchema | undefined,
   columns: ReadonlyArray<string>,
 ): Record<string, string> {
   const columnNames: Record<string, string> = {};
   for (const colPath of columns) {
-    columnNames[colPath] =
-      schema && rootSchema
-        ? getColumnInfo(schema, rootSchema, colPath)?.def.titleString ?? colPath
-        : colPath;
+    columnNames[colPath] = schema
+      ? getColumnInfo(schema, colPath)?.def.titleString ?? colPath
+      : colPath;
   }
   return columnNames;
 }

--- a/ui/src/components/widgets/datagrid/sql_data_source.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source.ts
@@ -27,11 +27,8 @@ import {
   UNKNOWN,
 } from '../../../trace_processor/query_result';
 import type {DataSource, DataSourceModel, DataSourceRows} from './data_source';
-import {
-  isSQLExpressionDef,
-  type SQLSchemaRegistry,
-  SQLSchemaResolver,
-} from './sql_schema';
+import {type SQLTableSchema, SQLSchemaResolver} from './sql_schema';
+
 import {SQLDataSourceFlat} from './sql_data_source/flat';
 import {SQLDataSourcePivot} from './sql_data_source/pivot';
 import {SQLDataSourceTree} from './sql_data_source/tree';
@@ -39,10 +36,8 @@ import {SQLDataSourceTree} from './sql_data_source/tree';
 /**
  * Configuration for SQLDataSource.
  */
-export interface DatagridEngineSQLConfig {
+export interface DatagridEngineSQLConfig extends SQLTableSchema {
   readonly engine: Engine;
-  readonly sqlSchema: SQLSchemaRegistry;
-  readonly rootSchemaName: string;
   readonly preamble?: string;
   readonly queue?: SerialTaskQueue;
 }
@@ -54,8 +49,7 @@ export interface DatagridEngineSQLConfig {
  */
 export class SQLDataSource implements DataSource {
   private readonly engine: Engine;
-  private readonly sqlSchema: SQLSchemaRegistry;
-  private readonly rootSchemaName: string;
+  private readonly sqlSchema: SQLTableSchema;
   private readonly preamble?: string;
   private readonly flatEngine: SQLDataSourceFlat;
   private readonly pivotEngine: SQLDataSourcePivot;
@@ -67,8 +61,7 @@ export class SQLDataSource implements DataSource {
 
   constructor(config: DatagridEngineSQLConfig) {
     this.engine = config.engine;
-    this.sqlSchema = config.sqlSchema;
-    this.rootSchemaName = config.rootSchemaName;
+    this.sqlSchema = config;
     this.preamble = config.preamble;
     this.queue = config.queue ?? new SerialTaskQueue();
     this.preambleSlot = new QuerySlot<void>(this.queue);
@@ -80,7 +73,6 @@ export class SQLDataSource implements DataSource {
       this.queue,
       this.engine,
       this.sqlSchema,
-      this.rootSchemaName,
     );
 
     this.pivotEngine = new SQLDataSourcePivot(
@@ -88,14 +80,12 @@ export class SQLDataSource implements DataSource {
       this.queue,
       this.engine,
       this.sqlSchema,
-      this.rootSchemaName,
     );
 
     this.treeEngine = new SQLDataSourceTree(
       this.queue,
       this.engine,
       this.sqlSchema,
-      this.rootSchemaName,
     );
   }
 
@@ -160,22 +150,19 @@ export class SQLDataSource implements DataSource {
     return this.distinctValuesSlot.use({
       key: column,
       queryFn: async () => {
-        const resolver = new SQLSchemaResolver(
-          this.sqlSchema,
-          this.rootSchemaName,
-        );
+        const resolver = new SQLSchemaResolver(this.sqlSchema);
         const sqlExpr = resolver.resolveColumnPath(column);
         if (sqlExpr === undefined) {
           return [];
         }
 
-        const baseTable = resolver.getBaseTable();
+        const baseTable = resolver.getBaseTableOrSubquery();
         const baseAlias = resolver.getBaseAlias();
         const joinClauses = resolver.buildJoinClauses();
 
         const query = `
           SELECT DISTINCT ${sqlExpr} AS value
-          FROM ${baseTable} AS ${baseAlias}
+          FROM (${baseTable}) AS ${baseAlias}
           ${joinClauses}
           ORDER BY 1
         `;
@@ -203,28 +190,20 @@ export class SQLDataSource implements DataSource {
     return this.parameterKeysSlot.use({
       key: prefix,
       queryFn: async () => {
-        const rootSchema = maybeUndefined(this.sqlSchema[this.rootSchemaName]);
-        if (!rootSchema) {
-          return [];
-        }
-
-        const colDef = maybeUndefined(rootSchema.columns[prefix]);
+        const colDef = maybeUndefined(this.sqlSchema.columns?.[prefix]);
         if (
           !colDef ||
-          !isSQLExpressionDef(colDef) ||
+          !('expression' in colDef) ||
           !colDef.parameterKeysQuery
         ) {
           return [];
         }
 
-        const baseTable = rootSchema.table;
-        const resolver = new SQLSchemaResolver(
-          this.sqlSchema,
-          this.rootSchemaName,
-        );
+        const baseTableOrSubquery = this.sqlSchema.tableOrSubquery;
+        const resolver = new SQLSchemaResolver(this.sqlSchema);
         const baseAlias = resolver.getBaseAlias();
 
-        const query = colDef.parameterKeysQuery(baseTable, baseAlias);
+        const query = colDef.parameterKeysQuery(baseTableOrSubquery, baseAlias);
         const queryResult = await this.engine.query(query);
         const keys: string[] = [];
         for (let it = queryResult.iter({key: UNKNOWN}); it.valid(); it.next()) {
@@ -233,6 +212,26 @@ export class SQLDataSource implements DataSource {
         return keys;
       },
     });
+  }
+
+  /**
+   * Returns the SQL that `useRows` would execute for this model, without
+   * running it. For pivot/tree modes this includes the statement that
+   * materializes their backing table, since traversing it standalone
+   * wouldn't mean much - see the mode-specific getQuery for details.
+   */
+  getQuery(model: DataSourceModel): string {
+    const mode = model.mode;
+    switch (mode) {
+      case 'flat':
+        return this.flatEngine.getQuery(model);
+      case 'pivot':
+        return this.pivotEngine.getQuery(model);
+      case 'tree':
+        return this.treeEngine.getQuery(model);
+      default:
+        assertUnreachable(mode);
+    }
   }
 
   async exportData(model: DataSourceModel): Promise<readonly Row[]> {

--- a/ui/src/components/widgets/datagrid/sql_data_source/flat.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/flat.ts
@@ -21,7 +21,7 @@ import type {Engine} from '../../../../trace_processor/engine';
 import {NUM, type Row} from '../../../../trace_processor/query_result';
 import {runQueryForQueryTable} from '../../../query_table/queries';
 import type {DataSourceRows, FlatModel} from '../data_source';
-import {type SQLSchemaRegistry, SQLSchemaResolver} from '../sql_schema';
+import {type SQLTableSchema, SQLSchemaResolver} from '../sql_schema';
 import {filterToSql, toAlias} from '../sql_utils';
 
 export class SQLDataSourceFlat {
@@ -35,8 +35,7 @@ export class SQLDataSourceFlat {
   constructor(
     queue: SerialTaskQueue,
     private readonly engine: Engine,
-    private readonly sqlSchema: SQLSchemaRegistry,
-    private readonly rootSchemaName: string,
+    private readonly sqlSchema: SQLTableSchema,
   ) {
     this.rowCountSlot = new QuerySlot<number>(queue);
     this.rowsSlot = new QuerySlot<{
@@ -66,10 +65,7 @@ export class SQLDataSourceFlat {
         filters: serializeFilters(filters),
       },
       queryFn: async () => {
-        const resolver = new SQLSchemaResolver(
-          this.sqlSchema,
-          this.rootSchemaName,
-        );
+        const resolver = new SQLSchemaResolver(this.sqlSchema);
 
         // Build aggregate expressions
         const selectExprs: string[] = [];
@@ -101,7 +97,7 @@ export class SQLDataSourceFlat {
         filters: serializeFilters(filters),
       },
       queryFn: async () => {
-        const query = buildQuery(this.sqlSchema, this.rootSchemaName, {
+        const query = buildQuery(this.sqlSchema, {
           mode: 'flat',
           columns,
           filters,
@@ -122,7 +118,7 @@ export class SQLDataSourceFlat {
       },
       retainOn: ['pagination', 'sort'],
       queryFn: async () => {
-        const query = buildQuery(this.sqlSchema, this.rootSchemaName, model);
+        const query = buildQuery(this.sqlSchema, model);
         const result = await runQueryForQueryTable(query, this.engine);
         const rows = result.rows;
         return {rows, rowOffset: pagination?.offset ?? 0};
@@ -139,11 +135,19 @@ export class SQLDataSourceFlat {
   }
 
   /**
+   * Returns the SQL query that `getRows` would execute for this model,
+   * without running it. Useful for debugging/inspection.
+   */
+  getQuery(model: FlatModel): string {
+    return buildQuery(this.sqlSchema, model);
+  }
+
+  /**
    * Export all data with current filters/sorting applied (no pagination).
    */
   async exportData(model: FlatModel): Promise<readonly Row[]> {
     // Build query without pagination
-    const query = buildQuery(this.sqlSchema, this.rootSchemaName, {
+    const query = buildQuery(this.sqlSchema, {
       ...model,
       pagination: undefined,
     });
@@ -168,11 +172,10 @@ function serializeFilters(filters: FlatModel['filters']) {
 }
 
 function buildQuery(
-  sqlSchema: SQLSchemaRegistry,
-  rootSchemaName: string,
+  sqlSchema: SQLTableSchema,
   {columns, filters, pagination, sort}: FlatModel,
 ): string {
-  const resolver = new SQLSchemaResolver(sqlSchema, rootSchemaName);
+  const resolver = new SQLSchemaResolver(sqlSchema);
 
   let sql = buildSelectClause(resolver, columns);
   sql = addFromClause(sql, resolver);
@@ -205,11 +208,11 @@ function buildSelectClause(
 }
 
 function addFromClause(sql: string, resolver: SQLSchemaResolver): string {
-  const baseTable = resolver.getBaseTable();
+  const baseTable = resolver.getBaseTableOrSubquery();
   const baseAlias = resolver.getBaseAlias();
   const joinClauses = resolver.buildJoinClauses();
 
-  sql += `\nFROM ${baseTable} AS ${baseAlias}`;
+  sql += `\nFROM (${baseTable}) AS ${baseAlias}`;
   if (joinClauses) {
     sql += `\n${joinClauses}`;
   }

--- a/ui/src/components/widgets/datagrid/sql_data_source/group_by.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/group_by.ts
@@ -21,7 +21,7 @@ import type {Engine} from '../../../../trace_processor/engine';
 import {NUM, type Row} from '../../../../trace_processor/query_result';
 import {runQueryForQueryTable} from '../../../query_table/queries';
 import type {DataSourceRows, PivotModel} from '../data_source';
-import {type SQLSchemaRegistry, SQLSchemaResolver} from '../sql_schema';
+import {type SQLTableSchema, SQLSchemaResolver} from '../sql_schema';
 import {filterToSql, sqlAggregateExpr, toAlias} from '../sql_utils';
 
 // Flat GROUP BY datasource - uses simple GROUP BY queries without hierarchy.
@@ -36,8 +36,7 @@ export class SQLDataSourceGroupBy {
   constructor(
     queue: SerialTaskQueue,
     private readonly engine: Engine,
-    private readonly sqlSchema: SQLSchemaRegistry,
-    private readonly rootSchemaName: string,
+    private readonly sqlSchema: SQLTableSchema,
   ) {
     this.rowCountSlot = new QuerySlot<number>(queue);
     this.rowsSlot = new QuerySlot<{
@@ -111,9 +110,17 @@ export class SQLDataSourceGroupBy {
     return result.rows;
   }
 
+  /**
+   * Returns the SQL query that `getRows` would execute for this model,
+   * without running it.
+   */
+  getQuery(model: PivotModel): string {
+    return this.buildGroupByQuery(model);
+  }
+
   private buildSummariesQuery(model: PivotModel): string {
     const {aggregates, filters = []} = model;
-    const resolver = new SQLSchemaResolver(this.sqlSchema, this.rootSchemaName);
+    const resolver = new SQLSchemaResolver(this.sqlSchema);
 
     const selectExprs: string[] = [];
     for (const agg of aggregates) {
@@ -127,12 +134,12 @@ export class SQLDataSourceGroupBy {
       selectExprs.push(`${aggExpr} AS ${toAlias(agg.alias)}`);
     }
 
-    const baseTable = resolver.getBaseTable();
+    const baseTable = resolver.getBaseTableOrSubquery();
     const baseAlias = resolver.getBaseAlias();
     const joinClauses = resolver.buildJoinClauses();
 
     let sql = `SELECT ${selectExprs.join(', ')}`;
-    sql += `\nFROM ${baseTable} AS ${baseAlias}`;
+    sql += `\nFROM (${baseTable}) AS ${baseAlias}`;
     if (joinClauses) {
       sql += `\n${joinClauses}`;
     }
@@ -153,7 +160,7 @@ export class SQLDataSourceGroupBy {
     options?: {countOnly?: boolean},
   ): string {
     const {groupBy, aggregates, filters = [], pagination, sort} = model;
-    const resolver = new SQLSchemaResolver(this.sqlSchema, this.rootSchemaName);
+    const resolver = new SQLSchemaResolver(this.sqlSchema);
 
     const selectExprs: string[] = [];
 
@@ -175,12 +182,12 @@ export class SQLDataSourceGroupBy {
       selectExprs.push(`${aggExpr} AS ${toAlias(agg.alias)}`);
     }
 
-    const baseTable = resolver.getBaseTable();
+    const baseTable = resolver.getBaseTableOrSubquery();
     const baseAlias = resolver.getBaseAlias();
     const joinClauses = resolver.buildJoinClauses();
 
     let sql = `SELECT ${selectExprs.join(', ')}`;
-    sql += `\nFROM ${baseTable} AS ${baseAlias}`;
+    sql += `\nFROM (${baseTable}) AS ${baseAlias}`;
     if (joinClauses) {
       sql += `\n${joinClauses}`;
     }

--- a/ui/src/components/widgets/datagrid/sql_data_source/pivot.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/pivot.ts
@@ -18,7 +18,7 @@ import type {Row} from '../../../../trace_processor/query_result';
 import type {DataSourceRows, PivotModel} from '../data_source';
 import {SQLDataSourceGroupBy} from './group_by';
 import {SQLDataSourceRollupTree} from './rollup_tree';
-import type {SQLSchemaRegistry} from '../sql_schema';
+import type {SQLTableSchema} from '../sql_schema';
 
 // Pivot datasource for DataGrid - delegates to flat or tree implementations.
 export class SQLDataSourcePivot {
@@ -29,22 +29,10 @@ export class SQLDataSourcePivot {
     uuid: string,
     queue: SerialTaskQueue,
     engine: Engine,
-    sqlSchema: SQLSchemaRegistry,
-    rootSchemaName: string,
+    sqlSchema: SQLTableSchema,
   ) {
-    this.flat = new SQLDataSourceGroupBy(
-      queue,
-      engine,
-      sqlSchema,
-      rootSchemaName,
-    );
-    this.tree = new SQLDataSourceRollupTree(
-      uuid,
-      queue,
-      engine,
-      sqlSchema,
-      rootSchemaName,
-    );
+    this.flat = new SQLDataSourceGroupBy(queue, engine, sqlSchema);
+    this.tree = new SQLDataSourceRollupTree(uuid, queue, engine, sqlSchema);
   }
 
   getRows(model: PivotModel): DataSourceRows {
@@ -65,6 +53,18 @@ export class SQLDataSourcePivot {
 
   exportData(model: PivotModel): Promise<readonly Row[]> {
     return this.flat.exportData(model);
+  }
+
+  /**
+   * Returns the SQL that materializes and traverses the pivot's backing
+   * table(s) for this model, without running it.
+   */
+  getQuery(model: PivotModel): string {
+    if (model.groupDisplay === 'flat') {
+      return this.flat.getQuery(model);
+    } else {
+      return this.tree.getQuery(model);
+    }
   }
 
   dispose(): void {

--- a/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
@@ -31,7 +31,7 @@ import {runQueryForQueryTable} from '../../../query_table/queries';
 import type {DataSourceRows, PivotModel} from '../data_source';
 import type {GroupPath} from '../model';
 import {serializeFilters} from './group_by';
-import {type SQLSchemaRegistry, SQLSchemaResolver} from '../sql_schema';
+import {type SQLTableSchema, SQLSchemaResolver} from '../sql_schema';
 import {filterToSql, sqlAggregateExpr, toAlias} from '../sql_utils';
 import {stringifyJsonWithBigints} from '../../../../base/json_utils';
 
@@ -109,8 +109,7 @@ export class SQLDataSourceRollupTree {
     private readonly uuid: string,
     queue: SerialTaskQueue,
     private readonly engine: Engine,
-    private readonly sqlSchema: SQLSchemaRegistry,
-    private readonly rootSchemaName: string,
+    private readonly sqlSchema: SQLTableSchema,
   ) {
     this.rowCountSlot = new QuerySlot<number>(queue);
     this.rowsSlot = new QuerySlot<{
@@ -140,28 +139,14 @@ export class SQLDataSourceRollupTree {
     const rollupTableName = rollupTableResult.data.name;
 
     // Build column alias mappings
-    const columnAliases: Record<string, string> = {};
-    const aliasToColumn: Record<string, string> = {};
-    for (let i = 0; i < groupBy.length; i++) {
-      columnAliases[`__group_${i}`] = toAlias(groupBy[i].alias);
-      aliasToColumn[groupBy[i].alias] = `__group_${i}`;
-    }
-    for (let i = 0; i < aggregates.length; i++) {
-      columnAliases[`__agg_${i}`] = toAlias(aggregates[i].alias);
-      aliasToColumn[aggregates[i].alias] = `__agg_${i}`;
-    }
+    const {columnAliases, aliasToColumn} = this.buildColumnAliases(
+      groupBy,
+      aggregates,
+    );
 
     // Determine sort column and direction
     // Default to __id ASC to preserve natural order when no sort is specified
-    let sortColumn = '__id';
-    let sortDirection: 'ASC' | 'DESC' = 'ASC';
-    if (sort) {
-      const column = aliasToColumn[sort.alias];
-      if (column) {
-        sortColumn = column;
-      }
-      sortDirection = sort.direction;
-    }
+    const {sortColumn, sortDirection} = this.resolveSort(sort, aliasToColumn);
 
     const pivotKey = {
       groupBy,
@@ -252,13 +237,7 @@ export class SQLDataSourceRollupTree {
 
     const rollupTableName = rollupTableResult.data.name;
 
-    const columnAliases: Record<string, string> = {};
-    for (let i = 0; i < groupBy.length; i++) {
-      columnAliases[`__group_${i}`] = toAlias(groupBy[i].alias);
-    }
-    for (let i = 0; i < aggregates.length; i++) {
-      columnAliases[`__agg_${i}`] = toAlias(aggregates[i].alias);
-    }
+    const {columnAliases} = this.buildColumnAliases(groupBy, aggregates);
 
     return this.summariesSlot.use({
       key: {
@@ -282,13 +261,7 @@ export class SQLDataSourceRollupTree {
 
     const sourceQuery = this.buildSourceQuery(filters);
     const groupByColumns = groupBy.map((col) => col.field);
-    const aggregateExprs = aggregates.map((agg) => {
-      if (agg.function === 'COUNT') {
-        return 'COUNT(*)';
-      } else {
-        return sqlAggregateExpr(agg.function, agg.field);
-      }
-    });
+    const aggregateExprs = this.buildAggregateExprs(aggregates);
 
     return this.rollupTableSlot.use({
       key: {
@@ -301,18 +274,135 @@ export class SQLDataSourceRollupTree {
           sourceTable: sourceQuery,
           groupByColumns,
           aggregateExprs,
-          tableName: `rollup_${this.uuid}`,
+          tableName: this.rollupTableName,
         });
       },
     });
   }
 
+  /**
+   * The name of this instance's materialized rollup table. Stable for the
+   * lifetime of this datasource, so it can be used to synthesize SQL even
+   * before the table has actually been created.
+   */
+  private get rollupTableName(): string {
+    return `rollup_${this.uuid}`;
+  }
+
+  private buildAggregateExprs(aggregates: PivotModel['aggregates']): string[] {
+    return aggregates.map((agg) => {
+      if (agg.function === 'COUNT') {
+        return 'COUNT(*)';
+      } else {
+        return sqlAggregateExpr(agg.function, agg.field);
+      }
+    });
+  }
+
+  /**
+   * Maps group/aggregate columns to their internal (`__group_N`/`__agg_N`)
+   * and back. Shared by `getRows`, `getSummaries` and `getQuery`.
+   */
+  private buildColumnAliases(
+    groupBy: PivotModel['groupBy'],
+    aggregates: PivotModel['aggregates'],
+  ): {
+    columnAliases: Record<string, string>;
+    aliasToColumn: Record<string, string>;
+  } {
+    const columnAliases: Record<string, string> = {};
+    const aliasToColumn: Record<string, string> = {};
+    for (let i = 0; i < groupBy.length; i++) {
+      columnAliases[`__group_${i}`] = toAlias(groupBy[i].alias);
+      aliasToColumn[groupBy[i].alias] = `__group_${i}`;
+    }
+    for (let i = 0; i < aggregates.length; i++) {
+      columnAliases[`__agg_${i}`] = toAlias(aggregates[i].alias);
+      aliasToColumn[aggregates[i].alias] = `__agg_${i}`;
+    }
+    return {columnAliases, aliasToColumn};
+  }
+
+  /**
+   * Resolves the internal column/direction to sort the rollup traversal by,
+   * given the model's `sort` (which refers to a column alias). Default to
+   * __id ASC to preserve natural order when no sort is specified.
+   */
+  private resolveSort(
+    sort: PivotModel['sort'],
+    aliasToColumn: Record<string, string>,
+  ): {sortColumn: string; sortDirection: 'ASC' | 'DESC'} {
+    let sortColumn = '__id';
+    let sortDirection: 'ASC' | 'DESC' = 'ASC';
+    if (sort) {
+      const column = aliasToColumn[sort.alias];
+      if (column) {
+        sortColumn = column;
+      }
+      sortDirection = sort.direction;
+    }
+    return {sortColumn, sortDirection};
+  }
+
+  /**
+   * Returns the SQL that materializes and traverses the rollup table for this
+   * model, without running it. The table name is stable for this datasource
+   * instance, so this can be computed even before the table has actually been
+   * created.
+   */
+  getQuery(model: PivotModel): string {
+    const {
+      groupBy,
+      aggregates,
+      filters = [],
+      expandedGroups,
+      collapsedGroups,
+    } = model;
+
+    const sourceQuery = this.buildSourceQuery(filters);
+    const groupByColumns = groupBy.map((col) => col.field);
+    const aggregateExprs = this.buildAggregateExprs(aggregates);
+    const tableName = this.rollupTableName;
+    const {columnAliases, aliasToColumn} = this.buildColumnAliases(
+      groupBy,
+      aggregates,
+    );
+    const {sortColumn, sortDirection} = this.resolveSort(
+      model.sort,
+      aliasToColumn,
+    );
+
+    const traversalQuery = buildTreeQuery(tableName, {
+      expandedGroups,
+      collapsedGroups,
+      sortColumn,
+      sortDirection,
+      offset: model.pagination?.offset,
+      limit: model.pagination?.limit,
+      minDepth: 1,
+      columnAliases,
+    });
+
+    return [
+      `-- Materialize rollup table:`,
+      `CREATE PERFETTO TABLE ${tableName} AS`,
+      buildRollupTableCreateQuery(
+        sourceQuery,
+        groupByColumns,
+        aggregateExprs,
+      ).trim(),
+      ``,
+      `-- Traverse rollup table:`,
+      traversalQuery.trim(),
+    ].join('\n');
+  }
+
   private buildSourceQuery(filters: PivotModel['filters']): string {
-    const resolver = new SQLSchemaResolver(this.sqlSchema, this.rootSchemaName);
-    const baseTable = resolver.getBaseTable();
+    const resolver = new SQLSchemaResolver(this.sqlSchema);
+    const baseTable = resolver.getBaseTableOrSubquery();
     const baseAlias = resolver.getBaseAlias();
 
-    let sql = `SELECT ${baseAlias}.* FROM ${baseTable} AS ${baseAlias}`;
+    let sql = `SELECT ${baseAlias}.* FROM (${baseTable}) AS ${baseAlias}`;
 
     if (filters && filters.length > 0) {
       for (const filter of filters) {
@@ -353,27 +443,17 @@ interface RollupTableConfig {
 }
 
 /**
- * Creates a rollup table using UNION ALL queries.
- *
- * The table contains all rollup levels with:
- * - __id: unique row identifier
- * - __parent_id: parent row id (NULL for root)
- * - __depth: hierarchy depth (0 for root, 1+ for groups)
- * - __child_count: number of direct children
- * - __group_0, __group_1, ...: hierarchy column values
- * - __agg_0, __agg_1, ...: aggregate values
+ * Builds the query used to materialize the rollup table (see
+ * `createRollupTable` for the shape of the resulting columns). Pure function
+ * of the source table/columns/aggregates - shared by `createRollupTable`
+ * (which executes it) and `SQLDataSourceRollupTree.getQuery` (which just
+ * shows it).
  */
-async function createRollupTable(
-  engine: Engine,
-  config: RollupTableConfig,
-): Promise<DisposableSqlEntity> {
-  const {
-    sourceTable,
-    groupByColumns,
-    aggregateExprs,
-    tableName = '__rollup_tree_default__',
-  } = config;
-
+function buildRollupTableCreateQuery(
+  sourceTable: string,
+  groupByColumns: readonly string[],
+  aggregateExprs: readonly string[],
+): string {
   const numHier = groupByColumns.length;
   const numAggs = aggregateExprs.length;
 
@@ -454,10 +534,7 @@ async function createRollupTable(
     groupCols.length > 0 ? prefixCols(groupCols, 'w') + ',' : '';
   const aggColsSelectW = prefixCols(aggCols, 'w');
 
-  // Drop existing table if it exists (in case of stale data)
-  await engine.query(`DROP TABLE IF EXISTS ${tableName}`);
-
-  const createQuery = `
+  return `
     WITH rollup_raw AS (
       ${unionQuery}
     ),
@@ -503,7 +580,38 @@ async function createRollupTable(
     )
     SELECT * FROM with_child_count
   `;
+}
 
+/**
+ * Creates a rollup table using UNION ALL queries.
+ *
+ * The table contains all rollup levels with:
+ * - __id: unique row identifier
+ * - __parent_id: parent row id (NULL for root)
+ * - __depth: hierarchy depth (0 for root, 1+ for groups)
+ * - __child_count: number of direct children
+ * - __group_0, __group_1, ...: hierarchy column values
+ * - __agg_0, __agg_1, ...: aggregate values
+ */
+async function createRollupTable(
+  engine: Engine,
+  config: RollupTableConfig,
+): Promise<DisposableSqlEntity> {
+  const {
+    sourceTable,
+    groupByColumns,
+    aggregateExprs,
+    tableName = '__rollup_tree_default__',
+  } = config;
+
+  const createQuery = buildRollupTableCreateQuery(
+    sourceTable,
+    groupByColumns,
+    aggregateExprs,
+  );
+
+  // Drop existing table if it exists (in case of stale data)
+  await engine.query(`DROP TABLE IF EXISTS ${tableName}`);
   await engine.query(createQuery);
 
   return await createPerfettoTable({

--- a/ui/src/components/widgets/datagrid/sql_data_source/tree.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/tree.ts
@@ -26,7 +26,7 @@ import {
 } from '../../../../trace_processor/sql_utils';
 import {runQueryForQueryTable} from '../../../query_table/queries';
 import type {DataSourceRows, TreeModel} from '../data_source';
-import {type SQLSchemaRegistry, SQLSchemaResolver} from '../sql_schema';
+import {type SQLTableSchema, SQLSchemaResolver} from '../sql_schema';
 import {filterToSql, sqlValue, toAlias} from '../sql_utils';
 
 /**
@@ -50,8 +50,7 @@ export class SQLDataSourceTree {
   constructor(
     queue: SerialTaskQueue,
     private readonly engine: Engine,
-    private readonly sqlSchema: SQLSchemaRegistry,
-    private readonly rootSchemaName: string,
+    private readonly sqlSchema: SQLTableSchema,
   ) {
     this.treeTableSlot = new QuerySlot<DisposableSqlEntity>(queue);
     this.rowCountSlot = new QuerySlot<number>(queue);
@@ -62,7 +61,7 @@ export class SQLDataSourceTree {
   }
 
   getRows(model: TreeModel): DataSourceRows {
-    const {columns, filters = [], pagination, sort, tree} = model;
+    const {columns, filters = [], pagination, tree} = model;
 
     // First, ensure the base table is materialized
     const treeTableResult = this.useTreeTable(model);
@@ -87,15 +86,7 @@ export class SQLDataSourceTree {
     }
 
     // Determine sort column and direction
-    let sortColumn = '__id';
-    let sortDirection: 'ASC' | 'DESC' = 'ASC';
-    if (sort) {
-      const sortCol = columns.find((c) => c.alias === sort.alias);
-      if (sortCol) {
-        sortColumn = toAlias(sortCol.alias);
-      }
-      sortDirection = sort.direction;
-    }
+    const {sortColumn, sortDirection} = this.resolveSort(model);
 
     const baseKey = {
       columns,
@@ -185,16 +176,8 @@ export class SQLDataSourceTree {
       return [];
     }
 
-    const {columns, sort, tree} = model;
-    let sortColumn = '__id';
-    let sortDirection: 'ASC' | 'DESC' = 'ASC';
-    if (sort) {
-      const sortCol = columns.find((c) => c.alias === sort.alias);
-      if (sortCol) {
-        sortColumn = toAlias(sortCol.alias);
-      }
-      sortDirection = sort.direction;
-    }
+    const {tree} = model;
+    const {sortColumn, sortDirection} = this.resolveSort(model);
 
     const query = buildTreeQuery(treeTableResult.data.name, {
       expandedIds: tree.expandedIds,
@@ -207,15 +190,16 @@ export class SQLDataSourceTree {
   }
 
   /**
-   * Materialize the base tree table with __id, __parent_id, __has_children,
-   * and all user columns. This is cached and only rebuilt when columns or
-   * filters change.
+   * Builds the query whose results get materialized into the tree table
+   * (__id, __parent_id, and all user columns). Pure function of the model -
+   * shared by `useTreeTable` (which executes it) and `getQuery` (which just
+   * shows it).
    */
-  private useTreeTable(model: TreeModel): QueryResult<DisposableSqlEntity> {
+  private buildSourceQuery(model: TreeModel): string {
     const {columns, filters = [], tree} = model;
 
-    const resolver = new SQLSchemaResolver(this.sqlSchema, this.rootSchemaName);
-    const baseTable = resolver.getBaseTable();
+    const resolver = new SQLSchemaResolver(this.sqlSchema);
+    const baseTable = resolver.getBaseTableOrSubquery();
     const baseAlias = resolver.getBaseAlias();
 
     // Resolve the id and parent_id columns
@@ -248,16 +232,56 @@ export class SQLDataSourceTree {
     const userColumns =
       selectExprs.length > 0 ? selectExprs.join(', ') : `${baseAlias}.*`;
 
-    // The source query that we'll materialize
-    const sourceQuery = `
+    return `
       SELECT
         ${idExpr} AS __id,
         ${parentIdExpr} AS __parent_id,
         ${userColumns}
-      FROM ${baseTable} AS ${baseAlias}
+      FROM (${baseTable}) AS ${baseAlias}
       ${joinClauses}
       ${whereClause}
     `;
+  }
+
+  /**
+   * The name of this instance's materialized tree table. Stable for the
+   * lifetime of this datasource, so it can be used to synthesize SQL even
+   * before the table has actually been created.
+   */
+  private get treeTableName(): string {
+    return `tree_${this.uuid}`;
+  }
+
+  /**
+   * Resolves the alias/direction to sort the tree traversal by, given the
+   * model's `sort` (which refers to a column alias). Shared by `getRows`,
+   * `exportData` and `getQuery`.
+   */
+  private resolveSort(model: TreeModel): {
+    sortColumn: string;
+    sortDirection: 'ASC' | 'DESC';
+  } {
+    const {columns, sort} = model;
+    let sortColumn = '__id';
+    let sortDirection: 'ASC' | 'DESC' = 'ASC';
+    if (sort) {
+      const sortCol = columns.find((c) => c.alias === sort.alias);
+      if (sortCol) {
+        sortColumn = toAlias(sortCol.alias);
+      }
+      sortDirection = sort.direction;
+    }
+    return {sortColumn, sortDirection};
+  }
+
+  /**
+   * Materialize the base tree table with __id, __parent_id, __has_children,
+   * and all user columns. This is cached and only rebuilt when columns or
+   * filters change.
+   */
+  private useTreeTable(model: TreeModel): QueryResult<DisposableSqlEntity> {
+    const {columns, filters = [], tree} = model;
+    const sourceQuery = this.buildSourceQuery(model);
 
     return this.treeTableSlot.use({
       key: {
@@ -269,10 +293,39 @@ export class SQLDataSourceTree {
       queryFn: async () => {
         return await createTreeTable(this.engine, {
           sourceQuery,
-          tableName: `tree_${this.uuid}`,
+          tableName: this.treeTableName,
         });
       },
     });
+  }
+
+  /**
+   * Returns the SQL that materializes and traverses the tree table for this
+   * model, without running it. The table name is stable for this datasource
+   * instance, so this can be computed even before the table has actually been
+   * created.
+   */
+  getQuery(model: TreeModel): string {
+    const sourceQuery = this.buildSourceQuery(model);
+    const tableName = this.treeTableName;
+    const {sortColumn, sortDirection} = this.resolveSort(model);
+    const traversalQuery = buildTreeQuery(tableName, {
+      expandedIds: model.tree.expandedIds,
+      collapsedIds: model.tree.collapsedIds,
+      sortColumn,
+      sortDirection,
+      offset: model.pagination?.offset,
+      limit: model.pagination?.limit,
+    });
+
+    return [
+      `-- Materialize tree table:`,
+      `CREATE PERFETTO TABLE ${tableName} AS`,
+      buildTreeTableCreateQuery(sourceQuery).trim(),
+      ``,
+      `-- Traverse tree table:`,
+      traversalQuery.trim(),
+    ].join('\n');
   }
 
   dispose(): void {
@@ -298,17 +351,13 @@ interface TreeTableConfig {
 }
 
 /**
- * Creates a materialized tree table with __id, __parent_id, __has_children,
- * and all user columns from the source query.
+ * Builds the query used to materialize the tree table (adds __has_children on
+ * top of the source query's __id/__parent_id/user columns). Pure function of
+ * the source query - shared by `createTreeTable` (which executes it) and
+ * `SQLDataSourceTree.getQuery` (which just shows it).
  */
-async function createTreeTable(
-  engine: Engine,
-  config: TreeTableConfig,
-): Promise<DisposableSqlEntity> {
-  const {sourceQuery, tableName} = config;
-
-  // Build the complete table with child counts
-  const createQuery = `
+function buildTreeTableCreateQuery(sourceQuery: string): string {
+  return `
     WITH base_data AS (
       ${sourceQuery}
     ),
@@ -326,6 +375,18 @@ async function createTreeTable(
     )
     SELECT * FROM with_children
   `;
+}
+
+/**
+ * Creates a materialized tree table with __id, __parent_id, __has_children,
+ * and all user columns from the source query.
+ */
+async function createTreeTable(
+  engine: Engine,
+  config: TreeTableConfig,
+): Promise<DisposableSqlEntity> {
+  const {sourceQuery, tableName} = config;
+  const createQuery = buildTreeTableCreateQuery(sourceQuery);
 
   return await createPerfettoTable({
     engine,

--- a/ui/src/components/widgets/datagrid/sql_schema.ts
+++ b/ui/src/components/widgets/datagrid/sql_schema.ts
@@ -19,21 +19,28 @@ import {maybeUndefined} from '../../../base/utils';
  *
  * This module defines how column paths (like 'parent.name' or 'thread.process.pid')
  * map to SQL queries with appropriate JOINs. It works in parallel with the UI
- * SchemaRegistry but focuses on SQL generation rather than rendering.
+ * ColumnSchema but focuses on SQL generation rather than rendering.
+ *
+ * A schema is a tree: joins embed the referenced table schema directly. For
+ * self-referential tables (e.g. a slice's parent slice) use a `get schema()`
+ * getter so the reference resolves lazily, after the object is constructed.
  *
  * Example usage:
  * ```typescript
- * const schema: SQLSchemaRegistry = {
- *   slice: {
- *     table: 'slice',
- *     columns: {
- *       id: {},
- *       name: {},
- *       parent: { ref: 'slice', foreignKey: 'parent_id' },
- *       args: {
- *         expression: (alias, key) => `extract_arg(${alias}.arg_set_id, '${key}')`,
- *         parameterized: true,
+ * const slice: SQLTableSchema = {
+ *   table: 'slice',
+ *   columns: {
+ *     id: {},
+ *     name: {},
+ *     parent: {
+ *       get schema() {
+ *         return slice; // Lazy self-reference.
  *       },
+ *       foreignKey: 'parent_id',
+ *     },
+ *     args: {
+ *       expression: (alias, key) => `extract_arg(${alias}.arg_set_id, '${key}')`,
+ *       parameterized: true,
  *     },
  *   },
  * };
@@ -41,21 +48,13 @@ import {maybeUndefined} from '../../../base/utils';
  */
 
 /**
- * Registry of named SQL schemas that can reference each other.
- * Parallel to SchemaRegistry but for SQL generation.
- */
-export interface SQLSchemaRegistry {
-  [schemaName: string]: SQLTableSchema;
-}
-
-/**
  * Defines how to produce SQL for a table's columns.
  */
 export interface SQLTableSchema {
   /**
-   * The SQL table name.
+   * The SQL table name or subquery
    */
-  readonly table: string;
+  readonly tableOrSubquery: string;
 
   /**
    * The primary key column (defaults to 'id').
@@ -65,7 +64,7 @@ export interface SQLTableSchema {
   /**
    * Column definitions.
    */
-  readonly columns: {
+  readonly columns?: {
     [columnName: string]: SQLColumnDef | SQLJoinDef | SQLExpressionDef;
   };
 }
@@ -85,9 +84,9 @@ export interface SQLColumnDef {
  */
 export interface SQLJoinDef {
   /**
-   * Name of the schema in the registry to join to.
+   * The schema of the table to join to.
    */
-  readonly ref: string;
+  readonly schema: SQLTableSchema;
 
   /**
    * Local column containing the foreign key (e.g., 'parent_id').
@@ -123,8 +122,8 @@ export interface SQLExpressionDef {
    * SQL query generator to fetch available parameter keys.
    * Only used when parameterized is true.
    *
-   * @param baseTable The base table name (e.g., 'slice')
-   * @param baseAlias The base table alias (e.g., 'slice_0')
+   * @param tableOrSubquery The base table name (e.g., 'slice')
+   * @param alias The base table alias (e.g., 'base')
    * @returns A SQL query that returns rows with a 'key' column
    *
    * Example for args:
@@ -140,36 +139,9 @@ export interface SQLExpressionDef {
    * ```
    */
   readonly parameterKeysQuery?: (
-    baseTable: string,
-    baseAlias: string,
+    tableOrSubquery: string,
+    alias: string,
   ) => string;
-}
-
-/**
- * Type guard for SQLJoinDef.
- */
-export function isSQLJoinDef(
-  def: SQLColumnDef | SQLJoinDef | SQLExpressionDef,
-): def is SQLJoinDef {
-  return 'ref' in def && 'foreignKey' in def;
-}
-
-/**
- * Type guard for SQLExpressionDef.
- */
-export function isSQLExpressionDef(
-  def: SQLColumnDef | SQLJoinDef | SQLExpressionDef,
-): def is SQLExpressionDef {
-  return 'expression' in def;
-}
-
-/**
- * Type guard for SQLColumnDef.
- */
-export function isSQLColumnDef(
-  def: SQLColumnDef | SQLJoinDef | SQLExpressionDef,
-): def is SQLColumnDef {
-  return !isSQLJoinDef(def) && !isSQLExpressionDef(def);
 }
 
 /**
@@ -177,12 +149,12 @@ export function isSQLColumnDef(
  */
 export interface ResolvedJoin {
   /**
-   * The table to join.
+   * The table or subquery to join.
    */
-  readonly table: string;
+  readonly tableOrSubquery: string;
 
   /**
-   * Unique alias for this join instance (e.g., 'slice_1', 'slice_2').
+   * Unique alias for this join instance (e.g., 't0', 't1').
    */
   readonly alias: string;
 
@@ -227,21 +199,20 @@ export interface ResolvedSQLColumn {
  */
 interface JoinKey {
   readonly fromAlias: string;
-  readonly table: string;
+  readonly tableOrSubquery: string;
   readonly foreignKey: string;
   readonly innerJoin: boolean;
 }
 
 function joinKeyToString(key: JoinKey): string {
-  return `${key.fromAlias}|${key.table}|${key.foreignKey}|${key.innerJoin}`;
+  return `${key.fromAlias}|${key.tableOrSubquery}|${key.foreignKey}|${key.innerJoin}`;
 }
 
 /**
  * Builder class for resolving column paths to SQL with JOIN deduplication.
  */
 export class SQLSchemaResolver {
-  private readonly registry: SQLSchemaRegistry;
-  private readonly rootSchemaName: string;
+  private readonly schema: SQLTableSchema;
   private readonly baseAlias: string;
 
   // Track existing joins to deduplicate
@@ -249,23 +220,13 @@ export class SQLSchemaResolver {
   private readonly joins: ResolvedJoin[] = [];
   private aliasCounter = 0;
 
-  constructor(
-    registry: SQLSchemaRegistry,
-    rootSchemaName: string,
-    baseAlias?: string,
-  ) {
-    this.registry = registry;
-    this.rootSchemaName = rootSchemaName;
+  constructor(schema: SQLTableSchema, baseAlias?: string) {
+    this.schema = schema;
 
-    if (baseAlias) {
-      this.baseAlias = baseAlias;
-    } else {
-      const table = registry[rootSchemaName]?.table ?? 'base';
-      // If the table is a subquery (starts with '('), use a generic alias
-      // to avoid creating invalid SQL like "(SELECT ...)_0"
-      const aliasBase = table.startsWith('(') ? 'subquery' : table;
-      this.baseAlias = `${aliasBase}_0`;
-    }
+    // Aliases are neutral identifiers ('base', 't0', 't1', ...). They only need
+    // to be unique and valid SQL - the table/subquery text is never embedded, so
+    // subqueries can't produce invalid aliases.
+    this.baseAlias = baseAlias ?? 'base';
   }
 
   /**
@@ -278,9 +239,8 @@ export class SQLSchemaResolver {
   /**
    * Gets the base table name.
    */
-  getBaseTable(): string {
-    const schema = this.registry[this.rootSchemaName];
-    return schema?.table ?? this.rootSchemaName;
+  getBaseTableOrSubquery(): string {
+    return this.schema.tableOrSubquery;
   }
 
   /**
@@ -298,25 +258,20 @@ export class SQLSchemaResolver {
    */
   resolveColumnPath(path: string): string | undefined {
     const parts = path.split('.');
-    return this.resolvePath(parts, this.rootSchemaName, this.baseAlias);
+    return this.resolvePath(parts, this.schema, this.baseAlias);
   }
 
   private resolvePath(
     parts: string[],
-    schemaName: string,
+    schema: SQLTableSchema,
     currentAlias: string,
   ): string | undefined {
     if (parts.length === 0) {
       return undefined;
     }
 
-    const schema = maybeUndefined(this.registry[schemaName]);
-    if (!schema) {
-      return undefined;
-    }
-
     const [first, ...rest] = parts;
-    const colDef = maybeUndefined(schema.columns[first]);
+    const colDef = maybeUndefined(schema.columns?.[first]);
 
     if (!colDef) {
       // Column not found in schema - treat as raw column name
@@ -327,7 +282,7 @@ export class SQLSchemaResolver {
       return undefined;
     }
 
-    if (isSQLExpressionDef(colDef)) {
+    if ('expression' in colDef) {
       // Expression column
       if (colDef.parameterized) {
         // Remaining parts form the parameter key
@@ -341,16 +296,12 @@ export class SQLSchemaResolver {
       return colDef.expression(currentAlias);
     }
 
-    if (isSQLJoinDef(colDef)) {
+    if ('schema' in colDef) {
       // JOIN column - need to add a join and continue resolving
-      const targetSchema = maybeUndefined(this.registry[colDef.ref]);
-      if (!targetSchema) {
-        return undefined;
-      }
-
+      const targetSchema = colDef.schema;
       const joinAlias = this.getOrCreateJoin(
         currentAlias,
-        targetSchema.table,
+        targetSchema.tableOrSubquery,
         colDef.foreignKey,
         targetSchema.primaryKey ?? 'id',
         colDef.innerJoin ?? false,
@@ -362,7 +313,7 @@ export class SQLSchemaResolver {
       }
 
       // Continue resolving into the joined table
-      return this.resolvePath(rest, colDef.ref, joinAlias);
+      return this.resolvePath(rest, colDef.schema, joinAlias);
     }
 
     // Simple column
@@ -376,12 +327,12 @@ export class SQLSchemaResolver {
 
   private getOrCreateJoin(
     fromAlias: string,
-    table: string,
+    tableOrSubquery: string,
     foreignKey: string,
     primaryKey: string,
     innerJoin: boolean,
   ): string {
-    const key: JoinKey = {fromAlias, table, foreignKey, innerJoin};
+    const key: JoinKey = {fromAlias, tableOrSubquery, foreignKey, innerJoin};
     const keyStr = joinKeyToString(key);
 
     const existing = this.joinMap.get(keyStr);
@@ -390,11 +341,11 @@ export class SQLSchemaResolver {
     }
 
     // Create new join
+    const alias = `t${this.aliasCounter}`;
     this.aliasCounter++;
-    const alias = `${table}_${this.aliasCounter}`;
 
     const join: ResolvedJoin = {
-      table,
+      tableOrSubquery,
       alias,
       fromAlias,
       foreignKey,
@@ -415,7 +366,7 @@ export class SQLSchemaResolver {
     return this.joins
       .map((join) => {
         const joinType = join.innerJoin ? 'JOIN' : 'LEFT JOIN';
-        return `${joinType} ${join.table} AS ${join.alias} ON ${join.alias}.${join.primaryKey} = ${join.fromAlias}.${join.foreignKey}`;
+        return `${joinType} (${join.tableOrSubquery}) AS ${join.alias} ON ${join.alias}.${join.primaryKey} = ${join.fromAlias}.${join.foreignKey}`;
       })
       .join('\n');
   }
@@ -428,42 +379,4 @@ export class SQLSchemaResolver {
     this.joins.length = 0;
     this.aliasCounter = 0;
   }
-}
-
-/**
- * Creates a simple schema from a table name or subquery.
- *
- * This enables using SQLDataSource with arbitrary queries/tables without
- * defining explicit column schemas. Columns are accessed directly by name.
- *
- * @param tableOrQuery A table name (e.g., 'slice') or subquery (e.g., 'SELECT * FROM slice')
- * @param schemaName Optional name for the schema (defaults to 'query')
- * @returns A SQLSchemaRegistry with a single schema entry
- *
- * Example usage:
- * ```typescript
- * const schema = createSimpleSchema('SELECT * FROM slice WHERE dur > 0');
- * const dataSource = new SQLDataSource({
- *   engine,
- *   sqlSchema: schema,
- *   rootSchemaName: 'query',
- * });
- * ```
- */
-export function createSimpleSchema(
-  tableOrQuery: string,
-  schemaName: string = 'query',
-): SQLSchemaRegistry {
-  // If it looks like a query (contains SELECT, spaces, etc.), wrap in parens
-  const isQuery =
-    tableOrQuery.trim().toUpperCase().startsWith('SELECT') ||
-    tableOrQuery.includes(' ');
-  const table = isQuery ? `(${tableOrQuery})` : tableOrQuery;
-
-  return {
-    [schemaName]: {
-      table,
-      columns: {}, // Empty columns - all column access falls through to direct access
-    },
-  };
 }

--- a/ui/src/core_plugins/dev.perfetto.SearchUtils/search_results_tab.ts
+++ b/ui/src/core_plugins/dev.perfetto.SearchUtils/search_results_tab.ts
@@ -19,7 +19,7 @@ import {Anchor} from '../../widgets/anchor';
 import {DetailsShell} from '../../widgets/details_shell';
 import {DataGrid} from '../../components/widgets/datagrid/datagrid';
 import type {Row} from '../../trace_processor/query_result';
-import type {SchemaRegistry} from '../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
 
 interface TabAttrs {
   trace: Trace;
@@ -32,39 +32,37 @@ export class SearchResultsTab implements m.ClassComponent<TabAttrs> {
     const searchResults = searchManager.searchResults;
     const searchText = searchManager.searchText;
 
-    const schema: SchemaRegistry = {
-      data: {
-        id: {
-          title: 'Event ID',
-          cellRenderer: (value, row) => {
-            if (typeof row.trackUri === 'string') {
-              return m(
-                Anchor,
-                {
-                  onclick: () => {
-                    trace.selection.selectTrackEvent(
-                      row.trackUri as string,
-                      value as number,
-                      {
-                        switchToCurrentSelectionTab: false,
-                        clearSearch: false,
-                        scrollToSelection: true,
-                      },
-                    );
-                  },
+    const schema: ColumnSchema = {
+      id: {
+        title: 'Event ID',
+        cellRenderer: (value, row) => {
+          if (typeof row.trackUri === 'string') {
+            return m(
+              Anchor,
+              {
+                onclick: () => {
+                  trace.selection.selectTrackEvent(
+                    row.trackUri as string,
+                    value as number,
+                    {
+                      switchToCurrentSelectionTab: false,
+                      clearSearch: false,
+                      scrollToSelection: true,
+                    },
+                  );
                 },
-                String(value),
-              );
-            }
-            return String(value);
-          },
+              },
+              String(value),
+            );
+          }
+          return String(value);
         },
-        ts: {
-          title: 'Timestamp',
-        },
-        trackUri: {
-          title: 'Track URI',
-        },
+      },
+      ts: {
+        title: 'Timestamp',
+      },
+      trackUri: {
+        title: 'Track URI',
       },
     };
 
@@ -97,7 +95,6 @@ export class SearchResultsTab implements m.ClassComponent<TabAttrs> {
       },
       m(DataGrid, {
         schema,
-        rootSchema: 'data',
         initialColumns: [
           {id: 'id', field: 'id'},
           {id: 'ts', field: 'ts'},

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
@@ -17,8 +17,7 @@ import type {Engine} from '../../../trace_processor/engine';
 import type {SqlValue} from '../../../trace_processor/query_result';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
-import {createSimpleSchema} from '../../../components/widgets/datagrid/sql_schema';
-import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../components/widgets/datagrid/datagrid_schema';
 import {fmtHex} from '../format';
 import type {Filter} from '../../../components/widgets/datagrid/model';
 import {
@@ -70,97 +69,95 @@ function buildQuery(activeDump: HeapDump): string {
   `;
 }
 
-function makeUiSchema(navigate: NavFn): SchemaRegistry {
+function makeUiSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      id: {
-        title: 'Object',
-        columnType: 'identifier',
-        cellRenderer: (value: SqlValue, row) => {
-          const id = Number(value);
-          const cls = String(row.cls ?? '');
-          const display = `${shortClassName(cls)} ${fmtHex(id)}`;
-          const str = row.str != null ? String(row.str) : null;
-          return m('span', [
-            m(
-              'button',
-              {
-                class: 'pf-hde-link',
-                onclick: () =>
-                  navigate('object', {id, label: str ? `"${str}"` : display}),
-              },
-              display,
-            ),
-            str
-              ? m(
-                  'span',
-                  {class: 'pf-hde-str-badge'},
-                  ` "${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`,
-                )
-              : null,
-          ]);
-        },
+    id: {
+      title: 'Object',
+      columnType: 'identifier',
+      cellRenderer: (value: SqlValue, row) => {
+        const id = Number(value);
+        const cls = String(row.cls ?? '');
+        const display = `${shortClassName(cls)} ${fmtHex(id)}`;
+        const str = row.str != null ? String(row.str) : null;
+        return m('span', [
+          m(
+            'button',
+            {
+              class: 'pf-hde-link',
+              onclick: () =>
+                navigate('object', {id, label: str ? `"${str}"` : display}),
+            },
+            display,
+          ),
+          str
+            ? m(
+                'span',
+                {class: 'pf-hde-str-badge'},
+                ` "${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`,
+              )
+            : null,
+        ]);
       },
-      self_size: {
-        title: colHeader('Shallow', COL_INFO.shallow),
-        titleString: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      native_size: {
-        title: colHeader('Native', COL_INFO.shallowNative),
-        titleString: 'Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained: {
-        title: colHeader('Retained', COL_INFO.retained),
-        titleString: 'Retained',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_native: {
-        title: colHeader('Retained Native', COL_INFO.retainedNative),
-        titleString: 'Retained Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_count: {
-        title: colHeader('Retained #', COL_INFO.retainedCount),
-        titleString: 'Retained #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      reachable_size: {
-        title: colHeader('Reachable', COL_INFO.reachable),
-        titleString: 'Reachable',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_native: {
-        title: colHeader('Reachable Native', COL_INFO.reachableNative),
-        titleString: 'Reachable Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_count: {
-        title: colHeader('Reachable #', COL_INFO.reachableCount),
-        titleString: 'Reachable #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      heap: {
-        title: 'Heap',
-        columnType: 'text',
-      },
-      cls: {
-        title: 'Class',
-        columnType: 'text',
-      },
-      str: {
-        title: 'String Value',
-        columnType: 'text',
-      },
+    },
+    self_size: {
+      title: colHeader('Shallow', COL_INFO.shallow),
+      titleString: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    native_size: {
+      title: colHeader('Native', COL_INFO.shallowNative),
+      titleString: 'Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained: {
+      title: colHeader('Retained', COL_INFO.retained),
+      titleString: 'Retained',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_native: {
+      title: colHeader('Retained Native', COL_INFO.retainedNative),
+      titleString: 'Retained Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_count: {
+      title: colHeader('Retained #', COL_INFO.retainedCount),
+      titleString: 'Retained #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    reachable_size: {
+      title: colHeader('Reachable', COL_INFO.reachable),
+      titleString: 'Reachable',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_native: {
+      title: colHeader('Reachable Native', COL_INFO.reachableNative),
+      titleString: 'Reachable Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_count: {
+      title: colHeader('Reachable #', COL_INFO.reachableCount),
+      titleString: 'Reachable #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    heap: {
+      title: 'Heap',
+      columnType: 'text',
+    },
+    cls: {
+      title: 'Class',
+      columnType: 'text',
+    },
+    str: {
+      title: 'String Value',
+      columnType: 'text',
     },
   };
 }
@@ -186,8 +183,7 @@ function AllObjectsView(): m.Component<AllObjectsViewAttrs> {
       const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(query),
-        rootSchemaName: 'query',
+        tableOrSubquery: query,
         preamble: SQL_PREAMBLE,
       });
       counter.init(engine, query, SQL_PREAMBLE);
@@ -205,7 +201,6 @@ function AllObjectsView(): m.Component<AllObjectsViewAttrs> {
         m('h2', {class: 'pf-hde-view-heading'}, counter.heading('Objects')),
         m(DataGrid, {
           schema: makeUiSchema(navigate),
-          rootSchema: 'query',
           data: dataSource,
           fillHeight: true,
           initialColumns: [

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
@@ -18,8 +18,7 @@ import type {SqlValue} from '../../../trace_processor/query_result';
 import {EmptyState} from '../../../widgets/empty_state';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
-import {createSimpleSchema} from '../../../components/widgets/datagrid/sql_schema';
-import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../components/widgets/datagrid/datagrid_schema';
 import type {Filter} from '../../../components/widgets/datagrid/model';
 import {fmtHex} from '../format';
 import {
@@ -52,55 +51,53 @@ function buildQuery(activeDump: HeapDump): string {
   `;
 }
 
-function makeUiSchema(navigate: NavFn): SchemaRegistry {
+function makeUiSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      id: {
-        title: 'Object',
-        columnType: 'identifier',
-        cellRenderer: (value: SqlValue, row) => {
-          const id = Number(value);
-          const cls = String(row.cls ?? '');
-          const display = `${shortClassName(cls)} ${fmtHex(id)}`;
-          return m(
-            'button',
-            {
-              class: 'pf-hde-link',
-              onclick: () => navigate('object', {id, label: display}),
-            },
-            display,
-          );
-        },
+    id: {
+      title: 'Object',
+      columnType: 'identifier',
+      cellRenderer: (value: SqlValue, row) => {
+        const id = Number(value);
+        const cls = String(row.cls ?? '');
+        const display = `${shortClassName(cls)} ${fmtHex(id)}`;
+        return m(
+          'button',
+          {
+            class: 'pf-hde-link',
+            onclick: () => navigate('object', {id, label: display}),
+          },
+          display,
+        );
       },
-      cls: {
-        title: 'Class',
-        columnType: 'text',
-      },
-      self_size: {
-        title: colHeader('Shallow', COL_INFO.shallow),
-        titleString: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      native_size: {
-        title: colHeader('Native', COL_INFO.shallowNative),
-        titleString: 'Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      element_count: {
-        title: 'Elements',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      heap: {
-        title: 'Heap',
-        columnType: 'text',
-      },
-      array_hash: {
-        title: 'Content Hash',
-        columnType: 'text',
-      },
+    },
+    cls: {
+      title: 'Class',
+      columnType: 'text',
+    },
+    self_size: {
+      title: colHeader('Shallow', COL_INFO.shallow),
+      titleString: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    native_size: {
+      title: colHeader('Native', COL_INFO.shallowNative),
+      titleString: 'Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    element_count: {
+      title: 'Elements',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    heap: {
+      title: 'Heap',
+      columnType: 'text',
+    },
+    array_hash: {
+      title: 'Content Hash',
+      columnType: 'text',
     },
   };
 }
@@ -135,8 +132,7 @@ function ArraysView(): m.Component<ArraysViewAttrs> {
       const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(query),
-        rootSchemaName: 'query',
+        tableOrSubquery: query,
       });
       counter.init(engine, query);
       applyNavFilter(vnode.attrs.initialArrayHash, vnode.attrs.clearNavParam);
@@ -160,7 +156,6 @@ function ArraysView(): m.Component<ArraysViewAttrs> {
         m('h2', {class: 'pf-hde-view-heading'}, counter.heading('Arrays')),
         m(DataGrid, {
           schema: makeUiSchema(navigate),
-          rootSchema: 'query',
           data: dataSource,
           fillHeight: true,
           initialColumns: [

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
@@ -20,7 +20,7 @@ import {Spinner} from '../../../widgets/spinner';
 import {EmptyState} from '../../../widgets/empty_state';
 import {Select} from '../../../widgets/select';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
-import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../components/widgets/datagrid/datagrid_schema';
 import type {Filter} from '../../../components/widgets/datagrid/model';
 import type {BitmapListRow, InstanceDetail} from '../types';
 import {fmtSize, fmtHex} from '../format';
@@ -38,11 +38,9 @@ import type {PathEntry} from '../types';
 import * as queries from '../queries';
 import type {HeapDump} from '../queries';
 
-const SUMMARY_SCHEMA: SchemaRegistry = {
-  query: {
-    property: {title: 'Property', columnType: 'text'},
-    value: {title: 'Value', columnType: 'text'},
-  },
+const SUMMARY_SCHEMA: ColumnSchema = {
+  property: {title: 'Property', columnType: 'text'},
+  value: {title: 'Value', columnType: 'text'},
 };
 
 function bitmapRowToRow(r: BitmapListRow): Row {
@@ -76,124 +74,122 @@ function bitmapRowToRow(r: BitmapListRow): Row {
   };
 }
 
-function makeBitmapListSchema(navigate: NavFn): SchemaRegistry {
+function makeBitmapListSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      id: {
-        title: 'Object',
-        columnType: 'identifier',
-        cellRenderer: (value: SqlValue, row) => {
-          const id = Number(value);
-          const cls = String(row.cls ?? '');
-          const display = `${shortClassName(cls)} ${fmtHex(id)}`;
-          return m(
-            'button',
-            {
-              class: 'pf-hde-link',
-              onclick: () =>
-                navigate('object', {
-                  id,
-                  label: `Bitmap ${row.dimensions}`,
-                }),
-            },
-            display,
-          );
-        },
+    id: {
+      title: 'Object',
+      columnType: 'identifier',
+      cellRenderer: (value: SqlValue, row) => {
+        const id = Number(value);
+        const cls = String(row.cls ?? '');
+        const display = `${shortClassName(cls)} ${fmtHex(id)}`;
+        return m(
+          'button',
+          {
+            class: 'pf-hde-link',
+            onclick: () =>
+              navigate('object', {
+                id,
+                label: `Bitmap ${row.dimensions}`,
+              }),
+          },
+          display,
+        );
       },
-      dimensions: {
-        title: 'Dimensions',
-        columnType: 'text',
-        cellRenderer: (value: SqlValue) =>
-          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
-      },
-      self_size: {
-        title: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      native_size: {
-        title: 'Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained: {
-        title: 'Retained',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_native: {
-        title: 'Retained Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_count: {
-        title: 'Retained #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      reachable_size: {
-        title: 'Reachable',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_native: {
-        title: 'Reachable Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_count: {
-        title: 'Reachable #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      heap: {
-        title: 'Heap',
-        columnType: 'text',
-      },
-      cls: {
-        title: 'Class',
-        columnType: 'text',
-      },
-      pixel_count: {
-        title: 'Pixels',
-        columnType: 'quantitative',
-      },
-      storage: {
-        title: colHeader('Storage', COL_INFO.bitmapStorage),
-        columnType: 'text',
-        cellRenderer: (value: SqlValue) =>
-          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
-      },
-      bitmap_id: {
-        title: colHeader('Bitmap ID', COL_INFO.bitmapId),
-        columnType: 'text',
-        cellRenderer: (value: SqlValue) =>
-          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
-      },
-      source_id: {
-        title: colHeader('Source ID', COL_INFO.bitmapSource),
-        columnType: 'text',
-        cellRenderer: (value: SqlValue) =>
-          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
-      },
-      source_process_name: {
-        title: colHeader('Source Process', COL_INFO.bitmapSource),
-        columnType: 'text',
-        cellRenderer: (value: SqlValue) =>
-          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
-      },
-      source_pid: {
-        title: colHeader('Source PID', COL_INFO.bitmapSource),
-        columnType: 'quantitative',
-        cellRenderer: (value: SqlValue) =>
-          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
-      },
-      source_storage: {
-        title: colHeader('Source Storage', COL_INFO.bitmapSource),
-        columnType: 'text',
-        cellRenderer: (value: SqlValue) =>
-          m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
-      },
+    },
+    dimensions: {
+      title: 'Dimensions',
+      columnType: 'text',
+      cellRenderer: (value: SqlValue) =>
+        m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+    },
+    self_size: {
+      title: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    native_size: {
+      title: 'Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained: {
+      title: 'Retained',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_native: {
+      title: 'Retained Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_count: {
+      title: 'Retained #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    reachable_size: {
+      title: 'Reachable',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_native: {
+      title: 'Reachable Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_count: {
+      title: 'Reachable #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    heap: {
+      title: 'Heap',
+      columnType: 'text',
+    },
+    cls: {
+      title: 'Class',
+      columnType: 'text',
+    },
+    pixel_count: {
+      title: 'Pixels',
+      columnType: 'quantitative',
+    },
+    storage: {
+      title: colHeader('Storage', COL_INFO.bitmapStorage),
+      columnType: 'text',
+      cellRenderer: (value: SqlValue) =>
+        m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+    },
+    bitmap_id: {
+      title: colHeader('Bitmap ID', COL_INFO.bitmapId),
+      columnType: 'text',
+      cellRenderer: (value: SqlValue) =>
+        m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+    },
+    source_id: {
+      title: colHeader('Source ID', COL_INFO.bitmapSource),
+      columnType: 'text',
+      cellRenderer: (value: SqlValue) =>
+        m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+    },
+    source_process_name: {
+      title: colHeader('Source Process', COL_INFO.bitmapSource),
+      columnType: 'text',
+      cellRenderer: (value: SqlValue) =>
+        m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+    },
+    source_pid: {
+      title: colHeader('Source PID', COL_INFO.bitmapSource),
+      columnType: 'quantitative',
+      cellRenderer: (value: SqlValue) =>
+        m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
+    },
+    source_storage: {
+      title: colHeader('Source Storage', COL_INFO.bitmapSource),
+      columnType: 'text',
+      cellRenderer: (value: SqlValue) =>
+        m('span', {class: 'pf-hde-mono'}, String(value ?? '')),
     },
   };
 }
@@ -549,7 +545,6 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
         m('div', {class: 'pf-hde-card pf-hde-mb-4'}, [
           m(DataGrid, {
             schema: SUMMARY_SCHEMA,
-            rootSchema: 'query',
             data: [
               {property: 'Total bitmaps', value: String(rows.length)},
               ...(withPixels.length > 0
@@ -597,7 +592,6 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
               ),
               m(DataGrid, {
                 schema: bitmapSchema,
-                rootSchema: 'query',
                 data: withPixels.map(bitmapRowToRow),
                 initialColumns: bitmapColumns,
                 filters,
@@ -615,7 +609,6 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
               ),
               m(DataGrid, {
                 schema: bitmapSchema,
-                rootSchema: 'query',
                 data: withoutPixels.map(bitmapRowToRow),
                 initialColumns: bitmapColumns,
                 filters,

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
@@ -17,8 +17,6 @@ import type {Engine} from '../../../trace_processor/engine';
 import type {SqlValue} from '../../../trace_processor/query_result';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
-import {createSimpleSchema} from '../../../components/widgets/datagrid/sql_schema';
-import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
 import type {Filter} from '../../../components/widgets/datagrid/model';
 import {
   type NavFn,
@@ -30,6 +28,7 @@ import {
 } from '../components';
 import * as queries from '../queries';
 import {dumpFilterSql, type HeapDump} from '../queries';
+import type {ColumnSchema} from '../../../components/widgets/datagrid/datagrid_schema';
 
 interface ClassesViewAttrs {
   readonly engine: Engine;
@@ -57,57 +56,55 @@ function buildQuery(activeDump: HeapDump): string {
   `;
 }
 
-function makeUiSchema(navigate: NavFn): SchemaRegistry {
+function makeUiSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      cls: {
-        title: 'Class',
-        columnType: 'text',
-        cellRenderer: (value: SqlValue) =>
-          m(
-            'button',
-            {
-              class: 'pf-hde-link',
-              onclick: () => navigate('objects', {cls: String(value)}),
-            },
-            String(value),
-          ),
-      },
-      cnt: {
-        title: 'Count',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      shallow: {
-        title: colHeader('Shallow', COL_INFO.shallow),
-        titleString: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      native_shallow: {
-        title: colHeader('Shallow Native', COL_INFO.shallowNative),
-        titleString: 'Shallow Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained: {
-        title: colHeader('Retained', COL_INFO.retained),
-        titleString: 'Retained',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_native: {
-        title: colHeader('Retained Native', COL_INFO.retainedNative),
-        titleString: 'Retained Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_count: {
-        title: colHeader('Retained #', COL_INFO.retainedCount),
-        titleString: 'Retained #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
+    cls: {
+      title: 'Class',
+      columnType: 'text',
+      cellRenderer: (value: SqlValue) =>
+        m(
+          'button',
+          {
+            class: 'pf-hde-link',
+            onclick: () => navigate('objects', {cls: String(value)}),
+          },
+          String(value),
+        ),
+    },
+    cnt: {
+      title: 'Count',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    shallow: {
+      title: colHeader('Shallow', COL_INFO.shallow),
+      titleString: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    native_shallow: {
+      title: colHeader('Shallow Native', COL_INFO.shallowNative),
+      titleString: 'Shallow Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained: {
+      title: colHeader('Retained', COL_INFO.retained),
+      titleString: 'Retained',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_native: {
+      title: colHeader('Retained Native', COL_INFO.retainedNative),
+      titleString: 'Retained Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_count: {
+      title: colHeader('Retained #', COL_INFO.retainedCount),
+      titleString: 'Retained #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
     },
   };
 }
@@ -139,8 +136,7 @@ function ClassesView(): m.Component<ClassesViewAttrs> {
       const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(query),
-        rootSchemaName: 'query',
+        tableOrSubquery: query,
         preamble: PREAMBLE,
       });
       counter.init(engine, query, PREAMBLE);
@@ -171,7 +167,6 @@ function ClassesView(): m.Component<ClassesViewAttrs> {
         m('h2', {class: 'pf-hde-view-heading'}, counter.heading('Classes')),
         m(DataGrid, {
           schema: makeUiSchema(navigate),
-          rootSchema: 'query',
           data: dataSource,
           fillHeight: true,
           initialColumns: [

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
@@ -17,8 +17,7 @@ import type {Engine} from '../../../trace_processor/engine';
 import type {SqlValue} from '../../../trace_processor/query_result';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
-import {createSimpleSchema} from '../../../components/widgets/datagrid/sql_schema';
-import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../components/widgets/datagrid/datagrid_schema';
 import {fmtHex} from '../format';
 import {
   type NavFn,
@@ -62,86 +61,84 @@ function buildQuery(activeDump: HeapDump): string {
   `;
 }
 
-function makeUiSchema(navigate: NavFn): SchemaRegistry {
+function makeUiSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      id: {
-        title: 'Object',
-        columnType: 'identifier',
-        cellRenderer: (value: SqlValue, row) => {
-          const id = Number(value);
-          const cls = String(row.cls ?? '');
-          const display = `${shortClassName(cls)} ${fmtHex(id)}`;
-          return m(
-            'button',
-            {
-              class: 'pf-hde-link',
-              onclick: () => navigate('object', {id, label: display}),
-            },
-            display,
-          );
-        },
+    id: {
+      title: 'Object',
+      columnType: 'identifier',
+      cellRenderer: (value: SqlValue, row) => {
+        const id = Number(value);
+        const cls = String(row.cls ?? '');
+        const display = `${shortClassName(cls)} ${fmtHex(id)}`;
+        return m(
+          'button',
+          {
+            class: 'pf-hde-link',
+            onclick: () => navigate('object', {id, label: display}),
+          },
+          display,
+        );
       },
-      retained: {
-        title: colHeader('Retained', COL_INFO.retained),
-        titleString: 'Retained',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_native: {
-        title: colHeader('Retained Native', COL_INFO.retainedNative),
-        titleString: 'Retained Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      self_size: {
-        title: colHeader('Shallow', COL_INFO.shallow),
-        titleString: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      native_size: {
-        title: colHeader('Shallow Native', COL_INFO.shallowNative),
-        titleString: 'Shallow Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_count: {
-        title: colHeader('Retained Count', COL_INFO.retainedCount),
-        titleString: 'Retained Count',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      reachable_size: {
-        title: colHeader('Reachable', COL_INFO.reachable),
-        titleString: 'Reachable',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_native: {
-        title: colHeader('Reachable Native', COL_INFO.reachableNative),
-        titleString: 'Reachable Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_count: {
-        title: colHeader('Reachable Count', COL_INFO.reachableCount),
-        titleString: 'Reachable Count',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      heap: {
-        title: 'Heap',
-        columnType: 'text',
-      },
-      cls: {
-        title: 'Class',
-        columnType: 'text',
-      },
-      root_type: {
-        title: 'Root Type',
-        columnType: 'text',
-      },
+    },
+    retained: {
+      title: colHeader('Retained', COL_INFO.retained),
+      titleString: 'Retained',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_native: {
+      title: colHeader('Retained Native', COL_INFO.retainedNative),
+      titleString: 'Retained Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    self_size: {
+      title: colHeader('Shallow', COL_INFO.shallow),
+      titleString: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    native_size: {
+      title: colHeader('Shallow Native', COL_INFO.shallowNative),
+      titleString: 'Shallow Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_count: {
+      title: colHeader('Retained Count', COL_INFO.retainedCount),
+      titleString: 'Retained Count',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    reachable_size: {
+      title: colHeader('Reachable', COL_INFO.reachable),
+      titleString: 'Reachable',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_native: {
+      title: colHeader('Reachable Native', COL_INFO.reachableNative),
+      titleString: 'Reachable Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_count: {
+      title: colHeader('Reachable Count', COL_INFO.reachableCount),
+      titleString: 'Reachable Count',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    heap: {
+      title: 'Heap',
+      columnType: 'text',
+    },
+    cls: {
+      title: 'Class',
+      columnType: 'text',
+    },
+    root_type: {
+      title: 'Root Type',
+      columnType: 'text',
     },
   };
 }
@@ -156,8 +153,7 @@ function DominatorsView(): m.Component<DominatorsViewAttrs> {
       const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(query),
-        rootSchemaName: 'query',
+        tableOrSubquery: query,
         preamble: SQL_PREAMBLE,
       });
       counter.init(engine, query, SQL_PREAMBLE);
@@ -171,7 +167,6 @@ function DominatorsView(): m.Component<DominatorsViewAttrs> {
         m('h2', {class: 'pf-hde-view-heading'}, counter.heading('Dominators')),
         m(DataGrid, {
           schema: makeUiSchema(navigate),
-          rootSchema: 'query',
           data: dataSource,
           fillHeight: true,
           initialColumns: [

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_objects_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_objects_view.ts
@@ -17,8 +17,7 @@ import type {Engine} from '../../../trace_processor/engine';
 import type {SqlValue} from '../../../trace_processor/query_result';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
-import {createSimpleSchema} from '../../../components/widgets/datagrid/sql_schema';
-import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../components/widgets/datagrid/datagrid_schema';
 import {fmtHex} from '../format';
 import {
   type NavFn,
@@ -76,97 +75,95 @@ export function flamegraphQuery(
   `;
 }
 
-function makeUiSchema(navigate: NavFn): SchemaRegistry {
+function makeUiSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      id: {
-        title: 'Object',
-        columnType: 'identifier',
-        cellRenderer: (value: SqlValue, row) => {
-          const id = Number(value);
-          const cls = String(row.cls ?? '');
-          const display = `${shortClassName(cls)} ${fmtHex(id)}`;
-          const str = row.str != null ? String(row.str) : null;
-          return m('span', [
-            m(
-              'button',
-              {
-                class: 'pf-hde-link',
-                onclick: () =>
-                  navigate('object', {id, label: str ? `"${str}"` : display}),
-              },
-              display,
-            ),
-            str
-              ? m(
-                  'span',
-                  {class: 'pf-hde-str-badge'},
-                  ` "${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`,
-                )
-              : null,
-          ]);
-        },
+    id: {
+      title: 'Object',
+      columnType: 'identifier',
+      cellRenderer: (value: SqlValue, row) => {
+        const id = Number(value);
+        const cls = String(row.cls ?? '');
+        const display = `${shortClassName(cls)} ${fmtHex(id)}`;
+        const str = row.str != null ? String(row.str) : null;
+        return m('span', [
+          m(
+            'button',
+            {
+              class: 'pf-hde-link',
+              onclick: () =>
+                navigate('object', {id, label: str ? `"${str}"` : display}),
+            },
+            display,
+          ),
+          str
+            ? m(
+                'span',
+                {class: 'pf-hde-str-badge'},
+                ` "${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`,
+              )
+            : null,
+        ]);
       },
-      self_size: {
-        title: colHeader('Shallow', COL_INFO.shallow),
-        titleString: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      native_size: {
-        title: colHeader('Native', COL_INFO.shallowNative),
-        titleString: 'Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained: {
-        title: colHeader('Retained', COL_INFO.retained),
-        titleString: 'Retained',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_native: {
-        title: colHeader('Retained Native', COL_INFO.retainedNative),
-        titleString: 'Retained Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_count: {
-        title: colHeader('Retained #', COL_INFO.retainedCount),
-        titleString: 'Retained #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      reachable_size: {
-        title: colHeader('Reachable', COL_INFO.reachable),
-        titleString: 'Reachable',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_native: {
-        title: colHeader('Reachable Native', COL_INFO.reachableNative),
-        titleString: 'Reachable Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_count: {
-        title: colHeader('Reachable #', COL_INFO.reachableCount),
-        titleString: 'Reachable #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      heap: {
-        title: 'Heap',
-        columnType: 'text',
-      },
-      cls: {
-        title: 'Class',
-        columnType: 'text',
-      },
-      str: {
-        title: 'String Value',
-        columnType: 'text',
-      },
+    },
+    self_size: {
+      title: colHeader('Shallow', COL_INFO.shallow),
+      titleString: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    native_size: {
+      title: colHeader('Native', COL_INFO.shallowNative),
+      titleString: 'Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained: {
+      title: colHeader('Retained', COL_INFO.retained),
+      titleString: 'Retained',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_native: {
+      title: colHeader('Retained Native', COL_INFO.retainedNative),
+      titleString: 'Retained Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_count: {
+      title: colHeader('Retained #', COL_INFO.retainedCount),
+      titleString: 'Retained #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    reachable_size: {
+      title: colHeader('Reachable', COL_INFO.reachable),
+      titleString: 'Reachable',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_native: {
+      title: colHeader('Reachable Native', COL_INFO.reachableNative),
+      titleString: 'Reachable Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_count: {
+      title: colHeader('Reachable #', COL_INFO.reachableCount),
+      titleString: 'Reachable #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    heap: {
+      title: 'Heap',
+      columnType: 'text',
+    },
+    cls: {
+      title: 'Class',
+      columnType: 'text',
+    },
+    str: {
+      title: 'String Value',
+      columnType: 'text',
     },
   };
 }
@@ -184,8 +181,7 @@ function FlamegraphObjectsView(): m.Component<FlamegraphObjectsViewAttrs> {
     const query = flamegraphQuery(pathHashes, isDominator);
     dataSource = new SQLDataSource({
       engine,
-      sqlSchema: createSimpleSchema(query),
-      rootSchemaName: 'query',
+      tableOrSubquery: query,
       preamble: SQL_PREAMBLE,
     });
     counter.init(engine, query, SQL_PREAMBLE);
@@ -254,7 +250,6 @@ function FlamegraphObjectsView(): m.Component<FlamegraphObjectsViewAttrs> {
         ]),
         m(DataGrid, {
           schema: makeUiSchema(navigate),
-          rootSchema: 'query',
           data: dataSource,
           fillHeight: true,
           initialColumns: [

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
@@ -22,7 +22,7 @@ import {
 import {Spinner} from '../../../widgets/spinner';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import type {
-  SchemaRegistry,
+  ColumnSchema,
   CellRenderResult,
 } from '../../../components/widgets/datagrid/datagrid_schema';
 import type {InstanceRow, InstanceDetail, HeapInfo, PrimOrRef} from '../types';
@@ -197,339 +197,328 @@ const METRIC_INFO: Record<string, string> = {
     'shortest-path tree. Includes objects also reachable via other paths.',
 };
 
-const SIZE_SCHEMA: SchemaRegistry = {
-  query: {
-    metric: {
-      title: 'Metric',
-      columnType: 'text',
-      cellRenderer: (value: SqlValue): CellRenderResult => {
-        const label = String(value ?? '');
-        const info = METRIC_INFO[label];
-        return {content: info ? colHeader(label, info) : label};
-      },
+const SIZE_SCHEMA: ColumnSchema = {
+  metric: {
+    title: 'Metric',
+    columnType: 'text',
+    cellRenderer: (value: SqlValue): CellRenderResult => {
+      const label = String(value ?? '');
+      const info = METRIC_INFO[label];
+      return {content: info ? colHeader(label, info) : label};
     },
-    java: {
-      title: 'Java',
-      columnType: 'quantitative',
-      cellRenderer: nullableSizeRenderer,
-    },
-    native: {
-      title: 'Native',
-      columnType: 'quantitative',
-      cellRenderer: nullableSizeRenderer,
-    },
-    count: {
-      title: 'Count',
-      columnType: 'quantitative',
-      cellRenderer: (value: SqlValue): CellRenderResult => {
-        if (value === null) {
-          return {
-            content: m(
-              'span',
-              {class: 'pf-hde-mono pf-hde-opacity-60'},
-              '\u2026',
-            ),
-            align: 'right',
-          };
-        }
+  },
+  java: {
+    title: 'Java',
+    columnType: 'quantitative',
+    cellRenderer: nullableSizeRenderer,
+  },
+  native: {
+    title: 'Native',
+    columnType: 'quantitative',
+    cellRenderer: nullableSizeRenderer,
+  },
+  count: {
+    title: 'Count',
+    columnType: 'quantitative',
+    cellRenderer: (value: SqlValue): CellRenderResult => {
+      if (value === null) {
         return {
           content: m(
             'span',
-            {class: 'pf-hde-mono'},
-            Number(value).toLocaleString(),
+            {class: 'pf-hde-mono pf-hde-opacity-60'},
+            '\u2026',
           ),
           align: 'right',
         };
-      },
+      }
+      return {
+        content: m(
+          'span',
+          {class: 'pf-hde-mono'},
+          Number(value).toLocaleString(),
+        ),
+        align: 'right',
+      };
     },
   },
 };
 
-function makeInstanceSchema(navigate: NavFn): SchemaRegistry {
+function makeInstanceSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      id: {
-        title: 'Object',
-        columnType: 'identifier',
-        cellRenderer: (value: SqlValue, row) => {
-          const id = Number(value);
-          const cls = String(row.cls ?? '');
-          const display = `${shortClassName(cls)} ${fmtHex(id)}`;
-          const str = row.str != null ? String(row.str) : null;
-          return m('span', [
-            m(
-              'button',
-              {
-                class: 'pf-hde-link',
-                onclick: () =>
-                  navigate('object', {id, label: str ? `"${str}"` : display}),
-              },
-              display,
-            ),
-            str
-              ? m(
-                  'span',
-                  {class: 'pf-hde-str-badge'},
-                  ` "${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`,
-                )
-              : null,
-          ]);
-        },
+    id: {
+      title: 'Object',
+      columnType: 'identifier',
+      cellRenderer: (value: SqlValue, row) => {
+        const id = Number(value);
+        const cls = String(row.cls ?? '');
+        const display = `${shortClassName(cls)} ${fmtHex(id)}`;
+        const str = row.str != null ? String(row.str) : null;
+        return m('span', [
+          m(
+            'button',
+            {
+              class: 'pf-hde-link',
+              onclick: () =>
+                navigate('object', {id, label: str ? `"${str}"` : display}),
+            },
+            display,
+          ),
+          str
+            ? m(
+                'span',
+                {class: 'pf-hde-str-badge'},
+                ` "${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`,
+              )
+            : null,
+        ]);
       },
-      self_size: {
-        title: colHeader('Shallow', COL_INFO.shallow),
-        titleString: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      native_size: {
-        title: colHeader('Shallow Native', COL_INFO.shallowNative),
-        titleString: 'Shallow Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained: {
-        title: colHeader('Retained', COL_INFO.retained),
-        titleString: 'Retained',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_native: {
-        title: colHeader('Retained Native', COL_INFO.retainedNative),
-        titleString: 'Retained Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_count: {
-        title: colHeader('Retained #', COL_INFO.retainedCount),
-        titleString: 'Retained #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      reachable_size: {
-        title: colHeader('Reachable', COL_INFO.reachable),
-        titleString: 'Reachable',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_native: {
-        title: colHeader('Reachable Native', COL_INFO.reachableNative),
-        titleString: 'Reachable Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_count: {
-        title: colHeader('Reachable #', COL_INFO.reachableCount),
-        titleString: 'Reachable #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      heap: {
-        title: 'Heap',
-        columnType: 'text',
-      },
-      cls: {
-        title: 'Class',
-        columnType: 'text',
-      },
-      str: {
-        title: 'String Value',
-        columnType: 'text',
-      },
+    },
+    self_size: {
+      title: colHeader('Shallow', COL_INFO.shallow),
+      titleString: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    native_size: {
+      title: colHeader('Shallow Native', COL_INFO.shallowNative),
+      titleString: 'Shallow Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained: {
+      title: colHeader('Retained', COL_INFO.retained),
+      titleString: 'Retained',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_native: {
+      title: colHeader('Retained Native', COL_INFO.retainedNative),
+      titleString: 'Retained Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_count: {
+      title: colHeader('Retained #', COL_INFO.retainedCount),
+      titleString: 'Retained #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    reachable_size: {
+      title: colHeader('Reachable', COL_INFO.reachable),
+      titleString: 'Reachable',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_native: {
+      title: colHeader('Reachable Native', COL_INFO.reachableNative),
+      titleString: 'Reachable Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_count: {
+      title: colHeader('Reachable #', COL_INFO.reachableCount),
+      titleString: 'Reachable #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    heap: {
+      title: 'Heap',
+      columnType: 'text',
+    },
+    cls: {
+      title: 'Class',
+      columnType: 'text',
+    },
+    str: {
+      title: 'String Value',
+      columnType: 'text',
     },
   };
 }
 
-function makeFieldSchema(navigate: NavFn): SchemaRegistry {
+function makeFieldSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      name: {
-        title: 'Name',
-        columnType: 'text',
-        cellRenderer: (value: SqlValue, row) => {
-          if (row.value_kind === 'ref' && row.ref_id !== null) {
-            return m(
-              'button',
-              {
-                class: 'pf-hde-link',
-                onclick: () =>
-                  navigate('object', {
-                    id: Number(row.ref_id),
-                    label: String(row.value_display ?? ''),
-                  }),
-              },
-              String(value),
-            );
-          }
-          return m('span', String(value ?? ''));
-        },
+    name: {
+      title: 'Name',
+      columnType: 'text',
+      cellRenderer: (value: SqlValue, row) => {
+        if (row.value_kind === 'ref' && row.ref_id !== null) {
+          return m(
+            'button',
+            {
+              class: 'pf-hde-link',
+              onclick: () =>
+                navigate('object', {
+                  id: Number(row.ref_id),
+                  label: String(row.value_display ?? ''),
+                }),
+            },
+            String(value),
+          );
+        }
+        return m('span', String(value ?? ''));
       },
-      type_name: {
-        title: 'Type',
-        columnType: 'text',
+    },
+    type_name: {
+      title: 'Type',
+      columnType: 'text',
+    },
+    value_display: {
+      title: 'Value',
+      columnType: 'text',
+      cellRenderer: (value: SqlValue, row) => {
+        if (row.value_kind === 'ref' && row.ref_id !== null) {
+          return m(PrimOrRefCell, {
+            v: {
+              kind: 'ref',
+              id: Number(row.ref_id),
+              display: String(value),
+              str: row.ref_str != null ? String(row.ref_str) : null,
+            },
+            navigate,
+          });
+        }
+        return m('span', {class: 'pf-hde-mono'}, String(value ?? ''));
       },
-      value_display: {
-        title: 'Value',
-        columnType: 'text',
-        cellRenderer: (value: SqlValue, row) => {
-          if (row.value_kind === 'ref' && row.ref_id !== null) {
-            return m(PrimOrRefCell, {
-              v: {
-                kind: 'ref',
-                id: Number(row.ref_id),
-                display: String(value),
-                str: row.ref_str != null ? String(row.ref_str) : null,
-              },
-              navigate,
-            });
-          }
-          return m('span', {class: 'pf-hde-mono'}, String(value ?? ''));
-        },
-      },
-      shallow: {
-        title: colHeader('Shallow', COL_INFO.shallow),
-        titleString: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      shallow_native: {
-        title: colHeader('Shallow Native', COL_INFO.shallowNative),
-        titleString: 'Shallow Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained: {
-        title: colHeader('Retained', COL_INFO.retained),
-        titleString: 'Retained',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_native: {
-        title: colHeader('Retained Native', COL_INFO.retainedNative),
-        titleString: 'Retained Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable: {
-        title: colHeader('Reachable', COL_INFO.reachable),
-        titleString: 'Reachable',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_native: {
-        title: colHeader('Reachable Native', COL_INFO.reachableNative),
-        titleString: 'Reachable Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_count: {
-        title: colHeader('Reachable #', COL_INFO.reachableCount),
-        titleString: 'Reachable #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      value_kind: {
-        title: 'Kind',
-        columnType: 'text',
-      },
-      ref_id: {
-        title: 'Ref ID',
-        columnType: 'identifier',
-      },
-      ref_str: {
-        title: 'Ref String',
-        columnType: 'text',
-      },
+    },
+    shallow: {
+      title: colHeader('Shallow', COL_INFO.shallow),
+      titleString: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    shallow_native: {
+      title: colHeader('Shallow Native', COL_INFO.shallowNative),
+      titleString: 'Shallow Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained: {
+      title: colHeader('Retained', COL_INFO.retained),
+      titleString: 'Retained',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_native: {
+      title: colHeader('Retained Native', COL_INFO.retainedNative),
+      titleString: 'Retained Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable: {
+      title: colHeader('Reachable', COL_INFO.reachable),
+      titleString: 'Reachable',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_native: {
+      title: colHeader('Reachable Native', COL_INFO.reachableNative),
+      titleString: 'Reachable Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_count: {
+      title: colHeader('Reachable #', COL_INFO.reachableCount),
+      titleString: 'Reachable #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    value_kind: {
+      title: 'Kind',
+      columnType: 'text',
+    },
+    ref_id: {
+      title: 'Ref ID',
+      columnType: 'identifier',
+    },
+    ref_str: {
+      title: 'Ref String',
+      columnType: 'text',
     },
   };
 }
 
-function makeArraySchema(
-  navigate: NavFn,
-  elemTypeName: string,
-): SchemaRegistry {
+function makeArraySchema(navigate: NavFn, elemTypeName: string): ColumnSchema {
   return {
-    query: {
-      idx: {
-        title: 'Index',
-        columnType: 'quantitative',
-        cellRenderer: (value: SqlValue): CellRenderResult => ({
-          content: m('span', {class: 'pf-hde-mono'}, String(value ?? 0)),
-          align: 'right',
-        }),
+    idx: {
+      title: 'Index',
+      columnType: 'quantitative',
+      cellRenderer: (value: SqlValue): CellRenderResult => ({
+        content: m('span', {class: 'pf-hde-mono'}, String(value ?? 0)),
+        align: 'right',
+      }),
+    },
+    value_display: {
+      title: `Value (${elemTypeName})`,
+      columnType: 'text',
+      cellRenderer: (value: SqlValue, row) => {
+        if (row.value_kind === 'ref' && row.ref_id !== null) {
+          return m(PrimOrRefCell, {
+            v: {
+              kind: 'ref',
+              id: Number(row.ref_id),
+              display: String(value),
+              str: row.ref_str != null ? String(row.ref_str) : null,
+            },
+            navigate,
+          });
+        }
+        return m('span', {class: 'pf-hde-mono'}, String(value ?? ''));
       },
-      value_display: {
-        title: `Value (${elemTypeName})`,
-        columnType: 'text',
-        cellRenderer: (value: SqlValue, row) => {
-          if (row.value_kind === 'ref' && row.ref_id !== null) {
-            return m(PrimOrRefCell, {
-              v: {
-                kind: 'ref',
-                id: Number(row.ref_id),
-                display: String(value),
-                str: row.ref_str != null ? String(row.ref_str) : null,
-              },
-              navigate,
-            });
-          }
-          return m('span', {class: 'pf-hde-mono'}, String(value ?? ''));
-        },
-      },
-      shallow: {
-        title: colHeader('Shallow', COL_INFO.shallow),
-        titleString: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      shallow_native: {
-        title: colHeader('Shallow Native', COL_INFO.shallowNative),
-        titleString: 'Shallow Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained: {
-        title: colHeader('Retained', COL_INFO.retained),
-        titleString: 'Retained',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      retained_native: {
-        title: colHeader('Retained Native', COL_INFO.retainedNative),
-        titleString: 'Retained Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable: {
-        title: colHeader('Reachable', COL_INFO.reachable),
-        titleString: 'Reachable',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_native: {
-        title: colHeader('Reachable Native', COL_INFO.reachableNative),
-        titleString: 'Reachable Native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_count: {
-        title: colHeader('Reachable #', COL_INFO.reachableCount),
-        titleString: 'Reachable #',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      value_kind: {
-        title: 'Kind',
-        columnType: 'text',
-      },
-      ref_id: {
-        title: 'Ref ID',
-        columnType: 'identifier',
-      },
-      ref_str: {
-        title: 'Ref String',
-        columnType: 'text',
-      },
+    },
+    shallow: {
+      title: colHeader('Shallow', COL_INFO.shallow),
+      titleString: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    shallow_native: {
+      title: colHeader('Shallow Native', COL_INFO.shallowNative),
+      titleString: 'Shallow Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained: {
+      title: colHeader('Retained', COL_INFO.retained),
+      titleString: 'Retained',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    retained_native: {
+      title: colHeader('Retained Native', COL_INFO.retainedNative),
+      titleString: 'Retained Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable: {
+      title: colHeader('Reachable', COL_INFO.reachable),
+      titleString: 'Reachable',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_native: {
+      title: colHeader('Reachable Native', COL_INFO.reachableNative),
+      titleString: 'Reachable Native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_count: {
+      title: colHeader('Reachable #', COL_INFO.reachableCount),
+      titleString: 'Reachable #',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    value_kind: {
+      title: 'Kind',
+      columnType: 'text',
+    },
+    ref_id: {
+      title: 'Ref ID',
+      columnType: 'identifier',
+    },
+    ref_str: {
+      title: 'Ref String',
+      columnType: 'text',
     },
   };
 }
@@ -815,7 +804,6 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
             ];
             return m(DataGrid, {
               schema: SIZE_SCHEMA,
-              rootSchema: 'query',
               data: sizeRows,
               initialColumns: [
                 {id: 'metric', field: 'metric'},
@@ -902,7 +890,6 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
           detail.reverseRefs.length > 0
             ? m(DataGrid, {
                 schema: makeInstanceSchema(navigate),
-                rootSchema: 'query',
                 data: detail.reverseRefs.map(instanceRowToRow),
                 initialColumns: [
                   {id: 'id', field: 'id'},
@@ -935,7 +922,6 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
           detail.dominated.length > 0
             ? m(DataGrid, {
                 schema: makeInstanceSchema(navigate),
-                rootSchema: 'query',
                 data: detail.dominated.map(instanceRowToRow),
                 initialColumns: [
                   {id: 'id', field: 'id'},
@@ -970,7 +956,6 @@ function renderFieldsGrid(fields: FieldRow[], navigate: NavFn): m.Children {
   }
   return m(DataGrid, {
     schema: makeFieldSchema(navigate),
-    rootSchema: 'query',
     data: fields.map(fieldRowToRow),
     initialColumns: [
       {id: 'type_name', field: 'type_name'},
@@ -1029,7 +1014,6 @@ function renderArrayGrid(
       : null,
     m(DataGrid, {
       schema: makeArraySchema(navigate, elemTypeName),
-      rootSchema: 'query',
       data: elems.map((e) => arrayElemToRow(e, elemTypeName)),
       initialColumns: [
         {id: 'idx', field: 'idx'},

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/overview_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/overview_view.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {Duration} from '../../../base/time';
 import type {SqlValue, Row} from '../../../trace_processor/query_result';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
-import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../components/widgets/datagrid/datagrid_schema';
 import type {OverviewData} from '../types';
 import {fmtSize} from '../format';
 import type {NavState} from '../nav_state';
@@ -32,164 +32,155 @@ import {
 } from '../../../widgets/grid';
 import {removeFalsyValues} from '../../../base/array_utils';
 
-const HEAP_SCHEMA: SchemaRegistry = {
-  query: {
-    heap: {
-      title: 'Heap',
-      columnType: 'text',
-    },
-    java_size: {
-      title: 'Java Size',
-      columnType: 'quantitative',
-      cellRenderer: sizeRenderer,
-    },
-    native_size: {
-      title: 'Native Size',
-      columnType: 'quantitative',
-      cellRenderer: sizeRenderer,
-    },
-    total_size: {
-      title: 'Total Size',
-      columnType: 'quantitative',
-      cellRenderer: sizeRenderer,
-    },
+const HEAP_SCHEMA: ColumnSchema = {
+  heap: {
+    title: 'Heap',
+    columnType: 'text',
+  },
+  java_size: {
+    title: 'Java Size',
+    columnType: 'quantitative',
+    cellRenderer: sizeRenderer,
+  },
+  native_size: {
+    title: 'Native Size',
+    columnType: 'quantitative',
+    cellRenderer: sizeRenderer,
+  },
+  total_size: {
+    title: 'Total Size',
+    columnType: 'quantitative',
+    cellRenderer: sizeRenderer,
   },
 };
 
-function makeDuplicateBitmapSchema(navigate: NavFn): SchemaRegistry {
+function makeDuplicateBitmapSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      dimensions: {
-        title: 'Dimensions',
-        columnType: 'text',
-      },
-      copies: {
-        title: 'Copies',
-        columnType: 'quantitative',
-        cellRenderer: (value: SqlValue, row) =>
-          m(
-            'button',
-            {
-              class: 'pf-hde-link',
-              onclick: () =>
-                navigate('bitmaps', {
-                  filterKey: String(row.groupKey ?? ''),
-                }),
-            },
-            String(value),
-          ),
-      },
-      total_bytes: {
-        title: 'Total',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      wasted_bytes: {
-        title: 'Wasted',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
+    dimensions: {
+      title: 'Dimensions',
+      columnType: 'text',
+    },
+    copies: {
+      title: 'Copies',
+      columnType: 'quantitative',
+      cellRenderer: (value: SqlValue, row) =>
+        m(
+          'button',
+          {
+            class: 'pf-hde-link',
+            onclick: () =>
+              navigate('bitmaps', {
+                filterKey: String(row.groupKey ?? ''),
+              }),
+          },
+          String(value),
+        ),
+    },
+    total_bytes: {
+      title: 'Total',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    wasted_bytes: {
+      title: 'Wasted',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
     },
   };
 }
 
-function makeDuplicateArraySchema(navigate: NavFn): SchemaRegistry {
+function makeDuplicateArraySchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      className: {
-        title: 'Array Type',
-        columnType: 'text',
-        cellRenderer: (value: SqlValue) =>
-          m(
-            'button',
-            {
-              class: 'pf-hde-link',
-              onclick: () => navigate('objects', {cls: String(value ?? '')}),
-            },
-            String(value ?? ''),
-          ),
-      },
-      arrayHash: {
-        title: 'Hash',
-        columnType: 'text',
-      },
-      copies: {
-        title: 'Copies',
-        columnType: 'quantitative',
-        cellRenderer: (value: SqlValue, row) =>
-          m(
-            'button',
-            {
-              class: 'pf-hde-link',
-              onclick: () =>
-                navigate('arrays', {
-                  arrayHash: String(row.arrayHash ?? ''),
-                }),
-            },
-            String(value),
-          ),
-      },
-      total_bytes: {
-        title: 'Total',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      wasted_bytes: {
-        title: 'Wasted',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
+    className: {
+      title: 'Array Type',
+      columnType: 'text',
+      cellRenderer: (value: SqlValue) =>
+        m(
+          'button',
+          {
+            class: 'pf-hde-link',
+            onclick: () => navigate('objects', {cls: String(value ?? '')}),
+          },
+          String(value ?? ''),
+        ),
+    },
+    arrayHash: {
+      title: 'Hash',
+      columnType: 'text',
+    },
+    copies: {
+      title: 'Copies',
+      columnType: 'quantitative',
+      cellRenderer: (value: SqlValue, row) =>
+        m(
+          'button',
+          {
+            class: 'pf-hde-link',
+            onclick: () =>
+              navigate('arrays', {
+                arrayHash: String(row.arrayHash ?? ''),
+              }),
+          },
+          String(value),
+        ),
+    },
+    total_bytes: {
+      title: 'Total',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    wasted_bytes: {
+      title: 'Wasted',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
     },
   };
 }
 
-function makeDuplicateStringSchema(navigate: NavFn): SchemaRegistry {
+function makeDuplicateStringSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      value: {
-        title: 'Value',
-        columnType: 'text',
-        cellRenderer: (value: SqlValue) =>
-          m(
-            'button',
-            {
-              class:
-                'pf-hde-link pf-hde-mono pf-hde-break-all pf-hde-str-color',
-              onclick: () =>
-                navigate('strings', {
-                  q: String(value ?? ''),
-                }),
-            },
-            '"' +
-              (String(value ?? '').length > 200
-                ? String(value).slice(0, 200) + '\u2026'
-                : String(value ?? '')) +
-              '"',
-          ),
-      },
-      copies: {
-        title: 'Copies',
-        columnType: 'quantitative',
-        cellRenderer: (value: SqlValue, row) =>
-          m(
-            'button',
-            {
-              class: 'pf-hde-link',
-              onclick: () => navigate('strings', {q: String(row.value ?? '')}),
-            },
-            String(value),
-          ),
-      },
-      total_bytes: {
-        title: 'Total',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      wasted_bytes: {
-        title: 'Wasted',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
+    value: {
+      title: 'Value',
+      columnType: 'text',
+      cellRenderer: (value: SqlValue) =>
+        m(
+          'button',
+          {
+            class: 'pf-hde-link pf-hde-mono pf-hde-break-all pf-hde-str-color',
+            onclick: () =>
+              navigate('strings', {
+                q: String(value ?? ''),
+              }),
+          },
+          '"' +
+            (String(value ?? '').length > 200
+              ? String(value).slice(0, 200) + '\u2026'
+              : String(value ?? '')) +
+            '"',
+        ),
+    },
+    copies: {
+      title: 'Copies',
+      columnType: 'quantitative',
+      cellRenderer: (value: SqlValue, row) =>
+        m(
+          'button',
+          {
+            class: 'pf-hde-link',
+            onclick: () => navigate('strings', {q: String(row.value ?? '')}),
+          },
+          String(value),
+        ),
+    },
+    total_bytes: {
+      title: 'Total',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    wasted_bytes: {
+      title: 'Wasted',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
     },
   };
 }
@@ -201,7 +192,7 @@ function renderDuplicateSection(
   targetView: string,
   linkLabel: string,
   navigate: NavFn,
-  schema: SchemaRegistry,
+  schema: ColumnSchema,
   data: Row[],
   columns: Array<{id: string; field: string}>,
 ): m.Children {
@@ -226,7 +217,6 @@ function renderDuplicateSection(
     m('div', {class: 'pf-hde-dup-grid-container'}, [
       m(DataGrid, {
         schema,
-        rootSchema: 'query',
         data,
         initialColumns: columns,
         fillHeight: true,
@@ -358,7 +348,6 @@ function OverviewView(): m.Component<OverviewViewAttrs> {
           m('h3', {class: 'pf-hde-sub-heading'}, 'Bytes Retained by Heap'),
           m(DataGrid, {
             schema: HEAP_SCHEMA,
-            rootSchema: 'query',
             data: heapRows,
             initialColumns: [
               {id: 'heap', field: 'heap'},

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
@@ -19,8 +19,7 @@ import {Spinner} from '../../../widgets/spinner';
 import {EmptyState} from '../../../widgets/empty_state';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
-import {createSimpleSchema} from '../../../components/widgets/datagrid/sql_schema';
-import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../components/widgets/datagrid/datagrid_schema';
 import type {StringListRow} from '../types';
 import {fmtSize, fmtHex} from '../format';
 import type {Filter} from '../../../components/widgets/datagrid/model';
@@ -65,94 +64,90 @@ function buildQuery(activeDump: HeapDump): string {
   `;
 }
 
-function makeUiSchema(navigate: NavFn): SchemaRegistry {
+function makeUiSchema(navigate: NavFn): ColumnSchema {
   return {
-    query: {
-      id: {
-        title: 'Object',
-        columnType: 'identifier',
-        cellRenderer: (value: SqlValue, row) => {
-          const id = Number(value);
-          const str = row.value != null ? String(row.value) : null;
-          const display = `String ${fmtHex(id)}`;
-          return m(
-            'button',
+    id: {
+      title: 'Object',
+      columnType: 'identifier',
+      cellRenderer: (value: SqlValue, row) => {
+        const id = Number(value);
+        const str = row.value != null ? String(row.value) : null;
+        const display = `String ${fmtHex(id)}`;
+        return m(
+          'button',
+          {
+            class: 'pf-hde-link',
+            onclick: () =>
+              navigate('object', {
+                id,
+                label: str
+                  ? `"${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`
+                  : display,
+              }),
+          },
+          m(
+            'span',
             {
-              class: 'pf-hde-link',
-              onclick: () =>
-                navigate('object', {
-                  id,
-                  label: str
-                    ? `"${str.length > 40 ? str.slice(0, 40) + '\u2026' : str}"`
-                    : display,
-                }),
+              class: 'pf-hde-mono pf-hde-break-all pf-hde-str-color',
             },
-            m(
-              'span',
-              {
-                class: 'pf-hde-mono pf-hde-break-all pf-hde-str-color',
-              },
-              str
-                ? '"' +
-                    (str.length > 300 ? str.slice(0, 300) + '\u2026' : str) +
-                    '"'
-                : display,
-            ),
-          );
-        },
+            str
+              ? '"' +
+                  (str.length > 300 ? str.slice(0, 300) + '\u2026' : str) +
+                  '"'
+              : display,
+          ),
+        );
       },
-      retained: {
-        title: colHeader('Retained', COL_INFO.retained),
-        titleString: 'Retained',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      len: {
-        title: 'Length',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
-      heap: {
-        title: 'Heap',
-        columnType: 'text',
-      },
-      value: {
-        title: 'Value',
-        columnType: 'text',
-      },
-      self_size: {
-        title: colHeader('Shallow', COL_INFO.shallow),
-        titleString: 'Shallow',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_size: {
-        title: colHeader('Reachable', COL_INFO.reachable),
-        titleString: 'Reachable',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_native: {
-        title: colHeader('Reachable native', COL_INFO.reachableNative),
-        titleString: 'Reachable native',
-        columnType: 'quantitative',
-        cellRenderer: sizeRenderer,
-      },
-      reachable_count: {
-        title: colHeader('Reachable count', COL_INFO.reachableCount),
-        titleString: 'Reachable count',
-        columnType: 'quantitative',
-        cellRenderer: countRenderer,
-      },
+    },
+    retained: {
+      title: colHeader('Retained', COL_INFO.retained),
+      titleString: 'Retained',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    len: {
+      title: 'Length',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
+    },
+    heap: {
+      title: 'Heap',
+      columnType: 'text',
+    },
+    value: {
+      title: 'Value',
+      columnType: 'text',
+    },
+    self_size: {
+      title: colHeader('Shallow', COL_INFO.shallow),
+      titleString: 'Shallow',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_size: {
+      title: colHeader('Reachable', COL_INFO.reachable),
+      titleString: 'Reachable',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_native: {
+      title: colHeader('Reachable native', COL_INFO.reachableNative),
+      titleString: 'Reachable native',
+      columnType: 'quantitative',
+      cellRenderer: sizeRenderer,
+    },
+    reachable_count: {
+      title: colHeader('Reachable count', COL_INFO.reachableCount),
+      titleString: 'Reachable count',
+      columnType: 'quantitative',
+      cellRenderer: countRenderer,
     },
   };
 }
 
-const SUMMARY_SCHEMA: SchemaRegistry = {
-  query: {
-    property: {title: 'Property', columnType: 'text'},
-    value: {title: 'Value', columnType: 'text'},
-  },
+const SUMMARY_SCHEMA: ColumnSchema = {
+  property: {title: 'Property', columnType: 'text'},
+  value: {title: 'Value', columnType: 'text'},
 };
 
 // --- StringsView -------------------------------------------------------------
@@ -189,8 +184,7 @@ function StringsView(): m.Component<StringsViewAttrs> {
       const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(query),
-        rootSchemaName: 'query',
+        tableOrSubquery: query,
         preamble: SQL_PREAMBLE,
       });
       counter.init(engine, query, SQL_PREAMBLE);
@@ -247,7 +241,6 @@ function StringsView(): m.Component<StringsViewAttrs> {
         m('div', {class: 'pf-hde-card pf-hde-mb-4 pf-hde-flex-none'}, [
           m(DataGrid, {
             schema: SUMMARY_SCHEMA,
-            rootSchema: 'query',
             data: summaryRows,
             initialColumns: [
               {id: 'property', field: 'property'},
@@ -259,7 +252,6 @@ function StringsView(): m.Component<StringsViewAttrs> {
         dataSource
           ? m(DataGrid, {
               schema: makeUiSchema(navigate),
-              rootSchema: 'query',
               data: dataSource,
               fillHeight: true,
               initialColumns: [

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/builder.ts
@@ -118,7 +118,6 @@ import {
   DrawerPanelVisibility,
 } from '../../../widgets/drawer_panel';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
-import {createSimpleSchema} from '../../../components/widgets/datagrid/sql_schema';
 import type {QueryResponse} from '../../../components/query_table/queries';
 import QueryPagePlugin from '../../dev.perfetto.QueryPage';
 import {SqlSourceNode} from './nodes/sources/sql_source';
@@ -639,8 +638,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
 
     this.dataSource = new SQLDataSource({
       engine,
-      sqlSchema: createSimpleSchema(result.tableName),
-      rootSchemaName: 'query',
+      tableOrSubquery: result.tableName,
     });
     this.isQueryRunning = false;
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_export_modal.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_export_modal.ts
@@ -19,7 +19,7 @@ import {CodeSnippet} from '../../../../widgets/code_snippet';
 import {traceSummarySpecToText} from '../../../../base/proto_utils_wasm';
 import {Spinner} from '../../../../widgets/spinner';
 import {DataGrid} from '../../../../components/widgets/datagrid/datagrid';
-import type {SchemaRegistry} from '../../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../../components/widgets/datagrid/datagrid_schema';
 import type {Row} from '../../../../trace_processor/query_result';
 import {Tabs} from '../../../../widgets/tabs';
 import type {Engine} from '../../../../trace_processor/engine';
@@ -60,7 +60,7 @@ function getMetricValue(
 }
 
 export interface MetricResult {
-  schema: SchemaRegistry;
+  schema: ColumnSchema;
   rows: Row[];
   metricId: string;
 }
@@ -86,19 +86,17 @@ export function parseMetricBundleForValue(
   const metricId = `${metricIdPrefix}_${valueColumn}`;
 
   // Build schema columns: dimensions (text) + this value (quantitative).
-  const schemaColumns: Record<
+  const schema: Record<
     string,
     {title: string; columnType: 'text' | 'quantitative'}
   > = {};
   for (const dim of dimensionNames) {
-    schemaColumns[dim] = {title: dim, columnType: 'text'};
+    schema[dim] = {title: dim, columnType: 'text'};
   }
-  schemaColumns[valueColumn] = {
+  schema[valueColumn] = {
     title: valueColumn,
     columnType: 'quantitative',
   };
-
-  const schema: SchemaRegistry = {[metricId]: schemaColumns};
 
   // Convert rows to DataGrid format.
   const rows: Row[] = [];
@@ -180,7 +178,6 @@ export async function showMetricsExportModal(
         return m(DataGrid, {
           data: state.result.rows,
           schema: state.result.schema,
-          rootSchema: state.result.metricId,
         });
     }
   };

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_node_unittest.ts
@@ -28,7 +28,6 @@ import {
   createMockNodeWithStructuredQuery,
   expectValidationSuccess,
 } from '../testing/test_utils';
-import {isColumnDef} from '../../../../components/widgets/datagrid/datagrid_schema';
 import protos from '../../../../protos';
 
 // Helper to build a minimal valid state with one value column.
@@ -1418,18 +1417,18 @@ describe('parseMetricBundleForValue', () => {
 
     expect(result).toBeDefined();
     if (result !== undefined) {
-      const schema = result.schema[result.metricId];
+      const schema = result.schema;
       const processEntry = schema['process'];
       const threadEntry = schema['thread'];
       const cpuEntry = schema['cpu'];
       // Schema values for leaf columns are ColumnDef objects with columnType.
       expect(
-        isColumnDef(processEntry) ? processEntry.columnType : undefined,
+        'columnType' in processEntry ? processEntry.columnType : undefined,
       ).toBe('text');
       expect(
-        isColumnDef(threadEntry) ? threadEntry.columnType : undefined,
+        'columnType' in threadEntry ? threadEntry.columnType : undefined,
       ).toBe('text');
-      expect(isColumnDef(cpuEntry) ? cpuEntry.columnType : undefined).toBe(
+      expect('columnType' in cpuEntry ? cpuEntry.columnType : undefined).toBe(
         'quantitative',
       );
     }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_results_panel.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_results_panel.ts
@@ -22,7 +22,7 @@ import {Spinner} from '../../../../widgets/spinner';
 import {Switch} from '../../../../widgets/switch';
 import {Intent} from '../../../../widgets/common';
 import {DataGrid} from '../../../../components/widgets/datagrid/datagrid';
-import type {SchemaRegistry} from '../../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../../components/widgets/datagrid/datagrid_schema';
 import type {Row} from '../../../../trace_processor/query_result';
 import {Tabs} from '../../../../widgets/tabs';
 import {
@@ -76,7 +76,7 @@ function extractDimensionNames(
 
 interface MetricBundleResult {
   metricId: string;
-  schema: SchemaRegistry;
+  schema: ColumnSchema;
   rows: Row[];
 }
 
@@ -111,19 +111,17 @@ function parseTraceSummaryProto(data: Uint8Array): MetricBundleResult[] {
 
     // Build one MetricBundleResult per metric (each gets its own tab).
     for (const {metricId, valueName, valueIndex} of metrics) {
-      const schemaColumns: Record<
+      const schema: Record<
         string,
         {title: string; columnType: 'text' | 'quantitative'}
       > = {};
       for (const dimName of dimensionNames) {
-        schemaColumns[dimName] = {title: dimName, columnType: 'text'};
+        schema[dimName] = {title: dimName, columnType: 'text'};
       }
-      schemaColumns[valueName] = {
+      schema[valueName] = {
         title: valueName,
         columnType: 'quantitative',
       };
-
-      const schema: SchemaRegistry = {[metricId]: schemaColumns};
 
       const rows: Row[] = [];
       for (const row of bundle.row ?? []) {
@@ -316,7 +314,6 @@ export class TraceSummaryResultsPanel
           return m(DataGrid, {
             data: bundle.rows,
             schema: bundle.schema,
-            rootSchema: bundle.metricId,
             fillHeight: true,
           });
         }
@@ -331,7 +328,6 @@ export class TraceSummaryResultsPanel
             content: m(DataGrid, {
               data: bundle.rows,
               schema: bundle.schema,
-              rootSchema: bundle.metricId,
               fillHeight: true,
             }),
           })),

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/results_panel.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/results_panel.ts
@@ -18,7 +18,6 @@ import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import type {
   CellRenderer,
   ColumnSchema,
-  SchemaRegistry,
 } from '../../../components/widgets/datagrid/datagrid_schema';
 import type {Column} from '../../../components/widgets/datagrid/model';
 import {Button, ButtonVariant} from '../../../widgets/button';
@@ -433,8 +432,7 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
           : null;
 
       // Build schema directly
-      const columnSchema: ColumnSchema = {};
-      const schema: SchemaRegistry = {data: columnSchema};
+      const schema: ColumnSchema = {};
 
       // Get sqlModules from attrs (centralized, not from node state)
       const {sqlModules} = attrs;
@@ -476,7 +474,7 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
           }
         }
 
-        columnSchema[c] = {cellRenderer, columnType};
+        schema[c] = {cellRenderer, columnType};
       }
 
       // Build menu items for joinid columns (add columns from related tables)
@@ -587,7 +585,6 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
         warning,
         m(DataGrid, {
           schema,
-          rootSchema: 'data',
           columns: this.columns,
           fillHeight: true,
           data: attrs.dataSource,

--- a/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
+++ b/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
@@ -29,7 +29,7 @@ import {Callout} from '../../widgets/callout';
 import {TextInput} from '../../widgets/text_input';
 import {Tabs} from '../../widgets/tabs';
 import {DataGrid} from '../../components/widgets/datagrid/datagrid';
-import type {SchemaRegistry} from '../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
 import type {Row} from '../../trace_processor/query_result';
 import protos from '../../protos';
 
@@ -39,7 +39,7 @@ const FORMATS: Format[] = ['json', 'prototext', 'proto'];
 // Parsed metric bundle for table display
 interface MetricBundle {
   metricId: string;
-  schema: SchemaRegistry;
+  schema: ColumnSchema;
   rows: Row[];
 }
 
@@ -255,20 +255,13 @@ function parseTraceSummary(data: Uint8Array): MetricBundle[] {
     }
 
     // Build schema for this metric
-    const schemaColumns: Record<
-      string,
-      {title: string; columnType: 'text' | 'quantitative'}
-    > = {};
+    const schema: ColumnSchema = {};
     for (const dimName of dimensionNames) {
-      schemaColumns[dimName] = {title: dimName, columnType: 'text'};
+      schema[dimName] = {title: dimName, columnType: 'text'};
     }
     for (const valueName of valueNames) {
-      schemaColumns[valueName] = {title: valueName, columnType: 'quantitative'};
+      schema[valueName] = {title: valueName, columnType: 'quantitative'};
     }
-
-    const schema: SchemaRegistry = {
-      [metricId]: schemaColumns,
-    };
 
     // Convert rows to DataGrid format
     const rows: Row[] = [];
@@ -506,7 +499,6 @@ function renderV2Result(
               m(DataGrid, {
                 data: bundle.rows,
                 schema: bundle.schema,
-                rootSchema: bundle.metricId,
               }),
             ),
           })),

--- a/ui/src/plugins/dev.perfetto.QueryPage/results_table.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/results_table.ts
@@ -18,10 +18,7 @@ import {Icons} from '../../base/semantic_icons';
 import {AddDebugTrackMenu} from '../../components/tracks/add_debug_track_menu';
 import {DataGrid, renderCell} from '../../components/widgets/datagrid/datagrid';
 import {InMemoryDataSource} from '../../components/widgets/datagrid/in_memory_data_source';
-import type {
-  ColumnSchema,
-  SchemaRegistry,
-} from '../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
 import type {Trace} from '../../public/trace';
 import type {Row} from '../../trace_processor/query_result';
 import {Anchor} from '../../widgets/anchor';
@@ -143,9 +140,7 @@ export class ResultsTable implements m.Component<ResultsTableAttrs> {
     attrs: ResultsTableAttrs,
     data: ResultsSuccess,
   ): m.Children {
-    const schema: SchemaRegistry = {};
-    const rootSchema: ColumnSchema = {};
-
+    const schema: ColumnSchema = {};
     const hasIdColumn = data.columns.includes('id');
     const autoDetected = this.detectAutoTable(data.columns);
     const resolvedTable = this.resolveIdTable(data.columns);
@@ -156,12 +151,11 @@ export class ResultsTable implements m.Component<ResultsTableAttrs> {
           ? (value: Row[string]) =>
               this.renderIdCell(value, resolvedTable, attrs.onIdClick!)
           : undefined;
-      rootSchema[col] = {
+      schema[col] = {
         title: col,
         cellRenderer,
       };
     }
-    schema['root'] = rootSchema;
 
     const selectedLabel =
       this.selectedIdTable === 'auto'
@@ -231,7 +225,6 @@ export class ResultsTable implements m.Component<ResultsTableAttrs> {
       m(DataGrid, {
         disablePivotControls: true, // In-memory datasource does not support pivoting
         schema: schema,
-        rootSchema: 'root',
         data: this.getDataSource(data.rows),
         fillHeight: true,
         emptyStateMessage: 'Query returned no rows',

--- a/ui/src/plugins/dev.perfetto.Smaps/smaps_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.Smaps/smaps_details_panel.ts
@@ -15,13 +15,9 @@
 import m from 'mithril';
 import type {time} from '../../base/time';
 import {DataGrid} from '../../components/widgets/datagrid/datagrid';
-import type {
-  ColumnSchema,
-  SchemaRegistry,
-} from '../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
 import type {Column} from '../../components/widgets/datagrid/model';
 import {SQLDataSource} from '../../components/widgets/datagrid/sql_data_source';
-import {createSimpleSchema} from '../../components/widgets/datagrid/sql_schema';
 import {asUpid} from '../../components/sql_utils/core_types';
 import {
   getProcessInfo,
@@ -34,8 +30,6 @@ import type {Engine} from '../../trace_processor/engine';
 import {NUM_NULL, type Row} from '../../trace_processor/query_result';
 import {DetailsShell} from '../../widgets/details_shell';
 import {Spinner} from '../../widgets/spinner';
-
-const ROOT_SCHEMA = 'mapping';
 
 const COLUMNS: ReadonlyArray<{name: string; title: string}> = [
   {name: 'path', title: 'Path'},
@@ -54,15 +48,15 @@ const COLUMNS: ReadonlyArray<{name: string; title: string}> = [
   {name: 'locked_kb', title: 'Locked (KB)'},
 ];
 
-function buildGridSchema(): SchemaRegistry {
-  const mapping: ColumnSchema = {};
+function buildGridSchema(): ColumnSchema {
+  const schema: ColumnSchema = {};
   for (const col of COLUMNS) {
-    mapping[col.name] = {
+    schema[col.name] = {
       title: col.title,
       columnType: col.name === 'path' ? 'text' : 'quantitative',
     };
   }
-  return {[ROOT_SCHEMA]: mapping};
+  return schema;
 }
 
 // Datagrid schema with all possible underlying columns.
@@ -121,12 +115,11 @@ export class SmapsDetailsPanel implements TrackEventDetailsPanel {
     ).join(', ');
     this.dataSource = new SQLDataSource({
       engine: trace.engine,
-      sqlSchema: createSimpleSchema(`
+      tableOrSubquery: `
         SELECT ${selectCols}
         FROM process_memory_mappings
         WHERE upid = ${upid} AND ts = ${ts}
-      `),
-      rootSchemaName: 'query',
+      `,
     });
   }
 
@@ -162,7 +155,6 @@ export class SmapsDetailsPanel implements TrackEventDetailsPanel {
     return m(DataGrid, {
       fillHeight: true,
       schema: SMAPS_SCHEMA,
-      rootSchema: ROOT_SCHEMA,
       initialColumns,
       data: this.dataSource,
       showExportButton: true,

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
@@ -40,7 +40,7 @@ import {
   UNKNOWN,
 } from '../../trace_processor/query_result';
 import {createPerfettoTable} from '../../trace_processor/sql_utils';
-import type {SQLSchemaRegistry} from '../../components/widgets/datagrid/sql_schema';
+import type {SQLTableSchema} from '../../components/widgets/datagrid/sql_schema';
 import {Anchor} from '../../widgets/anchor';
 import {formatDurationValue} from '../../components/aggregation_panel';
 
@@ -344,25 +344,23 @@ export class SliceSelectionAggregator implements Aggregator {
           parameterized: true,
         },
       },
-      // The aggregation table always has an `arg_set_id` column, so we can
-      // expose a parameterized `args.*` column to the data grid.
-      sqlConfig: ({tableName}): SQLSchemaRegistry => ({
-        query: {
-          table: tableName,
-          columns: {
-            args: {
-              expression: (alias, key) =>
-                `extract_arg(${alias}.arg_set_id, '${key}')`,
-              parameterized: true,
-              parameterKeysQuery: (baseTable, baseAlias) => `
+      // The aggregation table has an `arg_set_id` column, so we can expose a
+      // parameterized `args.*` column to the datagrid.
+      sqlConfig: ({tableName}): SQLTableSchema => ({
+        tableOrSubquery: tableName,
+        columns: {
+          args: {
+            expression: (alias, key) =>
+              `extract_arg(${alias}.arg_set_id, '${key}')`,
+            parameterized: true,
+            parameterKeysQuery: (tableOrSubquery, alias) => `
                 SELECT DISTINCT args.key
-                FROM ${baseTable} AS ${baseAlias}
-                JOIN args ON args.arg_set_id = ${baseAlias}.arg_set_id
+                FROM (${tableOrSubquery}) AS ${alias}
+                JOIN args ON args.arg_set_id = ${alias}.arg_set_id
                 WHERE args.key IS NOT NULL
                 ORDER BY args.key
                 LIMIT 1000
               `,
-            },
           },
         },
       }),

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
-import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../../components/widgets/datagrid/datagrid_schema';
 import type {Row, SqlValue} from '../../../trace_processor/query_result';
 import {InMemoryDataSource} from '../../../components/widgets/datagrid/in_memory_data_source';
 import type {
@@ -24,7 +24,7 @@ import type {
 } from '../../../components/widgets/datagrid/data_source';
 import type {QueryResult} from '../../../base/query_slot';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
-import type {SQLSchemaRegistry} from '../../../components/widgets/datagrid/sql_schema';
+import type {SQLTableSchema} from '../../../components/widgets/datagrid/sql_schema';
 import {renderDocSection, renderWidgetShowcase} from '../widgets_page_utils';
 import type {App} from '../../../public/app';
 import {Anchor} from '../../../widgets/anchor';
@@ -81,124 +81,122 @@ let cachedSliceDataSource: SQLDataSource | undefined;
 let employeeErrorDataSource: ErrorEmulatingDataSource | undefined;
 
 // SQL schema for slice table with track join
-const SLICE_SQL_SCHEMA: SQLSchemaRegistry = {
-  slice: {
-    table: 'slice',
-    columns: {
-      id: {},
-      ts: {},
-      dur: {},
-      track_id: {},
-      track: {
-        ref: 'track',
-        foreignKey: 'track_id',
-      },
-      parent: {
-        ref: 'slice',
-        foreignKey: 'parent_id',
-      },
-      args: {
-        expression: (alias, key) =>
-          `extract_arg(${alias}.arg_set_id, '${key}')`,
-        parameterized: true,
-        parameterKeysQuery: (baseTable) => `
-          SELECT DISTINCT args.key
-          FROM ${baseTable}
-          JOIN args ON args.arg_set_id = ${baseTable}.arg_set_id
-          WHERE args.key IS NOT NULL
-          ORDER BY args.key
-          LIMIT 1000
-        `,
-      },
-      all_args: {
-        expression: (alias) =>
-          `__intrinsic_arg_set_to_json(${alias}.arg_set_id)`,
+const SLICE_SQL_SCHEMA: SQLTableSchema = {
+  tableOrSubquery: 'slice',
+  columns: {
+    id: {},
+    ts: {},
+    dur: {},
+    track_id: {},
+    track: {
+      foreignKey: 'track_id',
+      schema: {
+        tableOrSubquery: 'track',
+        columns: {
+          id: {},
+          name: {},
+        },
       },
     },
-  },
-  track: {
-    table: 'track',
-    columns: {
-      id: {},
-      name: {},
+    parent: {
+      foreignKey: 'parent_id',
+      get schema() {
+        return SLICE_SQL_SCHEMA;
+      },
+    },
+    args: {
+      expression: (alias: string, key?: string) =>
+        `extract_arg(${alias}.arg_set_id, '${key}')`,
+      parameterized: true,
+      parameterKeysQuery: (tableOrSubquery: string, alias: string) => `
+        SELECT DISTINCT args.key
+        FROM (${tableOrSubquery}) AS ${alias}
+        JOIN args ON args.arg_set_id = ${alias}.arg_set_id
+        WHERE args.key IS NOT NULL
+        ORDER BY args.key
+        LIMIT 1000
+      `,
+    },
+    all_args: {
+      expression: (alias: string) =>
+        `__intrinsic_arg_set_to_json(${alias}.arg_set_id)`,
     },
   },
 };
 
 // UI schema for slice table (defines how columns are displayed)
-const SLICE_UI_SCHEMA: SchemaRegistry = {
-  slice: {
-    id: {
-      title: 'ID',
-      columnType: 'identifier',
-    },
-    ts: {
-      title: 'Timestamp',
-      columnType: 'quantitative',
-    },
-    dur: {
-      title: 'Duration',
-      columnType: 'quantitative',
-    },
-    name: {
-      title: 'Name',
-      columnType: 'text',
-    },
-    track_id: {
-      title: 'Track ID',
-      columnType: 'quantitative',
-    },
-    track: {
-      ref: 'track',
-      title: 'Track',
-    },
-    parent: {
-      ref: 'slice',
-      title: 'Parent',
-    },
-    args: {
-      parameterized: true,
-      title: 'Arg',
-    },
-    all_args: {
-      title: 'All Args',
-      columnType: 'text',
-      cellRenderer: (value) => {
-        if (value === null || value === undefined) {
-          return m('span.pf-null-value', 'NULL');
-        }
-        try {
-          const parsed = typeof value === 'string' ? JSON.parse(value) : value;
-          if (typeof parsed !== 'object' || parsed === null) {
-            return String(value);
-          }
-          const entries = Object.entries(parsed);
-          if (entries.length === 0) {
-            return m('span.pf-empty-value', '{}');
-          }
-          return m(
-            'span.pf-args-list',
-            entries.map(([key, val], i) => [
-              i > 0 ? ', ' : '',
-              m('b', key),
-              ': ',
-              String(val),
-            ]),
-          );
-        } catch {
-          return String(value);
-        }
+const SLICE_UI_SCHEMA: ColumnSchema = {
+  id: {
+    title: 'ID',
+    columnType: 'identifier',
+  },
+  ts: {
+    title: 'Timestamp',
+    columnType: 'quantitative',
+  },
+  dur: {
+    title: 'Duration',
+    columnType: 'quantitative',
+  },
+  name: {
+    title: 'Name',
+    columnType: 'text',
+  },
+  track_id: {
+    title: 'Track ID',
+    columnType: 'quantitative',
+  },
+  track: {
+    title: 'Track',
+    schema: {
+      id: {
+        title: 'ID',
+        columnType: 'quantitative',
+      },
+      name: {
+        title: 'Name',
+        columnType: 'text',
       },
     },
   },
-  track: {
-    id: {
-      title: 'ID',
-      columnType: 'quantitative',
+  parent: {
+    title: 'Parent',
+    get schema() {
+      return SLICE_UI_SCHEMA;
     },
-    name: {
-      title: 'Name',
-      columnType: 'text',
+  },
+  args: {
+    parameterized: true,
+    title: 'Arg',
+  },
+  all_args: {
+    title: 'All Args',
+    columnType: 'text',
+    cellRenderer: (value: SqlValue) => {
+      if (value === null || value === undefined) {
+        return m('span.pf-null-value', 'NULL');
+      }
+      try {
+        const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+        if (typeof parsed !== 'object' || parsed === null) {
+          return String(value);
+        }
+        const entries = Object.entries(parsed);
+        if (entries.length === 0) {
+          return m('span.pf-empty-value', '{}');
+        }
+        return m(
+          'span.pf-args-list',
+          entries.map(([key, val], i) => [
+            i > 0 ? ', ' : '',
+            m('b', key),
+            ': ',
+            String(val),
+          ]),
+        );
+      } catch {
+        return String(value);
+      }
     },
   },
 };
@@ -208,8 +206,7 @@ export function renderDataGrid(app: App): m.Children {
   if (app.trace && !cachedSliceDataSource) {
     cachedSliceDataSource = new SQLDataSource({
       engine: app.trace.engine,
-      sqlSchema: SLICE_SQL_SCHEMA,
-      rootSchemaName: 'slice',
+      ...SLICE_SQL_SCHEMA,
     });
   }
 
@@ -246,11 +243,10 @@ export function renderDataGrid(app: App): m.Children {
         }
         employeeErrorDataSource.failing = emulateError;
         return m(DataGrid, {
-          ...rest,
           fillHeight: true,
           schema: EMPLOYEE_SCHEMA,
-          rootSchema: 'employee',
           data: employeeErrorDataSource,
+          ...rest,
         });
       },
       initialOpts: {
@@ -305,10 +301,8 @@ export function renderDataGrid(app: App): m.Children {
         ? renderWidgetShowcase({
             renderWidget: ({...rest}) => {
               return m(DataGrid, {
-                ...rest,
                 fillHeight: true,
                 schema: SLICE_UI_SCHEMA,
-                rootSchema: 'slice',
                 data: cachedSliceDataSource!,
                 initialColumns: [
                   {id: 'id', field: 'id'},
@@ -316,6 +310,7 @@ export function renderDataGrid(app: App): m.Children {
                   {id: 'dur', field: 'dur'},
                   {id: 'track_name', field: 'track.name'},
                 ],
+                ...rest,
               });
             },
             initialOpts: {},
@@ -326,106 +321,114 @@ export function renderDataGrid(app: App): m.Children {
   ];
 }
 
-// Complex multi-table schema demonstrating relationships
-const EMPLOYEE_SCHEMA: SchemaRegistry = {
-  employee: {
-    id: {
-      title: 'ID',
-      columnType: 'quantitative',
-    },
-    name: {
-      title: 'Name',
-      columnType: 'text',
-    },
-    title: {
-      title: 'Job Title',
-      columnType: 'text',
-    },
-    email: {
-      title: 'Email',
-      columnType: 'text',
-    },
-    salary: {
-      title: 'Salary',
-      columnType: 'quantitative',
-    },
-    hireDate: {
-      title: 'Hire Date',
-      columnType: 'text',
-    },
-    // Self-referential: manager is also an employee
-    manager: {
-      ref: 'employee',
-      title: 'Manager',
-    },
-    // Cross-reference to department
-    department: {
-      ref: 'department',
-      title: 'Department',
-    },
-    // Cross-reference to current project
-    project: {
-      ref: 'project',
-      title: 'Current Project',
-    },
-    // Parameterized column for dynamic skill ratings
-    skills: {
-      parameterized: true,
-      title: 'Skills',
-      columnType: 'quantitative',
+// Department sub-schema (used by employee and project)
+const EMPLOYEE_DEPT_SCHEMA: ColumnSchema = {
+  id: {
+    title: 'Dept ID',
+    columnType: 'quantitative',
+  },
+  name: {
+    title: 'Name',
+    columnType: 'text',
+  },
+  budget: {
+    title: 'Budget',
+    columnType: 'quantitative',
+  },
+  location: {
+    title: 'Location',
+    columnType: 'text',
+  },
+  // Head of department is an employee
+  head: {
+    title: 'Department Head',
+    get schema() {
+      return EMPLOYEE_SCHEMA;
     },
   },
+};
+
+// Project sub-schema (used by employee)
+const EMPLOYEE_PROJECT_SCHEMA: ColumnSchema = {
+  id: {
+    title: 'Project ID',
+    columnType: 'quantitative',
+  },
+  name: {
+    title: 'Project Name',
+    columnType: 'text',
+  },
+  status: {
+    title: 'Status',
+    columnType: 'text',
+    distinctValues: true,
+  },
+  deadline: {
+    title: 'Deadline',
+    columnType: 'text',
+  },
+  // Project lead is an employee
+  lead: {
+    title: 'Project Lead',
+    get schema() {
+      return EMPLOYEE_SCHEMA;
+    },
+  },
+  // Project belongs to a department
   department: {
-    id: {
-      title: 'Dept ID',
-      columnType: 'quantitative',
-    },
-    name: {
-      title: 'Name',
-      columnType: 'text',
-    },
-    budget: {
-      title: 'Budget',
-      columnType: 'quantitative',
-    },
-    location: {
-      title: 'Location',
-      columnType: 'text',
-    },
-    // Head of department is an employee
-    head: {
-      ref: 'employee',
-      title: 'Department Head',
+    title: 'Owning Department',
+    schema: EMPLOYEE_DEPT_SCHEMA,
+  },
+};
+
+// Complex multi-table schema demonstrating relationships
+const EMPLOYEE_SCHEMA: ColumnSchema = {
+  id: {
+    title: 'ID',
+    columnType: 'quantitative',
+  },
+  name: {
+    title: 'Name',
+    columnType: 'text',
+  },
+  title: {
+    title: 'Job Title',
+    columnType: 'text',
+  },
+  email: {
+    title: 'Email',
+    columnType: 'text',
+  },
+  salary: {
+    title: 'Salary',
+    columnType: 'quantitative',
+  },
+  hireDate: {
+    title: 'Hire Date',
+    columnType: 'text',
+  },
+  // Self-referential: manager is also an employee
+  manager: {
+    title: 'Manager',
+    get schema() {
+      return EMPLOYEE_SCHEMA;
     },
   },
+  // Cross-reference to department
+  department: {
+    title: 'Department',
+    schema: EMPLOYEE_DEPT_SCHEMA,
+  },
+  // Cross-reference to current project
   project: {
-    id: {
-      title: 'Project ID',
-      columnType: 'quantitative',
-    },
-    name: {
-      title: 'Project Name',
-      columnType: 'text',
-    },
-    status: {
-      title: 'Status',
-      columnType: 'text',
-      distinctValues: true,
-    },
-    deadline: {
-      title: 'Deadline',
-      columnType: 'text',
-    },
-    // Project lead is an employee
-    lead: {
-      ref: 'employee',
-      title: 'Project Lead',
-    },
-    // Project belongs to a department
-    department: {
-      ref: 'department',
-      title: 'Owning Department',
-    },
+    title: 'Current Project',
+    schema: EMPLOYEE_PROJECT_SCHEMA,
+  },
+  // Parameterized column for dynamic skill ratings
+  skills: {
+    parameterized: true,
+    title: 'Skills',
+    filterType: 'quantitative',
   },
 };
 

--- a/ui/src/plugins/org.chromium.MemorySnapshots/index.ts
+++ b/ui/src/plugins/org.chromium.MemorySnapshots/index.ts
@@ -22,9 +22,9 @@ import {
 } from '../../components/sql_utils/process';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {DataGrid} from '../../components/widgets/datagrid/datagrid';
-import type {SchemaRegistry} from '../../components/widgets/datagrid/datagrid_schema';
+import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
 import {SQLDataSource} from '../../components/widgets/datagrid/sql_data_source';
-import type {SQLSchemaRegistry} from '../../components/widgets/datagrid/sql_schema';
+import type {SQLTableSchema} from '../../components/widgets/datagrid/sql_schema';
 import {Timestamp} from '../../components/widgets/timestamp';
 import type {TrackEventDetailsPanel} from '../../public/details_panel';
 import type {PerfettoPlugin} from '../../public/plugin';
@@ -47,35 +47,33 @@ function renderSize(value: unknown): string {
   return Number(value).toLocaleString();
 }
 
-const UI_SCHEMA: SchemaRegistry = {
-  memory_snapshot_node: {
-    path: {
-      title: 'Path',
-      columnType: 'text',
-    },
-    size: {
-      title: 'Size',
-      columnType: 'quantitative',
-      cellRenderer: (value) => renderSize(value),
-    },
-    effective_size: {
-      title: 'Effective Size',
-      columnType: 'quantitative',
-      cellRenderer: (value) => renderSize(value),
-    },
-    all_args: {
-      title: 'All Args',
-      columnType: 'text',
-    },
-    args: {
-      title: 'Args',
-      parameterized: true,
-    },
+const UI_SCHEMA: ColumnSchema = {
+  path: {
+    title: 'Path',
+    columnType: 'text',
+  },
+  size: {
+    title: 'Size',
+    columnType: 'quantitative',
+    cellRenderer: (value) => renderSize(value),
+  },
+  effective_size: {
+    title: 'Effective Size',
+    columnType: 'quantitative',
+    cellRenderer: (value) => renderSize(value),
+  },
+  all_args: {
+    title: 'All Args',
+    columnType: 'text',
+  },
+  args: {
+    title: 'Args',
+    parameterized: true,
   },
 };
 
 // SQL schema for memory_snapshot_node with args support
-function createMemorySnapshotSchema(snapshotId: number): SQLSchemaRegistry {
+function createMemorySnapshotSchema(snapshotId: number): SQLTableSchema {
   const query = `(
     SELECT
       SUBSTR(path, LENGTH(RTRIM(path, REPLACE(path, '/', ''))) + 1) AS path,
@@ -87,31 +85,29 @@ function createMemorySnapshotSchema(snapshotId: number): SQLSchemaRegistry {
     WHERE process_snapshot_id = ${snapshotId}
   )`;
   return {
-    memory_snapshot_node: {
-      table: query,
-      columns: {
-        id: {},
-        parent_node_id: {},
-        path: {},
-        size: {},
-        effective_size: {},
-        all_args: {
-          expression: (alias) =>
-            `__intrinsic_arg_set_to_json(${alias}.arg_set_id)`,
-        },
-        args: {
-          expression: (alias, key) =>
-            `extract_arg(${alias}.arg_set_id, '${key}')`,
-          parameterized: true,
-          parameterKeysQuery: (baseTable, baseAlias) => `
+    tableOrSubquery: query,
+    columns: {
+      id: {},
+      parent_node_id: {},
+      path: {},
+      size: {},
+      effective_size: {},
+      all_args: {
+        expression: (alias) =>
+          `__intrinsic_arg_set_to_json(${alias}.arg_set_id)`,
+      },
+      args: {
+        expression: (alias, key) =>
+          `extract_arg(${alias}.arg_set_id, '${key}')`,
+        parameterized: true,
+        parameterKeysQuery: (tableOrSubquery, alias) => `
             SELECT DISTINCT args.key
-            FROM ${baseTable} AS ${baseAlias}
-            JOIN args ON args.arg_set_id = ${baseAlias}.arg_set_id
+            FROM ${tableOrSubquery} AS ${alias}
+            JOIN args ON args.arg_set_id = ${alias}.arg_set_id
             WHERE args.key IS NOT NULL
             ORDER BY args.key
             LIMIT 1000
           `,
-        },
       },
     },
   };
@@ -132,14 +128,12 @@ class SnapshotTab implements m.ClassComponent<SnapshotTabAttrs> {
     if (!this.dataSource) {
       this.dataSource = new SQLDataSource({
         engine: trace.engine,
-        sqlSchema: createMemorySnapshotSchema(snapshotId),
-        rootSchemaName: 'memory_snapshot_node',
+        ...createMemorySnapshotSchema(snapshotId),
       });
     }
 
     return m(DataGrid, {
       schema: UI_SCHEMA,
-      rootSchema: 'memory_snapshot_node',
       data: this.dataSource,
       fillHeight: true,
       initialTree: {

--- a/ui/src/plugins/org.chromium.V8/v8_runtime_call_stats_tab.ts
+++ b/ui/src/plugins/org.chromium.V8/v8_runtime_call_stats_tab.ts
@@ -19,10 +19,10 @@ import {formatDuration} from '../../components/time_utils';
 import {DataGrid} from '../../components/widgets/datagrid/datagrid';
 import type {
   CellRenderResult,
-  SchemaRegistry,
+  ColumnSchema,
 } from '../../components/widgets/datagrid/datagrid_schema';
 import {SQLDataSource} from '../../components/widgets/datagrid/sql_data_source';
-import type {SQLSchemaRegistry} from '../../components/widgets/datagrid/sql_schema';
+import type {SQLTableSchema} from '../../components/widgets/datagrid/sql_schema';
 import {
   type AreaSelection,
   areaSelectionsEqual,
@@ -48,17 +48,15 @@ import {
 import {PopupPosition} from '../../widgets/popup';
 import {Spinner} from '../../widgets/spinner';
 
-const V8_RCS_SQL_SCHEMA: SQLSchemaRegistry = {
-  v8_rcs: {
-    table: 'v8_rcs_view',
-    columns: {
-      v8_rcs_group: {},
-      v8_rcs_name: {},
-      v8_rcs_count: {},
-      v8_rcs_dur: {},
-      v8_rcs_count_percent: {},
-      v8_rcs_dur_percent: {},
-    },
+const V8_RCS_SQL_SCHEMA: SQLTableSchema = {
+  tableOrSubquery: 'v8_rcs_view',
+  columns: {
+    v8_rcs_group: {},
+    v8_rcs_name: {},
+    v8_rcs_count: {},
+    v8_rcs_dur: {},
+    v8_rcs_count_percent: {},
+    v8_rcs_dur_percent: {},
   },
 };
 
@@ -128,7 +126,6 @@ export class V8RuntimeCallStatsTab implements Tab {
 
     return m(DataGrid, {
       schema: this.getUiSchema(),
-      rootSchema: 'v8_rcs',
       toolbarItemsLeft: this.renderGroupFilter(),
       toolbarItemsRight: this.renderExportButton(),
       data: this.dataSource,
@@ -162,38 +159,36 @@ export class V8RuntimeCallStatsTab implements Tab {
     });
   }
 
-  private getUiSchema(): SchemaRegistry {
+  private getUiSchema(): ColumnSchema {
     return {
-      v8_rcs: {
-        v8_rcs_group: {
-          title: 'Group',
-          columnType: 'text',
+      v8_rcs_group: {
+        title: 'Group',
+        columnType: 'text',
+      },
+      v8_rcs_name: {
+        title: 'Name',
+        columnType: 'text',
+      },
+      v8_rcs_dur: {
+        title: 'RCS Duration',
+        columnType: 'quantitative',
+        cellRenderer: (value) => {
+          return formatDuration(this.trace, value as duration);
         },
-        v8_rcs_name: {
-          title: 'Name',
-          columnType: 'text',
-        },
-        v8_rcs_dur: {
-          title: 'RCS Duration',
-          columnType: 'quantitative',
-          cellRenderer: (value) => {
-            return formatDuration(this.trace, value as duration);
-          },
-        },
-        v8_rcs_dur_percent: {
-          title: 'Duration %',
-          columnType: 'quantitative',
-          cellRenderer: (value, row) => this.renderPercentCell(value, row),
-        },
-        v8_rcs_count: {
-          title: 'RCS Count',
-          columnType: 'quantitative',
-        },
-        v8_rcs_count_percent: {
-          title: 'Count %',
-          columnType: 'quantitative',
-          cellRenderer: (value, row) => this.renderPercentCell(value, row),
-        },
+      },
+      v8_rcs_dur_percent: {
+        title: 'Duration %',
+        columnType: 'quantitative',
+        cellRenderer: (value, row) => this.renderPercentCell(value, row),
+      },
+      v8_rcs_count: {
+        title: 'RCS Count',
+        columnType: 'quantitative',
+      },
+      v8_rcs_count_percent: {
+        title: 'Count %',
+        columnType: 'quantitative',
+        cellRenderer: (value, row) => this.renderPercentCell(value, row),
       },
     };
   }
@@ -337,8 +332,7 @@ export class V8RuntimeCallStatsTab implements Tab {
       if (this.previousSelection === selection) {
         this.dataSource = new SQLDataSource({
           engine: this.trace.engine,
-          sqlSchema: V8_RCS_SQL_SCHEMA,
-          rootSchemaName: 'v8_rcs',
+          ...V8_RCS_SQL_SCHEMA,
         });
       }
     }

--- a/ui/src/plugins/org.chromium.V8/v8_sources_tab.ts
+++ b/ui/src/plugins/org.chromium.V8/v8_sources_tab.ts
@@ -14,10 +14,9 @@
 
 import m from 'mithril';
 import {DataGrid} from '../../components/widgets/datagrid/datagrid';
-import type {SchemaRegistry} from '../../components/widgets/datagrid/datagrid_schema';
 import type {Filter} from '../../components/widgets/datagrid/model';
 import {SQLDataSource} from '../../components/widgets/datagrid/sql_data_source';
-import type {SQLSchemaRegistry} from '../../components/widgets/datagrid/sql_schema';
+import type {SQLTableSchema} from '../../components/widgets/datagrid/sql_schema';
 import type {Tab} from '../../public/tab';
 import type {Trace} from '../../public/trace';
 import {
@@ -37,6 +36,7 @@ import {TextInput} from '../../widgets/text_input';
 import {Tree, TreeNode} from '../../widgets/tree';
 import {formatFileSize} from '../../base/file_utils';
 import {QuerySlot} from '../../base/query_slot';
+import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
 
 interface V8JsScript {
   v8_js_script_id: number;
@@ -52,37 +52,31 @@ interface ScriptResults {
   details: V8JsScript;
 }
 
-const V8_JS_SCRIPT_SCHEMA_NAME = 'v8JsScript';
-const V8_JS_SCRIPT_SCHEMA: SQLSchemaRegistry = {
-  [V8_JS_SCRIPT_SCHEMA_NAME]: {
-    table: 'v8_js_script_view',
-    columns: {
-      v8_js_script_id: {},
-      name: {},
-      domain: {},
-      script_type: {},
-      source: {},
-      v8_isolate_id: {},
-      script_size: {
-        expression: (alias) => `LENGTH(${alias}.source)`,
-      },
+const V8_JS_SCRIPT_SCHEMA: SQLTableSchema = {
+  tableOrSubquery: 'v8_js_script_view',
+  columns: {
+    v8_js_script_id: {},
+    name: {},
+    domain: {},
+    script_type: {},
+    source: {},
+    v8_isolate_id: {},
+    script_size: {
+      expression: (alias) => `LENGTH(${alias}.source)`,
     },
   },
 };
 
-const V8_JS_FUNCTION_SCHEMA_NAME = 'v8JsFunction';
-const V8_JS_FUNCTION_SCHEMA: SQLSchemaRegistry = {
-  [V8_JS_FUNCTION_SCHEMA_NAME]: {
-    table: 'v8_js_function',
-    columns: {
-      v8_js_function_id: {},
-      name: {},
-      v8_js_script_id: {},
-      is_toplevel: {},
-      kind: {},
-      line: {},
-      col: {},
-    },
+const V8_JS_FUNCTION_SCHEMA: SQLTableSchema = {
+  tableOrSubquery: 'v8_js_function',
+  columns: {
+    v8_js_function_id: {},
+    name: {},
+    v8_js_script_id: {},
+    is_toplevel: {},
+    kind: {},
+    line: {},
+    col: {},
   },
 };
 
@@ -124,13 +118,11 @@ export class V8SourcesTab implements Tab {
     this.trace = trace;
     this.dataSource = new SQLDataSource({
       engine: this.trace.engine,
-      sqlSchema: V8_JS_SCRIPT_SCHEMA,
-      rootSchemaName: V8_JS_SCRIPT_SCHEMA_NAME,
+      ...V8_JS_SCRIPT_SCHEMA,
     });
     this.functionsDataSource = new SQLDataSource({
       engine: this.trace.engine,
-      sqlSchema: V8_JS_FUNCTION_SCHEMA,
-      rootSchemaName: V8_JS_FUNCTION_SCHEMA_NAME,
+      ...V8_JS_FUNCTION_SCHEMA,
     });
     this.initialize();
   }
@@ -249,20 +241,17 @@ export class V8SourcesTab implements Tab {
     if (!scriptDetails) {
       return undefined;
     }
-    const v8JsFunctionUiSchema: SchemaRegistry = {
-      v8JsFunction: {
-        v8_js_function_id: {title: 'ID'},
-        name: {title: 'Name'},
-        is_toplevel: {title: 'Is Toplevel'},
-        kind: {title: 'Kind'},
-        line: {title: 'Line'},
-        col: {title: 'Column'},
-      },
+    const v8JsFunctionUiSchema: ColumnSchema = {
+      v8_js_function_id: {title: 'ID'},
+      name: {title: 'Name'},
+      is_toplevel: {title: 'Is Toplevel'},
+      kind: {title: 'Kind'},
+      line: {title: 'Line'},
+      col: {title: 'Column'},
     };
     return m(DataGrid, {
       data: this.functionsDataSource,
       schema: v8JsFunctionUiSchema,
-      rootSchema: V8_JS_FUNCTION_SCHEMA_NAME,
       fillHeight: true,
       initialFilters: this.functionsFilters,
       onFiltersChanged: (filters: readonly Filter[]) => {
@@ -287,43 +276,41 @@ export class V8SourcesTab implements Tab {
       queryFn: () => this.selectScript(selectedId),
     });
 
-    const v8JsScriptUiSchema: SchemaRegistry = {
-      v8JsScript: {
-        v8_js_script_id: {
-          title: 'ID',
-          cellRenderer: (value: unknown, row: Row) => {
-            return m(
-              Anchor,
-              {
-                onclick: (e: Event) => {
-                  e.preventDefault();
-                  this.selectedScriptId = row.v8_js_script_id as number;
-                },
+    const v8JsScriptUiSchema: ColumnSchema = {
+      v8_js_script_id: {
+        title: 'ID',
+        cellRenderer: (value: unknown, row: Row) => {
+          return m(
+            Anchor,
+            {
+              onclick: (e: Event) => {
+                e.preventDefault();
+                this.selectedScriptId = row.v8_js_script_id as number;
               },
-              String(value),
-            );
-          },
+            },
+            String(value),
+          );
         },
-        name: {
-          title: 'Name',
-          cellRenderer: formatUrlValue,
-        },
-        domain: {
-          title: 'Domain',
-        },
-        source: {
-          title: 'Source',
-        },
-        script_type: {
-          title: 'Type',
-        },
-        v8_isolate_id: {
-          title: 'Isolate',
-        },
-        script_size: {
-          title: 'Size',
-          cellRenderer: formatByteValue,
-        },
+      },
+      name: {
+        title: 'Name',
+        cellRenderer: formatUrlValue,
+      },
+      domain: {
+        title: 'Domain',
+      },
+      source: {
+        title: 'Source',
+      },
+      script_type: {
+        title: 'Type',
+      },
+      v8_isolate_id: {
+        title: 'Isolate',
+      },
+      script_size: {
+        title: 'Size',
+        cellRenderer: formatByteValue,
       },
     };
 
@@ -349,7 +336,6 @@ export class V8SourcesTab implements Tab {
         m(DataGrid, {
           data: this.dataSource,
           schema: v8JsScriptUiSchema,
-          rootSchema: V8_JS_SCRIPT_SCHEMA_NAME,
           fillHeight: true,
           filters: this.filters,
           onFiltersChanged: (filters: readonly Filter[]) => {


### PR DESCRIPTION
Currently the schema is a record of tables keyed by name, like this:

```js
{
  slice: {
    id: {},
    ts: {},
    dur: {},
    track: {ref: 'track', ...}, // Ref to the foreign table
  },
  track: {
    id: {},
    name: {}
  },
  parent: {ref: 'slice', ...}, // Recursive reference
}
```

This works but is messy:
- Can reference non-existent tables - must check for undefined everywhere.
- The vast majority of schemas in practice are flat (single table) which means we have to nest every single schema inside a dummy table name when its totally redundant.
- Field paths don't specify a 'root' table name so we must pass the 'root' (default) table name around as a string everywhere.

## The fix

This patch replaces this nominal structure with a structured definition which solves all of these problems:

E.g.

```js
const sliceSchema = {
  id: {},
  ts: {},
  dur: {},
  table: {
    schema: { // <-- Nested table schema
       id: {},
       name: {}
    },
  },
  parent: {
    get schema() { // <-- recursive references can exist - you just have to use a getter.
      return sliceSchema;
    }
  },
}
```

Notes:
- The recursive via getter trick is borrowed from [zod](https://zod.dev/api?id=recursive-objects#recursive-objects).
- The sqlSchema (the separate schema passed to the SQLDataSource has been restructured in a similar way.
- This is a big change due to the number of DataGrid call-sites, but it's mainly mechanical. Should be a no-op.

Key changes:
- SchemaRef.ref (string) → SchemaRef.schema (ColumnSchema), with get schema() for self-referential tables
- SQLTableSchema.table → SQLTableSchema.tableOrSubquery, always wrapped in parens in generated SQL
- DataGridAttrs.schema is now ColumnSchema (was SchemaRegistry), rootSchema removed
- SQLDataSource config extends SQLTableSchema directly (was sqlSchema + rootSchemaName)
- Add getQuery() to SQLDataSource and sub-engines for SQL inspection