### PR TITLE
ui: DataGrid: Style missing cells & invalidate invalid fields instead of guessing

### DIFF
--- a/ui/src/components/widgets/datagrid/datagrid.scss
+++ b/ui/src/components/widgets/datagrid/datagrid.scss
@@ -209,3 +209,22 @@
     flex-grow: 1;
   }
 }
+
+.pf-datagrid-cell--missing {
+  $missing-cell-stripe: color-mix(
+    in srgb,
+    var(--pf-color-danger) 10%,
+    transparent
+  );
+
+  // Patterned background to indicate missing data, similar to how Excel does it.
+  background-image: repeating-linear-gradient(
+    45deg,
+    $missing-cell-stripe,
+    $missing-cell-stripe 4px,
+    transparent 4px,
+    transparent 8px
+  );
+  color: var(--pf-color-danger);
+  font-style: italic;
+}

--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -1640,7 +1640,12 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
         return this.columns.map((col) => {
           const {field} = col;
           const alias = getColumnAlias(col);
-          const value = row[alias];
+          const value = maybeUndefined(row[alias]);
+
+          if (value === undefined) {
+            return renderMissingCell();
+          }
+
           const colInfo = columnInfoCache.get(field);
           const cellRenderer =
             colInfo?.cellRenderer ?? ((v: SqlValue) => renderCell(v, field));
@@ -2329,10 +2334,8 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
   }
 }
 
-export function renderCell(value: SqlValue, columnName?: string) {
-  if (value === undefined) {
-    return '';
-  } else if (value instanceof Uint8Array) {
+export function renderCell(value: SqlValue, columnName?: string): m.Children {
+  if (value instanceof Uint8Array) {
     return m(
       Anchor,
       {
@@ -2348,6 +2351,24 @@ export function renderCell(value: SqlValue, columnName?: string) {
   } else {
     return String(value);
   }
+}
+
+// Renders a cell for missing data (undefined value) with a placeholder message
+// and a distinct style. This is almost certainly a developer error
+// (misconfigured schema or initial column list), so we want to make it obvious
+// in the UI. We could throw, but throwing in the render loop takes the whole UI
+// down. We should attempt to handle errors in render loops more gracefully in
+// the future but for now this is better than the alternative which is a blank
+// cell.
+function renderMissingCell(): m.Children {
+  return m(
+    GridCell,
+    {
+      className: 'pf-datagrid-cell--missing',
+      align: 'center',
+    },
+    'no data',
+  );
 }
 
 function getAligment(value: SqlValue): 'left' | 'right' | 'center' {

--- a/ui/src/components/widgets/datagrid/sql_schema.ts
+++ b/ui/src/components/widgets/datagrid/sql_schema.ts
@@ -318,8 +318,8 @@ export class SQLSchemaResolver {
       );
 
       if (rest.length === 0) {
-        // Path ends at a join - return the primary key of the joined table
-        return `${joinAlias}.${targetSchema.primaryKey ?? 'id'}`;
+        // Path ends at a join - this is invalid
+        return undefined;
       }
 
       // Continue resolving into the joined table


### PR DESCRIPTION
- Style missing data cells with a striped background, similar to errored tracks. When a cell value is undefined, render a red diagonal-stripe pattern with "no data" placeholder text instead of leaving the cell blank.
- When a field path ends exactly at a join (no trailing column), treat this as invalid and return undefined instead of returning the primary key. This ensures such cases are caught and displayed as missing data.
