### PR TITLE
tp: rebuild flamegraphs from typed trees

### DIFF
--- a/include/perfetto/ext/base/utils.h
+++ b/include/perfetto/ext/base/utils.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <atomic>
 #include <functional>
@@ -71,6 +72,32 @@ inline uint32_t GetSysPageSize() {
 template <typename T, size_t TSize>
 constexpr size_t ArraySize(const T (&)[TSize]) {
   return TSize;
+}
+
+// Adds `a` and `b` into `*result`, returning false on overflow. The value of
+// `*result` is unspecified when false is returned.
+inline bool CheckedAdd(int64_t a, int64_t b, int64_t* result) {
+#if defined(__clang__) || defined(__GNUC__)
+  return !__builtin_add_overflow(a, b, result);
+#else
+  constexpr int64_t kMax = std::numeric_limits<int64_t>::max();
+  constexpr int64_t kMin = std::numeric_limits<int64_t>::min();
+  if ((b > 0 && a > kMax - b) || (b < 0 && a < kMin - b))
+    return false;
+  *result = a + b;
+  return true;
+#endif
+}
+
+// Returns whether `value` is positive or negative zero. Compares the bit
+// pattern so it can be used in translation units compiled with -Wfloat-equal.
+inline bool IsZero(double value) {
+  uint64_t bits;
+  memcpy(&bits, &value, sizeof(bits));
+  return (bits << 1) == 0;
+}
+inline bool IsZero(int64_t value) {
+  return value == 0;
 }
 
 // Adds `a` and `b`, clamping to INT64_MIN / INT64_MAX on overflow instead of

--- a/src/trace_processor/core/common/storage_types.h
+++ b/src/trace_processor/core/common/storage_types.h
@@ -57,6 +57,12 @@ struct String {
   using cpp_type = StringPool::Id;
 };
 
+// Represents a column with no values at all: every row is null. Such columns
+// carry no payload and no underlying value type.
+struct Null {
+  using cpp_type = void;
+};
+
 // TypeSet of all possible storage value types.
 using StorageType = core::TypeSet<Id, Uint32, Int32, Int64, Double, String>;
 

--- a/src/trace_processor/core/tree/tree.h
+++ b/src/trace_processor/core/tree/tree.h
@@ -49,7 +49,17 @@ struct Tree {
   static constexpr uint32_t kNullParent = std::numeric_limits<uint32_t>::max();
 
   struct Column {
-    using Type = TypeSet<Int64, Double, String>;
+    // Null-typed columns have no payload at all; their null_bv marks every
+    // row as null and their data is never read.
+    using Type = TypeSet<Int64, Double, String, Null>;
+
+    // Creates a null-typed column of |rows| rows: no payload, every row null.
+    static Column CreateNull(uint32_t rows) {
+      Column column;
+      column.type = Type(Null{});
+      column.null_bv = BitVector::CreateWithSize(rows, false);
+      return column;
+    }
 
     template <typename T>
     static Column Create(uint32_t rows, bool nullable = false) {

--- a/src/trace_processor/core/tree/tree_column_ops.cc
+++ b/src/trace_processor/core/tree/tree_column_ops.cc
@@ -59,46 +59,6 @@ Tree::Column GatherTyped(const Tree::Column& input, Span<const uint32_t> rows) {
   return output;
 }
 
-template <typename T>
-void GatherInto(const Tree::Column& input,
-                Span<const uint32_t> rows,
-                uint32_t offset,
-                Tree::Column* output) {
-  Span<T> destination =
-      output->unchecked_span<T>().subspan(offset, rows.size());
-  Span<const T> source = input.unchecked_span<T>();
-  for (uint32_t row = 0; row < rows.size(); ++row) {
-    const uint32_t source_row = rows[row];
-    if (input.null_bv.size() > 0 && !input.null_bv.is_set(source_row)) {
-      continue;
-    }
-    destination[row] = source[source_row];
-    output->null_bv.set(offset + row);
-  }
-}
-
-template <typename T>
-Tree::Column GatherConcatTyped(const Tree::Column& first,
-                               Span<const uint32_t> first_rows,
-                               const Tree::Column& second,
-                               Span<const uint32_t> second_rows) {
-  const uint32_t first_size = static_cast<uint32_t>(first_rows.size());
-  const uint32_t second_size = static_cast<uint32_t>(second_rows.size());
-  Tree::Column output = Tree::Column::Create<T>(first_size + second_size);
-  if (first.null_bv.size() == 0 && second.null_bv.size() == 0) {
-    Span<T> destination = output.unchecked_span<T>();
-    ops::GatherRows(first.unchecked_span<T>(),
-                    destination.subspan(0, first_size), first_rows);
-    ops::GatherRows(second.unchecked_span<T>(),
-                    destination.subspan(first_size, second_size), second_rows);
-    return output;
-  }
-  output.null_bv = BitVector::CreateWithSize(first_size + second_size, false);
-  GatherInto<T>(first, first_rows, 0, &output);
-  GatherInto<T>(second, second_rows, first_size, &output);
-  return output;
-}
-
 }  // namespace
 
 void UpdateRowHashes(const Tree::Column& column,
@@ -116,6 +76,13 @@ void UpdateRowHashes(const Tree::Column& column,
       UpdateTypedRowHashes(column.unchecked_span<StringPool::Id>(), non_null,
                            hashes);
       return;
+    case Tree::Column::Type::GetTypeIndex<Null>():
+      // Combine the same marker a nullable typed column contributes for a
+      // null row.
+      for (uint32_t row = 0; row < hashes.size(); ++row) {
+        hashes[row].Combine(false, int64_t{});
+      }
+      return;
     default:
       PERFETTO_FATAL("Unsupported tree column type");
   }
@@ -129,24 +96,8 @@ Tree::Column Gather(const Tree::Column& input, Span<const uint32_t> rows) {
       return GatherTyped<double>(input, rows);
     case Tree::Column::Type::GetTypeIndex<String>():
       return GatherTyped<StringPool::Id>(input, rows);
-    default:
-      PERFETTO_FATAL("Unsupported tree column type");
-  }
-}
-
-Tree::Column GatherConcat(const Tree::Column& first,
-                          Span<const uint32_t> first_rows,
-                          const Tree::Column& second,
-                          Span<const uint32_t> second_rows) {
-  PERFETTO_DCHECK(first.type.index() == second.type.index());
-  switch (first.type.index()) {
-    case Tree::Column::Type::GetTypeIndex<Int64>():
-      return GatherConcatTyped<int64_t>(first, first_rows, second, second_rows);
-    case Tree::Column::Type::GetTypeIndex<Double>():
-      return GatherConcatTyped<double>(first, first_rows, second, second_rows);
-    case Tree::Column::Type::GetTypeIndex<String>():
-      return GatherConcatTyped<StringPool::Id>(first, first_rows, second,
-                                               second_rows);
+    case Tree::Column::Type::GetTypeIndex<Null>():
+      return Tree::Column::CreateNull(static_cast<uint32_t>(rows.size()));
     default:
       PERFETTO_FATAL("Unsupported tree column type");
   }

--- a/src/trace_processor/core/tree/tree_column_ops.h
+++ b/src/trace_processor/core/tree/tree_column_ops.h
@@ -33,13 +33,6 @@ void UpdateRowHashes(const Tree::Column&,
 // its type and nullability.
 Tree::Column Gather(const Tree::Column&, Span<const uint32_t> rows);
 
-// Concatenates selected rows from two same-typed columns into a new dense
-// column while preserving nullability.
-Tree::Column GatherConcat(const Tree::Column& first,
-                          Span<const uint32_t> first_rows,
-                          const Tree::Column& second,
-                          Span<const uint32_t> second_rows);
-
 }  // namespace perfetto::trace_processor::core::tree_ops
 
 #endif  // SRC_TRACE_PROCESSOR_CORE_TREE_TREE_COLUMN_OPS_H_

--- a/src/trace_processor/core/tree/tree_column_ops_unittest.cc
+++ b/src/trace_processor/core/tree/tree_column_ops_unittest.cc
@@ -54,26 +54,5 @@ TEST(TreeColumnOpsTest, GathersNullableRows) {
   EXPECT_FALSE(output.null_bv.is_set(1));
 }
 
-TEST(TreeColumnOpsTest, ConcatenatesRowsAndNullability) {
-  Tree::Column first = Tree::Column::Create<int64_t>(2);
-  first.unchecked_span<int64_t>()[0] = 10;
-  first.unchecked_span<int64_t>()[1] = 20;
-  Tree::Column second = Tree::Column::Create<int64_t>(2);
-  second.unchecked_span<int64_t>()[0] = 30;
-  second.unchecked_span<int64_t>()[1] = 40;
-  second.null_bv = BitVector::CreateWithSize(2, true);
-  second.null_bv.clear(0);
-  const uint32_t first_rows[] = {1};
-  const uint32_t second_rows[] = {0, 1};
-
-  Tree::Column output =
-      GatherConcat(first, MakeSpan(first_rows), second, MakeSpan(second_rows));
-  EXPECT_EQ(output.unchecked_span<int64_t>()[0], 20);
-  EXPECT_EQ(output.unchecked_span<int64_t>()[2], 40);
-  EXPECT_TRUE(output.null_bv.is_set(0));
-  EXPECT_FALSE(output.null_bv.is_set(1));
-  EXPECT_TRUE(output.null_bv.is_set(2));
-}
-
 }  // namespace
 }  // namespace perfetto::trace_processor::core::tree_ops

--- a/src/trace_processor/core/tree/tree_from_dataframe.cc
+++ b/src/trace_processor/core/tree/tree_from_dataframe.cc
@@ -80,9 +80,10 @@ Tree::Column MoveRawColumn(dataframe::AdhocDataframeBuilder::RawColumn& rc) {
     } else {
       PERFETTO_FATAL("Unexpected storage type in raw column");
     }
+  } else {
+    // Columns which never saw a value have no storage and no value type.
+    tc.type = Tree::Column::Type(Null{});
   }
-  // All-null columns keep the default Int64 type with no payload; null_bv
-  // flags every row as null so the data is never read.
   tc.null_bv = std::move(rc.null_bv);
   return tc;
 }
@@ -96,8 +97,8 @@ Tree::Column GatherRawColumn(dataframe::AdhocDataframeBuilder::RawColumn& rc,
   const BitVector* source_non_null =
       rc.null_bv.size() > 0 ? &rc.null_bv : nullptr;
   if (!rc.storage) {
-    // All-null column: keep the default Int64 type with no payload; null_bv
-    // flags every row as null so the data is never read.
+    // Columns which never saw a value have no storage and no value type.
+    tc.type = Tree::Column::Type(Null{});
     tc.null_bv = BitVector::CreateWithSize(row_count);
     return tc;
   }

--- a/src/trace_processor/plugins/flamegraph/BUILD.gn
+++ b/src/trace_processor/plugins/flamegraph/BUILD.gn
@@ -26,10 +26,12 @@ source_set("flamegraph") {
   ]
   deps = [
     "../../../../gn:default_deps",
+    "../../../../include/perfetto/ext/base",
     "../../../base",
     "../../../base/regex",
     "../../containers",
-    "../../core/dataframe",
+    "../../core/common",
+    "../../core/tree",
     "../../core/util",
   ]
 }
@@ -44,7 +46,9 @@ if (enable_perfetto_benchmarks) {
       "../../../../gn:default_deps",
       "../../../base",
       "../../containers",
-      "../../core/dataframe",
+      "../../core/common",
+      "../../core/tree",
+      "../../core/util",
     ]
   }
 }
@@ -58,7 +62,7 @@ perfetto_unittest_source_set("unittests") {
     "../../../../gn:gtest_and_gmock",
     "../../../base",
     "../../containers",
-    "../../core/dataframe",
+    "../../core/tree",
     "../../core/util",
   ]
 }

--- a/src/trace_processor/plugins/flamegraph/flamegraph.cc
+++ b/src/trace_processor/plugins/flamegraph/flamegraph.cc
@@ -17,670 +17,1618 @@
 #include "src/trace_processor/plugins/flamegraph/flamegraph.h"
 
 #include <algorithm>
-#include <cmath>
+#include <cinttypes>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <string>
-#include <string_view>
+#include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/endian.h"
 #include "perfetto/ext/base/flat_hash_map.h"
