### PR TITLE
Revert "tp: improve performance of jank_cuj metric (#6650)"

### DIFF
--- a/src/trace_processor/metrics/sql/android/jank/slices.sql
+++ b/src/trace_processor/metrics/sql/android/jank/slices.sql
@@ -13,8 +13,6 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-INCLUDE PERFETTO MODULE intervals.intersect;
-
 DROP VIEW IF EXISTS android_jank_cuj_slice;
 CREATE PERFETTO VIEW android_jank_cuj_slice AS
 SELECT
@@ -95,117 +93,43 @@ JOIN slice
     AND slice.ts + slice.dur >= sf_boundary.ts AND slice.ts <= sf_boundary.ts_end
 WHERE slice.dur > 0;
 
--- The SF main thread is very busy, so even though there are only a handful of
--- (wide) per-CUJ boundaries, the naive "boundary JOIN slice ON <overlap>" nested
--- loop is expensive. As with the RenderEngine table above, we use
--- `interval_intersect` (interval tree, O(n log n)) with the two inputs
--- materialized into their own tables.
-DROP TABLE IF EXISTS android_jank_cuj_sf_main_thread_boundary_intervals;
-CREATE PERFETTO TABLE android_jank_cuj_sf_main_thread_boundary_intervals AS
-SELECT
-  -- interval_intersect requires an integer `id` on each input.
-  ROW_NUMBER() OVER (ORDER BY boundary.ts) AS id,
-  boundary.ts,
-  boundary.ts_end - boundary.ts AS dur,
-  boundary.utid,
-  boundary.cuj_id,
-  thread.upid
-FROM android_jank_cuj_sf_main_thread_cuj_boundary boundary
-JOIN thread USING (utid);
-
-DROP TABLE IF EXISTS android_jank_cuj_sf_main_thread_track_slice;
-CREATE PERFETTO TABLE android_jank_cuj_sf_main_thread_track_slice AS
-SELECT
-  slice.id,
-  slice.ts,
-  slice.dur,
-  thread_track.utid
-FROM slice
-JOIN thread_track
-  ON slice.track_id = thread_track.id
-WHERE
-  thread_track.utid IN (
-    SELECT DISTINCT utid FROM android_jank_cuj_sf_main_thread_boundary_intervals
-  )
-  AND slice.dur > 0;
-
 DROP TABLE IF EXISTS android_jank_cuj_sf_main_thread_slice;
 CREATE PERFETTO TABLE android_jank_cuj_sf_main_thread_slice AS
 SELECT
-  boundary.cuj_id,
-  boundary.upid,
-  boundary.utid,
+  cuj_id,
+  upid,
+  utid,
   slice.*,
   slice.ts + slice.dur AS ts_end
-FROM _interval_intersect!(
-  (
-    android_jank_cuj_sf_main_thread_boundary_intervals,
-    android_jank_cuj_sf_main_thread_track_slice
-  ),
-  (utid)
-) ii
-JOIN android_jank_cuj_sf_main_thread_boundary_intervals boundary
-  ON boundary.id = ii.id_0
+FROM android_jank_cuj_sf_main_thread_cuj_boundary boundary
+JOIN thread_track USING (utid)
+JOIN thread USING (utid)
 JOIN slice
-  ON slice.id = ii.id_1;
+  ON slice.track_id = thread_track.id
+    -- Take slices which overlap even they started before the boundaries
+    -- This is to be able to query slices that delayed start of a frame
+    AND slice.ts + slice.dur >= boundary.ts
+    AND slice.ts <= boundary.ts_end
+WHERE slice.dur > 0;
 
 -- For RenderEngine thread we use a different approach as it's only used when SF falls back to
 -- client composition. Instead of taking all slices during CUJ, we look at each frame explicitly
 -- and only take slices that are within RenderEngine frame boundaries.
