### PR TITLE
ui: add flag to keep current page when loading a new trace

### DIFF
--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -106,6 +106,13 @@ const FORCE_FULL_SORT_FLAG = featureFlags.register({
     'Forces the trace processor into performing a full sort ignoring any windowing logic',
   defaultValue: false,
 });
+const KEEP_CURRENT_PAGE_ON_TRACE_LOAD_FLAG = featureFlags.register({
+  id: 'keepCurrentPageOnTraceLoad',
+  name: 'Keep current page on trace load',
+  description:
+    'When loading a new trace, stay on the current page instead of navigating to the default landing page',
+  defaultValue: false,
+});
 
 // TODO(stevegolton): Move this into some global "SQL extensions" file and
 // ensure it's only run once.
@@ -275,7 +282,7 @@ async function loadTraceIntoEngine(
 
   // Plugins may call trace.initialPage.suggest(...) during onTraceLoad to
   // request that the app navigate somewhere other than /viewer.
-  const initialRoute = trace.initialPage.getWinner() ?? '/viewer';
+  const initialRoute = getInitialRoute(trace);
   Router.navigate(`#!${initialRoute}?local_cache_key=${cacheUuid}`);
 
   decideTabs(trace);
@@ -374,6 +381,15 @@ async function loadTraceIntoEngine(
   }
 
   return trace;
+}
+
+function getInitialRoute(trace: TraceImpl) {
+  if (KEEP_CURRENT_PAGE_ON_TRACE_LOAD_FLAG.get()) {
+    const currentRoute = Router.getCurrentRoute();
+    return `${currentRoute.page}${currentRoute.subpage}`;
+  } else {
+    return trace.initialPage.getWinner() ?? '/viewer';
+  }
 }
 
 function showStartupCommandIssuesDialog(


### PR DESCRIPTION
Currently every time a trace loads we navigate to the timeline page. During UI development, it's quite handy to just stay on the same page while reloading the UI frequently, and this automatic page changing can get frustrating.

This PR adds a 'keepCurrentPageOnTraceLoad' feature flag that, when enabled, preserves the current page and subpage instead of navigating to the default landing page (/viewer) when a new trace is loaded. The local_cache_key is still updated in the URL to maintain the trace link.