### PR TITLE
ui: filter debug track columns and expose arg_set_id in slices

### DIFF
--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -45,6 +45,7 @@ import type {DataGridApi} from './widgets/datagrid/datagrid';
 import {ExportButton} from '../widgets/export_button';
 import {SerialTaskQueue} from '../base/query_slot';
 import type {ColumnSchema} from './widgets/datagrid/datagrid_schema';
+import {ensureExists} from '../base/assert';
 
 export interface AggregationData {
   readonly tableName: string;
@@ -325,6 +326,8 @@ export function createAggregationTab(
           dataSource,
           gridConfig: aggregator.getGridConfig(),
           barChartData: data?.barChartData,
+          trace,
+          query: `SELECT * FROM ${ensureExists(data).tableName}`,
           onReady: (api: DataGridApi) => {
             dataGridApi = api;
           },

--- a/ui/src/components/aggregation_panel.ts
+++ b/ui/src/components/aggregation_panel.ts
@@ -14,8 +14,12 @@
 
 import m from 'mithril';
 import {Duration} from '../base/time';
+import type {Trace} from '../public/trace';
 import type {SqlValue} from '../trace_processor/query_result';
+import {AddDebugTrackMenu} from './tracks/add_debug_track_menu';
 import {Box} from '../widgets/box';
+import {Button} from '../widgets/button';
+import {Popup, PopupPosition} from '../widgets/popup';
 import {Stack, StackAuto, StackFixed} from '../widgets/stack';
 import type {BarChartData} from './aggregation';
 import {
@@ -25,12 +29,12 @@ import {
 } from './widgets/datagrid/datagrid';
 import {defaultValueFormatter} from './widgets/datagrid/export_utils';
 import type {AggregatorGridConfig, DataGridState} from './aggregation_adapter';
+import {getDefaultVisibleColumns} from './widgets/datagrid/datagrid_schema';
 import type {
   CellRenderer,
   ColumnType,
 } from './widgets/datagrid/datagrid_schema';
 import type {DataSource} from './widgets/datagrid/data_source';
-import {Button} from '../widgets/button';
 import {Icons} from '../base/semantic_icons';
 
 export interface AggregationPanelAttrs {
@@ -41,6 +45,8 @@ export interface AggregationPanelAttrs {
   readonly dataGridState?: DataGridState;
   readonly onClearGridState?: () => void;
   readonly controls?: m.Children;
+  readonly trace?: Trace;
+  readonly query?: string;
 }
 
 export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs> {
@@ -53,6 +59,8 @@ export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs>
       dataGridState,
       onClearGridState,
       controls,
+      trace,
+      query,
     } = attrs;
 
     return m(Stack, {fillHeight: true, spacing: 'none'}, [
@@ -66,6 +74,8 @@ export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs>
           onReady,
           dataGridState,
           onClearGridState,
+          trace,
+          query,
         ),
       ),
     ]);
@@ -78,7 +88,29 @@ export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs>
     onReady?: (api: DataGridApi) => void,
     dataGridState?: DataGridState,
     onClearGridState?: () => void,
+    trace?: Trace,
+    query?: string,
   ) {
+    const debugTrackButton =
+      trace && query
+        ? m(
+            Popup,
+            {
+              trigger: m(Button, {
+                label: 'Add debug track',
+                icon: 'add_chart',
+              }),
+              position: PopupPosition.Top,
+            },
+            m(AddDebugTrackMenu, {
+              trace,
+              query,
+              availableColumns: getDefaultVisibleColumns(gridConfig.schema),
+              onAdd: () => trace.navigate('#!/viewer'),
+            }),
+          )
+        : undefined;
+
     return m(DataGrid, {
       fillHeight: true,
       schema: gridConfig.schema,
@@ -95,6 +127,7 @@ export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs>
             onclick: () => onClearGridState(),
           }),
       ],
+      toolbarItemsRight: [debugTrackButton],
     });
   }
 

--- a/ui/src/components/aggregation_panel.ts
+++ b/ui/src/components/aggregation_panel.ts
@@ -34,7 +34,11 @@ import type {
   CellRenderer,
   ColumnType,
 } from './widgets/datagrid/datagrid_schema';
