### PR TITLE
tp: enforce parent-before-child Tree ordering

### DIFF
--- a/src/trace_processor/core/tree/tree.h
+++ b/src/trace_processor/core/tree/tree.h
@@ -34,7 +34,9 @@ namespace perfetto::trace_processor::core {
 //
 // Each column stores dense data as raw bytes (Slab<uint8_t>) with a dense null
 // bitvector. Node ids are implicit dense row indices. The parent array contains
-// row indices, with kNullParent used for roots.
+// row indices (kNullParent for roots), and every parent precedes its children:
+// parent[i] == kNullParent || parent[i] < i. This makes root-to-leaf and
+// leaf-to-root operations single forward and reverse passes.
 //
 // This is intentionally minimal: no sort state, no sparse nulls, and no shared
 // ownership. Tree operators consume it and can reuse its allocations.

--- a/src/trace_processor/core/tree/tree_algorithms_unittest.cc
+++ b/src/trace_processor/core/tree/tree_algorithms_unittest.cc
@@ -17,6 +17,8 @@
 #include "src/trace_processor/core/tree/tree_from_dataframe.h"
 
 #include <cstdint>
+#include <iterator>
+#include <optional>
 #include <utility>
 
 #include "src/trace_processor/containers/string_pool.h"
@@ -52,17 +54,43 @@ TEST(TreeFromDataframeTest, PreservesRowOrderAndNullableColumn) {
   Tree tree = std::move(result.value());
   ASSERT_EQ(tree.row_count, 3u);
   ASSERT_EQ(tree.columns.size(), 3u);
-
-  EXPECT_EQ(tree.parent[0], 2u);
-  EXPECT_EQ(tree.parent[1], Tree::kNullParent);
-  EXPECT_EQ(tree.parent[2], 1u);
+  EXPECT_THAT(tree.parent, testing::ElementsAre(Tree::kNullParent, 0u, 1u));
 
   const Tree::Column& values = tree.columns[2];
-  EXPECT_EQ(values.unchecked_span<int64_t>()[1], 30);
-  EXPECT_EQ(values.unchecked_span<int64_t>()[2], 20);
-  EXPECT_FALSE(values.null_bv.is_set(0));
+  EXPECT_EQ(values.unchecked_span<int64_t>()[0], 30);
+  EXPECT_EQ(values.unchecked_span<int64_t>()[1], 20);
+  EXPECT_TRUE(values.null_bv.is_set(0));
   EXPECT_TRUE(values.null_bv.is_set(1));
-  EXPECT_TRUE(values.null_bv.is_set(2));
+  EXPECT_FALSE(values.null_bv.is_set(2));
+}
+
+TEST(TreeFromDataframeTest, OrdersParentsBeforeChildrenDeterministically) {
+  StringPool pool;
+  dataframe::AdhocDataframeBuilder::Options options;
+  options.types = {dataframe::AdhocColumnType::kInt64,
+                   dataframe::AdhocColumnType::kInt64};
+  options.nullability_type = dataframe::NullabilityType::kDenseNull;
+  dataframe::AdhocDataframeBuilder builder({"id", "parent_id"}, &pool, options);
+
+  const int64_t ids[] = {30, 10, 21, 20, 11, 12};
+  const std::optional<int64_t> parents[] = {10,           std::nullopt, 20,
+                                            std::nullopt, 10,           10};
+  for (uint32_t row = 0; row < std::size(ids); ++row) {
+    ASSERT_TRUE(builder.PushNonNull(0, ids[row]));
+    if (parents[row]) {
+      ASSERT_TRUE(builder.PushNonNull(1, *parents[row]));
+    } else {
+      builder.PushNull(1);
+    }
+  }
+
+  auto result = BuildTree(std::move(builder));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  Tree tree = std::move(result.value());
+  EXPECT_THAT(tree.columns[0].unchecked_span<int64_t>(),
+              testing::ElementsAre(10, 30, 20, 21, 11, 12));
+  EXPECT_THAT(tree.parent, testing::ElementsAre(Tree::kNullParent, 0u,
+                                                Tree::kNullParent, 2u, 0u, 0u));
 }
 
 TEST(TreeFromDataframeTest, RejectsSelfLoop) {

--- a/src/trace_processor/core/tree/tree_from_dataframe.cc
+++ b/src/trace_processor/core/tree/tree_from_dataframe.cc
@@ -36,7 +36,7 @@
 #include "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h"
 #include "src/trace_processor/core/tree/tree.h"
 #include "src/trace_processor/core/util/flex_vector.h"
-#include "src/trace_processor/core/util/span.h"
+#include "src/trace_processor/core/util/ops.h"
 #include "src/trace_processor/core/util/slab.h"
 
 namespace perfetto::trace_processor::core {
@@ -44,16 +44,27 @@ namespace perfetto::trace_processor::core {
 namespace {
 
 template <typename T>
-Slab<uint8_t> CopyColumn(Span<const T> values) {
+Slab<uint8_t> GatherColumnData(Span<const T> values,
+                               Span<const uint32_t> order,
+                               const BitVector* source_non_null,
+                               BitVector* output_non_null) {
   auto bytes = static_cast<uint64_t>(values.size()) * sizeof(T);
   auto slab = Slab<uint8_t>::Alloc(bytes);
-  memcpy(slab.begin(), values.b, bytes);
+  T* output_data = reinterpret_cast<T*>(slab.data());
+  Span<T> output(output_data, output_data + order.size());
+  if (source_non_null) {
+    PERFETTO_DCHECK(output_non_null);
+    core::ops::GatherNullableRows(values, *source_non_null, output,
+                                  output_non_null, order);
+  } else {
+    PERFETTO_DCHECK(!output_non_null);
+    core::ops::GatherRows(values, output, order);
+  }
   return slab;
 }
 
-Tree::Column ConvertRawColumn(
-    dataframe::AdhocDataframeBuilder::RawColumn& rc,
-    uint32_t row_count) {
+Tree::Column MoveRawColumn(dataframe::AdhocDataframeBuilder::RawColumn& rc,
+                           uint32_t row_count) {
   Tree::Column tc;
   if (!rc.storage) {
     // All-null column: default to Int64 with zero data.
@@ -62,13 +73,16 @@ Tree::Column ConvertRawColumn(
            static_cast<uint64_t>(row_count) * sizeof(int64_t));
   } else if (rc.storage->type().Is<Int64>()) {
     tc.type = Tree::Column::Type(Int64{});
-    tc.data = CopyColumn(rc.storage->unchecked_get<Int64>().span());
+    auto& values = rc.storage->unchecked_get<Int64>();
+    tc.data = std::move(values).TakeSlab().TakeAsBytes();
   } else if (rc.storage->type().Is<Double>()) {
     tc.type = Tree::Column::Type(Double{});
-    tc.data = CopyColumn(rc.storage->unchecked_get<Double>().span());
+    auto& values = rc.storage->unchecked_get<Double>();
+    tc.data = std::move(values).TakeSlab().TakeAsBytes();
   } else if (rc.storage->type().Is<String>()) {
     tc.type = Tree::Column::Type(String{});
-    tc.data = CopyColumn(rc.storage->unchecked_get<String>().span());
+    auto& values = rc.storage->unchecked_get<String>();
+    tc.data = std::move(values).TakeSlab().TakeAsBytes();
   } else {
     PERFETTO_FATAL("Unexpected storage type in raw column");
   }
@@ -76,12 +90,45 @@ Tree::Column ConvertRawColumn(
   return tc;
 }
 
-uint32_t FindComponent(uint32_t row, Slab<uint32_t>& component) {
-  while (component[row] != row) {
-    component[row] = component[component[row]];
-    row = component[row];
+// Converts a raw column into parent-before-child row order. This is the only
+// payload copy needed when constructing a Tree from unordered input.
+Tree::Column GatherRawColumn(dataframe::AdhocDataframeBuilder::RawColumn& rc,
+                             uint32_t row_count,
+                             Span<const uint32_t> order) {
+  Tree::Column tc;
+  const BitVector* source_non_null =
+      rc.null_bv.size() > 0 ? &rc.null_bv : nullptr;
+  if (!rc.storage) {
+    // All-null column: default to Int64 with zero data.
+    tc = Tree::Column::Create<int64_t>(row_count);
+    memset(tc.data.begin(), 0,
+           static_cast<uint64_t>(row_count) * sizeof(int64_t));
+    tc.null_bv = BitVector::CreateWithSize(row_count);
+    return tc;
   }
-  return row;
+  if (source_non_null) {
+    tc.null_bv = BitVector::CreateWithSize(row_count);
+  }
+  BitVector* output_non_null = tc.null_bv.size() > 0 ? &tc.null_bv : nullptr;
+  if (rc.storage->type().Is<Int64>()) {
+    tc.type = Tree::Column::Type(Int64{});
+    const auto& values = rc.storage->unchecked_get<Int64>();
+    tc.data = GatherColumnData(values.span(), order, source_non_null,
+                               output_non_null);
+  } else if (rc.storage->type().Is<Double>()) {
+    tc.type = Tree::Column::Type(Double{});
+    const auto& values = rc.storage->unchecked_get<Double>();
+    tc.data = GatherColumnData(values.span(), order, source_non_null,
+                               output_non_null);
+  } else if (rc.storage->type().Is<String>()) {
+    tc.type = Tree::Column::Type(String{});
+    const auto& values = rc.storage->unchecked_get<String>();
+    tc.data = GatherColumnData(values.span(), order, source_non_null,
+                               output_non_null);
+  } else {
+    PERFETTO_FATAL("Unexpected storage type in raw column");
+  }
+  return tc;
 }
 
 struct IdIndex {
@@ -161,9 +208,7 @@ base::StatusOr<Tree> BuildFromRawColumns(
   bool identity_ids = true;
   bool uint32_ids = true;
   uint32_t max_id = 0;
-  Slab<uint32_t> component = Slab<uint32_t>::Alloc(row_count);
   for (uint32_t i = 0; i < row_count; ++i) {
-    component[i] = i;
     int64_t id = id_vec[i];
     identity_ids = identity_ids && id == i;
     if (id < 0 ||
@@ -198,50 +243,90 @@ base::StatusOr<Tree> BuildFromRawColumns(
   const IdIndex id_index{identity_ids, dense_ids, row_count,
                          MakeSpan(dense_index), &hash_index};
 
-  // Normalize parent_id to row indices and union each node with its parent.
-  // Because every node has at most one parent, an edge whose endpoints are
-  // already connected is exactly a directed cycle.
+  // Normalize parent_id to input row indices first. Track whether the input
+  // already satisfies the Tree ordering invariant while doing so.
   auto& pid_rc = raw_cols[1];
-  result.parent = Slab<uint32_t>::Alloc(row_count);
-  if (!pid_rc.storage) {
-    for (uint32_t row = 0; row < row_count; ++row) {
-      result.parent[row] = Tree::kNullParent;
-    }
-  } else {
-    if (!pid_rc.storage->type().Is<Int64>()) {
-      return base::ErrStatus("tree: parent_id column must be integer");
-    }
+  Slab<uint32_t> input_parent = Slab<uint32_t>::Alloc(row_count);
+  std::fill_n(input_parent.data(), row_count, Tree::kNullParent);
+  bool identity_order = true;
+  if (pid_rc.storage && !pid_rc.storage->type().Is<Int64>()) {
+    return base::ErrStatus("tree: parent_id column must be integer");
+  }
+  if (pid_rc.storage) {
     const auto& pid_vec = pid_rc.storage->unchecked_get<Int64>();
     for (uint32_t row = 0; row < row_count; ++row) {
       if (pid_rc.null_bv.size() > 0 && !pid_rc.null_bv.is_set(row)) {
-        result.parent[row] = Tree::kNullParent;
         continue;
       }
       std::optional<uint32_t> parent = id_index.Find(pid_vec[row]);
       if (PERFETTO_UNLIKELY(!parent)) {
         return base::ErrStatus("tree: parent_id not found in id column");
       }
-      result.parent[row] = *parent;
-      uint32_t row_component = FindComponent(row, component);
-      uint32_t parent_component = FindComponent(*parent, component);
-      if (PERFETTO_UNLIKELY(row_component == parent_component)) {
-        return base::ErrStatus("tree: cycle detected");
+      input_parent[row] = *parent;
+      if (*parent >= row) {
+        identity_order = false;
       }
-      // Prefer the component rooted at the later row. This keeps the next row
-      // close to the root for both parent-first and child-first inputs.
-      if (row_component < parent_component) {
-        component[row_component] = parent_component;
-      } else {
-        component[parent_component] = row_component;
+    }
+  }
+
+  std::vector<uint32_t> order;
+  if (identity_order) {
+    // A parent-before-child relation cannot contain a cycle. Keep its parent
+    // storage and columns in place without constructing any row maps.
+    result.parent = std::move(input_parent);
+  } else {
+    // Topologically order nodes directly through their parent pointers. Use
+    // the unfilled suffix of result.parent as the current path stack. Emitting
+    // the path parent-first then overwrites each input_parent slot with its
+    // output row, fusing parent normalization with topological ordering.
+    constexpr uint8_t kVisiting = 1;
+    constexpr uint8_t kVisited = 2;
+    std::vector<uint8_t> state(row_count);
+    order.reserve(row_count);
+    result.parent = Slab<uint32_t>::Alloc(row_count);
+    for (uint32_t start = 0; start < row_count; ++start) {
+      if (state[start] == kVisited) {
+        continue;
+      }
+
+      uint32_t path_size = 0;
+      uint32_t row = start;
+      while (row != Tree::kNullParent && state[row] == 0) {
+        state[row] = kVisiting;
+        result.parent[row_count - ++path_size] = row;
+        row = input_parent[row];
+      }
+      if (row != Tree::kNullParent && state[row] == kVisiting) {
+        return base::ErrStatus("tree: cycle detected in parent relation");
+      }
+
+      while (path_size > 0) {
+        uint32_t input_row = result.parent[row_count - path_size--];
+        uint32_t parent = input_parent[input_row];
+        uint32_t output_row = static_cast<uint32_t>(order.size());
+        result.parent[output_row] = parent == Tree::kNullParent
+                                        ? Tree::kNullParent
+                                        : input_parent[parent];
+        input_parent[input_row] = output_row;
+        state[input_row] = kVisited;
+        order.push_back(input_row);
       }
     }
   }
 
   result.names.reserve(raw_cols.size());
   result.columns.reserve(raw_cols.size());
-  for (auto& rc : raw_cols) {
-    result.names.push_back(std::move(rc.name));
-    result.columns.push_back(ConvertRawColumn(rc, row_count));
+  if (identity_order) {
+    for (auto& rc : raw_cols) {
+      result.names.push_back(std::move(rc.name));
+      result.columns.push_back(MoveRawColumn(rc, row_count));
+    }
+  } else {
+    // Gather all columns (including id/parent_id) in topological order.
+    for (auto& rc : raw_cols) {
+      result.names.push_back(std::move(rc.name));
+      result.columns.push_back(GatherRawColumn(rc, row_count, MakeSpan(order)));
+    }
   }
   return std::move(result);
 }

--- a/src/trace_processor/core/util/flex_vector.h
+++ b/src/trace_processor/core/util/flex_vector.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <cstring>
 #include <type_traits>
+#include <utility>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/utils.h"
@@ -226,6 +227,14 @@ class FlexVector {
 
   // Returns the current capacity (maximum size without reallocation).
   PERFETTO_ALWAYS_INLINE uint64_t capacity() const { return slab_.size(); }
+
+  // Transfers the backing allocation with its logical size. Any spare capacity
+  // remains allocated but is no longer part of the returned slab's size.
+  Slab<T> TakeSlab() && {
+    slab_.Truncate(size_);
+    size_ = 0;
+    return std::move(slab_);
+  }
 
  private:
   // Constructor used by Alloc.

--- a/src/trace_processor/core/util/flex_vector_unittest.cc
+++ b/src/trace_processor/core/util/flex_vector_unittest.cc
@@ -17,6 +17,8 @@
 #include "src/trace_processor/core/util/flex_vector.h"
 
 #include <cstddef>
+#include <cstdint>
+#include <utility>
 
 #include "test/gtest_and_gmock.h"
 
@@ -207,6 +209,26 @@ TEST(FlexVectorTest, CreateFilled) {
   for (uint64_t i = 0; i < vec.size(); ++i) {
     EXPECT_EQ(vec[i], 0xffffffffu);
   }
+}
+
+TEST(FlexVectorTest, TransfersBackingSlabAsBytes) {
+  auto vec = FlexVector<int64_t>::CreateWithCapacity(64);
+  vec.push_back(10);
+  vec.push_back(20);
+  int64_t* original_data = vec.data();
+
+  Slab<int64_t> slab = std::move(vec).TakeSlab();
+  ASSERT_EQ(slab.size(), 2u);
+  EXPECT_EQ(slab.data(), original_data);
+  EXPECT_EQ(slab[0], 10);
+  EXPECT_EQ(slab[1], 20);
+
+  Slab<uint8_t> bytes = std::move(slab).TakeAsBytes();
+  ASSERT_EQ(bytes.size(), 2u * sizeof(int64_t));
+  EXPECT_EQ(bytes.data(), reinterpret_cast<uint8_t*>(original_data));
+  const int64_t* values = reinterpret_cast<const int64_t*>(bytes.data());
+  EXPECT_EQ(values[0], 10);
+  EXPECT_EQ(values[1], 20);
 }
 
 TEST(FlexVectorTest, Reserve) {

--- a/src/trace_processor/core/util/ops.h
+++ b/src/trace_processor/core/util/ops.h
@@ -19,11 +19,59 @@
 
 #include <cstdint>
 
+#include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/span.h"
 
 namespace perfetto::trace_processor::core::ops {
+
+// Copies rows selected by |source_rows| into a dense output. Exact in-place
+// operation is supported when source_rows[i] >= i. Partial overlap is not
+// supported. Keep this pure-copy loop in the header: function and alias-check
+// overhead is measurable when Dataframe gathers small columns.
+template <typename T>
+void GatherRows(Span<const T> source,
+                Span<T> output,
+                Span<const uint32_t> source_rows) {
+  PERFETTO_DCHECK(output.size() >= source_rows.size());
+  const bool in_place = source.b == output.b;
+  for (uint32_t row = 0; row < source_rows.size(); ++row) {
+    PERFETTO_DCHECK(source_rows[row] < source.size());
+    PERFETTO_DCHECK(!in_place || source_rows[row] >= row);
+    output[row] = source[source_rows[row]];
+  }
+}
+
+// Gathers dense nullable rows. The value spans and null bitvectors can each
+// alias their corresponding input exactly when source_rows[i] >= i. Partial
+// overlap is not supported.
+template <typename T>
+void GatherNullableRows(Span<const T> source,
+                        const BitVector& source_non_null,
+                        Span<T> output,
+                        BitVector* output_non_null,
+                        Span<const uint32_t> source_rows) {
+  PERFETTO_DCHECK(output.size() >= source_rows.size());
+  PERFETTO_DCHECK(output_non_null->size() >= source_rows.size());
+  const bool values_in_place = source.b == output.b;
+  const bool nulls_in_place = &source_non_null == output_non_null;
+  for (uint32_t row = 0; row < source_rows.size(); ++row) {
+    const uint32_t source_row = source_rows[row];
+    PERFETTO_DCHECK(source_row < source.size());
+    PERFETTO_DCHECK((!values_in_place && !nulls_in_place) || source_row >= row);
+    const bool non_null = source_non_null.is_set(source_row);
+    if (non_null) {
+      output[row] = source[source_row];
+    }
+    if (nulls_in_place) {
+      output_non_null->change(row, non_null);
+    } else {
+      output_non_null->change_assume_unset(row, non_null);
+    }
+  }
+}
 
 // Estimates the number of distinct values using a bounded strided sample.
 template <typename T>

--- a/src/trace_processor/core/util/ops_unittest.cc
+++ b/src/trace_processor/core/util/ops_unittest.cc
@@ -19,11 +19,57 @@
 #include <cstdint>
 
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/span.h"
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto::trace_processor::core::ops {
 namespace {
+
+TEST(OpsTest, GatherRows) {
+  const int64_t source[] = {10, 20, 30, 40};
+  const uint32_t rows[] = {3, 1};
+  int64_t output[2];
+  GatherRows(MakeSpan(source), MakeMutableSpan(output), MakeSpan(rows));
+  EXPECT_THAT(output, testing::ElementsAre(40, 20));
+}
+
+TEST(OpsTest, GatherNullableRows) {
+  const int64_t source[] = {10, 20, 30};
+  BitVector source_non_null = BitVector::CreateWithSize(3, true);
+  source_non_null.clear(1);
+  const uint32_t rows[] = {1, 2};
+  int64_t output[2];
+  BitVector output_non_null = BitVector::CreateWithSize(2, false);
+  GatherNullableRows(MakeSpan(source), source_non_null, MakeMutableSpan(output),
+                     &output_non_null, MakeSpan(rows));
+  EXPECT_FALSE(output_non_null.is_set(0));
+  EXPECT_TRUE(output_non_null.is_set(1));
+  EXPECT_EQ(output[1], 30);
+}
+
+TEST(OpsTest, GatherRowsInPlace) {
+  int64_t values[] = {10, 20, 30, 40};
+  const uint32_t rows[] = {1, 3};
+  GatherRows(MakeSpan(values), MakeMutableSpan(values), MakeSpan(rows));
+  EXPECT_EQ(values[0], 20);
+  EXPECT_EQ(values[1], 40);
+}
+
+TEST(OpsTest, GatherNullableRowsInPlace) {
+  int64_t values[] = {10, 20, 30, 40};
+  BitVector non_null = BitVector::CreateWithSize(4, false);
+  non_null.set(1);
+  non_null.set(3);
+  const uint32_t rows[] = {1, 2};
+
+  GatherNullableRows(MakeSpan(values), non_null, MakeMutableSpan(values),
+                     &non_null, MakeSpan(rows));
+
+  EXPECT_EQ(values[0], 20);
+  EXPECT_TRUE(non_null.is_set(0));
+  EXPECT_FALSE(non_null.is_set(1));
+}
 
 TEST(OpsTest, EstimateDistinctCount) {
   base::FlatHashMap<int64_t, uint32_t> counts;

--- a/src/trace_processor/core/util/slab.h
+++ b/src/trace_processor/core/util/slab.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "perfetto/base/logging.h"
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/core/util/span.h"
@@ -71,6 +72,19 @@ class Slab {
         size);
   }
 
+  // Shrinks the logical size without changing the underlying allocation.
+  void Truncate(uint64_t size) {
+    PERFETTO_CHECK(size <= size_);
+    size_ = size;
+  }
+
+  // Transfers this allocation into a byte slab without copying.
+  Slab<uint8_t> TakeAsBytes() && {
+    static_assert(std::is_trivially_copyable_v<T>);
+    uint64_t bytes = size_ * sizeof(T);
+    return Slab<uint8_t>(reinterpret_cast<uint8_t*>(data_.release()), bytes);
+  }
+
   // Returns a pointer to the underlying data.
   PERFETTO_ALWAYS_INLINE const T* data() const { return data_.get(); }
   PERFETTO_ALWAYS_INLINE T* data() { return data_.get(); }
@@ -96,6 +110,9 @@ class Slab {
   }
 
  private:
+  template <typename U>
+  friend class Slab;
+
   // Constructor used by Alloc.
   Slab(T* data, uint64_t size) : data_(data), size_(size) {}
 


### PR DESCRIPTION
Reorder arbitrary DataFrame input while constructing Trees so every parent
precedes its children. Preserve the fast path for already ordered input and
detect cycles while computing the reordered traversal.
