### PR TITLE
tp: Migrate CUJ SF boundaries to stdlib

### DIFF
--- a/src/trace_processor/metrics/sql/android/jank/cujs_boundaries.sql
+++ b/src/trace_processor/metrics/sql/android/jank/cujs_boundaries.sql
@@ -25,16 +25,9 @@ DROP TABLE IF EXISTS android_jank_cuj_vsync_boundary;
 CREATE PERFETTO TABLE android_jank_cuj_vsync_boundary AS
 SELECT * FROM _android_jank_cuj_vsync_boundary;
 
--- Similarly, extract the min/max vsync for the SF from
--- commit/compose/onMessageInvalidate slices on its main thread.
 DROP TABLE IF EXISTS android_jank_cuj_sf_vsync_boundary;
 CREATE PERFETTO TABLE android_jank_cuj_sf_vsync_boundary AS
-SELECT
-  cuj_id,
-  MIN(vsync) AS vsync_min,
-  MAX(vsync) AS vsync_max
-FROM android_jank_cuj_sf_root_slice
-GROUP BY cuj_id;
+SELECT * FROM _android_jank_cuj_sf_vsync_boundary;
 
 DROP TABLE IF EXISTS android_jank_cuj_main_thread_frame_boundary;
 CREATE PERFETTO TABLE android_jank_cuj_main_thread_frame_boundary AS
@@ -56,77 +49,18 @@ DROP TABLE IF EXISTS android_jank_cuj_boundary;
 CREATE PERFETTO TABLE android_jank_cuj_boundary AS
 SELECT * FROM _android_jank_cuj_boundary;
 
--- Similar to `android_jank_cuj_main_thread_frame_boundary`, calculates the frame boundaries
--- based on when we *expected* the work to start and we use the end of the `composite` slice
--- as the end of the work on the frame.
 DROP TABLE IF EXISTS android_jank_cuj_sf_main_thread_frame_boundary;
 CREATE PERFETTO TABLE android_jank_cuj_sf_main_thread_frame_boundary AS
--- Join `commit` and `composite` slices using vsync IDs.
--- We treat the two slices as a single "fake slice" that starts when `commit` starts, and ends
--- when `composite` ends.
-WITH fake_commit_composite_slice AS (
-  SELECT
-    cuj_id,
-    commit_slice.utid,
-    vsync,
-    commit_slice.ts,
-    composite_slice.ts_end,
-    composite_slice.ts_end - commit_slice.ts AS dur
-  FROM android_jank_cuj_sf_commit_slice commit_slice
-  JOIN android_jank_cuj_sf_composite_slice composite_slice USING(cuj_id, vsync)
-),
--- As older builds will not have separate commit/composite slices for each frame, but instead
--- a single `onMessageInvalidate`, we UNION ALL the two tables. Exactly one of them should
--- have data.
-main_thread_slice AS (
-  SELECT utid, cuj_id, vsync, ts, dur, ts_end FROM fake_commit_composite_slice
-  UNION ALL
-  SELECT utid, cuj_id, vsync, ts, dur, ts_end FROM android_jank_cuj_sf_on_message_invalidate_slice
-)
-SELECT
-  cuj_id,
-  utid,
-  vsync,
-  expected_timeline.ts,
-  main_thread_slice.ts AS ts_main_thread_start,
-  main_thread_slice.ts_end,
-  main_thread_slice.ts_end - expected_timeline.ts AS dur
-FROM expected_frame_timeline_slice expected_timeline
-JOIN android_jank_cuj_sf_process USING (upid)
-JOIN main_thread_slice
-  ON main_thread_slice.vsync = CAST(expected_timeline.name AS INTEGER);
+SELECT * FROM _android_jank_cuj_sf_main_thread_frame_boundary;
 
--- Compute the CUJ boundary on the main thread from the frame boundaries.
 DROP TABLE IF EXISTS android_jank_cuj_sf_main_thread_cuj_boundary;
 CREATE PERFETTO TABLE android_jank_cuj_sf_main_thread_cuj_boundary AS
-SELECT
-  cuj_id,
-  utid,
-  MIN(ts) AS ts,
-  MAX(ts_end) AS ts_end,
-  MAX(ts_end) - MIN(ts) AS dur
-FROM android_jank_cuj_sf_main_thread_frame_boundary
-GROUP BY cuj_id, utid;
+SELECT * FROM _android_jank_cuj_sf_main_thread_cuj_boundary;
 
--- RenderEngine will only work on a frame if SF falls back to client composition.
--- Because of that we do not calculate overall CUJ boundaries so there is no
--- `android_jank_cuj_sf_render_engine_cuj_boundary` table created.
--- RenderEngine frame boundaries are calculated based on `composeSurfaces` slice start
--- on the main thread (this calls into RenderEngine), and when `REThreaded::drawLayers`
--- ends.
 DROP TABLE IF EXISTS android_jank_cuj_sf_render_engine_frame_boundary;
 CREATE PERFETTO TABLE android_jank_cuj_sf_render_engine_frame_boundary AS
