### PR TITLE
ui: guard SharedArrayBuffer check in assertIsArrayBufferView

### DIFF
--- a/ui/src/base/assert.ts
+++ b/ui/src/base/assert.ts
@@ -139,7 +139,12 @@ export function assertUnreachable(value: never, optMsg?: string): never {
 export function assertIsArrayBufferView(
   view: ArrayBufferView,
 ): asserts view is ArrayBufferView<ArrayBuffer> {
-  if (view.buffer instanceof SharedArrayBuffer) {
+  // SharedArrayBuffer is only defined in cross-origin isolated contexts; if the
+  // global isn't there, the buffer can't possibly be one.
+  if (
+    typeof SharedArrayBuffer !== 'undefined' &&
+    view.buffer instanceof SharedArrayBuffer
+  ) {
     // Copy the underlying buffer into the array, trimming to the byte bounds of the view
     throw new Error(
       "Underlying view is a SAB. If this is a problem we could convert it but we're being defensive as this could be expensive",


### PR DESCRIPTION
SharedArrayBuffer is only defined in cross-origin isolated contexts, so the bare instanceof check threw a ReferenceError elsewhere. Check the global exists first - if it doesn't, the buffer can't be one anyway.

Fixes: b/535630867
