### PR TITLE
Fix trace_bounds when last event is unfinished.

### DIFF
--- a/src/trace_processor/plugins/storage_tables/storage_tables.cc
+++ b/src/trace_processor/plugins/storage_tables/storage_tables.cc
@@ -241,7 +241,7 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
     }
     for (auto it = s.sched_slice_table().IterateRows(); it; ++it) {
       start_ns = std::min(it.ts(), start_ns);
-      end_ns = std::max(it.ts() + it.dur(), end_ns);
+      end_ns = std::max(it.ts() + std::max<int64_t>(it.dur(), 0), end_ns);
     }
     for (auto it = s.counter_table().IterateRows(); it; ++it) {
       start_ns = std::min(it.ts(), start_ns);
@@ -249,7 +249,7 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
     }
     for (auto it = s.slice_table().IterateRows(); it; ++it) {
       start_ns = std::min(it.ts(), start_ns);
-      end_ns = std::max(it.ts() + it.dur(), end_ns);
+      end_ns = std::max(it.ts() + std::max<int64_t>(it.dur(), 0), end_ns);
     }
     for (auto it = s.heap_profile_allocation_table().IterateRows(); it; ++it) {
       start_ns = std::min(it.ts(), start_ns);
@@ -261,7 +261,7 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
     }
     for (auto it = s.thread_state_table().IterateRows(); it; ++it) {
       start_ns = std::min(it.ts(), start_ns);
-      end_ns = std::max(it.ts() + it.dur(), end_ns);
+      end_ns = std::max(it.ts() + std::max<int64_t>(it.dur(), 0), end_ns);
     }
     for (auto it = s.log_table().IterateRows(); it; ++it) {
       start_ns = std::min(it.ts(), start_ns);
@@ -277,7 +277,7 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
     }
     for (auto it = s.state_table().IterateRows(); it; ++it) {
       start_ns = std::min(it.ts(), start_ns);
-      end_ns = std::max(it.ts() + it.dur(), end_ns);
+      end_ns = std::max(it.ts() + std::max<int64_t>(it.dur(), 0), end_ns);
     }
     // profiler_sample.ts is sorted: the first row holds the min, the last the
     // max.

--- a/test/trace_processor/diff_tests/tables/tests.py
+++ b/test/trace_processor/diff_tests/tables/tests.py
@@ -844,3 +844,55 @@ class Tables(TestSuite):
         10,"android.os.usertype.full.SECONDARY" 
         11,"android.os.usertype.full.GUEST"
         """))
+
+  # trace start and end time
+  def test_trace_bounds(self):
+    return DiffTestBlueprint(
+        trace=Path('../common/synth_1.py'),
+        query="""
+        SELECT * FROM trace_bounds;
+        """,
+        out=Csv("""
+        "start_ts","end_ts"
+        1,400
+        """))
+
+  # trace start and end time
+  def test_trace_bounds_unfinished_end(self):
+    return DiffTestBlueprint(
+        trace=TextProto("""
+          packet {
+            timestamp: 1000
+            trusted_packet_sequence_id: 1
+            track_event {
+              type: TYPE_SLICE_BEGIN
+              track_uuid: 1
+              name: "foo"
+            }
+          }
+          packet {
+            timestamp: 2000
+            trusted_packet_sequence_id: 1
+            track_event {
+              type: TYPE_SLICE_END
+              track_uuid: 1
+              name: "foo"
+            }
+          }
+          packet {
+            timestamp: 3000
+            trusted_packet_sequence_id: 1
+            track_event {
+              type: TYPE_SLICE_BEGIN
+              track_uuid: 1
+              name: "foo"
+            }
+          }
+        """),
+        query="""
+        SELECT * FROM trace_bounds;
+        """,
+        out=Csv("""
+        "start_ts","end_ts"
+        1000,3000
+        """))


### PR DESCRIPTION
When the last event is unfinished, the duration is -1. Trace bounds end is computed as ts + dur, which caused the trace end bounds being before the last event.

Note: for ftrace-based slices, this was never an issue since those were covered by the ftrace table scan. This is why the test uses track events.