### PR TITLE
tp: migrate macOS instruments samples onto profiler_sample

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,9 +22,9 @@ Unreleased:
       counter values keep the perf counter-set model, generalized as
       __intrinsic_profiler_counter_set.
     * Chrome streaming profiles, legacy V8 cpu profiles, gecko profiles,
-      simpleperf proto traces and perf script text now also populate
-      profiler_sample; cpu_profile_stack_sample keeps its schema as a
-      view over it.
+      simpleperf proto traces, perf script text and macOS Instruments
+      traces now also populate profiler_sample; cpu_profile_stack_sample
+      and instruments_sample keep their schemas as views over it.
     * The StackSample packet's counter descriptors now materialize as
       counter tracks (scoped per profiler session, or per session and
       cpu via the new CounterDescriptor.scope field, mirroring

--- a/src/trace_processor/importers/instruments/row_parser.cc
+++ b/src/trace_processor/importers/instruments/row_parser.cc
@@ -23,9 +23,9 @@
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/string_view.h"
 #include "src/trace_processor/importers/common/address_range.h"
+#include "src/trace_processor/importers/common/cpu_tracker.h"
 #include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/mapping_tracker.h"
-#include "src/trace_processor/importers/common/cpu_tracker.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/common/profiler_sample_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
@@ -44,7 +44,9 @@
 namespace perfetto::trace_processor::instruments_importer {
 
 RowParser::RowParser(TraceProcessorContext* context, RowDataTracker& data)
-    : context_(context), data_(data) {}
+    : context_(context),
+      data_(data),
+      instruments_source_id_(context->storage->InternString("instruments")) {}
 
 RowParser::~RowParser() = default;
 
@@ -142,12 +144,10 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
 
   tables::ProfilerSampleTable::Row sample_row;
   sample_row.ts = ts;
-  sample_row.source = context_->storage->InternString("instruments");
+  sample_row.source = instruments_source_id_;
   sample_row.utid = utid;
   sample_row.upid = upid;
-  sample_row.ucpu =
-      context_->cpu_tracker->GetOrCreateCpu(row.core_id).value;
-  sample_row.cpu_mode = context_->storage->InternString("");
+  sample_row.ucpu = context_->cpu_tracker->GetOrCreateCpu(row.core_id).value;
   sample_row.callsite_id = parent;
   context_->profiler_sample_tracker->AddSample(sample_row);
 }

--- a/src/trace_processor/importers/instruments/row_parser.cc
+++ b/src/trace_processor/importers/instruments/row_parser.cc
@@ -25,7 +25,9 @@
 #include "src/trace_processor/importers/common/address_range.h"
 #include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/mapping_tracker.h"
+#include "src/trace_processor/importers/common/cpu_tracker.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
+#include "src/trace_processor/importers/common/profiler_sample_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
 #include "src/trace_processor/importers/common/virtual_memory_mapping.h"
 #include "src/trace_processor/importers/instruments/row.h"
@@ -138,8 +140,16 @@ void RowParser::Parse(int64_t ts, instruments_importer::Row row) {
     depth++;
   }
 
-  context_->storage->mutable_instruments_sample_table()->Insert(
-      {ts, utid, parent, row.core_id});
+  tables::ProfilerSampleTable::Row sample_row;
+  sample_row.ts = ts;
+  sample_row.source = context_->storage->InternString("instruments");
+  sample_row.utid = utid;
+  sample_row.upid = upid;
+  sample_row.ucpu =
+      context_->cpu_tracker->GetOrCreateCpu(row.core_id).value;
+  sample_row.cpu_mode = context_->storage->InternString("");
+  sample_row.callsite_id = parent;
+  context_->profiler_sample_tracker->AddSample(sample_row);
 }
 
 DummyMemoryMapping* RowParser::GetDummyMapping(UniquePid upid) {

--- a/src/trace_processor/importers/instruments/row_parser.h
+++ b/src/trace_processor/importers/instruments/row_parser.h
@@ -43,6 +43,7 @@ class RowParser
 
   TraceProcessorContext* context_;
   RowDataTracker& data_;
+  const StringId instruments_source_id_;
 
   // Cache binary mappings by instruments binary pointers. These are already
   // de-duplicated in the instruments XML parsing.

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -641,7 +641,7 @@ WHERE
 
 -- Samples from MacOS Instruments.
 CREATE PERFETTO VIEW instruments_sample(
-  -- The id of the row.
+  -- The id of the row. Joinable with stack_sample.id.
   id ID,
   -- Timestamp of the sample.
   ts TIMESTAMP,
@@ -653,7 +653,16 @@ CREATE PERFETTO VIEW instruments_sample(
   cpu LONG
 )
 AS
-SELECT * FROM __intrinsic_instruments_sample;
+SELECT
+  ps.id,
+  ps.ts,
+  ps.utid,
+  ps.callsite_id,
+  c.cpu
+FROM __intrinsic_profiler_sample AS ps
+LEFT JOIN __intrinsic_cpu AS c
+  ON c.id = ps.ucpu
+WHERE ps.source = 'instruments';
 
 -- Symbolization data for a frame.
 CREATE PERFETTO VIEW stack_profile_symbol(

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/views.sql
@@ -653,16 +653,12 @@ CREATE PERFETTO VIEW instruments_sample(
   cpu LONG
 )
 AS
-SELECT
-  ps.id,
-  ps.ts,
-  ps.utid,
-  ps.callsite_id,
-  c.cpu
+SELECT ps.id, ps.ts, ps.utid, ps.callsite_id, c.cpu
 FROM __intrinsic_profiler_sample AS ps
 LEFT JOIN __intrinsic_cpu AS c
   ON c.id = ps.ucpu
-WHERE ps.source = 'instruments';
+WHERE
+  ps.source = 'instruments';
 
 -- Symbolization data for a frame.
 CREATE PERFETTO VIEW stack_profile_symbol(

--- a/src/trace_processor/plugins/storage_tables/storage_tables.cc
+++ b/src/trace_processor/plugins/storage_tables/storage_tables.cc
@@ -224,8 +224,8 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
            s.profiler_smaps_table().mutations() +
            s.thread_state_table().mutations() + s.log_table().mutations() +
            s.heap_graph_object_table().mutations() +
-           s.heap_graph_table().mutations() +
-           s.state_table().mutations() + s.profiler_sample_table().mutations();
+           s.heap_graph_table().mutations() + s.state_table().mutations() +
+           s.profiler_sample_table().mutations();
   }
 
   std::pair<int64_t, int64_t> GetTimestampBounds() override {

--- a/src/trace_processor/plugins/storage_tables/storage_tables.cc
+++ b/src/trace_processor/plugins/storage_tables/storage_tables.cc
@@ -119,7 +119,6 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
     AddDataframe(out, s->mutable_gpu_context_table());
     AddDataframe(out, s->mutable_gpu_counter_group_table());
     AddDataframe(out, s->mutable_gpu_table());
-    AddDataframe(out, s->mutable_instruments_sample_table());
     AddDataframe(out, s->mutable_machine_table());
     AddDataframe(out, s->mutable_memory_snapshot_edge_table());
     AddDataframe(out, s->mutable_memory_snapshot_table());
@@ -226,7 +225,6 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
            s.thread_state_table().mutations() + s.log_table().mutations() +
            s.heap_graph_object_table().mutations() +
            s.heap_graph_table().mutations() +
-           s.instruments_sample_table().mutations() +
            s.state_table().mutations() + s.profiler_sample_table().mutations();
   }
 
@@ -271,10 +269,6 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
       end_ns = std::max(it.graph_sample_ts(), end_ns);
     }
     for (auto it = s.heap_graph_table().IterateRows(); it; ++it) {
-      start_ns = std::min(it.ts(), start_ns);
-      end_ns = std::max(it.ts(), end_ns);
-    }
-    for (auto it = s.instruments_sample_table().IterateRows(); it; ++it) {
       start_ns = std::min(it.ts(), start_ns);
       end_ns = std::max(it.ts(), end_ns);
     }

--- a/src/trace_processor/storage/trace_storage.h
+++ b/src/trace_processor/storage/trace_storage.h
@@ -601,13 +601,6 @@ class TraceStorage {
     return mutable_table<tables::ProfilerSessionTable>();
   }
 
-  const tables::InstrumentsSampleTable& instruments_sample_table() const {
-    return table<tables::InstrumentsSampleTable>();
-  }
-  tables::InstrumentsSampleTable* mutable_instruments_sample_table() {
-    return mutable_table<tables::InstrumentsSampleTable>();
-  }
-
   const tables::ProfilerSampleTable& profiler_sample_table() const {
     return table<tables::ProfilerSampleTable>();
   }

--- a/src/trace_processor/tables/profiler_tables.py
+++ b/src/trace_processor/tables/profiler_tables.py
@@ -747,39 +747,6 @@ HEAP_GRAPH_JAVA_OOME_DETAILS_TABLE = Table(
         }),
 )
 
