### PR TITLE
ui: passthrough missing filename from postMessage

### DIFF
--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -329,6 +329,9 @@ function sanitizePostedTrace(postedTrace: RawPostedTrace): PostedTrace {
     appStateHash: postedTrace.appStateHash,
     pluginArgs: postedTrace.pluginArgs,
   };
+  if (postedTrace.fileName !== undefined) {
+    result.fileName = sanitizeString(postedTrace.fileName);
+  }
   if (postedTrace.url !== undefined) {
     result.url = sanitizeString(postedTrace.url);
   }

--- a/ui/src/frontend/post_message_handler_unittest.ts
+++ b/ui/src/frontend/post_message_handler_unittest.ts
@@ -102,6 +102,17 @@ describe('parsePostedTrace', () => {
       expect(result?.buffer).toBeInstanceOf(ArrayBuffer);
     });
 
+    test('file name is preserved and sanitized', () => {
+      const result = parsePostedTrace({
+        perfetto: {
+          buffer: new ArrayBuffer(),
+          title: 'foo',
+          fileName: 'my<trace>.pftrace',
+        },
+      });
+      expect(result?.fileName).toBe('my trace .pftrace');
+    });
+
     test('view is snipped to the view, not the underlying buffer', () => {
       // A 10-byte view starting at offset 2 of a 16-byte buffer.
       const underlying = new Uint8Array(16);


### PR DESCRIPTION
Fixes: https://github.com/google/perfetto/issues/6736
