### PR TITLE
tp: add __intrinsic_zstd(X) to compress a blob/string in SQL

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3155,6 +3155,7 @@ cc_test {
         ":perfetto_src_trace_processor_plugins_winscope_importer_winscope_importer",
         ":perfetto_src_trace_processor_plugins_winscope_proto_to_args_with_defaults_winscope_proto_to_args_with_defaults",
         ":perfetto_src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_winscope_surfaceflinger_hierarchy_paths",
+        ":perfetto_src_trace_processor_plugins_zstd_functions_zstd_functions",
         ":perfetto_src_trace_processor_sorter_sorter",
         ":perfetto_src_trace_processor_sqlite_bindings_bindings",
         ":perfetto_src_trace_processor_sqlite_sqlite",
@@ -3168,6 +3169,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_build_id",
         ":perfetto_src_trace_processor_util_bump_allocator",
         ":perfetto_src_trace_processor_util_clock",
+        ":perfetto_src_trace_processor_util_compressor",
         ":perfetto_src_trace_processor_util_decompressor",
         ":perfetto_src_trace_processor_util_descriptors",
         ":perfetto_src_trace_processor_util_elf_elf",
@@ -20494,6 +20496,14 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/plugins/zstd_functions:zstd_functions
+filegroup {
+    name: "perfetto_src_trace_processor_plugins_zstd_functions_zstd_functions",
+    srcs: [
+        "src/trace_processor/plugins/zstd_functions/zstd.cc",
+    ],
+}
+
 // GN: //src/trace_processor/rpc:client
 filegroup {
     name: "perfetto_src_trace_processor_rpc_client",
@@ -21010,6 +21020,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_plugins_winscope_importer_winscope_importer",
         ":perfetto_src_trace_processor_plugins_winscope_proto_to_args_with_defaults_winscope_proto_to_args_with_defaults",
         ":perfetto_src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_winscope_surfaceflinger_hierarchy_paths",
+        ":perfetto_src_trace_processor_plugins_zstd_functions_zstd_functions",
         ":perfetto_src_trace_processor_rpc_client",
         ":perfetto_src_trace_processor_rpc_deserializer",
         ":perfetto_src_trace_processor_rpc_httpd",
@@ -21033,6 +21044,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_build_id",
         ":perfetto_src_trace_processor_util_bump_allocator",
         ":perfetto_src_trace_processor_util_clock",
+        ":perfetto_src_trace_processor_util_compressor",
         ":perfetto_src_trace_processor_util_decompressor",
         ":perfetto_src_trace_processor_util_deobfuscation_deobfuscator",
         ":perfetto_src_trace_processor_util_descriptors",
@@ -21424,6 +21436,14 @@ filegroup {
     name: "perfetto_src_trace_processor_util_clock",
     srcs: [
         "src/trace_processor/util/clock_synchronizer.cc",
+    ],
+}
+
+// GN: //src/trace_processor/util:compressor
+filegroup {
+    name: "perfetto_src_trace_processor_util_compressor",
+    srcs: [
+        "src/trace_processor/util/zstd_compressor.cc",
     ],
 }
 
@@ -23943,6 +23963,7 @@ cc_test {
         ":perfetto_src_trace_processor_plugins_winscope_importer_winscope_importer",
         ":perfetto_src_trace_processor_plugins_winscope_proto_to_args_with_defaults_winscope_proto_to_args_with_defaults",
         ":perfetto_src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_winscope_surfaceflinger_hierarchy_paths",
+        ":perfetto_src_trace_processor_plugins_zstd_functions_zstd_functions",
         ":perfetto_src_trace_processor_rpc_client",
         ":perfetto_src_trace_processor_rpc_deserializer",
         ":perfetto_src_trace_processor_rpc_httpd",
@@ -23974,6 +23995,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_build_id",
         ":perfetto_src_trace_processor_util_bump_allocator",
         ":perfetto_src_trace_processor_util_clock",
+        ":perfetto_src_trace_processor_util_compressor",
         ":perfetto_src_trace_processor_util_decompressor",
         ":perfetto_src_trace_processor_util_deobfuscation_deobfuscator",
         ":perfetto_src_trace_processor_util_deobfuscation_unittests",
@@ -25057,6 +25079,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_plugins_winscope_importer_winscope_importer",
         ":perfetto_src_trace_processor_plugins_winscope_proto_to_args_with_defaults_winscope_proto_to_args_with_defaults",
         ":perfetto_src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_winscope_surfaceflinger_hierarchy_paths",
+        ":perfetto_src_trace_processor_plugins_zstd_functions_zstd_functions",
         ":perfetto_src_trace_processor_sorter_sorter",
         ":perfetto_src_trace_processor_sqlite_bindings_bindings",
         ":perfetto_src_trace_processor_sqlite_sqlite",
@@ -25070,6 +25093,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_build_id",
         ":perfetto_src_trace_processor_util_bump_allocator",
         ":perfetto_src_trace_processor_util_clock",
+        ":perfetto_src_trace_processor_util_compressor",
         ":perfetto_src_trace_processor_util_decompressor",
         ":perfetto_src_trace_processor_util_descriptors",
         ":perfetto_src_trace_processor_util_elf_elf",
@@ -25751,6 +25775,7 @@ cc_binary_host {
         ":perfetto_src_trace_processor_plugins_winscope_importer_winscope_importer",
         ":perfetto_src_trace_processor_plugins_winscope_proto_to_args_with_defaults_winscope_proto_to_args_with_defaults",
         ":perfetto_src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_winscope_surfaceflinger_hierarchy_paths",
+        ":perfetto_src_trace_processor_plugins_zstd_functions_zstd_functions",
         ":perfetto_src_trace_processor_sorter_sorter",
         ":perfetto_src_trace_processor_sqlite_bindings_bindings",
         ":perfetto_src_trace_processor_sqlite_sqlite",
@@ -25764,6 +25789,7 @@ cc_binary_host {
         ":perfetto_src_trace_processor_util_build_id",
         ":perfetto_src_trace_processor_util_bump_allocator",
         ":perfetto_src_trace_processor_util_clock",
+        ":perfetto_src_trace_processor_util_compressor",
         ":perfetto_src_trace_processor_util_decompressor",
         ":perfetto_src_trace_processor_util_deobfuscation_deobfuscator",
         ":perfetto_src_trace_processor_util_descriptors",

--- a/BUILD
+++ b/BUILD
@@ -533,6 +533,7 @@ perfetto_cc_library(
         ":src_trace_processor_plugins_winscope_proto_to_args_with_defaults_winscope_proto_to_args_with_defaults",
         ":src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_tables",
         ":src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_winscope_surfaceflinger_hierarchy_paths",
+        ":src_trace_processor_plugins_zstd_functions_zstd_functions",
         ":src_trace_processor_rpc_rpc",
         ":src_trace_processor_sorter_sorter",
         ":src_trace_processor_sqlite_bindings_bindings",
@@ -547,6 +548,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_blob",
         ":src_trace_processor_util_bump_allocator",
         ":src_trace_processor_util_clock",
+        ":src_trace_processor_util_compressor",
         ":src_trace_processor_util_decompressor",
         ":src_trace_processor_util_descriptors",
         ":src_trace_processor_util_elf_elf",
@@ -838,6 +840,7 @@ perfetto_cc_library(
         ":src_trace_processor_plugins_winscope_proto_to_args_with_defaults_winscope_proto_to_args_with_defaults",
         ":src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_tables",
         ":src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_winscope_surfaceflinger_hierarchy_paths",
+        ":src_trace_processor_plugins_zstd_functions_zstd_functions",
         ":src_trace_processor_rpc_client",
         ":src_trace_processor_rpc_deserializer",
         ":src_trace_processor_rpc_httpd",
@@ -861,6 +864,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_blob",
         ":src_trace_processor_util_bump_allocator",
         ":src_trace_processor_util_clock",
+        ":src_trace_processor_util_compressor",
         ":src_trace_processor_util_decompressor",
         ":src_trace_processor_util_descriptors",
         ":src_trace_processor_util_elf_elf",
@@ -5333,6 +5337,15 @@ perfetto_filegroup(
     ],
 )
 
+# GN target: //src/trace_processor/plugins/zstd_functions:zstd_functions
+perfetto_filegroup(
+    name = "src_trace_processor_plugins_zstd_functions_zstd_functions",
+    srcs = [
+        "src/trace_processor/plugins/zstd_functions/zstd.cc",
+        "src/trace_processor/plugins/zstd_functions/zstd_functions.h",
+    ],
+)
+
 # GN target: //src/trace_processor/rpc:client
 perfetto_filegroup(
     name = "src_trace_processor_rpc_client",
@@ -5859,6 +5872,15 @@ perfetto_filegroup(
     srcs = [
         "src/trace_processor/util/clock_synchronizer.cc",
         "src/trace_processor/util/clock_synchronizer.h",
+    ],
+)
+
+# GN target: //src/trace_processor/util:compressor
+perfetto_filegroup(
+    name = "src_trace_processor_util_compressor",
+    srcs = [
+        "src/trace_processor/util/zstd_compressor.cc",
+        "src/trace_processor/util/zstd_compressor.h",
     ],
 )
 
@@ -11552,6 +11574,7 @@ perfetto_cc_library(
         ":src_trace_processor_plugins_winscope_proto_to_args_with_defaults_winscope_proto_to_args_with_defaults",
         ":src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_tables",
         ":src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_winscope_surfaceflinger_hierarchy_paths",
+        ":src_trace_processor_plugins_zstd_functions_zstd_functions",
         ":src_trace_processor_sorter_sorter",
         ":src_trace_processor_sqlite_bindings_bindings",
         ":src_trace_processor_sqlite_sqlite",
@@ -11565,6 +11588,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_blob",
         ":src_trace_processor_util_bump_allocator",
         ":src_trace_processor_util_clock",
+        ":src_trace_processor_util_compressor",
         ":src_trace_processor_util_decompressor",
         ":src_trace_processor_util_descriptors",
         ":src_trace_processor_util_elf_elf",
@@ -11888,6 +11912,7 @@ perfetto_cc_binary(
         ":src_trace_processor_plugins_winscope_proto_to_args_with_defaults_winscope_proto_to_args_with_defaults",
         ":src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_tables",
         ":src_trace_processor_plugins_winscope_surfaceflinger_hierarchy_paths_winscope_surfaceflinger_hierarchy_paths",
+        ":src_trace_processor_plugins_zstd_functions_zstd_functions",
         ":src_trace_processor_sorter_sorter",
         ":src_trace_processor_sqlite_bindings_bindings",
         ":src_trace_processor_sqlite_sqlite",
@@ -11901,6 +11926,7 @@ perfetto_cc_binary(
         ":src_trace_processor_util_blob",
         ":src_trace_processor_util_bump_allocator",
         ":src_trace_processor_util_clock",
+        ":src_trace_processor_util_compressor",
         ":src_trace_processor_util_decompressor",
         ":src_trace_processor_util_descriptors",
         ":src_trace_processor_util_elf_elf",

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -260,6 +260,7 @@ if (enable_perfetto_trace_processor_sqlite) {
       "plugins/video_frame_importer",
       "plugins/wattson",
       "plugins/window_operator",
+      "plugins/zstd_functions",
       "sqlite",
       "storage",
       "tables",

--- a/src/trace_processor/plugins/zstd_functions/BUILD.gn
+++ b/src/trace_processor/plugins/zstd_functions/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/perfetto.gni")
+
+assert(enable_perfetto_trace_processor_sqlite)
+
+source_set("zstd_functions") {
+  sources = [
+    "zstd.cc",
+    "zstd_functions.h",
+  ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../base",
+    "../../core/plugin",
+    "../../perfetto_sql/engine",
+    "../../sqlite",
+    "../../util:compressor",
+  ]
+}

--- a/src/trace_processor/plugins/zstd_functions/BUILD.gn
+++ b/src/trace_processor/plugins/zstd_functions/BUILD.gn
@@ -28,5 +28,6 @@ source_set("zstd_functions") {
     "../../perfetto_sql/engine",
     "../../sqlite",
     "../../util:compressor",
+    "../../util:decompressor",
   ]
 }

--- a/src/trace_processor/plugins/zstd_functions/zstd.cc
+++ b/src/trace_processor/plugins/zstd_functions/zstd.cc
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/trace_processor/plugins/zstd_functions/zstd_functions.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/utils.h"
+#include "src/trace_processor/core/plugin/plugin.h"
+#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_function.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_result.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_type.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_value.h"
+#include "src/trace_processor/sqlite/sqlite_utils.h"
+#include "src/trace_processor/util/zstd_compressor.h"
+
+namespace perfetto::trace_processor {
+
+namespace {
+
+// A good ratio/speed balance for the compressible text (Chrome JSON etc.) this
+// is meant to store.
+constexpr int kLevel = 9;
+
+// __intrinsic_zstd(X) -> zstd(X) as a BLOB. X is a string or blob; NULL yields
+// NULL.
+struct Zstd : public sqlite::Function<Zstd> {
+  static constexpr char kName[] = "__intrinsic_zstd";
+  static constexpr int kArgCount = 1;
+
+  static void Step(sqlite3_context* ctx, int, sqlite3_value** argv) {
+    const uint8_t* src = nullptr;
+    size_t src_size = 0;
+    switch (sqlite::value::Type(argv[0])) {
+      case sqlite::Type::kNull:
+        return sqlite::utils::ReturnNullFromFunction(ctx);
+      case sqlite::Type::kInteger:
+      case sqlite::Type::kFloat:
+        return sqlite::utils::SetError(
+            ctx, "ZSTD: argument must be a string or blob");
+      case sqlite::Type::kText:
+        src = reinterpret_cast<const uint8_t*>(sqlite::value::Text(argv[0]));
+        src_size = static_cast<size_t>(sqlite::value::Bytes(argv[0]));
+        break;
+      case sqlite::Type::kBlob:
+        src = reinterpret_cast<const uint8_t*>(sqlite::value::Blob(argv[0]));
+        src_size = static_cast<size_t>(sqlite::value::Bytes(argv[0]));
+        break;
+    }
+
+    size_t out_size = 0;
+    auto out =
+        util::ZstdCompressor::CompressFully(src, src_size, &out_size, kLevel);
+    if (!out) {
+      return sqlite::utils::SetError(
+          ctx, "ZSTD: compression failed (is zstd compiled in?)");
+    }
+    return sqlite::result::RawBytes(ctx, out.release(),
+                                    static_cast<int>(out_size), free);
+  }
+};
+
+}  // namespace
+
+}  // namespace perfetto::trace_processor
+
+namespace perfetto::trace_processor::zstd_functions {
+namespace {
+
+class ZstdFunctionsPlugin : public Plugin<ZstdFunctionsPlugin> {
+ public:
+  ~ZstdFunctionsPlugin() override;
+  void RegisterFunctions(PerfettoSqlConnection*,
+                         std::vector<FunctionRegistration>& out) override {
+    out.push_back(MakeFunctionRegistration<Zstd>(nullptr));
+  }
+};
+ZstdFunctionsPlugin::~ZstdFunctionsPlugin() = default;
+
+}  // namespace
+
+void RegisterPlugin() {
+  static PluginRegistration reg(
+      []() -> std::unique_ptr<PluginBase> {
+        return std::make_unique<ZstdFunctionsPlugin>();
+      },
+      ZstdFunctionsPlugin::kPluginId, ZstdFunctionsPlugin::kDepIds.data(),
+      ZstdFunctionsPlugin::kDepIds.size());
+  base::ignore_result(reg);
+}
+
+}  // namespace perfetto::trace_processor::zstd_functions

--- a/src/trace_processor/plugins/zstd_functions/zstd.cc
+++ b/src/trace_processor/plugins/zstd_functions/zstd.cc
@@ -29,6 +29,7 @@
 #include "src/trace_processor/sqlite/bindings/sqlite_type.h"
 #include "src/trace_processor/sqlite/bindings/sqlite_value.h"
 #include "src/trace_processor/sqlite/sqlite_utils.h"
+#include "src/trace_processor/util/decompressor.h"
 #include "src/trace_processor/util/zstd_compressor.h"
 
 namespace perfetto::trace_processor {
@@ -39,10 +40,10 @@ namespace {
 // is meant to store.
 constexpr int kLevel = 9;
 
-// __intrinsic_zstd(X) -> zstd(X) as a BLOB. X is a string or blob; NULL yields
-// NULL.
-struct Zstd : public sqlite::Function<Zstd> {
-  static constexpr char kName[] = "__intrinsic_zstd";
+// __intrinsic_zstd_compress(X) -> zstd(X) as a BLOB. X is a string or blob;
+// NULL yields NULL.
+struct ZstdCompress : public sqlite::Function<ZstdCompress> {
+  static constexpr char kName[] = "__intrinsic_zstd_compress";
   static constexpr int kArgCount = 1;
 
   static void Step(sqlite3_context* ctx, int, sqlite3_value** argv) {
@@ -65,12 +66,15 @@ struct Zstd : public sqlite::Function<Zstd> {
         break;
     }
 
+    if (!util::IsZstdSupported()) {
+      return sqlite::utils::SetError(
+          ctx, "ZSTD: zstd is not compiled into this build");
+    }
     size_t out_size = 0;
     auto out =
         util::ZstdCompressor::CompressFully(src, src_size, &out_size, kLevel);
     if (!out) {
-      return sqlite::utils::SetError(
-          ctx, "ZSTD: compression failed (is zstd compiled in?)");
+      return sqlite::utils::SetError(ctx, "ZSTD: compression failed");
     }
     return sqlite::result::RawBytes(ctx, out.release(),
                                     static_cast<int>(out_size), free);
@@ -89,7 +93,7 @@ class ZstdFunctionsPlugin : public Plugin<ZstdFunctionsPlugin> {
   ~ZstdFunctionsPlugin() override;
   void RegisterFunctions(PerfettoSqlConnection*,
                          std::vector<FunctionRegistration>& out) override {
-    out.push_back(MakeFunctionRegistration<Zstd>(nullptr));
+    out.push_back(MakeFunctionRegistration<ZstdCompress>(nullptr));
   }
 };
 ZstdFunctionsPlugin::~ZstdFunctionsPlugin() = default;

--- a/src/trace_processor/plugins/zstd_functions/zstd_functions.h
+++ b/src/trace_processor/plugins/zstd_functions/zstd_functions.h
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_TRACE_PROCESSOR_PLUGINS_ZSTD_FUNCTIONS_ZSTD_FUNCTIONS_H_
+#define SRC_TRACE_PROCESSOR_PLUGINS_ZSTD_FUNCTIONS_ZSTD_FUNCTIONS_H_
+
+namespace perfetto::trace_processor::zstd_functions {
+
+void RegisterPlugin();
+
+}  // namespace perfetto::trace_processor::zstd_functions
+
+#endif  // SRC_TRACE_PROCESSOR_PLUGINS_ZSTD_FUNCTIONS_ZSTD_FUNCTIONS_H_

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -185,6 +185,7 @@
 #include "src/trace_processor/plugins/winscope_importer/winscope_importer.h"
 #include "src/trace_processor/plugins/winscope_proto_to_args_with_defaults/winscope_proto_to_args_with_defaults.h"
 #include "src/trace_processor/plugins/winscope_surfaceflinger_hierarchy_paths/winscope_surfaceflinger_hierarchy_paths.h"
+#include "src/trace_processor/plugins/zstd_functions/zstd_functions.h"
 #endif
 
 namespace perfetto::trace_processor {
@@ -391,6 +392,7 @@ TraceProcessorImpl::TraceProcessorImpl(const Config& cfg)
   winscope_importer::RegisterPlugin();
   winscope_proto_to_args_with_defaults::RegisterPlugin();
   winscope_surfaceflinger_hierarchy_paths::RegisterPlugin();
+  zstd_functions::RegisterPlugin();
 #endif
 
   // Initialize plugins using the statically pre-computed PluginSet.

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -95,6 +95,7 @@ source_set("compressor") {
   deps = [
     "../../../gn:default_deps",
     "../../../include/perfetto/base",
+    "../../../include/perfetto/ext/base:base",
   ]
   if (enable_perfetto_zstd) {
     deps += [ "../../../gn:zstd" ]

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -85,6 +85,22 @@ source_set("decompressor") {
   }
 }
 
+# One-shot compressors, the counterpart of ":decompressor". Kept separate so the
+# decompressor target stays decompression-only.
+source_set("compressor") {
+  sources = [
+    "zstd_compressor.cc",
+    "zstd_compressor.h",
+  ]
+  deps = [
+    "../../../gn:default_deps",
+    "../../../include/perfetto/base",
+  ]
+  if (enable_perfetto_zstd) {
+    deps += [ "../../../gn:zstd" ]
+  }
+}
+
 perfetto_component("build_id") {
   sources = [
     "build_id.cc",

--- a/src/trace_processor/util/zstd_compressor.cc
+++ b/src/trace_processor/util/zstd_compressor.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/zstd_compressor.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+
+#include "perfetto/base/build_config.h"
+#include "perfetto/ext/base/utils.h"
+
+#if PERFETTO_BUILDFLAG(PERFETTO_ZSTD)
+#include <zstd.h>
+#endif
+
+namespace perfetto::trace_processor::util {
+
+#if PERFETTO_BUILDFLAG(PERFETTO_ZSTD)
+
+// static
+std::unique_ptr<uint8_t, base::FreeDeleter> ZstdCompressor::CompressFully(
+    const uint8_t* data,
+    size_t len,
+    size_t* out_size,
+    int level) {
+  size_t bound = ZSTD_compressBound(len);
+  std::unique_ptr<uint8_t, base::FreeDeleter> out(
+      static_cast<uint8_t*>(malloc(bound)));
+  size_t n = ZSTD_compress(out.get(), bound, data, len, level);
+  if (ZSTD_isError(n)) {
+    return nullptr;
+  }
+  *out_size = n;
+  return out;
+}
+
+#else  // !PERFETTO_ZSTD
+
+// static
+std::unique_ptr<uint8_t, base::FreeDeleter>
+ZstdCompressor::CompressFully(const uint8_t*, size_t, size_t*, int) {
+  return nullptr;
+}
+
+#endif  // PERFETTO_BUILDFLAG(PERFETTO_ZSTD)
+
+}  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/zstd_compressor.cc
+++ b/src/trace_processor/util/zstd_compressor.cc
@@ -41,6 +41,10 @@ std::unique_ptr<uint8_t, base::FreeDeleter> ZstdCompressor::CompressFully(
   size_t bound = ZSTD_compressBound(len);
   std::unique_ptr<uint8_t, base::FreeDeleter> out(
       static_cast<uint8_t*>(malloc(bound)));
+  // ZSTD_compress allocates and frees a ZSTD_CCtx internally on every call.
+  // That is fine for the handful of blobs this is used on; if it is ever placed
+  // on a hot per-row path, reuse a ZSTD_compressCCtx with a (thread_local)
+  // context to avoid the per-call allocation.
   size_t n = ZSTD_compress(out.get(), bound, data, len, level);
   if (ZSTD_isError(n)) {
     return nullptr;

--- a/src/trace_processor/util/zstd_compressor.h
+++ b/src/trace_processor/util/zstd_compressor.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_UTIL_ZSTD_COMPRESSOR_H_
+#define SRC_TRACE_PROCESSOR_UTIL_ZSTD_COMPRESSOR_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "perfetto/ext/base/utils.h"
+
+namespace perfetto::trace_processor::util {
+
+// One-shot zstd compression, the counterpart of ZstdDecompressor. Check
+// IsZstdSupported() (decompressor.h) before relying on this.
+class ZstdCompressor {
+ public:
+  // Compresses |data| into a single zstd frame, returning a malloc()-allocated
+  // buffer (caller frees; the frame length is written to |*out_size|) or
+  // nullptr on error or when zstd is not compiled in.
+  static std::unique_ptr<uint8_t, base::FreeDeleter>
+  CompressFully(const uint8_t* data, size_t len, size_t* out_size, int level);
+};
+
+}  // namespace perfetto::trace_processor::util
+
+#endif  // SRC_TRACE_PROCESSOR_UTIL_ZSTD_COMPRESSOR_H_

--- a/test/trace_processor/diff_tests/syntax/function_tests.py
+++ b/test/trace_processor/diff_tests/syntax/function_tests.py
@@ -23,6 +23,23 @@ from google.protobuf import text_format
 
 class PerfettoFunction(TestSuite):
 
+  # Usage of __intrinsic_zstd: a string/blob compresses to a zstd frame (asserted
+  # via the version-stable frame magic 0x28b52ffd rather than exact bytes), and
+  # NULL passes through as NULL.
+  def test_zstd(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        SELECT
+          hex(substr(__intrinsic_zstd('hello, hello, hello'), 1, 4)) AS magic,
+          length(__intrinsic_zstd('hello, hello, hello')) > 0 AS has_output,
+          __intrinsic_zstd(NULL) IS NULL AS null_passthrough;
+      """,
+        out=Csv("""
+        "magic","has_output","null_passthrough"
+        "28B52FFD",1,1
+      """))
+
   def test_create_function(self):
     return DiffTestBlueprint(
         trace=TextProto(""),

--- a/test/trace_processor/diff_tests/syntax/function_tests.py
+++ b/test/trace_processor/diff_tests/syntax/function_tests.py
@@ -23,17 +23,17 @@ from google.protobuf import text_format
 
 class PerfettoFunction(TestSuite):
 
-  # Usage of __intrinsic_zstd: a string/blob compresses to a zstd frame (asserted
-  # via the version-stable frame magic 0x28b52ffd rather than exact bytes), and
-  # NULL passes through as NULL.
-  def test_zstd(self):
+  # Usage of __intrinsic_zstd_compress: a string/blob compresses to a zstd frame
+  # (asserted via the version-stable frame magic 0x28b52ffd rather than exact
+  # bytes), and NULL passes through as NULL.
+  def test_zstd_compress(self):
     return DiffTestBlueprint(
         trace=TextProto(""),
         query="""
         SELECT
-          hex(substr(__intrinsic_zstd('hello, hello, hello'), 1, 4)) AS magic,
-          length(__intrinsic_zstd('hello, hello, hello')) > 0 AS has_output,
-          __intrinsic_zstd(NULL) IS NULL AS null_passthrough;
+          hex(substr(__intrinsic_zstd_compress('hello, hello, hello'), 1, 4)) AS magic,
+          length(__intrinsic_zstd_compress('hello, hello, hello')) > 0 AS has_output,
+          __intrinsic_zstd_compress(NULL) IS NULL AS null_passthrough;
       """,
         out=Csv("""
         "magic","has_output","null_passthrough"


### PR DESCRIPTION
Compresses a string or blob into a zstd frame and returns it as a BLOB, the compression counterpart of the existing zstd decompression. Intended for compressing a payload generated in SQL (e.g. Chrome JSON assembled from the tables) before storing it; the frame is understood by the trace importer, so the blob re-opens as a trace. Uses zstd level 9, a good ratio/speed balance for the compressible text this targets.

Test: diff test PerfettoFunction:zstd asserts the zstd frame magic, non-empty output and NULL passthrough; verified a Chrome JSON compresses to a frame that zstd -d restores byte-for-byte and trace_processor re-opens as a trace.