---
--- Unlike the other slice tables above (which have few, wide, per-CUJ boundaries),
--- RenderEngine has one narrow boundary per frame - hundreds of them - so the naive
--- "boundary JOIN slice ON <overlap>" nested loop scans the (very busy) RenderEngine
--- track once per boundary and is by far the most expensive query in this metric. We
--- instead use `interval_intersect`, which matches boundaries to overlapping slices in
--- O(n log n) via an interval tree. The two inputs are materialized into their own
--- tables (rather than CTEs) because the macro references each input several times and
--- would otherwise re-evaluate them.
-DROP TABLE IF EXISTS android_jank_cuj_sf_render_engine_boundary_intervals;
-CREATE PERFETTO TABLE android_jank_cuj_sf_render_engine_boundary_intervals AS
-SELECT
-  -- interval_intersect requires an integer `id` on each input.
-  ROW_NUMBER() OVER (ORDER BY boundary.ts) AS id,
-  boundary.ts,
-  boundary.dur,
-  boundary.utid,
-  boundary.cuj_id,
-  thread.upid
-FROM android_jank_cuj_sf_render_engine_frame_boundary boundary
-JOIN thread USING (utid);
-
-DROP TABLE IF EXISTS android_jank_cuj_sf_render_engine_track_slice;
-CREATE PERFETTO TABLE android_jank_cuj_sf_render_engine_track_slice AS
-SELECT
-  slice.id,
-  slice.ts,
-  slice.dur,
-  thread_track.utid
-FROM slice
-JOIN thread_track
-  ON slice.track_id = thread_track.id
-WHERE
-  thread_track.utid IN (
-    SELECT DISTINCT utid FROM android_jank_cuj_sf_render_engine_boundary_intervals
-  )
-  AND slice.dur > 0;
-
 DROP TABLE IF EXISTS android_jank_cuj_sf_render_engine_slice;
 CREATE PERFETTO TABLE android_jank_cuj_sf_render_engine_slice AS
 SELECT
-  boundary.cuj_id,
-  boundary.upid,
-  boundary.utid,
+  cuj_id,
+  upid,
+  utid,
   slice.*,
   slice.ts + slice.dur AS ts_end
-FROM _interval_intersect!(
-  (
-    android_jank_cuj_sf_render_engine_boundary_intervals,
-    android_jank_cuj_sf_render_engine_track_slice
-  ),
-  (utid)
-) ii
-JOIN android_jank_cuj_sf_render_engine_boundary_intervals boundary
-  ON boundary.id = ii.id_0
+FROM android_jank_cuj_sf_render_engine_frame_boundary boundary
+JOIN thread_track USING (utid)
+JOIN thread USING (utid)
 JOIN slice
-  ON slice.id = ii.id_1;
+  ON slice.track_id = thread_track.id
+    -- Take slices which overlap even they started before the boundaries
+    -- This is to be able to query slices that delayed start of a frame
+    AND slice.ts + slice.dur >= boundary.ts
+    AND slice.ts <= boundary.ts_end
+WHERE slice.dur > 0;

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
@@ -49,21 +49,6 @@ WHERE
 
 -- Slices logged from FrameTracker#markEvent that describe when
 -- the instrumentation was started and the reason the CUJ ended.
---
--- The candidate marker slices are pre-filtered by name before the per-CUJ range
--- join. Without this the join scans every slice inside each (wide) CUJ time
--- window - i.e. large swathes of the whole `slice` table - only to discard all
--- but the handful of `FT#` / `#UIThread` markers. The `_cuj_state_marker_slice`
--- prefilter narrows the candidates to just those markers up front; it is a
--- superset of every name pattern matched in the WHERE below, so the result is
--- unchanged.
-CREATE PERFETTO TABLE _cuj_state_marker_slice AS
-SELECT id, ts, name, track_id
-FROM slice
-WHERE
-  name GLOB '*FT#*'
-  OR name GLOB '*#UIThread';
-
 CREATE PERFETTO TABLE _cuj_state_markers AS
 SELECT
   cuj.cuj_id,
@@ -80,7 +65,7 @@ SELECT
   cuj_state_marker.name AS marker_name,
   thread_track.utid AS utid
 FROM _jank_cujs_slices AS cuj
-LEFT JOIN _cuj_state_marker_slice AS cuj_state_marker
+LEFT JOIN slice AS cuj_state_marker
   ON cuj_state_marker.ts >= cuj.ts
   AND cuj_state_marker.ts < cuj.ts_end
 LEFT JOIN track AS marker_track


### PR DESCRIPTION
This reverts commit 0e26c4745eeb5c4f35843c5817fc322f8083fd83.

Causes failures with` CREATE PERFETTO TABLE(android_jank_cuj_sf_main_thread_slice): SQLite error while creating body: Interval intersect only works on intervals with non negative duration.`