-import type {DataSource} from './widgets/datagrid/data_source';
+import type {
+  DataSource,
+  DataSourceModel,
+  FlatModel,
+} from './widgets/datagrid/data_source';
 import {Icons} from '../base/semantic_icons';
 
 export interface AggregationPanelAttrs {
@@ -47,9 +51,22 @@ export interface AggregationPanelAttrs {
   readonly controls?: m.Children;
   readonly trace?: Trace;
   readonly query?: string;
+  /**
+   * Called when the grid is ready, providing the data source and a function
+   * to retrieve the current model (filters, sort, pagination, pivot state).
+   * Use this to build a query that reflects the current filtered result set,
+   * e.g. for creating a debug track from filtered data.
+   */
+  readonly onDataGridReady?: (
+    dataSource: DataSource,
+    getModel: () => DataSourceModel,
+  ) => void;
 }
 
 export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs> {
+  // Stores the getModel function from DataGridApi, set when the grid is ready.
+  private getModel?: () => DataSourceModel;
+
   view({attrs}: m.CVnode<AggregationPanelAttrs>) {
     const {
       dataSource,
@@ -61,6 +78,7 @@ export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs>
       controls,
       trace,
       query,
+      onDataGridReady,
     } = attrs;
 
     return m(Stack, {fillHeight: true, spacing: 'none'}, [
@@ -76,6 +94,7 @@ export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs>
           onClearGridState,
           trace,
           query,
+          onDataGridReady,
         ),
       ),
     ]);
@@ -90,9 +109,29 @@ export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs>
     onClearGridState?: () => void,
     trace?: Trace,
     query?: string,
+    onDataGridReady?: (
+      dataSource: DataSource,
+      getModel: () => DataSourceModel,
+    ) => void,
   ) {
+    // Use the filtered query if available, otherwise fall back to the static query.
+    const filteredQuery = query;
+
+    const gridModel = this.getModel?.();
+
+    const debugModel: FlatModel = {
+      mode: 'flat',
+      columns: gridModel.map((field) => ({
+        field,
+        alias: field,
+      })),
+      filters: gridModel?.filters,
+      pagination: undefined,
+      sort: undefined,
+    };
+
     const debugTrackButton =
-      trace && query
+      trace && filteredQuery
         ? m(
             Popup,
             {
@@ -104,7 +143,7 @@ export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs>
             },
             m(AddDebugTrackMenu, {
               trace,
-              query,
+              query: filteredQuery,
               availableColumns: getDefaultVisibleColumns(gridConfig.schema),
               onAdd: () => trace.navigate('#!/viewer'),
             }),
@@ -115,7 +154,11 @@ export class AggregationPanel implements m.ClassComponent<AggregationPanelAttrs>
       fillHeight: true,
       schema: gridConfig.schema,
       data: dataSource,
-      onReady,
+      onReady: (api: DataGridApi) => {
+        onReady?.(api);
+        this.getModel = api.getModel;
+        onDataGridReady?.(dataSource, api.getModel);
+      },
       // Spread controlled state props (columns, filters, pivot and callbacks)
       ...dataGridState,
       toolbarItemsLeft: [

--- a/ui/src/components/tracks/add_debug_track_menu.ts
+++ b/ui/src/components/tracks/add_debug_track_menu.ts
@@ -108,6 +108,7 @@ export class AddDebugTrackMenu implements m.ClassComponent<AddDebugTrackMenuAttr
         onSubmit: () => {
           attrs.onAdd?.();
           this.createTracks(attrs);
+          console.log(attrs.query);
         },
         submitLabel: 'Add Track',
         cancelLabel: 'Cancel',

--- a/ui/src/components/widgets/datagrid/data_source.ts
+++ b/ui/src/components/widgets/datagrid/data_source.ts
@@ -58,6 +58,14 @@ export interface DataSource {
    * Returns a promise that resolves to all filtered and sorted rows.
    */
   exportData(model: DataSourceModel): Promise<readonly Row[]>;
+
+  /**
+   * Returns the SQL query that would be executed for the given model,
+   * without running it. Useful for debugging or passing to external tools
+   * (e.g., creating a debug track from the filtered result set).
+   * Optional — only SQL-backed data sources implement this.
+   */
+  getQuery?(model: DataSourceModel): string;
 }
 
 // Common fields shared across all data source modes

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
@@ -137,6 +137,7 @@ export class SliceSelectionAggregator implements Aggregator {
           SELECT
             json_object('id', id, 'groupid', __groupid, 'partition', __partition) as id_with_lineage,
             name,
+            ts,
             dur,
             self_dur,
             arg_set_id
@@ -329,6 +330,10 @@ export class SliceSelectionAggregator implements Aggregator {
           title: 'Name',
           columnType: 'text',
         },
+        ts: {
+          title: 'Timestamp',
+          columnType: 'quantitative',
+        },
         dur: {
           title: 'Wall Duration',
           columnType: 'quantitative',
@@ -338,6 +343,10 @@ export class SliceSelectionAggregator implements Aggregator {
           title: 'Self Duration',
           columnType: 'quantitative',
           cellRenderer: formatDurationValue,
+        },
+        arg_set_id: {
+          title: 'Arg Set ID',
+          columnType: 'identifier',
         },
         args: {
           title: 'Args',


### PR DESCRIPTION
Only pass leaf columns (ColumnDef) to the AddDebugTrackMenu, filtering out parameterised columns and schema references. Previously, Object.keys(schema) included all entries, exposing non-leaf entries that can't be used for column mapping.

Also expose the arg_set_id column in the slice selection aggregator's grid schema. It was already present in the SQL query but not exposed in the datagrid schema definition.
