### PR TITLE
ui: don't crash the flamegraph measure picker when no metric is selected

### DIFF
--- a/ui/src/widgets/flamegraph.ts
+++ b/ui/src/widgets/flamegraph.ts
@@ -895,11 +895,12 @@ export class Flamegraph implements m.ClassComponent<FlamegraphAttrs> {
   }
 
   private renderMeasurePicker(attrs: FlamegraphAttrs) {
-    const selected = ensureExists(
-      attrs.metrics.find(
-        (metric) => metricId(metric) === attrs.state.selectedMetricId,
-      ),
+    const selected = attrs.metrics.find(
+      (metric) => metricId(metric) === attrs.state.selectedMetricId,
     );
+    if (selected === undefined) {
+      return undefined;
+    }
     const defaultMetrics = attrs.metrics.filter(
       (metric) => metric.provenance === 'DEFAULT',
     );


### PR DESCRIPTION
During the loading state the metric list can be empty, so ensureExists on the selected metric threw. Render nothing instead. Hit by opening the Heap Dump Explorer callstack tab for an OutOfMemoryError with no recorded callstack (data loss).