### PR TITLE
DNS: tp+ui: join display-video frames to their frame-timeline vsync id

### DIFF
--- a/protos/third_party/android/frameworks/native/tracing/frameworks_native_trace_packet.proto
+++ b/protos/third_party/android/frameworks/native/tracing/frameworks_native_trace_packet.proto
@@ -378,6 +378,23 @@ message FrameTimelineEvent {
     optional int64 cookie = 1;
   };
 
+  // Emitted once per composite queued to a virtual display's output surface
+  // (e.g. a display-video mirror feeding a MediaCodec input surface). Ties the
+  // frame-timeline token of that composite to the exact present time stamped on
+  // the queued buffer. A surface-input encoder carries that buffer timestamp
+  // through unchanged as the frame's presentation time, so present_time_us
+  // equals the encoded frame's presentationTimeUs and a consumer can join the
+  // token to that frame with certainty.
+  message VirtualDisplayComposite {
+    // SurfaceFlinger's id for the virtual display.
+    optional int64 display_id = 1;
+    // The frame-timeline token (vsync id) of the composite.
+    optional int64 vsync_id = 2;
+    // CLOCK_MONOTONIC present time stamped on the queued buffer, in
+    // microseconds. Equals the encoded frame's presentationTimeUs.
+    optional int64 present_time_us = 3;
+  };
+
   oneof event {
     ExpectedDisplayFrameStart expected_display_frame_start = 1;
     ActualDisplayFrameStart actual_display_frame_start = 2;
@@ -386,6 +403,8 @@ message FrameTimelineEvent {
     ActualSurfaceFrameStart actual_surface_frame_start = 4;
 
     FrameEnd frame_end = 5;
+
+    VirtualDisplayComposite virtual_display_composite = 6;
   }
 }
 

