### PR TITLE
perfetto: expose track_event's transitive proto closure as a filegroup

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -13383,6 +13383,42 @@ genrule {
     ],
 }
 
+// GN: transitive .proto closure of //protos/perfetto/trace/track_event:cpp
+filegroup {
+    name: "perfetto_protos_perfetto_trace_track_event_transitive_protos",
+    srcs: [
+        "protos/perfetto/trace/profiling/inline_callstack.proto",
+        "protos/perfetto/trace/track_event/chrome_active_processes.proto",
+        "protos/perfetto/trace/track_event/chrome_application_state_info.proto",
+        "protos/perfetto/trace/track_event/chrome_compositor_scheduler_state.proto",
+        "protos/perfetto/trace/track_event/chrome_content_settings_event_info.proto",
+        "protos/perfetto/trace/track_event/chrome_frame_reporter.proto",
+        "protos/perfetto/trace/track_event/chrome_histogram_sample.proto",
+        "protos/perfetto/trace/track_event/chrome_keyed_service.proto",
+        "protos/perfetto/trace/track_event/chrome_latency_info.proto",
+        "protos/perfetto/trace/track_event/chrome_legacy_ipc.proto",
+        "protos/perfetto/trace/track_event/chrome_message_pump.proto",
+        "protos/perfetto/trace/track_event/chrome_mojo_event_info.proto",
+        "protos/perfetto/trace/track_event/chrome_process_descriptor.proto",
+        "protos/perfetto/trace/track_event/chrome_renderer_scheduler_state.proto",
+        "protos/perfetto/trace/track_event/chrome_thread_descriptor.proto",
+        "protos/perfetto/trace/track_event/chrome_user_event.proto",
+        "protos/perfetto/trace/track_event/chrome_window_handle_event_info.proto",
+        "protos/perfetto/trace/track_event/counter_descriptor.proto",
+        "protos/perfetto/trace/track_event/debug_annotation.proto",
+        "protos/perfetto/trace/track_event/log_message.proto",
+        "protos/perfetto/trace/track_event/process_descriptor.proto",
+        "protos/perfetto/trace/track_event/range_of_interest.proto",
+        "protos/perfetto/trace/track_event/screenshot.proto",
+        "protos/perfetto/trace/track_event/source_location.proto",
+        "protos/perfetto/trace/track_event/state_descriptor.proto",
+        "protos/perfetto/trace/track_event/task_execution.proto",
+        "protos/perfetto/trace/track_event/thread_descriptor.proto",
+        "protos/perfetto/trace/track_event/track_descriptor.proto",
+        "protos/perfetto/trace/track_event/track_event.proto",
+    ],
+}
+
 // GN: //protos/perfetto/trace/track_event:zero
 filegroup {
     name: "perfetto_protos_perfetto_trace_track_event_zero",

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -197,6 +197,8 @@ proto_groups = {
 transitive_proto_filegroups = {
     'perfetto_protos_perfetto_trace_non_minimal_protos':
         '//protos/perfetto/trace:non_minimal_source_set',
+    'perfetto_protos_perfetto_trace_track_event_transitive_protos':
+        '//protos/perfetto/trace/track_event:cpp',
 }
 
 needs_libfts = [


### PR DESCRIPTION
TrackEvent gained a cross-package import (inline_callstack.proto) in #6793. Downstream Android.bp consumers outside this tree that only depended on perfetto_protos_perfetto_trace_track_event_cpp (which mirrors the GN target's own sources, not its deps) broke because that filegroup doesn't include files pulled in via `deps`.

Add a transitive_proto_filegroups entry for
//protos/perfetto/trace/track_event:cpp so external consumers can depend on a single filegroup that flattens the whole proto closure, instead of hand-listing every dep filegroup and having to update it each time track_event's dependencies change.
