### PR TITLE
perfetto: keep TrackEvent's inline callstack out of the profiling package

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -88,7 +88,6 @@ cc_binary {
         ":perfetto_protos_perfetto_trace_non_minimal_zero_gen",
         ":perfetto_protos_perfetto_trace_perfetto_zero_gen",
         ":perfetto_protos_perfetto_trace_power_zero_gen",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -195,7 +194,6 @@ cc_binary {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -396,7 +394,6 @@ cc_library_shared {
         ":perfetto_protos_perfetto_trace_non_minimal_zero_gen",
         ":perfetto_protos_perfetto_trace_perfetto_zero_gen",
         ":perfetto_protos_perfetto_trace_power_zero_gen",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -511,7 +508,6 @@ cc_library_shared {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -639,7 +635,6 @@ cc_library_shared {
         ":perfetto_protos_perfetto_trace_non_minimal_zero_gen",
         ":perfetto_protos_perfetto_trace_perfetto_zero_gen",
         ":perfetto_protos_perfetto_trace_power_zero_gen",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -775,7 +770,6 @@ cc_library_shared {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -944,7 +938,6 @@ cc_library {
         ":perfetto_protos_perfetto_trace_non_minimal_zero_gen",
         ":perfetto_protos_perfetto_trace_perfetto_zero_gen",
         ":perfetto_protos_perfetto_trace_power_zero_gen",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -1055,7 +1048,6 @@ cc_library {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -1180,7 +1172,6 @@ cc_library_static {
         ":perfetto_protos_perfetto_trace_non_minimal_zero_gen",
         ":perfetto_protos_perfetto_trace_perfetto_zero_gen",
         ":perfetto_protos_perfetto_trace_power_zero_gen",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -1293,7 +1284,6 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -1362,7 +1352,6 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -1564,7 +1553,6 @@ cc_binary {
         ":perfetto_protos_perfetto_trace_non_minimal_zero_gen",
         ":perfetto_protos_perfetto_trace_perfetto_zero_gen",
         ":perfetto_protos_perfetto_trace_power_zero_gen",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -1662,7 +1650,6 @@ cc_binary {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -10163,7 +10150,6 @@ genrule {
     name: "perfetto_protos_perfetto_trace_gpu_gpu_track_event_descriptor",
     srcs: [
         "protos/perfetto/trace/gpu/gpu_track_event.proto",
-        "protos/perfetto/trace/profiling/inline_callstack.proto",
         "protos/perfetto/trace/track_event/chrome_active_processes.proto",
         "protos/perfetto/trace/track_event/chrome_application_state_info.proto",
         "protos/perfetto/trace/track_event/chrome_compositor_scheduler_state.proto",
@@ -10215,7 +10201,6 @@ genrule {
     name: "perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero_gen",
     srcs: [
         ":perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
     ],
     tools: [
@@ -10233,7 +10218,6 @@ genrule {
     name: "perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero_gen_headers",
     srcs: [
         ":perfetto_protos_perfetto_trace_gpu_gpu_track_event_zero",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
     ],
     tools: [
@@ -13129,7 +13113,6 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_cpp_gen",
     srcs: [
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp",
         ":perfetto_protos_perfetto_trace_track_event_cpp",
     ],
     tools: [
@@ -13173,7 +13156,6 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_cpp_gen_headers",
     srcs: [
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp",
         ":perfetto_protos_perfetto_trace_track_event_cpp",
     ],
     tools: [
@@ -13221,7 +13203,6 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_descriptor",
     srcs: [
-        "protos/perfetto/trace/profiling/inline_callstack.proto",
         "protos/perfetto/trace/track_event/chrome_active_processes.proto",
         "protos/perfetto/trace/track_event/chrome_application_state_info.proto",
         "protos/perfetto/trace/track_event/chrome_compositor_scheduler_state.proto",
@@ -13299,7 +13280,6 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_lite_gen",
     srcs: [
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_lite",
         ":perfetto_protos_perfetto_trace_track_event_lite",
     ],
     tools: [
@@ -13342,7 +13322,6 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_lite_gen_headers",
     srcs: [
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_lite",
         ":perfetto_protos_perfetto_trace_track_event_lite",
     ],
     tools: [
@@ -13424,7 +13403,6 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_zero_gen",
     srcs: [
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
     ],
     tools: [
@@ -13468,7 +13446,6 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_track_event_zero_gen_headers",
     srcs: [
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
     ],
     tools: [
@@ -14505,7 +14482,6 @@ genrule {
     srcs: [
         ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_field_options_zero",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     ],
@@ -14525,7 +14501,6 @@ genrule {
     srcs: [
         ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_field_options_zero",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     ],
@@ -15325,7 +15300,6 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_chromium_descriptor",
     srcs: [
-        "protos/perfetto/trace/profiling/inline_callstack.proto",
         "protos/perfetto/trace/track_event/chrome_active_processes.proto",
         "protos/perfetto/trace/track_event/chrome_application_state_info.proto",
         "protos/perfetto/trace/track_event/chrome_compositor_scheduler_state.proto",
@@ -15396,7 +15370,6 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_chromium_zero_gen",
     srcs: [
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_chromium_zero",
     ],
@@ -15415,7 +15388,6 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_chromium_zero_gen_headers",
     srcs: [
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_third_party_chromium_zero",
     ],
@@ -26040,7 +26012,6 @@ cc_binary {
         ":perfetto_protos_perfetto_trace_non_minimal_zero_gen",
         ":perfetto_protos_perfetto_trace_perfetto_zero_gen",
         ":perfetto_protos_perfetto_trace_power_zero_gen",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -26169,7 +26140,6 @@ cc_binary {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -26295,7 +26265,6 @@ cc_binary {
         ":perfetto_protos_perfetto_trace_non_minimal_zero_gen",
         ":perfetto_protos_perfetto_trace_perfetto_zero_gen",
         ":perfetto_protos_perfetto_trace_power_zero_gen",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -26386,7 +26355,6 @@ cc_binary {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",
@@ -26521,7 +26489,6 @@ cc_binary {
         ":perfetto_protos_perfetto_trace_non_minimal_zero_gen",
         ":perfetto_protos_perfetto_trace_perfetto_zero_gen",
         ":perfetto_protos_perfetto_trace_power_zero_gen",
-        ":perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen",
         ":perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen",
         ":perfetto_protos_perfetto_trace_profiling_zero_gen",
         ":perfetto_protos_perfetto_trace_ps_zero_gen",
@@ -26615,7 +26582,6 @@ cc_binary {
         "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
         "perfetto_protos_perfetto_trace_perfetto_zero_gen_headers",
         "perfetto_protos_perfetto_trace_power_zero_gen_headers",
-        "perfetto_protos_perfetto_trace_profiling_inline_callstack_cpp_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_inline_callstack_zero_gen_headers",
         "perfetto_protos_perfetto_trace_profiling_zero_gen_headers",
         "perfetto_protos_perfetto_trace_ps_zero_gen_headers",

--- a/BUILD
+++ b/BUILD
@@ -266,7 +266,6 @@ perfetto_cc_library(
                ":protos_perfetto_trace_non_minimal_zero",
                ":protos_perfetto_trace_perfetto_zero",
                ":protos_perfetto_trace_power_zero",
-               ":protos_perfetto_trace_profiling_inline_callstack_cpp",
                ":protos_perfetto_trace_profiling_inline_callstack_zero",
                ":protos_perfetto_trace_profiling_zero",
                ":protos_perfetto_trace_ps_zero",
@@ -1163,7 +1162,6 @@ perfetto_cc_binary(
         ":protos_perfetto_trace_non_minimal_zero",
         ":protos_perfetto_trace_perfetto_zero",
         ":protos_perfetto_trace_power_zero",
-        ":protos_perfetto_trace_profiling_inline_callstack_cpp",
         ":protos_perfetto_trace_profiling_inline_callstack_zero",
         ":protos_perfetto_trace_profiling_zero",
         ":protos_perfetto_trace_ps_zero",
@@ -1309,7 +1307,6 @@ perfetto_cc_library(
                ":protos_perfetto_trace_non_minimal_zero",
                ":protos_perfetto_trace_perfetto_zero",
                ":protos_perfetto_trace_power_zero",
-               ":protos_perfetto_trace_profiling_inline_callstack_cpp",
                ":protos_perfetto_trace_profiling_inline_callstack_zero",
                ":protos_perfetto_trace_profiling_zero",
                ":protos_perfetto_trace_ps_zero",
@@ -7235,7 +7232,6 @@ perfetto_proto_library(
     name = "chromium_proto",
     visibility = PERFETTO_CONFIG.public_visibility,
     deps = [
-        ":protos_perfetto_trace_profiling_inline_callstack_protos",
         ":protos_perfetto_trace_track_event_protos",
         ":protos_third_party_chromium_protos",
     ],
@@ -9178,7 +9174,6 @@ perfetto_proto_library(
         PERFETTO_CONFIG.proto_library_visibility,
     ],
     deps = [
-        ":protos_perfetto_trace_profiling_inline_callstack_protos",
         ":protos_perfetto_trace_track_event_protos",
     ],
     exports = [
@@ -9191,7 +9186,6 @@ perfetto_cc_protozero_library(
     name = "protos_perfetto_trace_gpu_gpu_track_event_zero",
     deps = [
         ":protos_perfetto_trace_gpu_gpu_track_event_protos",
-        ":protos_perfetto_trace_profiling_inline_callstack_zero",
         ":protos_perfetto_trace_track_event_zero",
     ],
 )
@@ -9558,14 +9552,6 @@ perfetto_cc_protozero_library(
     ],
 )
 
-# GN target: //protos/perfetto/trace/profiling:inline_callstack_cpp
-perfetto_cc_protocpp_library(
-    name = "protos_perfetto_trace_profiling_inline_callstack_cpp",
-    deps = [
-        ":protos_perfetto_trace_profiling_inline_callstack_protos",
-    ],
-)
-
 # GN target: //protos/perfetto/trace/profiling:inline_callstack_source_set
 perfetto_proto_library(
     name = "protos_perfetto_trace_profiling_inline_callstack_protos",
@@ -9808,7 +9794,6 @@ perfetto_cc_protozero_library(
 perfetto_cc_protocpp_library(
     name = "protos_perfetto_trace_track_event_cpp",
     deps = [
-        ":protos_perfetto_trace_profiling_inline_callstack_cpp",
         ":protos_perfetto_trace_track_event_protos",
     ],
 )
@@ -9860,16 +9845,12 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
-    deps = [
-        ":protos_perfetto_trace_profiling_inline_callstack_protos",
-    ],
 )
 
 # GN target: //protos/perfetto/trace/track_event:zero
 perfetto_cc_protozero_library(
     name = "protos_perfetto_trace_track_event_zero",
     deps = [
-        ":protos_perfetto_trace_profiling_inline_callstack_zero",
         ":protos_perfetto_trace_track_event_protos",
     ],
 )
@@ -10424,7 +10405,6 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_trace_field_options_protos",
-        ":protos_perfetto_trace_profiling_inline_callstack_protos",
         ":protos_perfetto_trace_track_event_protos",
     ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
@@ -10438,7 +10418,6 @@ perfetto_cc_protozero_library(
     name = "protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     deps = [
         ":protos_perfetto_trace_field_options_zero",
-        ":protos_perfetto_trace_profiling_inline_callstack_zero",
         ":protos_perfetto_trace_track_event_zero",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_protos",
     ],
@@ -10667,7 +10646,6 @@ perfetto_proto_library(
         PERFETTO_CONFIG.proto_library_visibility,
     ],
     deps = [
-        ":protos_perfetto_trace_profiling_inline_callstack_protos",
         ":protos_perfetto_trace_track_event_protos",
     ],
     exports = [
@@ -11067,7 +11045,6 @@ perfetto_proto_library(
         PERFETTO_CONFIG.proto_library_visibility,
     ],
     deps = [
-        ":protos_perfetto_trace_profiling_inline_callstack_protos",
         ":protos_perfetto_trace_track_event_protos",
     ],
     exports = [
@@ -11079,7 +11056,6 @@ perfetto_proto_library(
 perfetto_cc_protozero_library(
     name = "protos_third_party_chromium_zero",
     deps = [
-        ":protos_perfetto_trace_profiling_inline_callstack_zero",
         ":protos_perfetto_trace_track_event_zero",
         ":protos_third_party_chromium_protos",
     ],
@@ -11297,7 +11273,6 @@ perfetto_cc_library(
                ":protos_perfetto_trace_non_minimal_zero",
                ":protos_perfetto_trace_perfetto_zero",
                ":protos_perfetto_trace_power_zero",
-               ":protos_perfetto_trace_profiling_inline_callstack_cpp",
                ":protos_perfetto_trace_profiling_inline_callstack_zero",
                ":protos_perfetto_trace_profiling_zero",
                ":protos_perfetto_trace_ps_zero",
@@ -11410,7 +11385,6 @@ perfetto_cc_binary(
         ":protos_perfetto_trace_non_minimal_zero",
         ":protos_perfetto_trace_perfetto_zero",
         ":protos_perfetto_trace_power_zero",
-        ":protos_perfetto_trace_profiling_inline_callstack_cpp",
         ":protos_perfetto_trace_profiling_inline_callstack_zero",
         ":protos_perfetto_trace_profiling_zero",
         ":protos_perfetto_trace_ps_zero",

--- a/include/perfetto/public/protos/trace/track_event/track_event.pzc.h
+++ b/include/perfetto/public/protos/trace/track_event/track_event.pzc.h
@@ -44,8 +44,8 @@ PERFETTO_PB_MSG_DECL(perfetto_protos_LogMessage);
 PERFETTO_PB_MSG_DECL(perfetto_protos_Screenshot);
 PERFETTO_PB_MSG_DECL(perfetto_protos_SourceLocation);
 PERFETTO_PB_MSG_DECL(perfetto_protos_TaskExecution);
-PERFETTO_PB_MSG_DECL(perfetto_protos_TrackEvent_Callstack);
-PERFETTO_PB_MSG_DECL(perfetto_protos_TrackEvent_Callstack_Frame);
+PERFETTO_PB_MSG_DECL(perfetto_protos_TrackEvent_InlineCallstack);
+PERFETTO_PB_MSG_DECL(perfetto_protos_TrackEvent_InlineCallstack_Frame);
 PERFETTO_PB_MSG_DECL(perfetto_protos_TrackEvent_LegacyEvent);
 
 PERFETTO_PB_ENUM_IN_MSG(perfetto_protos_TrackEvent, Type){
@@ -190,7 +190,7 @@ PERFETTO_PB_FIELD(perfetto_protos_TrackEvent,
                   54);
 PERFETTO_PB_FIELD(perfetto_protos_TrackEvent,
                   MSG,
-                  perfetto_protos_TrackEvent_Callstack,
+                  perfetto_protos_TrackEvent_InlineCallstack,
                   callstack,
                   55);
 PERFETTO_PB_FIELD(perfetto_protos_TrackEvent,
@@ -416,25 +416,25 @@ PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_LegacyEvent,
                   tid_override,
                   19);
 
-PERFETTO_PB_MSG(perfetto_protos_TrackEvent_Callstack);
-PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_Callstack,
+PERFETTO_PB_MSG(perfetto_protos_TrackEvent_InlineCallstack);
+PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_InlineCallstack,
                   MSG,
-                  perfetto_protos_TrackEvent_Callstack_Frame,
+                  perfetto_protos_TrackEvent_InlineCallstack_Frame,
                   frames,
                   1);
 
-PERFETTO_PB_MSG(perfetto_protos_TrackEvent_Callstack_Frame);
-PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_Callstack_Frame,
+PERFETTO_PB_MSG(perfetto_protos_TrackEvent_InlineCallstack_Frame);
+PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_InlineCallstack_Frame,
                   STRING,
                   const char*,
                   function_name,
                   1);
-PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_Callstack_Frame,
+PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_InlineCallstack_Frame,
                   STRING,
                   const char*,
                   source_file,
                   2);
-PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_Callstack_Frame,
+PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_InlineCallstack_Frame,
                   VARINT,
                   uint32_t,
                   line_number,

--- a/include/perfetto/public/protos/trace/track_event/track_event.pzc.h
+++ b/include/perfetto/public/protos/trace/track_event/track_event.pzc.h
@@ -40,11 +40,12 @@ PERFETTO_PB_MSG_DECL(perfetto_protos_ChromeRendererSchedulerState);
 PERFETTO_PB_MSG_DECL(perfetto_protos_ChromeUserEvent);
 PERFETTO_PB_MSG_DECL(perfetto_protos_ChromeWindowHandleEventInfo);
 PERFETTO_PB_MSG_DECL(perfetto_protos_DebugAnnotation);
-PERFETTO_PB_MSG_DECL(perfetto_protos_InlineCallstack);
 PERFETTO_PB_MSG_DECL(perfetto_protos_LogMessage);
 PERFETTO_PB_MSG_DECL(perfetto_protos_Screenshot);
 PERFETTO_PB_MSG_DECL(perfetto_protos_SourceLocation);
 PERFETTO_PB_MSG_DECL(perfetto_protos_TaskExecution);
+PERFETTO_PB_MSG_DECL(perfetto_protos_TrackEvent_Callstack);
+PERFETTO_PB_MSG_DECL(perfetto_protos_TrackEvent_Callstack_Frame);
 PERFETTO_PB_MSG_DECL(perfetto_protos_TrackEvent_LegacyEvent);
 
 PERFETTO_PB_ENUM_IN_MSG(perfetto_protos_TrackEvent, Type){
@@ -189,7 +190,7 @@ PERFETTO_PB_FIELD(perfetto_protos_TrackEvent,
                   54);
 PERFETTO_PB_FIELD(perfetto_protos_TrackEvent,
                   MSG,
-                  perfetto_protos_InlineCallstack,
+                  perfetto_protos_TrackEvent_Callstack,
                   callstack,
                   55);
 PERFETTO_PB_FIELD(perfetto_protos_TrackEvent,
@@ -414,5 +415,29 @@ PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_LegacyEvent,
                   int32_t,
                   tid_override,
                   19);
+
+PERFETTO_PB_MSG(perfetto_protos_TrackEvent_Callstack);
+PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_Callstack,
+                  MSG,
+                  perfetto_protos_TrackEvent_Callstack_Frame,
+                  frames,
+                  1);
+
+PERFETTO_PB_MSG(perfetto_protos_TrackEvent_Callstack_Frame);
+PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_Callstack_Frame,
+                  STRING,
+                  const char*,
+                  function_name,
+                  1);
+PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_Callstack_Frame,
+                  STRING,
+                  const char*,
+                  source_file,
+                  2);
+PERFETTO_PB_FIELD(perfetto_protos_TrackEvent_Callstack_Frame,
+                  VARINT,
+                  uint32_t,
+                  line_number,
+                  3);
 
 #endif  // INCLUDE_PERFETTO_PUBLIC_PROTOS_TRACE_TRACK_EVENT_TRACK_EVENT_PZC_H_

--- a/protos/perfetto/trace/profiling/BUILD.gn
+++ b/protos/perfetto/trace/profiling/BUILD.gn
@@ -29,8 +29,8 @@ perfetto_proto_library("@TYPE@") {
   ]
 }
 
-# Kept dependency-free so that messages embedding InlineCallstack (e.g.
-# TrackEvent) do not pull in the rest of the profiling protos.
+# Kept dependency-free so that messages embedding InlineCallstack do not pull
+# in the rest of the profiling protos.
 perfetto_proto_library("inline_callstack_@TYPE@") {
   sources = [ "inline_callstack.proto" ]
 }

--- a/protos/perfetto/trace/profiling/inline_callstack.proto
+++ b/protos/perfetto/trace/profiling/inline_callstack.proto
@@ -25,9 +25,8 @@ package perfetto.protos;
 // unique. For binary/library information (mappings, build ids, relative pcs)
 // or efficient repetition, use interned Callstacks instead.
 //
-// This lives in its own file (rather than profile_common.proto) so that
-// messages embedding it, like TrackEvent, do not pull in the rest of the
-// profiling protos and their transitive dependencies.
+// Used by StackSample as the inline (non-interned) variant of its callstack
+// field.
 message InlineCallstack {
   // A frame within an inline callstack.
   message Frame {

--- a/protos/perfetto/trace/track_event/BUILD.gn
+++ b/protos/perfetto/trace/track_event/BUILD.gn
@@ -15,7 +15,6 @@
 import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  deps = [ "../profiling:inline_callstack_@TYPE@" ]
   sources = [
     "chrome_active_processes.proto",
     "chrome_application_state_info.proto",

--- a/protos/perfetto/trace/track_event/track_event.proto
+++ b/protos/perfetto/trace/track_event/track_event.proto
@@ -294,7 +294,7 @@ message TrackEvent {
   oneof callstack_field {
     // Inline callstack data. Use this for simplicity when interning is not
     // needed (e.g., for unique callstacks or when trace size is not critical).
-    Callstack callstack = 55;
+    InlineCallstack callstack = 55;
 
     // Reference to interned Callstack (see InternedData.callstacks).
     // This is the efficient option when callstacks are repeated.
@@ -311,7 +311,7 @@ message TrackEvent {
   // Use this for simple callstacks with function names and source locations.
   // For binary/library information (mappings, build IDs, relative PCs), use
   // interned callstacks via callstack_iid instead.
-  message Callstack {
+  message InlineCallstack {
     // Frame within an inline callstack.
     message Frame {
       // Function name, e.g., "malloc" or "std::vector<int>::push_back"

--- a/protos/perfetto/trace/track_event/track_event.proto
+++ b/protos/perfetto/trace/track_event/track_event.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto2";
 
-import "protos/perfetto/trace/profiling/inline_callstack.proto";
 import "protos/perfetto/trace/track_event/debug_annotation.proto";
 import "protos/perfetto/trace/track_event/log_message.proto";
 import "protos/perfetto/trace/track_event/task_execution.proto";
@@ -293,16 +292,42 @@ message TrackEvent {
   //
   // Only one of these fields should be set.
   oneof callstack_field {
-    // Fully-inline callstack data. Use this for simplicity when interning is
-    // not needed (e.g., for unique callstacks or when trace size is not
-    // critical).
-    InlineCallstack callstack = 55;
+    // Inline callstack data. Use this for simplicity when interning is not
+    // needed (e.g., for unique callstacks or when trace size is not critical).
+    Callstack callstack = 55;
 
     // Reference to interned Callstack (see InternedData.callstacks).
     // This is the efficient option when callstacks are repeated.
     //
     // Note: iids *always* start from 1. A value of 0 is considered "not set".
     uint64 callstack_iid = 56;
+  }
+
+  // Inline callstack for TrackEvents when interning is not needed.
+  // This is a simplified version of the profiling Callstack/Frame messages,
+  // designed for cases where trace size is not critical or callstacks are
+  // unique.
+  //
+  // Use this for simple callstacks with function names and source locations.
+  // For binary/library information (mappings, build IDs, relative PCs), use
+  // interned callstacks via callstack_iid instead.
+  message Callstack {
+    // Frame within an inline callstack.
+    message Frame {
+      // Function name, e.g., "malloc" or "std::vector<int>::push_back"
+      optional string function_name = 1;
+
+      // Optional: Source file path, e.g., "/src/foo.cc"
+      optional string source_file = 2;
+
+      // Optional: Line number in the source file
+      optional uint32 line_number = 3;
+    }
+
+    // Frames of this callstack, ordered from bottom (outermost) to top
+    // (innermost). For example, if main() calls foo() which calls bar(), the
+    // frames would be: [main, foo, bar]
+    repeated Frame frames = 1;
   }
 
   // An optional additive value attributed to this callstack occurrence. When

--- a/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
+++ b/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
@@ -1168,25 +1168,25 @@ public class PerfettoTraceTest {
         TrackEvent event = packet.getTrackEvent();
         if (event.hasCallstack()) {
           hasCallstack = true;
-          TrackEvent.Callstack callstack = event.getCallstack();
+          TrackEvent.InlineCallstack callstack = event.getCallstack();
           assertThat(callstack.getFramesCount()).isEqualTo(4);
 
-          TrackEvent.Callstack.Frame frame0 = callstack.getFrames(0);
+          TrackEvent.InlineCallstack.Frame frame0 = callstack.getFrames(0);
           assertThat(frame0.getFunctionName()).isEqualTo("ClassD.methodD");
           assertThat(frame0.getSourceFile()).isEqualTo("FileD.java");
           assertThat(frame0.getLineNumber()).isEqualTo(40);
 
-          TrackEvent.Callstack.Frame frame1 = callstack.getFrames(1);
+          TrackEvent.InlineCallstack.Frame frame1 = callstack.getFrames(1);
           assertThat(frame1.getFunctionName()).isEqualTo("ClassC.methodC");
           assertThat(frame1.getSourceFile()).isEqualTo("FileC.java");
           assertThat(frame1.getLineNumber()).isEqualTo(30);
 
-          TrackEvent.Callstack.Frame frame2 = callstack.getFrames(2);
+          TrackEvent.InlineCallstack.Frame frame2 = callstack.getFrames(2);
           assertThat(frame2.getFunctionName()).isEqualTo("ClassB.methodB");
           assertThat(frame2.getSourceFile()).isEqualTo("FileB.java");
           assertThat(frame2.getLineNumber()).isEqualTo(20);
 
-          TrackEvent.Callstack.Frame frame3 = callstack.getFrames(3);
+          TrackEvent.InlineCallstack.Frame frame3 = callstack.getFrames(3);
           assertThat(frame3.getFunctionName()).isEqualTo("ClassA.methodA");
           assertThat(frame3.getSourceFile()).isEqualTo("FileA.java");
           assertThat(frame3.getLineNumber()).isEqualTo(10);

--- a/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
+++ b/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
@@ -46,7 +46,6 @@ import perfetto.protos.ChromeLatencyInfoOuterClass.ChromeLatencyInfo.ComponentIn
 import perfetto.protos.DataSourceConfigOuterClass.DataSourceConfig;
 import perfetto.protos.DebugAnnotationOuterClass.DebugAnnotation;
 import perfetto.protos.DebugAnnotationOuterClass.DebugAnnotationName;
-import perfetto.protos.InlineCallstackOuterClass.InlineCallstack;
 import perfetto.protos.InternedDataOuterClass.InternedData;
 import perfetto.protos.SourceLocationOuterClass.SourceLocation;
 import perfetto.protos.TraceConfigOuterClass.TraceConfig;
@@ -1169,25 +1168,25 @@ public class PerfettoTraceTest {
         TrackEvent event = packet.getTrackEvent();
         if (event.hasCallstack()) {
           hasCallstack = true;
-          InlineCallstack callstack = event.getCallstack();
+          TrackEvent.Callstack callstack = event.getCallstack();
           assertThat(callstack.getFramesCount()).isEqualTo(4);
 
-          InlineCallstack.Frame frame0 = callstack.getFrames(0);
+          TrackEvent.Callstack.Frame frame0 = callstack.getFrames(0);
           assertThat(frame0.getFunctionName()).isEqualTo("ClassD.methodD");
           assertThat(frame0.getSourceFile()).isEqualTo("FileD.java");
           assertThat(frame0.getLineNumber()).isEqualTo(40);
 
-          InlineCallstack.Frame frame1 = callstack.getFrames(1);
+          TrackEvent.Callstack.Frame frame1 = callstack.getFrames(1);
           assertThat(frame1.getFunctionName()).isEqualTo("ClassC.methodC");
           assertThat(frame1.getSourceFile()).isEqualTo("FileC.java");
           assertThat(frame1.getLineNumber()).isEqualTo(30);
 
-          InlineCallstack.Frame frame2 = callstack.getFrames(2);
+          TrackEvent.Callstack.Frame frame2 = callstack.getFrames(2);
           assertThat(frame2.getFunctionName()).isEqualTo("ClassB.methodB");
           assertThat(frame2.getSourceFile()).isEqualTo("FileB.java");
           assertThat(frame2.getLineNumber()).isEqualTo(20);
 
-          InlineCallstack.Frame frame3 = callstack.getFrames(3);
+          TrackEvent.Callstack.Frame frame3 = callstack.getFrames(3);
           assertThat(frame3.getFunctionName()).isEqualTo("ClassA.methodA");
           assertThat(frame3.getSourceFile()).isEqualTo("FileA.java");
           assertThat(frame3.getLineNumber()).isEqualTo(10);

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -97,7 +97,6 @@ source_set("minimal") {
     "../../../../protos/perfetto/trace/interned_data:zero",
     "../../../../protos/perfetto/trace/perfetto:zero",
     "../../../../protos/perfetto/trace/power:zero",
-    "../../../../protos/perfetto/trace/profiling:inline_callstack_zero",
     "../../../../protos/perfetto/trace/profiling:zero",
     "../../../../protos/perfetto/trace/ps:zero",
     "../../../../protos/perfetto/trace/sys_stats:zero",

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -1670,7 +1670,7 @@ class TrackEventEventImporter {
     // Handle inline callstack
     // Inline callstacks are simple: just function names and source locations
     if (event_.has_callstack()) {
-      protos::pbzero::TrackEvent::Callstack::Decoder callstack(
+      protos::pbzero::TrackEvent::InlineCallstack::Decoder callstack(
           event_.callstack());
       DummyMemoryMapping* dummy_mapping =
           parser_->GetOrCreateInlineCallstackDummyMapping();
@@ -1678,7 +1678,8 @@ class TrackEventEventImporter {
       std::optional<CallsiteId> callsite_id;
       uint32_t depth = 0;
       for (auto frame_it = callstack.frames(); frame_it; ++frame_it, ++depth) {
-        protos::pbzero::TrackEvent::Callstack::Frame::Decoder frame(*frame_it);
+        protos::pbzero::TrackEvent::InlineCallstack::Frame::Decoder frame(
+            *frame_it);
         std::optional<base::StringView> source_file;
         if (frame.has_source_file()) {
           source_file = frame.source_file();

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -35,7 +35,6 @@
 #include "perfetto/protozero/field.h"
 #include "perfetto/protozero/proto_decoder.h"
 #include "perfetto/public/compiler.h"
-#include "protos/perfetto/trace/profiling/inline_callstack.pbzero.h"
 #include "protos/perfetto/trace/profiling/profile_common.pbzero.h"
 #include "src/trace_processor/containers/null_term_string_view.h"
 #include "src/trace_processor/containers/string_pool.h"
@@ -1671,14 +1670,15 @@ class TrackEventEventImporter {
     // Handle inline callstack
     // Inline callstacks are simple: just function names and source locations
     if (event_.has_callstack()) {
-      protos::pbzero::InlineCallstack::Decoder callstack(event_.callstack());
+      protos::pbzero::TrackEvent::Callstack::Decoder callstack(
+          event_.callstack());
       DummyMemoryMapping* dummy_mapping =
           parser_->GetOrCreateInlineCallstackDummyMapping();
 
       std::optional<CallsiteId> callsite_id;
       uint32_t depth = 0;
       for (auto frame_it = callstack.frames(); frame_it; ++frame_it, ++depth) {
-        protos::pbzero::InlineCallstack::Frame::Decoder frame(*frame_it);
+        protos::pbzero::TrackEvent::Callstack::Frame::Decoder frame(*frame_it);
         std::optional<base::StringView> source_file;
         if (frame.has_source_file()) {
           source_file = frame.source_file();


### PR DESCRIPTION
top-level InlineCallstack in a new profiling/inline_callstack.proto, so both TrackEvent and StackSample could use it. That made track_event.proto import a file outside its own directory for the first time, which broke out-of-tree Android.bp genrules that only depended on the narrow, self-contained track_event proto filegroup (e.g. vendor consumers and frameworks/native/tracing), since Soong's sbox sandboxes only see explicitly listed srcs.

Revert TrackEvent's side: restore its own nested TrackEvent.Callstack message (same field numbers, wire-compatible) instead of importing InlineCallstack. StackSample keeps using the shared InlineCallstack from profiling/inline_callstack.proto, since that's a same-package dependency and was never the problem.

