### PR TITLE
ui: Add DataGrid playground as a separate widgets subpage

### DIFF
--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
@@ -231,6 +231,15 @@ export function renderDataGrid(app: App): m.Children {
         '"manager.manager.name" or "department.head.name". For parameterized columns ',
         'like "skills", you can type any key name (e.g., "typescript", "python").',
       ]),
+      m('p', [
+        'Want to experiment with custom schemas? Try the ',
+        m(
+          Anchor,
+          {href: '#!/widgets/datagrid-playground'},
+          'DataGrid Playground',
+        ),
+        ' for an interactive editor where you can define and test your own DataGrid configs.',
+      ]),
     ),
 
     renderWidgetShowcase({

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_playground.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_playground.ts
@@ -1,0 +1,298 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
+import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
+import {Editor} from '../../../widgets/editor';
+import {Button, ButtonVariant} from '../../../widgets/button';
+import {Callout} from '../../../widgets/callout';
+import {Intent} from '../../../widgets/common';
+import {EmptyState} from '../../../widgets/empty_state';
+import {Anchor} from '../../../widgets/anchor';
+import type {App} from '../../../public/app';
+import type {Trace} from '../../../public/trace';
+import type {DataGridAttrs} from '../../../components/widgets/datagrid/datagrid';
+import {SplitPanel} from '../../../widgets/split_panel';
+
+// The default config shown in the editor. Builds a DataGrid over the slice
+// table, joining to `track` and exposing the arg set as a parameterized column.
+const DEFAULT_CONFIG = `// Return the DataGrid config: { schema, data, initialColumns }.
+//
+// In scope:
+//   engine         - the current trace's query engine
+//   SQLDataSource  - constructs a SQL-backed datasource from a schema
+//   m              - the Mithril library, for constructing virtual DOM nodes
+
+// Describes how the columns are displayed in the grid, including in the 'add
+// column' menu and defines optional styling overrides.
+const schema = {
+  id: {title: 'ID', columnType: 'identifier'},
+  ts: {title: 'Timestamp', columnType: 'quantitative'},
+  dur: {title: 'Duration', columnType: 'quantitative'},
+  name: {title: 'Name', columnType: 'text'},
+  track: {
+    title: 'Track',
+    schema: {
+      id: {title: 'ID', columnType: 'quantitative'},
+      name: {title: 'Name', columnType: 'text'},
+    },
+  },
+  parent: {
+    get schema() {
+      return schema;
+    }
+  },
+  args: {title: 'Arg', parameterized: true},
+};
+
+// Describes the shape of the SQL data: which table, columns, joins and
+// parameterized (arg) columns are available.
+const sqlSchema = {
+  primaryKey: 'id',
+  tableOrSubquery: 'slice',
+  columns: {
+    track: {
+      foreignKey: 'track_id',
+      schema: {
+        tableOrSubquery: 'track',
+        columns: {
+          id: {},
+          name: {},
+        },
+      },
+    },
+    parent: {
+      foreignKey: 'parent_id',
+      get schema() {
+        return sqlSchema;
+      }
+    },
+    args: {
+      parameterized: true,
+      expression: (alias, key) =>
+        \`extract_arg(\${alias}.arg_set_id, '\${key}')\`,
+      parameterKeysQuery: (tableOrSubquery, alias) => \`
+        SELECT DISTINCT args.key
+        FROM (\${tableOrSubquery}) AS \${alias}
+        JOIN args ON args.arg_set_id = \${alias}.arg_set_id
+        WHERE args.key IS NOT NULL
+        ORDER BY args.key
+        LIMIT 1000
+      \`,
+    },
+  },
+};
+
+// To try pivot mode, uncomment this and add \`initialPivot\` to the returned
+// object below - groups slices by track name, showing a count and total
+// duration per track, in expandable tree form.
+// const initialPivot = {
+//   groupBy: [{id: 'track_name', field: 'track.name'}],
+//   aggregates: [
+//     {id: 'count', function: 'COUNT'},
+//     {id: 'total_dur', field: 'dur', function: 'SUM'},
+//   ],
+//   groupDisplay: 'tree',
+// };
+
+return {
+  schema,
+  data: new SQLDataSource({engine, ...sqlSchema}),
+  initialColumns: [
+    {id: 'id', field: 'id'},
+    {id: 'ts', field: 'ts'},
+    {id: 'dur', field: 'dur'},
+    {id: 'name', field: 'name'},
+    {id: 'track_name', field: 'track.name'},
+  ],
+  // initialPivot,
+};
+`;
+
+// Result of evaluating the user's config: either the DataGrid attrs to render,
+// or an error message to display.
+type EvalResult =
+  | {readonly ok: true; readonly attrs: DataGridAttrs}
+  | {readonly ok: false; readonly error: string};
+
+function evalConfig(trace: Trace, code: string): EvalResult {
+  try {
+    const fn = new Function('engine', 'SQLDataSource', 'm', code);
+    const result: unknown = fn(trace.engine, SQLDataSource, m);
+    if (
+      result === null ||
+      typeof result !== 'object' ||
+      !('schema' in result) ||
+      !('data' in result)
+    ) {
+      return {
+        ok: false,
+        error: 'Config must return an object with `schema` and `data`.',
+      };
+    }
+    return {ok: true, attrs: result as DataGridAttrs};
+  } catch (e) {
+    return {ok: false, error: `${e}`};
+  }
+}
+
+// Interactive DataGrid playground: edit a config on the left, see the resulting
+// grid on the right. The config is only (re)evaluated on demand (Ctrl/Cmd+Enter
+// or the Run button) so editing keystrokes don't rebuild the datasource.
+class DataGridDemo implements m.ClassComponent<{trace: Trace}> {
+  private text = DEFAULT_CONFIG;
+  private result?: EvalResult;
+  private generation = 0;
+  // The SQL query the grid last asked its datasource to run, kept in sync via
+  // the DataGrid's onReady callback. Only available for SQLDataSource - see
+  // SQLDataSource.getQuery.
+  private query?: string;
+
+  private run(trace: Trace) {
+    this.result = evalConfig(trace, this.text);
+    this.generation++;
+    this.query = undefined;
+  }
+
+  view({attrs}: m.Vnode<{trace: Trace}>): m.Children {
+    const {trace} = attrs;
+    if (this.result === undefined) {
+      this.run(trace);
+    }
+    const result = this.result!;
+
+    // Fill the remaining height as a flex child. `minHeight: 0` is load-bearing:
+    // without it this item won't shrink below the fillHeight DataGrid's content
+    // size, so the grid keeps growing its own available space and thrashes
+    // layout forever. The full-width page chain (see styles.scss) provides the
+    // bounded, min-height:0 ancestors this relies on.
+    return m(
+      '.pf-datagrid-demo',
+      {style: {flex: '1', minHeight: 0, marginTop: '16px'}},
+      m(SplitPanel, {
+        direction: 'horizontal',
+        firstPanel: m(
+          '.pf-datagrid-demo__editor',
+          {
+            style: {
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              minWidth: 0,
+            },
+          },
+          m(
+            '.pf-datagrid-demo__toolbar',
+            {style: {marginBottom: '4px'}},
+            m(Button, {
+              variant: ButtonVariant.Filled,
+              label: 'Run (Ctrl+Enter)',
+              intent: Intent.Primary,
+              onclick: () => this.run(trace),
+            }),
+          ),
+          m(
+            '.pf-datagrid-demo__editor-container',
+            {style: {flex: '1', minHeight: 0}},
+            m(Editor, {
+              fillHeight: true,
+              language: 'javascript',
+              text: this.text,
+              onUpdate: (text: string) => {
+                this.text = text;
+              },
+              onExecute: (text: string) => {
+                this.text = text;
+                this.run(trace);
+              },
+            }),
+          ),
+        ),
+        secondPanel: m(SplitPanel, {
+          direction: 'vertical',
+          firstPanel: result.ok
+            ? m(DataGrid, {
+                key: this.generation,
+                ...result.attrs,
+                fillHeight: true,
+                onReady: (api) => {
+                  const data = result.ok ? result.attrs.data : undefined;
+                  const query =
+                    data instanceof SQLDataSource
+                      ? data.getQuery(api.getModel())
+                      : undefined;
+                  if (query !== this.query) {
+                    this.query = query;
+                    m.redraw();
+                  }
+                },
+              })
+            : m(
+                Callout,
+                {intent: Intent.Danger, icon: 'error'},
+                m('pre', result.error),
+              ),
+          secondPanel: m(Editor, {
+            fillHeight: true,
+            readonly: true,
+            language: 'perfetto-sql',
+            text:
+              this.query ??
+              '-- SQL query not available (needs a SQLDataSource).',
+          }),
+        }),
+      }),
+    );
+  }
+}
+
+export function renderDataGrid(app: App): m.Children {
+  const trace = app.trace;
+  return m(
+    '',
+    {
+      // Flex column that fills the (bounded) full-width content area. minHeight:0
+      // lets it shrink so the DataGridDemo below can own the leftover height
+      // without the layout feedback loop.
+      style: {
+        height: '100%',
+        minHeight: 0,
+        display: 'flex',
+        flexDirection: 'column',
+      },
+    },
+    m(
+      '.pf-widget-intro',
+      m('h1', 'DataGrid Playground'),
+      m('p', [
+        'This is an interactive playground. Edit the config on the left to ',
+        'define a schema and datasource, then hit Run (or Ctrl/Cmd+Enter) to ',
+        'render it in the grid on the right.',
+      ]),
+      m('p', [
+        'See the ',
+        m(Anchor, {href: '#!/widgets/datagrid'}, 'DataGrid demo'),
+        ' for curated examples of schemas, relationships, and data sources.',
+      ]),
+    ),
+    trace
+      ? m(DataGridDemo, {trace})
+      : m(
+          EmptyState,
+          {title: 'Load a trace'},
+          'The DataGrid playground needs a trace to query against.',
+        ),
+  );
+}

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/styles.scss
@@ -121,12 +121,31 @@
   &__content-container {
     flex: 1;
     overflow-y: auto;
+
+    // Full-width pages own their own scrolling (e.g. a fillHeight DataGrid), so
+    // clip here instead of letting content grow this scroll region unbounded.
+    // Combined with min-height:0 down the chain, this bounds the height so a
+    // fillHeight child can't feed its own content back into its available
+    // space and thrash layout forever.
+    &--full-width {
+      overflow: hidden;
+      display: flex;
+      min-height: 0;
+    }
   }
 
   &__content {
     flex: 1;
     padding-inline: 16px;
+    padding-bottom: 16px;
     max-width: 900px;
-    padding-bottom: 32px;
+
+    &--full-width {
+      max-width: none;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      overflow: hidden;
+    }
   }
 }

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -27,7 +27,8 @@ import {renderChip} from './demos/chip_demo';
 import {renderCodeSnippet} from './demos/code_snippet_demo';
 import {renderCopyableLink} from './demos/copyable_link_demo';
 import {cursorTooltip} from './demos/cursor_tooltip_demo';
-import {renderDataGrid} from './demos/datagrid_demo';
+import {renderDataGrid as renderDataGridDemo} from './demos/datagrid_demo';
+import {renderDataGrid as renderDataGridPlayground} from './demos/datagrid_playground';
 import {renderDrawerPanel} from './demos/drawer_panel_demo';
 import {renderEditor} from './demos/editor_demo';
 import {renderEmptyState} from './demos/empty_state_demo';
@@ -66,6 +67,9 @@ interface WidgetSection {
   readonly id: string;
   readonly label: string;
   readonly view: (app: App) => m.Children;
+  // If set, the content area drops its max-width and fills the screen. Useful
+  // for pages showing wide, interactive widgets (e.g. DataGrid).
+  readonly fullWidth?: boolean;
 }
 
 const WIDGET_SECTIONS: WidgetSection[] = [
@@ -83,7 +87,13 @@ const WIDGET_SECTIONS: WidgetSection[] = [
   {id: 'combobox', label: 'Combobox', view: renderCombobox},
   {id: 'copyablelink', label: 'CopyableLink', view: renderCopyableLink},
   {id: 'cursor-tooltip', label: 'CursorTooltip', view: cursorTooltip},
-  {id: 'datagrid', label: 'DataGrid', view: renderDataGrid},
+  {id: 'datagrid', label: 'DataGrid', view: renderDataGridDemo},
+  {
+    id: 'datagrid-playground',
+    label: 'DataGrid Playground',
+    view: renderDataGridPlayground,
+    fullWidth: true,
+  },
   {id: 'drawer-panel', label: 'DrawerPanel', view: renderDrawerPanel},
   {id: 'editor', label: 'Editor', view: renderEditor},
   {id: 'emptystate', label: 'EmptyState', view: renderEmptyState},
@@ -153,9 +163,21 @@ export class WidgetsPage implements m.ClassComponent<WidgetsPageAttrs> {
       // Main content area
       m(
         '.pf-widgets-page__content-container',
-        {key: currentSection ? currentSection.id : 'no-section'},
+        {
+          key: currentSection ? currentSection.id : 'no-section',
+          className: classNames(
+            currentSection?.fullWidth &&
+              'pf-widgets-page__content-container--full-width',
+          ),
+        },
         m(
           '.pf-widgets-page__content',
+          {
+            className: classNames(
+              currentSection?.fullWidth &&
+                'pf-widgets-page__content--full-width',
+            ),
+          },
           currentSection
             ? currentSection.view(attrs.app)
             : m(


### PR DESCRIPTION
Split the DataGrid showcase into two pages: the original demo with curated examples, and a new interactive playground where users can edit and test custom DataGrid configs live.

Also add fullWidth support to WidgetsPage for pages that need more horizontal space.
