### PR TITLE
ui: Clean up memoization primitives

### DIFF
--- a/docs/ui-review-antipatterns.md
+++ b/docs/ui-review-antipatterns.md
@@ -99,8 +99,7 @@ How to use it:
   clicks faster than queries run. Use a `QuerySlot` (declare a key, poll it each
   render, render stale data with `retainOn`), or load inside
   `TrackEventDetailsPanel.load()`, which auto-cancels obsolete loads. Guard
-  concurrency with `AsyncLimiter.isRunning` rather than a bespoke flag. (Note:
-  `isFresh` is always `true` unless you use `retainOn` keys.)
+  concurrency with `AsyncLimiter.isRunning` rather than a bespoke flag.
   *(#4464, #4582, #4737, #5436, #4192)*
 
 - **❌ Keeping derived state that must be manually kept in sync → ✅ derive it from

--- a/ui/src/base/async_memo.ts
+++ b/ui/src/base/async_memo.ts
@@ -13,28 +13,31 @@
 // limitations under the License.
 
 /**
- * QuerySlot: Declarative async data fetching for synchronous render cycles.
+ * AsyncMemo: Declarative async data fetching for synchronous render cycles.
  *
  * ## Why it exists
  *
  * UI components (Mithril views, canvas tracks) render synchronously but need
- * async data from SQL queries. QuerySlot bridges this gap:
+ * async data e.g. from SQL queries. Manually tracking state changes and
+ * handling stale queries is difficult and error prone.
+ *
+ * AsyncMemo bridges this gap:
  * - Call `use()` every render cycle with the current parameters
  * - Get back whatever data is available (cached, stale, or undefined)
- * - New queries are scheduled automatically when parameters change
- * - Serial execution prevents race conditions with shared resources (temp tables)
+ * - New tasks are scheduled automatically when parameters change
+ * - Serial execution prevents race conditions with shared resources (temp
+ *   tables)
  *
- * ## Usage
+ * ## Example usage:
  *
- * ```typescript
+ * ```ts
  * class MyPanel implements m.ClassComponent<Attrs> {
- *   private readonly taskQueue = new SerialTaskQueue();
- *   private readonly dataSlot = new QuerySlot<MyData>(this.taskQueue);
+ *   private readonly memo = new AsyncMemo<MyData>();
  *
  *   view({attrs}: m.CVnode<Attrs>) {
- *     const result = this.dataSlot.use({
+ *     const result = this.memo.use({
  *       key: {filters: attrs.filters, pagination: this.pagination},
- *       queryFn: () => fetchData(attrs.filters, this.pagination),
+ *       compute: () => fetchData(attrs.filters, this.pagination),
  *       retainOn: ['pagination'],  // Show stale data during pagination changes
  *     });
  *
@@ -42,36 +45,37 @@
  *   }
  *
  *   onremove() {
- *     // Cancel pending queries and cleanup resources
- *     this.dataSlot.dispose();
+ *     // Cancel pending tasks and cleanup resources
+ *     this.memo.dispose();
  *   }
  * }
  * ```
  *
  * ## Key concepts
  *
- * - **key**: Object identifying the query. Changes trigger re-fetch.
+ * - **key**: Object identifying the memo. Changes trigger re-fetch.
  * - **retainOn**: Key fields that allow showing previous data while fetching.
- *   E.g., `retainOn: ['pagination']` shows old data during scroll for smoothness,
- *   but `filters` changing would show loading state.
- * - **enabled**: Truthy value required before query runs. Use for dependencies
+ *   E.g., `retainOn: ['pagination']` shows old data during scroll for
+ *   smoothness, but `filters` changing would show loading state.
+ * - **enabled**: Truthy value required before task runs. Use for dependencies
  *   like `enabled: tableResult.data` to wait for a temp table to be created.
  *
  * ## Behavior
  *
  * - Tasks within a queue run serially (no interleaving)
- * - Only the latest pending task per slot is kept (intermediates dropped)
- * - Each slot has a single-entry cache (most recent result)
- * - If queryFn returns an AsyncDisposable, it is automatically disposed before
- *   running the next query and when the slot is disposed. Disposal runs through
- *   the queue to stay synchronized with in-flight queries.
+ * - Only the latest pending task per memo is kept (intermediates dropped)
+ * - Each memo has a single-entry cache (most recent result)
+ * - If compute() returns an AsyncDisposable, it is automatically disposed
+ *   before running the next task and when the memo is disposed. Disposal runs
+ *   through the queue to stay synchronized with in-flight tasks.
  */
 
 import m from 'mithril';
-import {stringifyJsonWithBigints} from './json_utils';
+import {isAsyncDisposable} from './disposable';
+import {type JSONCompatible, stringifyJsonWithBigints} from './json_utils';
 
 /**
- * Signal passed to queryFn to check if the query has been cancelled.
+ * Signal passed to compute() to check if the task has been cancelled.
  * Check this periodically during long-running operations to bail out early.
  */
 export interface CancellationSignal {
@@ -79,54 +83,25 @@ export interface CancellationSignal {
 }
 
 /**
- * Special return value from queryFn indicating the query was cancelled.
+ * Special return value from compute() indicating the task was cancelled.
  * When returned, the result is not cached.
  */
-export const QUERY_CANCELLED = Symbol('QUERY_CANCELLED');
-
-function isAsyncDisposable(value: unknown): value is AsyncDisposable {
-  return (
-    value !== null &&
-    typeof value === 'object' &&
-    Symbol.asyncDispose in value &&
-    typeof (value as AsyncDisposable)[Symbol.asyncDispose] === 'function'
-  );
-}
+export const TASK_CANCELLED = Symbol('TASK_CANCELLED');
 
 // Simple alias for a function that returns a Promise of type T.
 type AsyncFunc<T> = () => Promise<T>;
 
-// TODO(stevegolton): Eventually these types should be moved to json_utils.ts
-// and used in the definitions for stringifyJsonWithBigints and friends, but
-// there are too many dependencies that depend on these functions using 'any'
-// right now. They should instead use zod to narrow the types properly.
-type JSONPrimitive = string | number | boolean | null | undefined | bigint;
-
-type JSONObject = {
-  [key: string]: JSONValue;
-};
-type JSONValue = JSONPrimitive | JSONValue[] | JSONObject;
-
-type JSONCompatible<T> = unknown extends T
-  ? never
-  : {
-      [P in keyof T]: T[P] extends JSONValue
-        ? T[P]
-        : T[P] extends NotAssignableToJson
-          ? never
-          : JSONCompatible<T[P]>;
-    };
-
-type NotAssignableToJson = symbol | Function;
-
 /**
- * Runs async tasks one at a time with cancellation support.
+ * Runs async functions one at a time with cancellation support.
  *
- * Tasks are keyed by an object reference. If a new task is scheduled with
- * the same key, it replaces any pending task for that key ("latest wins").
- * Tasks that have already started running cannot be cancelled.
+ * Compelling use case - to avoid interlaving queries in async functions that
+ * run more than one query.
+ *
+ * Tasks are keyed by an object reference. If a new task is scheduled with the
+ * same key, it replaces any pending task for that key ("latest wins"). Tasks
+ * that have already started running cannot be cancelled.
  */
-export class SerialTaskQueue {
+export class AtomicTaskQueue {
   private pending = new Map<object, AsyncFunc<void>>();
   private running = false;
 
@@ -168,34 +143,46 @@ export class SerialTaskQueue {
   }
 }
 
-export interface QueryOptions<T, K extends JSONCompatible<K>> {
-  key: K;
-  // Query function receives a cancellation signal. Check signal.isCancelled
-  // periodically during long operations and return QUERY_CANCELLED to bail out.
-  queryFn: (signal: CancellationSignal) => Promise<T | typeof QUERY_CANCELLED>;
-  // If provided, query only runs when this is truthy
-  // e.g., enabled: viewResult.data
-  enabled?: boolean;
-  retainOn?: (keyof K)[];
+export interface AsyncMemoOptions<T, K extends JSONCompatible<K>> {
+  readonly key: K;
+  // Function to call when the key changes to fetch the memo data.
+  readonly compute: (
+    signal: CancellationSignal,
+  ) => Promise<T | typeof TASK_CANCELLED>;
+  // If provided, compute() only runs when this is truthy.
+  readonly enabled?: boolean;
+  // Keep returning the previous memo while the new one loads as long as only
+  // keys in this set have changed.
+  readonly retainOn?: (keyof K)[];
 }
 
-export interface QueryResult<T> {
-  data: T | undefined;
-  isPending: boolean;
-  isFresh: boolean;
+export type AsyncMemoResult<T> =
+  | {
+      readonly isPending: true;
+      readonly data?: T; // Stale data may be available.
+    }
+  | {
+      readonly isPending: false;
+      readonly data: T;
+    };
+
+interface Cache<T> {
+  readonly key: object;
+  readonly keyStr: string;
+  readonly data: T;
 }
 
 /**
- * A single query slot with a single-entry cache.
+ * A single async memo with a single-entry cache.
  *
- * Created once per query on a component. Multiple slots share a
- * SerialTaskQueue for serialized execution.
+ * Created once per piece of data you want to memoize on a component. Multiple
+ * memos should share a SerialTaskQueue for atomic compute task execution.
  *
- * If T is an AsyncDisposable, the slot will automatically dispose of
- * previous results before running a new query and when the slot is disposed.
+ * If T is an AsyncDisposable, the memo will automatically dispose of previous
+ * results before running a new compute and when the memo is disposed.
  */
-export class QuerySlot<T> {
-  private cache?: {key: object; keyStr: string; data: T};
+export class AsyncMemo<T> {
+  private cache?: Cache<T>;
   private pendingKey?: object;
   private disposed = false;
   private currentSignal?: {cancelled: boolean};
@@ -203,20 +190,21 @@ export class QuerySlot<T> {
   private error?: {keyStr: string; error: Error};
 
   constructor(
-    private readonly queue: SerialTaskQueue = new SerialTaskQueue(),
+    private readonly queue: AtomicTaskQueue = new AtomicTaskQueue(),
   ) {}
 
   /**
-   * Call every render cycle to get the current query result.
+   * Call every render cycle to get the current memoized result.
+   *
    * @throws Error if called after dispose()
    */
   use<K extends JSONCompatible<K>>(
-    options: QueryOptions<T, K>,
-  ): QueryResult<T> {
+    options: AsyncMemoOptions<T, K>,
+  ): AsyncMemoResult<T> {
     if (this.disposed) {
-      throw new Error('QuerySlot.use() called after dispose()');
+      throw new Error('AsyncMemo.use() called after dispose()');
     }
-    const {key, queryFn, enabled, retainOn = []} = options;
+    const {key, compute, enabled, retainOn = []} = options;
     const keyStr = stringifyJsonWithBigints(key);
 
     // If we have a stored error for this key, throw it
@@ -224,7 +212,7 @@ export class QuerySlot<T> {
       throw this.error.error;
     }
 
-    // Check if we need to schedule a new query
+    // Check if we need to schedule a new task
     const pendingKeyStr = this.pendingKey
       ? stringifyJsonWithBigints(this.pendingKey)
       : undefined;
@@ -238,31 +226,31 @@ export class QuerySlot<T> {
     const canRun = enabled === undefined || enabled;
 
     if (isKeyDifferentFromPending && isKeyDifferentFromCache && canRun) {
-      // Cancel any in-flight query
+      // Cancel any in-flight task
       if (this.currentSignal) {
         this.currentSignal.cancelled = true;
       }
 
-      // Create new signal for this query
+      // Create new signal for this task
       const signal = {cancelled: false};
       this.currentSignal = signal;
 
       this.pendingKey = key;
       this.queue.schedule(this, async () => {
         try {
-          // Dispose of previous result before running new query
+          // Dispose of previous result before running new task
           await this.disposeCache();
-          const result = await queryFn({
+          const result = await compute({
             get isCancelled() {
               return signal.cancelled;
             },
           });
 
-          this.finaliseQuery(key, result);
+          this.finaliseTask(key, result);
         } catch (e) {
-          // Support both throwing and returning QUERY_CANCELLED
-          if (e === QUERY_CANCELLED) {
-            this.finaliseQuery(key, QUERY_CANCELLED);
+          // Support both throwing and returning TASK_CANCELLED
+          if (e === TASK_CANCELLED) {
+            this.finaliseTask(key, TASK_CANCELLED);
           } else {
             this.finaliseError(key, e);
           }
@@ -276,13 +264,16 @@ export class QuerySlot<T> {
     const isPending = this.pendingKey !== undefined;
 
     if (!this.cache) {
-      return {data: undefined, isPending, isFresh: false};
+      // Without cached data, the result remains pending. This also covers a
+      // memo blocked by `enabled`, whose dependency has not resolved yet.
+      return {data: undefined, isPending: true};
     }
 
-    // Check if we can use stale data
-    const isFresh = this.cache.keyStr === keyStr;
-    if (isFresh) {
-      return {data: this.cache.data, isPending, isFresh: true};
+    // Check if we can use cached data
+    if (this.cache.keyStr === keyStr) {
+      return isPending
+        ? {data: this.cache.data, isPending: true}
+        : {data: this.cache.data, isPending: false};
     }
 
     // Key differs - can we use stale data?
@@ -292,18 +283,20 @@ export class QuerySlot<T> {
       retainOn as string[],
     );
     if (canUseStale) {
-      return {data: this.cache.data, isPending, isFresh: false};
+      return isPending
+        ? {data: this.cache.data, isPending: true}
+        : {data: this.cache.data, isPending: false};
     }
 
     // Can't use stale data
-    return {data: undefined, isPending, isFresh: false};
+    return {data: undefined, isPending: true};
   }
 
   /**
-   * Called when a query completes. Clears the pending state and optionally
+   * Called when a task completes. Clears the pending state and optionally
    * caches the result (if not cancelled).
    */
-  private finaliseQuery(key: object, result: T | typeof QUERY_CANCELLED): void {
+  private finaliseTask(key: object, result: T | typeof TASK_CANCELLED): void {
     const keyStr = stringifyJsonWithBigints(key);
 
     // Clear pending if it matches
@@ -315,14 +308,14 @@ export class QuerySlot<T> {
     }
 
     // Cache the result (unless cancelled)
-    if (result !== QUERY_CANCELLED) {
+    if (result !== TASK_CANCELLED) {
       this.cache = {key, keyStr, data: result};
     }
   }
 
   /**
-   * Called when a query fails with an error. Stores the error keyed by the
-   * query key - next use() with the same key will throw this error.
+   * Called when a task fails with an error. Stores the error keyed by the key -
+   * next use() with the same key will throw this error.
    */
   private finaliseError(key: object, e: unknown): void {
     const keyStr = stringifyJsonWithBigints(key);
@@ -331,7 +324,8 @@ export class QuerySlot<T> {
       error: e instanceof Error ? e : new Error(String(e)),
     };
 
-    // Clear pending if it matches (don't clear if a different query was scheduled)
+    // Clear pending if it matches (don't clear if a different task was
+    // scheduled)
     if (
       this.pendingKey &&
       stringifyJsonWithBigints(this.pendingKey) === keyStr
@@ -350,15 +344,15 @@ export class QuerySlot<T> {
   }
 
   /**
-   * Clear the cached result and any stored error, forcing the next use()
-   * with any key to re-run its queryFn. Unlike dispose(), the slot remains
-   * usable. Cancels any in-flight query and disposes cached AsyncDisposable
+   * Clear the cached result and any stored error, forcing the next use() with
+   * any key to re-run its compute function. Unlike dispose(), the memo remains
+   * usable. Cancels any in-flight task and disposes cached AsyncDisposable
    * data through the queue to stay synchronized with pending work.
    */
   invalidate(): void {
     if (this.disposed) return;
 
-    // Cancel any in-flight query and clear pending state so the next use()
+    // Cancel any in-flight task and clear pending state so the next use()
     // reschedules from scratch.
     if (this.currentSignal) {
       this.currentSignal.cancelled = true;
@@ -368,7 +362,7 @@ export class QuerySlot<T> {
     this.error = undefined;
 
     // Schedule cache disposal/clearing through the queue so it runs after any
-    // in-flight query settles.
+    // in-flight task settles.
     this.queue.schedule(this, async () => {
       await this.disposeCache();
       this.cache = undefined;
@@ -376,9 +370,9 @@ export class QuerySlot<T> {
   }
 
   /**
-   * Dispose this slot. Cancels pending work and disposes any cached
+   * Dispose this memo. Cancels pending work and disposes any cached
    * AsyncDisposable through the queue to maintain synchronization.
-   * Call this in component's onremove() to prevent orphaned queries.
+   * Call this in component's onremove() to prevent orphaned tasks.
    */
   dispose(): void {
     if (this.disposed) return;
@@ -388,7 +382,7 @@ export class QuerySlot<T> {
     this.pendingKey = undefined;
 
     // Schedule cache disposal through the queue. This runs after any
-    // in-flight query completes, ensuring we dispose whatever ends up
+    // in-flight task completes, ensuring we dispose whatever ends up
     // in the cache (either existing data or newly fetched data).
     this.queue.schedule(this, async () => {
       await this.disposeCache();

--- a/ui/src/base/async_memo_unittest.ts
+++ b/ui/src/base/async_memo_unittest.ts
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {QuerySlot, SerialTaskQueue, QUERY_CANCELLED} from './query_slot';
+import {AsyncMemo, AtomicTaskQueue, TASK_CANCELLED} from './async_memo';
 
 // Helper to wait for pending promises to resolve
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 test('basic query execution', async () => {
-  const slot = new QuerySlot<number>();
+  const slot = new AsyncMemo<number>();
 
   const queryFn = vi.fn().mockImplementation(async () => 42);
 
   const result1 = slot.use({
     key: {id: 1},
-    queryFn,
+    compute: queryFn,
   });
 
   expect(result1.data).toBeUndefined();
@@ -34,7 +34,7 @@ test('basic query execution', async () => {
 
   const result2 = slot.use({
     key: {id: 1},
-    queryFn,
+    compute: queryFn,
   });
 
   expect(result2.data).toBe(42);
@@ -43,38 +43,37 @@ test('basic query execution', async () => {
 });
 
 test('cached result is returned without re-query', async () => {
-  const slot = new QuerySlot<number>();
+  const slot = new AsyncMemo<number>();
 
   const queryFn = vi.fn().mockResolvedValue(42);
 
-  slot.use({key: {id: 1}, queryFn});
+  slot.use({key: {id: 1}, compute: queryFn});
   await flushPromises();
 
   // Call use() again with same key - should return cached, not re-query
-  const result = slot.use({key: {id: 1}, queryFn});
+  const result = slot.use({key: {id: 1}, compute: queryFn});
 
   expect(result.data).toBe(42);
-  expect(result.isFresh).toBe(true);
   expect(queryFn).toHaveBeenCalledTimes(1); // Still just once
 });
 
 test('dispose cancels queued work across render cycles', async () => {
-  const executor = new SerialTaskQueue();
+  const executor = new AtomicTaskQueue();
 
   // Simulate first component mounting and starting a long query
-  const slot1 = new QuerySlot<number>(executor);
+  const slot1 = new AsyncMemo<number>(executor);
   let query1Resolved = false;
   const queryFn1 = vi.fn().mockImplementation(async () => {
     await flushPromises(); // Simulate some async work
     query1Resolved = true;
     return 1;
   });
-  slot1.use({key: {id: 1}, queryFn: queryFn1});
+  slot1.use({key: {id: 1}, compute: queryFn1});
 
   // Simulate second component mounting while first query is in-flight
-  const slot2 = new QuerySlot<number>(executor);
+  const slot2 = new AsyncMemo<number>(executor);
   const queryFn2 = vi.fn().mockResolvedValue(2);
-  slot2.use({key: {id: 2}, queryFn: queryFn2});
+  slot2.use({key: {id: 2}, compute: queryFn2});
 
   // Second component unmounts before its query runs (it's queued behind first)
   slot2.dispose();
@@ -90,9 +89,9 @@ test('dispose cancels queued work across render cycles', async () => {
 });
 
 test('multiple slots same executor run serially', async () => {
-  const executor = new SerialTaskQueue();
-  const slot1 = new QuerySlot<number>(executor);
-  const slot2 = new QuerySlot<number>(executor);
+  const executor = new AtomicTaskQueue();
+  const slot1 = new AsyncMemo<number>(executor);
+  const slot2 = new AsyncMemo<number>(executor);
 
   const order: number[] = [];
 
@@ -106,8 +105,8 @@ test('multiple slots same executor run serially', async () => {
     return 2;
   });
 
-  slot1.use({key: {id: 1}, queryFn: queryFn1});
-  slot2.use({key: {id: 2}, queryFn: queryFn2});
+  slot1.use({key: {id: 1}, compute: queryFn1});
+  slot2.use({key: {id: 2}, compute: queryFn2});
 
   await flushPromises();
   await flushPromises();
@@ -118,7 +117,7 @@ test('multiple slots same executor run serially', async () => {
 });
 
 test('rapid key changes on same slot only runs first and last', async () => {
-  const slot = new QuerySlot<number>();
+  const slot = new AsyncMemo<number>();
 
   const queryFn1 = vi.fn().mockResolvedValue(1);
   const queryFn2 = vi.fn().mockResolvedValue(2);
@@ -126,9 +125,9 @@ test('rapid key changes on same slot only runs first and last', async () => {
 
   // Schedule three different queries rapidly on the same slot
   // First one starts immediately, subsequent ones replace in pending queue
-  slot.use({key: {id: 1}, queryFn: queryFn1});
-  slot.use({key: {id: 2}, queryFn: queryFn2});
-  slot.use({key: {id: 3}, queryFn: queryFn3});
+  slot.use({key: {id: 1}, compute: queryFn1});
+  slot.use({key: {id: 2}, compute: queryFn2});
+  slot.use({key: {id: 3}, compute: queryFn3});
 
   await flushPromises();
   await flushPromises();
@@ -140,14 +139,14 @@ test('rapid key changes on same slot only runs first and last', async () => {
 });
 
 test('retainOn allows showing previous data during compatible changes', async () => {
-  const slot = new QuerySlot<number>();
+  const slot = new AsyncMemo<number>();
 
   const queryFn1 = vi.fn().mockResolvedValue(100);
 
   // First query
   slot.use({
     key: {filter: 'a', page: 1},
-    queryFn: queryFn1,
+    compute: queryFn1,
     retainOn: ['page'],
   });
 
@@ -156,29 +155,27 @@ test('retainOn allows showing previous data during compatible changes', async ()
   // Verify first result cached
   const result1 = slot.use({
     key: {filter: 'a', page: 1},
-    queryFn: queryFn1,
+    compute: queryFn1,
     retainOn: ['page'],
   });
   expect(result1.data).toBe(100);
-  expect(result1.isFresh).toBe(true);
 
   // Change only page (in retainOn) - should show stale data
   const queryFn2 = vi.fn().mockResolvedValue(200);
   const result2 = slot.use({
     key: {filter: 'a', page: 2},
-    queryFn: queryFn2,
+    compute: queryFn2,
     retainOn: ['page'],
   });
 
   expect(result2.data).toBe(100); // Stale data shown
-  expect(result2.isFresh).toBe(false);
   expect(result2.isPending).toBe(true);
 
   // Change filter (not in retainOn) - should NOT show stale data
   const queryFn3 = vi.fn().mockResolvedValue(300);
   const result3 = slot.use({
     key: {filter: 'b', page: 2},
-    queryFn: queryFn3,
+    compute: queryFn3,
     retainOn: ['page'],
   });
 
@@ -187,14 +184,14 @@ test('retainOn allows showing previous data during compatible changes', async ()
 });
 
 test('enabled prevents query from running', async () => {
-  const slot = new QuerySlot<number>();
+  const slot = new AsyncMemo<number>();
 
   const queryFn = vi.fn().mockResolvedValue(42);
 
   // Query with enabled=false
   slot.use({
     key: {id: 1},
-    queryFn,
+    compute: queryFn,
     enabled: false,
   });
 
@@ -205,7 +202,7 @@ test('enabled prevents query from running', async () => {
   // Now enable it
   slot.use({
     key: {id: 1},
-    queryFn,
+    compute: queryFn,
     enabled: true,
   });
 
@@ -213,7 +210,7 @@ test('enabled prevents query from running', async () => {
 
   const result = slot.use({
     key: {id: 1},
-    queryFn,
+    compute: queryFn,
     enabled: true,
   });
 
@@ -222,35 +219,35 @@ test('enabled prevents query from running', async () => {
 });
 
 test('use after dispose throws', async () => {
-  const slot = new QuerySlot<number>();
+  const slot = new AsyncMemo<number>();
 
   const queryFn = vi.fn().mockResolvedValue(42);
 
-  slot.use({key: {id: 1}, queryFn});
+  slot.use({key: {id: 1}, compute: queryFn});
   await flushPromises();
 
   slot.dispose();
 
-  expect(() => slot.use({key: {id: 1}, queryFn})).toThrow(
-    'QuerySlot.use() called after dispose()',
+  expect(() => slot.use({key: {id: 1}, compute: queryFn})).toThrow(
+    'AsyncMemo.use() called after dispose()',
   );
 });
 
 test('queued work is cancelled when slot is disposed', async () => {
-  const executor = new SerialTaskQueue();
-  const slot1 = new QuerySlot<number>(executor);
-  const slot2 = new QuerySlot<number>(executor);
+  const executor = new AtomicTaskQueue();
+  const slot1 = new AsyncMemo<number>(executor);
+  const slot2 = new AsyncMemo<number>(executor);
 
   // Start a slow query on slot1
   const queryFn1 = vi.fn().mockImplementation(async () => {
     await flushPromises();
     return 1;
   });
-  slot1.use({key: {id: 1}, queryFn: queryFn1});
+  slot1.use({key: {id: 1}, compute: queryFn1});
 
   // Queue work on slot2
   const queryFn2 = vi.fn().mockResolvedValue(2);
-  slot2.use({key: {id: 2}, queryFn: queryFn2});
+  slot2.use({key: {id: 2}, compute: queryFn2});
 
   // Dispose slot2 while its work is still queued
   slot2.dispose();
@@ -264,7 +261,7 @@ test('queued work is cancelled when slot is disposed', async () => {
 });
 
 test('AsyncDisposable is disposed before running next queryFn', async () => {
-  const slot = new QuerySlot<AsyncDisposable>();
+  const slot = new AsyncMemo<AsyncDisposable>();
 
   const events: string[] = [];
 
@@ -291,13 +288,13 @@ test('AsyncDisposable is disposed before running next queryFn', async () => {
   });
 
   // First query
-  slot.use({key: {id: 1}, queryFn: queryFn1});
+  slot.use({key: {id: 1}, compute: queryFn1});
   await flushPromises();
 
   expect(events).toEqual(['query1']);
 
   // Second query with different key - should dispose first before running second
-  slot.use({key: {id: 2}, queryFn: queryFn2});
+  slot.use({key: {id: 2}, compute: queryFn2});
   await flushPromises();
 
   expect(events).toEqual(['query1', 'dispose1', 'query2']);
@@ -305,7 +302,7 @@ test('AsyncDisposable is disposed before running next queryFn', async () => {
 });
 
 test('slot dispose calls AsyncDisposable dispose after in-flight task completes', async () => {
-  const slot = new QuerySlot<AsyncDisposable>();
+  const slot = new AsyncMemo<AsyncDisposable>();
 
   const events: string[] = [];
   let resolveQuery: () => void;
@@ -327,7 +324,7 @@ test('slot dispose calls AsyncDisposable dispose after in-flight task completes'
   });
 
   // Start query
-  slot.use({key: {id: 1}, queryFn});
+  slot.use({key: {id: 1}, compute: queryFn});
   await flushPromises();
 
   expect(events).toEqual(['query-start']);
@@ -351,7 +348,7 @@ test('slot dispose calls AsyncDisposable dispose after in-flight task completes'
 });
 
 test('cancellation signal is set when new query is scheduled', async () => {
-  const slot = new QuerySlot<number>();
+  const slot = new AsyncMemo<number>();
 
   const events: string[] = [];
   let query1Signal: {isCancelled: boolean} | undefined;
@@ -366,7 +363,7 @@ test('cancellation signal is set when new query is scheduled', async () => {
     await query1Promise;
     events.push(`query1-end (cancelled=${signal.isCancelled})`);
     if (Boolean(signal.isCancelled)) {
-      return QUERY_CANCELLED;
+      return TASK_CANCELLED;
     }
     return 1;
   });
@@ -377,14 +374,14 @@ test('cancellation signal is set when new query is scheduled', async () => {
   });
 
   // Start first query
-  slot.use({key: {id: 1}, queryFn: queryFn1});
+  slot.use({key: {id: 1}, compute: queryFn1});
   await flushPromises();
 
   expect(events).toEqual(['query1-start']);
   expect(query1Signal?.isCancelled).toBe(false);
 
   // Schedule second query while first is in-flight
-  slot.use({key: {id: 2}, queryFn: queryFn2});
+  slot.use({key: {id: 2}, compute: queryFn2});
 
   // First query's signal should now be cancelled
   expect(query1Signal?.isCancelled).toBe(true);
@@ -403,21 +400,21 @@ test('cancellation signal is set when new query is scheduled', async () => {
   ]);
 
   // Final result should be from query2
-  const result = slot.use({key: {id: 2}, queryFn: queryFn2});
+  const result = slot.use({key: {id: 2}, compute: queryFn2});
   expect(result.data).toBe(2);
 });
 
 test('QUERY_CANCELLED result is not cached', async () => {
-  const slot = new QuerySlot<number>();
+  const slot = new AsyncMemo<number>();
 
   // Query that always returns QUERY_CANCELLED
-  const queryFn = vi.fn().mockImplementation(async () => QUERY_CANCELLED);
+  const queryFn = vi.fn().mockImplementation(async () => TASK_CANCELLED);
 
-  slot.use({key: {id: 1}, queryFn});
+  slot.use({key: {id: 1}, compute: queryFn});
   await flushPromises();
 
   // Result should be undefined since QUERY_CANCELLED was returned
-  const result = slot.use({key: {id: 1}, queryFn});
+  const result = slot.use({key: {id: 1}, compute: queryFn});
   expect(result.data).toBeUndefined();
 
   // Wait for the second query to execute

--- a/ui/src/base/disposable.ts
+++ b/ui/src/base/disposable.ts
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function isDisposable(value: unknown): value is Disposable {
+  return (
+    value !== null &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    Symbol.dispose in value &&
+    typeof value[Symbol.dispose] === 'function'
+  );
+}
+
+export function isAsyncDisposable(value: unknown): value is AsyncDisposable {
+  return (
+    value !== null &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    Symbol.asyncDispose in value &&
+    typeof value[Symbol.asyncDispose] === 'function'
+  );
+}

--- a/ui/src/base/json_utils.ts
+++ b/ui/src/base/json_utils.ts
@@ -12,6 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// JSON-compatible types for use with stringifyJsonWithBigints and friends.
+export type JSONPrimitive =
+  string | number | boolean | null | undefined | bigint;
+export type JSONObject = {
+  [key: string]: JSONValue;
+};
+export type JSONValue = JSONPrimitive | JSONValue[] | JSONObject;
+export type NotAssignableToJson = symbol | Function;
+export type JSONCompatible<T> = unknown extends T
+  ? never
+  : {
+      [P in keyof T]: T[P] extends JSONValue
+        ? T[P]
+        : T[P] extends NotAssignableToJson
+          ? never
+          : JSONCompatible<T[P]>;
+    };
+
 // Similar to JSON.stringify() but supports bigints.
 // Bigints are simply serialized to a string, so the original object cannot be
 // recovered with JSON.parse(), as bigints will turn into strings.

--- a/ui/src/base/memo.ts
+++ b/ui/src/base/memo.ts
@@ -1,0 +1,123 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Memo: Synchronous memoization keyed by a JSON-serializable value.
+ *
+ * ## Why it exists
+ *
+ * Components often need to compute derived values that are expensive to
+ * calculate but stable across render cycles when inputs haven't changed.
+ * Memo provides a single-entry cache keyed by a JSON-serializable object:
+ * - Call `use()` every render cycle with the current key and compute function
+ * - Get back the cached value if the key hasn't changed
+ * - Recompute automatically when the key changes
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * class MyPanel implements m.ClassComponent<Attrs> {
+ *   private readonly computedCache = new Memo<MyData>();
+ *
+ *   view({attrs}: m.CVnode<Attrs>) {
+ *     const data = this.computedCache.use({
+ *       key: {filters: attrs.filters, count: this.count},
+ *       compute: () => expensiveCompute(attrs.filters, this.count),
+ *     });
+ *
+ *     return m('div', renderData(data));
+ *   }
+ * }
+ * ```
+ *
+ * ## Key concepts
+ *
+ * - **key**: JSON-serializable object identifying the computation. Changes
+ *   trigger a recompute. Supports primitives, arrays, objects, and bigints.
+ * - **compute**: Synchronous function that returns the value to cache.
+ *   Called only when the key changes.
+ * - **disposal**: Cached `Disposable` values are disposed when replaced,
+ *   invalidated, or when the memo itself is disposed.
+ */
+
+import {isDisposable} from './disposable';
+import {type JSONCompatible, stringifyJsonWithBigints} from './json_utils';
+
+export interface MemoOptions<T, K extends JSONCompatible<K>> {
+  /**
+   * JSON-serializable key identifying this computation.
+   * Changes to the key (compared via stringifyJsonWithBigints)
+   * trigger a recompute.
+   */
+  readonly key: K;
+  /**
+   * Synchronous function that computes the value.
+   * Called only when the key changes.
+   */
+  readonly compute: () => T;
+}
+
+interface Cache<T> {
+  readonly keyStr: string;
+  readonly value: T;
+}
+
+/**
+ * A single-entry synchronous memo cache.
+ *
+ * Created once per computed value on a component. Calls to `use()` with
+ * the same key return the cached result; key changes trigger a recompute.
+ * The memo owns cached `Disposable` values and disposes them when evicted.
+ */
+export class Memo<T> implements Disposable {
+  private cache?: Cache<T>;
+
+  use<K extends JSONCompatible<K>>(options: MemoOptions<T, K>): T {
+    const {key, compute} = options;
+    const keyStr = stringifyJsonWithBigints(key);
+
+    if (this.cache !== undefined && this.cache.keyStr === keyStr) {
+      return this.cache.value;
+    }
+
+    this.disposeCache();
+    const value = compute();
+    this.cache = {keyStr, value};
+    return value;
+  }
+
+  /**
+   * Clear and dispose the cached value, forcing the next use() to recompute.
+   */
+  invalidate(): void {
+    this.disposeCache();
+  }
+
+  /** Dispose the cached value. */
+  dispose(): void {
+    this[Symbol.dispose]();
+  }
+
+  [Symbol.dispose](): void {
+    this.disposeCache();
+  }
+
+  private disposeCache(): void {
+    const cache = this.cache;
+    this.cache = undefined;
+    if (cache !== undefined && isDisposable(cache.value)) {
+      cache.value[Symbol.dispose]();
+    }
+  }
+}

--- a/ui/src/base/memo_unittest.ts
+++ b/ui/src/base/memo_unittest.ts
@@ -1,0 +1,223 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Memo} from './memo';
+
+test('returns computed value on first call', () => {
+  const memo = new Memo<number>();
+  const compute = vi.fn(() => 42);
+
+  const result = memo.use({key: {id: 1}, compute});
+
+  expect(result).toBe(42);
+  expect(compute).toHaveBeenCalledTimes(1);
+});
+
+test('caches result for same key', () => {
+  const memo = new Memo<string>();
+  const compute = vi.fn(() => 'hello');
+
+  memo.use({key: {id: 1}, compute});
+  memo.use({key: {id: 1}, compute});
+  memo.use({key: {id: 1}, compute});
+
+  expect(compute).toHaveBeenCalledTimes(1);
+});
+
+test('recomputes when key changes', () => {
+  const memo = new Memo<string>();
+  let count = 0;
+  const compute = vi.fn(() => `v${++count}`);
+
+  expect(memo.use({key: {id: 1}, compute})).toBe('v1');
+  expect(memo.use({key: {id: 2}, compute})).toBe('v2');
+  expect(memo.use({key: {id: 3}, compute})).toBe('v3');
+
+  expect(compute).toHaveBeenCalledTimes(3);
+});
+
+test('different object references with same values are treated as equal', () => {
+  const memo = new Memo<number>();
+  const compute = vi.fn(() => 42);
+
+  memo.use({key: {a: 1, b: 'x'}, compute});
+  memo.use({key: {a: 1, b: 'x'}, compute});
+
+  expect(compute).toHaveBeenCalledTimes(1);
+});
+
+test('supports nested objects and arrays in key', () => {
+  const memo = new Memo<number>();
+  const compute = vi.fn(() => 1);
+
+  const key = {
+    filters: {name: 'foo', values: [1, 2, 3]},
+    nested: {deep: {value: true}},
+  };
+
+  memo.use({key, compute});
+  memo.use({key: {...key}, compute});
+  memo.use({key: structuredClone(key), compute});
+
+  expect(compute).toHaveBeenCalledTimes(1);
+});
+
+test('supports bigints in key', () => {
+  const memo = new Memo<string>();
+  const compute = vi.fn(() => 'ok');
+
+  memo.use({key: {ts: 123n, id: 1}, compute});
+  memo.use({key: {ts: 123n, id: 1}, compute});
+
+  expect(compute).toHaveBeenCalledTimes(1);
+
+  // Different bigint triggers recompute
+  memo.use({key: {ts: 456n, id: 1}, compute});
+  expect(compute).toHaveBeenCalledTimes(2);
+});
+
+test('invalidate clears the cache', () => {
+  const memo = new Memo<number>();
+  let count = 0;
+  const compute = vi.fn(() => ++count);
+
+  expect(memo.use({key: {id: 1}, compute})).toBe(1);
+  memo.invalidate();
+  expect(memo.use({key: {id: 1}, compute})).toBe(2);
+
+  expect(compute).toHaveBeenCalledTimes(2);
+});
+
+test('returns undefined when compute returns undefined', () => {
+  const memo = new Memo<string | undefined>();
+  const compute = vi.fn(() => undefined);
+
+  const result = memo.use({key: {id: 1}, compute});
+
+  expect(result).toBeUndefined();
+  expect(compute).toHaveBeenCalledTimes(1);
+
+  // Should still cache the undefined value
+  memo.use({key: {id: 1}, compute});
+  expect(compute).toHaveBeenCalledTimes(1);
+});
+
+test('uses latest compute function on key change', () => {
+  const memo = new Memo<number>();
+
+  let multiplier = 1;
+  expect(
+    memo.use({
+      key: {id: 1},
+      compute: () => 10 * multiplier,
+    }),
+  ).toBe(10);
+
+  multiplier = 2;
+  expect(
+    memo.use({
+      key: {id: 2},
+      compute: () => 10 * multiplier,
+    }),
+  ).toBe(20);
+});
+
+test('primitive keys work', () => {
+  const memo = new Memo<number>();
+  const compute = vi.fn(() => 42);
+
+  memo.use({key: 'simple', compute});
+  memo.use({key: 'simple', compute});
+  memo.use({key: 'different', compute});
+
+  expect(compute).toHaveBeenCalledTimes(2);
+});
+
+test('array keys work', () => {
+  const memo = new Memo<number>();
+  const compute = vi.fn(() => 42);
+
+  memo.use({key: [1, 2, 3], compute});
+  memo.use({key: [1, 2, 3], compute});
+  memo.use({key: [1, 2, 4], compute});
+
+  expect(compute).toHaveBeenCalledTimes(2);
+});
+
+test('null and undefined key fields are distinguished', () => {
+  const memo = new Memo<number>();
+  const compute = vi.fn(() => 42);
+
+  memo.use({key: {val: null}, compute});
+  memo.use({key: {val: null}, compute});
+  memo.use({key: {val: undefined}, compute});
+
+  expect(compute).toHaveBeenCalledTimes(2);
+});
+
+test('undefined key does not crash', () => {
+  const memo = new Memo();
+  memo.use({
+    key: undefined,
+    compute: () => {},
+  });
+});
+
+test('null key does not crash', () => {
+  const memo = new Memo();
+  memo.use({
+    key: null,
+    compute: () => {},
+  });
+});
+
+test('disposes cached value when key changes', () => {
+  const memo = new Memo<Disposable>();
+  const firstDispose = vi.fn();
+  const secondDispose = vi.fn();
+  const first = {[Symbol.dispose]: firstDispose};
+  const second = {[Symbol.dispose]: secondDispose};
+
+  memo.use({key: 1, compute: () => first});
+  memo.use({key: 1, compute: () => first});
+  expect(firstDispose).not.toHaveBeenCalled();
+
+  memo.use({key: 2, compute: () => second});
+  expect(firstDispose).toHaveBeenCalledOnce();
+  expect(secondDispose).not.toHaveBeenCalled();
+});
+
+test('invalidate disposes the cached value', () => {
+  const memo = new Memo<Disposable>();
+  const dispose = vi.fn();
+
+  memo.use({key: 1, compute: () => ({[Symbol.dispose]: dispose})});
+  memo.invalidate();
+  memo.invalidate();
+
+  expect(dispose).toHaveBeenCalledOnce();
+});
+
+test('dispose clears the cache and allows reuse', () => {
+  const memo = new Memo<Disposable>();
+  const firstDispose = vi.fn();
+  const second = {[Symbol.dispose]: vi.fn()};
+
+  memo.use({key: 1, compute: () => ({[Symbol.dispose]: firstDispose})});
+  memo.dispose();
+  memo.dispose();
+
+  expect(firstDispose).toHaveBeenCalledOnce();
+  expect(memo.use({key: 1, compute: () => second})).toBe(second);
+});

--- a/ui/src/bigtrace/query/bigtrace_async_data_source.ts
+++ b/ui/src/bigtrace/query/bigtrace_async_data_source.ts
@@ -19,7 +19,7 @@ import type {
 } from '../../components/widgets/datagrid/data_source';
 import type {Filter} from '../../components/widgets/datagrid/model';
 import type {Row, SqlValue} from '../../trace_processor/query_result';
-import type {QueryResult} from '../../base/query_slot';
+import type {AsyncMemoResult} from '../../base/async_memo';
 import {
   type BigtraceQueryClient,
   BigtraceHttpError,
@@ -239,22 +239,22 @@ export class BigtraceAsyncDataSource implements DataSource {
     return this.columns;
   }
 
-  useAggregateSummaries(_model: DataSourceModel): QueryResult<Row> {
-    return {data: undefined, isPending: false, isFresh: true};
+  useAggregateSummaries(_model: DataSourceModel): AsyncMemoResult<Row> {
+    return {data: {}, isPending: false};
   }
 
   useDistinctValues(
     _column: string | undefined,
-  ): QueryResult<readonly SqlValue[]> {
+  ): AsyncMemoResult<readonly SqlValue[]> {
     // `data: []` (not `undefined`) avoids a permanent "Loading…" in the
     // column-filter "Equals" submenu. Cell-context menu filtering still works.
-    return {data: [], isPending: false, isFresh: true};
+    return {data: [], isPending: false};
   }
 
   useParameterKeys(
     _prefix: string | undefined,
-  ): QueryResult<readonly string[]> {
-    return {data: undefined, isPending: false, isFresh: true};
+  ): AsyncMemoResult<readonly string[]> {
+    return {data: [], isPending: false};
   }
 
   async exportData(_model: DataSourceModel): Promise<readonly Row[]> {

--- a/ui/src/bigtrace/query/bigtrace_trace_list_data_source.ts
+++ b/ui/src/bigtrace/query/bigtrace_trace_list_data_source.ts
@@ -19,7 +19,7 @@ import type {
 } from '../../components/widgets/datagrid/data_source';
 import type {Filter} from '../../components/widgets/datagrid/model';
 import type {Row, SqlValue} from '../../trace_processor/query_result';
-import type {QueryResult} from '../../base/query_slot';
+import type {AsyncMemoResult} from '../../base/async_memo';
 import type {SettingFilter} from '../settings/settings_types';
 import {
   type BigtraceQueryClient,
@@ -223,22 +223,22 @@ export class BigtraceTraceListDataSource implements DataSource {
     return this.columns;
   }
 
-  useAggregateSummaries(_model: DataSourceModel): QueryResult<Row> {
-    return {data: undefined, isPending: false, isFresh: true};
+  useAggregateSummaries(_model: DataSourceModel): AsyncMemoResult<Row> {
+    return {data: {}, isPending: false};
   }
 
   useDistinctValues(
     _column: string | undefined,
-  ): QueryResult<readonly SqlValue[]> {
+  ): AsyncMemoResult<readonly SqlValue[]> {
     // `data: []` (not undefined) keeps the column-filter "Equals" submenu from
     // sticking on "Loading…"; cell-context-menu filtering still works.
-    return {data: [], isPending: false, isFresh: true};
+    return {data: [], isPending: false};
   }
 
   useParameterKeys(
     _prefix: string | undefined,
-  ): QueryResult<readonly string[]> {
-    return {data: undefined, isPending: false, isFresh: true};
+  ): AsyncMemoResult<readonly string[]> {
+    return {data: [], isPending: false};
   }
 
   async exportData(_model: DataSourceModel): Promise<readonly Row[]> {

--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -43,7 +43,7 @@ import {
 } from '../trace_processor/sql_utils';
 import type {DataGridApi} from './widgets/datagrid/datagrid';
 import {ExportButton} from '../widgets/export_button';
-import {SerialTaskQueue} from '../base/query_slot';
+import {AtomicTaskQueue} from '../base/async_memo';
 import type {ColumnSchema} from './widgets/datagrid/datagrid_schema';
 
 export interface AggregationData {
@@ -226,7 +226,7 @@ export function createAggregationTab(
   priority: number = 0,
 ): AreaSelectionTab {
   const limiter = new AsyncLimiter();
-  const queue = new SerialTaskQueue();
+  const queue = new AtomicTaskQueue();
   let currentSelection: AreaSelection | undefined;
   let aggregation: Aggregation | undefined;
   let data: AggregationData | undefined;

--- a/ui/src/components/distribution_panel.ts
+++ b/ui/src/components/distribution_panel.ts
@@ -14,7 +14,7 @@
 
 import './distribution_panel.scss';
 import m from 'mithril';
-import {QuerySlot} from '../base/query_slot';
+import {AsyncMemo} from '../base/async_memo';
 import {Icons} from '../base/semantic_icons';
 import type {Trace} from '../public/trace';
 import type {Dataset, DatasetSchema} from '../trace_processor/dataset';
@@ -193,9 +193,9 @@ export interface DistributionSummaryAttrs extends DistributionInputs {
 // the filtered dataset as a Perfetto table so the histogram and stats share
 // a single aggregation source.
 export class DistributionSummary implements m.ClassComponent<DistributionSummaryAttrs> {
-  private readonly tableSlot = new QuerySlot<DisposableSqlEntity>();
-  private readonly boundsSlot = new QuerySlot<NiceBuckets>();
-  private readonly statsSlot = new QuerySlot<DistributionStats>();
+  private readonly tableSlot = new AsyncMemo<DisposableSqlEntity>();
+  private readonly boundsSlot = new AsyncMemo<NiceBuckets>();
+  private readonly statsSlot = new AsyncMemo<DistributionStats>();
 
   private histogramLoader?: SQLHistogramLoader;
   private histogramLoaderTableName?: string;
@@ -208,11 +208,11 @@ export class DistributionSummary implements m.ClassComponent<DistributionSummary
     const tableName = tableEntity.name;
     const bounds = this.boundsSlot.use({
       key: {tableName, valueColumn: attrs.valueColumn},
-      queryFn: () => fetchBounds(attrs, tableName),
+      compute: () => fetchBounds(attrs, tableName),
     });
     const stats = this.statsSlot.use({
       key: {tableName, brush: attrs.brush},
-      queryFn: () => fetchStats(attrs, tableName),
+      compute: () => fetchStats(attrs, tableName),
       retainOn: ['brush'],
     });
     const histogram = this.useHistogramLoader(attrs, tableName, bounds.data);
@@ -238,7 +238,7 @@ export class DistributionSummary implements m.ClassComponent<DistributionSummary
     const sourceQuery = buildSourceQuery(attrs, [attrs.valueColumn]);
     return this.tableSlot.use({
       key: {sourceQuery},
-      queryFn: () =>
+      compute: () =>
         createPerfettoTable({engine: attrs.trace.engine, as: sourceQuery}),
     }).data;
   }
@@ -364,7 +364,7 @@ export interface DistributionPanelAttrs extends DistributionInputs {
 // Two-pane "value distribution" tab: instances grid + histogram summary,
 // both reading from a single materialized Perfetto table.
 export class DistributionPanel implements m.ClassComponent<DistributionPanelAttrs> {
-  private readonly tableSlot = new QuerySlot<DisposableSqlEntity>();
+  private readonly tableSlot = new AsyncMemo<DisposableSqlEntity>();
 
   private dataSource?: SQLDataSource;
   private dataSourceTableName?: string;
@@ -441,7 +441,7 @@ export class DistributionPanel implements m.ClassComponent<DistributionPanelAttr
     ]);
     return this.tableSlot.use({
       key: {sourceQuery},
-      queryFn: () =>
+      compute: () =>
         createPerfettoTable({engine: attrs.trace.engine, as: sourceQuery}),
     }).data;
   }

--- a/ui/src/components/tracks/counter_track.ts
+++ b/ui/src/components/tracks/counter_track.ts
@@ -22,10 +22,10 @@ import type {Point2D} from '../../base/geom';
 import {formatNumber} from '../../base/number_format';
 import {
   type CancellationSignal,
-  QUERY_CANCELLED,
-  QuerySlot,
-  SerialTaskQueue,
-} from '../../base/query_slot';
+  TASK_CANCELLED,
+  AsyncMemo,
+  AtomicTaskQueue,
+} from '../../base/async_memo';
 import {Icons} from '../../base/semantic_icons';
 import type {duration, time} from '../../base/time';
 import type {TimeScale} from '../../base/time_scale';
@@ -268,10 +268,10 @@ export interface CounterTrackAttrs {
 
 export class CounterTrack implements TrackRenderer {
   // QuerySlot infrastructure
-  private readonly queue = new SerialTaskQueue();
-  private readonly initSlot = new QuerySlot<AsyncDisposable | void>(this.queue);
-  private readonly tableSlot = new QuerySlot<MipmapTableResult>(this.queue);
-  private readonly dataSlot = new QuerySlot<DataFrame>(this.queue);
+  private readonly queue = new AtomicTaskQueue();
+  private readonly initSlot = new AsyncMemo<AsyncDisposable | void>(this.queue);
+  private readonly tableSlot = new AsyncMemo<MipmapTableResult>(this.queue);
+  private readonly dataSlot = new AsyncMemo<DataFrame>(this.queue);
 
   // Buffered bounds tracking
   private readonly bufferedBounds = new BufferedBounds();
@@ -649,7 +649,7 @@ export class CounterTrack implements TrackRenderer {
     // Step 0: Call onInit with a constant key
     const initResult = this.initSlot.use({
       key: {init: true},
-      queryFn: () => this.onInitFn?.() ?? Promise.resolve(),
+      compute: () => this.onInitFn?.() ?? Promise.resolve(),
     });
 
     if (initResult.isPending) {
@@ -665,7 +665,7 @@ export class CounterTrack implements TrackRenderer {
         yMode,
         yDisplay,
       },
-      queryFn: () => this.createMipmapTable(),
+      compute: () => this.createMipmapTable(),
     });
 
     const table = tableResult.data;
@@ -691,7 +691,7 @@ export class CounterTrack implements TrackRenderer {
         yMode,
         yDisplay,
       },
-      queryFn: async (signal) => {
+      compute: async (signal) => {
         return await this.trace.taskTracker.track(
           this.fetchCounterData(
             table.tableName,
@@ -908,7 +908,7 @@ export class CounterTrack implements TrackRenderer {
       );
     `);
 
-    if (signal.isCancelled) throw QUERY_CANCELLED;
+    if (signal.isCancelled) throw TASK_CANCELLED;
 
     const priority = CHUNKED_TASK_BACKGROUND_PRIORITY.get()
       ? 'background'
@@ -932,7 +932,7 @@ export class CounterTrack implements TrackRenderer {
     let max = 0;
 
     for (let row = 0; it.valid(); it.next(), row++) {
-      if (signal.isCancelled) throw QUERY_CANCELLED;
+      if (signal.isCancelled) throw TASK_CANCELLED;
       if (row % 50 === 0 && task.shouldYield()) {
         await task.yield();
       }

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -26,10 +26,10 @@ import {ensureExists} from '../../base/assert';
 import {Monitor} from '../../base/monitor';
 import {
   type CancellationSignal,
-  QuerySlot,
-  QUERY_CANCELLED,
-  SerialTaskQueue,
-} from '../../base/query_slot';
+  AsyncMemo,
+  TASK_CANCELLED,
+  AtomicTaskQueue,
+} from '../../base/async_memo';
 import {type duration, Time, type time} from '../../base/time';
 import type {TimeScale} from '../../base/time_scale';
 import {clamp, floatEqual} from '../../base/math_utils';
@@ -333,9 +333,9 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
   private sliceLayout: SliceLayout;
   private readonly attrs: SliceTrackAttrs<T>;
   private readonly instantWidthPx: number;
-  private readonly queue = new SerialTaskQueue();
-  private readonly tablesSlot = new QuerySlot<Tables>(this.queue);
-  private readonly dataFrameSlot = new QuerySlot<DataFrame<T>>(this.queue);
+  private readonly queue = new AtomicTaskQueue();
+  private readonly tablesSlot = new AsyncMemo<Tables>(this.queue);
+  private readonly dataFrameSlot = new AsyncMemo<DataFrame<T>>(this.queue);
   private readonly bufferedBounds = new BufferedBounds();
   private readonly hoverMonitor = new Monitor([() => this.hoveredSlice?.id]);
 
@@ -810,7 +810,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     // 1. Create the mipmap tables which only depend on the sql query source
     const {data: tables} = this.tablesSlot.use({
       key: {sqlSource},
-      queryFn: () => this.createTables(sqlSource),
+      compute: () => this.createTables(sqlSource),
     });
 
     // Can't do anything until we have the tables.
@@ -832,7 +832,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
         resolution: bounds.resolution,
         key: this.attrs.getKey?.(),
       },
-      queryFn: async (signal) => {
+      compute: async (signal) => {
         const promise = (async () => {
           // Load complete and incomplete slices in a single query
           const instants = await this.getInstantBuffers(
@@ -902,7 +902,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
       CROSS JOIN (${sqlSource}) s using (id)
     `);
 
-    if (signal.isCancelled) throw QUERY_CANCELLED;
+    if (signal.isCancelled) throw TASK_CANCELLED;
     const task = await this.deferChunkedTask();
 
     // Initialize buffers
@@ -921,7 +921,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
     for (let i = 0; it.valid(); it.next(), ++i) {
       if (i % 64 === 0) {
-        if (signal.isCancelled) throw QUERY_CANCELLED;
+        if (signal.isCancelled) throw TASK_CANCELLED;
         if (task.shouldYield()) await task.yield();
       }
 
@@ -1004,7 +1004,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
       WHERE i.ts < ${end} AND IFNULL(i.next_ts, ${end}) > ${start}
     `);
 
-    if (signal.isCancelled) throw QUERY_CANCELLED;
+    if (signal.isCancelled) throw TASK_CANCELLED;
     const task = await this.deferChunkedTask();
 
     const count = sliceQueryRes.numRows();
@@ -1026,7 +1026,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
     for (let i = 0; it.valid(); it.next(), ++i) {
       if (i % 64 === 0) {
-        if (signal.isCancelled) throw QUERY_CANCELLED;
+        if (signal.isCancelled) throw TASK_CANCELLED;
         if (task.shouldYield()) await task.yield();
       }
 

--- a/ui/src/components/widgets/charts/boxplot_loader.ts
+++ b/ui/src/components/widgets/charts/boxplot_loader.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {QuerySlot, type QueryResult} from '../../../base/query_slot';
+import {AsyncMemo, type AsyncMemoResult} from '../../../base/async_memo';
 import type {Engine} from '../../../trace_processor/engine';
 import {NUM, STR} from '../../../trace_processor/query_result';
 import type {BoxplotData} from './boxplot';
@@ -58,7 +58,7 @@ export class SQLBoxplotLoader {
   private readonly query: string;
   private readonly categoryColumn: string;
   private readonly valueColumn: string;
-  private readonly querySlot = new QuerySlot<BoxplotData>();
+  private readonly querySlot = new AsyncMemo<BoxplotData>();
 
   constructor(opts: SQLBoxplotLoaderOpts) {
     validateColumnName(opts.categoryColumn);
@@ -69,7 +69,7 @@ export class SQLBoxplotLoader {
     this.valueColumn = opts.valueColumn;
   }
 
-  use(config: BoxplotLoaderConfig): QueryResult<BoxplotData> {
+  use(config: BoxplotLoaderConfig): AsyncMemoResult<BoxplotData> {
     const limit = config.limit ?? 20;
     const cat = this.categoryColumn;
     const val = this.valueColumn;
@@ -124,7 +124,7 @@ LIMIT ${limit}`.trim();
     return this.querySlot.use({
       key: {sql},
       retainOn: ['sql'],
-      queryFn: async () => {
+      compute: async () => {
         const queryResult = await this.engine.query(sql);
         const items = [];
 

--- a/ui/src/components/widgets/charts/chart_sql_source.ts
+++ b/ui/src/components/widgets/charts/chart_sql_source.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {assertUnreachable} from '../../../base/assert';
-import {QuerySlot} from '../../../base/query_slot';
+import {AsyncMemo} from '../../../base/async_memo';
 import type {Engine} from '../../../trace_processor/engine';
 import type {QueryResult as TPQueryResult} from '../../../trace_processor/query_result';
 import type {Filter} from '../datagrid/model';
@@ -691,7 +691,7 @@ export interface ChartLoaderResult<TData> {
 export abstract class SQLChartLoader<TConfig, TData> {
   private readonly engine: Engine;
   protected readonly source: ChartSource;
-  private readonly querySlot = new QuerySlot<TData>();
+  private readonly querySlot = new AsyncMemo<TData>();
 
   constructor(engine: Engine, source: ChartSource) {
     this.engine = engine;
@@ -705,7 +705,7 @@ export abstract class SQLChartLoader<TConfig, TData> {
     const key = {sql, ...extra};
     const result = this.querySlot.use({
       key,
-      queryFn: async () => {
+      compute: async () => {
         const queryResult = await this.engine.query(sql);
         return this.parseResult(queryResult, config);
       },

--- a/ui/src/components/widgets/charts/heatmap_loader.ts
+++ b/ui/src/components/widgets/charts/heatmap_loader.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {QuerySlot, type QueryResult} from '../../../base/query_slot';
+import {AsyncMemo, type AsyncMemoResult} from '../../../base/async_memo';
 import type {Engine} from '../../../trace_processor/engine';
 import {
   NUM,
@@ -70,7 +70,7 @@ export class SQLHeatmapLoader {
   private readonly xColumn: string;
   private readonly yColumn: string;
   private readonly valueColumn: string;
-  private readonly querySlot = new QuerySlot<HeatmapData>();
+  private readonly querySlot = new AsyncMemo<HeatmapData>();
 
   constructor(opts: SQLHeatmapLoaderOpts) {
     validateColumnName(opts.xColumn);
@@ -83,7 +83,7 @@ export class SQLHeatmapLoader {
     this.valueColumn = opts.valueColumn;
   }
 
-  use(config: HeatmapLoaderConfig): QueryResult<HeatmapData> {
+  use(config: HeatmapLoaderConfig): AsyncMemoResult<HeatmapData> {
     const agg = config.aggregation ?? 'SUM';
     const xLimit = config.xLimit ?? 20;
     const yLimit = config.yLimit ?? 20;
@@ -122,7 +122,7 @@ ORDER BY _x, _y`.trim();
     return this.querySlot.use({
       key: {sql},
       retainOn: ['sql'],
-      queryFn: async () => {
+      compute: async () => {
         const queryResult = await this.engine.query(sql);
         return parseHeatmapResult(queryResult);
       },

--- a/ui/src/components/widgets/datagrid/data_source.ts
+++ b/ui/src/components/widgets/datagrid/data_source.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type {QueryResult} from '../../../base/query_slot';
+import type {AsyncMemoResult} from '../../../base/async_memo';
 import type {Row, SqlValue} from '../../../trace_processor/query_result';
 import type {AggregateFunction, Filter, GroupPath, IdBasedTree} from './model';
 
@@ -21,7 +21,7 @@ import type {AggregateFunction, Filter, GroupPath, IdBasedTree} from './model';
  *
  * Uses a slot-like API where each use* method:
  * - Takes the current model/parameters
- * - Returns the current state (data, isPending, isFresh)
+ * - Returns the current state (data, isPending)
  * - Automatically schedules fetches when parameters change
  *
  * Call these methods on every render cycle - they handle caching internally.
@@ -37,7 +37,7 @@ export interface DataSource {
    * Fetch aggregate summaries (aggregates across all filtered rows).
    * Returns summaries for columns with aggregate functions or pivot aggregates.
    */
-  useAggregateSummaries(model: DataSourceModel): QueryResult<Row>;
+  useAggregateSummaries(model: DataSourceModel): AsyncMemoResult<Row>;
 
   /**
    * Fetch distinct values for a column (for filter dropdowns).
@@ -45,13 +45,15 @@ export interface DataSource {
    */
   useDistinctValues(
     column: string | undefined,
-  ): QueryResult<readonly SqlValue[]>;
+  ): AsyncMemoResult<readonly SqlValue[]>;
 
   /**
    * Fetch parameter keys for a parameterized column prefix (e.g., 'args' -> ['foo', 'bar']).
    * Pass undefined to skip fetching.
    */
-  useParameterKeys(prefix: string | undefined): QueryResult<readonly string[]>;
+  useParameterKeys(
+    prefix: string | undefined,
+  ): AsyncMemoResult<readonly string[]>;
 
   /**
    * Export all data with current filters/sorting applied (no pagination).

--- a/ui/src/components/widgets/datagrid/in_memory_data_source.ts
+++ b/ui/src/components/widgets/datagrid/in_memory_data_source.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type {QueryResult} from '../../../base/query_slot';
+import type {AsyncMemoResult} from '../../../base/async_memo';
 import {stringifyJsonWithBigints} from '../../../base/json_utils';
 import {assertUnreachable} from '../../../base/assert';
 import type {Row, SqlValue} from '../../../trace_processor/query_result';
@@ -106,9 +106,9 @@ export class InMemoryDataSource implements DataSource {
    */
   useDistinctValues(
     column: string | undefined,
-  ): QueryResult<readonly SqlValue[]> {
+  ): AsyncMemoResult<readonly SqlValue[]> {
     if (column === undefined) {
-      return {data: undefined, isPending: false, isFresh: true};
+      return {data: [], isPending: false};
     }
 
     if (!this.distinctValuesCache.has(column)) {
@@ -144,18 +144,19 @@ export class InMemoryDataSource implements DataSource {
     }
 
     return {
-      data: this.distinctValuesCache.get(column),
+      data: this.distinctValuesCache.get(column) ?? [],
       isPending: false,
-      isFresh: true,
     };
   }
 
   /**
    * Fetch parameter keys for a parameterized column prefix.
    */
-  useParameterKeys(prefix: string | undefined): QueryResult<readonly string[]> {
+  useParameterKeys(
+    prefix: string | undefined,
+  ): AsyncMemoResult<readonly string[]> {
     if (prefix === undefined) {
-      return {data: undefined, isPending: false, isFresh: true};
+      return {data: [], isPending: false};
     }
 
     if (!this.parameterKeysCache.has(prefix)) {
@@ -183,26 +184,21 @@ export class InMemoryDataSource implements DataSource {
     }
 
     return {
-      data: this.parameterKeysCache.get(prefix),
+      data: this.parameterKeysCache.get(prefix) ?? [],
       isPending: false,
-      isFresh: true,
     };
   }
 
   /**
    * Fetch aggregate summaries (aggregates across all filtered rows).
    */
-  useAggregateSummaries(_model: DataSourceModel): QueryResult<Row> {
+  useAggregateSummaries(_model: DataSourceModel): AsyncMemoResult<Row> {
     // Aggregates are computed in useRows, just return the cache
-    const data =
-      Object.keys(this.aggregateSummariesCache).length > 0
-        ? this.aggregateSummariesCache
-        : undefined;
+    const data = this.aggregateSummariesCache;
 
     return {
       data,
       isPending: false,
-      isFresh: true,
     };
   }
 

--- a/ui/src/components/widgets/datagrid/sql_data_source.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source.ts
@@ -14,10 +14,10 @@
 
 import {assertUnreachable} from '../../../base/assert';
 import {
-  type QueryResult,
-  QuerySlot,
-  SerialTaskQueue,
-} from '../../../base/query_slot';
+  type AsyncMemoResult,
+  AsyncMemo,
+  AtomicTaskQueue,
+} from '../../../base/async_memo';
 import {maybeUndefined} from '../../../base/utils';
 import {shortUuid} from '../../../base/uuid';
 import type {Engine} from '../../../trace_processor/engine';
@@ -39,7 +39,7 @@ import {SQLDataSourceTree} from './sql_data_source/tree';
 export interface DatagridEngineSQLConfig extends SQLTableSchema {
   readonly engine: Engine;
   readonly preamble?: string;
-  readonly queue?: SerialTaskQueue;
+  readonly queue?: AtomicTaskQueue;
 }
 
 /**
@@ -54,19 +54,19 @@ export class SQLDataSource implements DataSource {
   private readonly flatEngine: SQLDataSourceFlat;
   private readonly pivotEngine: SQLDataSourcePivot;
   private readonly treeEngine: SQLDataSourceTree;
-  private readonly queue: SerialTaskQueue;
-  private readonly preambleSlot: QuerySlot<void>;
-  private readonly distinctValuesSlot: QuerySlot<readonly SqlValue[]>;
-  private readonly parameterKeysSlot: QuerySlot<readonly string[]>;
+  private readonly queue: AtomicTaskQueue;
+  private readonly preambleSlot: AsyncMemo<void>;
+  private readonly distinctValuesSlot: AsyncMemo<readonly SqlValue[]>;
+  private readonly parameterKeysSlot: AsyncMemo<readonly string[]>;
 
   constructor(config: DatagridEngineSQLConfig) {
     this.engine = config.engine;
     this.sqlSchema = config;
     this.preamble = config.preamble;
-    this.queue = config.queue ?? new SerialTaskQueue();
-    this.preambleSlot = new QuerySlot<void>(this.queue);
-    this.distinctValuesSlot = new QuerySlot<readonly SqlValue[]>(this.queue);
-    this.parameterKeysSlot = new QuerySlot<readonly string[]>(this.queue);
+    this.queue = config.queue ?? new AtomicTaskQueue();
+    this.preambleSlot = new AsyncMemo<void>(this.queue);
+    this.distinctValuesSlot = new AsyncMemo<readonly SqlValue[]>(this.queue);
+    this.parameterKeysSlot = new AsyncMemo<readonly string[]>(this.queue);
     const uuid = shortUuid();
 
     this.flatEngine = new SQLDataSourceFlat(
@@ -121,7 +121,7 @@ export class SQLDataSource implements DataSource {
   /**
    * Fetch aggregate summaries (aggregates across all filtered rows).
    */
-  useAggregateSummaries(model: DataSourceModel): QueryResult<Row> {
+  useAggregateSummaries(model: DataSourceModel): AsyncMemoResult<Row> {
     const mode = model.mode;
     switch (mode) {
       case 'flat':
@@ -140,16 +140,19 @@ export class SQLDataSource implements DataSource {
    */
   useDistinctValues(
     column: string | undefined,
-  ): QueryResult<readonly SqlValue[]> {
+  ): AsyncMemoResult<readonly SqlValue[]> {
     const {isPending: preamblePending} = this.usePreamble();
 
-    if (column === undefined || preamblePending) {
-      return {data: undefined, isPending: preamblePending, isFresh: true};
+    if (column === undefined) {
+      return {data: [], isPending: false};
+    }
+    if (preamblePending) {
+      return {isPending: true};
     }
 
     return this.distinctValuesSlot.use({
       key: column,
-      queryFn: async () => {
+      compute: async () => {
         const resolver = new SQLSchemaResolver(this.sqlSchema);
         const sqlExpr = resolver.resolveColumnPath(column);
         if (sqlExpr === undefined) {
@@ -180,16 +183,21 @@ export class SQLDataSource implements DataSource {
   /**
    * Fetch parameter keys for a parameterized column prefix (e.g., 'args' -> ['foo', 'bar']).
    */
-  useParameterKeys(prefix: string | undefined): QueryResult<readonly string[]> {
+  useParameterKeys(
+    prefix: string | undefined,
+  ): AsyncMemoResult<readonly string[]> {
     const {isPending: preamblePending} = this.usePreamble();
 
-    if (prefix === undefined || preamblePending) {
-      return {data: undefined, isPending: preamblePending, isFresh: true};
+    if (prefix === undefined) {
+      return {data: [], isPending: false};
+    }
+    if (preamblePending) {
+      return {isPending: true};
     }
 
     return this.parameterKeysSlot.use({
       key: prefix,
-      queryFn: async () => {
+      compute: async () => {
         const colDef = maybeUndefined(this.sqlSchema.columns?.[prefix]);
         if (
           !colDef ||
@@ -257,10 +265,10 @@ export class SQLDataSource implements DataSource {
   /**
    * Run the preamble query if configured. Returns pending status.
    */
-  private usePreamble(): QueryResult<void> {
+  private usePreamble(): AsyncMemoResult<void> {
     return this.preambleSlot.use({
       key: {preamble: this.preamble ?? ''},
-      queryFn: async () => {
+      compute: async () => {
         if (this.preamble) {
           await this.engine.query(this.preamble);
         }

--- a/ui/src/components/widgets/datagrid/sql_data_source/flat.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/flat.ts
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import {
-  type QueryResult,
-  QuerySlot,
-  type SerialTaskQueue,
-} from '../../../../base/query_slot';
+  type AsyncMemoResult,
+  AsyncMemo,
+  type AtomicTaskQueue,
+} from '../../../../base/async_memo';
 import type {Engine} from '../../../../trace_processor/engine';
 import {NUM, type Row} from '../../../../trace_processor/query_result';
 import {runQueryForQueryTable} from '../../../query_table/queries';
@@ -25,30 +25,30 @@ import {type SQLTableSchema, SQLSchemaResolver} from '../sql_schema';
 import {filterToSql, quoteIdentifier} from '../sql_utils';
 
 export class SQLDataSourceFlat {
-  private readonly rowCountSlot: QuerySlot<number>;
-  private readonly rowsSlot: QuerySlot<{
+  private readonly rowCountSlot: AsyncMemo<number>;
+  private readonly rowsSlot: AsyncMemo<{
     readonly rows: readonly Row[];
     readonly rowOffset: number;
   }>;
-  private readonly summariesSlot: QuerySlot<Row>;
+  private readonly summariesSlot: AsyncMemo<Row>;
 
   constructor(
-    queue: SerialTaskQueue,
+    queue: AtomicTaskQueue,
     private readonly engine: Engine,
     private readonly sqlSchema: SQLTableSchema,
   ) {
-    this.rowCountSlot = new QuerySlot<number>(queue);
-    this.rowsSlot = new QuerySlot<{
+    this.rowCountSlot = new AsyncMemo<number>(queue);
+    this.rowsSlot = new AsyncMemo<{
       readonly rows: readonly Row[];
       readonly rowOffset: number;
     }>(queue);
-    this.summariesSlot = new QuerySlot<Row>(queue);
+    this.summariesSlot = new AsyncMemo<Row>(queue);
   }
 
   /**
    * Returns aggregate summaries for columns that have an aggregate function defined.
    */
-  getSummaries(model: FlatModel): QueryResult<Row> {
+  getSummaries(model: FlatModel): AsyncMemoResult<Row> {
     const {columns, filters = []} = model;
 
     // Find columns with aggregate functions
@@ -56,7 +56,7 @@ export class SQLDataSourceFlat {
 
     // If no aggregate columns, return empty result
     if (aggColumns.length === 0) {
-      return {data: undefined, isPending: false, isFresh: true};
+      return {data: {}, isPending: false};
     }
 
     return this.summariesSlot.use({
@@ -64,7 +64,7 @@ export class SQLDataSourceFlat {
         columns: aggColumns,
         filters: serializeFilters(filters),
       },
-      queryFn: async () => {
+      compute: async () => {
         const resolver = new SQLSchemaResolver(this.sqlSchema);
 
         // Build aggregate expressions
@@ -98,7 +98,7 @@ export class SQLDataSourceFlat {
         columns,
         filters: serializeFilters(filters),
       },
-      queryFn: async () => {
+      compute: async () => {
         const query = buildQuery(this.sqlSchema, {
           mode: 'flat',
           columns,
@@ -119,7 +119,7 @@ export class SQLDataSourceFlat {
         sort,
       },
       retainOn: ['pagination', 'sort'],
-      queryFn: async () => {
+      compute: async () => {
         const query = buildQuery(this.sqlSchema, model);
         const result = await runQueryForQueryTable(query, this.engine);
         const rows = result.rows;

--- a/ui/src/components/widgets/datagrid/sql_data_source/group_by.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/group_by.ts
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import {
-  type QueryResult,
-  QuerySlot,
-  type SerialTaskQueue,
-} from '../../../../base/query_slot';
+  type AsyncMemoResult,
+  AsyncMemo,
+  type AtomicTaskQueue,
+} from '../../../../base/async_memo';
 import type {Engine} from '../../../../trace_processor/engine';
 import {NUM, type Row} from '../../../../trace_processor/query_result';
 import {runQueryForQueryTable} from '../../../query_table/queries';
@@ -26,24 +26,24 @@ import {filterToSql, quoteIdentifier, sqlAggregateExpr} from '../sql_utils';
 
 // Flat GROUP BY datasource - uses simple GROUP BY queries without hierarchy.
 export class SQLDataSourceGroupBy {
-  private readonly rowCountSlot: QuerySlot<number>;
-  private readonly rowsSlot: QuerySlot<{
+  private readonly rowCountSlot: AsyncMemo<number>;
+  private readonly rowsSlot: AsyncMemo<{
     readonly rows: readonly Row[];
     readonly rowOffset: number;
   }>;
-  private readonly summariesSlot: QuerySlot<Row>;
+  private readonly summariesSlot: AsyncMemo<Row>;
 
   constructor(
-    queue: SerialTaskQueue,
+    queue: AtomicTaskQueue,
     private readonly engine: Engine,
     private readonly sqlSchema: SQLTableSchema,
   ) {
-    this.rowCountSlot = new QuerySlot<number>(queue);
-    this.rowsSlot = new QuerySlot<{
+    this.rowCountSlot = new AsyncMemo<number>(queue);
+    this.rowsSlot = new AsyncMemo<{
       readonly rows: readonly Row[];
       readonly rowOffset: number;
     }>(queue);
-    this.summariesSlot = new QuerySlot<Row>(queue);
+    this.summariesSlot = new AsyncMemo<Row>(queue);
   }
 
   getRows(model: PivotModel): DataSourceRows {
@@ -57,7 +57,7 @@ export class SQLDataSourceGroupBy {
 
     const rowCountResult = this.rowCountSlot.use({
       key: queryKey,
-      queryFn: async () => {
+      compute: async () => {
         const query = this.buildGroupByQuery(model, {countOnly: true});
         const result = await this.engine.query(query);
         return result.firstRow({count: NUM}).count;
@@ -67,7 +67,7 @@ export class SQLDataSourceGroupBy {
     const rowsResult = this.rowsSlot.use({
       key: {...queryKey, pagination, sort},
       retainOn: ['pagination', 'sort'],
-      queryFn: async () => {
+      compute: async () => {
         const query = this.buildGroupByQuery(model);
         const result = await runQueryForQueryTable(query, this.engine);
         return {
@@ -85,7 +85,7 @@ export class SQLDataSourceGroupBy {
     };
   }
 
-  getSummaries(model: PivotModel): QueryResult<Row> {
+  getSummaries(model: PivotModel): AsyncMemoResult<Row> {
     const {aggregates, filters = []} = model;
 
     return this.summariesSlot.use({
@@ -93,7 +93,7 @@ export class SQLDataSourceGroupBy {
         aggregates,
         filters: serializeFilters(filters),
       },
-      queryFn: async () => {
+      compute: async () => {
         const query = this.buildSummariesQuery(model);
         const result = await this.engine.query(query);
         return result.firstRow({}) as Row;

--- a/ui/src/components/widgets/datagrid/sql_data_source/pivot.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/pivot.ts
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type {QueryResult, SerialTaskQueue} from '../../../../base/query_slot';
+import type {
+  AsyncMemoResult,
+  AtomicTaskQueue,
+} from '../../../../base/async_memo';
 import type {Engine} from '../../../../trace_processor/engine';
 import type {Row} from '../../../../trace_processor/query_result';
 import type {DataSourceRows, PivotModel} from '../data_source';
@@ -27,7 +30,7 @@ export class SQLDataSourcePivot {
 
   constructor(
     uuid: string,
-    queue: SerialTaskQueue,
+    queue: AtomicTaskQueue,
     engine: Engine,
     sqlSchema: SQLTableSchema,
   ) {
@@ -43,7 +46,7 @@ export class SQLDataSourcePivot {
     }
   }
 
-  getSummaries(model: PivotModel): QueryResult<Row> {
+  getSummaries(model: PivotModel): AsyncMemoResult<Row> {
     if (model.groupDisplay === 'tree') {
       return this.tree.getSummaries(model);
     } else {

--- a/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import {
-  type QueryResult,
-  QuerySlot,
-  type SerialTaskQueue,
-} from '../../../../base/query_slot';
+  type AsyncMemoResult,
+  AsyncMemo,
+  type AtomicTaskQueue,
+} from '../../../../base/async_memo';
 import type {Engine} from '../../../../trace_processor/engine';
 import {
   NUM,
@@ -97,27 +97,27 @@ function buildPathCondition(
 
 // Rollup tree datasource - uses pure SQL with UNION ALL and window functions.
 export class SQLDataSourceRollupTree {
-  private readonly rowCountSlot: QuerySlot<number>;
-  private readonly rowsSlot: QuerySlot<{
+  private readonly rowCountSlot: AsyncMemo<number>;
+  private readonly rowsSlot: AsyncMemo<{
     readonly rows: readonly Row[];
     readonly rowOffset: number;
   }>;
-  private readonly rollupTableSlot: QuerySlot<DisposableSqlEntity>;
-  private readonly summariesSlot: QuerySlot<Row>;
+  private readonly rollupTableSlot: AsyncMemo<DisposableSqlEntity>;
+  private readonly summariesSlot: AsyncMemo<Row>;
 
   constructor(
     private readonly uuid: string,
-    queue: SerialTaskQueue,
+    queue: AtomicTaskQueue,
     private readonly engine: Engine,
     private readonly sqlSchema: SQLTableSchema,
   ) {
-    this.rowCountSlot = new QuerySlot<number>(queue);
-    this.rowsSlot = new QuerySlot<{
+    this.rowCountSlot = new AsyncMemo<number>(queue);
+    this.rowsSlot = new AsyncMemo<{
       readonly rows: readonly Row[];
       readonly rowOffset: number;
     }>(queue);
-    this.rollupTableSlot = new QuerySlot<DisposableSqlEntity>(queue);
-    this.summariesSlot = new QuerySlot<Row>(queue);
+    this.rollupTableSlot = new AsyncMemo<DisposableSqlEntity>(queue);
+    this.summariesSlot = new AsyncMemo<Row>(queue);
   }
 
   getRows(model: PivotModel): DataSourceRows {
@@ -132,7 +132,7 @@ export class SQLDataSourceRollupTree {
     } = model;
 
     const rollupTableResult = this.useRollupTable(model);
-    if (rollupTableResult.isPending || !rollupTableResult.data) {
+    if (rollupTableResult.isPending) {
       return {isPending: true};
     }
 
@@ -170,7 +170,7 @@ export class SQLDataSourceRollupTree {
         sortDirection,
       },
       retainOn: ['expandedGroups', 'collapsedGroups'],
-      queryFn: async () => {
+      compute: async () => {
         const query = buildTreeQuery(rollupTableName, {
           expandedGroups,
           collapsedGroups,
@@ -200,7 +200,7 @@ export class SQLDataSourceRollupTree {
         'sortColumn',
         'sortDirection',
       ],
-      queryFn: async () => {
+      compute: async () => {
         const query = buildTreeQuery(rollupTableName, {
           expandedGroups,
           collapsedGroups,
@@ -227,12 +227,12 @@ export class SQLDataSourceRollupTree {
     };
   }
 
-  getSummaries(model: PivotModel): QueryResult<Row> {
+  getSummaries(model: PivotModel): AsyncMemoResult<Row> {
     const {groupBy, aggregates, filters = []} = model;
 
     const rollupTableResult = this.useRollupTable(model);
-    if (rollupTableResult.isPending || !rollupTableResult.data) {
-      return {isPending: true, data: undefined, isFresh: false};
+    if (rollupTableResult.isPending) {
+      return {isPending: true};
     }
 
     const rollupTableName = rollupTableResult.data.name;
@@ -245,7 +245,7 @@ export class SQLDataSourceRollupTree {
         aggregates,
         filters: serializeFilters(filters),
       },
-      queryFn: async () => {
+      compute: async () => {
         const query = buildTreeQuery(rollupTableName, {
           maxDepth: 0,
           columnAliases,
@@ -256,7 +256,9 @@ export class SQLDataSourceRollupTree {
     });
   }
 
-  private useRollupTable(model: PivotModel): QueryResult<DisposableSqlEntity> {
+  private useRollupTable(
+    model: PivotModel,
+  ): AsyncMemoResult<DisposableSqlEntity> {
     const {groupBy, aggregates, filters = []} = model;
 
     const sourceQuery = this.buildSourceQuery(filters);
@@ -269,7 +271,7 @@ export class SQLDataSourceRollupTree {
         groupByColumns,
         aggregateExprs,
       },
-      queryFn: async () => {
+      compute: async () => {
         return await createRollupTable(this.engine, {
           sourceTable: sourceQuery,
           groupByColumns,

--- a/ui/src/components/widgets/datagrid/sql_data_source/tree.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/tree.ts
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import {
-  type QueryResult,
-  QuerySlot,
-  type SerialTaskQueue,
-} from '../../../../base/query_slot';
+  type AsyncMemoResult,
+  AsyncMemo,
+  type AtomicTaskQueue,
+} from '../../../../base/async_memo';
 import {shortUuid} from '../../../../base/uuid';
 import type {Engine} from '../../../../trace_processor/engine';
 import {NUM, type Row} from '../../../../trace_processor/query_result';
@@ -40,21 +40,21 @@ import {filterToSql, quoteIdentifier, sqlValue} from '../sql_utils';
  */
 export class SQLDataSourceTree {
   private readonly uuid = shortUuid();
-  private readonly treeTableSlot: QuerySlot<DisposableSqlEntity>;
-  private readonly rowCountSlot: QuerySlot<number>;
-  private readonly rowsSlot: QuerySlot<{
+  private readonly treeTableSlot: AsyncMemo<DisposableSqlEntity>;
+  private readonly rowCountSlot: AsyncMemo<number>;
+  private readonly rowsSlot: AsyncMemo<{
     readonly rows: readonly Row[];
     readonly rowOffset: number;
   }>;
 
   constructor(
-    queue: SerialTaskQueue,
+    queue: AtomicTaskQueue,
     private readonly engine: Engine,
     private readonly sqlSchema: SQLTableSchema,
   ) {
-    this.treeTableSlot = new QuerySlot<DisposableSqlEntity>(queue);
-    this.rowCountSlot = new QuerySlot<number>(queue);
-    this.rowsSlot = new QuerySlot<{
+    this.treeTableSlot = new AsyncMemo<DisposableSqlEntity>(queue);
+    this.rowCountSlot = new AsyncMemo<number>(queue);
+    this.rowsSlot = new AsyncMemo<{
       readonly rows: readonly Row[];
       readonly rowOffset: number;
     }>(queue);
@@ -65,7 +65,7 @@ export class SQLDataSourceTree {
 
     // First, ensure the base table is materialized
     const treeTableResult = this.useTreeTable(model);
-    if (treeTableResult.isPending || !treeTableResult.data) {
+    if (treeTableResult.isPending) {
       return {isPending: true};
     }
 
@@ -106,7 +106,7 @@ export class SQLDataSourceTree {
         sortDirection,
       },
       retainOn: ['expandedIds', 'collapsedIds'],
-      queryFn: async () => {
+      compute: async () => {
         const query = buildTreeQuery(treeTableName, {
           expandedIds: tree.expandedIds,
           collapsedIds: tree.collapsedIds,
@@ -135,7 +135,7 @@ export class SQLDataSourceTree {
         'sortColumn',
         'sortDirection',
       ],
-      queryFn: async () => {
+      compute: async () => {
         const query = buildTreeQuery(treeTableName, {
           expandedIds: tree.expandedIds,
           collapsedIds: tree.collapsedIds,
@@ -163,8 +163,8 @@ export class SQLDataSourceTree {
   /**
    * Tree mode doesn't support aggregate summaries.
    */
-  getSummaries(_model: TreeModel): QueryResult<Row> {
-    return {data: undefined, isPending: false, isFresh: true};
+  getSummaries(_model: TreeModel): AsyncMemoResult<Row> {
+    return {data: {}, isPending: false};
   }
 
   /**
@@ -279,7 +279,7 @@ export class SQLDataSourceTree {
    * and all user columns. This is cached and only rebuilt when columns or
    * filters change.
    */
-  private useTreeTable(model: TreeModel): QueryResult<DisposableSqlEntity> {
+  private useTreeTable(model: TreeModel): AsyncMemoResult<DisposableSqlEntity> {
     const {columns, filters = [], tree} = model;
     const sourceQuery = this.buildSourceQuery(model);
 
@@ -290,7 +290,7 @@ export class SQLDataSourceTree {
         idColumn: tree.idField,
         parentIdColumn: tree.parentIdField,
       },
-      queryFn: async () => {
+      compute: async () => {
         return await createTreeTable(this.engine, {
           sourceQuery,
           tableName: this.treeTableName,

--- a/ui/src/plugins/com.android.AndroidInputLifecycle/android_input_event_source.ts
+++ b/ui/src/plugins/com.android.AndroidInputLifecycle/android_input_event_source.ts
@@ -25,7 +25,7 @@ import {
   getTrackUriForTrackId,
   enrichDepths,
 } from '../../components/related_events/utils';
-import {QuerySlot, type QueryResult} from '../../base/query_slot';
+import {AsyncMemo, type AsyncMemoResult} from '../../base/async_memo';
 import type {
   InputLifecycleExtension,
   CellData,
@@ -50,17 +50,17 @@ interface InputLifecycleSpec extends Row {
 }
 
 export class AndroidInputEventSource {
-  private readonly dataSlot = new QuerySlot<InputChainRow[]>();
+  private readonly dataSlot = new AsyncMemo<InputChainRow[]>();
 
   constructor(
     private readonly trace: Trace,
     private readonly activeExtensions: ReadonlyArray<InputLifecycleExtension>,
   ) {}
 
-  use(sliceId: number): QueryResult<InputChainRow[]> {
+  use(sliceId: number): AsyncMemoResult<InputChainRow[]> {
     return this.dataSlot.use({
       key: {sliceId},
-      queryFn: async () => {
+      compute: async () => {
         const resolvedSliceId = await this.resolveSliceId(sliceId);
         const rows = await this.fetchRows(resolvedSliceId);
         await this.enrichAllDepths(rows);

--- a/ui/src/plugins/com.android.AndroidInputLifecycle/index.ts
+++ b/ui/src/plugins/com.android.AndroidInputLifecycle/index.ts
@@ -26,7 +26,7 @@ import {
   type InputChainRow,
 } from './android_input_event_source';
 import {AndroidInputLifecycleTab} from './tab';
-import type {QueryResult} from '../../base/query_slot';
+import type {AsyncMemoResult} from '../../base/async_memo';
 import type {InputLifecycleExtension, NavTarget} from './extensions/interface';
 import {PixelInputLifecycleExtension} from './extensions/pixel_extension';
 
@@ -111,11 +111,11 @@ export default class AndroidInputLifecyclePlugin implements PerfettoPlugin {
   private useRowState(
     trace: Trace,
     source: AndroidInputEventSource,
-  ): QueryResult<InputChainRow[]> {
+  ): AsyncMemoResult<InputChainRow[]> {
     const selection = trace.selection.selection;
 
     if (selection.kind !== 'track_event') {
-      return {data: [], isPending: false, isFresh: true};
+      return {data: [], isPending: false};
     }
 
     return source.use(selection.eventId);

--- a/ui/src/plugins/com.android.AndroidLockContention/android_lock_contention_event_source.ts
+++ b/ui/src/plugins/com.android.AndroidLockContention/android_lock_contention_event_source.ts
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import {
-  type QueryResult,
-  QuerySlot,
-  SerialTaskQueue,
-} from '../../base/query_slot';
+  type AsyncMemoResult,
+  AsyncMemo,
+  AtomicTaskQueue,
+} from '../../base/async_memo';
 import {type duration, Duration, type time, Time} from '../../base/time';
 import {getTrackUriForTrackId} from '../../components/related_events/utils';
 import type {Trace} from '../../public/trace';
@@ -97,14 +97,14 @@ export interface LockContentionDetails {
 }
 
 export class AndroidLockContentionEventSource {
-  private readonly queue = new SerialTaskQueue();
-  private readonly dataSlot = new QuerySlot<LockContentionDetails | null>(
+  private readonly queue = new AtomicTaskQueue();
+  private readonly dataSlot = new AsyncMemo<LockContentionDetails | null>(
     this.queue,
   );
-  private readonly mergedDataSlot = new QuerySlot<LockContentionDetails[]>(
+  private readonly mergedDataSlot = new AsyncMemo<LockContentionDetails[]>(
     this.queue,
   );
-  private readonly allDetailsSlot = new QuerySlot<{
+  private readonly allDetailsSlot = new AsyncMemo<{
     details: LockContentionDetails[];
     threadStates: Map<number, ReadonlyArray<ContentionState>>;
     blockedFunctions: Map<number, ReadonlyArray<ContentionBlockedFunction>>;
@@ -112,21 +112,21 @@ export class AndroidLockContentionEventSource {
 
   constructor(private readonly trace: Trace) {}
 
-  useMerged(mergedId: number): QueryResult<LockContentionDetails[]> {
+  useMerged(mergedId: number): AsyncMemoResult<LockContentionDetails[]> {
     return this.mergedDataSlot.use({
       key: {mergedId},
-      queryFn: async () => this.fetchMergedDetails(mergedId),
+      compute: async () => this.fetchMergedDetails(mergedId),
     });
   }
 
-  useAllDetails(mergedId: number): QueryResult<{
+  useAllDetails(mergedId: number): AsyncMemoResult<{
     details: LockContentionDetails[];
     threadStates: Map<number, ReadonlyArray<ContentionState>>;
     blockedFunctions: Map<number, ReadonlyArray<ContentionBlockedFunction>>;
   }> {
     return this.allDetailsSlot.use({
       key: {mergedId},
-      queryFn: async () => this.fetchAllDetails(mergedId),
+      compute: async () => this.fetchAllDetails(mergedId),
     });
   }
 
@@ -313,10 +313,10 @@ export class AndroidLockContentionEventSource {
   use(
     eventId: number,
     trackUri: string,
-  ): QueryResult<LockContentionDetails | null> {
+  ): AsyncMemoResult<LockContentionDetails | null> {
     return this.dataSlot.use({
       key: {eventId, trackUri},
-      queryFn: async () => this.fetchDetails(eventId, trackUri),
+      compute: async () => this.fetchDetails(eventId, trackUri),
     });
   }
 

--- a/ui/src/plugins/com.android.AndroidLockContention/index.ts
+++ b/ui/src/plugins/com.android.AndroidLockContention/index.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import './styles.scss';
-import {QuerySlot, SerialTaskQueue} from '../../base/query_slot';
+import {AsyncMemo, AtomicTaskQueue} from '../../base/async_memo';
 import {LockOwnerDetailsPanel} from './lock_owner_details_panel';
 import {LOCK_CONTENTION_SQL} from './lock_contention_sql';
 import type {Selection} from '../../public/selection';
@@ -45,8 +45,8 @@ export default class AndroidLockContentionPlugin implements PerfettoPlugin {
   static readonly description =
     'Visualise lock contention events in the trace. You can navigate between contention events using ] and [';
 
-  private readonly connectionsTaskQueue = new SerialTaskQueue();
-  private readonly connectionsSlot = new QuerySlot<ArrowConnection[]>(
+  private readonly connectionsTaskQueue = new AtomicTaskQueue();
+  private readonly connectionsSlot = new AsyncMemo<ArrowConnection[]>(
     this.connectionsTaskQueue,
   );
   public highlightedTargetIds = new Set<number>();
@@ -251,7 +251,7 @@ export default class AndroidLockContentionPlugin implements PerfettoPlugin {
           .sort()
           .join(','),
       },
-      queryFn: () => this.fetchConnections(trace, selection),
+      compute: () => this.fetchConnections(trace, selection),
     });
 
     return result.data ?? [];

--- a/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
+++ b/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
@@ -45,7 +45,7 @@ import type {Store} from '../../base/store';
 import type {Trace} from '../../public/trace';
 import {Icons} from '../../base/semantic_icons';
 import {MenuItem} from '../../widgets/menu';
-import {SerialTaskQueue, QuerySlot} from '../../base/query_slot';
+import {AtomicTaskQueue, AsyncMemo} from '../../base/async_memo';
 
 const ROW_H = 24;
 
@@ -90,9 +90,9 @@ interface LogEntries {
 
 export class LogPanel implements m.ClassComponent<LogPanelAttrs> {
   private readonly trace: Trace;
-  private readonly executor = new SerialTaskQueue();
-  private readonly viewQuery = new QuerySlot<AsyncDisposable>(this.executor);
-  private readonly entriesQuery = new QuerySlot<LogEntries>(this.executor);
+  private readonly executor = new AtomicTaskQueue();
+  private readonly viewQuery = new AsyncMemo<AsyncDisposable>(this.executor);
+  private readonly entriesQuery = new AsyncMemo<LogEntries>(this.executor);
   private pagination: Pagination = {
     offset: 0,
     count: 0,
@@ -116,7 +116,7 @@ export class LogPanel implements m.ClassComponent<LogPanelAttrs> {
     // Query 1: Create the filtered_logs table (no staleOn = always-fresh)
     const viewResult = this.viewQuery.use({
       key: {filters},
-      queryFn: () => updateLogView(engine, filters),
+      compute: () => updateLogView(engine, filters),
     });
 
     // Query 2: Read from the table (staleOn=['pagination'] for smooth scrolling)
@@ -127,7 +127,7 @@ export class LogPanel implements m.ClassComponent<LogPanelAttrs> {
         pagination,
       },
       retainOn: ['pagination', 'viewport'],
-      queryFn: () => updateLogEntries(engine, visibleSpan, pagination),
+      compute: () => updateLogEntries(engine, visibleSpan, pagination),
       enabled: !!viewResult.data,
     });
 

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
@@ -22,7 +22,7 @@ import {
   type FlamegraphState,
   type FlamegraphOptionalAction,
 } from '../../../widgets/flamegraph';
-import {QuerySlot} from '../../../base/query_slot';
+import {AsyncMemo} from '../../../base/async_memo';
 import {
   isHeapGraphIncomplete,
   incompleteFlamegraphModal,
@@ -178,7 +178,7 @@ export function FlamegraphView(): m.Component<FlamegraphViewAttrs> {
   // the flamegraph behind a dismissible warning modal. Keyed by dump so it
   // re-arms when the dump changes; the check runs (and the modal is shown) only
   // when this view is rendered, i.e. when the flamegraph tab is active.
-  const incompleteSlot = new QuerySlot<{
+  const incompleteSlot = new AsyncMemo<{
     isIncomplete: boolean;
     dismissed: boolean;
   }>();
@@ -198,7 +198,7 @@ export function FlamegraphView(): m.Component<FlamegraphViewAttrs> {
 
       const incomplete = incompleteSlot.use({
         key: {upid: attrs.upid, ts: attrs.ts},
-        queryFn: async () => ({
+        compute: async () => ({
           isIncomplete: await isHeapGraphIncomplete(attrs.trace),
           dismissed: false,
         }),

--- a/ui/src/plugins/com.meta.GpuCompute/index.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/index.ts
@@ -42,7 +42,7 @@ import {
   type AnalysisProvider,
   AnalysisProviderHolder,
 } from './analysis';
-import {SerialTaskQueue, QuerySlot} from '../../base/query_slot';
+import {AtomicTaskQueue, AsyncMemo} from '../../base/async_memo';
 
 export interface GpuComputeContext {
   humanizeMetrics: boolean;
@@ -83,8 +83,8 @@ class Compute {
   // trigger mithril redraws; render() reads the current selection and
   // polls the QuerySlot which handles deduplication, background
   // fetching, and race-condition prevention.
-  private readonly taskQueue = new SerialTaskQueue();
-  private readonly selectionSlot = new QuerySlot<{
+  private readonly taskQueue = new AtomicTaskQueue();
+  private readonly selectionSlot = new AsyncMemo<{
     hasMetrics: boolean;
     toolbar?: ToolbarInfo;
   }>(this.taskQueue);
@@ -276,7 +276,7 @@ class Compute {
 
       const result = this.selectionSlot.use({
         key: {sliceId: id},
-        queryFn: async () => {
+        compute: async () => {
           const data = await fetchSelectedKernelMetricData(
             this.ctx,
             this.engine,

--- a/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
@@ -23,10 +23,10 @@ import {assertTrue} from '../../base/assert';
 import {Monitor} from '../../base/monitor';
 import {
   type CancellationSignal,
-  QUERY_CANCELLED,
-  QuerySlot,
-  SerialTaskQueue,
-} from '../../base/query_slot';
+  TASK_CANCELLED,
+  AsyncMemo,
+  AtomicTaskQueue,
+} from '../../base/async_memo';
 import type {StepAreaBuffers} from '../../base/renderer';
 import {type duration, type time, Time} from '../../base/time';
 import type {TimeScale} from '../../base/time_scale';
@@ -122,9 +122,9 @@ export class CpuFreqTrack implements TrackRenderer {
   ]);
 
   // QuerySlot infrastructure
-  private readonly queue = new SerialTaskQueue();
-  private readonly tableSlot = new QuerySlot<MipmapTables>(this.queue);
-  private readonly dataSlot = new QuerySlot<Data>(this.queue);
+  private readonly queue = new AtomicTaskQueue();
+  private readonly tableSlot = new AsyncMemo<MipmapTables>(this.queue);
+  private readonly dataSlot = new AsyncMemo<Data>(this.queue);
 
   // Cached data for rendering (populated from dataSlot)
   private data?: Data;
@@ -238,7 +238,7 @@ export class CpuFreqTrack implements TrackRenderer {
     end: time,
     resolution: duration,
     signal: CancellationSignal,
-  ): Promise<Data | typeof QUERY_CANCELLED> {
+  ): Promise<Data | typeof TASK_CANCELLED> {
     // The resolution should always be a power of two for the logic of this
     // function to make sense.
     assertTrue(BIMath.popcount(resolution) === 1, `${resolution} not pow of 2`);
@@ -256,7 +256,7 @@ export class CpuFreqTrack implements TrackRenderer {
       );
     `);
 
-    if (signal.isCancelled) return QUERY_CANCELLED;
+    if (signal.isCancelled) return TASK_CANCELLED;
 
     const idleResult = await this.trace.engine.query(`
       SELECT last_value as lastIdle
@@ -267,7 +267,7 @@ export class CpuFreqTrack implements TrackRenderer {
       );
     `);
 
-    if (signal.isCancelled) return QUERY_CANCELLED;
+    if (signal.isCancelled) return TASK_CANCELLED;
 
     const priority = CHUNKED_TASK_BACKGROUND_PRIORITY.get()
       ? 'background'
@@ -304,7 +304,7 @@ export class CpuFreqTrack implements TrackRenderer {
     });
     for (let i = 0; freqIt.valid(); ++i, freqIt.next(), idleIt.next()) {
       if (i % 50 === 0) {
-        if (signal.isCancelled) return QUERY_CANCELLED;
+        if (signal.isCancelled) return TASK_CANCELLED;
         if (task.shouldYield()) {
           await task.yield();
         }
@@ -396,7 +396,7 @@ export class CpuFreqTrack implements TrackRenderer {
         freqTrackId: this.config.freqTrackId,
         idleTrackId: this.config.idleTrackId,
       },
-      queryFn: () => this.createMipmapTables(),
+      compute: () => this.createMipmapTables(),
     });
 
     // Step 2: Declaratively fetch data from the tables with buffered bounds
@@ -410,7 +410,7 @@ export class CpuFreqTrack implements TrackRenderer {
         end: bounds.end,
         resolution: bounds.resolution,
       },
-      queryFn: async (signal) => {
+      compute: async (signal) => {
         const result = await this.trace.taskTracker.track(
           this.fetchData(
             tableResult.data!.freqTableName,

--- a/ui/src/plugins/dev.perfetto.Ftrace/ftrace_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/ftrace_explorer.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {SerialTaskQueue, QuerySlot} from '../../base/query_slot';
+import {AtomicTaskQueue, AsyncMemo} from '../../base/async_memo';
 import {type time, Time} from '../../base/time';
 import {materialColorScheme} from '../../components/colorizer';
 import {Timestamp} from '../../components/widgets/timestamp';
@@ -141,9 +141,9 @@ export class FtraceExplorer implements m.ClassComponent<FtraceExplorerAttrs> {
   };
 
   // Query slots for declarative data fetching
-  private readonly executor = new SerialTaskQueue();
-  private readonly countSlot = new QuerySlot<number>(this.executor);
-  private readonly eventsSlot = new QuerySlot<FtracePanelData>(this.executor);
+  private readonly executor = new AtomicTaskQueue();
+  private readonly countSlot = new AsyncMemo<number>(this.executor);
+  private readonly eventsSlot = new AsyncMemo<FtracePanelData>(this.executor);
 
   constructor({attrs}: m.CVnode<FtraceExplorerAttrs>) {
     this.trace = attrs.trace;
@@ -181,14 +181,14 @@ export class FtraceExplorer implements m.ClassComponent<FtraceExplorerAttrs> {
     const {data: numEvents} = this.countSlot.use({
       key: {viewport: {start, end}, filters},
       retainOn: ['viewport'],
-      queryFn: () => fetchFtraceEventCount(engine, start, end, filters),
+      compute: () => fetchFtraceEventCount(engine, start, end, filters),
     });
 
     // Events query - stale on pagination for smooth scrolling
     const {data} = this.eventsSlot.use({
       key: {viewport: {start, end}, filters, pagination},
       retainOn: ['pagination', 'viewport'],
-      queryFn: () =>
+      compute: () =>
         fetchFtraceEvents(
           engine,
           pagination.offset,

--- a/ui/src/plugins/dev.perfetto.JournaldLog/logs_panel.ts
+++ b/ui/src/plugins/dev.perfetto.JournaldLog/logs_panel.ts
@@ -46,7 +46,7 @@ import type {Store} from '../../base/store';
 import type {Trace} from '../../public/trace';
 import {Icons} from '../../base/semantic_icons';
 import {MenuItem} from '../../widgets/menu';
-import {SerialTaskQueue, QuerySlot} from '../../base/query_slot';
+import {AtomicTaskQueue, AsyncMemo} from '../../base/async_memo';
 import {Anchor} from '../../widgets/anchor';
 import {getThreadUriPrefix} from '../../public/utils';
 
@@ -100,9 +100,9 @@ export const JOURNALD_PRIORITIES = [
 
 export class JournaldLogPanel implements m.ClassComponent<JournaldLogPanelAttrs> {
   private readonly trace: Trace;
-  private readonly executor = new SerialTaskQueue();
-  private readonly viewQuery = new QuerySlot<AsyncDisposable>(this.executor);
-  private readonly entriesQuery = new QuerySlot<LogEntries>(this.executor);
+  private readonly executor = new AtomicTaskQueue();
+  private readonly viewQuery = new AsyncMemo<AsyncDisposable>(this.executor);
+  private readonly entriesQuery = new AsyncMemo<LogEntries>(this.executor);
   private pagination: Pagination = {
     offset: 0,
     count: 0,
@@ -125,7 +125,7 @@ export class JournaldLogPanel implements m.ClassComponent<JournaldLogPanelAttrs>
 
     const viewResult = this.viewQuery.use({
       key: {filters},
-      queryFn: () => updateLogView(engine, filters),
+      compute: () => updateLogView(engine, filters),
     });
 
     const entriesResult = this.entriesQuery.use({
@@ -135,7 +135,7 @@ export class JournaldLogPanel implements m.ClassComponent<JournaldLogPanelAttrs>
         pagination,
       },
       retainOn: ['pagination', 'viewport'],
-      queryFn: () => updateLogEntries(engine, visibleSpan, pagination),
+      compute: () => updateLogEntries(engine, visibleSpan, pagination),
       enabled: !!viewResult.data,
     });
 

--- a/ui/src/plugins/dev.perfetto.Llm/settings_ui.ts
+++ b/ui/src/plugins/dev.perfetto.Llm/settings_ui.ts
@@ -37,7 +37,7 @@ import {
 } from './config';
 import {Checkbox} from '../../widgets/checkbox';
 import {assertIsInstance} from '../../base/assert';
-import {QuerySlot} from '../../base/query_slot';
+import {AsyncMemo} from '../../base/async_memo';
 
 type ModelFetchResult =
   | {readonly status: 'done'; readonly models: readonly string[]}
@@ -143,7 +143,7 @@ interface ProviderEditorAttrs {
 }
 
 function ProviderEditor(): m.Component<ProviderEditorAttrs> {
-  const modelsSlot = new QuerySlot<ModelFetchResult>();
+  const modelsSlot = new AsyncMemo<ModelFetchResult>();
 
   return {
     view({attrs}: m.Vnode<ProviderEditorAttrs>) {
@@ -155,7 +155,7 @@ function ProviderEditor(): m.Component<ProviderEditorAttrs> {
         // TODO: wire the QuerySlot's CancellationSignal through to
         // fetchAvailableModels' AbortSignal so in-flight fetches are actually
         // cancelled when the key changes.
-        queryFn: () => fetchAvailableModels(gateway, provider),
+        compute: () => fetchAvailableModels(gateway, provider),
       });
 
       let status: m.Children = null;

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {assertIsInstance} from '../../../../base/assert';
-import {QuerySlot} from '../../../../base/query_slot';
+import {AsyncMemo} from '../../../../base/async_memo';
 import type {Trace} from '../../../../public/trace';
 import type {Engine} from '../../../../trace_processor/engine';
 import {
@@ -48,7 +48,7 @@ export interface MemoryOverviewPageAttrs {
 type ProcWithMem = readonly ProcMemStat[];
 
 export class MemoryOverviewPage implements m.Component<MemoryOverviewPageAttrs> {
-  private readonly slot = new QuerySlot<ProcWithMem>();
+  private readonly slot = new AsyncMemo<ProcWithMem>();
 
   view({attrs}: m.Vnode<MemoryOverviewPageAttrs>) {
     const {trace, subpage, onSubpageChange} = attrs;
@@ -72,7 +72,7 @@ export class MemoryOverviewPage implements m.Component<MemoryOverviewPageAttrs> 
   ) {
     const procsWithMemResult = this.slot.use({
       key: '',
-      queryFn: () => loadProcessMemoryStats(trace.engine),
+      compute: () => loadProcessMemoryStats(trace.engine),
     });
 
     const procs = procsWithMemResult.data;

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/proc_mem_overview.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {Gate} from '../../../../base/mithril_utils';
-import {QuerySlot} from '../../../../base/query_slot';
+import {AsyncMemo} from '../../../../base/async_memo';
 import {Time, type time} from '../../../../base/time';
 import {ProportionBar} from '../../../../components/widgets/charts/proportion_bar';
 import type {Trace} from '../../../../public/trace';
@@ -115,10 +115,10 @@ export interface ProcessMemDetailsAttrs {
 export class ProcessMemDetails implements m.ClassComponent<ProcessMemDetailsAttrs> {
   // The capture-strip facts: process name + per-source sample counts. Its own
   // slot keyed by (trace, upid) so it reloads when the selected process changes.
-  private readonly captureSlot = new QuerySlot<CaptureInfo>();
+  private readonly captureSlot = new AsyncMemo<CaptureInfo>();
   // Whole-trace per-snapshot smaps breakdown for the growth bar (keyed by
   // upid; independent of the page's snapshot selection).
-  private readonly growthSlot = new QuerySlot<GrowthSnapshot[]>();
+  private readonly growthSlot = new AsyncMemo<GrowthSnapshot[]>();
   private activeTab: 'summary' | 'smaps' = 'summary';
   // The page-wide snapshot selection, driven by the composition timeline and
   // shared with the other summary sections as they're added.
@@ -136,7 +136,7 @@ export class ProcessMemDetails implements m.ClassComponent<ProcessMemDetailsAttr
     try {
       capture = this.captureSlot.use({
         key: {traceId: trace.traceInfo.uuid, upid},
-        queryFn: () => loadCaptureInfo(trace, upid),
+        compute: () => loadCaptureInfo(trace, upid),
       }).data;
     } catch (e) {
       error = String(e);
@@ -238,7 +238,7 @@ export class ProcessMemDetails implements m.ClassComponent<ProcessMemDetailsAttr
   ): m.Children {
     const snaps = this.growthSlot.use({
       key: {traceId: trace.traceInfo.uuid, upid},
-      queryFn: () => loadGrowthData(trace, upid),
+      compute: () => loadGrowthData(trace, upid),
     }).data;
     if (snaps === undefined || snaps.length < 2) return undefined;
     const firstSnap = snaps[0];

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/smaps_detail.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/smaps_detail.ts
@@ -18,7 +18,7 @@
 // Self-contained: owns its query slots and loading.
 
 import m from 'mithril';
-import {QuerySlot} from '../../../../base/query_slot';
+import {AsyncMemo} from '../../../../base/async_memo';
 import type {Trace} from '../../../../public/trace';
 import {LONG, NUM, STR} from '../../../../trace_processor/query_result';
 import {Button} from '../../../../widgets/button';
@@ -228,8 +228,8 @@ export interface SmapsDetailAttrs {
 }
 
 export class SmapsDetail implements m.ClassComponent<SmapsDetailAttrs> {
-  private readonly slot = new QuerySlot<SmapsPathRow[]>();
-  private readonly snapshotsSlot = new QuerySlot<SmapsSnapshotInfo[]>();
+  private readonly slot = new AsyncMemo<SmapsPathRow[]>();
+  private readonly snapshotsSlot = new AsyncMemo<SmapsSnapshotInfo[]>();
   // View state.
   private smapsFlat = false;
   private smapsAllCols = false;
@@ -249,7 +249,7 @@ export class SmapsDetail implements m.ClassComponent<SmapsDetailAttrs> {
     const snapshots =
       this.snapshotsSlot.use({
         key: {traceId: trace.traceInfo.uuid, upid},
-        queryFn: () => loadSmapsSnapshots(trace, upid),
+        compute: () => loadSmapsSnapshots(trace, upid),
       }).data ?? [];
     const rows = this.slot.use({
       key: {
@@ -257,7 +257,7 @@ export class SmapsDetail implements m.ClassComponent<SmapsDetailAttrs> {
         upid,
         ts: this.selectedTs?.toString() ?? 'latest',
       },
-      queryFn: () => loadSmapsPaths(trace, upid, this.selectedTs),
+      compute: () => loadSmapsPaths(trace, upid, this.selectedTs),
     }).data;
     if (rows === undefined) {
       return m(

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
@@ -17,7 +17,7 @@
 // Self-contained: owns its query slot and loading logic.
 
 import m from 'mithril';
-import {QuerySlot} from '../../../../../base/query_slot';
+import {AsyncMemo} from '../../../../../base/async_memo';
 import {Time, type time} from '../../../../../base/time';
 import type {Trace} from '../../../../../public/trace';
 import {
@@ -267,7 +267,7 @@ export interface BitmapsSectionAttrs {
 }
 
 export class BitmapsSection implements m.ClassComponent<BitmapsSectionAttrs> {
-  private readonly slot = new QuerySlot<BitmapsData>();
+  private readonly slot = new AsyncMemo<BitmapsData>();
 
   onremove() {
     this.slot.dispose();
@@ -277,7 +277,7 @@ export class BitmapsSection implements m.ClassComponent<BitmapsSectionAttrs> {
     const {trace, upid, selTs, baseTs} = attrs;
     const data = this.slot.use({
       key: {traceId: trace.traceInfo.uuid, upid},
-      queryFn: () => loadBitmapsData(trace, upid),
+      compute: () => loadBitmapsData(trace, upid),
       // Emulate an empty response
       // queryFn: async () => ({
       //   dumps: [],

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/composition_timeline.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/composition_timeline.ts
@@ -18,7 +18,7 @@
 // selection.
 
 import m from 'mithril';
-import {QuerySlot} from '../../../../../base/query_slot';
+import {AsyncMemo} from '../../../../../base/async_memo';
 import {Time, type time} from '../../../../../base/time';
 import {
   LineChartSvg,
@@ -65,7 +65,7 @@ export interface CompositionTimelineAttrs {
 }
 
 export class CompositionTimeline implements m.ClassComponent<CompositionTimelineAttrs> {
-  private readonly slot = new QuerySlot<TimelineData>();
+  private readonly slot = new AsyncMemo<TimelineData>();
 
   onremove() {
     this.slot.dispose();
@@ -75,7 +75,7 @@ export class CompositionTimeline implements m.ClassComponent<CompositionTimeline
     const {trace, upid, selection, onSelect, belowChart} = attrs;
     const data = this.slot.use({
       key: {traceId: trace.traceInfo.uuid, upid},
-      queryFn: () => loadTimelineData(trace, upid),
+      compute: () => loadTimelineData(trace, upid),
     }).data;
     if (data === undefined) {
       return loadingPanel({title: 'Composition over time'}); // Still loading.

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/java_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/java_section.ts
@@ -19,7 +19,7 @@
 
 import m from 'mithril';
 import {Icons} from '../../../../../base/semantic_icons';
-import {QuerySlot} from '../../../../../base/query_slot';
+import {AsyncMemo} from '../../../../../base/async_memo';
 import {Time, type time} from '../../../../../base/time';
 import type {Trace} from '../../../../../public/trace';
 import {LONG, NUM, STR} from '../../../../../trace_processor/query_result';
@@ -423,7 +423,7 @@ export interface JavaSectionAttrs {
 }
 
 export class JavaSection implements m.ClassComponent<JavaSectionAttrs> {
-  private readonly slot = new QuerySlot<JavaData>();
+  private readonly slot = new AsyncMemo<JavaData>();
 
   onremove() {
     this.slot.dispose();
@@ -433,7 +433,7 @@ export class JavaSection implements m.ClassComponent<JavaSectionAttrs> {
     const {trace, upid, selTs, baseTs} = attrs;
     const data = this.slot.use({
       key: {traceId: trace.traceInfo.uuid, upid},
-      queryFn: () => loadJavaData(trace, upid),
+      compute: () => loadJavaData(trace, upid),
       // Emulate no data available
       // queryFn: async () => ({
       //   dumps: [],

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/memory_map.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/memory_map.ts
@@ -19,7 +19,7 @@
 // its own query slot and loading logic and shows the latest smaps snapshot.
 
 import m from 'mithril';
-import {QuerySlot} from '../../../../../base/query_slot';
+import {AsyncMemo} from '../../../../../base/async_memo';
 import {Time, type time} from '../../../../../base/time';
 import {
   FlamegraphChart,
@@ -159,10 +159,10 @@ export interface MemoryMapAttrs {
 
 export class MemoryMap implements m.ClassComponent<MemoryMapAttrs> {
   // Per-snapshot tree inputs (keyed by upid; the selection doesn't reload it).
-  private readonly slot = new QuerySlot<MemoryMapData>();
+  private readonly slot = new AsyncMemo<MemoryMapData>();
   // The flame-tree for the selected/baseline snapshot, keyed by selection so it
   // is only (re)built when the snapshot changes, not on every redraw.
-  private readonly treeSlot = new QuerySlot<MemTreeResult>();
+  private readonly treeSlot = new AsyncMemo<MemTreeResult>();
 
   onremove() {
     this.slot.dispose();
@@ -176,7 +176,7 @@ export class MemoryMap implements m.ClassComponent<MemoryMapAttrs> {
       'selected snapshot.';
     const data = this.slot.use({
       key: {traceId: trace.traceInfo.uuid, upid},
-      queryFn: () => loadMemoryMapData(trace, upid),
+      compute: () => loadMemoryMapData(trace, upid),
     }).data;
     if (data === undefined) {
       return loadingPanel({title: TITLE, subtitle}); // Still loading.
@@ -211,7 +211,7 @@ export class MemoryMap implements m.ClassComponent<MemoryMapAttrs> {
         sel: snap.ts.toString(),
         base: base !== undefined ? base.ts.toString() : null,
       },
-      queryFn: async () => {
+      compute: async () => {
         // In compare mode, annotate each block with its Δ vs the baseline tree.
         const baseByLabel =
           base !== undefined

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/native_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/native_section.ts
@@ -18,7 +18,7 @@
 // loading logic.
 
 import m from 'mithril';
-import {QuerySlot} from '../../../../../base/query_slot';
+import {AsyncMemo} from '../../../../../base/async_memo';
 import type {time} from '../../../../../base/time';
 import type {Trace} from '../../../../../public/trace';
 import {
@@ -315,7 +315,7 @@ export interface NativeSectionAttrs {
 }
 
 export class NativeSection implements m.ClassComponent<NativeSectionAttrs> {
-  private readonly slot = new QuerySlot<NativeData>();
+  private readonly slot = new AsyncMemo<NativeData>();
 
   onremove() {
     this.slot.dispose();
@@ -330,7 +330,7 @@ export class NativeSection implements m.ClassComponent<NativeSectionAttrs> {
         sel: selTs !== undefined ? selTs.toString() : null,
         base: baseTs !== undefined ? baseTs.toString() : null,
       },
-      queryFn: () => loadNativeData(trace, upid, selTs, baseTs),
+      compute: () => loadNativeData(trace, upid, selTs, baseTs),
       // Keep the previous window's data while the new one loads, so the panel
       // doesn't flash empty on every snapshot change.
       retainOn: ['sel', 'base'],

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/trace_overview.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/trace_overview.ts
@@ -19,7 +19,7 @@
 // Spans the whole trace, independent of the page's snapshot selection.
 
 import m from 'mithril';
-import {QuerySlot} from '../../../../../base/query_slot';
+import {AsyncMemo} from '../../../../../base/async_memo';
 import {Time, type time} from '../../../../../base/time';
 import type {Trace} from '../../../../../public/trace';
 import {
@@ -157,9 +157,9 @@ export interface TraceOverviewAttrs {
 
 export class TraceOverview implements m.ClassComponent<TraceOverviewAttrs> {
   // One slot per query, so the three load and redraw independently.
-  private readonly statsSlot = new QuerySlot<StatsData>();
-  private readonly counterSlot = new QuerySlot<CounterData>();
-  private readonly smapsSlot = new QuerySlot<AnonSwapSeries>();
+  private readonly statsSlot = new AsyncMemo<StatsData>();
+  private readonly counterSlot = new AsyncMemo<CounterData>();
+  private readonly smapsSlot = new AsyncMemo<AnonSwapSeries>();
 
   onremove() {
     this.statsSlot.dispose();
@@ -172,15 +172,15 @@ export class TraceOverview implements m.ClassComponent<TraceOverviewAttrs> {
     const key = {traceId: trace.traceInfo.uuid, upid};
     const stats = this.statsSlot.use({
       key,
-      queryFn: () => loadStats(trace, upid),
+      compute: () => loadStats(trace, upid),
     }).data;
     const counters = this.counterSlot.use({
       key,
-      queryFn: () => loadCounters(trace, upid),
+      compute: () => loadCounters(trace, upid),
     }).data;
     const snaps = this.smapsSlot.use({
       key,
-      queryFn: () => loadAnonSwap(trace, upid),
+      compute: () => loadAnonSwap(trace, upid),
     }).data;
 
     const statsLoading = stats === undefined;

--- a/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
@@ -24,10 +24,10 @@ import {assertExists, assertTrue} from '../../base/assert';
 import {Monitor} from '../../base/monitor';
 import {
   type CancellationSignal,
-  QUERY_CANCELLED,
-  QuerySlot,
-  SerialTaskQueue,
-} from '../../base/query_slot';
+  TASK_CANCELLED,
+  AsyncMemo,
+  AtomicTaskQueue,
+} from '../../base/async_memo';
 import type {RowLayout} from '../../base/renderer';
 import {type duration, type time, Time} from '../../base/time';
 import type {TimeScale} from '../../base/time_scale';
@@ -145,9 +145,9 @@ export class GroupSummaryTrack implements TrackRenderer {
   ]);
 
   // QuerySlot infrastructure
-  private readonly queue = new SerialTaskQueue();
-  private readonly tableSlot = new QuerySlot<MipmapTable>(this.queue);
-  private readonly dataSlot = new QuerySlot<Data>(this.queue);
+  private readonly queue = new AtomicTaskQueue();
+  private readonly tableSlot = new AsyncMemo<MipmapTable>(this.queue);
+  private readonly dataSlot = new AsyncMemo<Data>(this.queue);
 
   // Cached data for rendering (populated from dataSlot)
   private data?: Data;
@@ -359,7 +359,7 @@ export class GroupSummaryTrack implements TrackRenderer {
     const queryRes = await this.queryData(tableName, start, end, resolution);
 
     // Check cancellation after query completes
-    if (signal.isCancelled) throw QUERY_CANCELLED;
+    if (signal.isCancelled) throw TASK_CANCELLED;
 
     const priority = CHUNKED_TASK_BACKGROUND_PRIORITY.get()
       ? 'background'
@@ -401,7 +401,7 @@ export class GroupSummaryTrack implements TrackRenderer {
       // Periodically check for cancellation during iteration
       if (row % 50 === 0) {
         if (signal.isCancelled) {
-          throw QUERY_CANCELLED;
+          throw TASK_CANCELLED;
         }
 
         if (task.shouldYield()) {
@@ -526,7 +526,7 @@ export class GroupSummaryTrack implements TrackRenderer {
     const tableResult = this.tableSlot.use({
       // Key is constant - table only needs to be created once
       key: {mode: this.mode, upid: this.config.upid, utid: this.config.utid},
-      queryFn: () => this.createMipmapTable(trackNode),
+      compute: () => this.createMipmapTable(trackNode),
     });
 
     // Update sliceTracks from table result for tooltip rendering
@@ -545,7 +545,7 @@ export class GroupSummaryTrack implements TrackRenderer {
         end: bounds.end,
         resolution: bounds.resolution,
       },
-      queryFn: async (signal) => {
+      compute: async (signal) => {
         const result = await this.trace.taskTracker.track(
           this.fetchData(
             tableResult.data!.tableName,

--- a/ui/src/plugins/dev.perfetto.Sched/waker_overlay.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/waker_overlay.ts
@@ -14,7 +14,7 @@
 
 import {canvasSave, drawDoubleHeadedArrow} from '../../base/canvas_utils';
 import type {Size2D} from '../../base/geom';
-import {QuerySlot} from '../../base/query_slot';
+import {AsyncMemo} from '../../base/async_memo';
 import {Duration, type time} from '../../base/time';
 import type {TimeScale} from '../../base/time_scale';
 import {drawVerticalLineAtTime} from '../../base/vertical_line_helper';
@@ -36,7 +36,7 @@ const ARROW_HEIGHT = 12;
 
 export class WakerOverlay implements Overlay {
   private readonly trace: Trace;
-  private readonly wakeupSlot = new QuerySlot<SchedWakeupInfo | undefined>();
+  private readonly wakeupSlot = new AsyncMemo<SchedWakeupInfo | undefined>();
 
   constructor(trace: Trace) {
     this.trace = trace;
@@ -59,7 +59,7 @@ export class WakerOverlay implements Overlay {
     // Declaratively fetch wakeup info - QuerySlot handles caching and scheduling
     const result = this.wakeupSlot.use({
       key: {eventId: selection.eventId},
-      queryFn: () => this.loadWakeupInfo(selection),
+      compute: () => this.loadWakeupInfo(selection),
     });
 
     const wakeup = result.data;

--- a/ui/src/plugins/dev.perfetto.Screenshots/screenshots_track.ts
+++ b/ui/src/plugins/dev.perfetto.Screenshots/screenshots_track.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {QuerySlot} from '../../base/query_slot';
+import {AsyncMemo} from '../../base/async_memo';
 import {materialColorScheme} from '../../components/colorizer';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import type {Trace} from '../../public/trace';
@@ -22,7 +22,7 @@ import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {ScreenshotDetailsPanel} from './screenshot_panel';
 
 export function createScreenshotsTrack(trace: Trace, uri: string) {
-  const imageSlot = new QuerySlot<string>();
+  const imageSlot = new AsyncMemo<string>();
 
   // Screenshot slices are instants (0 dur), but we want the tooltip to show up
   // not only when hovering over the instant event exactly, but also when
@@ -72,7 +72,7 @@ export function createScreenshotsTrack(trace: Trace, uri: string) {
       const screenshot = imageSlot.use({
         key: {id: data.id},
         retainOn: ['id'],
-        queryFn: async () => {
+        compute: async () => {
           const result = await trace.engine.query(`
             select extract_arg(arg_set_id, 'screenshot.jpg_image') as image_data
             from slice

--- a/ui/src/plugins/dev.perfetto.TrackEvent/track_event_callstack_flamegraph.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/track_event_callstack_flamegraph.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {QuerySlot} from '../../base/query_slot';
+import {AsyncMemo} from '../../base/async_memo';
 import {sqliteString} from '../../base/string_utils';
 import {FlamegraphPanel} from '../../components/flamegraph_panel';
 import {
@@ -41,7 +41,7 @@ export class TrackEventCallstackFlamegraphTab implements AreaSelectionTab {
   readonly id = 'track_event_callstack_flamegraph';
   readonly name = 'Track Event Callstacks';
 
-  private readonly metadataSlot = new QuerySlot<Metadata>();
+  private readonly metadataSlot = new AsyncMemo<Metadata>();
   private metricsCache?: MetricsCache;
 
   constructor(
@@ -59,7 +59,7 @@ export class TrackEventCallstackFlamegraphTab implements AreaSelectionTab {
     const samplesSql = buildSamplesSql(selection, trackIds);
     const metadata = this.metadataSlot.use({
       key: {start: selection.start, end: selection.end, trackIds},
-      queryFn: () => this.queryMetadata(samplesSql),
+      compute: () => this.queryMetadata(samplesSql),
     });
     if (metadata.data === undefined) {
       return {isLoading: metadata.isPending, content: undefined};

--- a/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.VideoFrames/video_frames_track.ts
@@ -14,7 +14,7 @@
 
 import './video_frames.scss';
 import m from 'mithril';
-import {QuerySlot} from '../../base/query_slot';
+import {AsyncMemo} from '../../base/async_memo';
 import {materialColorScheme} from '../../components/colorizer';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import type {Trace} from '../../public/trace';
@@ -51,7 +51,7 @@ export function createVideoFramesTrack(
   `;
 
   // QuerySlot caches the decoded hover image per frame id.
-  const imageSlot = new QuerySlot<string | undefined>();
+  const imageSlot = new AsyncMemo<string | undefined>();
 
   // Singleton panel so mithril patches in place instead of remounting the
   // canvas on every selection (a remount would detach the canvas and stop
@@ -73,7 +73,7 @@ export function createVideoFramesTrack(
         // Keep the previous frame on screen while the next decodes, so
         // sweeping the cursor doesn't blink back to 'Loading...'.
         retainOn: ['id'],
-        queryFn: () => player.decodeFrameImage(data.id),
+        compute: () => player.decodeFrameImage(data.id),
       });
       if (image.data) {
         return [m('img.pf-video-frame-tooltip__img', {src: image.data})];

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
@@ -22,7 +22,7 @@ import type {
   DataSourceModel,
   DataSourceRows,
 } from '../../../components/widgets/datagrid/data_source';
-import type {QueryResult} from '../../../base/query_slot';
+import type {AsyncMemoResult} from '../../../base/async_memo';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
 import type {SQLTableSchema} from '../../../components/widgets/datagrid/sql_schema';
 import {renderDocSection, renderWidgetShowcase} from '../widgets_page_utils';
@@ -48,20 +48,22 @@ class ErrorEmulatingDataSource implements DataSource {
     return this.inner.useRows(model);
   }
 
-  useAggregateSummaries(model: DataSourceModel): QueryResult<Row> {
+  useAggregateSummaries(model: DataSourceModel): AsyncMemoResult<Row> {
     if (this.failing) {
-      return {data: undefined, isPending: false, isFresh: true};
+      return {data: {}, isPending: false};
     }
     return this.inner.useAggregateSummaries(model);
   }
 
   useDistinctValues(
     column: string | undefined,
-  ): QueryResult<readonly SqlValue[]> {
+  ): AsyncMemoResult<readonly SqlValue[]> {
     return this.inner.useDistinctValues(column);
   }
 
-  useParameterKeys(prefix: string | undefined): QueryResult<readonly string[]> {
+  useParameterKeys(
+    prefix: string | undefined,
+  ): AsyncMemoResult<readonly string[]> {
     return this.inner.useParameterKeys(prefix);
   }
 

--- a/ui/src/plugins/org.chromium.V8/v8_sources_tab.ts
+++ b/ui/src/plugins/org.chromium.V8/v8_sources_tab.ts
@@ -35,7 +35,7 @@ import {Tabs} from '../../widgets/tabs';
 import {TextInput} from '../../widgets/text_input';
 import {Tree, TreeNode} from '../../widgets/tree';
 import {formatFileSize} from '../../base/file_utils';
-import {QuerySlot} from '../../base/query_slot';
+import {AsyncMemo} from '../../base/async_memo';
 import type {ColumnSchema} from '../../components/widgets/datagrid/datagrid_schema';
 
 interface V8JsScript {
@@ -105,7 +105,7 @@ const TAB_FUNCTIONS = 'functions';
 
 export class V8SourcesTab implements Tab {
   private currentTab = TAB_SOURCE;
-  private readonly slot = new QuerySlot<ScriptResults | undefined>();
+  private readonly slot = new AsyncMemo<ScriptResults | undefined>();
   private selectedScriptId: number | undefined = undefined;
   private trace: Trace;
   private dataSource: SQLDataSource;
@@ -273,7 +273,7 @@ export class V8SourcesTab implements Tab {
     const {data: scriptResult} = this.slot.use({
       key: {id: selectedId},
       retainOn: ['id'],
-      queryFn: () => this.selectScript(selectedId),
+      compute: () => this.selectScript(selectedId),
     });
 
     const v8JsScriptUiSchema: ColumnSchema = {


### PR DESCRIPTION
- Rename `QuerySlot` to `AsyncMemo` because it has nothing to do with queries and everything to do with memoization with async tasks.
- Add `Memo` for synchronous memoization.
- Rename `SerialTaskQueue` to `AtomicTaskQueue` because it is used to make tasks run atomically without interleaving one another.

While in the area, do some cleanup:
- Remove `isFresh` from `AsyncMemo.use()` because the value wasn't consumed anywhere.
- Enforce `data` field returned by `AsyncMemo.use()` to be defined when `isPending` is false at the type system level. This avoids double checking.
- Move shared JSON types and disposable type predicates to base utility files.
