### PR TITLE
tperf: remove references to the now-obsolete LSM sysprop

### DIFF
--- a/test/cts/traced_perf_test_cts.cc
+++ b/test/cts/traced_perf_test_cts.cc
@@ -40,13 +40,6 @@
 namespace perfetto {
 namespace {
 
-// Skip these tests if the device in question doesn't have the necessary kernel
-// LSM hooks in perf_event_open. This comes up when a device with an older
-// kernel upgrades to R.
-bool HasPerfLsmHooks() {
-  return base::GetAndroidProp("sys.init.perf_lsm_hooks") == "1";
-}
-
 std::string RandomSessionName() {
   std::random_device rd;
   std::default_random_engine generator(rd());
@@ -165,9 +158,6 @@ void AssertNoStacksForPid(std::vector<protos::gen::TracePacket> packets,
 }
 
 TEST(TracedPerfCtsTest, SystemWideDebuggableApp) {
-  if (!HasPerfLsmHooks())
-    GTEST_SKIP() << "skipped due to lack of perf_event_open LSM hooks";
-
   std::string app_name = "android.perfetto.cts.app.debuggable";
   const auto& packets = ProfileSystemWide(app_name);
   int app_pid = PidForProcessName(app_name);
@@ -179,9 +169,6 @@ TEST(TracedPerfCtsTest, SystemWideDebuggableApp) {
 }
 
 TEST(TracedPerfCtsTest, SystemWideProfileableApp) {
-  if (!HasPerfLsmHooks())
-    GTEST_SKIP() << "skipped due to lack of perf_event_open LSM hooks";
-
   std::string app_name = "android.perfetto.cts.app.profileable";
   const auto& packets = ProfileSystemWide(app_name);
   int app_pid = PidForProcessName(app_name);
@@ -193,9 +180,6 @@ TEST(TracedPerfCtsTest, SystemWideProfileableApp) {
 }
 
 TEST(TracedPerfCtsTest, SystemWideNonProfileableApp) {
-  if (!HasPerfLsmHooks())
-    GTEST_SKIP() << "skipped due to lack of perf_event_open LSM hooks";
-
   std::string app_name = "android.perfetto.cts.app.nonprofileable";
   const auto& packets = ProfileSystemWide(app_name);
   int app_pid = PidForProcessName(app_name);
@@ -210,9 +194,6 @@ TEST(TracedPerfCtsTest, SystemWideNonProfileableApp) {
 }
 
 TEST(TracedPerfCtsTest, SystemWideReleaseApp) {
-  if (!HasPerfLsmHooks())
-    GTEST_SKIP() << "skipped due to lack of perf_event_open LSM hooks";
-
   std::string app_name = "android.perfetto.cts.app.release";
   const auto& packets = ProfileSystemWide(app_name);
   int app_pid = PidForProcessName(app_name);
@@ -230,9 +211,6 @@ TEST(TracedPerfCtsTest, SystemWideReleaseApp) {
 // Loads a platform process with work (we use traced_probes which runs as
 // AID_NOBODY), and profiles it.
 TEST(TracedPerfCtsTest, ProfilePlatformProcess) {
-  if (!HasPerfLsmHooks())
-    GTEST_SKIP() << "skipped due to lack of perf_event_open LSM hooks";
-
   int target_pid = PidForProcessName("/system/bin/traced_probes");
   ASSERT_GT(target_pid, 0) << "failed to find pid for target process";
 
@@ -281,9 +259,6 @@ TEST(TracedPerfCtsTest, ProfilePlatformProcess) {
 }
 
 TEST(TracedPerfCtsTest, ProfileKernelCallstack) {
-  if (!HasPerfLsmHooks())
-    GTEST_SKIP() << "skipped due to lack of perf_event_open LSM hooks";
-
   TraceConfig trace_config;
   trace_config.add_buffers()->set_size_kb(1024);
   trace_config.set_duration_ms(3000);

--- a/traced_perf.rc
+++ b/traced_perf.rc
@@ -33,15 +33,14 @@ service traced_perf /system/bin/traced_perf
 # Daemon run state:
 # * initially off
 # * |persist.traced_perf.enable| forces daemon to run unconditionally
-# * if kernel doesn't have perf_event_open LSM hooks, daemon is stopped
 # * otherwise, follow |traced.lazy.traced_perf| as an on-demand service
 on property:persist.traced_perf.enable=1
     start traced_perf
-on property:persist.traced_perf.enable="" && property:sys.init.perf_lsm_hooks=""
+on property:persist.traced_perf.enable=""
     stop traced_perf
-on property:persist.traced_perf.enable="" && property:sys.init.perf_lsm_hooks=1 && property:traced.lazy.traced_perf=1
+on property:persist.traced_perf.enable="" && property:traced.lazy.traced_perf=1
     start traced_perf
-on property:persist.traced_perf.enable="" && property:sys.init.perf_lsm_hooks=1 && property:traced.lazy.traced_perf=""
+on property:persist.traced_perf.enable="" && property:traced.lazy.traced_perf=""
     stop traced_perf
 
 on property:persist.traced_perf.enable=0


### PR DESCRIPTION
This system property was used to detect whether a running kernel had LSM support for the perf_event_open syscall. Since the pre-v5.5 kernels are now EOL in Android, the hooks are always assumed to be present, and the platform always sets the sysprop for existing scripts [1].

This patch cleans up traced_perf's references to the sysprop entirely.

[1] system/core/rootdir/init-perfetto.rc