### PR TITLE
protos: add control flags for libgestures events

### DIFF
--- a/protos/perfetto/config/android/android_input_event_config.proto
+++ b/protos/perfetto/config/android/android_input_event_config.proto
@@ -139,7 +139,8 @@ message AndroidInputEventConfig {
   // Trace hardware states sent to the Gestures library.
   optional bool trace_libgestures_hardware_states = 6;
 
-  // Trace all Gestures library events other than input hardware states (i.e. device
-  // additions, detected gestures, property value changes, and timer deadlines).
+  // Trace all Gestures library events other than input hardware states (i.e.
+  // device additions, detected gestures, property value changes, and timer
+  // deadlines).
   optional bool trace_libgestures_events = 7;
 }

--- a/protos/perfetto/config/android/android_input_event_config.proto
+++ b/protos/perfetto/config/android/android_input_event_config.proto
@@ -22,7 +22,7 @@ package perfetto.protos;
 //
 // NOTE: Input traces can only be taken on debuggable (userdebug/eng) builds!
 //
-// Next ID: 6
+// Next ID: 8
 message AndroidInputEventConfig {
   // Trace modes are tracing presets that are included in the system.
   enum TraceMode {
@@ -135,4 +135,11 @@ message AndroidInputEventConfig {
   // Trace evdev events received from the kernel, including device additions and
   // removals.
   optional bool trace_evdev_events = 5;
+
+  // Trace hardware states sent to the Gestures library.
+  optional bool trace_libgestures_hardware_states = 6;
+
+  // Trace all Gestures library events other than input hardware states (i.e. device
+  // additions, detected gestures, property value changes, and timer deadlines).
+  optional bool trace_libgestures_events = 7;
 }

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -695,7 +695,7 @@ message AndroidGameInterventionListConfig {
 //
 // NOTE: Input traces can only be taken on debuggable (userdebug/eng) builds!
 //
-// Next ID: 6
+// Next ID: 8
 message AndroidInputEventConfig {
   // Trace modes are tracing presets that are included in the system.
   enum TraceMode {
@@ -808,6 +808,13 @@ message AndroidInputEventConfig {
   // Trace evdev events received from the kernel, including device additions and
   // removals.
   optional bool trace_evdev_events = 5;
+
+  // Trace hardware states sent to the Gestures library.
+  optional bool trace_libgestures_hardware_states = 6;
+
+  // Trace all Gestures library events other than input hardware states (i.e. device
+  // additions, detected gestures, property value changes, and timer deadlines).
+  optional bool trace_libgestures_events = 7;
 }
 
 // End of protos/perfetto/config/android/android_input_event_config.proto

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -812,8 +812,9 @@ message AndroidInputEventConfig {
   // Trace hardware states sent to the Gestures library.
   optional bool trace_libgestures_hardware_states = 6;
 
-  // Trace all Gestures library events other than input hardware states (i.e. device
-  // additions, detected gestures, property value changes, and timer deadlines).
+  // Trace all Gestures library events other than input hardware states (i.e.
+  // device additions, detected gestures, property value changes, and timer
+  // deadlines).
   optional bool trace_libgestures_events = 7;
 }
 

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -695,7 +695,7 @@ message AndroidGameInterventionListConfig {
 //
 // NOTE: Input traces can only be taken on debuggable (userdebug/eng) builds!
 //
-// Next ID: 6
+// Next ID: 8
 message AndroidInputEventConfig {
   // Trace modes are tracing presets that are included in the system.
   enum TraceMode {
@@ -808,6 +808,13 @@ message AndroidInputEventConfig {
   // Trace evdev events received from the kernel, including device additions and
   // removals.
   optional bool trace_evdev_events = 5;
+
+  // Trace hardware states sent to the Gestures library.
+  optional bool trace_libgestures_hardware_states = 6;
+
+  // Trace all Gestures library events other than input hardware states (i.e. device
+  // additions, detected gestures, property value changes, and timer deadlines).
+  optional bool trace_libgestures_events = 7;
 }
 
 // End of protos/perfetto/config/android/android_input_event_config.proto

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -812,8 +812,9 @@ message AndroidInputEventConfig {
   // Trace hardware states sent to the Gestures library.
   optional bool trace_libgestures_hardware_states = 6;
 
-  // Trace all Gestures library events other than input hardware states (i.e. device
-  // additions, detected gestures, property value changes, and timer deadlines).
+  // Trace all Gestures library events other than input hardware states (i.e.
+  // device additions, detected gestures, property value changes, and timer
+  // deadlines).
   optional bool trace_libgestures_events = 7;
 }
 


### PR DESCRIPTION
For trace size and privacy reasons, we don't want libgestures hardware states and gesture events in every input trace. Add boolean control flags (trace_libgestures_hardware_states and trace_libgestures_events) to AndroidInputEventConfig to allow conditionally enabling/disabling libgestures event tracing.

Bug: b/527860283
Bug: b/528082274
