### PR TITLE
Migrate CUJ slices metric to stdlib

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -18742,6 +18742,7 @@ filegroup {
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/cuj_frame_counters.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/frames.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/relevant_slices.sql",
+        "src/trace_processor/perfetto_sql/stdlib/android/cujs/slices.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/threads.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/desktop_mode.sql",

--- a/BUILD
+++ b/BUILD
@@ -3751,6 +3751,7 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/cuj_frame_counters.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/frames.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/relevant_slices.sql",
+        "src/trace_processor/perfetto_sql/stdlib/android/cujs/slices.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/threads.sql",
     ],

--- a/src/trace_processor/metrics/sql/android/jank/slices.sql
+++ b/src/trace_processor/metrics/sql/android/jank/slices.sql
@@ -13,64 +13,20 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+INCLUDE PERFETTO MODULE android.cujs.slices;
+
+
 DROP VIEW IF EXISTS android_jank_cuj_slice;
 CREATE PERFETTO VIEW android_jank_cuj_slice AS
-SELECT
-  cuj_id,
-  process.upid,
-  process.name AS process_name,
-  thread.utid,
-  thread.name AS thread_name,
-  slice.*,
-  slice.ts + slice.dur AS ts_end
-FROM android_jank_cuj_boundary boundary
-JOIN process USING (upid)
-JOIN thread USING (upid)
-JOIN thread_track USING (utid)
-JOIN slice
-  ON slice.track_id = thread_track.id
-    -- Take slices which overlap even they started before the boundaries
-    -- This is to be able to query slices that delayed start of a frame
-    AND slice.ts + slice.dur >= boundary.ts AND slice.ts <= boundary.ts_end
-WHERE slice.dur > 0;
+SELECT * FROM _android_jank_cuj_slice;
 
 DROP TABLE IF EXISTS android_jank_cuj_main_thread_slice;
 CREATE PERFETTO TABLE android_jank_cuj_main_thread_slice AS
-SELECT
-  cuj_id,
-  upid,
-  utid,
-  slice.*,
-  slice.ts + slice.dur AS ts_end
-FROM android_jank_cuj_main_thread_cuj_boundary boundary
-JOIN thread_track USING (utid)
-JOIN thread USING (utid)
-JOIN slice
-  ON slice.track_id = thread_track.id
-    -- Take slices which overlap even they started before the boundaries
-    -- This is to be able to query slices that delayed start of a frame
-    AND slice.ts + slice.dur >= boundary.ts
-    AND slice.ts <= boundary.ts_end
-WHERE slice.dur > 0;
+SELECT * FROM _android_jank_cuj_main_thread_slice;
 
 DROP TABLE IF EXISTS android_jank_cuj_render_thread_slice;
 CREATE PERFETTO TABLE android_jank_cuj_render_thread_slice AS
