### PR TITLE
perfetto: document how to update the AI skill

### DIFF
--- a/docs/getting-started/using-ai.md
+++ b/docs/getting-started/using-ai.md
@@ -42,6 +42,21 @@ install into that agent's default directory.
 To share the setup with your team, point `--target` at a per-agent directory
 in your repo (for example `.claude/skills/`) and commit the result.
 
+## Update
+
+Updating uses the same mechanism as installing:
+
+| Installed via | Update by |
+| ------------- | --------- |
+| Claude Code marketplace | Claude Code's normal plugin update flow (`/plugin` → manage/update, which pulls the latest `ai-agents` branch). |
+| Codex marketplace | Codex's plugin update mechanism. |
+| OpenCode `skills.urls` | Nothing to do — the URL always serves the latest published skill. |
+| Fallback installer | Re-run the same `curl ... agents-install` command. It detects the existing install and asks before replacing it (pass `--yes` to skip the prompt). |
+
+New skill versions are published with each Perfetto release. The fallback
+installer installs the latest release by default; pass `--version vX.Y` to
+pin a specific one.
+
 ## Ad-hoc trace analysis
 
 Mention a trace file and ask your question; the agent loads the trace,


### PR DESCRIPTION
The install docs never said how to get a newer version of the skill,
so users were left guessing whether to reinstall, delete, or wait.
The answer is simple - the update path is the install path - but it
differs per agent, so spell it out.

Fixes #6516.