--- a/src/trace_processor/plugins/video_frame_importer/BUILD.gn
+++ b/src/trace_processor/plugins/video_frame_importer/BUILD.gn
@@ -37,6 +37,7 @@ source_set("video_frame_importer") {
     "../../../../protos/perfetto/common:zero",
     "../../../../protos/perfetto/trace:zero",
     "../../../../protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_trace_packet_zero",
+    "../../../../protos/third_party/android/frameworks/native/tracing:frameworks_native_trace_packet_zero",
     "../../../base",
     "../../../protozero",
     "../../core/plugin",

--- a/src/trace_processor/plugins/video_frame_importer/tables.py
+++ b/src/trace_processor/plugins/video_frame_importer/tables.py
@@ -39,6 +39,9 @@ ANDROID_VIDEO_FRAMES_TABLE = Table(
         C('is_key_frame', CppOptional(CppInt32())),
         C('pts_us', CppOptional(CppInt64())),
         C('is_config', CppOptional(CppInt32())),
+        C('frame_timeline_vsync_id',
+          CppOptional(CppInt64()),
+          cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE),
     ],
     tabledoc=TableDoc(
         doc='''
@@ -63,6 +66,11 @@ ANDROID_VIDEO_FRAMES_TABLE = Table(
             'pts_us': 'For access units: codec presentation timestamp (us).',
             'is_config': '1 if this row carries codec_config '
                          '(decoder setup), not a displayable frame.',
+            'frame_timeline_vsync_id':
+                'For access units: the frame-timeline vsync id (SurfaceFlinger '
+                'DisplayFrame token) of the composite that produced this frame, '
+                'joined from VirtualDisplayComposite frame-timeline events by '
+                'matching pts_us to the composite present time.',
         }))
 
 # Keep this list sorted.

--- a/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
+++ b/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
@@ -40,10 +40,13 @@
 #include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.pbzero.h"
+#include "protos/third_party/android/frameworks/native/tracing/frameworks_native_trace_packet.pbzero.h"
 
 namespace perfetto::trace_processor {
 
+using ::com::android::internal::pbzero::FrameTimelineEvent;
 using ::com::android::internal::pbzero::FrameworksBaseTracePacket;
+using ::com::android::internal::pbzero::FrameworksNativeTracePacket;
 using ::com::android::internal::pbzero::VideoFrame;
 using ::com::android::internal::pbzero::VideoFrameError;
 using ::perfetto::protos::pbzero::TracePacket;
@@ -58,6 +61,11 @@ VideoFrameModule::VideoFrameModule(ProtoImporterModuleContext* mc,
       au_data_(au_data) {
   RegisterForField(FrameworksBaseTracePacket::kVideoFrameFieldNumber);
   RegisterForField(FrameworksBaseTracePacket::kVideoFrameErrorFieldNumber);
+  // Also observe frame-timeline events, to pick out VirtualDisplayComposite and
+  // join the exact composite token onto each video frame by present time. This
+  // field is also handled by GraphicsEventModule; multiple modules per field is
+  // supported.
+  RegisterForField(FrameworksNativeTracePacket::kFrameTimelineEventFieldNumber);
 }
 
 VideoFrameModule::~VideoFrameModule() = default;
@@ -99,6 +107,10 @@ void VideoFrameModule::ParseField(const ParseFieldArgs& args) {
       ParseVideoFrameError(
           args.field.Cast<FrameworksBaseTracePacket::kVideoFrameError>(),
           args.ts);
+      break;
+    case FrameworksNativeTracePacket::kFrameTimelineEventFieldNumber:
+      ParseFrameTimelineEvent(
+          args.field.Cast<FrameworksNativeTracePacket::kFrameTimelineEvent>());
       break;
     default:
       break;
@@ -174,11 +186,17 @@ void VideoFrameModule::ParseVideoFrame(protozero::ConstBytes bytes,
   }
   info.emitted_bytes += static_cast<int64_t>(payload.size);
 
-  auto id = table_->Insert(row).id.value;
+  auto id_and_row = table_->Insert(row);
+  auto id = id_and_row.id.value;
   // Signal frame output to trace doctor (see TraceStorage).
   context_->storage->set_has_android_video_frames();
   // au_data is parallel to the table, indexed by row id.
   PERFETTO_DCHECK(id == au_data_->size());
+  // Remember access-unit rows so their vsync id can be backfilled from
+  // VirtualDisplayComposite events once all packets are parsed.
+  if (row.pts_us.has_value()) {
+    row_pts_us_.emplace_back(id_and_row.row, *row.pts_us);
+  }
   const TraceBlobView& packet = data.packet;
   const uint8_t* base = packet.blob()->data();
   PERFETTO_DCHECK(payload.data >= base &&
@@ -226,6 +244,34 @@ void VideoFrameModule::ParseVideoFrameError(protozero::ConstBytes bytes,
         inserter.AddArg(context_->storage->InternString("display_id"),
                         Variadic::UnsignedInteger(display_id));
       });
+}
+
+void VideoFrameModule::ParseFrameTimelineEvent(protozero::ConstBytes bytes) {
+  FrameTimelineEvent::Decoder event(bytes);
+  if (!event.has_virtual_display_composite()) {
+    return;
+  }
+  FrameTimelineEvent::VirtualDisplayComposite::Decoder vdc(
+      event.virtual_display_composite());
+  if (!vdc.has_present_time_us() || !vdc.has_vsync_id()) {
+    return;
+  }
+  // present_time_us is the composite buffer's present time in microseconds,
+  // which a surface-input encoder carries through unchanged as the frame's
+  // pts_us, so it is the exact join key.
+  vsync_id_by_present_us_[vdc.present_time_us()] = vdc.vsync_id();
+}
+
+void VideoFrameModule::OnEventsFullyExtracted() {
+  if (vsync_id_by_present_us_.size() == 0) {
+    return;
+  }
+  for (const auto& [row, pts_us] : row_pts_us_) {
+    const int64_t* vsync_id = vsync_id_by_present_us_.Find(pts_us);
+    if (vsync_id) {
+      (*table_)[row].set_frame_timeline_vsync_id(*vsync_id);
+    }
+  }
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/plugins/video_frame_importer/video_frame_module.h
+++ b/src/trace_processor/plugins/video_frame_importer/video_frame_module.h
@@ -52,6 +52,11 @@ class VideoFrameModule : public ProtoImporterModule {
 
   void ParseField(const ParseFieldArgs& args) override;
 
+  // Backfills frame_timeline_vsync_id on the video-frame rows from the
+  // VirtualDisplayComposite events collected during parsing. Runs once all
+  // packets are parsed, so it does not depend on frame/composite ordering.
+  void OnEventsFullyExtracted() override;
+
   // Parse-time per-stream byte cap, a backstop against traces recorded
   // without a producer cap. Matches the producer's 256 MB default.
   static constexpr int64_t kDefaultMaxStreamSizeBytes = 256ll * 1024 * 1024;
@@ -64,6 +69,7 @@ class VideoFrameModule : public ProtoImporterModule {
                        int64_t ts,
                        const TracePacketData& data);
   void ParseVideoFrameError(protozero::ConstBytes bytes, int64_t ts);
+  void ParseFrameTimelineEvent(protozero::ConstBytes bytes);
 
   struct StreamInfo {
     // display_name and codec_string arrive on the codec_config packet and
@@ -78,6 +84,13 @@ class VideoFrameModule : public ProtoImporterModule {
   std::vector<TraceBlobView>* const au_data_;
   int64_t max_stream_size_bytes_ = kDefaultMaxStreamSizeBytes;
   base::FlatHashMap<uint32_t, StreamInfo> stream_info_by_id_;
+
+  // present_time_us -> vsync id, from VirtualDisplayComposite events. Used at
+  // end of parsing to backfill frame_timeline_vsync_id by matching pts_us.
+  base::FlatHashMap<int64_t, int64_t> vsync_id_by_present_us_;
+  // (table row, pts_us) recorded as access-unit rows are inserted, so the
+  // backfill can look up the vsync id without needing to re-read pts_us.
+  std::vector<std::pair<uint32_t, int64_t>> row_pts_us_;
 };
 
 }  // namespace perfetto::trace_processor

--- a/ui/src/components/details/thread_slice_details_tab.ts
+++ b/ui/src/components/details/thread_slice_details_tab.ts
@@ -212,6 +212,9 @@ export interface TrackEventDetailsPanelSection {
 }
 
 export interface ThreadSliceDetailsPanelAttrs {
+  // Optional sections rendered at the top of the left column, above the
+  // standard details (e.g. a prominent cross-reference link).
+  topSections?: TrackEventDetailsPanelSection[];
   // Optional additional sections to render in the left column
   leftSections?: TrackEventDetailsPanelSection[];
   // Optional additional sections to render in the right column
@@ -256,6 +259,7 @@ export class ThreadSliceDetailsPanel implements TrackEventDetailsPanel {
 
     // Load additional sections
     const sectionsToLoad = [
+      ...(this.attrs.topSections ?? []),
       ...(this.attrs.leftSections ?? []),
       ...(this.attrs.rightSections ?? []),
     ];
@@ -272,7 +276,10 @@ export class ThreadSliceDetailsPanel implements TrackEventDetailsPanel {
     }
     const slice = this.sliceDetails;
 
-    // Render additional left and right sections
+    // Render additional top, left and right sections
+    const additionalTop = this.attrs.topSections?.map((section) =>
+      section.render(),
+    );
     const additionalLeft = this.attrs.leftSections?.map((section) =>
       section.render(),
     );
@@ -291,6 +298,7 @@ export class ThreadSliceDetailsPanel implements TrackEventDetailsPanel {
         GridLayout,
         m(
           GridLayoutColumn,
+          additionalTop,
           renderDetails(this.trace, slice, this.breakdownByThreadState),
           additionalLeft,
         ),

--- a/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
@@ -20,6 +20,7 @@ import type {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
+import {VideoFrameLinkSection} from './video_frame_link';
 
 // color named and defined based on Material Design color palettes
 // 500 colors indicate a timeline slice is not a partial jank (not a jank or
@@ -77,7 +78,12 @@ export function createActualFramesTrack(
     },
     initialMaxDepth: maxDepth,
     rootTableName: 'slice',
-    detailsPanel: () => new ThreadSliceDetailsPanel(trace),
+    // Link, above the standard details, to the captured display-video frame
+    // this composite produced (self-hides when the trace has no video frames).
+    detailsPanel: () =>
+      new ThreadSliceDetailsPanel(trace, {
+        topSections: [new VideoFrameLinkSection(trace)],
+      }),
   });
 }
 

--- a/ui/src/plugins/dev.perfetto.Frames/video_frame_link.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/video_frame_link.ts
@@ -1,0 +1,77 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Anchor} from '../../widgets/anchor';
+import {Section} from '../../widgets/section';
+import {NUM} from '../../trace_processor/query_result';
+import type {Trace} from '../../public/trace';
+import type {TrackEventSelection} from '../../public/selection';
+import type {TrackEventDetailsPanelSection} from '../../components/details/thread_slice_details_tab';
+
+// Details-panel section for an actual frame-timeline slice - both the
+// SurfaceFlinger DisplayFrame composite and the app SurfaceFrames under it -
+// linking to the captured display-video frame that composite produced, when
+// the trace has one. Both slice kinds carry the same DisplayFrame token, so a
+// single join on frame_timeline_vsync_id covers both. Renders nothing when
+// there's no matching frame, so it self-hides on traces without video.
+export class VideoFrameLinkSection implements TrackEventDetailsPanelSection {
+  private readonly trace: Trace;
+  private videoFrame?: {id: number; displayId: number};
+
+  constructor(trace: Trace) {
+    this.trace = trace;
+  }
+
+  async load(selection: TrackEventSelection): Promise<void> {
+    this.videoFrame = undefined;
+    try {
+      const res = await this.trace.engine.query(`
+        SELECT vf.id AS id, vf.display_id AS displayId
+        FROM actual_frame_timeline_slice s
+        JOIN __intrinsic_video_frames vf
+          ON vf.frame_timeline_vsync_id = s.display_frame_token
+        WHERE s.id = ${selection.eventId}
+        LIMIT 1
+      `);
+      if (res.numRows() === 0) return;
+      const row = res.firstRow({id: NUM, displayId: NUM});
+      this.videoFrame = {id: row.id, displayId: row.displayId};
+    } catch {
+      // No video-frame table in this build; leave the section hidden.
+    }
+  }
+
+  render(): m.Children {
+    const vf = this.videoFrame;
+    if (vf === undefined) return undefined;
+    return m(
+      Section,
+      {title: 'Display video'},
+      m(
+        Anchor,
+        {
+          icon: 'movie',
+          onclick: () =>
+            this.trace.selection.selectTrackEvent(
+              `/video_frames/${vf.displayId}`,
+              vf.id,
+              {scrollToSelection: true},
+            ),
+        },
+        'Jump to video frame',
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_details_panel.ts
@@ -17,6 +17,8 @@ import m from 'mithril';
 import {ensureIsInstance} from '../../base/assert';
 import {Time} from '../../base/time';
 import {Timestamp} from '../../components/widgets/timestamp';
+import {LONG_NULL, NUM, STR_NULL} from '../../trace_processor/query_result';
+import {Anchor} from '../../widgets/anchor';
 import type {TrackEventDetailsPanel} from '../../public/details_panel';
 import type {TrackEventSelection} from '../../public/selection';
 import {Button, ButtonBar} from '../../widgets/button';
@@ -31,8 +33,21 @@ import type {VideoFramePlayer} from './video_frame_player';
 // Playback speed options, in real-time multiples.
 const PLAYBACK_RATES = [0.1, 0.2, 0.5, 1, 1.5, 2];
 
+// One app (SurfaceFrame) that was composited into this frame's DisplayFrame.
+interface AppFrame {
+  sliceId: number; // actual_frame_timeline_slice.id, to jump to
+  token?: bigint; // surface_frame_token: this app's own vsync id
+  process: string; // process name (falls back to layer name)
+}
+
 export class VideoFrameDetailsPanel implements TrackEventDetailsPanel {
   private readonly player: VideoFramePlayer;
+
+  // App frames composited into the current frame's DisplayFrame, cached per
+  // vsync id so we query at most once as long as the selection stays put.
+  private appFramesVsyncId?: bigint;
+  private appFramesLoaded = false;
+  private appFrames: AppFrame[] = [];
 
   constructor(player: VideoFramePlayer) {
     this.player = player;
@@ -64,6 +79,30 @@ export class VideoFrameDetailsPanel implements TrackEventDetailsPanel {
         right: m(Timestamp, {trace: p.trace, ts: Time.fromRaw(frame.ts)}),
       }),
     ];
+    if (frame.vsyncId !== undefined) {
+      const vsyncId = frame.vsyncId;
+      // Fetch (once per vsync id) the app frames composited into this
+      // DisplayFrame, shown nested below so you can jump straight to an app's
+      // frame timeline without the SurfaceFlinger round trip.
+      this.ensureAppFrames(vsyncId);
+      detailRows.push(
+        m(
+          TreeNode,
+          {
+            left: 'Frame timeline vsync id',
+            // Clickable (highlighted like the Timestamp): jump to the
+            // SurfaceFlinger DisplayFrame (frame-timeline slice) this frame
+            // was composited in.
+            right: m(
+              Anchor,
+              {onclick: () => this.jumpToDisplayFrame(vsyncId)},
+              `${vsyncId}`,
+            ),
+          },
+          this.renderAppFrameNodes(vsyncId),
+        ),
+      );
+    }
     for (const err of p.errors) {
       detailRows.push(m(TreeNode, {left: 'Stream error', right: err}));
     }
@@ -95,6 +134,94 @@ export class VideoFrameDetailsPanel implements TrackEventDetailsPanel {
               ),
         ),
       ),
+    );
+  }
+
+  // Selects and scrolls to the SurfaceFlinger DisplayFrame (frame-timeline
+  // slice) with this composite token, so you can jump from a captured video
+  // frame to the composite that produced it.
+  private async jumpToDisplayFrame(vsyncId: bigint) {
+    const trace = this.player.trace;
+    const res = await trace.engine.query(`
+      SELECT id
+      FROM actual_frame_timeline_slice
+      WHERE display_frame_token = ${vsyncId} AND layer_name IS NULL
+      ORDER BY ts
+      LIMIT 1
+    `);
+    if (res.numRows() === 0) return;
+    const id = res.firstRow({id: NUM}).id;
+    trace.selection.selectSqlEvent('slice', id, {scrollToSelection: true});
+  }
+
+  // Loads the app frames (SurfaceFrames) that were composited into the
+  // DisplayFrame with this token, unless already cached for this vsync id.
+  // A SurfaceFrame carries the display_frame_token of the DisplayFrame it was
+  // presented in, so this needs no round trip through SurfaceFlinger.
+  private ensureAppFrames(vsyncId: bigint) {
+    if (this.appFramesVsyncId === vsyncId) return; // already loaded or loading
+    this.appFramesVsyncId = vsyncId;
+    this.appFramesLoaded = false;
+    this.appFrames = [];
+    void this.loadAppFrames(vsyncId);
+  }
+
+  private async loadAppFrames(vsyncId: bigint) {
+    const res = await this.player.trace.engine.query(`
+      SELECT
+        s.id AS sliceId,
+        s.surface_frame_token AS token,
+        COALESCE(p.name, s.layer_name) AS process
+      FROM actual_frame_timeline_slice s
+      LEFT JOIN process p USING (upid)
+      WHERE s.display_frame_token = ${vsyncId} AND s.layer_name IS NOT NULL
+      ORDER BY process, token
+    `);
+    // A newer selection superseded us while the query was in flight.
+    if (this.appFramesVsyncId !== vsyncId) return;
+    const rows: AppFrame[] = [];
+    const it = res.iter({sliceId: NUM, token: LONG_NULL, process: STR_NULL});
+    for (; it.valid(); it.next()) {
+      rows.push({
+        sliceId: it.sliceId,
+        token: it.token ?? undefined,
+        process: it.process ?? '<unknown>',
+      });
+    }
+    this.appFrames = rows;
+    this.appFramesLoaded = true;
+    m.redraw();
+  }
+
+  // The app-frame rows shown nested under the SF vsync id: process name on the
+  // left, the app's own vsync id (surface_frame_token) as a clickable link on
+  // the right that jumps straight to that app's frame timeline slice.
+  private renderAppFrameNodes(vsyncId: bigint): m.Children {
+    if (!this.appFramesLoaded || this.appFramesVsyncId !== vsyncId) {
+      return m(TreeNode, {left: 'Loading app frames…'});
+    }
+    if (this.appFrames.length === 0) {
+      return m(TreeNode, {left: 'No app frames'});
+    }
+    return this.appFrames.map((af) =>
+      m(TreeNode, {
+        left: af.process,
+        right:
+          af.token === undefined
+            ? '(no vsync id)'
+            : m(
+                Anchor,
+                {
+                  onclick: () =>
+                    this.player.trace.selection.selectSqlEvent(
+                      'slice',
+                      af.sliceId,
+                      {scrollToSelection: true},
+                    ),
+                },
+                `${af.token}`,
+              ),
+      }),
     );
   }
 

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_player.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frame_player.ts
@@ -14,7 +14,13 @@
 
 import m from 'mithril';
 import type {Trace} from '../../public/trace';
-import {BLOB, LONG, NUM, STR_NULL} from '../../trace_processor/query_result';
+import {
+  BLOB,
+  LONG,
+  LONG_NULL,
+  NUM,
+  STR_NULL,
+} from '../../trace_processor/query_result';
 
 // Max in-flight decoder inputs before the feed loop awaits, to bound the
 // decoder's queue and held-frame memory.
@@ -32,6 +38,9 @@ export interface FrameInfo {
   frameNumber: number;
   isKey: boolean;
   ptsUs: number;
+  // Frame-timeline vsync id (SurfaceFlinger DisplayFrame token) of the
+  // composite that produced this frame, when available.
+  vsyncId?: bigint;
 }
 
 // Decoder setup, cached once per stream.
@@ -129,6 +138,7 @@ export class VideoFramePlayer {
              COALESCE(is_key_frame, 0) AS isKey,
              COALESCE(pts_us, 0) AS ptsUs,
              COALESCE(is_config, 0) AS isConfig,
+             frame_timeline_vsync_id AS vsyncId,
              codec_string AS codecString
       FROM __intrinsic_video_frames
       WHERE display_id = ${this.displayId}
@@ -141,6 +151,7 @@ export class VideoFramePlayer {
       isKey: NUM,
       ptsUs: NUM,
       isConfig: NUM,
+      vsyncId: LONG_NULL,
       codecString: STR_NULL,
     });
     for (; it.valid(); it.next()) {
@@ -155,6 +166,7 @@ export class VideoFramePlayer {
         frameNumber: it.frameNumber,
         isKey: it.isKey !== 0,
         ptsUs: it.ptsUs,
+        vsyncId: it.vsyncId ?? undefined,
       });
     }
 

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
@@ -40,7 +40,13 @@ export function createVideoFramesTrack(
       ts,
       COALESCE(LEAD(ts) OVER (ORDER BY ts) - ts, 0) AS dur,
       0 AS depth,
-      'Frame ' || frame_number AS name
+      -- When the frame is aligned to a SurfaceFlinger composite, name it by
+      -- that vsync id; otherwise fall back to the frame number.
+      CASE
+        WHEN frame_timeline_vsync_id IS NOT NULL
+          THEN 'vsync ' || frame_timeline_vsync_id
+        ELSE 'Frame ' || frame_number
+      END AS name
     FROM __intrinsic_video_frames
     WHERE display_id = ${displayId}
       AND COALESCE(is_config, 0) = 0


### PR DESCRIPTION
SurfaceFlinger emits a VirtualDisplayComposite frame-timeline event per virtual-display composite, tying the composite's vsync id (the DisplayFrame token) to the exact present time stamped on the buffer it queues to a surface-input encoder. That present time is carried through unchanged as the encoded frame's presentationTimeUs, so it is a bit-exact join key.

Add the VirtualDisplayComposite message to FrameTimelineEvent, parse it in the video-frame importer (which also registers for frame_timeline_event), and backfill each video frame's new frame_timeline_vsync_id column by matching pts_us to the composite present time once all packets are parsed. Surface the id in the video-frame details panel as a clickable link (styled like the Timestamp) that jumps to the SurfaceFlinger DisplayFrame it was composited in.
