### PR TITLE
Add algorithm header for std::transform

### DIFF
--- a/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrackEventExtra.cc
+++ b/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrackEventExtra.cc
@@ -22,6 +22,7 @@
 #include "src/android_sdk/nativehelper/scoped_utf_chars.h"
 #include "src/android_sdk/perfetto_sdk_for_jni/tracing_sdk.h"
 
+#include <algorithm>
 #include <list>
 #include <utility>
 


### PR DESCRIPTION
Libc++ have started removing more transitive includes so we need the algorithm header in this file for std::transform.
