### PR TITLE
java_sdk: add weighted overload to expensiveDebugCallStack

### DIFF
--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
@@ -354,15 +354,37 @@ public final class PerfettoTrace {
     if (!category.isEnabled() || stackTrace == null || stackTrace.length == 0) {
         return PerfettoTrace.instant(category, eventName);
     }
+    return writeCallStack(PerfettoTrace.instant(category, eventName).beginProto(), stackTrace)
+        .endProto();
+  }
 
+  /**
+   * Like {@link #expensiveDebugCallStack(Category, String, StackTraceElement[])}, but also
+   * attaches {@code callstackWeight} as an additive measure on the call stack (for example the
+   * number of bytes allocated), used for weighted flamegraph aggregation. Weighted and unweighted
+   * samples are never mixed, so set the weight on every event of a track or on none of them.
+   */
+  public static PerfettoTrackEventBuilder expensiveDebugCallStack(
+      Category category, String eventName, StackTraceElement[] stackTrace, double callstackWeight) {
+    if (!category.isEnabled() || stackTrace == null || stackTrace.length == 0) {
+        return PerfettoTrace.instant(category, eventName);
+    }
+    final long FIELD_TRACK_EVENT_CALLSTACK_WEIGHT = 57L;
+    PerfettoTrackEventBuilder builder = PerfettoTrace.instant(category, eventName)
+        .beginProto().addField(FIELD_TRACK_EVENT_CALLSTACK_WEIGHT, callstackWeight);
+    return writeCallStack(builder, stackTrace).endProto();
+  }
+
+  /** Writes the call stack as a nested TrackEvent.callstack; caller owns beginProto/endProto. */
+  private static PerfettoTrackEventBuilder writeCallStack(
+      PerfettoTrackEventBuilder builder, StackTraceElement[] stackTrace) {
     final long FIELD_TRACK_EVENT_CALLSTACK = 55L;
     final long FIELD_CALLSTACK_FRAMES = 1L;
     final long FIELD_FRAME_FUNCTION_NAME = 1L;
     final long FIELD_FRAME_SOURCE_FILE = 2L;
     final long FIELD_FRAME_LINE_NUMBER = 3L;
 
-    PerfettoTrackEventBuilder builder = PerfettoTrace.instant(category, eventName)
-        .beginProto().beginNested(FIELD_TRACK_EVENT_CALLSTACK);
+    builder = builder.beginNested(FIELD_TRACK_EVENT_CALLSTACK);
 
     for (int i = stackTrace.length - 1; i >= 0; i--) {
         StackTraceElement element = stackTrace[i];
@@ -384,7 +406,7 @@ public final class PerfettoTrace {
         builder = builder.endNested();
     }
 
-    return builder.endNested().endProto();
+    return builder.endNested();
   }
 
   /**

--- a/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
+++ b/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
@@ -1201,6 +1201,43 @@ public class PerfettoTraceTest {
   }
 
   @Test
+  public void testExpensiveDebugCallStackWithWeight() throws Exception {
+    TraceConfig traceConfig = getTraceConfig(FOO);
+
+    PerfettoTrace.Session session = new PerfettoTrace.Session(true, traceConfig.toByteArray());
+
+    StackTraceElement[] stackTrace =
+        new StackTraceElement[] {
+          new StackTraceElement("ClassA", "methodA", "FileA.java", 10),
+          new StackTraceElement("ClassB", "methodB", "FileB.java", 20)
+        };
+
+    PerfettoTrace.expensiveDebugCallStack(FOO_CATEGORY, "event_callstack", stackTrace, 1234.0)
+        .emit();
+
+    byte[] traceBytes = session.close();
+
+    Trace trace = Trace.parseFrom(traceBytes);
+
+    boolean hasWeightedCallstack = false;
+
+    for (TracePacket packet : trace.getPacketList()) {
+      if (packet.hasTrackEvent()) {
+        TrackEvent event = packet.getTrackEvent();
+        if (event.hasCallstack()) {
+          hasWeightedCallstack = true;
+          assertThat(event.getCallstack().getFramesCount()).isEqualTo(2);
+          assertThat(event.hasCallstackWeight()).isTrue();
+          assertThat(event.getCallstackWeight()).isEqualTo(1234.0);
+        }
+      }
+      collectInternedData(packet);
+    }
+
+    assertThat(hasWeightedCallstack).isTrue();
+  }
+
+  @Test
   public void testExpensiveDebugCallStackVariousStates() throws Exception {
     TraceConfig traceConfig = getTraceConfig(FOO);
     PerfettoTrace.Session session = new PerfettoTrace.Session(true, traceConfig.toByteArray());


### PR DESCRIPTION
Add an expensiveDebugCallStack overload taking a callstackWeight, written to TrackEvent.callstack_weight (field 57) alongside the inline callstack. This attaches an additive per-event measure (e.g. bytes allocated) for weighted flamegraph aggregation; weighted and unweighted samples are never mixed. The frame-writing is factored into a shared helper so both overloads use it.

