### PR TITLE
ai: save a report at the end of every skill analysis

### DIFF
--- a/ai/skills/perfetto/SKILL-template.md
+++ b/ai/skills/perfetto/SKILL-template.md
@@ -78,3 +78,13 @@ If you want to load a trace and write custom PerfettoSQL queries:
 
 Workflows above are self-contained (they carry their own queries); read
 `querying.md` only for ad-hoc work outside a workflow.
+
+## Finishing any analysis
+
+Whichever path you took — a guided workflow or ad-hoc queries — end by
+**saving a report of the analysis** as a markdown file in the working
+directory (default name: `perfetto_analysis_report.md`, or where the user
+asked). It should contain: the question investigated, the trace file(s)
+used, the findings with concrete numbers, the key validated queries so the
+analysis can be re-run, and open questions or suggested next steps. Tell
+the user the report's path in your final message.

--- a/ai/skills/perfetto/infra-references/querying.md
+++ b/ai/skills/perfetto/infra-references/querying.md
@@ -317,6 +317,12 @@ To ensure accuracy and efficiency, follow these steps:
 4. **Cleanup & Finalize:**
   - Explicitly return and state the final validated SQL and explain the
     results to the user.
+  - **Save an analysis report.** Write a markdown file in the working
+    directory (default `perfetto_analysis_report.md`) containing: the
+    question investigated, the trace file(s) analyzed, the findings with
+    concrete numbers, the final validated queries (so the analysis can be
+    re-run), and open questions / next steps. Point the user at it in
+    your final message.
   - Before finishing, delete any temporary SQL files created in `/tmp/`.
 
 ## Where to look for more


### PR DESCRIPTION
The opinionated workflows mostly end with a summary in the chat, and
ad-hoc analysis often ends with nothing durable at all: once the session
ends, the findings and the validated queries are gone.

Instruct the agent (in the router, which every path reads, and in the
ad-hoc querying SOP) to finish any analysis by saving a markdown report
with the question, findings, validated queries and next steps, so the
analysis is reproducible after the session.

Fixes #6678.

Stacked on #6954.