### PR TITLE
docs: clean up the converting and synthetic track event pages

### DIFF
--- a/docs/getting-started/converting.md
+++ b/docs/getting-started/converting.md
@@ -184,7 +184,7 @@ To create slices from your custom data, you'll typically:
 2.  For each event in your data, emit `TrackEvent` packets to mark the beginning
     and end of the slice.
 
-### Python Example
+### Python Example: Basic Slices
 
 Let's say you have data representing tasks with a name, start time, and end
 time. Here's how you could convert them into Perfetto slices on a custom track.
@@ -286,7 +286,7 @@ This is very common for:
 
 The Perfetto UI will visually nest these slices, making the hierarchy clear.
 
-### Python Example
+### Python Example: Nested Slices
 
 This example demonstrates creating multiple stacks of nested slices on a custom
 track. The packets are emitted in timestamp order to correctly represent the
@@ -392,7 +392,7 @@ This is a convention and can be controlled by the user. For more details, see
 the section on controlling merging in the
 [synthetic track event reference docs](/docs/reference/synthetic-track-event.md#controlling-track-merging).
 
-### Python Example
+### Python Example: Asynchronous Slices
 
 Imagine we are tracking active network connections. Each connection is an
 independent asynchronous event. We'll give all connection tracks the same name
@@ -484,7 +484,7 @@ To create a counter track, you'll:
     have a `timestamp` and a `counter_value` (which can be an integer or a
     double).
 
-### Python Example
+### Python Example: Counters
 
 Let's say we want to track the number of outstanding network requests over time.
 
@@ -580,7 +580,7 @@ with consistent colors) without implying causality. See the
 [Linking Related Events with Correlation IDs](/docs/reference/synthetic-track-event.md#linking-related-events-with-correlation-ids)
 section in the Advanced Guide for details.
 
-### Python Example
+### Python Example: Flows
 
 Let's model a simple system where a "Request Handler" track dispatches work to a
 "Data Processor" track. We'll use flows to link the request dispatch to its
@@ -691,7 +691,7 @@ A parent track can serve two main purposes:
 
 The Perfetto UI will typically render these as an expandable tree.
 
-### Python Example
+### Python Example: Track Hierarchies
 
 Let's create a hierarchy:
 
@@ -1127,7 +1127,7 @@ repeated callstacks or when you need binary mapping information, use
 [interned callstacks](/docs/reference/synthetic-track-event.md#callstacks)
 instead.
 
-### Python Example
+### Python Example: Inline Callstacks
 
 Each frame includes a function name, and optionally a source file and line
 number.
@@ -1278,7 +1278,7 @@ the `attributes` section of a
 [trace manifest](/docs/reference/perfetto-manifest.md#attributes), which
 uses its own `manifest_attribute.*` namespace.
 
-### Python Example
+### Python Example: Trace Metadata
 
 Copy the following Python code into the `populate_packets(builder)` function in
 your `trace_converter_template.py` script.

--- a/docs/reference/synthetic-track-event.md
+++ b/docs/reference/synthetic-track-event.md
@@ -15,12 +15,19 @@ We assume you are familiar with:
   traces, and that the Python examples provided here are intended to be used
   within its `populate_packets(builder)` function.
 
-This guide will currently focus on advanced `TrackEvent` features, such as:
+This guide covers advanced `TrackEvent` features, grouped into the following
+areas:
 
-- Associating your timeline data with operating system (OS) processes and
-  threads for richer integration.
-- Explicit track sorting and data interning for optimizing trace size and
-  detail.
+- **Associating tracks with OS concepts:** attaching your timeline data to
+  operating system (OS) processes and threads for richer integration.
+- **Customizing track display:** controlling how the UI sorts, merges and
+  presents your tracks.
+- **Interning:** reducing trace size by deduplicating frequently repeated
+  strings and callstacks.
+- **Enriching events with additional data:** callstack weights, correlation
+  IDs, and custom typed fields via proto extensions.
+- **Handling large traces:** streaming packets to disk to keep memory usage
+  low.
 
 While `TrackEvent` is a primary method for representing timeline data,
 `TracePacket` is a versatile container. In the future, this guide may expand to
@@ -67,7 +74,7 @@ Unlike with "global" tracks, these track types may interact with other data
 sources and as such having a timestamp makes sure that Trace Processor can
 accurately sort the descriptor into the right place.
 
-#### Python Example
+#### Python Example: Process-Scoped Counter
 
 Let's say you want to emit a custom counter (e.g. "Active DB Connections") and
 have it appear under a specific process named "MyDatabaseService" with PID 1234.
@@ -128,9 +135,6 @@ your `trace_converter_template.py` script.
 
 </details>
 
-If you only have symbolized function names, call `add_frame(...)` with just the
-interned function name ID: e.g. `add_frame(packet.interned_data, FRAME_MAIN, FUNC_MAIN)`.
-
 ![Associating Tracks with Processes](/docs/images/synthetic-track-event-process-counter.png)
 
 You can query process-associated counter data using SQL in the Perfetto UI's Query tab or with [Trace Processor](/docs/analysis/getting-started.md):
@@ -189,7 +193,7 @@ information from the kernel). Unlike with "global" tracks, these track types may
 interact with other data sources and as such having a timestamp makes sure that
 Trace Processor can accurately sort the descriptor into the right place.
 
-**Python Example: Thread-Specific Slices**
+#### Python Example: Thread-Specific Slices
 
 This example defines a thread "MainWorkLoop" (TID 5678) belonging to process
 "MyApplication" (PID 1234). It then emits a couple of slices directly onto this
@@ -282,10 +286,12 @@ WHERE tid = 5678;
 For details on how to explicitly control the display order of threads within a process, see
 [Controlling Track Sorting Order](#controlling-track-sorting-order).
 
-## Advanced Track Customization
+## Customizing Track Display
 
 Beyond associating tracks with OS concepts, Perfetto offers ways to fine-tune
-how your tracks are presented and how data is encoded.
+how your tracks are presented in the UI: how sibling tracks are sorted and
+merged, how counters share their scale, and how tracks are described to the
+user.
 
 ### Controlling Track Sorting Order
 
@@ -295,7 +301,7 @@ you might want to explicitly define the order in which tracks appear. This
 sorting behavior differs depending on whether you are ordering standard custom
 child tracks, processes, or threads within a process.
 
-#### Non-OS Scoped (Child Tracks) Sorting
+#### Child Track Sorting
 
 For standard custom tracks that are parented to another custom track using `parent_uuid`,
 you can configure child ordering on the parent track.
@@ -348,7 +354,7 @@ orderings, there are contexts in which the UI reserves the right _not_ to show
 them in this order; generally this would be if the user explicitly requested
 this or if the UI has some special handling for these tracks.
 
-**Python Example: Demonstrating All Sorting Types**
+#### Python Example: Demonstrating All Sorting Types
 
 This example defines three parent tracks demonstrating different `child_ordering` modes,
 as well as configuring explicit process and thread ordering on the root track.
@@ -492,6 +498,133 @@ your `trace_converter_template.py` script.
 
 ![Controlling Track Sorting Order](/docs/images/synthetic-track-event-sorting.png)
 
+### {#controlling-track-merging} Controlling Track Merging
+
+By default, the Perfetto UI merges tracks that share the same name. This is
+often the desired behavior for grouping related asynchronous events. However,
+there are scenarios where you need more explicit control. You can override this
+default merging logic using the `sibling_merge_behavior` and `sibling_merge_key`
+fields in the `TrackDescriptor`.
+
+This allows you to:
+
+- **Prevent merging**: Force tracks, even with the same name, to always be
+  displayed separately.
+- **Merge by key**: Force tracks to merge based on a custom key, regardless of
+  their names.
+
+The `sibling_merge_behavior` field can be set to one of the following values:
+
+- `SIBLING_MERGE_BEHAVIOR_BY_TRACK_NAME` (the default): Merges sibling tracks
+  that have the same `name`.
+- `SIBLING_MERGE_BEHAVIOR_NONE`: Prevents the track from being merged with any
+  of its siblings.
+- `SIBLING_MERGE_BEHAVIOR_BY_SIBLING_MERGE_KEY`: Merges sibling tracks that have
+  the same `sibling_merge_key` string.
+
+#### Python Example: Preventing Merging
+
+In this example, we create two tracks with the same name. By setting their
+`sibling_merge_behavior` to `SIBLING_MERGE_BEHAVIOR_NONE`, we ensure they are
+always displayed as distinct tracks in the UI.
+
+<details>
+<summary><b>Click to expand/collapse Python code</b></summary>
+
+```python
+    TRUSTED_PACKET_SEQUENCE_ID = 9003
+
+    # --- Define Track UUIDs ---
+    track1_uuid = 1
+    track2_uuid = 2
+
+    # Helper to define a TrackDescriptor
+    def define_custom_track(track_uuid, name):
+        packet = builder.add_packet()
+        desc = packet.track_descriptor
+        desc.uuid = track_uuid
+        desc.name = name
+        desc.sibling_merge_behavior = TrackDescriptor.SIBLING_MERGE_BEHAVIOR_NONE
+
+    # 1. Define the tracks
+    define_custom_track(track1_uuid, "My Separate Track")
+    define_custom_track(track2_uuid, "My Separate Track")
+
+    # Helper to add a slice event
+    def add_slice_event(ts, event_type, event_track_uuid, name=None):
+        packet = builder.add_packet()
+        packet.timestamp = ts
+        packet.track_event.type = event_type
+        packet.track_event.track_uuid = event_track_uuid
+        if name:
+            packet.track_event.name = name
+        packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
+
+    # 2. Add events to the tracks
+    add_slice_event(ts=1000, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track1_uuid, name="Slice 1")
+    add_slice_event(ts=1100, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track1_uuid)
+
+    add_slice_event(ts=1200, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track2_uuid, name="Slice 2")
+    add_slice_event(ts=1300, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track2_uuid)
+```
+
+</details>
+
+![Preventing Merging](/docs/images/synthetic-track-event-no-merge.png)
+
+#### Python Example: Merging by Key
+
+In this example, we create two tracks with different names but the same
+`sibling_merge_key`. By setting their `sibling_merge_behavior` to
+`SIBLING_MERGE_BEHAVIOR_BY_SIBLING_MERGE_KEY`, we instruct the UI to merge them
+into a single visual track. The name of the merged group will be taken from one
+of the tracks (usually the one with the lower UUID).
+
+<details>
+<summary><b>Click to expand/collapse Python code</b></summary>
+
+```python
+    TRUSTED_PACKET_SEQUENCE_ID = 9004
+
+    # --- Define Track UUIDs ---
+    track1_uuid = 1
+    track2_uuid = 2
+
+    # Helper to define a TrackDescriptor
+    def define_custom_track(track_uuid, name, merge_key):
+        packet = builder.add_packet()
+        desc = packet.track_descriptor
+        desc.uuid = track_uuid
+        desc.name = name
+        desc.sibling_merge_behavior = TrackDescriptor.SIBLING_MERGE_BEHAVIOR_BY_SIBLING_MERGE_KEY
+        desc.sibling_merge_key = merge_key
+
+    # 1. Define the tracks with the same merge key
+    define_custom_track(track1_uuid, "HTTP GET", "conn-123")
+    define_custom_track(track2_uuid, "HTTP POST", "conn-123")
+
+    # Helper to add a slice event
+    def add_slice_event(ts, event_type, event_track_uuid, name=None):
+        packet = builder.add_packet()
+        packet.timestamp = ts
+        packet.track_event.type = event_type
+        packet.track_event.track_uuid = event_track_uuid
+        if name:
+            packet.track_event.name = name
+        packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
+
+    # 2. Add events to the tracks
+    add_slice_event(ts=1000, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track1_uuid, name="GET /data")
+    add_slice_event(ts=1100, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track1_uuid)
+
+    add_slice_event(ts=1200, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track2_uuid, name="POST /submit")
+    add_slice_event(ts=1300, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track2_uuid)
+```
+
+</details>
+
+![Merging by Key](/docs/images/synthetic-track-event-merge-by-key.png)
+
 ### Sharing Y-Axis Between Counters
 
 When visualizing multiple counter tracks, it is often useful to have them share
@@ -502,7 +635,7 @@ supports this feature through the `y_axis_share_key` field in the
 All counter tracks that have the same `y_axis_share_key` and the same parent
 track will share their Y-axis range in the UI.
 
-**Python Example: Sharing Y-Axis**
+#### Python Example: Sharing Y-Axis
 
 In this example, we create two counter tracks with the same `y_axis_share_key`.
 This will cause them to be rendered with the same Y-axis range in the Perfetto
@@ -563,7 +696,7 @@ it should be interpreted, especially in complex custom traces.
 To add a description, you simply set the optional `description` field in the
 track's `TrackDescriptor`.
 
-#### Python Example
+#### Python Example: Track Descriptions
 
 This example defines two tracks: one with a `description` field set and one
 without, to illustrate the difference in the UI.
@@ -624,12 +757,7 @@ your `trace_converter_template.py` script.
 
 ![Adding a Track Description](/docs/images/synthetic-track-event-description.png)
 
-## Advanced Event Writing
-
-This section covers advanced TrackEvent features for specialized use cases,
-including data optimization techniques and event linking mechanisms.
-
-### Interning Data for Trace Size Optimization
+## Interning Data for Trace Size Optimization
 
 Interning is a technique used to reduce the size of trace files by emitting
 frequently repeated strings (like event names or categories) only once in the
@@ -665,7 +793,7 @@ events that share the same name or other string-based attributes.
     to the existing valid dictionary) will set
     `TracePacket.SEQ_NEEDS_INCREMENTAL_STATE`.
 
-**Python Example: Interning Event Names**
+#### Python Example: Interning Event Names
 
 This example shows how to define an interned string for an event name and then
 use it multiple times.
@@ -990,6 +1118,13 @@ the following output:
 
 ![Interned Callstacks](/docs/images/synthetic-track-event-interned-callstack.png)
 
+## Enriching Events with Additional Data
+
+Beyond a name and a timestamp, each event can carry extra data: weights that
+change how callstacks aggregate into flamegraphs, correlation IDs that link
+related events together, and fully custom typed fields defined by your own
+protobuf schema.
+
 ### {#callstack-weights} Weighted Callstacks and Custom Measures
 
 By default, every callstack attached to an event counts once when aggregated
@@ -1233,7 +1368,7 @@ Perfetto supports three types of correlation identifiers:
   [Interning Data for Trace Size Optimization](#interning-data-for-trace-size-optimization)
   above for details on interning)
 
-#### Python Example
+#### Python Example: Correlation IDs
 
 This example demonstrates correlation IDs using integer identifiers by
 simulating different stages of processing for two separate requests across
@@ -1377,7 +1512,7 @@ protoc -I. --include_imports \
        acme_extension.proto
 ```
 
-#### Python Example
+#### Python Example: Setting Extension Fields
 
 The extension payload is written as protobuf wire bytes onto the
 `TrackEvent` — a length-delimited field (wire type 2) whose value is the
@@ -1459,133 +1594,6 @@ SELECT
 FROM slice
 WHERE EXTRACT_ARG(slice.arg_set_id, 'request_metadata.request_id') IS NOT NULL;
 ```
-
-## {#controlling-track-merging} Controlling Track Merging
-
-By default, the Perfetto UI merges tracks that share the same name. This is
-often the desired behavior for grouping related asynchronous events. However,
-there are scenarios where you need more explicit control. You can override this
-default merging logic using the `sibling_merge_behavior` and `sibling_merge_key`
-fields in the `TrackDescriptor`.
-
-This allows you to:
-
-- **Prevent merging**: Force tracks, even with the same name, to always be
-  displayed separately.
-- **Merge by key**: Force tracks to merge based on a custom key, regardless of
-  their names.
-
-The `sibling_merge_behavior` field can be set to one of the following values:
-
-- `SIBLING_MERGE_BEHAVIOR_BY_TRACK_NAME` (the default): Merges sibling tracks
-  that have the same `name`.
-- `SIBLING_MERGE_BEHAVIOR_NONE`: Prevents the track from being merged with any
-  of its siblings.
-- `SIBLING_MERGE_BEHAVIOR_BY_SIBLING_MERGE_KEY`: Merges sibling tracks that have
-  the same `sibling_merge_key` string.
-
-### Python Example: Preventing Merging
-
-In this example, we create two tracks with the same name. By setting their
-`sibling_merge_behavior` to `SIBLING_MERGE_BEHAVIOR_NONE`, we ensure they are
-always displayed as distinct tracks in the UI.
-
-<details>
-<summary><b>Click to expand/collapse Python code</b></summary>
-
-```python
-    TRUSTED_PACKET_SEQUENCE_ID = 9003
-
-    # --- Define Track UUIDs ---
-    track1_uuid = 1
-    track2_uuid = 2
-
-    # Helper to define a TrackDescriptor
-    def define_custom_track(track_uuid, name):
-        packet = builder.add_packet()
-        desc = packet.track_descriptor
-        desc.uuid = track_uuid
-        desc.name = name
-        desc.sibling_merge_behavior = TrackDescriptor.SIBLING_MERGE_BEHAVIOR_NONE
-
-    # 1. Define the tracks
-    define_custom_track(track1_uuid, "My Separate Track")
-    define_custom_track(track2_uuid, "My Separate Track")
-
-    # Helper to add a slice event
-    def add_slice_event(ts, event_type, event_track_uuid, name=None):
-        packet = builder.add_packet()
-        packet.timestamp = ts
-        packet.track_event.type = event_type
-        packet.track_event.track_uuid = event_track_uuid
-        if name:
-            packet.track_event.name = name
-        packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
-
-    # 2. Add events to the tracks
-    add_slice_event(ts=1000, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track1_uuid, name="Slice 1")
-    add_slice_event(ts=1100, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track1_uuid)
-
-    add_slice_event(ts=1200, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track2_uuid, name="Slice 2")
-    add_slice_event(ts=1300, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track2_uuid)
-```
-
-</details>
-
-![Preventing Merging](/docs/images/synthetic-track-event-no-merge.png)
-
-### Python Example: Merging by Key
-
-In this example, we create two tracks with different names but the same
-`sibling_merge_key`. By setting their `sibling_merge_behavior` to
-`SIBLING_MERGE_BEHAVIOR_BY_SIBLING_MERGE_KEY`, we instruct the UI to merge them
-into a single visual track. The name of the merged group will be taken from one
-of the tracks (usually the one with the lower UUID).
-
-<details>
-<summary><b>Click to expand/collapse Python code</b></summary>
-
-```python
-    TRUSTED_PACKET_SEQUENCE_ID = 9004
-
-    # --- Define Track UUIDs ---
-    track1_uuid = 1
-    track2_uuid = 2
-
-    # Helper to define a TrackDescriptor
-    def define_custom_track(track_uuid, name, merge_key):
-        packet = builder.add_packet()
-        desc = packet.track_descriptor
-        desc.uuid = track_uuid
-        desc.name = name
-        desc.sibling_merge_behavior = TrackDescriptor.SIBLING_MERGE_BEHAVIOR_BY_SIBLING_MERGE_KEY
-        desc.sibling_merge_key = merge_key
-
-    # 1. Define the tracks with the same merge key
-    define_custom_track(track1_uuid, "HTTP GET", "conn-123")
-    define_custom_track(track2_uuid, "HTTP POST", "conn-123")
-
-    # Helper to add a slice event
-    def add_slice_event(ts, event_type, event_track_uuid, name=None):
-        packet = builder.add_packet()
-        packet.timestamp = ts
-        packet.track_event.type = event_type
-        packet.track_event.track_uuid = event_track_uuid
-        if name:
-            packet.track_event.name = name
-        packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
-
-    # 2. Add events to the tracks
-    add_slice_event(ts=1000, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track1_uuid, name="GET /data")
-    add_slice_event(ts=1100, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track1_uuid)
-
-    add_slice_event(ts=1200, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track2_uuid, name="POST /submit")
-    add_slice_event(ts=1300, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track2_uuid)
-```
-
-</details>
-
-![Merging by Key](/docs/images/synthetic-track-event-merge-by-key.png)
 
 ## {#handling-large-traces-with-streaming} Handling Large Traces with Streaming
 


### PR DESCRIPTION
Give every Python example a unique heading (duplicate headings broke
the quick-jump sidebar) and regroup the synthetic track event
reference page into cleaner sections.
