### PR TITLE
ai: add TraceConfig reference and exemplar configs to skill

### DIFF
--- a/ai/skills/perfetto/SKILL-template.md
+++ b/ai/skills/perfetto/SKILL-template.md
@@ -28,6 +28,11 @@ If you need to capture a new trace from an Android device:
 *   To record Java/native heap dumps, CPU stack samples, system traces, or a
     custom config via the Perfetto helper scripts, read
     [recording_android_traces.md]($SKILL_ROOT/infra-references/recording_android_traces.md).
+*   To synthesize a custom trace config (mixing data sources: scheduling,
+    atrace, memory counters, heap profiles, long/ring-buffer traces), read
+    [trace_config_reference.md]($SKILL_ROOT/infra-references/trace_config_reference.md)
+    and start from the exemplars in
+    `$SKILL_ROOT/infra-references/example-configs/`.
 
 ## 2. Are you trying to solve memory issues?
 

--- a/ai/skills/perfetto/SKILL-template.md
+++ b/ai/skills/perfetto/SKILL-template.md
@@ -23,16 +23,14 @@ written against. It is the only always-required file.
 
 ## 1. Are you trying to record a trace?
 
-If you need to capture a new trace from an Android device:
+If you need to capture a new trace:
 
-*   To record Java/native heap dumps, CPU stack samples, system traces, or a
-    custom config via the Perfetto helper scripts, read
+*   **On an Android device:** to record Java/native heap dumps, CPU stack
+    samples, system traces, or a custom config via the Perfetto helper
+    scripts, read
     [recording_android_traces.md]($SKILL_ROOT/infra-references/recording_android_traces.md).
-*   To synthesize a custom trace config (mixing data sources: scheduling,
-    atrace, memory counters, heap profiles, long/ring-buffer traces), read
-    [trace_config_reference.md]($SKILL_ROOT/infra-references/trace_config_reference.md)
-    and start from the exemplars in
-    `$SKILL_ROOT/infra-references/example-configs/`.
+*   **On Linux:** to record config-driven traces with `tracebox`, read
+    [recording_linux_traces.md]($SKILL_ROOT/infra-references/recording_linux_traces.md).
 
 ## 2. Are you trying to solve memory issues?
 

--- a/ai/skills/perfetto/infra-references/example-configs/app_jank.pftxt
+++ b/ai/skills/perfetto/infra-references/example-configs/app_jank.pftxt
@@ -1,0 +1,43 @@
+# App jank / slow UI: framework + app atrace events, frame deadlines from
+# SurfaceFlinger, and the scheduling context underneath.
+# Replace com.example.myapp with the app's package name.
+buffers {
+  size_kb: 65536
+  fill_policy: RING_BUFFER
+}
+duration_ms: 10000
+
+data_sources {
+  config {
+    name: "linux.ftrace"
+    ftrace_config {
+      ftrace_events: "sched/sched_switch"
+      ftrace_events: "sched/sched_wakeup"
+      ftrace_events: "sched/sched_waking"
+      ftrace_events: "power/cpu_frequency"
+      ftrace_events: "power/cpu_idle"
+      atrace_categories: "gfx"
+      atrace_categories: "view"
+      atrace_categories: "wm"
+      atrace_categories: "am"
+      atrace_categories: "input"
+      atrace_apps: "com.example.myapp"
+    }
+  }
+}
+
+# Per-frame expected vs actual timelines (actual jank classification).
+data_sources {
+  config {
+    name: "android.surfaceflinger.frametimeline"
+  }
+}
+
+data_sources {
+  config {
+    name: "linux.process_stats"
+    process_stats_config {
+      scan_all_processes_on_start: true
+    }
+  }
+}

