### PR TITLE
docs: fix perfetto.dev asset compression

### DIFF
--- a/infra/perfetto.dev/BUILD.gn
+++ b/infra/perfetto.dev/BUILD.gn
@@ -399,11 +399,11 @@ group("all_mdfiles") {
   deps = mdtargets
 }
 
-# Builds assets/search_index.json.gz, the client-side full-text search index
+# Builds assets/search_index.json, the client-side full-text search index
 # consumed by setupSearch() in src/assets/script.js. Hand-written docs are
 # indexed in full; the huge auto-generated reference pages (SQL tables, stdlib,
 # protos) are indexed by title + headings only to keep the shipped index small.
-gen_search_index_out = "${perfetto_website_out_dir}/assets/search_index.json.gz"
+gen_search_index_out = "${perfetto_website_out_dir}/assets/search_index.json"
 
 nodejs_script("gen_search_index") {
   script = "src/gen_search_index.js"

--- a/infra/perfetto.dev/appengine/main.py
+++ b/infra/perfetto.dev/appengine/main.py
@@ -57,11 +57,18 @@ def main(path=''):
   blob = bucket.get_blob(path[1:])
   if blob is None:
     return flask.abort(404)
-  data = blob.download_as_bytes()
+
+  content_encoding = blob.content_encoding
+  accepts_encoding = bool(
+      content_encoding and
+      flask.request.accept_encodings[content_encoding] > 0)
+  data = blob.download_as_bytes(raw_download=accepts_encoding)
   resp = flask.Response(data)
   resp.headers['Content-Type'] = blob.content_type
   resp.headers['Content-Length'] = len(data)
-  resp.headers['Content-Encoding'] = blob.content_encoding
+  if accepts_encoding:
+    resp.headers['Content-Encoding'] = content_encoding
+  resp.headers['Vary'] = 'Accept-Encoding'
   if os.path.splitext(path)[1] in ('.png', '.svg'):
     resp.headers['Cache-Control'] = 'public, max-age=86400'  # 1 Day
   else:

--- a/infra/perfetto.dev/deploy
+++ b/infra/perfetto.dev/deploy
@@ -58,6 +58,7 @@ EOF
 # Basic checks before uploading. Test both the existence and the mime type.
 [ "$(file $OUT_DIR/index.html)" == "text/html" ]
 [ "$(file $OUT_DIR/assets/style.css)" == "text/css" ]
+[ "$(file $OUT_DIR/assets/search_index.json)" == "application/json" ]
 [ "$(file $OUT_DIR/assets/home.png)" == "image/png" ]
 [ "$(file $OUT_DIR/docs/images/perfetto-stack.svg)" == "image/svg+xml" ]
 [ "$(file $OUT_DIR/docs/images/perfetto-stack.svg)" == "image/svg+xml" ]
@@ -69,5 +70,5 @@ EOF
 # -r: recursive.
 # The trailing slash appended to $OUT_DIR is to prevent that gsutil creates a
 # nested sub-directory inside gs://perfetto.dev/.
-gsutil -m rsync -j html,js,css,svg -d -c -r \
+gsutil -m rsync -j html,js,css,svg,json -d -c -r \
   "$OUT_DIR/" gs://perfetto.dev/

--- a/infra/perfetto.dev/mime_util/file
+++ b/infra/perfetto.dev/mime_util/file
@@ -21,7 +21,7 @@ def main():
       '.html': 'text/html',
       '.css': 'text/css',
       '.js': 'text/javascript',
-      '.gz': 'application/gzip',
+      '.json': 'application/json',
       '.jpg': 'image/jpeg',
       '.png': 'image/png',
       '.svg': 'image/svg+xml',

--- a/infra/perfetto.dev/src/assets/script.js
+++ b/infra/perfetto.dev/src/assets/script.js
@@ -374,7 +374,7 @@ function initMermaid() {
 
 // ---------------------------------------------------------------------------
 // Client-side docs search. We ship a build-time full-text index
-// (assets/search_index.json.gz, built by src/gen_search_index.js) and rank it
+// (assets/search_index.json, built by src/gen_search_index.js) and rank it
 // locally with BM25. The old Google Custom Search Engine couldn't see a doc
 // until Googlebot crawled it, often weeks after it shipped.
 // ---------------------------------------------------------------------------
@@ -396,12 +396,9 @@ function searchTokenize(str) {
 }
 
 async function loadSearchIndex() {
-  const resp = await fetch("/assets/search_index.json.gz");
+  const resp = await fetch("/assets/search_index.json");
   if (!resp.ok) throw new Error(`search index HTTP ${resp.status}`);
-  // The server doesn't gzip this file, so it's gzipped at build time and
-  // decompressed here.
-  const stream = resp.body.pipeThrough(new DecompressionStream("gzip"));
-  const data = await new Response(stream).json();
+  const data = await resp.json();
 
   const postings = new Map();  // token -> Map(docIdx -> weight)
   for (let i = 0; i < data.terms.length; i++) {

--- a/infra/perfetto.dev/src/gen_search_index.js
+++ b/infra/perfetto.dev/src/gen_search_index.js
@@ -14,8 +14,8 @@
 
 "use strict";
 
-// Builds the client-side full-text search index (search_index.json.gz) consumed
-// by setupSearch() in assets/script.js.
+// Builds the client-side full-text search index (search_index.json) consumed by
+// setupSearch() in assets/script.js.
 //
 // Inputs (wired up in BUILD.gn):
 //   --full     <md>   Hand-written docs: title, headings and body are indexed.
@@ -28,7 +28,6 @@
 // README.md -> /docs/).
 
 const fs = require("fs");
-const zlib = require("zlib");
 const path = require("path");
 const marked = require("marked");
 const argv = require("yargs").argv;
@@ -260,11 +259,8 @@ function main() {
 
   docs.sort((a, b) => a.u.localeCompare(b.u)); // Deterministic output.
   const index = buildInvertedIndex(docs);
-  // The docs-site proxy serves this file uncompressed, so gzip it here and let
-  // script.js inflate it. Level 9: built once, so size wins over speed.
-  const json = JSON.stringify({docs, ...index});
   fs.mkdirSync(path.dirname(outFile), {recursive: true});
-  fs.writeFileSync(outFile, zlib.gzipSync(json, {level: 9}));
+  fs.writeFileSync(outFile, JSON.stringify({docs, ...index}));
 }
 
 main();


### PR DESCRIPTION
Fixes #6739.

## Problem

The perfetto.dev App Engine proxy downloads GCS objects in decompressed
form, but copies the stored `Content-Encoding` onto every response. This
makes the response body disagree with its headers and prevents assets from
being served with the expected compression.

The docs search worked around this in #6702 by generating a pre-gzipped
`search_index.json.gz` and decompressing it explicitly in the browser.

## Changes

- Negotiate the stored content encoding against the request's
  `Accept-Encoding` header.
- Use `raw_download=True` when the client accepts the stored encoding, so
  the response body remains compressed.
- Only set `Content-Encoding` when returning the corresponding compressed
  representation.
- Add `Vary: Accept-Encoding` to prevent caches from mixing compressed and
  identity responses.
- Restore the search index as `search_index.json`.
- Remove build-time gzip and browser-side `DecompressionStream` handling.
- Compress JSON assets through the existing gsutil deployment pipeline and
  serve them as `application/json`.
- Keep the precomputed search index and loading improvements introduced by
  #6702.

## Testing

- Exercised the App Engine handler with Flask's test client and mocked GCS
  blobs for HTML, JavaScript, CSS, and the search index.
- Verified gzip responses contain the raw gzip body with matching
  `Content-Encoding` and `Content-Length`.
- Verified identity responses contain the decompressed body without a
  `Content-Encoding` header.
- Verified objects without stored compression never produce
  `Content-Encoding: None`.
- Ran Python and JavaScript syntax checks.
- Verified JSON MIME detection and `git diff --check`.

The full docs build is covered by `repo-checks`.