### PR TITLE
ui: Remove inlineDynamicImports from vite.config.mjs

### DIFF
--- a/ui/vite.config.mjs
+++ b/ui/vite.config.mjs
@@ -368,7 +368,6 @@ export default defineConfig(({command}) => {
                 if (name.endsWith('.css')) return `${BUNDLE}.css`;
                 return '[name][extname]';
               },
-              inlineDynamicImports: true,
             },
             onwarn(warning, warn) {
               if (warning.code === 'CIRCULAR_DEPENDENCY') {


### PR DESCRIPTION
Squashes the warning encountered when running the build with the new version of vite