### PR TITLE
ai: make trace_processor sessions the default querying workflow

### DIFF
--- a/ai/skills/README.md
+++ b/ai/skills/README.md
@@ -90,8 +90,8 @@ bare `infra-references/querying.md` either. Likewise a helper script is
 `trace_processor` invocation spells the full path:
 
 ```sh
-trace_processor query --query-file \
-  $SKILL_ROOT/workflows/android_memory/scripts/triage_dominator_path.sql TRACE_FILE
+trace_processor query --remote SESSION --query-file \
+  $SKILL_ROOT/workflows/android_memory/scripts/triage_dominator_path.sql
 ```
 
 `$SKILL_ROOT` is the one anchor that makes this unambiguous. The skill

--- a/ai/skills/perfetto/infra-references/querying.md
+++ b/ai/skills/perfetto/infra-references/querying.md
@@ -14,83 +14,58 @@ runs on top of, including the Perfetto UI. Reference docs:
 > `$SKILL_ROOT/environment-references/setup.md`. It defines how to make
 > the bare `trace_processor` commands below work in this environment.
 
-## Quickstart
+## Querying a trace: sessions
 
-To run a single query and exit:
+Querying goes through a **session**: load the trace once into a named
+background session, then run every query against it with `--remote`.
+Parsing a trace is the expensive part (tens of seconds for a multi-GB
+trace); the session pays it once, and every real analysis runs more than
+one query.
 
 ```sh
-trace_processor query TRACE_FILE "SELECT ts, dur FROM slice LIMIT 10"
+# 1. Load the trace into a background session — once per trace.
+#    Pick a descriptive session name (e.g. derived from the trace file).
+trace_processor server unix --name mysession --daemonize TRACE_FILE
+
+# 2. Run queries against the warm session: instant, no reparse.
+trace_processor query --remote mysession \
+  "SELECT ts, dur, name FROM slice WHERE dur > 5e8 LIMIT 5"
+
+# 3. When you are completely done with the trace:
+trace_processor server kill mysession
 ```
 
 Multiple statements separated by `;` are supported in one invocation.
 
+Session rules:
+
+- Session names are managed by trace_processor in a per-user session
+  directory — there are no ports to choose and no collisions with other
+  agents or the Perfetto UI.
+- **Session state persists across `query --remote` calls.** A
+  `CREATE PERFETTO TABLE` or `INCLUDE PERFETTO MODULE` run in one call is
+  visible in the next, so materializing intermediate results pays off
+  across invocations.
+- Flags that configure trace loading (`--full-sort`,
+  `--add-sql-package`, ...) belong on the `server unix` invocation, not
+  on `query --remote` — the client rejects them with an explanatory
+  error.
+- `--remote` also accepts an absolute `*.sock` path or `host:port`;
+  names are the common case.
+- Forgotten sessions are reaped automatically after 30 minutes idle
+  (`--idle-timeout`), but kill your session when the analysis is done.
+
 `TRACE_FILE` can be a local path, an `http(s)://` URL, or a Perfetto UI
 share link (`https://ui.perfetto.dev/#!/?s=<hash>`) — in the last two
-cases trace_processor downloads the trace for you, resolving the share
-link to its underlying trace first:
+cases trace_processor downloads the trace for you (cached under
+`~/.cache/perfetto/` or the platform equivalent), resolving the share
+link to its underlying trace first.
 
