### PR TITLE
ui: Serialise workspaces to permalink

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Unreleased:
     * Fixed flicker when selecting between track events.
     * Memscope: native callstack snippet table no longer truncates frames.
     * Intelletto: registered tools with Chrome's WebMCP API.
+    * Serialize workspaces to permalinks.
   SDK:
     *
 

--- a/ui/src/core/state_serialization.ts
+++ b/ui/src/core/state_serialization.ts
@@ -19,10 +19,66 @@ import {
   type SerializedStoreState,
   type SerializedSelection,
   type SerializedAppState,
+  type SerializedTrackNode,
 } from './state_serialization_schema';
+import {TrackNode} from '../public/workspace';
 import type {TraceImpl} from './trace_impl';
 import {errResult, okResult, type Result} from '../base/result';
 import {HighPrecisionTimeSpan} from '../base/high_precision_time_span';
+
+export function serializeTrackNode(node: TrackNode): SerializedTrackNode {
+  const res: SerializedTrackNode = {};
+  if (node.name !== undefined) res.name = node.name;
+  if (node.uri !== undefined) res.uri = node.uri;
+  if (node.headless) res.headless = node.headless;
+  if (node.sortOrder !== undefined) res.sortOrder = node.sortOrder;
+  if (node.collapsed !== undefined) res.collapsed = node.collapsed;
+  if (node.isSummary) res.isSummary = node.isSummary;
+  if (node.removable) res.removable = node.removable;
+  if (node.subtitle !== undefined) res.subtitle = node.subtitle;
+  if (node.chips && node.chips.length > 0) res.chips = Array.from(node.chips);
+  if (node.children.length > 0) {
+    res.children = serializeTrackNodes(node.children);
+  }
+  return res;
+}
+
+export function serializeTrackNodes(
+  nodes: ReadonlyArray<TrackNode>,
+): SerializedTrackNode[] {
+  return nodes.map(serializeTrackNode);
+}
+
+export function deserializeTrackNode(sNode: SerializedTrackNode): TrackNode {
+  const node = new TrackNode({
+    name: sNode.name,
+    uri: sNode.uri,
+    headless: sNode.headless,
+    sortOrder: sNode.sortOrder,
+    collapsed: sNode.collapsed,
+    isSummary: sNode.isSummary,
+    removable: sNode.removable,
+    subtitle: sNode.subtitle,
+    chips: sNode.chips,
+  });
+  if (sNode.children) {
+    for (const sChild of sNode.children) {
+      const childNode = deserializeTrackNode(sChild);
+      node.addChildLast(childNode);
+    }
+  }
+  return node;
+}
+
+export function deserializeTrackNodes(
+  sNodes: SerializedTrackNode[],
+  parent: TrackNode,
+): void {
+  for (const sNode of sNodes) {
+    const node = deserializeTrackNode(sNode);
+    parent.addChildLast(node);
+  }
+}
 
 // When it comes to serialization & permalinks there are two different use cases
 // 1. Uploading the current trace in a Cloud Storage (GCS) file AND serializing
@@ -104,6 +160,15 @@ export function serializeAppState(trace: TraceImpl): SerializedAppState {
     store.push({id, state: pluginState});
   }
 
+  const workspaces = trace.workspaces.all
+    .filter((w) => w !== trace.defaultWorkspace)
+    .map((w) => ({
+      title: w.title,
+      userEditable: w.userEditable,
+      pinnedTracks: serializeTrackNodes(w.pinnedTracks),
+      tracks: serializeTrackNodes(w.tracks.children),
+    }));
+
   return {
     version: SERIALIZED_STATE_VERSION,
     // Only store pinned tracks from the default workspace
@@ -117,6 +182,8 @@ export function serializeAppState(trace: TraceImpl): SerializedAppState {
     notes,
     selection,
     store,
+    workspaces,
+    currentWorkspace: trace.workspaces.currentWorkspace.title,
   };
 }
 
@@ -182,6 +249,28 @@ export function deserializeAppStatePhase2(
     const track = trace.defaultWorkspace.getTrackByUri(uri);
     if (track) {
       track.pin();
+    }
+  }
+
+  // Restore non-default workspaces.
+  for (const ws of appState.workspaces ?? []) {
+    const workspace = trace.workspaces.createEmptyWorkspace(ws.title);
+    if (ws.userEditable !== undefined) {
+      workspace.userEditable = ws.userEditable;
+    }
+    deserializeTrackNodes(ws.tracks, workspace.tracks);
+    for (const pinned of ws.pinnedTracks) {
+      const node = deserializeTrackNode(pinned);
+      workspace.pinnedTracksNode.addChildLast(node);
+    }
+  }
+
+  if (appState.currentWorkspace !== undefined) {
+    const targetWs = trace.workspaces.all.find(
+      (w) => w.title === appState.currentWorkspace,
+    );
+    if (targetWs) {
+      trace.workspaces.switchWorkspace(targetWs);
     }
   }
 

