### PR TITLE
ui: fix Heap Dump Explorer deeplink class filter being dropped

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
@@ -56,7 +56,8 @@ function stateToParts(state: NavState): {path: string; query: string} {
     case 'dominators':
       return {path: 'dominators', query: ''};
     case 'objects':
-      return {path: 'objects', query: queryParam('cls', state.params.cls)};
+      // Class filter in the path, not the query: the router drops query params.
+      return {path: pathSegment('objects', state.params.cls), query: ''};
     case 'object':
       return {
         path: pathSegment('object', `0x${state.params.id.toString(16)}`),
@@ -135,7 +136,7 @@ export function subpageToState(subpage: string | undefined): NavState {
     case 'dominators':
       return {view: 'dominators', params: {}};
     case 'objects': {
-      const cls = sp.get('cls') ?? undefined;
+      const cls = param ? decodeURIComponent(param) : undefined;
       return {view: 'objects', params: cls ? {cls} : {}};
     }
     case 'object': {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
@@ -191,14 +191,18 @@ export class HeapDumpExplorerSession {
   };
 
   readonly clearNavParam = (key: string): void => {
-    // A consumed nav param (e.g. ?cls=Foo) becomes a one-shot grid filter, so
-    // drop it from the nav. Otherwise it would re-apply on restore and clobber
-    // the user's later manual filter edits to the same grid.
+    // A consumed nav param becomes a one-shot grid filter, so drop it from the
+    // nav — from both the store and the URL. Otherwise it re-applies on the next
+    // sync and clobbers the user's later manual filter edits. Query params are
+    // already gone (the router strips them), but path-encoded ones (e.g.
+    // objects_<class>) survive in the URL, so we must rewrite it here.
+    const nav = subpageToState(this.store.state.nav);
+    delete (nav.params as Record<string, unknown>)[key];
+    const sub = stateToSubpage(nav);
     this.store.edit((s) => {
-      const nav = subpageToState(s.nav);
-      delete (nav.params as Record<string, unknown>)[key];
-      s.nav = stateToSubpage(nav);
+      s.nav = sub;
     });
+    this._navigateCallback?.(sub);
   };
 
   // Mirrors URL-driven nav (back/forward, address bar) into the store, on path

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
@@ -123,11 +123,11 @@ export function topTable(opts: {
   ]);
 }
 
-// Link to the Heap Dump Explorer's object list, filtered to one class. The HDE
-// page (com.android.HeapDumpExplorer) parses `cls` out of the query string, so
-// the value is URI-encoded the same way the explorer's own links are.
+// Link to the Heap Dump Explorer's objects list, filtered to one class. The
+// filter goes in the path, not the query (the router drops query params); this
+// matches the explorer's own objects_<class> links.
 export function heapDumpClassHref(cls: string): string {
-  return `#!/heapdump/objects?cls=${encodeURIComponent(cls)}`;
+  return `#!/heapdump/objects_${encodeURIComponent(cls)}`;
 }
 
 // A class-name cell. The class name links to that class's instances in the Heap


### PR DESCRIPTION
Deeplinking to the Objects tab filtered by class (a Memscope class link) dropped the filter: the class was a query param, but the router parses everything after '?' as global route args and discards unknown keys, so it never reached the explorer.

Encode the class in the path (objects_<class>) like the object and bitmaps views, so the raw link survives the router, and update Memscope's link to match. The class is still consumed as a one-shot grid filter via the existing clearNavParam, which now also drops the param from the URL — it only edited the store before, relying on the router to strip the query, but path-encoded params aren't stripped.