-SELECT
-  cuj_id,
-  upid,
-  utid,
-  slice.*,
-  slice.ts + slice.dur AS ts_end
-FROM android_jank_cuj_render_thread_cuj_boundary boundary
-JOIN thread_track USING (utid)
-JOIN thread USING (utid)
-JOIN slice
-  ON slice.track_id = thread_track.id
-    -- Take slices which overlap even they started before the boundaries
-    -- This is to be able to query slices that delayed start of a frame
-    AND slice.ts + slice.dur >= boundary.ts
-    AND slice.ts <= boundary.ts_end
-WHERE slice.dur > 0;
+SELECT * FROM _android_jank_cuj_render_thread_slice;
 
 DROP VIEW IF EXISTS android_jank_cuj_sf_slice;
 CREATE PERFETTO VIEW android_jank_cuj_sf_slice AS

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/BUILD.gn
@@ -21,6 +21,7 @@ perfetto_sql_source_set("cujs") {
     "cuj_frame_counters.sql",
     "frames.sql",
     "relevant_slices.sql",
+    "slices.sql",
     "sysui_cujs.sql",
     "threads.sql",
   ]

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/slices.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/slices.sql
@@ -1,0 +1,195 @@
+--
+-- Copyright 2026 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+INCLUDE PERFETTO MODULE android.cujs.boundaries;
+
+-- Slices overlapping with the CUJ boundaries in the app processes.
+CREATE PERFETTO TABLE _android_jank_cuj_slice(
+  -- Unique incremental ID for each CUJ.
+  cuj_id LONG,
+  -- Process ID of the process.
+  upid JOINID(process.id),
+  -- Name of the process.
+  process_name STRING,
+  -- Thread ID of the thread.
+  utid JOINID(thread.id),
+  -- Name of the thread.
+  thread_name STRING,
+  -- Slice id.
+  id ID(slice.id),
+  -- Timestamp of the slice.
+  ts TIMESTAMP,
+  -- Duration of the slice.
+  dur LONG,
+  -- Track id of the slice.
+  track_id JOINID(track.id),
+  -- Name of the slice.
+  name STRING,
+  -- Depth of the slice in the stack.
+  depth LONG,
+  -- Parent slice id.
+  parent_id LONG,
+  -- Arg set id.
+  arg_set_id LONG,
+  -- Thread timestamp.
+  thread_ts TIMESTAMP,
+  -- Thread duration.
+  thread_dur LONG,
+  -- Legacy slice id alias.
+  slice_id LONG,
+  -- End timestamp of the slice.
+  ts_end TIMESTAMP
+)
+AS
+SELECT
+  cuj_id,
+  process.upid,
+  process.name AS process_name,
+  thread.utid,
+  thread.name AS thread_name,
+  slice.id,
+  slice.ts,
+  slice.dur,
+  slice.track_id,
+  slice.name,
+  slice.depth,
+  slice.parent_id,
+  slice.arg_set_id,
+  slice.thread_ts,
+  slice.thread_dur,
+  slice.slice_id,
+  slice.ts + slice.dur AS ts_end
+FROM _android_jank_cuj_boundary AS boundary
+JOIN process USING (upid)
+JOIN thread USING (upid)
+JOIN thread_track USING (utid)
+JOIN slice
+  ON slice.track_id = thread_track.id
+  -- Take slices which overlap even they started before the boundaries
+  -- This is to be able to query slices that delayed start of a frame
+  AND slice.ts + slice.dur >= boundary.ts
+  AND slice.ts <= boundary.ts_end
+WHERE
+  slice.dur > 0;
+
+-- Slices overlapping with the main thread CUJ boundaries in the app processes.
+CREATE PERFETTO TABLE _android_jank_cuj_main_thread_slice(
+  -- Unique incremental ID for each CUJ.
+  cuj_id LONG,
+  -- Process ID of the process.
+  upid JOINID(process.id),
+  -- Thread ID of the thread.
+  utid JOINID(thread.id),
+  -- Slice id.
+  id ID(slice.id),
+  -- Timestamp of the slice.
+  ts TIMESTAMP,
+  -- Duration of the slice.
+  dur LONG,
+  -- Track id of the slice.
+  track_id JOINID(track.id),
+  -- Category of the slice.
+  category STRING,
+  -- Name of the slice.
+  name STRING,
+  -- Depth of the slice in the stack.
+  depth LONG,
+  -- Parent slice id.
+  parent_id LONG,
+  -- Arg set id.
+  arg_set_id LONG,
+  -- Thread timestamp.
+  thread_ts TIMESTAMP,
+  -- Thread duration.
+  thread_dur LONG,
+  -- Thread instruction count.
+  thread_instruction_count LONG,
+  -- Thread instruction delta.
+  thread_instruction_delta LONG,
+  -- Legacy category alias.
+  cat STRING,
+  -- Legacy slice id alias.
+  slice_id LONG,
+  -- End timestamp of the slice.
+  ts_end TIMESTAMP
+)
+AS
+SELECT cuj_id, upid, utid, slice.*, slice.ts + slice.dur AS ts_end
+FROM _android_jank_cuj_main_thread_cuj_boundary AS boundary
+JOIN thread_track USING (utid)
+JOIN thread USING (utid)
+JOIN slice
+  ON slice.track_id = thread_track.id
+  -- Take slices which overlap even they started before the boundaries
+  -- This is to be able to query slices that delayed start of a frame
+  AND slice.ts + slice.dur >= boundary.ts
+  AND slice.ts <= boundary.ts_end
+WHERE
+  slice.dur > 0;
+
+-- Slices overlapping with the render thread CUJ boundaries in the app processes.
+CREATE PERFETTO TABLE _android_jank_cuj_render_thread_slice(
+  -- Unique incremental ID for each CUJ.
+  cuj_id LONG,
+  -- Process ID of the process.
+  upid JOINID(process.id),
+  -- Thread ID of the thread.
+  utid JOINID(thread.id),
+  -- Slice id.
+  id ID(slice.id),
+  -- Timestamp of the slice.
+  ts TIMESTAMP,
+  -- Duration of the slice.
+  dur LONG,
+  -- Track id of the slice.
+  track_id JOINID(track.id),
+  -- Category of the slice.
+  category STRING,
+  -- Name of the slice.
+  name STRING,
+  -- Depth of the slice in the stack.
+  depth LONG,
+  -- Parent slice id.
+  parent_id LONG,
+  -- Arg set id.
+  arg_set_id LONG,
+  -- Thread timestamp.
+  thread_ts TIMESTAMP,
+  -- Thread duration.
+  thread_dur LONG,
+  -- Thread instruction count.
+  thread_instruction_count LONG,
+  -- Thread instruction delta.
+  thread_instruction_delta LONG,
+  -- Legacy category alias.
+  cat STRING,
+  -- Legacy slice id alias.
+  slice_id LONG,
+  -- End timestamp of the slice.
+  ts_end TIMESTAMP
+)
+AS
+SELECT cuj_id, upid, utid, slice.*, slice.ts + slice.dur AS ts_end
+FROM _android_jank_cuj_render_thread_cuj_boundary AS boundary
+JOIN thread_track USING (utid)
+JOIN thread USING (utid)
+JOIN slice
+  ON slice.track_id = thread_track.id
+  -- Take slices which overlap even they started before the boundaries
+  -- This is to be able to query slices that delayed start of a frame
+  AND slice.ts + slice.dur >= boundary.ts
+  AND slice.ts <= boundary.ts_end
+WHERE
+  slice.dur > 0;


### PR DESCRIPTION
And remove a few columns that were coming from `slice.*` but we were not using, and very likely nobody was using.