### PR TITLE
ui: rank table search by relevance then importance

### DIFF
--- a/ui/src/base/fuzzy.ts
+++ b/ui/src/base/fuzzy.ts
@@ -22,6 +22,9 @@ export interface FuzzySegment {
 export interface FuzzyResult<T> {
   item: T;
   segments: FuzzySegment[];
+  // Relevance score of the match, higher is better. Exact matches score higher
+  // than fuzzy ones. Empty search terms produce a uniform score of 1.
+  score: number;
 }
 
 export type KeyLookup<T> = (x: T) => string;
@@ -64,13 +67,18 @@ export class FuzzyFinder<T> {
         return {
           item,
           segments: [{matching: false, value: normalisedTerm}],
+          score: 1,
         };
       });
     }
     return this.miniSearch.search(searchTerm).map((result) => {
       const item = this.items[result.id as number];
       const text = this.keyLookup(item);
-      return {item, segments: computeHighlightSegments(searchTerm, text)};
+      return {
+        item,
+        segments: computeHighlightSegments(searchTerm, text),
+        score: result.score,
+      };
     });
   }
 }

--- a/ui/src/base/fuzzy_unittest.ts
+++ b/ui/src/base/fuzzy_unittest.ts
@@ -22,12 +22,16 @@ describe('FuzzyFinder', () => {
     const result = finder.find('');
     // Expect all results are returned in original order.
     expect(result).toEqual([
-      {item: 'aaa', segments: [{matching: false, value: 'aaa'}]},
-      {item: 'aba', segments: [{matching: false, value: 'aba'}]},
-      {item: 'zzz', segments: [{matching: false, value: 'zzz'}]},
-      {item: 'c z d z e', segments: [{matching: false, value: 'c z d z e'}]},
-      {item: 'CAPS', segments: [{matching: false, value: 'CAPS'}]},
-      {item: 'ababc', segments: [{matching: false, value: 'ababc'}]},
+      {item: 'aaa', segments: [{matching: false, value: 'aaa'}], score: 1},
+      {item: 'aba', segments: [{matching: false, value: 'aba'}], score: 1},
+      {item: 'zzz', segments: [{matching: false, value: 'zzz'}], score: 1},
+      {
+        item: 'c z d z e',
+        segments: [{matching: false, value: 'c z d z e'}],
+        score: 1,
+      },
+      {item: 'CAPS', segments: [{matching: false, value: 'CAPS'}], score: 1},
+      {item: 'ababc', segments: [{matching: false, value: 'ababc'}], score: 1},
     ]);
   });
 
@@ -35,7 +39,10 @@ describe('FuzzyFinder', () => {
     const result = finder.find('aaa');
     expect(result).toEqual(
       expect.arrayContaining([
-        {item: 'aaa', segments: [{matching: true, value: 'aaa'}]},
+        expect.objectContaining({
+          item: 'aaa',
+          segments: [{matching: true, value: 'aaa'}],
+        }),
       ]),
     );
   });
@@ -45,22 +52,22 @@ describe('FuzzyFinder', () => {
     // Allow finding results in any order.
     expect(result).toEqual(
       expect.arrayContaining([
-        {
+        expect.objectContaining({
           item: 'aaa',
           // Either |aa|a or a|aa| is valid.
           segments: expect.arrayContaining([
             {matching: true, value: 'aa'},
             {matching: false, value: 'a'},
           ]),
-        },
-        {
+        }),
+        expect.objectContaining({
           item: 'aba',
           segments: [
             {matching: true, value: 'a'},
             {matching: false, value: 'b'},
             {matching: true, value: 'a'},
           ],
-        },
+        }),
       ]),
     );
   });
@@ -77,7 +84,10 @@ describe('FuzzyFinder', () => {
     const result = finder.find('caps');
     expect(result).toEqual(
       expect.arrayContaining([
-        {item: 'CAPS', segments: [{matching: true, value: 'CAPS'}]},
+        expect.objectContaining({
+          item: 'CAPS',
+          segments: [{matching: true, value: 'CAPS'}],
+        }),
       ]),
     );
   });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
@@ -512,7 +512,10 @@ export class TableList implements m.ClassComponent<TableListAttrs> {
     }
 
     // Perform the actual search for display
