### PR TITLE
tp: fix export subcommand writing to in-memory database

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20424,6 +20424,7 @@ filegroup {
     srcs: [
         "src/trace_processor/shell/convert_helpers_unittest.cc",
         "src/trace_processor/shell/find_subcommand_unittest.cc",
+        "src/trace_processor/shell/shell_utils_unittest.cc",
         "src/trace_processor/shell/subcommand_flags_unittest.cc",
     ],
 }

--- a/src/trace_processor/shell/BUILD.gn
+++ b/src/trace_processor/shell/BUILD.gn
@@ -110,6 +110,7 @@ source_set("unittests") {
   sources = [
     "convert_helpers_unittest.cc",
     "find_subcommand_unittest.cc",
+    "shell_utils_unittest.cc",
     "subcommand_flags_unittest.cc",
   ]
   deps = [
@@ -118,6 +119,7 @@ source_set("unittests") {
     "../../../gn:default_deps",
     "../../../gn:gtest_and_gmock",
     "../../../gn:protobuf_full",
+    "../../../gn:sqlite",
     "../../base",
   ]
 }

--- a/src/trace_processor/shell/shell_utils.cc
+++ b/src/trace_processor/shell/shell_utils.cc
@@ -16,7 +16,9 @@
 
 #include "src/trace_processor/shell/shell_utils.h"
 
+#include <algorithm>
 #include <cinttypes>
+#include <cstdint>
 #include <cstdio>
 #include <string>
 
@@ -51,6 +53,39 @@ bool StderrSupportsColors() {
 }
 
 namespace {
+
+// The main trace processor connection is opened on the in-memory "memdb" VFS.
+// ATTACH DATABASE inherits the connection's VFS, so a plain path would create
+// the export database in memory too. Force the OS-backed VFS instead.
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+constexpr char kExportVfs[] = "win32";
+#else
+constexpr char kExportVfs[] = "unix";
+#endif
+
+// Builds a SQLite "file:" URI for `path`, percent-encoding characters that are
+// not safe in a URI path.
+std::string MakeExportFileUri(const std::string& path) {
+  std::string normalized = path;
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  std::replace(normalized.begin(), normalized.end(), '\\', '/');
+#endif
+  std::string uri = "file:";
+  for (char c : normalized) {
+    bool unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                      (c >= '0' && c <= '9') || c == '-' || c == '.' ||
+                      c == '_' || c == '~' || c == '/' || c == ':';
+    if (unreserved) {
+      uri.push_back(c);
+    } else {
+      base::StackString<4> escaped("%%%02X", static_cast<uint8_t>(c));
+      uri.append(escaped.c_str());
+    }
+  }
+  uri.append("?vfs=");
+  uri.append(kExportVfs);
+  return uri;
+}
 
 base::Status PrintStatsSection(TraceProcessor* tp,
                                const char* header,
@@ -151,13 +186,24 @@ base::Status ExportTraceToDatabase(TraceProcessor* trace_processor,
     PERFETTO_CHECK(res == 0);
   }
 
-  std::string attach_sql =
-      "ATTACH DATABASE '" + output_name + "' AS perfetto_export";
+  std::string attach_sql = "ATTACH DATABASE '" +
+                           MakeExportFileUri(output_name) +
+                           "' AS perfetto_export";
   auto attach_it = trace_processor->ExecuteQuery(attach_sql);
   bool attach_has_more = attach_it.Next();
   PERFETTO_DCHECK(!attach_has_more);
 
   RETURN_IF_ERROR(attach_it.Status());
+
+  // The export database is written once and regenerated from the trace on
+  // failure, so trade durability for speed and lower I/O.
+  for (const char* pragma : {"PRAGMA perfetto_export.journal_mode=OFF",
+                             "PRAGMA perfetto_export.synchronous=OFF"}) {
+    auto pragma_it = trace_processor->ExecuteQuery(pragma);
+    while (pragma_it.Next()) {
+    }
+    RETURN_IF_ERROR(pragma_it.Status());
+  }
 
   // Export real and virtual tables.
   auto tables_it =
@@ -196,7 +242,7 @@ base::Status ExportTraceToDatabase(TraceProcessor* trace_processor,
 
   auto detach_it =
       trace_processor->ExecuteQuery("DETACH DATABASE perfetto_export");
-  bool detach_has_more = attach_it.Next();
+  bool detach_has_more = detach_it.Next();
   PERFETTO_DCHECK(!detach_has_more);
   return detach_it.Status();
 }

--- a/src/trace_processor/shell/shell_utils_unittest.cc
+++ b/src/trace_processor/shell/shell_utils_unittest.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/shell_utils.h"
+
+#include <sqlite3.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "perfetto/base/build_config.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/temp_file.h"
+#include "perfetto/trace_processor/basic_types.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+int64_t ScalarCount(TraceProcessor* tp, const std::string& sql) {
+  auto it = tp->ExecuteQuery(sql);
+  PERFETTO_CHECK(it.Next());
+  int64_t value = it.Get(0).AsLong();
+  PERFETTO_CHECK(!it.Next());
+  PERFETTO_CHECK(it.Status().ok());
+  return value;
+}
+
+int64_t ScalarCount(sqlite3* db, const std::string& sql) {
+  sqlite3_stmt* stmt = nullptr;
+  PERFETTO_CHECK(sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) ==
+                 SQLITE_OK);
+  PERFETTO_CHECK(sqlite3_step(stmt) == SQLITE_ROW);
+  int64_t value = sqlite3_column_int64(stmt, 0);
+  sqlite3_finalize(stmt);
+  return value;
+}
+
+// Builds a file: URI that forces the OS-backed VFS, so a memdb-based trace
+// processor connection attaches the on-disk file rather than a memory database.
+std::string MakeAttachUri(const std::string& path) {
+  std::string normalized = path;
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  std::replace(normalized.begin(), normalized.end(), '\\', '/');
+  const char* vfs = "win32";
+#else
+  const char* vfs = "unix";
+#endif
+  return "file:" + normalized + "?vfs=" + vfs;
+}
+
+// Verifies the export produces an on-disk SQLite database that can be read back
+// by a standalone SQLite connection and re-attached and queried by a trace
+// processor.
+TEST(ShellUtilsTest, ExportTraceToDatabaseWritesToDisk) {
+  auto tp = TraceProcessor::CreateInstance(Config());
+
+  int64_t expected_tables = ScalarCount(tp.get(),
+                                        "SELECT COUNT(*) FROM "
+                                        "perfetto_tables");
+  int64_t expected_views = ScalarCount(
+      tp.get(), "SELECT COUNT(*) FROM sqlite_master WHERE type='view'");
+
+  base::TempDir dir = base::TempDir::Create();
+  std::string output = dir.path() + "/export.db";
+
+  ASSERT_TRUE(ExportTraceToDatabase(tp.get(), output).ok());
+
+  std::string contents;
+  ASSERT_TRUE(base::ReadFile(output, &contents));
+  ASSERT_GT(contents.size(), 0u);
+  ASSERT_EQ(contents.rfind("SQLite format 3", 0), 0u);
+
+  // Read back with a standalone connection on the default (on-disk) VFS.
+  PERFETTO_CHECK(sqlite3_initialize() == SQLITE_OK);
+  sqlite3* db = nullptr;
+  ASSERT_EQ(sqlite3_open(output.c_str(), &db), SQLITE_OK);
+  EXPECT_EQ(
+      ScalarCount(db, "SELECT COUNT(*) FROM sqlite_master WHERE type='table'"),
+      expected_tables);
+  EXPECT_EQ(
+      ScalarCount(db, "SELECT COUNT(*) FROM sqlite_master WHERE type='view'"),
+      expected_views);
+  sqlite3_close(db);
+
+  // Reload the exported database into a fresh trace processor and query it.
+  auto reloaded = TraceProcessor::CreateInstance(Config());
+  {
+    auto it = reloaded->ExecuteQuery("ATTACH DATABASE '" +
+                                     MakeAttachUri(output) + "' AS reimported");
+    EXPECT_FALSE(it.Next());
+    ASSERT_TRUE(it.Status().ok()) << it.Status().c_message();
+  }
+  std::string table;
+  {
+    auto it = tp->ExecuteQuery(
+        "SELECT name FROM perfetto_tables ORDER BY name LIMIT 1");
+    ASSERT_TRUE(it.Next());
+    table = it.Get(0).string_value;
+    ASSERT_TRUE(it.Status().ok());
+  }
+  EXPECT_EQ(
+      ScalarCount(reloaded.get(), "SELECT COUNT(*) FROM reimported." + table),
+      ScalarCount(tp.get(), "SELECT COUNT(*) FROM " + table));
+  reloaded.reset();
+
+  base::Unlink(output.c_str());
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor


### PR DESCRIPTION
The trace processor connection is opened on the in-memory "memdb" VFS. ATTACH DATABASE inherits the connection's VFS, so the export attached its output database in memory as well: every table was materialized in RAM and the on-disk file was left empty, while the command still reported success. This regressed in #5766, which moved the connection onto the memdb VFS; before that the connection used ":memory:", so the plain-path ATTACH resolved to the on-disk VFS and worked.

Attach the export database through a file: URI that selects the OS-backed VFS so the tables are streamed to disk instead. This fixes the empty output and roughly halves peak RSS, since the tables are no longer duplicated in memory. Also disable the rollback journal and fsync on the export database (it is regenerated from the trace on failure) and fix the detach statement never being stepped.

Add a unit test that exports and verifies the result reads back through a standalone SQLite connection and reloads into a trace processor.