### PR TITLE
tbV2: relocate fully-read scraped chunks instead of rewriting them

### DIFF
--- a/protos/perfetto/common/trace_stats.proto
+++ b/protos/perfetto/common/trace_stats.proto
@@ -70,6 +70,14 @@ message TraceStats {
     // the same chunk with additional packets appended to the end.
     optional uint64 chunks_rewritten = 10;
 
+    // TraceBufferV2 only. Num. chunks that we moved to the write cursor
+    // instead of rewriting in place. We do this for scraped chunks that have
+    // been fully read: their old position can be so close to the write cursor
+    // that the packets we just recovered would be overwritten before any read.
+    //
+    // Introduced in v59 / Android 26Q3+.
+    optional uint64 chunks_relocated = 20;
+
     // Num. chunks overwritten before they have been read (i.e. loss of data).
     optional uint64 chunks_overwritten = 3;
 

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -6170,6 +6170,14 @@ message TraceStats {
     // the same chunk with additional packets appended to the end.
     optional uint64 chunks_rewritten = 10;
 
+    // TraceBufferV2 only. Num. chunks that we moved to the write cursor
+    // instead of rewriting in place. We do this for scraped chunks that have
+    // been fully read: their old position can be so close to the write cursor
+    // that the packets we just recovered would be overwritten before any read.
+    //
+    // Introduced in v59 / Android 26Q3+.
+    optional uint64 chunks_relocated = 20;
+
     // Num. chunks overwritten before they have been read (i.e. loss of data).
     optional uint64 chunks_overwritten = 3;
 

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -1165,6 +1165,9 @@ void ProtoTraceReader::ParseTraceStats(ConstBytes blob) {
         stats::traced_buf_chunks_read, buf_num,
         static_cast<int64_t>(buf.chunks_read()));
     context_->stats_tracker->SetIndexedStats(
+        stats::traced_buf_chunks_relocated, buf_num,
+        static_cast<int64_t>(buf.chunks_relocated()));
+    context_->stats_tracker->SetIndexedStats(
         stats::traced_buf_chunks_committed_out_of_order, buf_num,
         static_cast<int64_t>(buf.chunks_committed_out_of_order()));
     context_->stats_tracker->SetIndexedStats(

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -257,6 +257,11 @@ namespace perfetto::trace_processor::stats {
   F(traced_buf_chunks_discarded,          kIndexed, kInfo,     kTrace, Scope::kMachineAndTrace,    ""), \
   F(traced_buf_chunks_overwritten,        kIndexed, kInfo,     kTrace, Scope::kMachineAndTrace,    ""), \
   F(traced_buf_chunks_read,               kIndexed, kInfo,     kTrace, Scope::kMachineAndTrace,    ""), \
+  F(traced_buf_chunks_relocated,          kIndexed, kInfo,     kTrace, Scope::kMachineAndTrace,         \
+    "TraceBufferV2 only. Num. chunks that we moved to the write cursor "       \
+    "instead of rewriting in place. We do this for scraped chunks that have "  \
+    "been fully read, as their old position can be too close to the write "    \
+    "cursor to be safe."),                                                     \
   F(traced_buf_chunks_rewritten,          kIndexed, kInfo,     kTrace, Scope::kMachineAndTrace,    ""), \
   F(traced_buf_chunks_written,            kIndexed, kInfo,     kTrace, Scope::kMachineAndTrace,    ""), \
   F(traced_buf_chunks_committed_out_of_order,                                  \

--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -881,9 +881,9 @@ void TraceBufferV2::CopyChunkUntrusted(
     const bool commit_adds_new_data =
         chunk_complete && all_frags_size > recommit_chunk->payload_size;
 
-    // EraseCurrentChunk() only supports the first chunk of a sequence. Chunks
-    // committed out of order keep the in-place rewrite: the race needs a stale
-    // offset, while out-of-order commits resolve within one scrape cycle.
+    // EraseCurrentChunk() only supports the first chunk of a sequence. Later
+    // chunks may stay physically ahead of the relocated one, which is fine:
+    // reads follow chunk_list, which is ordered by ChunkID and not by offset.
     const bool copy_is_first_chunk_of_seq =
         *chunk_list.begin() == OffsetOf(recommit_chunk);
 
@@ -924,7 +924,7 @@ void TraceBufferV2::CopyChunkUntrusted(
     stats_.set_chunks_relocated(stats_.chunks_relocated() + 1);
     previously_consumed_payload = recommit_chunk->payload_size;
     internal::ChunkSeqIterator(this, &seq).EraseCurrentChunk();
-  }
+  }  // if (recommit_chunk)
 
   // If there isn't enough room from the given write position: write a padding
   // record to clear the end of the buffer, wrap and start at offset 0.

--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -863,23 +863,67 @@ void TraceBufferV2::CopyChunkUntrusted(
       PERFETTO_DCHECK(suppress_client_dchecks_for_testing_);
       return;
     }
-    // Only clear kChunkIncomplete on real IPC recommits (chunk_complete=true).
-    // During scraping the producer may still be writing, so the chunk should
-    // remain incomplete until the producer explicitly commits it.
-    if (chunk_complete)
-      recommit_chunk->flags &= ~kChunkIncomplete;
-    if (all_frags_size == recommit_chunk->payload_size) {
-      TRACE_BUFFER_V2_DLOG("  skipping recommit of identical chunk");
+
+    // Decide whether to relocate this re-commit rather than rewrite it in
+    // place. A scraped chunk that has been fully read keeps its copy at the
+    // offset where it was scraped, which can sit arbitrarily close to the
+    // write cursor, so the recovered packets could be overwritten before the
+    // next read. Relocating skips the already-consumed payload as in the
+    // re-admit of evicted chunks above. See b/518755701 for more details.
+
+    // The copy came from a scrape, so more payload may still be coming.
+    const bool copy_is_scraped = recommit_chunk->flags & kChunkIncomplete;
+
+    // Nothing for the erase to lose, nothing for the relocation to duplicate.
+    const bool copy_fully_consumed = recommit_chunk->payload_avail == 0;
+
+    // The producer's final commit (not another scrape), with new fragments.
+    const bool commit_adds_new_data =
+        chunk_complete && all_frags_size > recommit_chunk->payload_size;
+
+    // EraseCurrentChunk() only supports the first chunk of a sequence. Chunks
+    // committed out of order keep the in-place rewrite: the race needs a stale
+    // offset, while out-of-order commits resolve within one scrape cycle.
+    const bool copy_is_first_chunk_of_seq =
+        *chunk_list.begin() == OffsetOf(recommit_chunk);
+
+    // Only a ring buffer laps, so only there can the stale copy be overwritten.
+    // On kDiscard, routing the commit through the write path below could also
+    // hit the end-of-buffer DiscardWrite(), dropping the very fragments we are
+    // recovering and sealing the buffer for good.
+    const bool buffer_can_lap = overwrite_policy_ == kOverwrite;
+
+    const bool should_relocate_chunk =
+        copy_is_scraped && copy_fully_consumed && commit_adds_new_data &&
+        copy_is_first_chunk_of_seq && buffer_can_lap;
+
+    if (PERFETTO_LIKELY(!should_relocate_chunk)) {
+      // Only clear kChunkIncomplete on real IPC recommits
+      // (chunk_complete=true). During scraping the producer may still be
+      // writing, so the chunk should remain incomplete until the producer
+      // explicitly commits it.
+      if (chunk_complete)
+        recommit_chunk->flags &= ~kChunkIncomplete;
+      if (all_frags_size == recommit_chunk->payload_size) {
+        TRACE_BUFFER_V2_DLOG("  skipping recommit of identical chunk");
+        return;
+      }
+      uint16_t payload_consumed =
+          recommit_chunk->payload_size - recommit_chunk->payload_avail;
+      recommit_chunk->payload_size = all_frags_size_u16;
+      recommit_chunk->payload_avail = all_frags_size_u16 - payload_consumed;
+      memcpy(recommit_chunk->fragments_begin(), src, all_frags_size);
+      recommit_chunk->flags |= chunk_flags;
+      stats_.set_chunks_rewritten(stats_.chunks_rewritten() + 1);
       return;
     }
-    uint16_t payload_consumed =
-        recommit_chunk->payload_size - recommit_chunk->payload_avail;
-    recommit_chunk->payload_size = all_frags_size_u16;
-    recommit_chunk->payload_avail = all_frags_size_u16 - payload_consumed;
-    memcpy(recommit_chunk->fragments_begin(), src, all_frags_size);
-    recommit_chunk->flags |= chunk_flags;
-    stats_.set_chunks_rewritten(stats_.chunks_rewritten() + 1);
-    return;
+
+    // Erase the stale copy and fall through to the write path below, which
+    // re-creates the chunk at the write cursor.
+    TRACE_BUFFER_V2_DLOG("  Relocating consumed scraped chunk %u", chunk_id);
+    stats_.set_chunks_relocated(stats_.chunks_relocated() + 1);
+    previously_consumed_payload = recommit_chunk->payload_size;
+    internal::ChunkSeqIterator(this, &seq).EraseCurrentChunk();
   }
 
   // If there isn't enough room from the given write position: write a padding
@@ -904,8 +948,9 @@ void TraceBufferV2::CopyChunkUntrusted(
   // Deletes all chunks from |wptr_| to |wptr_| + |record_size|.
   DeleteNextChunksFor(tbchunk_outer_size);
 
-  // If the DeleteNextChunksFor happens to delete a chunk in the same sequence,
-  // the insert_pos becomes invalid and we need to recompute that.
+  // |insert_pos| is invalid if any chunk was removed from this sequence since
+  // it was computed: either by the DeleteNextChunksFor above, or by the
+  // relocation erase.
   // Why don't we compute the insert_pos here? Because we also need to check
   // for re-commits (which are rare, but possible) and don't want to iterate
   // over the chunk list twice in most cases.

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -1092,6 +1092,260 @@ TEST_F(TraceBufferV2Test, DataLoss_ReassemblyGap) {
       previous_packet_dropped);
 }
 
+// A scraped chunk is fully read, then the write cursor almost laps the ring
+// before the producer's final commit arrives. Rewriting in place would leave
+// the recovered fragments right in the cursor's path, so they'd be evicted
+// before the next read (and the kFragBegin at the end would strand its
+// continuation). The commit must be relocated to the write cursor instead.
+TEST_F(TraceBufferV2Test, ScrapedChunkRecommit_RelocateToWritePos) {
+  ResetBuffer(4096);
+  const auto& stats = trace_buffer()->stats();
+
+  // Scrape of the writer's open chunk: 'b' is dropped as the incomplete tail.
+  // The full SMB chunk size (512) is reserved so re-commits can grow.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(32, 'a')
+      .AddPacket(32, 'b')
+      .PadTo(512)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/false);
+
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(32, 'a')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+
+  // Other writers fill the rest of the buffer exactly up to the end and get
+  // drained: the write cursor is now right behind the pinned scraped copy in
+  // ring order.
+  for (ChunkID c = 0; c < 3; c++) {
+    CreateChunk(ProducerID(2), WriterID(2), c)
+        .AddPacket(1024 - 16, 'x')
+        .CopyIntoTraceBuffer();
+  }
+  CreateChunk(ProducerID(2), WriterID(2), ChunkID(3))
+      .AddPacket(512 - 16, 'y')
+      .CopyIntoTraceBuffer();
+  ASSERT_EQ(0u, size_to_end());
+  trace_buffer()->BeginRead();
+  while (!ReadPacket().empty()) {
+  }
+  EXPECT_EQ(0u, stats.readaheads_failed());
+  EXPECT_EQ(0u, stats.chunks_overwritten());
+
+  // The producer finally commits ChunkID(0) for real: the payload grew and the
+  // chunk now ends with a fragment continuing on the (still uncommitted) next
+  // chunk.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(32, 'a')
+      .AddPacket(32, 'b')
+      .AddPacket(64, 'c', kContOnNextChunk)
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(0u, stats.chunks_rewritten());
+  EXPECT_EQ(1u, stats.chunks_relocated());
+  EXPECT_EQ(1u, stats.write_wrap_count());
+
+  // An unrelated write lands where the stale copy used to be. With the
+  // in-place rewrite this used to evict the re-committed fragments.
+  CreateChunk(ProducerID(2), WriterID(2), ChunkID(4))
+      .AddPacket(512 - 16, 'z')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(0u, stats.readaheads_failed());
+  EXPECT_EQ(0u, stats.chunks_overwritten());
+
+  // The continuation chunk arrives at the next flush.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(32, 'd', kContFromPrevChunk)
+      .AddPacket(32, 'e')
+      .CopyIntoTraceBuffer();
+
+  // Everything is readable: 'b' and the reassembled c+d packet. The consumed
+  // 'a' is not duplicated and no data loss is reported on the sequence.
+  trace_buffer()->BeginRead();
+  uint32_t previous_packet_dropped = 0;
+  TraceBuffer::PacketSequenceProperties seq_props{};
+  ASSERT_THAT(ReadPacket(&seq_props, &previous_packet_dropped),
+              ElementsAre(FakePacketFragment(32, 'b')));
+  EXPECT_EQ(ProducerID(1), seq_props.producer_id_trusted);
+  EXPECT_EQ(0u, previous_packet_dropped);
+  ASSERT_THAT(
+      ReadPacket(nullptr, &previous_packet_dropped),
+      ElementsAre(FakePacketFragment(64, 'c'), FakePacketFragment(32, 'd')));
+  EXPECT_EQ(0u, previous_packet_dropped);
+  ASSERT_THAT(ReadPacket(nullptr, &previous_packet_dropped),
+              ElementsAre(FakePacketFragment(512 - 16, 'z')));
+  EXPECT_EQ(0u, previous_packet_dropped);
+  ASSERT_THAT(ReadPacket(nullptr, &previous_packet_dropped),
+              ElementsAre(FakePacketFragment(32, 'e')));
+  EXPECT_EQ(0u, previous_packet_dropped);
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+  EXPECT_EQ(1u, stats.readaheads_succeeded());
+}
+
+// Only the producer's final commit of a fully-read scraped copy may relocate.
+// This walks the two ways that can fail, on the same chunk: first a second
+// scrape (not the final commit), then the final commit arriving while the copy
+// still has unread fragments. Both must keep the in-place rewrite, which is
+// the only way to grow the chunk without re-ordering the unread payload.
+TEST_F(TraceBufferV2Test, ScrapedChunkRecommit_InPlaceWhenGatesFail) {
+  ResetBuffer(4096);
+  const auto& stats = trace_buffer()->stats();
+
+  // First scrape: only 'a' visible ('b' dropped as the incomplete tail). The
+  // full SMB chunk size (512) is reserved so re-commits can grow.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(32, 'a')
+      .AddPacket(32, 'b')
+      .PadTo(512)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/false);
+
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(32, 'a')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+
+  // Second scrape grows the payload ('b' becomes visible, 'c' is the new
+  // incomplete tail). 'a' is fully consumed, but this is not the final commit.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(32, 'a')
+      .AddPacket(32, 'b')
+      .AddPacket(32, 'c')
+      .PadTo(512)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/false);
+  EXPECT_EQ(1u, stats.chunks_rewritten());
+  EXPECT_EQ(0u, stats.chunks_relocated());
+
+  // The final commit arrives, but 'b' and 'c' have not been read yet.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(32, 'a')
+      .AddPacket(32, 'b')
+      .AddPacket(32, 'c')
+      .AddPacket(32, 'd')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(2u, stats.chunks_rewritten());
+  EXPECT_EQ(0u, stats.chunks_relocated());
+
+  // 'a' is not re-emitted; everything written after it reads back in order.
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(32, 'b')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(32, 'c')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(32, 'd')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+}
+
+// kDiscard counterpart of Override_ReCommitIncompleteOnFullBuffer. The write
+// cursor never wraps here, so the stale-offset race can't happen, and
+// relocating would hit the end-of-buffer DiscardWrite() and drop the
+// recovered 'b'/'c'. The |buffer_can_lap| guard keeps the in-place rewrite.
+TEST_F(TraceBufferV2Test, ScrapedChunkRecommit_InPlaceOnFullDiscardBuffer) {
+  ResetBuffer(4096, TraceBuffer::kDiscard);
+  const auto& stats = trace_buffer()->stats();
+
+  // Scrape chunk 0: [Whole 'a'] [kFragBegin 'b'] padded to 1024. Only 'a' is
+  // visible; the 1024-byte slot is reserved for the later commit.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(20, 'a')
+      .AddPacket(10, 'b', kContOnNextChunk)
+      .PadTo(1024)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/false);
+
+  // Read 'a'. payload_avail → 0 but kChunkIncomplete keeps the copy pinned.
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(20, 'a')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+
+  // Fill the buffer up to the end. wr_ reaches size_ (size_to_end() == 0).
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(1))
+      .AddPacket(1024 - 16, 'x')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(2))
+      .AddPacket(1024 - 16, 'y')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(3))
+      .AddPacket(1024 - 16, 'z')
+      .CopyIntoTraceBuffer();
+  ASSERT_EQ(0u, size_to_end());
+
+  // Final commit of chunk 0. On kDiscard this must be rewritten in place, not
+  // relocated: the recovered 'b'/'c' are preserved, nothing is discarded and
+  // the write cursor does not wrap.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(20, 'a')
+      .AddPacket(10, 'b')
+      .AddPacket(100, 'c')
+      .PadTo(1024)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/true);
+  EXPECT_EQ(1u, stats.chunks_rewritten());
+  EXPECT_EQ(0u, stats.chunks_relocated());
+  EXPECT_EQ(0u, stats.chunks_discarded());
+  EXPECT_EQ(0u, stats.write_wrap_count());
+
+  // 'a' is not re-emitted; the recovered 'b'/'c' survive alongside x/y/z. The
+  // in-place rewrite keeps chunk 0 at its original offset (ahead of x/y/z in
+  // buffer order), so 'b'/'c' read back first.
+  trace_buffer()->BeginRead();
+  uint32_t dropped = 0;
+  ASSERT_THAT(ReadPacket(nullptr, &dropped),
+              ElementsAre(FakePacketFragment(10, 'b')));
+  EXPECT_FALSE(dropped);
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(100, 'c')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'x')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'y')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'z')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+}
+
+// The continuation chunk is already in the buffer when the final commit
+// arrives: reads stall on the incomplete chunk, so a later chunk of the same
+// sequence sits behind it in seq.chunks. The erase must leave the sequence
+// non-empty and reassembly must still work across the relocation boundary.
+TEST_F(TraceBufferV2Test, ScrapedChunkRecommit_ContinuationAlreadyPresent) {
+  ResetBuffer(4096);
+  const auto& stats = trace_buffer()->stats();
+
+  // Scrape chunk 0: only 'a' visible ('b' dropped).
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(32, 'a')
+      .AddPacket(32, 'b')
+      .PadTo(512)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/false);
+
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(32, 'a')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+
+  // Chunk 1 (the continuation, complete) arrives while chunk 0 is still the
+  // pinned incomplete first chunk: reads stalled on chunk 0, so chunk 1 sits
+  // behind it in seq.chunks.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(32, 'd', kContFromPrevChunk)
+      .AddPacket(32, 'e')
+      .CopyIntoTraceBuffer();
+
+  // Final commit of chunk 0: grows and ends with a kFragBegin ('c') that
+  // continues onto the already-present chunk 1.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(32, 'a')
+      .AddPacket(32, 'b')
+      .AddPacket(64, 'c', kContOnNextChunk)
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(0u, stats.chunks_rewritten());
+  EXPECT_EQ(1u, stats.chunks_relocated());
+
+  // 'a' not re-emitted; 'b', then the reassembled c+d, then 'e'. No data loss.
+  trace_buffer()->BeginRead();
+  uint32_t dropped = 0;
+  ASSERT_THAT(ReadPacket(nullptr, &dropped),
+              ElementsAre(FakePacketFragment(32, 'b')));
+  EXPECT_EQ(0u, dropped);
+  ASSERT_THAT(
+      ReadPacket(nullptr, &dropped),
+      ElementsAre(FakePacketFragment(64, 'c'), FakePacketFragment(32, 'd')));
+  EXPECT_EQ(0u, dropped);
+  ASSERT_THAT(ReadPacket(nullptr, &dropped),
+              ElementsAre(FakePacketFragment(32, 'e')));
+  EXPECT_EQ(0u, dropped);
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+  EXPECT_EQ(1u, stats.readaheads_succeeded());
+}
+
 // ---------------------
 // Malicious input tests
 // ---------------------
