### PR TITLE
ui: Tint track shell when the track is selected

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.Timeline/track_view.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/track_view.ts
@@ -201,6 +201,7 @@ export class TrackView {
         collapsible: collapsible && node.hasChildren,
         collapsed: collapsible && node.collapsed,
         highlight: this.isHighlighted(),
+        selected: this.isSelected(),
         summary: node.isSummary,
         reorderable,
         depth: attrs.depth,
@@ -456,6 +457,30 @@ export class TrackView {
     }
 
     return false;
+  }
+
+  // Returns true if this track is part of the current selection, either because
+  // it's directly selected, or - for summary tracks - because one of its
+  // children is.
+  private isSelected() {
+    const {node, trace} = this;
+    const selection = trace.selection.selection;
+
+    switch (selection.kind) {
+      case 'area':
+        if (node.isSummary) {
+          return selection.trackUris.some((uri) => node.getTrackByUri(uri));
+        }
+        return node.uri !== undefined && selection.trackUris.includes(node.uri);
+      case 'track':
+      case 'track_event':
+        if (node.isSummary) {
+          return Boolean(node.getTrackByUri(selection.trackUri));
+        }
+        return node.uri === selection.trackUri;
+      default:
+        return false;
+    }
   }
 
   private renderAreaSelectionCheckbox(): m.Children {

--- a/ui/src/widgets/track_shell.scss
+++ b/ui/src/widgets/track_shell.scss
@@ -82,6 +82,16 @@
     border-style: solid;
     border-color: var(--pf-color-border-secondary);
 
+    // A subtle tint to indicate this track is part of the current selection.
+    // Declared before --highlight so that highlighting wins.
+    &--selected {
+      background-color: color-mix(
+        in srgb,
+        var(--pf-color-accent) 12%,
+        transparent
+      );
+    }
+
     &--highlight {
       background-color: var(--pf-color-highlight);
       color: var(--pf-color-text);

--- a/ui/src/widgets/track_shell.ts
+++ b/ui/src/widgets/track_shell.ts
@@ -84,6 +84,10 @@ export interface TrackShellAttrs extends HTMLAttrs {
   // Whether to highlight the track or not.
   readonly highlight?: boolean;
 
+  // Whether this track is part of the current selection - tints the shell
+  // subtly.
+  readonly selected?: boolean;
+
   // Whether the shell should be draggable and emit drag/drop events.
   readonly reorderable?: boolean;
 
@@ -194,6 +198,7 @@ export class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       onMoveInside = () => {},
       buttons,
       highlight,
+      selected,
       lite,
       summary,
     } = attrs;
@@ -219,6 +224,7 @@ export class TrackShell implements m.ClassComponent<TrackShellAttrs> {
         className: classNames(
           collapsible && 'pf-track__shell--clickable',
           highlight && 'pf-track__shell--highlight',
+          selected && 'pf-track__shell--selected',
           lite && 'pf-track__shell--lite',
         ),
         onclick: () => {


### PR DESCRIPTION
Tracks that are part of the current selection - whether that's an area selection or a single track/event selection - now get a subtle accent tint on their shell, so it's easier to see at a glance which tracks the selection covers.

Fixes: https://github.com/google/perfetto/issues/6749

Area selection:

<img width="832" height="467" alt="image" src="https://github.com/user-attachments/assets/b93452aa-2905-4a14-9521-f22fced2ca22" />

Single selection:

<img width="667" height="418" alt="image" src="https://github.com/user-attachments/assets/524fd745-4d31-4fad-a822-fd3b7cabcde2" />