-#include "perfetto/ext/base/regex.h"
+#include "perfetto/ext/base/hash.h"
+#include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
-#include "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h"
-#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/utils.h"
+#include "src/trace_processor/core/tree/tree_column_ops.h"
+#include "src/trace_processor/core/tree/tree_path_interner.h"
+#include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/slab.h"
+#include "src/trace_processor/core/util/sort.h"
 
 namespace perfetto::trace_processor::flamegraph {
 namespace {
 
-using core::FlexVector;
+// A bit outside the SHOW_STACK mask. Once set, equality with the required
+// SHOW_STACK mask is impossible, rejecting this path and all its descendants.
+constexpr uint64_t kHideStackBit = uint64_t{1} << 63;
 
-// Show-stack and show-from filters are tracked as per-frame bitmasks, one
-// bit per filter, ORed along each path: a stack satisfies them when every
-// bit is present.
-constexpr size_t kMaxBitFilters = 63;
-
-// Row helpers for the flattened metric columns; explicit loops so they
-// inline instead of dispatching into libc for a handful of bytes.
-void AddRow(double* dst, const double* src, uint32_t k) {
-  for (uint32_t m = 0; m < k; ++m) {
-    dst[m] += src[m];
-  }
-}
-
-void CopyRow(double* dst, const double* src, uint32_t k) {
-  for (uint32_t m = 0; m < k; ++m) {
-    dst[m] = src[m];
-  }
-}
-
-bool AnyNonZero(const double* row, uint32_t k) {
-  for (uint32_t m = 0; m < k; ++m) {
-    if (row[m] < 0 || row[m] > 0) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// The compiled filter regexes. The pivot pattern is an extra show-stack
-// filter (only pivot-containing stacks are shown), remembered by index so
-// pivot frames can be identified from the match bitmask.
-struct Filters {
-  std::vector<base::Regex> show_stack;
-  std::vector<base::Regex> hide_stack;
-  std::vector<base::Regex> show_from;
-  std::vector<base::Regex> hide_frame;
-  uint32_t pivot_idx = 0;
-  uint64_t show_stack_mask = 0;
-  uint64_t show_from_mask = 0;
-  // A bit outside the mask: assigning it to a frame's bits makes its
-  // stacks unable to ever satisfy the mask, implementing hide-stack.
-  uint64_t impossible_bits = 0;
-
-  bool any() const {
-    return !show_stack.empty() || !hide_stack.empty() || !show_from.empty() ||
-           !hide_frame.empty();
-  }
-};
-
-base::StatusOr<Filters> CompileFilters(const Config& config) {
-  Filters f;
-  for (const auto& spec : config.filters) {
-    ASSIGN_OR_RETURN(base::Regex re, base::Regex::Create(spec.pattern));
-    switch (spec.kind) {
-      case Config::FilterKind::kShowStack:
-        f.show_stack.push_back(std::move(re));
-        break;
-      case Config::FilterKind::kHideStack:
-        f.hide_stack.push_back(std::move(re));
-        break;
-      case Config::FilterKind::kShowFromFrame:
-        f.show_from.push_back(std::move(re));
-        break;
-      case Config::FilterKind::kHideFrame:
-        f.hide_frame.push_back(std::move(re));
-        break;
-    }
-  }
-  if (config.view == Config::View::kPivot) {
-    if (!config.pivot_pattern) {
-      return base::ErrStatus(
-          "flamegraph: pivot pattern is required for the pivot view");
-    }
-    ASSIGN_OR_RETURN(base::Regex re,
-                     base::Regex::Create(*config.pivot_pattern));
-    f.pivot_idx = static_cast<uint32_t>(f.show_stack.size());
-    f.show_stack.push_back(std::move(re));
-  } else if (config.pivot_pattern) {
-    return base::ErrStatus(
-        "flamegraph: pivot pattern is only valid for the pivot view");
-  }
-  if (f.show_stack.size() > kMaxBitFilters ||
-      f.show_from.size() > kMaxBitFilters) {
-    return base::ErrStatus("flamegraph: too many filters (max %zu per kind)",
-                           kMaxBitFilters);
-  }
-  f.show_stack_mask = (uint64_t(1) << f.show_stack.size()) - 1;
-  f.show_from_mask = (uint64_t(1) << f.show_from.size()) - 1;
-  f.impossible_bits = uint64_t(1) << f.show_stack.size();
-  return base::StatusOr<Filters>(std::move(f));
-}
-
-// Returns the frames in parents-before-children order, excluding frames
-// unreachable from a root (dangling parent indices, cycles). Input that is
-// already ordered, the common case, is detected and returned as the
-// identity order with no index built.
-FlexVector<uint32_t> TopoOrder(const Forest& forest) {
-  auto n = static_cast<uint32_t>(forest.size());
-  bool ordered = true;
-  for (uint32_t i = 0; i < n && ordered; ++i) {
-    uint32_t p = forest.parent[i];
-    ordered = p == kNoParent || p < i;
-  }
-  auto order = FlexVector<uint32_t>::CreateWithSize(n);
-  if (ordered) {
-    for (uint32_t i = 0; i < n; ++i) {
-      order[i] = i;
-    }
-    return order;
-  }
-  // Reverse the parent index into child lists with a count + scatter pass,
-  // then DFS from the roots.
-  auto child_offset = FlexVector<uint32_t>::CreateFilled(n + 2, 0);
-  for (uint32_t i = 0; i < n; ++i) {
-    if (forest.parent[i] < n) {
-      child_offset[forest.parent[i] + 2]++;
-    }
-  }
-  for (uint32_t i = 2; i < n + 2; ++i) {
-    child_offset[i] += child_offset[i - 1];
-  }
-  auto child_list = FlexVector<uint32_t>::CreateWithSize(child_offset[n + 1]);
-  for (uint32_t i = 0; i < n; ++i) {
-    if (forest.parent[i] < n) {
-      child_list[child_offset[forest.parent[i] + 1]++] = i;
-    }
-  }
-  order.clear();
-  FlexVector<uint32_t> stack;
-  for (uint32_t i = n; i-- > 0;) {
-    if (forest.parent[i] == kNoParent) {
-      stack.push_back(i);
-    }
-  }
-  while (!stack.empty()) {
-    uint32_t i = stack.back();
-    stack.pop_back();
-    order.push_back(i);
-    for (uint32_t c = child_offset[i + 1]; c-- > child_offset[i];) {
-      stack.push_back(child_list[c]);
-    }
-  }
-  return order;
-}
-
-// A merged tree under construction. Node identity is (parent node, key),
-// resolved through one exact hash map; nodes are created in
-// parents-before-children order by construction. |expected_nodes| sizes
-// the map and node columns so steady-state growth never reallocates; pass
-// 0 when the output is expected to be small (pivot views).
-struct Trie {
-  Trie(uint32_t metric_count, uint32_t expected_nodes)
-      : k(metric_count),
-        // 1.5x keeps the expected node count under the map's load limit.
-        map(NextPow2(uint64_t(expected_nodes) + expected_nodes / 2)) {
-    parent.reserve(expected_nodes);
-    rep_frame.reserve(expected_nodes);
-    self.reserve(uint64_t(expected_nodes) * k);
-    cumulative.reserve(uint64_t(expected_nodes) * k);
-  }
-
-  static size_t NextPow2(uint64_t v) {
-    uint64_t p = 16;
-    while (p < v) {
-      p *= 2;
-    }
-    PERFETTO_CHECK(p <= std::numeric_limits<size_t>::max());
-    return static_cast<size_t>(p);
-  }
-
-  uint32_t ChildOf(uint32_t node, uint32_t key, uint32_t frame) {
-    auto next = static_cast<uint32_t>(parent.size());
-    auto [id, inserted] = map.Insert((uint64_t(node) << 32) | key, next);
-    if (inserted) {
-      parent.push_back(node);
-      rep_frame.push_back(frame);
-      self.push_back_multiple(0, k);
-      cumulative.push_back_multiple(0, k);
-    }
-    return *id;
-  }
-
-  size_t size() const { return parent.size(); }
-
-  uint32_t k;
-  base::FlatHashMapV2<uint64_t, uint32_t> map;
-  FlexVector<uint32_t> parent;
-  FlexVector<uint32_t> rep_frame;
-  FlexVector<double> self;
-  FlexVector<double> cumulative;
-};
-
-// Drops every node whose subtree is zero on all metrics (uncounted or
-// valueless stacks) and packs the survivors into the output Tree, along
-// with the constituent index built from the (node, frame) pairs by a
-// count + scatter pass.
-Tree PackTree(Trie trie, const FlexVector<uint64_t>& node_frame_pairs) {
-  auto nodes = static_cast<uint32_t>(trie.size());
-  uint32_t k = trie.k;
-  if (nodes == 0) {
-    Tree tree;
-    tree.metric_count = k;
-    tree.constituents_offset = FlexVector<uint32_t>::CreateFilled(1, 0);
-    return tree;
-  }
-  // A node stays if its own subtree has value; children come after their
-  // parent, so one reverse scan propagates "has a kept descendant".
-  auto keep = FlexVector<uint8_t>::CreateFilled(nodes, 0);
-  for (uint32_t i = nodes; i-- > 0;) {
-    keep[i] = keep[i] || AnyNonZero(&trie.cumulative[i * k], k);
-    if (keep[i] && trie.parent[i] != kNoParent) {
-      keep[trie.parent[i]] = 1;
-    }
-  }
-  auto remap = FlexVector<uint32_t>::CreateWithSize(nodes);
-  uint32_t packed = 0;
-  for (uint32_t i = 0; i < nodes; ++i) {
-    remap[i] = keep[i] ? packed++ : kNoParent;
-  }
-
-  Tree tree;
-  tree.metric_count = k;
-  if (packed == nodes) {
-    // Nothing dropped: adopt the trie's columns as-is (remap is the
-    // identity).
-    tree.parent = std::move(trie.parent);
-    tree.rep_frame = std::move(trie.rep_frame);
-    tree.self = std::move(trie.self);
-    tree.cumulative = std::move(trie.cumulative);
+template <typename T>
+bool TryAdd(T value, T* total) {
+  static_assert(std::is_same_v<T, int64_t> || std::is_same_v<T, double>);
+  if constexpr (std::is_same_v<T, int64_t>) {
+    return base::CheckedAdd(*total, value, total);
   } else {
-    tree.parent = FlexVector<uint32_t>::CreateWithSize(packed);
-    tree.rep_frame = FlexVector<uint32_t>::CreateWithSize(packed);
-    tree.self = FlexVector<double>::CreateWithSize(uint64_t(packed) * k);
-    tree.cumulative = FlexVector<double>::CreateWithSize(uint64_t(packed) * k);
-    for (uint32_t i = 0; i < nodes; ++i) {
-      if (!keep[i]) {
-        continue;
-      }
-      uint32_t out = remap[i];
-      tree.parent[out] =
-          trie.parent[i] == kNoParent ? kNoParent : remap[trie.parent[i]];
-      tree.rep_frame[out] = trie.rep_frame[i];
-      CopyRow(&tree.self[out * k], &trie.self[i * k], k);
-      CopyRow(&tree.cumulative[out * k], &trie.cumulative[i * k], k);
-    }
+    *total += value;
+    return true;
   }
-
-  tree.constituents_offset = FlexVector<uint32_t>::CreateFilled(packed + 1, 0);
-  for (uint64_t pair : node_frame_pairs) {
-    uint32_t node = remap[pair >> 32];
-    if (node != kNoParent) {
-      tree.constituents_offset[node + 1]++;
-    }
-  }
-  for (uint32_t i = 1; i <= packed; ++i) {
-    tree.constituents_offset[i] += tree.constituents_offset[i - 1];
-  }
-  tree.constituents =
-      FlexVector<uint32_t>::CreateWithSize(tree.constituents_offset[packed]);
-  if (packed != 0) {
-    auto cursor = FlexVector<uint32_t>::CreateWithSize(packed);
-    memcpy(cursor.data(), tree.constituents_offset.data(),
-           packed * sizeof(uint32_t));
-    for (uint64_t pair : node_frame_pairs) {
-      uint32_t node = remap[pair >> 32];
-      if (node != kNoParent) {
-        tree.constituents[cursor[node]++] = static_cast<uint32_t>(pair);
-      }
-    }
-  }
-  return tree;
 }
 
-// The state shared by the phases of one Build() call. See Build() at the
-// bottom for the phase sequence.
-class Builder {
- public:
-  Builder(const Forest& forest,
-          const Config& config,
-          const StringPool& pool,
-          Filters filters)
-      : forest_(forest),
-        config_(config),
-        pool_(pool),
-        filters_(std::move(filters)),
-        frame_count_(static_cast<uint32_t>(forest.size())),
-        metric_count_(forest.metric_count),
-        // Full top-down / bottom-up output has up to one node per frame;
-        // pivot output is typically far smaller, so let that grow on
-        // demand.
-        expected_nodes_(config.view == Config::View::kPivot ? 0
-                                                            : frame_count_) {}
-
-  Flamegraph Run() {
-    EvaluateNameMasks();
-    order_ = TopoOrder(forest_);
-    EvaluatePaths();
-    SelectAnchors();
-    Flamegraph result;
-    result.down.metric_count = metric_count_;
-    result.down.constituents_offset = FlexVector<uint32_t>::CreateFilled(1, 0);
-    result.up.metric_count = metric_count_;
-    result.up.constituents_offset = FlexVector<uint32_t>::CreateFilled(1, 0);
-    if (config_.view != Config::View::kBottomUp) {
-      result.down = BuildDown();
-    }
-    if (config_.view != Config::View::kTopDown) {
-      result.up = BuildUp();
-    }
-    return result;
+template <typename T>
+bool AccumulateSum(T value,
+                   uint32_t destination,
+                   core::Span<T> sums,
+                   core::BitVector* has_value) {
+  PERFETTO_DCHECK(destination < sums.size());
+  PERFETTO_DCHECK(has_value->size() == sums.size());
+  if (!has_value->is_set(destination)) {
+    sums[destination] = value;
+    has_value->set(destination);
+    return true;
   }
+  return TryAdd(value, &sums[destination]);
+}
 
- private:
-  // Per distinct name, its regex results across all filters.
-  struct NameMasks {
-    uint64_t show_stack_bits;
-    uint64_t show_from_bits;
-    bool shown;
+template <typename T>
+core::Slab<T> AllocFilled(uint64_t size, T value) {
+  core::Slab<T> slab = core::Slab<T>::Alloc(size);
+  std::fill_n(slab.data(), size, value);
+  return slab;
+}
+
+void UpdateNonZeroRows(const core::Tree::Column& column,
+                       uint32_t offset,
+                       core::Span<uint8_t> rows) {
+  if (column.type.Is<core::Int64>()) {
+    core::Span<const int64_t> values =
+        column.unchecked_span<int64_t>().subspan(offset, rows.size());
+    for (uint32_t row = 0; row < rows.size(); ++row) {
+      rows[row] |= !base::IsZero(values[row]);
+    }
+    return;
+  }
+  PERFETTO_DCHECK(column.type.Is<core::Double>());
+  core::Span<const double> values =
+      column.unchecked_span<double>().subspan(offset, rows.size());
+  for (uint32_t row = 0; row < rows.size(); ++row) {
+    rows[row] |= !base::IsZero(values[row]);
+  }
+}
+
+struct FilterMatches {
+  uint64_t show_stack : Config::kMaxShowStackFilters;
+  uint64_t view_pattern : 1;
+  uint64_t hide_stack : 1;
+  uint64_t hide_frame : 1;
+};
+static_assert(sizeof(FilterMatches) == 8);
+
+constexpr FilterMatches kNoFilterMatches{};
+
+// Everything later phases need from the root-to-row path traversal. Keeping
+// the path-compressed retained frame avoids any later ancestor search.
+struct PathState {
+  // SHOW_STACK matches on retained frames, plus kHideStackBit if a retained
+  // frame on this path matched HIDE_STACK. Removed frames inherit this value
+  // unchanged, so their names cannot affect stack filtering.
+  uint64_t stack_bits;
+
+  // The nearest retained input row. A retained frame points to itself, while a
+  // removed frame inherits its nearest retained ancestor.
+  uint32_t retained_frame;
+  uint8_t padding[4];
+
+  bool IsRetained(uint32_t row) const;
+  bool StackIsHidden() const;
+  bool StackContributes(uint64_t required_show_stack_bits) const;
+};
+static_assert(sizeof(PathState) == 16);
+
+static constexpr PathState kEmptyPathState =
+    PathState{0, core::Tree::kNullParent, {}};
+
+struct UpwardPath {
+  uint32_t root;
+  uint32_t leaf;
+};
+static_assert(sizeof(UpwardPath) == 8);
+
+struct UpwardAnchor {
+  uint32_t frame;
+  UpwardPath path;
+};
+static_assert(sizeof(UpwardAnchor) == 12);
+
+struct TreeConstituent {
+  uint32_t frame;
+  uint32_t node;
+};
+static_assert(sizeof(TreeConstituent) == 8);
+
+// Self and cumulative values for one value column, indexed by combined node
+// id: downward nodes first, then upward nodes offset by the downward size.
+// Aggregate columns use the same combined id space.
+struct MetricColumns {
+  core::Tree::Column self;
+  core::Tree::Column cumulative;
+};
+
+// Outputs of the three build stages, produced in order by Run().
+
+// View-independent per-row analysis: frame identity, filter matching and
+// path compression. Depends only on the input tree and the config's
+// regexes; both halves are built from it.
+struct PathAnalysis {
+  std::vector<base::MurmurHashCombiner> frame_hashes;
+  core::Slab<PathState> states;
+  // Retained rows whose frame matches the view pattern. Allocated only when
+  // the config has a view pattern.
+  core::BitVector view_pattern_matches;
+};
+
+// The merged downward (descendant) half of the view.
+struct DownwardHalf {
+  explicit DownwardHalf(uint32_t interner_capacity) : tree(interner_capacity) {}
+
+  core::TreePathInterner tree;
+  // Input row -> merged node receiving its values, kNullParent when the row
+  // is outside the downward half.
+  core::Slab<uint32_t> node;
+};
+
+// The merged upward (ancestor) half of the view.
+struct UpwardHalf {
+  explicit UpwardHalf(uint32_t interner_capacity) : tree(interner_capacity) {}
+
+  core::TreePathInterner tree;
+  core::Slab<UpwardPath> bottom_up_paths;
+  core::FlexVector<UpwardAnchor> pivot_anchors;
+  core::FlexVector<TreeConstituent> aggregate_constituents;
+};
+
+// Compact two-level routing for aggregates. Output nodes reference retained
+// frames, and retained frames reference the input rows folded into them.
+struct AggregateRouting {
+  core::Slab<uint32_t> output_frame_offsets;
+  core::Slab<uint32_t> output_frames;
+  core::Slab<uint32_t> frame_row_offsets;
+  core::Slab<uint32_t> frame_rows;
+  bool frame_rows_are_identity = false;
+};
+
+// Appends the textual form of an aggregated value: strings verbatim,
+// numbers formatted directly so numeric columns need no per-row interning.
+void AppendValue(StringPool::Id value,
+                 const StringPool& pool,
+                 std::string* out) {
+  const NullTermStringView str = pool.Get(value);
+  out->append(str.data(), str.size());
+}
+void AppendValue(int64_t value, const StringPool&, std::string* out) {
+  base::StackString<32> str("%" PRId64, value);
+  out->append(str.c_str(), str.len());
+}
+void AppendValue(double value, const StringPool&, std::string* out) {
+  base::StackString<32> str("%.15g", value);
+  out->append(str.c_str(), str.len());
+  // Match SQLite's REAL rendering: integral values keep a trailing ".0".
+  // The scan set also skips infinities and NaNs.
+  if (strcspn(str.c_str(), ".eEnN") == str.len()) {
+    out->append(".0");
+  }
+}
+
+// Canonical 64-bit pattern used to count distinct aggregate values without
+// comparing the values themselves (which -Wfloat-equal forbids for doubles).
+uint64_t DistinctKey(StringPool::Id value) {
+  return value.raw_id();
+}
+uint64_t DistinctKey(int64_t value) {
+  return static_cast<uint64_t>(value);
+}
+uint64_t DistinctKey(double value) {
+  if (base::IsZero(value)) {
+    return 0;  // Canonicalize -0.0 to +0.0.
+  }
+  uint64_t bits;
+  memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+struct NativeFrameRouting {
+  core::Span<const PathState> states;
+  core::Span<const uint32_t> downward_nodes;
+  core::Span<const TreeConstituent> upward_constituents;
+  uint32_t downward_size;
+  uint64_t required_show_stack_bits;
+  bool has_downward;
+};
+
+class AggregateOperator {
+ public:
+  enum class InputMode {
+    kRowsToOutputs,
+    kNativeRowsToFramesThenFramesToOutputs,
   };
 
-  const NameMasks& MasksOf(uint32_t frame) const {
-    return masks_[forest_.name[frame]];
+  virtual ~AggregateOperator();
+  virtual InputMode input_mode() const { return InputMode::kRowsToOutputs; }
+  virtual base::Status UpdateBatch(core::Span<const uint32_t>,
+                                   core::Span<const uint32_t>) {
+    PERFETTO_FATAL("Aggregate operator does not support direct row updates");
+  }
+  virtual base::Status UpdateFrames(const NativeFrameRouting&) {
+    PERFETTO_FATAL("Aggregate operator does not support frame aggregation");
+  }
+  virtual base::Status MergeFrames(const NativeFrameRouting&) {
+    PERFETTO_FATAL("Aggregate operator does not support frame merging");
+  }
+  virtual base::Status Finalize() { return base::OkStatus(); }
+  virtual core::Tree::Column TakeOutput() = 0;
+};
+
+AggregateOperator::~AggregateOperator() = default;
+
+template <typename T>
+class SumAggregateOperator final : public AggregateOperator {
+ public:
+  SumAggregateOperator(const core::Tree::Column& input, uint32_t output_rows)
+      : input_(input),
+        frame_totals_(core::Tree::Column::Create<T>(
+            static_cast<uint32_t>(input.unchecked_span<T>().size()))),
+        output_(core::Tree::Column::Create<T>(output_rows)) {
+    frame_totals_.null_bv = core::BitVector::CreateWithSize(
+        input.unchecked_span<T>().size(), false);
+    output_.null_bv = core::BitVector::CreateWithSize(output_rows, false);
   }
 
-  bool IsPivotFrame(uint32_t frame) const {
-    return ((MasksOf(frame).show_stack_bits >> filters_.pivot_idx) & 1) != 0;
+  InputMode input_mode() const override {
+    return InputMode::kNativeRowsToFramesThenFramesToOutputs;
   }
 
-  // Runs every filter regex against every distinct name once.
-  void EvaluateNameMasks() {
-    auto names = static_cast<uint32_t>(forest_.name_table.size());
-    masks_ = FlexVector<NameMasks>::CreateFilled(names, {0, 0, true});
-    if (!filters_.any()) {
+  base::Status UpdateFrames(const NativeFrameRouting& routing) override {
+    core::Span<const T> input = input_.unchecked_span<T>();
+    core::Span<T> totals = frame_totals_.unchecked_span<T>();
+    for (uint32_t row = 0; row < input.size(); ++row) {
+      if (input_.null_bv.size() > 0 && !input_.null_bv.is_set(row)) {
+        continue;
+      }
+      const PathState& state = routing.states[row];
+      if (state.retained_frame == core::Tree::kNullParent ||
+          state.StackIsHidden()) {
+        continue;
+      }
+      if (!AccumulateSum(input[row], state.retained_frame, totals,
+                         &frame_totals_.null_bv)) {
+        return base::ErrStatus("flamegraph: integer aggregate overflow");
+      }
+    }
+    return base::OkStatus();
+  }
+
+  base::Status MergeFrames(const NativeFrameRouting& routing) override {
+    const core::Tree::Column& frame_totals = frame_totals_;
+    core::Span<const T> totals = frame_totals.unchecked_span<T>();
+    core::Span<T> output = output_.unchecked_span<T>();
+    if (routing.has_downward) {
+      for (uint32_t frame = 0; frame < routing.states.size(); ++frame) {
+        const PathState& state = routing.states[frame];
+        if (!state.IsRetained(frame) || !frame_totals_.null_bv.is_set(frame) ||
+            routing.downward_nodes[frame] == core::Tree::kNullParent ||
+            !state.StackContributes(routing.required_show_stack_bits)) {
+          continue;
+        }
+        if (!AccumulateSum(totals[frame], routing.downward_nodes[frame], output,
+                           &output_.null_bv)) {
+          return base::ErrStatus("flamegraph: integer aggregate overflow");
+        }
+      }
+    }
+    for (const TreeConstituent& constituent : routing.upward_constituents) {
+      if (!frame_totals_.null_bv.is_set(constituent.frame)) {
+        continue;
+      }
+      if (!AccumulateSum(totals[constituent.frame],
+                         routing.downward_size + constituent.node, output,
+                         &output_.null_bv)) {
+        return base::ErrStatus("flamegraph: integer aggregate overflow");
+      }
+    }
+    return base::OkStatus();
+  }
+
+  core::Tree::Column TakeOutput() override { return std::move(output_); }
+
+ private:
+  const core::Tree::Column& input_;
+  core::Tree::Column frame_totals_;
+  core::Tree::Column output_;
+};
+
+template <typename T>
+class OneOrSummaryAggregateOperator final : public AggregateOperator {
+ public:
+  OneOrSummaryAggregateOperator(const core::Tree::Column& input,
+                                StringPool& pool,
+                                uint32_t output_rows)
+      : input_(input),
+        pool_(pool),
+        output_(core::Tree::Column::Create<StringPool::Id>(output_rows)) {
+    output_.null_bv = core::BitVector::CreateWithSize(output_rows, false);
+  }
+
+  base::Status UpdateBatch(core::Span<const uint32_t> output_rows,
+                           core::Span<const uint32_t> input_rows) override {
+    core::Span<const T> input = input_.unchecked_span<T>();
+    for (uint32_t i = 0; i < input_rows.size(); ++i) {
+      const uint32_t input_row = input_rows[i];
+      if (input_.null_bv.size() > 0 && !input_.null_bv.is_set(input_row)) {
+        continue;
+      }
+      if (output_rows[i] != current_output_row_) {
+        FinishGroup();
+        current_output_row_ = output_rows[i];
+      }
+      Add(input[input_row]);
+    }
+    return base::OkStatus();
+  }
+
+  base::Status Finalize() override {
+    FinishGroup();
+    return base::OkStatus();
+  }
+
+  core::Tree::Column TakeOutput() override { return std::move(output_); }
+
+ private:
+  void Add(T value) {
+    const uint64_t key = DistinctKey(value);
+    if (!has_value_) {
+      representative_ = value;
+      representative_key_ = key;
+      has_value_ = true;
+    } else if (!has_multiple_values_ && key != representative_key_) {
+      distinct_keys_.push_back(representative_key_);
+      distinct_keys_.push_back(key);
+      has_multiple_values_ = true;
+    } else if (has_multiple_values_) {
+      distinct_keys_.push_back(key);
+    }
+  }
+
+  void FinishGroup() {
+    if (!has_value_) {
       return;
     }
-    for (uint32_t t = 0; t < names; ++t) {
-      NullTermStringView name = pool_.Get(forest_.name_table[t]);
-      std::string_view view(name.data(), name.size());
-      auto matches = [&](const base::Regex& re) {
-        if (re.PartialMatch(view)) {
-          return true;
+    core::Span<StringPool::Id> output =
+        output_.unchecked_span<StringPool::Id>();
+    if constexpr (std::is_same_v<T, StringPool::Id>) {
+      if (!has_multiple_values_) {
+        output[current_output_row_] = representative_;
+        output_.null_bv.set(current_output_row_);
+        ResetGroup();
+        return;
+      }
+    }
+    summary_.clear();
+    AppendValue(representative_, pool_, &summary_);
+    if (has_multiple_values_) {
+      std::sort(distinct_keys_.begin(), distinct_keys_.end());
+      const size_t distinct_count = static_cast<size_t>(std::distance(
+          distinct_keys_.begin(),
+          std::unique(distinct_keys_.begin(), distinct_keys_.end())));
+      summary_ += " and ";
+      summary_ += std::to_string(distinct_count);
+      summary_ += " others";
+    }
+    output[current_output_row_] =
+        pool_.InternString(base::StringView(summary_));
+    output_.null_bv.set(current_output_row_);
+    ResetGroup();
+  }
+
+  void ResetGroup() {
+    distinct_keys_.clear();
+    has_value_ = false;
+    has_multiple_values_ = false;
+  }
+
+  const core::Tree::Column& input_;
+  StringPool& pool_;
+  core::Tree::Column output_;
+  std::vector<uint64_t> distinct_keys_;
+  std::string summary_;
+  T representative_{};
+  uint64_t representative_key_ = 0;
+  uint32_t current_output_row_ = core::Tree::kNullParent;
+  bool has_value_ = false;
+  bool has_multiple_values_ = false;
+};
+
+template <typename T>
+class ConcatAggregateOperator final : public AggregateOperator {
+ public:
+  ConcatAggregateOperator(const core::Tree::Column& input,
+                          StringPool& pool,
+                          uint32_t output_rows)
+      : input_(input),
+        pool_(pool),
+        output_(core::Tree::Column::Create<StringPool::Id>(output_rows)) {
+    output_.null_bv = core::BitVector::CreateWithSize(output_rows, false);
+  }
+
+  base::Status UpdateBatch(core::Span<const uint32_t> output_rows,
+                           core::Span<const uint32_t> input_rows) override {
+    core::Span<const T> input = input_.unchecked_span<T>();
+    for (uint32_t i = 0; i < input_rows.size(); ++i) {
+      const uint32_t input_row = input_rows[i];
+      if (input_.null_bv.size() > 0 && !input_.null_bv.is_set(input_row)) {
+        continue;
+      }
+      if (output_rows[i] != current_output_row_) {
+        FinishGroup();
+        current_output_row_ = output_rows[i];
+      }
+      if (!text_.empty()) {
+        text_.push_back(',');
+      }
+      AppendValue(input[input_row], pool_, &text_);
+    }
+    return base::OkStatus();
+  }
+
+  base::Status Finalize() override {
+    FinishGroup();
+    return base::OkStatus();
+  }
+
+  core::Tree::Column TakeOutput() override { return std::move(output_); }
+
+ private:
+  void FinishGroup() {
+    if (text_.empty()) {
+      return;
+    }
+    output_.unchecked_span<StringPool::Id>()[current_output_row_] =
+        pool_.InternString(base::StringView(text_));
+    output_.null_bv.set(current_output_row_);
+    text_.clear();
+  }
+
+  const core::Tree::Column& input_;
+  StringPool& pool_;
+  core::Tree::Column output_;
+  std::string text_;
+  uint32_t current_output_row_ = core::Tree::kNullParent;
+};
+
+struct PackedTree {
+  explicit PackedTree(uint32_t capacity)
+      : depths(core::Slab<int64_t>::Alloc(capacity)),
+        source_nodes(core::Slab<uint32_t>::Alloc(capacity)),
+        parents(core::Slab<uint32_t>::Alloc(capacity)),
+        representative_frames(core::Slab<uint32_t>::Alloc(capacity)) {}
+
+  void Append(int64_t depth,
+              uint32_t source_node,
+              uint32_t parent,
+              uint32_t representative_frame) {
+    PERFETTO_DCHECK(rows < depths.size());
+    depths[rows] = depth;
+    source_nodes[rows] = source_node;
+    parents[rows] = parent;
+    representative_frames[rows] = representative_frame;
+    ++rows;
+  }
+
+  uint32_t size() const { return rows; }
+  core::Span<const uint32_t> source_node_span() const {
+    return source_nodes.span().subspan(0, rows);
+  }
+  core::Span<const uint32_t> representative_frame_span() const {
+    return representative_frames.span().subspan(0, rows);
+  }
+
+  core::Slab<int64_t> depths;
+  core::Slab<uint32_t> source_nodes;
+  core::Slab<uint32_t> parents;
+  core::Slab<uint32_t> representative_frames;
+  uint32_t rows = 0;
+};
+
+// Owns all temporary state for one flamegraph computation. The methods are the
+// algorithm phases in execution order; helpers are outlined below to keep the
+// class declaration readable.
+class FlamegraphBuilder {
+ public:
+  FlamegraphBuilder(const core::Tree& input, const Config& config);
+
+  base::StatusOr<core::Tree> Run();
+
+ private:
+  FilterMatches MatchText(const char* value) const;
+
+  template <typename T>
+  FilterMatches MatchNumber(T value) const;
+
+  FilterMatches MatchColumn(const core::Tree::Column& column,
+                            uint32_t row) const;
+  FilterMatches MatchFrame(uint32_t row) const;
+  void PrepareFrameHashes();
+  void AnalyzePaths();
+  void BuildDownwardHalf();
+  base::Status BuildUpwardHalf();
+  UpwardPath BuildUpwardPath(uint32_t frame, bool include_aggregates);
+  bool ContributesToDownwardCumulative(uint32_t row) const;
+  base::Status AccumulateMetrics();
+  void BuildAggregateRouting();
+  base::Status RunAggregateOperator(AggregateOperator* op);
+  base::Status ComputeAggregates();
+  base::StatusOr<core::Tree> PackOutput();
+
+  template <typename T>
+  base::Status MarkActiveBottomUpAnchors(const core::Tree::Column& column,
+                                         core::Span<uint8_t> active);
+
+  template <typename T>
+  static void InitializeMetricColumns(uint32_t rows, MetricColumns* output);
+
+  template <typename T>
+  base::Status AccumulateMetric(const core::Tree::Column& input,
+                                MetricColumns* output);
+
+  template <typename T>
+  base::Status AccumulateDownwardMetric(const core::Tree::Column& input,
+                                        core::Span<T> self,
+                                        core::Span<T> cumulative);
+
+  template <typename T>
+  base::Status AccumulateUpwardMetric(const core::Tree::Column& input,
+                                      core::Span<T> self,
+                                      core::Span<T> cumulative);
+
+  template <typename T>
+  base::Status AccumulateBottomUpMetric(const core::Tree::Column& input,
+                                        core::Span<T> self,
+                                        core::Span<T> cumulative);
+
+  template <typename T>
+  base::Status AccumulatePivotUpwardMetric(const core::Tree::Column& input,
+                                           core::Span<T> self,
+                                           core::Span<T> cumulative);
+
+  template <typename T>
+  static base::Status PropagateCumulative(const core::TreePathInterner& tree,
+                                          core::Span<T> cumulative);
+
+  void AppendPackedNodes(const core::TreePathInterner& tree,
+                         uint32_t id_offset,
+                         bool upward,
+                         PackedTree* output) const;
+
+  const core::Tree& input_;
+  const Config& config_;
+  uint64_t required_show_stack_bits_;
+
+  PathAnalysis analysis_;
+  DownwardHalf downward_;
+  UpwardHalf upward_;
+  AggregateRouting aggregate_routing_;
+  std::vector<MetricColumns> metrics_;
+  std::vector<core::Tree::Column> aggregate_columns_;
+};
+
+bool IsValidConfig(const core::Tree& input, const Config& config) {
+  if (!config.name || !config.name->type.Is<core::String>() ||
+      config.value_columns.empty()) {
+    return false;
+  }
+  for (const core::Tree::Column* value : config.value_columns) {
+    if (!value || !IsNumericColumn(*value)) {
+      return false;
+    }
+  }
+
+  std::vector<std::string> output_names{"depth", "name"};
+  const auto add_output_name = [&](std::string name) {
+    if (name.empty() || std::find(output_names.begin(), output_names.end(),
+                                  name) != output_names.end()) {
+      return false;
+    }
+    output_names.push_back(std::move(name));
+    return true;
+  };
+  for (const core::Tree::Column* grouping : config.grouping_columns) {
+    if (!grouping ||
+        !add_output_name(std::string(input.ColumnName(grouping)))) {
+      return false;
+    }
+  }
+  for (const core::Tree::Column* value : config.value_columns) {
+    const std::string name(input.ColumnName(value));
+    if (!add_output_name("self_" + name) ||
+        !add_output_name("cumulative_" + name)) {
+      return false;
+    }
+  }
+  for (const Config::AggregateColumn& aggregate : config.aggregate_columns) {
+    if (!aggregate.input || !add_output_name(aggregate.output_name)) {
+      return false;
+    }
+    if (aggregate.input->type.Is<core::Null>()) {
+      // A column with no values aggregates to no values under any mode.
+    } else if (aggregate.aggregate == Config::Aggregate::kSum &&
+               !IsNumericColumn(*aggregate.input)) {
+      return false;
+    }
+  }
+  if (config.show_stack_filters.size() > Config::kMaxShowStackFilters) {
+    return false;
+  }
+  const bool is_pattern_view = config.view.IsAnyOf<Config::PatternViews>();
+  return is_pattern_view == config.view_pattern.has_value();
+}
+
+bool PathState::IsRetained(uint32_t row) const {
+  return retained_frame == row;
+}
+
+bool PathState::StackIsHidden() const {
+  return (stack_bits & kHideStackBit) != 0;
+}
+
+bool PathState::StackContributes(uint64_t required_show_stack_bits) const {
+  return retained_frame != core::Tree::kNullParent &&
+         stack_bits == required_show_stack_bits;
+}
+
+bool FlamegraphBuilder::ContributesToDownwardCumulative(uint32_t row) const {
+  return downward_.node[row] != core::Tree::kNullParent &&
+         analysis_.states[row].StackContributes(required_show_stack_bits_);
+}
+
+FlamegraphBuilder::FlamegraphBuilder(const core::Tree& input,
+                                     const Config& config)
+    : input_(input),
+      config_(config),
+      required_show_stack_bits_(
+          (uint64_t{1} << config.show_stack_filters.size()) - 1),
+      downward_(config.view.Is<Config::TopDown>() ? input.row_count : 0),
+      upward_(config.view.Is<Config::BottomUp>() ? input.row_count : 0) {}
+
+base::StatusOr<core::Tree> FlamegraphBuilder::Run() {
+  AnalyzePaths();
+  BuildDownwardHalf();
+  RETURN_IF_ERROR(BuildUpwardHalf());
+  analysis_.frame_hashes.clear();
+  analysis_.frame_hashes.shrink_to_fit();
+  RETURN_IF_ERROR(AccumulateMetrics());
+  upward_.bottom_up_paths = {};
+  upward_.pivot_anchors = {};
+  RETURN_IF_ERROR(ComputeAggregates());
+  analysis_.states = {};
+  upward_.aggregate_constituents = {};
+  return PackOutput();
+}
+
+FilterMatches FlamegraphBuilder::MatchText(const char* value) const {
+  FilterMatches matches{};
+  if (config_.view_pattern) {
+    matches.view_pattern = config_.view_pattern->PartialMatch(value);
+  }
+  for (size_t i = 0; i < config_.show_stack_filters.size(); ++i) {
+    if (config_.show_stack_filters[i].PartialMatch(value)) {
+      matches.show_stack |= uint64_t{1} << i;
+    }
+  }
+  for (const base::Regex& filter : config_.hide_stack_filters) {
+    if (filter.PartialMatch(value)) {
+      matches.hide_stack = 1;
+      break;
+    }
+  }
+  for (const base::Regex& filter : config_.hide_frame_filters) {
+    if (filter.PartialMatch(value)) {
+      matches.hide_frame = 1;
+      break;
+    }
+  }
+  return matches;
+}
+
+void FlamegraphBuilder::PrepareFrameHashes() {
+  analysis_.frame_hashes.resize(input_.row_count);
+  core::Span<base::MurmurHashCombiner> hashes =
+      core::MakeMutableSpan(analysis_.frame_hashes);
+  core::tree_ops::UpdateRowHashes(*config_.name, hashes);
+  for (const core::Tree::Column* column : config_.grouping_columns) {
+    core::tree_ops::UpdateRowHashes(*column, hashes);
+  }
+}
+
+template <typename T>
+FilterMatches FlamegraphBuilder::MatchNumber(T value) const {
+  if constexpr (std::is_same_v<T, int64_t>) {
+    return MatchText(base::StackString<32>("%" PRId64, value).c_str());
+  } else {
+    return MatchText(base::StackString<32>("%.15g", value).c_str());
+  }
+}
+
+FilterMatches FlamegraphBuilder::MatchColumn(const core::Tree::Column& column,
+                                             uint32_t row) const {
+  if (column.null_bv.size() > 0 && !column.null_bv.is_set(row)) {
+    return kNoFilterMatches;
+  }
+  if (column.type.Is<core::String>()) {
+    const StringPool::Id value = column.unchecked_data<StringPool::Id>()[row];
+    return value.is_null() ? kNoFilterMatches
+                           : MatchText(config_.pool.Get(value).c_str());
+  }
+  if (column.type.Is<core::Int64>()) {
+    return MatchNumber(column.unchecked_data<int64_t>()[row]);
+  }
+  return MatchNumber(column.unchecked_data<double>()[row]);
+}
+
+FilterMatches FlamegraphBuilder::MatchFrame(uint32_t row) const {
+  FilterMatches matches = MatchColumn(*config_.name, row);
+  for (const core::Tree::Column* column : config_.grouping_columns) {
+    const FilterMatches column_matches = MatchColumn(*column, row);
+    matches.show_stack |= column_matches.show_stack;
+    matches.view_pattern |= column_matches.view_pattern;
+    matches.hide_stack |= column_matches.hide_stack;
+    matches.hide_frame |= column_matches.hide_frame;
+  }
+  return matches;
+}
+
+void FlamegraphBuilder::AnalyzePaths() {
+  PrepareFrameHashes();
+  analysis_.states = core::Slab<PathState>::Alloc(input_.row_count);
+  if (config_.view_pattern) {
+    analysis_.view_pattern_matches =
+        core::BitVector::CreateWithSize(input_.row_count, false);
+  }
+  const bool needs_matching = config_.HasFilters() || config_.view_pattern;
+  base::FlatHashMapV2<uint64_t, uint32_t, base::AlreadyHashed<uint64_t>>
+      frame_match_index;
+  base::FlatHashMapV2<StringPool::Id, uint32_t> name_match_index;
+  std::vector<FilterMatches> match_pool;
+  const StringPool::Id* names = config_.name->unchecked_data<StringPool::Id>();
+
+  for (uint32_t row = 0; row < input_.row_count; ++row) {
+    // Tree guarantees parents precede children, so inheritance is an O(1)
+    // reference rather than an ancestor walk or a copy. Roots inherit the
+    // shared empty path.
+    const uint32_t parent = input_.parent[row];
+    const PathState& inheritance = parent == core::Tree::kNullParent
+                                       ? kEmptyPathState
+                                       : analysis_.states[parent];
+    PERFETTO_DCHECK(parent == core::Tree::kNullParent || parent < row);
+
+    // A HIDE_FRAME row folds into its parent's path and cannot affect stack
+    // filtering.
+    PathState& state = analysis_.states[row];
+    const FilterMatches* matches = &kNoFilterMatches;
+    if (needs_matching) {
+      const uint32_t next_index = static_cast<uint32_t>(match_pool.size());
+      uint32_t* index;
+      bool inserted;
+      StringPool::Id matched_name;
+      if (config_.grouping_columns.empty()) {
+        const bool is_null = config_.name->null_bv.size() > 0 &&
+                             !config_.name->null_bv.is_set(row);
+        matched_name = is_null ? StringPool::Id() : names[row];
+        std::tie(index, inserted) =
+            name_match_index.Insert(matched_name, next_index);
+      } else {
+        const uint64_t frame_hash = analysis_.frame_hashes[row].digest();
+        std::tie(index, inserted) =
+            frame_match_index.Insert(frame_hash, next_index);
+      }
+      if (inserted) {
+        if (config_.grouping_columns.empty()) {
+          match_pool.push_back(
+              matched_name.is_null()
+                  ? kNoFilterMatches
+                  : MatchText(config_.pool.Get(matched_name).c_str()));
+        } else {
+          match_pool.push_back(MatchFrame(row));
         }
-        if (forest_.match_offset.empty()) {
-          return false;
-        }
-        for (uint32_t s = forest_.match_offset[t];
-             s < forest_.match_offset[t + 1]; ++s) {
-          NullTermStringView extra = pool_.Get(forest_.match_strings[s]);
-          if (re.PartialMatch(std::string_view(extra.data(), extra.size()))) {
-            return true;
+      }
+      matches = &match_pool[*index];
+    }
+    if (matches->hide_frame) {
+      state = inheritance;
+      PERFETTO_DCHECK(!state.IsRetained(row));
+      continue;
+    }
+
+    // Every other row is retained, even when it is outside the built halves.
+    // This lets matching descendants start roots and lets upward paths walk
+    // through retained ancestors.
+    state.retained_frame = row;
+    if (config_.view_pattern && matches->view_pattern) {
+      analysis_.view_pattern_matches.set(row);
+    }
+    state.stack_bits = matches->hide_stack
+                           ? kHideStackBit
+                           : matches->show_stack | inheritance.stack_bits;
+  }
+}
+
+void FlamegraphBuilder::BuildDownwardHalf() {
+  if (!config_.view.IsAnyOf<Config::DownwardViews>()) {
+    // Every row sits outside the downward half.
+    downward_.node =
+        AllocFilled<uint32_t>(input_.row_count, core::Tree::kNullParent);
+    return;
+  }
+  downward_.node = core::Slab<uint32_t>::Alloc(input_.row_count);
+  for (uint32_t row = 0; row < input_.row_count; ++row) {
+    const uint32_t parent = input_.parent[row];
+    const uint32_t parent_node = parent == core::Tree::kNullParent
+                                     ? core::Tree::kNullParent
+                                     : downward_.node[parent];
+    const PathState& state = analysis_.states[row];
+    if (!state.IsRetained(row)) {
+      downward_.node[row] = parent_node;
+      continue;
+    }
+
+    // Top-down starts at every retained root. Pivot and from-frame start only
+    // at matching frames; nested matches deliberately start another root.
+    // Bottom-up has no downward half and never starts one.
+    const bool has_retained_parent =
+        parent != core::Tree::kNullParent &&
+        analysis_.states[parent].retained_frame != core::Tree::kNullParent;
+    const bool is_top_down_root =
+        config_.view.Is<Config::TopDown>() && !has_retained_parent;
+    const bool starts_downward_tree =
+        (config_.view_pattern && analysis_.view_pattern_matches.is_set(row)) ||
+        is_top_down_root;
+    if (!starts_downward_tree && parent_node == core::Tree::kNullParent) {
+      downward_.node[row] = core::Tree::kNullParent;
+      continue;
+    }
+
+    // Equivalent frames under the same merged parent share a node. The first
+    // row which creates the node remains its representative.
+    downward_.node[row] = downward_.tree.Intern(
+        starts_downward_tree ? core::Tree::kNullParent : parent_node,
+        analysis_.frame_hashes[row], row);
+  }
+}
+
+template <typename T>
+base::Status FlamegraphBuilder::MarkActiveBottomUpAnchors(
+    const core::Tree::Column& column,
+    core::Span<uint8_t> active) {
+  core::Span<const T> values = column.unchecked_span<T>();
+  for (uint32_t row = 0; row < input_.row_count; ++row) {
+    if (column.null_bv.size() > 0 && !column.null_bv.is_set(row)) {
+      continue;
+    }
+    const T value = values[row];
+    if (value < 0) {
+      return base::ErrStatus("flamegraph: value columns must be non-negative");
+    }
+    const PathState& state = analysis_.states[row];
+    if (!base::IsZero(value) &&
+        state.StackContributes(required_show_stack_bits_)) {
+      active[state.retained_frame] = 1;
+    }
+  }
+  return base::OkStatus();
+}
+
+base::Status FlamegraphBuilder::BuildUpwardHalf() {
+  if (config_.view.Is<Config::Pivot>()) {
+    // Anchors are the retained rows matching the view pattern, in row order.
+    for (uint32_t row = 0; row < input_.row_count; ++row) {
+      if (!analysis_.view_pattern_matches.is_set(row)) {
+        continue;
+      }
+      const bool include_aggregates =
+          !config_.aggregate_columns.empty() &&
+          analysis_.states[row].StackContributes(required_show_stack_bits_);
+      upward_.pivot_anchors.push_back(
+          UpwardAnchor{row, BuildUpwardPath(row, include_aggregates)});
+    }
+    return base::OkStatus();
+  }
+  if (!config_.view.Is<Config::BottomUp>()) {
+    return base::OkStatus();
+  }
+
+  auto active = AllocFilled<uint8_t>(input_.row_count, 0);
+  for (const core::Tree::Column* column : config_.value_columns) {
+    if (column->type.Is<core::Int64>()) {
+      RETURN_IF_ERROR(
+          MarkActiveBottomUpAnchors<int64_t>(*column, active.mutable_span()));
+    } else {
+      RETURN_IF_ERROR(
+          MarkActiveBottomUpAnchors<double>(*column, active.mutable_span()));
+    }
+  }
+  constexpr UpwardPath kNoPath{core::Tree::kNullParent,
+                               core::Tree::kNullParent};
+  upward_.bottom_up_paths = AllocFilled<UpwardPath>(input_.row_count, kNoPath);
+  for (uint32_t row = 0; row < input_.row_count; ++row) {
+    if (active[row]) {
+      upward_.bottom_up_paths[row] = BuildUpwardPath(row, true);
+    }
+  }
+  return base::OkStatus();
+}
+
+UpwardPath FlamegraphBuilder::BuildUpwardPath(uint32_t frame,
+                                              bool include_aggregates) {
+  UpwardPath result{core::Tree::kNullParent, core::Tree::kNullParent};
+  uint32_t upward_parent = core::Tree::kNullParent;
+  while (frame != core::Tree::kNullParent) {
+    upward_parent = upward_.tree.Intern(upward_parent,
+                                        analysis_.frame_hashes[frame], frame);
+    if (result.root == core::Tree::kNullParent) {
+      result.root = upward_parent;
+    }
+    if (include_aggregates) {
+      upward_.aggregate_constituents.push_back(
+          TreeConstituent{frame, upward_parent});
+    }
+    const uint32_t parent = input_.parent[frame];
+    frame = parent == core::Tree::kNullParent
+                ? core::Tree::kNullParent
+                : analysis_.states[parent].retained_frame;
+  }
+  result.leaf = upward_parent;
+  return result;
+}
+
+template <typename T>
+void FlamegraphBuilder::InitializeMetricColumns(uint32_t rows,
+                                                MetricColumns* output) {
+  output->self = core::Tree::Column::Create<T>(rows);
+  output->cumulative = core::Tree::Column::Create<T>(rows);
+  core::Span<T> self = output->self.unchecked_span<T>();
+  core::Span<T> cumulative = output->cumulative.unchecked_span<T>();
+  std::fill(self.begin(), self.end(), T{});
+  std::fill(cumulative.begin(), cumulative.end(), T{});
+}
+
+template <typename T>
+base::Status FlamegraphBuilder::AccumulateMetric(
+    const core::Tree::Column& input,
+    MetricColumns* output) {
+  const uint32_t downward_size = downward_.tree.size();
+  const uint32_t upward_size = upward_.tree.size();
+  InitializeMetricColumns<T>(downward_size + upward_size, output);
+  core::Span<T> self = output->self.unchecked_span<T>();
+  core::Span<T> cumulative = output->cumulative.unchecked_span<T>();
+  RETURN_IF_ERROR(
+      AccumulateDownwardMetric<T>(input, self.subspan(0, downward_size),
+                                  cumulative.subspan(0, downward_size)));
+  return AccumulateUpwardMetric<T>(
+      input, self.subspan(downward_size, upward_size),
+      cumulative.subspan(downward_size, upward_size));
+}
+
+template <typename T>
+base::Status FlamegraphBuilder::PropagateCumulative(
+    const core::TreePathInterner& tree,
+    core::Span<T> cumulative) {
+  PERFETTO_DCHECK(tree.size() == cumulative.size());
+  for (uint32_t node = tree.size(); node-- > 0;) {
+    const uint32_t parent = tree.parent(node);
+    if (parent != core::Tree::kNullParent &&
+        !TryAdd(cumulative[node], &cumulative[parent])) {
+      return base::ErrStatus("flamegraph: integer value overflow");
+    }
+  }
+  return base::OkStatus();
+}
+
+template <typename T>
+base::Status FlamegraphBuilder::AccumulateDownwardMetric(
+    const core::Tree::Column& input,
+    core::Span<T> self,
+    core::Span<T> cumulative) {
+  if (!config_.view.IsAnyOf<Config::DownwardViews>()) {
+    return base::OkStatus();
+  }
+
+  core::Span<const T> values = input.unchecked_span<T>();
+  for (uint32_t row = 0; row < input_.row_count; ++row) {
+    if (input.null_bv.size() > 0 && !input.null_bv.is_set(row)) {
+      continue;
+    }
+    const T value = values[row];
+    if (value < 0) {
+      return base::ErrStatus("flamegraph: value columns must be non-negative");
+    }
+
+    const uint32_t node = downward_.node[row];
+    if (node == core::Tree::kNullParent) {
+      continue;
+    }
+    if (analysis_.states[row].StackContributes(required_show_stack_bits_) &&
+        (!TryAdd(value, &self[node]) || !TryAdd(value, &cumulative[node]))) {
+      return base::ErrStatus("flamegraph: integer value overflow");
+    }
+  }
+
+  return PropagateCumulative(downward_.tree, cumulative);
+}
+
+template <typename T>
+base::Status FlamegraphBuilder::AccumulateUpwardMetric(
+    const core::Tree::Column& input,
+    core::Span<T> self,
+    core::Span<T> cumulative) {
+  if (!config_.view.IsAnyOf<Config::UpwardViews>()) {
+    return base::OkStatus();
+  }
+  return config_.view.Is<Config::BottomUp>()
+             ? AccumulateBottomUpMetric<T>(input, self, cumulative)
+             : AccumulatePivotUpwardMetric<T>(input, self, cumulative);
+}
+
+template <typename T>
+base::Status FlamegraphBuilder::AccumulateBottomUpMetric(
+    const core::Tree::Column& input,
+    core::Span<T> self,
+    core::Span<T> cumulative) {
+  core::Span<const T> values = input.unchecked_span<T>();
+  for (uint32_t row = 0; row < input_.row_count; ++row) {
+    if (input.null_bv.size() > 0 && !input.null_bv.is_set(row)) {
+      continue;
+    }
+    const T value = values[row];
+    const PathState& state = analysis_.states[row];
+    if (base::IsZero(value) ||
+        !state.StackContributes(required_show_stack_bits_)) {
+      continue;
+    }
+    const uint32_t retained = state.retained_frame;
+    const UpwardPath& path = upward_.bottom_up_paths[retained];
+    const uint32_t root = path.root;
+    const uint32_t leaf = path.leaf;
+    PERFETTO_DCHECK(root != core::Tree::kNullParent);
+    PERFETTO_DCHECK(leaf != core::Tree::kNullParent);
+    if (!TryAdd(value, &self[root]) || !TryAdd(value, &cumulative[leaf])) {
+      return base::ErrStatus("flamegraph: integer value overflow");
+    }
+  }
+  return PropagateCumulative(upward_.tree, cumulative);
+}
+
+template <typename T>
+base::Status FlamegraphBuilder::AccumulatePivotUpwardMetric(
+    const core::Tree::Column& input,
+    core::Span<T> self,
+    core::Span<T> cumulative) {
+  core::Span<const T> values = input.unchecked_span<T>();
+
+  auto anchor_weights = AllocFilled<T>(input_.row_count, T{});
+  for (uint32_t row = 0; row < input_.row_count; ++row) {
+    if (input.null_bv.size() > 0 && !input.null_bv.is_set(row)) {
+      continue;
+    }
+    const PathState& state = analysis_.states[row];
+    if (ContributesToDownwardCumulative(row) &&
+        !TryAdd(values[row], &anchor_weights[state.retained_frame])) {
+      return base::ErrStatus("flamegraph: integer value overflow");
+    }
+  }
+
+  for (uint32_t row = input_.row_count; row-- > 0;) {
+    const PathState& state = analysis_.states[row];
+    const uint32_t node = downward_.node[row];
+    if (!state.IsRetained(row) || node == core::Tree::kNullParent ||
+        downward_.tree.parent(node) == core::Tree::kNullParent) {
+      continue;
+    }
+    const uint32_t parent = input_.parent[row];
+    PERFETTO_DCHECK(parent != core::Tree::kNullParent);
+    const uint32_t retained_parent = analysis_.states[parent].retained_frame;
+    PERFETTO_DCHECK(retained_parent != core::Tree::kNullParent);
+    if (!TryAdd(anchor_weights[row], &anchor_weights[retained_parent])) {
+      return base::ErrStatus("flamegraph: integer value overflow");
+    }
+  }
+
+  for (const UpwardAnchor& anchor : upward_.pivot_anchors) {
+    const T value = anchor_weights[anchor.frame];
+    if (!TryAdd(value, &self[anchor.path.root]) ||
+        !TryAdd(value, &cumulative[anchor.path.leaf])) {
+      return base::ErrStatus("flamegraph: integer value overflow");
+    }
+  }
+  return PropagateCumulative(upward_.tree, cumulative);
+}
+
+base::Status FlamegraphBuilder::AccumulateMetrics() {
+  metrics_.resize(config_.value_columns.size());
+  for (uint32_t i = 0; i < config_.value_columns.size(); ++i) {
+    const core::Tree::Column& column = *config_.value_columns[i];
+    switch (column.type.index()) {
+      case core::Tree::Column::Type::GetTypeIndex<core::Int64>():
+        RETURN_IF_ERROR(AccumulateMetric<int64_t>(column, &metrics_[i]));
+        break;
+      case core::Tree::Column::Type::GetTypeIndex<core::Double>():
+        RETURN_IF_ERROR(AccumulateMetric<double>(column, &metrics_[i]));
+        break;
+      default:
+        PERFETTO_FATAL("Unsupported flamegraph value column type");
+    }
+  }
+  return base::OkStatus();
+}
+
+void FlamegraphBuilder::BuildAggregateRouting() {
+  const uint32_t rows = input_.row_count;
+  aggregate_routing_.frame_rows_are_identity = true;
+  for (uint32_t row = 0; row < rows; ++row) {
+    const PathState& state = analysis_.states[row];
+    if (state.retained_frame != row || state.StackIsHidden()) {
+      aggregate_routing_.frame_rows_are_identity = false;
+      break;
+    }
+  }
+  if (!aggregate_routing_.frame_rows_are_identity) {
+    aggregate_routing_.frame_row_offsets =
+        core::Slab<uint32_t>::Alloc(uint64_t{rows} + 1);
+    std::fill(aggregate_routing_.frame_row_offsets.begin(),
+              aggregate_routing_.frame_row_offsets.end(), 0u);
+    uint32_t routed_rows = 0;
+    for (uint32_t row = 0; row < rows; ++row) {
+      const PathState& state = analysis_.states[row];
+      if (state.retained_frame != core::Tree::kNullParent &&
+          !state.StackIsHidden()) {
+        aggregate_routing_.frame_row_offsets[state.retained_frame + 1]++;
+        routed_rows++;
+      }
+    }
+    for (uint32_t frame = 0; frame < rows; ++frame) {
+      aggregate_routing_.frame_row_offsets[frame + 1] +=
+          aggregate_routing_.frame_row_offsets[frame];
+    }
+    aggregate_routing_.frame_rows = core::Slab<uint32_t>::Alloc(routed_rows);
+    core::Slab<uint32_t> frame_fill = core::Slab<uint32_t>::Alloc(rows);
+    memcpy(frame_fill.data(), aggregate_routing_.frame_row_offsets.data(),
+           rows * sizeof(uint32_t));
+    for (uint32_t row = 0; row < rows; ++row) {
+      const PathState& state = analysis_.states[row];
+      if (state.retained_frame != core::Tree::kNullParent &&
+          !state.StackIsHidden()) {
+        aggregate_routing_.frame_rows[frame_fill[state.retained_frame]++] = row;
+      }
+    }
+  }
+
+  const uint32_t downward_size = downward_.tree.size();
+  const uint32_t nodes = downward_size + upward_.tree.size();
+  aggregate_routing_.output_frame_offsets =
+      core::Slab<uint32_t>::Alloc(uint64_t{nodes} + 1);
+  std::fill(aggregate_routing_.output_frame_offsets.begin(),
+            aggregate_routing_.output_frame_offsets.end(), 0u);
+  uint32_t routed_frames = 0;
+  if (config_.view.IsAnyOf<Config::DownwardViews>()) {
+    for (uint32_t frame = 0; frame < rows; ++frame) {
+      if (analysis_.states[frame].IsRetained(frame) &&
+          ContributesToDownwardCumulative(frame)) {
+        aggregate_routing_.output_frame_offsets[downward_.node[frame] + 1]++;
+        routed_frames++;
+      }
+    }
+  }
+  for (const TreeConstituent& constituent : upward_.aggregate_constituents) {
+    aggregate_routing_
+        .output_frame_offsets[downward_size + constituent.node + 1]++;
+    routed_frames++;
+  }
+  for (uint32_t node = 0; node < nodes; ++node) {
+    aggregate_routing_.output_frame_offsets[node + 1] +=
+        aggregate_routing_.output_frame_offsets[node];
+  }
+  aggregate_routing_.output_frames = core::Slab<uint32_t>::Alloc(routed_frames);
+  core::Slab<uint32_t> output_fill = core::Slab<uint32_t>::Alloc(nodes);
+  memcpy(output_fill.data(), aggregate_routing_.output_frame_offsets.data(),
+         nodes * sizeof(uint32_t));
+  if (config_.view.IsAnyOf<Config::DownwardViews>()) {
+    for (uint32_t frame = 0; frame < rows; ++frame) {
+      if (analysis_.states[frame].IsRetained(frame) &&
+          ContributesToDownwardCumulative(frame)) {
+        const uint32_t node = downward_.node[frame];
+        aggregate_routing_.output_frames[output_fill[node]++] = frame;
+      }
+    }
+  }
+  for (const TreeConstituent& constituent : upward_.aggregate_constituents) {
+    const uint32_t node = downward_size + constituent.node;
+    aggregate_routing_.output_frames[output_fill[node]++] = constituent.frame;
+  }
+}
+
+base::Status FlamegraphBuilder::RunAggregateOperator(AggregateOperator* op) {
+  constexpr size_t kBatchSize = 4096;
+  std::vector<uint32_t> destinations;
+  std::vector<uint32_t> sources;
+  destinations.reserve(kBatchSize);
+  sources.reserve(kBatchSize);
+
+  if (op->input_mode() ==
+      AggregateOperator::InputMode::kNativeRowsToFramesThenFramesToOutputs) {
+    const core::Slab<PathState>& states = analysis_.states;
+    const core::Slab<uint32_t>& downward_nodes = downward_.node;
+    const core::FlexVector<TreeConstituent>& upward_constituents =
+        upward_.aggregate_constituents;
+    NativeFrameRouting routing{
+        states.span(),
+        downward_nodes.span(),
+        upward_constituents.span(),
+        downward_.tree.size(),
+        required_show_stack_bits_,
+        config_.view.IsAnyOf<Config::DownwardViews>(),
+    };
+    RETURN_IF_ERROR(op->UpdateFrames(routing));
+    RETURN_IF_ERROR(op->MergeFrames(routing));
+    return op->Finalize();
+  }
+
+  const uint32_t nodes = downward_.tree.size() + upward_.tree.size();
+  for (uint32_t node = 0; node < nodes; ++node) {
+    for (uint32_t fi = aggregate_routing_.output_frame_offsets[node];
+         fi < aggregate_routing_.output_frame_offsets[node + 1]; ++fi) {
+      const uint32_t frame = aggregate_routing_.output_frames[fi];
+      if (aggregate_routing_.frame_rows_are_identity) {
+        destinations.push_back(node);
+        sources.push_back(frame);
+      } else {
+        for (uint32_t ri = aggregate_routing_.frame_row_offsets[frame];
+             ri < aggregate_routing_.frame_row_offsets[frame + 1]; ++ri) {
+          destinations.push_back(node);
+          sources.push_back(aggregate_routing_.frame_rows[ri]);
+          if (sources.size() == kBatchSize) {
+            RETURN_IF_ERROR(op->UpdateBatch(core::MakeSpan(destinations),
+                                            core::MakeSpan(sources)));
+            destinations.clear();
+            sources.clear();
           }
         }
-        return false;
-      };
-      uint64_t sb = 0;
-      for (uint32_t j = 0; j < filters_.show_stack.size(); ++j) {
-        sb |= uint64_t(matches(filters_.show_stack[j])) << j;
       }
-      bool hidden = std::any_of(filters_.hide_stack.begin(),
-                                filters_.hide_stack.end(), matches);
-      masks_[t].show_stack_bits = hidden ? filters_.impossible_bits : sb;
-      for (uint32_t j = 0; j < filters_.show_from.size(); ++j) {
-        masks_[t].show_from_bits |= uint64_t(matches(filters_.show_from[j]))
-                                    << j;
-      }
-      masks_[t].shown = !std::any_of(filters_.hide_frame.begin(),
-                                     filters_.hide_frame.end(), matches);
-    }
-  }
-
-  // One pass along every path, in topological order. Per frame: whether it
-  // is kept (hide-frame, show-from), its nearest kept ancestor, whether
-  // its stack satisfies every show/hide-stack filter (so its values
-  // count), and its metrics with hidden frames' values folded into the
-  // kept ancestor.
-  void EvaluatePaths() {
-    kept_ = FlexVector<uint8_t>::CreateFilled(frame_count_, 0);
-    counted_ = FlexVector<uint8_t>::CreateFilled(frame_count_, 0);
-    ancestor_ = FlexVector<uint32_t>::CreateFilled(frame_count_, kNoParent);
-    auto sb_path = FlexVector<uint64_t>::CreateWithSize(frame_count_);
-    auto sf_path = FlexVector<uint64_t>::CreateWithSize(frame_count_);
-    folded_ = FlexVector<double>::CreateWithSize(uint64_t(frame_count_) *
-                                                 metric_count_);
-    memcpy(folded_.data(), forest_.metrics.data(),
-           uint64_t(frame_count_) * metric_count_ * sizeof(double));
-    for (uint32_t i : order_) {
-      uint32_t p = forest_.parent[i];
-      bool has_parent = p != kNoParent;
-      const NameMasks& m = MasksOf(i);
-      sf_path[i] =
-          (has_parent ? sf_path[p] : 0) | (m.shown ? m.show_from_bits : 0);
-      kept_[i] = m.shown && sf_path[i] == filters_.show_from_mask;
-      ancestor_[i] = !has_parent ? kNoParent : (kept_[p] ? p : ancestor_[p]);
-      sb_path[i] =
-          (has_parent ? sb_path[p] : 0) | (kept_[i] ? m.show_stack_bits : 0);
-      counted_[i] = kept_[i] && sb_path[i] == filters_.show_stack_mask;
-      if (!kept_[i] && ancestor_[i] != kNoParent) {
-        AddRow(&folded_[ancestor_[i] * metric_count_],
-               &forest_.metrics[i * metric_count_], metric_count_);
+      if (sources.size() == kBatchSize) {
+        RETURN_IF_ERROR(op->UpdateBatch(core::MakeSpan(destinations),
+                                        core::MakeSpan(sources)));
+        destinations.clear();
+        sources.clear();
       }
     }
   }
+  if (!sources.empty()) {
+    RETURN_IF_ERROR(
+        op->UpdateBatch(core::MakeSpan(destinations), core::MakeSpan(sources)));
+  }
+  return op->Finalize();
+}
 
-  // Selects the frames the merged trees grow from and re-root at. This is
-  // the only place the views differ; every phase after this treats
-  // anchors uniformly.
-  void SelectAnchors() {
-    anchor_ = FlexVector<uint8_t>::CreateFilled(frame_count_, 0);
-    for (uint32_t i : order_) {
-      switch (config_.view) {
-        case Config::View::kTopDown:
-          // The roots of the kept forest.
-          anchor_[i] = kept_[i] && ancestor_[i] == kNoParent;
-          break;
-        case Config::View::kBottomUp:
-          // Every frame whose own values count: each one is a stack
-          // sample whose caller chain the up tree attributes.
-          anchor_[i] = counted_[i];
-          break;
-        case Config::View::kPivot:
-          // Frames matching the pivot pattern; nested matches re-root.
-          anchor_[i] = kept_[i] && IsPivotFrame(i);
-          break;
-      }
+base::Status FlamegraphBuilder::ComputeAggregates() {
+  bool needs_materialized_routing = false;
+  for (const Config::AggregateColumn& aggregate : config_.aggregate_columns) {
+    needs_materialized_routing |=
+        aggregate.aggregate != Config::Aggregate::kSum;
+  }
+  if (needs_materialized_routing) {
+    BuildAggregateRouting();
+  }
+  const uint32_t nodes = downward_.tree.size() + upward_.tree.size();
+  aggregate_columns_.resize(config_.aggregate_columns.size());
+  for (uint32_t i = 0; i < config_.aggregate_columns.size(); ++i) {
+    const Config::AggregateColumn& aggregate = config_.aggregate_columns[i];
+    const core::Tree::Column& input = *aggregate.input;
+    if (input.type.Is<core::Null>()) {
+      aggregate_columns_[i] = core::Tree::Column::CreateNull(nodes);
+      continue;
+    }
+    switch (aggregate.aggregate) {
+      case Config::Aggregate::kSum:
+        if (input.type.Is<core::Int64>()) {
+          SumAggregateOperator<int64_t> op(input, nodes);
+          RETURN_IF_ERROR(RunAggregateOperator(&op));
+          aggregate_columns_[i] = op.TakeOutput();
+        } else {
+          SumAggregateOperator<double> op(input, nodes);
+          RETURN_IF_ERROR(RunAggregateOperator(&op));
+          aggregate_columns_[i] = op.TakeOutput();
+        }
+        break;
+      case Config::Aggregate::kOneOrSummary:
+        if (input.type.Is<core::String>()) {
+          OneOrSummaryAggregateOperator<StringPool::Id> op(input, config_.pool,
+                                                           nodes);
+          RETURN_IF_ERROR(RunAggregateOperator(&op));
+          aggregate_columns_[i] = op.TakeOutput();
+        } else if (input.type.Is<core::Int64>()) {
+          OneOrSummaryAggregateOperator<int64_t> op(input, config_.pool, nodes);
+          RETURN_IF_ERROR(RunAggregateOperator(&op));
+          aggregate_columns_[i] = op.TakeOutput();
+        } else {
+          OneOrSummaryAggregateOperator<double> op(input, config_.pool, nodes);
+          RETURN_IF_ERROR(RunAggregateOperator(&op));
+          aggregate_columns_[i] = op.TakeOutput();
+        }
+        break;
+      case Config::Aggregate::kConcatWithComma:
+        if (input.type.Is<core::String>()) {
+          ConcatAggregateOperator<StringPool::Id> op(input, config_.pool,
+                                                     nodes);
+          RETURN_IF_ERROR(RunAggregateOperator(&op));
+          aggregate_columns_[i] = op.TakeOutput();
+        } else if (input.type.Is<core::Int64>()) {
+          ConcatAggregateOperator<int64_t> op(input, config_.pool, nodes);
+          RETURN_IF_ERROR(RunAggregateOperator(&op));
+          aggregate_columns_[i] = op.TakeOutput();
+        } else {
+          ConcatAggregateOperator<double> op(input, config_.pool, nodes);
+          RETURN_IF_ERROR(RunAggregateOperator(&op));
+          aggregate_columns_[i] = op.TakeOutput();
+        }
+        break;
     }
   }
+  return base::OkStatus();
+}
 
-  // The downward half: one forward scan with a trie cursor. Anchors start
-  // merged roots; every other kept frame merges under its ancestor's
-  // node.
-  Tree BuildDown() {
-    Trie trie(metric_count_, expected_nodes_);
-    auto trie_of = FlexVector<uint32_t>::CreateFilled(frame_count_, kNoParent);
-    for (uint32_t i : order_) {
-      if (!kept_[i]) {
-        continue;
-      }
-      uint32_t node;
-      if (anchor_[i]) {
-        node = trie.ChildOf(kNoParent, forest_.key[i], i);
-      } else if (ancestor_[i] != kNoParent &&
-                 trie_of[ancestor_[i]] != kNoParent) {
-        node = trie.ChildOf(trie_of[ancestor_[i]], forest_.key[i], i);
-      } else {
-        continue;  // Not under any anchor.
-      }
-      trie_of[i] = node;
-      // Self shows the merged frames' own values regardless of stack
-      // filters; only cumulative is limited to counted stacks.
-      AddRow(&trie.self[node * metric_count_], &folded_[i * metric_count_],
-             metric_count_);
-      if (counted_[i]) {
-        AddRow(&trie.cumulative[node * metric_count_],
-               &folded_[i * metric_count_], metric_count_);
-      }
-    }
-    // Cumulative: children were created after their parent, so one
-    // reverse scan sums subtrees onto the counted bases.
-    for (uint32_t i = static_cast<uint32_t>(trie.size()); i-- > 0;) {
-      if (trie.parent[i] != kNoParent) {
-        AddRow(&trie.cumulative[trie.parent[i] * metric_count_],
-               &trie.cumulative[i * metric_count_], metric_count_);
-      }
-    }
-    FlexVector<uint64_t> pairs;
-    for (uint32_t i = 0; i < frame_count_; ++i) {
-      if (trie_of[i] != kNoParent) {
-        pairs.push_back((uint64_t(trie_of[i]) << 32) | i);
-      }
-    }
-    return PackTree(std::move(trie), pairs);
+void FlamegraphBuilder::AppendPackedNodes(const core::TreePathInterner& tree,
+                                          uint32_t id_offset,
+                                          bool upward,
+                                          PackedTree* output) const {
+  auto keep = AllocFilled<uint8_t>(tree.size(), 0);
+  for (const MetricColumns& metric : metrics_) {
+    UpdateNonZeroRows(metric.cumulative, id_offset, keep.mutable_span());
   }
 
-  // The upward half: walk each anchor's kept ancestor chain, descending
-  // the trie by key and attributing the anchor's weight to every node on
-  // the chain.
-  Tree BuildUp() {
-    FlexVector<double> weights = AnchorWeights();
-    // Unlike the downward half, the up tree is usually much smaller than
-    // the input (distinct caller suffixes); growing on demand keeps the
-    // map compact and cache-resident.
-    Trie trie(metric_count_, 0);
-    FlexVector<uint64_t> pairs;
-    for (uint32_t i : order_) {
-      if (!anchor_[i] ||
-          !AnyNonZero(&weights[i * metric_count_], metric_count_)) {
-        continue;
-      }
-      uint32_t node = kNoParent;
-      for (uint32_t f = i; f != kNoParent; f = ancestor_[f]) {
-        node = trie.ChildOf(node, forest_.key[f], f);
-        AddRow(&trie.cumulative[node * metric_count_],
-               &weights[i * metric_count_], metric_count_);
-        AddRow(&trie.self[node * metric_count_], &folded_[f * metric_count_],
-               metric_count_);
-        pairs.push_back((uint64_t(node) << 32) | f);
-      }
+  auto output_row = AllocFilled<uint32_t>(tree.size(), core::Tree::kNullParent);
+  for (uint32_t node = 0; node < tree.size(); ++node) {
+    if (!keep[node]) {
+      continue;
     }
-    return PackTree(std::move(trie), pairs);
+    const uint32_t parent = tree.parent(node);
+    const uint32_t packed_parent = parent == core::Tree::kNullParent
+                                       ? core::Tree::kNullParent
+                                       : output_row[parent];
+    PERFETTO_DCHECK(parent == core::Tree::kNullParent ||
+                    packed_parent != core::Tree::kNullParent);
+    const int64_t depth =
+        packed_parent == core::Tree::kNullParent
+            ? (upward ? -1 : 1)
+            : output->depths[packed_parent] + (upward ? -1 : 1);
+    output_row[node] = output->size();
+    output->Append(depth, id_offset + node, packed_parent,
+                   tree.representative_row(node));
+  }
+}
+
+base::StatusOr<core::Tree> FlamegraphBuilder::PackOutput() {
+  PackedTree packed(downward_.tree.size() + upward_.tree.size());
+  AppendPackedNodes(downward_.tree, 0, false, &packed);
+  AppendPackedNodes(upward_.tree, downward_.tree.size(), true, &packed);
+
+  core::Tree output;
+  output.row_count = packed.size();
+  const size_t column_count = 2 + config_.grouping_columns.size() +
+                              2 * config_.value_columns.size() +
+                              config_.aggregate_columns.size();
+  output.names.reserve(column_count);
+  output.columns.reserve(column_count);
+
+  // The packed arrays are already in output order: adopt them.
+  packed.parents.Truncate(packed.size());
+  output.parent = std::move(packed.parents);
+  packed.depths.Truncate(packed.size());
+  core::Tree::Column depth;
+  depth.data = std::move(packed.depths).TakeAsBytes();
+  output.names.push_back("depth");
+  output.columns.push_back(std::move(depth));
+
+  // TODO(lalitm): the copies below exist because every Tree operation
+  // materializes a full rewritten tree for the next one to consume. If tree
+  // operations composed as a linear pipeline of ops over the source instead,
+  // the intermediate rewrites (and this packing step with them) would
+  // largely disappear.
+  const core::Span<const uint32_t> representatives =
+      packed.representative_frame_span();
+  output.names.push_back("name");
+  output.columns.push_back(
+      core::tree_ops::Gather(*config_.name, representatives));
+  for (const core::Tree::Column* grouping : config_.grouping_columns) {
+    output.names.emplace_back(input_.ColumnName(grouping));
+    output.columns.push_back(
+        core::tree_ops::Gather(*grouping, representatives));
   }
 
-  // The weight each anchor carries up its caller chain: its counted
-  // subtree total, accumulated bottom-up along the kept tree and stopping
-  // at other anchors (the same re-rooting the downward half applies).
-  // With bottom-up anchors, where every counted frame is an anchor, this
-  // reduces to each frame's own values.
-  FlexVector<double> AnchorWeights() {
-    auto weights = FlexVector<double>::CreateFilled(
-        uint64_t(frame_count_) * metric_count_, 0);
-    for (uint32_t idx = static_cast<uint32_t>(order_.size()); idx-- > 0;) {
-      uint32_t i = order_[idx];
-      if (!kept_[i]) {
-        continue;
-      }
-      if (counted_[i]) {
-        AddRow(&weights[i * metric_count_], &folded_[i * metric_count_],
-               metric_count_);
-      }
-      if (!anchor_[i] && ancestor_[i] != kNoParent) {
-        AddRow(&weights[ancestor_[i] * metric_count_],
-               &weights[i * metric_count_], metric_count_);
-      }
-    }
-    return weights;
+  // Kept nodes are appended in id order, so the packed sources are a strictly
+  // increasing filter over the combined id space. When every node is kept the
+  // filter is the identity and the builder-owned columns can be adopted
+  // outright instead of gathered.
+  const core::Span<const uint32_t> packed_sources = packed.source_node_span();
+  const bool keep_all =
+      packed.size() == downward_.tree.size() + upward_.tree.size();
+  const auto take_or_gather = [&](core::Tree::Column& column) {
+    return keep_all ? std::move(column)
+                    : core::tree_ops::Gather(column, packed_sources);
+  };
+  for (uint32_t i = 0; i < config_.value_columns.size(); ++i) {
+    const std::string name(input_.ColumnName(config_.value_columns[i]));
+    output.names.push_back("self_" + name);
+    output.columns.push_back(take_or_gather(metrics_[i].self));
+    output.names.push_back("cumulative_" + name);
+    output.columns.push_back(take_or_gather(metrics_[i].cumulative));
   }
-
-  const Forest& forest_;
-  const Config& config_;
-  const StringPool& pool_;
-  Filters filters_;
-  uint32_t frame_count_;
-  uint32_t metric_count_;
-  uint32_t expected_nodes_;
-
-  FlexVector<NameMasks> masks_;
-  FlexVector<uint32_t> order_;     // Topological, unreachable frames absent.
-  FlexVector<uint8_t> kept_;       // Survives hide-frame / show-from.
-  FlexVector<uint8_t> counted_;    // Kept and stack satisfies every filter.
-  FlexVector<uint8_t> anchor_;     // Roots the merged trees. SelectAnchors().
-  FlexVector<uint32_t> ancestor_;  // Nearest kept ancestor, or kNoParent.
-  FlexVector<double> folded_;      // Metrics, hidden frames folded in.
-};
+  for (uint32_t i = 0; i < config_.aggregate_columns.size(); ++i) {
+    output.names.push_back(config_.aggregate_columns[i].output_name);
+    output.columns.push_back(take_or_gather(aggregate_columns_[i]));
+  }
+  return std::move(output);
+}
 
 }  // namespace
 
-base::StatusOr<Flamegraph> Build(const Forest& forest,
-                                 const Config& config,
-                                 const StringPool& pool) {
-  auto n = static_cast<uint32_t>(forest.size());
-  uint32_t k = forest.metric_count;
-  if (k == 0) {
-    return base::ErrStatus("flamegraph: at least one metric is required");
+base::StatusOr<core::Tree> Build(const core::Tree& tree, const Config& config) {
+  if (!IsValidConfig(tree, config)) {
+    return base::ErrStatus("flamegraph: invalid configuration");
   }
-  if (forest.key.size() != n || forest.name.size() != n ||
-      forest.metrics.size() != uint64_t(n) * k) {
-    return base::ErrStatus("flamegraph: forest column sizes do not match");
-  }
-  for (uint32_t i = 0; i < n; ++i) {
-    if (forest.name[i] >= forest.name_table.size()) {
-      return base::ErrStatus("flamegraph: frame name index out of range");
-    }
-  }
-  if (!forest.match_offset.empty() &&
-      forest.match_offset.size() != forest.name_table.size() + 1) {
-    return base::ErrStatus(
-        "flamegraph: match_offset must have one entry per name plus one");
-  }
-  ASSIGN_OR_RETURN(Filters filters, CompileFilters(config));
-  if (n == 0) {
-    Flamegraph empty;
-    empty.down.metric_count = k;
-    empty.down.constituents_offset = FlexVector<uint32_t>::CreateFilled(1, 0);
-    empty.up.metric_count = k;
-    empty.up.constituents_offset = FlexVector<uint32_t>::CreateFilled(1, 0);
-    return base::StatusOr<Flamegraph>(std::move(empty));
-  }
-  return Builder(forest, config, pool, std::move(filters)).Run();
+  return FlamegraphBuilder(tree, config).Run();
 }
 
-base::StatusOr<core::dataframe::Dataframe> ToDataframe(
-    const Flamegraph& flamegraph,
-    const Forest& forest,
-    StringPool* pool) {
-  uint32_t k = forest.metric_count;
-  std::vector<std::string> columns = {"id", "parentId", "depth", "name"};
-  for (uint32_t m = 0; m < k; ++m) {
-    std::string suffix = k == 1 ? "" : std::to_string(m);
-    columns.push_back("selfValue" + suffix);
-    columns.push_back("cumulativeValue" + suffix);
+namespace {}  // namespace
+
+// Lays out siblings widest first: a stable radix sort orders all nodes by
+// descending width, and distributing that order into per-parent buckets
+// keeps it within every sibling list. A breadth-first walk then packs each
+// node's children left-to-right from the node's own position; the walk
+// order is the render order.
+Layout ComputeLayout(const core::Tree& tree,
+                     const core::Tree::Column& cumulative,
+                     const core::Tree::Column& depth) {
+  const uint32_t row_count = tree.row_count;
+  if (row_count == 0) {
+    return {};
   }
-  // Sums of integral inputs are integral, so inspecting the output values
-  // decides each metric's column type.
-  std::vector<bool> integral(k, true);
-  for (const Tree* tree : {&flamegraph.down, &flamegraph.up}) {
-    for (const FlexVector<double>* col : {&tree->self, &tree->cumulative}) {
-      for (uint64_t i = 0; i < col->size(); ++i) {
-        double v = (*col)[i];
-        double t = std::trunc(v);
-        if (t < v || t > v) {
-          integral[i % k] = false;
-        }
-      }
+  const core::Span<const int64_t> depths = depth.unchecked_span<int64_t>();
+  core::Slab<double> width = core::Slab<double>::Alloc(row_count);
+  const bool cumulative_is_int = cumulative.type.Is<core::Int64>();
+  for (uint32_t node = 0; node < row_count; ++node) {
+    if (cumulative.null_bv.size() > 0 && !cumulative.null_bv.is_set(node)) {
+      width[node] = 0;
+      continue;
+    }
+    const double value =
+        cumulative_is_int
+            ? static_cast<double>(cumulative.unchecked_data<int64_t>()[node])
+            : cumulative.unchecked_data<double>()[node];
+    width[node] = std::max(value, 0.0);
+  }
+
+  // Order all nodes by descending width, ties in input order. The key is the
+  // complemented big-endian IEEE representation, whose unsigned order matches
+  // descending width for the non-negative widths used here.
+  core::Slab<uint64_t> keys = core::Slab<uint64_t>::Alloc(row_count);
+  core::Slab<uint32_t> by_width = core::Slab<uint32_t>::Alloc(row_count);
+  for (uint32_t node = 0; node < row_count; ++node) {
+    uint64_t bits;
+    memcpy(&bits, &width[node], sizeof(bits));
+    keys[node] = base::HostToBE64(~bits);
+    by_width[node] = node;
+  }
+  core::Slab<uint32_t> scratch = core::Slab<uint32_t>::Alloc(row_count);
+  core::Slab<uint32_t> radix_counts = core::Slab<uint32_t>::Alloc(1u << 16);
+  const uint32_t* by_width_sorted = core::RadixSort(
+      by_width.begin(), by_width.end(), scratch.begin(), radix_counts.data(),
+      sizeof(uint64_t), [&](uint32_t node) {
+        return reinterpret_cast<const uint8_t*>(&keys[node]);
+      });
+
+  // Distribute the width order into per-parent buckets. Roots go to one
+  // strip per traversal direction, each starting at x = 0.
+  uint32_t downward_root_count = 0;
+  uint32_t upward_root_count = 0;
+  core::Slab<uint32_t> child_offset =
+      core::Slab<uint32_t>::Alloc(row_count + 1);
+  std::fill(child_offset.begin(), child_offset.end(), 0u);
+  for (uint32_t node = 0; node < row_count; ++node) {
+    if (tree.parent[node] != core::Tree::kNullParent) {
+      child_offset[tree.parent[node] + 1]++;
+    } else if (depths[node] >= 0) {
+      downward_root_count++;
+    } else {
+      upward_root_count++;
+    }
+  }
+  for (uint32_t node = 0; node < row_count; ++node) {
+    child_offset[node + 1] += child_offset[node];
+  }
+  core::Slab<uint32_t> child_fill = core::Slab<uint32_t>::Alloc(row_count);
+  memcpy(child_fill.data(), child_offset.data(), row_count * sizeof(uint32_t));
+  core::Slab<uint32_t> children =
+      core::Slab<uint32_t>::Alloc(child_offset[row_count]);
+  core::Slab<uint32_t> downward_roots =
+      core::Slab<uint32_t>::Alloc(downward_root_count);
+  core::Slab<uint32_t> upward_roots =
+      core::Slab<uint32_t>::Alloc(upward_root_count);
+  uint32_t downward_fill = 0;
+  uint32_t upward_fill = 0;
+  for (uint32_t i = 0; i < row_count; ++i) {
+    const uint32_t node = by_width_sorted[i];
+    const uint32_t parent = tree.parent[node];
+    if (parent != core::Tree::kNullParent) {
+      children[child_fill[parent]++] = node;
+    } else if (depths[node] >= 0) {
+      downward_roots[downward_fill++] = node;
+    } else {
+      upward_roots[upward_fill++] = node;
     }
   }
 
-  core::dataframe::AdhocDataframeBuilder builder(columns, pool);
-  bool ok = true;
-  int64_t base = 0;
-  for (const Tree* tree : {&flamegraph.down, &flamegraph.up}) {
-    bool up = tree == &flamegraph.up;
-    std::vector<int64_t> depth(tree->size());
-    for (uint32_t i = 0; ok && i < tree->size(); ++i) {
-      bool root = tree->parent[i] == kNoParent;
-      depth[i] = root ? 1 : depth[tree->parent[i]] + 1;
-      ok = ok && builder.PushNonNull(0, base + i);
-      ok = ok &&
-           builder.PushNonNull(1, root ? int64_t(-1) : base + tree->parent[i]);
-      ok = ok && builder.PushNonNull(2, up ? -depth[i] : depth[i]);
-      ok = ok && builder.PushNonNull(
-                     3, forest.name_table[forest.name[tree->rep_frame[i]]]);
-      for (uint32_t m = 0; m < k; ++m) {
-        double self = tree->self[i * k + m];
-        double cumulative = tree->cumulative[i * k + m];
-        if (integral[m]) {
-          ok = ok && builder.PushNonNull(4 + 2 * m, static_cast<int64_t>(self));
-          ok = ok &&
-               builder.PushNonNull(5 + 2 * m, static_cast<int64_t>(cumulative));
-        } else {
-          ok = ok && builder.PushNonNull(4 + 2 * m, self);
-          ok = ok && builder.PushNonNull(5 + 2 * m, cumulative);
-        }
-      }
+  core::Slab<double> x = core::Slab<double>::Alloc(row_count);
+  double strip_x = 0;
+  for (const uint32_t root : downward_roots) {
+    x[root] = strip_x;
+    strip_x += width[root];
+  }
+  strip_x = 0;
+  for (const uint32_t root : upward_roots) {
+    x[root] = strip_x;
+    strip_x += width[root];
+  }
+
+  Layout layout;
+  layout.node = core::Slab<uint32_t>::Alloc(row_count);
+  layout.parent_row = core::Slab<uint32_t>::Alloc(row_count);
+  layout.x_start = core::Slab<double>::Alloc(row_count);
+  uint32_t tail = 0;
+  const auto emit = [&](uint32_t node, uint32_t parent_row) {
+    layout.node[tail] = node;
+    layout.parent_row[tail] = parent_row;
+    layout.x_start[tail] = x[node];
+    tail++;
+  };
+
+  // Each strip is in x order, so merging them by position (the downward
+  // strip first on ties) yields the roots' render order; the walk keeps it
+  // level by level.
+  for (uint32_t di = 0, ui = 0;
+       di < downward_roots.size() || ui < upward_roots.size();) {
+    if (ui >= upward_roots.size() ||
+        (di < downward_roots.size() &&
+         x[downward_roots[di]] <= x[upward_roots[ui]])) {
+      emit(downward_roots[di++], core::Tree::kNullParent);
+    } else {
+      emit(upward_roots[ui++], core::Tree::kNullParent);
     }
-    base += static_cast<int64_t>(tree->size());
   }
-  if (!ok) {
-    return builder.status();
+  for (uint32_t row = 0; row < tail; ++row) {
+    const uint32_t node = layout.node[row];
+    double offset = layout.x_start[row];
+    for (uint32_t i = child_offset[node]; i < child_offset[node + 1]; ++i) {
+      const uint32_t child = children[i];
+      x[child] = offset;
+      offset += width[child];
+      emit(child, row);
+    }
   }
-  ASSIGN_OR_RETURN(core::dataframe::Dataframe df, std::move(builder).Build());
-  df.Finalize();
-  return base::StatusOr<core::dataframe::Dataframe>(std::move(df));
+  PERFETTO_DCHECK(tail == row_count);
+  return layout;
 }
 
 }  // namespace perfetto::trace_processor::flamegraph

--- a/src/trace_processor/plugins/flamegraph/flamegraph.h
+++ b/src/trace_processor/plugins/flamegraph/flamegraph.h
@@ -17,147 +17,118 @@
 #ifndef SRC_TRACE_PROCESSOR_PLUGINS_FLAMEGRAPH_FLAMEGRAPH_H_
 #define SRC_TRACE_PROCESSOR_PLUGINS_FLAMEGRAPH_FLAMEGRAPH_H_
 
-#include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <optional>
 #include <string>
 #include <vector>
 
+#include "perfetto/ext/base/regex.h"
 #include "perfetto/ext/base/status_or.h"
 #include "src/trace_processor/containers/string_pool.h"
-#include "src/trace_processor/core/dataframe/dataframe.h"
-#include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/tree/tree.h"
+#include "src/trace_processor/core/util/slab.h"
+#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::flamegraph {
 
-// Computes merged flamegraph trees from a forest of stack frames.
-//
-// A flamegraph is the trie of key-paths: every path through the input
-// forest with the same sequence of keys collapses into one merged node.
-// This library computes that trie and nothing else: no sibling ordering,
-// no x layout, no output formatting. Those are cheap post-passes over the
-// (much smaller) merged tree and belong to downstream consumers.
-//
-// All columns are structure-of-arrays; per-frame and per-node metric
-// values are flattened row-major with a constant stride of |metric_count|
-// values per row.
+inline bool IsNumericColumn(const core::Tree::Column& column) {
+  return column.type.Is<core::Int64>() || column.type.Is<core::Double>();
+}
 
-constexpr uint32_t kNoParent = std::numeric_limits<uint32_t>::max();
-
-// A forest of stack frames, column-oriented: index i across all vectors
-// describes frame i. Frames reference parents by index; kNoParent marks
-// roots. Any frame order is accepted; parents-before-children order is
-// detected and used as a fast path. Frames unreachable from a root
-// (dangling parent indices, cycles) are ignored.
-struct Forest {
-  core::FlexVector<uint32_t> parent;
-  // Merge identity: frames merge iff their path of keys from the root
-  // matches. Callers fold whatever defines identity (name, mapping, ...)
-  // into this one interned value.
-  core::FlexVector<uint32_t> key;
-  // The distinct display names occurring in the forest, and per frame an
-  // index into that table. Filters and the pivot pattern match against
-  // each distinct name once, so builders should dedup names here (they
-  // intern them anyway).
-  core::FlexVector<StringPool::Id> name_table;
-  core::FlexVector<uint32_t> name;
-  // Optional extra strings filters also match against, per name_table
-  // entry: match_strings[match_offset[t]..match_offset[t + 1]). Builders
-  // that fold extra dimensions into entries (e.g. property values merged
-  // into the key) list them here so filters see them too. Empty means
-  // names match alone; otherwise match_offset has name_table size + 1
-  // entries.
-  core::FlexVector<StringPool::Id> match_strings;
-  core::FlexVector<uint32_t> match_offset;
-  // Self values: metric m of frame i is metrics[i * metric_count + m].
-  // All metrics are summed through the merge; a merged subtree is dropped
-  // only when every metric sums to zero across it. Must be >= 1.
-  uint32_t metric_count = 1;
-  core::FlexVector<double> metrics;
-
-  size_t size() const { return parent.size(); }
-};
-
+// Fully resolved inputs to the flamegraph algorithm. The SQL layer is
+// responsible for resolving column names, validating column types, and
+// compiling patterns before calling Build. Per-row matching remains part of
+// the algorithm.
+// Column pointers refer to the Tree passed to Build and only need to remain
+// valid for that call.
 struct Config {
-  enum class View : uint8_t { kTopDown, kBottomUp, kPivot };
-  enum class FilterKind : uint8_t {
-    // Keep only stacks where some frame matches.
-    kShowStack,
-    // Drop stacks where any frame matches.
-    kHideStack,
-    // Drop frames above the first match on each stack.
-    kShowFromFrame,
-    // Drop matching frames, folding their self values into the nearest
-    // kept ancestor.
-    kHideFrame,
+  explicit Config(StringPool& string_pool) : pool(string_pool) {}
+
+  static constexpr uint32_t kMaxShowStackFilters = 61;
+
+  // Structural orientations of the output. The named subsets below describe
+  // which views share a behaviour; membership tests use View::IsAnyOf.
+  struct TopDown {};
+  struct BottomUp {};
+  struct Pivot {};
+  struct FromFrame {};
+  using View = core::TypeSet<TopDown, BottomUp, Pivot, FromFrame>;
+
+  // Views anchored on frames matching |view_pattern|.
+  using PatternViews = core::TypeSet<Pivot, FromFrame>;
+  // Views which build the downward (descendant) half of the output.
+  using DownwardViews = core::TypeSet<TopDown, Pivot, FromFrame>;
+  // Views which build the upward (ancestor) half of the output.
+  using UpwardViews = core::TypeSet<BottomUp, Pivot>;
+
+  enum class Aggregate {
+    kSum,
+    kOneOrSummary,
+    kConcatWithComma,
   };
-  struct Filter {
-    FilterKind kind;
-    // A regex (ECMAScript syntax) matched against frame names.
-    std::string pattern;
+
+  struct AggregateColumn {
+    const core::Tree::Column* input;
+    Aggregate aggregate;
+    std::string output_name;
   };
 
-  View view = View::kTopDown;
-  // Regex selecting the pivot frames. Must be set iff |view| is kPivot.
-  std::optional<std::string> pivot_pattern;
-  std::vector<Filter> filters;
+  StringPool& pool;
+
+  // Structural orientation. Pivot builds both descendants and ancestors of
+  // rows matching |view_pattern|. From-frame builds only descendants of the
+  // matching rows. |view_pattern| is set exactly for those two views.
+  View view = View(TopDown{});
+  std::optional<base::Regex> view_pattern;
+
+  // Frame identity. Grouping columns, together with name, determine which
+  // frames can be merged. Regex filters match against all of these columns.
+  const core::Tree::Column* name = nullptr;
+  std::vector<const core::Tree::Column*> grouping_columns;
+
+  // Filtering, separated by operation before entering the algorithm.
+  std::vector<base::Regex> show_stack_filters;
+  std::vector<base::Regex> hide_stack_filters;
+  std::vector<base::Regex> hide_frame_filters;
+
+  // Numeric sample-weight columns. Each is SUM-aggregated into a
+  // self_<name>/cumulative_<name> output pair. At least one is required.
+  std::vector<const core::Tree::Column*> value_columns;
+
+  // Additional aggregates carried through structural folds. They do not
+  // contribute to flamegraph geometry.
+  std::vector<AggregateColumn> aggregate_columns;
+
+  // Returns true if any filters are configured, false otherwise.
+  bool HasFilters() const {
+    return !show_stack_filters.empty() || !hide_stack_filters.empty() ||
+           !hide_frame_filters.empty();
+  }
 };
 
-// A merged tree. Nodes are stored parents-before-children in creation
-// order; no sibling order is implied.
-struct Tree {
-  core::FlexVector<uint32_t> parent;  // kNoParent for roots.
-  // A representative input frame per node (the first one merged in),
-  // giving downstream access to names and any other per-frame data.
-  core::FlexVector<uint32_t> rep_frame;
-  // Metric sums, flattened like Forest::metrics: metric m of node n is
-  // self[n * metric_count + m]. |self| sums the merged frames' own
-  // values regardless of stack filters; |cumulative| sums the node's
-  // subtree counting only frames whose stack satisfies every filter. Going up
-  // (bottom-up / above-pivot), |cumulative| is instead the sum of the
-  // originating anchors' weights: the classic bottom-up "attributed to this
-  // caller chain" value.
-  uint32_t metric_count = 1;
-  core::FlexVector<double> self;
-  core::FlexVector<double> cumulative;
-  // The input frames merged into each node:
-  // constituents[constituents_offset[n]..constituents_offset[n + 1]).
-  // Going up a frame appears once per stack it contributes through, so
-  // duplicates encode multiplicity.
-  core::FlexVector<uint32_t> constituents_offset;  // size() + 1 entries.
-  core::FlexVector<uint32_t> constituents;
+// Builds a merged structural flamegraph from a parent-before-child tree.
+// Presentation layout is a separate operation: see ComputeLayout.
+base::StatusOr<core::Tree> Build(const core::Tree&, const Config&);
 
-  size_t size() const { return parent.size(); }
+// Presentation geometry for one built flamegraph, in render order:
+// breadth-first, siblings packed left-to-right by decreasing cumulative
+// value. A node's width is its cumulative value clamped to zero, so its end
+// position is x_start plus that width.
+struct Layout {
+  core::Slab<uint32_t> node;        // output row -> tree row
+  core::Slab<uint32_t> parent_row;  // output row -> parent output row
+  core::Slab<double> x_start;
 };
 
-// The result: a downward tree (top-down view, or the subtrees hanging off
-// pivot frames) and an upward tree (bottom-up view, or the caller chains
-// of pivot frames). Views populate the halves they define; the other is
-// empty.
-struct Flamegraph {
-  Tree down;
-  Tree up;
-};
-
-base::StatusOr<Flamegraph> Build(const Forest& forest,
-                                 const Config& config,
-                                 const StringPool& pool);
-
-// Converts the merged trees into one flat dataframe: one row per node,
-// parents before children, with columns
-//   id, parentId (-1 for roots), depth (1, 2, ... going down and
-//   -1, -2, ... going up), name, and per metric selfValue and
-//   cumulativeValue (suffixed with the metric index when there is more
-//   than one).
-// A metric's columns are LONG when all its values are integral, DOUBLE
-// otherwise. Presentation (sibling order, x extents) is deliberately
-// absent: consumers compute it over this far smaller output, or consume
-// the trees directly.
-base::StatusOr<core::dataframe::Dataframe> ToDataframe(
-    const Flamegraph& flamegraph,
-    const Forest& forest,
-    StringPool* pool);
+// Computes presentation geometry for a tree returned by Build, positioning
+// each node by |cumulative|, one of the tree's cumulative value columns.
+// |depth| is the tree's depth column; its sign separates the downward and
+// upward halves of the flamegraph, which are laid out as independent strips.
+// Nodes with non-positive cumulative value take up no width but keep their
+// position so that consumers of secondary value columns still see them.
+Layout ComputeLayout(const core::Tree&,
+                     const core::Tree::Column& cumulative,
+                     const core::Tree::Column& depth);
 
 }  // namespace perfetto::trace_processor::flamegraph
 

--- a/src/trace_processor/plugins/flamegraph/flamegraph_benchmark.cc
+++ b/src/trace_processor/plugins/flamegraph/flamegraph_benchmark.cc
@@ -16,21 +16,20 @@
 
 #include <benchmark/benchmark.h>
 
-#include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <vector>
 
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/containers/string_pool.h"
-#include "src/trace_processor/core/dataframe/dataframe.h"
-#include "src/trace_processor/core/dataframe/specs.h"
+#include "src/trace_processor/core/tree/tree.h"
+#include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/plugins/flamegraph/flamegraph.h"
 
 namespace perfetto::trace_processor::flamegraph {
 namespace {
 
-// Deterministic LCG so runs are comparable.
 struct Rng {
   uint64_t state = 42;
   uint32_t operator()() {
@@ -39,254 +38,179 @@ struct Rng {
   }
 };
 
-// A forest plus the per-frame property columns the collection step would
-// intern alongside it: |mapping| groups (and is folded into the merge
-// key), |source_file| aggregates.
-struct BenchInput {
-  Forest forest;
-  std::vector<StringPool::Id> mapping;
-  std::vector<StringPool::Id> source_file;
-};
+template <typename T>
+core::Tree::Column ColumnFromValues(const std::vector<T>& values) {
+  auto column =
+      core::Tree::Column::Create<T>(static_cast<uint32_t>(values.size()));
+  memcpy(column.data.begin(), values.data(), values.size() * sizeof(T));
+  return column;
+}
 
-BenchInput GenForest(StringPool* pool,
-                     uint32_t n,
-                     uint32_t metric_count,
-                     bool with_properties) {
-  constexpr uint32_t kNameCardinality = 10000;
-  constexpr uint32_t kMappingCardinality = 40;
-  constexpr uint32_t kSourceFileCardinality = 2000;
-
+core::Tree MakeInput(StringPool* pool, uint32_t rows) {
+  constexpr uint32_t kNames = 10000;
   Rng rng;
-  BenchInput in;
-  Forest& forest = in.forest;
-  forest.metric_count = metric_count;
-  for (uint32_t t = 0; t < kNameCardinality; ++t) {
-    forest.name_table.push_back(
-        pool->InternString(base::StringView("frame_" + std::to_string(t))));
+  std::vector<StringPool::Id> name_table;
+  for (uint32_t i = 0; i < kNames; ++i) {
+    name_table.push_back(
+        pool->InternString(base::StringView("frame_" + std::to_string(i))));
   }
-  std::vector<StringPool::Id> mappings;
-  for (uint32_t t = 0; t < kMappingCardinality && with_properties; ++t) {
-    mappings.push_back(
-        pool->InternString(base::StringView("mapping_" + std::to_string(t))));
-  }
-  std::vector<StringPool::Id> files;
-  for (uint32_t t = 0; t < kSourceFileCardinality && with_properties; ++t) {
-    files.push_back(
-        pool->InternString(base::StringView("file_" + std::to_string(t))));
-  }
+  core::Tree tree;
+  tree.row_count = rows;
+  tree.parent = core::Slab<uint32_t>::Alloc(rows);
+  std::vector<StringPool::Id> names;
+  std::vector<int64_t> values;
+  std::vector<int64_t> groupings;
+  names.reserve(rows);
+  values.reserve(rows);
+  groupings.reserve(rows);
   std::vector<uint32_t> stack;
-  for (uint32_t i = 0; i < n; ++i) {
+  for (uint32_t row = 0; row < rows; ++row) {
     if (!stack.empty() && rng() % 100 < 40) {
       stack.resize(stack.size() - (rng() % stack.size()));
     }
-    forest.parent.push_back(stack.empty() ? kNoParent : stack.back());
-    uint32_t name = rng() % kNameCardinality;
-    forest.name.push_back(name);
-    // The merge key folds the grouping properties in; the generated
-    // mapping is a function of the name, so the name index is exactly the
-    // distinct (name, mapping) id.
-    forest.key.push_back(name);
-    for (uint32_t m = 0; m < metric_count; ++m) {
-      forest.metrics.push_back(rng() % 3 == 0 ? rng() % 100 : 0);
-    }
-    if (with_properties) {
-      in.mapping.push_back(mappings[name % kMappingCardinality]);
-      in.source_file.push_back(files[rng() % kSourceFileCardinality]);
-    }
-    stack.push_back(i);
+    tree.parent[row] = stack.empty() ? core::Tree::kNullParent : stack.back();
+    names.push_back(name_table[rng() % kNames]);
+    values.push_back(rng() % 3 == 0 ? rng() % 100 : 0);
+    groupings.push_back(row);
+    stack.push_back(row);
   }
-  return in;
+  tree.names = {"name", "value", "grouping"};
+  tree.columns.push_back(ColumnFromValues(names));
+  tree.columns.push_back(ColumnFromValues(values));
+  tree.columns.push_back(ColumnFromValues(groupings));
+  return tree;
 }
 
-// Converts the trees to a flat dataframe like the library's ToDataframe,
-// additionally emitting the grouping property of the representative frame
-// and the ONE_OR_SUMMARY aggregation of the constituents' values: the
-// work the SQL intrinsic glue does for property columns.
-constexpr auto PropsRowSpec() {
-  using core::dataframe::CreateTypedColumnSpec;
-  using core::dataframe::Int64;
-  using core::dataframe::NonNull;
-  using core::dataframe::String;
-  using core::dataframe::Unsorted;
-  return core::dataframe::CreateTypedDataframeSpec(
-      {"id", "parentId", "depth", "name", "mapping", "sourceFile", "selfValue",
-       "cumulativeValue"},
-      CreateTypedColumnSpec(Int64{}, NonNull{}, Unsorted{}),
-      CreateTypedColumnSpec(Int64{}, NonNull{}, Unsorted{}),
-      CreateTypedColumnSpec(Int64{}, NonNull{}, Unsorted{}),
-      CreateTypedColumnSpec(String{}, NonNull{}, Unsorted{}),
-      CreateTypedColumnSpec(String{}, NonNull{}, Unsorted{}),
-      CreateTypedColumnSpec(String{}, NonNull{}, Unsorted{}),
-      CreateTypedColumnSpec(Int64{}, NonNull{}, Unsorted{}),
-      CreateTypedColumnSpec(Int64{}, NonNull{}, Unsorted{}));
-}
-
-core::dataframe::Dataframe TreesToDataframeWithProps(const Flamegraph& fg,
-                                                     const BenchInput& in,
-                                                     StringPool* pool) {
-  static constexpr auto kSpec = PropsRowSpec();
-  auto df = core::dataframe::Dataframe::CreateFromTypedSpec(kSpec, pool);
-  std::vector<StringPool::Id> seen;
-  int64_t base = 0;
-  for (const Tree* tree : {&fg.down, &fg.up}) {
-    uint32_t k = tree->metric_count;
-    std::vector<int64_t> depth(tree->size());
-    for (uint32_t i = 0; i < tree->size(); ++i) {
-      bool root = tree->parent[i] == kNoParent;
-      depth[i] = root ? 1 : depth[tree->parent[i]] + 1;
-      // ONE_OR_SUMMARY: the representative frame's value, with a summary
-      // suffix when the merged frames had several distinct ones. The
-      // double space and the count including the shown value mirror the
-      // SQL surface this replaces.
-      seen.clear();
-      for (uint32_t c = tree->constituents_offset[i];
-           c < tree->constituents_offset[i + 1]; ++c) {
-        StringPool::Id file = in.source_file[tree->constituents[c]];
-        if (std::find(seen.begin(), seen.end(), file) == seen.end()) {
-          seen.push_back(file);
-        }
-      }
-      StringPool::Id file = in.source_file[tree->rep_frame[i]];
-      if (seen.size() > 1) {
-        std::string text = pool->Get(file).ToStdString() + "  and " +
-                           std::to_string(seen.size()) + " others";
-        file = pool->InternString(base::StringView(text));
-      }
-      df.InsertUnchecked(
-          kSpec, base + i, root ? -1 : base + tree->parent[i],
-          tree == &fg.up ? -depth[i] : depth[i],
-          in.forest.name_table[in.forest.name[tree->rep_frame[i]]],
-          in.mapping[tree->rep_frame[i]], file,
-          static_cast<int64_t>(tree->self[i * k]),
-          static_cast<int64_t>(tree->cumulative[i * k]));
-    }
-    base += static_cast<int64_t>(tree->size());
+struct RunOptions {
+  static RunOptions Filtered() {
+    RunOptions options;
+    options.filtered = true;
+    return options;
   }
-  df.Finalize();
-  return df;
-}
+  static RunOptions Pivot() {
+    RunOptions options;
+    options.pivot = true;
+    return options;
+  }
+  static RunOptions Aggregate() {
+    RunOptions options;
+    options.aggregate = true;
+    return options;
+  }
+  static RunOptions SummaryAggregate() {
+    RunOptions options;
+    options.summary_aggregate = true;
+    return options;
+  }
+  static RunOptions ConcatAggregate() {
+    RunOptions options;
+    options.concat_aggregate = true;
+    return options;
+  }
+  static RunOptions NumericFilter() {
+    RunOptions options;
+    options.numeric_filter = true;
+    return options;
+  }
 
-void Run(benchmark::State& state,
-         const BenchInput& in,
-         const Config& config,
-         StringPool* pool) {
+  bool filtered = false;
+  bool pivot = false;
+  bool aggregate = false;
+  bool summary_aggregate = false;
+  bool concat_aggregate = false;
+  bool numeric_filter = false;
+};
+
+void Run(benchmark::State& state, Config::View view, RunOptions options = {}) {
+  StringPool pool;
+  uint32_t rows = static_cast<uint32_t>(state.range(0));
   for (auto _ : state) {
-    auto fg = Build(in.forest, config, *pool);
-    PERFETTO_CHECK(fg.ok());
-    benchmark::DoNotOptimize(fg);
-  }
-  state.counters["frames/s"] =
-      benchmark::Counter(static_cast<double>(in.forest.size()),
-                         benchmark::Counter::kIsIterationInvariantRate);
-}
-
-// Build plus the dataframe conversion (and property aggregation when the
-// input has properties).
-void RunWithRows(benchmark::State& state,
-                 const BenchInput& in,
-                 const Config& config,
-                 StringPool* pool) {
-  for (auto _ : state) {
-    auto fg = Build(in.forest, config, *pool);
-    PERFETTO_CHECK(fg.ok());
-    if (in.mapping.empty()) {
-      auto df = ToDataframe(*fg, in.forest, pool);
-      PERFETTO_CHECK(df.ok());
-      benchmark::DoNotOptimize(df);
-    } else {
-      auto df = TreesToDataframeWithProps(*fg, in, pool);
-      benchmark::DoNotOptimize(df);
+    state.PauseTiming();
+    core::Tree input = MakeInput(&pool, rows);
+    Config config(pool);
+    config.view = view;
+    config.name = &input.columns[0];
+    config.value_columns.push_back(&input.columns[1]);
+    if (options.aggregate) {
+      config.aggregate_columns.push_back(
+          {&input.columns[1], Config::Aggregate::kSum, "sum_value"});
     }
+    if (options.summary_aggregate) {
+      config.aggregate_columns.push_back(
+          {&input.columns[2], Config::Aggregate::kOneOrSummary, "summary"});
+    }
+    if (options.concat_aggregate) {
+      config.aggregate_columns.push_back({&input.columns[2],
+                                          Config::Aggregate::kConcatWithComma,
+                                          "concatenated"});
+    }
+    if (options.numeric_filter) {
+      config.grouping_columns.push_back(&input.columns[2]);
+      config.show_stack_filters.push_back(
+          base::Regex::CreateOrCheck("^12345$"));
+    }
+    if (options.filtered) {
+      config.show_stack_filters.push_back(
+          base::Regex::CreateOrCheck("frame_1\\d\\d"));
+      config.hide_frame_filters.push_back(
+          base::Regex::CreateOrCheck("frame_2\\d\\d"));
+    }
+    if (options.pivot) {
+      config.view_pattern = base::Regex::CreateOrCheck("frame_12");
+    }
+    state.ResumeTiming();
+    auto output = Build(std::move(input), config);
+    PERFETTO_CHECK(output.ok());
+    benchmark::DoNotOptimize(output);
   }
-  state.counters["frames/s"] =
-      benchmark::Counter(static_cast<double>(in.forest.size()),
-                         benchmark::Counter::kIsIterationInvariantRate);
+  state.counters["frames/s"] = benchmark::Counter(
+      static_cast<double>(rows), benchmark::Counter::kIsIterationInvariantRate);
 }
 
-void BM_FlamegraphTreeTopDown(benchmark::State& state) {
-  StringPool pool;
-  BenchInput in =
-      GenForest(&pool, static_cast<uint32_t>(state.range(0)), 1, false);
-  Run(state, in, Config{}, &pool);
+void BM_FlamegraphTopDown(benchmark::State& state) {
+  Run(state, Config::View(Config::TopDown{}));
 }
-BENCHMARK(BM_FlamegraphTreeTopDown)->Arg(100000)->Arg(1000000);
+BENCHMARK(BM_FlamegraphTopDown)->Arg(100000)->Arg(1000000);
 
-void BM_FlamegraphTreeTopDown4Metrics(benchmark::State& state) {
-  StringPool pool;
-  BenchInput in =
-      GenForest(&pool, static_cast<uint32_t>(state.range(0)), 4, false);
-  Run(state, in, Config{}, &pool);
+void BM_FlamegraphTopDownFiltered(benchmark::State& state) {
+  Run(state, Config::View(Config::TopDown{}), RunOptions::Filtered());
 }
-BENCHMARK(BM_FlamegraphTreeTopDown4Metrics)->Arg(100000)->Arg(1000000);
+BENCHMARK(BM_FlamegraphTopDownFiltered)->Arg(100000)->Arg(1000000);
 
-void BM_FlamegraphTreeTopDownFiltered(benchmark::State& state) {
-  StringPool pool;
-  BenchInput in =
-      GenForest(&pool, static_cast<uint32_t>(state.range(0)), 1, false);
-  Config config;
-  config.filters.push_back({Config::FilterKind::kShowStack, "frame_1\\d\\d"});
-  config.filters.push_back({Config::FilterKind::kHideFrame, "frame_2\\d\\d"});
-  Run(state, in, config, &pool);
+void BM_FlamegraphTopDownAggregate(benchmark::State& state) {
+  Run(state, Config::View(Config::TopDown{}), RunOptions::Aggregate());
 }
-BENCHMARK(BM_FlamegraphTreeTopDownFiltered)->Arg(100000)->Arg(1000000);
+BENCHMARK(BM_FlamegraphTopDownAggregate)->Arg(100000)->Arg(1000000);
 
-void BM_FlamegraphTreeBottomUp(benchmark::State& state) {
-  StringPool pool;
-  BenchInput in =
-      GenForest(&pool, static_cast<uint32_t>(state.range(0)), 1, false);
-  Config config;
-  config.view = Config::View::kBottomUp;
-  Run(state, in, config, &pool);
+void BM_FlamegraphTopDownNumericFilter(benchmark::State& state) {
+  Run(state, Config::View(Config::TopDown{}), RunOptions::NumericFilter());
 }
-BENCHMARK(BM_FlamegraphTreeBottomUp)->Arg(100000)->Arg(1000000);
+BENCHMARK(BM_FlamegraphTopDownNumericFilter)->Arg(100000)->Arg(1000000);
 
-void BM_FlamegraphTreePivot(benchmark::State& state) {
-  StringPool pool;
-  BenchInput in =
-      GenForest(&pool, static_cast<uint32_t>(state.range(0)), 1, false);
-  Config config;
-  config.view = Config::View::kPivot;
-  config.pivot_pattern = "frame_12";
-  Run(state, in, config, &pool);
+void BM_FlamegraphBottomUp(benchmark::State& state) {
+  Run(state, Config::View(Config::BottomUp{}));
 }
-BENCHMARK(BM_FlamegraphTreePivot)->Arg(100000)->Arg(1000000);
+BENCHMARK(BM_FlamegraphBottomUp)->Arg(100000)->Arg(1000000);
 
-void BM_FlamegraphTreeTopDownRows(benchmark::State& state) {
-  StringPool pool;
-  BenchInput in =
-      GenForest(&pool, static_cast<uint32_t>(state.range(0)), 1, false);
-  RunWithRows(state, in, Config{}, &pool);
+void BM_FlamegraphBottomUpAggregate(benchmark::State& state) {
+  Run(state, Config::View(Config::BottomUp{}), RunOptions::Aggregate());
 }
-BENCHMARK(BM_FlamegraphTreeTopDownRows)->Arg(100000)->Arg(1000000);
+BENCHMARK(BM_FlamegraphBottomUpAggregate)->Arg(100000)->Arg(1000000);
 
-void BM_FlamegraphTreeTopDownPropertiesRows(benchmark::State& state) {
-  StringPool pool;
-  BenchInput in =
-      GenForest(&pool, static_cast<uint32_t>(state.range(0)), 1, true);
-  RunWithRows(state, in, Config{}, &pool);
+void BM_FlamegraphTopDownSummaryAggregate(benchmark::State& state) {
+  Run(state, Config::View(Config::TopDown{}), RunOptions::SummaryAggregate());
 }
-BENCHMARK(BM_FlamegraphTreeTopDownPropertiesRows)->Arg(100000)->Arg(1000000);
+BENCHMARK(BM_FlamegraphTopDownSummaryAggregate)->Arg(100000)->Arg(1000000);
 
-void BM_FlamegraphTreeBottomUpRows(benchmark::State& state) {
-  StringPool pool;
-  BenchInput in =
-      GenForest(&pool, static_cast<uint32_t>(state.range(0)), 1, false);
-  Config config;
-  config.view = Config::View::kBottomUp;
-  RunWithRows(state, in, config, &pool);
+void BM_FlamegraphTopDownConcatAggregate(benchmark::State& state) {
+  Run(state, Config::View(Config::TopDown{}), RunOptions::ConcatAggregate());
 }
-BENCHMARK(BM_FlamegraphTreeBottomUpRows)->Arg(100000)->Arg(1000000);
+BENCHMARK(BM_FlamegraphTopDownConcatAggregate)->Arg(100000)->Arg(1000000);
 
-void BM_FlamegraphTreePivotRows(benchmark::State& state) {
-  StringPool pool;
-  BenchInput in =
-      GenForest(&pool, static_cast<uint32_t>(state.range(0)), 1, false);
-  Config config;
-  config.view = Config::View::kPivot;
-  config.pivot_pattern = "frame_12";
-  RunWithRows(state, in, config, &pool);
+void BM_FlamegraphPivot(benchmark::State& state) {
+  Run(state, Config::View(Config::Pivot{}), RunOptions::Pivot());
 }
-BENCHMARK(BM_FlamegraphTreePivotRows)->Arg(100000)->Arg(1000000);
+BENCHMARK(BM_FlamegraphPivot)->Arg(100000)->Arg(1000000);
 
 }  // namespace
 }  // namespace perfetto::trace_processor::flamegraph

--- a/src/trace_processor/plugins/flamegraph/flamegraph_unittest.cc
+++ b/src/trace_processor/plugins/flamegraph/flamegraph_unittest.cc
@@ -16,511 +16,356 @@
 
 #include "src/trace_processor/plugins/flamegraph/flamegraph.h"
 
-#include <algorithm>
 #include <cstdint>
-#include <map>
+#include <cstring>
+#include <limits>
 #include <optional>
 #include <string>
-#include <tuple>
-#include <utility>
-#include <variant>
 #include <vector>
 
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/containers/string_pool.h"
-#include "src/trace_processor/core/dataframe/cursor.h"
-#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/tree/tree.h"
+#include "src/trace_processor/core/tree/tree_column_ops.h"
+#include "src/trace_processor/core/util/slab.h"
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto::trace_processor::flamegraph {
 namespace {
 
-struct FrameSpec {
+struct Frame {
   std::string name;
   std::optional<uint32_t> parent;
-  std::vector<double> metrics;
+  int64_t value;
 };
 
-using Cell = std::variant<std::monostate, int64_t, double, std::string>;
-
-Cell I(int64_t v) {
-  return Cell(v);
-}
-Cell D(double v) {
-  return Cell(v);
-}
-Cell S(const char* v) {
-  return Cell(std::string(v));
+template <typename T>
+core::Tree::Column ColumnFromValues(const std::vector<T>& values) {
+  auto column =
+      core::Tree::Column::Create<T>(static_cast<uint32_t>(values.size()));
+  memcpy(column.data.begin(), values.data(), values.size() * sizeof(T));
+  return column;
 }
 
-struct CellCollector : core::dataframe::CellCallback {
-  void OnCell(int64_t v) { value = v; }
-  void OnCell(double v) { value = v; }
-  void OnCell(NullTermStringView v) { value = std::string(v.data(), v.size()); }
-  void OnCell(std::nullptr_t) { value = std::monostate(); }
-  void OnCell(uint32_t v) { value = static_cast<int64_t>(v); }
-  void OnCell(int32_t v) { value = static_cast<int64_t>(v); }
-  Cell value;
-};
+core::Tree MakeTree(StringPool* pool, const std::vector<Frame>& frames) {
+  core::Tree tree;
+  tree.row_count = static_cast<uint32_t>(frames.size());
+  tree.parent = core::Slab<uint32_t>::Alloc(frames.size());
+  std::vector<StringPool::Id> names;
+  std::vector<int64_t> values;
+  for (uint32_t i = 0; i < frames.size(); ++i) {
+    tree.parent[i] = frames[i].parent.value_or(core::Tree::kNullParent);
+    names.push_back(pool->InternString(base::StringView(frames[i].name)));
+    values.push_back(frames[i].value);
+  }
+  tree.names = {"name", "value"};
+  tree.columns.push_back(ColumnFromValues(names));
+  tree.columns.push_back(ColumnFromValues(values));
+  return tree;
+}
 
-void ExpectTable(const core::dataframe::Dataframe& df,
-                 const std::vector<std::string>& cols,
-                 const std::vector<std::vector<Cell>>& expected) {
-  ASSERT_EQ(df.row_count(), expected.size());
-  for (uint32_t r = 0; r < expected.size(); ++r) {
-    std::vector<Cell> actual;
-    for (const std::string& c : cols) {
-      auto idx = df.IndexOfColumnLegacy(c);
-      ASSERT_TRUE(idx.has_value()) << c;
-      CellCollector collector;
-      df.GetCell(r, *idx, collector);
-      actual.push_back(collector.value);
+template <typename T>
+void AddColumn(core::Tree* tree,
+               const char* name,
+               const std::vector<T>& values) {
+  tree->names.emplace_back(name);
+  tree->columns.push_back(ColumnFromValues(values));
+}
+
+void AddStringColumn(core::Tree* tree,
+                     StringPool* pool,
+                     const char* name,
+                     const std::vector<std::string>& values) {
+  std::vector<StringPool::Id> ids;
+  ids.reserve(values.size());
+  for (const std::string& value : values) {
+    ids.push_back(pool->InternString(base::StringView(value)));
+  }
+  AddColumn(tree, name, ids);
+}
+
+Config MakeConfig(const core::Tree& tree, StringPool& pool) {
+  Config config(pool);
+  config.name = &tree.columns[0];
+  config.value_columns.push_back(&tree.columns[1]);
+  return config;
+}
+
+template <typename T>
+T Value(const core::Tree& tree, const char* name, uint32_t row) {
+  auto column = tree.Find(name);
+  PERFETTO_CHECK(column);
+  return (*column)->unchecked_data<T>()[row];
+}
+
+TEST(FlamegraphTest, TopDownMergesSiblings) {
+  StringPool pool;
+  core::Tree input = MakeTree(
+      &pool,
+      {{"main", std::nullopt, 1}, {"b", 0, 2}, {"b", 0, 3}, {"c", 1, 4}});
+  Config config = MakeConfig(input, pool);
+  auto result = Build(std::move(input), config);
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result->row_count, 3u);
+  EXPECT_EQ(pool.Get(Value<StringPool::Id>(*result, "name", 0)).ToStdString(),
+            "main");
+  EXPECT_EQ(Value<int64_t>(*result, "cumulative_value", 0), 10);
+  EXPECT_EQ(Value<int64_t>(*result, "self_value", 1), 5);
+  EXPECT_EQ(Value<int64_t>(*result, "cumulative_value", 1), 9);
+  EXPECT_EQ(result->parent[2], 1u);
+}
+
+TEST(FlamegraphTest, LayoutPacksWidestFirstBreadthFirst) {
+  StringPool pool;
+  core::Tree input = MakeTree(
+      &pool,
+      {{"main", std::nullopt, 4}, {"a", 0, 3}, {"b", 0, 6}, {"c", 1, 2}});
+  Config config = MakeConfig(input, pool);
+  auto result = Build(input, config);
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result->row_count, 4u);
+
+  auto cumulative = result->Find("cumulative_value");
+  auto depth = result->Find("depth");
+  ASSERT_TRUE(cumulative && depth);
+  Layout layout = ComputeLayout(*result, **cumulative, **depth);
+
+  auto name_at = [&](uint32_t row) {
+    return pool.Get(Value<StringPool::Id>(*result, "name", layout.node[row]))
+        .ToStdString();
+  };
+  EXPECT_EQ(name_at(0), "main");
+  EXPECT_EQ(name_at(1), "b");
+  EXPECT_EQ(name_at(2), "a");
+  EXPECT_EQ(name_at(3), "c");
+  EXPECT_EQ(layout.parent_row[0], core::Tree::kNullParent);
+  EXPECT_EQ(layout.parent_row[1], 0u);
+  EXPECT_EQ(layout.parent_row[2], 0u);
+  EXPECT_EQ(layout.parent_row[3], 2u);
+  EXPECT_DOUBLE_EQ(layout.x_start[0], 0.0);
+  EXPECT_DOUBLE_EQ(layout.x_start[1], 0.0);
+  EXPECT_DOUBLE_EQ(layout.x_start[2], 6.0);
+  EXPECT_DOUBLE_EQ(layout.x_start[3], 6.0);
+}
+
+TEST(FlamegraphTest, StringAggregates) {
+  StringPool pool;
+  core::Tree input =
+      MakeTree(&pool, {{"main", std::nullopt, 1}, {"x", 0, 2}, {"x", 0, 3}});
+  AddStringColumn(&input, &pool, "source", {"root", "a", "b"});
+  AddColumn(&input, "num", std::vector<int64_t>{5, 7, 8});
+  AddColumn(&input, "frac", std::vector<double>{1.5, 2.0, 2.0});
+  Config config = MakeConfig(input, pool);
+  config.aggregate_columns.push_back(
+      {&input.columns[2], Config::Aggregate::kOneOrSummary, "summary"});
+  config.aggregate_columns.push_back(
+      {&input.columns[2], Config::Aggregate::kConcatWithComma, "concatenated"});
+  config.aggregate_columns.push_back(
+      {&input.columns[3], Config::Aggregate::kOneOrSummary, "num_summary"});
+  config.aggregate_columns.push_back(
+      {&input.columns[3], Config::Aggregate::kConcatWithComma, "nums"});
+  config.aggregate_columns.push_back(
+      {&input.columns[4], Config::Aggregate::kOneOrSummary, "frac_summary"});
+  config.aggregate_columns.push_back(
+      {&input.columns[4], Config::Aggregate::kConcatWithComma, "fracs"});
+
+  auto result = Build(input, config);
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result->row_count, 2u);
+  EXPECT_EQ(
+      pool.Get(Value<StringPool::Id>(*result, "summary", 0)).ToStdString(),
+      "root");
+  EXPECT_EQ(
+      pool.Get(Value<StringPool::Id>(*result, "summary", 1)).ToStdString(),
+      "a and 2 others");
+  EXPECT_EQ(
+      pool.Get(Value<StringPool::Id>(*result, "concatenated", 1)).ToStdString(),
+      "a,b");
+  EXPECT_EQ(
+      pool.Get(Value<StringPool::Id>(*result, "num_summary", 0)).ToStdString(),
+      "5");
+  EXPECT_EQ(
+      pool.Get(Value<StringPool::Id>(*result, "num_summary", 1)).ToStdString(),
+      "7 and 2 others");
+  EXPECT_EQ(pool.Get(Value<StringPool::Id>(*result, "nums", 1)).ToStdString(),
+            "7,8");
+  EXPECT_EQ(
+      pool.Get(Value<StringPool::Id>(*result, "frac_summary", 0)).ToStdString(),
+      "1.5");
+  EXPECT_EQ(
+      pool.Get(Value<StringPool::Id>(*result, "frac_summary", 1)).ToStdString(),
+      "2.0");
+  EXPECT_EQ(pool.Get(Value<StringPool::Id>(*result, "fracs", 1)).ToStdString(),
+            "2.0,2.0");
+}
+
+// The dataframe layer materializes a column whose rows are all null as a
+// null-typed column. Every aggregate mode over such a column produces an
+// all-null output.
+TEST(FlamegraphTest, AllNullAggregates) {
+  StringPool pool;
+  core::Tree input =
+      MakeTree(&pool, {{"main", std::nullopt, 1}, {"x", 0, 2}, {"x", 0, 3}});
+  input.names.emplace_back("source");
+  input.columns.push_back(core::Tree::Column::CreateNull(3));
+  Config config = MakeConfig(input, pool);
+  config.aggregate_columns.push_back(
+      {&input.columns[2], Config::Aggregate::kOneOrSummary, "summary"});
+  config.aggregate_columns.push_back(
+      {&input.columns[2], Config::Aggregate::kConcatWithComma, "concatenated"});
+  config.aggregate_columns.push_back(
+      {&input.columns[2], Config::Aggregate::kSum, "summed"});
+
+  auto result = Build(input, config);
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result->row_count, 2u);
+  for (uint32_t row = 0; row < result->row_count; ++row) {
+    for (const char* name : {"summary", "concatenated", "summed"}) {
+      auto output = result->Find(name);
+      ASSERT_TRUE(output);
+      ASSERT_TRUE((*output)->null_bv.size() > 0);
+      EXPECT_FALSE((*output)->null_bv.is_set(row));
     }
-    EXPECT_EQ(actual, expected[r]) << "row " << r;
   }
 }
 
-// Path -> (self, cumulative, sorted constituent names): everything a test
-// asserts on, independent of node and frame numbering.
-using TreeSummary = std::map<std::string,
-                             std::tuple<std::vector<double>,
-                                        std::vector<double>,
-                                        std::vector<std::string>>>;
+TEST(FlamegraphTest, BottomUp) {
+  StringPool pool;
+  core::Tree input =
+      MakeTree(&pool, {{"main", std::nullopt, 1}, {"a", 0, 2}, {"b", 1, 4}});
+  Config config = MakeConfig(input, pool);
+  config.view = Config::View(Config::BottomUp{});
+  auto result = Build(std::move(input), config);
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result->row_count, 6u);
+  EXPECT_EQ(Value<int64_t>(*result, "depth", 0), -1);
+  EXPECT_EQ(Value<int64_t>(*result, "self_value", 4), 0);
+  EXPECT_EQ(Value<int64_t>(*result, "cumulative_value", 4), 4);
+}
 
-class FlamegraphTest : public ::testing::Test {
- protected:
-  Forest MakeForest(const std::vector<FrameSpec>& frames,
-                    uint32_t metric_count = 1) {
-    Forest f;
-    f.metric_count = metric_count;
-    std::map<std::string, uint32_t> name_idx;
-    for (const FrameSpec& fr : frames) {
-      auto [it, inserted] = name_idx.insert(
-          {fr.name, static_cast<uint32_t>(f.name_table.size())});
-      if (inserted) {
-        f.name_table.push_back(pool_.InternString(base::StringView(fr.name)));
-      }
-      f.name.push_back(it->second);
-      f.key.push_back(it->second);
-      f.parent.push_back(fr.parent ? *fr.parent : kNoParent);
-      PERFETTO_CHECK(fr.metrics.size() == metric_count);
-      for (double m : fr.metrics) {
-        f.metrics.push_back(m);
-      }
+TEST(FlamegraphTest, PivotAndFromFrameViews) {
+  StringPool pool;
+  const std::vector<Frame> frames = {{"main", std::nullopt, 1},
+                                     {"pivot", 0, 2},
+                                     {"leaf", 1, 4},
+                                     {"other", 0, 8}};
+  for (bool pivot : {false, true}) {
+    core::Tree input = MakeTree(&pool, frames);
+    Config config = MakeConfig(input, pool);
+    config.view = pivot ? Config::View(Config::Pivot{})
+                        : Config::View(Config::FromFrame{});
+    config.view_pattern = base::Regex::CreateOrCheck("^pivot$");
+    auto result = Build(std::move(input), config);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(result->row_count, pivot ? 4u : 2u);
+    EXPECT_EQ(pool.Get(Value<StringPool::Id>(*result, "name", 0)).ToStdString(),
+              "pivot");
+    EXPECT_EQ(Value<int64_t>(*result, "depth", 0), 1);
+    EXPECT_EQ(pool.Get(Value<StringPool::Id>(*result, "name", 1)).ToStdString(),
+              "leaf");
+    if (pivot) {
+      EXPECT_EQ(
+          pool.Get(Value<StringPool::Id>(*result, "name", 2)).ToStdString(),
+          "pivot");
+      EXPECT_EQ(
+          pool.Get(Value<StringPool::Id>(*result, "name", 3)).ToStdString(),
+          "main");
+      EXPECT_EQ(Value<int64_t>(*result, "depth", 3), -2);
     }
-    return f;
   }
+}
 
-  Flamegraph BuildOk(const Forest& forest, const Config& config) {
-    auto res = Build(forest, config, pool_);
-    PERFETTO_CHECK(res.ok());
-    return std::move(*res);
+TEST(FlamegraphTest, ShowAndHideStackFilters) {
+  StringPool pool;
+  core::Tree input = MakeTree(&pool, {{"main", std::nullopt, 1},
+                                      {"show", 0, 2},
+                                      {"leaf", 1, 4},
+                                      {"hidden", 0, 8},
+                                      {"hidden_leaf", 3, 16}});
+  Config config = MakeConfig(input, pool);
+  config.show_stack_filters.push_back(base::Regex::CreateOrCheck("^leaf$"));
+  config.hide_stack_filters.push_back(
+      base::Regex::CreateOrCheck("^hidden_leaf$"));
+  auto result = Build(std::move(input), config);
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result->row_count, 3u);
+  EXPECT_EQ(pool.Get(Value<StringPool::Id>(*result, "name", 0)).ToStdString(),
+            "main");
+  EXPECT_EQ(pool.Get(Value<StringPool::Id>(*result, "name", 1)).ToStdString(),
+            "show");
+  EXPECT_EQ(pool.Get(Value<StringPool::Id>(*result, "name", 2)).ToStdString(),
+            "leaf");
+}
+
+TEST(FlamegraphTest, RejectsInvalidConfig) {
+  StringPool pool;
+  core::Tree input =
+      MakeTree(&pool, {{"main", std::nullopt, 1}, {"child", 0, 2}});
+
+  Config missing_value(pool);
+  missing_value.name = &input.columns[0];
+  EXPECT_FALSE(Build(input, missing_value).ok());
+
+  Config non_numeric = MakeConfig(input, pool);
+  non_numeric.value_columns = {&input.columns[0]};
+  EXPECT_FALSE(Build(input, non_numeric).ok());
+
+  Config duplicate_output = MakeConfig(input, pool);
+  duplicate_output.aggregate_columns.push_back(
+      {&input.columns[1], Config::Aggregate::kSum, "self_value"});
+  EXPECT_FALSE(Build(input, duplicate_output).ok());
+}
+
+TEST(FlamegraphTest, RejectsIntegerOverflow) {
+  StringPool pool;
+  {
+    core::Tree input = MakeTree(
+        &pool, {{"main", std::nullopt, std::numeric_limits<int64_t>::max()},
+                {"main", std::nullopt, 1}});
+    Config config = MakeConfig(input, pool);
+    EXPECT_FALSE(Build(std::move(input), config).ok());
   }
-
-  std::string NameOf(const Forest& forest, uint32_t frame) {
-    return pool_.Get(forest.name_table[forest.name[frame]]).ToStdString();
+  {
+    core::Tree input = MakeTree(
+        &pool, {{"main", std::nullopt, std::numeric_limits<int64_t>::max()},
+                {"child", 0, 1}});
+    Config config = MakeConfig(input, pool);
+    EXPECT_FALSE(Build(std::move(input), config).ok());
   }
-
-  TreeSummary Summarize(const Tree& tree, const Forest& forest) {
-    uint32_t k = tree.metric_count;
-    std::vector<std::string> path(tree.size());
-    TreeSummary out;
-    for (uint32_t i = 0; i < tree.size(); ++i) {
-      path[i] =
-          (tree.parent[i] == kNoParent ? "" : path[tree.parent[i]] + "/") +
-          NameOf(forest, tree.rep_frame[i]);
-      std::vector<double> self(tree.self.data() + i * k,
-                               tree.self.data() + (i + 1) * k);
-      std::vector<double> cum(tree.cumulative.data() + i * k,
-                              tree.cumulative.data() + (i + 1) * k);
-      std::vector<std::string> cons;
-      for (uint32_t c = tree.constituents_offset[i];
-           c < tree.constituents_offset[i + 1]; ++c) {
-        cons.push_back(NameOf(forest, tree.constituents[c]));
-      }
-      std::sort(cons.begin(), cons.end());
-      out[path[i]] = {self, cum, cons};
-    }
-    return out;
-  }
-
-  StringPool pool_;
-};
-
-TEST_F(FlamegraphTest, TopDownMergesSiblingsByKey) {
-  // main -> {b, b, c}; the two b siblings merge, c stays under the merged
-  // b node's sibling set.
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"b", 0, {2}},
-      {"b", 0, {3}},
-      {"c", 1, {4}},
-  });
-  Flamegraph fg = BuildOk(f, Config{});
-  EXPECT_EQ(fg.up.size(), 0u);
-  ASSERT_EQ(fg.up.constituents_offset.size(), 1u);
-  EXPECT_EQ(fg.up.constituents_offset[0], 0u);
-  TreeSummary s = Summarize(fg.down, f);
-  ASSERT_EQ(s.size(), 3u);
-  EXPECT_EQ(s["main"],
-            (std::tuple{std::vector<double>{1}, std::vector<double>{10},
-                        std::vector<std::string>{"main"}}));
-  EXPECT_EQ(s["main/b"],
-            (std::tuple{std::vector<double>{5}, std::vector<double>{9},
-                        std::vector<std::string>{"b", "b"}}));
-  EXPECT_EQ(s["main/b/c"],
-            (std::tuple{std::vector<double>{4}, std::vector<double>{4},
-                        std::vector<std::string>{"c"}}));
 }
 
-TEST_F(FlamegraphTest, TopDownMergesRoots) {
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"main", std::nullopt, {2}},
-      {"a", 1, {4}},
-  });
-  Flamegraph fg = BuildOk(f, Config{});
-  TreeSummary s = Summarize(fg.down, f);
-  ASSERT_EQ(s.size(), 2u);
-  EXPECT_EQ(std::get<0>(s["main"]), std::vector<double>{3});
-  EXPECT_EQ(std::get<1>(s["main"]), std::vector<double>{7});
-  EXPECT_EQ(std::get<1>(s["main/a"]), std::vector<double>{4});
+TEST(FlamegraphTest, EmptyLayout) {
+  core::Tree tree;
+  core::Tree::Column cumulative = core::Tree::Column::Create<int64_t>(0);
+  core::Tree::Column depth = core::Tree::Column::Create<int64_t>(0);
+  Layout layout = ComputeLayout(tree, cumulative, depth);
+  EXPECT_EQ(layout.node.size(), 0u);
+  EXPECT_EQ(layout.parent_row.size(), 0u);
+  EXPECT_EQ(layout.x_start.size(), 0u);
 }
 
-TEST_F(FlamegraphTest, NonTopologicalOrderMatchesTopological) {
-  Forest ordered = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"b", 0, {2}},
-      {"b", 0, {3}},
-      {"c", 1, {4}},
-  });
-  // The same forest with children listed before their parents.
-  Forest shuffled = MakeForest({
-      {"c", 3, {4}},
-      {"b", 2, {3}},
-      {"main", std::nullopt, {1}},
-      {"b", 2, {2}},
-  });
-  Flamegraph a = BuildOk(ordered, Config{});
-  Flamegraph b = BuildOk(shuffled, Config{});
-  EXPECT_EQ(Summarize(a.down, ordered), Summarize(b.down, shuffled));
-}
-
-TEST_F(FlamegraphTest, DanglingParentsAndCyclesAreIgnored) {
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"dangling", 100, {10}},
-      {"cycle_a", 3, {10}},
-      {"cycle_b", 2, {10}},
-  });
-  Flamegraph fg = BuildOk(f, Config{});
-  TreeSummary s = Summarize(fg.down, f);
-  ASSERT_EQ(s.size(), 1u);
-  EXPECT_EQ(std::get<1>(s["main"]), std::vector<double>{1});
-}
-
-TEST_F(FlamegraphTest, BottomUp) {
-  // main -> a -> b; every frame has a value, so every frame anchors a
-  // caller chain.
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"a", 0, {2}},
-      {"b", 1, {4}},
-  });
-  Config config;
-  config.view = Config::View::kBottomUp;
-  Flamegraph fg = BuildOk(f, config);
-  EXPECT_EQ(fg.down.size(), 0u);
-  ASSERT_EQ(fg.down.constituents_offset.size(), 1u);
-  EXPECT_EQ(fg.down.constituents_offset[0], 0u);
-  TreeSummary s = Summarize(fg.up, f);
-  ASSERT_EQ(s.size(), 6u);
-  EXPECT_EQ(std::get<1>(s["main"]), std::vector<double>{1});
-  EXPECT_EQ(std::get<1>(s["a"]), std::vector<double>{2});
-  EXPECT_EQ(std::get<1>(s["a/main"]), std::vector<double>{2});
-  EXPECT_EQ(std::get<1>(s["b"]), std::vector<double>{4});
-  EXPECT_EQ(std::get<1>(s["b/a"]), std::vector<double>{4});
-  EXPECT_EQ(std::get<1>(s["b/a/main"]), std::vector<double>{4});
-  // Self on an up node sums the frames at that chain position.
-  EXPECT_EQ(std::get<0>(s["b/a"]), std::vector<double>{2});
-  EXPECT_EQ(std::get<2>(s["b/a"]), std::vector<std::string>{"a"});
-}
-
-TEST_F(FlamegraphTest, BottomUpMergesSharedSuffixes) {
-  // Two different b frames under main: their caller chains merge under
-  // the same b root, and the shared main suffix appears once per anchor
-  // in the constituents.
-  Forest f = MakeForest({
-      {"main", std::nullopt, {0}},
-      {"b", 0, {2}},
-      {"b", 0, {3}},
-  });
-  Config config;
-  config.view = Config::View::kBottomUp;
-  Flamegraph fg = BuildOk(f, config);
-  TreeSummary s = Summarize(fg.up, f);
-  ASSERT_EQ(s.size(), 2u);
-  EXPECT_EQ(std::get<1>(s["b"]), std::vector<double>{5});
-  EXPECT_EQ(std::get<0>(s["b"]), std::vector<double>{5});
-  EXPECT_EQ(std::get<1>(s["b/main"]), std::vector<double>{5});
-  EXPECT_EQ(std::get<2>(s["b/main"]),
-            (std::vector<std::string>{"main", "main"}));
-}
-
-TEST_F(FlamegraphTest, Pivot) {
-  // main -> a -> x -> c and main -> x: pivoting on x roots both halves at
-  // the merged x.
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"a", 0, {2}},
-      {"x", 1, {3}},
-      {"c", 2, {4}},
-      {"x", 0, {5}},
-  });
-  Config config;
-  config.view = Config::View::kPivot;
-  config.pivot_pattern = "x";
-  Flamegraph fg = BuildOk(f, config);
-
-  TreeSummary down = Summarize(fg.down, f);
-  ASSERT_EQ(down.size(), 2u);
-  EXPECT_EQ(std::get<0>(down["x"]), std::vector<double>{8});
-  EXPECT_EQ(std::get<1>(down["x"]), std::vector<double>{12});
-  EXPECT_EQ(std::get<1>(down["x/c"]), std::vector<double>{4});
-
-  TreeSummary up = Summarize(fg.up, f);
-  ASSERT_EQ(up.size(), 4u);
-  // Each anchor carries its own subtree total up its caller chain.
-  EXPECT_EQ(std::get<1>(up["x"]), std::vector<double>{12});
-  EXPECT_EQ(std::get<1>(up["x/a"]), std::vector<double>{7});
-  EXPECT_EQ(std::get<1>(up["x/a/main"]), std::vector<double>{7});
-  EXPECT_EQ(std::get<1>(up["x/main"]), std::vector<double>{5});
-}
-
-TEST_F(FlamegraphTest, PivotReRootsNestedMatches) {
-  // x -> a -> x: the nested x starts its own root; the outer x's subtree
-  // stops at it.
-  Forest f = MakeForest({
-      {"x", std::nullopt, {1}},
-      {"a", 0, {2}},
-      {"x", 1, {4}},
-  });
-  Config config;
-  config.view = Config::View::kPivot;
-  config.pivot_pattern = "x";
-  Flamegraph fg = BuildOk(f, config);
-  TreeSummary down = Summarize(fg.down, f);
-  ASSERT_EQ(down.size(), 2u);
-  EXPECT_EQ(std::get<0>(down["x"]), std::vector<double>{5});
-  EXPECT_EQ(std::get<1>(down["x"]), std::vector<double>{7});
-  EXPECT_EQ(std::get<1>(down["x/a"]), std::vector<double>{2});
-  // Upward, the outer x weighs 3 (itself + a, stopping at the nested x)
-  // and the nested x weighs 4; both merge into the x root.
-  TreeSummary up = Summarize(fg.up, f);
-  EXPECT_EQ(std::get<1>(up["x"]), std::vector<double>{7});
-  EXPECT_EQ(std::get<1>(up["x/a"]), std::vector<double>{4});
-  EXPECT_EQ(std::get<1>(up["x/a/x"]), std::vector<double>{4});
-}
-
-TEST_F(FlamegraphTest, HideFrameFoldsValuesIntoKeptAncestor) {
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"hideme", 0, {2}},
-      {"b", 1, {4}},
-  });
-  Config config;
-  config.filters.push_back({Config::FilterKind::kHideFrame, "hideme"});
-  Flamegraph fg = BuildOk(f, config);
-  TreeSummary s = Summarize(fg.down, f);
-  ASSERT_EQ(s.size(), 2u);
-  EXPECT_EQ(s["main"],
-            (std::tuple{std::vector<double>{3}, std::vector<double>{7},
-                        std::vector<std::string>{"main"}}));
-  EXPECT_EQ(std::get<1>(s["main/b"]), std::vector<double>{4});
-}
-
-TEST_F(FlamegraphTest, HiddenRootValuesAreDropped) {
-  Forest f = MakeForest({
-      {"hideme", std::nullopt, {1}},
-      {"b", 0, {4}},
-  });
-  Config config;
-  config.filters.push_back({Config::FilterKind::kHideFrame, "hideme"});
-  Flamegraph fg = BuildOk(f, config);
-  TreeSummary s = Summarize(fg.down, f);
-  ASSERT_EQ(s.size(), 1u);
-  EXPECT_EQ(std::get<1>(s["b"]), std::vector<double>{4});
-}
-
-TEST_F(FlamegraphTest, ShowStackDropsValuelessSubtrees) {
-  Forest f = MakeForest({
-      {"root", std::nullopt, {1}},
-      {"keepme", 0, {2}},
-      {"other", 0, {4}},
-  });
-  Config config;
-  config.filters.push_back({Config::FilterKind::kShowStack, "keepme"});
-  Flamegraph fg = BuildOk(f, config);
-  TreeSummary s = Summarize(fg.down, f);
-  ASSERT_EQ(s.size(), 2u);
-  // root's own value still shows as self, but does not count towards any
-  // cumulative value (its stack prefix has no match).
-  EXPECT_EQ(std::get<0>(s["root"]), std::vector<double>{1});
-  EXPECT_EQ(std::get<1>(s["root"]), std::vector<double>{2});
-  EXPECT_EQ(std::get<1>(s["root/keepme"]), std::vector<double>{2});
-}
-
-TEST_F(FlamegraphTest, HideStack) {
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"bad", 0, {2}},
-      {"c", 1, {3}},
-      {"ok", 0, {4}},
-  });
-  Config config;
-  config.filters.push_back({Config::FilterKind::kHideStack, "bad"});
-  Flamegraph fg = BuildOk(f, config);
-  TreeSummary s = Summarize(fg.down, f);
-  ASSERT_EQ(s.size(), 2u);
-  EXPECT_EQ(std::get<1>(s["main"]), std::vector<double>{5});
-  EXPECT_EQ(std::get<1>(s["main/ok"]), std::vector<double>{4});
-}
-
-TEST_F(FlamegraphTest, ShowFromFrame) {
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"start", 0, {2}},
-      {"b", 1, {3}},
-  });
-  Config config;
-  config.filters.push_back({Config::FilterKind::kShowFromFrame, "start"});
-  Flamegraph fg = BuildOk(f, config);
-  TreeSummary s = Summarize(fg.down, f);
-  ASSERT_EQ(s.size(), 2u);
-  EXPECT_EQ(std::get<1>(s["start"]), std::vector<double>{5});
-  EXPECT_EQ(std::get<1>(s["start/b"]), std::vector<double>{3});
-}
-
-TEST_F(FlamegraphTest, MultipleMetrics) {
-  Forest f = MakeForest(
-      {
-          {"main", std::nullopt, {1, 0}},
-          {"a", 0, {0, 2}},
-          {"b", 0, {0, 0}},
-      },
-      2);
-  Flamegraph fg = BuildOk(f, Config{});
-  TreeSummary s = Summarize(fg.down, f);
-  // b is zero on every metric and is dropped; a survives via metric 1.
-  ASSERT_EQ(s.size(), 2u);
-  EXPECT_EQ(std::get<0>(s["main"]), (std::vector<double>{1, 0}));
-  EXPECT_EQ(std::get<1>(s["main"]), (std::vector<double>{1, 2}));
-  EXPECT_EQ(std::get<1>(s["main/a"]), (std::vector<double>{0, 2}));
-}
-
-TEST_F(FlamegraphTest, EmptyForest) {
-  Forest f = MakeForest({});
-  Flamegraph fg = BuildOk(f, Config{});
-  EXPECT_EQ(fg.down.size(), 0u);
-  EXPECT_EQ(fg.up.size(), 0u);
-  ASSERT_EQ(fg.down.constituents_offset.size(), 1u);
-  EXPECT_EQ(fg.down.constituents_offset[0], 0u);
-  ASSERT_EQ(fg.up.constituents_offset.size(), 1u);
-  EXPECT_EQ(fg.up.constituents_offset[0], 0u);
-}
-
-TEST_F(FlamegraphTest, FiltersMatchExtraStrings) {
-  // Filters also match the extra strings attached to a name entry (how
-  // builders expose property values folded into the key).
-  Forest f = MakeForest({
-      {"root", std::nullopt, {1}},
-      {"aa", 0, {2}},
-      {"bb", 0, {4}},
-  });
-  f.match_offset.push_back(0);  // root: no extras.
-  f.match_offset.push_back(0);  // aa: one extra, "libkeep.so".
-  f.match_offset.push_back(1);
-  f.match_offset.push_back(1);  // bb: none.
-  f.match_strings.push_back(pool_.InternString("libkeep.so"));
-  Config config;
-  config.filters.push_back({Config::FilterKind::kShowStack, "libkeep"});
-  Flamegraph fg = BuildOk(f, config);
-  TreeSummary s = Summarize(fg.down, f);
-  ASSERT_EQ(s.size(), 2u);
-  EXPECT_EQ(std::get<1>(s["root"]), std::vector<double>{2});
-  EXPECT_EQ(std::get<1>(s["root/aa"]), std::vector<double>{2});
-}
-
-TEST_F(FlamegraphTest, ToDataframe) {
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1}},
-      {"b", 0, {2}},
-      {"b", 0, {3}},
-  });
-  Flamegraph fg = BuildOk(f, Config{});
-  auto df = ToDataframe(fg, f, &pool_);
-  ASSERT_TRUE(df.ok());
-  ExpectTable(
-      *df, {"id", "parentId", "depth", "name", "selfValue", "cumulativeValue"},
-      {
-          {I(0), I(-1), I(1), S("main"), I(1), I(6)},
-          {I(1), I(0), I(2), S("b"), I(5), I(5)},
-      });
-}
-
-TEST_F(FlamegraphTest, ToDataframeBottomUpAndDoubles) {
-  // A fractional value makes the metric's columns DOUBLE; the up tree
-  // emits negative depths.
-  Forest f = MakeForest({
-      {"main", std::nullopt, {1.5}},
-      {"a", 0, {2}},
-  });
-  Config config;
-  config.view = Config::View::kBottomUp;
-  Flamegraph fg = BuildOk(f, config);
-  auto df = ToDataframe(fg, f, &pool_);
-  ASSERT_TRUE(df.ok());
-  ExpectTable(
-      *df, {"id", "parentId", "depth", "name", "selfValue", "cumulativeValue"},
-      {
-          {I(0), I(-1), I(-1), S("main"), D(1.5), D(1.5)},
-          {I(1), I(-1), I(-1), S("a"), D(2), D(2)},
-          {I(2), I(1), I(-2), S("main"), D(1.5), D(2)},
-      });
-}
-
-TEST_F(FlamegraphTest, ToDataframeMultipleMetrics) {
-  Forest f = MakeForest(
-      {
-          {"main", std::nullopt, {1, 0}},
-          {"a", 0, {0, 2.5}},
-      },
-      2);
-  Flamegraph fg = BuildOk(f, Config{});
-  auto df = ToDataframe(fg, f, &pool_);
-  ASSERT_TRUE(df.ok());
-  ExpectTable(*df,
-              {"id", "parentId", "depth", "name", "selfValue0",
-               "cumulativeValue0", "selfValue1", "cumulativeValue1"},
-              {
-                  {I(0), I(-1), I(1), S("main"), I(1), I(1), D(0), D(2.5)},
-                  {I(1), I(0), I(2), S("a"), I(0), I(0), D(2.5), D(2.5)},
-              });
-}
-
-TEST_F(FlamegraphTest, ConfigValidation) {
-  Forest f = MakeForest({{"main", std::nullopt, {1}}});
-  Config pivot_without_pattern;
-  pivot_without_pattern.view = Config::View::kPivot;
-  EXPECT_FALSE(Build(f, pivot_without_pattern, pool_).ok());
-
-  Config pattern_without_pivot;
-  pattern_without_pivot.pivot_pattern = "x";
-  EXPECT_FALSE(Build(f, pattern_without_pivot, pool_).ok());
-
-  Forest no_metrics;
-  no_metrics.metric_count = 0;
-  EXPECT_FALSE(Build(no_metrics, Config{}, pool_).ok());
+TEST(FlamegraphTest, HideFrameFoldsValue) {
+  StringPool pool;
+  core::Tree input =
+      MakeTree(&pool, {{"main", std::nullopt, 1}, {"hide", 0, 2}, {"b", 1, 4}});
+  AddStringColumn(&input, &pool, "source", {"root", "hidden", "child"});
+  Config config = MakeConfig(input, pool);
+  config.hide_frame_filters.push_back(base::Regex::CreateOrCheck("hide"));
+  config.aggregate_columns.push_back(
+      {&input.columns[2], Config::Aggregate::kOneOrSummary, "summary"});
+  config.aggregate_columns.push_back(
+      {&input.columns[2], Config::Aggregate::kConcatWithComma, "concatenated"});
+  auto result = Build(std::move(input), config);
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result->row_count, 2u);
+  EXPECT_EQ(Value<int64_t>(*result, "self_value", 0), 3);
+  EXPECT_EQ(Value<int64_t>(*result, "cumulative_value", 0), 7);
+  EXPECT_EQ(
+      pool.Get(Value<StringPool::Id>(*result, "summary", 0)).ToStdString(),
+      "root and 2 others");
+  EXPECT_EQ(
+      pool.Get(Value<StringPool::Id>(*result, "concatenated", 0)).ToStdString(),
+      "root,hidden");
 }
 
 }  // namespace


### PR DESCRIPTION
Consume the core Tree representation directly and preserve typed values while
merging top-down, bottom-up, pivot, and filtered flamegraph views.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>