### PR TITLE
ui: prefer readonly T[] syntax over ReadonlyArray<T> in style guide

### DIFF
--- a/docs/AGENTS-ui.md
+++ b/docs/AGENTS-ui.md
@@ -267,13 +267,13 @@ function getValue(): string | null { return null; }
 function getValue(): string | undefined { return undefined; }
 ```
 
-**Use `ReadonlyArray<T>` for arrays that shouldn't be modified:**
+**Use `readonly T[]` for arrays that shouldn't be modified:**
 ```typescript
 // Bad
 function process(items: string[]): void { ... }
 
 // Good
-function process(items: ReadonlyArray<string>): void { ... }
+function process(items: readonly string[]): void { ... }
 ```
 
 **Use `classNames()` utility for building CSS class strings:**


### PR DESCRIPTION
Update the AGENTS-ui.md style guide to recommend the modern TypeScript readonly modifier syntax (readonly T[]) instead of the older ReadonlyArray<T> generic. The modifier syntax is more idiomatic and consistent with TypeScript's evolving style recommendations.