### PR TITLE
tp: add follower counters to stack sampling

### DIFF
--- a/protos/perfetto/trace/profiling/stack_sample.proto
+++ b/protos/perfetto/trace/profiling/stack_sample.proto
@@ -183,10 +183,17 @@ message StackSample {
   // The value attributed to this sample for the primary counter (e.g. the
   // number of cycles or nanoseconds this sample represents).
   optional uint64 primary_weight = 11;
+
+  // Additional counters read at the same sample (e.g. instructions, cache
+  // misses read alongside a cycles timebase). follower_weights is positional
+  // with whichever of follower_descriptors / follower_descriptor_iids is set.
+  repeated CounterDescriptor follower_descriptors = 12;
+  repeated uint64 follower_descriptor_iids = 13 [packed = true];
+  repeated uint64 follower_weights = 14 [packed = true];
 }
 
 // Per-sequence defaults for StackSample. Lets a producer declare the source and
-// the common timebase once instead of on every sample.
+// the common timebase / followers once instead of on every sample.
 message StackSampleDefaults {
   // Identifies the profiler that produced these samples, e.g. "linux.perf",
   // "python.wall". Recorded once per sampling stream.
@@ -194,4 +201,7 @@ message StackSampleDefaults {
 
   // Default primary timebase for samples that omit their own.
   optional StackSample.CounterDescriptor primary_descriptor = 2;
+
+  // Default follower counters, positional with StackSample.follower_weights.
+  repeated StackSample.CounterDescriptor follower_descriptors = 3;
 }

--- a/src/trace_processor/plugins/stack_sample_importer/module.cc
+++ b/src/trace_processor/plugins/stack_sample_importer/module.cc
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <vector>
 
 #include "perfetto/ext/base/fnv_hash.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
@@ -135,13 +136,15 @@ StackSampleModule::StackSampleModule(
     tables::StackSampleTable* table,
     tables::StackSampleTaskContextTable* task_context_table,
     tables::StackSampleExecutionContextTable* exec_context_table,
-    tables::StackSampleTimebaseTable* timebase_table)
+    tables::StackSampleCounterTable* counter_table,
+    tables::StackSampleFollowerTable* follower_table)
     : ProtoImporterModule(module_context),
       context_(context),
       table_(table),
       task_context_table_(task_context_table),
       exec_context_table_(exec_context_table),
