### PR TITLE
tp: add (pid)/(tid) field options and annotate frameworks_base

### DIFF
--- a/protos/perfetto/trace/field_options.proto
+++ b/protos/perfetto/trace/field_options.proto
@@ -26,4 +26,10 @@ extend google.protobuf.FieldOptions {
   // Fully-qualified flags enum for a bitmask int field; trace_processor expands
   // the mask into one string arg per set flag.
   optional string flags_enum = 73921;
+
+  // Marks an int field as a pid; emits companion upid + process_name args.
+  optional bool pid = 73922;
+
+  // Marks an int field as a tid; emits companion utid + thread_name args.
+  optional bool tid = 73923;
 }

--- a/protos/perfetto/trace/field_options.proto
+++ b/protos/perfetto/trace/field_options.proto
@@ -27,9 +27,11 @@ extend google.protobuf.FieldOptions {
   // the mask into one string arg per set flag.
   optional string flags_enum = 73921;
 
-  // Marks an int field as a pid; emits companion upid + process_name args.
-  optional bool pid = 73922;
+  // Marks an int field as a process id; trace_processor emits a companion
+  // "<...>upid" arg (a trailing "pid" replaced with "upid").
+  optional bool is_pid = 73922;
 
-  // Marks an int field as a tid; emits companion utid + thread_name args.
-  optional bool tid = 73923;
+  // Marks an int field as a thread id; trace_processor emits a companion
+  // "<...>utid" arg (a trailing "tid" replaced with "utid").
+  optional bool is_tid = 73923;
 }

