### PR TITLE
tp: add interned callstacks to stack sampling

### DIFF
--- a/protos/perfetto/trace/profiling/stack_sample.proto
+++ b/protos/perfetto/trace/profiling/stack_sample.proto
@@ -165,13 +165,14 @@ message StackSample {
     uint64 execution_context_iid = 4;
   }
 
-  // The captured callstack, bottom frame first.
+  // The captured callstack, bottom frame first. Give it inline via `callstack`
+  // or reference an interned Callstack via `callstack_iid`.
   oneof callstack_field {
-    // Inline callstack. The only supported form for now.
+    // Inline callstack.
     Callstack callstack = 5;
 
-    // Reserved: an interned callstack variant may be added later.
-    // uint64 callstack_iid = 6;
+    // Interned callstack, referencing InternedData.callstacks.
+    uint64 callstack_iid = 6;
   }
 
   // Set if stack unwinding was incomplete; describes the data, not producer

--- a/src/trace_processor/plugins/stack_sample_importer/module.cc
+++ b/src/trace_processor/plugins/stack_sample_importer/module.cc
@@ -113,19 +113,23 @@ ResolvedCounterDescriptor ResolveCounterDescriptor(
   return out;
 }
 
-// Resolves an inline callstack (a profile_common Callstack whose frame_ids are
-// interned frame iids).
+// Resolves a callstack that is either interned (callstack_iid) or inline (a
+// profile_common Callstack whose frame_ids are interned frame iids).
 std::optional<CallsiteId> ResolveCallstack(
     PacketSequenceStateGeneration* sequence_state,
     std::optional<UniquePid> upid,
     const protos::pbzero::StackSample::Decoder& sample) {
-  if (!sample.has_callstack()) {
-    return std::nullopt;
-  }
   auto* state = sequence_state->GetCustomState<StackProfileSequenceState>();
-  protos::pbzero::Callstack::Decoder callstack(sample.callstack());
-  return state->FindOrInsertCallstackFromFrames(sequence_state, upid,
-                                                callstack);
+  if (sample.has_callstack_iid()) {
+    return state->FindOrInsertCallstack(sequence_state, upid,
+                                        sample.callstack_iid());
+  }
+  if (sample.has_callstack()) {
+    protos::pbzero::Callstack::Decoder callstack(sample.callstack());
+    return state->FindOrInsertCallstackFromFrames(sequence_state, upid,
+                                                  callstack);
+  }
+  return std::nullopt;
 }
 
 }  // namespace

--- a/test/trace_processor/diff_tests/parser/profiling/stack_sample.textproto
+++ b/test/trace_processor/diff_tests/parser/profiling/stack_sample.textproto
@@ -41,6 +41,10 @@ packet {
       rel_pc: 0x100
       function_name_id: 1
     }
+    callstacks {
+      iid: 1
+      frame_ids: 1
+    }
   }
 }
 
@@ -61,6 +65,23 @@ packet {
     }
     primary_weight: 1000000
     follower_weights: 500
+  }
+}
+
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 2000
+  stack_sample {
+    task_context {
+      pid: 100
+      tid: 101
+    }
+    execution_context {
+      cpu: 2
+      mode: MODE_KERNEL
+    }
+    callstack_iid: 1
+    primary_weight: 2000000
   }
 }
 

--- a/test/trace_processor/diff_tests/parser/profiling/tests.py
+++ b/test/trace_processor/diff_tests/parser/profiling/tests.py
@@ -666,6 +666,7 @@ class Profiling(TestSuite):
         out=Csv("""
         "ts","cpu","mode","weight","source","timebase_name","unit","frame_name"
         1000,2,"user",1000000,"python.wall","wall-time","ns","foo"
+        2000,2,"kernel",2000000,"python.wall","wall-time","ns","foo"
         6000,"[NULL]","[NULL]",4000000,"python.wall","wall-time","ns","foo"
         7000,"[NULL]","[NULL]",7000000,"python.wall","wall-time","ns","foo"
         """))
@@ -692,8 +693,28 @@ class Profiling(TestSuite):
         out=Csv("""
         "ts","process_name","cpu","mode"
         1000,"myproc",2,"user"
+        2000,"myproc",2,"kernel"
         6000,"myproc","[NULL]","[NULL]"
         7000,"[NULL]","[NULL]","[NULL]"
+        """))
+
+  def test_stack_sample_interned_callstack(self):
+    return DiffTestBlueprint(
+        trace=Path('stack_sample.textproto'),
+        query="""
+        -- The ts=2000 sample references its callstack via callstack_iid.
+        SELECT
+          ss.ts,
+          ss.weight,
+          spf.name AS frame_name
+        FROM __intrinsic_stack_sample ss
+        JOIN stack_profile_callsite spc ON ss.callsite_id = spc.id
+        JOIN stack_profile_frame spf ON spc.frame_id = spf.id
+        WHERE ss.ts = 2000;
+        """,
+        out=Csv("""
+        "ts","weight","frame_name"
+        2000,2000000,"foo"
         """))
 
   def test_stack_sample_async(self):


### PR DESCRIPTION
Add callstack_iid to the StackSample callstack oneof so a sample can
reference a callstack interned in InternedData.callstacks instead of
inlining it. The parser resolves the iid via StackProfileSequenceState.
