### PR TITLE
ui: make heap-dump flamegraph path hash aggregatable; pivot on class

### DIFF
--- a/docs/visualization/heap-dump-explorer.md
+++ b/docs/visualization/heap-dump-explorer.md
@@ -404,10 +404,9 @@ pivoted, and removing the chip returns to Top Down.
 
 The object tab integrates with pivot directly: the
 _Shortest Path from GC Root_ and _Dominator Tree Path_ sections each
-have a _View in Flamegraph_ button that opens this tab pivoted on
-that specific instance's path (the chip reads
-`ClassName (this instance)`), using the _Object Size_ or
-_Dominated Object Size_ metric respectively.
+have a _View class in Flamegraph_ button that opens this tab pivoted
+on the object's class (the chip reads `ClassName`), using the
+_Object Size_ or _Dominated Object Size_ metric respectively.
 
 ### Node actions
 

--- a/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
@@ -245,7 +245,7 @@ function buildTabs(
         activeDump,
         heaps: overview.heaps,
         navigate: navigateWithTabs,
-        openFlamegraphPivotedAt: session.openFlamegraphPivotedAt,
+        openFlamegraphPivotedOnClass: session.openFlamegraphPivotedOnClass,
         params: {id: obj.objId},
       }),
     });

--- a/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
@@ -19,7 +19,8 @@ import type {Setting} from '../../public/settings';
 import type {Store} from '../../base/store';
 import {NUM} from '../../trace_processor/query_result';
 
-import {SQL_PREAMBLE} from './components';
+import {SQL_PREAMBLE, shortClassName} from './components';
+import {escapeRegex} from '../../widgets/flamegraph_regex';
 import {flamegraphQuery} from './views/flamegraph_objects_view';
 import * as queries from './queries';
 import {
@@ -376,12 +377,8 @@ export class HeapDumpExplorerSession {
     });
   };
 
