### PR TITLE
tp: add and parse UIDs for Android process lifecycle events

### DIFF
--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
@@ -677,7 +677,7 @@ message AndroidFreezerEvent {
 }
 
 message AndroidProcessStartEvent {
-  // The uid of the ProcessRecord.
+  // Real (kernel) uid of the ProcessRecord.
   optional int32 uid = 1;
 
   // The process pid.
@@ -706,12 +706,21 @@ message AndroidProcessStartEvent {
 
   // start sequence id which is assigned to a process during start update
   optional int64 start_seq_id = 10;
+
+  // The host package uid.
+  optional int32 package_uid = 11;
+
+  // The caller uid. See HostingRecord#getCallerUid.
+  optional int32 caller_uid = 12;
+
+  // The defining uid. See HostingRecord#getDefiningUid.
+  optional int32 defining_uid = 13;
 }
 
 // This can be delayed for up to 15s in some cases. It should typically
 // be paired with AndroidBinderDiedEvent which has less latency.
 message AndroidProcessDiedEvent {
-  // Uid of the package of the dying process.
+  // Real (kernel) uid of the dying process.
   optional int32 uid = 1;
 
   // Pid of the dying process.
@@ -737,12 +746,18 @@ message AndroidProcessDiedEvent {
 
   // start sequence id which is assigned to a process during start update
   optional int64 start_seq_id = 9;
+
+  // The host package uid.
+  optional int32 package_uid = 10;
+
+  // The defining uid. See HostingRecord#getDefiningUid.
+  optional int32 defining_uid = 11;
 }
 
 // This is expected to come earlier than AndroidProcessDiedEvent.
 // For death reasons, see AndroidProcessDiedEvent.
 message AndroidBinderDiedEvent {
-  // Uid of the package of the dying process.
+  // The real (kernel) uid of the dying process.
   optional int32 uid = 1;
 
   // Pid of the dying process.

--- a/src/trace_processor/plugins/android_framework_track_event/android_framework_track_event.cc
+++ b/src/trace_processor/plugins/android_framework_track_event/android_framework_track_event.cc
@@ -115,6 +115,15 @@ class Parser : public TrackEventExtensionParser {
     if (evt.has_start_seq_id()) {
       row.set_start_seq_id(evt.start_seq_id());
     }
+    if (evt.has_package_uid()) {
+      row.set_package_uid(evt.package_uid());
+    }
+    if (evt.has_caller_uid()) {
+      row.set_caller_uid(evt.caller_uid());
+    }
+    if (evt.has_defining_uid()) {
+      row.set_defining_uid(evt.defining_uid());
+    }
     if (!row.fw_start_ts().has_value()) {
       row.set_fw_start_ts(ts);
     }

--- a/src/trace_processor/plugins/android_framework_track_event/tables.py
+++ b/src/trace_processor/plugins/android_framework_track_event/tables.py
@@ -32,6 +32,15 @@ ANDROID_TRACK_EVENT_PROCESS_TABLE = Table(
         C('start_seq_id',
           CppOptional(CppInt64()),
           cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C('package_uid',
+          CppOptional(CppInt32()),
+          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C('caller_uid',
+          CppOptional(CppInt32()),
+          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
+        C('defining_uid',
+          CppOptional(CppInt32()),
+          cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
         C('fw_start_ts',
           CppOptional(CppInt64()),
           cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE),
@@ -62,6 +71,12 @@ ANDROID_TRACK_EVENT_PROCESS_TABLE = Table(
                 'The process this row describes.',
             'start_seq_id':
                 'start_seq assigned when the process started.',
+            'package_uid':
+                'The host package uid.',
+            'caller_uid':
+                'The caller uid.',
+            'defining_uid':
+                'The defining uid.',
             'fw_start_ts':
                 'Timestamp of AndroidProcessStartEvent.',
             'fw_end_ts':

--- a/test/trace_processor/diff_tests/parser/android/android_framework_track_event.textproto
+++ b/test/trace_processor/diff_tests/parser/android/android_framework_track_event.textproto
@@ -26,6 +26,9 @@ packet {
       pid: 100
       process_name: "com.example.app"
       start_seq_id: 42
+      package_uid: 10002
+      caller_uid: 10003
+      defining_uid: 10004
     }
   }
 }

--- a/test/trace_processor/diff_tests/parser/android/tests.py
+++ b/test/trace_processor/diff_tests/parser/android/tests.py
@@ -295,13 +295,22 @@ class AndroidParser(TestSuite):
     return DiffTestBlueprint(
         trace=Path('android_framework_track_event.textproto'),
         query="""
-        SELECT p.pid, p.name, p.uid, t.start_seq_id, t.fw_start_ts, t.fw_end_ts
+        SELECT
+          p.pid,
+          p.name,
+          p.uid,
+          t.start_seq_id,
+          t.package_uid,
+          t.caller_uid,
+          t.defining_uid,
+          t.fw_start_ts,
+          t.fw_end_ts
         FROM __intrinsic_android_track_event_process t
         JOIN process p USING (upid);
         """,
         out=Csv("""
-          "pid","name","uid","start_seq_id","fw_start_ts","fw_end_ts"
-          100,"com.example.app",10001,42,2000,5000
+          "pid","name","uid","start_seq_id","package_uid","caller_uid","defining_uid","fw_start_ts","fw_end_ts"
+          100,"com.example.app",10001,42,10002,10003,10004,2000,5000
         """))
 
   def test_android_framework_track_event_enum(self):


### PR DESCRIPTION
This PR extends Android process lifecycle track event definitions with UID fields and parses them into Trace Processor:

1. Proto Definitions (`frameworks_base_track_event.proto`):
   - Adds `package_uid`, `caller_uid`, and `defining_uid` to `AndroidProcessStartEvent`.
   - Adds `package_uid` and `defining_uid` to `AndroidProcessDiedEvent`.

2. Trace Processor (`android_framework_track_event` plugin):
   - Extends the `__intrinsic_android_track_event_process` table in `tables.py` with `package_uid`, `caller_uid`, and `defining_uid` columns.
   - Updates `HandleProcessStart(...)` in `android_framework_track_event.cc` to extract the UIDs from `AndroidProcessStartEvent` and populate them in the table rows.                                                                                                                                                              
   
3. Testing:
   - Extends parser diff tests (`android_framework_track_event.textproto` and `tests.py`) to verify that UID fields are correctly parsed into `__intrinsic_android_track_event_process`.
