### PR TITLE
ui: Toggle task colors based on niceness

### DIFF
--- a/ui/src/components/colorizer.ts
+++ b/ui/src/components/colorizer.ts
@@ -164,6 +164,19 @@ export function colorForThread(thread?: {
   return colorForTid(tid);
 }
 
+export function colorForPriority(priority: number): ColorScheme {
+  if (priority < 100) {
+    // Realtime scheduling priorities (0..99) -> Red
+    return MD_PALETTE[0];
+  }
+  if (priority < 120) {
+    // High priority CFS tasks (100..119) -> Yellow
+    return MD_PALETTE[17];
+  }
+  // Priority 120 onwards (nice >= 0) -> Blue
+  return MD_PALETTE[5];
+}
+
 export function colorForCpu(cpu: number): Color {
   if (USE_CONSISTENT_COLORS.get()) {
     return materialColorScheme(cpu.toString()).base;

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -244,6 +244,11 @@ export interface SliceTrackAttrs<T extends DatasetSchema> {
   colorizer?(row: T): ColorScheme;
 
   /**
+   * Optional function returning a key for invalidating cached slice data frames when track attributes/modes change.
+   */
+  readonly getKey?: () => string;
+
+  /**
    * Override the text displayed on each event (title).
    */
   sliceName?(row: T): string;
@@ -825,6 +830,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
         start: bounds.start,
         end: bounds.end,
         resolution: bounds.resolution,
+        key: this.attrs.getKey?.(),
       },
       queryFn: async (signal) => {
         const promise = (async () => {

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_track.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {colorForThread} from '../../components/colorizer';
+import {colorForPriority, colorForThread} from '../../components/colorizer';
 import {SliceTrack, ColorVariant} from '../../components/tracks/slice_track';
 import {LONG, NUM} from '../../trace_processor/query_result';
 import type {Trace} from '../../public/trace';
@@ -21,6 +21,7 @@ import type {ThreadMap} from '../dev.perfetto.Thread/threads';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {RECT_PATTERN_HATCHED} from '../../base/renderer';
 import {SchedSliceDetailsPanel} from './sched_details_tab';
+import SchedPlugin from './index';
 
 const MARGIN_TOP = 3;
 const RECT_HEIGHT = 24;
@@ -65,7 +66,12 @@ export function createCpuSliceTrack(
       sliceHeight: RECT_HEIGHT,
     },
 
+    getKey: () => SchedPlugin.taskColorModeSetting?.get(),
+
     colorizer(row) {
+      if (SchedPlugin.taskColorModeSetting?.get() === 'priority') {
+        return colorForPriority(row.priority);
+      }
       const threadInfo = threads.get(row.utid);
       return colorForThread(threadInfo);
     },

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -60,6 +60,8 @@ import {Cpu} from '../../components/cpu';
 import {ThreadStateByCpuAggregator} from './thread_state_by_cpu_aggregator';
 import type {App} from '../../public/app';
 import type {Flag} from '../../public/feature_flag';
+import type {Setting} from '../../public/settings';
+import {z} from 'zod';
 
 function uriForThreadStateTrack(upid: number | null, utid: number): string {
   return `${getThreadUriPrefix(upid, utid)}_state`;
@@ -78,6 +80,7 @@ export default class SchedPlugin implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.Sched';
   static readonly dependencies = [ProcessThreadGroupsPlugin, ThreadPlugin];
   static threadStateByCpuFlag: Flag;
+  static taskColorModeSetting: Setting<'process' | 'priority'>;
 
   static onActivate(app: App) {
     SchedPlugin.threadStateByCpuFlag = app.featureFlags.register({
@@ -86,6 +89,26 @@ export default class SchedPlugin implements PerfettoPlugin {
       description:
         'Add a new area selection aggregation tab showing thread states broken down by CPU.',
       defaultValue: true,
+    });
+
+    SchedPlugin.taskColorModeSetting = app.settings.register({
+      id: 'dev.perfetto.Sched#taskColorMode',
+      name: 'Task slice color mode',
+      description:
+        'Color scheme used for task (CPU scheduling) slices: by process/thread or by priority (realtime & niceness).',
+      schema: z.enum(['process', 'priority']),
+      defaultValue: 'process',
+    });
+
+    app.commands.registerCommand({
+      id: 'dev.perfetto.Sched#toggleTaskColorMode',
+      name: 'Toggle task slice color mode (Process vs Priority)',
+      defaultHotkey: 'Shift+C',
+      callback: () => {
+        const current = SchedPlugin.taskColorModeSetting.get();
+        const next = current === 'process' ? 'priority' : 'process';
+        SchedPlugin.taskColorModeSetting.set(next);
+      },
     });
   }
 


### PR DESCRIPTION
Add a hotkey (shift + C) to toggle color of task slices based on their niceness. This distinguishes tasks based on realtime, high-priority CFS tasks (usually foreground tasks), and low priority tasks.

The task slice visualization Perfetto UI offers is invaluable, as the color representation helps to easily spot patterns or trends with tasks being run or scheduled. By color coding different priority tasks, it's significantly easier to visualize how different priority tasks are being scheduled, which is especially helpful when developing new scheduling features, or debugging scheduling issues.

Bug: 537887463
Test: ui/run-unittests --no-build
