### PR TITLE
tp: fix crash due to inability to access urandom in wasm

### DIFF
--- a/src/trace_processor/importers/instruments/BUILD.gn
+++ b/src/trace_processor/importers/instruments/BUILD.gn
@@ -41,6 +41,7 @@ if (enable_perfetto_trace_processor_mac_instruments) {
       "../../../../include/perfetto/public",
       "../../../../include/perfetto/trace_processor:trace_processor",
       "../../../../protos/perfetto/trace:zero",
+      "../../../base",
       "../../sorter",
       "../../storage",
       "../../types",

--- a/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
+++ b/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
@@ -38,6 +38,7 @@
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
+#include "perfetto/ext/base/uuid.h"
 #include "perfetto/public/compiler.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "protos/perfetto/trace/clock_snapshot.pbzero.h"
@@ -169,6 +170,10 @@ class InstrumentsXmlTokenizer::Impl {
       parser_ = XML_ParserCreate(nullptr);
       if (!parser_) {
         return base::ErrStatus("Failed to create XML parser");
+      }
+      if (!XML_SetHashSalt(
+              parser_, static_cast<unsigned long>(base::Uuidv4().lsb()))) {
+        return base::ErrStatus("Failed to set XML parser hash salt");
       }
       XML_SetElementHandler(parser_, ElementStart, ElementEnd);
       XML_SetCharacterDataHandler(parser_, CharacterData);

--- a/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
+++ b/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
@@ -171,8 +171,8 @@ class InstrumentsXmlTokenizer::Impl {
       if (!parser_) {
         return base::ErrStatus("Failed to create XML parser");
       }
-      if (!XML_SetHashSalt(
-              parser_, static_cast<unsigned long>(base::Uuidv4().lsb()))) {
+      if (!XML_SetHashSalt(parser_,
+                           static_cast<unsigned long>(base::Uuidv4().lsb()))) {
         return base::ErrStatus("Failed to set XML parser hash salt");
       }
       XML_SetElementHandler(parser_, ElementStart, ElementEnd);


### PR DESCRIPTION
With WASM we cannot access the filesystem anymore - this includes urandom
which expat tries to access.

Fix this by explicitly setting a salt.
