### PR TITLE
ui: Format UI codebase with Prettier 3.9.5

### DIFF
--- a/ui/src/assets/typefaces.scss
+++ b/ui/src/assets/typefaces.scss
@@ -5,9 +5,10 @@
   font-weight: 100 900;
   font-display: swap;
   src: url(assets/Roboto.woff2) format("woff2");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-    U+FEFF, U+FFFD;
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
+    U+FFFD;
 }
 
 /* latin */
@@ -18,9 +19,10 @@
   font-weight: 100 900;
   font-stretch: 50%;
   src: url(assets/Roboto.woff2) format("woff2");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-    U+FEFF, U+FFFD;
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
+    U+FFFD;
 }
 
 /* latin */
@@ -30,9 +32,10 @@
   font-weight: 400;
   font-display: swap;
   src: url(assets/RobotoMono-Regular.woff2) format("woff2");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-    U+FEFF, U+FFFD;
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
+    U+FFFD;
 }
 
 @font-face {

--- a/ui/src/base/comparison_utils.ts
+++ b/ui/src/base/comparison_utils.ts
@@ -43,12 +43,7 @@ export function withDirection<T>(
 }
 
 export type SortableValue =
-  | string
-  | number
-  | bigint
-  | null
-  | Uint8Array
-  | undefined;
+  string | number | bigint | null | Uint8Array | undefined;
 
 function columnTypeKind(a: SortableValue): number {
   if (a === undefined) {

--- a/ui/src/base/gl/webgl_renderer.ts
+++ b/ui/src/base/gl/webgl_renderer.ts
@@ -40,8 +40,7 @@ export class WebGLRenderer implements Renderer {
   private readonly stepArea: StepAreaBatch;
   private transform = Transform2D.Identity;
   private clipRect:
-    | {left: number; top: number; right: number; bottom: number}
-    | undefined;
+    {left: number; top: number; right: number; bottom: number} | undefined;
 
   constructor(c2d: CanvasRenderingContext2D, gl: WebGL2RenderingContext) {
     this.c2d = c2d;

--- a/ui/src/base/shared_disposable.ts
+++ b/ui/src/base/shared_disposable.ts
@@ -51,9 +51,9 @@ import {assertFalse} from './assert';
  * }
  * ```
  */
-export class SharedAsyncDisposable<T extends AsyncDisposable>
-  implements AsyncDisposable
-{
+export class SharedAsyncDisposable<
+  T extends AsyncDisposable,
+> implements AsyncDisposable {
   // A shared core which is referenced by al instances of this class used to
   // store the reference count
   private readonly sharedCore: {refCount: number};

--- a/ui/src/base/touchscreen_handler.ts
+++ b/ui/src/base/touchscreen_handler.ts
@@ -240,9 +240,7 @@ export class TouchscreenHandler {
 }
 
 export type TouchEventTranslation =
-  | 'down-up-move'
-  | 'pan-x'
-  | 'pinch-zoom-as-ctrl-wheel';
+  'down-up-move' | 'pan-x' | 'pinch-zoom-as-ctrl-wheel';
 export function convertTouchIntoMouseEvents(
   target: HTMLElement,
   events: TouchEventTranslation[],

--- a/ui/src/bigtrace/pages/bigtrace_settings_bar.ts
+++ b/ui/src/bigtrace/pages/bigtrace_settings_bar.ts
@@ -33,9 +33,7 @@ export interface BigtraceSettingsBarAttrs {
 // trace filters) plus an "+ Add" chip opening the Settings modal. Trace-metadata
 // columns aren't shown here — they live only in the modal's Query Result Columns
 // card.
-export class BigtraceSettingsBar
-  implements m.ClassComponent<BigtraceSettingsBarAttrs>
-{
+export class BigtraceSettingsBar implements m.ClassComponent<BigtraceSettingsBarAttrs> {
   view({attrs}: m.Vnode<BigtraceSettingsBarAttrs>): m.Children {
     const {tab, tabsState, bindings} = attrs;
     return m(
@@ -70,8 +68,7 @@ export class BigtraceSettingsBar
 function renderSettingChips(bindings: SettingsBindings): m.Children {
   return bindings.getEffectiveSettings().map((entry) => {
     const setting = bigTraceSettingsStorage.get(entry.settingId) as
-      | BigTraceSetting<unknown>
-      | undefined;
+      BigTraceSetting<unknown> | undefined;
     if (setting === undefined) return null;
     return renderSettingChip(setting, entry.values);
   });

--- a/ui/src/bigtrace/pages/query_tabs_state.ts
+++ b/ui/src/bigtrace/pages/query_tabs_state.ts
@@ -252,18 +252,18 @@ export class QueryTabsState {
         : [...traceFilterState.get()];
     // Restored: persisted; history-reopen: null (runner rehydrates); fresh: global.
     const traceMetadataColumns: readonly string[] | null = isFromStorage
-      ? stored?.traceMetadataColumns ?? null
+      ? (stored?.traceMetadataColumns ?? null)
       : isFromHistory
         ? null
         : traceQueryColumnsState.get();
     const traceOrderBy: string = isFromStorage
-      ? stored?.traceOrderBy ?? ''
+      ? (stored?.traceOrderBy ?? '')
       : isFromHistory
         ? ''
         : traceOrderByState.get();
     // Restored tabs keep their layout; fresh/history start at show-all (null).
     const resultColumns: readonly string[] | null = isFromStorage
-      ? stored?.resultColumns ?? null
+      ? (stored?.resultColumns ?? null)
       : null;
     // Per-tab enable/disable. Fresh tabs mirror the current global state, then
     // diverge independently; restored tabs use their persisted set.

--- a/ui/src/bigtrace/pages/settings_page.ts
+++ b/ui/src/bigtrace/pages/settings_page.ts
@@ -92,9 +92,7 @@ interface BigTraceSettingsCardAttrs extends m.Attributes {
   onReset?: () => void;
 }
 
-class BigTraceSettingsCard
-  implements m.ClassComponent<BigTraceSettingsCardAttrs>
-{
+class BigTraceSettingsCard implements m.ClassComponent<BigTraceSettingsCardAttrs> {
   view(vnode: m.Vnode<BigTraceSettingsCardAttrs>) {
     const {
       id,

--- a/ui/src/bigtrace/query/query_history.ts
+++ b/ui/src/bigtrace/query/query_history.ts
@@ -29,9 +29,7 @@ interface QueryHistoryComponentAttrs {
 
 export {setHistoryActiveTab} from './history_store';
 
-export class QueryHistoryComponent
-  implements m.ClassComponent<QueryHistoryComponentAttrs>
-{
+export class QueryHistoryComponent implements m.ClassComponent<QueryHistoryComponentAttrs> {
   oninit(vnode: m.CVnode<QueryHistoryComponentAttrs>) {
     historyStore.requestRefresh(vnode.attrs.refreshSignal ?? 0);
   }

--- a/ui/src/bigtrace/settings/bigtrace_settings_service.ts
+++ b/ui/src/bigtrace/settings/bigtrace_settings_service.ts
@@ -42,12 +42,8 @@ function toSettingDescriptor(
   const {id = '', name = '', description = '', disabled, category} = option;
 
   let type:
-    | 'string'
-    | 'number'
-    | 'boolean'
-    | 'enum'
-    | 'multi-select'
-    | 'string-array' = 'string';
+    'string' | 'number' | 'boolean' | 'enum' | 'multi-select' | 'string-array' =
+    'string';
   let schema: z.ZodType<unknown> = z.any();
   let defaultValue: unknown = undefined;
   let optionsList: {value: string; label: string}[] | undefined = undefined;

--- a/ui/src/bigtrace/settings/endpoint_storage.ts
+++ b/ui/src/bigtrace/settings/endpoint_storage.ts
@@ -36,5 +36,5 @@ endpointStorage.register({
 // null/empty handling call sites would otherwise re-inline.
 export function getBigtraceEndpoint(): string {
   const setting = endpointStorage.get('bigtraceEndpoint');
-  return setting ? (setting.get() as string) ?? '' : '';
+  return setting ? ((setting.get() as string) ?? '') : '';
 }

--- a/ui/src/bigtrace/settings/setting_impl.ts
+++ b/ui/src/bigtrace/settings/setting_impl.ts
@@ -29,12 +29,7 @@ export class SettingImpl<T> implements Setting<T> {
   public readonly name: string;
   public readonly description: string;
   public readonly type:
-    | 'string'
-    | 'number'
-    | 'boolean'
-    | 'enum'
-    | 'multi-select'
-    | 'string-array';
+    'string' | 'number' | 'boolean' | 'enum' | 'multi-select' | 'string-array';
   public readonly schema: z.ZodType<T>;
   public readonly defaultValue: T;
   public readonly category?: string;

--- a/ui/src/bigtrace/settings/settings_types.ts
+++ b/ui/src/bigtrace/settings/settings_types.ts
@@ -34,12 +34,7 @@ export interface SettingDescriptor<T> {
 
   // Defaults to 'string' if omitted.
   readonly type?:
-    | 'string'
-    | 'number'
-    | 'boolean'
-    | 'enum'
-    | 'multi-select'
-    | 'string-array';
+    'string' | 'number' | 'boolean' | 'enum' | 'multi-select' | 'string-array';
 
   // Zod schema validating the value.
   readonly schema: z.ZodType<T>;

--- a/ui/src/bigtrace/settings/settings_widgets.ts
+++ b/ui/src/bigtrace/settings/settings_widgets.ts
@@ -39,9 +39,7 @@ interface DeferredCommitInputAttrs {
 // focus guard, so binding it to setting.get() would let an unrelated redraw wipe
 // the typed text; rendering the local buffer avoids that. Re-syncs to the
 // external value when it changes and there's no pending edit (e.g. a reset).
-class DeferredCommitInput
-  implements m.ClassComponent<DeferredCommitInputAttrs>
-{
+class DeferredCommitInput implements m.ClassComponent<DeferredCommitInputAttrs> {
   private local = '';
   private syncedInitial: string | undefined;
 

--- a/ui/src/chrome_extension/consumer_port_types.ts
+++ b/ui/src/chrome_extension/consumer_port_types.ts
@@ -32,21 +32,16 @@ export function isTyped(obj: object): obj is Typed {
 }
 
 export interface ReadBuffersResponse
-  extends Typed,
-    protos.IReadBuffersResponse {}
+  extends Typed, protos.IReadBuffersResponse {}
 export interface EnableTracingResponse
-  extends Typed,
-    protos.IEnableTracingResponse {}
+  extends Typed, protos.IEnableTracingResponse {}
 export interface GetTraceStatsResponse
-  extends Typed,
-    protos.IGetTraceStatsResponse {}
+  extends Typed, protos.IGetTraceStatsResponse {}
 export interface FreeBuffersResponse
-  extends Typed,
-    protos.IFreeBuffersResponse {}
+  extends Typed, protos.IFreeBuffersResponse {}
 export interface GetCategoriesResponse extends Typed {}
 export interface DisableTracingResponse
-  extends Typed,
-    protos.IDisableTracingResponse {}
+  extends Typed, protos.IDisableTracingResponse {}
 
 export type ConsumerPortResponse =
   | EnableTracingResponse

--- a/ui/src/components/aggregation_panel.ts
+++ b/ui/src/components/aggregation_panel.ts
@@ -43,9 +43,7 @@ export interface AggregationPanelAttrs {
   readonly controls?: m.Children;
 }
 
-export class AggregationPanel
-  implements m.ClassComponent<AggregationPanelAttrs>
-{
+export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs> {
   view({attrs}: m.CVnode<AggregationPanelAttrs>) {
     const {
       dataSource,

--- a/ui/src/components/details/thread_state.ts
+++ b/ui/src/components/details/thread_state.ts
@@ -156,9 +156,7 @@ interface BreakdownByThreadStateTreeNodeAttrs {
 }
 
 // A tree node that displays a nested breakdown a time interval by thread state.
-export class BreakdownByThreadStateTreeNode
-  implements m.ClassComponent<BreakdownByThreadStateTreeNodeAttrs>
-{
+export class BreakdownByThreadStateTreeNode implements m.ClassComponent<BreakdownByThreadStateTreeNodeAttrs> {
   view({attrs}: m.Vnode<BreakdownByThreadStateTreeNodeAttrs>): m.Child[] {
     return renderChildren(attrs.trace, attrs.data.root, attrs.dur);
   }

--- a/ui/src/components/distribution_panel.ts
+++ b/ui/src/components/distribution_panel.ts
@@ -192,9 +192,7 @@ export interface DistributionSummaryAttrs extends DistributionInputs {
 // Reusable left-half: histogram (with brush) + percentile stats. Materializes
 // the filtered dataset as a Perfetto table so the histogram and stats share
 // a single aggregation source.
-export class DistributionSummary
-  implements m.ClassComponent<DistributionSummaryAttrs>
-{
+export class DistributionSummary implements m.ClassComponent<DistributionSummaryAttrs> {
   private readonly tableSlot = new QuerySlot<DisposableSqlEntity>();
   private readonly boundsSlot = new QuerySlot<NiceBuckets>();
   private readonly statsSlot = new QuerySlot<DistributionStats>();
@@ -365,9 +363,7 @@ export interface DistributionPanelAttrs extends DistributionInputs {
 
 // Two-pane "value distribution" tab: instances grid + histogram summary,
 // both reading from a single materialized Perfetto table.
-export class DistributionPanel
-  implements m.ClassComponent<DistributionPanelAttrs>
-{
+export class DistributionPanel implements m.ClassComponent<DistributionPanelAttrs> {
   private readonly tableSlot = new QuerySlot<DisposableSqlEntity>();
 
   private dataSource?: SQLDataSource;
@@ -574,13 +570,11 @@ function buildGridSchema(
 function gridColumns(attrs: DistributionPanelAttrs): Column[] {
   return [
     {id: attrs.idColumn, field: attrs.idColumn},
-    ...attrs.displayColumns.map(
-      (field): Column => ({
-        id: field,
-        field,
-        sort: field === attrs.valueColumn ? 'DESC' : undefined,
-      }),
-    ),
+    ...attrs.displayColumns.map((field): Column => ({
+      id: field,
+      field,
+      sort: field === attrs.valueColumn ? 'DESC' : undefined,
+    })),
   ];
 }
 

--- a/ui/src/components/tracks/add_debug_track_menu.ts
+++ b/ui/src/components/tracks/add_debug_track_menu.ts
@@ -67,9 +67,7 @@ interface ConfigurationOptions {
   color: string;
 }
 
-export class AddDebugTrackMenu
-  implements m.ClassComponent<AddDebugTrackMenuAttrs>
-{
+export class AddDebugTrackMenu implements m.ClassComponent<AddDebugTrackMenuAttrs> {
   private trackName = '';
   private trackType: TrackType = 'slice';
   private readonly options: Partial<ConfigurationOptions>;

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -1041,7 +1041,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
       depths[i] = depth;
       patterns[i] = isIncomplete
         ? RECT_PATTERN_FADE_RIGHT
-        : this.attrs.slicePattern?.(it) ?? 0;
+        : (this.attrs.slicePattern?.(it) ?? 0);
       slices[i] = {
         id,
         title,

--- a/ui/src/components/tracks/slice_track_details_panel.ts
+++ b/ui/src/components/tracks/slice_track_details_panel.ts
@@ -36,9 +36,9 @@ import {Time} from '../../base/time';
  * - Common slice fields (name, ts, dur) with appropriate formatting
  * - All other dataset columns as readable strings
  */
-export class SliceTrackDetailsPanel<T extends RowSchema>
-  implements TrackEventDetailsPanel
-{
+export class SliceTrackDetailsPanel<
+  T extends RowSchema,
+> implements TrackEventDetailsPanel {
   constructor(
     private readonly trace: Trace,
     private readonly dataset: SourceDataset<T>,

--- a/ui/src/components/widgets/charts/chart_sql_source.ts
+++ b/ui/src/components/widgets/charts/chart_sql_source.ts
@@ -180,9 +180,7 @@ export interface HistogramQueryConfig {
 
 /** Union of all query config types. */
 export type QueryConfig =
-  | AggregatedQueryConfig
-  | PointsQueryConfig
-  | HistogramQueryConfig;
+  AggregatedQueryConfig | PointsQueryConfig | HistogramQueryConfig;
 
 // ---------------------------------------------------------------------------
 // ChartSource

--- a/ui/src/components/widgets/charts/echart_view.ts
+++ b/ui/src/components/widgets/charts/echart_view.ts
@@ -262,12 +262,9 @@ function autoAdjustGridSpacing(
       const labels = collectYAxisLabels(opt);
       if (labels.length > 0) {
         const axisLabel = yAxis.axisLabel as
-          | Record<string, unknown>
-          | undefined;
+          Record<string, unknown> | undefined;
         const formatter = axisLabel?.formatter as
-          | LabelFormatter
-          | string
-          | undefined;
+          LabelFormatter | string | undefined;
         let maxWidth = 0;
         for (const l of labels) {
           const text = formatLabel(l, formatter);
@@ -309,8 +306,7 @@ function themeHash(colors: ChartThemeColors): string {
 export interface EChartBrushEndParams {
   readonly areas?: ReadonlyArray<{
     readonly coordRange?:
-      | [number, number]
-      | [[number, number], [number, number]];
+      [number, number] | [[number, number], [number, number]];
   }>;
 }
 

--- a/ui/src/components/widgets/charts/histogram.ts
+++ b/ui/src/components/widgets/charts/histogram.ts
@@ -33,8 +33,7 @@ function resolveBucketColors(
   if (series === undefined) return option;
   for (const s of series) {
     const data = s.data as
-      | ReadonlyArray<{itemStyle?: Record<string, unknown>}>
-      | undefined;
+      ReadonlyArray<{itemStyle?: Record<string, unknown>}> | undefined;
     if (data === undefined) continue;
     for (const item of data) {
       const style = item.itemStyle;

--- a/ui/src/components/widgets/charts_svg/histogram_svg.ts
+++ b/ui/src/components/widgets/charts_svg/histogram_svg.ts
@@ -60,7 +60,7 @@ export class HistogramSvg implements m.ClassComponent<HistogramAttrs> {
       if (this.hover === undefined || data === undefined) return false;
       const rawFmtX = attrs.formatXValue ?? ((v: number) => formatNumber(v));
       const fmtX =
-        attrs.integerDimension ?? false
+        (attrs.integerDimension ?? false)
           ? (v: number) => rawFmtX(Math.round(v))
           : rawFmtX;
       const fmtY = attrs.formatYValue ?? formatNumber;

--- a/ui/src/components/widgets/datagrid/add_column_menu.ts
+++ b/ui/src/components/widgets/datagrid/add_column_menu.ts
@@ -123,9 +123,7 @@ export interface AddColumnParamMenuItemAttrs {
  * the keys available in the data source. Keys are only fetched when the submenu
  * is opened.
  */
-export class AddColumnParamMenuItem
-  implements m.ClassComponent<AddColumnParamMenuItemAttrs>
-{
+export class AddColumnParamMenuItem implements m.ClassComponent<AddColumnParamMenuItemAttrs> {
   view({attrs}: m.Vnode<AddColumnParamMenuItemAttrs>) {
     const {pathPrefix, existingColumns, datasource, onSelect, label, icon} =
       attrs;

--- a/ui/src/components/widgets/datagrid/column_filter_menu.ts
+++ b/ui/src/components/widgets/datagrid/column_filter_menu.ts
@@ -53,9 +53,7 @@ interface DistinctValuesSubmenuAttrs {
   readonly onApply: (selectedValues: Set<SqlValue>) => void;
 }
 
-export class DistinctValuesSubmenu
-  implements m.ClassComponent<DistinctValuesSubmenuAttrs>
-{
+export class DistinctValuesSubmenu implements m.ClassComponent<DistinctValuesSubmenuAttrs> {
   private selectedValues = new Set<SqlValue>();
   private searchQuery = '';
   private static readonly MAX_VISIBLE_ITEMS = 100;
@@ -205,9 +203,7 @@ interface TextFilterSubmenuAttrs {
   readonly onApply: (value: string | number) => void;
 }
 
-export class TextFilterSubmenu
-  implements m.ClassComponent<TextFilterSubmenuAttrs>
-{
+export class TextFilterSubmenu implements m.ClassComponent<TextFilterSubmenuAttrs> {
   private inputValue = '';
 
   view({attrs}: m.Vnode<TextFilterSubmenuAttrs>) {

--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -693,7 +693,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
               title:
                 this.filters.length > 0
                   ? 'No results match your filters'
-                  : emptyStateMessage ?? 'No data available',
+                  : (emptyStateMessage ?? 'No data available'),
               fillHeight: true,
             },
             this.filters.length > 0 &&
@@ -1514,7 +1514,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
             canAdd: attrs.canAddColumns ?? true,
             canRemove: this.columns.length > 1,
             onRemove:
-              attrs.canRemoveColumns ?? true
+              (attrs.canRemoveColumns ?? true)
                 ? () => this.removeColumn(colId, attrs)
                 : undefined,
             schema,
@@ -1681,9 +1681,9 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
             GridCell,
             {
               actionButtons: colInfo?.actions?.(value, row),
-              align: isRich ? rendered.align ?? 'left' : getAligment(value),
+              align: isRich ? (rendered.align ?? 'left') : getAligment(value),
               nullish: isRich
-                ? rendered.nullish ?? value === null
+                ? (rendered.nullish ?? value === null)
                 : value === null,
               chevron,
               onChevronClick,
@@ -2103,9 +2103,9 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
             m(
               GridCell,
               {
-                align: isRich ? rendered.align ?? 'left' : getAligment(value),
+                align: isRich ? (rendered.align ?? 'left') : getAligment(value),
                 nullish: isRich
-                  ? rendered.nullish ?? value === null
+                  ? (rendered.nullish ?? value === null)
                   : value === null,
                 className: classNames(
                   'pf-data-grid__groupby-column',
@@ -2195,9 +2195,9 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
               GridCell,
               {
                 // Default to 'right' for aggregates, but allow override
-                align: isRich ? rendered.align ?? 'left' : getAligment(value),
+                align: isRich ? (rendered.align ?? 'left') : getAligment(value),
                 nullish: isRich
-                  ? rendered.nullish ?? value === null
+                  ? (rendered.nullish ?? value === null)
                   : value === null,
               },
               isRich ? rendered.content : rendered,

--- a/ui/src/components/widgets/datagrid/export_utils.ts
+++ b/ui/src/components/widgets/datagrid/export_utils.ts
@@ -64,8 +64,8 @@ export function formatRows(
       // Use field path for schema lookup if provided, otherwise use alias
       const fieldPath = aliasToField?.[colAlias] ?? colAlias;
       const formatter = schema
-        ? getColumnInfo(schema, fieldPath)?.cellFormatter ??
-          defaultValueFormatter
+        ? (getColumnInfo(schema, fieldPath)?.cellFormatter ??
+          defaultValueFormatter)
         : defaultValueFormatter;
       formattedRow[colAlias] = formatter(value, row);
     }
@@ -85,7 +85,7 @@ export function buildColumnNames(
   const columnNames: Record<string, string> = {};
   for (const colPath of columns) {
     columnNames[colPath] = schema
-      ? getColumnInfo(schema, colPath)?.def.titleString ?? colPath
+      ? (getColumnInfo(schema, colPath)?.def.titleString ?? colPath)
       : colPath;
   }
   return columnNames;

--- a/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
@@ -673,7 +673,7 @@ function buildTreeQuery(
 
   // Determine expansion mode
   const useDenylist = collapsedGroups !== undefined;
-  const expansionPaths = useDenylist ? collapsedGroups : expandedGroups ?? [];
+  const expansionPaths = useDenylist ? collapsedGroups : (expandedGroups ?? []);
 
   // Build expansion check expressions using actual column comparisons
   // This properly handles nulls, empty strings, and blobs

--- a/ui/src/components/widgets/duration_precision_menu_items.ts
+++ b/ui/src/components/widgets/duration_precision_menu_items.ts
@@ -21,9 +21,7 @@ interface DurationPrecisionMenuItemAttrs {
   trace: Trace;
 }
 
-export class DurationPrecisionMenuItem
-  implements m.ClassComponent<DurationPrecisionMenuItemAttrs>
-{
+export class DurationPrecisionMenuItem implements m.ClassComponent<DurationPrecisionMenuItemAttrs> {
   view({attrs}: m.Vnode<DurationPrecisionMenuItemAttrs>) {
     function renderMenuItem(value: DurationPrecision, label: string) {
       return m(MenuItem, {

--- a/ui/src/components/widgets/query_history.ts
+++ b/ui/src/components/widgets/query_history.ts
@@ -30,9 +30,7 @@ export interface QueryHistoryComponentAttrs {
   setQuery: (query: string) => void;
 }
 
-export class QueryHistoryComponent
-  implements m.ClassComponent<QueryHistoryComponentAttrs>
-{
+export class QueryHistoryComponent implements m.ClassComponent<QueryHistoryComponentAttrs> {
   view({attrs}: m.CVnode<QueryHistoryComponentAttrs>) {
     const {trace, runQuery, setQuery, ...rest} = attrs;
     const unstarred: HistoryItemComponentAttrs[] = [];
@@ -67,9 +65,7 @@ export interface HistoryItemComponentAttrs {
   setQuery: (query: string) => void;
 }
 
-export class HistoryItemComponent
-  implements m.ClassComponent<HistoryItemComponentAttrs>
-{
+export class HistoryItemComponent implements m.ClassComponent<HistoryItemComponentAttrs> {
   view(vnode: m.Vnode<HistoryItemComponentAttrs>): m.Child {
     const query = vnode.attrs.entry.query;
     return m(

--- a/ui/src/components/widgets/sql/details/details.ts
+++ b/ui/src/components/widgets/sql/details/details.ts
@@ -336,12 +336,7 @@ type ResolvedArray = {
 class ScalarValueSchema {
   constructor(
     public kind:
-      | 'timestamp'
-      | 'duration'
-      | 'arg_set_id'
-      | 'value'
-      | 'url'
-      | 'boolean',
+      'timestamp' | 'duration' | 'arg_set_id' | 'value' | 'url' | 'boolean',
     public sourceExpression: string,
     public params?: ScalarValueParams,
   ) {}

--- a/ui/src/components/widgets/sql/table/menus/select_column_menu.ts
+++ b/ui/src/components/widgets/sql/table/menus/select_column_menu.ts
@@ -79,9 +79,7 @@ function onColumnSelectedClickHandler(
 }
 
 // Core implementation of the selectable column list.
-class SelectColumnMenuImpl
-  implements m.ClassComponent<SelectColumnMenuImplAttrs>
-{
+class SelectColumnMenuImpl implements m.ClassComponent<SelectColumnMenuImplAttrs> {
   // When the menu elements are updated (e.g. when filtering), the popup
   // can flicker a lot. To prevent that, we fix the size of the popup
   // after the first layout.
@@ -148,9 +146,7 @@ class SelectColumnMenuImpl
   }
 }
 
-export class SelectColumnMenu
-  implements m.ClassComponent<SelectColumnMenuAttrs>
-{
+export class SelectColumnMenu implements m.ClassComponent<SelectColumnMenuAttrs> {
   private searchText = '';
   columns?: {key: string; column: TableColumn}[];
 

--- a/ui/src/components/widgets/sql/table/menus/transform_column_menu.ts
+++ b/ui/src/components/widgets/sql/table/menus/transform_column_menu.ts
@@ -243,9 +243,7 @@ interface TransformMenuItemAttrs {
   formSubmitLabel: string;
 }
 
-class ConfigureTransformMenu
-  implements m.ClassComponent<TransformMenuItemAttrs>
-{
+class ConfigureTransformMenu implements m.ClassComponent<TransformMenuItemAttrs> {
   private paramState: {value: string; error: boolean}[] = [];
   private readonly uuid = uuidv4();
 

--- a/ui/src/components/widgets/sql/table/state.ts
+++ b/ui/src/components/widgets/sql/table/state.ts
@@ -164,7 +164,7 @@ export class SqlTableState {
     const columns: {[key: string]: SqlColumn} = Object.fromEntries(
       this.columns.map((c) => [
         tableColumnAlias(c),
-        mode === 'data' ? c.column : c.display ?? c.column,
+        mode === 'data' ? c.column : (c.display ?? c.column),
       ]),
     );
 

--- a/ui/src/components/widgets/timestamp_format_menu.ts
+++ b/ui/src/components/widgets/timestamp_format_menu.ts
@@ -22,9 +22,7 @@ interface TimestampFormatMenuItemAttrs {
   trace: Trace;
 }
 
-export class TimestampFormatMenuItem
-  implements m.ClassComponent<TimestampFormatMenuItemAttrs>
-{
+export class TimestampFormatMenuItem implements m.ClassComponent<TimestampFormatMenuItemAttrs> {
   view({attrs}: m.Vnode<TimestampFormatMenuItemAttrs>) {
     const timeline = attrs.trace.timeline;
     function renderMenuItem(value: TimestampFormat, label: string) {

--- a/ui/src/core/event_set.ts
+++ b/ui/src/core/event_set.ts
@@ -192,9 +192,9 @@ export interface Sort {
 // Together this means in the minimal case subclasses only *have* to
 // implement the single abstract method: materialise(). Everything else
 // is handled for you.
-export abstract class OptimisingEventSet<P extends KeySet>
-  implements EventSet<P>
-{
+export abstract class OptimisingEventSet<
+  P extends KeySet,
+> implements EventSet<P> {
   abstract readonly keys: P;
 
   // OptimisingEventSet provides the synchronous refinement methods.

--- a/ui/src/core/metatracing.ts
+++ b/ui/src/core/metatracing.ts
@@ -74,8 +74,7 @@ export function isMetatracingEnabled(): boolean {
 }
 
 export function getEnabledMetatracingCategories():
-  | protos.MetatraceCategories
-  | undefined {
+  protos.MetatraceCategories | undefined {
   return enabledCategories;
 }
 

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal.ts
@@ -398,9 +398,7 @@ export class AddExtensionServerModal {
           disabled: this.isEmbedderManaged,
           onchange: (e: Event) => {
             const keyType = (e.target as HTMLSelectElement).value as
-              | 'bearer'
-              | 'x_api_key'
-              | 'custom';
+              'bearer' | 'x_api_key' | 'custom';
             input.auth = {
               ...auth,
               keyType,

--- a/ui/src/core_plugins/dev.perfetto.FlowEventsPanel/flow_events_panel.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlowEventsPanel/flow_events_panel.ts
@@ -25,9 +25,7 @@ export interface FlowEventsAreaSelectedPanelAttrs {
   trace: TraceImpl;
 }
 
-export class FlowEventsAreaSelectedPanel
-  implements m.ClassComponent<FlowEventsAreaSelectedPanelAttrs>
-{
+export class FlowEventsAreaSelectedPanel implements m.ClassComponent<FlowEventsAreaSelectedPanelAttrs> {
   view({attrs}: m.CVnode<FlowEventsAreaSelectedPanelAttrs>) {
     const selection = attrs.trace.selection.selection;
     if (selection.kind !== 'area') {

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller.ts
@@ -62,10 +62,7 @@ export interface MachineEntry {
 // The possible error states for the modal, used to show a helpful message
 // to the user and disable the "Open Traces" button.
 export type LoadingError =
-  | 'NO_TRACES'
-  | 'DUPLICATE_NAMES'
-  | 'ANALYZING'
-  | 'TRACE_ERROR';
+  'NO_TRACES' | 'DUPLICATE_NAMES' | 'ANALYZING' | 'TRACE_ERROR';
 
 // Minimum spacing between auto-run alignment dry-runs. The first change after a
 // quiet period checks immediately (leading edge); rapid follow-ups coalesce

--- a/ui/src/core_plugins/dev.perfetto.Timeline/current_selection_tab.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/current_selection_tab.ts
@@ -34,9 +34,7 @@ export interface CurrentSelectionTabAttrs {
   readonly trace: TraceImpl;
 }
 
-export class CurrentSelectionTab
-  implements m.ClassComponent<CurrentSelectionTabAttrs>
-{
+export class CurrentSelectionTab implements m.ClassComponent<CurrentSelectionTabAttrs> {
   private readonly fadeContext = new FadeContext();
 
   view({attrs}: m.Vnode<CurrentSelectionTabAttrs>): m.Children {

--- a/ui/src/core_plugins/dev.perfetto.Timeline/flow_events_renderer.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/flow_events_renderer.ts
@@ -45,8 +45,7 @@ const FOCUSED_FLOW_INTENSITY = 55;
 const DEFAULT_FLOW_INTENSITY = 70;
 
 type VerticalEdgeOrPoint =
-  | ({kind: 'vertical_edge'} & Point2D)
-  | ({kind: 'point'} & Point2D);
+  ({kind: 'vertical_edge'} & Point2D) | ({kind: 'point'} & Point2D);
 
 export interface TrackInfo {
   readonly node: TrackNode;

--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -143,10 +143,7 @@ export function maybeShowErrorDialog(err: ErrorDetails) {
 
 class ErrorDialogComponent implements m.ClassComponent<ErrorDetails> {
   private traceState:
-    | 'NOT_AVAILABLE'
-    | 'NOT_UPLOADED'
-    | 'UPLOADING'
-    | 'UPLOADED';
+    'NOT_AVAILABLE' | 'NOT_UPLOADED' | 'UPLOADING' | 'UPLOADED';
   private traceType: string = 'No trace loaded';
   private traceData?: ArrayBuffer | File;
   private traceUrl?: string;
@@ -443,9 +440,7 @@ interface TraceParseErrorAttrs {
   readonly message: string;
 }
 
-class TraceParseErrorComponent
-  implements m.ClassComponent<TraceParseErrorAttrs>
-{
+class TraceParseErrorComponent implements m.ClassComponent<TraceParseErrorAttrs> {
   view({attrs}: m.Vnode<TraceParseErrorAttrs>): m.Children {
     const {variant, message} = attrs;
     const details = extractTraceParseDetails(message);

--- a/ui/src/frontend/views/engine_status_badge.ts
+++ b/ui/src/frontend/views/engine_status_badge.ts
@@ -52,7 +52,7 @@ export const EngineStatusBadge: m.Component<EngineStatusBadgeAttrs> = {
       '.pf-sidebar__dbg-info-square',
       {className: modifier, title},
       m('div', label),
-      m('div', failed ? 'FAIL' : engine?.numRequestsPending ?? '-'),
+      m('div', failed ? 'FAIL' : (engine?.numRequestsPending ?? '-')),
     );
   },
 };

--- a/ui/src/plugins/com.android.AndroidInputLifecycle/extensions/pixel_extension.ts
+++ b/ui/src/plugins/com.android.AndroidInputLifecycle/extensions/pixel_extension.ts
@@ -90,6 +90,6 @@ export class PixelInputLifecycleExtension implements InputLifecycleExtension {
     `;
     const result = await trace.engine.query(query);
     const it = result.iter({input_id: STR_NULL});
-    return it.valid() ? it.input_id ?? undefined : undefined;
+    return it.valid() ? (it.input_id ?? undefined) : undefined;
   }
 }

--- a/ui/src/plugins/com.android.AndroidInputLifecycle/tab.ts
+++ b/ui/src/plugins/com.android.AndroidInputLifecycle/tab.ts
@@ -48,9 +48,7 @@ export interface AndroidInputLifecycleTabAttrs {
   activeExtensions: InputLifecycleExtension[];
 }
 
-export class AndroidInputLifecycleTab
-  implements m.ClassComponent<AndroidInputLifecycleTabAttrs>
-{
+export class AndroidInputLifecycleTab implements m.ClassComponent<AndroidInputLifecycleTabAttrs> {
   view({attrs}: m.Vnode<AndroidInputLifecycleTabAttrs>): m.Children {
     if (attrs.loading) {
       return m(

--- a/ui/src/plugins/com.android.AndroidLockContention/lock_owner_details_panel.ts
+++ b/ui/src/plugins/com.android.AndroidLockContention/lock_owner_details_panel.ts
@@ -321,9 +321,7 @@ interface MonitorContentionCardAttrs {
   readonly blockedFunctions: ReadonlyArray<ContentionBlockedFunction>;
 }
 
-class MonitorContentionCard
-  implements m.ClassComponent<MonitorContentionCardAttrs>
-{
+class MonitorContentionCard implements m.ClassComponent<MonitorContentionCardAttrs> {
   view({attrs}: m.Vnode<MonitorContentionCardAttrs>) {
     const {trace, plugin, row, threadStates, blockedFunctions} = attrs;
     const dur = row.dur;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -813,7 +813,7 @@ export async function fetchShortestPaths(
       if (!row) continue;
       const field =
         i < chain.length - 1
-          ? fieldMap.get(`${chain[i]}:${chain[i + 1]}`) ?? ''
+          ? (fieldMap.get(`${chain[i]}:${chain[i + 1]}`) ?? '')
           : '';
       path.push({row, field, isDominator: false});
     }
@@ -954,7 +954,7 @@ export async function fetchDominatorPaths(
       if (!row) continue;
       const field =
         i < chain.length - 1
-          ? fieldMap.get(`${chain[i]}:${chain[i + 1]}`) ?? ''
+          ? (fieldMap.get(`${chain[i]}:${chain[i + 1]}`) ?? '')
           : '';
       path.push({row, field, isDominator: true});
     }
@@ -1446,7 +1446,7 @@ async function computeBitmapDumpData(
 
   `);
   const fmtIt = fmtRes.iter({int_value: NUM_NULL});
-  const format = fmtIt.valid() ? fmtIt.int_value ?? 1 : 1;
+  const format = fmtIt.valid() ? (fmtIt.int_value ?? 1) : 1;
 
   // Step 4: Get DumpData's references — natives (long[]) and buffers (Object[]).
   const refsRes = await engine.query(`

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
@@ -578,7 +578,7 @@ export function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
                   pathData:
                     pathMode === 'none'
                       ? undefined
-                      : pathMaps[pathMode].get(r.row.id) ?? null,
+                      : (pathMaps[pathMode].get(r.row.id) ?? null),
                 }),
               ),
             )

--- a/ui/src/plugins/com.google.PerfettoMcp/gemini_client.ts
+++ b/ui/src/plugins/com.google.PerfettoMcp/gemini_client.ts
@@ -41,9 +41,7 @@ interface GeminiFunctionResponsePart {
 }
 
 type GeminiPart =
-  | GeminiTextPart
-  | GeminiFunctionCallPart
-  | GeminiFunctionResponsePart;
+  GeminiTextPart | GeminiFunctionCallPart | GeminiFunctionResponsePart;
 
 interface GeminiContent {
   readonly role: 'user' | 'model';

--- a/ui/src/plugins/com.meta.GpuCompute/details.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/details.ts
@@ -140,7 +140,7 @@ export function renderPercentBar(
     }),
     m(
       '.pf-gpu-compute__pct-bar-label',
-      showPctVal ? currentPctLabel : customLabel ?? '',
+      showPctVal ? currentPctLabel : (customLabel ?? ''),
     ),
   ]);
 }
@@ -428,14 +428,12 @@ function buildMetricSectionData(
         .filter((tableDecl) => isTableVisible(tableDecl, availableMetrics))
         .map((tableDecl) => ({
           table_desc: tableDecl.description(terminology),
-          data: tableDecl.rows.map(
-            (row): MetricRow => ({
-              metric_id: row.id,
-              metric_label: row.label(terminology),
-              metric_unit: row.unit(terminology),
-              metric_value: getMetric(row.id),
-            }),
-          ),
+          data: tableDecl.rows.map((row): MetricRow => ({
+            metric_id: row.id,
+            metric_label: row.label(terminology),
+            metric_unit: row.unit(terminology),
+            metric_value: getMetric(row.id),
+          })),
         })),
     }))
     .filter((section) => section.tables.length > 0);
@@ -847,8 +845,7 @@ export const KernelMetricsSection: m.Component<
     if (!state.kernelTableData) return null;
 
     const baselineLookup:
-      | Map<string, {unit: string; value: number | string}>
-      | undefined = (() => {
+      Map<string, {unit: string; value: number | string}> | undefined = (() => {
       const baseline = attrs.baseline;
       if (!baseline) return undefined;
 

--- a/ui/src/plugins/com.meta.GpuCompute/summary.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/summary.ts
@@ -183,13 +183,7 @@ export interface SummarySectionAttrs extends m.Attributes {
 
 // Column keys that the table can be sorted by.
 type SortKey =
-  | 'id'
-  | 'name'
-  | 'duration'
-  | 'compute'
-  | 'memory'
-  | 'registers'
-  | 'grid_size';
+  'id' | 'name' | 'duration' | 'compute' | 'memory' | 'registers' | 'grid_size';
 
 // Returns the sortable primitive for `key` from a row.
 function getSortableValue(

--- a/ui/src/plugins/dev.perfetto.AggregateProfiles/aggregate_profiles_page.ts
+++ b/ui/src/plugins/dev.perfetto.AggregateProfiles/aggregate_profiles_page.ts
@@ -38,9 +38,7 @@ export interface AggregateProfilesPageAttrs {
   readonly profiles: ReadonlyArray<AggregateProfile>;
 }
 
-export class AggregateProfilesPage
-  implements m.ClassComponent<AggregateProfilesPageAttrs>
-{
+export class AggregateProfilesPage implements m.ClassComponent<AggregateProfilesPageAttrs> {
   private profiles?: ReadonlyArray<AggregateProfile>;
   private readonly monitor = new Monitor([() => this.profiles]);
   private flamegraphMetrics?: ReadonlyArray<QueryFlamegraphMetric>;

--- a/ui/src/plugins/dev.perfetto.AggregationBenchmark/benchmark.ts
+++ b/ui/src/plugins/dev.perfetto.AggregationBenchmark/benchmark.ts
@@ -18,10 +18,7 @@ import type {Engine} from '../../trace_processor/engine';
 import {LONG, NUM, STR_NULL} from '../../trace_processor/query_result';
 
 export type ApproachType =
-  | 'uri_string'
-  | 'track_index'
-  | 'groupid'
-  | 'no_lineage';
+  'uri_string' | 'track_index' | 'groupid' | 'no_lineage';
 
 export interface BenchmarkResult {
   approach: ApproachType;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
@@ -235,9 +235,7 @@ class DashboardChartAdapter implements ChartColumnProvider {
  * If the table name is not yet available, this component triggers execution
  * via `source.requestExecution()` and waits for a redraw.
  */
-export class DashboardChartView
-  implements m.ClassComponent<DashboardChartViewAttrs>
-{
+export class DashboardChartView implements m.ClassComponent<DashboardChartViewAttrs> {
   /** Adapter class exposed for use by Dashboard's config popup. */
   static Adapter = DashboardChartAdapter;
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer.ts
@@ -116,8 +116,7 @@ export interface DataExplorerState {
 
 type StateUpdateFn = (
   update:
-    | DataExplorerState
-    | ((current: DataExplorerState) => DataExplorerState),
+    DataExplorerState | ((current: DataExplorerState) => DataExplorerState),
 ) => void;
 
 interface DataExplorerAttrs {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
@@ -255,8 +255,7 @@ export default class implements PerfettoPlugin {
   private makeOnStateUpdate(tabId: string) {
     return (
       update:
-        | DataExplorerState
-        | ((current: DataExplorerState) => DataExplorerState),
+        DataExplorerState | ((current: DataExplorerState) => DataExplorerState),
     ) => {
       const tab = this.tabs.find((t) => t.id === tabId);
       if (!tab) return;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
@@ -450,8 +450,7 @@ function migrateNodeState(type: NodeType, state: unknown): unknown {
     }
     case NodeType.kAddColumns: {
       const columnTypes = s.columnTypes as
-        | Record<string, PerfettoSqlType | string>
-        | undefined;
+        Record<string, PerfettoSqlType | string> | undefined;
       if (!columnTypes) return s;
       return {
         ...s,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
@@ -1068,8 +1068,7 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
 
     const deserializedModifyNode = deserializedTableNode.nextNodes[0] as
-      | ModifyColumnsNode
-      | undefined;
+      ModifyColumnsNode | undefined;
     expect(deserializedModifyNode).toBeDefined();
     expect(deserializedModifyNode?.type).toBe(NodeType.kModifyColumns);
 
@@ -1087,8 +1086,7 @@ describe('JSON serialization/deserialization', () => {
     // Verify the aggregation node still sees the aliased column
     expect(deserializedModifyNode?.nextNodes.length).toBe(1);
     const deserializedAggNode = deserializedModifyNode?.nextNodes[0] as
-      | AggregationNode
-      | undefined;
+      AggregationNode | undefined;
     expect(deserializedAggNode).toBeDefined();
     expect(deserializedAggNode?.type).toBe(NodeType.kAggregation);
     expect(deserializedAggNode?.attrs.groupByColumns.length).toBe(1);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/pbtxt_import_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/pbtxt_import_unittest.ts
@@ -467,8 +467,7 @@ describe('templateSpecToMetricsState', () => {
     const state = templateSpecToMetricsState(spec);
 
     const configs = state.dimensionConfigs as
-      | Record<string, Record<string, unknown>>
-      | undefined;
+      Record<string, Record<string, unknown>> | undefined;
     expect(configs).toBeDefined();
     expect(configs?.process_name?.displayName).toBe('Process');
     expect(configs?.process_name?.displayHelp).toBe('The process name');
@@ -1688,8 +1687,7 @@ describe('metricSpecToMetricsState', () => {
     const state = metricSpecToMetricsState(spec);
 
     const configs = state.dimensionConfigs as
-      | Record<string, Record<string, unknown>>
-      | undefined;
+      Record<string, Record<string, unknown>> | undefined;
     expect(configs).toBeDefined();
     expect(configs?.process_name?.displayName).toBe('Process');
     expect(configs?.process_name?.displayHelp).toBe('Target process');

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/builder.ts
@@ -402,7 +402,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
             icon: 'info',
             title: `${attrs.selectedNodes.size} nodes selected`,
           })
-        : selectedNode?.customResultsPanel?.() ??
+        : (selectedNode?.customResultsPanel?.() ??
           (selectedNode
             ? m(ResultsPanel, {
                 trace: this.trace,
@@ -447,7 +447,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
             : m(ResultsPanelEmptyState, {
                 icon: 'info',
                 title: 'Select a node to see the data',
-              })),
+              }))),
       mainContent: [
         m(
           '.pf-qb-node-graph',

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/function_list.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/function_list.ts
@@ -61,14 +61,11 @@ function getMatchTypeLabel(matchType: MatchType): string | undefined {
 }
 
 // Renders a search input bar
-class SearchBar
-  implements
-    m.ClassComponent<{
-      query: string;
-      onQueryChange: (query: string) => void;
-      autofocus?: boolean;
-    }>
-{
+class SearchBar implements m.ClassComponent<{
+  query: string;
+  onQueryChange: (query: string) => void;
+  autofocus?: boolean;
+}> {
   view({
     attrs,
   }: m.CVnode<{
@@ -92,16 +89,13 @@ class SearchBar
 }
 
 // Renders a single function card
-class FunctionCard
-  implements
-    m.ClassComponent<{
-      functionWithModule: FunctionWithModule;
-      segments: FuzzySegment[];
-      matchType: MatchType;
-      onFunctionClick: (fn: FunctionWithModule) => void;
-      isSelected: boolean;
-    }>
-{
+class FunctionCard implements m.ClassComponent<{
+  functionWithModule: FunctionWithModule;
+  segments: FuzzySegment[];
+  matchType: MatchType;
+  onFunctionClick: (fn: FunctionWithModule) => void;
+  isSelected: boolean;
+}> {
   view({
     attrs,
   }: m.CVnode<{

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/help.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/help.ts
@@ -22,9 +22,7 @@ export interface DataExplorerHelpAttrs {
   onTableClick: (tableName: string, event: MouseEvent) => void;
 }
 
-export class DataExplorerHelp
-  implements m.ClassComponent<DataExplorerHelpAttrs>
-{
+export class DataExplorerHelp implements m.ClassComponent<DataExplorerHelpAttrs> {
   private searchQuery = '';
 
   view({attrs}: m.CVnode<DataExplorerHelpAttrs>) {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/join_widgets.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/join_widgets.ts
@@ -182,9 +182,7 @@ export interface JoinConditionSelectorAttrs {
   onRightColumnAlias: (index: number, alias: string) => void;
 }
 
-export class JoinConditionSelector
-  implements m.ClassComponent<JoinConditionSelectorAttrs>
-{
+export class JoinConditionSelector implements m.ClassComponent<JoinConditionSelectorAttrs> {
   view({attrs}: m.Vnode<JoinConditionSelectorAttrs>) {
     const {
       leftLabel,
@@ -247,9 +245,7 @@ export interface JoinConditionDisplayAttrs {
   operator?: string;
 }
 
-export class JoinConditionDisplay
-  implements m.ClassComponent<JoinConditionDisplayAttrs>
-{
+export class JoinConditionDisplay implements m.ClassComponent<JoinConditionDisplayAttrs> {
   view({attrs}: m.Vnode<JoinConditionDisplayAttrs>) {
     const {
       leftAlias,
@@ -280,9 +276,7 @@ export interface JoinColumnSelectorAttrs {
   onRightColumnsChange: (columns: ColumnInfo[]) => void;
 }
 
-export class JoinColumnSelector
-  implements m.ClassComponent<JoinColumnSelectorAttrs>
-{
+export class JoinColumnSelector implements m.ClassComponent<JoinColumnSelectorAttrs> {
   view({attrs}: m.Vnode<JoinColumnSelectorAttrs>) {
     const {
       leftAlias,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/navigation_sidepanel.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/navigation_sidepanel.ts
@@ -102,9 +102,7 @@ export interface NavigationSidePanelAttrs {
   readonly onLoadRecentGraph?: (json: string) => void;
 }
 
-export class NavigationSidePanel
-  implements m.ClassComponent<NavigationSidePanelAttrs>
-{
+export class NavigationSidePanel implements m.ClassComponent<NavigationSidePanelAttrs> {
   view({attrs}: m.CVnode<NavigationSidePanelAttrs>) {
     const results: m.Children[] = [];
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_configuration_modal.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_configuration_modal.ts
@@ -42,9 +42,7 @@ export interface AddColumnsConfigurationModalAttrs {
   readonly onColumnAlias: (columnName: string, alias: string) => void;
 }
 
-export class AddColumnsConfigurationModal
-  implements m.ClassComponent<AddColumnsConfigurationModalAttrs>
-{
+export class AddColumnsConfigurationModal implements m.ClassComponent<AddColumnsConfigurationModalAttrs> {
   view({attrs}: m.Vnode<AddColumnsConfigurationModalAttrs>) {
     const {
       sourceCols,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal.ts
@@ -191,9 +191,7 @@ export interface FunctionSelectStepAttrs {
 /**
  * Component for the function selection step
  */
-export class FunctionSelectStep
-  implements m.ClassComponent<FunctionSelectStepAttrs>
-{
+export class FunctionSelectStep implements m.ClassComponent<FunctionSelectStepAttrs> {
   view({attrs}: m.CVnode<FunctionSelectStepAttrs>) {
     return m(
       '.pf-exp-node-panel-help',
@@ -225,9 +223,7 @@ export interface FunctionConfigureStepAttrs {
 /**
  * Component for the function configuration step
  */
-export class FunctionConfigureStep
-  implements m.ClassComponent<FunctionConfigureStepAttrs>
-{
+export class FunctionConfigureStep implements m.ClassComponent<FunctionConfigureStepAttrs> {
   view({attrs}: m.CVnode<FunctionConfigureStepAttrs>) {
     const {
       selectedFunctionWithModule,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
@@ -1279,7 +1279,7 @@ export class AddColumnsNode implements QueryNode {
     const suggestions = this.getJoinSuggestions();
     const selectedTable = this.attrs.selectedSuggestionTable;
     const selectedColumns = selectedTable
-      ? this.attrs.suggestionSelections?.[selectedTable] ?? []
+      ? (this.attrs.suggestionSelections?.[selectedTable] ?? [])
       : [];
 
     return m(AddColumnsSuggestionModal, {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_suggestion_modal.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_suggestion_modal.ts
@@ -55,9 +55,7 @@ export interface AddColumnsSuggestionModalAttrs {
   readonly onColumnAlias: (columnName: string, alias: string) => void;
 }
 
-export class AddColumnsSuggestionModal
-  implements m.ClassComponent<AddColumnsSuggestionModalAttrs>
-{
+export class AddColumnsSuggestionModal implements m.ClassComponent<AddColumnsSuggestionModalAttrs> {
   oncreate({attrs}: m.VnodeDOM<AddColumnsSuggestionModalAttrs>) {
     // Auto-select if there's only one suggestion and nothing is selected yet
     if (attrs.suggestions.length === 1 && !attrs.selectedTable) {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/group_node/inner_graph_preview.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/group_node/inner_graph_preview.ts
@@ -32,9 +32,7 @@ interface InnerGraphPreviewAttrs {
  * Owns its own view-layer state (recenter tracking) so that GroupNode
  * remains a pure data model.
  */
-export class InnerGraphPreview
-  implements m.ClassComponent<InnerGraphPreviewAttrs>
-{
+export class InnerGraphPreview implements m.ClassComponent<InnerGraphPreviewAttrs> {
   private recentered = false;
   private lastInnerNodeCount = 0;
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
@@ -137,7 +137,7 @@ export class JoinNode implements QueryNode {
           name: col.name,
           type: col.type,
           description: col.description,
-          checked: isFirstInit ? false : oldCol?.checked ?? false,
+          checked: isFirstInit ? false : (oldCol?.checked ?? false),
           alias: oldCol?.alias,
           typeUserModified: oldCol?.typeUserModified,
         };

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_results_panel.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_results_panel.ts
@@ -166,9 +166,7 @@ export interface TraceSummaryResultsPanelAttrs {
   readonly onchange?: () => void;
 }
 
-export class TraceSummaryResultsPanel
-  implements m.ClassComponent<TraceSummaryResultsPanelAttrs>
-{
+export class TraceSummaryResultsPanel implements m.ClassComponent<TraceSummaryResultsPanelAttrs> {
   private executionState: ExecutionState = {kind: 'idle'};
   private activeTab?: string;
   private prevSpecHash?: string;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/structured_query_builder.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/structured_query_builder.ts
@@ -47,9 +47,7 @@ import {nextNodeId, type QueryNode} from '../query_node';
  * Builder methods accept nodes or structured queries and extract/use them internally.
  */
 export type QuerySource =
-  | QueryNode
-  | protos.PerfettoSqlStructuredQuery
-  | undefined;
+  QueryNode | protos.PerfettoSqlStructuredQuery | undefined;
 
 /**
  * Helper function to extract a structured query from a QuerySource.

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
@@ -50,10 +50,7 @@ interface TableWithModule {
 
 // Type of match when searching for tables
 type MatchType =
-  | 'table-name'
-  | 'column-name'
-  | 'table-description'
-  | 'column-description';
+  'table-name' | 'column-name' | 'table-description' | 'column-description';
 
 // Helper function to get the display label for importance levels.
 function getImportanceLabel(
@@ -79,15 +76,12 @@ function isTimestampedTable(table: SqlTable): boolean {
 // Renders a search input bar.
 // This component is responsible for handling user input for searching
 // and communicating the query back to the parent component.
-class SearchBar
-  implements
-    m.ClassComponent<{
-      query: string;
-      onQueryChange: (query: string) => void;
-      autofocus?: boolean;
-      placeholder?: string;
-    }>
-{
+class SearchBar implements m.ClassComponent<{
+  query: string;
+  onQueryChange: (query: string) => void;
+  autofocus?: boolean;
+  placeholder?: string;
+}> {
   view({
     attrs,
   }: m.CVnode<{
@@ -128,17 +122,14 @@ function getMatchTypeLabel(matchType: MatchType): string | undefined {
 // Renders a single table card in the list.
 // This component displays the table name, its module, and description.
 // It also highlights the parts of the name that match the search query.
-class TableCard
-  implements
-    m.ClassComponent<{
-      tableWithModule: TableWithModule;
-      segments: FuzzySegment[];
-      matchType: MatchType;
-      onTableClick: (tableName: string, event: MouseEvent) => void;
-      sqlModules: SqlModules;
-      selectedTables?: Set<string>;
-    }>
-{
+class TableCard implements m.ClassComponent<{
+  tableWithModule: TableWithModule;
+  segments: FuzzySegment[];
+  matchType: MatchType;
+  onTableClick: (tableName: string, event: MouseEvent) => void;
+  sqlModules: SqlModules;
+  selectedTables?: Set<string>;
+}> {
   view({
     attrs,
   }: m.CVnode<{

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/widgets.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/widgets.ts
@@ -73,9 +73,7 @@ export interface ResultsPanelEmptyStateAttrs {
   readonly variant?: ResultsPanelEmptyStateVariant;
 }
 
-export class ResultsPanelEmptyState
-  implements m.ClassComponent<ResultsPanelEmptyStateAttrs>
-{
+export class ResultsPanelEmptyState implements m.ClassComponent<ResultsPanelEmptyStateAttrs> {
   view({attrs, children}: m.CVnode<ResultsPanelEmptyStateAttrs>) {
     const {icon, title, variant = 'default'} = attrs;
 
@@ -284,9 +282,7 @@ export interface TableDescriptionAttrs {
   table: SqlTable;
 }
 
-export class TableDescription
-  implements m.ClassComponent<TableDescriptionAttrs>
-{
+export class TableDescription implements m.ClassComponent<TableDescriptionAttrs> {
   view({attrs}: m.Vnode<TableDescriptionAttrs>) {
     const {table} = attrs;
 
@@ -322,9 +318,7 @@ export interface AdvancedModeChangeButtonAttrs {
   onclick: () => void;
 }
 
-export class AdvancedModeChangeButton
-  implements m.ClassComponent<AdvancedModeChangeButtonAttrs>
-{
+export class AdvancedModeChangeButton implements m.ClassComponent<AdvancedModeChangeButtonAttrs> {
   view({attrs}: m.Vnode<AdvancedModeChangeButtonAttrs>) {
     const {label, icon, onclick} = attrs;
 
@@ -487,9 +481,7 @@ export interface OutlinedFieldReadOnlyAttrs {
   className?: string;
 }
 
-export class OutlinedFieldReadOnly
-  implements m.ClassComponent<OutlinedFieldReadOnlyAttrs>
-{
+export class OutlinedFieldReadOnly implements m.ClassComponent<OutlinedFieldReadOnlyAttrs> {
   view({attrs}: m.Vnode<OutlinedFieldReadOnlyAttrs>) {
     const {label, value, className} = attrs;
 
@@ -512,9 +504,7 @@ export interface OutlinedMultiSelectAttrs {
   compact?: boolean;
 }
 
-export class OutlinedMultiSelect
-  implements m.ClassComponent<OutlinedMultiSelectAttrs>
-{
+export class OutlinedMultiSelect implements m.ClassComponent<OutlinedMultiSelectAttrs> {
   view({attrs}: m.Vnode<OutlinedMultiSelectAttrs>) {
     return m('.pf-outlined-multiselect', m(PopupMultiSelect, attrs));
   }
@@ -528,9 +518,7 @@ export interface AddItemPlaceholderAttrs {
   onclick?: () => void;
 }
 
-export class AddItemPlaceholder
-  implements m.ClassComponent<AddItemPlaceholderAttrs>
-{
+export class AddItemPlaceholder implements m.ClassComponent<AddItemPlaceholderAttrs> {
   view({attrs}: m.Vnode<AddItemPlaceholderAttrs>) {
     const {label, icon, onclick} = attrs;
 
@@ -565,9 +553,9 @@ export interface InlineEditListAttrs<T> {
   emptyItem: () => T; // Factory function to create a new empty item
 }
 
-export class InlineEditList<T>
-  implements m.ClassComponent<InlineEditListAttrs<T>>
-{
+export class InlineEditList<T> implements m.ClassComponent<
+  InlineEditListAttrs<T>
+> {
   view({attrs}: m.Vnode<InlineEditListAttrs<T>>) {
     const {
       items,
@@ -808,9 +796,7 @@ export interface ResizableSqlEditorAttrs {
   autofocus?: boolean;
 }
 
-export class ResizableSqlEditor
-  implements m.ClassComponent<ResizableSqlEditorAttrs>
-{
+export class ResizableSqlEditor implements m.ClassComponent<ResizableSqlEditorAttrs> {
   private editorHeight: number = 0;
   private editorElement?: HTMLElement;
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/recent_graphs.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/recent_graphs.ts
@@ -407,9 +407,7 @@ class RecentGraphCard implements m.ClassComponent<RecentGraphCardAttrs> {
  * Starred graphs appear first, followed by unstarred graphs.
  * Always shows the section header, even when empty.
  */
-export class RecentGraphsSection
-  implements m.ClassComponent<RecentGraphsSectionAttrs>
-{
+export class RecentGraphsSection implements m.ClassComponent<RecentGraphsSectionAttrs> {
   view({attrs}: m.CVnode<RecentGraphsSectionAttrs>): m.Children {
     const recentGraphs = recentGraphsStorage.data;
 

--- a/ui/src/plugins/dev.perfetto.DeeplinkQuerystring/index.ts
+++ b/ui/src/plugins/dev.perfetto.DeeplinkQuerystring/index.ts
@@ -78,13 +78,11 @@ export default class implements PerfettoPlugin {
 function zoomPendingDeeplink(trace: Trace, visStart: string, visEnd: string) {
   const visualStart = Time.fromRaw(BigInt(visStart));
   const visualEnd = Time.fromRaw(BigInt(visEnd));
-  if (
-    !(
-      visualStart < visualEnd &&
-      trace.traceInfo.start <= visualStart &&
-      visualEnd <= trace.traceInfo.end
-    )
-  ) {
+  if (!(
+    visualStart < visualEnd &&
+    trace.traceInfo.start <= visualStart &&
+    visualEnd <= trace.traceInfo.end
+  )) {
     return;
   }
   trace.timeline.panSpanIntoView(visualStart, visualEnd, {align: 'zoom'});

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -173,9 +173,7 @@ interface Props {
   type: ProfileType;
 }
 
-export class HeapProfileFlamegraphDetailsPanel
-  implements TrackEventDetailsPanel
-{
+export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel {
   private readonly props: Props;
   private flamegraphModalDismissed = false;
   private oomeErrorMsg?: string;

--- a/ui/src/plugins/dev.perfetto.JournaldLog/logs_panel.ts
+++ b/ui/src/plugins/dev.perfetto.JournaldLog/logs_panel.ts
@@ -98,9 +98,7 @@ export const JOURNALD_PRIORITIES = [
   'Debug',
 ];
 
-export class JournaldLogPanel
-  implements m.ClassComponent<JournaldLogPanelAttrs>
-{
+export class JournaldLogPanel implements m.ClassComponent<JournaldLogPanelAttrs> {
   private readonly trace: Trace;
   private readonly executor = new SerialTaskQueue();
   private readonly viewQuery = new QuerySlot<AsyncDisposable>(this.executor);

--- a/ui/src/plugins/dev.perfetto.Llm/protocol.ts
+++ b/ui/src/plugins/dev.perfetto.Llm/protocol.ts
@@ -97,11 +97,7 @@ export type StopReason =
 
 // Normalised backend error categories. Surfaced to the user in the chat.
 export type ErrorKind =
-  | 'rate-limit'
-  | 'auth'
-  | 'context-length'
-  | 'network'
-  | 'unknown';
+  'rate-limit' | 'auth' | 'context-length' | 'network' | 'unknown';
 
 export interface Error {
   readonly kind: ErrorKind;

--- a/ui/src/plugins/dev.perfetto.LlmProtocolChromePrompt/chrome_prompt_protocol.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolChromePrompt/chrome_prompt_protocol.ts
@@ -44,10 +44,7 @@ import type {Provider} from '../dev.perfetto.Llm/config';
 // These globals aren't in the TS DOM lib yet, so we declare the shapes we touch.
 
 type Availability =
-  | 'unavailable'
-  | 'downloadable'
-  | 'downloading'
-  | 'available';
+  'unavailable' | 'downloadable' | 'downloading' | 'available';
 
 interface LanguageModelMessage {
   readonly role: 'system' | 'user' | 'assistant';

--- a/ui/src/plugins/dev.perfetto.LlmProtocolGemini/gemini_protocol.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolGemini/gemini_protocol.ts
@@ -50,9 +50,7 @@ interface GeminiFunctionResponsePart {
   };
 }
 type GeminiPart =
-  | GeminiTextPart
-  | GeminiFunctionCallPart
-  | GeminiFunctionResponsePart;
+  GeminiTextPart | GeminiFunctionCallPart | GeminiFunctionResponsePart;
 
 interface GeminiContent {
   readonly role: 'user' | 'model';

--- a/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/openai_protocol.ts
+++ b/ui/src/plugins/dev.perfetto.LlmProtocolOpenAi/openai_protocol.ts
@@ -191,7 +191,7 @@ class ToolCallAssembler {
       const key =
         tc.index !== undefined
           ? `i${tc.index}`
-          : tc.id ?? `seq${this.fallbackSeq++}`;
+          : (tc.id ?? `seq${this.fallbackSeq++}`);
       const cur = this.byKey.get(key) ?? {name: '', argsStr: ''};
 
       const rawArgs = tc.function?.arguments;

--- a/ui/src/plugins/dev.perfetto.Memscope/views/connection.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/connection.ts
@@ -215,7 +215,7 @@ export class ConnectionPage implements m.ClassComponent<ConnectionPageAttrs> {
       this.wdpDevices.map((dev) => {
         const ready = dev.proxyStatus === 'ADB' && dev.adbStatus === 'DEVICE';
         const model =
-          dev.proxyStatus === 'ADB' ? dev.adbProps?.model ?? '?' : '?';
+          dev.proxyStatus === 'ADB' ? (dev.adbProps?.model ?? '?') : '?';
         const label = ready
           ? `${model} [${dev.serialNumber}]`
           : `${dev.proxyStatus}/${dev.adbStatus} [${dev.serialNumber}]`;
@@ -546,7 +546,7 @@ export class ConnectionPage implements m.ClassComponent<ConnectionPageAttrs> {
       }
 
       const model =
-        dev.proxyStatus === 'ADB' ? dev.adbProps?.model ?? '?' : '?';
+        dev.proxyStatus === 'ADB' ? (dev.adbProps?.model ?? '?') : '?';
       this.wdpDeviceConnecting = false;
       attrs.onConnected({
         device: result.value,

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.ts
@@ -47,9 +47,7 @@ export interface MemoryOverviewPageAttrs {
 
 type ProcWithMem = readonly ProcMemStat[];
 
-export class MemoryOverviewPage
-  implements m.Component<MemoryOverviewPageAttrs>
-{
+export class MemoryOverviewPage implements m.Component<MemoryOverviewPageAttrs> {
   private readonly slot = new QuerySlot<ProcWithMem>();
 
   view({attrs}: m.Vnode<MemoryOverviewPageAttrs>) {

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
@@ -112,9 +112,7 @@ export interface ProcessMemDetailsAttrs {
   readonly upid: number;
 }
 
-export class ProcessMemDetails
-  implements m.ClassComponent<ProcessMemDetailsAttrs>
-{
+export class ProcessMemDetails implements m.ClassComponent<ProcessMemDetailsAttrs> {
   // The capture-strip facts: process name + per-source sample counts. Its own
   // slot keyed by (trace, upid) so it reloads when the selected process changes.
   private readonly captureSlot = new QuerySlot<CaptureInfo>();
@@ -368,7 +366,7 @@ export class ProcessMemDetails
               m('span.pf-memscope-capture__label', s.label),
               m(
                 'span.pf-memscope-capture__facts',
-                loading ? '…' : s.facts ?? 'none',
+                loading ? '…' : (s.facts ?? 'none'),
               ),
             ],
           ),

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
@@ -304,7 +304,9 @@ export class BitmapsSection implements m.ClassComponent<BitmapsSectionAttrs> {
       baseTs !== undefined ? nearestByTs(data.dumps, baseTs) : undefined;
     const comparing = baseDump !== undefined && baseDump.ts !== cur.ts;
     const groups = data.groupsByTs.get(cur.ts) ?? [];
-    const baseGroups = comparing ? data.groupsByTs.get(baseDump.ts) ?? [] : [];
+    const baseGroups = comparing
+      ? (data.groupsByTs.get(baseDump.ts) ?? [])
+      : [];
 
     const totalCount = groups.reduce((s, g) => s + g.count, 0);
     const totalBytes = groups.reduce((s, g) => s + bytesOf(g), 0);
@@ -336,7 +338,7 @@ export class BitmapsSection implements m.ClassComponent<BitmapsSectionAttrs> {
     const javaRetainedPct =
       javaRetained > 0 ? (bitmapHeapNative / javaRetained) * 100 : 0;
     const baseJavaRetained = comparing
-      ? data.javaRetainedByTs.get(baseDump.ts) ?? 0
+      ? (data.javaRetainedByTs.get(baseDump.ts) ?? 0)
       : 0;
     const baseBitmapHeapNative = baseGroups.reduce(
       (s, g) => s + g.selfSize + g.nativeSize,

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/composition_timeline.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/composition_timeline.ts
@@ -64,9 +64,7 @@ export interface CompositionTimelineAttrs {
   readonly belowChart?: m.Children;
 }
 
-export class CompositionTimeline
-  implements m.ClassComponent<CompositionTimelineAttrs>
-{
+export class CompositionTimeline implements m.ClassComponent<CompositionTimelineAttrs> {
   private readonly slot = new QuerySlot<TimelineData>();
 
   onremove() {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/credentials_interfaces.d.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/credentials_interfaces.d.ts
@@ -27,8 +27,7 @@ declare global {
     constructor(data: PasswordCredentialData);
   }
 
-  export interface PasswordCredentialRequestOptions
-    extends CredentialRequestOptions {
+  export interface PasswordCredentialRequestOptions extends CredentialRequestOptions {
     password?: boolean;
   }
 }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/interfaces/tracing_session.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/interfaces/tracing_session.ts
@@ -45,10 +45,7 @@ export interface TracingSession {
 }
 
 export type TracingSessionState =
-  | 'RECORDING'
-  | 'STOPPING'
-  | 'FINISHED'
-  | 'ERRORED';
+  'RECORDING' | 'STOPPING' | 'FINISHED' | 'ERRORED';
 
 export interface TracingSessionLogEntry {
   readonly timestamp: Date;

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
@@ -327,7 +327,7 @@ class RecordingCtl implements m.ClassComponent<RecCtlAttrs> {
         '.record-target',
         recordingInProgress
           ? `Recording${eta ? ', ETA ' + eta : ''}`
-          : target?.name ?? 'No target selected',
+          : (target?.name ?? 'No target selected'),
       ),
       recordingInProgress
         ? m(Button, {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
@@ -356,7 +356,7 @@ class RecordConfigSelector implements m.ClassComponent<RecMgrAttrs> {
             m(
               '.pf-preset-card__title',
               hasUnsavedCustomConfig
-                ? recMgr.customConfigFileName ?? 'Imported config'
+                ? (recMgr.customConfigFileName ?? 'Imported config')
                 : 'Custom',
             ),
             m('.pf-preset-card__subtitle', 'Click to save'),

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
@@ -60,7 +60,7 @@ export class Slider implements ProbeSetting {
     // otherwise fall back on the first value of the fixed range... otherwise 0.
     this._value = exists(value)
       ? value
-      : this.attrs.default ?? this.attrs.values[0] ?? 0;
+      : (this.attrs.default ?? this.attrs.values[0] ?? 0);
     return this._value;
   }
 

--- a/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
+++ b/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
@@ -478,10 +478,7 @@ interface MsgSessionStop {
 
 // In case of new messages, they should be "or-ed" here.
 type SyncMessages =
-  | MsgSetViewport
-  | MsgAdvertise
-  | MsgSessionStart
-  | MsgSessionStop;
+  MsgSetViewport | MsgAdvertise | MsgSessionStart | MsgSessionStop;
 
 interface SyncMessage {
   perfettoSync: SyncMessages;

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/diagnostics.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/diagnostics.ts
@@ -335,9 +335,7 @@ export interface TraceDoctorDrawerAttrs {
   readonly onDiagnosticClick: (index: number) => void;
 }
 
-export class TraceDoctorDrawer
-  implements m.ClassComponent<TraceDoctorDrawerAttrs>
-{
+export class TraceDoctorDrawer implements m.ClassComponent<TraceDoctorDrawerAttrs> {
   view({attrs}: m.CVnode<TraceDoctorDrawerAttrs>): m.Children {
     return m(
       '.pf-trace-info-doctor-details-tab',

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/android.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/android.ts
@@ -268,8 +268,8 @@ class PackageListSection implements m.ClassComponent<PackageListSectionAttrs> {
         ],
         rowData: packageList.map((pkg) => {
           const flags = [
-            pkg.debuggable ?? 0 ? 'debuggable' : '',
-            pkg.profileableFromShell ?? 0 ? 'profileable' : '',
+            (pkg.debuggable ?? 0) ? 'debuggable' : '',
+            (pkg.profileableFromShell ?? 0) ? 'profileable' : '',
           ]
             .filter(Boolean)
             .join(' ');
@@ -314,9 +314,7 @@ function formatCurrentMode(mode: number | null): string {
   return mode !== null ? String(mode) : 'Unknown';
 }
 
-class AndroidGameInterventionList
-  implements m.ClassComponent<AndroidGameInterventionListAttrs>
-{
+class AndroidGameInterventionList implements m.ClassComponent<AndroidGameInterventionListAttrs> {
   view({attrs}: m.CVnode<AndroidGameInterventionListAttrs>) {
     const data = attrs.data;
     if (data === undefined || data.length === 0) {
@@ -394,9 +392,7 @@ interface AndroidAflagsSectionAttrs {
   aflagErrors: string[];
 }
 
-class AndroidAflagsSection
-  implements m.ClassComponent<AndroidAflagsSectionAttrs>
-{
+class AndroidAflagsSection implements m.ClassComponent<AndroidAflagsSectionAttrs> {
   private selectedTs?: bigint;
 
   view({attrs}: m.CVnode<AndroidAflagsSectionAttrs>) {

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/ui_loading_errors.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/ui_loading_errors.ts
@@ -26,9 +26,7 @@ export interface UiLoadingErrorsTabAttrs {
   data: UiLoadingErrorsData;
 }
 
-export class UiLoadingErrorsTab
-  implements m.ClassComponent<UiLoadingErrorsTabAttrs>
-{
+export class UiLoadingErrorsTab implements m.ClassComponent<UiLoadingErrorsTabAttrs> {
   view({attrs}: m.CVnode<UiLoadingErrorsTabAttrs>) {
     const errors = attrs.data.errors;
 

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/callstack_details_section.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/callstack_details_section.ts
@@ -120,7 +120,7 @@ export class CallstackDetailsSection implements TrackEventDetailsPanelSection {
           const location =
             frame.sourceFile && frame.lineNumber !== undefined
               ? `${frame.sourceFile}:${frame.lineNumber}`
-              : frame.sourceFile ?? '';
+              : (frame.sourceFile ?? '');
 
           return m(TreeNode, {
             left: `#${index}`,

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -574,7 +574,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
     // different nodes.
     const name = typeof group === 'string' ? group : group.name;
     const expanded =
-      typeof group === 'string' ? false : group.expanded ?? false;
+      typeof group === 'string' ? false : (group.expanded ?? false);
     const groupId = `tp_group_${scopeId}_${name.toLowerCase().replace(' ', '_')}`;
     const groupNode = this.groups.get(groupId);
     if (groupNode) {

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_counter_track.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_counter_track.ts
@@ -22,8 +22,10 @@ import type {TrackMouseEvent} from '../../public/track';
 import {LONG, LONG_NULL, NUM} from '../../trace_processor/query_result';
 import {CounterDetailsPanel} from './counter_details_panel';
 
-export interface TraceProcessorCounterTrackAttrs
-  extends Omit<CounterTrackAttrs, 'sqlSource'> {
+export interface TraceProcessorCounterTrackAttrs extends Omit<
+  CounterTrackAttrs,
+  'sqlSource'
+> {
   /** The trace processor track id. */
   readonly trackId: number;
 

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/types.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/types.ts
@@ -15,10 +15,7 @@
 import type {StandardGroup} from '../dev.perfetto.StandardGroups';
 
 export type TopLevelTrackGroup =
-  | 'PROCESS'
-  | 'THREAD'
-  | StandardGroup
-  | undefined;
+  'PROCESS' | 'THREAD' | StandardGroup | undefined;
 
 export interface TrackGroupSchema {
   name: string;

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
@@ -1937,8 +1937,7 @@ function ScatterChartDemo(): m.Component<{
   legendPosition: LegendPosition;
 }> {
   let brushRange:
-    | {xMin: number; xMax: number; yMin: number; yMax: number}
-    | undefined;
+    {xMin: number; xMax: number; yMin: number; yMax: number} | undefined;
 
   return {
     view: ({attrs}) => {
@@ -2260,8 +2259,7 @@ function SQLScatterChartDemo(): m.Component<{
 }> {
   let loader: SQLScatterChartLoader | undefined;
   let brushRange:
-    | {xMin: number; xMax: number; yMin: number; yMax: number}
-    | undefined;
+    {xMin: number; xMax: number; yMin: number; yMax: number} | undefined;
 
   return {
     view: ({attrs}) => {

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/nodegraph_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/nodegraph_demo.ts
@@ -332,8 +332,7 @@ function renderSortNode(
           onchange: (e: Event) => {
             updateNode({
               sortOrder: (e.target as HTMLSelectElement).value as
-                | 'ASC'
-                | 'DESC',
+                'ASC' | 'DESC',
             });
           },
         },

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page_utils.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page_utils.ts
@@ -64,9 +64,9 @@ export interface WidgetShowcaseAttrs<T extends Options> {
  * this component as using the component directly can be fiddly to get right
  * with the generics.
  */
-class WidgetShowcase<T extends Options>
-  implements m.ClassComponent<WidgetShowcaseAttrs<T>>
-{
+class WidgetShowcase<T extends Options> implements m.ClassComponent<
+  WidgetShowcaseAttrs<T>
+> {
   private options?: Options;
   private optionValues: Record<string, unknown> = {};
 

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_details_panel.ts
@@ -429,7 +429,7 @@ export class EventLatencySliceDetailsPanel implements TrackEventDetailsPanel {
 
     return m(
       Section,
-      {title: this.isJankStage ? `Jank Cause: ${name}` : name ?? '[null]'},
+      {title: this.isJankStage ? `Jank Cause: ${name}` : (name ?? '[null]')},
       childWidgets,
     );
   }

--- a/ui/src/trace_processor/dataset.ts
+++ b/ui/src/trace_processor/dataset.ts
@@ -155,9 +155,9 @@ interface SourceDatasetConfig<T extends DatasetSchema> {
  * Defines a dataset with a source SQL select statement of table name, a
  * schema describing the columns, and an optional filter.
  */
-export class SourceDataset<T extends DatasetSchema = DatasetSchema>
-  implements Dataset<T>
-{
+export class SourceDataset<
+  T extends DatasetSchema = DatasetSchema,
+> implements Dataset<T> {
   readonly src: string;
   readonly schema: T;
   readonly filter?: Filter;
@@ -277,9 +277,9 @@ const MAX_SUBQUERIES_PER_UNION = 500;
 /**
  * A dataset that represents the union of multiple datasets.
  */
-export class UnionDataset<T extends DatasetSchema = DatasetSchema>
-  implements Dataset<T>
-{
+export class UnionDataset<
+  T extends DatasetSchema = DatasetSchema,
+> implements Dataset<T> {
   /**
    * This factory method creates a new union dataset but retains the specific
    * types of the input datasets. It's a factory function because it's not
@@ -538,9 +538,9 @@ interface PartitionMapWithUnfiltered<T> {
  * }
  * ```
  */
-export class UnionDatasetWithLineage<T extends DatasetSchema>
-  implements Dataset<T>
-{
+export class UnionDatasetWithLineage<
+  T extends DatasetSchema,
+> implements Dataset<T> {
   readonly sourceDatasets: ReadonlyArray<Dataset>;
   private readonly sourceGroupArray: Array<[string, Array<{dataset: Dataset}>]>;
   private readonly partitionMaps: Map<

--- a/ui/src/trace_processor/proto_ring_buffer_unittest.ts
+++ b/ui/src/trace_processor/proto_ring_buffer_unittest.ts
@@ -121,7 +121,7 @@ test('ProtoRingBufferTest.RandomSizes', () => {
     mergedLen += msg.length;
   }
 
-  for (let fragSum = 0; fragSum < mergedLen /**/; ) {
+  for (let fragSum = 0; fragSum < mergedLen /**/;) {
     let fragLen = 1 + Rnd(1024 * 32);
     fragLen = Math.min(fragLen, mergedLen - fragSum);
     buf.append(mergedBuf.subarray(fragSum, fragSum + fragLen));

--- a/ui/src/trace_processor/query_result.ts
+++ b/ui/src/trace_processor/query_result.ts
@@ -56,11 +56,7 @@ import {utf8Decode} from '../base/string_utils';
 import {Duration, type duration, Time, type time} from '../base/time';
 
 export type SqlValue =
-  | string
-  | number
-  | bigint
-  | null
-  | Uint8Array<ArrayBuffer>;
+  string | number | bigint | null | Uint8Array<ArrayBuffer>;
 
 export const UNKNOWN: SqlValue = null;
 export const NUM = 0;

--- a/ui/src/widgets/accordion.ts
+++ b/ui/src/widgets/accordion.ts
@@ -49,9 +49,7 @@ export interface AccordionSectionAttrs {
   readonly defaultOpen?: boolean;
 }
 
-export class AccordionSection
-  implements m.ClassComponent<AccordionSectionAttrs>
-{
+export class AccordionSection implements m.ClassComponent<AccordionSectionAttrs> {
   private isOpen = false;
   private pendingScrollOpen = false;
 

--- a/ui/src/widgets/download_to_file_button.ts
+++ b/ui/src/widgets/download_to_file_button.ts
@@ -27,9 +27,7 @@ export interface DownloadToFileButtonAttrs {
   readonly filePicker?: FilePickerOptions;
 }
 
-export class DownloadToFileButton
-  implements m.ClassComponent<DownloadToFileButtonAttrs>
-{
+export class DownloadToFileButton implements m.ClassComponent<DownloadToFileButtonAttrs> {
   private helper = new ActionButtonHelper();
 
   view({attrs}: m.Vnode<DownloadToFileButtonAttrs>): m.Children {

--- a/ui/src/widgets/drawer_panel.ts
+++ b/ui/src/widgets/drawer_panel.ts
@@ -202,7 +202,7 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
 
     // Get active tab key (controlled or uncontrolled)
     const activeKey = isTabsMode
-      ? activeTabKey ?? this.internalActiveTab ?? tabs[0].key
+      ? (activeTabKey ?? this.internalActiveTab ?? tabs[0].key)
       : undefined;
 
     // Render tabs UI and drawer content based on mode

--- a/ui/src/widgets/flamegraph.ts
+++ b/ui/src/widgets/flamegraph.ts
@@ -243,11 +243,7 @@ export interface FlamegraphAttrs {
 }
 
 type FilterType =
-  | 'SHOW_STACK'
-  | 'HIDE_STACK'
-  | 'SHOW_FROM_FRAME'
-  | 'HIDE_FRAME'
-  | 'PIVOT';
+  'SHOW_STACK' | 'HIDE_STACK' | 'SHOW_FROM_FRAME' | 'HIDE_FRAME' | 'PIVOT';
 
 interface FilterTypeOption {
   readonly value: FilterType;

--- a/ui/src/widgets/multiselect.ts
+++ b/ui/src/widgets/multiselect.ts
@@ -238,9 +238,7 @@ export class MultiSelect implements m.ClassComponent<MultiSelectAttrs> {
 
 // The same multi-select component that functions as a drop-down instead of
 // a list.
-export class PopupMultiSelect
-  implements m.ClassComponent<PopupMultiSelectAttrs>
-{
+export class PopupMultiSelect implements m.ClassComponent<PopupMultiSelectAttrs> {
   view({attrs}: m.CVnode<PopupMultiSelectAttrs>) {
     const {
       icon,

--- a/ui/src/widgets/multiselect_input.ts
+++ b/ui/src/widgets/multiselect_input.ts
@@ -73,9 +73,7 @@ export interface MultiselectInputAttrs extends HTMLAttrs {
   readonly placeholder?: string;
 }
 
-export class MultiselectInput
-  implements m.ClassComponent<MultiselectInputAttrs>
-{
+export class MultiselectInput implements m.ClassComponent<MultiselectInputAttrs> {
   private currentTextValue = '';
   private selectedItemIndex = 0;
   private popupIsOpen = false;

--- a/ui/src/widgets/nodegraph.ts
+++ b/ui/src/widgets/nodegraph.ts
@@ -424,8 +424,7 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
   let recenterApi: (() => void) | null = null;
   let resetZoom: (() => void) | null = null;
   let findPlacementForNodeApi:
-    | ((newNode: Omit<Node, 'x' | 'y'>) => Position)
-    | null = null;
+    ((newNode: Omit<Node, 'x' | 'y'>) => Position) | null = null;
 
   const handleMouseMove = (e: PointerEvent) => {
     m.redraw();

--- a/ui/src/widgets/overlay_container.ts
+++ b/ui/src/widgets/overlay_container.ts
@@ -21,9 +21,7 @@ export interface OverlayContainerAttrs {
   readonly fillHeight?: boolean;
 }
 
-export class OverlayContainer
-  implements m.ClassComponent<OverlayContainerAttrs>
-{
+export class OverlayContainer implements m.ClassComponent<OverlayContainerAttrs> {
   view({attrs, children}: m.Vnode<OverlayContainerAttrs>) {
     const {fillHeight = false} = attrs as OverlayContainerAttrs;
     return m(

--- a/ui/src/widgets/popper_utils.ts
+++ b/ui/src/widgets/popper_utils.ts
@@ -15,6 +15,5 @@
 import type {Modifier, StrictModifiers} from '@popperjs/core';
 
 export type CustomModifier =
-  | Modifier<'sameWidth', {}>
-  | Modifier<'hideOnInvisible', {}>;
+  Modifier<'sameWidth', {}> | Modifier<'hideOnInvisible', {}>;
 export type ExtendedModifiers = StrictModifiers | CustomModifier;

--- a/ui/src/widgets/text_paragraph.ts
+++ b/ui/src/widgets/text_paragraph.ts
@@ -42,9 +42,7 @@ interface MultiParagraphTextAttrs {
   className?: string;
 }
 
-export class MultiParagraphText
-  implements m.ClassComponent<MultiParagraphTextAttrs>
-{
+export class MultiParagraphText implements m.ClassComponent<MultiParagraphTextAttrs> {
   view({attrs, children}: m.Vnode<MultiParagraphTextAttrs>): m.Children {
     const {className = ''} = attrs;
 

--- a/ui/src/widgets/virtual_overlay_canvas.ts
+++ b/ui/src/widgets/virtual_overlay_canvas.ts
@@ -133,9 +133,7 @@ function getScrollAxesFromOverflow(x: Overflow, y: Overflow) {
 // This mithril component acts as scrolling container for tall and/or wide
 // content. Adds a virtually scrolling canvas over the top of any child elements
 // rendered inside it.
-export class VirtualOverlayCanvas
-  implements m.ClassComponent<VirtualOverlayCanvasAttrs>
-{
+export class VirtualOverlayCanvas implements m.ClassComponent<VirtualOverlayCanvasAttrs> {
   readonly trash = new DisposableStack();
   private ctx?: CanvasRenderingContext2D;
   private virtualCanvas?: VirtualCanvas;


### PR DESCRIPTION
Upgrade formatting across UI source files following Prettier 3.9.5 rules.
The Prettier 3.9 update introduces changes to default formatting (such as
single implements/extends clauses and union types) that are not configurable
in Prettier, but the updated formatting is generally reasonable.

TODO: After landing - add the resulting squash commit to `.git-blame-ignore-revs`