@@ -3066,11 +3320,11 @@ TEST_F(TraceBufferV2Test, NoOverwriteCountIfReaderCatchesUp) {
 }
 
 // Scrape → read → recommit when the buffer is full. The producer's complete
-// commit arrives when wr_ has reached size_, so cached_size_to_end is 0 and
-// the wrap path would otherwise evict the same kChunkIncomplete chunk we are
-// about to recommit. The recommit must rewrite the chunk in place: the
-// consumer must see only the new packets ('b' and 'c'), not the previously-
-// drained 'a' a second time.
+// commit arrives when wr_ has reached size_, so cached_size_to_end is 0. The
+// scraped copy is fully consumed, so the commit is relocated to the write
+// cursor, which wraps to offset 0. Either way the consumer must see only the
+// new packets ('b' and 'c'), not the previously-drained 'a' a second time. See
+// ScrapedChunkRecommit_InPlaceOnFullDiscardBuffer for the kDiscard counterpart.
 TEST_F(TraceBufferV2Test, Override_ReCommitIncompleteOnFullBuffer) {
   ResetBuffer(4096);
 
@@ -3103,8 +3357,7 @@ TEST_F(TraceBufferV2Test, Override_ReCommitIncompleteOnFullBuffer) {
 
   // Producer commits chunk 0 with the final payload from the same SMB slot.
   // Bytes 0..21 are still 'a' (an SMB invariant: producers never rewrite
-  // already-written bytes). The recommit must be detected and written in
-  // place — not turned into a fresh write that would re-emit 'a'.
+  // already-written bytes). The commit must not re-emit 'a'.
   CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
       .AddPacket(20, 'a')
       .AddPacket(10, 'b')
@@ -3113,17 +3366,17 @@ TEST_F(TraceBufferV2Test, Override_ReCommitIncompleteOnFullBuffer) {
       .CopyIntoTraceBuffer(/*chunk_complete=*/true);
 
   // Expected: 'a' is not delivered again; 'b' and 'c' are the newly-recovered
-  // packets; 'x', 'y', 'z' from the filler sequence follow. No data loss is
-  // signalled.
+  // packets. They follow 'x', 'y', 'z' in buffer order because the relocated
+  // chunk now sits at the write cursor. No data loss is signalled.
   trace_buffer()->BeginRead();
   uint32_t dropped = 0;
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'x')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'y')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'z')));
   ASSERT_THAT(ReadPacket(nullptr, &dropped),
               ElementsAre(FakePacketFragment(10, 'b')));
   EXPECT_FALSE(dropped);
   ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(100, 'c')));
