### PR TITLE
tp: migrate the cpu_profile sample sources onto profiler_sample

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,10 @@ Unreleased:
       samples which captured a callstack, across sources. Per-sample
       counter values keep the perf counter-set model, generalized as
       __intrinsic_profiler_counter_set.
+    * Chrome streaming profiles, legacy V8 cpu profiles, gecko profiles,
+      simpleperf proto traces and perf script text now also populate
+      profiler_sample; cpu_profile_stack_sample keeps its schema as a
+      view over it.
     * The StackSample packet's counter descriptors now materialize as
       counter tracks (scoped per profiler session, or per session and
       cpu via the new CounterDescriptor.scope field, mirroring

--- a/docs/getting-started/other-formats.md
+++ b/docs/getting-started/other-formats.md
@@ -439,7 +439,7 @@ stacks, timestamps, process/thread identifiers, CPU number, and event names.
   - The primary focus of this importer is on **CPU samples and their associated
     call stacks**.
   - When such data is parsed, it populates Perfetto's standard profiling tables
-    (e.g., `cpu_profile_stack_sample_table` for the samples, and
+    (e.g., `cpu_profile_stack_sample` for the samples, and
     `stack_profile_callsite`, `stack_profile_frame`, `stack_profile_mapping` for
     the call stack information).
   - This allows the CPU profile data from the `perf script` output to be

--- a/python/perfetto/trace_data_checks.py
+++ b/python/perfetto/trace_data_checks.py
@@ -151,7 +151,7 @@ TABLE_DATA_CHECK_SQL = {
 
     # From prelude.after_eof.views (profiling / virtualization)
     'cpu_profile_stack_sample':
-        'SELECT 1 FROM __intrinsic_cpu_profile_stack_sample',
+        'SELECT 1 FROM cpu_profile_stack_sample',
     'pkvm_hypervisor_events':
         'SELECT 1 FROM slice WHERE category = \'pkvm_hyp\'',
 

--- a/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc
+++ b/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc
@@ -30,6 +30,7 @@
 #include "src/trace_processor/importers/common/mapping_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
+#include "src/trace_processor/importers/common/profiler_sample_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 #include "src/trace_processor/storage/stats.h"
@@ -184,8 +185,14 @@ base::Status LegacyV8CpuProfileTracker::AddSample(int64_t ts,
     return base::ErrStatus("v8 callsite id does not exist: cannot add sample");
   }
   UniqueTid utid = context_->process_tracker->UpdateThread(tid, pid);
-  auto* samples = context_->storage->mutable_cpu_profile_stack_sample_table();
-  samples->Insert({ts, *id, utid, 0});
+  tables::ProfilerSampleTable::Row row;
+  row.ts = ts;
+  row.source = context_->storage->InternString("legacy_v8");
+  row.utid = utid;
+  row.upid = context_->process_tracker->GetOrCreateProcess(pid);
+  row.cpu_mode = context_->storage->InternString("");
+  row.callsite_id = *id;
+  context_->profiler_sample_tracker->AddSample(row);
   return base::OkStatus();
 }
 

--- a/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc
+++ b/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc
@@ -42,7 +42,8 @@ namespace perfetto::trace_processor {
 
 LegacyV8CpuProfileTracker::LegacyV8CpuProfileTracker(
     TraceProcessorContext* context)
-    : context_(context) {}
+    : context_(context),
+      legacy_v8_source_id_(context->storage->InternString("legacy_v8")) {}
 
 LegacyV8CpuProfileTracker::~LegacyV8CpuProfileTracker() = default;
 
@@ -187,10 +188,9 @@ base::Status LegacyV8CpuProfileTracker::AddSample(int64_t ts,
   UniqueTid utid = context_->process_tracker->UpdateThread(tid, pid);
   tables::ProfilerSampleTable::Row row;
   row.ts = ts;
-  row.source = context_->storage->InternString("legacy_v8");
+  row.source = legacy_v8_source_id_;
   row.utid = utid;
   row.upid = context_->process_tracker->GetOrCreateProcess(pid);
-  row.cpu_mode = context_->storage->InternString("");
   row.callsite_id = *id;
   context_->profiler_sample_tracker->AddSample(row);
   return base::OkStatus();

--- a/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h
+++ b/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h
@@ -88,6 +88,7 @@ class LegacyV8CpuProfileTracker
       state_by_session_and_pid_;
 
   TraceProcessorContext* const context_;
+  const StringPool::Id legacy_v8_source_id_;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/gecko/gecko_trace_parser.cc
+++ b/src/trace_processor/importers/gecko/gecko_trace_parser.cc
@@ -64,7 +64,8 @@ constexpr auto kFirefoxMarkerBlueprint = tracks::SliceBlueprint(
 }  // namespace
 
 GeckoTraceParser::GeckoTraceParser(TraceProcessorContext* context)
-    : context_(context) {}
+    : context_(context),
+      gecko_source_id_(context->storage->InternString("gecko")) {}
 
 GeckoTraceParser::~GeckoTraceParser() = default;
 
@@ -80,9 +81,8 @@ void GeckoTraceParser::ParseStackSample(int64_t ts,
                                         const GeckoEvent::StackSample& sample) {
   tables::ProfilerSampleTable::Row row;
   row.ts = ts;
-  row.source = context_->storage->InternString("gecko");
+  row.source = gecko_source_id_;
   row.utid = context_->process_tracker->GetOrCreateThread(sample.tid);
-  row.cpu_mode = context_->storage->InternString("");
   row.callsite_id = sample.callsite_id;
   context_->profiler_sample_tracker->AddSample(row);
 }

--- a/src/trace_processor/importers/gecko/gecko_trace_parser.cc
+++ b/src/trace_processor/importers/gecko/gecko_trace_parser.cc
@@ -21,6 +21,7 @@
 #include "perfetto/base/compiler.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
+#include "src/trace_processor/importers/common/profiler_sample_tracker.h"
 #include "src/trace_processor/importers/common/slice_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
 #include "src/trace_processor/importers/common/track_tracker.h"
@@ -77,12 +78,13 @@ void GeckoTraceParser::ParseThreadMetadata(
 
 void GeckoTraceParser::ParseStackSample(int64_t ts,
                                         const GeckoEvent::StackSample& sample) {
-  auto* ss = context_->storage->mutable_cpu_profile_stack_sample_table();
-  tables::CpuProfileStackSampleTable::Row row;
+  tables::ProfilerSampleTable::Row row;
   row.ts = ts;
-  row.callsite_id = sample.callsite_id;
+  row.source = context_->storage->InternString("gecko");
   row.utid = context_->process_tracker->GetOrCreateThread(sample.tid);
-  ss->Insert(row);
+  row.cpu_mode = context_->storage->InternString("");
+  row.callsite_id = sample.callsite_id;
+  context_->profiler_sample_tracker->AddSample(row);
 }
 
 void GeckoTraceParser::ParseMarker(int64_t ts,

--- a/src/trace_processor/importers/gecko/gecko_trace_parser.h
+++ b/src/trace_processor/importers/gecko/gecko_trace_parser.h
@@ -21,6 +21,7 @@
 
 #include "src/trace_processor/importers/gecko/gecko_event.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
+#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
 namespace perfetto::trace_processor::gecko_importer {
@@ -39,6 +40,7 @@ class GeckoTraceParser
   void ParseMarker(int64_t ts, const GeckoEvent::Marker&);
 
   TraceProcessorContext* const context_;
+  const StringPool::Id gecko_source_id_;
 };
 
 }  // namespace perfetto::trace_processor::gecko_importer

--- a/src/trace_processor/importers/proto/profile_module.cc
+++ b/src/trace_processor/importers/proto/profile_module.cc
@@ -111,6 +111,8 @@ ProfileModule::ProfileModule(ProtoImporterModuleContext* module_context,
                              TraceProcessorContext* context)
     : ProtoImporterModule(module_context),
       context_(context),
+      chrome_source_id_(context->storage->InternString("chrome")),
+      linux_perf_source_id_(context->storage->InternString("linux.perf")),
       perf_sample_tracker_(context),
       streaming_profile_stream_(context->sorter->CreateStream(
           std::make_unique<StreamingProfileSink>(this))) {
@@ -226,10 +228,9 @@ void ProfileModule::ParseStreamingProfileSample(
 
   tables::ProfilerSampleTable::Row row;
   row.ts = ts;
-  row.source = context_->storage->InternString("chrome");
+  row.source = chrome_source_id_;
   row.utid = utid;
   row.upid = upid;
-  row.cpu_mode = context_->storage->InternString("");
   row.callsite_id = *opt_cs_id;
   auto sample_id = context_->profiler_sample_tracker->AddSample(row);
   if (event.process_priority != 0) {
@@ -363,7 +364,7 @@ void ProfileModule::ParsePerfSample(
 
   tables::ProfilerSampleTable::Row row;
   row.ts = ts;
-  row.source = storage->InternString("linux.perf");
+  row.source = linux_perf_source_id_;
   row.utid = utid;
   row.upid = upid;
   if (sample.has_cpu()) {

--- a/src/trace_processor/importers/proto/profile_module.cc
+++ b/src/trace_processor/importers/proto/profile_module.cc
@@ -224,10 +224,18 @@ void ProfileModule::ParseStreamingProfileSample(
     return;
   }
 
-  tables::CpuProfileStackSampleTable::Row sample_row{ts, *opt_cs_id, utid,
-                                                     event.process_priority};
-  context_->storage->mutable_cpu_profile_stack_sample_table()->Insert(
-      sample_row);
+  tables::ProfilerSampleTable::Row row;
+  row.ts = ts;
+  row.source = context_->storage->InternString("chrome");
+  row.utid = utid;
+  row.upid = upid;
+  row.cpu_mode = context_->storage->InternString("");
+  row.callsite_id = *opt_cs_id;
+  auto sample_id = context_->profiler_sample_tracker->AddSample(row);
+  if (event.process_priority != 0) {
+    context_->storage->mutable_chrome_stack_sample_extras_table()->Insert(
+        {sample_id, event.process_priority});
+  }
 }
 
 void ProfileModule::ParsePerfSample(

--- a/src/trace_processor/importers/proto/profile_module.h
+++ b/src/trace_processor/importers/proto/profile_module.h
@@ -93,6 +93,8 @@ class ProfileModule : public ProtoImporterModule {
   };
 
   TraceProcessorContext* context_;
+  const StringPool::Id chrome_source_id_;
+  const StringPool::Id linux_perf_source_id_;
   PerfSampleTracker perf_sample_tracker_;
   std::unique_ptr<TraceSorter::Stream<StreamingProfileSampleEvent>>
       streaming_profile_stream_;

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -2842,24 +2842,31 @@ TEST_F(ProtoTraceParserTest, ParseCPUProfileSamplesIntoTable) {
   Tokenize();
   context_.sorter->ExtractEventsForced();
 
-  // Verify cpu_profile_samples.
-  const auto& samples = storage_->cpu_profile_stack_sample_table();
+  // Verify the profiler samples.
+  const auto& samples = storage_->profiler_sample_table();
   EXPECT_EQ(samples.row_count(), 3u);
 
   EXPECT_EQ(samples[0].ts(), 11000);
   EXPECT_EQ(samples[0].callsite_id(), CallsiteId{0});
   EXPECT_EQ(samples[0].utid(), 1u);
-  EXPECT_EQ(samples[0].process_priority(), 20);
 
   EXPECT_EQ(samples[1].ts(), 26000);
   EXPECT_EQ(samples[1].callsite_id(), CallsiteId{1});
   EXPECT_EQ(samples[1].utid(), 1u);
-  EXPECT_EQ(samples[1].process_priority(), 20);
 
   EXPECT_EQ(samples[2].ts(), 68000);
   EXPECT_EQ(samples[2].callsite_id(), CallsiteId{0});
   EXPECT_EQ(samples[2].utid(), 1u);
-  EXPECT_EQ(samples[2].process_priority(), 30);
+
+  // Process priorities land in the chrome extras table, keyed by sample.
+  const auto& extras = storage_->chrome_stack_sample_extras_table();
+  EXPECT_EQ(extras.row_count(), 3u);
+  EXPECT_EQ(extras[0].profiler_sample_id(), samples[0].id());
+  EXPECT_EQ(extras[0].process_priority(), 20);
+  EXPECT_EQ(extras[1].profiler_sample_id(), samples[1].id());
+  EXPECT_EQ(extras[1].process_priority(), 20);
+  EXPECT_EQ(extras[2].profiler_sample_id(), samples[2].id());
+  EXPECT_EQ(extras[2].process_priority(), 30);
 
   // Breakpad build_ids should not be modified/mangled.
   ASSERT_STREQ(
@@ -2929,7 +2936,7 @@ TEST_F(ProtoTraceParserTest, CPUProfileSamplesTimestampsAreClockMonotonic) {
   Tokenize();
   context_.sorter->ExtractEventsForced();
 
-  const auto& samples = storage_->cpu_profile_stack_sample_table();
+  const auto& samples = storage_->profiler_sample_table();
   EXPECT_EQ(samples.row_count(), 1u);
 
   // Should have been translated to boottime, i.e. 10015 us absolute.

--- a/src/trace_processor/importers/simpleperf_proto/simpleperf_proto_parser.cc
+++ b/src/trace_processor/importers/simpleperf_proto/simpleperf_proto_parser.cc
@@ -39,7 +39,9 @@ namespace perfetto::trace_processor::simpleperf_proto_importer {
 
 SimpleperfProtoParser::SimpleperfProtoParser(TraceProcessorContext* context,
                                              SimpleperfProtoTracker* tracker)
-    : context_(context), tracker_(tracker) {}
+    : context_(context),
+      tracker_(tracker),
+      simpleperf_source_id_(context->storage->InternString("simpleperf")) {}
 
 SimpleperfProtoParser::~SimpleperfProtoParser() = default;
 
@@ -109,9 +111,8 @@ void SimpleperfProtoParser::Parse(int64_t ts,
     if (callsite_id.has_value()) {
       tables::ProfilerSampleTable::Row row;
       row.ts = ts;
-      row.source = context_->storage->InternString("simpleperf");
+      row.source = simpleperf_source_id_;
       row.utid = utid;
-      row.cpu_mode = context_->storage->InternString("");
       row.callsite_id = *callsite_id;
       context_->profiler_sample_tracker->AddSample(row);
     }

--- a/src/trace_processor/importers/simpleperf_proto/simpleperf_proto_parser.cc
+++ b/src/trace_processor/importers/simpleperf_proto/simpleperf_proto_parser.cc
@@ -24,6 +24,7 @@
 #include "perfetto/ext/base/string_view.h"
 #include "src/trace_processor/importers/common/mapping_tracker.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
+#include "src/trace_processor/importers/common/profiler_sample_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 #include "src/trace_processor/importers/common/virtual_memory_mapping.h"
@@ -103,15 +104,16 @@ void SimpleperfProtoParser::Parse(int64_t ts,
       depth++;
     }
 
-    // Insert into cpu_profile_stack_sample table with the leaf callsite
-    // (the last callsite created, which has the highest depth)
+    // Insert the leaf callsite (the last callsite created, which has the
+    // highest depth) as a profiler sample.
     if (callsite_id.has_value()) {
-      tables::CpuProfileStackSampleTable::Row row;
+      tables::ProfilerSampleTable::Row row;
       row.ts = ts;
-      row.callsite_id = *callsite_id;
+      row.source = context_->storage->InternString("simpleperf");
       row.utid = utid;
-      row.process_priority = 0;  // Default priority
-      context_->storage->mutable_cpu_profile_stack_sample_table()->Insert(row);
+      row.cpu_mode = context_->storage->InternString("");
+      row.callsite_id = *callsite_id;
+      context_->profiler_sample_tracker->AddSample(row);
     }
     return;
   }

--- a/src/trace_processor/importers/simpleperf_proto/simpleperf_proto_parser.h
+++ b/src/trace_processor/importers/simpleperf_proto/simpleperf_proto_parser.h
@@ -22,6 +22,7 @@
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/simpleperf_proto/simpleperf_proto_tracker.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
+#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
 namespace perfetto::trace_processor::simpleperf_proto_importer {
@@ -43,6 +44,7 @@ class SimpleperfProtoParser
  private:
   TraceProcessorContext* const context_;
   SimpleperfProtoTracker* const tracker_;
+  const StringPool::Id simpleperf_source_id_;
 };
 
 }  // namespace perfetto::trace_processor::simpleperf_proto_importer

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -615,7 +615,7 @@ SELECT * FROM __intrinsic_stack_profile_callsite;
 
 -- Table containing stack samples from CPU profiling.
 CREATE PERFETTO VIEW cpu_profile_stack_sample(
-  -- The id of the row.
+  -- The id of the row. Joinable with stack_sample.id.
   id ID,
   -- Timestamp of the sample.
   ts TIMESTAMP,
@@ -627,7 +627,16 @@ CREATE PERFETTO VIEW cpu_profile_stack_sample(
   process_priority LONG
 )
 AS
-SELECT * FROM __intrinsic_cpu_profile_stack_sample;
+SELECT
+  ps.id,
+  ps.ts,
+  ps.callsite_id,
+  ps.utid,
+  coalesce(x.process_priority, 0) AS process_priority
+FROM __intrinsic_profiler_sample AS ps
+LEFT JOIN __intrinsic_chrome_stack_sample_extras AS x
+  ON x.profiler_sample_id = ps.id
+WHERE ps.source IN ('chrome', 'legacy_v8', 'gecko', 'simpleperf', 'perf_text');
 
 -- Samples from MacOS Instruments.
 CREATE PERFETTO VIEW instruments_sample(

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -636,7 +636,8 @@ SELECT
 FROM __intrinsic_profiler_sample AS ps
 LEFT JOIN __intrinsic_chrome_stack_sample_extras AS x
   ON x.profiler_sample_id = ps.id
-WHERE ps.source IN ('chrome', 'legacy_v8', 'gecko', 'simpleperf', 'perf_text');
+WHERE
+  ps.source IN ('chrome', 'legacy_v8', 'gecko', 'simpleperf', 'perf_text');
 
 -- Samples from MacOS Instruments.
 CREATE PERFETTO VIEW instruments_sample(

--- a/src/trace_processor/plugins/perf_text/perf_text_trace_parser.cc
+++ b/src/trace_processor/plugins/perf_text/perf_text_trace_parser.cc
@@ -29,15 +29,15 @@
 namespace perfetto::trace_processor::perf_text_importer {
 
 PerfTextTraceParser::PerfTextTraceParser(TraceProcessorContext* context)
-    : context_(context) {}
+    : context_(context),
+      perf_text_source_id_(context->storage->InternString("perf_text")) {}
 
 PerfTextTraceParser::~PerfTextTraceParser() = default;
 
 void PerfTextTraceParser::Parse(int64_t ts, PerfTextEvent evt) {
   tables::ProfilerSampleTable::Row row;
   row.ts = ts;
-  row.source = context_->storage->InternString("perf_text");
-  row.cpu_mode = context_->storage->InternString("");
+  row.source = perf_text_source_id_;
   row.callsite_id = evt.callsite_id;
   UniqueTid utid =
       evt.pid ? context_->process_tracker->UpdateThread(evt.tid, *evt.pid)

--- a/src/trace_processor/plugins/perf_text/perf_text_trace_parser.cc
+++ b/src/trace_processor/plugins/perf_text/perf_text_trace_parser.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 
 #include "src/trace_processor/importers/common/process_tracker.h"
+#include "src/trace_processor/importers/common/profiler_sample_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
 #include "src/trace_processor/plugins/perf_text/perf_text_event.h"
 #include "src/trace_processor/storage/trace_storage.h"
@@ -33,18 +34,23 @@ PerfTextTraceParser::PerfTextTraceParser(TraceProcessorContext* context)
 PerfTextTraceParser::~PerfTextTraceParser() = default;
 
 void PerfTextTraceParser::Parse(int64_t ts, PerfTextEvent evt) {
-  auto* ss = context_->storage->mutable_cpu_profile_stack_sample_table();
-  tables::CpuProfileStackSampleTable::Row row;
+  tables::ProfilerSampleTable::Row row;
   row.ts = ts;
+  row.source = context_->storage->InternString("perf_text");
+  row.cpu_mode = context_->storage->InternString("");
   row.callsite_id = evt.callsite_id;
-  row.utid = evt.pid
-                 ? context_->process_tracker->UpdateThread(evt.tid, *evt.pid)
-                 : context_->process_tracker->GetOrCreateThread(evt.tid);
+  UniqueTid utid =
+      evt.pid ? context_->process_tracker->UpdateThread(evt.tid, *evt.pid)
+              : context_->process_tracker->GetOrCreateThread(evt.tid);
+  row.utid = utid;
+  if (evt.pid) {
+    row.upid = context_->process_tracker->GetOrCreateProcess(*evt.pid);
+  }
   if (evt.comm) {
     context_->process_tracker->UpdateThreadNameAndMaybeProcessName(
-        row.utid, *evt.comm, ThreadNamePriority::kOther);
+        utid, *evt.comm, ThreadNamePriority::kOther);
   }
-  ss->Insert(row);
+  context_->profiler_sample_tracker->AddSample(row);
 }
 
 }  // namespace perfetto::trace_processor::perf_text_importer

--- a/src/trace_processor/plugins/perf_text/perf_text_trace_parser.h
+++ b/src/trace_processor/plugins/perf_text/perf_text_trace_parser.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 
+#include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/plugins/perf_text/perf_text_event.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
 #include "src/trace_processor/types/trace_processor_context.h"
@@ -35,6 +36,7 @@ class PerfTextTraceParser
 
  private:
   TraceProcessorContext* const context_;
+  const StringPool::Id perf_text_source_id_;
 };
 
 }  // namespace perfetto::trace_processor::perf_text_importer

--- a/src/trace_processor/plugins/storage_tables/storage_tables.cc
+++ b/src/trace_processor/plugins/storage_tables/storage_tables.cc
@@ -227,8 +227,7 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
            s.heap_graph_object_table().mutations() +
            s.heap_graph_table().mutations() +
            s.instruments_sample_table().mutations() +
-           s.state_table().mutations() +
-           s.profiler_sample_table().mutations();
+           s.state_table().mutations() + s.profiler_sample_table().mutations();
   }
 
   std::pair<int64_t, int64_t> GetTimestampBounds() override {

--- a/src/trace_processor/plugins/storage_tables/storage_tables.cc
+++ b/src/trace_processor/plugins/storage_tables/storage_tables.cc
@@ -107,7 +107,7 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
     AddDataframe(out, s->mutable_modules_table());
     AddDataframe(out, s->mutable_clock_snapshot_table());
     AddDataframe(out, s->mutable_cpu_freq_table());
-    AddDataframe(out, s->mutable_cpu_profile_stack_sample_table());
+    AddDataframe(out, s->mutable_chrome_stack_sample_extras_table());
     AddDataframe(out, s->mutable_elf_file_table());
     AddDataframe(out, s->mutable_etm_v4_configuration_table());
     AddDataframe(out, s->mutable_etm_v4_session_table());
@@ -228,7 +228,6 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
            s.heap_graph_table().mutations() +
            s.instruments_sample_table().mutations() +
            s.state_table().mutations() +
-           s.cpu_profile_stack_sample_table().mutations() +
            s.profiler_sample_table().mutations();
   }
 
@@ -277,10 +276,6 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
       end_ns = std::max(it.ts(), end_ns);
     }
     for (auto it = s.instruments_sample_table().IterateRows(); it; ++it) {
-      start_ns = std::min(it.ts(), start_ns);
-      end_ns = std::max(it.ts(), end_ns);
-    }
-    for (auto it = s.cpu_profile_stack_sample_table().IterateRows(); it; ++it) {
       start_ns = std::min(it.ts(), start_ns);
       end_ns = std::max(it.ts(), end_ns);
     }

--- a/src/trace_processor/storage/trace_storage.h
+++ b/src/trace_processor/storage/trace_storage.h
@@ -585,12 +585,12 @@ class TraceStorage {
     return mutable_table<tables::TraceFileTable>();
   }
 
-  const tables::CpuProfileStackSampleTable& cpu_profile_stack_sample_table()
+  const tables::ChromeStackSampleExtrasTable& chrome_stack_sample_extras_table()
       const {
-    return table<tables::CpuProfileStackSampleTable>();
+    return table<tables::ChromeStackSampleExtrasTable>();
   }
-  tables::CpuProfileStackSampleTable* mutable_cpu_profile_stack_sample_table() {
-    return mutable_table<tables::CpuProfileStackSampleTable>();
+  tables::ChromeStackSampleExtrasTable* mutable_chrome_stack_sample_extras_table() {
+    return mutable_table<tables::ChromeStackSampleExtrasTable>();
   }
 
   const tables::ProfilerSessionTable& profiler_session_table() const {

--- a/src/trace_processor/storage/trace_storage.h
+++ b/src/trace_processor/storage/trace_storage.h
@@ -589,7 +589,8 @@ class TraceStorage {
       const {
     return table<tables::ChromeStackSampleExtrasTable>();
   }
-  tables::ChromeStackSampleExtrasTable* mutable_chrome_stack_sample_extras_table() {
+  tables::ChromeStackSampleExtrasTable*
+  mutable_chrome_stack_sample_extras_table() {
     return mutable_table<tables::ChromeStackSampleExtrasTable>();
   }
 

--- a/src/trace_processor/tables/profiler_tables.py
+++ b/src/trace_processor/tables/profiler_tables.py
@@ -441,47 +441,6 @@ STACK_PROFILE_CALLSITE_TABLE = Table(
                 '''Frame at this position in the callstack.'''
         }))
 
-CPU_PROFILE_STACK_SAMPLE_TABLE = Table(
-    python_module=__file__,
-    class_name='CpuProfileStackSampleTable',
-    sql_name='__intrinsic_cpu_profile_stack_sample',
-    wrapping_sql_view=WrappingSqlView('cpu_profile_stack_sample'),
-    columns=[
-        C(
-            'ts',
-            CppInt64(),
-            cpp_access=CppAccess.READ,
-            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
-        ),
-        C(
-            'callsite_id',
-            CppTableId(STACK_PROFILE_CALLSITE_TABLE),
-            cpp_access=CppAccess.READ,
-            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
-        ),
-        C(
-            'utid',
-            CppUint32(),
-            cpp_access=CppAccess.READ,
-            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
-        ),
-        C(
-            'process_priority',
-            CppInt32(),
-            cpp_access=CppAccess.READ,
-            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
-        ),
-    ],
-    tabledoc=TableDoc(
-        doc='Table containing stack samples from CPU profiling.',
-        group='Callstack profilers',
-        columns={
-            'ts': '''timestamp of the sample.''',
-            'callsite_id': '''unwound callstack.''',
-            'utid': '''thread that was active when the sample was taken.''',
-            'process_priority': ''''''
-        }))
-
 PROFILER_SESSION_TABLE = Table(
     python_module=__file__,
     class_name='ProfilerSessionTable',
@@ -643,6 +602,36 @@ PROFILER_SAMPLE_TABLE = Table(
             'counter_set_id':
                 '''References the set of counter values recorded at this
                    sample point in __intrinsic_profiler_counter_set.''',
+        }))
+
+CHROME_STACK_SAMPLE_EXTRAS_TABLE = Table(
+    python_module=__file__,
+    class_name='ChromeStackSampleExtrasTable',
+    sql_name='__intrinsic_chrome_stack_sample_extras',
+    columns=[
+        C(
+            'profiler_sample_id',
+            CppTableId(PROFILER_SAMPLE_TABLE),
+            cpp_access=CppAccess.READ,
+            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
+        ),
+        C(
+            'process_priority',
+            CppInt32(),
+            cpp_access=CppAccess.READ,
+            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
+        ),
+    ],
+    tabledoc=TableDoc(
+        doc='''Chrome-specific attributes of a profiler sample. One row per
+               chrome streaming profile sample with a non-default process
+               priority.''',
+        group='Callstack profilers',
+        columns={
+            'profiler_sample_id':
+                '''The profiler sample these attributes belong to.''',
+            'process_priority':
+                '''Priority of the process when the sample was taken.''',
         }))
 
 HEAP_GRAPH_TABLE = Table(
@@ -1628,7 +1617,7 @@ EXPERIMENTAL_FLAMEGRAPH_TABLE = Table(
 ALL_TABLES = [
     AGGREGATE_PROFILE_TABLE,
     AGGREGATE_SAMPLE_TABLE,
-    CPU_PROFILE_STACK_SAMPLE_TABLE,
+    CHROME_STACK_SAMPLE_EXTRAS_TABLE,
     EXPERIMENTAL_FLAMEGRAPH_TABLE,
     GPU_CONTEXT_TABLE,
     GPU_COUNTER_GROUP_TABLE,


### PR DESCRIPTION
Chrome streaming profiles, legacy V8 cpu profiles, gecko profiles,
simpleperf proto traces and perf script text all wrote their samples
into the cpu_profile_stack_sample table. Write them into the generic
profiler_sample table instead, tagged with their source and with process
attribution where the importer knows the pid.

cpu_profile_stack_sample keeps its exact schema as a view over
profiler_sample; the chrome-only process_priority column moves to a slim
extras table keyed by sample, populated only for samples with a
non-default priority.
