### PR TITLE
tp: workaround SQLite bug with LEFT JOINs

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -18799,6 +18799,14 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/perfetto_sql/stdlib/std/thread:thread
+filegroup {
+    name: "perfetto_src_trace_processor_perfetto_sql_stdlib_std_thread_thread",
+    srcs: [
+        "src/trace_processor/perfetto_sql/stdlib/std/thread/with_context.sql",
+    ],
+}
+
 // GN: //src/trace_processor/perfetto_sql/stdlib/std/traceinfo:traceinfo
 filegroup {
     name: "perfetto_src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
@@ -18840,6 +18848,7 @@ genrule {
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_stacks_stacks",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_std_gpu_gpu",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_std_metasql_metasql",
+        ":perfetto_src_trace_processor_perfetto_sql_stdlib_std_thread_thread",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_std_trees_trees",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_time_time",

--- a/BUILD
+++ b/BUILD
@@ -4164,6 +4164,14 @@ perfetto_filegroup(
     ],
 )
 
+# GN target: //src/trace_processor/perfetto_sql/stdlib/std/thread:thread
+perfetto_filegroup(
+    name = "src_trace_processor_perfetto_sql_stdlib_std_thread_thread",
+    srcs = [
+        "src/trace_processor/perfetto_sql/stdlib/std/thread/with_context.sql",
+    ],
+)
+
 # GN target: //src/trace_processor/perfetto_sql/stdlib/std/traceinfo:traceinfo
 perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
@@ -4290,6 +4298,7 @@ perfetto_cpp_blob_header(
         ":src_trace_processor_perfetto_sql_stdlib_stacks_stacks",
         ":src_trace_processor_perfetto_sql_stdlib_std_gpu_gpu",
         ":src_trace_processor_perfetto_sql_stdlib_std_metasql_metasql",
+        ":src_trace_processor_perfetto_sql_stdlib_std_thread_thread",
         ":src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
         ":src_trace_processor_perfetto_sql_stdlib_std_trees_trees",
         ":src_trace_processor_perfetto_sql_stdlib_time_time",

--- a/src/trace_processor/perfetto_sql/stdlib/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/BUILD.gn
@@ -37,6 +37,7 @@ perfetto_amalgamated_sql_header("stdlib") {
     "stacks",
     "std/gpu",
     "std/metasql",
+    "std/thread",
     "std/traceinfo",
     "std/trees",
     "time",

--- a/src/trace_processor/perfetto_sql/stdlib/sched/with_context.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/sched/with_context.sql
@@ -13,6 +13,8 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+INCLUDE PERFETTO MODULE std.thread.with_context;
+
 -- View of scheduling slices with extended information.
 -- It holds slices with kernel thread scheduling information. These slices are
 -- collected when the Linux "ftrace" data source is used with the
@@ -56,16 +58,16 @@ SELECT
   sched.dur,
   utid,
   upid,
-  thread.name AS thread_name,
-  process.name AS process_name,
+  _thread_with_process.thread_name,
+  _thread_with_process.process_name,
   sched.cpu,
   sched.end_state,
   sched.priority
--- Join order matters: list the small dimensions first and the large fact table
--- (sched) last. A `LEFT JOIN` pins its right table after everything to its
--- left, so writing `sched ... LEFT JOIN process` forces `process` to be
--- re-probed once per sched row; attaching `process` to `thread` and joining
--- `sched` last lets the planner drive from whichever dimension is filtered.
-FROM thread
-LEFT JOIN process USING (upid)
+-- Join order matters. The thread/process context is pre-joined in
+-- `_thread_with_process` so that all joins here are INNER (the `thread LEFT JOIN
+-- process` is materialized in that table): SQLite will not reorder a virtual
+-- table across a LEFT JOIN, which would stop the planner from driving an
+-- id-keyed join into this view off `sched.id`. Dimensions first, the large fact
+-- table (sched) last, so the planner can drive from whichever side is filtered.
+FROM _thread_with_process
 JOIN sched USING (utid);

--- a/src/trace_processor/perfetto_sql/stdlib/slices/with_context.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/slices/with_context.sql
@@ -13,6 +13,8 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+INCLUDE PERFETTO MODULE std.thread.with_context;
+
 -- All thread slices with data about thread, thread track and process.
 CREATE PERFETTO VIEW thread_slice(
   -- Slice
@@ -63,26 +65,26 @@ SELECT
   slice.name,
   slice.track_id,
   thread_track.name AS track_name,
-  thread.name AS thread_name,
-  thread.utid,
-  thread.tid,
-  thread.is_main_thread,
-  process.name AS process_name,
-  process.upid,
-  process.pid,
+  _thread_with_process.thread_name,
+  _thread_with_process.utid,
+  _thread_with_process.tid,
+  _thread_with_process.is_main_thread,
+  _thread_with_process.process_name,
+  _thread_with_process.upid,
+  _thread_with_process.pid,
   slice.depth,
   slice.parent_id,
   slice.arg_set_id,
   slice.thread_ts,
   slice.thread_dur
--- Join order matters: dimensions first, the large fact table (slice) last. A
--- `LEFT JOIN` pins its right table after everything to its left, so
--- `slice ... LEFT JOIN process` re-probes `process` once per slice; attaching
--- `process` to `thread` and joining `slice` last lets the planner drive from
--- whichever dimension is filtered.
+-- Join order matters. The thread/process context is pre-joined in
+-- `_thread_with_process` so that all joins here are INNER (the `thread LEFT JOIN
+-- process` is materialized in that table): SQLite will not reorder a virtual
+-- table across a LEFT JOIN, which would stop the planner from driving an
+-- id-keyed join into this view off `slice.id`. Dimensions first, the large fact
+-- table (slice) last, so the planner can drive from whichever side is filtered.
 FROM thread_track
-JOIN thread USING (utid)
-LEFT JOIN process USING (upid)
+JOIN _thread_with_process USING (utid)
 JOIN slice
   ON slice.track_id = thread_track.id;
 
@@ -186,19 +188,18 @@ SELECT
   slice.name,
   slice.track_id,
   thread_track.name AS track_name,
-  thread.name AS thread_name,
-  thread.utid,
-  thread.tid,
-  process.name AS process_name,
-  process.upid AS upid,
-  process.pid AS pid,
+  _thread_with_process.thread_name,
+  _thread_with_process.utid,
+  _thread_with_process.tid,
+  _thread_with_process.process_name,
+  _thread_with_process.upid,
+  _thread_with_process.pid,
   slice.depth,
   slice.parent_id,
   slice.arg_set_id
 -- Dimensions first, fact table (slice) last -- see thread_slice above.
 FROM thread_track
-JOIN thread USING (utid)
-LEFT JOIN process USING (upid)
+JOIN _thread_with_process USING (utid)
 JOIN slice
   ON slice.track_id = thread_track.id
 UNION ALL

--- a/src/trace_processor/perfetto_sql/stdlib/std/thread/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/std/thread/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../../../gn/perfetto_sql.gni")
+
+perfetto_sql_source_set("thread") {
+  sources = [ "with_context.sql" ]
+}

--- a/src/trace_processor/perfetto_sql/stdlib/std/thread/with_context.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/std/thread/with_context.sql
@@ -1,0 +1,37 @@
+--
+-- Copyright 2026 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Each thread joined with its (optional) process, materialized into a table so
+-- that callers can attach thread+process context with a single INNER JOIN on
+-- `utid` instead of writing `thread LEFT JOIN process`.
+--
+-- Why this exists: SQLite will not reorder a virtual table across a LEFT JOIN,
+-- so a context view that embeds `thread ... LEFT JOIN process` directly cannot
+-- be driven from a point-lookup on the fact table's id when it is joined into
+-- from another table (the id constraint is never offered to xBestIndex, and the
+-- join collapses into a full scan). Pre-computing the thread/process LEFT JOIN
+-- here lets those views use only INNER joins, which the planner can reorder
+-- freely. Internal only for now.
+CREATE PERFETTO TABLE _thread_with_process AS
+SELECT
+  thread.utid,
+  thread.tid,
+  thread.name AS thread_name,
+  thread.is_main_thread,
+  process.upid,
+  process.pid,
+  process.name AS process_name
+FROM thread
+LEFT JOIN process USING (upid);


### PR DESCRIPTION
There's a missing optimization with left joins which I believe is an
SQLite bug. Reported upstream but in the meantime workaround it.

Fixes: b/535068603