--- a/ai/skills/perfetto/infra-references/example-configs/cpu_profile.pftxt
+++ b/ai/skills/perfetto/infra-references/example-configs/cpu_profile.pftxt
@@ -1,0 +1,35 @@
+# CPU callstack sampling via traced_perf: periodic stack samples to find hot
+# functions. Prefer the cpu_profile helper script for a standalone profile;
+# use this config when combining with other data sources.
+# Replace com.example.myapp with the app's package name, or drop the scope
+# block to sample all processes.
+buffers {
+  size_kb: 65536
+  fill_policy: RING_BUFFER
+}
+duration_ms: 10000
+
+data_sources {
+  config {
+    name: "linux.perf"
+    perf_event_config {
+      timebase {
+        frequency: 100
+      }
+      callstack_sampling {
+        scope {
+          target_cmdline: "com.example.myapp"
+        }
+      }
+    }
+  }
+}
+
+data_sources {
+  config {
+    name: "linux.process_stats"
+    process_stats_config {
+      scan_all_processes_on_start: true
+    }
+  }
+}

--- a/ai/skills/perfetto/infra-references/example-configs/java_heap_dump.pftxt
+++ b/ai/skills/perfetto/infra-references/example-configs/java_heap_dump.pftxt
@@ -1,0 +1,21 @@
+# Java heap dump (retention graph) of one app. Prefer the java_heap_dump
+# helper script for a standalone dump; use this config when combining a heap
+# dump with other data sources in one trace.
+# Replace com.example.myapp with the app's package name.
+buffers {
+  size_kb: 102400
+}
+duration_ms: 30000
+
+data_sources {
+  config {
+    name: "android.java_hprof"
+    java_hprof_config {
+      process_cmdline: "com.example.myapp"
+    }
+  }
+}
+
+# Heap dumps can be large; stream to the output file instead of relying on
+# the in-memory buffer alone.
+write_into_file: true

--- a/ai/skills/perfetto/infra-references/example-configs/long_background.pftxt
+++ b/ai/skills/perfetto/infra-references/example-configs/long_background.pftxt
@@ -1,0 +1,37 @@
+# Long / field trace: runs until stopped, keeps the most recent data in a
+# ring buffer, and periodically flushes to the output file so the trace
+# survives longer than RAM allows.
+buffers {
+  size_kb: 65536
+  fill_policy: RING_BUFFER
+}
+
+# No duration_ms: stop manually (Ctrl-C on record_android_trace), or add one.
+# Move data to the output file periodically instead of only at the end.
+write_into_file: true
+file_write_period_ms: 2500
+# Commit app shared-memory buffers periodically so events stay ordered.
+flush_period_ms: 30000
+# Stop when the output file reaches this size (bytes).
+max_file_size_bytes: 1000000000
+
+data_sources {
+  config {
+    name: "linux.ftrace"
+    ftrace_config {
+      ftrace_events: "sched/sched_switch"
+      ftrace_events: "sched/sched_wakeup"
+      ftrace_events: "power/cpu_frequency"
+      ftrace_events: "power/cpu_idle"
+    }
+  }
+}
+
+data_sources {
+  config {
+    name: "linux.process_stats"
+    process_stats_config {
+      scan_all_processes_on_start: true
+    }
+  }
+}

--- a/ai/skills/perfetto/infra-references/example-configs/memory_counters.pftxt
+++ b/ai/skills/perfetto/infra-references/example-configs/memory_counters.pftxt
@@ -1,0 +1,45 @@
+# System and per-process memory over time: meminfo/vmstat counters polled
+# periodically, per-process RSS via both polling and kernel rss_stat events,
+# and low-memory-killer activity.
+buffers {
+  size_kb: 32768
+}
+duration_ms: 30000
+
+data_sources {
+  config {
+    name: "linux.sys_stats"
+    sys_stats_config {
+      meminfo_period_ms: 1000
+      meminfo_counters: MEMINFO_MEM_TOTAL
+      meminfo_counters: MEMINFO_MEM_FREE
+      meminfo_counters: MEMINFO_MEM_AVAILABLE
+      meminfo_counters: MEMINFO_SWAP_FREE
+      vmstat_period_ms: 1000
+      vmstat_counters: VMSTAT_NR_FREE_PAGES
+      vmstat_counters: VMSTAT_PGFAULT
+      vmstat_counters: VMSTAT_PGMAJFAULT
+    }
+  }
+}
+
+data_sources {
+  config {
+    name: "linux.process_stats"
+    process_stats_config {
+      proc_stats_poll_ms: 10000
+      scan_all_processes_on_start: true
+    }
+  }
+}
+
+data_sources {
+  config {
+    name: "linux.ftrace"
+    ftrace_config {
+      ftrace_events: "kmem/rss_stat"
+      ftrace_events: "lowmemorykiller/lowmemory_kill"
+      ftrace_events: "oom/oom_score_adj_update"
+    }
+  }
+}