-    const sortedFuzzyResults = searchAndRankTables(allTables, attrs.searchQuery);
+    const sortedFuzzyResults = searchAndRankTables(
+      allTables,
+      attrs.searchQuery,
+    );
 
     const tableCards = sortedFuzzyResults.map(({item, segments, matchType}) =>
       m(TableCard, {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
@@ -228,6 +228,181 @@ class TableCard
   }
 }
 
+interface SearchResult {
+  item: TableWithModule;
+  segments: FuzzySegment[];
+  matchType: MatchType;
+  // Fuzzy relevance score for table-name matches, higher is better. Unused for
+  // the other (substring-based) match types.
+  score: number;
+}
+
+// Searches tables by query. Returns results in priority order: table name,
+// column name, table description, column description.
+export function searchTables(
+  tables: ReadonlyArray<TableWithModule>,
+  query: string,
+): SearchResult[] {
+  if (query.trim() === '') {
+    return tables.map((table) => ({
+      item: table,
+      segments: [{matching: false, value: table.table.name}],
+      matchType: 'table-name' as MatchType,
+      score: 1,
+    }));
+  }
+
+  // Track which tables have been matched to avoid duplicates
+  const matchedTableNames = new Set<string>();
+
+  // 1. Search by table name (highest priority)
+  const tableFinder = new FuzzyFinder(tables, (item) => item.table.name);
+  const tableNameResults = tableFinder.find(query).map((result) => {
+    matchedTableNames.add(result.item.table.name);
+    return {
+      ...result,
+      matchType: 'table-name' as MatchType,
+    };
+  });
+
+  // 2. Search by column names (second priority) - exact match
+  const columnNameResults: SearchResult[] = [];
+
+  const lowerQuery = query.toLowerCase();
+  for (const tableWithModule of tables) {
+    if (matchedTableNames.has(tableWithModule.table.name)) {
+      continue;
+    }
+
+    const hasMatch = tableWithModule.table.columns.some((col) =>
+      col.name.toLowerCase().includes(lowerQuery),
+    );
+
+    if (hasMatch) {
+      matchedTableNames.add(tableWithModule.table.name);
+      columnNameResults.push({
+        item: tableWithModule,
+        segments: [{matching: false, value: tableWithModule.table.name}],
+        matchType: 'column-name',
+        score: 0,
+      });
+    }
+  }
+
+  // 3. Search by table description (third priority) - exact match
+  const tableDescriptionResults: SearchResult[] = [];
+
+  for (const tableWithModule of tables) {
+    if (matchedTableNames.has(tableWithModule.table.name)) {
+      continue;
+    }
+
+    if (
+      tableWithModule.table.description &&
+      tableWithModule.table.description.toLowerCase().includes(lowerQuery)
+    ) {
+      matchedTableNames.add(tableWithModule.table.name);
+      tableDescriptionResults.push({
+        item: tableWithModule,
+        segments: [{matching: false, value: tableWithModule.table.name}],
+        matchType: 'table-description',
+        score: 0,
+      });
+    }
+  }
+
+  // 4. Search by column descriptions (lowest priority) - exact match
+  const columnDescriptionResults: SearchResult[] = [];
+
+  for (const tableWithModule of tables) {
+    if (matchedTableNames.has(tableWithModule.table.name)) {
+      continue;
+    }
+
+    const hasMatch = tableWithModule.table.columns.some(
+      (col) =>
+        col.description !== undefined &&
+        col.description.toLowerCase().includes(lowerQuery),
+    );
+
+    if (hasMatch) {
+      matchedTableNames.add(tableWithModule.table.name);
+      columnDescriptionResults.push({
+        item: tableWithModule,
+        segments: [{matching: false, value: tableWithModule.table.name}],
+        matchType: 'column-description',
+        score: 0,
+      });
+    }
+  }
+
+  return [
+    ...tableNameResults,
+    ...columnNameResults,
+    ...tableDescriptionResults,
+    ...columnDescriptionResults,
+  ];
+}
+
+// Rounds a fuzzy relevance score into coarse buckets. Matches whose scores land
+// in the same bucket are treated as equally relevant and are then ordered by
+// importance. Larger buckets let importance decide more matches; smaller buckets
+// let fuzzy relevance dominate.
+const FUZZY_SCORE_BUCKET = 0.5;
+
+function fuzzyBucket(score: number): number {
+  return Math.round(score / FUZZY_SCORE_BUCKET);
+}
+
+// Importance as a sortable rank, higher is more important. Tables with no
+// declared importance sit between 'mid' and 'low', matching the previous order.
+const IMPORTANCE_RANK = {core: 4, high: 3, mid: 2, low: 0} as const;
+const DEFAULT_IMPORTANCE_RANK = 1;
+
+function importanceRank(importance?: 'core' | 'high' | 'mid' | 'low'): number {
+  return importance === undefined
+    ? DEFAULT_IMPORTANCE_RANK
+    : IMPORTANCE_RANK[importance];
+}
+
+// Ranks a group of matches lexicographically: bucketed fuzzy relevance first,
+// importance second. So a clearly better match always wins, and importance only
+// decides the order between matches of comparable relevance. The substring match
+// groups carry no fuzzy score, so this reduces to ordering them by importance.
+function rankByRelevance(results: ReadonlyArray<SearchResult>): SearchResult[] {
+  return [...results].sort((a, b) => {
+    const bucketDiff = fuzzyBucket(b.score) - fuzzyBucket(a.score);
+    if (bucketDiff !== 0) return bucketDiff;
+    return (
+      importanceRank(b.item.table.importance) -
+      importanceRank(a.item.table.importance)
+    );
+  });
+}
+
+// Searches and ranks tables for display. Within each match group the order is
+// bucketed fuzzy relevance first, importance second, so that for example the
+// query `androidx_` surfaces the exact extension-server matches
+// (`androidx_art_metrics`) above the merely-fuzzy stdlib matches
+// (`android_frames`), while more important tables still come first among matches
+// of comparable relevance.
+export function searchAndRankTables(
+  tables: ReadonlyArray<TableWithModule>,
+  query: string,
+): SearchResult[] {
+  const searchResults = searchTables(tables, query);
+
+  const rankGroup = (matchType: MatchType) =>
+    rankByRelevance(searchResults.filter((r) => r.matchType === matchType));
+
+  return [
+    ...rankGroup('table-name'),
+    ...rankGroup('column-name'),
+    ...rankGroup('table-description'),
+    ...rankGroup('column-description'),
+  ];
+}
+
 // The main component that displays a searchable list of SQL tables.
 // It orchestrates the search bar, the list of tables, and handles filtering.
 export class TableList implements m.ClassComponent<TableListAttrs> {
@@ -289,125 +464,6 @@ export class TableList implements m.ClassComponent<TableListAttrs> {
         .filter((module) => module.tables.length > 0);
     }
 
-    // Helper function to search tables by query (used for both display and tag filtering)
-    // Returns results in priority order: table name, column name, table description, column description
-    const searchTables = (
-      tables: TableWithModule[],
-      query: string,
-    ): Array<{
-      item: TableWithModule;
-      segments: FuzzySegment[];
-      matchType: MatchType;
-    }> => {
-      if (query.trim() === '') {
-        return tables.map((table) => ({
-          item: table,
-          segments: [{matching: false, value: table.table.name}],
-          matchType: 'table-name' as MatchType,
-        }));
-      }
-
-      // Track which tables have been matched to avoid duplicates
-      const matchedTableNames = new Set<string>();
-
-      // 1. Search by table name (highest priority)
-      const tableFinder = new FuzzyFinder(tables, (item) => item.table.name);
-      const tableNameResults = tableFinder.find(query).map((result) => {
-        matchedTableNames.add(result.item.table.name);
-        return {
-          ...result,
-          matchType: 'table-name' as MatchType,
-        };
-      });
-
-      // 2. Search by column names (second priority) - exact match
-      const columnNameResults: Array<{
-        item: TableWithModule;
-        segments: FuzzySegment[];
-        matchType: MatchType;
-      }> = [];
-
-      const lowerQuery = query.toLowerCase();
-      for (const tableWithModule of tables) {
-        if (matchedTableNames.has(tableWithModule.table.name)) {
-          continue;
-        }
-
-        const hasMatch = tableWithModule.table.columns.some((col) =>
-          col.name.toLowerCase().includes(lowerQuery),
-        );
-
-        if (hasMatch) {
-          matchedTableNames.add(tableWithModule.table.name);
-          columnNameResults.push({
-            item: tableWithModule,
-            segments: [{matching: false, value: tableWithModule.table.name}],
-            matchType: 'column-name',
-          });
-        }
-      }
-
-      // 3. Search by table description (third priority) - exact match
-      const tableDescriptionResults: Array<{
-        item: TableWithModule;
-        segments: FuzzySegment[];
-        matchType: MatchType;
-      }> = [];
-
-      for (const tableWithModule of tables) {
-        if (matchedTableNames.has(tableWithModule.table.name)) {
-          continue;
-        }
-
-        if (
-          tableWithModule.table.description &&
-          tableWithModule.table.description.toLowerCase().includes(lowerQuery)
-        ) {
-          matchedTableNames.add(tableWithModule.table.name);
-          tableDescriptionResults.push({
-            item: tableWithModule,
-            segments: [{matching: false, value: tableWithModule.table.name}],
-            matchType: 'table-description',
-          });
-        }
-      }
-
-      // 4. Search by column descriptions (lowest priority) - exact match
-      const columnDescriptionResults: Array<{
-        item: TableWithModule;
-        segments: FuzzySegment[];
-        matchType: MatchType;
-      }> = [];
-
-      for (const tableWithModule of tables) {
-        if (matchedTableNames.has(tableWithModule.table.name)) {
-          continue;
-        }
-
-        const hasMatch = tableWithModule.table.columns.some(
-          (col) =>
-            col.description !== undefined &&
-            col.description.toLowerCase().includes(lowerQuery),
-        );
-
-        if (hasMatch) {
-          matchedTableNames.add(tableWithModule.table.name);
-          columnDescriptionResults.push({
-            item: tableWithModule,
-            segments: [{matching: false, value: tableWithModule.table.name}],
-            matchType: 'column-description',
-          });
-        }
-      }
-
-      return [
-        ...tableNameResults,
-        ...columnNameResults,
-        ...tableDescriptionResults,
-        ...columnDescriptionResults,
-      ];
-    };
-
     const allTables: TableWithModule[] = filteredModules.flatMap((module) =>
       module.tables.map((table) => ({table, moduleName: module.includeKey})),
     );
@@ -456,46 +512,7 @@ export class TableList implements m.ClassComponent<TableListAttrs> {
     }
 
     // Perform the actual search for display
-    const searchResults = searchTables(allTables, attrs.searchQuery);
-
-    // Helper function to sort by importance within a group
-    const sortByImportance = (
-      results: Array<{
-        item: TableWithModule;
-        segments: FuzzySegment[];
-        matchType: MatchType;
-      }>,
-    ) => {
-      const core = results.filter((r) => r.item.table.importance === 'core');
-      const high = results.filter((r) => r.item.table.importance === 'high');
-      const mid = results.filter((r) => r.item.table.importance === 'mid');
-      const normal = results.filter(
-        (r) => r.item.table.importance === undefined,
-      );
-      const low = results.filter((r) => r.item.table.importance === 'low');
-      return [...core, ...high, ...mid, ...normal, ...low];
-    };
-
-    // Group by match type (already ordered by searchTables), then sort by importance within each group
-    const tableNameResults = searchResults.filter(
-      (r) => r.matchType === 'table-name',
-    );
-    const columnNameResults = searchResults.filter(
-      (r) => r.matchType === 'column-name',
-    );
-    const tableDescResults = searchResults.filter(
-      (r) => r.matchType === 'table-description',
-    );
-    const columnDescResults = searchResults.filter(
-      (r) => r.matchType === 'column-description',
-    );
-
-    const sortedFuzzyResults = [
-      ...sortByImportance(tableNameResults),
-      ...sortByImportance(columnNameResults),
-      ...sortByImportance(tableDescResults),
-      ...sortByImportance(columnDescResults),
-    ];
+    const sortedFuzzyResults = searchAndRankTables(allTables, attrs.searchQuery);
 
     const tableCards = sortedFuzzyResults.map(({item, segments, matchType}) =>
       m(TableCard, {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list_unittest.ts
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 import {searchAndRankTables} from './table_list';
-import type {SqlColumn, SqlTable} from '../../dev.perfetto.SqlModules/sql_modules';
+import type {
+  SqlColumn,
+  SqlTable,
+} from '../../dev.perfetto.SqlModules/sql_modules';
 
 function mkTable(
   name: string,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list_unittest.ts
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {searchAndRankTables} from './table_list';
+import type {SqlColumn, SqlTable} from '../../dev.perfetto.SqlModules/sql_modules';
+
+function mkTable(
+  name: string,
+  opts: {
+    importance?: 'core' | 'high' | 'mid' | 'low';
+    description?: string;
+    columns?: ReadonlyArray<{name: string; description?: string}>;
+  } = {},
+): {table: SqlTable; moduleName: string} {
+  const columns: SqlColumn[] = (opts.columns ?? []).map((c) => ({
+    name: c.name,
+    description: c.description,
+  }));
+  const table = {
+    name,
+    description: opts.description ?? '',
+    type: 'TABLE',
+    importance: opts.importance,
+    columns,
+    getTableColumns: () => [],
+  } as unknown as SqlTable;
+  return {table, moduleName: `module.${name}`};
+}
+
+describe('searchAndRankTables', () => {
+  it('ranks strong fuzzy matches above weak high-importance ones', () => {
+    // Regression test for #6559: searching `androidx_` returned only the fuzzy
+    // stdlib `android_*` matches (which are high importance) while the strong
+    // extension `androidx_*` matches were buried below them. Importance must
+    // not override a clearly better fuzzy match.
+    const tables = [
+      mkTable('android_frames', {importance: 'high'}),
+      mkTable('android_binder_txns', {importance: 'high'}),
+      mkTable('android_input_events', {importance: 'core'}),
+      mkTable('androidx_art_metrics'),
+      mkTable('androidx_frame_timing'),
+    ];
+
+    const ranked = searchAndRankTables(tables, 'androidx_').map(
+      (r) => r.item.table.name,
+    );
+
+    expect(ranked.slice(0, 2)).toEqual([
+      'androidx_art_metrics',
+      'androidx_frame_timing',
+    ]);
+  });
+
+  it('orders matches of comparable relevance by importance', () => {
+    const tables = [
+      mkTable('thread_state', {importance: 'mid'}),
+      mkTable('thread', {importance: 'core'}),
+      mkTable('thread_track', {importance: 'high'}),
+    ];
+
+    const ranked = searchAndRankTables(tables, 'thread').map(
+      (r) => r.item.table.name,
+    );
+
+    expect(ranked).toEqual(['thread', 'thread_track', 'thread_state']);
+  });
+
+  it('ranks name matches above column and description matches', () => {
+    const tables = [
+      mkTable('unrelated', {
+        columns: [{name: 'slice_id'}],
+      }),
+      mkTable('has_desc', {description: 'mentions slice somewhere'}),
+      mkTable('slice_table'),
+    ];
+
+    const ranked = searchAndRankTables(tables, 'slice').map(
+      (r) => r.item.table.name,
+    );
+
+    expect(ranked[0]).toEqual('slice_table');
+    expect(ranked).toContain('unrelated');
+    expect(ranked).toContain('has_desc');
+  });
+
+  it('preserves importance ordering when browsing with an empty query', () => {
+    const tables = [
+      mkTable('b_table', {importance: 'low'}),
+      mkTable('a_table', {importance: 'core'}),
+    ];
+
+    const ranked = searchAndRankTables(tables, '').map(
+      (r) => r.item.table.name,
+    );
+
+    expect(ranked).toEqual(['a_table', 'b_table']);
+  });
+});


### PR DESCRIPTION
The Data Explorer "Choose a table" search ordered table-name matches
purely by table importance, discarding the fuzzy finder's relevance
order. A fuzzy but high-importance stdlib match like android_frames then
floated above an exact match like androidx_art_metrics, so searching
androidx_ surfaced only the stdlib android_* tables and buried the
extension-server androidx_* tables below them.

Rank each match group lexicographically: bucketed fuzzy relevance first,
importance second. A clearly better match always wins, and importance
only decides the order between matches of comparable relevance. Rounding
the fuzzy score into coarse buckets is what lets importance break ties
between similarly-relevant tables.

Expose the match score from FuzzyFinder and extract the search and
ranking out of the Mithril view into pure searchTables and
searchAndRankTables functions with unit tests.

Bug: #6559
