### PR TITLE
tp: Fix TraceRedactorTest.EmptyTimelineReturnsError on Windows

### DIFF
--- a/src/trace_redaction/trace_redactor_unittest.cc
+++ b/src/trace_redaction/trace_redactor_unittest.cc
@@ -41,11 +41,9 @@ TEST(TraceRedactorTest, EmptyTimelineReturnsError) {
 
   std::string serialized = trace.SerializeAsString();
 
-  auto fd = base::OpenFile(input_file.path(), O_RDWR | O_CREAT, 0666);
-  ASSERT_TRUE(fd);
-  ASSERT_EQ(base::WriteAll(fd.get(), serialized.data(), serialized.size()),
-            static_cast<ssize_t>(serialized.size()));
-  base::CloseFile(fd.release());
+  ASSERT_EQ(
+      base::WriteAll(input_file.fd(), serialized.data(), serialized.size()),
+      static_cast<ssize_t>(serialized.size()));
 
   TraceRedactor::Config config;
   config.verify = false;


### PR DESCRIPTION
base::TempFile::Create() creates the file via CreateFileA() with only FILE_SHARE_DELETE | FILE_SHARE_READ and keeps it open. 

Re-opening the same path with O_RDWR therefore fails with a sharing violation on Windows, making ASSERT_TRUE(fd) fail. 

On POSIX the reopen is harmless, so the breakage was Windows-only.

Write the serialized trace through the fd the TempFile already owns instead of reopening the path. The redactor's read-only mmap of the input is still allowed by FILE_SHARE_READ, and it returns the empty timeline error before it ever opens the output file.
