### PR TITLE
Source Android jank CUJ pin from stdlib summary table

### DIFF
--- a/python/tools/check_ratchet.py
+++ b/python/tools/check_ratchet.py
@@ -37,7 +37,7 @@ import dataclasses
 from dataclasses import dataclass
 
 EXPECTED_ANY_COUNT = 28
-EXPECTED_RUN_METRIC_COUNT = 4
+EXPECTED_RUN_METRIC_COUNT = 3
 
 ROOT_DIR = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/frames.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/frames.sql
@@ -278,3 +278,91 @@ WITH
   )
 SELECT *, ROW_NUMBER() OVER (PARTITION BY cuj_id ORDER BY vsync) AS frame_number
 FROM android_jank_cuj_sf_frame_base;
+
+-- Per-CUJ summary used to pin jank CUJs as a track. Contains one row per CUJ
+-- slice (including canceled and unknown-state CUJs, unlike `android_jank_cuj`),
+-- with aggregated frame stats, resolved layer name and boundary-aware
+-- timestamps. This bundles everything needed to display jank CUJs so that
+-- consumers (e.g. the UI) can query it directly without additional logic.
+CREATE PERFETTO TABLE android_jank_cuj_slice_summary(
+  -- CUJ id.
+  cuj_id LONG,
+  -- Name of the CUJ slice (e.g. 'J<CUJ_NAME>').
+  name STRING,
+  -- Name of the process the CUJ belongs to.
+  process_name STRING,
+  -- State of the CUJ. One of 'completed', 'canceled' or NULL.
+  state STRING,
+  -- Total number of frames in the CUJ.
+  total_frames LONG,
+  -- Number of frames where the app missed the deadline.
+  missed_app_frames LONG,
+  -- Number of frames where SurfaceFlinger missed the deadline.
+  missed_sf_frames LONG,
+  -- Layer name of the CUJ.
+  layer_name STRING,
+  -- Start timestamp of the CUJ. The main thread boundary start if available,
+  -- otherwise the CUJ slice ts (e.g. for canceled CUJs).
+  ts TIMESTAMP,
+  -- Duration of the CUJ. The main thread boundary duration if available,
+  -- otherwise the CUJ slice dur (e.g. for canceled CUJs).
+  dur DURATION,
+  -- Track id of the CUJ slice.
+  track_id JOINID(track.id),
+  -- Slice id of the CUJ slice.
+  slice_id JOINID(slice.id)
+)
+AS
+WITH
+  frame_counts AS (
+    SELECT
+      cuj_id,
+      count(*) AS total_frames,
+      sum(app_missed) AS missed_app_frames,
+      sum(sf_missed) AS missed_sf_frames
+    FROM _android_jank_cuj_frame_timeline
+    GROUP BY
+      cuj_id
+  )
+SELECT
+  cuj.cuj_id,
+  cuj.cuj_slice_name AS name,
+  cuj.process_name,
+  CASE
+    WHEN EXISTS (
+      SELECT 1
+      FROM _cuj_state_markers AS csm
+      WHERE
+        csm.cuj_id = cuj.cuj_id
+        AND csm.marker_type = 'cancel'
+    ) THEN 'canceled'
+    WHEN EXISTS (
+      SELECT 1
+      FROM _cuj_state_markers AS csm
+      WHERE
+        csm.cuj_id = cuj.cuj_id
+        AND csm.marker_type = 'end'
+    ) THEN 'completed'
+    ELSE NULL
+  END AS state,
+  fc.total_frames,
+  fc.missed_app_frames,
+  fc.missed_sf_frames,
+  layer.layer_name,
+  coalesce(boundary.ts, cuj.ts) AS ts,
+  coalesce(boundary.dur, cuj.dur) AS dur,
+  s.track_id,
+  cuj.slice_id
+FROM _jank_cujs_slices AS cuj
+JOIN slice AS s
+  ON s.id = cuj.slice_id
+-- Gate frame stats and boundary on android_jank_cuj membership: canceled/invalid
+-- CUJs get NULL stats and fall back to raw slice ts/dur. Layer name covers all
+-- CUJs, so it joins on the raw cuj_id.
+LEFT JOIN android_jank_cuj AS ajc USING (cuj_id)
+LEFT JOIN frame_counts AS fc
+  ON fc.cuj_id = ajc.cuj_id
+LEFT JOIN android_jank_cuj_layer_name AS layer
+  ON layer.cuj_id = cuj.cuj_id
+LEFT JOIN _android_jank_cuj_main_thread_cuj_boundary AS boundary
+  ON boundary.cuj_id = ajc.cuj_id;