-      timebase_table_(timebase_table) {
+      counter_table_(counter_table),
+      follower_table_(follower_table) {
   RegisterForField(TracePacket::kStackSampleFieldNumber);
 }
 
@@ -182,25 +185,74 @@ StackSampleModule::InternExecutionContext(std::optional<uint32_t> cpu,
   return id;
 }
 
-tables::StackSampleTimebaseTable::Id StackSampleModule::InternTimebase(
+tables::StackSampleCounterTable::Id StackSampleModule::InternCounter(
     StringId source,
     const ResolvedCounterDescriptor& desc) {
   uint64_t key = base::FnvHasher::Combine(
       source.raw_id(), desc.name.raw_id(), OptStringKey(desc.unit),
       desc.unit_multiplier ? static_cast<uint64_t>(*desc.unit_multiplier) : 0,
       OptStringKey(desc.description));
-  if (auto* id = timebases_.Find(key)) {
+  if (auto* id = counters_.Find(key)) {
     return *id;
   }
-  tables::StackSampleTimebaseTable::Row row;
+  tables::StackSampleCounterTable::Row row;
   row.source = source;
   row.name = desc.name;
   row.unit = desc.unit;
   row.unit_multiplier = desc.unit_multiplier;
   row.description = desc.description;
-  auto id = timebase_table_->Insert(row).id;
-  timebases_.Insert(key, id);
+  auto id = counter_table_->Insert(row).id;
+  counters_.Insert(key, id);
   return id;
+}
+
+void StackSampleModule::ParseFollowers(
+    tables::StackSampleTable::Id sample_id,
+    PacketSequenceStateGeneration* sequence_state,
+    StringId source,
+    const protos::pbzero::StackSample::Decoder& sample,
+    const std::optional<protos::pbzero::StackSampleDefaults::Decoder>& defaults) {
+  using protos::pbzero::InternedData;
+  using CounterDescriptor = protos::pbzero::StackSample::CounterDescriptor;
+
+  std::vector<tables::StackSampleCounterTable::Id> counters;
+  for (auto it = sample.follower_descriptors(); it; ++it) {
+    CounterDescriptor::Decoder desc(*it);
+    counters.push_back(
+        InternCounter(source, ResolveCounterDescriptor(context_, desc)));
+  }
+  bool parse_error = false;
+  if (counters.empty()) {
+    for (auto it = sample.follower_descriptor_iids(&parse_error); it; ++it) {
+      auto* desc = sequence_state->LookupInternedMessage<
+          InternedData::kStackSampleCounterDescriptorsFieldNumber,
+          CounterDescriptor>(*it);
+      if (!desc) {
+        continue;
+      }
+      counters.push_back(
+          InternCounter(source, ResolveCounterDescriptor(context_, *desc)));
+    }
+  }
+  if (counters.empty() && defaults) {
+    for (auto it = defaults->follower_descriptors(); it; ++it) {
+      CounterDescriptor::Decoder desc(*it);
+      counters.push_back(
+          InternCounter(source, ResolveCounterDescriptor(context_, desc)));
+    }
+  }
+
+  size_t i = 0;
+  for (auto it = sample.follower_weights(&parse_error); it; ++it, ++i) {
+    if (i >= counters.size()) {
+      break;
+    }
+    tables::StackSampleFollowerTable::Row row;
+    row.stack_sample_id = sample_id;
+    row.counter_id = counters[i];
+    row.weight = static_cast<int64_t>(*it);
+    follower_table_->Insert(row);
+  }
 }
 
 void StackSampleModule::ParseStackSample(
@@ -314,8 +366,8 @@ void StackSampleModule::ParseStackSample(
     CounterDescriptor::Decoder d(defaults->primary_descriptor());
     primary = ResolveCounterDescriptor(context_, d);
   }
-  tables::StackSampleTimebaseTable::Id timebase_id =
-      InternTimebase(source_id, primary);
+  tables::StackSampleCounterTable::Id timebase_id =
+      InternCounter(source_id, primary);
 
   std::optional<CallsiteId> cs_id =
       ResolveCallstack(sequence_state, upid, sample);
@@ -332,7 +384,9 @@ void StackSampleModule::ParseStackSample(
   row.timebase_id = timebase_id;
   row.callsite_id = cs_id;
   row.weight = weight;
-  table_->Insert(row);
+  tables::StackSampleTable::Id sample_id = table_->Insert(row).id;
+
+  ParseFollowers(sample_id, sequence_state, source_id, sample, defaults);
 }
 
 }  // namespace perfetto::trace_processor::stack_sample_importer

--- a/src/trace_processor/plugins/stack_sample_importer/module.cc
+++ b/src/trace_processor/plugins/stack_sample_importer/module.cc
@@ -211,7 +211,8 @@ void StackSampleModule::ParseFollowers(
     PacketSequenceStateGeneration* sequence_state,
     StringId source,
     const protos::pbzero::StackSample::Decoder& sample,
-    const std::optional<protos::pbzero::StackSampleDefaults::Decoder>& defaults) {
+    const std::optional<protos::pbzero::StackSampleDefaults::Decoder>&
+        defaults) {
   using protos::pbzero::InternedData;
   using CounterDescriptor = protos::pbzero::StackSample::CounterDescriptor;
 

--- a/src/trace_processor/plugins/stack_sample_importer/module.h
+++ b/src/trace_processor/plugins/stack_sample_importer/module.h
@@ -53,7 +53,8 @@ class StackSampleModule : public ProtoImporterModule {
       tables::StackSampleTable* table,
       tables::StackSampleTaskContextTable* task_context_table,
       tables::StackSampleExecutionContextTable* exec_context_table,
-      tables::StackSampleTimebaseTable* timebase_table);
+      tables::StackSampleCounterTable* counter_table,
+      tables::StackSampleFollowerTable* follower_table);
 
   void ParseField(const ParseFieldArgs& args) override;
 
@@ -64,9 +65,16 @@ class StackSampleModule : public ProtoImporterModule {
   tables::StackSampleExecutionContextTable::Id InternExecutionContext(
       std::optional<uint32_t> cpu,
       StringId mode);
-  tables::StackSampleTimebaseTable::Id InternTimebase(
+  tables::StackSampleCounterTable::Id InternCounter(
       StringId source,
       const ResolvedCounterDescriptor& desc);
+  void ParseFollowers(
+      tables::StackSampleTable::Id sample_id,
+      PacketSequenceStateGeneration* sequence_state,
+      StringId source,
+      const protos::pbzero::StackSample::Decoder& sample,
+      const std::optional<
+          protos::pbzero::StackSampleDefaults::Decoder>& defaults);
 
   void ParseStackSample(int64_t ts,
                         PacketSequenceStateGeneration* sequence_state,
@@ -76,14 +84,15 @@ class StackSampleModule : public ProtoImporterModule {
   tables::StackSampleTable* const table_;
   tables::StackSampleTaskContextTable* const task_context_table_;
   tables::StackSampleExecutionContextTable* const exec_context_table_;
-  tables::StackSampleTimebaseTable* const timebase_table_;
+  tables::StackSampleCounterTable* const counter_table_;
+  tables::StackSampleFollowerTable* const follower_table_;
 
   // Content-dedup maps: fingerprint of the context fields -> interned row id.
   base::FlatHashMap<uint64_t, tables::StackSampleTaskContextTable::Id>
       task_contexts_;
   base::FlatHashMap<uint64_t, tables::StackSampleExecutionContextTable::Id>
       exec_contexts_;
-  base::FlatHashMap<uint64_t, tables::StackSampleTimebaseTable::Id> timebases_;
+  base::FlatHashMap<uint64_t, tables::StackSampleCounterTable::Id> counters_;
 };
 
 }  // namespace perfetto::trace_processor::stack_sample_importer

--- a/src/trace_processor/plugins/stack_sample_importer/module.h
+++ b/src/trace_processor/plugins/stack_sample_importer/module.h
@@ -22,6 +22,8 @@
 
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/protozero/field.h"
+#include "protos/perfetto/trace/profiling/stack_sample.pbzero.h"
+#include "protos/perfetto/trace/trace_packet_defaults.pbzero.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/plugins/stack_sample_importer/tables_py.h"
 #include "src/trace_processor/storage/trace_storage.h"
@@ -73,8 +75,8 @@ class StackSampleModule : public ProtoImporterModule {
       PacketSequenceStateGeneration* sequence_state,
       StringId source,
       const protos::pbzero::StackSample::Decoder& sample,
-      const std::optional<
-          protos::pbzero::StackSampleDefaults::Decoder>& defaults);
+      const std::optional<protos::pbzero::StackSampleDefaults::Decoder>&
+          defaults);
 
   void ParseStackSample(int64_t ts,
                         PacketSequenceStateGeneration* sequence_state,

--- a/src/trace_processor/plugins/stack_sample_importer/plugin.cc
+++ b/src/trace_processor/plugins/stack_sample_importer/plugin.cc
@@ -50,8 +50,11 @@ class StackSampleImporter : public Plugin<StackSampleImporter> {
     out.push_back({&exec_context_table_->dataframe(),
                    tables::StackSampleExecutionContextTable::Name(),
                    {}});
-    out.push_back({&timebase_table_->dataframe(),
-                   tables::StackSampleTimebaseTable::Name(),
+    out.push_back({&counter_table_->dataframe(),
+                   tables::StackSampleCounterTable::Name(),
+                   {}});
+    out.push_back({&follower_table_->dataframe(),
+                   tables::StackSampleFollowerTable::Name(),
                    {}});
   }
 
@@ -61,7 +64,8 @@ class StackSampleImporter : public Plugin<StackSampleImporter> {
     EnsureTables();
     module_context->modules.emplace_back(new StackSampleModule(
         module_context, trace_context, table_.get(), task_context_table_.get(),
-        exec_context_table_.get(), timebase_table_.get()));
+        exec_context_table_.get(), counter_table_.get(),
+        follower_table_.get()));
   }
 
   uint64_t GetBoundsMutationCount() override {
@@ -88,13 +92,15 @@ class StackSampleImporter : public Plugin<StackSampleImporter> {
         std::make_unique<tables::StackSampleTaskContextTable>(pool);
     exec_context_table_ =
         std::make_unique<tables::StackSampleExecutionContextTable>(pool);
-    timebase_table_ = std::make_unique<tables::StackSampleTimebaseTable>(pool);
+    counter_table_ = std::make_unique<tables::StackSampleCounterTable>(pool);
+    follower_table_ = std::make_unique<tables::StackSampleFollowerTable>(pool);
   }
 
   std::unique_ptr<tables::StackSampleTable> table_;
   std::unique_ptr<tables::StackSampleTaskContextTable> task_context_table_;
   std::unique_ptr<tables::StackSampleExecutionContextTable> exec_context_table_;
-  std::unique_ptr<tables::StackSampleTimebaseTable> timebase_table_;
+  std::unique_ptr<tables::StackSampleCounterTable> counter_table_;
+  std::unique_ptr<tables::StackSampleFollowerTable> follower_table_;
 };
 
 StackSampleImporter::~StackSampleImporter() = default;

--- a/src/trace_processor/plugins/stack_sample_importer/tables.py
+++ b/src/trace_processor/plugins/stack_sample_importer/tables.py
@@ -162,12 +162,9 @@ STACK_SAMPLE_FOLLOWER_TABLE = Table(
                point as the primary timebase.''',
         group='Callstack profilers',
         columns={
-            'stack_sample_id':
-                '''The sample this follower value belongs to.''',
-            'counter_id':
-                '''The follower counter this value is for.''',
-            'weight':
-                '''The follower counter value at this sample.''',
+            'stack_sample_id': '''The sample this follower value belongs to.''',
+            'counter_id': '''The follower counter this value is for.''',
+            'weight': '''The follower counter value at this sample.''',
         }))
 
 # Keep this list sorted.

--- a/src/trace_processor/plugins/stack_sample_importer/tables.py
+++ b/src/trace_processor/plugins/stack_sample_importer/tables.py
@@ -72,10 +72,10 @@ STACK_SAMPLE_EXECUTION_CONTEXT_TABLE = Table(
                    "kernel"). Empty if unknown.''',
         }))
 
-STACK_SAMPLE_TIMEBASE_TABLE = Table(
+STACK_SAMPLE_COUNTER_TABLE = Table(
     python_module=__file__,
-    class_name='StackSampleTimebaseTable',
-    sql_name='__intrinsic_stack_sample_timebase',
+    class_name='StackSampleCounterTable',
+    sql_name='__intrinsic_stack_sample_counter',
     columns=[
         C('source', CppString()),
         C('name', CppString()),
@@ -85,9 +85,9 @@ STACK_SAMPLE_TIMEBASE_TABLE = Table(
     ],
     tabledoc=TableDoc(
         doc='''
-          The counter timebase a stack sample is measured against: the profiler
-          source and the primary CounterDescriptor. Deduplicated, one row per
-          distinct timebase.
+          A counter a stack sample is measured against: the profiler source and
+          a CounterDescriptor. Used both for the primary timebase and for
+          follower counters. Deduplicated, one row per distinct counter.
         ''',
         group='Callstack profilers',
         columns={
@@ -120,7 +120,7 @@ STACK_SAMPLE_TABLE = Table(
           CppOptional(CppTableId(STACK_SAMPLE_TASK_CONTEXT_TABLE))),
         C('execution_context_id',
           CppOptional(CppTableId(STACK_SAMPLE_EXECUTION_CONTEXT_TABLE))),
-        C('timebase_id', CppTableId(STACK_SAMPLE_TIMEBASE_TABLE)),
+        C('timebase_id', CppTableId(STACK_SAMPLE_COUNTER_TABLE)),
         C('callsite_id', CppOptional(CppTableId(STACK_PROFILE_CALLSITE_TABLE))),
         C('weight', CppOptional(CppInt64())),
     ],
@@ -138,7 +138,8 @@ STACK_SAMPLE_TABLE = Table(
                 '''The execution state (cpu, privilege mode) at sample time, if
                    known.''',
             'timebase_id':
-                '''The counter timebase this sample is measured against.''',
+                '''The primary counter (timebase) this sample is measured
+                   against.''',
             'callsite_id':
                 '''If set, the captured callstack.''',
             'weight':
@@ -146,10 +147,34 @@ STACK_SAMPLE_TABLE = Table(
                    set.''',
         }))
 
+STACK_SAMPLE_FOLLOWER_TABLE = Table(
+    python_module=__file__,
+    class_name='StackSampleFollowerTable',
+    sql_name='__intrinsic_stack_sample_follower',
+    columns=[
+        C('stack_sample_id', CppTableId(STACK_SAMPLE_TABLE)),
+        C('counter_id', CppTableId(STACK_SAMPLE_COUNTER_TABLE)),
+        C('weight', CppInt64()),
+    ],
+    tabledoc=TableDoc(
+        doc='''A follower counter value recorded alongside a stack sample: an
+               additional counter (e.g. instructions) read at the same sample
+               point as the primary timebase.''',
+        group='Callstack profilers',
+        columns={
+            'stack_sample_id':
+                '''The sample this follower value belongs to.''',
+            'counter_id':
+                '''The follower counter this value is for.''',
+            'weight':
+                '''The follower counter value at this sample.''',
+        }))
+
 # Keep this list sorted.
 ALL_TABLES = [
+    STACK_SAMPLE_COUNTER_TABLE,
     STACK_SAMPLE_EXECUTION_CONTEXT_TABLE,
+    STACK_SAMPLE_FOLLOWER_TABLE,
     STACK_SAMPLE_TABLE,
     STACK_SAMPLE_TASK_CONTEXT_TABLE,
-    STACK_SAMPLE_TIMEBASE_TABLE,
 ]

--- a/test/trace_processor/diff_tests/parser/profiling/stack_sample.textproto
+++ b/test/trace_processor/diff_tests/parser/profiling/stack_sample.textproto
@@ -21,6 +21,10 @@ packet {
         name: "wall-time"
         unit: UNIT_NANOSECONDS
       }
+      follower_descriptors {
+        name: "instructions"
+        unit: UNIT_INSTRUCTIONS
+      }
     }
   }
   interned_data {
@@ -56,6 +60,7 @@ packet {
       frame_ids: 1
     }
     primary_weight: 1000000
+    follower_weights: 500
   }
 }
 

--- a/test/trace_processor/diff_tests/parser/profiling/tests.py
+++ b/test/trace_processor/diff_tests/parser/profiling/tests.py
@@ -656,7 +656,7 @@ class Profiling(TestSuite):
           tb.unit,
           spf.name AS frame_name
         FROM __intrinsic_stack_sample ss
-        JOIN __intrinsic_stack_sample_timebase tb ON ss.timebase_id = tb.id
+        JOIN __intrinsic_stack_sample_counter tb ON ss.timebase_id = tb.id
         LEFT JOIN __intrinsic_stack_sample_execution_context ec
           ON ss.execution_context_id = ec.id
         JOIN stack_profile_callsite spc ON ss.callsite_id = spc.id
@@ -692,6 +692,27 @@ class Profiling(TestSuite):
         "ts","process_name","cpu","mode"
         1000,"myproc",2,"user"
         7000,"[NULL]","[NULL]","[NULL]"
+        """))
+
+  def test_stack_sample_followers(self):
+    return DiffTestBlueprint(
+        trace=Path('stack_sample.textproto'),
+        query="""
+        -- The ts=1000 sample has one follower ("instructions") with value 500;
+        -- the primary timebase and the follower share the counter table.
+        SELECT
+          ss.ts,
+          c.name AS counter_name,
+          c.unit,
+          f.weight
+        FROM __intrinsic_stack_sample ss
+        JOIN __intrinsic_stack_sample_follower f ON f.stack_sample_id = ss.id
+        JOIN __intrinsic_stack_sample_counter c ON f.counter_id = c.id
+        ORDER BY ss.ts, f.id;
+        """,
+        out=Csv("""
+        "ts","counter_name","unit","weight"
+        1000,"instructions","instructions",500
         """))
 
   def test_frame_types(self):


### PR DESCRIPTION
Add follower counters to StackSample: secondary counters read at the same
sample point as the primary timebase (e.g. instructions alongside cycles).
follower_weights is positional with follower_descriptors /
follower_descriptor_iids, defaulting from StackSampleDefaults.

Generalize the timebase table into __intrinsic_stack_sample_counter, shared
by the primary timebase and followers, and add __intrinsic_stack_sample_follower
mapping each sample to its follower counter values.
