### PR TITLE
tp: rename import logs tracker methods to be less error-centric

### DIFF
--- a/src/trace_processor/importers/common/clock_tracker.cc
+++ b/src/trace_processor/importers/common/clock_tracker.cc
@@ -78,7 +78,7 @@ base::StatusOr<uint32_t> ClockTracker::AddSnapshot(
   // in-app trace + a system trace on the same machine).
   if (PERFETTO_UNLIKELY(!is_primary_ && current_file_tag_ == 0)) {
     if (PERFETTO_UNLIKELY(num_conversions_ > 0)) {
-      context_->import_logs_tracker->RecordAnalysisError(
+      context_->import_logs_tracker->RecordAnalysisLog(
           stats::clock_sync_mixed_clock_sources,
           [&](ArgsTracker::BoundInserter& inserter) {
             StringId key = context_->storage->InternString(
@@ -322,7 +322,7 @@ void ClockTracker::BridgeToTraceTime(ClockId clock_id, ClockId trace_time) {
   // are dropped (and counted by clock_sync_failure_no_path). Record a clear
   // analysis log explaining why, rather than leaving only that generic
   // no-path error which advises emitting ClockSnapshots.
-  context_->import_logs_tracker->RecordAnalysisError(
+  context_->import_logs_tracker->RecordAnalysisLog(
       stats::clock_sync_unrelatable_clock_domains,
       [&](ArgsTracker::BoundInserter& inserter) {
         inserter.AddArg(source_clock_id_key_,
@@ -381,10 +381,10 @@ void ClockTracker::RecordConversionError(const ClockSyncError& error,
                     Variadic::Integer(error.target_clock.clock_id));
   };
   if (byte_offset) {
-    context_->import_logs_tracker->RecordTokenizationError(stat_key,
-                                                           *byte_offset, args);
+    context_->import_logs_tracker->RecordTokenizationLog(stat_key, *byte_offset,
+                                                         args);
   } else {
-    context_->import_logs_tracker->RecordAnalysisError(stat_key, args);
+    context_->import_logs_tracker->RecordAnalysisLog(stat_key, args);
   }
 }
 

--- a/src/trace_processor/importers/common/import_logs_tracker.cc
+++ b/src/trace_processor/importers/common/import_logs_tracker.cc
@@ -56,7 +56,7 @@ void ImportLogsTracker::RecordImportLog(
   }
 }
 
-void ImportLogsTracker::RecordTokenizationError(
+void ImportLogsTracker::RecordTokenizationLog(
     size_t stat_key,
     int64_t byte_offset,
     std::function<void(ArgsTracker::BoundInserter&)> args_callback) {
@@ -65,7 +65,7 @@ void ImportLogsTracker::RecordTokenizationError(
                   std::move(args_callback));
 }
 
-void ImportLogsTracker::RecordParserError(
+void ImportLogsTracker::RecordParserLog(
     size_t stat_key,
     int64_t timestamp,
     std::function<void(ArgsTracker::BoundInserter&)> args_callback) {
@@ -73,7 +73,7 @@ void ImportLogsTracker::RecordParserError(
                   /*byte_offset=*/std::nullopt, std::move(args_callback));
 }
 
-void ImportLogsTracker::RecordCollectionError(
+void ImportLogsTracker::RecordCollectionLog(
     size_t stat_key,
     int64_t timestamp,
     std::function<void(ArgsTracker::BoundInserter&)> args_callback) {
@@ -81,14 +81,14 @@ void ImportLogsTracker::RecordCollectionError(
                   /*byte_offset=*/std::nullopt, std::move(args_callback));
 }
 
-void ImportLogsTracker::RecordCollectionError(
+void ImportLogsTracker::RecordCollectionLog(
     size_t stat_key,
     std::function<void(ArgsTracker::BoundInserter&)> args_callback) {
   RecordImportLog(stat_key, /*timestamp=*/std::nullopt,
                   /*byte_offset=*/std::nullopt, std::move(args_callback));
 }
 
-void ImportLogsTracker::RecordAnalysisError(
+void ImportLogsTracker::RecordAnalysisLog(
     size_t stat_key,
     std::function<void(ArgsTracker::BoundInserter&)> args_callback) {
   RecordImportLog(stat_key,

--- a/src/trace_processor/importers/common/import_logs_tracker.h
+++ b/src/trace_processor/importers/common/import_logs_tracker.h
@@ -29,59 +29,61 @@ namespace perfetto::trace_processor {
 
 class TraceProcessorContext;
 
-// Tracks import-time errors and warnings, recording them both as stats
-// (for aggregate metrics) and in the TraceImportLogsTable (for detailed,
+// Tracks errors and other notable import-time events, recording them both as
+// stats (for aggregate metrics) and in the TraceImportLogsTable (for detailed,
 // queryable logs with context).
 class ImportLogsTracker {
  public:
   explicit ImportLogsTracker(TraceProcessorContext*,
                              tables::TraceFileTable::Id trace_id);
 
-  // For "tokenization" errors (pre-parsing, only have byte offset)
+  // For "tokenization" logs (pre-parsing, only have byte offset).
   // Use when reading raw bytes and encountering malformed data.
-  void RecordTokenizationError(
+  void RecordTokenizationLog(
       size_t stat_key,
       int64_t byte_offset,
       std::function<void(ArgsTracker::BoundInserter&)> args_callback = {});
 
-  // Overload for size_t byte offset (e.g., from TraceBlobView::offset())
-  void RecordTokenizationError(
+  // Overload for size_t byte offset (e.g., from TraceBlobView::offset()).
+  void RecordTokenizationLog(
       size_t stat_key,
       size_t byte_offset,
       std::function<void(ArgsTracker::BoundInserter&)> args_callback = {}) {
-    RecordTokenizationError(stat_key, static_cast<int64_t>(byte_offset),
-                            std::move(args_callback));
+    RecordTokenizationLog(stat_key, static_cast<int64_t>(byte_offset),
+                          std::move(args_callback));
   }
 
-  // For "parser" errors (post-parsing, have timestamp + context)
+  // For "parser" logs (post-parsing, have timestamp + context).
   // Use when you have a parsed event but it's invalid/problematic.
-  void RecordParserError(
+  void RecordParserLog(
       size_t stat_key,
       int64_t timestamp,
       std::function<void(ArgsTracker::BoundInserter&)> args_callback = {});
 
-  // For "collection" errors (errors occurring during trace recording on device)
-  // Use when the trace contains explicit error information from the producer.
-  void RecordCollectionError(
+  // For "collection" logs (e.g. errors occurring during trace recording on
+  // device).
+  // Use when recording information that was explicitly supplied by the
+  // producer.
+  void RecordCollectionLog(
       size_t stat_key,
       int64_t timestamp,
       std::function<void(ArgsTracker::BoundInserter&)> args_callback = {});
 
-  // Overload for collection errors not tied to a specific timestamp, e.g.
-  // trace-setup errors reported in a summary packet.
-  void RecordCollectionError(
+  // Overload for collection logs not tied to a specific timestamp (e.g.
+  // trace-setup errors reported in a summary packet).
+  void RecordCollectionLog(
       size_t stat_key,
       std::function<void(ArgsTracker::BoundInserter&)> args_callback);
 
-  // For "analysis" errors (validation/resolution phase, no specific event)
-  // Use ONLY when the error occurs during analysis/validation, not tied to a
-  // specific packet or event (e.g., track hierarchy validation).
-  // IMPORTANT: This should be rare - prefer RecordTokenizationError or
-  // RecordParserError when you have context (byte offset or timestamp).
+  // For "analysis" logs (validation/resolution phase, no specific event)
+  // Use ONLY when the observation occurs during analysis/validation, not tied
+  // to a specific packet or event (e.g., track hierarchy validation).
+  // IMPORTANT: This should be rare - prefer RecordTokenizationLog or
+  // RecordParserLog when you have context (byte offset or timestamp).
   // IMPORTANT: Since this API has neither timestamp nor byte offset, you MUST
   // provide args_callback with sufficient context to identify and disambiguate
   // the specific error occurrence (e.g., track_uuid, utid, upid, etc.).
-  void RecordAnalysisError(
+  void RecordAnalysisLog(
       size_t stat_key,
       std::function<void(ArgsTracker::BoundInserter&)> args_callback);
 

--- a/src/trace_processor/importers/common/process_tracker.cc
+++ b/src/trace_processor/importers/common/process_tracker.cc
@@ -454,10 +454,10 @@ void ProcessTracker::SetProcessParent(UniquePid upid,
     prr.set_parent_upid(pupid);
   } else if (*prev_parent_upid != pupid) {
     if (timestamp) {
-      context_->import_logs_tracker->RecordParserError(
+      context_->import_logs_tracker->RecordParserLog(
           stats::process_tracker_parent_pid_changed, *timestamp);
     } else {
-      context_->import_logs_tracker->RecordAnalysisError(
+      context_->import_logs_tracker->RecordAnalysisLog(
           stats::process_tracker_parent_pid_changed, {});
     }
   }

--- a/src/trace_processor/importers/common/slice_tracker.cc
+++ b/src/trace_processor/importers/common/slice_tracker.cc
@@ -77,8 +77,8 @@ SliceTracker::~SliceTracker() {
 }
 
 void SliceTracker::RecordSliceNegativeDuration(int64_t timestamp) {
-  context_->import_logs_tracker->RecordParserError(
-      stats::slice_negative_duration, timestamp);
+  context_->import_logs_tracker->RecordParserLog(stats::slice_negative_duration,
+                                                 timestamp);
 }
 
 bool SliceTracker::PrepareStartSlice(TrackInfo& track_info,
@@ -109,7 +109,7 @@ void SliceTracker::LogMaxDepthExceeded(const SliceInfo& parent,
       parent.row.ToRowReference(slices).name().value_or(kNullStringId);
   StringId current_name_id = name.is_null() ? kNullStringId : name;
 
-  context_->import_logs_tracker->RecordParserError(
+  context_->import_logs_tracker->RecordParserLog(
       stats::slice_max_depth_exceeded, timestamp,
       [this, parent_name_id,
        current_name_id](ArgsTracker::BoundInserter& inserter) {
@@ -464,7 +464,7 @@ bool SliceTracker::MaybeCloseStack(TrackInfo& track_info,
         // Nobody can recover this slice, so drop it but log the offending
         // events (rather than only bumping a stat) so the user can find and fix
         // them.
-        context_->import_logs_tracker->RecordParserError(
+        context_->import_logs_tracker->RecordParserLog(
             stats::slice_drop_overlapping_complete_event, new_ts,
             [this, info](ArgsTracker::BoundInserter& inserter) {
               AddOverlapArgs(info, inserter);

--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -779,7 +779,7 @@ base::Status FtraceParser::ParseFtraceStats(ConstBytes blob,
       auto record = [&](const std::string& message) {
         any_errors = true;
         StringId message_id = storage->InternString(base::StringView(message));
-        context_->import_logs_tracker->RecordCollectionError(
+        context_->import_logs_tracker->RecordCollectionLog(
             stats::ftrace_setup_errors,
             [&](ArgsTracker::BoundInserter& inserter) {
               inserter.AddArg(message_key, Variadic::String(message_id));

--- a/src/trace_processor/importers/ftrace/gpu_work_period_tracker.cc
+++ b/src/trace_processor/importers/ftrace/gpu_work_period_tracker.cc
@@ -60,7 +60,7 @@ void GpuWorkPeriodTracker::ParseGpuWorkPeriodEvent(int64_t timestamp,
   const auto duration =
       static_cast<int64_t>(evt.end_time_ns() - evt.start_time_ns());
   if (duration < 0) {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::gpu_work_period_negative_duration, timestamp,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(

--- a/src/trace_processor/importers/instruments/row_parser.cc
+++ b/src/trace_processor/importers/instruments/row_parser.cc
@@ -53,13 +53,13 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
 
   Thread* thread = data_.GetThread(row.thread);
   if (!thread) {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::instruments_row_missing_thread, ts);
     return;
   }
   Process* process = data_.GetProcess(thread->process);
   if (!process) {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::instruments_row_missing_process, ts);
     return;
   }
@@ -80,7 +80,7 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
 
   Backtrace* backtrace = data_.GetBacktrace(row.backtrace);
   if (!backtrace) {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::instruments_row_missing_backtrace, ts);
     return;
   }
@@ -91,7 +91,7 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
        ++it) {
     Frame* frame = data_.GetFrame(*it);
     if (!frame) {
-      context_->import_logs_tracker->RecordParserError(
+      context_->import_logs_tracker->RecordParserLog(
           stats::instruments_row_missing_frame, ts);
       continue;
     }

--- a/src/trace_processor/importers/json/json_trace_parser.cc
+++ b/src/trace_processor/importers/json/json_trace_parser.cc
@@ -589,7 +589,7 @@ void JsonTraceParser::RecordEventError(
   StringId name_id = event.name;
   const char phase_str[2] = {event.phase, '\0'};
   StringId phase_id = context_->storage->InternString(phase_str);
-  context_->import_logs_tracker->RecordParserError(
+  context_->import_logs_tracker->RecordParserLog(
       stat_key, timestamp,
       [name_key, name_id, phase_key, phase_id,
        extra_args =

--- a/src/trace_processor/importers/json/json_trace_tokenizer.cc
+++ b/src/trace_processor/importers/json/json_trace_tokenizer.cc
@@ -555,7 +555,7 @@ void JsonTraceTokenizer::RecordEventError(size_t stat_key,
     error_id = context_->storage->InternString(status.c_message());
   }
   StringId error_key = context_->storage->InternString("error");
-  context_->import_logs_tracker->RecordTokenizationError(
+  context_->import_logs_tracker->RecordTokenizationLog(
       stat_key, CurrentByteOffset(),
       [raw_key, raw_id, error_key,
        error_id](ArgsTracker::BoundInserter& inserter) {

--- a/src/trace_processor/importers/primes/primes_trace_parser.cc
+++ b/src/trace_processor/importers/primes/primes_trace_parser.cc
@@ -66,7 +66,7 @@ void PrimesTraceParser::Parse(int64_t ts, TraceBlobView trace_edge) {
   } else if (edge_decoder.has_mark()) {
     HandleMark(ts, edge_decoder);
   } else {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::primes_unknown_edge_type, ts,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(
@@ -98,7 +98,7 @@ void PrimesTraceParser::HandleSliceBegin(
   } else if (details_decoder.has_parent_id()) {
     auto* it = edge_to_executor_map_.Find(parent_id);
     if (!it) {
-      context_->import_logs_tracker->RecordParserError(
+      context_->import_logs_tracker->RecordParserLog(
           stats::primes_executor_not_found, ts,
           [&](ArgsTracker::BoundInserter& inserter) {
             inserter.AddArg(edge_id_string_, Variadic::Integer(edge_id));
@@ -109,7 +109,7 @@ void PrimesTraceParser::HandleSliceBegin(
     executor_id = *it;
     executor_name = kNullStringId;
   } else {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::primes_missing_parent_id, ts,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(edge_id_string_, Variadic::Integer(edge_id));
@@ -148,7 +148,7 @@ void PrimesTraceParser::HandleSliceEnd(
   // A SliceEnd edge has the same ID as the corresponding SliceBegin edge.
   int64_t* executor_id = edge_to_executor_map_.Find(edge_id);
   if (!executor_id) {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::primes_end_without_matching_begin, ts,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(edge_id_string_, Variadic::Integer(edge_id));
@@ -168,7 +168,7 @@ void PrimesTraceParser::HandleMark(int64_t ts,
   int64_t edge_id = static_cast<int64_t>(edge_decoder.id());
   auto mark_decoder = primespb::TraceEdge_Mark_Decoder(edge_decoder.mark());
   if (!mark_decoder.has_entity_details()) {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::primes_missing_entity_details, ts,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(edge_id_string_, Variadic::Integer(edge_id));
@@ -178,7 +178,7 @@ void PrimesTraceParser::HandleMark(int64_t ts,
   auto details_decoder = primespb::TraceEdge_TraceEntityDetails_Decoder(
       mark_decoder.entity_details());
   if (!details_decoder.has_parent_id()) {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::primes_missing_parent_id, ts,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(edge_id_string_, Variadic::Integer(edge_id));
@@ -190,7 +190,7 @@ void PrimesTraceParser::HandleMark(int64_t ts,
   int64_t parent_id = static_cast<int64_t>(details_decoder.parent_id());
   auto* executor_id = edge_to_executor_map_.Find(parent_id);
   if (!executor_id) {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::primes_executor_not_found, ts,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(debug_edge_id_, Variadic::Integer(edge_id));

--- a/src/trace_processor/importers/primes/primes_trace_tokenizer.cc
+++ b/src/trace_processor/importers/primes/primes_trace_tokenizer.cc
@@ -88,7 +88,7 @@ base::Status PrimesTraceTokenizer::OnPushDataToSorter() {
     primespb::TraceEdge::Decoder edge_decoder(*edge);
     if (!edge_decoder.has_trace_start_offset()) {
       PERFETTO_ELOG("Edge missing trace_start_offset.");
-      context_->import_logs_tracker->RecordTokenizationError(
+      context_->import_logs_tracker->RecordTokenizationLog(
           stats::primes_malformed_timestamp, ts_decoder.read_offset());
       continue;
     }

--- a/src/trace_processor/importers/proto/android_probes_module.cc
+++ b/src/trace_processor/importers/proto/android_probes_module.cc
@@ -119,7 +119,7 @@ ModuleResult AndroidProbesModule::TokenizePacket(
     parser_.ParseRailDescriptor(evt);
 
     if (!evt.has_energy_data()) {
-      context_->import_logs_tracker->RecordParserError(
+      context_->import_logs_tracker->RecordParserLog(
           stats::power_rail_empty_packet, args.ts);
       return ModuleResult::Handled();
     }

--- a/src/trace_processor/importers/proto/android_probes_parser.cc
+++ b/src/trace_processor/importers/proto/android_probes_parser.cc
@@ -775,7 +775,7 @@ StringId AndroidProbesParser::ToFlagTypeId(int32_t type) {
 void AndroidProbesParser::ParseAndroidAflags(int64_t ts, ConstBytes blob) {
   protos::pbzero::AndroidAflags::Decoder decoder(blob.data, blob.size);
   if (decoder.has_error()) {
-    context_->import_logs_tracker->RecordCollectionError(
+    context_->import_logs_tracker->RecordCollectionLog(
         stats::android_aflags_errors, ts,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(context_->storage->InternString("error"),

--- a/src/trace_processor/importers/proto/concurrent_sessions_module.cc
+++ b/src/trace_processor/importers/proto/concurrent_sessions_module.cc
@@ -96,7 +96,7 @@ void ConcurrentSessionsModule::ParseConcurrentSessionEvent(
       break;
     default:
       // STATE_UNSPECIFIED or a state added by a newer version of the proto.
-      context_->import_logs_tracker->RecordParserError(
+      context_->import_logs_tracker->RecordParserLog(
           stats::concurrent_session_event_unknown_state, ts,
           [&](ArgsTracker::BoundInserter& inserter) {
             inserter.AddArg(context_->storage->InternString("state"),

--- a/src/trace_processor/importers/proto/graphics_event_module.cc
+++ b/src/trace_processor/importers/proto/graphics_event_module.cc
@@ -89,7 +89,7 @@ ModuleResult GraphicsEventModule::TokenizePacket(
   // only flag/drop the packet when it actually carries samples. Returning a
   // non-Ignored result stops it from reaching the sorter.
   if (event.counters() && !args.decoder.has_timestamp()) {
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::gpu_counters_missing_timestamp, args.packet->offset());
     return ModuleResult::Handled();
   }
@@ -161,19 +161,19 @@ void GraphicsEventModule::TokenizeGpuCounterEvent(
     for (auto it = descriptor.specs(); it; ++it) {
       GpuCounterDescriptor::GpuCounterSpec::Decoder spec(*it);
       if (!spec.has_counter_id()) {
-        context_->import_logs_tracker->RecordTokenizationError(
+        context_->import_logs_tracker->RecordTokenizationLog(
             stats::gpu_counters_invalid_spec, packet_offset);
         continue;
       }
       if (!spec.has_name()) {
-        context_->import_logs_tracker->RecordTokenizationError(
+        context_->import_logs_tracker->RecordTokenizationLog(
             stats::gpu_counters_invalid_spec, packet_offset);
         continue;
       }
 
       auto counter_id = spec.counter_id();
       if (legacy_gpu_counters_.Find(counter_id)) {
-        context_->import_logs_tracker->RecordTokenizationError(
+        context_->import_logs_tracker->RecordTokenizationLog(
             stats::gpu_counters_invalid_spec, packet_offset,
             [this, counter_id, &spec](ArgsTracker::BoundInserter& inserter) {
               inserter.AddArg(counter_id_key_id_,

--- a/src/trace_processor/importers/proto/profile_module.cc
+++ b/src/trace_processor/importers/proto/profile_module.cc
@@ -192,7 +192,7 @@ ModuleResult ProfileModule::TokenizeStreamingProfilePacket(
   for (auto callstack_it = decoder.callstack_iid(); callstack_it;
        ++callstack_it, ++timestamp_it) {
     if (!timestamp_it) {
-      context_->import_logs_tracker->RecordTokenizationError(
+      context_->import_logs_tracker->RecordTokenizationLog(
           stats::stackprofile_parser_error, packet->offset());
       break;
     }
@@ -228,7 +228,7 @@ void ProfileModule::ParseStreamingProfileSample(
   auto opt_cs_id = stack_profile_sequence_state.FindOrInsertCallstack(
       sequence_state, upid, event.callstack_iid);
   if (!opt_cs_id) {
-    context_->import_logs_tracker->RecordParserError(
+    context_->import_logs_tracker->RecordParserLog(
         stats::stackprofile_parser_error, ts,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(context_->storage->InternString("callstack_iid"),

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -218,7 +218,7 @@ ProtoTraceReader::ProtoTraceReader(TraceProcessorContext* ctx,
         reinterpret_cast<const uint8_t*>(raw_bytes.data()), raw_bytes.size(),
         {}, true);
     if (!status.ok()) {
-      context_->import_logs_tracker->RecordAnalysisError(
+      context_->import_logs_tracker->RecordAnalysisLog(
           stats::extra_parsing_descriptors_error,
           [&](ArgsTracker::BoundInserter& ins) {
             ins.AddArg(context_->storage->InternString("message"),
@@ -402,7 +402,7 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
         PacketAnalyzer::Get(context_)->ProcessPacket(packet, annotation);
       }
       scoped_state->needs_incremental_state_skipped++;
-      context_->import_logs_tracker->RecordTokenizationError(
+      context_->import_logs_tracker->RecordTokenizationLog(
           stats::packet_skipped_seq_needs_incremental_state_invalid,
           packet.offset(),
           [this, seq_id](ArgsTracker::BoundInserter& inserter) {
@@ -447,7 +447,7 @@ ProtoTraceReader::ClockResolution ProtoTraceReader::ResolveTimestampToTraceTime(
   }
 
   // Cannot defer: record the error and drop the packet.
-  context_->import_logs_tracker->RecordTokenizationError(
+  context_->import_logs_tracker->RecordTokenizationLog(
       stats::clock_sync_failure_undeferrable_packet_loss, packet->offset());
   return ClockResolution::kDropped;
 }
@@ -581,7 +581,7 @@ void ProtoTraceReader::HandleIncrementalStateCleared(
     const protos::pbzero::TracePacket::Decoder& packet_decoder,
     const TraceBlobView& packet) {
   if (PERFETTO_UNLIKELY(!packet_decoder.has_trusted_packet_sequence_id())) {
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::incremental_state_cleared_missing_sequence_id, packet.offset());
     return;
   }
@@ -625,7 +625,7 @@ void ProtoTraceReader::HandlePreviousPacketDropped(
     const protos::pbzero::TracePacket::Decoder& packet_decoder,
     const TraceBlobView& packet) {
   if (PERFETTO_UNLIKELY(!packet_decoder.has_trusted_packet_sequence_id())) {
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::previous_packet_dropped_missing_sequence_id, packet.offset());
     return;
   }
@@ -661,7 +661,7 @@ void ProtoTraceReader::ParseTracePacketDefaults(
     const protos::pbzero::TracePacket_Decoder& packet_decoder,
     TraceBlobView trace_packet_defaults) {
   if (PERFETTO_UNLIKELY(!packet_decoder.has_trusted_packet_sequence_id())) {
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::trace_packet_defaults_missing_sequence_id,
         trace_packet_defaults.offset());
     return;
@@ -676,7 +676,7 @@ void ProtoTraceReader::ParseInternedData(
     const protos::pbzero::TracePacket::Decoder& packet_decoder,
     TraceBlobView interned_data) {
   if (PERFETTO_UNLIKELY(!packet_decoder.has_trusted_packet_sequence_id())) {
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::interned_data_missing_sequence_id, interned_data.offset());
     return;
   }
@@ -688,7 +688,7 @@ void ProtoTraceReader::ParseInternedData(
   // they could otherwise be associated with the wrong generation in the state.
   if (!state->IsIncrementalStateValid()) {
     uint32_t seq_id = packet_decoder.trusted_packet_sequence_id();
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::interned_data_skipped_incremental_state_invalid,
         interned_data.offset(),
         [this, seq_id](ArgsTracker::BoundInserter& inserter) {

--- a/src/trace_processor/importers/proto/protovm_incremental_tracing.cc
+++ b/src/trace_processor/importers/proto/protovm_incremental_tracing.cc
@@ -62,7 +62,7 @@ void ProtoVmIncrementalTracing::ProcessProtoVmsPacket(
          ++producer_id) {
       auto* sequence_ids = producer_id_to_sequence_ids_.Find(*producer_id);
       if (!sequence_ids) {
-        context_->import_logs_tracker->RecordTokenizationError(
+        context_->import_logs_tracker->RecordTokenizationLog(
             stats::protovm_registration_error, packet.offset());
         continue;
       }
@@ -91,8 +91,8 @@ std::optional<TraceBlobView> ProtoVmIncrementalTracing::TryProcessPatch(
       return SerializeIncrementalState(*vm, patch);
     }
     if (status.IsAbort()) {
-      context_->import_logs_tracker->RecordTokenizationError(
-          stats::protovm_abort, packet.offset());
+      context_->import_logs_tracker->RecordTokenizationLog(stats::protovm_abort,
+                                                           packet.offset());
     }
   }
   return std::nullopt;

--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -821,7 +821,7 @@ void SystemProbesParser::ParseProcessTree(int64_t ts, ConstBytes blob) {
       }
       if (!context_->process_tracker->UpdateNamespacedThread(
               tgid, tid, std::move(nstid))) {
-        context_->import_logs_tracker->RecordParserError(
+        context_->import_logs_tracker->RecordParserLog(
             stats::namespaced_thread_missing_process, ts);
       }
     }

--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -112,8 +112,8 @@ ModuleResult TrackEventTokenizer::TokenizeRangeOfInterestPacket(
       args.field
           .Cast<protos::pbzero::TracePacket::kTrackEventRangeOfInterest>());
   if (!range_of_interest.has_start_us()) {
-    RecordTokenizationError(
-        stats::track_event_range_of_interest_missing_start_us, args.packet);
+    RecordTokenizationLog(stats::track_event_range_of_interest_missing_start_us,
+                          args.packet);
     return ModuleResult::Handled();
   }
   track_event_tracker_->set_range_of_interest_us(range_of_interest.start_us());
@@ -133,7 +133,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackDescriptorPacket(
   Reservation reservation;
 
   if (!track.has_uuid()) {
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::track_descriptor_missing_uuid, args.packet->offset());
     return ModuleResult::Handled();
   }
@@ -157,7 +157,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackDescriptorPacket(
         reservation.ordering = Reservation::ChildTracksOrdering::kExplicit;
         break;
       default:
-        context_->import_logs_tracker->RecordTokenizationError(
+        context_->import_logs_tracker->RecordTokenizationLog(
             stats::track_descriptor_invalid_child_ordering,
             args.packet->offset(),
             [this, &track](ArgsTracker::BoundInserter& inserter) {
@@ -245,7 +245,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackDescriptorPacket(
     protos::pbzero::ThreadDescriptor::Decoder thread(track.thread());
 
     if (!thread.has_pid() || !thread.has_tid()) {
-      context_->import_logs_tracker->RecordTokenizationError(
+      context_->import_logs_tracker->RecordTokenizationLog(
           stats::track_descriptor_thread_missing_pid_tid, args.packet->offset(),
           [&](ArgsTracker::BoundInserter& inserter) {
             inserter.AddArg(track_uuid_key_id_,
@@ -283,7 +283,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackDescriptorPacket(
     protos::pbzero::ProcessDescriptor::Decoder process(track.process());
 
     if (!process.has_pid()) {
-      context_->import_logs_tracker->RecordTokenizationError(
+      context_->import_logs_tracker->RecordTokenizationLog(
           stats::track_descriptor_process_missing_pid, args.packet->offset(),
           [&](ArgsTracker::BoundInserter& inserter) {
             inserter.AddArg(track_uuid_key_id_,
@@ -385,7 +385,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackDescriptorPacket(
 ModuleResult TrackEventTokenizer::TokenizeThreadDescriptorPacket(
     const TokenizePacketArgs& args) {
   if (PERFETTO_UNLIKELY(!args.decoder.has_trusted_packet_sequence_id())) {
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::thread_descriptor_missing_sequence_id, args.packet->offset());
     return ModuleResult::Handled();
   }
@@ -427,7 +427,7 @@ void TrackEventTokenizer::TokenizeThreadDescriptor(
 ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
     const TokenizePacketArgs& args) {
   if (PERFETTO_UNLIKELY(!args.decoder.has_trusted_packet_sequence_id())) {
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::track_event_missing_sequence_id, args.packet->offset());
     return ModuleResult::Handled();
   }
@@ -477,7 +477,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
   } else if (args.decoder.has_timestamp()) {
     timestamp = args.ts;
   } else {
-    context_->import_logs_tracker->RecordTokenizationError(
+    context_->import_logs_tracker->RecordTokenizationLog(
         stats::track_event_missing_timestamp,
         data.trace_packet_data.packet.offset());
     return ModuleResult::Handled();
@@ -540,8 +540,8 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
     } else if (defaults && defaults->has_track_uuid()) {
       track_uuid = defaults->track_uuid();
     } else {
-      RecordTokenizationError(stats::track_event_counter_missing_track_uuid,
-                              &data.trace_packet_data.packet);
+      RecordTokenizationLog(stats::track_event_counter_missing_track_uuid,
+                            &data.trace_packet_data.packet);
       return ModuleResult::Handled();
     }
 
@@ -574,8 +574,8 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
 
   if (event.type() == protos::pbzero::TrackEvent::TYPE_STATE) {
     if (!event.has_track_uuid() && (!defaults || !defaults->has_track_uuid())) {
-      RecordTokenizationError(stats::track_event_state_missing_track_uuid,
-                              &data.trace_packet_data.packet);
+      RecordTokenizationLog(stats::track_event_state_missing_track_uuid,
+                            &data.trace_packet_data.packet);
       return ModuleResult::Handled();
     }
   }
@@ -719,17 +719,17 @@ base::Status TrackEventTokenizer::TokenizeLegacySampleEvent(
   return base::OkStatus();
 }
 
-void TrackEventTokenizer::RecordTokenizationError(size_t stat_key,
-                                                  TraceBlobView* packet) {
-  context_->import_logs_tracker->RecordTokenizationError(stat_key,
-                                                         packet->offset());
+void TrackEventTokenizer::RecordTokenizationLog(size_t stat_key,
+                                                TraceBlobView* packet) {
+  context_->import_logs_tracker->RecordTokenizationLog(stat_key,
+                                                       packet->offset());
 }
 
 void TrackEventTokenizer::RecordTokenizationErrorWithTrackUuid(
     size_t stat_key,
     uint64_t track_uuid,
     TraceBlobView* packet) {
-  context_->import_logs_tracker->RecordTokenizationError(
+  context_->import_logs_tracker->RecordTokenizationLog(
       stat_key, packet->offset(),
       [this, track_uuid](ArgsTracker::BoundInserter& inserter) {
         inserter.AddArg(track_uuid_key_id_,
@@ -741,7 +741,7 @@ void TrackEventTokenizer::RecordTokenizationErrorWithSeqId(
     size_t stat_key,
     uint32_t packet_sequence_id,
     TraceBlobView* packet) {
-  context_->import_logs_tracker->RecordTokenizationError(
+  context_->import_logs_tracker->RecordTokenizationLog(
       stat_key, packet->offset(),
       [this, packet_sequence_id](ArgsTracker::BoundInserter& inserter) {
         inserter.AddArg(packet_sequence_id_key_id_,

--- a/src/trace_processor/importers/proto/track_event_tokenizer.h
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.h
@@ -82,7 +82,7 @@ class TrackEventTokenizer {
       PacketSequenceStateGeneration& state);
 
   // Helper to record tokenization errors with packet offset
-  void RecordTokenizationError(size_t stat_key, TraceBlobView* packet);
+  void RecordTokenizationLog(size_t stat_key, TraceBlobView* packet);
   // Helper to record tokenization errors with track_uuid arg
   void RecordTokenizationErrorWithTrackUuid(size_t stat_key,
                                             uint64_t track_uuid,

--- a/src/trace_processor/importers/proto/track_event_tracker.cc
+++ b/src/trace_processor/importers/proto/track_event_tracker.cc
@@ -177,7 +177,7 @@ void TrackEventTracker::ReserveDescriptorTrack(
     uint64_t uuid,
     const DescriptorTrackReservation& reservation) {
   if (uuid == kDefaultDescriptorTrackUuid && reservation.parent_uuid) {
-    context_->import_logs_tracker->RecordAnalysisError(
+    context_->import_logs_tracker->RecordAnalysisLog(
         stats::track_descriptor_default_track_with_parent,
         [&](ArgsTracker::BoundInserter& inserter) {
           inserter.AddArg(parent_uuid_key_id_,
@@ -736,7 +736,7 @@ bool TrackEventTracker::IsTrackHierarchyValid(uint64_t uuid) {
 }
 
 void TrackEventTracker::RecordTrackError(size_t stat_key, uint64_t track_uuid) {
-  context_->import_logs_tracker->RecordAnalysisError(
+  context_->import_logs_tracker->RecordAnalysisLog(
       stat_key, [this, track_uuid](ArgsTracker::BoundInserter& inserter) {
         inserter.AddArg(track_uuid_key_id_,
                         Variadic::UnsignedInteger(track_uuid));

--- a/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
+++ b/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
@@ -163,7 +163,7 @@ void VideoFrameModule::ParseVideoFrame(protozero::ConstBytes bytes,
       max_stream_size_bytes_) {
     if (!info.size_cap_hit) {
       info.size_cap_hit = true;
-      context_->import_logs_tracker->RecordParserError(
+      context_->import_logs_tracker->RecordParserLog(
           stats::android_video_parse_size_cap_hit, ts,
           [this, display_id](ArgsTracker::BoundInserter& inserter) {
             inserter.AddArg(context_->storage->InternString("display_id"),
@@ -221,7 +221,7 @@ void VideoFrameModule::ParseVideoFrameError(protozero::ConstBytes bytes,
   }
   // Producer-reported failure: record to the import logs (which also bumps the
   // reason's stat), with the affected display as a queryable arg.
-  context_->import_logs_tracker->RecordCollectionError(
+  context_->import_logs_tracker->RecordCollectionLog(
       stat, ts, [this, display_id](ArgsTracker::BoundInserter& inserter) {
         inserter.AddArg(context_->storage->InternString("display_id"),
                         Variadic::UnsignedInteger(display_id));


### PR DESCRIPTION
There are cases where it's useful to record import-time observations that are not outright errors (e.g. #6363), and the tracker fully supports that since the severity is part of the "stats" key.

Make the import logs tracker naming vague enough to cover such possibilities.