### PR TITLE
ui: Datagrid: Escape dots in field names

### DIFF
--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -58,6 +58,7 @@ import {
   getColumnInfo,
   getDefaultVisibleColumns,
   isCellRenderResult,
+  splitPath,
 } from './datagrid_schema';
 import {DataGridToolbar, GridFilterChip} from './datagrid_toolbar';
 import {ExportButton} from '../../../widgets/export_button';
@@ -644,7 +645,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           this.pivot?.drillDown &&
           this.pivot.drillDown.map(({field, value}) => {
             const colInfo = getColumnInfo(schema, field);
-            const titleParts = colInfo?.titleParts ?? field.split('.');
+            const titleParts = colInfo?.titleParts ?? splitPath(field);
             return {
               title: buildColumnTitle(titleParts),
               value: formatChipValue(value, colInfo?.cellFormatter),
@@ -1480,7 +1481,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       const colInfo = columnInfoCache.get(field);
 
       // Build column title with chevron separators
-      const titleParts = colInfo?.titleParts ?? field.split('.');
+      const titleParts = colInfo?.titleParts ?? splitPath(field);
       const titleContent = buildColumnTitle(titleParts);
 
       // Build menu items
@@ -1803,7 +1804,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
 
       // Get column info from schema
       const colInfo = getColumnInfo(schema, field);
-      const titleParts = colInfo?.titleParts ?? field.split('.');
+      const titleParts = colInfo?.titleParts ?? splitPath(field);
       const titleContent = buildColumnTitle(titleParts);
 
       // Build menu items for groupBy column
@@ -2295,7 +2296,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
     const colInfo = getColumnInfo(schema, filter.field);
 
     // Build column title with chevron separators
-    const titleParts = colInfo?.titleParts ?? filter.field.split('.');
+    const titleParts = colInfo?.titleParts ?? splitPath(filter.field);
     const columnDisplay = buildColumnTitle(titleParts);
 
     if ('value' in filter) {

--- a/ui/src/components/widgets/datagrid/datagrid_schema.ts
+++ b/ui/src/components/widgets/datagrid/datagrid_schema.ts
@@ -170,6 +170,21 @@ export interface ColumnInfo {
 }
 
 /**
+ * Escapes dots in a column name so it can be used as a datagrid field path.
+ * The schema resolver splits paths on single dots (via splitPath()), so a
+ * literal dot is represented by doubling it up.
+ *
+ * @param path The raw column name to escape
+ * @returns The escaped path suitable for use as a datagrid field
+ * @example
+ *   escapePath("foo.bar")  // "foo..bar"
+ *   escapePath("a.b.c")    // "a..b..c"
+ */
+export function escapePath(path: string): string {
+  return path.replace(/\./g, '..');
+}
+
+/**
  * Resolves a column path and returns all information needed for rendering.
  * This consolidates multiple schema lookups into a single traversal.
  *
@@ -177,11 +192,45 @@ export interface ColumnInfo {
  * @param path The column path (e.g., "parent.parent.name")
  * @returns Complete column info, or undefined if path is invalid
  */
+/**
+ * Splits a dot-separated path into its parts. A double dot (`..`) is treated
+ * as an escaped literal dot rather than a separator; a single dot separates
+ * parts.
+ *
+ * @example
+ *   splitPath("parent.child")        → ["parent", "child"]
+ *   splitPath("parent.name..dots")   → ["parent", "name.dots"]
+ *   splitPath("foo..bar")            → ["foo.bar"]
+ *   splitPath("foo..bar.baz")        → ["foo.bar", "baz"]
+ */
+export function splitPath(path: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let i = 0;
+  while (i < path.length) {
+    if (path[i] === '.') {
+      if (path[i + 1] === '.') {
+        current += '.';
+        i += 2;
+      } else {
+        parts.push(current);
+        current = '';
+        i += 1;
+      }
+    } else {
+      current += path[i];
+      i += 1;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
 export function getColumnInfo(
   schema: ColumnSchema,
   path: string,
 ): ColumnInfo | undefined {
-  const parts = path.split('.');
+  const parts = splitPath(path);
 
   const titleParts: m.Children[] = [];
   let currentSchema = schema;

--- a/ui/src/components/widgets/datagrid/datagrid_schema_unittest.ts
+++ b/ui/src/components/widgets/datagrid/datagrid_schema_unittest.ts
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {escapePath, splitPath} from './datagrid_schema';
+
+describe('splitPath', () => {
+  test('empty string returns single empty part', () => {
+    expect(splitPath('')).toStrictEqual(['']);
+  });
+
+  test('single segment with no dots', () => {
+    expect(splitPath('foo')).toStrictEqual(['foo']);
+  });
+
+  test('two segments separated by dot', () => {
+    expect(splitPath('parent.child')).toStrictEqual(['parent', 'child']);
+  });
+
+  test('three segments', () => {
+    expect(splitPath('a.b.c')).toStrictEqual(['a', 'b', 'c']);
+  });
+
+  test('trailing dot produces empty last part', () => {
+    expect(splitPath('foo.')).toStrictEqual(['foo', '']);
+  });
+
+  test('leading dot produces empty first part', () => {
+    expect(splitPath('.foo')).toStrictEqual(['', 'foo']);
+  });
+
+  test('escaped period is preserved in the part', () => {
+    expect(splitPath('parent.name..with..dots')).toStrictEqual([
+      'parent',
+      'name.with.dots',
+    ]);
+  });
+
+  test('escaped period at the start', () => {
+    expect(splitPath('foo..bar.baz')).toStrictEqual(['foo.bar', 'baz']);
+  });
+
+  test('multiple consecutive escaped periods', () => {
+    expect(splitPath('a..b..c..d')).toStrictEqual(['a.b.c.d']);
+  });
+
+  test('mix of escaped and unescaped periods', () => {
+    expect(splitPath('a.b..c.d..e.f')).toStrictEqual(['a', 'b.c', 'd.e', 'f']);
+  });
+
+  test('escaped period between unescaped separators', () => {
+    expect(splitPath('x.y..z.w')).toStrictEqual(['x', 'y.z', 'w']);
+  });
+
+  test('only escaped periods', () => {
+    expect(splitPath('a..b..c')).toStrictEqual(['a.b.c']);
+  });
+
+  test('odd number of dots ends the part on a literal dot', () => {
+    // "foo." followed by a separator then "bar".
+    expect(splitPath('foo...bar')).toStrictEqual(['foo.', 'bar']);
+  });
+});
+
+describe('escapePath', () => {
+  test('leaves plain names unchanged', () => {
+    expect(escapePath('foo')).toBe('foo');
+  });
+
+  test('doubles a single dot', () => {
+    expect(escapePath('foo.bar')).toBe('foo..bar');
+  });
+
+  test('doubles every dot', () => {
+    expect(escapePath('a.b.c')).toBe('a..b..c');
+  });
+
+  test('round-trips through splitPath as a single part', () => {
+    const name = 'weird.name.with.dots';
+    expect(splitPath(escapePath(name))).toStrictEqual([name]);
+  });
+});

--- a/ui/src/components/widgets/datagrid/in_memory_data_source.ts
+++ b/ui/src/components/widgets/datagrid/in_memory_data_source.ts
@@ -23,6 +23,7 @@ import type {
   FlatModel,
 } from './data_source';
 import type {Filter} from './model';
+import {splitPath} from './datagrid_schema';
 
 // Column shape from FlatModel
 type FlatColumn = FlatModel['columns'][number];
@@ -53,7 +54,16 @@ export class InMemoryDataSource implements DataSource {
       return {isPending: false};
     }
 
-    const columns = model.columns;
+    const columns = model.columns.map((col) => {
+      // Split the paths (unescapes dots) and re-join. In-memory datasource
+      // doesn't haev the concept of paths really, so we just index using dots
+      // directly into the datasource.
+      const path = splitPath(col.field).join('.');
+      return {
+        field: path,
+        alias: col.alias,
+      };
+    });
     const filters = model.filters ?? [];
     const sort = model.sort;
 

--- a/ui/src/components/widgets/datagrid/in_memory_data_source_unittest.ts
+++ b/ui/src/components/widgets/datagrid/in_memory_data_source_unittest.ts
@@ -20,53 +20,67 @@ import type {Filter} from './model';
 describe('InMemoryDataSource', () => {
   const sampleData: ReadonlyArray<Row> = [
     {
-      id: 1,
-      name: 'Alice',
-      value: 100,
-      active: 1,
-      tag: 'A',
-      blob: new Uint8Array([1, 2]),
+      'id': 1,
+      'name': 'Alice',
+      'value': 100,
+      'active': 1,
+      'tag': 'A',
+      'blob': new Uint8Array([1, 2]),
+      'foo.bar': 'foo.bar value 1',
     },
     {
-      id: 2,
-      name: 'Bob',
-      value: 200,
-      active: 0,
-      tag: 'B',
-      blob: new Uint8Array([3, 4, 5]),
-    },
-    {id: 3, name: 'Charlie', value: 150, active: 1, tag: 'A', blob: null},
-    {
-      id: 4,
-      name: 'David',
-      value: null,
-      active: 0,
-      tag: 'C',
-      blob: new Uint8Array([6]),
+      'id': 2,
+      'name': 'Bob',
+      'value': 200,
+      'active': 0,
+      'tag': 'B',
+      'blob': new Uint8Array([3, 4, 5]),
+      'foo.bar': 'foo.bar value 2',
     },
     {
-      id: 5,
-      name: 'Eve',
-      value: 100,
-      active: 1,
-      tag: 'B',
-      blob: new Uint8Array([7, 8, 9, 0]),
+      'id': 3,
+      'name': 'Charlie',
+      'value': 150,
+      'active': 1,
+      'tag': 'A',
+      'blob': null,
+      'foo.bar': 'foo.bar value 3',
     },
     {
-      id: 6,
-      name: 'Mallory',
-      value: 300n,
-      active: 0,
-      tag: 'C',
-      blob: new Uint8Array([0]),
+      'id': 4,
+      'name': 'David',
+      'value': null,
+      'active': 0,
+      'tag': 'C',
+      'blob': new Uint8Array([6]),
+      'foo.bar': 'foo.bar value 1',
     },
     {
-      id: 7,
-      name: 'Trent',
-      value: 250n,
-      active: 1,
-      tag: 'A',
-      blob: new Uint8Array([1, 1]),
+      'id': 5,
+      'name': 'Eve',
+      'value': 100,
+      'active': 1,
+      'tag': 'B',
+      'blob': new Uint8Array([7, 8, 9, 0]),
+      'foo.bar': 'foo.bar value 2',
+    },
+    {
+      'id': 6,
+      'name': 'Mallory',
+      'value': 300n,
+      'active': 0,
+      'tag': 'C',
+      'blob': new Uint8Array([0]),
+      'foo.bar': 'foo.bar value 3',
+    },
+    {
+      'id': 7,
+      'name': 'Trent',
+      'value': 250n,
+      'active': 1,
+      'tag': 'A',
+      'blob': new Uint8Array([1, 1]),
+      'foo.bar': 'foo.bar value 4',
     },
   ];
 
@@ -378,5 +392,52 @@ describe('InMemoryDataSource', () => {
     );
     expect(resultAfterUpdate.totalRows).toBe(0);
     expect(resultAfterUpdate.rows).toEqual([]);
+  });
+
+  test('can index field with dot in the name as well as escaped dots in the name', () => {
+    const result = dataSource.useRows(
+      makeModel({
+        columns: [
+          {field: 'foo.bar', alias: 'straight'},
+          {field: 'foo..bar', alias: 'escaped'},
+        ],
+      }),
+    );
+    expect(result.rows?.[0]).toEqual({
+      straight: 'foo.bar value 1',
+      escaped: 'foo.bar value 1',
+    });
+  });
+
+  test('can filter on a field with a dot in the name', () => {
+    const filters: Filter[] = [
+      {field: 'foo.bar', op: '=', value: 'foo.bar value 2'},
+    ];
+    const result = dataSource.useRows(
+      makeModel({
+        columns: [
+          {field: 'id', alias: 'id'},
+          {field: 'foo.bar', alias: 'fooBar'},
+        ],
+        filters,
+      }),
+    );
+    expect(result.rows?.map((r) => r.id).sort()).toEqual([2, 5]); // Bob, Eve
+  });
+
+  test('can filter on a field with a dot in the name using glob', () => {
+    const filters: Filter[] = [
+      {field: 'foo.bar', op: 'glob', value: '*value 3'},
+    ];
+    const result = dataSource.useRows(
+      makeModel({
+        columns: [
+          {field: 'id', alias: 'id'},
+          {field: 'foo.bar', alias: 'fooBar'},
+        ],
+        filters,
+      }),
+    );
+    expect(result.rows?.map((r) => r.id).sort()).toEqual([3, 6]); // Charlie, Mallory
   });
 });

--- a/ui/src/components/widgets/datagrid/sql_data_source/flat.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/flat.ts
@@ -22,7 +22,7 @@ import {NUM, type Row} from '../../../../trace_processor/query_result';
 import {runQueryForQueryTable} from '../../../query_table/queries';
 import type {DataSourceRows, FlatModel} from '../data_source';
 import {type SQLTableSchema, SQLSchemaResolver} from '../sql_schema';
-import {filterToSql, toAlias} from '../sql_utils';
+import {filterToSql, quoteIdentifier} from '../sql_utils';
 
 export class SQLDataSourceFlat {
   private readonly rowCountSlot: QuerySlot<number>;
@@ -73,7 +73,9 @@ export class SQLDataSourceFlat {
           const sqlExpr = resolver.resolveColumnPath(col.field);
           const field = sqlExpr ?? col.field;
           const aggFunc = col.aggregate!;
-          selectExprs.push(`${aggFunc}(${field}) AS ${toAlias(col.alias)}`);
+          selectExprs.push(
+            `${aggFunc}(${field}) AS ${quoteIdentifier(col.alias)}`,
+          );
         }
 
         let sql = `SELECT ${selectExprs.join(', ')}`;
@@ -195,7 +197,7 @@ function buildSelectClause(
   for (const col of columns) {
     const sqlExpr = resolver.resolveColumnPath(col.field);
     if (sqlExpr) {
-      const alias = toAlias(col.alias);
+      const alias = quoteIdentifier(col.alias);
       selectExprs.push(`${sqlExpr} AS ${alias}`);
     }
   }

--- a/ui/src/components/widgets/datagrid/sql_data_source/group_by.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/group_by.ts
@@ -22,7 +22,7 @@ import {NUM, type Row} from '../../../../trace_processor/query_result';
 import {runQueryForQueryTable} from '../../../query_table/queries';
 import type {DataSourceRows, PivotModel} from '../data_source';
 import {type SQLTableSchema, SQLSchemaResolver} from '../sql_schema';
-import {filterToSql, sqlAggregateExpr, toAlias} from '../sql_utils';
+import {filterToSql, quoteIdentifier, sqlAggregateExpr} from '../sql_utils';
 
 // Flat GROUP BY datasource - uses simple GROUP BY queries without hierarchy.
 export class SQLDataSourceGroupBy {
@@ -131,7 +131,7 @@ export class SQLDataSourceGroupBy {
         const fieldExpr = resolver.resolveColumnPath(agg.field);
         aggExpr = sqlAggregateExpr(agg.function, fieldExpr ?? agg.field);
       }
-      selectExprs.push(`${aggExpr} AS ${toAlias(agg.alias)}`);
+      selectExprs.push(`${aggExpr} AS ${quoteIdentifier(agg.alias)}`);
     }
 
     const baseTable = resolver.getBaseTableOrSubquery();
@@ -167,7 +167,7 @@ export class SQLDataSourceGroupBy {
     for (const col of groupBy) {
       const sqlExpr = resolver.resolveColumnPath(col.field);
       if (sqlExpr) {
-        selectExprs.push(`${sqlExpr} AS ${toAlias(col.alias)}`);
+        selectExprs.push(`${sqlExpr} AS ${quoteIdentifier(col.alias)}`);
       }
     }
 
@@ -179,7 +179,7 @@ export class SQLDataSourceGroupBy {
         const fieldExpr = resolver.resolveColumnPath(agg.field);
         aggExpr = sqlAggregateExpr(agg.function, fieldExpr ?? agg.field);
       }
-      selectExprs.push(`${aggExpr} AS ${toAlias(agg.alias)}`);
+      selectExprs.push(`${aggExpr} AS ${quoteIdentifier(agg.alias)}`);
     }
 
     const baseTable = resolver.getBaseTableOrSubquery();
@@ -211,7 +211,7 @@ export class SQLDataSourceGroupBy {
 
     if (sort) {
       // Sort strings case insensitively
-      sql += `\nORDER BY ${toAlias(sort.alias)} COLLATE NOCASE ${sort.direction} `;
+      sql += `\nORDER BY ${quoteIdentifier(sort.alias)} COLLATE NOCASE ${sort.direction} `;
     }
 
     if (pagination) {

--- a/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
@@ -32,7 +32,7 @@ import type {DataSourceRows, PivotModel} from '../data_source';
 import type {GroupPath} from '../model';
 import {serializeFilters} from './group_by';
 import {type SQLTableSchema, SQLSchemaResolver} from '../sql_schema';
-import {filterToSql, sqlAggregateExpr, toAlias} from '../sql_utils';
+import {filterToSql, quoteIdentifier, sqlAggregateExpr} from '../sql_utils';
 import {stringifyJsonWithBigints} from '../../../../base/json_utils';
 
 /**
@@ -313,11 +313,11 @@ export class SQLDataSourceRollupTree {
     const columnAliases: Record<string, string> = {};
     const aliasToColumn: Record<string, string> = {};
     for (let i = 0; i < groupBy.length; i++) {
-      columnAliases[`__group_${i}`] = toAlias(groupBy[i].alias);
+      columnAliases[`__group_${i}`] = quoteIdentifier(groupBy[i].alias);
       aliasToColumn[groupBy[i].alias] = `__group_${i}`;
     }
     for (let i = 0; i < aggregates.length; i++) {
-      columnAliases[`__agg_${i}`] = toAlias(aggregates[i].alias);
+      columnAliases[`__agg_${i}`] = quoteIdentifier(aggregates[i].alias);
       aliasToColumn[aggregates[i].alias] = `__agg_${i}`;
     }
     return {columnAliases, aliasToColumn};

--- a/ui/src/components/widgets/datagrid/sql_data_source/tree.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/tree.ts
@@ -27,7 +27,7 @@ import {
 import {runQueryForQueryTable} from '../../../query_table/queries';
 import type {DataSourceRows, TreeModel} from '../data_source';
 import {type SQLTableSchema, SQLSchemaResolver} from '../sql_schema';
-import {filterToSql, sqlValue, toAlias} from '../sql_utils';
+import {filterToSql, quoteIdentifier, sqlValue} from '../sql_utils';
 
 /**
  * SQL data source for tree mode using id/parent_id columns.
@@ -82,7 +82,7 @@ export class SQLDataSourceTree {
     // Build column alias mappings
     const columnAliases: Record<string, string> = {};
     for (const col of columns) {
-      columnAliases[col.field] = toAlias(col.alias);
+      columnAliases[col.field] = quoteIdentifier(col.alias);
     }
 
     // Determine sort column and direction
@@ -212,7 +212,7 @@ export class SQLDataSourceTree {
     for (const col of columns) {
       const sqlExpr = resolver.resolveColumnPath(col.field);
       if (sqlExpr) {
-        selectExprs.push(`${sqlExpr} AS ${toAlias(col.alias)}`);
+        selectExprs.push(`${sqlExpr} AS ${quoteIdentifier(col.alias)}`);
       }
     }
 
@@ -267,7 +267,7 @@ export class SQLDataSourceTree {
     if (sort) {
       const sortCol = columns.find((c) => c.alias === sort.alias);
       if (sortCol) {
-        sortColumn = toAlias(sortCol.alias);
+        sortColumn = quoteIdentifier(sortCol.alias);
       }
       sortDirection = sort.direction;
     }

--- a/ui/src/components/widgets/datagrid/sql_schema.ts
+++ b/ui/src/components/widgets/datagrid/sql_schema.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import {maybeUndefined} from '../../../base/utils';
+import {splitPath} from './datagrid_schema';
+import {quoteIdentifier} from './sql_utils';
 
 /**
  * SQL Schema system for SQLDataSource.
@@ -39,7 +41,11 @@ import {maybeUndefined} from '../../../base/utils';
  *       foreignKey: 'parent_id',
  *     },
  *     args: {
- *       expression: (alias, key) => `extract_arg(${alias}.arg_set_id, '${key}')`,
+ *       // `key` may come from user/trace data, so it must go through
+ *       // sqlValue() rather than being interpolated directly - otherwise a
+ *       // key containing a quote could break out of the string literal.
+ *       expression: (alias, key) =>
+ *         `extract_arg(${alias}.arg_set_id, ${sqlValue(key ?? null)})`,
  *       parameterized: true,
  *     },
  *   },
@@ -108,7 +114,9 @@ export interface SQLExpressionDef {
    * SQL expression generator.
    *
    * For simple expressions: (alias) => `${alias}.some_col`
-   * For parameterized: (alias, key) => `extract_arg(${alias}.arg_set_id, '${key}')`
+   * For parameterized (escape `key` with sqlValue() - it may come from
+   * user/trace data): (alias, key) =>
+   *   `extract_arg(${alias}.arg_set_id, ${sqlValue(key ?? null)})`
    */
   readonly expression: (tableAlias: string, paramKey?: string) => string;
 
@@ -257,7 +265,7 @@ export class SQLSchemaResolver {
    * @returns The SQL expression, or undefined if the path is invalid
    */
   resolveColumnPath(path: string): string | undefined {
-    const parts = path.split('.');
+    const parts = splitPath(path);
     return this.resolvePath(parts, this.schema, this.baseAlias);
   }
 
@@ -274,10 +282,12 @@ export class SQLSchemaResolver {
     const colDef = maybeUndefined(schema.columns?.[first]);
 
     if (!colDef) {
-      // Column not found in schema - treat as raw column name
-      // This allows passthrough for columns not explicitly defined
+      // Column not found in schema - treat as raw column name.
+      // This allows passthrough for columns not explicitly defined, so the
+      // name (which may come from user/trace data rather than a trusted
+      // schema definition) must be quoted as an identifier.
       if (rest.length === 0) {
-        return `${currentAlias}.${first}`;
+        return `${currentAlias}.${quoteIdentifier(first)}`;
       }
       return undefined;
     }

--- a/ui/src/components/widgets/datagrid/sql_utils.ts
+++ b/ui/src/components/widgets/datagrid/sql_utils.ts
@@ -39,10 +39,11 @@ export function sqlValue(value: SqlValue): string {
 }
 
 /**
- * Converts a string to a valid SQL alias by wrapping in double quotes.
+ * Converts a string to a valid SQL identifier (e.g. column, table, or alias
+ * name) by wrapping in double quotes.
  * Escapes internal double quotes by doubling them (SQL standard).
  */
-export function toAlias(id: string): string {
+export function quoteIdentifier(id: string): string {
   return `"${id.replace(/"/g, '""')}"`;
 }
 

--- a/ui/src/components/widgets/datagrid/sql_utils_unittest.ts
+++ b/ui/src/components/widgets/datagrid/sql_utils_unittest.ts
@@ -14,13 +14,13 @@
 
 import {
   filterToSql,
+  quoteIdentifier,
   sqlAggregateExpr,
   sqlPathMatch,
   sqlPathNotMatch,
   sqlPathsIn,
   sqlPathsNotIn,
   sqlValue,
-  toAlias,
 } from './sql_utils';
 
 describe('sqlValue', () => {
@@ -57,13 +57,13 @@ describe('sqlValue', () => {
   });
 });
 
-describe('toAlias', () => {
+describe('quoteIdentifier', () => {
   test('simple identifier', () => {
-    expect(toAlias('foo')).toBe('"foo"');
+    expect(quoteIdentifier('foo')).toBe('"foo"');
   });
 
   test('identifier with spaces', () => {
-    expect(toAlias('foo bar')).toBe('"foo bar"');
+    expect(quoteIdentifier('foo bar')).toBe('"foo bar"');
   });
 });
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/results_panel.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/results_panel.ts
@@ -15,6 +15,7 @@
 import m from 'mithril';
 import type {QueryResponse} from '../../../components/query_table/queries';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
+import {escapePath} from '../../../components/widgets/datagrid/datagrid_schema';
 import type {
   CellRenderer,
   ColumnSchema,
@@ -474,7 +475,7 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
           }
         }
 
-        schema[c] = {cellRenderer, columnType};
+        schema[escapePath(c)] = {cellRenderer, columnType};
       }
 
       // Build menu items for joinid columns (add columns from related tables)
@@ -577,8 +578,8 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
       const sortDir = this.columns.find((c) => c.sort)?.sort;
       this.columns = attrs.response.columns.map((col) => ({
         id: col,
-        field: col,
-        ...(col === sortedColId ? {sort: sortDir} : {}),
+        field: escapePath(col),
+        ...(escapePath(col) === sortedColId ? {sort: sortDir} : {}),
       }));
 
       return [

--- a/ui/src/plugins/dev.perfetto.QueryPage/results_table.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/results_table.ts
@@ -18,7 +18,10 @@ import {Icons} from '../../base/semantic_icons';
 import {AddDebugTrackMenu} from '../../components/tracks/add_debug_track_menu';
 import {DataGrid, renderCell} from '../../components/widgets/datagrid/datagrid';
 import {InMemoryDataSource} from '../../components/widgets/datagrid/in_memory_data_source';
-import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
+import {
+  escapePath,
+  type ColumnSchema,
+} from '../../components/widgets/datagrid/datagrid_schema';
 import type {Trace} from '../../public/trace';
 import type {Row} from '../../trace_processor/query_result';
 import {Anchor} from '../../widgets/anchor';
@@ -146,12 +149,13 @@ export class ResultsTable implements m.Component<ResultsTableAttrs> {
     const resolvedTable = this.resolveIdTable(data.columns);
 
     for (const col of data.columns) {
+      const field = escapePath(col);
       const cellRenderer =
         col === 'id' && attrs.onIdClick
           ? (value: Row[string]) =>
               this.renderIdCell(value, resolvedTable, attrs.onIdClick!)
           : undefined;
-      schema[col] = {
+      schema[field] = {
         title: col,
         cellRenderer,
       };


### PR DESCRIPTION
Add splitPath/escapePath so column names containing literal dots work correctly. Rename toAlias() to quoteIdentifier().

Field names passed to datagrid (field paths) are dot separated (e.g. parent.id, or track.name) when used to reference nested tables as defined by the schema. The trouble is sometimes we provide these field names from unescaped raw values from the user, which can themselves contain dots.

This patch establishes an escaping format where we dots are treated as path delimiters but double dots are escaped.
E.g.
  - `foo.bar` -> `['foo', 'bar']`
  - `foo..bar` -> `['foo.bar']`
  - `foo...bar` -> `['foo.', 'bar']`