--- a/test/trace_processor/diff_tests/stdlib/android/frames_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/android/frames_tests.py
@@ -273,3 +273,22 @@ class Frames(TestSuite):
         160,266000000,7000000,2000000,1,"[NULL]","[NULL]","[NULL]"
         1000,480000000,250000000,100000000,1,1,1,1
         """))
+
+  def test_android_jank_cuj_slice_summary(self):
+    return DiffTestBlueprint(
+        trace=Path('../../metrics/graphics/android_jank_cuj.py'),
+        query="""
+        INCLUDE PERFETTO MODULE android.cujs.frames;
+
+        SELECT
+          name, process_name, state, total_frames, missed_app_frames,
+          missed_sf_frames, layer_name, ts, dur
+        FROM android_jank_cuj_slice_summary
+        ORDER BY name, ts;
+        """,
+        out=Csv("""
+        "name","process_name","state","total_frames","missed_app_frames","missed_sf_frames","layer_name","ts","dur"
+        "J<CANCELED>","com.android.systemui","canceled","[NULL]","[NULL]","[NULL]","[NULL]",100100000,898900000
+        "J<FIRST_CUJ>","com.android.systemui","completed",6,5,1,"TX - NotificationShade#0",0,115000000
+        "J<SHADE_ROW_EXPAND>","com.android.systemui","completed",13,7,2,"TX - NotificationShade#0",0,802000000
+        """))

--- a/ui/src/plugins/com.android.AndroidCujs/index.ts
+++ b/ui/src/plugins/com.android.AndroidCujs/index.ts
@@ -42,9 +42,24 @@ export async function addJankCUJDebugTrack(
 }
 
 const JANK_CUJ_QUERY_PRECONDITIONS = `
-  SELECT RUN_METRIC('android/jank/android_jank_cuj_init.sql');
+  INCLUDE PERFETTO MODULE android.cujs.frames;
   INCLUDE PERFETTO MODULE android.critical_blocking_calls;
 `;
+
+/**
+ * Builds the comma separated list of quoted CUJ slice names (both latency 'L<>'
+ * and jank 'J<>' variants) to use in a SQL `IN (...)` clause, or empty string
+ * if no names were requested.
+ *
+ * @param {string | string[]} cujNames List of CUJs to filter by
+ * @returns Returns the SQL `IN` list contents, or '' if unfiltered
+ */
+function cujNameInList(cujNames: string | string[]): string {
+  const cujNamesList = typeof cujNames === 'string' ? [cujNames] : cujNames;
+  return cujNamesList.length > 0
+    ? cujNamesList.map((name) => `'L<${name}>','J<${name}>'`).join(',')
+    : '';
+}
 
 /**
  * Generate the Track config for a multiple Jank CUJ slices
@@ -55,76 +70,45 @@ const JANK_CUJ_QUERY_PRECONDITIONS = `
 function generateJankCujTrackConfig(cujNames: string | string[] = []) {
   // This method expects the caller to have run JANK_CUJ_QUERY_PRECONDITIONS
   // Not running the precondition query here to save time in case already run
-  return generateCujTrackConfig(cujNames, JANK_CUJ_QUERY, JANK_COLUMNS);
+  const inList = cujNameInList(cujNames);
+  // The stdlib table exposes the raw (undecorated) CUJ name, so we can filter on
+  // it directly even though the selected `name` column is emoji-decorated.
+  const filterCuj = inList ? ` WHERE name IN (${inList})` : '';
+  return {
+    data: {
+      sqlSource: `${JANK_CUJ_QUERY}${filterCuj}`,
+      columns: JANK_COLUMNS,
+    },
+    rawColumns: JANK_COLUMNS,
+  };
 }
 
+// Maps the stdlib CUJ `state` column to a status indicator prefixed to each
+// pinned slice name. The icons live here (a display concern) so that the SQL
+// stays a plain query over the stdlib table.
+const CUJ_STATUS_INDICATOR = {
+  canceled: '❌',
+  completed: '✅',
+  unknown: '❓',
+};
+
 const JANK_CUJ_QUERY = `
-    WITH missed_frame_counts AS (
-      SELECT cuj_id,
-        COUNT(*) AS total_frames,
-        SUM(app_missed) AS missed_app_frames,
-        SUM(sf_missed) AS missed_sf_frames
-      FROM
-        android_jank_cuj_frame_timeline
-      GROUP BY cuj_id
-    )
     SELECT
-      CASE
-        WHEN
-          EXISTS(
-              SELECT 1
-              FROM slice AS cuj_state_marker
-                     JOIN track marker_track
-                          ON marker_track.id = cuj_state_marker.track_id
-              WHERE
-                cuj_state_marker.ts >= cuj.ts
-                AND cuj_state_marker.ts + cuj_state_marker.dur <= cuj.ts + cuj.dur
-                AND
-                ( /* e.g. J<CUJ_NAME>#FT#cancel#0 this for backward compatibility */
-                      cuj_state_marker.name GLOB(cuj.name || '#FT#cancel*')
-                    OR (marker_track.name = cuj.name AND cuj_state_marker.name GLOB 'FT#cancel*')
-                  )
-            )
-          THEN ' ❌ '
-        WHEN
-          EXISTS(
-              SELECT 1
-              FROM slice AS cuj_state_marker
-                     JOIN track marker_track
-                          ON marker_track.id = cuj_state_marker.track_id
-              WHERE
-                cuj_state_marker.ts >= cuj.ts
-                AND cuj_state_marker.ts + cuj_state_marker.dur <= cuj.ts + cuj.dur
-                AND
-                ( /* e.g. J<CUJ_NAME>#FT#end#0 this for backward compatibility */
-                      cuj_state_marker.name GLOB(cuj.name || '#FT#end*')
-                    OR (marker_track.name = cuj.name AND cuj_state_marker.name GLOB 'FT#end*')
-                  )
-            )
-          THEN ' ✅ '
-        ELSE ' ❓ '
-        END || cuj.name AS name,
-      p.name AS process_name,
+      CASE state
+        WHEN 'canceled' THEN ' ${CUJ_STATUS_INDICATOR.canceled} '
+        WHEN 'completed' THEN ' ${CUJ_STATUS_INDICATOR.completed} '
+        ELSE ' ${CUJ_STATUS_INDICATOR.unknown} '
+      END || name AS name,
+      process_name,
       total_frames,
       missed_app_frames,
       missed_sf_frames,
-      cuj_layer.layer_name,
-      /* Boundaries table doesn't contain ts and dur when a CUJ didn't complete successfully.
-        In that case we still want to show that it was canceled, so let's take the slice timestamps. */
-      CASE WHEN boundaries.ts IS NOT NULL THEN boundaries.ts ELSE cuj.ts END AS ts,
-      CASE WHEN boundaries.dur IS NOT NULL THEN boundaries.dur ELSE cuj.dur END AS dur,
-      cuj.track_id,
-      cuj.slice_id
-    FROM slice AS cuj
-          JOIN process_track AS pt ON cuj.track_id = pt.id
-          JOIN process AS p ON pt.upid = p.upid
-          LEFT JOIN android_jank_cuj jc
-                    ON pt.upid = jc.upid AND cuj.name = jc.cuj_slice_name AND cuj.ts = jc.ts
-          LEFT JOIN android_jank_cuj_main_thread_cuj_boundary boundaries using (cuj_id)
-          LEFT JOIN android_jank_cuj_layer_name cuj_layer USING (cuj_id)
-          LEFT JOIN missed_frame_counts USING (cuj_id)
-    WHERE cuj.name GLOB 'J<*>'
-      AND cuj.dur > 0
+      layer_name,
+      ts,
+      dur,
+      track_id,
+      slice_id
+    FROM android_jank_cuj_slice_summary
 `;
 
 const JANK_COLUMNS = [
@@ -261,13 +245,8 @@ function generateCujTrackConfig(
 ) {
   // This method expects the caller to have run JANK_CUJ_QUERY_PRECONDITIONS
   // Not running the precondition query here to save time in case already run
-  const cujNamesList = typeof cujNames === 'string' ? [cujNames] : cujNames;
-  const filterCuj =
-    cujNamesList?.length > 0
-      ? ` AND cuj.name IN (${cujNamesList
-          .map((name) => `'L<${name}>','J<${name}>'`)
-          .join(',')})`
-      : '';
+  const inList = cujNameInList(cujNames);
+  const filterCuj = inList ? ` AND cuj.name IN (${inList})` : '';
 
   return {
     data: {


### PR DESCRIPTION
This moves most of the logic that was in the ui plugin to a table that everyone interested in displaying CUJs can use.

The emoji handling is still in the plugin though.