--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
@@ -551,13 +551,13 @@ message AndroidBroadcastEvent {
   optional int32 receiver_uid = 1;
 
   // The pid of the broadcast receiver.
-  optional int32 receiver_pid = 2;
+  optional int32 receiver_pid = 2 [(perfetto.protos.pid) = true];
 
   // The package uid of the broadcast sender.
   optional int32 sender_uid = 3;
 
   // The pid of the broadcast sender.
-  optional int32 sender_pid = 4;
+  optional int32 sender_pid = 4 [(perfetto.protos.pid) = true];
 
   // The action name of the broadcast.
   optional string action_name = 5;
@@ -611,7 +611,7 @@ message AndroidFreezerEvent {
   optional int32 uid = 1;
 
   // The pid of the process being frozen or unfrozen.
-  optional int32 pid = 2;
+  optional int32 pid = 2 [(perfetto.protos.pid) = true];
 
   // Time since last unfrozen.
   optional int64 unfrozen_dur_ms = 3;
@@ -628,7 +628,7 @@ message AndroidProcessStartEvent {
   optional int32 uid = 1;
 
   // The process pid.
-  optional int32 pid = 2;
+  optional int32 pid = 2 [(perfetto.protos.pid) = true];
 
   // The process name.
   optional string process_name = 3;
@@ -659,7 +659,7 @@ message AndroidProcessDiedEvent {
   optional int32 uid = 1;
 
   // Pid of the dying process.
-  optional int32 pid = 2;
+  optional int32 pid = 2 [(perfetto.protos.pid) = true];
 
   // The process name of the dying process.
   optional string process_name = 3;
@@ -687,7 +687,7 @@ message AndroidBinderDiedEvent {
   optional int32 uid = 1;
 
   // Pid of the dying process.
-  optional int32 pid = 2;
+  optional int32 pid = 2 [(perfetto.protos.pid) = true];
 
   // The process name of the dying process.
   optional string process_name = 3;
@@ -698,7 +698,7 @@ message AndroidProcessStateChangedEvent {
   optional int32 uid = 1;
 
   // Pid of the process changing state.
-  optional int32 pid = 2;
+  optional int32 pid = 2 [(perfetto.protos.pid) = true];
 
   // Previous proc state.
   optional ProcessStateEnum prev_proc_state = 3;
@@ -748,7 +748,7 @@ message AndroidServiceStateChangedEvent {
   // UID of the app hosting the service.
   optional int32 uid = 1;
   // PID of the app hosting the service.
-  optional int32 pid = 2;
+  optional int32 pid = 2 [(perfetto.protos.pid) = true];
   // Component name of the service.
   optional string component_name = 3;
   // Intent action used to bind/start the service.
@@ -762,7 +762,7 @@ message AndroidServiceStateChangedEvent {
   // UID of the app accessing the service.
   optional int32 caller_uid = 7;
   // PID of the app accessing the service.
-  optional int32 caller_pid = 8;
+  optional int32 caller_pid = 8 [(perfetto.protos.pid) = true];
   optional ServiceRestartReason reason_enum = 9;
   // Bitmask of flags used in the service binding.
   optional int32 bind_flags = 10
@@ -773,13 +773,13 @@ message AndroidProviderStateChangedEvent {
   // UID of the app hosting the provider.
   optional int32 uid = 1;
   // PID of the app hosting the provider.
-  optional int32 pid = 2;
+  optional int32 pid = 2 [(perfetto.protos.pid) = true];
   // Authority of the content provider.
   optional string authority = 3;
   // UID of the app accessing the provider.
   optional int32 caller_uid = 4;
   // PID of the app accessing the provider.
-  optional int32 caller_pid = 5;
+  optional int32 caller_pid = 5 [(perfetto.protos.pid) = true];
   // Whether the connection is stable.
   optional int32 is_stable = 6;
 }
@@ -806,7 +806,7 @@ message AndroidCapabilityUpdateEvent {
   optional OomChangeReasonEnum reason = 2;
 
   // Pid of the process.
-  optional int32 pid = 3;
+  optional int32 pid = 3 [(perfetto.protos.pid) = true];
 
   // The capabilities computed by CapabilityController.
   optional int32 capability = 4;

--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
@@ -551,13 +551,13 @@ message AndroidBroadcastEvent {
   optional int32 receiver_uid = 1;
 
   // The pid of the broadcast receiver.
-  optional int32 receiver_pid = 2 [(perfetto.protos.pid) = true];
+  optional int32 receiver_pid = 2 [(perfetto.protos.is_pid) = true];
 
   // The package uid of the broadcast sender.
   optional int32 sender_uid = 3;
 
   // The pid of the broadcast sender.
-  optional int32 sender_pid = 4 [(perfetto.protos.pid) = true];
+  optional int32 sender_pid = 4 [(perfetto.protos.is_pid) = true];
 
   // The action name of the broadcast.
   optional string action_name = 5;
@@ -611,7 +611,7 @@ message AndroidFreezerEvent {
   optional int32 uid = 1;
 
   // The pid of the process being frozen or unfrozen.
-  optional int32 pid = 2 [(perfetto.protos.pid) = true];
+  optional int32 pid = 2 [(perfetto.protos.is_pid) = true];
 
   // Time since last unfrozen.
   optional int64 unfrozen_dur_ms = 3;
@@ -628,7 +628,7 @@ message AndroidProcessStartEvent {
   optional int32 uid = 1;
 
   // The process pid.
-  optional int32 pid = 2 [(perfetto.protos.pid) = true];
+  optional int32 pid = 2 [(perfetto.protos.is_pid) = true];
 
   // The process name.
   optional string process_name = 3;
@@ -659,7 +659,7 @@ message AndroidProcessDiedEvent {
   optional int32 uid = 1;
 
   // Pid of the dying process.
-  optional int32 pid = 2 [(perfetto.protos.pid) = true];
+  optional int32 pid = 2 [(perfetto.protos.is_pid) = true];
 
   // The process name of the dying process.
   optional string process_name = 3;
@@ -687,7 +687,7 @@ message AndroidBinderDiedEvent {
   optional int32 uid = 1;
 
   // Pid of the dying process.
-  optional int32 pid = 2 [(perfetto.protos.pid) = true];
+  optional int32 pid = 2 [(perfetto.protos.is_pid) = true];
 
   // The process name of the dying process.
   optional string process_name = 3;
@@ -698,7 +698,7 @@ message AndroidProcessStateChangedEvent {
   optional int32 uid = 1;
 
   // Pid of the process changing state.
-  optional int32 pid = 2 [(perfetto.protos.pid) = true];
+  optional int32 pid = 2 [(perfetto.protos.is_pid) = true];
 
   // Previous proc state.
   optional ProcessStateEnum prev_proc_state = 3;
@@ -748,7 +748,7 @@ message AndroidServiceStateChangedEvent {
   // UID of the app hosting the service.
   optional int32 uid = 1;
   // PID of the app hosting the service.
-  optional int32 pid = 2 [(perfetto.protos.pid) = true];
+  optional int32 pid = 2 [(perfetto.protos.is_pid) = true];
   // Component name of the service.
   optional string component_name = 3;
   // Intent action used to bind/start the service.
@@ -762,7 +762,7 @@ message AndroidServiceStateChangedEvent {
   // UID of the app accessing the service.
   optional int32 caller_uid = 7;
   // PID of the app accessing the service.
-  optional int32 caller_pid = 8 [(perfetto.protos.pid) = true];
+  optional int32 caller_pid = 8 [(perfetto.protos.is_pid) = true];
   optional ServiceRestartReason reason_enum = 9;
   // Bitmask of flags used in the service binding.
   optional int32 bind_flags = 10
@@ -773,13 +773,13 @@ message AndroidProviderStateChangedEvent {
   // UID of the app hosting the provider.
   optional int32 uid = 1;
   // PID of the app hosting the provider.
-  optional int32 pid = 2 [(perfetto.protos.pid) = true];
+  optional int32 pid = 2 [(perfetto.protos.is_pid) = true];
   // Authority of the content provider.
   optional string authority = 3;
   // UID of the app accessing the provider.
   optional int32 caller_uid = 4;
   // PID of the app accessing the provider.
-  optional int32 caller_pid = 5 [(perfetto.protos.pid) = true];
+  optional int32 caller_pid = 5 [(perfetto.protos.is_pid) = true];
   // Whether the connection is stable.
   optional int32 is_stable = 6;
 }
@@ -806,7 +806,7 @@ message AndroidCapabilityUpdateEvent {
   optional OomChangeReasonEnum reason = 2;
 
   // Pid of the process.
-  optional int32 pid = 3 [(perfetto.protos.pid) = true];
+  optional int32 pid = 3 [(perfetto.protos.is_pid) = true];
 
   // The capabilities computed by CapabilityController.
   optional int32 capability = 4;

--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -217,10 +217,14 @@ class ProcessTracker {
   // to the pid.
   UniquePid GetOrCreateProcessWithoutMainThread(int64_t pid);
 
-  // Returns the upid for a given pid.
-  std::optional<UniquePid> UpidForPidForTesting(uint32_t pid) {
+  // Non-mutating lookup of the upid for |pid| (cf. GetThreadOrNull).
+  std::optional<UniquePid> GetProcessOrNull(int64_t pid) {
     auto* it = pids_.Find(pid);
     return it ? std::make_optional(*it) : std::nullopt;
+  }
+
+  std::optional<UniquePid> UpidForPidForTesting(uint32_t pid) {
+    return GetProcessOrNull(pid);
   }
 
   // Returns the bounds of a range that includes all UniqueTids that have the

--- a/src/trace_processor/importers/proto/args_parser.cc
+++ b/src/trace_processor/importers/proto/args_parser.cc
@@ -40,9 +40,9 @@ using BoundInserter = ArgsTracker::BoundInserter;
 ArgsParser::ArgsParser(int64_t packet_timestamp,
                        BoundInserter& inserter,
                        TraceStorage& storage,
+                       ProcessTracker& process_tracker,
                        PacketSequenceStateGeneration* sequence_state,
-                       bool support_json,
-                       ProcessTracker* process_tracker)
+                       bool support_json)
     : support_json_(support_json),
       packet_timestamp_(packet_timestamp),
       sequence_state_(sequence_state),
@@ -90,40 +90,14 @@ void ArgsParser::AddBoolean(Id flat_key, Id key, bool value) {
 }
 
 void ArgsParser::AddUpid(Id flat_key, Id key, int64_t pid) {
-  if (!process_tracker_)
-    return;
-  if (auto upid = process_tracker_->GetProcessOrNull(pid)) {
+  if (auto upid = process_tracker_.GetProcessOrNull(pid)) {
     inserter_.AddArg(flat_key, key, Variadic::Integer(*upid));
   }
 }
 
-void ArgsParser::AddProcessName(Id flat_key, Id key, int64_t pid) {
-  if (!process_tracker_)
-    return;
-  auto upid = process_tracker_->GetProcessOrNull(pid);
-  if (!upid)
-    return;
-  if (auto name = storage_.process_table()[*upid].name()) {
-    inserter_.AddArg(flat_key, key, Variadic::String(*name));
-  }
-}
-
 void ArgsParser::AddUtid(Id flat_key, Id key, int64_t tid) {
-  if (!process_tracker_)
-    return;
-  if (auto utid = process_tracker_->GetThreadOrNull(tid)) {
+  if (auto utid = process_tracker_.GetThreadOrNull(tid)) {
     inserter_.AddArg(flat_key, key, Variadic::Integer(*utid));
-  }
-}
-
-void ArgsParser::AddThreadName(Id flat_key, Id key, int64_t tid) {
-  if (!process_tracker_)
-    return;
-  auto utid = process_tracker_->GetThreadOrNull(tid);
-  if (!utid)
-    return;
-  if (auto name = storage_.thread_table()[*utid].name()) {
-    inserter_.AddArg(flat_key, key, Variadic::String(*name));
   }
 }
 

--- a/src/trace_processor/importers/proto/args_parser.cc
+++ b/src/trace_processor/importers/proto/args_parser.cc
@@ -25,6 +25,7 @@
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/protozero/field.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
+#include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/variadic.h"
@@ -40,12 +41,14 @@ ArgsParser::ArgsParser(int64_t packet_timestamp,
                        BoundInserter& inserter,
                        TraceStorage& storage,
                        PacketSequenceStateGeneration* sequence_state,
-                       bool support_json)
+                       bool support_json,
+                       ProcessTracker* process_tracker)
     : support_json_(support_json),
       packet_timestamp_(packet_timestamp),
       sequence_state_(sequence_state),
       inserter_(inserter),
-      storage_(storage) {}
+      storage_(storage),
+      process_tracker_(process_tracker) {}
 
 ArgsParser::~ArgsParser() = default;
 
@@ -84,6 +87,44 @@ void ArgsParser::AddPointer(Id flat_key, Id key, uint64_t value) {
 
 void ArgsParser::AddBoolean(Id flat_key, Id key, bool value) {
   inserter_.AddArg(flat_key, key, Variadic::Boolean(value));
+}
+
+void ArgsParser::AddUpid(Id flat_key, Id key, int64_t pid) {
+  if (!process_tracker_)
+    return;
+  if (auto upid = process_tracker_->GetProcessOrNull(pid)) {
+    inserter_.AddArg(flat_key, key, Variadic::Integer(*upid));
+  }
+}
+
+void ArgsParser::AddProcessName(Id flat_key, Id key, int64_t pid) {
+  if (!process_tracker_)
+    return;
+  auto upid = process_tracker_->GetProcessOrNull(pid);
+  if (!upid)
+    return;
+  if (auto name = storage_.process_table()[*upid].name()) {
+    inserter_.AddArg(flat_key, key, Variadic::String(*name));
+  }
+}
+
+void ArgsParser::AddUtid(Id flat_key, Id key, int64_t tid) {
+  if (!process_tracker_)
+    return;
+  if (auto utid = process_tracker_->GetThreadOrNull(tid)) {
+    inserter_.AddArg(flat_key, key, Variadic::Integer(*utid));
+  }
+}
+
+void ArgsParser::AddThreadName(Id flat_key, Id key, int64_t tid) {
+  if (!process_tracker_)
+    return;
+  auto utid = process_tracker_->GetThreadOrNull(tid);
+  if (!utid)
+    return;
+  if (auto name = storage_.thread_table()[*utid].name()) {
+    inserter_.AddArg(flat_key, key, Variadic::String(*name));
+  }
 }
 
 void ArgsParser::AddBytes(Id flat_key,

--- a/src/trace_processor/importers/proto/args_parser.h
+++ b/src/trace_processor/importers/proto/args_parser.h
@@ -31,13 +31,13 @@ class ArgsParser : public util::ProtoToArgsParser::Delegate {
   using Key = util::ProtoToArgsParser::Key;
   using Id = StringPool::Id;
 
-  // |process_tracker| (nullable) resolves (pid)/(tid) companion args.
+  // |process_tracker| resolves (is_pid)/(is_tid) fields to upid/utid.
   ArgsParser(int64_t packet_timestamp,
              ArgsTracker::BoundInserter& inserter,
              TraceStorage& storage,
+             ProcessTracker& process_tracker,
              PacketSequenceStateGeneration* sequence_state = nullptr,
-             bool support_json = false,
-             ProcessTracker* process_tracker = nullptr);
+             bool support_json = false);
   ~ArgsParser() override;
   Id InternString(base::StringView) override;
   void AddInteger(Id flat_key, Id key, int64_t) override;
@@ -48,9 +48,7 @@ class ArgsParser : public util::ProtoToArgsParser::Delegate {
   void AddPointer(Id flat_key, Id key, uint64_t) override;
   void AddBoolean(Id flat_key, Id key, bool) override;
   void AddUpid(Id flat_key, Id key, int64_t pid) override;
-  void AddProcessName(Id flat_key, Id key, int64_t pid) override;
   void AddUtid(Id flat_key, Id key, int64_t tid) override;
-  void AddThreadName(Id flat_key, Id key, int64_t tid) override;
   void AddBytes(Id flat_key, Id key, const protozero::ConstBytes&) override;
   bool AddJson(Id flat_key, Id key, const protozero::ConstChars&) override;
   void AddNull(Id flat_key, Id key) override;
@@ -69,7 +67,7 @@ class ArgsParser : public util::ProtoToArgsParser::Delegate {
   PacketSequenceStateGeneration* const sequence_state_;
   ArgsTracker::BoundInserter& inserter_;
   TraceStorage& storage_;
-  ProcessTracker* const process_tracker_;
+  ProcessTracker& process_tracker_;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/args_parser.h
+++ b/src/trace_processor/importers/proto/args_parser.h
@@ -31,11 +31,13 @@ class ArgsParser : public util::ProtoToArgsParser::Delegate {
   using Key = util::ProtoToArgsParser::Key;
   using Id = StringPool::Id;
 
+  // |process_tracker| (nullable) resolves (pid)/(tid) companion args.
   ArgsParser(int64_t packet_timestamp,
              ArgsTracker::BoundInserter& inserter,
              TraceStorage& storage,
              PacketSequenceStateGeneration* sequence_state = nullptr,
-             bool support_json = false);
+             bool support_json = false,
+             ProcessTracker* process_tracker = nullptr);
   ~ArgsParser() override;
   Id InternString(base::StringView) override;
   void AddInteger(Id flat_key, Id key, int64_t) override;
@@ -45,6 +47,10 @@ class ArgsParser : public util::ProtoToArgsParser::Delegate {
   void AddDouble(Id flat_key, Id key, double) override;
   void AddPointer(Id flat_key, Id key, uint64_t) override;
   void AddBoolean(Id flat_key, Id key, bool) override;
+  void AddUpid(Id flat_key, Id key, int64_t pid) override;
+  void AddProcessName(Id flat_key, Id key, int64_t pid) override;
+  void AddUtid(Id flat_key, Id key, int64_t tid) override;
+  void AddThreadName(Id flat_key, Id key, int64_t tid) override;
   void AddBytes(Id flat_key, Id key, const protozero::ConstBytes&) override;
   bool AddJson(Id flat_key, Id key, const protozero::ConstChars&) override;
   void AddNull(Id flat_key, Id key) override;
@@ -63,6 +69,7 @@ class ArgsParser : public util::ProtoToArgsParser::Delegate {
   PacketSequenceStateGeneration* const sequence_state_;
   ArgsTracker::BoundInserter& inserter_;
   TraceStorage& storage_;
+  ProcessTracker* const process_tracker_;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/statsd_module.cc
+++ b/src/trace_processor/importers/proto/statsd_module.cc
@@ -187,7 +187,8 @@ void StatsdModule::ParseAtom(int64_t ts, protozero::ConstBytes nested_bytes) {
   context_->slice_tracker->Scoped(
       ts, InternTrackId(), kNullStringId, atom_name, 0,
       [&](ArgsTracker::BoundInserter* inserter) {
-        ArgsParser delegate(ts, *inserter, *context_->storage);
+        ArgsParser delegate(ts, *inserter, *context_->storage,
+                            *context_->process_tracker);
 
         const auto& descriptor =
             context_->descriptor_pool_->descriptors()[descriptor_idx_];

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -1449,7 +1449,8 @@ class TrackEventEventImporter {
     log_errors(ParseCallstack());
 
     ArgsParser args_writer(ts_, *inserter, *storage_, sequence_state_,
-                           /*support_json=*/true);
+                           /*support_json=*/true,
+                           context_->process_tracker.get());
     int unknown_extensions = 0;
     log_errors(parser_->args_parser_.ParseMessage(
         blob_, ".perfetto.protos.TrackEvent", &parser_->reflect_fields_,

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -1448,9 +1448,9 @@ class TrackEventEventImporter {
 
     log_errors(ParseCallstack());
 
-    ArgsParser args_writer(ts_, *inserter, *storage_, sequence_state_,
-                           /*support_json=*/true,
-                           context_->process_tracker.get());
+    ArgsParser args_writer(ts_, *inserter, *storage_,
+                           *context_->process_tracker, sequence_state_,
+                           /*support_json=*/true);
     int unknown_extensions = 0;
     log_errors(parser_->args_parser_.ParseMessage(
         blob_, ".perfetto.protos.TrackEvent", &parser_->reflect_fields_,

--- a/src/trace_processor/plugins/winscope_importer/android_input_event_parser.cc
+++ b/src/trace_processor/plugins/winscope_importer/android_input_event_parser.cc
@@ -110,7 +110,8 @@ void AndroidInputEventParser::ParseMotionEvent(
                           .id;
   ArgsTracker args_tracker(&context_);
   auto inserter = args_tracker.AddArgsTo(event_row_id);
-  ArgsParser writer{packet_ts, inserter, *context_.storage};
+  ArgsParser writer{packet_ts, inserter, *context_.storage,
+                    *context_.process_tracker};
 
   base::Status status =
       args_parser_.ParseMessage(bytes,
@@ -149,7 +150,8 @@ void AndroidInputEventParser::ParseKeyEvent(
                           .id;
   ArgsTracker args_tracker(&context_);
   auto inserter = args_tracker.AddArgsTo(event_row_id);
-  ArgsParser writer{packet_ts, inserter, *context_.storage};
+  ArgsParser writer{packet_ts, inserter, *context_.storage,
+                    *context_.process_tracker};
 
   base::Status status =
       args_parser_.ParseMessage(bytes,
@@ -186,7 +188,8 @@ void AndroidInputEventParser::ParseWindowDispatchEvent(
 
   ArgsTracker args_tracker(&context_);
   auto inserter = args_tracker.AddArgsTo(event_row_id);
-  ArgsParser writer{packet_ts, inserter, *context_.storage};
+  ArgsParser writer{packet_ts, inserter, *context_.storage,
+                    *context_.process_tracker};
 
   base::Status status = args_parser_.ParseMessage(
       bytes,

--- a/src/trace_processor/plugins/winscope_importer/shell_transitions_parser.cc
+++ b/src/trace_processor/plugins/winscope_importer/shell_transitions_parser.cc
@@ -66,7 +66,8 @@ void ShellTransitionsParser::ParseTransition(protozero::ConstBytes blob) {
   winscope::ShellTransitionsTracker& transition_tracker =
       context_->shell_transitions_tracker_;
   ArgsInserter& inserter = transition_tracker.AddArgsTo(transition_id);
-  ArgsParser writer(/*packet_timestamp=*/0, inserter, *storage);
+  ArgsParser writer(/*packet_timestamp=*/0, inserter, *storage,
+                    *context_->trace_processor_context_->process_tracker);
   base::Status status = args_parser_.ParseMessage(
       blob,
       *util::winscope_proto_mapping::GetProtoName(

--- a/src/trace_processor/plugins/winscope_importer/surfaceflinger_layers_parser.cc
+++ b/src/trace_processor/plugins/winscope_importer/surfaceflinger_layers_parser.cc
@@ -138,7 +138,8 @@ const SnapshotId SurfaceFlingerLayersParser::ParseSnapshot(
 
   ArgsTracker args_tracker(context_->trace_processor_context_);
   auto inserter = args_tracker.AddArgsTo(snapshot_id);
-  ArgsParser writer(timestamp, inserter, *storage);
+  ArgsParser writer(timestamp, inserter, *storage,
+                    *context_->trace_processor_context_->process_tracker);
   const auto table_name = tables::SurfaceFlingerLayersSnapshotTable::Name();
   auto allowed_fields =
       util::winscope_proto_mapping::GetAllowedFields(table_name);
@@ -165,7 +166,8 @@ void SurfaceFlingerLayersParser::ParseLayer(
   auto row_id =
       InsertLayerRow(blob, snapshot_id, visibility, layers_by_id, rects);
   auto inserter = tracker.AddArgsTo(row_id);
-  ArgsParser writer(timestamp, inserter, *storage);
+  ArgsParser writer(timestamp, inserter, *storage,
+                    *context_->trace_processor_context_->process_tracker);
   base::Status status =
       args_parser_.ParseMessage(blob,
                                 *util::winscope_proto_mapping::GetProtoName(

--- a/src/trace_processor/plugins/winscope_importer/surfaceflinger_transactions_parser.cc
+++ b/src/trace_processor/plugins/winscope_importer/surfaceflinger_transactions_parser.cc
@@ -57,7 +57,8 @@ void SurfaceFlingerTransactionsParser::Parse(int64_t timestamp,
 
   ArgsTracker args_tracker(context_);
   auto inserter = args_tracker.AddArgsTo(snapshot_id);
-  ArgsParser writer(timestamp, inserter, *context_->storage);
+  ArgsParser writer(timestamp, inserter, *context_->storage,
+                    *context_->process_tracker);
   base::Status status = args_parser_.ParseMessage(
       blob,
       *util::winscope_proto_mapping::GetProtoName(
@@ -399,7 +400,8 @@ void SurfaceFlingerTransactionsParser::AddArgs(
     std::optional<protozero::ConstBytes> transaction) {
   ArgsTracker tracker(context_);
   auto inserter = tracker.AddArgsTo(row_id);
-  ArgsParser writer(timestamp, inserter, *context_->storage);
+  ArgsParser writer(timestamp, inserter, *context_->storage,
+                    *context_->process_tracker);
   base::Status status = args_parser_.ParseMessage(
       blob, message_type, nullptr /* parse all fields */, writer);
   if (!status.ok()) {

--- a/src/trace_processor/plugins/winscope_importer/viewcapture_args_parser.cc
+++ b/src/trace_processor/plugins/winscope_importer/viewcapture_args_parser.cc
@@ -39,7 +39,11 @@ ViewCaptureArgsParser::ViewCaptureArgsParser(
     PacketSequenceStateGeneration* sequence_state,
     ViewCaptureRow* snapshot_row,
     ViewRow* view_row)
-    : ArgsParser(packet_timestamp, inserter, *context.storage, sequence_state),
+    : ArgsParser(packet_timestamp,
+                 inserter,
+                 *context.storage,
+                 *context.process_tracker,
+                 sequence_state),
       context_(context),
       snapshot_row_(snapshot_row),
       view_row_(view_row) {}

--- a/src/trace_processor/plugins/winscope_importer/windowmanager_parser.cc
+++ b/src/trace_processor/plugins/winscope_importer/windowmanager_parser.cc
@@ -82,7 +82,8 @@ tables::WindowManagerTable::Id WindowManagerParser::InsertSnapshotRow(
 
   ArgsTracker tracker(trace_processor_context);
   auto inserter = tracker.AddArgsTo(row_id);
-  ArgsParser writer(timestamp, inserter, *trace_processor_context->storage);
+  ArgsParser writer(timestamp, inserter, *trace_processor_context->storage,
+                    *trace_processor_context->process_tracker);
   base::Status status =
       args_parser_.ParseMessage(pruned_proto_bytes,
                                 *util::winscope_proto_mapping::GetProtoName(
@@ -197,7 +198,8 @@ void WindowManagerParser::InsertWindowContainerArgs(
 
   auto inserter = tracker.AddArgsTo(row_id);
   ArgsParser writer(timestamp, inserter,
-                    *context_->trace_processor_context_->storage);
+                    *context_->trace_processor_context_->storage,
+                    *context_->trace_processor_context_->process_tracker);
 
   base::Status status = args_parser_.ParseMessage(
       bytes, proto_name, nullptr /* parse all fields */, writer);

--- a/src/trace_processor/plugins/winscope_importer/winscope_module.cc
+++ b/src/trace_processor/plugins/winscope_importer/winscope_module.cc
@@ -200,7 +200,8 @@ void WinscopeModule::ParseInputMethodClientsData(int64_t timestamp,
 
   ArgsTracker tracker(trace_processor_context);
   auto inserter = tracker.AddArgsTo(rowId);
-  ArgsParser writer(timestamp, inserter, *trace_processor_context->storage);
+  ArgsParser writer(timestamp, inserter, *trace_processor_context->storage,
+                    *trace_processor_context->process_tracker);
   base::Status status =
       args_parser_.ParseMessage(blob,
                                 *util::winscope_proto_mapping::GetProtoName(
@@ -229,7 +230,8 @@ void WinscopeModule::ParseInputMethodManagerServiceData(
 
   ArgsTracker tracker(trace_processor_context);
   auto inserter = tracker.AddArgsTo(rowId);
-  ArgsParser writer(timestamp, inserter, *trace_processor_context->storage);
+  ArgsParser writer(timestamp, inserter, *trace_processor_context->storage,
+                    *trace_processor_context->process_tracker);
   base::Status status = args_parser_.ParseMessage(
       blob,
       *util::winscope_proto_mapping::GetProtoName(
@@ -257,7 +259,8 @@ void WinscopeModule::ParseInputMethodServiceData(int64_t timestamp,
 
   ArgsTracker tracker(trace_processor_context);
   auto inserter = tracker.AddArgsTo(rowId);
-  ArgsParser writer(timestamp, inserter, *trace_processor_context->storage);
+  ArgsParser writer(timestamp, inserter, *trace_processor_context->storage,
+                    *trace_processor_context->process_tracker);
   base::Status status =
       args_parser_.ParseMessage(blob,
                                 *util::winscope_proto_mapping::GetProtoName(

--- a/src/trace_processor/util/descriptors.cc
+++ b/src/trace_processor/util/descriptors.cc
@@ -651,10 +651,10 @@ DescriptorPool::CustomOptionNumbers DescriptorPool::FindCustomOptionNumbers()
   if (const auto* opt = field_options.FindFieldByName("flags_enum")) {
     numbers.flags_enum = opt->number();
   }
-  if (const auto* opt = field_options.FindFieldByName("pid")) {
+  if (const auto* opt = field_options.FindFieldByName("is_pid")) {
     numbers.pid = opt->number();
   }
-  if (const auto* opt = field_options.FindFieldByName("tid")) {
+  if (const auto* opt = field_options.FindFieldByName("is_tid")) {
     numbers.tid = opt->number();
   }
   return numbers;

--- a/src/trace_processor/util/descriptors.cc
+++ b/src/trace_processor/util/descriptors.cc
@@ -169,6 +169,13 @@ bool AreEnumValuesCompatible(const ProtoDescriptor& existing,
   return true;
 }
 
+// True if the bool option |option_number| is set on |field|.
+bool FieldBoolOption(const FieldDescriptor& field, uint32_t option_number) {
+  protozero::ProtoDecoder opt(field.options().data(), field.options().size());
+  auto f = opt.FindField(option_number);
+  return f.valid() && f.as_bool();
+}
+
 }  // namespace
 
 std::optional<uint32_t> DescriptorPool::ResolveShortType(
@@ -520,14 +527,8 @@ base::Status DescriptorPool::AddFromFileDescriptorSet(
     }
   }
 
-  // Fifth pass: resolve all "uninterpreted" options to real options, and
-  // resolve the (flags_enum) option to its enum's descriptor index.
-  std::optional<uint32_t> flags_enum_option_number;
-  if (auto idx = FindDescriptorIdx(".google.protobuf.FieldOptions")) {
-    if (const auto* opt = descriptors_[*idx].FindFieldByName("flags_enum")) {
-      flags_enum_option_number = opt->number();
-    }
-  }
+  // Fifth pass: interpret options and resolve Perfetto's custom field options.
+  const CustomOptionNumbers option_numbers = FindCustomOptionNumbers();
   for (ProtoDescriptor& descriptor : descriptors_) {
     for (auto& entry : *descriptor.mutable_fields()) {
       FieldDescriptor& field = entry.second;
@@ -535,9 +536,7 @@ base::Status DescriptorPool::AddFromFileDescriptorSet(
         continue;
       }
       ResolveUninterpretedOption(descriptor, field, *field.mutable_options());
-      if (flags_enum_option_number) {
-        ResolveFlagsEnumOption(descriptor, *flags_enum_option_number, &field);
-      }
+      ResolveCustomFieldOptions(descriptor, option_numbers, &field);
     }
   }
   return base::OkStatus();
@@ -638,6 +637,41 @@ void DescriptorPool::ResolveFlagsEnumOption(const ProtoDescriptor& descriptor,
   if (auto enum_idx =
           ResolveShortType(descriptor.full_name(), f.as_std_string())) {
     field->set_flags_enum_descriptor_idx(*enum_idx);
+  }
+}
+
+DescriptorPool::CustomOptionNumbers DescriptorPool::FindCustomOptionNumbers()
+    const {
+  CustomOptionNumbers numbers;
+  auto idx = FindDescriptorIdx(".google.protobuf.FieldOptions");
+  if (!idx) {
+    return numbers;
+  }
+  const ProtoDescriptor& field_options = descriptors_[*idx];
+  if (const auto* opt = field_options.FindFieldByName("flags_enum")) {
+    numbers.flags_enum = opt->number();
+  }
+  if (const auto* opt = field_options.FindFieldByName("pid")) {
+    numbers.pid = opt->number();
+  }
+  if (const auto* opt = field_options.FindFieldByName("tid")) {
+    numbers.tid = opt->number();
+  }
+  return numbers;
+}
+
+void DescriptorPool::ResolveCustomFieldOptions(
+    const ProtoDescriptor& descriptor,
+    const CustomOptionNumbers& numbers,
+    FieldDescriptor* field) {
+  if (numbers.flags_enum) {
+    ResolveFlagsEnumOption(descriptor, *numbers.flags_enum, field);
+  }
+  if (numbers.pid && FieldBoolOption(*field, *numbers.pid)) {
+    field->set_is_pid(true);
+  }
+  if (numbers.tid && FieldBoolOption(*field, *numbers.tid)) {
+    field->set_is_tid(true);
   }
 }
 

--- a/src/trace_processor/util/descriptors.h
+++ b/src/trace_processor/util/descriptors.h
@@ -54,6 +54,8 @@ class FieldDescriptor {
   std::optional<uint32_t> flags_enum_descriptor_idx() const {
     return flags_enum_descriptor_idx_;
   }
+  bool is_pid() const { return is_pid_; }
+  bool is_tid() const { return is_tid_; }
   bool is_repeated() const { return is_repeated_; }
   bool is_packed() const { return is_packed_; }
   bool is_extension() const { return is_extension_; }
@@ -75,6 +77,9 @@ class FieldDescriptor {
     flags_enum_descriptor_idx_ = idx;
   }
 
+  void set_is_pid(bool is_pid) { is_pid_ = is_pid; }
+  void set_is_tid(bool is_tid) { is_tid_ = is_tid; }
+
   void set_extension_full_name(const std::string& extension_full_name) {
     extension_full_name_ = extension_full_name;
   }
@@ -86,6 +91,8 @@ class FieldDescriptor {
   std::string raw_type_name_;
   std::string resolved_type_name_;
   std::optional<uint32_t> flags_enum_descriptor_idx_;
+  bool is_pid_ = false;
+  bool is_tid_ = false;
   std::vector<uint8_t> options_;
   std::optional<std::string> default_value_;
   bool is_repeated_;
@@ -302,6 +309,17 @@ class DescriptorPool {
   void ResolveFlagsEnumOption(const ProtoDescriptor& descriptor,
                               uint32_t option_number,
                               FieldDescriptor* field);
+
+  // The field numbers of Perfetto's custom field options, looked up once.
+  struct CustomOptionNumbers {
+    std::optional<uint32_t> flags_enum;
+    std::optional<uint32_t> pid;
+    std::optional<uint32_t> tid;
+  };
+  CustomOptionNumbers FindCustomOptionNumbers() const;
+  void ResolveCustomFieldOptions(const ProtoDescriptor& descriptor,
+                                 const CustomOptionNumbers& numbers,
+                                 FieldDescriptor* field);
 
   // Adds a new descriptor to the pool and returns its index. There must not be
   // already a descriptor with the same full_name in the pool.

--- a/src/trace_processor/util/proto_to_args_parser.cc
+++ b/src/trace_processor/util/proto_to_args_parser.cc
@@ -588,6 +588,12 @@ base::Status ProtoToArgsParser::ParseSimpleField(
             delegate);
       }
       delegate.AddInteger(fk, k, field.as_int32());
+      if (descriptor.is_pid()) {
+        AddPid(field.as_int32(), delegate);
+      }
+      if (descriptor.is_tid()) {
+        AddTid(field.as_int32(), delegate);
+      }
       return base::OkStatus();
     case FieldDescriptorProto::TYPE_SINT32:
       delegate.AddInteger(fk, k, field.as_sint32());
@@ -598,6 +604,12 @@ base::Status ProtoToArgsParser::ParseSimpleField(
         return AddFlags(*idx, field.as_int64(), delegate);
       }
       delegate.AddInteger(fk, k, field.as_int64());
+      if (descriptor.is_pid()) {
+        AddPid(field.as_int64(), delegate);
+      }
+      if (descriptor.is_tid()) {
+        AddTid(field.as_int64(), delegate);
+      }
       return base::OkStatus();
     case FieldDescriptorProto::TYPE_SINT64:
       delegate.AddInteger(fk, k, field.as_sint64());
@@ -789,6 +801,41 @@ base::Status ProtoToArgsParser::AddFlags(uint32_t enum_descriptor_idx,
     emit(i, protozero::ConstChars{hex.c_str(), hex.len()});
   }
   return base::OkStatus();
+}
+
+namespace {
+// "caller_pid" + ("pid","upid") -> "caller_upid"; else appends "_<to>".
+std::string ReplaceKeySuffix(const std::string& key,
+                             const std::string& from,
+                             const std::string& to) {
+  if (base::EndsWith(key, from))
+    return key.substr(0, key.size() - from.size()) + to;
+  return key + "_" + to;
+}
+}  // namespace
+
+std::pair<StringPool::Id, StringPool::Id> ProtoToArgsParser::InternSuffixedKeys(
+    Delegate& delegate,
+    const std::string& from,
+    const std::string& to) {
+  std::string flat_key = ReplaceKeySuffix(key_prefix_.flat_key, from, to);
+  std::string key = ReplaceKeySuffix(key_prefix_.key, from, to);
+  return {delegate.InternString(base::StringView(flat_key)),
+          delegate.InternString(base::StringView(key))};
+}
+
+void ProtoToArgsParser::AddPid(int64_t pid, Delegate& delegate) {
+  auto [upid_fk, upid_k] = InternSuffixedKeys(delegate, "pid", "upid");
+  delegate.AddUpid(upid_fk, upid_k, pid);
+  auto [name_fk, name_k] = InternSuffixedKeys(delegate, "pid", "process_name");
+  delegate.AddProcessName(name_fk, name_k, pid);
+}
+
+void ProtoToArgsParser::AddTid(int64_t tid, Delegate& delegate) {
+  auto [utid_fk, utid_k] = InternSuffixedKeys(delegate, "tid", "utid");
+  delegate.AddUtid(utid_fk, utid_k, tid);
+  auto [name_fk, name_k] = InternSuffixedKeys(delegate, "tid", "thread_name");
+  delegate.AddThreadName(name_fk, name_k, tid);
 }
 
 // ===========================================================================

--- a/src/trace_processor/util/proto_to_args_parser.cc
+++ b/src/trace_processor/util/proto_to_args_parser.cc
@@ -803,39 +803,30 @@ base::Status ProtoToArgsParser::AddFlags(uint32_t enum_descriptor_idx,
   return base::OkStatus();
 }
 
-namespace {
-// "caller_pid" + ("pid","upid") -> "caller_upid"; else appends "_<to>".
-std::string ReplaceKeySuffix(const std::string& key,
-                             const std::string& from,
-                             const std::string& to) {
-  if (base::EndsWith(key, from))
-    return key.substr(0, key.size() - from.size()) + to;
-  return key + "_" + to;
-}
-}  // namespace
-
 std::pair<StringPool::Id, StringPool::Id> ProtoToArgsParser::InternSuffixedKeys(
     Delegate& delegate,
-    const std::string& from,
-    const std::string& to) {
-  std::string flat_key = ReplaceKeySuffix(key_prefix_.flat_key, from, to);
-  std::string key = ReplaceKeySuffix(key_prefix_.key, from, to);
-  return {delegate.InternString(base::StringView(flat_key)),
-          delegate.InternString(base::StringView(key))};
+    std::string_view from,
+    std::string_view to) {
+  auto intern = [&](const std::string& key) {
+    const bool matched = base::StringView(key).EndsWith(from);
+    suffixed_key_scratch_.assign(
+        key, 0, matched ? key.size() - from.size() : key.size());
+    if (!matched)
+      suffixed_key_scratch_.push_back('_');
+    suffixed_key_scratch_.append(to);
+    return delegate.InternString(base::StringView(suffixed_key_scratch_));
+  };
+  return {intern(key_prefix_.flat_key), intern(key_prefix_.key)};
 }
 
 void ProtoToArgsParser::AddPid(int64_t pid, Delegate& delegate) {
-  auto [upid_fk, upid_k] = InternSuffixedKeys(delegate, "pid", "upid");
-  delegate.AddUpid(upid_fk, upid_k, pid);
-  auto [name_fk, name_k] = InternSuffixedKeys(delegate, "pid", "process_name");
-  delegate.AddProcessName(name_fk, name_k, pid);
+  auto [fk, k] = InternSuffixedKeys(delegate, "pid", "upid");
+  delegate.AddUpid(fk, k, pid);
 }
 
 void ProtoToArgsParser::AddTid(int64_t tid, Delegate& delegate) {
-  auto [utid_fk, utid_k] = InternSuffixedKeys(delegate, "tid", "utid");
-  delegate.AddUtid(utid_fk, utid_k, tid);
-  auto [name_fk, name_k] = InternSuffixedKeys(delegate, "tid", "thread_name");
-  delegate.AddThreadName(name_fk, name_k, tid);
+  auto [fk, k] = InternSuffixedKeys(delegate, "tid", "utid");
+  delegate.AddUtid(fk, k, tid);
 }
 
 // ===========================================================================

--- a/src/trace_processor/util/proto_to_args_parser.h
+++ b/src/trace_processor/util/proto_to_args_parser.h
@@ -121,6 +121,10 @@ class ProtoToArgsParser {
     virtual void AddDouble(Id flat_key, Id key, double value) = 0;
     virtual void AddPointer(Id flat_key, Id key, uint64_t value) = 0;
     virtual void AddBoolean(Id flat_key, Id key, bool value) = 0;
+    virtual void AddUpid(Id, Id, int64_t) {}
+    virtual void AddProcessName(Id, Id, int64_t) {}
+    virtual void AddUtid(Id, Id, int64_t) {}
+    virtual void AddThreadName(Id, Id, int64_t) {}
     virtual void AddBytes(Id flat_key,
                           Id key,
                           const protozero::ConstBytes& value) {
@@ -343,6 +347,16 @@ class ProtoToArgsParser {
   base::Status AddFlags(uint32_t enum_descriptor_idx,
                         int64_t value,
                         Delegate& delegate);
+
+  // Emit companion args for (pid)/(tid) fields.
+  void AddPid(int64_t pid, Delegate& delegate);
+  void AddTid(int64_t tid, Delegate& delegate);
+
+  // Interns the current flat_key/key with a trailing |from| replaced by |to|.
+  std::pair<StringPool::Id, StringPool::Id> InternSuffixedKeys(
+      Delegate& delegate,
+      const std::string& from,
+      const std::string& to);
 
   // A node in the traversal tree, a flattened trie over the descriptor path.
   // Nodes live in the |path_nodes_| arena and reference each other by index, so

--- a/src/trace_processor/util/proto_to_args_parser.h
+++ b/src/trace_processor/util/proto_to_args_parser.h
@@ -122,9 +122,7 @@ class ProtoToArgsParser {
     virtual void AddPointer(Id flat_key, Id key, uint64_t value) = 0;
     virtual void AddBoolean(Id flat_key, Id key, bool value) = 0;
     virtual void AddUpid(Id, Id, int64_t) {}
-    virtual void AddProcessName(Id, Id, int64_t) {}
     virtual void AddUtid(Id, Id, int64_t) {}
-    virtual void AddThreadName(Id, Id, int64_t) {}
     virtual void AddBytes(Id flat_key,
                           Id key,
                           const protozero::ConstBytes& value) {
@@ -355,8 +353,8 @@ class ProtoToArgsParser {
   // Interns the current flat_key/key with a trailing |from| replaced by |to|.
   std::pair<StringPool::Id, StringPool::Id> InternSuffixedKeys(
       Delegate& delegate,
-      const std::string& from,
-      const std::string& to);
+      std::string_view from,
+      std::string_view to);
 
   // A node in the traversal tree, a flattened trie over the descriptor path.
   // Nodes live in the |path_nodes_| arena and reference each other by index, so
@@ -420,6 +418,8 @@ class ProtoToArgsParser {
   std::vector<PathNode> path_nodes_;
   // Reused scratch buffer for AddFlags (flag-name views), to avoid per-call
   // allocation.
+  // Reused buffer for InternSuffixedKeys, to avoid a per-field allocation.
+  std::string suffixed_key_scratch_;
   std::vector<std::string_view> flag_views_;
   // Edge -> child node index in |path_nodes_| (see |PathEdgeKey|). Roots are
   // keyed by pool descriptor index under the kNoPath parent.

--- a/src/trace_processor/util/proto_to_args_parser_unittest.cc
+++ b/src/trace_processor/util/proto_to_args_parser_unittest.cc
@@ -144,6 +144,30 @@ class ProtoToArgsParserTest : public ::testing::Test,
     args_.push_back(ss.str());
   }
 
+  void AddUpid(Id fk, Id k, int64_t pid) override {
+    std::stringstream ss;
+    ss << K(fk) << " " << K(k) << " upid_of(" << pid << ")";
+    args_.push_back(ss.str());
+  }
+
+  void AddProcessName(Id fk, Id k, int64_t pid) override {
+    std::stringstream ss;
+    ss << K(fk) << " " << K(k) << " process_name_of(" << pid << ")";
+    args_.push_back(ss.str());
+  }
+
+  void AddUtid(Id fk, Id k, int64_t tid) override {
+    std::stringstream ss;
+    ss << K(fk) << " " << K(k) << " utid_of(" << tid << ")";
+    args_.push_back(ss.str());
+  }
+
+  void AddThreadName(Id fk, Id k, int64_t tid) override {
+    std::stringstream ss;
+    ss << K(fk) << " " << K(k) << " thread_name_of(" << tid << ")";
+    args_.push_back(ss.str());
+  }
+
   bool AddJson(Id fk, Id k, const protozero::ConstChars& value) override {
     std::stringstream ss;
     ss << K(fk) << " " << K(k) << " " << std::hex << value.ToStdString()
@@ -831,6 +855,30 @@ class DebugAnnotationParserTest : public ::testing::Test,
     args_.push_back(ss.str());
   }
 
+  void AddUpid(Id fk, Id k, int64_t pid) override {
+    std::stringstream ss;
+    ss << K(fk) << " " << K(k) << " upid_of(" << pid << ")";
+    args_.push_back(ss.str());
+  }
+
+  void AddProcessName(Id fk, Id k, int64_t pid) override {
+    std::stringstream ss;
+    ss << K(fk) << " " << K(k) << " process_name_of(" << pid << ")";
+    args_.push_back(ss.str());
+  }
+
+  void AddUtid(Id fk, Id k, int64_t tid) override {
+    std::stringstream ss;
+    ss << K(fk) << " " << K(k) << " utid_of(" << tid << ")";
+    args_.push_back(ss.str());
+  }
+
+  void AddThreadName(Id fk, Id k, int64_t tid) override {
+    std::stringstream ss;
+    ss << K(fk) << " " << K(k) << " thread_name_of(" << tid << ")";
+    args_.push_back(ss.str());
+  }
+
   bool AddJson(Id fk, Id k, const protozero::ConstChars& value) override {
     std::stringstream ss;
     ss << K(fk) << " " << K(k) << " " << std::hex << value.ToStdString()
@@ -1244,6 +1292,80 @@ TEST_F(ProtoToArgsParserTest, FlagsFieldSurfacesUnknownBits) {
 
   EXPECT_THAT(args(),
               testing::ElementsAre("caps caps[0] CAP_A", "caps caps[1] 0x8"));
+}
+
+namespace {
+// Builds a descriptor set with a FieldOptions carrying the (pid) and (tid)
+// options and a message with a "caller_pid" field annotated (pid) and a
+// "caller_tid" field annotated (tid).
+std::vector<uint8_t> BuildPidTidDescriptorSet() {
+  using namespace protos::pbzero;
+  protozero::HeapBuffered<FileDescriptorSet> fds{kChunkSize, kChunkSize};
+
+  auto* opts_file = fds->add_file();
+  opts_file->set_name("descriptor.proto");
+  opts_file->set_package("google.protobuf");
+  auto* opts = opts_file->add_message_type();
+  opts->set_name("FieldOptions");
+  auto add_bool_opt = [&](const char* name, int32_t number) {
+    auto* o = opts->add_field();
+    o->set_name(name);
+    o->set_number(number);
+    o->set_type(FieldDescriptorProto::TYPE_BOOL);
+    o->set_label(FieldDescriptorProto::LABEL_OPTIONAL);
+  };
+  add_bool_opt("pid", 51002);
+  add_bool_opt("tid", 51003);
+
+  auto* file = fds->add_file();
+  file->set_name("test.proto");
+  file->set_package("test");
+  auto* msg = file->add_message_type();
+  msg->set_name("Msg");
+  auto add_field = [&](const char* name, int32_t number, uint32_t opt_number) {
+    auto* f = msg->add_field();
+    f->set_name(name);
+    f->set_number(number);
+    f->set_type(FieldDescriptorProto::TYPE_INT32);
+    f->set_label(FieldDescriptorProto::LABEL_OPTIONAL);
+    f->set_options()->AppendVarInt(opt_number, 1);
+  };
+  add_field("caller_pid", 1, 51002);
+  add_field("caller_tid", 2, 51003);
+  // "owner" does not end in "pid": exercises the append fallback.
+  add_field("owner", 3, 51002);
+  return fds.SerializeAsArray();
+}
+}  // namespace
+
+TEST_F(ProtoToArgsParserTest, PidTidFieldsEmitCompanionArgs) {
+  auto fds_bytes = BuildPidTidDescriptorSet();
+  DescriptorPool pool;
+  ASSERT_OK(pool.AddFromFileDescriptorSet(fds_bytes.data(), fds_bytes.size()));
+
+  protozero::HeapBuffered<protozero::Message> msg_proto{kChunkSize, kChunkSize};
+  msg_proto->AppendVarInt(1, 4321);
+  msg_proto->AppendVarInt(2, 99);
+  msg_proto->AppendVarInt(3, 7);
+  auto binary = msg_proto.SerializeAsArray();
+
+  ProtoToArgsParser parser(pool, string_pool_);
+  ASSERT_OK(
+      parser.ParseMessage(protozero::ConstBytes{binary.data(), binary.size()},
+                          ".test.Msg", nullptr, *this));
+
+  // Each id field emits its raw value plus two companion args, keyed by
+  // replacing the trailing "pid"/"tid". Resolution itself is the delegate's
+  // job.
+  EXPECT_THAT(
+      args(),
+      testing::ElementsAre(
+          "caller_pid caller_pid 4321", "caller_upid caller_upid upid_of(4321)",
+          "caller_process_name caller_process_name process_name_of(4321)",
+          "caller_tid caller_tid 99", "caller_utid caller_utid utid_of(99)",
+          "caller_thread_name caller_thread_name thread_name_of(99)",
+          "owner owner 7", "owner_upid owner_upid upid_of(7)",
+          "owner_process_name owner_process_name process_name_of(7)"));
 }
 
 }  // namespace

--- a/src/trace_processor/util/proto_to_args_parser_unittest.cc
+++ b/src/trace_processor/util/proto_to_args_parser_unittest.cc
@@ -150,21 +150,9 @@ class ProtoToArgsParserTest : public ::testing::Test,
     args_.push_back(ss.str());
   }
 
-  void AddProcessName(Id fk, Id k, int64_t pid) override {
-    std::stringstream ss;
-    ss << K(fk) << " " << K(k) << " process_name_of(" << pid << ")";
-    args_.push_back(ss.str());
-  }
-
   void AddUtid(Id fk, Id k, int64_t tid) override {
     std::stringstream ss;
     ss << K(fk) << " " << K(k) << " utid_of(" << tid << ")";
-    args_.push_back(ss.str());
-  }
-
-  void AddThreadName(Id fk, Id k, int64_t tid) override {
-    std::stringstream ss;
-    ss << K(fk) << " " << K(k) << " thread_name_of(" << tid << ")";
     args_.push_back(ss.str());
   }
 
@@ -861,21 +849,9 @@ class DebugAnnotationParserTest : public ::testing::Test,
     args_.push_back(ss.str());
   }
 
-  void AddProcessName(Id fk, Id k, int64_t pid) override {
-    std::stringstream ss;
-    ss << K(fk) << " " << K(k) << " process_name_of(" << pid << ")";
-    args_.push_back(ss.str());
-  }
-
   void AddUtid(Id fk, Id k, int64_t tid) override {
     std::stringstream ss;
     ss << K(fk) << " " << K(k) << " utid_of(" << tid << ")";
-    args_.push_back(ss.str());
-  }
-
-  void AddThreadName(Id fk, Id k, int64_t tid) override {
-    std::stringstream ss;
-    ss << K(fk) << " " << K(k) << " thread_name_of(" << tid << ")";
     args_.push_back(ss.str());
   }
 
@@ -1314,8 +1290,8 @@ std::vector<uint8_t> BuildPidTidDescriptorSet() {
     o->set_type(FieldDescriptorProto::TYPE_BOOL);
     o->set_label(FieldDescriptorProto::LABEL_OPTIONAL);
   };
-  add_bool_opt("pid", 51002);
-  add_bool_opt("tid", 51003);
+  add_bool_opt("is_pid", 51002);
+  add_bool_opt("is_tid", 51003);
 
   auto* file = fds->add_file();
   file->set_name("test.proto");
@@ -1354,18 +1330,14 @@ TEST_F(ProtoToArgsParserTest, PidTidFieldsEmitCompanionArgs) {
       parser.ParseMessage(protozero::ConstBytes{binary.data(), binary.size()},
                           ".test.Msg", nullptr, *this));
 
-  // Each id field emits its raw value plus two companion args, keyed by
-  // replacing the trailing "pid"/"tid". Resolution itself is the delegate's
-  // job.
+  // Each id field emits its raw value plus a companion upid/utid, keyed by
+  // replacing (or appending) the trailing "pid"/"tid".
   EXPECT_THAT(
       args(),
       testing::ElementsAre(
           "caller_pid caller_pid 4321", "caller_upid caller_upid upid_of(4321)",
-          "caller_process_name caller_process_name process_name_of(4321)",
           "caller_tid caller_tid 99", "caller_utid caller_utid utid_of(99)",
-          "caller_thread_name caller_thread_name thread_name_of(99)",
-          "owner owner 7", "owner_upid owner_upid upid_of(7)",
-          "owner_process_name owner_process_name process_name_of(7)"));
+          "owner owner 7", "owner_upid owner_upid upid_of(7)"));
 }
 
 }  // namespace


### PR DESCRIPTION
Adds two custom field options (in field_options.proto) for integer fields that hold OS ids:

- (perfetto.protos.pid): the field is a process id. Alongside the raw value, trace_processor emits two extra args keyed by replacing the trailing "pid": "<name>upid" (the trace-unique upid) and "<name>process_name". e.g. caller_pid -> caller_upid + caller_process_name.
- (perfetto.protos.tid): the same for thread ids, emitting "<name>utid" and "<name>thread_name".

The upid/utid come from GetProcessOrNull/GetThreadOrNull, which are plain lookups: if the pid/tid was never seen, no extra arg is emitted and no process/thread is created.

Also annotates the pid, caller_pid, sender_pid and receiver_pid fields in frameworks_base_track_event.proto.
