### PR TITLE
tp: add minimal flatbuffer reader and writer

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -21281,6 +21281,22 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/util:flatbuffer_reader
+filegroup {
+    name: "perfetto_src_trace_processor_util_flatbuffer_reader",
+    srcs: [
+        "src/trace_processor/util/flatbuffer_reader.cc",
+    ],
+}
+
+// GN: //src/trace_processor/util:flatbuffer_writer
+filegroup {
+    name: "perfetto_src_trace_processor_util_flatbuffer_writer",
+    srcs: [
+        "src/trace_processor/util/flatbuffer_writer.cc",
+    ],
+}
+
 // GN: //src/trace_processor/util:galloping_search
 filegroup {
     name: "perfetto_src_trace_processor_util_galloping_search",
@@ -21492,6 +21508,7 @@ filegroup {
     srcs: [
         "src/trace_processor/util/bump_allocator_unittest.cc",
         "src/trace_processor/util/descriptors_unittest.cc",
+        "src/trace_processor/util/flatbuffer_reader_unittest.cc",
         "src/trace_processor/util/galloping_search_unittest.cc",
         "src/trace_processor/util/glob_unittest.cc",
         "src/trace_processor/util/gzip_decompressor_unittest.cc",
@@ -23763,6 +23780,8 @@ cc_test {
         ":perfetto_src_trace_processor_util_deobfuscation_unittests",
         ":perfetto_src_trace_processor_util_descriptors",
         ":perfetto_src_trace_processor_util_elf_elf",
+        ":perfetto_src_trace_processor_util_flatbuffer_reader",
+        ":perfetto_src_trace_processor_util_flatbuffer_writer",
         ":perfetto_src_trace_processor_util_galloping_search",
         ":perfetto_src_trace_processor_util_glob",
         ":perfetto_src_trace_processor_util_interned_message_view",

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -442,10 +442,33 @@ source_set("tar_writer") {
   ]
 }
 
+source_set("flatbuffer_writer") {
+  sources = [
+    "flatbuffer_writer.cc",
+    "flatbuffer_writer.h",
+  ]
+  deps = [
+    "../../../gn:default_deps",
+    "../../../include/perfetto/base",
+  ]
+}
+
+source_set("flatbuffer_reader") {
+  sources = [
+    "flatbuffer_reader.cc",
+    "flatbuffer_reader.h",
+  ]
+  deps = [
+    "../../../gn:default_deps",
+    "../../../include/perfetto/base",
+  ]
+}
+
 source_set("unittests") {
   sources = [
     "bump_allocator_unittest.cc",
     "descriptors_unittest.cc",
+    "flatbuffer_reader_unittest.cc",
     "galloping_search_unittest.cc",
     "glob_unittest.cc",
     "json_parser_unittest.cc",
@@ -469,6 +492,8 @@ source_set("unittests") {
     ":bump_allocator",
     ":decompressor",
     ":descriptors",
+    ":flatbuffer_reader",
+    ":flatbuffer_writer",
     ":galloping_search",
     ":glob",
     ":json_parser",

--- a/src/trace_processor/util/flatbuffer_reader.cc
+++ b/src/trace_processor/util/flatbuffer_reader.cc
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/flatbuffer_reader.h"
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string_view>
+
+#include "perfetto/base/compiler.h"
+
+namespace perfetto::trace_processor::util {
+
+// static
+uint16_t FlatBufferReader::ReadU16(const uint8_t* p) {
+  uint16_t v;
+  memcpy(&v, p, 2);
+  return v;
+}
+
+// static
+uint32_t FlatBufferReader::ReadU32(const uint8_t* p) {
+  uint32_t v;
+  memcpy(&v, p, 4);
+  return v;
+}
+
+// All bounds checks below work in the "byte offset from buf_" domain using
+// uint64_t/int64_t arithmetic. This keeps every comparison immune to 32-bit
+// wraparound (offsets read from an untrusted buffer are full-range uint32_t)
+// and never forms a pointer before its target offset has been checked
+// against buf_size_.
+const uint8_t* FlatBufferReader::FollowOffset(const uint8_t* p,
+                                              uint32_t target_size) const {
+  uint32_t rel = ReadU32(p);
+  uint64_t p_offset = static_cast<uint64_t>(p - buf_);
+  uint64_t target_offset = p_offset + rel;
+  if (PERFETTO_UNLIKELY(target_offset > buf_size_)) {
+    return nullptr;
+  }
+  uint64_t remaining = static_cast<uint64_t>(buf_size_) - target_offset;
+  if (PERFETTO_UNLIKELY(target_size > remaining)) {
+    return nullptr;
+  }
+  return buf_ + target_offset;
+}
+
+const uint8_t* FlatBufferReader::FieldRaw(uint32_t field_index,
+                                          uint32_t field_size) const {
+  if (PERFETTO_UNLIKELY(!table_)) {
+    return nullptr;
+  }
+  // Invariant: every non-null table_ was validated (by GetRoot/Table/
+  // FlatBufferTableVec) to have at least 4 bytes available for its soffset.
+  int32_t soff;
+  memcpy(&soff, table_, 4);
+  uint64_t table_offset = static_cast<uint64_t>(table_ - buf_);
+  int64_t voffset = static_cast<int64_t>(table_offset) - soff;
+  if (PERFETTO_UNLIKELY(voffset < 0 ||
+                        static_cast<uint64_t>(voffset) > buf_size_)) {
+    return nullptr;
+  }
+  uint64_t vtable_offset = static_cast<uint64_t>(voffset);
+  uint64_t remaining_at_vtable =
+      static_cast<uint64_t>(buf_size_) - vtable_offset;
+  if (PERFETTO_UNLIKELY(remaining_at_vtable < 4)) {
+    return nullptr;
+  }
+  const uint8_t* vtable = buf_ + vtable_offset;
+  uint16_t vtable_size = ReadU16(vtable);
+
+  uint64_t slot_pos = 4 + static_cast<uint64_t>(field_index) * 2;
+  if (PERFETTO_UNLIKELY(slot_pos + 2 > vtable_size)) {
+    return nullptr;  // Field absent: beyond the vtable's declared extent.
+  }
+  if (PERFETTO_UNLIKELY(slot_pos + 2 > remaining_at_vtable)) {
+    return nullptr;  // Malformed: vtable_size lies about the buffer size.
+  }
+  uint16_t field_off = ReadU16(vtable + slot_pos);
+  if (PERFETTO_UNLIKELY(field_off == 0)) {
+    return nullptr;  // Field absent.
+  }
+
+  uint64_t field_offset = table_offset + field_off;
+  if (PERFETTO_UNLIKELY(field_offset > buf_size_)) {
+    return nullptr;
+  }
+  uint64_t remaining_at_field = static_cast<uint64_t>(buf_size_) - field_offset;
+  if (PERFETTO_UNLIKELY(field_size > remaining_at_field)) {
+    return nullptr;
+  }
+  return buf_ + field_offset;
+}
+
+std::string_view FlatBufferReader::String(uint32_t field_index) const {
+  const uint8_t* p = FieldRaw(field_index, 4);
+  if (PERFETTO_UNLIKELY(!p)) {
+    return {};
+  }
+  const uint8_t* s = FollowOffset(p, 4);
+  if (PERFETTO_UNLIKELY(!s)) {
+    return {};
+  }
+  uint32_t len = ReadU32(s);
+  uint64_t data_offset = static_cast<uint64_t>(s - buf_) + 4;
+  uint64_t remaining = static_cast<uint64_t>(buf_size_) - data_offset;
+  if (PERFETTO_UNLIKELY(len > remaining)) {
+    return {};
+  }
+  return {reinterpret_cast<const char*>(s + 4), len};
+}
+
+FlatBufferReader FlatBufferReader::Table(uint32_t field_index) const {
+  const uint8_t* p = FieldRaw(field_index, 4);
+  if (PERFETTO_UNLIKELY(!p)) {
+    return {};
+  }
+  const uint8_t* t = FollowOffset(p, 4);
+  if (PERFETTO_UNLIKELY(!t)) {
+    return {};
+  }
+  return {buf_, buf_size_, t};
+}
+
+const uint8_t* FlatBufferReader::VecRaw(uint32_t field_index,
+                                        uint32_t elem_size,
+                                        uint32_t* count) const {
+  const uint8_t* p = FieldRaw(field_index, 4);
+  if (PERFETTO_UNLIKELY(!p)) {
+    return nullptr;
+  }
+  const uint8_t* vec = FollowOffset(p, 4);
+  if (PERFETTO_UNLIKELY(!vec)) {
+    return nullptr;
+  }
+  uint32_t n = ReadU32(vec);
+  uint64_t elems_offset = static_cast<uint64_t>(vec - buf_) + 4;
+  uint64_t remaining = static_cast<uint64_t>(buf_size_) - elems_offset;
+  uint64_t needed = static_cast<uint64_t>(n) * static_cast<uint64_t>(elem_size);
+  if (PERFETTO_UNLIKELY(needed > remaining)) {
+    return nullptr;
+  }
+  *count = n;
+  return buf_ + elems_offset;
+}
+
+FlatBufferTableVec FlatBufferReader::VecTable(uint32_t field_index) const {
+  uint32_t count = 0;
+  const uint8_t* base = VecRaw(field_index, 4, &count);
+  if (PERFETTO_UNLIKELY(!base)) {
+    return {};
+  }
+  return {buf_, buf_size_, base, count};
+}
+
+FlatBufferStringVec FlatBufferReader::VecString(uint32_t field_index) const {
+  uint32_t count = 0;
+  const uint8_t* base = VecRaw(field_index, 4, &count);
+  if (PERFETTO_UNLIKELY(!base)) {
+    return {};
+  }
+  return {buf_, buf_size_, base, count};
+}
+
+// static
+std::optional<FlatBufferReader> FlatBufferReader::GetRoot(const uint8_t* data,
+                                                          uint32_t size) {
+  if (PERFETTO_UNLIKELY(size < 4)) {
+    return std::nullopt;
+  }
+  FlatBufferReader tmp(data, size, nullptr);
+  const uint8_t* root = tmp.FollowOffset(data, 4);
+  if (PERFETTO_UNLIKELY(!root)) {
+    return std::nullopt;
+  }
+  return FlatBufferReader(data, size, root);
+}
+
+FlatBufferReader FlatBufferTableVec::operator[](uint32_t i) const {
+  if (PERFETTO_UNLIKELY(i >= count_)) {
+    return {};
+  }
+  const uint8_t* slot = base_ + static_cast<uint64_t>(i) * 4;
+  FlatBufferReader tmp(buf_, buf_size_, nullptr);
+  const uint8_t* target = tmp.FollowOffset(slot, 4);
+  if (PERFETTO_UNLIKELY(!target)) {
+    return {};
+  }
+  return {buf_, buf_size_, target};
+}
+
+std::string_view FlatBufferStringVec::operator[](uint32_t i) const {
+  if (PERFETTO_UNLIKELY(i >= count_)) {
+    return {};
+  }
+  const uint8_t* slot = base_ + static_cast<uint64_t>(i) * 4;
+  FlatBufferReader tmp(buf_, buf_size_, nullptr);
+  const uint8_t* s = tmp.FollowOffset(slot, 4);
+  if (PERFETTO_UNLIKELY(!s)) {
+    return {};
+  }
+  uint32_t len = FlatBufferReader::ReadU32(s);
+  uint64_t data_offset = static_cast<uint64_t>(s - buf_) + 4;
+  uint64_t remaining = static_cast<uint64_t>(buf_size_) - data_offset;
+  if (PERFETTO_UNLIKELY(len > remaining)) {
+    return {};
+  }
+  return {reinterpret_cast<const char*>(s + 4), len};
+}
+
+}  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/flatbuffer_reader.h
+++ b/src/trace_processor/util/flatbuffer_reader.h
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_UTIL_FLATBUFFER_READER_H_
+#define SRC_TRACE_PROCESSOR_UTIL_FLATBUFFER_READER_H_
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string_view>
+
+#include "perfetto/base/compiler.h"
+
+namespace perfetto::trace_processor::util {
+
+// Minimal read-only FlatBuffer API, sufficient for parsing Arrow IPC metadata
+// and similar small schemas without pulling in the flatbuffers library.
+//
+// Every access is bounds-checked against the buffer passed at construction:
+// this reader is designed to be safe on untrusted input. Absent or malformed
+// fields uniformly read back as defaults (empty views, invalid readers),
+// never out-of-bounds accesses.
+//
+// FlatBuffer wire format recap:
+//   - A Table starts with an int32 "soffset" pointing backwards to its vtable.
+//   - VTable layout: [u16 vtable_size, u16 table_size, u16 field0_off, ...]
+//   - Field offsets are relative to the table start; 0 means "not present".
+//   - Strings: u32 length followed by UTF-8 bytes + null terminator.
+//   - Vectors: u32 element count followed by the elements.
+//   - Offsets (to strings, tables, vectors) are u32 relative to the offset's
+//     own position: target = &offset + *offset.
+//   - Structs are stored inline (no vtable indirection).
+//   - The root table offset is at the very start of the buffer.
+
+// A typed view over a vector of inline scalars (or packed structs) in a
+// flatbuffer. The whole extent [data, data + size * sizeof(T)) is validated
+// at creation, so operator[] needs no further checks.
+template <typename T>
+class FlatBufferScalarVec {
+ public:
+  FlatBufferScalarVec() = default;
+  FlatBufferScalarVec(const uint8_t* data, uint32_t size)
+      : data_(data), size_(size) {}
+
+  uint32_t size() const { return size_; }
+
+  T operator[](uint32_t i) const {
+    T v;
+    memcpy(&v, data_ + i * sizeof(T), sizeof(T));
+    return v;
+  }
+
+ private:
+  const uint8_t* data_ = nullptr;
+  uint32_t size_ = 0;
+};
+
+class FlatBufferReader;
+
+// A view over a vector of table offsets in a flatbuffer.
+class FlatBufferTableVec {
+ public:
+  FlatBufferTableVec() = default;
+  FlatBufferTableVec(const uint8_t* buf,
+                     uint32_t buf_size,
+                     const uint8_t* base,
+                     uint32_t count)
+      : buf_(buf), buf_size_(buf_size), base_(base), count_(count) {}
+
+  uint32_t size() const { return count_; }
+  // Returns an invalid reader (operator bool == false) if the element's
+  // offset is out of bounds.
+  FlatBufferReader operator[](uint32_t i) const;
+
+ private:
+  const uint8_t* buf_ = nullptr;
+  uint32_t buf_size_ = 0;
+  const uint8_t* base_ = nullptr;
+  uint32_t count_ = 0;
+};
+
+// A view over a vector of string offsets in a flatbuffer.
+class FlatBufferStringVec {
+ public:
+  FlatBufferStringVec() = default;
+  FlatBufferStringVec(const uint8_t* buf,
+                      uint32_t buf_size,
+                      const uint8_t* base,
+                      uint32_t count)
+      : buf_(buf), buf_size_(buf_size), base_(base), count_(count) {}
+
+  uint32_t size() const { return count_; }
+  // Returns an empty view if the element's offset is out of bounds.
+  std::string_view operator[](uint32_t i) const;
+
+ private:
+  const uint8_t* buf_ = nullptr;
+  uint32_t buf_size_ = 0;
+  const uint8_t* base_ = nullptr;
+  uint32_t count_ = 0;
+};
+
+// Read-only handle to a single flatbuffer table. Zero-copy: just pointer
+// arithmetic over the underlying buffer. A default-constructed reader
+// represents a missing/absent table; all accessors return defaults.
+class FlatBufferReader {
+ public:
+  FlatBufferReader() = default;
+  FlatBufferReader(const uint8_t* buf, uint32_t buf_size, const uint8_t* table)
+      : buf_(buf), buf_size_(buf_size), table_(table) {}
+
+  // Returns a pointer to the raw field data at |field_index|, or nullptr if
+  // the field is absent (vtable too short or offset is zero) or would point
+  // outside the buffer. |field_size| bytes starting at the returned pointer
+  // are guaranteed to be in bounds.
+  const uint8_t* FieldRaw(uint32_t field_index, uint32_t field_size) const;
+
+  // Reads a scalar field stored inline at the vtable offset.
+  template <typename T>
+  T Scalar(uint32_t field_index, T default_val = {}) const {
+    const uint8_t* p = FieldRaw(field_index, sizeof(T));
+    if (PERFETTO_UNLIKELY(!p)) {
+      return default_val;
+    }
+    T v;
+    memcpy(&v, p, sizeof(T));
+    return v;
+  }
+
+  // Reads a string field (offset -> length-prefixed UTF-8). Empty view if
+  // absent or malformed.
+  std::string_view String(uint32_t field_index) const;
+
+  // Reads a sub-table field (offset -> child table). Invalid reader if
+  // absent or malformed.
+  FlatBufferReader Table(uint32_t field_index) const;
+
+  // Reads a vector of inline scalars or packed structs of type T. Empty view
+  // if absent, malformed or extending past the end of the buffer.
+  template <typename T>
+  FlatBufferScalarVec<T> VecScalar(uint32_t field_index) const {
+    uint32_t count = 0;
+    const uint8_t* elems = VecRaw(field_index, sizeof(T), &count);
+    if (PERFETTO_UNLIKELY(!elems)) {
+      return {};
+    }
+    return {elems, count};
+  }
+
+  // Reads a vector of tables. Empty view if absent or malformed.
+  FlatBufferTableVec VecTable(uint32_t field_index) const;
+
+  // Reads a vector of strings. Empty view if absent or malformed.
+  FlatBufferStringVec VecString(uint32_t field_index) const;
+
+  // Returns the root table reader for a flatbuffer at |data| of |size|
+  // bytes, or std::nullopt if the buffer is too small or the root offset is
+  // out of bounds.
+  static std::optional<FlatBufferReader> GetRoot(const uint8_t* data,
+                                                 uint32_t size);
+
+  explicit operator bool() const { return table_ != nullptr; }
+
+ private:
+  friend class FlatBufferTableVec;
+  friend class FlatBufferStringVec;
+
+  static uint16_t ReadU16(const uint8_t* p);
+  static uint32_t ReadU32(const uint8_t* p);
+
+  // Follows a relative u32 offset at |p|, requiring |target_size| bytes to be
+  // available at the target. Returns nullptr if out of bounds.
+  const uint8_t* FollowOffset(const uint8_t* p, uint32_t target_size) const;
+
+  // Resolves an offset field to a vector and validates that all |*count|
+  // elements of |elem_size| bytes are in bounds. Returns a pointer to the
+  // first element, or nullptr on absence or bounds failure.
+  const uint8_t* VecRaw(uint32_t field_index,
+                        uint32_t elem_size,
+                        uint32_t* count) const;
+
+  const uint8_t* buf_ = nullptr;
+  uint32_t buf_size_ = 0;
+  const uint8_t* table_ = nullptr;
+};
+
+}  // namespace perfetto::trace_processor::util
+
+#endif  // SRC_TRACE_PROCESSOR_UTIL_FLATBUFFER_READER_H_

--- a/src/trace_processor/util/flatbuffer_reader.h
+++ b/src/trace_processor/util/flatbuffer_reader.h
@@ -47,7 +47,7 @@ namespace perfetto::trace_processor::util {
 
 // A typed view over a vector of inline scalars (or packed structs) in a
 // flatbuffer. The whole extent [data, data + size * sizeof(T)) is validated
-// at creation, so operator[] needs no further checks.
+// at creation; out-of-range indices read back as a default-constructed T.
 template <typename T>
 class FlatBufferScalarVec {
  public:
@@ -58,8 +58,11 @@ class FlatBufferScalarVec {
   uint32_t size() const { return size_; }
 
   T operator[](uint32_t i) const {
+    if (PERFETTO_UNLIKELY(i >= size_)) {
+      return T{};
+    }
     T v;
-    memcpy(&v, data_ + i * sizeof(T), sizeof(T));
+    memcpy(&v, data_ + static_cast<uint64_t>(i) * sizeof(T), sizeof(T));
     return v;
   }
 

--- a/src/trace_processor/util/flatbuffer_reader_unittest.cc
+++ b/src/trace_processor/util/flatbuffer_reader_unittest.cc
@@ -1,0 +1,395 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/flatbuffer_reader.h"
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "src/trace_processor/util/flatbuffer_writer.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::util {
+namespace {
+
+using W = FlatBufferWriter;
+
+std::vector<uint8_t> Build(W::Offset root, FlatBufferWriter& w) {
+  w.Finish(root);
+  return w.Release();
+}
+
+std::optional<FlatBufferReader> GetRoot(const std::vector<uint8_t>& buf) {
+  return FlatBufferReader::GetRoot(buf.data(),
+                                   static_cast<uint32_t>(buf.size()));
+}
+
+TEST(FlatBufferRoundTripTest, ScalarFields) {
+  FlatBufferWriter w;
+  w.StartTable();
+  w.FieldI32(0, 42);
+  w.FieldI16(1, 7);
+  w.FieldBool(2, true);
+  w.FieldU8(3, 200);
+  w.FieldI64(4, 0x123456789ABCDEF0LL);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  EXPECT_EQ(reader->Scalar<int32_t>(0), 42);
+  EXPECT_EQ(reader->Scalar<int16_t>(1), 7);
+  EXPECT_EQ(reader->Scalar<uint8_t>(2), 1);  // bool stored as u8.
+  EXPECT_EQ(reader->Scalar<uint8_t>(3), 200);
+  EXPECT_EQ(reader->Scalar<int64_t>(4), 0x123456789ABCDEF0LL);
+}
+
+// Regression test: EndTable() must survive a buffer grow between prepending
+// the soffset placeholder and patching it (the vtable prepend in between can
+// reallocate and shift the buffer contents).
+TEST(FlatBufferRoundTripTest, GrowDuringEndTable) {
+  for (uint32_t capacity = 4; capacity <= 64; capacity += 4) {
+    FlatBufferWriter w(capacity);
+    w.StartTable();
+    for (uint32_t i = 0; i < 24; i++) {
+      w.FieldI32(i, static_cast<int32_t>(i * 3));
+    }
+    auto root = w.EndTable();
+    auto buf = Build(root, w);
+
+    auto reader = GetRoot(buf);
+    ASSERT_TRUE(reader.has_value()) << "capacity " << capacity;
+    for (uint32_t i = 0; i < 24; i++) {
+      EXPECT_EQ(reader->Scalar<int32_t>(i), static_cast<int32_t>(i * 3))
+          << "capacity " << capacity << " field " << i;
+    }
+  }
+}
+
+TEST(FlatBufferRoundTripTest, AbsentFieldReturnsDefault) {
+  FlatBufferWriter w;
+  w.StartTable();
+  w.FieldI32(1, 55);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  EXPECT_EQ(reader->Scalar<int32_t>(0, -1), -1);
+  EXPECT_EQ(reader->Scalar<int32_t>(1), 55);
+  // Field index well beyond the vtable's extent is also absent.
+  EXPECT_EQ(reader->Scalar<int32_t>(50, -7), -7);
+}
+
+TEST(FlatBufferRoundTripTest, StringField) {
+  FlatBufferWriter w;
+  auto hello = w.WriteString("hello");
+  w.StartTable();
+  w.FieldOffset(0, hello);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  EXPECT_EQ(reader->String(0), "hello");
+}
+
+TEST(FlatBufferRoundTripTest, SubTable) {
+  FlatBufferWriter w;
+  w.StartTable();
+  w.FieldI32(0, 99);
+  auto child = w.EndTable();
+
+  w.StartTable();
+  w.FieldOffset(0, child);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  auto child_reader = reader->Table(0);
+  ASSERT_TRUE(child_reader);
+  EXPECT_EQ(child_reader.Scalar<int32_t>(0), 99);
+
+  // Absent sub-table is an invalid reader.
+  EXPECT_FALSE(reader->Table(5));
+}
+
+TEST(FlatBufferRoundTripTest, VecTable) {
+  FlatBufferWriter w;
+  w.StartTable();
+  w.FieldI32(0, 10);
+  auto c0 = w.EndTable();
+
+  w.StartTable();
+  w.FieldI32(0, 20);
+  auto c1 = w.EndTable();
+
+  W::Offset offs[] = {c0, c1};
+  auto vec = w.WriteVecOffsets(offs, 2);
+
+  w.StartTable();
+  w.FieldOffset(0, vec);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  auto tv = reader->VecTable(0);
+  ASSERT_EQ(tv.size(), 2u);
+  EXPECT_EQ(tv[0].Scalar<int32_t>(0), 10);
+  EXPECT_EQ(tv[1].Scalar<int32_t>(0), 20);
+}
+
+TEST(FlatBufferRoundTripTest, VecString) {
+  FlatBufferWriter w;
+  auto s0 = w.WriteString("alpha");
+  auto s1 = w.WriteString("beta");
+  W::Offset offs[] = {s0, s1};
+  auto vec = w.WriteVecOffsets(offs, 2);
+
+  w.StartTable();
+  w.FieldOffset(0, vec);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  auto sv = reader->VecString(0);
+  ASSERT_EQ(sv.size(), 2u);
+  EXPECT_EQ(sv[0], "alpha");
+  EXPECT_EQ(sv[1], "beta");
+}
+
+TEST(FlatBufferRoundTripTest, VecScalar) {
+  int32_t vals[] = {10, 20, 30};
+  FlatBufferWriter w;
+  auto vec_off = w.WriteVecStruct(vals, sizeof(int32_t), 3, alignof(int32_t));
+  w.StartTable();
+  w.FieldOffset(0, vec_off);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  auto sv = reader->VecScalar<int32_t>(0);
+  ASSERT_EQ(sv.size(), 3u);
+  EXPECT_EQ(sv[0], 10);
+  EXPECT_EQ(sv[1], 20);
+  EXPECT_EQ(sv[2], 30);
+}
+
+TEST(FlatBufferRoundTripTest, EmptyVec) {
+  FlatBufferWriter w;
+  auto vec = w.WriteVecOffsets(nullptr, 0);
+  w.StartTable();
+  w.FieldOffset(0, vec);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  EXPECT_EQ(reader->VecTable(0).size(), 0u);
+  EXPECT_EQ(reader->VecString(0).size(), 0u);
+  EXPECT_EQ(reader->VecScalar<int32_t>(0).size(), 0u);
+}
+
+TEST(FlatBufferRoundTripTest, GetRootTooSmall) {
+  uint8_t tiny[] = {0, 0};
+  EXPECT_FALSE(FlatBufferReader::GetRoot(tiny, sizeof(tiny)).has_value());
+  EXPECT_FALSE(FlatBufferReader::GetRoot(nullptr, 0).has_value());
+}
+
+// Simulate a minimal Arrow Schema: Schema { endianness: i16, fields: [Field] }
+// where Field { name: string, nullable: bool, type_type: u8 }.
+TEST(FlatBufferRoundTripTest, ArrowSchemaLike) {
+  FlatBufferWriter w;
+
+  auto name0 = w.WriteString("col_a");
+  auto name1 = w.WriteString("col_b");
+
+  w.StartTable();
+  w.FieldOffset(0, name0);
+  w.FieldBool(1, false);
+  w.FieldU8(2, 2);  // kTypeInt
+  auto field0 = w.EndTable();
+
+  w.StartTable();
+  w.FieldOffset(0, name1);
+  w.FieldBool(1, true);
+  w.FieldU8(2, 5);  // kTypeUtf8
+  auto field1 = w.EndTable();
+
+  W::Offset field_offs[] = {field0, field1};
+  auto fields_vec = w.WriteVecOffsets(field_offs, 2);
+
+  w.StartTable();
+  w.FieldI16(0, 0);  // little-endian
+  w.FieldOffset(1, fields_vec);
+  auto schema = w.EndTable();
+
+  auto buf = Build(schema, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  EXPECT_EQ(reader->Scalar<int16_t>(0), 0);
+
+  auto fields = reader->VecTable(1);
+  ASSERT_EQ(fields.size(), 2u);
+
+  EXPECT_EQ(fields[0].String(0), "col_a");
+  EXPECT_EQ(fields[0].Scalar<uint8_t>(1), 0);
+  EXPECT_EQ(fields[0].Scalar<uint8_t>(2), 2);
+
+  EXPECT_EQ(fields[1].String(0), "col_b");
+  EXPECT_EQ(fields[1].Scalar<uint8_t>(1), 1);
+  EXPECT_EQ(fields[1].Scalar<uint8_t>(2), 5);
+}
+
+// ---------------------------------------------------------------------------
+// Malformed / untrusted input tests.
+// ---------------------------------------------------------------------------
+
+TEST(FlatBufferMalformedTest, TruncatedBufferNeverCrashes) {
+  FlatBufferWriter w;
+  auto name0 = w.WriteString("col_a");
+  auto name1 = w.WriteString("col_b");
+
+  w.StartTable();
+  w.FieldOffset(0, name0);
+  w.FieldBool(1, false);
+  w.FieldU8(2, 2);
+  auto field0 = w.EndTable();
+
+  w.StartTable();
+  w.FieldOffset(0, name1);
+  w.FieldBool(1, true);
+  w.FieldU8(2, 5);
+  auto field1 = w.EndTable();
+
+  W::Offset field_offs[] = {field0, field1};
+  auto fields_vec = w.WriteVecOffsets(field_offs, 2);
+
+  w.StartTable();
+  w.FieldI16(0, 0);
+  w.FieldOffset(1, fields_vec);
+  auto schema = w.EndTable();
+
+  auto full = Build(schema, w);
+
+  // Truncate at every possible length and verify accessors return defaults
+  // rather than reading out of bounds (ASan/MSan builds will catch OOB
+  // accesses; here we also sanity check the returned values are inert).
+  for (uint32_t len = 0; len < full.size(); len++) {
+    auto reader = FlatBufferReader::GetRoot(full.data(), len);
+    if (!reader.has_value()) {
+      continue;
+    }
+    EXPECT_EQ(reader->Scalar<int32_t>(99, -1), -1);
+    auto fields = reader->VecTable(1);
+    for (uint32_t i = 0; i < fields.size(); i++) {
+      auto f = fields[i];
+      if (f) {
+        f.String(0);
+        f.Scalar<uint8_t>(1);
+      }
+    }
+    reader->String(5);
+    reader->Table(5);
+    reader->VecString(1);
+    reader->VecScalar<int32_t>(1);
+  }
+}
+
+TEST(FlatBufferMalformedTest, VecScalarHugeCountIsRejected) {
+  // Hand-craft a buffer: root offset -> table with one vtable field pointing
+  // at a "vector" whose declared count is enormous but the buffer itself is
+  // tiny. VecScalar must return an empty view, not read out of bounds.
+  //
+  // Layout (all offsets relative, little endian):
+  //   [0..4)   root offset -> table at offset 4
+  //   [4..8)   table soffset -> vtable at offset 8 (back from 4: 4-8=-4)
+  //   [8..12)  vtable: size=6, table_size=6
+  //   [12..14) vtable slot for field 0: offset 6 (points to table+6=10)
+  //   table field data at offset 10: u32 offset to the "vector"
+  //   vector location: count = 0xFFFFFFFF, no actual elements follow.
+  std::vector<uint8_t> buf(24, 0);
+  auto put_u32 = [&](uint32_t pos, uint32_t v) {
+    memcpy(buf.data() + pos, &v, 4);
+  };
+  auto put_u16 = [&](uint32_t pos, uint16_t v) {
+    memcpy(buf.data() + pos, &v, 2);
+  };
+  auto put_i32 = [&](uint32_t pos, int32_t v) {
+    memcpy(buf.data() + pos, &v, 4);
+  };
+
+  put_u32(0, 4);            // root offset: table at 4.
+  put_i32(4, -4);           // table soffset: vtable at 4-(-4)=8.
+  put_u16(8, 6);            // vtable_size.
+  put_u16(10, 6);           // table_size.
+  put_u16(12, 6);           // slot 0 -> table + 6 = offset 10.
+  put_u32(10, 20 - 10);     // field: relative offset to "vector" at 20.
+  put_u32(20, 0xFFFFFFFF);  // vector count: enormous, buffer ends at 24.
+
+  auto reader =
+      FlatBufferReader::GetRoot(buf.data(), static_cast<uint32_t>(buf.size()));
+  ASSERT_TRUE(reader.has_value());
+  auto sv = reader->VecScalar<int32_t>(0);
+  EXPECT_EQ(sv.size(), 0u);
+  auto tv = reader->VecTable(0);
+  EXPECT_EQ(tv.size(), 0u);
+  auto strv = reader->VecString(0);
+  EXPECT_EQ(strv.size(), 0u);
+}
+
+TEST(FlatBufferMalformedTest, OffsetPastEndIsRejected) {
+  // Same skeleton as above, but the field holds an offset that resolves
+  // past the end of the buffer entirely.
+  std::vector<uint8_t> buf(16, 0);
+  auto put_u32 = [&](uint32_t pos, uint32_t v) {
+    memcpy(buf.data() + pos, &v, 4);
+  };
+  auto put_u16 = [&](uint32_t pos, uint16_t v) {
+    memcpy(buf.data() + pos, &v, 2);
+  };
+  auto put_i32 = [&](uint32_t pos, int32_t v) {
+    memcpy(buf.data() + pos, &v, 4);
+  };
+
+  put_u32(0, 4);
+  put_i32(4, -4);
+  put_u16(8, 6);
+  put_u16(10, 6);
+  put_u16(12, 6);
+  // Field holds a relative offset that points miles past the 16-byte buffer.
+  put_u32(10, 0x7FFFFFFF);
+
+  auto reader =
+      FlatBufferReader::GetRoot(buf.data(), static_cast<uint32_t>(buf.size()));
+  ASSERT_TRUE(reader.has_value());
+  EXPECT_EQ(reader->String(0), "");
+  EXPECT_FALSE(reader->Table(0));
+  EXPECT_EQ(reader->VecScalar<int32_t>(0).size(), 0u);
+  EXPECT_EQ(reader->VecTable(0).size(), 0u);
+  EXPECT_EQ(reader->VecString(0).size(), 0u);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/flatbuffer_reader_unittest.cc
+++ b/src/trace_processor/util/flatbuffer_reader_unittest.cc
@@ -210,6 +210,65 @@ TEST(FlatBufferRoundTripTest, EmptyVec) {
   EXPECT_EQ(reader->VecScalar<int32_t>(0).size(), 0u);
 }
 
+TEST(FlatBufferRoundTripTest, VecIndexOutOfBoundsReturnsDefault) {
+  // Indexing any vector type at or past size() must return a default value,
+  // never read out of bounds. The last valid index still reads correctly.
+  int64_t i64s[] = {10, 20};
+  double f64s[] = {0.5, 1.5};
+  uint8_t u8s[] = {7};
+  FlatBufferWriter w;
+  auto i64_off = w.WriteVecStruct(i64s, sizeof(int64_t), 2, alignof(int64_t));
+  auto f64_off = w.WriteVecStruct(f64s, sizeof(double), 2, alignof(double));
+  auto u8_off = w.WriteVecStruct(u8s, sizeof(uint8_t), 1, alignof(uint8_t));
+  auto s0 = w.WriteString("only");
+  auto str_vec = w.WriteVecOffsets(&s0, 1);
+
+  w.StartTable();
+  w.FieldI32(0, 42);
+  auto c0 = w.EndTable();
+  auto tbl_vec = w.WriteVecOffsets(&c0, 1);
+
+  w.StartTable();
+  w.FieldOffset(0, i64_off);
+  w.FieldOffset(1, f64_off);
+  w.FieldOffset(2, u8_off);
+  w.FieldOffset(3, str_vec);
+  w.FieldOffset(4, tbl_vec);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+
+  auto i64v = reader->VecScalar<int64_t>(0);
+  ASSERT_EQ(i64v.size(), 2u);
+  EXPECT_EQ(i64v[1], 20);
+  EXPECT_EQ(i64v[2], 0);
+  EXPECT_EQ(i64v[0xFFFFFFFF], 0);
+
+  auto f64v = reader->VecScalar<double>(1);
+  ASSERT_EQ(f64v.size(), 2u);
+  EXPECT_DOUBLE_EQ(f64v[1], 1.5);
+  EXPECT_DOUBLE_EQ(f64v[2], 0.0);
+
+  auto u8v = reader->VecScalar<uint8_t>(2);
+  ASSERT_EQ(u8v.size(), 1u);
+  EXPECT_EQ(u8v[0], 7);
+  EXPECT_EQ(u8v[1], 0);
+
+  auto strv = reader->VecString(3);
+  ASSERT_EQ(strv.size(), 1u);
+  EXPECT_EQ(strv[0], "only");
+  EXPECT_EQ(strv[1], "");
+  EXPECT_EQ(strv[0xFFFFFFFF], "");
+
+  auto tv = reader->VecTable(4);
+  ASSERT_EQ(tv.size(), 1u);
+  EXPECT_EQ(tv[0].Scalar<int32_t>(0), 42);
+  EXPECT_FALSE(tv[1]);
+  EXPECT_FALSE(tv[0xFFFFFFFF]);
+}
+
 TEST(FlatBufferRoundTripTest, GetRootTooSmall) {
   uint8_t tiny[] = {0, 0};
   EXPECT_FALSE(FlatBufferReader::GetRoot(tiny, sizeof(tiny)).has_value());

--- a/src/trace_processor/util/flatbuffer_writer.cc
+++ b/src/trace_processor/util/flatbuffer_writer.cc
@@ -19,8 +19,12 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <string_view>
 #include <vector>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
 
 namespace perfetto::trace_processor::util {
 
@@ -44,7 +48,7 @@ void FlatBufferWriter::GrowIfNeeded(uint32_t bytes) {
 
 void FlatBufferWriter::Align(uint32_t alignment) {
   min_align_ = std::max(min_align_, alignment);
-  uint32_t pad = (alignment - (GetSize() % alignment)) % alignment;
+  uint32_t pad = (alignment - (size() % alignment)) % alignment;
   GrowIfNeeded(pad);
   for (uint32_t i = 0; i < pad; i++) {
     buf_[--head_] = 0;
@@ -66,7 +70,7 @@ FlatBufferWriter::Offset FlatBufferWriter::WriteString(std::string_view s) {
   // sized so that the LENGTH PREFIX (not the string tail) ends up 4-byte
   // aligned once the terminator and characters have been prepended.
   auto n = static_cast<uint32_t>(s.size());
-  uint32_t pad = (4 - ((GetSize() + n + 1) % 4)) % 4;
+  uint32_t pad = (4 - ((size() + n + 1) % 4)) % 4;
   GrowIfNeeded(pad);
   for (uint32_t i = 0; i < pad; i++) {
     buf_[--head_] = 0;
@@ -74,7 +78,7 @@ FlatBufferWriter::Offset FlatBufferWriter::WriteString(std::string_view s) {
   Prepend<uint8_t>(0);
   PrependBytes(s.data(), n);
   Prepend<uint32_t>(n);
-  return Offset{GetSize()};
+  return Offset{size()};
 }
 
 // ---------------------------------------------------------------------------
@@ -88,11 +92,11 @@ FlatBufferWriter::Offset FlatBufferWriter::WriteVecOffsets(
   for (int32_t i = static_cast<int32_t>(count) - 1; i >= 0; i--) {
     Align(sizeof(uint32_t));
     // Relative offset: from the slot position to the target.
-    uint32_t stored = GetSize() + sizeof(uint32_t) - offsets[i].o;
+    uint32_t stored = size() + sizeof(uint32_t) - offsets[i].o;
     Prepend(stored);
   }
   Prepend<uint32_t>(count);
-  return Offset{GetSize()};
+  return Offset{size()};
 }
 
 FlatBufferWriter::Offset FlatBufferWriter::WriteVecStruct(const void* data,
@@ -102,7 +106,7 @@ FlatBufferWriter::Offset FlatBufferWriter::WriteVecStruct(const void* data,
   Align(elem_align);
   PrependBytes(data, elem_size * count);
   Prepend<uint32_t>(count);
-  return Offset{GetSize()};
+  return Offset{size()};
 }
 
 // ---------------------------------------------------------------------------
@@ -110,46 +114,46 @@ FlatBufferWriter::Offset FlatBufferWriter::WriteVecStruct(const void* data,
 // ---------------------------------------------------------------------------
 
 void FlatBufferWriter::StartTable() {
-  table_body_start_ = GetSize();
+  table_body_start_ = size();
   fields_.clear();
 }
 
 void FlatBufferWriter::FieldBool(uint32_t index, bool val) {
   Align(sizeof(uint8_t));
   Prepend<uint8_t>(val ? 1 : 0);
-  fields_.push_back({index, GetSize()});
+  fields_.push_back({index, size()});
 }
 
 void FlatBufferWriter::FieldU8(uint32_t index, uint8_t val) {
   Align(sizeof(uint8_t));
   Prepend(val);
-  fields_.push_back({index, GetSize()});
+  fields_.push_back({index, size()});
 }
 
 void FlatBufferWriter::FieldI16(uint32_t index, int16_t val) {
   Align(sizeof(int16_t));
   Prepend(val);
-  fields_.push_back({index, GetSize()});
+  fields_.push_back({index, size()});
 }
 
 void FlatBufferWriter::FieldI32(uint32_t index, int32_t val) {
   Align(sizeof(int32_t));
   Prepend(val);
-  fields_.push_back({index, GetSize()});
+  fields_.push_back({index, size()});
 }
 
 void FlatBufferWriter::FieldI64(uint32_t index, int64_t val) {
   Align(sizeof(int64_t));
   Prepend(val);
-  fields_.push_back({index, GetSize()});
+  fields_.push_back({index, size()});
 }
 
 void FlatBufferWriter::FieldOffset(uint32_t index, Offset off) {
   Align(sizeof(uint32_t));
   // Relative offset from the slot position to the target.
-  uint32_t stored = GetSize() + sizeof(uint32_t) - off.o;
+  uint32_t stored = size() + sizeof(uint32_t) - off.o;
   Prepend(stored);
-  fields_.push_back({index, GetSize()});
+  fields_.push_back({index, size()});
 }
 
 FlatBufferWriter::Offset FlatBufferWriter::EndTable() {
@@ -159,7 +163,7 @@ FlatBufferWriter::Offset FlatBufferWriter::EndTable() {
   // all data and invalidates absolute indices.
   Align(sizeof(int32_t));
   Prepend<int32_t>(0);
-  uint32_t table_off = GetSize();
+  uint32_t table_off = size();
 
   uint32_t max_index = 0;
   for (const auto& f : fields_) {
@@ -168,6 +172,15 @@ FlatBufferWriter::Offset FlatBufferWriter::EndTable() {
   uint32_t num_slots = fields_.empty() ? 0 : max_index + 1;
   uint32_t vtable_size = 4 + num_slots * 2;
   uint32_t table_size = table_off - table_body_start_;
+
+  // Every vtable entry below is bounded by table_size, so this single check
+  // covers all of them as well as the table_size entry itself.
+  if (PERFETTO_UNLIKELY(table_size > std::numeric_limits<uint16_t>::max())) {
+    PERFETTO_ELOG(
+        "FlatBufferWriter: table size %u overflows the 16-bit vtable "
+        "encoding; the resulting buffer will be corrupt",
+        table_size);
+  }
 
   // Each vtable entry is the byte offset from the table start (soffset
   // position) to the field data. 0 means "not present".
@@ -184,7 +197,7 @@ FlatBufferWriter::Offset FlatBufferWriter::EndTable() {
   }
   Prepend(static_cast<uint16_t>(table_size));
   Prepend(static_cast<uint16_t>(vtable_size));
-  uint32_t vtable_off = GetSize();
+  uint32_t vtable_off = size();
 
   // Patch soffset: signed offset from the table to its vtable, i.e. the
   // reader computes vtable = table - soffset.
@@ -204,13 +217,13 @@ void FlatBufferWriter::Finish(Offset root) {
   // alignment used. All element positions are aligned relative to the
   // buffer end; an aligned total size makes them aligned relative to the
   // buffer start as well.
-  uint32_t total = GetSize() + sizeof(uint32_t);
+  uint32_t total = size() + sizeof(uint32_t);
   uint32_t pad = (min_align_ - (total % min_align_)) % min_align_;
   GrowIfNeeded(pad);
   for (uint32_t i = 0; i < pad; i++) {
     buf_[--head_] = 0;
   }
-  uint32_t stored = GetSize() + sizeof(uint32_t) - root.o;
+  uint32_t stored = size() + sizeof(uint32_t) - root.o;
   Prepend(stored);
 }
 

--- a/src/trace_processor/util/flatbuffer_writer.cc
+++ b/src/trace_processor/util/flatbuffer_writer.cc
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/flatbuffer_writer.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <vector>
+
+namespace perfetto::trace_processor::util {
+
+FlatBufferWriter::FlatBufferWriter(uint32_t initial_capacity)
+    : buf_(initial_capacity, 0), head_(initial_capacity) {}
+
+void FlatBufferWriter::GrowIfNeeded(uint32_t bytes) {
+  if (head_ >= bytes) {
+    return;
+  }
+  uint32_t old_size = static_cast<uint32_t>(buf_.size());
+  uint32_t new_size = std::max(old_size * 2, old_size + bytes);
+  buf_.resize(new_size, 0);
+  // Shift existing data to the end of the new buffer.
+  uint32_t data_len = old_size - head_;
+  uint32_t new_head = new_size - data_len;
+  memmove(&buf_[new_head], &buf_[head_], data_len);
+  memset(&buf_[head_], 0, new_head - head_);
+  head_ = new_head;
+}
+
+void FlatBufferWriter::Align(uint32_t alignment) {
+  min_align_ = std::max(min_align_, alignment);
+  uint32_t pad = (alignment - (GetSize() % alignment)) % alignment;
+  GrowIfNeeded(pad);
+  for (uint32_t i = 0; i < pad; i++) {
+    buf_[--head_] = 0;
+  }
+}
+
+void FlatBufferWriter::PrependBytes(const void* src, uint32_t len) {
+  GrowIfNeeded(len);
+  head_ -= len;
+  memcpy(&buf_[head_], src, len);
+}
+
+// ---------------------------------------------------------------------------
+// Strings
+// ---------------------------------------------------------------------------
+
+FlatBufferWriter::Offset FlatBufferWriter::WriteString(std::string_view s) {
+  // Final buffer layout: [u32 len][chars...][null][pad]. The padding must be
+  // sized so that the LENGTH PREFIX (not the string tail) ends up 4-byte
+  // aligned once the terminator and characters have been prepended.
+  auto n = static_cast<uint32_t>(s.size());
+  uint32_t pad = (4 - ((GetSize() + n + 1) % 4)) % 4;
+  GrowIfNeeded(pad);
+  for (uint32_t i = 0; i < pad; i++) {
+    buf_[--head_] = 0;
+  }
+  Prepend<uint8_t>(0);
+  PrependBytes(s.data(), n);
+  Prepend<uint32_t>(n);
+  return Offset{GetSize()};
+}
+
+// ---------------------------------------------------------------------------
+// Vectors
+// ---------------------------------------------------------------------------
+
+FlatBufferWriter::Offset FlatBufferWriter::WriteVecOffsets(
+    const Offset* offsets,
+    uint32_t count) {
+  // Elements are written back-to-front (last element first).
+  for (int32_t i = static_cast<int32_t>(count) - 1; i >= 0; i--) {
+    Align(sizeof(uint32_t));
+    // Relative offset: from the slot position to the target.
+    uint32_t stored = GetSize() + sizeof(uint32_t) - offsets[i].o;
+    Prepend(stored);
+  }
+  Prepend<uint32_t>(count);
+  return Offset{GetSize()};
+}
+
+FlatBufferWriter::Offset FlatBufferWriter::WriteVecStruct(const void* data,
+                                                          uint32_t elem_size,
+                                                          uint32_t count,
+                                                          uint32_t elem_align) {
+  Align(elem_align);
+  PrependBytes(data, elem_size * count);
+  Prepend<uint32_t>(count);
+  return Offset{GetSize()};
+}
+
+// ---------------------------------------------------------------------------
+// Tables
+// ---------------------------------------------------------------------------
+
+void FlatBufferWriter::StartTable() {
+  table_body_start_ = GetSize();
+  fields_.clear();
+}
+
+void FlatBufferWriter::FieldBool(uint32_t index, bool val) {
+  Align(sizeof(uint8_t));
+  Prepend<uint8_t>(val ? 1 : 0);
+  fields_.push_back({index, GetSize()});
+}
+
+void FlatBufferWriter::FieldU8(uint32_t index, uint8_t val) {
+  Align(sizeof(uint8_t));
+  Prepend(val);
+  fields_.push_back({index, GetSize()});
+}
+
+void FlatBufferWriter::FieldI16(uint32_t index, int16_t val) {
+  Align(sizeof(int16_t));
+  Prepend(val);
+  fields_.push_back({index, GetSize()});
+}
+
+void FlatBufferWriter::FieldI32(uint32_t index, int32_t val) {
+  Align(sizeof(int32_t));
+  Prepend(val);
+  fields_.push_back({index, GetSize()});
+}
+
+void FlatBufferWriter::FieldI64(uint32_t index, int64_t val) {
+  Align(sizeof(int64_t));
+  Prepend(val);
+  fields_.push_back({index, GetSize()});
+}
+
+void FlatBufferWriter::FieldOffset(uint32_t index, Offset off) {
+  Align(sizeof(uint32_t));
+  // Relative offset from the slot position to the target.
+  uint32_t stored = GetSize() + sizeof(uint32_t) - off.o;
+  Prepend(stored);
+  fields_.push_back({index, GetSize()});
+}
+
+FlatBufferWriter::Offset FlatBufferWriter::EndTable() {
+  // Prepend the soffset placeholder (patched below once the vtable position
+  // is known). Its position must be tracked as an offset from the end of the
+  // buffer: prepending the vtable below may grow the buffer, which shifts
+  // all data and invalidates absolute indices.
+  Align(sizeof(int32_t));
+  Prepend<int32_t>(0);
+  uint32_t table_off = GetSize();
+
+  uint32_t max_index = 0;
+  for (const auto& f : fields_) {
+    max_index = std::max(max_index, f.index);
+  }
+  uint32_t num_slots = fields_.empty() ? 0 : max_index + 1;
+  uint32_t vtable_size = 4 + num_slots * 2;
+  uint32_t table_size = table_off - table_body_start_;
+
+  // Each vtable entry is the byte offset from the table start (soffset
+  // position) to the field data. 0 means "not present".
+  std::vector<uint16_t> vt_entries(num_slots, 0);
+  for (const auto& f : fields_) {
+    vt_entries[f.index] = static_cast<uint16_t>(table_off - f.off_from_end);
+  }
+
+  // Prepend the vtable back-to-front: entries (last first), table_size,
+  // vtable_size.
+  Align(sizeof(uint16_t));
+  for (int32_t i = static_cast<int32_t>(num_slots) - 1; i >= 0; i--) {
+    Prepend(vt_entries[static_cast<uint32_t>(i)]);
+  }
+  Prepend(static_cast<uint16_t>(table_size));
+  Prepend(static_cast<uint16_t>(vtable_size));
+  uint32_t vtable_off = GetSize();
+
+  // Patch soffset: signed offset from the table to its vtable, i.e. the
+  // reader computes vtable = table - soffset.
+  auto soff = static_cast<int32_t>(vtable_off - table_off);
+  memcpy(&buf_[static_cast<uint32_t>(buf_.size()) - table_off], &soff,
+         sizeof(int32_t));
+
+  return Offset{table_off};
+}
+
+// ---------------------------------------------------------------------------
+// Finalize
+// ---------------------------------------------------------------------------
+
+void FlatBufferWriter::Finish(Offset root) {
+  // Pad so that the finished buffer's size is a multiple of the largest
+  // alignment used. All element positions are aligned relative to the
+  // buffer end; an aligned total size makes them aligned relative to the
+  // buffer start as well.
+  uint32_t total = GetSize() + sizeof(uint32_t);
+  uint32_t pad = (min_align_ - (total % min_align_)) % min_align_;
+  GrowIfNeeded(pad);
+  for (uint32_t i = 0; i < pad; i++) {
+    buf_[--head_] = 0;
+  }
+  uint32_t stored = GetSize() + sizeof(uint32_t) - root.o;
+  Prepend(stored);
+}
+
+std::vector<uint8_t> FlatBufferWriter::Release() {
+  std::vector<uint8_t> result(buf_.begin() + head_, buf_.end());
+  buf_.clear();
+  head_ = 0;
+  return result;
+}
+
+}  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/flatbuffer_writer.h
+++ b/src/trace_processor/util/flatbuffer_writer.h
@@ -111,10 +111,6 @@ class FlatBufferWriter {
     memcpy(&buf_[head_], &val, sizeof(T));
   }
 
-  uint32_t GetSize() const {
-    return static_cast<uint32_t>(buf_.size()) - head_;
-  }
-
   std::vector<uint8_t> buf_;
   uint32_t head_ = 0;
   // Largest alignment any element requested. Element positions are aligned

--- a/src/trace_processor/util/flatbuffer_writer.h
+++ b/src/trace_processor/util/flatbuffer_writer.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_UTIL_FLATBUFFER_WRITER_H_
+#define SRC_TRACE_PROCESSOR_UTIL_FLATBUFFER_WRITER_H_
+
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <vector>
+
+namespace perfetto::trace_processor::util {
+
+// Minimal FlatBuffer writer. Builds a valid flatbuffer back-to-front (the
+// standard approach) so all offsets are naturally forward-pointing.
+//
+// Exists so trace processor can emit small flatbuffer-encoded metadata (e.g.
+// Arrow IPC framing) without depending on the flatbuffers library.
+//
+// Usage:
+//   FlatBufferWriter w;
+//   auto name = w.WriteString("hello");
+//   w.StartTable();
+//   w.FieldOffset(0, name);
+//   w.FieldI32(1, 42);
+//   auto root = w.EndTable();
+//   w.Finish(root);
+//   auto buf = w.Release();
+//
+// Buffers produced by this writer can be parsed by
+// FlatBufferReader::GetRoot() (see flatbuffer_reader.h).
+class FlatBufferWriter {
+ public:
+  // Opaque handle to a previously written object's position, expressed as
+  // "bytes from the end of the buffer".
+  struct Offset {
+    uint32_t o = 0;
+  };
+
+  explicit FlatBufferWriter(uint32_t initial_capacity = 256);
+
+  // Writes a length-prefixed UTF-8 string. Returns an offset handle.
+  Offset WriteString(std::string_view s);
+
+  // Writes a vector of offset elements (for vectors of tables or strings).
+  Offset WriteVecOffsets(const Offset* offsets, uint32_t count);
+
+  // Writes a vector of inline structs. |data| points to |count| packed
+  // structs of |elem_size| bytes each, aligned to |elem_align|.
+  Offset WriteVecStruct(const void* data,
+                        uint32_t elem_size,
+                        uint32_t count,
+                        uint32_t elem_align);
+
+  // Begins building a table. All Field* calls between StartTable/EndTable add
+  // fields to this table. Tables cannot be nested: finish the child table
+  // first, then reference it via FieldOffset.
+  void StartTable();
+
+  // Adds scalar fields to the table under construction.
+  void FieldBool(uint32_t index, bool val);
+  void FieldU8(uint32_t index, uint8_t val);
+  void FieldI16(uint32_t index, int16_t val);
+  void FieldI32(uint32_t index, int32_t val);
+  void FieldI64(uint32_t index, int64_t val);
+
+  // Adds an offset field (string, sub-table, or vector).
+  void FieldOffset(uint32_t index, Offset off);
+
+  // Finishes the current table. Returns an offset handle.
+  Offset EndTable();
+
+  // Finalizes the buffer by writing the root table offset prefix.
+  void Finish(Offset root);
+
+  // Access the finished buffer.
+  const uint8_t* data() const { return buf_.data() + head_; }
+  uint32_t size() const { return static_cast<uint32_t>(buf_.size()) - head_; }
+
+  // Takes ownership of the finished buffer as a tight vector.
+  std::vector<uint8_t> Release();
+
+ private:
+  // Ensures at least |bytes| of space is available before head_.
+  void GrowIfNeeded(uint32_t bytes);
+
+  // Pads so that the current written size is a multiple of |alignment|.
+  void Align(uint32_t alignment);
+
+  // Prepends raw bytes (order preserved in the final buffer).
+  void PrependBytes(const void* src, uint32_t len);
+
+  // Prepends a single scalar value.
+  template <typename T>
+  void Prepend(T val) {
+    GrowIfNeeded(sizeof(T));
+    head_ -= sizeof(T);
+    memcpy(&buf_[head_], &val, sizeof(T));
+  }
+
+  uint32_t GetSize() const {
+    return static_cast<uint32_t>(buf_.size()) - head_;
+  }
+
+  std::vector<uint8_t> buf_;
+  uint32_t head_ = 0;
+  // Largest alignment any element requested. Element positions are aligned
+  // relative to the buffer end, so Finish() pads the total size to a
+  // multiple of this to make them aligned relative to the start too (which
+  // is what strict flatbuffers verifiers check).
+  uint32_t min_align_ = 4;
+
+  // State for the table currently being built.
+  uint32_t table_body_start_ = 0;
+  struct FieldLoc {
+    uint32_t index;
+    uint32_t off_from_end;
+  };
+  std::vector<FieldLoc> fields_;
+};
+
+}  // namespace perfetto::trace_processor::util
+
+#endif  // SRC_TRACE_PROCESSOR_UTIL_FLATBUFFER_WRITER_H_


### PR DESCRIPTION
Trace processor needs to emit and parse small flatbuffer-encoded
metadata (Arrow IPC framing) without taking a dependency on the
flatbuffers library, which would have to be vendored for every
embedder including the Wasm and Android builds.

The writer builds buffers back-to-front so offsets are naturally
forward-pointing. It tracks the maximum requested alignment and pads
the final size to a multiple of it: element positions are aligned
relative to the buffer end, so an aligned total size is what makes
them aligned relative to the start, which is what strict flatbuffers
verifiers check. String length prefixes are padded the same way.

The reader is designed for untrusted input: every table, vtable,
string and vector access is bounds-checked in 64-bit offset arithmetic
and malformed or absent data uniformly reads back as defaults.
