### PR TITLE
docs: document trace_processor sessions and --remote

### DIFF
--- a/docs/analysis/trace-processor.md
+++ b/docs/analysis/trace-processor.md
@@ -105,6 +105,46 @@ ts                   value
 ...
 ```
 
+### {#sessions} Keeping a trace warm: sessions
+
+Parsing a trace is the expensive part of any analysis — tens of seconds
+for large traces. If you run more than one `query` invocation against the
+same trace, don't pay that cost every time: load the trace once into a
+named background **session** and point each invocation at it with
+`--remote`.
+
+```bash
+# 1. Load the trace into a background session (once per trace).
+trace_processor server unix --name mysession --daemonize trace.pftrace
+
+# 2. Query the warm session: no trace path, no reparse.
+trace_processor query --remote mysession \
+  "SELECT ts, dur, name FROM slice LIMIT 10"
+
+# 3. Stop the session when you're done with the trace.
+trace_processor server kill mysession
+```
+
+How sessions behave:
+
+- Sessions are addressed by name; their sockets live in a per-user session
+  directory, so there are no ports to pick and concurrent sessions don't
+  collide with each other or with the Perfetto UI.
+- Session state persists across `--remote` invocations: a
+  `CREATE PERFETTO TABLE` or `INCLUDE PERFETTO MODULE` from one call is
+  visible to the next, exactly as within a single interactive shell.
+- Flags that configure trace loading (`--full-sort`, `--add-sql-package`,
+  ...) must be passed to `server unix` when starting the session;
+  `query --remote` rejects them with an explanatory error.
+- Idle sessions are reaped automatically (after 30 minutes by default for
+  unix mode; tune with `--idle-timeout`).
+- `--remote` also accepts an explicit socket path (`*.sock`) or the
+  `host:port` of an HTTP server; names are the common case.
+
+`--remote` is accepted by the `query`, `interactive`, `metrics` and
+`summarize` subcommands alike (described below), all speaking the same
+TraceProcessor RPC interface the Perfetto UI uses.
+
 ### {#subcommands} Subcommand interface
 
 In addition to launching an interactive REPL, `trace_processor` exposes a
@@ -130,7 +170,7 @@ If no command is given, opens an interactive SQL shell on the trace file.
 Commands:
   query         Load a trace and run a SQL query.
   interactive   Interactive SQL shell (default if no command is given).
-  server        Start an RPC server (http or stdio).
+  server        Start an RPC server.
   summarize     Compute a trace summary from specs and/or built-in metrics.
   export        Export a trace to a database file.
   metrics       Run v1 metrics (deprecated; use 'summarize --metrics-v2').
@@ -175,6 +215,10 @@ cat queries.sql | trace_processor query trace.pftrace
 
 Useful flags:
 
+- `--remote ADDR` — run against a warm session instead of loading a local
+  trace; `ADDR` is a session name, a `*.sock`/absolute socket path, or
+  `host:port` (see [sessions](#sessions)). No trace-file argument is
+  passed in this mode.
 - `-f, --query-file FILE` — read SQL from `FILE` (or `-` for stdin).
 - `-i, --interactive` — drop into the interactive REPL after the queries
   finish.
@@ -193,7 +237,7 @@ section. This is the default subcommand when none is specified, so
 `trace_processor interactive trace.pftrace` are equivalent. The only
 subcommand-specific flag is `-W, --wide`.
 
-#### {#subcommand-server} `server` — HTTP / stdio RPC
+#### {#subcommand-server} `server` — HTTP / stdio / unix RPC
 
 Exposes trace processor over a remote-procedure-call protocol.
 
@@ -207,6 +251,13 @@ trace_processor server http trace.pftrace
 # stdio server (length-prefixed RPC; used by tooling that embeds
 # trace_processor as a subprocess).
 trace_processor server stdio
+
+# Named unix-socket session: keeps the trace warm for repeated
+# `query --remote <name>` calls (see the sessions section above).
+trace_processor server unix --name mysession --daemonize trace.pftrace
+
+# Stop a unix session by name or socket path.
+trace_processor server kill mysession
 ```
 
 Server-specific flags:
@@ -216,9 +267,18 @@ Server-specific flags:
 - `--additional-cors-origins O1,O2,...` — extra CORS-allowed origins on
   top of the defaults (`https://ui.perfetto.dev`, `http://localhost:10000`,
   `http://127.0.0.1:10000`).