-  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'x')));
-  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'y')));
-  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'z')));
   ASSERT_THAT(ReadPacket(), IsEmpty());
 }
 

--- a/test/trace_processor/diff_tests/parser/parsing/android_sched_and_ps_stats.out
+++ b/test/trace_processor/diff_tests/parser/parsing/android_sched_and_ps_stats.out
@@ -184,6 +184,7 @@
 "traced_buf_chunks_discarded",0,"info","trace",0
 "traced_buf_chunks_overwritten",0,"info","trace",0
 "traced_buf_chunks_read",0,"info","trace",0
+"traced_buf_chunks_relocated",0,"info","trace",0
 "traced_buf_chunks_rewritten",0,"info","trace",0
 "traced_buf_chunks_written",0,"info","trace",4603
 "traced_buf_padding_bytes_cleared",0,"info","trace",0


### PR DESCRIPTION
Fixes a data-loss race seen in 24h field traces with sporadic writers.
Fingerprint: orphan_continuation = overwrite = sequence_packet_loss = 1 on the
buffer, one packet with previous_packet_dropped = 73.

The race:
- A flush scrapes a writer's half-full chunk; the incomplete copy is pinned in
  the buffer and read over time.
- Hours later the writer commits the chunk. The recommit rewrote it in place,
  at the now-stale offset, with the write cursor almost a lap ahead: the
  never-read fragments could be overwritten before the next read pass.
- If the chunk ends with kFragBegin, that eviction destroys the begin fragment
  and its continuation later reads back as an orphan.

The fix:
- If the scraped copy is fully consumed and the final commit brings new
  fragments, erase the stale copy and relocate the chunk to the write cursor,
  reusing the re-admit path for evicted chunks (#5372).
- previously_consumed_payload skips what was already read, so nothing is
  duplicated; ChunkIDs stay consecutive, so no read gap.
- Rescrapes, partially-consumed and out-of-order recommits keep the in-place
  rewrite, as do kDiscard buffers (they never lap, and the write path could hit
  DiscardWrite() and drop the fragments being recovered).

New chunks_relocated stat (BufferStats field 20) counts these, mirroring
chunks_rewritten. Field 20 was never assigned in BufferStats: the CL below
added bytes_discarded_per_buffer = 20 to FilterStats but bumped the "Next id"
above BufferStats, leaving a phantom hole. https://r.android.com/2882818

Four new tests cover the race itself, the rescrape / unread-payload / kDiscard
exclusions, and the case where the continuation chunk is already buffered.

Bug: 518755701.
