### PR TITLE
tp: fix perfetto_unittests failures on Fuchsia

### DIFF
--- a/src/trace_processor/shell/shell_utils_unittest.cc
+++ b/src/trace_processor/shell/shell_utils_unittest.cc
@@ -24,8 +24,10 @@
 #include <string>
 
 #include "perfetto/base/build_config.h"
+#include "perfetto/base/status.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/temp_file.h"
+#include "perfetto/ext/base/utils.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "perfetto/trace_processor/trace_processor.h"
 #include "test/gtest_and_gmock.h"
@@ -68,6 +70,18 @@ std::string MakeAttachUri(const std::string& path) {
 // by a standalone SQLite connection and re-attached and queried by a trace
 // processor.
 TEST(ShellUtilsTest, ExportTraceToDatabaseWritesToDisk) {
+  // trace_processor_shell is not supported on Fuchsia, where attaching through
+  // the OS-backed SQLite VFS fails.
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_FUCHSIA)
+  GTEST_SKIP() << "on-disk SQLite databases are not supported";
+#endif
+
+  base::TempDir dir = base::TempDir::Create();
+  std::string output = dir.path() + "/export.db";
+
+  auto remove_output =
+      base::OnScopeExit([&output] { base::Unlink(output.c_str()); });
+
   auto tp = TraceProcessor::CreateInstance(Config());
 
   int64_t expected_tables = ScalarCount(tp.get(),
@@ -76,10 +90,8 @@ TEST(ShellUtilsTest, ExportTraceToDatabaseWritesToDisk) {
   int64_t expected_views = ScalarCount(
       tp.get(), "SELECT COUNT(*) FROM sqlite_master WHERE type='view'");
 
-  base::TempDir dir = base::TempDir::Create();
-  std::string output = dir.path() + "/export.db";
-
-  ASSERT_TRUE(ExportTraceToDatabase(tp.get(), output).ok());
+  base::Status export_status = ExportTraceToDatabase(tp.get(), output);
+  ASSERT_TRUE(export_status.ok()) << export_status.c_message();
 
   std::string contents;
   ASSERT_TRUE(base::ReadFile(output, &contents));
@@ -118,8 +130,6 @@ TEST(ShellUtilsTest, ExportTraceToDatabaseWritesToDisk) {
       ScalarCount(reloaded.get(), "SELECT COUNT(*) FROM reimported." + table),
       ScalarCount(tp.get(), "SELECT COUNT(*) FROM " + table));
   reloaded.reset();
-
-  base::Unlink(output.c_str());
 }
 
 }  // namespace

--- a/src/trace_redaction/trace_redactor.cc
+++ b/src/trace_redaction/trace_redactor.cc
@@ -25,6 +25,7 @@
 #include "perfetto/ext/base/scoped_file.h"
 #include "perfetto/ext/base/scoped_mmap.h"
 #include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
 #include "perfetto/trace_processor/trace_blob.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
@@ -54,6 +55,25 @@ namespace perfetto::trace_redaction {
 using Trace = protos::pbzero::Trace;
 using TracePacket = protos::pbzero::TracePacket;
 
+namespace {
+
+base::StatusOr<trace_processor::TraceBlob> LoadTrace(const std::string& path) {
+#if PERFETTO_HAS_MMAP()
+  base::ScopedMmap mapped = base::ReadMmapWholeFile(path);
+  if (mapped.IsValid()) {
+    return trace_processor::TraceBlob::FromMmap(std::move(mapped));
+  }
+#endif
+  std::string contents;
+  if (!base::ReadFile(path, &contents)) {
+    return base::ErrStatus("TraceRedactor: failed to read trace (%s)",
+                           path.c_str());
+  }
+  return trace_processor::TraceBlob::CopyFrom(contents.data(), contents.size());
+}
+
+}  // namespace
+
 TraceRedactor::TraceRedactor() = default;
 
 TraceRedactor::~TraceRedactor() = default;
@@ -62,14 +82,9 @@ base::Status TraceRedactor::Redact(std::string_view source_filename,
                                    std::string_view dest_filename,
                                    Context* context) const {
   const std::string source_filename_str(source_filename);
-  base::ScopedMmap mapped = base::ReadMmapWholeFile(source_filename_str);
-  if (!mapped.IsValid()) {
-    return base::ErrStatus("TraceRedactor: failed to map pages for trace (%s)",
-                           source_filename_str.c_str());
-  }
-
-  trace_processor::TraceBlobView whole_view(
-      trace_processor::TraceBlob::FromMmap(std::move(mapped)));
+  ASSIGN_OR_RETURN(trace_processor::TraceBlob blob,
+                   LoadTrace(source_filename_str));
+  trace_processor::TraceBlobView whole_view(std::move(blob));
 
   RETURN_IF_ERROR(Collect(context, whole_view));
 


### PR DESCRIPTION
base::ScopedMmap has no implementation outside Linux/Android/FreeBSD/Apple/ Windows, so on Fuchsia TraceRedactor::Redact() bailed out on every trace with "failed to map pages". Load the trace through a helper that falls back on base::ReadFile() when PERFETTO_HAS_MMAP() is 0 or the mapping fails, mirroring what ReadTraceUnfinalized() does.

ShellUtilsTest.ExportTraceToDatabaseWritesToDisk attaches an on-disk SQLite database, which fails on Fuchsia; skip it there. Also unlink the exported file on every path out of the test: gtest returns early on a failed assertion, which left the file behind and made ~TempDir() CHECK on a non-empty directory, taking down the whole test binary. 

Bug: 536803974