### PR TITLE
ui: Fix bigtrace and open_perfetto_trace tsconfig settings

### DIFF
--- a/ui/src/bigtrace/tsconfig.json
+++ b/ui/src/bigtrace/tsconfig.json
@@ -2,16 +2,23 @@
   "extends": "../../tsconfig.base.json",
   "include": [
     ".",
+    "../types/vite.d.ts"
   ],
   "exclude": [
     "../gen/"
   ],
   "compilerOptions": {
+    "rootDir": "..",
     "outDir": "../../out/tsc/bigtrace",
+    "types": ["*"],
     "lib": [
-      "dom", // Need to be explicitly mentioned now since we're overriding default included libs.
-      "es2022", // Need this to use Promise.allSettled, replaceAll, Error.cause, etc
+      "dom",
+      "es2024",
+      "dom.iterable",
     ],
+    "paths": {
+      "*" : ["./*", "../../node_modules/@tsundoku/micromodal_types/*"]
+    },
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
   }

--- a/ui/src/open_perfetto_trace/tsconfig.json
+++ b/ui/src/open_perfetto_trace/tsconfig.json
@@ -1,15 +1,24 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": [ "." ],
+  "include": [
+    ".",
+    "../types/vite.d.ts"
+  ],
   "exclude": [
     "../gen/"
   ],
   "compilerOptions": {
+    "rootDir": "..",
     "outDir": "../../out/tsc/open_perfetto_trace",
+    "types": ["*"],
     "lib": [
-      "dom",                               // Need to be explicitly mentioned now since we're overriding default included libs.
-      "es2021",                            // Need this to use Promise.allSettled, replaceAll, etc
+      "dom",
+      "es2024",
+      "dom.iterable",
     ],
+    "paths": {
+      "*" : ["./*", "../../node_modules/@tsundoku/micromodal_types/*"]
+    },
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
   }


### PR DESCRIPTION
Set rootDir to parent directory, include vite.d.ts for SCSS module declarations, and update lib to es2024 to support Symbol.dispose.
