### PR TITLE
perfetto: allow mmapping files that others have open for writing

### DIFF
--- a/src/base/scoped_mmap.cc
+++ b/src/base/scoped_mmap.cc
@@ -42,9 +42,14 @@ ScopedPlatformHandle OpenFileForMmap(const std::string& file_path) {
   return OpenFile(file_path, O_RDONLY);
 #elif PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
   // This does not use base::OpenFile to avoid getting an exclusive lock.
+  //
+  // The share flags mirror the POSIX open(O_RDONLY) above, which has no notion
+  // of share modes. Same flags as LLVM's openNativeFileInternal():
+  // https://github.com/llvm/llvm-project/blob/main/llvm/lib/Support/Windows/Path.inc
   return ScopedPlatformHandle(
-      CreateFileA(file_path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
-                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+      CreateFileA(file_path.c_str(), GENERIC_READ,
+                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                  nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
 #else
   // mmap is not supported. Do not even open the file.
   base::ignore_result(file_path);

--- a/src/base/scoped_mmap_unittest.cc
+++ b/src/base/scoped_mmap_unittest.cc
@@ -24,6 +24,7 @@
 #endif
 
 #include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/temp_file.h"
 #include "src/base/test/tmp_dir_tree.h"
 #include "test/gtest_and_gmock.h"
 
@@ -66,6 +67,19 @@ TEST_F(ScopedMmapTest, WholeOneByteFile) {
   ASSERT_TRUE(mapped.IsValid());
   ASSERT_NE(mapped.data(), nullptr);
   ASSERT_EQ(mapped.length(), 1u);
+  EXPECT_EQ(*static_cast<char*>(mapped.data()), 'c');
+}
+
+// base::TempFile keeps the file open for writing, which used to make the
+// mapping fail on Windows.
+TEST_F(ScopedMmapTest, WholeFileHeldOpenForWriting) {
+  TempFile file = TempFile::Create();
+  ASSERT_EQ(WriteAll(file.fd(), "ccccc", 5), 5);
+
+  ScopedMmap mapped = ReadMmapWholeFile(file.path());
+
+  ASSERT_TRUE(mapped.IsValid());
+  ASSERT_EQ(mapped.length(), 5u);
   EXPECT_EQ(*static_cast<char*>(mapped.data()), 'c');
 }
 


### PR DESCRIPTION
On Windows, OpenFileForMmap() passed FILE_SHARE_READ only, so CreateFileA failed with ERROR_SHARING_VIOLATION whenever another handle had the file open with GENERIC_WRITE. That is stricter than the POSIX open(O_RDONLY) this is meant to mirror, and it means a trace file still held open by its writer cannot be mapped at all: callers either fail outright, as TraceRedactor does, or silently degrade to read(), as ReadTraceUnfinalized does.