--- a/ai/skills/perfetto/infra-references/example-configs/native_heap.pftxt
+++ b/ai/skills/perfetto/infra-references/example-configs/native_heap.pftxt
@@ -1,0 +1,21 @@
+# Native (C/C++) heap profiling via heapprofd: sampled malloc/free callstacks
+# for one app. Prefer the heap_profile helper script for a standalone profile;
+# use this config when combining with other data sources.
+# Replace com.example.myapp with the app's package name.
+buffers {
+  size_kb: 65536
+}
+duration_ms: 30000
+
+data_sources {
+  config {
+    name: "android.heapprofd"
+    heapprofd_config {
+      sampling_interval_bytes: 4096
+      process_cmdline: "com.example.myapp"
+      # To profile ART/JNI and custom allocators too, add: all_heaps: true
+    }
+  }
+}
+
+write_into_file: true

--- a/ai/skills/perfetto/infra-references/example-configs/sched_cpu.pftxt
+++ b/ai/skills/perfetto/infra-references/example-configs/sched_cpu.pftxt
@@ -1,0 +1,33 @@
+# CPU scheduling: who ran when, on which core, at what clock speed.
+# The base layer for almost any performance investigation.
+buffers {
+  size_kb: 32768
+  fill_policy: RING_BUFFER
+}
+duration_ms: 10000
+
+data_sources {
+  config {
+    name: "linux.ftrace"
+    ftrace_config {
+      ftrace_events: "sched/sched_switch"
+      ftrace_events: "sched/sched_wakeup"
+      ftrace_events: "sched/sched_waking"
+      ftrace_events: "sched/sched_process_exit"
+      ftrace_events: "sched/sched_process_free"
+      ftrace_events: "power/cpu_frequency"
+      ftrace_events: "power/cpu_idle"
+      ftrace_events: "power/suspend_resume"
+    }
+  }
+}
+
+# Resolves thread/process ids in sched events to readable names.
+data_sources {
+  config {
+    name: "linux.process_stats"
+    process_stats_config {
+      scan_all_processes_on_start: true
+    }
+  }
+}

--- a/ai/skills/perfetto/infra-references/recording_android_traces.md
+++ b/ai/skills/perfetto/infra-references/recording_android_traces.md
@@ -123,14 +123,18 @@ System).
 
 --------------------------------------------------------------------------------
 
-## 4. Fallback: "Choose Your Own Adventure" (Custom Configs)
+## 4. Custom Configs (Mix & Match Data Sources)
 
 If you need a custom mixture of data sources (e.g., combining Java heap dumps
-with ftrace) that is not covered by the specialized scripts:
+with ftrace), or control the command-line flags don't offer (ring buffers,
+long traces, per-counter polling), synthesize a config:
 
-1.  **Synthesize the Config:** Draft a custom Perfetto protobuf text
-    configuration (`config.pftxt`) based on the data source schemas and examples
-    from the official
+1.  **Read the config reference:**
+    [trace_config_reference.md]($SKILL_ROOT/infra-references/trace_config_reference.md)
+    explains the config shape and every common data source, and points to
+    ready-made exemplar configs in
+    `$SKILL_ROOT/infra-references/example-configs/` that you can start from
+    and merge. For exotic data sources not covered there, draft from the
     [Perfetto Data Sources Documentation](https://perfetto.dev/docs/data-sources/).
 2.  **Save the Config:** Write the synthesized text configuration to a local
     file (e.g., `config.pftxt`).
@@ -141,3 +145,6 @@ with ftrace) that is not covered by the specialized scripts:
     ```bash
     ./record_android_trace -c config.pftxt -o ./my_trace.perfetto-trace
     ```
