### PR TITLE
docs: polish the trace_processor CLI documentation

### DIFF
--- a/docs/analysis/trace-processor.md
+++ b/docs/analysis/trace-processor.md
@@ -1,32 +1,30 @@
 # Trace Processor (C++)
 
-_The Trace Processor is a C++ library
-([/src/trace_processor](/src/trace_processor)) that ingests traces encoded in a
-wide variety of formats and exposes an SQL interface for querying trace events
-contained in a consistent set of tables. It also has other features including
-computation of trace summaries, annotating the trace with user-friendly
-descriptions and deriving new events from the contents of the trace._
+Trace Processor is a C++ library ([src/trace_processor](/src/trace_processor))
+that ingests traces in a variety of formats and exposes an SQL interface for
+querying them through a consistent set of tables. It also computes trace
+summaries, annotates traces with human-readable descriptions, and derives new
+events from trace contents.
 
 ![Trace processor block diagram](/docs/images/trace-processor.png)
 
-Most users will interact with Trace Processor through the
+Most users interact with Trace Processor through the
 [`trace_processor` shell](#shell), a command-line wrapper around the library
-that opens an interactive PerfettoSQL prompt. Embedders that want to integrate
-Trace Processor into another C++ application should jump to
-[Embedding the C++ library](#embedding). Python users should see the
-[Python API](trace-processor-python.md) instead.
+that opens an interactive PerfettoSQL prompt. To embed Trace Processor in
+another C++ application, see [Embedding the C++ library](#embedding). Python
+users should use the [Python API](trace-processor-python.md) instead.
 
 ## {#shell} The trace_processor shell
 
-The `trace_processor` shell is a command-line binary which wraps the C++
-library, providing a convenient way to interactively analyze traces.
+The `trace_processor` shell is a command-line binary that loads a trace and
+opens an interactive SQL prompt on it.
 
 ### Downloading the shell
 
-The shell can be downloaded from the Perfetto website. The download is a thin
-Python wrapper that fetches and caches the correct native binary for your
+The shell is a thin Python wrapper that you download from the Perfetto
+website. On first use it fetches and caches the native binary for your
 platform (including `trace_processor_shell.exe` on Windows) under
-`~/.local/share/perfetto/prebuilts` on first use.
+`~/.local/share/perfetto/prebuilts`.
 
 <?tabs>
 
@@ -50,7 +48,7 @@ and later.
 
 ### Running the shell
 
-Once downloaded, you can immediately use it to open a trace file:
+Once downloaded, run it on a trace file:
 
 <?tabs>
 
@@ -68,15 +66,15 @@ python trace_processor trace.perfetto-trace
 
 </tabs?>
 
-This will open an interactive SQL shell where you can query the trace. For
-more information on how to write queries, see the
+This opens an interactive SQL shell where you can query the trace. For how to
+write queries, see the
 [Getting Started with PerfettoSQL](perfetto-sql-getting-started.md) guide.
 
 TIP: the trace file can also be a ZIP or TAR archive containing several
 traces: they are merged onto a single timeline. See
 [Merging traces with Trace Processor](/docs/analysis/merging-traces.md).
 
-For example, to see all the slices in a trace, you can run the following query:
+For example, to see all the slices in a trace:
 
 ```sql
 > SELECT ts, dur, name FROM slice LIMIT 10;
@@ -107,32 +105,37 @@ ts                   value
 
 ### {#sessions} Keeping a trace warm: sessions
 
-If you run more than one invocation against the same trace, don't re-pay
-trace parsing every time: load the trace once into a named background
-session (`server unix --name mysession --daemonize trace.pftrace`) and
-point each invocation at it with `--remote mysession`. The `query`,
-`interactive`, `metrics` and `summarize` subcommands all accept
-`--remote`, speaking the same TraceProcessor RPC interface the Perfetto
-UI uses. For the task-oriented walkthrough, see
-[Analyzing traces from the command line](/docs/getting-started/command-line-analysis.md);
-the mode and flag details are under the
-[`server` subcommand](#subcommand-server) below.
+Parsing a large trace takes time. If you plan to run several queries against
+the same trace, load it once into a named background session and point each
+invocation at that session:
+
+```bash
+# Load the trace once into a background session.
+trace_processor server unix --name mysession --daemonize trace.pftrace
+
+# Run queries against the warm session instead of re-loading the trace.
+trace_processor query --remote mysession "SELECT count(*) FROM slice"
+```
+
+The `query`, `interactive`, `metrics` and `summarize` subcommands all accept
+`--remote`, which talks to a session over the same TraceProcessor RPC
+interface the Perfetto UI uses. See
+[Analyzing traces from the command line](/docs/getting-started/command-line-analysis.md)
+for a walkthrough, and the [`server` subcommand](#subcommand-server) below
+for the mode and flag details.
 
 ### {#subcommands} Subcommand interface
 
-In addition to launching an interactive REPL, `trace_processor` exposes a
-subcommand-based CLI for non-interactive workflows: running a SQL query,
-computing trace summaries, exporting to SQLite, starting an RPC server, and
-converting between trace formats. The general invocation is:
+Besides the interactive REPL, `trace_processor` takes a subcommand as its
+first argument for non-interactive workflows:
 
 ```text
 trace_processor <command> [flags] [positional args]
 ```
 
-Run `trace_processor --help` for the top-level summary, or
-`trace_processor help <command>` (equivalently `trace_processor <command> --help`)
-for the flags accepted by a specific subcommand. The top-level help looks
-like this:
+`trace_processor --help` prints the top-level summary below. To see the flags
+of one subcommand, run `trace_processor <command> --help` (equivalently
+`trace_processor help <command>`):
 
 ```text
 Perfetto Trace Processor.
@@ -158,71 +161,70 @@ Common flags (apply to all commands):
   -m, --metatrace FILE        Enable metatracing, write to FILE.
 ```
 
-> **Backwards compatibility.** The previous flat-flag interface (e.g. `-q`,
-> `-Q`, `--httpd`, `--summary`, `--run-metrics`, `-e`, `--stdiod`) is fully
-> supported via an internal translation layer; existing scripts and
-> integrations continue to work unchanged. Run
-> `trace_processor --help-classic` to see the full classic flag reference.
+> **Backwards compatibility.** The classic flat-flag interface (`-q`, `-Q`,
+> `--httpd`, `--summary`, `--run-metrics`, `-e`, `--stdiod`) is still
+> supported through an internal translation layer, so existing scripts keep
+> working unchanged. Run `trace_processor --help-classic` for the full list
+> of classic flags.
 
-#### {#subcommand-query} `query` — run SQL
+#### {#subcommand-query} `query`: run SQL
 
-Loads a trace, runs one or more `;`-separated SQL statements, prints the
-results to stdout, and exits. Every statement's result set is printed as
-CSV, with consecutive result sets separated by a single blank line (since
-all string values are quoted, a blank line unambiguously marks a result-set
-boundary). SQL can be supplied as an inline positional
-argument, read from a file with `-f/--query-file`, or piped on stdin
-(either by passing `-` to `--query-file` or by piping when no SQL was
-specified):
+`query` loads a trace, runs one or more `;`-separated SQL statements, prints
+the results to stdout, and exits. SQL can be passed as an argument, read from
+a file, or piped on stdin:
 
 ```bash
-# 1. Inline query.
+# Pass SQL as an argument.
 trace_processor query trace.pftrace "SELECT ts, dur, name FROM slice LIMIT 5"
 
-# 2. From a file.
+# Read SQL from a file.
 trace_processor query -f queries.sql trace.pftrace
 
-# 3. From stdin.
+# Pipe SQL on stdin.
 cat queries.sql | trace_processor query trace.pftrace
 ```
 
-Useful flags:
+Each statement's result set is printed as CSV, and consecutive result sets
+are separated by a single blank line. The separator is unambiguous because
+every string value is quoted.
 
-- `--remote ADDR` — run against a warm session instead of loading a local
-  trace; `ADDR` is a session name, a `*.sock`/absolute socket path, or
-  `host:port` (see [sessions](#sessions)). No trace-file argument is
-  passed in this mode.
-- `-f, --query-file FILE` — read SQL from `FILE` (or `-` for stdin).
-- `-i, --interactive` — drop into the interactive REPL after the queries
+Flags:
+
+- `--remote ADDR`: run against a warm session instead of loading a local
+  trace; see [sessions](#sessions). `ADDR` is a session name, a `*.sock` or
+  absolute socket path, or `host:port`. No trace-file argument is passed in
+  this mode.
+- `-f, --query-file FILE`: read SQL from `FILE`; pass `-` to read from stdin.
+- `-i, --interactive`: drop into the interactive REPL after the queries
   finish.
-- `-W, --wide` — double-width columns when printing results.
-- `--perf-file FILE` — write trace-load and query timings to `FILE`.
-- `--structured-query-id ID` + `--summary-spec FILE` _(advanced)_ — execute
-  a single structured query by ID from one or more
-  [TraceSummarySpec](trace-summary.md) files. The spec(s) replace the
-  inline/file/stdin SQL source.
+- `-W, --wide`: use double-width columns when printing results.
+- `--perf-file FILE`: write trace-load and query timings to `FILE`.
+- `--structured-query-id ID` plus `--summary-spec FILE` _(advanced)_: run a
+  single structured query by ID from one or more
+  [TraceSummarySpec](trace-summary.md) files, instead of the SQL sources
+  above.
 
-#### {#subcommand-interactive} `interactive` — REPL
+#### {#subcommand-interactive} `interactive`: REPL
 
-Opens the same interactive PerfettoSQL prompt shown in the previous
-section. This is the default subcommand when none is specified, so
+`interactive` opens the same interactive PerfettoSQL prompt shown in the
+previous section. It is the default subcommand, so
 `trace_processor trace.pftrace` and
 `trace_processor interactive trace.pftrace` are equivalent. The only
 subcommand-specific flag is `-W, --wide`.
 
-#### {#subcommand-server} `server` — HTTP / stdio / unix RPC
+#### {#subcommand-server} `server`: HTTP, stdio, or unix RPC
 
-Exposes trace processor over a remote-procedure-call protocol.
+`server` exposes trace processor over a remote-procedure-call protocol:
 
 ```bash
-# HTTP server (used by ui.perfetto.dev). Listens on 9001 by default.
+# HTTP server, used by ui.perfetto.dev. Listens on port 9001 by default.
 trace_processor server http
 
 # Pre-load a trace and serve it over HTTP.
 trace_processor server http trace.pftrace
 
-# stdio server (length-prefixed RPC; used by tooling that embeds
-# trace_processor as a subprocess).
+# stdio server: length-prefixed RPC for tooling that embeds
+# trace_processor as a subprocess.
 trace_processor server stdio
 
 # Named unix-socket session: keeps the trace warm for repeated
@@ -233,66 +235,66 @@ trace_processor server unix --name mysession --daemonize trace.pftrace
 trace_processor server kill mysession
 ```
 
-Server-specific flags:
+Flags:
 
-- `--port PORT` — HTTP port (default 9001).
-- `--ip-address IP` — HTTP bind address.
-- `--additional-cors-origins O1,O2,...` — extra CORS-allowed origins on
-  top of the defaults (`https://ui.perfetto.dev`, `http://localhost:10000`,
+- `--port PORT`: HTTP port (default 9001).
+- `--ip-address IP`: HTTP bind address.
+- `--additional-cors-origins O1,O2,...`: extra CORS-allowed origins on top
+  of the defaults (`https://ui.perfetto.dev`, `http://localhost:10000`,
   `http://127.0.0.1:10000`).
-- `--name NAME` — session name for unix mode (default: auto-generated).
-- `--path PATH` — explicit socket path for unix mode (mutually exclusive
+- `--name NAME`: session name for unix mode (default: auto-generated).
+- `--path PATH`: explicit socket path for unix mode (mutually exclusive
   with `--name`).
-- `--daemonize` — detach into the background (unix mode, POSIX only).
-- `--idle-timeout auto|DUR` — reap the server after this much inactivity
+- `--daemonize`: detach into the background (unix mode, POSIX only).
+- `--idle-timeout auto|DUR`: reap the server after this much inactivity
   (e.g. `30m`, `90s`); `auto` means 30 minutes for unix and never for
   http, `0`/`never` disables.
-- `--idle-start auto|orphaned|last-query` — when the idle clock applies
+- `--idle-start auto|orphaned|last-query`: when the idle clock applies
   (default `auto`: owner-aware).
 
-The trace file is optional in `http` and `unix` modes: clients can also
-load traces remotely. The most common client is the Perfetto UI, which auto-detects a
-local server and offloads trace parsing to it; see
+The trace file is optional in `http` and `unix` modes; clients can also
+load traces remotely. The most common client is the Perfetto UI, which
+auto-detects a local server and offloads trace parsing to it. See
 [Visualising large traces](/docs/visualization/large-traces.md) for the
 end-user flow, or
 [trace_processor.proto](/protos/perfetto/trace_processor/trace_processor.proto)
 for the RPC wire schema.
 
-#### {#subcommand-summarize} `summarize` — trace summaries and v2 metrics
+#### {#subcommand-summarize} `summarize`: compute trace summaries
 
-Computes a [trace summary](trace-summary.md). Spec files are passed as
-extra positional arguments after the trace file; built-in v2 metrics are
-selected with `--metrics-v2`:
+`summarize` computes a [trace summary](trace-summary.md). Pass the trace
+file first, then any spec files; select built-in v2 metrics with
+`--metrics-v2`:
 
 ```bash
-# Run all available v2 metrics.
+# Run every available v2 metric.
 trace_processor summarize --metrics-v2 all trace.pftrace
 
-# Run two specific metric ids defined in spec.textproto.
+# Run two specific metrics defined in spec.textproto.
 trace_processor summarize \
   --metrics-v2 startup_metric,memory_metric \
   trace.pftrace spec.textproto
 ```
 
-Subcommand flags:
+Flags:
 
-- `--metrics-v2 IDS` — comma-separated metric ids, or the literal `all`.
-- `--metadata-query ID` — query id used to populate the summary's
+- `--metrics-v2 IDS`: comma-separated metric ids, or the literal `all`.
+- `--metadata-query ID`: query id used to populate the summary's
   `metadata` field.
-- `--format text|binary` — output format for the `TraceSummary` proto
-  (default: `text`).
-- `--post-query FILE` — SQL file run after summarization. When set, the
-  summary proto is _not_ printed; the SQL output is printed instead.
-- `--perf-file FILE` — write load/query timings to `FILE`.
-- `-i, --interactive` — drop into the REPL after summarization finishes.
+- `--format text|binary`: output format for the `TraceSummary` proto
+  (default `text`).
+- `--post-query FILE`: run this SQL file after summarization. When set, the
+  summary proto is not printed; the SQL output is printed instead.
+- `--perf-file FILE`: write load/query timings to `FILE`.
+- `-i, --interactive`: drop into the REPL after summarization finishes.
 
-Spec files are auto-detected as binary or text based on extension
-(`.pb` → binary, `.textproto` → text) with a content-sniffing fallback.
+Spec files are detected as binary or text by extension (`.pb` for binary,
+`.textproto` for text), with content sniffing as a fallback.
 
 #### {#global-flags} Global flags (apply to every subcommand)
 
-These flags are accepted in addition to the subcommand-specific flags
-above and behave identically across subcommands:
+These flags are accepted in addition to the subcommand-specific flags above
+and behave the same across all subcommands:
 
 - **Trace ingestion:** `--full-sort`, `--no-ftrace-raw`,
   `--analyze-trace-proto-content`, `--crop-track-events`.
@@ -300,22 +302,22 @@ above and behave identically across subcommands:
   `--override-sql-package PATH[@PKG]`, `--override-stdlib PATH`
   (requires `--dev`).
 - **Metric extensions:** `--metric-extension DISK_PATH@VIRTUAL_PATH`.
-- **Auxiliary file content:** `--register-files-dir PATH` — exposes the
+- **Auxiliary file content:** `--register-files-dir PATH` exposes the
   contents of files under `PATH` to importers (e.g. ETM decoders).
 - **Development:** `--dev`, `--dev-flag KEY=VALUE`, `--extra-checks`.
-- **Metatracing:** `-m, --metatrace FILE`,
-  `--metatrace-buffer-capacity N`, `--metatrace-categories CATEGORIES` —
-  produces a Perfetto trace of trace processor itself, which can be
-  loaded back into the UI for performance debugging.
+- **Metatracing:** `-m, --metatrace FILE`, `--metatrace-buffer-capacity N`,
+  `--metatrace-categories CATEGORIES`. This produces a Perfetto trace of
+  trace processor itself, which you can load back into the UI for
+  performance debugging.
 
 ## {#embedding} Embedding the C++ library
 
-The public API is centered on the `TraceProcessor` class defined in
-[`trace_processor.h`](/include/perfetto/trace_processor/trace_processor.h). All
-high-level operations — parsing trace bytes, executing SQL queries, computing
-summaries — are member functions on this class.
+The public API centers on the `TraceProcessor` class in
+[`trace_processor.h`](/include/perfetto/trace_processor/trace_processor.h).
+All high-level operations (parsing trace bytes, executing SQL queries,
+computing summaries) are member functions of this class.
 
-A `TraceProcessor` instance is created via `CreateInstance`:
+Create an instance with `CreateInstance`:
 
 ```cpp
 #include "perfetto/trace_processor/trace_processor.h"
@@ -329,7 +331,7 @@ std::unique_ptr<TraceProcessor> tp = TraceProcessor::CreateInstance(config);
 ### Loading a trace
 
 To ingest a trace, call `Parse` repeatedly with chunks of trace bytes, then
-`NotifyEndOfFile` once the entire trace has been pushed:
+`NotifyEndOfFile` once the whole trace has been pushed:
 
 ```cpp
 while (/* more data available */) {
@@ -355,8 +357,8 @@ calls `NotifyEndOfFile` for you.
 
 ### Executing queries
 
-Queries are submitted via `ExecuteQuery`, which returns an `Iterator` that
-streams rows back to the caller:
+Run queries with `ExecuteQuery`, which returns an `Iterator` that streams
+rows back to the caller:
 
 ```cpp
 auto it = tp->ExecuteQuery("SELECT ts, name FROM slice LIMIT 10");
@@ -387,14 +389,14 @@ iterator API.
 
 The `TraceProcessor` class also exposes:
 
-- **Trace summarization** (`Summarize`) — computes structured summaries of a
-  trace. See [Trace Summarization](trace-summary.md) for the user-facing
-  description of this feature.
-- **Custom SQL packages** (`RegisterSqlPackage`) — registers PerfettoSQL files
-  under a package name so they can be `INCLUDE`d by queries.
-- **Out-of-band file content** (`RegisterFileContent`) — passes auxiliary data
+- **Trace summarization** (`Summarize`): computes structured summaries of a
+  trace. See [Trace Summarization](trace-summary.md) for a user-facing
+  description.
+- **Custom SQL packages** (`RegisterSqlPackage`): registers PerfettoSQL files
+  under a package name so queries can `INCLUDE` them.
+- **Out-of-band file content** (`RegisterFileContent`): passes auxiliary data
   to importers, e.g. binaries used to decode ETM traces.
-- **Metatracing** (`EnableMetatrace` / `DisableAndReadMetatrace`) — traces the
+- **Metatracing** (`EnableMetatrace` / `DisableAndReadMetatrace`): traces
   Trace Processor itself for performance debugging.
 
 Refer to the comments in

--- a/docs/getting-started/android-trace-analysis.md
+++ b/docs/getting-started/android-trace-analysis.md
@@ -1,4 +1,4 @@
-# Cookbook: Analysing Android Traces
+# Cookbook: Analyzing Android Traces
 
 This page will take you through some real world examples on how you can analyse
 issues with SQL and more advanced features of the Perfetto UI.

--- a/docs/getting-started/command-line-analysis.md
+++ b/docs/getting-started/command-line-analysis.md
@@ -26,7 +26,7 @@ prints each result set as CSV (blank line between result sets):
 # Inline SQL.
 trace_processor query trace.pftrace "SELECT ts, dur, name FROM slice LIMIT 5"
 
-# From a file (or `-f -` for stdin) — the natural form for scripts.
+# From a file (`-f -` for stdin): the natural form for scripts.
 trace_processor query -f queries.sql trace.pftrace
 ```
 
@@ -36,8 +36,8 @@ cached locally under `~/.cache/perfetto/`.
 
 ## Iterate without re-parsing: sessions
 
-Parsing the trace is the expensive part — tens of seconds for large
-traces — and a plain `query` invocation pays it every time. When you'll
+Parsing the trace is the expensive part (tens of seconds for large
+traces), and a plain `query` invocation pays it every time. When you'll
 run more than one query against the same trace, load it once into a named
 background **session** and point each invocation at it with `--remote`:
 
@@ -55,7 +55,7 @@ trace_processor server kill mysession
 
 Session state persists across `--remote` invocations: a
 `CREATE PERFETTO TABLE` or `INCLUDE PERFETTO MODULE` from one call is
-visible to the next, exactly as within a single interactive shell — so
+visible to the next, exactly as within a single interactive shell, so
 materializing intermediate results pays off across calls. Idle sessions
 are reaped automatically after 30 minutes.
 
@@ -65,7 +65,7 @@ Two things to know:
   `--add-sql-package`, ...) belong on the `server unix` invocation;
   `query --remote` rejects them.
 - `--remote` works with `interactive` and `summarize` too, so you can
-  drop into a REPL on — or summarize — an already-warm session.
+  drop into a REPL on an already-warm session, or summarize it.
 
 Session naming, socket paths and idle-timeout tuning:
 [reference](/docs/analysis/trace-processor.md#subcommand-server).
@@ -73,8 +73,8 @@ Session naming, socket paths and idle-timeout tuning:
 ## Merge traces
 
 To analyze several trace files as one (e.g. traces from two devices, or a
-system trace plus an in-process trace), pass a zip or concatenation of
-them — for the common case no configuration is needed:
+system trace plus an in-process trace), pass a zip or a concatenation of
+them. For the common case, no configuration is needed:
 
 ```bash
 zip traces.zip trace1.pftrace trace2.pftrace
@@ -84,8 +84,8 @@ trace_processor query traces.zip "SELECT count(*) FROM slice"
 cat trace1.pftrace trace2.pftrace > merged.pftrace
 ```
 
-When you need control over how the traces combine — keeping devices'
-data separate, aligning unsynchronized clocks, naming machines — use a
+When you need control over how the traces combine (keeping devices'
+data separate, aligning unsynchronized clocks, naming machines), use a
 trace manifest: see
 [Merging traces with Trace Processor](/docs/analysis/merging-traces.md).
 

--- a/docs/getting-started/command-line-analysis.md
+++ b/docs/getting-started/command-line-analysis.md
@@ -1,4 +1,4 @@
-# Analyzing traces from the command line
+# Cookbook: Analyzing Traces from the Command Line
 
 This page is a set of task-oriented recipes for working with traces from a
 shell using `trace_processor`: running queries, iterating without

--- a/docs/getting-started/linux-cookbook.md
+++ b/docs/getting-started/linux-cookbook.md
@@ -1,4 +1,4 @@
-# Cookbook: Linux Tracing Recipes
+# Cookbook: Tracing on Linux
 
 This page collects **end-to-end recipes** for profiling and tracing your own
 programs on Linux: how to build so that traces can be symbolized, how to record

--- a/docs/getting-started/local-android-trace-recording.md
+++ b/docs/getting-started/local-android-trace-recording.md
@@ -1,4 +1,4 @@
-# Cookbook: Local Android Trace Recording
+# Cookbook: Recording Android Traces Locally
 
 This page collects **end-to-end recipes** for recording Perfetto traces on
 Android in situations that the standard interactive workflow does not cover.

--- a/docs/getting-started/periodic-trace-snapshots.md
+++ b/docs/getting-started/periodic-trace-snapshots.md
@@ -1,4 +1,4 @@
-# Cookbook: Periodic Trace Snapshots
+# Cookbook: Capturing Periodic Trace Snapshots
 
 In this guide, you'll learn how to:
 

--- a/docs/getting-started/using-ai.md
+++ b/docs/getting-started/using-ai.md
@@ -1,4 +1,4 @@
-# Using AI with Perfetto
+# Cookbook: Using AI with Perfetto
 
 NOTE: **Googlers**: use [go/perfetto-ai-skills](http://go/perfetto-ai-skills)
 and

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -21,11 +21,11 @@
 
   - [Cookbooks](#)
 
-    - [Local Android Recording](getting-started/local-android-trace-recording.md) {.tag-android}
-    - [Analysing Android Traces](getting-started/android-trace-analysis.md) {.tag-android}
-    - [Command-Line Trace Analysis](getting-started/command-line-analysis.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
-    - [Linux Tracing Recipes](getting-started/linux-cookbook.md) {.tag-linux}
-    - [Periodic Trace Snapshots](getting-started/periodic-trace-snapshots.md) {.tag-android .tag-linux}
+    - [Recording Android Traces Locally](getting-started/local-android-trace-recording.md) {.tag-android}
+    - [Analyzing Android Traces](getting-started/android-trace-analysis.md) {.tag-android}
+    - [Analyzing Traces from the Command Line](getting-started/command-line-analysis.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Tracing on Linux](getting-started/linux-cookbook.md) {.tag-linux}
+    - [Capturing Periodic Trace Snapshots](getting-started/periodic-trace-snapshots.md) {.tag-android .tag-linux}
     - [Using AI with Perfetto](getting-started/using-ai.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
 
   - [Case Studies](#)


### PR DESCRIPTION
Cleanup pass over the trace_processor command-line documentation.

- Make cookbook titles consistent: the Cookbooks nav mixed noun phrases
  with gerunds, two pages lacked the 'Cookbook:' H1 prefix the other four
  carry, and one title used British spelling in an otherwise
  American-English set. Normalized to verb-led nav labels ('Recording ...',
  'Analyzing ...', 'Tracing on Linux'), 'Cookbook: <label>' H1s, and
  American spelling throughout. URLs are unchanged.
- Clean up the Trace Processor reference (docs/analysis/trace-processor.md):
  drop the italicized intro and other AI-flavored phrasing, replace
  em-dashes with colons or parentheses, and lay out the session and query
  examples as proper code blocks. Flag lists are now consistently
  formatted. No technical content changes; anchors, flags, links, and code
  examples are preserved.
- Clean up the command-line analysis cookbook
  (docs/getting-started/command-line-analysis.md): remove em-dashes and
  rework a few awkward sentences.