### PR TITLE
ui: massively improve performance of callstack flamegraph

### DIFF
--- a/ui/src/plugins/dev.perfetto.TrackEvent/track_event_callstack_flamegraph.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/track_event_callstack_flamegraph.ts
@@ -259,7 +259,7 @@ function buildSamplesSql(
   trackIds: ReadonlyArray<number>,
 ): string {
   return `
-    WITH relevant_slices AS (
+    WITH relevant_slices AS MATERIALIZED (
       SELECT id
       FROM _interval_intersect_single!(
         ${selection.start},


### PR DESCRIPTION
The join here was not O(1) when it ideally would be, adding materialized
here is a cheap workaround

Separately we should ideally make the track event callstack table
indexed in some way but that requires more thinking
