### PR TITLE
tp: fix FlatBufferWriter crash on empty writes

### DIFF
--- a/src/trace_processor/util/flatbuffer_reader_unittest.cc
+++ b/src/trace_processor/util/flatbuffer_reader_unittest.cc
@@ -210,6 +210,21 @@ TEST(FlatBufferRoundTripTest, EmptyVec) {
   EXPECT_EQ(reader->VecScalar<int32_t>(0).size(), 0u);
 }
 
+TEST(FlatBufferRoundTripTest, EmptyVecStruct) {
+  // A zero-element struct vector is the first thing written, so the writer's
+  // buffer is still empty when the (empty) element payload is prepended.
+  FlatBufferWriter w;
+  auto vec = w.WriteVecStruct(nullptr, sizeof(int32_t), 0, alignof(int32_t));
+  w.StartTable();
+  w.FieldOffset(0, vec);
+  auto root = w.EndTable();
+  auto buf = Build(root, w);
+
+  auto reader = GetRoot(buf);
+  ASSERT_TRUE(reader.has_value());
+  EXPECT_EQ(reader->VecScalar<int32_t>(0).size(), 0u);
+}
+
 TEST(FlatBufferRoundTripTest, VecIndexOutOfBoundsReturnsDefault) {
   // Indexing any vector type at or past size() must return a default value,
   // never read out of bounds. The last valid index still reads correctly.

--- a/src/trace_processor/util/flatbuffer_writer.cc
+++ b/src/trace_processor/util/flatbuffer_writer.cc
@@ -41,8 +41,8 @@ void FlatBufferWriter::GrowIfNeeded(uint32_t bytes) {
   // Shift existing data to the end of the new buffer.
   uint32_t data_len = old_size - head_;
   uint32_t new_head = new_size - data_len;
-  memmove(&buf_[new_head], &buf_[head_], data_len);
-  memset(&buf_[head_], 0, new_head - head_);
+  memmove(buf_.data() + new_head, buf_.data() + head_, data_len);
+  memset(buf_.data() + head_, 0, new_head - head_);
   head_ = new_head;
 }
 
@@ -56,6 +56,9 @@ void FlatBufferWriter::Align(uint32_t alignment) {
 }
 
 void FlatBufferWriter::PrependBytes(const void* src, uint32_t len) {
+  if (len == 0) {
+    return;
+  }
   GrowIfNeeded(len);
   head_ -= len;
   memcpy(&buf_[head_], src, len);


### PR DESCRIPTION
FlatBufferWriter writes back-to-front, so head_ starts at buf_.size() and moves down. Before anything is written head_ == buf_.size(), and then:

  memcpy(&buf_[head_], src, len);   // buf_[buf_.size()]

We never touch that reference when len is 0, but operator[] asserts the index is in range before returning it. Chromium enables libc++ hardening, so the Arrow tests abort there while passing for us:

  https://chromium-review.googlesource.com/c/chromium/src/+/8129407

len is 0 whenever WriteVecStruct() gets count == 0, which happens for a dataframe whose only column is the implicit id column: no field nodes, no buffers. So return early. That also avoids passing a null src to memcpy, which the footer's empty dictionaries vector already does.

GrowIfNeeded() can hit the same thing on an empty buffer, so index it with buf_.data() + n instead. No caller reaches it today.