--- a/ui/src/core/state_serialization.ts
+++ b/ui/src/core/state_serialization.ts
@@ -163,6 +163,7 @@ export function serializeAppState(trace: TraceImpl): SerializedAppState {
   const workspaces = trace.workspaces.all
     .filter((w) => w !== trace.defaultWorkspace)
     .map((w) => ({
+      uuid: w.uuid,
       title: w.title,
       userEditable: w.userEditable,
       pinnedTracks: serializeTrackNodes(w.pinnedTracks),
@@ -183,7 +184,7 @@ export function serializeAppState(trace: TraceImpl): SerializedAppState {
     selection,
     store,
     workspaces,
-    currentWorkspace: trace.workspaces.currentWorkspace.title,
+    currentWorkspace: trace.workspaces.currentWorkspace.uuid,
   };
 }
 
@@ -254,7 +255,24 @@ export function deserializeAppStatePhase2(
 
   // Restore non-default workspaces.
   for (const ws of appState.workspaces ?? []) {
-    const workspace = trace.workspaces.createEmptyWorkspace(ws.title);
+    let workspace = ws.uuid
+      ? trace.workspaces.all.find((w) => w.uuid === ws.uuid)
+      : undefined;
+
+    if (!workspace) {
+      workspace = trace.workspaces.all.find((w) => w.title === ws.title);
+    }
+
+    if (!workspace) {
+      workspace = trace.workspaces.createEmptyWorkspace(ws.title, ws.uuid);
+    } else {
+      workspace.clear();
+      workspace.title = ws.title;
+      if (ws.uuid) {
+        workspace.uuid = ws.uuid;
+      }
+    }
+
     if (ws.userEditable !== undefined) {
       workspace.userEditable = ws.userEditable;
     }
@@ -267,7 +285,9 @@ export function deserializeAppStatePhase2(
 
   if (appState.currentWorkspace !== undefined) {
     const targetWs = trace.workspaces.all.find(
-      (w) => w.title === appState.currentWorkspace,
+      (w) =>
+        w.uuid === appState.currentWorkspace ||
+        w.title === appState.currentWorkspace,
     );
     if (targetWs) {
       trace.workspaces.switchWorkspace(targetWs);

--- a/ui/src/core/state_serialization.ts
+++ b/ui/src/core/state_serialization.ts
@@ -19,10 +19,66 @@ import {
   type SerializedStoreState,
   type SerializedSelection,
   type SerializedAppState,
+  type SerializedTrackNode,
 } from './state_serialization_schema';
+import {TrackNode} from '../public/workspace';
 import type {TraceImpl} from './trace_impl';
 import {errResult, okResult, type Result} from '../base/result';
 import {HighPrecisionTimeSpan} from '../base/high_precision_time_span';
+
+export function serializeTrackNode(node: TrackNode): SerializedTrackNode {
+  const res: SerializedTrackNode = {};
+  if (node.name !== undefined) res.name = node.name;
+  if (node.uri !== undefined) res.uri = node.uri;
+  if (node.headless) res.headless = node.headless;
+  if (node.sortOrder !== undefined) res.sortOrder = node.sortOrder;
+  if (node.collapsed !== undefined) res.collapsed = node.collapsed;
+  if (node.isSummary) res.isSummary = node.isSummary;
+  if (node.removable) res.removable = node.removable;
+  if (node.subtitle !== undefined) res.subtitle = node.subtitle;
+  if (node.chips && node.chips.length > 0) res.chips = Array.from(node.chips);
+  if (node.children.length > 0) {
+    res.children = serializeTrackNodes(node.children);
+  }
+  return res;
+}
+
+export function serializeTrackNodes(
+  nodes: ReadonlyArray<TrackNode>,
+): SerializedTrackNode[] {
+  return nodes.map(serializeTrackNode);
+}
+
+export function deserializeTrackNode(sNode: SerializedTrackNode): TrackNode {
+  const node = new TrackNode({
+    name: sNode.name,
+    uri: sNode.uri,
+    headless: sNode.headless,
+    sortOrder: sNode.sortOrder,
+    collapsed: sNode.collapsed,
+    isSummary: sNode.isSummary,
+    removable: sNode.removable,
+    subtitle: sNode.subtitle,
+    chips: sNode.chips,
+  });
+  if (sNode.children) {
+    for (const sChild of sNode.children) {
+      const childNode = deserializeTrackNode(sChild);
+      node.addChildLast(childNode);
+    }
+  }
+  return node;
+}
+
+export function deserializeTrackNodes(
+  sNodes: SerializedTrackNode[],
+  parent: TrackNode,
+): void {
+  for (const sNode of sNodes) {
+    const node = deserializeTrackNode(sNode);
+    parent.addChildLast(node);
+  }
+}
 
 // When it comes to serialization & permalinks there are two different use cases
 // 1. Uploading the current trace in a Cloud Storage (GCS) file AND serializing
@@ -104,6 +160,16 @@ export function serializeAppState(trace: TraceImpl): SerializedAppState {
     store.push({id, state: pluginState});
   }
 
+  const workspaces = trace.workspaces.all
+    .filter((w) => w !== trace.defaultWorkspace)
+    .map((w) => ({
+      id: w.id,
+      title: w.title,
+      userEditable: w.userEditable,
+      pinnedTracks: serializeTrackNodes(w.pinnedTracks),
+      tracks: serializeTrackNodes(w.tracks.children),
+    }));
+
   return {
     version: SERIALIZED_STATE_VERSION,
     // Only store pinned tracks from the default workspace
@@ -117,6 +183,8 @@ export function serializeAppState(trace: TraceImpl): SerializedAppState {
     notes,
     selection,
     store,
+    workspaces,
+    currentWorkspace: trace.workspaces.currentWorkspace.id,
   };
 }
 
@@ -182,6 +250,37 @@ export function deserializeAppStatePhase2(
     const track = trace.defaultWorkspace.getTrackByUri(uri);
     if (track) {
       track.pin();
+    }
+  }
+
+  // Restore non-default workspaces. The serialized state is the source of
+  // truth: remove all existing non-default workspaces (including any created
+  // by plugins) and recreate exactly what was serialized.
+  const serializedWorkspaces = appState.workspaces;
+  if (serializedWorkspaces) {
+    // Delete all non-default workspaces
+    for (const ws of trace.workspaces.all) {
+      if (ws !== trace.defaultWorkspace) {
+        trace.workspaces.removeWorkspace(ws);
+      }
+    }
+
+    for (const ws of serializedWorkspaces) {
+      const workspace = trace.workspaces.createEmptyWorkspace(ws.title, ws.id);
+      if (ws.userEditable !== undefined) {
+        workspace.userEditable = ws.userEditable;
+      }
+      deserializeTrackNodes(ws.tracks, workspace.tracks);
+      deserializeTrackNodes(ws.pinnedTracks, workspace.pinnedTracksNode);
+    }
+  }
+
+  if (appState.currentWorkspace !== undefined) {
+    const targetWs = trace.workspaces.all.find(
+      (w) => w.id === appState.currentWorkspace,
+    );
+    if (targetWs) {
+      trace.workspaces.switchWorkspace(targetWs);
     }
   }
 

--- a/ui/src/core/state_serialization_schema.ts
+++ b/ui/src/core/state_serialization_schema.ts
@@ -70,6 +70,33 @@ const STORE_SCHEMA = z.object({
 
 export type SerializedStoreState = z.infer<typeof STORE_SCHEMA>;
 
+const TRACK_NODE_SCHEMA = z.object({
+  name: z.string().optional(),
+  uri: z.string().optional(),
+  headless: z.boolean().optional(),
+  sortOrder: z.number().optional(),
+  collapsed: z.boolean().optional(),
+  isSummary: z.boolean().optional(),
+  removable: z.boolean().optional(),
+  subtitle: z.string().optional(),
+  chips: z.array(z.string()).optional(),
+  get children() {
+    return z.array(TRACK_NODE_SCHEMA).optional();
+  },
+});
+
+export type SerializedTrackNode = z.infer<typeof TRACK_NODE_SCHEMA>;
+
+const WORKSPACE_SCHEMA = z.object({
+  id: z.string(),
+  title: z.string(),
+  userEditable: z.boolean().optional(),
+  pinnedTracks: z.array(TRACK_NODE_SCHEMA).default([]),
+  tracks: z.array(TRACK_NODE_SCHEMA).default([]),
+});
+
+export type SerializedWorkspace = z.infer<typeof WORKSPACE_SCHEMA>;
+
 export const APP_STATE_SCHEMA = z.object({
   version: z.number(),
   pinnedTracks: z.array(z.string()).default([]),
@@ -82,6 +109,8 @@ export const APP_STATE_SCHEMA = z.object({
   selection: z.array(SELECTION_SCHEMA).default([]),
   notes: z.array(NOTE_SCHEMA).default([]),
   store: z.array(STORE_SCHEMA).default([]),
+  workspaces: z.array(WORKSPACE_SCHEMA).optional(),
+  currentWorkspace: z.string().optional(),
 });
 
 export type SerializedAppState = z.infer<typeof APP_STATE_SCHEMA>;

--- a/ui/src/core/state_serialization_schema.ts
+++ b/ui/src/core/state_serialization_schema.ts
@@ -99,6 +99,7 @@ const TRACK_NODE_SCHEMA: z.ZodType<SerializedTrackNode> = z.lazy(() =>
 );
 
 const WORKSPACE_SCHEMA = z.object({
+  uuid: z.string().optional(),
   title: z.string(),
   userEditable: z.boolean().optional(),
   pinnedTracks: z.array(TRACK_NODE_SCHEMA).default([]),

--- a/ui/src/core/state_serialization_schema.ts
+++ b/ui/src/core/state_serialization_schema.ts
@@ -70,6 +70,43 @@ const STORE_SCHEMA = z.object({
 
 export type SerializedStoreState = z.infer<typeof STORE_SCHEMA>;
 
+export type SerializedTrackNode = {
+  name?: string;
+  uri?: string;
+  headless?: boolean;
+  sortOrder?: number;
+  collapsed?: boolean;
+  isSummary?: boolean;
+  removable?: boolean;
+  subtitle?: string;
+  chips?: string[];
+  children?: SerializedTrackNode[];
+};
+
+const TRACK_NODE_SCHEMA: z.ZodType<SerializedTrackNode> = z.lazy(() =>
+  z.object({
+    name: z.string().optional(),
+    uri: z.string().optional(),
+    headless: z.boolean().optional(),
+    sortOrder: z.number().optional(),
+    collapsed: z.boolean().optional(),
+    isSummary: z.boolean().optional(),
+    removable: z.boolean().optional(),
+    subtitle: z.string().optional(),
+    chips: z.array(z.string()).optional(),
+    children: z.array(TRACK_NODE_SCHEMA).optional(),
+  }),
+);
+
+const WORKSPACE_SCHEMA = z.object({
+  title: z.string(),
+  userEditable: z.boolean().optional(),
+  pinnedTracks: z.array(TRACK_NODE_SCHEMA).default([]),
+  tracks: z.array(TRACK_NODE_SCHEMA).default([]),
+});
+
+export type SerializedWorkspace = z.infer<typeof WORKSPACE_SCHEMA>;
+
 export const APP_STATE_SCHEMA = z.object({
   version: z.number(),
   pinnedTracks: z.array(z.string()).default([]),
@@ -82,6 +119,8 @@ export const APP_STATE_SCHEMA = z.object({
   selection: z.array(SELECTION_SCHEMA).default([]),
   notes: z.array(NOTE_SCHEMA).default([]),
   store: z.array(STORE_SCHEMA).default([]),
+  workspaces: z.array(WORKSPACE_SCHEMA).default([]),
+  currentWorkspace: z.string().optional(),
 });
 
 export type SerializedAppState = z.infer<typeof APP_STATE_SCHEMA>;

--- a/ui/src/core/state_serialization_unittest.ts
+++ b/ui/src/core/state_serialization_unittest.ts
@@ -16,13 +16,16 @@ import {z} from 'zod';
 import {Time} from '../base/time';
 import type {TrackEventDetailsPanel} from '../public/details_panel';
 import type {Track} from '../public/track';
+import {TrackNode} from '../public/workspace';
 import {createFakeTraceImpl} from './fake_trace_impl';
 import {
   deserializeAppStatePhase1,
   deserializeAppStatePhase2,
+  deserializeTrackNode,
   JsonSerialize,
   parseAppState,
   serializeAppState,
+  serializeTrackNode,
 } from './state_serialization';
 
 vi.hoisted(() => {
@@ -208,5 +211,183 @@ describe('state serialization', () => {
       });
     });
     expect(trace2.selection.getDetailsPanelForSelection()).toBeUndefined();
+  });
+
+  test('serialize and deserialize TrackNode', () => {
+    const root = new TrackNode({
+      name: 'Group A',
+      collapsed: false,
+      isSummary: true,
+    });
+    const child = new TrackNode({
+      name: 'Track 1',
+      uri: 'test.track.1',
+      collapsed: true,
+      removable: true,
+    });
+    root.addChildLast(child);
+
+    const serialized = serializeTrackNode(root);
+    expect(serialized.name).toBe('Group A');
+    expect(serialized.collapsed).toBe(false);
+    expect(serialized.isSummary).toBe(true);
+    expect(serialized.children).toHaveLength(1);
+    expect(serialized.children![0].name).toBe('Track 1');
+    expect(serialized.children![0].uri).toBe('test.track.1');
+
+    const deserialized = deserializeTrackNode(serialized);
+    expect(deserialized.name).toBe('Group A');
+    expect(deserialized.collapsed).toBe(false);
+    expect(deserialized.isSummary).toBe(true);
+    expect(deserialized.children).toHaveLength(1);
+    expect(deserialized.children[0].name).toBe('Track 1');
+    expect(deserialized.children[0].uri).toBe('test.track.1');
+    expect(deserialized.children[0].removable).toBe(true);
+  });
+
+  test('serialize and deserialize non-default workspaces', () => {
+    const trace = createFakeTraceImpl();
+
+    const customWs = trace.workspaces.createEmptyWorkspace('Custom Workspace');
+    customWs.userEditable = false;
+
+    const track = new TrackNode({
+      name: 'Custom Track',
+      uri: 'foo.bar.track',
+    });
+    customWs.tracks.addChildLast(track);
+
+    const pinnedTrack = new TrackNode({
+      name: 'Pinned Track',
+      uri: 'foo.bar.pinned',
+    });
+    customWs.pinnedTracksNode.addChildLast(pinnedTrack);
+
+    const serialized = serializeAppState(trace);
+    expect(serialized.workspaces).toHaveLength(1);
+    expect(serialized.workspaces![0].title).toBe('Custom Workspace');
+    expect(serialized.workspaces![0].userEditable).toBe(false);
+    expect(serialized.workspaces![0].tracks).toHaveLength(1);
+    expect(serialized.workspaces![0].tracks[0].name).toBe('Custom Track');
+    expect(serialized.workspaces![0].tracks[0].uri).toBe('foo.bar.track');
+    expect(serialized.workspaces![0].pinnedTracks).toHaveLength(1);
+    expect(serialized.workspaces![0].pinnedTracks[0].uri).toBe(
+      'foo.bar.pinned',
+    );
+
+    const targetTrace = createFakeTraceImpl();
+    deserializeAppStatePhase2(serialized, targetTrace);
+
+    const workspaces = targetTrace.workspaces.all;
+    const restoredWs = workspaces.find((w) => w.title === 'Custom Workspace');
+    expect(restoredWs).toBeDefined();
+    expect(restoredWs!.userEditable).toBe(false);
+    expect(restoredWs!.tracks.children).toHaveLength(1);
+    expect(restoredWs!.tracks.children[0].name).toBe('Custom Track');
+    expect(restoredWs!.tracks.children[0].uri).toBe('foo.bar.track');
+    expect(restoredWs!.pinnedTracks).toHaveLength(1);
+    expect(restoredWs!.pinnedTracks[0].name).toBe('Pinned Track');
+    expect(restoredWs!.pinnedTracks[0].uri).toBe('foo.bar.pinned');
+  });
+
+  test('serialize and deserialize current workspace', () => {
+    const trace = createFakeTraceImpl();
+
+    const customWs = trace.workspaces.createEmptyWorkspace('Active Workspace');
+    trace.workspaces.switchWorkspace(customWs);
+
+    const serialized = serializeAppState(trace);
+    expect(serialized.currentWorkspace).toBe(customWs.id);
+
+    const targetTrace = createFakeTraceImpl();
+    deserializeAppStatePhase2(serialized, targetTrace);
+
+    expect(targetTrace.workspaces.currentWorkspace.title).toBe(
+      'Active Workspace',
+    );
+    expect(targetTrace.workspaces.currentWorkspace.id).toBe(customWs.id);
+  });
+
+  test('serialize and deserialize default workspace as current workspace', () => {
+    const trace = createFakeTraceImpl();
+
+    const serialized = serializeAppState(trace);
+    expect(serialized.currentWorkspace).toBe(trace.defaultWorkspace.id);
+
+    const targetTrace = createFakeTraceImpl();
+    const otherWs =
+      targetTrace.workspaces.createEmptyWorkspace('Other Workspace');
+    targetTrace.workspaces.switchWorkspace(otherWs);
+
+    deserializeAppStatePhase2(serialized, targetTrace);
+
+    expect(targetTrace.workspaces.currentWorkspace).toBe(
+      targetTrace.defaultWorkspace,
+    );
+    expect(targetTrace.workspaces.currentWorkspace.id).toBe(
+      serialized.currentWorkspace,
+    );
+  });
+
+  test('replaces non-default workspaces when loading multiple times', () => {
+    const trace = createFakeTraceImpl();
+
+    const customWs = trace.workspaces.createEmptyWorkspace(
+      'Plugin Workspace',
+      'stable-plugin-id-1234',
+    );
+    customWs.tracks.addChildLast(
+      new TrackNode({name: 'Track A', uri: 'track.a'}),
+    );
+
+    const serialized = serializeAppState(trace);
+    expect(serialized.workspaces![0].id).toBe('stable-plugin-id-1234');
+
+    const targetTrace = createFakeTraceImpl();
+    deserializeAppStatePhase2(serialized, targetTrace);
+    deserializeAppStatePhase2(serialized, targetTrace);
+
+    const nonDefaultWorkspaces = targetTrace.workspaces.all.filter(
+      (w) => w !== targetTrace.defaultWorkspace,
+    );
+    expect(nonDefaultWorkspaces).toHaveLength(1);
+    expect(nonDefaultWorkspaces[0].id).toBe('stable-plugin-id-1234');
+    expect(nonDefaultWorkspaces[0].title).toBe('Plugin Workspace');
+    expect(nonDefaultWorkspaces[0].tracks.children).toHaveLength(1);
+  });
+
+  test('legacy state without workspaces preserves existing non-default workspaces', () => {
+    const targetTrace = createFakeTraceImpl();
+    targetTrace.workspaces.createEmptyWorkspace('Plugin Workspace');
+
+    const legacyState = parseAppState({version: 1});
+    expect(legacyState.ok).toBe(true);
+    if (!legacyState.ok) return;
+    expect(legacyState.value.workspaces).toBeUndefined();
+
+    deserializeAppStatePhase2(legacyState.value, targetTrace);
+
+    const nonDefaultWorkspaces = targetTrace.workspaces.all.filter(
+      (w) => w !== targetTrace.defaultWorkspace,
+    );
+    expect(nonDefaultWorkspaces).toHaveLength(1);
+    expect(nonDefaultWorkspaces[0].title).toBe('Plugin Workspace');
+  });
+
+  test('state with empty workspaces removes existing non-default workspaces', () => {
+    const targetTrace = createFakeTraceImpl();
+    targetTrace.workspaces.createEmptyWorkspace('Plugin Workspace');
+
+    const state = parseAppState({version: 1, workspaces: []});
+    expect(state.ok).toBe(true);
+    if (!state.ok) return;
+    expect(state.value.workspaces).toEqual([]);
+
+    deserializeAppStatePhase2(state.value, targetTrace);
+
+    const nonDefaultWorkspaces = targetTrace.workspaces.all.filter(
+      (w) => w !== targetTrace.defaultWorkspace,
+    );
+    expect(nonDefaultWorkspaces).toHaveLength(0);
   });
 });

--- a/ui/src/core/state_serialization_unittest.ts
+++ b/ui/src/core/state_serialization_unittest.ts
@@ -104,7 +104,7 @@ describe('state_serialization', () => {
     trace.workspaces.switchWorkspace(customWs);
 
     const serialized = serializeAppState(trace);
-    expect(serialized.currentWorkspace).toBe('Active Workspace');
+    expect(serialized.currentWorkspace).toBe(customWs.uuid);
 
     const targetTrace = createFakeTraceImpl();
     deserializeAppStatePhase2(serialized, targetTrace);
@@ -112,5 +112,32 @@ describe('state_serialization', () => {
     expect(targetTrace.workspaces.currentWorkspace.title).toBe(
       'Active Workspace',
     );
+  });
+
+  test('deduplicate workspaces by uuid when loading multiple times', () => {
+    const trace = createFakeTraceImpl();
+
+    const customWs = trace.workspaces.createEmptyWorkspace(
+      'Plugin Workspace',
+      'stable-plugin-uuid-1234',
+    );
+    customWs.tracks.addChildLast(
+      new TrackNode({name: 'Track A', uri: 'track.a'}),
+    );
+
+    const serialized = serializeAppState(trace);
+    expect(serialized.workspaces[0].uuid).toBe('stable-plugin-uuid-1234');
+
+    const targetTrace = createFakeTraceImpl();
+    deserializeAppStatePhase2(serialized, targetTrace);
+    deserializeAppStatePhase2(serialized, targetTrace);
+
+    const nonDefaultWorkspaces = targetTrace.workspaces.all.filter(
+      (w) => w !== targetTrace.defaultWorkspace,
+    );
+    expect(nonDefaultWorkspaces).toHaveLength(1);
+    expect(nonDefaultWorkspaces[0].uuid).toBe('stable-plugin-uuid-1234');
+    expect(nonDefaultWorkspaces[0].title).toBe('Plugin Workspace');
+    expect(nonDefaultWorkspaces[0].tracks.children).toHaveLength(1);
   });
 });

--- a/ui/src/core/state_serialization_unittest.ts
+++ b/ui/src/core/state_serialization_unittest.ts
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {createFakeTraceImpl} from './fake_trace_impl';
+import {
+  deserializeAppStatePhase2,
+  deserializeTrackNode,
+  serializeAppState,
+  serializeTrackNode,
+} from './state_serialization';
+import {TrackNode} from '../public/workspace';
+
+describe('state_serialization', () => {
+  test('serialize and deserialize TrackNode', () => {
+    const root = new TrackNode({
+      name: 'Group A',
+      collapsed: false,
+      isSummary: true,
+    });
+    const child = new TrackNode({
+      name: 'Track 1',
+      uri: 'test.track.1',
+      collapsed: true,
+      removable: true,
+    });
+    root.addChildLast(child);
+
+    const serialized = serializeTrackNode(root);
+    expect(serialized.name).toBe('Group A');
+    expect(serialized.collapsed).toBe(false);
+    expect(serialized.isSummary).toBe(true);
+    expect(serialized.children).toHaveLength(1);
+    expect(serialized.children![0].name).toBe('Track 1');
+    expect(serialized.children![0].uri).toBe('test.track.1');
+
+    const deserialized = deserializeTrackNode(serialized);
+    expect(deserialized.name).toBe('Group A');
+    expect(deserialized.collapsed).toBe(false);
+    expect(deserialized.isSummary).toBe(true);
+    expect(deserialized.children).toHaveLength(1);
+    expect(deserialized.children[0].name).toBe('Track 1');
+    expect(deserialized.children[0].uri).toBe('test.track.1');
+    expect(deserialized.children[0].removable).toBe(true);
+  });
+
+  test('serialize and deserialize non-default workspaces', () => {
+    const trace = createFakeTraceImpl();
+
+    const customWs = trace.workspaces.createEmptyWorkspace('Custom Workspace');
+    customWs.userEditable = false;
+
+    const track = new TrackNode({
+      name: 'Custom Track',
+      uri: 'foo.bar.track',
+    });
+    customWs.tracks.addChildLast(track);
+
+    const pinnedTrack = new TrackNode({
+      name: 'Pinned Track',
+      uri: 'foo.bar.pinned',
+    });
+    customWs.pinnedTracksNode.addChildLast(pinnedTrack);
+
+    const serialized = serializeAppState(trace);
+    expect(serialized.workspaces).toHaveLength(1);
+    expect(serialized.workspaces[0].title).toBe('Custom Workspace');
+    expect(serialized.workspaces[0].userEditable).toBe(false);
+    expect(serialized.workspaces[0].tracks).toHaveLength(1);
+    expect(serialized.workspaces[0].tracks[0].name).toBe('Custom Track');
+    expect(serialized.workspaces[0].tracks[0].uri).toBe('foo.bar.track');
+    expect(serialized.workspaces[0].pinnedTracks).toHaveLength(1);
+    expect(serialized.workspaces[0].pinnedTracks[0].uri).toBe('foo.bar.pinned');
+
+    const targetTrace = createFakeTraceImpl();
+    deserializeAppStatePhase2(serialized, targetTrace);
+
+    const workspaces = targetTrace.workspaces.all;
+    const restoredWs = workspaces.find((w) => w.title === 'Custom Workspace');
+    expect(restoredWs).toBeDefined();
+    expect(restoredWs!.userEditable).toBe(false);
+    expect(restoredWs!.tracks.children).toHaveLength(1);
+    expect(restoredWs!.tracks.children[0].name).toBe('Custom Track');
+    expect(restoredWs!.tracks.children[0].uri).toBe('foo.bar.track');
+    expect(restoredWs!.pinnedTracks).toHaveLength(1);
+    expect(restoredWs!.pinnedTracks[0].name).toBe('Pinned Track');
+    expect(restoredWs!.pinnedTracks[0].uri).toBe('foo.bar.pinned');
+  });
+
+  test('serialize and deserialize current workspace', () => {
+    const trace = createFakeTraceImpl();
+
+    const customWs = trace.workspaces.createEmptyWorkspace('Active Workspace');
+    trace.workspaces.switchWorkspace(customWs);
+
+    const serialized = serializeAppState(trace);
+    expect(serialized.currentWorkspace).toBe('Active Workspace');
+
+    const targetTrace = createFakeTraceImpl();
+    deserializeAppStatePhase2(serialized, targetTrace);
+
+    expect(targetTrace.workspaces.currentWorkspace.title).toBe(
+      'Active Workspace',
+    );
+  });
+});

--- a/ui/src/core/workspace_manager.ts
+++ b/ui/src/core/workspace_manager.ts
@@ -16,6 +16,7 @@ import {assertTrue} from '../base/assert';
 import {Workspace, type WorkspaceManager} from '../public/workspace';
 import {featureFlags} from './feature_flags';
 
+export const DEFAULT_WORKSPACE_ID = 'default';
 const DEFAULT_WORKSPACE_NAME = 'Default Workspace';
 const DEFAULT_WORKSPACE_EDITABLE_FLAG = featureFlags.register({
   id: 'defaultWorkspaceEditable',
@@ -26,7 +27,7 @@ const DEFAULT_WORKSPACE_EDITABLE_FLAG = featureFlags.register({
 });
 
 export class WorkspaceManagerImpl implements WorkspaceManager {
-  readonly defaultWorkspace = new Workspace();
+  readonly defaultWorkspace = new Workspace(DEFAULT_WORKSPACE_ID);
   private _workspaces: Workspace[] = [];
   private _currentWorkspace: Workspace;
 
@@ -36,8 +37,8 @@ export class WorkspaceManagerImpl implements WorkspaceManager {
     this._currentWorkspace = this.defaultWorkspace;
   }
 
-  createEmptyWorkspace(title: string): Workspace {
-    const workspace = new Workspace();
+  createEmptyWorkspace(title: string, id?: string): Workspace {
+    const workspace = new Workspace(id);
     workspace.title = title;
     this._workspaces.push(workspace);
     return workspace;

--- a/ui/src/core/workspace_manager.ts
+++ b/ui/src/core/workspace_manager.ts
@@ -36,8 +36,8 @@ export class WorkspaceManagerImpl implements WorkspaceManager {
     this._currentWorkspace = this.defaultWorkspace;
   }
 
-  createEmptyWorkspace(title: string): Workspace {
-    const workspace = new Workspace();
+  createEmptyWorkspace(title: string, uuid?: string): Workspace {
+    const workspace = new Workspace(uuid);
     workspace.title = title;
     this._workspaces.push(workspace);
     return workspace;

--- a/ui/src/public/workspace.ts
+++ b/ui/src/public/workspace.ts
@@ -14,12 +14,13 @@
 
 import {assertTrue} from '../base/assert';
 import {errResult, okResult, type Result} from '../base/result';
+import {uuidv4} from '../base/uuid';
 
 export interface WorkspaceManager {
   // This is the same of ctx.workspace, exposed for consistency also here.
   readonly currentWorkspace: Workspace;
   readonly all: ReadonlyArray<Workspace>;
-  createEmptyWorkspace(displayName: string): Workspace;
+  createEmptyWorkspace(displayName: string, id?: string): Workspace;
   switchWorkspace(workspace: Workspace): void;
 }
 
@@ -574,6 +575,9 @@ export class TrackNode {
  */
 export class Workspace {
   public title = '<untitled-workspace>';
+  // Unique identifier for this workspace. Must be globally unique as it is
+  // persisted in permalink state to track and restore workspaces across
+  // sessions.
   public readonly id: string;
   public userEditable: boolean = true;
 
@@ -585,8 +589,8 @@ export class Workspace {
     return this.pinnedTracksNode.children;
   }
 
-  constructor() {
-    this.id = createSessionUniqueId();
+  constructor(id?: string) {
+    this.id = id ?? uuidv4();
     this.pinnedTracksNode._workspace = this;
     this.tracks._workspace = this;
 

--- a/ui/src/public/workspace.ts
+++ b/ui/src/public/workspace.ts
@@ -14,12 +14,13 @@
 
 import {assertTrue} from '../base/assert';
 import {errResult, okResult, type Result} from '../base/result';
+import {uuidv4} from '../base/uuid';
 
 export interface WorkspaceManager {
   // This is the same of ctx.workspace, exposed for consistency also here.
   readonly currentWorkspace: Workspace;
   readonly all: ReadonlyArray<Workspace>;
-  createEmptyWorkspace(displayName: string): Workspace;
+  createEmptyWorkspace(displayName: string, uuid?: string): Workspace;
   switchWorkspace(workspace: Workspace): void;
 }
 
@@ -575,6 +576,7 @@ export class TrackNode {
 export class Workspace {
   public title = '<untitled-workspace>';
   public readonly id: string;
+  public uuid: string;
   public userEditable: boolean = true;
 
   // Dummy node to contain the pinned tracks
@@ -585,8 +587,9 @@ export class Workspace {
     return this.pinnedTracksNode.children;
   }
 
-  constructor() {
+  constructor(uuid?: string) {
     this.id = createSessionUniqueId();
+    this.uuid = uuid ?? uuidv4();
     this.pinnedTracksNode._workspace = this;
     this.tracks._workspace = this;
 


### PR DESCRIPTION
Serialise and restore all non-default workspaces to the permalink.

When workspaces are present in the serialised state - all non-default workspaces are wiped and replaced with the workspaces from the permalink.

The currently selected workspace is also stored and restored.

Localstorage testing:
- Create some workspaces, move some tracks over and pin some tracks on those workspaces.
- Rename the workspace.
- Run Mod+Shift+P -> Quicksave UI state to localStorage
- Reload the page (resets the state).
- Run Mod+Shift+P -> Quickload UI state from localStorage
- Check the workspaces have been restored.

Permalink testing (internal only):
- Create some custom workspaces as above
- Click share to share the trace + UI state.
- Copy the link and paste into a new tab.
- Check the workspaces have been restored.

Fixes: b/556607258