+- `--name NAME` — session name for unix mode (default: auto-generated).
+- `--path PATH` — explicit socket path for unix mode (mutually exclusive
+  with `--name`).
+- `--daemonize` — detach into the background (unix mode, POSIX only).
+- `--idle-timeout auto|DUR` — reap the server after this much inactivity
+  (e.g. `30m`, `90s`); `auto` means 30 minutes for unix and never for
+  http, `0`/`never` disables.
+- `--idle-start auto|orphaned|last-query` — when the idle clock applies
+  (default `auto`: owner-aware).
 
-The trace file is optional in `http` mode: clients can also load traces
-remotely. The most common client is the Perfetto UI, which auto-detects a
+The trace file is optional in `http` and `unix` modes: clients can also
+load traces remotely. The most common client is the Perfetto UI, which auto-detects a
 local server and offloads trace parsing to it; see
 [Visualising large traces](/docs/visualization/large-traces.md) for the
 end-user flow, or

--- a/docs/analysis/trace-processor.md
+++ b/docs/analysis/trace-processor.md
@@ -107,43 +107,16 @@ ts                   value
 
 ### {#sessions} Keeping a trace warm: sessions
 
-Parsing a trace is the expensive part of any analysis — tens of seconds
-for large traces. If you run more than one `query` invocation against the
-same trace, don't pay that cost every time: load the trace once into a
-named background **session** and point each invocation at it with
-`--remote`.
-
-```bash
-# 1. Load the trace into a background session (once per trace).
-trace_processor server unix --name mysession --daemonize trace.pftrace
-
-# 2. Query the warm session: no trace path, no reparse.
-trace_processor query --remote mysession \
-  "SELECT ts, dur, name FROM slice LIMIT 10"
-
-# 3. Stop the session when you're done with the trace.
-trace_processor server kill mysession
-```
-
-How sessions behave:
-
-- Sessions are addressed by name; their sockets live in a per-user session
-  directory, so there are no ports to pick and concurrent sessions don't
-  collide with each other or with the Perfetto UI.
-- Session state persists across `--remote` invocations: a
-  `CREATE PERFETTO TABLE` or `INCLUDE PERFETTO MODULE` from one call is
-  visible to the next, exactly as within a single interactive shell.
-- Flags that configure trace loading (`--full-sort`, `--add-sql-package`,
-  ...) must be passed to `server unix` when starting the session;
-  `query --remote` rejects them with an explanatory error.
-- Idle sessions are reaped automatically (after 30 minutes by default for
-  unix mode; tune with `--idle-timeout`).
-- `--remote` also accepts an explicit socket path (`*.sock`) or the
-  `host:port` of an HTTP server; names are the common case.
-
-`--remote` is accepted by the `query`, `interactive`, `metrics` and
-`summarize` subcommands alike (described below), all speaking the same
-TraceProcessor RPC interface the Perfetto UI uses.
+If you run more than one invocation against the same trace, don't re-pay
+trace parsing every time: load the trace once into a named background
+session (`server unix --name mysession --daemonize trace.pftrace`) and
+point each invocation at it with `--remote mysession`. The `query`,
+`interactive`, `metrics` and `summarize` subcommands all accept
+`--remote`, speaking the same TraceProcessor RPC interface the Perfetto
+UI uses. For the task-oriented walkthrough, see
+[Analyzing traces from the command line](/docs/getting-started/command-line-analysis.md);
+the mode and flag details are under the
+[`server` subcommand](#subcommand-server) below.
 
 ### {#subcommands} Subcommand interface
 

--- a/docs/getting-started/command-line-analysis.md
+++ b/docs/getting-started/command-line-analysis.md
@@ -1,0 +1,123 @@
+# Analyzing traces from the command line
+
+This page is a set of task-oriented recipes for working with traces from a
+shell using `trace_processor`: running queries, iterating without
+re-parsing, merging, exporting and converting. It shows the common form of
+each task; the full list of subcommands and flags is in the
+[Trace Processor reference](/docs/analysis/trace-processor.md).
+
+## Get the binary
+
+```bash
+curl -LO https://get.perfetto.dev/trace_processor
+chmod +x ./trace_processor
+```
+
+This is a thin Python wrapper that fetches and caches the right native
+binary for your platform on first use (Windows and other options:
+[reference](/docs/analysis/trace-processor.md#shell)).
+
+## Run a query
+
+`query` loads a trace, runs one or more `;`-separated SQL statements, and
+prints each result set as CSV (blank line between result sets):
+
+```bash
+# Inline SQL.
+trace_processor query trace.pftrace "SELECT ts, dur, name FROM slice LIMIT 5"
+
+# From a file (or `-f -` for stdin) — the natural form for scripts.
+trace_processor query -f queries.sql trace.pftrace
+```
+
+The trace argument can also be an `http(s)://` URL or a Perfetto UI share
+link (`https://ui.perfetto.dev/#!/?s=<hash>`); the trace is downloaded and
+cached locally under `~/.cache/perfetto/`.
+
+## Iterate without re-parsing: sessions
+
+Parsing the trace is the expensive part — tens of seconds for large
+traces — and a plain `query` invocation pays it every time. When you'll
+run more than one query against the same trace, load it once into a named
+background **session** and point each invocation at it with `--remote`:
+
+```bash
+# 1. Load the trace into a background session (once per trace).
+trace_processor server unix --name mysession --daemonize trace.pftrace
+
+# 2. Query the warm session: no trace path, no reparse.
+trace_processor query --remote mysession \
+  "SELECT ts, dur, name FROM slice LIMIT 10"
+
+# 3. Stop the session when you're done with the trace.
+trace_processor server kill mysession
+```
+
+Session state persists across `--remote` invocations: a
+`CREATE PERFETTO TABLE` or `INCLUDE PERFETTO MODULE` from one call is
+visible to the next, exactly as within a single interactive shell — so
+materializing intermediate results pays off across calls. Idle sessions
+are reaped automatically after 30 minutes.
+
+Two things to know:
+
+- Flags that configure trace loading (`--full-sort`,
+  `--add-sql-package`, ...) belong on the `server unix` invocation;
+  `query --remote` rejects them.
+- `--remote` works with `interactive` and `summarize` too, so you can
+  drop into a REPL on — or summarize — an already-warm session.
+
+Session naming, socket paths and idle-timeout tuning:
+[reference](/docs/analysis/trace-processor.md#subcommand-server).
+
+## Merge traces
+
+To analyze several trace files as one (e.g. traces from two devices, or a
+system trace plus an in-process trace), pass a zip or concatenation of
+them — for the common case no configuration is needed:
+
+```bash
+zip traces.zip trace1.pftrace trace2.pftrace
+trace_processor query traces.zip "SELECT count(*) FROM slice"
+
+# Or concatenate protobuf traces directly.
+cat trace1.pftrace trace2.pftrace > merged.pftrace
+```
+
+When you need control over how the traces combine — keeping devices'
+data separate, aligning unsynchronized clocks, naming machines — use a
+trace manifest: see
+[Merging traces with Trace Processor](/docs/analysis/merging-traces.md).
+
+## Export to a SQLite database
+
+To use tools that speak SQLite (or to hand the data to someone without
+Perfetto), export every trace processor table to a database file:
+
+```bash
+trace_processor export sqlite -o trace.db trace.pftrace
+```
+
+## Convert to another trace format
+
+`convert` wraps the traceconv tool to translate a Perfetto trace into
+other formats, e.g. Chrome JSON (loadable in chrome://tracing or other
+Catapult tooling) or pprof:
+
+```bash
+trace_processor convert json trace.pftrace trace.json
+trace_processor convert text trace.pftrace trace.txt
+```
+
+Run `trace_processor convert --help` for the full format list, and see
+[Converting from Perfetto](/docs/quickstart/traceconv.md) for more on the
+underlying traceconv tool.
+
+## Next steps
+
+- Writing the queries themselves:
+  [Getting started with PerfettoSQL](/docs/analysis/perfetto-sql-getting-started.md).
+- Automating analysis across many traces from Python:
+  [Batch Trace Processor](/docs/analysis/batch-trace-processor.md).
+- Every subcommand and flag:
+  [Trace Processor reference](/docs/analysis/trace-processor.md).

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -23,6 +23,7 @@
 
     - [Local Android Recording](getting-started/local-android-trace-recording.md) {.tag-android}
     - [Analysing Android Traces](getting-started/android-trace-analysis.md) {.tag-android}
+    - [Command-Line Trace Analysis](getting-started/command-line-analysis.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Linux Tracing Recipes](getting-started/linux-cookbook.md) {.tag-linux}
     - [Periodic Trace Snapshots](getting-started/periodic-trace-snapshots.md) {.tag-android .tag-linux}
     - [Using AI with Perfetto](getting-started/using-ai.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}


### PR DESCRIPTION
trace_processor gained named unix-socket sessions and a --remote client
(#6286) but the docs still only describe the http/stdio server modes,
leaving the load-once / query-many workflow undiscoverable.

Add a task-oriented sessions section to the trace-processor page
showing the flow (server unix --daemonize, query --remote, server kill)
and its semantics (state persistence across calls, idle reaping,
load-time flags belong on the server), and extend the query/server
subcommand reference with the new modes and flags.