### PR TITLE
ui: add "Copy main thread tracks to workspace" command

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.TracklUtils/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.TracklUtils/index.ts
@@ -381,8 +381,13 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
     ctx.commands.registerCommand({
       id: 'dev.perfetto.CopyMainThreadTracksToWorkspace',
       name: 'Copy main thread tracks to workspace',
-      callback: (workspaceNameArg: unknown) =>
-        copyMainThreadTracksToWorkspace(ctx, workspaceNameArg),
+      callback: (workspaceNameArg: unknown) => {
+        const workspaceName =
+          typeof workspaceNameArg === 'string'
+            ? workspaceNameArg
+            : 'Main threads';
+        copyMainThreadTracksToWorkspace(ctx, workspaceName);
+      },
     });
 
     ctx.commands.registerCommand({
@@ -681,13 +686,10 @@ async function resolveTracksFromSliceQuery(
     .filter((track) => track !== undefined);
 }
 
-async function copyMainThreadTracksToWorkspace(
+function copyMainThreadTracksToWorkspace(
   ctx: Trace,
-  workspaceNameArg: unknown,
-): Promise<void> {
-  const workspaceName =
-    typeof workspaceNameArg === 'string' ? workspaceNameArg : 'Main threads';
-
+  workspaceName: string,
+): void {
   const tracks = ctx.tracks
     .getAllTracks()
     .filter((track) => track.tags?.isMainThread === true)

--- a/ui/src/core_plugins/dev.perfetto.TracklUtils/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.TracklUtils/index.ts
@@ -379,6 +379,13 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
+      id: 'dev.perfetto.CopyMainThreadTracksToWorkspace',
+      name: 'Copy main thread tracks to workspace',
+      callback: (workspaceNameArg: unknown) =>
+        copyMainThreadTracksToWorkspace(ctx, workspaceNameArg),
+    });
+
+    ctx.commands.registerCommand({
       id: 'dev.perfetto.AddNoteAtUtcTimestamp',
       name: 'Add note at UTC timestamp',
       callback: async (utcTimestampArg: unknown, noteTextArg: unknown) => {
@@ -672,4 +679,65 @@ async function resolveTracksFromSliceQuery(
   return resolved
     .map((event) => ctx.currentWorkspace.getTrackByUri(event.trackUri))
     .filter((track) => track !== undefined);
+}
+
+// De-duplicated tracks backing the ids returned by `query` (an `id` column in
+// `rootTableName`). resolveSqlEvents is generic over a track's rootTableName, so
+// this handles both 'slice' and 'thread_state'.
+async function resolveTracksFromEventQuery(
+  ctx: Trace,
+  query: string,
+  rootTableName: string,
+): Promise<TrackNode[]> {
+  const result = await ctx.engine.query(query);
+  const iter = result.iter({id: NUM});
+  const ids = [];
+  for (; iter.valid(); iter.next()) {
+    ids.push(iter.id);
+  }
+  const resolved = await ctx.selection.resolveSqlEvents(rootTableName, ids);
+  const tracksByUri = new Map<string, TrackNode>();
+  for (const {trackUri} of resolved) {
+    if (tracksByUri.has(trackUri)) continue;
+    const track = ctx.currentWorkspace.getTrackByUri(trackUri);
+    if (track !== undefined) {
+      tracksByUri.set(trackUri, track);
+    }
+  }
+  return Array.from(tracksByUri.values());
+}
+
+// Copy each process's main-thread thread_state and slice tracks into a
+// workspace, grouped under their process, and switch to it. Each query picks one
+// event per track so every track resolves exactly once.
+async function copyMainThreadTracksToWorkspace(
+  ctx: Trace,
+  workspaceNameArg: unknown,
+): Promise<void> {
+  const workspaceName =
+    typeof workspaceNameArg === 'string' ? workspaceNameArg : 'Main threads';
+
+  const mainThreadJoin = 'join thread th using (utid) where th.is_main_thread';
+
+  const stateTracks = await resolveTracksFromEventQuery(
+    ctx,
+    `select min(ts.id) as id from thread_state ts ${mainThreadJoin}
+     group by ts.utid`,
+    'thread_state',
+  );
+  const sliceTracks = await resolveTracksFromEventQuery(
+    ctx,
+    `select min(s.id) as id from slice s
+     join thread_track tt on s.track_id = tt.id ${mainThreadJoin}
+     group by s.track_id`,
+    'slice',
+  );
+
+  const targetWorkspace =
+    ctx.workspaces.all.find((ws) => ws.title === workspaceName) ??
+    ctx.workspaces.createEmptyWorkspace(workspaceName);
+
+  copyTracksWithAncestors([...stateTracks, ...sliceTracks], targetWorkspace);
+
+  ctx.workspaces.switchWorkspace(targetWorkspace);
 }

--- a/ui/src/core_plugins/dev.perfetto.TracklUtils/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.TracklUtils/index.ts
@@ -681,35 +681,6 @@ async function resolveTracksFromSliceQuery(
     .filter((track) => track !== undefined);
 }
 
-// De-duplicated tracks backing the ids returned by `query` (an `id` column in
-// `rootTableName`). resolveSqlEvents is generic over a track's rootTableName, so
-// this handles both 'slice' and 'thread_state'.
-async function resolveTracksFromEventQuery(
-  ctx: Trace,
-  query: string,
-  rootTableName: string,
-): Promise<TrackNode[]> {
-  const result = await ctx.engine.query(query);
-  const iter = result.iter({id: NUM});
-  const ids = [];
-  for (; iter.valid(); iter.next()) {
-    ids.push(iter.id);
-  }
-  const resolved = await ctx.selection.resolveSqlEvents(rootTableName, ids);
-  const tracksByUri = new Map<string, TrackNode>();
-  for (const {trackUri} of resolved) {
-    if (tracksByUri.has(trackUri)) continue;
-    const track = ctx.currentWorkspace.getTrackByUri(trackUri);
-    if (track !== undefined) {
-      tracksByUri.set(trackUri, track);
-    }
-  }
-  return Array.from(tracksByUri.values());
-}
-
-// Copy each process's main-thread thread_state and slice tracks into a
-// workspace, grouped under their process, and switch to it. Each query picks one
-// event per track so every track resolves exactly once.
 async function copyMainThreadTracksToWorkspace(
   ctx: Trace,
   workspaceNameArg: unknown,
@@ -717,27 +688,16 @@ async function copyMainThreadTracksToWorkspace(
   const workspaceName =
     typeof workspaceNameArg === 'string' ? workspaceNameArg : 'Main threads';
 
-  const mainThreadJoin = 'join thread th using (utid) where th.is_main_thread';
-
-  const stateTracks = await resolveTracksFromEventQuery(
-    ctx,
-    `select min(ts.id) as id from thread_state ts ${mainThreadJoin}
-     group by ts.utid`,
-    'thread_state',
-  );
-  const sliceTracks = await resolveTracksFromEventQuery(
-    ctx,
-    `select min(s.id) as id from slice s
-     join thread_track tt on s.track_id = tt.id ${mainThreadJoin}
-     group by s.track_id`,
-    'slice',
-  );
+  const tracks = ctx.tracks
+    .getAllTracks()
+    .filter((track) => track.tags?.isMainThread === true)
+    .map((track) => ctx.currentWorkspace.getTrackByUri(track.uri))
+    .filter(exists);
 
   const targetWorkspace =
     ctx.workspaces.all.find((ws) => ws.title === workspaceName) ??
     ctx.workspaces.createEmptyWorkspace(workspaceName);
 
-  copyTracksWithAncestors([...stateTracks, ...sliceTracks], targetWorkspace);
-
+  copyTracksWithAncestors(tracks, targetWorkspace);
   ctx.workspaces.switchWorkspace(targetWorkspace);
 }

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -366,6 +366,7 @@ export default class SchedPlugin implements PerfettoPlugin {
           utid,
           upid: upid ?? undefined,
           ...(isKernelThread === 1 && {kernelThread: true}),
+          ...(isMainThread === 1 && {isMainThread: true}),
         },
         renderer: createThreadStateTrack(ctx, uri, utid),
       });

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -436,6 +436,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
           upid: upid ?? undefined,
           utid: utid ?? undefined,
           ...(isKernelThread === 1 && {kernelThread: true}),
+          ...(isMainThread === 1 && {isMainThread: true}),
           hasCallstacks: hasCallstacks === 1,
         },
         renderer: await createTraceProcessorSliceTrack({


### PR DESCRIPTION
Copy every process's main-thread (thread.is_main_thread) thread_state and slice tracks into a workspace, grouped under their process.
