### PR TITLE
perfetto: don't reference nonexistent zstd targets in embedder builds

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -467,25 +467,10 @@ if (enable_perfetto_zstd) {
     if (perfetto_root_path == "//") {
       public_configs = [ "//buildtools:zstd_config" ]
       public_deps = [ "//buildtools:zstd" ]
-    } else if (build_with_chromium) {
-      # Chromium's //third_party/zstd exposes per-stage source_sets rather than
-      # a single :zstd target + :zstd_config, so map to those and supply the
-      # include path ourselves.
-      # https://crsrc.org/c/third_party/zstd/BUILD.gn
-      public_configs = [ ":zstd_chromium_include_path" ]
-      public_deps = [
-        "//third_party/zstd:compress",
-        "//third_party/zstd:decompress",
-      ]
     } else {
-      public_configs = [ "//third_party/zstd:zstd_config" ]
-      public_deps = [ "//third_party/zstd" ]
-    }
-  }
-
-  config("zstd_chromium_include_path") {
-    if (build_with_chromium) {
-      include_dirs = [ "//third_party/zstd/src/lib" ]
+      assert(false,
+             "Zstd is unsupported in embedder builds. Set " +
+                 "enable_perfetto_zstd=false or override //gn:zstd.")
     }
   }
 }

--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -393,13 +393,16 @@ declare_args() {
   # service) and to decompress traces (by trace_processor), as an alternative
   # to Zlib/deflate.
   #
-  # Off in Chromium builds: enabling it makes the tracing service the first
-  # thing to pull Chromium's //third_party/zstd:compress (the zstd *encoder*)
-  # into size-optimized Android. Chrome only ever linked the decoder there, so
-  # this added ~235 KB to Trichrome, which is too much to justify. See the
-  # size increase on the Chromium roll: https://crrev.com/c/8065805
+  # Only on builds that have zstd in buildtools/ (standalone, Android tree,
+  # generators). GN embedders have no common zstd target, see //gn:zstd.
+  # Chromium does have one (//third_party/zstd:{compress,decompress}) but is
+  # left out on purpose: Chrome only ever linked the zstd *decoder*, so turning
+  # this on made the tracing service the first thing to pull the *encoder* into
+  # size-optimized Android, adding ~235 KB to Trichrome. See the size increase
+  # on the Chromium roll: https://crrev.com/c/8065805
   enable_perfetto_zstd =
-      !build_with_chromium &&
+      (perfetto_build_standalone || perfetto_build_with_android ||
+       is_perfetto_build_generator) &&
       (enable_perfetto_trace_processor || enable_perfetto_platform_services)
 
   # Enables PCRE2 support. Individual modules that should not pull libpcre2


### PR DESCRIPTION
- //gn:zstd pointed embedders at //third_party/zstd{,:zstd_config},
  which doesn't exist in Chromium-derived trees. Merely defining the
  group broke `gn gen` in WebRTC.
- enable_perfetto_zstd now defaults on only where buildtools/zstd is
  defines, so embedders no longer need enable_perfetto_zstd=false 
  as a workaround. Chromium stays off, same as before.

Bug: 539472184
