### PR TITLE
perfetto: don't count aborted packets as ABI violations

### DIFF
--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -739,9 +739,13 @@ void TraceBufferV2::CopyChunkUntrusted(
     std::optional<Frag> maybe_frag = frag_iter.NextFragmentInChunk();
     if (!maybe_frag.has_value()) {
       // Either we found less fragments than what the header said, or some
-      // fragment is out of bounds.
-      stats_.set_abi_violations(stats_.abi_violations() + 1);
-      PERFETTO_DCHECK(suppress_client_dchecks_for_testing_);
+      // fragment is out of bounds. The exception is a TraceWriter that
+      // deliberately aborted the packet (kPacketSizeDropPacket), which is not
+      // an ABI violation and is accounted via trace_writer_packet_loss.
+      if (!frag_iter.trace_writer_data_drop()) {
+        stats_.set_abi_violations(stats_.abi_violations() + 1);
+        PERFETTO_DCHECK(suppress_client_dchecks_for_testing_);
+      }
       break;
     }
     Frag& f = *maybe_frag;

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -752,6 +752,24 @@ TEST_F(TraceBufferV2Test, Fragments_DiscardedOnPacketSizeDropPacket) {
   ASSERT_THAT(ReadPacket(), IsEmpty());
 }
 
+TEST_F(TraceBufferV2Test, Fragments_PacketSizeDropPacketIsNotAbiViolation) {
+  ResetBuffer(4096);
+  // A TraceWriter aborting a packet with kPacketSizeDropPacket is legitimate
+  // behaviour since Android R. It must be accounted as a trace writer data
+  // loss and not as an ABI violation.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(10, 'a')
+      // Var-int encoded TraceWriterImpl::kPacketSizeDropPacket.
+      .AddPacket({0xff, 0xff, 0xff, 0x7f})
+      .CopyIntoTraceBuffer();
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(10, 'a')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+
+  EXPECT_EQ(0u, trace_buffer()->stats().abi_violations());
+  EXPECT_EQ(1u, trace_buffer()->stats().trace_writer_packet_loss());
+}
+
 TEST_F(TraceBufferV2Test, Fragments_IncompleteChunkNeedsPatching) {
   ResetBuffer(4096);
   CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))


### PR DESCRIPTION
A TraceWriter can abort a packet by writing kPacketSizeDropPacket in the fragment header. 

FragIterator already treats this as expected behaviour, but CopyChunkUntrusted counted the resulting missing fragment as an ABI violation. 

Skip the counter (and the client DCHECK) when the fragment iterator reports a writer abort, which is already tracked separately by trace_writer_packet_loss.