-INSTRUMENTS_SAMPLE_TABLE = Table(
-    python_module=__file__,
-    class_name='InstrumentsSampleTable',
-    sql_name='__intrinsic_instruments_sample',
-    wrapping_sql_view=WrappingSqlView('instruments_sample'),
-    columns=[
-        C(
-            'ts',
-            CppInt64(),
-            flags=ColumnFlag.SORTED,
-            cpp_access=CppAccess.READ,
-            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
-        ),
-        C('utid', CppUint32()),
-        C('callsite_id', CppOptional(CppTableId(STACK_PROFILE_CALLSITE_TABLE))),
-        C('cpu', CppOptional(CppUint32())),
-    ],
-    tabledoc=TableDoc(
-        doc='''
-          Samples from MacOS Instruments.
-        ''',
-        group='Callstack profilers',
-        columns={
-            'ts':
-                '''Timestamp of the sample.''',
-            'utid':
-                '''Sampled thread.''',
-            'callsite_id':
-                '''If set, unwound callstack of the sampled thread.''',
-            'cpu':
-                '''Core the sampled thread was running on.''',
-        }))
-
 SYMBOL_TABLE = Table(
     python_module=__file__,
     class_name='SymbolTable',
@@ -1631,7 +1598,6 @@ ALL_TABLES = [
     HEAP_GRAPH_THREAD_CALLSITE_TABLE,
     HEAP_PROFILE_TABLE,
     HEAP_PROFILE_ALLOCATION_TABLE,
-    INSTRUMENTS_SAMPLE_TABLE,
     PACKAGE_LIST_TABLE,
     PROFILER_COUNTER_SET_TABLE,
     PROFILER_SAMPLE_TABLE,


### PR DESCRIPTION
The macOS Instruments importer wrote its samples into a dedicated
instruments_sample table. Write them into the generic profiler_sample
table instead, tagged with the instruments source and with the core id
mapped to a ucpu. instruments_sample keeps its exact schema as a view
over profiler_sample.