-```sh
-trace_processor query "https://ui.perfetto.dev/#!/?s=<hash>" \
-  "SELECT name, dur FROM slice ORDER BY dur DESC LIMIT 10"
-```
-
-Downloaded traces are cached locally (under `~/.cache/perfetto/`, or the
-platform equivalent), so re-running on the same URL doesn't re-download.
-The same `URL`/share-link form works anywhere a trace path is accepted
-(`query`, `server`, the interactive shell, etc.).
-
-## Long-running mode (preferred for iteration)
-
-Reparsing a trace on every query is slow — for a multi-GB trace it's tens
-of seconds, every time. When you expect to run more than a couple of
-queries, start the shell once as an HTTP RPC server and drive it from
-the Python client. (If the `perfetto` Python package is not installed
-yet, `pip install perfetto protobuf` — ideally into a venv.)
-
-```sh
-# Terminal A: pick a random high port and start the server on it.
-# Always pass --port explicitly: the default (9001) is also used by
-# the Perfetto UI, and a fixed port collides with any other agent
-# already running a trace_processor server.
-PORT=$((9100 + RANDOM % 900))
-trace_processor server http --port $PORT TRACE_FILE
-```
-
-```python
-# Terminal B (or any Python process): connect to the running server.
-# PORT is the value chosen in Terminal A.
-from perfetto.trace_processor import TraceProcessor
-
-tp = TraceProcessor(addr='127.0.0.1:PORT')
-for row in tp.query('SELECT ts, dur, name FROM slice WHERE dur > 5e8 LIMIT 5'):
-    print(row.dur, row.name)
-
-# Pandas is also supported if the dependency is installed:
-df = tp.query('SELECT ts, dur, name FROM slice LIMIT 100').as_pandas_dataframe()
-
-tp.close()
-```
-
-The server keeps the trace parsed in memory; each `tp.query()` call is
-just a query against the existing session. This is the same RPC channel
-`ui.perfetto.dev` uses when you load a trace there.
-
-Notes:
-
-- Use `'127.0.0.1:PORT'`, not `'localhost:PORT'`. The server binds on
-  IPv4/IPv6 explicitly and `localhost` resolution can pick an interface
-  that isn't bound on macOS.
-- A quick liveness check from the shell:
-  `curl http://127.0.0.1:PORT/status` returns plain JSON-ish status
-  (loaded path, version) and is the fastest way to confirm the server
-  is up.
-- The on-the-wire `/query`, `/parse`, `/rpc` endpoints take protobuf-
-  encoded `QueryArgs`/`TraceProcessorRpc` payloads. **Do not hand-craft
-  HTTP calls with `curl`** — use the Python client (or the WASM
-  client embedded in the UI). Hand-crafted calls work for `/status` only.
-- If you want to stay in the C++ shell instead of Python, a one-shot
-  `trace_processor query TRACE_FILE "..."` is fine for a handful of
-  queries; the server is the right answer the moment iteration starts.
+For a single throwaway query on a small trace you *can* skip the session
+(`trace_processor query TRACE_FILE "..."` parses, queries, and exits),
+but treat that as the exception: it re-parses the trace on every
+invocation and forgets created tables and included modules between
+calls. Default to a session.
 
 ## Discovering what's in the trace
 
@@ -303,7 +278,8 @@ To ensure accuracy and efficiency, follow these steps:
   - [ ] **String Matching:** Did you use `GLOB` or `=` instead of `LIKE`?
   - [ ] **Span Join Check:** If using `SPAN_JOIN`, are tables `PARTITIONED`
     and materialized?
