### PR TITLE
ui: normalize unknown flamegraph node names

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/callstacks/stack_profile.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/callstacks/stack_profile.sql
@@ -82,7 +82,7 @@ SELECT
     'V8: ' || v8c.function_name,
     'JIT: ' || jc.function_name,
     demangle(coalesce(s.name, f.deobfuscated_name, f.name)),
-    coalesce(s.name, f.deobfuscated_name, f.name, '[Unknown]')
+    coalesce(s.name, f.deobfuscated_name, f.name, 'unknown')
   ) AS name,
   f.mapping AS mapping_id,
   s.source_file,

--- a/test/trace_processor/diff_tests/stdlib/stacks/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/stacks/tests.py
@@ -180,3 +180,59 @@ class Stacks(TestSuite):
         "upid","module","build_id","rel_pc","breakpad_module_id"
         1,"/libc.so","6275696c642d6964",123456,"[NULL]"
         """))
+
+  def test_stack_profile_unknown_frame_name(self):
+    return DiffTestBlueprint(
+        trace=TextProto("""
+        packet {
+          timestamp: 6
+          trusted_packet_sequence_id: 1
+          incremental_state_cleared: true
+          interned_data {
+            function_names {
+              iid: 1
+              str: "named_frame"
+            }
+            mapping_paths {
+              iid: 1
+              str: "libc.so"
+            }
+            mappings {
+              iid: 1
+              path_string_ids: 1
+            }
+            frames {
+              iid: 1
+              mapping_id: 1
+              rel_pc: 123
+            }
+            frames {
+              iid: 2
+              function_name_id: 1
+              mapping_id: 1
+              rel_pc: 456
+            }
+            callstacks {
+              iid: 1
+              frame_ids: 1
+              frame_ids: 2
+            }
+          }
+          perf_sample {
+            cpu: 0
+            cpu_mode: MODE_USER
+            pid: 123
+            tid: 123
+            callstack_iid: 1
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE callstacks.stack_profile;
+        SELECT name FROM _callstack_spc_forest ORDER BY name;
+        """,
+        out=Csv("""
+        "name"
+        "named_frame"
+        "unknown"
+        """))

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
@@ -89,7 +89,7 @@ function buildMetric(
       select
         id,
         parent_id as parentId,
-        ifnull(name, '[Unknown]') as name,
+        ifnull(name, 'unknown') as name,
         root_type,
         heap_type,
         ${valueColumn} as value,

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -412,7 +412,7 @@ function flamegraphMetrics(
             select
               id,
               parent_id as parentId,
-              ifnull(name, '[Unknown]') as name,
+              ifnull(name, 'unknown') as name,
               root_type,
               heap_type,
               self_size as value,
@@ -454,7 +454,7 @@ function flamegraphMetrics(
             select
               id,
               parent_id as parentId,
-              ifnull(name, '[Unknown]') as name,
+              ifnull(name, 'unknown') as name,
               root_type,
               heap_type,
               self_size,
@@ -491,7 +491,7 @@ function flamegraphMetrics(
             select
               id,
               parent_id as parentId,
-              ifnull(name, '[Unknown]') as name,
+              ifnull(name, 'unknown') as name,
               root_type,
               heap_type,
               self_size as value,
@@ -533,7 +533,7 @@ function flamegraphMetrics(
             select
               id,
               parent_id as parentId,
-              ifnull(name, '[Unknown]') as name,
+              ifnull(name, 'unknown') as name,
               root_type,
               heap_type,
               self_size,


### PR DESCRIPTION
Use the canonical lowercase 'unknown' sentinel for unnamed frames and
heap graph classes. The flamegraph widget recognizes this value and
renders it with the neutral color instead of hashing '[Unknown]' like an
ordinary name.

Cover unnamed stack frames with a diff test.