-  // Open the flamegraph pivoted at `pathHash`. The metric matches the tree the
-  // hash came from. The chip shows `<label> (this instance)` since the raw hash
-  // regex is unreadable.
-  readonly openFlamegraphPivotedAt = (
-    pathHash: string,
-    label: string,
+  readonly openFlamegraphPivotedOnClass = (
+    className: string,
     isDominator: boolean,
   ): void => {
     this.setFlamegraphPanelState({
@@ -392,8 +389,8 @@ export class HeapDumpExplorerSession {
       filters: [],
       view: {
         kind: 'PIVOT',
-        pivot: `/^${pathHash}$/`,
-        displayLabel: `${label} (this instance)`,
+        pivot: `/^${escapeRegex(className)}$/`,
+        displayLabel: shortClassName(className),
       },
     });
     this.navigate('flamegraph');

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
@@ -28,7 +28,7 @@ import {
   incompleteFlamegraphModal,
 } from '../../dev.perfetto.HeapProfile/incomplete_flamegraph';
 
-// Referenced by session.openFlamegraphPivotedAt.
+// Referenced by session.openFlamegraphPivotedOnClass.
 export const METRIC_OBJECT_SIZE = 'Object Size';
 export const METRIC_DOMINATED_OBJECT_SIZE = 'Dominated Object Size';
 
@@ -42,25 +42,25 @@ interface FlamegraphViewAttrs {
   readonly onShowObjects: (pathHashes: string, isDominator: boolean) => void;
 }
 
-// path_hash_stable is exposed unaggregatable (and CAST to TEXT in SQL,
-// since the stdlib emits it as INT64 and the flamegraph reads
-// unaggregatable columns as STR_NULL) so it lands in `matchingColumns`
-// — that's what lets a PIVOT filter target a specific node by its hash.
-// Hidden from the tooltip via `isVisible: false`.
 const UNAGG_PROPS = [
   {name: 'root_type', displayName: 'Root Type'},
   {name: 'heap_type', displayName: 'Heap Type'},
-  {
-    name: 'path_hash_stable',
-    displayName: 'Path Hash',
-    isVisible: () => false,
-  },
 ];
 
 const SELF_COUNT_AGG_PROP = {
   name: 'self_count',
   displayName: 'Self Count',
   mergeAggregation: 'SUM' as const,
+};
+
+// Must stay aggregatable: as a frame-identity column it would split
+// otherwise-identical frames in bottom-up. Merged nodes get the comma-joined
+// hash list, read by the "Show objects" drill-down.
+const PATH_HASH_AGG_PROP = {
+  name: 'path_hash_stable',
+  displayName: 'Path Hash',
+  mergeAggregation: 'CONCAT_WITH_COMMA' as const,
+  isVisible: () => false,
 };
 
 // Build a JAVA_HEAP_GRAPH metric for the BFS or dominator class tree,
@@ -100,7 +100,9 @@ function buildMetric(
     `,
     unaggregatableProperties: UNAGG_PROPS,
     aggregatableProperties:
-      valueColumn === 'self_size' ? [SELF_COUNT_AGG_PROP] : [],
+      valueColumn === 'self_size'
+        ? [SELF_COUNT_AGG_PROP, PATH_HASH_AGG_PROP]
+        : [PATH_HASH_AGG_PROP],
     optionalNodeActions: [showObjectsAction],
   };
 }

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
@@ -14,11 +14,7 @@
 
 import m from 'mithril';
 import type {Engine} from '../../../trace_processor/engine';
-import {
-  STR,
-  type Row,
-  type SqlValue,
-} from '../../../trace_processor/query_result';
+import type {Row, SqlValue} from '../../../trace_processor/query_result';
 import {Spinner} from '../../../widgets/spinner';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import type {
@@ -47,11 +43,10 @@ export interface ObjectParams {
   readonly id: number;
 }
 
-// Open the flamegraph pivoted at the given path. Routed through the
-// session so flamegraph state has a single owner.
-export type OpenFlamegraphPivotedAt = (
-  pathHash: string,
-  label: string,
+// Open the flamegraph pivoted on the given class. Routed through the session
+// so flamegraph state has a single owner.
+export type OpenFlamegraphPivotedOnClass = (
+  className: string,
   isDominator: boolean,
 ) => void;
 
@@ -60,7 +55,7 @@ interface ObjectViewAttrs {
   readonly activeDump: HeapDump;
   readonly heaps: ReadonlyArray<HeapInfo>;
   readonly navigate: NavFn;
-  readonly openFlamegraphPivotedAt: OpenFlamegraphPivotedAt;
+  readonly openFlamegraphPivotedOnClass: OpenFlamegraphPivotedOnClass;
   readonly params: ObjectParams;
 }
 
@@ -608,19 +603,14 @@ export function ObjectView(): m.Component<ObjectViewAttrs> {
               'button',
               {
                 class: 'pf-hde-link',
-                title: isDominator
-                  ? 'Open in Flamegraph pivoted on this dominator path'
-                  : 'Open in Flamegraph pivoted on this shortest path',
+                title: 'View this class in the Flamegraph',
                 onclick: () =>
-                  openInFlamegraph(
-                    vnode.attrs.engine,
-                    row.id,
+                  vnode.attrs.openFlamegraphPivotedOnClass(
                     row.className,
                     isDominator,
-                    vnode.attrs.openFlamegraphPivotedAt,
                   ),
               },
-              'View in Flamegraph',
+              'View class in Flamegraph',
             )
           : null;
 
@@ -1032,33 +1022,6 @@ function renderArrayGrid(
       showExportButton: true,
     }),
   ]);
-}
-
-// Look up the object's path_hash in the chosen tree (BFS or dominator)
-// and open the flamegraph pivoted on it with the matching metric. The
-// hash is tree-specific so the tree dictates both. No-op if the object
-// has no entry (e.g. unreachable garbage).
-async function openInFlamegraph(
-  engine: Engine,
-  id: number,
-  cls: string,
-  isDominator: boolean,
-  openFlamegraphPivotedAt: OpenFlamegraphPivotedAt,
-): Promise<void> {
-  const moduleName = isDominator
-    ? 'android.memory.heap_graph.dominator_class_tree'
-    : 'android.memory.heap_graph.class_tree';
-  const table = isDominator
-    ? '_heap_graph_dominator_path_hashes'
-    : '_heap_graph_path_hashes';
-  await engine.query(`INCLUDE PERFETTO MODULE ${moduleName};`);
-  const res = await engine.query(
-    `SELECT CAST(path_hash AS TEXT) AS path_hash
-       FROM ${table} WHERE id = ${id} LIMIT 1`,
-  );
-  const it = res.iter({path_hash: STR});
-  if (!it.valid()) return;
-  openFlamegraphPivotedAt(it.path_hash, shortClassName(cls), isDominator);
 }
 
 // `java.lang.Class<Foo>` has no useful subclasses in heap_graph_class; the


### PR DESCRIPTION
Make the Heap Dump Explorer's path_hash_stable aggregatable instead of unaggregatable so bottom-up merges same-class frames on different paths, matching the timeline heap-graph flamegraph.

path_hash is therefore no longer matchable, so the object tab's "View in Flamegraph" can no longer target one instance's path; pivot on the class instead (button renamed "View class in Flamegraph").
