### PR TITLE
ui: Upgrade Playwright and fix CodeMirror EditorView import

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,7 +41,7 @@
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.6.0",
     "@lezer/generator": "^1.8.0",
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.61.1",
     "@testing-library/dom": "^10.4.1",
     "@types/chrome": "0.0.268",
     "@types/color-convert": "^2.0.3",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -67,7 +67,6 @@ export default defineConfig({
         viewport: {width: 1920, height: 1080},
         launchOptions: {
           args: [
-            '--headless',
             '--disable-accelerated-2d-canvas',
             '--disable-font-subpixel-positioning',
             '--ignore-gpu-blocklist', // Allow llvmpipe software rendering

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -96,6 +96,6 @@ export default defineConfig({
     url: 'http://127.0.0.1:10000',
     reuseExistingServer: true,
     timeout: 5 * 60 * 1000,
-    stdout: 'pipe',
+    stdout: 'ignore',
   },
 });

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -104,8 +104,8 @@ devDependencies:
     specifier: ^1.8.0
     version: 1.8.0
   '@playwright/test':
-    specifier: ^1.58.2
-    version: 1.58.2
+    specifier: ^1.61.1
+    version: 1.61.1
   '@testing-library/dom':
     specifier: ^10.4.1
     version: 10.4.1
@@ -803,12 +803,12 @@ packages:
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dev: true
 
-  /@playwright/test@1.58.2:
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  /@playwright/test@1.61.1:
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.61.1
     dev: true
 
   /@popperjs/core@2.11.8:
@@ -2764,18 +2764,18 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  /playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
     dev: true
 
-  /playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  /playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/ui/run-integrationtests
+++ b/ui/run-integrationtests
@@ -186,7 +186,7 @@ def run_in_docker(args):
   docker_cmd = [
       'docker', 'run',
       '--rm', # Remove the container after it exits
-      '--ipc=host', # Share host IPC/shared memory to prevent Chrome crashes with high worker counts
+      '--shm-size=2gb', # Provide ample shared memory without polluting host IPC namespace
       '-t', # Allocate a pseudo-TTY for better output formatting
       '-v', f'{REPO_ROOT}:{REPO_ROOT}', # Mount the repo root into the container
       '-w', f'{REPO_ROOT}/ui', # Set working directory to /ui

--- a/ui/src/widgets/editor.ts
+++ b/ui/src/widgets/editor.ts
@@ -21,8 +21,8 @@ import {
   type Transaction,
 } from '@codemirror/state';
 import {oneDark} from '@codemirror/theme-one-dark';
-import {keymap, tooltips} from '@codemirror/view';
-import {basicSetup, EditorView} from 'codemirror';
+import {EditorView, keymap, tooltips} from '@codemirror/view';
+import {basicSetup} from 'codemirror';
 import {javascript} from '@codemirror/lang-javascript';
 import m from 'mithril';
 import {removeFalsyValues} from '../base/array_utils';


### PR DESCRIPTION
Upgrade @playwright/test to 1.61.1. In addition, update EditorView import in ui/src/widgets/editor.ts to be imported directly from @codemirror/view instead of the codemirror umbrella package, avoiding type conflicts from version mismatches.