### PR TITLE
ui: Pull skills into intelletto

### DIFF
--- a/ui/src/plugins/dev.perfetto.Intelletto/chat_session.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/chat_session.ts
@@ -17,7 +17,8 @@ import type {LlmGateway} from '../dev.perfetto.Llm/gateway';
 import {Agent} from './agent';
 import type {ContextRegistry} from './context';
 import type {ToolRegistry} from './tools';
-import {SYSTEM_PROMPT} from './system_prompt';
+import {SYSTEM_PROMPT, GUIDES_HEADER} from './system_prompt';
+import {router} from '../../virtual/guides';
 
 /** A single line in the conversation transcript. */
 export interface ChatLine {
@@ -226,10 +227,19 @@ export class ChatSession {
 // effect on the next one.
 function assembleSystemPrompt(context: ContextRegistry): string {
   const descriptions = context.descriptions();
-  if (descriptions.length === 0) return SYSTEM_PROMPT;
-  return [
-    SYSTEM_PROMPT,
-    'Context payload formats (for the context preamble on user messages):',
-    ...descriptions,
-  ].join('\n\n');
+
+  const sections = [SYSTEM_PROMPT];
+
+  if (router !== '') {
+    sections.push(`${GUIDES_HEADER}\n\n${router}`);
+  }
+
+  if (descriptions.length > 0) {
+    sections.push(
+      'Context payload formats (for the context preamble on user messages):',
+      ...descriptions,
+    );
+  }
+
+  return sections.join('\n\n');
 }

--- a/ui/src/plugins/dev.perfetto.Intelletto/core_tools.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/core_tools.ts
@@ -17,6 +17,7 @@ import type {Trace} from '../../public/trace';
 import QueryPagePlugin from '../dev.perfetto.QueryPage';
 import {runQueryForModel} from './query';
 import type {ToolRegistry} from './tools';
+import {guides} from '../../virtual/guides';
 
 /**
  * Register the core tools (run_query, get_schema, get_selection, show_query,
@@ -104,6 +105,43 @@ export function registerCoreTools(reg: ToolRegistry, trace: Trace): void {
     callback: async ({page}) => {
       trace.navigate(page);
       return 'OK';
+    },
+  });
+
+  reg.registerTool({
+    name: 'read_guide',
+    description:
+      'Read a Perfetto trace-analysis guide: expert instructions, guided ' +
+      'workflows, references, and queries (memory leak debugging, GPU ' +
+      'performance analysis, etc.). The PERFETTO TRACE ANALYSIS GUIDES ' +
+      'section of the system prompt lists the paths to pass here and says ' +
+      'which one applies; guides reference further files by path as you go.',
+    shape: {
+      path: z
+        .string()
+        .describe(
+          'Path of the guide to read, relative to the guide tree root, ' +
+            'e.g. "workflows/android_memory/heap_dump.md".',
+        ),
+    },
+    callback: async ({path}) => {
+      let normalized = path;
+      if (normalized.startsWith('$SKILL_ROOT/')) {
+        normalized = normalized.slice('$SKILL_ROOT/'.length);
+      } else if (normalized.startsWith('/')) {
+        normalized = normalized.slice(1);
+      }
+
+      const content = guides[normalized];
+      if (content === undefined) {
+        return (
+          `Error: guide "${path}" not found. Available guides:\n` +
+          Object.keys(guides)
+            .map((k) => `- ${k}`)
+            .join('\n')
+        );
+      }
+      return content;
     },
   });
 }

--- a/ui/src/plugins/dev.perfetto.Intelletto/system_prompt.ts
+++ b/ui/src/plugins/dev.perfetto.Intelletto/system_prompt.ts
@@ -13,6 +13,44 @@
 // limitations under the License.
 
 /**
+ * Header for the router, which is inlined verbatim after it. The guides are the
+ * Agent Skill at ai/skills/perfetto, shared as-is with the CLI coding agents
+ * that install it - so they assume a shell, a filesystem and a trace_processor
+ * binary, none of which exist here, and they refer to themselves as a skill.
+ * Rather than fork them, we tell the model what it's reading and how to map
+ * those steps onto the tools it does have.
+ */
+export const GUIDES_HEADER = `
+PERFETTO TRACE ANALYSIS GUIDES
+You have guides for analysing traces - workflows and references - routed by the
+file below. Use the \`read_guide\` tool to read the files it points to.
+
+The guides are an agent skill, written for a command-line coding agent with bash
+and converted for use here, so they still describe themselves as a skill and
+assume tools you don't have. You run inside a browser tab: no shell, no
+filesystem, no trace_processor binary. Translate as you read them:
+- The trace is already open. Skip any step that asks the user for a file path,
+  downloads a trace, or loads one into trace processor.
+- Where a workflow runs a query file - e.g.
+  \`trace_processor query --query-file scripts/foo.sql TRACE\` - read
+  scripts/foo.sql with \`read_guide\` and pass its contents to \`run_query\`.
+  Placeholders in a query (like <owner_classname>) are yours to substitute
+  before running it.
+- Ignore setup instructions about \`$SKILL_ROOT\`, \`PATH\`, and installing
+  trace_processor. Paths are relative to the guide tree root; pass them to
+  \`read_guide\` as written.
+- Skip environment-references/setup.md and infra-references/querying.md: they
+  cover installing trace_processor and driving its CLI. You have \`run_query\`
+  and \`get_schema\` instead.
+- You cannot record traces or run Python or shell scripts. If a workflow's next
+  step is one - including anything in infra-references/recording_android_traces.md
+  or a scripts/*.py file - tell the user it needs the command-line tools rather
+  than improvising.
+- When the user should browse a full result table themselves, prefer
+  \`show_query\` over summarising rows.
+`.trim();
+
+/**
  * The assistant plugin's application system prompt. Kept stable (it sits at the
  * front of the cache-stable prefix) and deliberately small. A per-model system
  * prompt (from the Model config) is prepended to this by the gateway.

--- a/ui/src/virtual/guides.d.ts
+++ b/ui/src/virtual/guides.d.ts
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The .js implementation of this module is synthesised at build time by
+// pluginPerfettoGuides in ui/vite.config.mjs, which pulls in the markdown under
+// ai/skills/perfetto. Don't add a real guides.ts next to this file.
+export declare const guides: Record<string, string>;
+export declare const router: string;

--- a/ui/vite.config.mjs
+++ b/ui/vite.config.mjs
@@ -169,6 +169,61 @@ export function pluginPerfettoVersion() {
   });
 }
 
+// Exposes ai/skills/perfetto via ui/src/virtual/guides (typed by guides.d.ts)
+// as two exports: `router` (the SKILL-template.md body, which the assistant
+// inlines into its system prompt) and `guides` (every other file, keyed by path
+// relative to the skill root, as the router links to them). It's one Agent
+// Skill to the CLI harnesses that install it, but the UI has no skill
+// discovery, so to the assistant it's just a router plus a pile of guides.
+export function pluginPerfettoGuides() {
+  const SKILL_DIR = path.join(ROOT_DIR, 'ai/skills/perfetto');
+  const ROUTER_FILE = 'SKILL-template.md';
+
+  const generate = (ctx) => {
+    const guides = {};
+    let router = '';
+
+    const walk = (dir) => {
+      for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        const child = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(child);
+          continue;
+        }
+        if (!entry.isFile()) continue;
+        ctx.addWatchFile(child);
+        const relPath = path.relative(SKILL_DIR, child);
+        const content = fs.readFileSync(child, 'utf8');
+        if (relPath === ROUTER_FILE) {
+          // The YAML frontmatter is there so agent harnesses can discover and
+          // route to the skill; the UI has neither discovery nor sibling skills
+          // to route between, so drop it and inline just the body. $SKILL_ROOT
+          // anchors paths against an install dir that doesn't exist here.
+          router = content
+            .replace(/^---\n[\s\S]*?\n---\n+/, '')
+            .replace(/\$SKILL_ROOT\//g, '');
+        } else {
+          guides[relPath] = content;
+        }
+      }
+    };
+    walk(SKILL_DIR);
+
+    let tsContent = 'export const guides = {\n';
+    for (const [key, value] of Object.entries(guides)) {
+      tsContent += `  ${JSON.stringify(key)}: ${JSON.stringify(value)},\n`;
+    }
+    tsContent += '};\n';
+    tsContent += `export const router = ${JSON.stringify(router)};\n`;
+    return tsContent;
+  };
+
+  return makeSynthModulePlugin({
+    name: 'perfetto:guides',
+    modules: {[path.join(SRC, 'virtual', 'guides')]: generate},
+  });
+}
+
 function pluginGenRelativeImports() {
   return {
     name: 'perfetto:gen-relative-imports',
@@ -267,6 +322,7 @@ export default defineConfig(({command}) => {
     publicDir: false,
     plugins: [
       pluginPerfettoVersion(),
+      pluginPerfettoGuides(),
       // Compiles *.grammar files (lezer parser definitions) on import. Replaces
       // the old "manually run lezer-generator and commit gen/*.js" workflow.
       lezer(),


### PR DESCRIPTION
- Make ai/skills/perfetto available in the UI via virtual bundler module.
- Add read_skill tool to intelltto.
- Inject the SKILLS.md router file into the system prompt.

Note: The existing skills are designed to work inside a coding harness with access to bash, which are not available to intelletto running in the browser. That said, they do contain invaluable information about how to work with traces and some of the commands are transferrable to the UI.
Thus, when embedding into Intelletto we add a warning desribing the limitations and some guidance about how to perfom equivalent actions in the UI.