### PR TITLE
ui: show OOME heap-dump metadata as a key-value grid

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -252,6 +252,7 @@ export async function getOverview(
   activeDump: HeapDump,
 ): Promise<OverviewData> {
   const dumpFilter = dumpFilterSql(activeDump, 'o');
+  const oomeInfo = await getOome(engine, activeDump);
   const countRes = await engine.query(`
     SELECT
       sum(iif(o.reachable, 1, 0)) AS reachable,
@@ -521,6 +522,7 @@ export async function getOverview(
     anonRssAndSwapSize,
     dmabufRssSize,
     processUptime,
+    oome: oomeInfo?.details,
   };
 }
 
@@ -529,14 +531,35 @@ export async function getOome(
   activeDump: HeapDump,
 ): Promise<OomeData | undefined> {
   const oomeRes = await engine.query(`
-    SELECT upid, ts
-    FROM heap_graph
-    WHERE upid = ${activeDump.upid} AND dump_reason = 'OOME'
+    INCLUDE PERFETTO MODULE android.memory.heap_graph.oome;
+    SELECT
+      g.upid AS upid,
+      g.ts AS ts,
+      o.allocation_size_bytes AS allocationSizeBytes,
+      o.free_bytes_until_oom AS freeBytesUntilOom,
+      o.error_msg AS errorMsg
+    FROM heap_graph g
+    LEFT JOIN android_heap_graph_java_oome_details o ON o.heap_graph_id = g.id
+    WHERE g.upid = ${activeDump.upid} AND g.dump_reason = 'OOME'
     LIMIT 1
   `);
   if (oomeRes.numRows() > 0) {
-    const row = oomeRes.firstRow({upid: NUM, ts: LONG});
-    return {upid: row.upid, ts: Time.fromRaw(row.ts)};
+    const row = oomeRes.firstRow({
+      upid: NUM,
+      ts: LONG,
+      allocationSizeBytes: LONG_NULL,
+      freeBytesUntilOom: LONG_NULL,
+      errorMsg: STR_NULL,
+    });
+    return {
+      upid: row.upid,
+      ts: Time.fromRaw(row.ts),
+      details: {
+        allocationSizeBytes: row.allocationSizeBytes ?? undefined,
+        freeBytesUntilOom: row.freeBytesUntilOom ?? undefined,
+        errorMsg: row.errorMsg ?? undefined,
+      },
+    };
   }
   return undefined;
 }

--- a/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import type {time} from '../../base/time';
+import type {OomeDetails} from '../dev.perfetto.HeapProfile/oome_callstack_common';
+
+export type {OomeDetails};
 
 export interface HeapInfo {
   name: string;
@@ -48,6 +51,7 @@ export interface DuplicateArrayGroup {
 export interface OomeData {
   upid: number;
   ts: time;
+  details: OomeDetails;
 }
 
 export interface OverviewData {
@@ -70,6 +74,8 @@ export interface OverviewData {
   dmabufRssSize: bigint | null;
   /** The process uptime at the time of the heap dump. */
   processUptime: bigint | null;
+  /** OOME details, if the dump was triggered by an OutOfMemoryError. */
+  oome: OomeDetails | undefined;
 }
 
 export type PrimOrRef =

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/callstack_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/callstack_view.ts
@@ -14,7 +14,6 @@
 
 import m from 'mithril';
 import type {Trace} from '../../../public/trace';
-import type {time} from '../../../base/time';
 import type {QueryFlamegraphMetric} from '../../../components/query_flamegraph';
 import {FlamegraphPanel} from '../../../components/flamegraph_panel';
 import {Flamegraph, type FlamegraphState} from '../../../widgets/flamegraph';
@@ -23,7 +22,7 @@ import {EmptyState} from '../../../widgets/empty_state';
 
 import {
   buildOomeCallstackMetrics,
-  loadOomeErrorMsg,
+  renderOomeDetails,
 } from '../../dev.perfetto.HeapProfile/oome_callstack_common';
 import type {OomeData} from '../types';
 import {getOome} from '../queries';
@@ -44,14 +43,8 @@ export class CallstackView implements m.ClassComponent<CallstackViewAttrs> {
   private oomeDataLoaded = false;
   private cachedMetrics?: ReadonlyArray<QueryFlamegraphMetric>;
   private cachedKey?: string;
-  private errorMsg?: string;
   private readonly limiter = new AsyncLimiter();
   private monitor?: Monitor;
-
-  async loadErrorMsg(trace: Trace, ts: time) {
-    this.errorMsg = await loadOomeErrorMsg(trace.engine, ts);
-    m.redraw();
-  }
 
   view({attrs}: m.Vnode<CallstackViewAttrs>) {
     this.monitor ??= new Monitor([() => attrs.dump]);
@@ -105,8 +98,6 @@ export class CallstackView implements m.ClassComponent<CallstackViewAttrs> {
     if (this.cachedMetrics === undefined || key !== this.cachedKey) {
       this.cachedMetrics = buildOomeCallstackMetrics(ts);
       this.cachedKey = key;
-      this.errorMsg = undefined;
-      this.loadErrorMsg(attrs.trace, ts);
     }
     const metrics = this.cachedMetrics;
 
@@ -122,12 +113,7 @@ export class CallstackView implements m.ClassComponent<CallstackViewAttrs> {
       m(
         Stack,
         {orientation: 'vertical'},
-        this.errorMsg &&
-          m(
-            'div',
-            {style: {padding: '8px', fontSize: '14px', color: '#ff4081'}},
-            this.errorMsg,
-          ),
+        renderOomeDetails(this.oomeData?.details),
         m(FlamegraphPanel, {
           trace: attrs.trace,
           metrics,

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/overview_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/overview_view.ts
@@ -31,6 +31,10 @@ import {
   type GridRow,
 } from '../../../widgets/grid';
 import {removeFalsyValues} from '../../../base/array_utils';
+import {
+  OOME_DETAILS_TITLE,
+  renderOomeDetailsGrid,
+} from '../../dev.perfetto.HeapProfile/oome_callstack_common';
 
 const HEAP_SCHEMA: ColumnSchema = {
   heap: {
@@ -357,6 +361,12 @@ export function OverviewView(): m.Component<OverviewViewAttrs> {
             ],
           }),
         ]),
+        overview.oome !== undefined
+          ? m('div', {class: 'pf-hde-card pf-hde-mt-4'}, [
+              m('h3', {class: 'pf-hde-sub-heading'}, OOME_DETAILS_TITLE),
+              renderOomeDetailsGrid(overview.oome),
+            ])
+          : null,
         overview.duplicateBitmaps && overview.duplicateBitmaps.length > 0
           ? renderDuplicateSection(
               'Duplicate Bitmaps',

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -50,7 +50,9 @@ import {Popup, PopupPosition} from '../../widgets/popup';
 import {type ProfileDescriptor, ProfileType} from './common';
 import {
   buildOomeCallstackMetrics,
-  loadOomeErrorMsg,
+  loadOomeDetails,
+  renderOomeDetails,
+  type OomeDetails,
 } from './oome_callstack_common';
 
 const DOCS_NATIVE_HEAP_PROFILER =
@@ -176,7 +178,7 @@ interface Props {
 export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel {
   private readonly props: Props;
   private flamegraphModalDismissed = false;
-  private oomeErrorMsg?: string;
+  private oomeDetails?: OomeDetails;
 
   // TODO(lalitm): we should be able remove this around the 26Q2 timeframe
   // We moved serialization from being attached to selections to instead being
@@ -226,7 +228,7 @@ export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel
 
   async load() {
     if (this.props.type === ProfileType.OOME_CALLSTACK) {
-      this.oomeErrorMsg = await loadOomeErrorMsg(this.trace.engine, this.ts);
+      this.oomeDetails = await loadOomeDetails(this.trace.engine, this.ts);
       m.redraw();
     }
 
@@ -259,8 +261,7 @@ export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel
               label: this.profileDescriptor.label,
               help: profileHelp(this.profileDescriptor),
             }),
-            this.oomeErrorMsg &&
-              m('span.pf-heap-profile-oome-error', this.oomeErrorMsg),
+            renderOomeDetails(this.oomeDetails),
           ),
           buttons: m(Stack, {orientation: 'horizontal', spacing: 'large'}, [
             m('span', `Snapshot time: `, m(Timestamp, {trace: this.trace, ts})),

--- a/ui/src/plugins/dev.perfetto.HeapProfile/oome_callstack_common.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/oome_callstack_common.ts
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import type {time} from '../../base/time';
 import type {QueryFlamegraphMetric} from '../../components/query_flamegraph';
 import type {Engine} from '../../trace_processor/engine';
-import {STR_NULL} from '../../trace_processor/query_result';
+import {LONG_NULL, STR_NULL} from '../../trace_processor/query_result';
+import {formatFileSize} from '../../base/file_utils';
+import {removeFalsyValues} from '../../base/array_utils';
+import {Grid, GridCell, GridHeaderCell, type GridRow} from '../../widgets/grid';
 
 export function buildOomeCallstackMetrics(
   ts: time,
@@ -64,20 +68,86 @@ export function buildOomeCallstackMetrics(
   ];
 }
 
-export async function loadOomeErrorMsg(
+// Details of the OutOfMemoryError that triggered the heap dump.
+export interface OomeDetails {
+  readonly allocationSizeBytes?: bigint;
+  readonly freeBytesUntilOom?: bigint;
+  readonly errorMsg?: string;
+}
+
+export async function loadOomeDetails(
   engine: Engine,
   ts: time,
-): Promise<string | undefined> {
-  const errorMsgRes = await engine.query(`
+): Promise<OomeDetails | undefined> {
+  const res = await engine.query(`
       INCLUDE PERFETTO MODULE android.memory.heap_graph.oome;
-      SELECT oome.error_msg 
+      SELECT
+        oome.allocation_size_bytes AS allocationSizeBytes,
+        oome.free_bytes_until_oom AS freeBytesUntilOom,
+        oome.error_msg AS errorMsg
       FROM heap_graph g
-      JOIN android_heap_graph_java_oome_details oome ON oome.heap_graph_id = g.id
+      JOIN android_heap_graph_java_oome_details oome
+        ON oome.heap_graph_id = g.id
       WHERE g.ts = ${ts}
       LIMIT 1
     `);
-  if (errorMsgRes.numRows() > 0) {
-    return errorMsgRes.firstRow({error_msg: STR_NULL}).error_msg ?? undefined;
+  if (res.numRows() === 0) {
+    return undefined;
   }
-  return undefined;
+  const row = res.firstRow({
+    allocationSizeBytes: LONG_NULL,
+    freeBytesUntilOom: LONG_NULL,
+    errorMsg: STR_NULL,
+  });
+  return {
+    allocationSizeBytes: row.allocationSizeBytes ?? undefined,
+    freeBytesUntilOom: row.freeBytesUntilOom ?? undefined,
+    errorMsg: row.errorMsg ?? undefined,
+  };
+}
+
+export const OOME_DETAILS_TITLE = 'Out of Memory Error';
+
+function oomeDetailRows(details: OomeDetails): GridRow[] {
+  const row = (property: string, value: string): GridRow => [
+    m(GridCell, property),
+    m(GridCell, value),
+  ];
+  return removeFalsyValues([
+    details.allocationSizeBytes !== undefined &&
+      row('Allocation size', formatFileSize(details.allocationSizeBytes)),
+    details.freeBytesUntilOom !== undefined &&
+      row('Free until OOM', formatFileSize(details.freeBytesUntilOom)),
+    details.errorMsg !== undefined && row('Error message', details.errorMsg),
+  ]);
+}
+
+// The OOME details as a Property/Value grid, without a heading.
+export function renderOomeDetailsGrid(details?: OomeDetails): m.Children {
+  if (details === undefined) {
+    return undefined;
+  }
+  const rowData = oomeDetailRows(details);
+  if (rowData.length === 0) {
+    return undefined;
+  }
+  return m(Grid, {
+    columns: [
+      {key: 'property', header: m(GridHeaderCell, 'Property')},
+      {key: 'value', header: m(GridHeaderCell, 'Value')},
+    ],
+    rowData,
+  });
+}
+
+// The OOME grid with a heading, for the flamegraph headers.
+export function renderOomeDetails(details?: OomeDetails): m.Children {
+  const grid = renderOomeDetailsGrid(details);
+  if (grid === undefined) {
+    return undefined;
+  }
+  return m('div', [
+    m('h3', {class: 'pf-hde-sub-heading'}, OOME_DETAILS_TITLE),
+    grid,
+  ]);
 }


### PR DESCRIPTION
Render the OutOfMemoryError summary shown above the heap-dump callstack flamegraph as a Property/Value grid (allocation size, free until OOM, and the raw error message) instead of just the raw string.

The same grid is reused in the HeapProfile details panel, the Heap Dump Explorer callstack page, and a new
"Out of Memory Error" section in the overview