-SELECT
-  cuj_id,
-  utid,
-  vsync,
-  draw_layers.ts_compose_surfaces AS ts,
-  draw_layers.ts AS ts_draw_layers_start,
-  draw_layers.ts_end,
-  draw_layers.ts_end - draw_layers.ts_compose_surfaces AS dur
-FROM android_jank_cuj_sf_draw_layers_slice draw_layers;
+SELECT * FROM _android_jank_cuj_sf_render_engine_frame_boundary;
 
 DROP TABLE IF EXISTS android_jank_cuj_sf_boundary;
 CREATE PERFETTO TABLE android_jank_cuj_sf_boundary AS
-SELECT cuj_id, ts, ts_end, dur
-FROM android_jank_cuj_sf_main_thread_cuj_boundary;
+SELECT * FROM _android_jank_cuj_sf_boundary;

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/boundaries.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/boundaries.sql
@@ -15,6 +15,8 @@
 
 INCLUDE PERFETTO MODULE android.cujs.base;
 
+INCLUDE PERFETTO MODULE android.surfaceflinger;
+
 INCLUDE PERFETTO MODULE android.cujs.relevant_slices;
 
 -- Stores the min and max vsync IDs for each of the CUJs which are extracted
@@ -323,3 +325,91 @@ FROM _android_jank_cuj_render_thread_frame_boundary
 GROUP BY
   cuj_id,
   utid;
+
+-- Similarly, extract the min/max vsync for the SF from
+-- commit/compose/onMessageInvalidate slices on its main thread.
+CREATE PERFETTO TABLE _android_jank_cuj_sf_vsync_boundary(
+  -- CUJ id.
+  cuj_id LONG,
+  -- Minimum vsync ID within the CUJ.
+  vsync_min LONG,
+  -- Maximum vsync ID within the CUJ.
+  vsync_max LONG
+)
+AS
+SELECT cuj_id, MIN(vsync) AS vsync_min, MAX(vsync) AS vsync_max
+FROM _android_jank_cuj_sf_root_slice
+GROUP BY
+  cuj_id;
+
+-- Compute the CUJ boundary on the main thread from the frame boundaries.
+CREATE PERFETTO TABLE _android_jank_cuj_sf_main_thread_cuj_boundary(
+  -- CUJ id.
+  cuj_id LONG,
+  -- Thread id of the SF main thread.
+  utid JOINID(thread.id),
+  -- Start timestamp of the CUJ on the SF main thread.
+  ts TIMESTAMP,
+  -- End timestamp of the CUJ on the SF main thread.
+  ts_end TIMESTAMP,
+  -- Duration of the CUJ on the SF main thread.
+  dur DURATION
+)
+AS
+SELECT
+  cuj_id,
+  utid,
+  MIN(ts) AS ts,
+  MAX(ts_end) AS ts_end,
+  MAX(ts_end) - MIN(ts) AS dur
+FROM _android_jank_cuj_sf_main_thread_frame_boundary
+GROUP BY
+  cuj_id,
+  utid;
+
+-- RenderEngine will only work on a frame if SF falls back to client composition.
+-- Because of that we do not calculate overall CUJ boundaries so there is no
+-- `_android_jank_cuj_sf_render_engine_cuj_boundary` table created.
+-- RenderEngine frame boundaries are calculated based on `composeSurfaces` slice start
+-- on the main thread (this calls into RenderEngine), and when `REThreaded::drawLayers`
+-- ends.
+CREATE PERFETTO TABLE _android_jank_cuj_sf_render_engine_frame_boundary(
+  -- CUJ id.
+  cuj_id LONG,
+  -- Thread id of the RenderEngine thread.
+  utid JOINID(thread.id),
+  -- Vsync ID of this frame.
+  vsync LONG,
+  -- Timestamp of the composeSurfaces slice bounding this drawLayers.
+  ts TIMESTAMP,
+  -- Start timestamp of the drawLayers slice.
+  ts_draw_layers_start TIMESTAMP,
+  -- End timestamp of the drawLayers slice.
+  ts_end TIMESTAMP,
+  -- Duration of the frame boundary.
+  dur DURATION
+)
+AS
+SELECT
+  cuj_id,
+  utid,
+  vsync,
+  draw_layers.ts_compose_surfaces AS ts,
+  draw_layers.ts AS ts_draw_layers_start,
+  draw_layers.ts_end,
+  draw_layers.ts_end - draw_layers.ts_compose_surfaces AS dur
+FROM _android_jank_cuj_sf_draw_layers_slice AS draw_layers;
+
+CREATE PERFETTO TABLE _android_jank_cuj_sf_boundary(
+  -- CUJ id.
+  cuj_id LONG,
+  -- Start timestamp of the CUJ.
+  ts TIMESTAMP,
+  -- End timestamp of the CUJ.
+  ts_end TIMESTAMP,
+  -- Duration of the CUJ.
+  dur DURATION
+)
+AS
+SELECT cuj_id, ts, ts_end, dur
+FROM _android_jank_cuj_sf_main_thread_cuj_boundary;


### PR DESCRIPTION
Moving the sf boundaries to the stdlib, keeping the original tables unchanged to avoid breaking pipelines that rely on them for now