### PR TITLE
tp: add flags_enum annotation to broadcast_type

### DIFF
--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
@@ -583,7 +583,8 @@ message AndroidBroadcastEvent {
   optional PackageStoppedState package_stopped_state = 11;
 
   // The type of the broadcast. It's a mask of BroadcastType.
-  optional int32 broadcast_type = 12;
+  optional int32 broadcast_type = 12
+      [(perfetto.protos.flags_enum) = ".com.android.internal.BroadcastType"];
 
   // Delivery group policy set for the broadcast.
   optional BroadcastDeliveryGroupPolicy delivery_group_policy = 13;


### PR DESCRIPTION
This updates `frameworks_base_track_event.proto` to add the `.com.android.internal.BroadcastType` proto flags_enum annotation to the `broadcast_type` field. 
