### PR TITLE
ui: record page: extract a shared base for the adb recording targets

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_device.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_device.ts
@@ -39,6 +39,9 @@ export abstract class AdbDevice {
 
   abstract close(): void;
 
+  // True while the underlying transport is connected.
+  abstract get connected(): boolean;
+
   /** Invoke a command and return its stdout+err. */
   async shell(cmd: string): Promise<Result<string>> {
     const cmdOut = new ResizableArrayBuffer();

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_recording_target.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_recording_target.ts
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type protos from '../../../protos';
+import {errResult, type Result} from '../../../base/result';
+import {AsyncLazy} from '../../../base/async_lazy';
+import type {ConsumerIpcTracingSession} from '../tracing_protocol/consumer_ipc_tracing_session';
+import type {AdbDevice} from './adb_device';
+import {
+  createAdbTracingSession,
+  getAdbTracingServiceState,
+} from './adb_tracing_session';
+
+// Behaviour shared by every adb-based RecordingTarget (WebUSB, WebSocket, Web
+// Device Proxy). Subclasses only provide connectIfNeeded() and their identity
+// (id / name / runPreflightChecks); everything that operates on the connected
+// device lives here, so it isn't copy-pasted per transport.
+export abstract class AdbRecordingTarget<T extends AdbDevice> {
+  readonly kind = 'LIVE_RECORDING';
+  readonly platform = 'ANDROID';
+  protected adbDevice = new AsyncLazy<T>();
+
+  // Connects to the device (or returns the cached connection).
+  protected abstract connectIfNeeded(): Promise<Result<T>>;
+
+  get connected(): boolean {
+    return this.adbDevice.value?.connected ?? false;
+  }
+
+  async getServiceState(): Promise<Result<protos.ITracingServiceState>> {
+    if (this.adbDevice.value === undefined) {
+      return errResult('ADB transport disconnected');
+    }
+    return getAdbTracingServiceState(this.adbDevice.value);
+  }
+
+  async startTracing(
+    traceConfig: protos.ITraceConfig,
+  ): Promise<Result<ConsumerIpcTracingSession>> {
+    const dev = await this.connectIfNeeded();
+    if (!dev.ok) return dev;
+    return createAdbTracingSession(dev.value, traceConfig);
+  }
+
+  disconnect(): void {
+    this.adbDevice.value?.close();
+    this.adbDevice.reset();
+  }
+}

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/web_device_proxy/wdp_target.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/web_device_proxy/wdp_target.ts
@@ -12,33 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type protos from '../../../../protos';
 import {errResult, okResult, type Result} from '../../../../base/result';
 import type {PreflightCheck} from '../../interfaces/connection_check';
 import type {RecordingTarget} from '../../interfaces/recording_target';
-import type {ConsumerIpcTracingSession} from '../../tracing_protocol/consumer_ipc_tracing_session';
 import {checkAndroidTarget} from '../adb_platform_checks';
-import {
-  createAdbTracingSession,
-  getAdbTracingServiceState,
-} from '../adb_tracing_session';
 import {AdbWebsocketDevice} from '../websocket/adb_websocket_device';
-import {AsyncLazy} from '../../../../base/async_lazy';
 import type {WdpDevice} from './wdp_schema';
 import {showPopupWindow} from '../../../../base/popup_window';
 import {defer} from '../../../../base/deferred';
+import {AdbRecordingTarget} from '../adb_recording_target';
 
-export class WebDeviceProxyTarget implements RecordingTarget {
-  readonly kind = 'LIVE_RECORDING';
-  readonly platform = 'ANDROID';
-
-  private adbDevice = new AsyncLazy<AdbWebsocketDevice>();
+export class WebDeviceProxyTarget
+  extends AdbRecordingTarget<AdbWebsocketDevice>
+  implements RecordingTarget
+{
   readonly id: string;
 
   constructor(
     private wsUrl: string,
     private devJson: WdpDevice,
   ) {
+    super();
     this.id = this.devJson.serialNumber;
     this.updateWdpState(devJson);
   }
@@ -79,10 +73,6 @@ export class WebDeviceProxyTarget implements RecordingTarget {
     return `${this.devJson.proxyStatus} [${this.id}]`;
   }
 
-  get connected(): boolean {
-    return this.adbDevice.value?.connected ?? false;
-  }
-
   async *runPreflightChecks(): AsyncGenerator<PreflightCheck> {
     await this.connectIfNeeded();
 
@@ -94,7 +84,7 @@ export class WebDeviceProxyTarget implements RecordingTarget {
     yield* checkAndroidTarget(this.adbDevice.value);
   }
 
-  private async connectIfNeeded(): Promise<Result<AdbWebsocketDevice>> {
+  protected async connectIfNeeded(): Promise<Result<AdbWebsocketDevice>> {
     return this.adbDevice.getOrCreate(async () => {
       for (let attempt = 0; attempt < 2; attempt++) {
         if (this.devJson.proxyStatus === 'PROXY_UNAUTHORIZED') {
@@ -126,29 +116,5 @@ export class WebDeviceProxyTarget implements RecordingTarget {
           'authorize access and try again',
       );
     });
-  }
-
-  disconnect(): void {
-    // There isn't much to do in this case. If the device is disconnected,
-    // the per-stream sockets will be naturally closed by adb. In turn,
-    // websocket_bridge will propagate that as a closure of the per-stream
-    // WebSockets.
-    this.adbDevice.value?.close();
-    this.adbDevice.reset();
-  }
-
-  async getServiceState(): Promise<Result<protos.ITracingServiceState>> {
-    if (this.adbDevice.value === undefined) {
-      return errResult('WebSocket transport disconnected');
-    }
-    return getAdbTracingServiceState(this.adbDevice.value);
-  }
-
-  async startTracing(
-    traceConfig: protos.ITraceConfig,
-  ): Promise<Result<ConsumerIpcTracingSession>> {
-    const adbDeviceStatus = await this.connectIfNeeded();
-    if (!adbDeviceStatus.ok) return adbDeviceStatus;
-    return await createAdbTracingSession(adbDeviceStatus.value, traceConfig);
   }
 }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_target.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_target.ts
@@ -12,31 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type protos from '../../../../protos';
-import {errResult, okResult, type Result} from '../../../../base/result';
 import type {PreflightCheck} from '../../interfaces/connection_check';
 import type {RecordingTarget} from '../../interfaces/recording_target';
-import type {ConsumerIpcTracingSession} from '../../tracing_protocol/consumer_ipc_tracing_session';
+import {okResult, type Result} from '../../../../base/result';
 import {checkAndroidTarget} from '../adb_platform_checks';
-import {
-  createAdbTracingSession,
-  getAdbTracingServiceState,
-} from '../adb_tracing_session';
 import {AdbWebsocketDevice} from './adb_websocket_device';
-import {AsyncLazy} from '../../../../base/async_lazy';
+import {AdbRecordingTarget} from '../adb_recording_target';
 
-export class AdbWebsocketTarget implements RecordingTarget {
-  readonly kind = 'LIVE_RECORDING';
-  readonly platform = 'ANDROID';
+export class AdbWebsocketTarget
+  extends AdbRecordingTarget<AdbWebsocketDevice>
+  implements RecordingTarget
+{
   readonly transportType = 'WebSocket';
-
-  private adbDevice = new AsyncLazy<AdbWebsocketDevice>();
 
   constructor(
     private wsUrl: string,
     private serial: string,
     private model: string,
-  ) {}
+  ) {
+    super();
+  }
 
   get id(): string {
     return this.serial;
@@ -44,10 +39,6 @@ export class AdbWebsocketTarget implements RecordingTarget {
 
   get name(): string {
     return `${this.model} [${this.serial}]`;
-  }
-
-  get connected(): boolean {
-    return this.adbDevice.value?.connected ?? false;
   }
 
   async *runPreflightChecks(): AsyncGenerator<PreflightCheck> {
@@ -63,33 +54,9 @@ export class AdbWebsocketTarget implements RecordingTarget {
     yield* checkAndroidTarget(this.adbDevice.value);
   }
 
-  private async connectIfNeeded(): Promise<Result<AdbWebsocketDevice>> {
+  protected connectIfNeeded(): Promise<Result<AdbWebsocketDevice>> {
     return this.adbDevice.getOrCreate(() =>
       AdbWebsocketDevice.connect(this.wsUrl, this.serial, 'WEBSOCKET_BRIDGE'),
     );
-  }
-
-  disconnect(): void {
-    // There isn't much to do in this case. If the device is disconnected,
-    // the per-stream sockets will be naturally closed by adb. In turn,
-    // websocket_bridge will propagate that as a closure of the per-stream
-    // WebSockets.
-    this.adbDevice.value?.close();
-    this.adbDevice.reset();
-  }
-
-  async getServiceState(): Promise<Result<protos.ITracingServiceState>> {
-    if (this.adbDevice.value === undefined) {
-      return errResult('WebSocket transport disconnected');
-    }
-    return getAdbTracingServiceState(this.adbDevice.value);
-  }
-
-  async startTracing(
-    traceConfig: protos.ITraceConfig,
-  ): Promise<Result<ConsumerIpcTracingSession>> {
-    const adbDeviceStatus = await this.connectIfNeeded();
-    if (!adbDeviceStatus.ok) return adbDeviceStatus;
-    return await createAdbTracingSession(adbDeviceStatus.value, traceConfig);
   }
 }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_target.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_target.ts
@@ -12,31 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type protos from '../../../../protos';
 import type {RecordingTarget} from '../../interfaces/recording_target';
 import type {PreflightCheck} from '../../interfaces/connection_check';
 import type {AdbKeyManager} from './adb_key_manager';
-import {
-  createAdbTracingSession,
-  getAdbTracingServiceState,
-} from '../adb_tracing_session';
 import {AdbWebusbDevice} from './adb_webusb_device';
 import {type AdbUsbInterface, usbDeviceToStr} from './adb_webusb_utils';
-import {errResult, okResult, type Result} from '../../../../base/result';
+import {okResult, type Result} from '../../../../base/result';
 import {checkAndroidTarget} from '../adb_platform_checks';
-import type {ConsumerIpcTracingSession} from '../../tracing_protocol/consumer_ipc_tracing_session';
-import {AsyncLazy} from '../../../../base/async_lazy';
+import {AdbRecordingTarget} from '../adb_recording_target';
 
-export class AdbWebusbTarget implements RecordingTarget {
-  readonly kind = 'LIVE_RECORDING';
-  readonly platform = 'ANDROID';
+export class AdbWebusbTarget
+  extends AdbRecordingTarget<AdbWebusbDevice>
+  implements RecordingTarget
+{
   readonly transportType = 'WebUSB';
-  private adbDevice = new AsyncLazy<AdbWebusbDevice>();
 
   constructor(
     private usbiface: AdbUsbInterface,
     private adbKeyMgr: AdbKeyManager,
-  ) {}
+  ) {
+    super();
+  }
+
+  get id(): string {
+    return usbDeviceToStr(this.usbiface.dev);
+  }
+
+  get name(): string {
+    const dev = this.usbiface.dev;
+    return `${dev.productName} [${dev.serialNumber}]`;
+  }
 
   async *runPreflightChecks(): AsyncGenerator<PreflightCheck> {
     const status = await this.connectIfNeeded();
@@ -53,42 +58,9 @@ export class AdbWebusbTarget implements RecordingTarget {
     yield* checkAndroidTarget(this.adbDevice.value);
   }
 
-  async connectIfNeeded(): Promise<Result<AdbWebusbDevice>> {
+  protected connectIfNeeded(): Promise<Result<AdbWebusbDevice>> {
     return this.adbDevice.getOrCreate(() =>
       AdbWebusbDevice.connect(this.usbiface.dev, this.adbKeyMgr),
     );
-  }
-
-  get connected(): boolean {
-    return this.adbDevice.value?.connected ?? false;
-  }
-
-  get id(): string {
-    return usbDeviceToStr(this.usbiface.dev);
-  }
-
-  get name(): string {
-    const dev = this.usbiface.dev;
-    return `${dev.productName} [${dev.serialNumber}]`;
-  }
-
-  async getServiceState(): Promise<Result<protos.ITracingServiceState>> {
-    if (this.adbDevice.value === undefined) {
-      return errResult('WebUSB transport disconnected');
-    }
-    return getAdbTracingServiceState(this.adbDevice.value);
-  }
-
-  async startTracing(
-    traceConfig: protos.ITraceConfig,
-  ): Promise<Result<ConsumerIpcTracingSession>> {
-    const adbDeviceStatus = await this.connectIfNeeded();
-    if (!adbDeviceStatus.ok) return adbDeviceStatus;
-    return await createAdbTracingSession(adbDeviceStatus.value, traceConfig);
-  }
-
-  disconnect(): void {
-    this.adbDevice.value?.close();
-    this.adbDevice.reset();
   }
 }


### PR DESCRIPTION
The three adb-based RecordingTargets (WebUSB, WebSocket, Web Device Proxy) duplicate their connected / getServiceState / startTracing / disconnect logic and the AsyncLazy<AdbDevice> field, differing only in how they connect. Pull the shared behaviour into a generic AdbRecordingTarget<T> base so each transport only provides connectIfNeeded() plus its identity (id/name/preflight). AdbDevice gains an abstract `connected` getter so the base can read it generically.

Pure refactor, in preparation for sharing a runShellCommand() across the transports that an upcoming probe pre-flight hook needs. No behaviour change beyond consolidating the identical "<transport> transport disconnected" error into a single message.
