### PR TITLE
tp: allow TarWriter to write to an abstract sink

### DIFF
--- a/src/trace_processor/util/tar_writer.cc
+++ b/src/trace_processor/util/tar_writer.cc
@@ -17,12 +17,14 @@
 #include "src/trace_processor/util/tar_writer.h"
 
 #include <fcntl.h>
-#include <algorithm>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <ctime>
+#include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
@@ -48,42 +50,126 @@ void SafeCopyToCharArray(char (&dest)[DestN], const char (&src)[SrcN]) {
     memset(dest + copy_len, 0, DestN - copy_len);
   }
 }
+
+// Writes to a file descriptor. Backs the path/ScopedFile constructors.
+class FdTarWriterSink : public TarWriterSink {
+ public:
+  explicit FdTarWriterSink(base::ScopedFile fd) : fd_(std::move(fd)) {
+    PERFETTO_CHECK(fd_);
+  }
+
+  base::Status Write(const void* data, size_t len) override {
+    ssize_t written = base::WriteAll(fd_.get(), data, len);
+    if (written != static_cast<ssize_t>(len)) {
+      return base::ErrStatus("Failed to write to TAR output");
+    }
+    return base::OkStatus();
+  }
+
+  base::Status WriteFromFd(int fd, size_t) override {
+    return base::CopyFileContents(fd, *fd_);
+  }
+
+ private:
+  base::ScopedFile fd_;
+};
+
 }  // namespace
+
+// --- TarWriterSink ---
+
+TarWriterSink::~TarWriterSink() = default;
+
+// --- BufferTarWriterSink ---
+
+BufferTarWriterSink::BufferTarWriterSink(std::vector<uint8_t>* buffer)
+    : buffer_(buffer) {
+  PERFETTO_CHECK(buffer_);
+}
+
+base::Status BufferTarWriterSink::Write(const void* data, size_t len) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  buffer_->insert(buffer_->end(), bytes, bytes + len);
+  return base::OkStatus();
+}
+
+base::Status BufferTarWriterSink::WriteFromFd(int fd, size_t len) {
+  size_t old_size = buffer_->size();
+  buffer_->resize(old_size + len);
+  ssize_t rd = base::Read(fd, buffer_->data() + old_size, len);
+  if (rd != static_cast<ssize_t>(len)) {
+    buffer_->resize(old_size);
+    return base::ErrStatus("Failed to read from fd");
+  }
+  return base::OkStatus();
+}
+
+// --- CallbackTarWriterSink ---
+
+CallbackTarWriterSink::CallbackTarWriterSink(WriteCallback callback)
+    : callback_(std::move(callback)) {
+  PERFETTO_CHECK(callback_);
+}
+
+base::Status CallbackTarWriterSink::Write(const void* data, size_t len) {
+  return callback_(data, len);
+}
+
+base::Status CallbackTarWriterSink::WriteFromFd(int fd, size_t len) {
+  std::vector<uint8_t> buf(len);
+  ssize_t rd = base::Read(fd, buf.data(), len);
+  if (rd != static_cast<ssize_t>(len)) {
+    return base::ErrStatus("Failed to read from fd");
+  }
+  return callback_(buf.data(), buf.size());
+}
+
+// --- TarWriter ---
 
 TarWriter::TarWriter(const std::string& output_path)
     : TarWriter(
           base::OpenFile(output_path, O_CREAT | O_WRONLY | O_TRUNC, 0644)) {}
 
 TarWriter::TarWriter(base::ScopedFile output_file)
