### PR TITLE
pb: choose a more unique extension id for FieldOptions

### DIFF
--- a/protos/perfetto/trace/field_options.proto
+++ b/protos/perfetto/trace/field_options.proto
@@ -25,5 +25,5 @@ package perfetto.protos;
 extend google.protobuf.FieldOptions {
   // Fully-qualified flags enum for a bitmask int field; trace_processor expands
   // the mask into one string arg per set flag.
-  optional string flags_enum = 51001;
+  optional string flags_enum = 73921;
 }


### PR DESCRIPTION
The chosen id has a conflict in google3. Try a different one in the 50000-99999 range. Checked via g3 presubmit.

Fixes: #6472.