### PR TITLE
ui: fix integration tests with rootless Docker

### DIFF
--- a/ui/run-integrationtests
+++ b/ui/run-integrationtests
@@ -144,7 +144,7 @@ def run_native(args):
       return 1
     cmd += ['--ui']
   elif args.rebaseline:
-    cmd += ['--update-snapshots=all']
+    cmd += ['--update-snapshots']
 
   if args.workers:
     cmd += ['--workers', args.workers]
@@ -183,7 +183,7 @@ def run_in_docker(args):
       './pnpm', 'exec', 'playwright', 'test'
   ]
   if args.rebaseline:
-    playwright_cmd_parts += ['--update-snapshots=all']
+    playwright_cmd_parts += ['--update-snapshots']
   if args.workers:
     playwright_cmd_parts += ['--workers', args.workers]
   playwright_cmd_parts += args.filters

--- a/ui/run-integrationtests
+++ b/ui/run-integrationtests
@@ -99,6 +99,23 @@ def needs_sudo_for_docker():
     return True
 
 
+def is_docker_rootless(use_sudo):
+  """Check whether the Docker daemon uses rootless user namespacing."""
+  cmd = ['docker', 'info', '--format', '{{json .SecurityOptions}}']
+  if use_sudo:
+    cmd = ['sudo'] + cmd
+  try:
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    return result.returncode == 0 and 'name=rootless' in result.stdout
+  except (subprocess.TimeoutExpired, FileNotFoundError):
+    return False
+
+
 def run_build(args):
   """Run the build script to ensure we have something to test."""
   build_args = []
@@ -127,7 +144,7 @@ def run_native(args):
       return 1
     cmd += ['--ui']
   elif args.rebaseline:
-    cmd += ['--update-snapshots']
+    cmd += ['--update-snapshots=all']
 
   if args.workers:
     cmd += ['--workers', args.workers]
@@ -148,6 +165,7 @@ def run_native(args):
 def run_in_docker(args):
   """Run tests inside a Docker container with pre-installed Chrome."""
   use_sudo = needs_sudo_for_docker()
+  rootless = is_docker_rootless(use_sudo)
 
   # Get the Playwright version and build/use matching Docker image
   try:
@@ -165,7 +183,7 @@ def run_in_docker(args):
       './pnpm', 'exec', 'playwright', 'test'
   ]
   if args.rebaseline:
-    playwright_cmd_parts += ['--update-snapshots']
+    playwright_cmd_parts += ['--update-snapshots=all']
   if args.workers:
     playwright_cmd_parts += ['--workers', args.workers]
   playwright_cmd_parts += args.filters
@@ -183,6 +201,10 @@ def run_in_docker(args):
   if dev_server_args:
     env_args += ['-e', f'DEV_SERVER_ARGS={" ".join(dev_server_args)}']
 
+  # With rootless Docker, container root maps to the host user. Running as the
+  # host's numeric uid instead would map to an unrelated subordinate uid and
+  # make owner-only build dependencies inaccessible inside the container.
+  user_args = [] if rootless else ['-u', f'{os.getuid()}:{os.getgid()}']
   docker_cmd = [
       'docker', 'run',
       '--rm', # Remove the container after it exits
@@ -190,7 +212,7 @@ def run_in_docker(args):
       '-t', # Allocate a pseudo-TTY for better output formatting
       '-v', f'{REPO_ROOT}:{REPO_ROOT}', # Mount the repo root into the container
       '-w', f'{REPO_ROOT}/ui', # Set working directory to /ui
-      '-u', f'{os.getuid()}:{os.getgid()}', # Run as current user to avoid permission issues
+      *user_args,
       '-e', 'HOME=/tmp', # Chrome needs a writable home for crashpad
       *env_args,
       image,


### PR DESCRIPTION
Run Playwright containers as container root when Docker
uses rootless user namespacing, keeping owner-only build
dependencies accessible through bind mounts. Also pass an
explicit snapshot update mode for current Playwright versions.
