### PR TITLE
tp: rationalize sample stdlib onto the stack_sample view

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/stacks/cpu_profiling.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/stacks/cpu_profiling.sql
@@ -60,7 +60,8 @@ FROM stack_sample AS ss
 LEFT JOIN __intrinsic_profiler_session AS s
   ON s.id = ss.session_id
 LEFT JOIN thread AS t USING (utid)
-LEFT JOIN cpu AS c ON c.id = ss.ucpu
+LEFT JOIN cpu AS c
+  ON c.id = ss.ucpu
 WHERE
   s.timebase_unit IS NULL
   OR s.timebase_unit IN ('ns', 'cycles', 'instructions')

--- a/src/trace_processor/perfetto_sql/stdlib/stacks/cpu_profiling.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/stacks/cpu_profiling.sql
@@ -16,17 +16,17 @@
 INCLUDE PERFETTO MODULE callstacks.stack_profile;
 
 -- Table containing all the timestamped samples of CPU profiling which occurred
--- during the trace.
+-- during the trace: a convenience projection of the `stack_sample` view with
+-- thread and cpu information denormalized.
 --
--- Currently, this table is backed by the following data sources:
---  * Linux perf
---  * Simpleperf proto format
---  * macOS instruments
---  * Chrome CPU profiling
---  * Legacy V8 CPU profiling
---  * Profiling data in Gecko traces
+-- This covers every callstack profiler source (linux perf, simpleperf, macOS
+-- instruments, Chrome, legacy V8, gecko, the StackSample packet, ...) but only
+-- samples from what is generally considered CPU profiling: sampling on time,
+-- cpu cycles or instructions. Samples from sessions known to sample on some
+-- other quantity (off-cpu sampling, tracepoint-based sampling, ...) are
+-- excluded.
 CREATE PERFETTO TABLE cpu_profiling_samples(
-  -- The id of the sample.
+  -- The id of the sample. Joinable with stack_sample.id.
   id LONG,
   -- The timestamp of the sample.
   ts TIMESTAMP,
@@ -41,33 +41,31 @@ CREATE PERFETTO TABLE cpu_profiling_samples(
   -- The cpu of the sample, if available.
   cpu LONG,
   -- The callsite id of the sample.
-  callsite_id LONG
+  callsite_id LONG,
+  -- The profiler that produced the sample (e.g. "linux.perf", "chrome").
+  source STRING
 )
 AS
-WITH
-  raw_samples AS (
-    -- Linux perf samples.
-    SELECT p.ts, p.utid, p.cpu AS ucpu, p.callsite_id FROM perf_sample AS p
-    UNION ALL
-    -- Instruments samples.
-    SELECT p.ts, p.utid, p.cpu AS ucpu, p.callsite_id
-    FROM instruments_sample AS p
-    UNION ALL
-    -- All other CPU profiling.
-    SELECT s.ts, s.utid, NULL AS ucpu, s.callsite_id
-    FROM cpu_profile_stack_sample AS s
-  )
 SELECT
-  row_number() OVER (ORDER BY ts) AS id,
-  r.*,
+  ss.id,
+  ss.ts,
+  ss.utid,
   t.tid,
   t.name AS thread_name,
-  c.cpu
-FROM raw_samples AS r
+  ss.ucpu,
+  c.cpu,
+  ss.callsite_id,
+  ss.source
+FROM stack_sample AS ss
+LEFT JOIN __intrinsic_profiler_session AS s
+  ON s.id = ss.session_id
 LEFT JOIN thread AS t USING (utid)
-LEFT JOIN cpu AS c USING (ucpu)
+LEFT JOIN cpu AS c ON c.id = ss.ucpu
+WHERE
+  s.timebase_unit IS NULL
+  OR s.timebase_unit IN ('ns', 'cycles', 'instructions')
 ORDER BY
-  ts;
+  ss.ts;
 
 CREATE PERFETTO TABLE _cpu_profiling_self_callsites AS
 SELECT *

--- a/src/trace_processor/perfetto_sql/stdlib/viz/summary/threads.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/summary/threads.sql
@@ -35,21 +35,14 @@ JOIN _slice_track_summary USING (id)
 GROUP BY
   utid;
 
-CREATE PERFETTO TABLE _perf_sample_summary AS
-SELECT utid, count() AS perf_sample_cnt
-FROM perf_sample
+CREATE PERFETTO TABLE _stack_sample_summary AS
+SELECT utid, source, count() AS sample_cnt
+FROM stack_sample
 WHERE
-  callsite_id IS NOT NULL
+  utid IS NOT NULL
 GROUP BY
-  utid;
-
-CREATE PERFETTO TABLE _instruments_sample_summary AS
-SELECT utid, count() AS instruments_sample_cnt
-FROM instruments_sample
-WHERE
-  callsite_id IS NOT NULL
-GROUP BY
-  utid;
+  utid,
+  source;
 
 CREATE PERFETTO TABLE _thread_available_info_summary AS
 WITH
@@ -60,12 +53,17 @@ WITH
       ss.sum_running_dur,
       ss.running_count,
       (SELECT slice_count FROM _thread_track_summary WHERE utid = t.utid) AS slice_count,
-      (SELECT perf_sample_cnt FROM _perf_sample_summary WHERE utid = t.utid) AS perf_sample_count,
       (
-        SELECT instruments_sample_cnt
-        FROM _instruments_sample_summary
+        SELECT sample_cnt
+        FROM _stack_sample_summary
         WHERE
-          utid = t.utid
+          utid = t.utid AND source = 'linux.perf'
+      ) AS perf_sample_count,
+      (
+        SELECT sample_cnt
+        FROM _stack_sample_summary
+        WHERE
+          utid = t.utid AND source = 'instruments'
       ) AS instruments_sample_count
     FROM thread AS t
     LEFT JOIN _sched_summary AS ss USING (utid)
@@ -86,5 +84,5 @@ WHERE
   AND r.slice_count IS NULL
   AND r.perf_sample_count IS NULL
   AND r.instruments_sample_count IS NULL)