-  - [ ] **Execute:** Run using `trace_processor query TRACE_FILE "QUERY"`.
+  - [ ] **Execute:** Run against the session:
+    `trace_processor query --remote SESSION "QUERY"`.
 
    **Execution Rules:**
   - **File Usage:** If you must create a SQL file to execute queries (for

--- a/ai/skills/perfetto/workflows/android_memory/heap_dump.md
+++ b/ai/skills/perfetto/workflows/android_memory/heap_dump.md
@@ -22,7 +22,7 @@ good, not working, or inconclusive.
     the query result as CSV.
 
     ```bash
-    trace_processor query --query-file $SKILL_ROOT/workflows/android_memory/scripts/triage_dominator_path.sql TRACE_FILE
+    trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/android_memory/scripts/triage_dominator_path.sql
     ```
 
 2.  Parse the returned string CSV to identify the columns and extract the values

--- a/ai/skills/perfetto/workflows/android_memory/java_allocation_profile.md
+++ b/ai/skills/perfetto/workflows/android_memory/java_allocation_profile.md
@@ -29,7 +29,7 @@ This section is the mandatory first-pass triage for analyzing a Java allocation 
 1.  Run the trace query using the provided compiled script to extract the top allocation path. For triage, we look at the top allocator by default (unreleased, but the script can be adapted or we assume it's the primary signal).
 
     ```bash
-    trace_processor query --query-file $SKILL_ROOT/workflows/android_memory/scripts/triage_java_allocation.sql TRACE_FILE
+    trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/android_memory/scripts/triage_java_allocation.sql
     ```
 
 2.  Parse the returned string CSV to identify the columns and extract the values for `process_name`, `path` (callstack), `class_name` (leaf method), and `self_size` (allocated bytes). If the response is empty or contains only a header, inform the user that the query returned no matching data for this trace.

--- a/ai/skills/perfetto/workflows/android_memory/native_heap.md
+++ b/ai/skills/perfetto/workflows/android_memory/native_heap.md
@@ -13,7 +13,7 @@ This section is the mandatory first-pass triage for analyzing a native heap prof
 1.  Run the trace query using the provided compiled script to extract the top unreleased allocation path. The script takes the trace file as its argument and returns the query result as CSV.
 
     ```bash
-    trace_processor query --query-file $SKILL_ROOT/workflows/android_memory/scripts/triage_native_heap.sql TRACE_FILE
+    trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/android_memory/scripts/triage_native_heap.sql
     ```
 
 2.  Parse the returned string CSV to identify the columns and extract the values for `process_name`, `path` (callstack), `class_name` (leaf function), and `self_size` (allocated bytes). If the response is empty or contains only a header, inform the user that the query returned no matching data for this trace.

--- a/ai/skills/perfetto/workflows/gpu/compute/kernel_analysis.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/kernel_analysis.md
@@ -27,7 +27,7 @@ Run this before drilling any single kernel; it names the hotspot. The table is
 verdict needs vendor throughput counters and comes from Phase 2 (Speed of Light).
 
 ```bash
-trace_processor query --query-file $SKILL_ROOT/workflows/gpu/compute/scripts/kernels_summary.sql TRACE_FILE
+trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/compute/scripts/kernels_summary.sql
 ```
 
 Columns: `id` (launch order), `kernel`, `ugpu`, `dur_ns`, `block_size`,

--- a/ai/skills/perfetto/workflows/gpu/compute/launch_statistics.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/launch_statistics.md
@@ -17,7 +17,7 @@ producer — so this workflow is self-contained (no vendor layer).
 ## Get the data
 
 ```bash
-trace_processor query --query-file $SKILL_ROOT/workflows/gpu/compute/scripts/launch_statistics.sql TRACE_FILE
+trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/compute/scripts/launch_statistics.sql
 ```
 
 Columns: `id`, `kernel`, `block_size`, `grid_size`, `thread_count`,

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/occupancy.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/occupancy.md
@@ -5,7 +5,7 @@ block-size / waves / binding-resource interpretation from
 [occupancy.md]($SKILL_ROOT/workflows/gpu/compute/occupancy.md).
 
 ```bash
-trace_processor query --query-file $SKILL_ROOT/workflows/gpu/compute/nvidia/scripts/occupancy.sql TRACE_FILE
+trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/compute/nvidia/scripts/occupancy.sql
 ```
 
 One row per compute kernel (longest first). Display label → output column →

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/speed_of_light.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/speed_of_light.md
@@ -5,7 +5,7 @@ Run it, then apply the bound-type interpretation from
 [speed_of_light.md]($SKILL_ROOT/workflows/gpu/compute/speed_of_light.md).
 
 ```bash
-trace_processor query --query-file $SKILL_ROOT/workflows/gpu/compute/nvidia/scripts/speed_of_light.sql TRACE_FILE
+trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/compute/nvidia/scripts/speed_of_light.sql
 ```
 
 One row per compute kernel (longest first). Display label → output column →

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/workload_analysis.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/workload_analysis.md
@@ -5,7 +5,7 @@ it, then apply the interpretation from
 [workload_analysis.md]($SKILL_ROOT/workflows/gpu/compute/workload_analysis.md).
 
 ```bash
-trace_processor query --query-file $SKILL_ROOT/workflows/gpu/compute/nvidia/scripts/workload_analysis.sql TRACE_FILE
+trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/compute/nvidia/scripts/workload_analysis.sql
 ```
 
 One row per compute kernel (longest first). Display label → output column →

--- a/ai/skills/perfetto/workflows/gpu/frequency_residency.md
+++ b/ai/skills/perfetto/workflows/gpu/frequency_residency.md
@@ -34,7 +34,7 @@ Run this before any open-ended exploration. It produces the headline verdict.
     returns one row per GPU (that has a frequency track) as CSV.
 
     ```bash
-    trace_processor query --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_frequency_residency.sql TRACE_FILE
+    trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_frequency_residency.sql
     ```
 
     Columns: `gpu`, `gpu_name`, `active_span_ns`, `gpu_busy_ns`,
@@ -133,7 +133,7 @@ Run this before any open-ended exploration. It produces the headline verdict.
     a healthy state:
 
     ```bash
-    trace_processor query --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_dvfs_ramp.sql TRACE_FILE
+    trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_dvfs_ramp.sql
     ```
 
     Returns, worst first: `gpu`, `gpu_name`, `edge_rel_ns`, `idle_gap_ns`,
@@ -206,7 +206,7 @@ Run this before any open-ended exploration. It produces the headline verdict.
     had already reached target in the same burst — with thermal/power context:
 
     ```bash
-    trace_processor query --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_sustained_throttle.sql TRACE_FILE
+    trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_sustained_throttle.sql
     ```
 
     Returns, longest first: `gpu`, `gpu_name`, `start_rel_ns`, `dur_ns`,

--- a/ai/skills/perfetto/workflows/gpu/gpu_info.md
+++ b/ai/skills/perfetto/workflows/gpu/gpu_info.md
@@ -18,7 +18,7 @@ If the user has not yet loaded a trace into `trace_processor`, follow
 ## Enumerate the GPUs
 
 ```bash
-trace_processor query --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_info.sql TRACE_FILE
+trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_info.sql
 ```
 
 Columns: `machine_id`, `is_host`, `ugpu`, `gpu_index`, `vendor`, `name`,

--- a/ai/skills/perfetto/workflows/gpu/timeline_occupancy.md
+++ b/ai/skills/perfetto/workflows/gpu/timeline_occupancy.md
@@ -29,7 +29,7 @@ Run this before any open-ended exploration. It produces the headline verdict.
     returns one row per GPU as CSV.
 
     ```bash
-    trace_processor query --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_timeline_decomposition.sql TRACE_FILE
+    trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_timeline_decomposition.sql
     ```
 
     Columns: `gpu`, `gpu_name`, `activities`, `trace_wall_ns`, `active_span_ns`,
@@ -92,7 +92,7 @@ Run this before any open-ended exploration. It produces the headline verdict.
 1.  List the largest idle gaps on the GPU timeline:
 
     ```bash
-    trace_processor query --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_idle_gaps.sql TRACE_FILE
+    trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/scripts/gpu_idle_gaps.sql
     ```
 
     Returns `gap_start_rel_ns` (relative to trace start) and `gap_dur_ns`,


### PR DESCRIPTION
The skill taught two querying paths: one-shot invocations that reparse
the trace on every call, and an HTTP server driven through the Python
client, which needed pip installs, a random port to dodge collisions,
and glue code. Agents picked between them inconsistently and mostly
re-paid trace parsing on every query.

trace_processor now has first-class named sessions (server unix +
query --remote, #6286), and the v57.2 prebuilt the skill bundles already
supports them. Make sessions the single default: querying.md teaches
load-once / query-many with session state that persists across calls,
every workflow triage command runs against the session via
--remote SESSION, and the HTTP/Python-client guidance is removed
entirely.