### PR TITLE
tp,ui,docs: Surface the display-video user-build sysprop in docs, record page and trace doctor

### DIFF
--- a/docs/data-sources/video-frames.md
+++ b/docs/data-sources/video-frames.md
@@ -56,7 +56,7 @@ disabled by default: unlock it first by setting a system property over
 ADB.
 
 ```
-adb shell setprop debug.video_tracing_allowed true
+adb shell setprop debug.tracing_video_allowed true
 ```
 
 This property is **not persistent** — it is cleared on the next reboot.

--- a/docs/data-sources/video-frames.md
+++ b/docs/data-sources/video-frames.md
@@ -7,17 +7,21 @@ per-display timeline track that decodes them in the browser. You can
 hover the track to preview a frame, play the frames back like a video,
 and click any frame to line it up with the tracks below it.
 
-It records the actual contents of the screen, so it is meant for
-`userdebug` (debuggable) devices only, and any trace that contains it is
-sensitive: it shows exactly what was on the display.
+It records the actual contents of the screen, so any trace that contains
+it is sensitive: it shows exactly what was on the display. On `userdebug`
+(debuggable) devices it is available out of the box. On `user`
+(production) builds it is disabled by default and must be unlocked with a
+system property first — see [Prerequisite on `user`
+builds](#prerequisite-on-user-builds).
 
 This guide covers:
 
 - [How it works, and what it costs](#how-it-works-and-what-it-costs) —
   how the frames get into the trace, and the overhead on the device.
-- [Capturing display video](#capturing-display-video): the three ways to
-  turn it on — the on-device toggle, the record page, and a raw config
-  with full control over quality and size.
+- [Capturing display video](#capturing-display-video): the property to
+  set first on `user` builds, then the three ways to turn it on — the
+  on-device toggle, the record page, and a raw config with full control
+  over quality and size.
 - [Viewing display video](#viewing-display-video): the timeline track,
   hovering to preview a frame, and playing the capture back with the
   timeline kept in sync.
@@ -41,7 +45,24 @@ When the data source is off, it costs nothing.
 ## Capturing display video
 
 There are three ways to turn on display-video capture, from the simplest
-to the most control.
+to the most control. On `user` builds there is also a one-time-per-boot
+property to set first — see the prerequisite below.
+
+### Prerequisite on `user` builds
+
+On `userdebug` (debuggable) devices, display-video capture works out of
+the box, and you can skip this step. On `user` (production) builds it is
+disabled by default: unlock it first by setting a system property over
+ADB.
+
+```
+adb shell setprop debug.video_tracing_allowed true
+```
+
+This property is **not persistent** — it is cleared on the next reboot.
+After the device restarts you have to set it again before you can capture
+display video. Once it is set, capture works through any of the methods
+below: the on-device toggle, the record page, or a raw config.
 
 ### On the device, with System Tracing
 

--- a/src/trace_processor/importers/common/trace_diagnostics_tracker.cc
+++ b/src/trace_processor/importers/common/trace_diagnostics_tracker.cc
@@ -429,16 +429,12 @@ void RuleDisplayVideoNotEnabled(const TraceConfigDecoder& config,
       });
   if (!has_display_video)
     return;
-  // On userdebug/eng builds capture works out of the box, so an empty table
-  // there points at something else; only fire on user (production) builds.
+  // userdebug/eng builds capture out of the box; only fire on user builds.
   if (!helper->IsAndroidUserBuild())
     return;
-  // Frames were captured: nothing wrong.
-  if (helper->HasVideoFramesEmitted())
+  if (helper->HasVideoFrames())
     return;
-  // The producer reported a failure (codec error, no encoder, size cap, ...);
-  // video *did* run but failed for a known reason, so the sysprop hint would
-  // be misleading.
+  // Producer reported a failure: video ran but failed for another reason.
   if (helper->HasVideoErrorStats())
     return;
   helper->AddTraceDiagnostic(

--- a/src/trace_processor/importers/common/trace_diagnostics_tracker.cc
+++ b/src/trace_processor/importers/common/trace_diagnostics_tracker.cc
@@ -415,6 +415,43 @@ void RuleHeapprofdSamplingIntervalTooLow(const TraceConfigDecoder& config,
       });
 }
 
+// android.display.video was configured but produced no frames, on a user
+// build with no producer error — the most likely cause is that the
+// debug.tracing_video_allowed system property was not enabled (it gates
+// display-video capture on user builds and resets on reboot).
+void RuleDisplayVideoNotEnabled(const TraceConfigDecoder& config,
+                                TraceDiagnosticsHelper* helper) {
+  bool has_display_video = false;
+  helper->ForEachDataSourceConfig(
+      config, [&](const protos::pbzero::DataSourceConfig::Decoder& ds_cfg) {
+        if (ds_cfg.name().ToStdStringView() == "android.display.video")
+          has_display_video = true;
+      });
+  if (!has_display_video)
+    return;
+  // On userdebug/eng builds capture works out of the box, so an empty table
+  // there points at something else; only fire on user (production) builds.
+  if (!helper->IsAndroidUserBuild())
+    return;
+  // Frames were captured: nothing wrong.
+  if (helper->HasVideoFramesEmitted())
+    return;
+  // The producer reported a failure (codec error, no encoder, size cap, ...);
+  // video *did* run but failed for a known reason, so the sysprop hint would
+  // be misleading.
+  if (helper->HasVideoErrorStats())
+    return;
+  helper->AddTraceDiagnostic(
+      "display_video_not_enabled", "Display video not captured",
+      "The trace config requested android.display.video, but no frames were "
+      "captured and the producer reported no errors. On user (production) "
+      "builds display video is disabled until the debug.tracing_video_allowed "
+      "system property is set; it resets on reboot.",
+      "Enable it over ADB before recording, then record again (re-run after "
+      "each reboot): adb shell setprop debug.tracing_video_allowed true",
+      0.7);
+}
+
 constexpr RuleFn kRules[] = {
     &RulePreserveFtraceBufferLateStart,    //
     &RuleTinyFtraceBuffer,                 //
@@ -425,6 +462,7 @@ constexpr RuleFn kRules[] = {
     &RuleDiscardBufferForStreaming,        //
     &RuleAtraceWildcardApps,               //
     &RuleHeapprofdSamplingIntervalTooLow,  //
+    &RuleDisplayVideoNotEnabled,           //
 };
 
 }  // namespace

--- a/src/trace_processor/importers/common/trace_diagnostics_tracker_helper.cc
+++ b/src/trace_processor/importers/common/trace_diagnostics_tracker_helper.cc
@@ -115,4 +115,36 @@ bool TraceDiagnosticsHelper::HasHeapprofdErrorStats() const {
   });
 }
 
+bool TraceDiagnosticsHelper::IsAndroidUserBuild() const {
+  std::optional<SqlValue> fp = context_->metadata_tracker->GetMetadata(
+      metadata::android_build_fingerprint);
+  if (!fp.has_value() || fp->type != SqlValue::kString)
+    return false;
+  // The fingerprint is brand/product/device:release/id/incr:type/tags, so the
+  // build type is the token after the last ':' up to the following '/'.
+  base::StringView s(fp->AsString());
+  size_t colon = s.rfind(':');
+  if (colon == base::StringView::npos)
+    return false;
+  base::StringView rest = s.substr(colon + 1);
+  size_t slash = rest.find('/');
+  base::StringView type =
+      slash == base::StringView::npos ? rest : rest.substr(0, slash);
+  return type == base::StringView("user");
+}
+
+bool TraceDiagnosticsHelper::HasVideoFramesEmitted() const {
+  return AnyPositiveStat(context_, [](size_t key) {
+    return key == stats::android_video_frames_emitted;
+  });
+}
+
+bool TraceDiagnosticsHelper::HasVideoErrorStats() const {
+  return AnyPositiveStat(context_, [](size_t key) {
+    return (stats::kSeverities[key] == stats::kError ||
+            stats::kSeverities[key] == stats::kDataLoss) &&
+           base::StringView(stats::kNames[key]).StartsWith("android_video_");
+  });
+}
+
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/common/trace_diagnostics_tracker_helper.cc
+++ b/src/trace_processor/importers/common/trace_diagnostics_tracker_helper.cc
@@ -133,10 +133,8 @@ bool TraceDiagnosticsHelper::IsAndroidUserBuild() const {
   return type == base::StringView("user");
 }
 
-bool TraceDiagnosticsHelper::HasVideoFramesEmitted() const {
-  return AnyPositiveStat(context_, [](size_t key) {
-    return key == stats::android_video_frames_emitted;
-  });
+bool TraceDiagnosticsHelper::HasVideoFrames() const {
+  return context_->storage->has_android_video_frames();
 }
 
 bool TraceDiagnosticsHelper::HasVideoErrorStats() const {

--- a/src/trace_processor/importers/common/trace_diagnostics_tracker_helper.h
+++ b/src/trace_processor/importers/common/trace_diagnostics_tracker_helper.h
@@ -77,10 +77,8 @@ class TraceDiagnosticsHelper {
   // absent or the build type is anything else (userdebug/eng) or unparseable.
   bool IsAndroidUserBuild() const;
 
-  // Returns true if any android.display.video frames were written to the
-  // __intrinsic_video_frames table (i.e. the android_video_frames_emitted stat
-  // is non-zero) for this (trace, machine).
-  bool HasVideoFramesEmitted() const;
+  // True if the display.video importer emitted any frames.
+  bool HasVideoFrames() const;
 
   // Returns true if any android_video_* stat of severity kError/kDataLoss is
   // non-zero for this (trace, machine), i.e. the producer reported a failure

--- a/src/trace_processor/importers/common/trace_diagnostics_tracker_helper.h
+++ b/src/trace_processor/importers/common/trace_diagnostics_tracker_helper.h
@@ -71,6 +71,23 @@ class TraceDiagnosticsHelper {
   // this (trace, machine).
   bool HasHeapprofdErrorStats() const;
 
+  // Returns true if the trace looks like it came from an Android `user`
+  // (production) build, derived from the build type token in the
+  // android_build_fingerprint metadata. Returns false if the fingerprint is
+  // absent or the build type is anything else (userdebug/eng) or unparseable.
+  bool IsAndroidUserBuild() const;
+
+  // Returns true if any android.display.video frames were written to the
+  // __intrinsic_video_frames table (i.e. the android_video_frames_emitted stat
+  // is non-zero) for this (trace, machine).
+  bool HasVideoFramesEmitted() const;
+
+  // Returns true if any android_video_* stat of severity kError/kDataLoss is
+  // non-zero for this (trace, machine), i.e. the producer reported a failure
+  // (codec error, no encoder, size cap, ...) rather than silently emitting
+  // nothing.
+  bool HasVideoErrorStats() const;
+
   // Invokes `fn` with the decoded DataSourceConfig of every data source in the
   // config.
   template <typename Fn>

--- a/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
+++ b/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
@@ -175,10 +175,8 @@ void VideoFrameModule::ParseVideoFrame(protozero::ConstBytes bytes,
   info.emitted_bytes += static_cast<int64_t>(payload.size);
 
   auto id = table_->Insert(row).id.value;
-  // Count emitted frames so the trace-config diagnostics can tell "no frames
-  // captured" (e.g. debug.tracing_video_allowed not set on a user build) apart
-  // from a producer error, without reaching into this plugin-owned table.
-  context_->stats_tracker->IncrementStats(stats::android_video_frames_emitted);
+  // Signal frame output to trace doctor (see TraceStorage).
+  context_->storage->set_has_android_video_frames();
   // au_data is parallel to the table, indexed by row id.
   PERFETTO_DCHECK(id == au_data_->size());
   const TraceBlobView& packet = data.packet;

--- a/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
+++ b/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
@@ -175,6 +175,10 @@ void VideoFrameModule::ParseVideoFrame(protozero::ConstBytes bytes,
   info.emitted_bytes += static_cast<int64_t>(payload.size);
 
   auto id = table_->Insert(row).id.value;
+  // Count emitted frames so the trace-config diagnostics can tell "no frames
+  // captured" (e.g. debug.tracing_video_allowed not set on a user build) apart
+  // from a producer error, without reaching into this plugin-owned table.
+  context_->stats_tracker->IncrementStats(stats::android_video_frames_emitted);
   // au_data is parallel to the table, indexed by row id.
   PERFETTO_DCHECK(id == au_data_->size());
   const TraceBlobView& packet = data.packet;

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -57,10 +57,6 @@ namespace perfetto::trace_processor::stats {
   F(android_video_parse_size_cap_hit,     kSingle,  kDataLoss, kTrace, Scope::kMachineAndTrace,         \
       "android.display.video stream exceeded the parse-time size cap; frames " \
       "dropped. See the trace_import_logs table for the affected display."),   \
-  F(android_video_frames_emitted,         kSingle,  kInfo,     kTrace, Scope::kMachineAndTrace,         \
-      "Number of android.display.video frames written to "                     \
-      "__intrinsic_video_frames. Zero alongside a display-video config on a "  \
-      "user build usually means debug.tracing_video_allowed was not set."),    \
   F(deobfuscate_location_parse_error,     kSingle,  kError,    kAnalysis, Scope::kGlobal,          ""), \
   F(energy_breakdown_missing_values,      kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
   F(energy_descriptor_invalid,            kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -57,6 +57,10 @@ namespace perfetto::trace_processor::stats {
   F(android_video_parse_size_cap_hit,     kSingle,  kDataLoss, kTrace, Scope::kMachineAndTrace,         \
       "android.display.video stream exceeded the parse-time size cap; frames " \
       "dropped. See the trace_import_logs table for the affected display."),   \
+  F(android_video_frames_emitted,         kSingle,  kInfo,     kTrace, Scope::kMachineAndTrace,         \
+      "Number of android.display.video frames written to "                     \
+      "__intrinsic_video_frames. Zero alongside a display-video config on a "  \
+      "user build usually means debug.tracing_video_allowed was not set."),    \
   F(deobfuscate_location_parse_error,     kSingle,  kError,    kAnalysis, Scope::kGlobal,          ""), \
   F(energy_breakdown_missing_values,      kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \
   F(energy_descriptor_invalid,            kSingle,  kError,    kAnalysis, Scope::kMachineAndTrace, ""), \

--- a/src/trace_processor/storage/trace_storage.h
+++ b/src/trace_processor/storage/trace_storage.h
@@ -1095,11 +1095,21 @@ class TraceStorage {
     return static_cast<Variadic::Type>(idx);
   }
 
+  // Set by the display.video importer when it emits a frame; read by trace
+  // doctor to tell "no capture" from a producer error. A flag not a stat, to
+  // keep per-event counts out of stats. TODO(lalitm): drop once trace doctor
+  // is pluginized and can read __intrinsic_video_frames directly.
+  bool has_android_video_frames() const { return has_android_video_frames_; }
+  void set_has_android_video_frames() { has_android_video_frames_ = true; }
+
  private:
   using StringHash = uint64_t;
 
   TraceStorage(const TraceStorage&) = delete;
   TraceStorage& operator=(const TraceStorage&) = delete;
+
+  // See has_android_video_frames().
+  bool has_android_video_frames_ = false;
 
   TraceStorage(TraceStorage&&) = delete;
   TraceStorage& operator=(TraceStorage&&) = delete;

--- a/test/trace_processor/diff_tests/tables/tests_trace_diagnostics.py
+++ b/test/trace_processor/diff_tests/tables/tests_trace_diagnostics.py
@@ -448,6 +448,62 @@ class TraceDiagnostics(TestSuite):
         0
         """))
 
+  # android.display.video configured on a user build, but no frames captured
+  # and no producer error: trips display_video_not_enabled (the sysprop hint).
+  def test_display_video_not_enabled_on_user_build(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          system_info {
+            android_build_fingerprint: "google/x/x:14/AB/1:user/release-keys"
+          }
+        }
+        packet {
+          trace_config {
+            data_sources {
+              config {
+                name: "android.display.video"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        SELECT key FROM __intrinsic_trace_diagnostics;
+        """,
+        out=Csv("""
+        "key"
+        "display_video_not_enabled"
+        """))
+
+  # Same config on a userdebug build, where display video works out of the box:
+  # the rule must not fire.
+  def test_display_video_userdebug_ok(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          system_info {
+            android_build_fingerprint: "google/x/x:14/AB/1:userdebug/dev-keys"
+          }
+        }
+        packet {
+          trace_config {
+            data_sources {
+              config {
+                name: "android.display.video"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        SELECT count(*) AS n FROM __intrinsic_trace_diagnostics;
+        """,
+        out=Csv("""
+        "n"
+        0
+        """))
+
   # preserve_ftrace_buffer is set but there is no tracing_started_ns metadata to
   # tell how long after boot tracing started. The rule must degrade gracefully.
   def test_preserve_ftrace_buffer_without_clock(self):

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/android.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/android.ts
@@ -147,8 +147,13 @@ function displayVideo(): RecordProbe {
   return {
     id: 'android_display_video',
     title: 'Display video frames',
-    description: 'Captures what each display showed during the trace.',
+    description:
+      'Captures what each display showed during the trace. On user ' +
+      '(production) builds this must be enabled first, until the next ' +
+      'reboot, by running:' +
+      '```adb shell setprop debug.tracing_video_allowed true```',
     supportedPlatforms: ['ANDROID'],
+    docsLink: 'https://perfetto.dev/docs/data-sources/video-frames',
     genConfig: function (tc: TraceConfigBuilder) {
       tc.addDataSource('android.display.video');
     },


### PR DESCRIPTION
  Screen recording (`android.display.video`) is now capturable on `user`
  (production) builds, not just `userdebug`. On user builds it must be unlocked
  first, over ADB, until the next reboot:                              
 
      adb shell setprop debug.tracing_video_allowed true                                                                                      
                                                                       
  The property is cleared on reboot, so it has to be re-set after each restart                                                                
  before display video can be captured. Once set, capture works through any of the                                                            
  existing methods (the on-device toggle, the record page, or a raw config).                                                                  
                                                                       
  This makes that requirement discoverable in three places:                                                                                   
                                                                                                                                              
  **Docs** (`docs/data-sources/video-frames.md`)                                                                                              
  - Drop the "userdebug devices only" statement.                                                                                              
  - Add a "Prerequisite on `user` builds" section documenting the property, the                                                               
    command, and its reset-on-reboot behaviour; point the intro/TOC at it.
                                                                                                                                              
  **Record page** (`Display video frames` probe)                       
  - The probe description now spells out the user-build requirement and shows the
    `setprop` command as a code snippet, and links to the data-source doc.                                                                    
                                                                       
  **Trace doctor** (new `display_video_not_enabled` diagnostic)        
  - Fires when a trace requested `android.display.video` but captured no frames,
    on a `user` build, with no producer error stats — the usual cause being the                                                               
    property was not set. 
  - The video-frames table is owned by the `video_frame_importer` plugin and isn't                                                            
    reachable from the common diagnostics framework, so the plugin now bumps a new                                                            
    `android_video_frames_emitted` stat per inserted frame; the rule reads                                                                    
    emptiness through that stat, alongside the existing `android_video_*` error                                                               
    stats.          