-    : output_file_(std::move(output_file)) {
-  PERFETTO_CHECK(output_file_);
+    : owned_sink_(new FdTarWriterSink(std::move(output_file))),
+      sink_(owned_sink_.get()) {}
+
+TarWriter::TarWriter(TarWriterSink* sink) : sink_(sink) {
+  PERFETTO_CHECK(sink_);
 }
 
 TarWriter::~TarWriter() {
-  // Write two 512-byte blocks of zeros to mark end of archive
-  char zero_block[512] = {0};
-  ssize_t written1 = base::WriteAll(output_file_.get(), zero_block, 512);
-  PERFETTO_CHECK(written1 == 512);
+  base::Status status = Finalize();
+  if (!status.ok()) {
+    PERFETTO_ELOG("Failed to finalize TAR archive: %s", status.c_message());
+  }
+}
 
-  ssize_t written2 = base::WriteAll(output_file_.get(), zero_block, 512);
-  PERFETTO_CHECK(written2 == 512);
+base::Status TarWriter::Finalize() {
+  if (finalized_) {
+    return base::OkStatus();
+  }
+  finalized_ = true;
+  // Write two 512-byte blocks of zeros to mark end of archive.
+  char zero_block[512] = {0};
+  RETURN_IF_ERROR(sink_->Write(zero_block, sizeof(zero_block)));
+  RETURN_IF_ERROR(sink_->Write(zero_block, sizeof(zero_block)));
+  return base::OkStatus();
 }
 
 base::Status TarWriter::AddFile(const std::string& filename,
                                 const std::string& content) {
+  return AddFile(filename, reinterpret_cast<const uint8_t*>(content.data()),
+                 content.size());
+}
+
+base::Status TarWriter::AddFile(const std::string& filename,
+                                const uint8_t* data,
+                                size_t size) {
   RETURN_IF_ERROR(ValidateFilename(filename));
-  RETURN_IF_ERROR(CreateAndWriteHeader(filename, content.size()));
-
-  // Write file content
-  ssize_t bytes_written =
-      base::WriteAll(output_file_.get(), content.data(), content.size());
-  if (bytes_written != static_cast<ssize_t>(content.size())) {
-    return base::Status("Failed to write file content");
-  }
-
-  // Write padding to align to 512-byte boundary
-  RETURN_IF_ERROR(WritePadding(content.size()));
-
+  RETURN_IF_ERROR(CreateAndWriteHeader(filename, size));
+  RETURN_IF_ERROR(sink_->Write(data, size));
+  RETURN_IF_ERROR(WritePadding(size));
   return base::OkStatus();
 }
 
@@ -94,23 +180,28 @@ base::Status TarWriter::AddFileFromPath(const std::string& filename,
   // Get file size
   auto file_size_opt = base::GetFileSize(file_path);
   if (!file_size_opt) {
-    return base::Status("Failed to get file size: " + file_path);
+    return base::ErrStatus("Failed to get file size: %s", file_path.c_str());
   }
   size_t file_size = static_cast<size_t>(*file_size_opt);
 
   base::ScopedFile file = base::OpenFile(file_path, O_RDONLY);
   if (!file) {
-    return base::Status("Failed to open file: " + file_path);
+    return base::ErrStatus("Failed to open file: %s", file_path.c_str());
   }
 
   RETURN_IF_ERROR(CreateAndWriteHeader(filename, file_size));
-
-  RETURN_IF_ERROR(base::CopyFileContents(*file, *output_file_));
-
-  // Write padding to align to 512-byte boundary
+  RETURN_IF_ERROR(sink_->WriteFromFd(*file, file_size));
   RETURN_IF_ERROR(WritePadding(file_size));
 
   return base::OkStatus();
+}
+
+base::StatusOr<TarWriter::ScopedFileWriter> TarWriter::BeginFile(
+    const std::string& filename,
+    size_t size) {
+  RETURN_IF_ERROR(ValidateFilename(filename));
+  RETURN_IF_ERROR(CreateAndWriteHeader(filename, size));
+  return ScopedFileWriter(sink_, size);
 }
 
 base::Status TarWriter::CreateAndWriteHeader(const std::string& filename,
@@ -152,14 +243,7 @@ base::Status TarWriter::CreateAndWriteHeader(const std::string& filename,
   header.checksum[6] = '\0';
   header.checksum[7] = ' ';
 
-  // Write header
-  ssize_t written =
-      base::WriteAll(output_file_.get(), reinterpret_cast<const char*>(&header),
-                     sizeof(header));
-  if (written != static_cast<ssize_t>(sizeof(header))) {
-    return base::Status("Failed to write TAR header");
-  }
-  return base::OkStatus();
+  return sink_->Write(&header, sizeof(header));
 }
 
 base::Status TarWriter::WritePadding(size_t size) {
@@ -167,10 +251,7 @@ base::Status TarWriter::WritePadding(size_t size) {
   size_t padding_needed = (512 - (size % 512)) % 512;
   if (padding_needed > 0) {
     char zeros[512] = {0};
-    ssize_t written = base::WriteAll(output_file_.get(), zeros, padding_needed);
-    if (written != static_cast<ssize_t>(padding_needed)) {
-      return base::Status("Failed to write TAR padding");
-    }
+    RETURN_IF_ERROR(sink_->Write(zeros, padding_needed));
   }
   return base::OkStatus();
 }
@@ -178,17 +259,69 @@ base::Status TarWriter::WritePadding(size_t size) {
 base::Status TarWriter::ValidateFilename(const std::string& filename) {
   // TAR header name field is 100 bytes, but we need null termination
   if (filename.empty()) {
-    return base::Status("Filename cannot be empty");
+    return base::ErrStatus("Filename cannot be empty");
   }
   if (filename.length() > 99) {
-    return base::Status("Filename too long for TAR format (max 99 chars): " +
-                        filename);
+    return base::ErrStatus(
+        "Filename too long for TAR format (max 99 chars): %s",
+        filename.c_str());
   }
   // Check for invalid characters that might cause issues
   if (filename.find('\0') != std::string::npos) {
-    return base::Status("Filename contains null character: " + filename);
+    return base::ErrStatus("Filename contains null character: %s",
+                           filename.c_str());
   }
   return base::OkStatus();
+}
+
+// --- TarWriter::ScopedFileWriter ---
+
+TarWriter::ScopedFileWriter::ScopedFileWriter(TarWriterSink* sink, size_t size)
+    : sink_(sink), size_(size) {}
+
+TarWriter::ScopedFileWriter::ScopedFileWriter(ScopedFileWriter&& other) noexcept
+    : sink_(other.sink_), size_(other.size_), finished_(other.finished_) {
+  other.sink_ = nullptr;
+  other.finished_ = true;
+}
+
+TarWriter::ScopedFileWriter& TarWriter::ScopedFileWriter::operator=(
+    ScopedFileWriter&& other) noexcept {
+  if (this != &other) {
+    sink_ = other.sink_;
+    size_ = other.size_;
+    finished_ = other.finished_;
+    other.sink_ = nullptr;
+    other.finished_ = true;
+  }
+  return *this;
+}
+
+TarWriter::ScopedFileWriter::~ScopedFileWriter() {
+  if (finished_ || !sink_) {
+    return;
+  }
+  base::Status status = Finish();
+  if (!status.ok()) {
+    PERFETTO_ELOG("Failed to finalize TAR file entry: %s", status.c_message());
+  }
+}
+
+base::Status TarWriter::ScopedFileWriter::Write(const void* data, size_t len) {
+  return sink_->Write(data, len);
+}
+
+base::Status TarWriter::ScopedFileWriter::Finish() {
+  if (finished_) {
+    return base::OkStatus();
+  }
+  finished_ = true;
+  size_t padding_needed = (512 - (size_ % 512)) % 512;
+  if (padding_needed == 0) {
+    return base::OkStatus();
+  }
+  char zeros[512] = {0};
+  return sink_->Write(zeros, padding_needed);
 }
 
 }  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/tar_writer.cc
+++ b/src/trace_processor/util/tar_writer.cc
@@ -280,7 +280,9 @@ TarWriter::ScopedFileWriter::ScopedFileWriter(TarWriter* writer, size_t size)
     : writer_(writer), size_(size) {}
 
 TarWriter::ScopedFileWriter::ScopedFileWriter(ScopedFileWriter&& other) noexcept
-    : writer_(other.writer_), size_(other.size_) {
+    : writer_(other.writer_),
+      size_(other.size_),
+      bytes_written_(other.bytes_written_) {
   other.writer_ = nullptr;
 }
 
@@ -301,14 +303,29 @@ TarWriter::ScopedFileWriter::~ScopedFileWriter() {
   PERFETTO_CHECK(status.ok());
 }
 
-base::Status TarWriter::ScopedFileWriter::Write(const void* data, size_t len) {
+base::Status TarWriter::ScopedFileWriter::CheckCanWrite(size_t len) {
   PERFETTO_CHECK(writer_);
-  return writer_->WriteToSink(data, len);
+  PERFETTO_DCHECK(bytes_written_ <= size_);
+  if (len > size_ - bytes_written_) {
+    return writer_->PoisonIfError(base::ErrStatus(
+        "Cannot write %zu bytes to TAR entry: only %zu bytes remain", len,
+        size_ - bytes_written_));
+  }
+  return base::OkStatus();
+}
+
+base::Status TarWriter::ScopedFileWriter::Write(const void* data, size_t len) {
+  RETURN_IF_ERROR(CheckCanWrite(len));
+  RETURN_IF_ERROR(writer_->WriteToSink(data, len));
+  bytes_written_ += len;
+  return base::OkStatus();
 }
 
 base::Status TarWriter::ScopedFileWriter::WriteFromFd(int fd, size_t len) {
-  PERFETTO_CHECK(writer_);
-  return writer_->WriteFromFdToSink(fd, len);
+  RETURN_IF_ERROR(CheckCanWrite(len));
+  RETURN_IF_ERROR(writer_->WriteFromFdToSink(fd, len));
+  bytes_written_ += len;
+  return base::OkStatus();
 }
 
 base::Status TarWriter::ScopedFileWriter::Finalize() {
@@ -320,6 +337,11 @@ base::Status TarWriter::ScopedFileWriter::Finalize() {
   }
   TarWriter* writer = writer_;
   writer_ = nullptr;
+  if (bytes_written_ != size_) {
+    return writer->PoisonIfError(base::ErrStatus(
+        "TAR entry expected %zu bytes, but only %zu were written", size_,
+        bytes_written_));
+  }
   size_t padding_needed = (512 - (size_ % 512)) % 512;
   if (padding_needed == 0) {
     return base::OkStatus();

--- a/src/trace_processor/util/tar_writer.cc
+++ b/src/trace_processor/util/tar_writer.cc
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <ctime>
 #include <memory>
+#include <new>
 #include <string>
 #include <utility>
 #include <vector>
@@ -49,6 +50,87 @@ void SafeCopyToCharArray(char (&dest)[DestN], const char (&src)[SrcN]) {
   if constexpr (copy_len < DestN) {
     memset(dest + copy_len, 0, DestN - copy_len);
   }
+}
+
+// TAR header structure (512 bytes)
+struct TarHeader {
+  char name[100];      // File name
+  char mode[8];        // File mode (octal)
+  char uid[8];         // User ID (octal)
+  char gid[8];         // Group ID (octal)
+  char size[12];       // File size in bytes (octal)
+  char mtime[12];      // Modification time (octal)
+  char checksum[8];    // Header checksum
+  char typeflag;       // File type
+  char linkname[100];  // Name of linked file
+  char magic[6];       // USTAR indicator
+  char version[2];     // USTAR version
+  char uname[32];      // User name
+  char gname[32];      // Group name
+  char devmajor[8];    // Device major number
+  char devminor[8];    // Device minor number
+  char prefix[155];    // Filename prefix
+  char padding[12];    // Padding to 512 bytes
+};
+static_assert(sizeof(TarHeader) == 512, "TarHeader must be 512 bytes");
+
+base::Status ValidateFilename(const std::string& filename) {
+  // TAR header name field is 100 bytes, but we need null termination
+  if (filename.empty()) {
+    return base::ErrStatus("Filename cannot be empty");
+  }
+  if (filename.length() > 99) {
+    return base::ErrStatus(
+        "Filename too long for TAR format (max 99 chars): %s",
+        filename.c_str());
+  }
+  // Check for invalid characters that might cause issues
+  if (filename.find('\0') != std::string::npos) {
+    return base::ErrStatus("Filename contains null character: %s",
+                           filename.c_str());
+  }
+  return base::OkStatus();
+}
+
+TarHeader MakeTarHeader(const std::string& filename, size_t file_size) {
+  TarHeader header;
+
+  // Initialize header
+  memset(&header, 0, sizeof(TarHeader));
+  SafeCopyToCharArray(header.mode, "0644   ");   // Regular file, rw-r--r--
+  SafeCopyToCharArray(header.uid, "0000000");    // Root user
+  SafeCopyToCharArray(header.gid, "0000000");    // Root group
+  header.typeflag = '0';                         // Regular file
+  SafeCopyToCharArray(header.magic, "ustar\0");  // POSIX ustar format
+  SafeCopyToCharArray(header.version, "00");     // Version
+  SafeCopyToCharArray(header.uname, "root");     // User name
+  SafeCopyToCharArray(header.gname, "root");     // Group name
+  SafeCopyToCharArray(header.devmajor, "0000000");
+  SafeCopyToCharArray(header.devminor, "0000000");
+  memset(header.checksum, ' ', sizeof(header.checksum));
+
+  // Set filename
+  base::StringCopy(header.name, filename.c_str(), sizeof(header.name));
+
+  // Set file size (in octal)
+  snprintf(header.size, sizeof(header.size), "%011lo",
+           static_cast<unsigned long>(file_size));
+
+  // Set modification time to current time (in octal)
+  snprintf(header.mtime, sizeof(header.mtime), "%011lo",
+           static_cast<unsigned long>(time(nullptr)));
+
+  // Compute checksum
+  unsigned int sum = 0;
+  const unsigned char* bytes = reinterpret_cast<const unsigned char*>(&header);
+  for (size_t i = 0; i < sizeof(TarHeader); i++) {
+    sum += bytes[i];
+  }
+  snprintf(header.checksum, sizeof(header.checksum), "%06o", sum);
+  header.checksum[6] = '\0';
+  header.checksum[7] = ' ';
+
+  return header;
 }
 
 // Writes to a file descriptor. Backs the path/ScopedFile constructors.
@@ -104,26 +186,6 @@ base::Status BufferTarWriterSink::WriteFromFd(int fd, size_t len) {
   return base::OkStatus();
 }
 
-// --- CallbackTarWriterSink ---
-
-CallbackTarWriterSink::CallbackTarWriterSink(WriteCallback callback)
-    : callback_(std::move(callback)) {
-  PERFETTO_CHECK(callback_);
-}
-
-base::Status CallbackTarWriterSink::Write(const void* data, size_t len) {
-  return callback_(data, len);
-}
-
-base::Status CallbackTarWriterSink::WriteFromFd(int fd, size_t len) {
-  std::vector<uint8_t> buf(len);
-  ssize_t rd = base::Read(fd, buf.data(), len);
-  if (rd != static_cast<ssize_t>(len)) {
-    return base::ErrStatus("Failed to read from fd");
-  }
-  return callback_(buf.data(), buf.size());
-}
-
 // --- TarWriter ---
 
 TarWriter::TarWriter(const std::string& output_path)
@@ -131,18 +193,17 @@ TarWriter::TarWriter(const std::string& output_path)
           base::OpenFile(output_path, O_CREAT | O_WRONLY | O_TRUNC, 0644)) {}
 
 TarWriter::TarWriter(base::ScopedFile output_file)
-    : owned_sink_(new FdTarWriterSink(std::move(output_file))),
-      sink_(owned_sink_.get()) {}
+    : TarWriter(std::unique_ptr<TarWriterSink>(
+          new FdTarWriterSink(std::move(output_file)))) {}
 
-TarWriter::TarWriter(TarWriterSink* sink) : sink_(sink) {
+TarWriter::TarWriter(std::unique_ptr<TarWriterSink> sink)
+    : sink_(std::move(sink)) {
   PERFETTO_CHECK(sink_);
 }
 
 TarWriter::~TarWriter() {
   base::Status status = Finalize();
-  if (!status.ok()) {
-    PERFETTO_ELOG("Failed to finalize TAR archive: %s", status.c_message());
-  }
+  PERFETTO_CHECK(status.ok());
 }
 
 base::Status TarWriter::Finalize() {
@@ -152,9 +213,24 @@ base::Status TarWriter::Finalize() {
   finalized_ = true;
   // Write two 512-byte blocks of zeros to mark end of archive.
   char zero_block[512] = {0};
-  RETURN_IF_ERROR(sink_->Write(zero_block, sizeof(zero_block)));
-  RETURN_IF_ERROR(sink_->Write(zero_block, sizeof(zero_block)));
+  RETURN_IF_ERROR(WriteToSink(zero_block, sizeof(zero_block)));
+  RETURN_IF_ERROR(WriteToSink(zero_block, sizeof(zero_block)));
   return base::OkStatus();
+}
+
+base::Status TarWriter::WriteToSink(const void* data, size_t len) {
+  return PoisonIfError(sink_->Write(data, len));
+}
+
+base::Status TarWriter::WriteFromFdToSink(int fd, size_t len) {
+  return PoisonIfError(sink_->WriteFromFd(fd, len));
+}
+
+base::Status TarWriter::PoisonIfError(base::Status status) {
+  if (!status.ok()) {
+    finalized_ = true;
+  }
+  return status;
 }
 
 base::Status TarWriter::AddFile(const std::string& filename,
@@ -166,162 +242,90 @@ base::Status TarWriter::AddFile(const std::string& filename,
 base::Status TarWriter::AddFile(const std::string& filename,
                                 const uint8_t* data,
                                 size_t size) {
-  RETURN_IF_ERROR(ValidateFilename(filename));
-  RETURN_IF_ERROR(CreateAndWriteHeader(filename, size));
-  RETURN_IF_ERROR(sink_->Write(data, size));
-  RETURN_IF_ERROR(WritePadding(size));
-  return base::OkStatus();
+  ASSIGN_OR_RETURN(ScopedFileWriter file, StreamFile(filename, size));
+  RETURN_IF_ERROR(file.Write(data, size));
+  return file.Finalize();
 }
 
 base::Status TarWriter::AddFileFromPath(const std::string& filename,
                                         const std::string& file_path) {
-  RETURN_IF_ERROR(ValidateFilename(filename));
-
-  // Get file size
   auto file_size_opt = base::GetFileSize(file_path);
   if (!file_size_opt) {
     return base::ErrStatus("Failed to get file size: %s", file_path.c_str());
   }
   size_t file_size = static_cast<size_t>(*file_size_opt);
 
-  base::ScopedFile file = base::OpenFile(file_path, O_RDONLY);
-  if (!file) {
+  base::ScopedFile fd = base::OpenFile(file_path, O_RDONLY);
+  if (!fd) {
     return base::ErrStatus("Failed to open file: %s", file_path.c_str());
   }
 
-  RETURN_IF_ERROR(CreateAndWriteHeader(filename, file_size));
-  RETURN_IF_ERROR(sink_->WriteFromFd(*file, file_size));
-  RETURN_IF_ERROR(WritePadding(file_size));
-
-  return base::OkStatus();
+  ASSIGN_OR_RETURN(ScopedFileWriter file, StreamFile(filename, file_size));
+  RETURN_IF_ERROR(file.WriteFromFd(*fd, file_size));
+  return file.Finalize();
 }
 
-base::StatusOr<TarWriter::ScopedFileWriter> TarWriter::BeginFile(
+base::StatusOr<TarWriter::ScopedFileWriter> TarWriter::StreamFile(
     const std::string& filename,
     size_t size) {
   RETURN_IF_ERROR(ValidateFilename(filename));
-  RETURN_IF_ERROR(CreateAndWriteHeader(filename, size));
-  return ScopedFileWriter(sink_, size);
-}
-
-base::Status TarWriter::CreateAndWriteHeader(const std::string& filename,
-                                             size_t file_size) {
-  TarHeader header;
-
-  // Initialize header
-  memset(&header, 0, sizeof(TarHeader));
-  SafeCopyToCharArray(header.mode, "0644   ");   // Regular file, rw-r--r--
-  SafeCopyToCharArray(header.uid, "0000000");    // Root user
-  SafeCopyToCharArray(header.gid, "0000000");    // Root group
-  header.typeflag = '0';                         // Regular file
-  SafeCopyToCharArray(header.magic, "ustar\0");  // POSIX ustar format
-  SafeCopyToCharArray(header.version, "00");     // Version
-  SafeCopyToCharArray(header.uname, "root");     // User name
-  SafeCopyToCharArray(header.gname, "root");     // Group name
-  SafeCopyToCharArray(header.devmajor, "0000000");
-  SafeCopyToCharArray(header.devminor, "0000000");
-  memset(header.checksum, ' ', sizeof(header.checksum));
-
-  // Set filename
-  base::StringCopy(header.name, filename.c_str(), sizeof(header.name));
-
-  // Set file size (in octal)
-  snprintf(header.size, sizeof(header.size), "%011lo",
-           static_cast<unsigned long>(file_size));
-
-  // Set modification time to current time (in octal)
-  snprintf(header.mtime, sizeof(header.mtime), "%011lo",
-           static_cast<unsigned long>(time(nullptr)));
-
-  // Compute checksum
-  unsigned int sum = 0;
-  const unsigned char* bytes = reinterpret_cast<const unsigned char*>(&header);
-  for (size_t i = 0; i < sizeof(TarHeader); i++) {
-    sum += bytes[i];
-  }
-  snprintf(header.checksum, sizeof(header.checksum), "%06o", sum);
-  header.checksum[6] = '\0';
-  header.checksum[7] = ' ';
-
-  return sink_->Write(&header, sizeof(header));
-}
-
-base::Status TarWriter::WritePadding(size_t size) {
-  // TAR files must be padded to 512-byte boundaries
-  size_t padding_needed = (512 - (size % 512)) % 512;
-  if (padding_needed > 0) {
-    char zeros[512] = {0};
-    RETURN_IF_ERROR(sink_->Write(zeros, padding_needed));
-  }
-  return base::OkStatus();
-}
-
-base::Status TarWriter::ValidateFilename(const std::string& filename) {
-  // TAR header name field is 100 bytes, but we need null termination
-  if (filename.empty()) {
-    return base::ErrStatus("Filename cannot be empty");
-  }
-  if (filename.length() > 99) {
-    return base::ErrStatus(
-        "Filename too long for TAR format (max 99 chars): %s",
-        filename.c_str());
-  }
-  // Check for invalid characters that might cause issues
-  if (filename.find('\0') != std::string::npos) {
-    return base::ErrStatus("Filename contains null character: %s",
-                           filename.c_str());
-  }
-  return base::OkStatus();
+  TarHeader header = MakeTarHeader(filename, size);
+  RETURN_IF_ERROR(WriteToSink(&header, sizeof(header)));
+  return ScopedFileWriter(this, size);
 }
 
 // --- TarWriter::ScopedFileWriter ---
 
-TarWriter::ScopedFileWriter::ScopedFileWriter(TarWriterSink* sink, size_t size)
-    : sink_(sink), size_(size) {}
+TarWriter::ScopedFileWriter::ScopedFileWriter(TarWriter* writer, size_t size)
+    : writer_(writer), size_(size) {}
 
 TarWriter::ScopedFileWriter::ScopedFileWriter(ScopedFileWriter&& other) noexcept
-    : sink_(other.sink_), size_(other.size_), finished_(other.finished_) {
-  other.sink_ = nullptr;
-  other.finished_ = true;
+    : writer_(other.writer_), size_(other.size_) {
+  other.writer_ = nullptr;
 }
 
 TarWriter::ScopedFileWriter& TarWriter::ScopedFileWriter::operator=(
     ScopedFileWriter&& other) noexcept {
   if (this != &other) {
-    sink_ = other.sink_;
-    size_ = other.size_;
-    finished_ = other.finished_;
-    other.sink_ = nullptr;
-    other.finished_ = true;
+    this->~ScopedFileWriter();
+    new (this) ScopedFileWriter(std::move(other));
   }
   return *this;
 }
 
 TarWriter::ScopedFileWriter::~ScopedFileWriter() {
-  if (finished_ || !sink_) {
+  if (!writer_) {
     return;
   }
-  base::Status status = Finish();
-  if (!status.ok()) {
-    PERFETTO_ELOG("Failed to finalize TAR file entry: %s", status.c_message());
-  }
+  base::Status status = Finalize();
+  PERFETTO_CHECK(status.ok());
 }
 
 base::Status TarWriter::ScopedFileWriter::Write(const void* data, size_t len) {
-  return sink_->Write(data, len);
+  PERFETTO_CHECK(writer_);
+  return writer_->WriteToSink(data, len);
 }
 
-base::Status TarWriter::ScopedFileWriter::Finish() {
-  if (finished_) {
+base::Status TarWriter::ScopedFileWriter::WriteFromFd(int fd, size_t len) {
+  PERFETTO_CHECK(writer_);
+  return writer_->WriteFromFdToSink(fd, len);
+}
+
+base::Status TarWriter::ScopedFileWriter::Finalize() {
+  // A poisoned writer means the archive is already corrupt: padding it is
+  // pointless, so this becomes a no-op.
+  if (!writer_ || writer_->finalized_) {
+    writer_ = nullptr;
     return base::OkStatus();
   }
-  finished_ = true;
+  TarWriter* writer = writer_;
+  writer_ = nullptr;
   size_t padding_needed = (512 - (size_ % 512)) % 512;
   if (padding_needed == 0) {
     return base::OkStatus();
   }
   char zeros[512] = {0};
-  return sink_->Write(zeros, padding_needed);
+  return writer->WriteToSink(zeros, padding_needed);
 }
 
 }  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/tar_writer.h
+++ b/src/trace_processor/util/tar_writer.h
@@ -112,17 +112,20 @@ class TarWriter {
     // Copies `len` bytes from `fd` into the archive.
     base::Status WriteFromFd(int fd, size_t len);
 
-    // Writes the 512-byte-boundary padding. Must be called once after
-    // exactly the `size` bytes passed to StreamFile() have been written.
+    // Validates that exactly the `size` bytes passed to StreamFile() were
+    // written, then writes the 512-byte-boundary padding.
     base::Status Finalize();
 
    private:
     friend class TarWriter;
     ScopedFileWriter(TarWriter* writer, size_t size);
 
+    base::Status CheckCanWrite(size_t len);
+
     // Null once the entry is finalized or moved-from.
     TarWriter* writer_;
     size_t size_;
+    size_t bytes_written_ = 0;
   };
 
   // Writes the TAR header for `filename` immediately and returns a writer

--- a/src/trace_processor/util/tar_writer.h
+++ b/src/trace_processor/util/tar_writer.h
@@ -18,12 +18,55 @@
 #define SRC_TRACE_PROCESSOR_UTIL_TAR_WRITER_H_
 
 #include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/scoped_file.h"
+#include "perfetto/ext/base/status_or.h"
 
 namespace perfetto::trace_processor::util {
+
+// Destination for the bytes produced by a TarWriter.
+class TarWriterSink {
+ public:
+  virtual ~TarWriterSink();
+  virtual base::Status Write(const void* data, size_t len) = 0;
+  // Copies len bytes from fd to the sink. Default implementation may read
+  // into a buffer and call Write; fd-backed sinks can override with an
+  // efficient fd-to-fd copy.
+  virtual base::Status WriteFromFd(int fd, size_t len) = 0;
+};
+
+// Appends written bytes to an in-memory buffer.
+class BufferTarWriterSink : public TarWriterSink {
+ public:
+  explicit BufferTarWriterSink(std::vector<uint8_t>* buffer);
+  base::Status Write(const void* data, size_t len) override;
+  base::Status WriteFromFd(int fd, size_t len) override;
+
+ private:
+  std::vector<uint8_t>* buffer_;
+};
+
+// Forwards written bytes to a caller-supplied callback, e.g. to stream a
+// TAR archive over an RPC connection.
+class CallbackTarWriterSink : public TarWriterSink {
+ public:
+  // A failing status aborts the write that triggered it; it is propagated
+  // back to the TarWriter caller.
+  using WriteCallback =
+      std::function<base::Status(const void* data, size_t len)>;
+  explicit CallbackTarWriterSink(WriteCallback callback);
+  base::Status Write(const void* data, size_t len) override;
+  base::Status WriteFromFd(int fd, size_t len) override;
+
+ private:
+  WriteCallback callback_;
+};
 
 // Simple TAR writer that creates uncompressed TAR archives.
 //
@@ -41,7 +84,11 @@ class TarWriter {
  public:
   explicit TarWriter(const std::string& output_path);
   explicit TarWriter(base::ScopedFile output_file);
+  // `sink` is not owned and must outlive the TarWriter.
+  explicit TarWriter(TarWriterSink* sink);
   ~TarWriter();
+  TarWriter(const TarWriter&) = delete;
+  TarWriter& operator=(const TarWriter&) = delete;
 
   // Adds a file to the TAR archive.
   // filename: The name of the file in the archive (max 100 chars)
@@ -49,12 +96,53 @@ class TarWriter {
   // Returns OkStatus() on success, error Status on failure.
   base::Status AddFile(const std::string& filename, const std::string& content);
 
+  // Adds a file to the TAR archive from raw bytes.
+  base::Status AddFile(const std::string& filename,
+                       const uint8_t* data,
+                       size_t size);
+
   // Adds a file to the TAR archive from a file path.
   // filename: The name of the file in the archive (max 100 chars)
   // file_path: Path to the file to add
   // Returns OkStatus() on success, error Status on failure.
   base::Status AddFileFromPath(const std::string& filename,
                                const std::string& file_path);
+
+  // Handle for streaming a single file's content into the archive without
+  // buffering it all in memory first. Returned by BeginFile(). Move-only.
+  class ScopedFileWriter {
+   public:
+    ScopedFileWriter(ScopedFileWriter&&) noexcept;
+    ScopedFileWriter& operator=(ScopedFileWriter&&) noexcept;
+    // Best-effort Finish() if not already called; logs (never crashes) on
+    // failure, since a broken pipe on teardown must not abort the process.
+    ~ScopedFileWriter();
+    ScopedFileWriter(const ScopedFileWriter&) = delete;
+    ScopedFileWriter& operator=(const ScopedFileWriter&) = delete;
+
+    base::Status Write(const void* data, size_t len);
+
+    // Writes the 512-byte-boundary padding. Must be called once after
+    // exactly the `size` bytes passed to BeginFile() have been written.
+    base::Status Finish();
+
+   private:
+    friend class TarWriter;
+    ScopedFileWriter(TarWriterSink* sink, size_t size);
+
+    TarWriterSink* sink_;
+    size_t size_;
+    bool finished_ = false;
+  };
+
+  // Writes the TAR header for `filename` immediately and returns a writer
+  // for streaming exactly `size` bytes of content.
+  base::StatusOr<ScopedFileWriter> BeginFile(const std::string& filename,
+                                             size_t size);
+
+  // Writes the two zero end-of-archive blocks. Idempotent: calls after the
+  // first always return OkStatus() without writing anything further.
+  base::Status Finalize();
 
  private:
   // TAR header structure (512 bytes)
@@ -84,7 +172,11 @@ class TarWriter {
                                     size_t file_size);
   base::Status WritePadding(size_t size);
 
-  base::ScopedFile output_file_;
+  // Owned when constructed from a path/fd; null when a caller-provided sink
+  // is used instead. `sink_` always points at the sink actually used.
+  std::unique_ptr<TarWriterSink> owned_sink_;
+  TarWriterSink* sink_;
+  bool finalized_ = false;
 };
 
 }  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/tar_writer.h
+++ b/src/trace_processor/util/tar_writer.h
@@ -19,7 +19,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -52,22 +51,6 @@ class BufferTarWriterSink : public TarWriterSink {
   std::vector<uint8_t>* buffer_;
 };
 
-// Forwards written bytes to a caller-supplied callback, e.g. to stream a
-// TAR archive over an RPC connection.
-class CallbackTarWriterSink : public TarWriterSink {
- public:
-  // A failing status aborts the write that triggered it; it is propagated
-  // back to the TarWriter caller.
-  using WriteCallback =
-      std::function<base::Status(const void* data, size_t len)>;
-  explicit CallbackTarWriterSink(WriteCallback callback);
-  base::Status Write(const void* data, size_t len) override;
-  base::Status WriteFromFd(int fd, size_t len) override;
-
- private:
-  WriteCallback callback_;
-};
-
 // Simple TAR writer that creates uncompressed TAR archives.
 //
 // Implements the POSIX ustar format for maximum compatibility:
@@ -84,8 +67,9 @@ class TarWriter {
  public:
   explicit TarWriter(const std::string& output_path);
   explicit TarWriter(base::ScopedFile output_file);
-  // `sink` is not owned and must outlive the TarWriter.
-  explicit TarWriter(TarWriterSink* sink);
+  explicit TarWriter(std::unique_ptr<TarWriterSink> sink);
+  // Finalizes the archive if Finalize() was not already called and crashes
+  // if that write fails. Call Finalize() explicitly to handle failures.
   ~TarWriter();
   TarWriter(const TarWriter&) = delete;
   TarWriter& operator=(const TarWriter&) = delete;
@@ -114,68 +98,52 @@ class TarWriter {
    public:
     ScopedFileWriter(ScopedFileWriter&&) noexcept;
     ScopedFileWriter& operator=(ScopedFileWriter&&) noexcept;
-    // Best-effort Finish() if not already called; logs (never crashes) on
-    // failure, since a broken pipe on teardown must not abort the process.
+    // Finalizes the entry if Finalize() was not already called and crashes
+    // if that write fails. Call Finalize() explicitly to handle failures.
     ~ScopedFileWriter();
     ScopedFileWriter(const ScopedFileWriter&) = delete;
     ScopedFileWriter& operator=(const ScopedFileWriter&) = delete;
 
+    // A failed write poisons both the entry and the TarWriter: the archive
+    // is corrupt at that point, so all further finalization becomes a no-op.
+    // Must not be called after Finalize(); doing so crashes.
     base::Status Write(const void* data, size_t len);
 
+    // Copies `len` bytes from `fd` into the archive.
+    base::Status WriteFromFd(int fd, size_t len);
+
     // Writes the 512-byte-boundary padding. Must be called once after
-    // exactly the `size` bytes passed to BeginFile() have been written.
-    base::Status Finish();
+    // exactly the `size` bytes passed to StreamFile() have been written.
+    base::Status Finalize();
 
    private:
     friend class TarWriter;
-    ScopedFileWriter(TarWriterSink* sink, size_t size);
+    ScopedFileWriter(TarWriter* writer, size_t size);
 
-    TarWriterSink* sink_;
+    // Null once the entry is finalized or moved-from.
+    TarWriter* writer_;
     size_t size_;
-    bool finished_ = false;
   };
 
   // Writes the TAR header for `filename` immediately and returns a writer
   // for streaming exactly `size` bytes of content.
-  base::StatusOr<ScopedFileWriter> BeginFile(const std::string& filename,
-                                             size_t size);
+  base::StatusOr<ScopedFileWriter> StreamFile(const std::string& filename,
+                                              size_t size);
 
   // Writes the two zero end-of-archive blocks. Idempotent: calls after the
-  // first always return OkStatus() without writing anything further.
+  // first always return OkStatus() without writing anything further. Also a
+  // no-op once any write to the sink has failed: the archive is already
+  // corrupt, so nothing further is written on teardown.
   base::Status Finalize();
 
  private:
-  // TAR header structure (512 bytes)
-  struct TarHeader {
-    char name[100];      // File name
-    char mode[8];        // File mode (octal)
-    char uid[8];         // User ID (octal)
-    char gid[8];         // Group ID (octal)
-    char size[12];       // File size in bytes (octal)
-    char mtime[12];      // Modification time (octal)
-    char checksum[8];    // Header checksum
-    char typeflag;       // File type
-    char linkname[100];  // Name of linked file
-    char magic[6];       // USTAR indicator
-    char version[2];     // USTAR version
-    char uname[32];      // User name
-    char gname[32];      // Group name
-    char devmajor[8];    // Device major number
-    char devminor[8];    // Device minor number
-    char prefix[155];    // Filename prefix
-    char padding[12];    // Padding to 512 bytes
-  };
-  static_assert(sizeof(TarHeader) == 512, "TarHeader must be 512 bytes");
+  // All sink writes go through these: a failure poisons the writer via
+  // PoisonIfError() so no further writes are attempted on teardown.
+  base::Status WriteToSink(const void* data, size_t len);
+  base::Status WriteFromFdToSink(int fd, size_t len);
+  base::Status PoisonIfError(base::Status status);
 
-  base::Status ValidateFilename(const std::string& filename);
-  base::Status CreateAndWriteHeader(const std::string& filename,
-                                    size_t file_size);
-  base::Status WritePadding(size_t size);
-
-  // Owned when constructed from a path/fd; null when a caller-provided sink
-  // is used instead. `sink_` always points at the sink actually used.
-  std::unique_ptr<TarWriterSink> owned_sink_;
-  TarWriterSink* sink_;
+  std::unique_ptr<TarWriterSink> sink_;
   bool finalized_ = false;
 };
 

--- a/src/trace_processor/util/tar_writer_unittest.cc
+++ b/src/trace_processor/util/tar_writer_unittest.cc
@@ -328,5 +328,220 @@ TEST_F(TarWriterTest, DisableWindows(AutomaticFinalization)) {
   EXPECT_EQ(headers[0].name, "test.txt");
 }
 
+TEST_F(TarWriterTest, DisableWindows(ExplicitFinalizeThenDestructorNoop)) {
+  {
+    TarWriter writer(output_path_);
+    ASSERT_OK(writer.AddFile("test.txt", "content"));
+    ASSERT_OK(writer.Finalize());
+    // A second explicit call is a no-op that still succeeds.
+    ASSERT_OK(writer.Finalize());
+
+    std::string tar_content_after_explicit = ReadFile(output_path_);
+    EXPECT_EQ(tar_content_after_explicit.size(), 2048u);
+  }  // Destructor calls Finalize() again; must be a no-op.
+
+  std::string tar_content = ReadFile(output_path_);
+  EXPECT_EQ(tar_content.size(), 2048u);
+}
+
+TEST_F(TarWriterTest, BufferSinkSingleFile) {
+  const std::string test_content = "In-memory TAR content";
+
+  std::vector<uint8_t> buffer;
+  {
+    BufferTarWriterSink sink(&buffer);
+    TarWriter writer(&sink);
+    ASSERT_OK(writer.AddFile("inmem.txt", test_content));
+  }
+
+  std::string tar_content(buffer.begin(), buffer.end());
+  auto headers = ParseTarFile(tar_content);
+
+  ASSERT_EQ(headers.size(), 1u);
+  EXPECT_EQ(headers[0].name, "inmem.txt");
+  EXPECT_EQ(headers[0].size, test_content.size());
+
+  size_t content_offset = 512;
+  std::string extracted =
+      tar_content.substr(content_offset, test_content.size());
+  EXPECT_EQ(extracted, test_content);
+
+  // Two 512-byte zero blocks for end of archive.
+  EXPECT_EQ(buffer.size(), 512u + 512u + 1024u);
+}
+
+TEST_F(TarWriterTest, BufferSinkMultipleFiles) {
+  std::vector<uint8_t> buffer;
+  {
+    BufferTarWriterSink sink(&buffer);
+    TarWriter writer(&sink);
+    ASSERT_OK(writer.AddFile("a.txt", "alpha"));
+    ASSERT_OK(writer.AddFile("dir/b.txt", "bravo-content"));
+  }
+
+  std::string tar_content(buffer.begin(), buffer.end());
+  auto headers = ParseTarFile(tar_content);
+
+  ASSERT_EQ(headers.size(), 2u);
+  EXPECT_EQ(headers[0].name, "a.txt");
+  EXPECT_EQ(headers[0].size, 5u);
+  EXPECT_EQ(headers[1].name, "dir/b.txt");
+  EXPECT_EQ(headers[1].size, 13u);
+}
+
+TEST_F(TarWriterTest, DisableWindows(AddFileRawBytes)) {
+  const uint8_t data[] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x42};
+
+  {
+    TarWriter writer(output_path_);
+    ASSERT_OK(writer.AddFile("raw.bin", data, sizeof(data)));
+  }
+
+  std::string tar_content = ReadFile(output_path_);
+  auto headers = ParseTarFile(tar_content);
+
+  ASSERT_EQ(headers.size(), 1u);
+  EXPECT_EQ(headers[0].name, "raw.bin");
+  EXPECT_EQ(headers[0].size, sizeof(data));
+
+  size_t content_offset = 512;
+  EXPECT_EQ(memcmp(tar_content.data() + content_offset, data, sizeof(data)), 0);
+}
+
+TEST_F(TarWriterTest, DisableWindows(BeginFileStreamingRoundTrip)) {
+  const std::string part1 = "Hello, ";
+  const std::string part2 = "streamed TAR world!";
+  const std::string full_content = part1 + part2;
+
+  {
+    TarWriter writer(output_path_);
+    auto file_or = writer.BeginFile("streamed.txt", full_content.size());
+    ASSERT_OK(file_or.status());
+    TarWriter::ScopedFileWriter file = std::move(file_or.value());
+    ASSERT_OK(file.Write(part1.data(), part1.size()));
+    ASSERT_OK(file.Write(part2.data(), part2.size()));
+    ASSERT_OK(file.Finish());
+  }
+
+  std::string tar_content = ReadFile(output_path_);
+  auto headers = ParseTarFile(tar_content);
+
+  ASSERT_EQ(headers.size(), 1u);
+  EXPECT_EQ(headers[0].name, "streamed.txt");
+  EXPECT_EQ(headers[0].size, full_content.size());
+
+  size_t content_offset = 512;
+  std::string extracted =
+      tar_content.substr(content_offset, full_content.size());
+  EXPECT_EQ(extracted, full_content);
+
+  // Header (512) + content (27, padded to 512) + end markers (1024).
+  EXPECT_EQ(tar_content.size(), 512u + 512u + 1024u);
+
+  // Padding bytes after the content should be zero.
+  for (size_t i = content_offset + full_content.size(); i < 1024; i++) {
+    EXPECT_EQ(tar_content[i], '\0')
+        << "Padding byte at position " << i << " is not zero";
+  }
+}
+
+TEST_F(TarWriterTest, DisableWindows(BeginFileAutomaticFinish)) {
+  const std::string content = "no explicit Finish() call";
+
+  {
+    TarWriter writer(output_path_);
+    auto file_or = writer.BeginFile("auto.txt", content.size());
+    ASSERT_OK(file_or.status());
+    TarWriter::ScopedFileWriter file = std::move(file_or.value());
+    ASSERT_OK(file.Write(content.data(), content.size()));
+    // Destructor of `file` should write the padding.
+  }
+
+  std::string tar_content = ReadFile(output_path_);
+  auto headers = ParseTarFile(tar_content);
+
+  ASSERT_EQ(headers.size(), 1u);
+  EXPECT_EQ(headers[0].name, "auto.txt");
+  EXPECT_EQ(headers[0].size, content.size());
+}
+
+TEST_F(TarWriterTest, CallbackSinkAddFilePropagatesError) {
+  size_t bytes_seen = 0;
+  const size_t kFailAfter = 8;
+  CallbackTarWriterSink sink(
+      [&](const void* /*data*/, size_t len) -> base::Status {
+        if (bytes_seen >= kFailAfter) {
+          return base::ErrStatus("callback sink: simulated write failure");
+        }
+        bytes_seen += len;
+        return base::OkStatus();
+      });
+  TarWriter writer(&sink);
+
+  // The header write succeeds (0 < kFailAfter), but the subsequent content
+  // write pushes bytes_seen past kFailAfter and should surface the
+  // callback's error.
+  auto status = writer.AddFile("fails.txt", "some content");
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.message(), HasSubstr("simulated write failure"));
+}
+
+TEST_F(TarWriterTest, CallbackSinkBeginFilePropagatesError) {
+  bool fail_next = false;
+  CallbackTarWriterSink sink(
+      [&](const void* /*data*/, size_t /*len*/) -> base::Status {
+        if (fail_next) {
+          return base::ErrStatus("callback sink: simulated write failure");
+        }
+        fail_next = true;
+        return base::OkStatus();
+      });
+  TarWriter writer(&sink);
+
+  // The header write (first callback invocation) succeeds; BeginFile()
+  // itself should thus succeed here.
+  auto file_or = writer.BeginFile("fails.txt", 5);
+  ASSERT_OK(file_or.status());
+  TarWriter::ScopedFileWriter file = std::move(file_or.value());
+  auto status = file.Write("hello", 5);
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.message(), HasSubstr("simulated write failure"));
+
+  // Finish() should also propagate the failure without crashing.
+  auto finish_status = file.Finish();
+  EXPECT_FALSE(finish_status.ok());
+}
+
+TEST_F(TarWriterTest, CallbackSinkFinalizeErrorDoesNotCrash) {
+  CallbackTarWriterSink sink(
+      [&](const void* /*data*/, size_t /*len*/) -> base::Status {
+        return base::ErrStatus("callback sink: simulated write failure");
+      });
+
+  {
+    TarWriter writer(&sink);
+    auto status = writer.Finalize();
+    EXPECT_FALSE(status.ok());
+
+    // Idempotent: the second call is a no-op that reports success even
+    // though the underlying write never happened.
+    auto second_status = writer.Finalize();
+    EXPECT_TRUE(second_status.ok());
+  }  // Destructor calls Finalize() again; must not crash (logs instead).
+}
+
+TEST_F(TarWriterTest, CallbackSinkDestructorFinalizeFailureDoesNotCrash) {
+  CallbackTarWriterSink sink(
+      [&](const void* /*data*/, size_t /*len*/) -> base::Status {
+        return base::ErrStatus("callback sink: simulated write failure");
+      });
+
+  // Never call Finalize() explicitly; the destructor's best-effort
+  // finalization must swallow the error (logging it) rather than crash.
+  {
+    TarWriter writer(&sink);
+  }
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/tar_writer_unittest.cc
+++ b/src/trace_processor/util/tar_writer_unittest.cc
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <ios>
 #include <iterator>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -34,6 +35,7 @@
 namespace perfetto::trace_processor::util {
 namespace {
 
+using perfetto::base::gtest_matchers::IsError;
 using testing::ElementsAre;
 using testing::HasSubstr;
 
@@ -220,7 +222,7 @@ TEST_F(TarWriterTest, DisableWindows(AddFileFromNonexistentPath)) {
 
   TarWriter writer(output_path_);
   auto status = writer.AddFileFromPath("archived.txt", nonexistent_path);
-  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status, IsError());
 }
 
 TEST_F(TarWriterTest, DisableWindows(AddLargeFile)) {
@@ -250,13 +252,11 @@ TEST_F(TarWriterTest, DisableWindows(ValidateFilenameConstraints)) {
   TarWriter writer(temp_file_.ReleaseFD());
 
   // Empty filename should fail
-  auto status1 = writer.AddFile("", "content");
-  EXPECT_FALSE(status1.ok());
+  EXPECT_THAT(writer.AddFile("", "content"), IsError());
 
   // Very long filename should fail (TAR limit is 99 chars for basic format)
   std::string long_name(100, 'a');
-  auto status2 = writer.AddFile(long_name, "content");
-  EXPECT_FALSE(status2.ok());
+  EXPECT_THAT(writer.AddFile(long_name, "content"), IsError());
 
   // Valid filename at boundary should work
   std::string boundary_name(99, 'b');
@@ -349,8 +349,7 @@ TEST_F(TarWriterTest, BufferSinkSingleFile) {
 
   std::vector<uint8_t> buffer;
   {
-    BufferTarWriterSink sink(&buffer);
-    TarWriter writer(&sink);
+    TarWriter writer(std::make_unique<BufferTarWriterSink>(&buffer));
     ASSERT_OK(writer.AddFile("inmem.txt", test_content));
   }
 
@@ -373,8 +372,7 @@ TEST_F(TarWriterTest, BufferSinkSingleFile) {
 TEST_F(TarWriterTest, BufferSinkMultipleFiles) {
   std::vector<uint8_t> buffer;
   {
-    BufferTarWriterSink sink(&buffer);
-    TarWriter writer(&sink);
+    TarWriter writer(std::make_unique<BufferTarWriterSink>(&buffer));
     ASSERT_OK(writer.AddFile("a.txt", "alpha"));
     ASSERT_OK(writer.AddFile("dir/b.txt", "bravo-content"));
   }
@@ -408,19 +406,19 @@ TEST_F(TarWriterTest, DisableWindows(AddFileRawBytes)) {
   EXPECT_EQ(memcmp(tar_content.data() + content_offset, data, sizeof(data)), 0);
 }
 
-TEST_F(TarWriterTest, DisableWindows(BeginFileStreamingRoundTrip)) {
+TEST_F(TarWriterTest, DisableWindows(StreamFileRoundTrip)) {
   const std::string part1 = "Hello, ";
   const std::string part2 = "streamed TAR world!";
   const std::string full_content = part1 + part2;
 
   {
     TarWriter writer(output_path_);
-    auto file_or = writer.BeginFile("streamed.txt", full_content.size());
+    auto file_or = writer.StreamFile("streamed.txt", full_content.size());
     ASSERT_OK(file_or.status());
     TarWriter::ScopedFileWriter file = std::move(file_or.value());
     ASSERT_OK(file.Write(part1.data(), part1.size()));
     ASSERT_OK(file.Write(part2.data(), part2.size()));
-    ASSERT_OK(file.Finish());
+    ASSERT_OK(file.Finalize());
   }
 
   std::string tar_content = ReadFile(output_path_);
@@ -445,12 +443,12 @@ TEST_F(TarWriterTest, DisableWindows(BeginFileStreamingRoundTrip)) {
   }
 }
 
-TEST_F(TarWriterTest, DisableWindows(BeginFileAutomaticFinish)) {
-  const std::string content = "no explicit Finish() call";
+TEST_F(TarWriterTest, DisableWindows(StreamFileAutomaticFinalize)) {
+  const std::string content = "no explicit Finalize() call";
 
   {
     TarWriter writer(output_path_);
-    auto file_or = writer.BeginFile("auto.txt", content.size());
+    auto file_or = writer.StreamFile("auto.txt", content.size());
     ASSERT_OK(file_or.status());
     TarWriter::ScopedFileWriter file = std::move(file_or.value());
     ASSERT_OK(file.Write(content.data(), content.size()));
@@ -465,82 +463,76 @@ TEST_F(TarWriterTest, DisableWindows(BeginFileAutomaticFinish)) {
   EXPECT_EQ(headers[0].size, content.size());
 }
 
-TEST_F(TarWriterTest, CallbackSinkAddFilePropagatesError) {
-  size_t bytes_seen = 0;
-  const size_t kFailAfter = 8;
-  CallbackTarWriterSink sink(
-      [&](const void* /*data*/, size_t len) -> base::Status {
-        if (bytes_seen >= kFailAfter) {
-          return base::ErrStatus("callback sink: simulated write failure");
-        }
-        bytes_seen += len;
-        return base::OkStatus();
-      });
-  TarWriter writer(&sink);
+// Accepts the first `fail_after` bytes, then fails every write.
+class FailAfterSink : public TarWriterSink {
+ public:
+  explicit FailAfterSink(size_t fail_after) : fail_after_(fail_after) {}
 
-  // The header write succeeds (0 < kFailAfter), but the subsequent content
-  // write pushes bytes_seen past kFailAfter and should surface the
-  // callback's error.
+  base::Status Write(const void*, size_t len) override {
+    if (bytes_seen_ + len > fail_after_) {
+      return base::ErrStatus("simulated write failure");
+    }
+    bytes_seen_ += len;
+    return base::OkStatus();
+  }
+
+  base::Status WriteFromFd(int, size_t) override {
+    return base::ErrStatus("simulated write failure");
+  }
+
+ private:
+  size_t fail_after_;
+  size_t bytes_seen_ = 0;
+};
+
+TEST_F(TarWriterTest, CustomSinkAddFilePropagatesError) {
+  // Allow the 512-byte header through; fail on the content write.
+  TarWriter writer(std::make_unique<FailAfterSink>(512));
+
   auto status = writer.AddFile("fails.txt", "some content");
-  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status, IsError());
   EXPECT_THAT(status.message(), HasSubstr("simulated write failure"));
+
+  // The failed write poisons the writer: finalization becomes a no-op, so
+  // the destructor does not crash.
+  EXPECT_OK(writer.Finalize());
 }
 
-TEST_F(TarWriterTest, CallbackSinkBeginFilePropagatesError) {
-  bool fail_next = false;
-  CallbackTarWriterSink sink(
-      [&](const void* /*data*/, size_t /*len*/) -> base::Status {
-        if (fail_next) {
-          return base::ErrStatus("callback sink: simulated write failure");
-        }
-        fail_next = true;
-        return base::OkStatus();
-      });
-  TarWriter writer(&sink);
+TEST_F(TarWriterTest, CustomSinkStreamFilePropagatesError) {
+  TarWriter writer(std::make_unique<FailAfterSink>(512));
 
-  // The header write (first callback invocation) succeeds; BeginFile()
-  // itself should thus succeed here.
-  auto file_or = writer.BeginFile("fails.txt", 5);
+  // The header write succeeds, so StreamFile() itself succeeds.
+  auto file_or = writer.StreamFile("fails.txt", 5);
   ASSERT_OK(file_or.status());
   TarWriter::ScopedFileWriter file = std::move(file_or.value());
   auto status = file.Write("hello", 5);
-  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status, IsError());
   EXPECT_THAT(status.message(), HasSubstr("simulated write failure"));
 
-  // Finish() should also propagate the failure without crashing.
-  auto finish_status = file.Finish();
-  EXPECT_FALSE(finish_status.ok());
+  // The failed write poisons both the entry and the writer: finalization
+  // becomes a no-op at both levels and teardown does not crash.
+  EXPECT_OK(file.Finalize());
+  EXPECT_OK(writer.Finalize());
 }
 
-TEST_F(TarWriterTest, CallbackSinkFinalizeErrorDoesNotCrash) {
-  CallbackTarWriterSink sink(
-      [&](const void* /*data*/, size_t /*len*/) -> base::Status {
-        return base::ErrStatus("callback sink: simulated write failure");
-      });
-
-  {
-    TarWriter writer(&sink);
-    auto status = writer.Finalize();
-    EXPECT_FALSE(status.ok());
-
-    // Idempotent: the second call is a no-op that reports success even
-    // though the underlying write never happened.
-    auto second_status = writer.Finalize();
-    EXPECT_TRUE(second_status.ok());
-  }  // Destructor calls Finalize() again; must not crash (logs instead).
+TEST_F(TarWriterTest, CustomSinkPoisonedTeardownDoesNotCrash) {
+  TarWriter writer(std::make_unique<FailAfterSink>(512));
+  auto file_or = writer.StreamFile("fails.txt", 5);
+  ASSERT_OK(file_or.status());
+  TarWriter::ScopedFileWriter file = std::move(file_or.value());
+  EXPECT_THAT(file.Write("hello", 5), IsError());
+  // No explicit Finalize() anywhere: the failed write poisons the entry and
+  // the writer, so both destructors must be no-ops.
 }
 
-TEST_F(TarWriterTest, CallbackSinkDestructorFinalizeFailureDoesNotCrash) {
-  CallbackTarWriterSink sink(
-      [&](const void* /*data*/, size_t /*len*/) -> base::Status {
-        return base::ErrStatus("callback sink: simulated write failure");
-      });
+TEST_F(TarWriterTest, CustomSinkFinalizeErrorPropagates) {
+  TarWriter writer(std::make_unique<FailAfterSink>(0));
 
-  // Never call Finalize() explicitly; the destructor's best-effort
-  // finalization must swallow the error (logging it) rather than crash.
-  {
-    TarWriter writer(&sink);
-  }
+  EXPECT_THAT(writer.Finalize(), IsError());
+
+  // Idempotent: the second call is a no-op that reports success even though
+  // the underlying write never happened; the destructor is likewise a no-op.
+  EXPECT_OK(writer.Finalize());
 }
 
 }  // namespace

--- a/src/trace_processor/util/tar_writer_unittest.cc
+++ b/src/trace_processor/util/tar_writer_unittest.cc
@@ -463,6 +463,39 @@ TEST_F(TarWriterTest, DisableWindows(StreamFileAutomaticFinalize)) {
   EXPECT_EQ(headers[0].size, content.size());
 }
 
+TEST_F(TarWriterTest, StreamFileRejectsCumulativeOversize) {
+  std::vector<uint8_t> buffer;
+  TarWriter writer(std::make_unique<BufferTarWriterSink>(&buffer));
+  auto file_or = writer.StreamFile("oversize.txt", 5);
+  ASSERT_OK(file_or.status());
+  TarWriter::ScopedFileWriter file = std::move(file_or.value());
+
+  ASSERT_OK(file.Write("abc", 3));
+  auto status = file.Write("def", 3);
+  EXPECT_THAT(status, IsError());
+  EXPECT_THAT(status.message(), HasSubstr("only 2 bytes remain"));
+
+  // The rejected write poisons the writer, making finalization a no-op.
+  EXPECT_OK(file.Finalize());
+  EXPECT_OK(writer.Finalize());
+}
+
+TEST_F(TarWriterTest, StreamFileRejectsUndersizeOnFinalize) {
+  std::vector<uint8_t> buffer;
+  TarWriter writer(std::make_unique<BufferTarWriterSink>(&buffer));
+  auto file_or = writer.StreamFile("undersize.txt", 5);
+  ASSERT_OK(file_or.status());
+  TarWriter::ScopedFileWriter file = std::move(file_or.value());
+
+  ASSERT_OK(file.Write("data", 4));
+  auto status = file.Finalize();
+  EXPECT_THAT(status, IsError());
+  EXPECT_THAT(status.message(), HasSubstr("expected 5 bytes"));
+
+  // The incomplete entry poisons the writer, making finalization a no-op.
+  EXPECT_OK(writer.Finalize());
+}
+
 // Accepts the first `fail_after` bytes, then fails every write.
 class FailAfterSink : public TarWriterSink {
  public:


### PR DESCRIPTION
TarWriter could only write to a file descriptor, which makes it
unusable for streaming an archive over an RPC connection. Introduce a
TarWriterSink interface with buffer- and callback-backed
implementations; the existing path/fd constructors keep working via an
internal fd sink.

Also make the error handling suitable for streaming consumers: a
failing callback aborts the write and propagates its status,
finalization is an explicit Status-returning operation (the destructor
only finalizes best-effort and never crashes on a broken pipe), and
the new StreamFile API streams a member's content into the archive
without buffering it in memory first.
