### PR TITLE
Add Jank Badges 

### DIFF
--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -74,6 +74,8 @@ import {
 } from '../../base/renderer';
 import {cropText} from '../../base/string_utils';
 
+import type {VisualMarkerStyle} from './visual_marker';
+
 const SLICE_MIN_WIDTH_FOR_TEXT_PX = 5;
 const CHEVRON_WIDTH_PX = 10;
 
@@ -277,6 +279,16 @@ export interface SliceTrackAttrs<T extends DatasetSchema> {
    * Define buttons displayed on the track shell.
    */
   shellButtons?(): m.Children;
+
+  /**
+   * Provides fixed-size overlay markers for events of interest (e.g. Jank, Cadence Drop).
+   */
+  markerProvider?(row: T): VisualMarkerStyle | undefined;
+
+  /**
+   * Priority score generator for row markers when clustering overlapping markers.
+   */
+  markerPriority?(row: T): number;
 
   /**
    * Called once per render cycle before drawing. Return an array of
@@ -634,6 +646,163 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
         rowHeightFromLayout(rowLayout, depths[selectedIdx]) + THICKNESS,
       );
     }
+
+    // Draw generic fixed-size visual markers and cluster overlays
+    if (this.attrs.markerProvider) {
+      this.renderVisualMarkersOverlay(
+        ctx,
+        slices,
+        starts,
+        ends,
+        depths,
+        count,
+        pxPerNs,
+        baseOffsetPx,
+        pxEnd,
+        rowLayout,
+      );
+    }
+  }
+
+  private renderVisualMarkersOverlay(
+    ctx: CanvasRenderingContext2D,
+    slices: readonly Slice<T>[],
+    starts: Float32Array,
+    ends: Float32Array,
+    depths: Uint16Array,
+    count: number,
+    pxPerNs: number,
+    baseOffsetPx: number,
+    pxEnd: number,
+    rowLayout: RowLayout,
+  ): void {
+    if (!this.attrs.markerProvider) return;
+
+    interface MarkerItem {
+      screenX: number;
+      depth: number;
+      style: VisualMarkerStyle;
+      priority: number;
+    }
+
+    const itemsByDepth = new Map<number, MarkerItem[]>();
+    for (let j = 0; j < count; j++) {
+      const rawLeft = starts[j] * pxPerNs + baseOffsetPx;
+      const rawRight = ends[j] * pxPerNs + baseOffsetPx;
+      const screenX = (rawLeft + rawRight) / 2;
+
+      // Skip offscreen slices early before markerProvider lookup
+      if (screenX < -20 || screenX > pxEnd + 20) continue;
+
+      const slice = slices[j];
+      const style = this.attrs.markerProvider(slice.row);
+      if (!style) continue;
+
+      const depth = depths[j];
+      const priority = this.attrs.markerPriority?.(slice.row) ?? 1;
+      let depthItems = itemsByDepth.get(depth);
+      if (!depthItems) {
+        depthItems = [];
+        itemsByDepth.set(depth, depthItems);
+      }
+      depthItems.push({screenX, depth, style, priority});
+    }
+
+    if (itemsByDepth.size === 0) return;
+
+    const MIN_DIST = 16;
+    const clusters: Array<{
+      screenX: number;
+      depth: number;
+      count: number;
+      bestStyle: VisualMarkerStyle;
+    }> = [];
+
+    // Cluster per depth row
+    for (const [, items] of itemsByDepth) {
+      let current: MarkerItem[] = [];
+      for (const item of items) {
+        if (current.length === 0) {
+          current.push(item);
+          continue;
+        }
+        const prev = current[current.length - 1];
+        if (Math.abs(item.screenX - prev.screenX) < MIN_DIST) {
+          current.push(item);
+        } else {
+          clusters.push(this.makeMarkerCluster(current));
+          current = [item];
+        }
+      }
+      if (current.length > 0) {
+        clusters.push(this.makeMarkerCluster(current));
+      }
+    }
+
+    // Draw canvas badges
+    for (const cl of clusters) {
+      const yTop = rowTopFromLayout(rowLayout, cl.depth);
+      const rowH = rowHeightFromLayout(rowLayout, cl.depth);
+      const yCenter = yTop + rowH / 2;
+      this.drawBadgeMarker(ctx, cl.screenX, yCenter, cl.bestStyle, cl.count);
+    }
+  }
+
+  private makeMarkerCluster(
+    items: Array<{
+      screenX: number;
+      depth: number;
+      style: VisualMarkerStyle;
+      priority: number;
+    }>,
+  ) {
+    let best = items[0];
+    let sumX = 0;
+    for (const it of items) {
+      sumX += it.screenX;
+      if (it.priority > best.priority) best = it;
+    }
+    return {
+      screenX: sumX / items.length,
+      depth: best.depth,
+      count: items.length,
+      bestStyle: best.style,
+    };
+  }
+
+  private drawBadgeMarker(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    style: VisualMarkerStyle,
+    count: number,
+  ): void {
+    const size = style.sizePx ?? 16;
+    const radius = size / 2;
+
+    ctx.save();
+    ctx.translate(x, y);
+
+    if (style.render) {
+      style.render(ctx, 0, 0, size, style.colorScheme);
+    } else {
+      ctx.beginPath();
+      ctx.arc(0, 0, radius, 0, 2 * Math.PI);
+      ctx.fillStyle = style.colorScheme.base.cssString;
+      ctx.fill();
+      ctx.lineWidth = 1.5;
+      ctx.strokeStyle = style.strokeColor ?? '#FFFFFF';
+      ctx.stroke();
+
+      const text = count > 1 ? `${count}` : style.icon ?? '⚠️';
+      ctx.fillStyle = style.textColor ?? style.colorScheme.textBase.cssString;
+      ctx.font = 'bold 10px Roboto, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(text, 0, 0);
+    }
+
+    ctx.restore();
   }
 
   private renderInstants(

--- a/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {HSLColor} from '../../base/color';
 import {makeColorScheme} from '../../components/colorizer';
 import type {ColorScheme} from '../../base/color_scheme';
@@ -37,6 +38,37 @@ const LIGHT_GREEN_100 = makeColorScheme(new HSLColor('#DCEDC8'));
 const PINK_500 = makeColorScheme(new HSLColor('#F515E0'));
 const PINK_200 = makeColorScheme(new HSLColor('#F48FB1'));
 const WHITE_200 = makeColorScheme(new HSLColor('#F5F5F5'));
+
+const JANK_TYPE_DESCRIPTIONS: Record<string, string> = {
+  'App Deadline Missed':
+    'The application failed to finish rendering the frame within its deadline.',
+  'SurfaceFlinger CPU Deadline Missed':
+    'SurfaceFlinger composition work failed to finish within the deadline in HWC composition.',
+  'SurfaceFlinger GPU Deadline Missed':
+    'SurfaceFlinger composition work failed to finish within the deadline in GPU composition.',
+  'SurfaceFlinger Scheduling':
+    'The frame was presented at an unexpected time due to reasons within SurfaceFlinger.',
+  'Prediction Error':
+    'Discrepancy between predicted VSYNC timestamp and actual display hardware presentation timestamp.',
+  'Display HAL':
+    'The frame was presented at an unexpected time due to reasons within Hardware Composer.',
+  'Buffer Stuffing':
+    'The frame was presented late as there were a prior frame in the queue that was presented instead',
+  'SurfaceFlinger Stuffing':
+    'SurfaceFlinger composited frame was presented late as there were a prior frame in the HWC queue that was presented instead',
+  'App Resynced Jitter':
+    'The application shifted/changed its animation time due to delays in Choreographer execution.',
+  'Dropped Frame': 'The frame buffer was not presented on display.',
+  'Non Animating':
+    'The frame was not presented on time, but it is not causing a perceivable jank as it is not part of an animation (e.g. a cursor blinking).',
+  'Display not ON':
+    'The frame was presented while the display was not on (off or doze).',
+  'ModeChange in progress':
+    'The frame was not presented on time due to a display mode change (refresh rate or resolution).',
+  'PowerModeChange in progress':
+    'The frame was not presented on time due to an active display power state transition.',
+  'Unknown Jank': 'The frame was not presented on time due to unknown reasons.',
+};
 
 export function createActualFramesTrack(
   trace: Trace,
@@ -67,6 +99,36 @@ export function createActualFramesTrack(
         in: trackIds,
       },
     }),
+    tooltip: (slice) => {
+      const row = slice.row;
+      const tag = useExperimentalJankForClassification
+        ? row.jank_tag_experimental
+        : row.jank_tag;
+      const jankType = row.jank_type;
+
+      if (tag && tag !== 'No Jank' && tag !== 'None') {
+        const elements: m.Children = [];
+        elements.push(
+          m('div', {style: 'font-weight: bold; margin-bottom: 4px;'}, `${tag}`),
+        );
+
+        if (jankType && jankType !== 'None' && jankType !== 'Unspecified') {
+          const reasons = jankType.split(',').map((r) => r.trim());
+          for (const reason of reasons) {
+            const desc = JANK_TYPE_DESCRIPTIONS[reason];
+            elements.push(
+              m('div', {style: 'margin-top: 4px;'}, [
+                m('span', {style: 'font-weight: 500;'}, `${reason}: `),
+                m('span', desc || 'Rendering performance delay.'),
+              ]),
+            );
+          }
+        }
+
+        return elements;
+      }
+      return undefined;
+    },
     colorizer: (row) => {
       return getColorSchemeForJank(
         useExperimentalJankForClassification

--- a/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
@@ -53,9 +53,9 @@ const JANK_TYPE_DESCRIPTIONS: Record<string, string> = {
   'Display HAL':
     'The frame was presented at an unexpected time due to reasons within Hardware Composer.',
   'Buffer Stuffing':
-    'The frame was presented late as there were a prior frame in the queue that was presented instead',
+    'The frame was presented late as there was a prior frame in the queue that was presented instead.',
   'SurfaceFlinger Stuffing':
-    'SurfaceFlinger composited frame was presented late as there were a prior frame in the HWC queue that was presented instead',
+    'A SurfaceFlinger composited frame was presented late as there was a prior frame in the HWC queue that was presented instead.',
   'App Resynced Jitter':
     'The application shifted/changed its animation time due to delays in Choreographer execution.',
   'Dropped Frame': 'The frame buffer was not presented on display.',
@@ -107,13 +107,16 @@ export function createActualFramesTrack(
       const jankType = row.jank_type;
 
       if (tag && tag !== 'No Jank' && tag !== 'None') {
-        const elements: m.Children = [];
+        const elements: m.Vnode[] = [];
         elements.push(
           m('div', {style: 'font-weight: bold; margin-bottom: 4px;'}, `${tag}`),
         );
 
         if (jankType && jankType !== 'None' && jankType !== 'Unspecified') {
-          const reasons = jankType.split(',').map((r) => r.trim());
+          const reasons = jankType
+            .split(',')
+            .map((r) => r.trim())
+            .filter(Boolean);
           for (const reason of reasons) {
             const desc = JANK_TYPE_DESCRIPTIONS[reason];
             elements.push(

--- a/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
@@ -70,6 +70,46 @@ const JANK_TYPE_DESCRIPTIONS: Record<string, string> = {
   'Unknown Jank': 'The frame was not presented on time due to unknown reasons.',
 };
 
+export interface JankBadgeSpec {
+  readonly icon: string;
+  readonly title: string;
+  readonly priority: number;
+  readonly strokeColor: string;
+}
+
+const JANK_BADGE_SPECS: Record<string, JankBadgeSpec> = {
+  'Self Jank': {
+    icon: '🔴',
+    title: 'Self Jank',
+    priority: 40,
+    strokeColor: '#FFFFFF',
+  },
+  'Other Jank': {
+    icon: '🟡',
+    title: 'Other Jank',
+    priority: 30,
+    strokeColor: '#000000',
+  },
+  'Dropped Frame': {
+    icon: '🚫',
+    title: 'Dropped Frame',
+    priority: 20,
+    strokeColor: '#FFFFFF',
+  },
+  'Dropped': {
+    icon: '🚫',
+    title: 'Dropped Frame',
+    priority: 20,
+    strokeColor: '#FFFFFF',
+  },
+  'Non-perceivable Jank': {
+    icon: '⚪',
+    title: 'Non-perceivable Jank',
+    priority: 10,
+    strokeColor: '#000000',
+  },
+};
+
 export function createActualFramesTrack(
   trace: Trace,
   uri: string,
@@ -108,8 +148,16 @@ export function createActualFramesTrack(
 
       if (tag && tag !== 'No Jank' && tag !== 'None') {
         const elements: m.Vnode[] = [];
+        const spec = tag ? JANK_BADGE_SPECS[tag] : undefined;
+        const headerIcon = spec?.icon ?? '🟡';
+        const headerTitle = spec?.title ?? `${tag}`;
+
         elements.push(
-          m('div', {style: 'font-weight: bold; margin-bottom: 4px;'}, `${tag}`),
+          m(
+            'div',
+            {style: 'font-weight: bold; margin-bottom: 4px;'},
+            `${headerIcon} ${headerTitle}`,
+          ),
         );
 
         if (jankType && jankType !== 'None' && jankType !== 'Unspecified') {
@@ -131,6 +179,29 @@ export function createActualFramesTrack(
         return elements;
       }
       return undefined;
+    },
+    markerProvider: (row) => {
+      const tag = useExperimentalJankForClassification
+        ? row.jank_tag_experimental
+        : row.jank_tag;
+      if (!tag) return undefined;
+      const spec = JANK_BADGE_SPECS[tag];
+      if (spec === undefined) return undefined;
+      const colorScheme = getColorSchemeForJank(tag, row.jank_severity_type);
+      return {
+        sizePx: 16,
+        icon: spec.icon,
+        colorScheme,
+        strokeColor: spec.strokeColor,
+      };
+    },
+    markerPriority: (row) => {
+      const tag = useExperimentalJankForClassification
+        ? row.jank_tag_experimental
+        : row.jank_tag;
+      if (!tag) return 0;
+      const spec = JANK_BADGE_SPECS[tag];
+      return spec !== undefined ? spec.priority : 0;
     },
     colorizer: (row) => {
       return getColorSchemeForJank(

--- a/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
@@ -110,6 +110,28 @@ const JANK_BADGE_SPECS: Record<string, JankBadgeSpec> = {
   },
 };
 
+export function getJankBadgeSpec(
+  jankTag: string | null,
+  jankSeverityType: string | null,
+): VisualMarkerStyle | undefined {
+  if (!jankTag) return undefined;
+  const spec = JANK_BADGE_SPECS[jankTag];
+  if (spec === undefined) return undefined;
+  const colorScheme = getColorSchemeForJank(jankTag, jankSeverityType);
+  return {
+    sizePx: 16,
+    icon: spec.icon,
+    colorScheme,
+    strokeColor: spec.strokeColor,
+  };
+}
+
+export function getJankBadgePriority(jankTag: string | null): number {
+  if (!jankTag) return 0;
+  const spec = JANK_BADGE_SPECS[jankTag];
+  return spec !== undefined ? spec.priority : 0;
+}
+
 export function createActualFramesTrack(
   trace: Trace,
   uri: string,
@@ -184,24 +206,13 @@ export function createActualFramesTrack(
       const tag = useExperimentalJankForClassification
         ? row.jank_tag_experimental
         : row.jank_tag;
-      if (!tag) return undefined;
-      const spec = JANK_BADGE_SPECS[tag];
-      if (spec === undefined) return undefined;
-      const colorScheme = getColorSchemeForJank(tag, row.jank_severity_type);
-      return {
-        sizePx: 16,
-        icon: spec.icon,
-        colorScheme,
-        strokeColor: spec.strokeColor,
-      };
+      return getJankBadgeSpec(tag, row.jank_severity_type);
     },
     markerPriority: (row) => {
       const tag = useExperimentalJankForClassification
         ? row.jank_tag_experimental
         : row.jank_tag;
-      if (!tag) return 0;
-      const spec = JANK_BADGE_SPECS[tag];
-      return spec !== undefined ? spec.priority : 0;
+      return getJankBadgePriority(tag);
     },
     colorizer: (row) => {
       return getColorSchemeForJank(

--- a/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
@@ -21,6 +21,7 @@ import type {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
+import type {VisualMarkerStyle} from '../../components/tracks/visual_marker';
 
 // color named and defined based on Material Design color palettes
 // 500 colors indicate a timeline slice is not a partial jank (not a jank or


### PR DESCRIPTION
### Problem Statement
In long trace captures (spanning seconds or minutes), timeline frame slices shrink down to sub-pixel or fractional-pixel widths when zoomed out. Consequently, performance anomalies—such as severe Jank frames (`Self Jank` 🔴, `Other Jank` 🟡, `Dropped Frame` 🚫, `Non-perceivable Jank` ⚪)—become completely invisible. Developers are forced to manually pan and zoom repeatedly across thousands of frames to discover where jank occurred.

### Solution
Implement a high-performance, generic **Jank Badges Framework** in `SliceTrack`:
1. **Zoom-Invariant Visibility:** Renders fixed-screen-size canvas overlay badges (constant 16px badges) directly over timeline events so performance anomalies stand out immediately at macro zoom levels.
2. **Spatial Clustering & Priority Matrix:** When events cluster together when zoomed out, a render priority matrix resolves overlapping badges cleanly per depth row:
   `Self Jank (40) > Other Jank (30) > Dropped Frame (20) > Non-perceivable Jank (10)`
3. **Precision Alignment:** As the user zooms in, badges lock onto the exact start timestamp of the slice.
4. **Frame Timeline Registration:** Registers standard Android frame jank badges (`Self Jank` 🔴, `Other Jank` 🟡, `Dropped Frame` 🚫, `Non-perceivable Jank` ⚪) in `ActualFramesTrack`.
