### PR TITLE
tp: look up the default SQLite VFS name for export

### DIFF
--- a/src/trace_processor/shell/BUILD.gn
+++ b/src/trace_processor/shell/BUILD.gn
@@ -55,6 +55,7 @@ source_set("shell") {
     ":subcommands",
     "../../../gn:default_deps",
     "../../../gn:protobuf_full",
+    "../../../gn:sqlite",
     "../../../include/perfetto/ext/trace_processor:trace_processor_shell",
     "../../../protos/perfetto/trace_processor:zero",
     "../../base",

--- a/src/trace_processor/shell/shell_utils.cc
+++ b/src/trace_processor/shell/shell_utils.cc
@@ -16,6 +16,7 @@
 
 #include "src/trace_processor/shell/shell_utils.h"
 
+#include <sqlite3.h>
 #include <algorithm>
 #include <cinttypes>
 #include <cstdint>
@@ -54,17 +55,13 @@ bool StderrSupportsColors() {
 
 namespace {
 
-// The main trace processor connection is opened on the in-memory "memdb" VFS.
-// ATTACH DATABASE inherits the connection's VFS, so a plain path would create
-// the export database in memory too. Force the OS-backed VFS instead.
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-constexpr char kExportVfs[] = "win32";
-#else
-constexpr char kExportVfs[] = "unix";
-#endif
-
 // Builds a SQLite "file:" URI for `path`, percent-encoding characters that are
 // not safe in a URI path.
+//
+// The main trace processor connection is opened on the in-memory "memdb" VFS.
+// ATTACH DATABASE inherits the connection's VFS, so a plain path would create
+// the export database in memory too. Pin the default VFS instead: it is the
+// OS-backed one, under a platform-dependent name ("unix", "win32", ...).
 std::string MakeExportFileUri(const std::string& path) {
   std::string normalized = path;
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
@@ -82,8 +79,11 @@ std::string MakeExportFileUri(const std::string& path) {
       uri.append(escaped.c_str());
     }
   }
+  // Lookup default VFS.
+  sqlite3_vfs* vfs = sqlite3_vfs_find(nullptr);
+  PERFETTO_CHECK(vfs);
   uri.append("?vfs=");
-  uri.append(kExportVfs);
+  uri.append(vfs->zName);
   return uri;
 }
 

--- a/src/trace_processor/shell/shell_utils_unittest.cc
+++ b/src/trace_processor/shell/shell_utils_unittest.cc
@@ -58,11 +58,10 @@ std::string MakeAttachUri(const std::string& path) {
   std::string normalized = path;
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
   std::replace(normalized.begin(), normalized.end(), '\\', '/');
-  const char* vfs = "win32";
-#else
-  const char* vfs = "unix";
 #endif
-  return "file:" + normalized + "?vfs=" + vfs;
+  sqlite3_vfs* vfs = sqlite3_vfs_find(nullptr);
+  PERFETTO_CHECK(vfs);
+  return "file:" + normalized + "?vfs=" + vfs->zName;
 }
 
 // Verifies the export produces an on-disk SQLite database that can be read back


### PR DESCRIPTION
The export path hardcoded the OS-backed VFS name as "win32" on Windows and "unix" everywhere else. SQLite does not register a VFS named "unix" on every platform, so on Fuchsia the "?vfs=" URI parameter failed to resolve and both ExportTraceToDatabase and its unit test broke.

Ask SQLite for the default VFS instead. It is always the OS-backed one (memdb is registered non-default), and its name is correct on every platform.