+
+    If the config has a typo, this fails fast with a parse error naming the
+    bad field — fix the config and retry.

--- a/ai/skills/perfetto/infra-references/recording_android_traces.md
+++ b/ai/skills/perfetto/infra-references/recording_android_traces.md
@@ -1,9 +1,10 @@
 # Recording Perfetto Traces on Android (Helper Scripts)
 
 > [!IMPORTANT] **Scope:** This guide is **strictly for recording traces on
-> Android devices**. For other platforms (such as Linux, macOS, or Chrome),
-> please refer to the platform-specific documentation on
-> [perfetto.dev/docs](https://perfetto.dev/docs/).
+> Android devices**. For Linux, read
+> [recording_linux_traces.md]($SKILL_ROOT/infra-references/recording_linux_traces.md);
+> for other platforms (macOS, Chrome), please refer to the platform-specific
+> documentation on [perfetto.dev/docs](https://perfetto.dev/docs/).
 
 Rather than running raw `adb` commands, you should use the official Perfetto
 helper scripts. They automatically handle pushing configurations, starting the

--- a/ai/skills/perfetto/infra-references/recording_linux_traces.md
+++ b/ai/skills/perfetto/infra-references/recording_linux_traces.md
@@ -1,0 +1,66 @@
+# Recording Perfetto Traces on Linux
+
+> [!IMPORTANT] **Scope:** This guide is for recording traces on **Linux**
+> (desktop, server, embedded). For Android devices, read
+> [recording_android_traces.md]($SKILL_ROOT/infra-references/recording_android_traces.md)
+> instead. For other platforms (macOS, Chrome), see
+> [perfetto.dev/docs](https://perfetto.dev/docs/).
+
+On Linux everything is driven by a single statically-linked binary,
+`tracebox`, which bundles the tracing daemons (`traced`, `traced_probes`)
+and the `perfetto` recording command. There are no helper scripts and no
+category shorthand — recording is always config-driven.
+
+## 1. Download tracebox
+
+```bash
+curl -LO https://get.perfetto.dev/tracebox
+chmod +x tracebox
+```
+
+The binary is self-contained and can be copied to any Linux machine
+(x86_64 and arm64 builds are served automatically for the current host).
+
+## 2. Write a trace config
+
+Configs are the standard `TraceConfig` protobuf text format — the same
+format as everywhere else in Perfetto. Read
+[trace_config_reference.md]($SKILL_ROOT/infra-references/trace_config_reference.md)
+for the config shape and start from the exemplars in
+`$SKILL_ROOT/infra-references/example-configs/`.
+
+Linux-specific notes on the exemplars:
+
+*   `sched_cpu.pftxt`, `memory_counters.pftxt`, `cpu_profile.pftxt` and
+    `long_background.pftxt` work as-is on Linux.
+*   Anything Android-only does not apply: `atrace_categories` /
+    `atrace_apps` inside `ftrace_config`, and the `android.*` data sources
+    (`android.java_hprof`, `android.heapprofd`,
+    `android.surfaceflinger.frametimeline`, `android.log`, ...). Strip
+    those blocks when adapting an exemplar.
+*   In `linux.perf` / `heapprofd`-style scopes, `process_cmdline` matches
+    the process command line as on Android.
+
+## 3. Record
+
+```bash
+# ftrace needs root on most distros: run under sudo.
+sudo ./tracebox -o trace.perfetto-trace --txt -c config.pftxt
+```
+
+*   `--txt` says the config is text format (omit it for a binary-encoded
+    config).
+*   If the config has no `duration_ms`, recording runs until Ctrl-C.
+*   A config typo fails fast here with a parse error naming the bad
+    field — fix the config and retry.
+*   Data sources that only poll /proc (`linux.sys_stats`,
+    `linux.process_stats`) work without root; ftrace and `linux.perf`
+    generally need root or the right capabilities/sysctls
+    (`kernel.perf_event_paranoid` for `linux.perf`).
+
+## 4. Analyze
+
+The output file is a normal Perfetto trace: open it in
+[ui.perfetto.dev](https://ui.perfetto.dev) or query it directly on the
+same machine with `trace_processor` (see
+[querying.md]($SKILL_ROOT/infra-references/querying.md)).

--- a/ai/skills/perfetto/infra-references/trace_config_reference.md
+++ b/ai/skills/perfetto/infra-references/trace_config_reference.md
@@ -1,0 +1,99 @@
+# Synthesizing Perfetto Trace Configs (Mix & Match)
+
+Read this when you need a custom trace config — a mixture of data sources
+the specialized helper scripts don't cover. Start from the exemplar configs
+in `$SKILL_ROOT/infra-references/example-configs/`, then add, remove, or
+merge the pieces described below.
+
+## Shape of a config
+
+A config is a `TraceConfig` protobuf written in protobuf **text format**
+(conventionally saved as `config.pftxt`):
+
+```
+buffers {
+  size_kb: 32768            # sizes are in KB, not bytes
+  fill_policy: RING_BUFFER  # keep newest data; DISCARD keeps oldest
+}
+duration_ms: 10000          # omit to trace until stopped manually
+
+data_sources {
+  config {
+    name: "linux.ftrace"    # which producer to enable
+    ftrace_config { ... }   # that producer's own options
+  }
+}
+# ...more data_sources blocks, one per source...
+```
+
+Merging two configs = keep one `buffers` section and concatenate their
+`data_sources` blocks. Each data source may appear at most once (the
+`linux.ftrace` config especially: merge all `ftrace_events` /
+`atrace_categories` / `atrace_apps` entries into a single block).
+
+## Exemplar configs
+
+| File (under `$SKILL_ROOT/infra-references/example-configs/`) | Use case |
+| --- | --- |
+| `sched_cpu.pftxt` | CPU scheduling + frequency/idle. The base layer for most investigations. |
+| `app_jank.pftxt` | Slow UI / dropped frames: atrace categories, app events, frame timeline. |
+| `memory_counters.pftxt` | System + per-process memory over time, LMK activity. |
+| `java_heap_dump.pftxt` | Java heap retention graph for one app. |
+| `native_heap.pftxt` | Sampled native malloc/free callstacks (heapprofd). |
+| `cpu_profile.pftxt` | Periodic CPU callstack samples (traced_perf). |
+| `long_background.pftxt` | Long/field traces: ring buffer + periodic file writes. |
+
+For a standalone heap dump / native heap profile / CPU profile, prefer the
+dedicated helper scripts in
+[recording_android_traces.md]($SKILL_ROOT/infra-references/recording_android_traces.md);
+use the exemplars when one trace must combine several sources.
+
+## Data sources at a glance
+
+| `name` | What it records | Key options |
+| --- | --- | --- |
+| `linux.ftrace` | Kernel events and atrace | `ftrace_events` (e.g. `sched/sched_switch`, `power/cpu_frequency`, `kmem/rss_stat`, `binder/binder_transaction`); `atrace_categories` (`gfx`, `view`, `wm`, `am`, `input`, `binder_driver`, `dalvik`, ...); `atrace_apps` (package name, required for an app's own trace events) |
+| `linux.process_stats` | Process/thread names; per-process counters | `scan_all_processes_on_start: true`; `proc_stats_poll_ms` for periodic RSS/OOM-score polling |
+| `linux.sys_stats` | /proc counters polled periodically | `meminfo_period_ms` + `meminfo_counters` (`MEMINFO_MEM_FREE`, ...); `vmstat_period_ms` + `vmstat_counters`; `stat_period_ms` + `stat_counters` (CPU times); `cpufreq_period_ms` |
+| `android.log` | Logcat | `android_log_config { log_ids: LID_DEFAULT ... }` |
+| `android.surfaceflinger.frametimeline` | Per-frame expected/actual timelines (jank classification) | none needed |
+| `android.java_hprof` | Java heap dump | `java_hprof_config { process_cmdline: "<pkg>" }` |
+| `android.heapprofd` | Native heap profiling | `heapprofd_config { sampling_interval_bytes, process_cmdline, all_heaps }` |
+| `linux.perf` | CPU callstack sampling | `perf_event_config { timebase { frequency }, callstack_sampling { scope { target_cmdline } } }` |
+| `android.packages_list` | Package name/version/uid mapping | none needed |
+| `android.power` | Battery counters | `android_power_config { battery_poll_ms, battery_counters }` |
+| `track_event` | SDK-instrumented app events | `track_event_config { enabled_categories }` |
+
+The full, authoritative field list for every data source is the generated
+[TraceConfig reference](https://perfetto.dev/docs/reference/trace-config-proto);
+per-source guides live under
+[perfetto.dev/docs/data-sources](https://perfetto.dev/docs/data-sources/).
+
+## Top-level knobs
+
+- `duration_ms` — trace length. Omit it to trace until the recording
+  command is stopped (Ctrl-C on `record_android_trace`).
+- `buffers.fill_policy` — `RING_BUFFER` keeps the newest data (right choice
+  when the interesting moment is at the end); `DISCARD` keeps the oldest.
+- Long traces: `write_into_file: true` + `file_write_period_ms` stream the
+  buffer to disk periodically so the trace can exceed RAM;
+  `flush_period_ms: 30000` keeps app-emitted events ordered;
+  `max_file_size_bytes` bounds the output.
+- Buffer sizing rule of thumb: 32–64 MB (`size_kb: 32768`–`65536`) is
+  plenty for most 10–30s traces; heap dumps need ~100 MB or
+  `write_into_file`.
+
+## Pitfalls
+
+- All buffer sizes are **KB** (`size_kb: 32768` = 32 MB); durations are
+  **ms**.
+- atrace data (categories and app events) only flows through the
+  `linux.ftrace` data source — there is no separate "atrace" source, and
+  an app's custom trace events appear only if its package is listed in
+  `atrace_apps` (or `atrace_apps: "*"`).
+- Field-name typos are only caught when the config is parsed at record
+  time: `record_android_trace -c config.pftxt` fails fast with a parse
+  error naming the bad field, so treat that as your validator and fix and
+  retry.
+- Text-format enum values are bare identifiers (`fill_policy: RING_BUFFER`),
+  strings are quoted.

--- a/ai/skills/perfetto/infra-references/trace_config_reference.md
+++ b/ai/skills/perfetto/infra-references/trace_config_reference.md
@@ -7,8 +7,11 @@ merge the pieces described below.
 
 ## Shape of a config
 
-A config is a `TraceConfig` protobuf written in protobuf **text format**
-(conventionally saved as `config.pftxt`):
+A config is a `TraceConfig` protobuf — authoritative schema:
+<https://raw.githubusercontent.com/google/perfetto/main/protos/perfetto/config/trace_config.proto>
+(per-source option messages live under `protos/perfetto/config/` in the same
+repo, e.g. `.../ftrace/ftrace_config.proto`) — written in protobuf **text
+format** (conventionally saved as `config.pftxt`):
 
 ```
 buffers {


### PR DESCRIPTION
The recording part of the skill only covered the helper scripts; for
anything custom it pointed agents at the perfetto.dev data source docs
and left them to guess the config syntax, which produces configs with
invalid fields or missing data sources.

Add a mix-and-match TraceConfig reference and seven protoc-validated
exemplar configs the agent can start from and merge, and route to them
from the recording reference and the skill router.

Fixes #6514.