### PR TITLE
tools: fix trace_video_conv on ring-buffer traces

### DIFF
--- a/python/tools/trace_video_conv.py
+++ b/python/tools/trace_video_conv.py
@@ -184,9 +184,9 @@ def select_range(frames, start_ts, end_ts):
 
 
 def build_stream(config, frames):
-  # Frames are Annex-B access units (already start-code delimited), so the
-  # elementary stream is the config (SPS/PPS) followed by the frames.
-  return b''.join(f.data for f in config + frames)
+  # The config (SPS/PPS) is re-emitted before every key frame; one copy is
+  # enough, and stacking them all makes libav reject the stream.
+  return b''.join(f.data for f in config[:1] + frames)
 
 
 def load_clip(bin_path, trace, clip):


### PR DESCRIPTION
Latest android builds re-emits the codec config (SPS/PPS) before every key frame, so build_stream stacked every copy at the front of the elementary stream and libav rejected it. Prepend only one.