-  OR utid IN (SELECT utid FROM cpu_profile_stack_sample)
+  OR utid IN (SELECT utid FROM _stack_sample_summary)
   OR utid IN (SELECT utid FROM thread_counter_track);

--- a/src/trace_processor/perfetto_sql/stdlib/viz/summary/threads.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/summary/threads.sql
@@ -57,13 +57,15 @@ WITH
         SELECT sample_cnt
         FROM _stack_sample_summary
         WHERE
-          utid = t.utid AND source = 'linux.perf'
+          utid = t.utid
+          AND source = 'linux.perf'
       ) AS perf_sample_count,
       (
         SELECT sample_cnt
         FROM _stack_sample_summary
         WHERE
-          utid = t.utid AND source = 'instruments'
+          utid = t.utid
+          AND source = 'instruments'
       ) AS instruments_sample_count
     FROM thread AS t
     LEFT JOIN _sched_summary AS ss USING (utid)

--- a/test/trace_processor/diff_tests/parser/profiling/tests.py
+++ b/test/trace_processor/diff_tests/parser/profiling/tests.py
@@ -864,6 +864,157 @@ class Profiling(TestSuite):
         1000,"instructions","instructions",500
         """))
 
+  def test_stack_sample_cpu_profiling_samples(self):
+    return DiffTestBlueprint(
+        trace=Path('stack_sample.textproto'),
+        query="""
+        INCLUDE PERFETTO MODULE stacks.cpu_profiling;
+
+        SELECT source, count(*) AS cnt
+        FROM cpu_profiling_samples
+        GROUP BY source;
+        """,
+        out=Csv("""
+        "source","cnt"
+        "python.wall",4
+        """))
+
+  def test_cpu_profiling_samples_timebase_filter(self):
+    return DiffTestBlueprint(
+        trace=TextProto(R"""
+        packet {
+          trusted_packet_sequence_id: 1
+          incremental_state_cleared: true
+          timestamp: 1000
+          trace_packet_defaults {
+            perf_sample_defaults {
+              timebase {
+                counter: SW_CPU_CLOCK
+                frequency: 100
+              }
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          sequence_flags: 2
+          timestamp: 2000
+          interned_data {
+            build_ids { iid: 1 str: "" }
+            mapping_paths { iid: 1 str: "libfoo.so" }
+            mappings { iid: 1 build_id: 1 path_string_ids: 1 }
+            function_names { iid: 1 str: "on_cpu_func" }
+            frames { iid: 1 mapping_id: 1 function_name_id: 1 }
+            callstacks { iid: 1 frame_ids: 1 }
+          }
+          perf_sample {
+            cpu: 0
+            pid: 10
+            tid: 10
+            cpu_mode: MODE_USER
+            callstack_iid: 1
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 2
+          incremental_state_cleared: true
+          timestamp: 1000
+          trace_packet_defaults {
+            perf_sample_defaults {
+              timebase {
+                counter: SW_PAGE_FAULTS
+                frequency: 100
+              }
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 2
+          sequence_flags: 2
+          timestamp: 3000
+          interned_data {
+            build_ids { iid: 1 str: "" }
+            mapping_paths { iid: 1 str: "libfoo.so" }
+            mappings { iid: 1 build_id: 1 path_string_ids: 1 }
+            function_names { iid: 1 str: "fault_func" }
+            frames { iid: 1 mapping_id: 1 function_name_id: 1 }
+            callstacks { iid: 1 frame_ids: 1 }
+          }
+          perf_sample {
+            cpu: 1
+            pid: 10
+            tid: 10
+            cpu_mode: MODE_USER
+            callstack_iid: 1
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE stacks.cpu_profiling;
+
+        -- Two perf sessions: one sampling on cpu-clock, one on page faults.
+        -- Both capture callstacks, but only the cpu-clock session's samples
+        -- are CPU profiling.
+        SELECT
+          (SELECT count(*) FROM stack_sample) AS stack_samples,
+          (SELECT count(*) FROM cpu_profiling_samples) AS profiling_samples,
+          (SELECT ts FROM cpu_profiling_samples) AS profiling_ts,
+          (
+            SELECT count(*) FROM profiler_session WHERE timebase_unit = 'ns'
+          ) AS ns_sessions,
+          (
+            SELECT count(*) FROM profiler_session WHERE timebase_unit = 'count'
+          ) AS count_sessions;
+        """,
+        out=Csv("""
+        "stack_samples","profiling_samples","profiling_ts","ns_sessions","count_sessions"
+        2,1,2000,1,1
+        """))
+
+  def test_cpu_profiling_samples_counter_only_excluded(self):
+    return DiffTestBlueprint(
+        trace=TextProto(R"""
+        packet {
+          trusted_packet_sequence_id: 1
+          incremental_state_cleared: true
+          timestamp: 1000
+          trace_packet_defaults {
+            perf_sample_defaults {
+              timebase {
+                name: "leader"
+                counter: SW_CPU_CLOCK
+                frequency: 1000
+              }
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 3000
+          perf_sample {
+            cpu: 0
+            pid: 1
+            tid: 42
+            cpu_mode: MODE_USER
+            timebase_count: 512
+            sample_skipped_reason: PROFILER_SKIP_NOT_IN_SCOPE
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE stacks.cpu_profiling;
+
+        -- Counter-only perf samples have no callstack: they show up in
+        -- perf_sample but not in cpu_profiling_samples.
+        SELECT
+          (SELECT count(*) FROM perf_sample) AS perf_samples,
+          (SELECT count(*) FROM cpu_profiling_samples) AS profiling_samples;
+        """,
+        out=Csv("""
+        "perf_samples","profiling_samples"
+        1,0
+        """))
+
   def test_frame_types(self):
     return DiffTestBlueprint(
         trace=Path('frame_types.textproto'),


### PR DESCRIPTION
cpu_profiling_samples was a UNION ALL over the three legacy sample
tables with a synthetic row_number id, and the viz thread summaries
scanned each table separately. With every source now writing
profiler_sample, both collapse onto the stack_sample view:

- cpu_profiling_samples becomes a single projection, covering all
  sources including the StackSample packet. Its id is now the real
  sample id (joinable with stack_sample) and it gained a source column.
  It now only keeps samples from sessions sampling on time, cycles or
  instructions, i.e. what is generally considered CPU profiling: other
  sampling types (off-cpu sampling, tracepoint-based sampling, ...) are
  excluded via the session's timebase unit.
- The viz thread summary computes one per-(thread, source) count table,
  so any new sample source gets thread tracks without further plumbing.
