### PR TITLE
ui: Speed up integration tests

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -92,7 +92,7 @@ export default defineConfig({
   webServer: {
     // Just run the server without building
     command:
-      './run-dev-server --no-build --no-depscheck ' +
+      './build --serve --no-build --no-depscheck ' +
       (process.env.DEV_SERVER_ARGS ?? ''),
     url: 'http://127.0.0.1:10000',
     reuseExistingServer: true,


### PR DESCRIPTION
Switch to using normal `ui/build --serve` instead of the vite dev server when running integration tests. The dev server is not required as the sources don't change, and it just adds overhead.