### PR TITLE
docs: merge traces with util merge, not cat

### DIFF
--- a/docs/analysis/merging-traces.md
+++ b/docs/analysis/merging-traces.md
@@ -1,13 +1,13 @@
-# Merging traces with Trace Processor
+# Merging traces from the command line
 
 Trace Processor can import several trace files as one merged trace: events
 from every file end up on a single timeline, with their processes, threads
 and CPUs kept attributed to the machine they came from. This page shows how
 to do it from the command line and in scripted or CI setups. For the
 interactive equivalent see
-[Merging traces in the Perfetto UI](/docs/visualization/merging-traces.md);
+[Merging traces in the UI](/docs/visualization/merging-traces.md);
 for how the merging actually works see
-[How trace merging works](/docs/concepts/merging-traces.md).
+[Trace merging](/docs/concepts/merging-traces.md).
 
 ## The model: one archive in, one trace out
 
@@ -227,7 +227,7 @@ or, at a higher level, the `_metadata_by_trace` view in the
   files directly.
 - **Hidden files are ignored**: any archive entry whose name has a path
   component starting with a `.` is skipped and never parsed as a trace. This
-  covers the metadata that archiving tools add automatically — most notably the
+  covers the metadata that archiving tools add automatically, most notably the
   AppleDouble resource-fork files (`._foo`) and `.DS_Store` entries that macOS
   `tar` and Finder-created ZIPs sprinkle next to the real files. As a result a
   `.tar`/`.zip` built on macOS loads without a spurious "unknown trace type"
@@ -238,7 +238,7 @@ or, at a higher level, the `_metadata_by_trace` view in the
 
 - [Trace manifest format](/docs/reference/perfetto-manifest.md): the
   normative reference for the manifest.
-- [How trace merging works](/docs/concepts/merging-traces.md): clock graph,
+- [Trace merging](/docs/concepts/merging-traces.md): clock graph,
   placement rules and the machine model.
 - [Multi-machine recording](/docs/learning-more/multi-machine-tracing.md):
   recording a single trace from several machines live, instead of merging

--- a/docs/analysis/trace-processor.md
+++ b/docs/analysis/trace-processor.md
@@ -72,7 +72,7 @@ write queries, see the
 
 TIP: the trace file can also be a ZIP or TAR archive containing several
 traces: they are merged onto a single timeline. See
-[Merging traces with Trace Processor](/docs/analysis/merging-traces.md).
+[Merging traces from the command line](/docs/analysis/merging-traces.md).
 
 For example, to see all the slices in a trace:
 

--- a/docs/concepts/clock-sync.md
+++ b/docs/concepts/clock-sync.md
@@ -245,7 +245,7 @@ distinct nodes, related by explicit edges (recording-time clock sync, a
 wall-clock rendezvous, or a
 [trace manifest](/docs/reference/perfetto-manifest.md)). All edges,
 whatever their origin, are recorded in the `clock_snapshot` table. See
-[How trace merging works](/docs/concepts/merging-traces.md) for the full
+[Trace merging](/docs/concepts/merging-traces.md) for the full
 model.
 
 [6756fb05]: https://android-review.googlesource.com/c/platform/external/perfetto/+/1101915/

--- a/docs/concepts/merging-traces.md
+++ b/docs/concepts/merging-traces.md
@@ -1,4 +1,4 @@
-# How trace merging works
+# Trace merging
 
 Trace Processor can open several trace files together and merge them onto a
 single timeline: traces from different devices, from different processes on
@@ -8,8 +8,8 @@ comparable timestamps, and how data stays attributed to the machine it came
 from.
 
 This is an explanation of the machinery. For task-oriented guides see
-[Merging traces in the Perfetto UI](/docs/visualization/merging-traces.md)
-and [Merging traces with Trace Processor](/docs/analysis/merging-traces.md).
+[Merging traces in the UI](/docs/visualization/merging-traces.md)
+and [Merging traces from the command line](/docs/analysis/merging-traces.md).
 
 ## The problem
 
@@ -152,7 +152,7 @@ from different host machines.
 
 - [Trace manifest format](/docs/reference/perfetto-manifest.md): the
   full reference for manual merge configuration.
-- [Merging traces with Trace Processor](/docs/analysis/merging-traces.md):
+- [Merging traces from the command line](/docs/analysis/merging-traces.md):
   building merged archives and querying the result.
 - [Clock synchronization](/docs/concepts/clock-sync.md): the single-trace
   clock model this builds on.

--- a/docs/deployment/multi-machine-architecture.md
+++ b/docs/deployment/multi-machine-architecture.md
@@ -157,7 +157,7 @@ namespaces, etc.).
 * [Multi-machine recording](/docs/learning-more/multi-machine-tracing.md) —
   step-by-step walk-through of recording a multi-machine trace between two
   Linux hosts.
-* [How trace merging works](/docs/concepts/merging-traces.md) — combining
+* [Trace merging](/docs/concepts/merging-traces.md) — combining
   independently recorded traces into the same multi-machine model after
   the fact.
 * [Clock Synchronization](/docs/concepts/clock-sync.md) — the single-machine

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -61,5 +61,5 @@ Yes. In the UI, use "Open multiple trace files" (or select/drop several
 files): a dialog lets you configure how they merge onto a shared timeline.
 From the command line, pass a ZIP or TAR archive of the traces to
 `trace_processor`. See
-[Merging traces in the Perfetto UI](/docs/visualization/merging-traces.md)
-and [Merging traces with Trace Processor](/docs/analysis/merging-traces.md).
+[Merging traces in the UI](/docs/visualization/merging-traces.md)
+and [Merging traces from the command line](/docs/analysis/merging-traces.md).

--- a/docs/getting-started/command-line-analysis.md
+++ b/docs/getting-started/command-line-analysis.md
@@ -73,21 +73,31 @@ Session naming, socket paths and idle-timeout tuning:
 ## Merge traces
 
 To analyze several trace files as one (e.g. traces from two devices, or a
-system trace plus an in-process trace), pass a zip or a concatenation of
-them. For the common case, no configuration is needed:
+system trace plus an in-process trace), pack them into one archive. For
+the common case (traces whose clocks already relate), no configuration is
+needed:
 
 ```bash
-zip traces.zip trace1.pftrace trace2.pftrace
-trace_processor query traces.zip "SELECT count(*) FROM slice"
-
-# Or concatenate protobuf traces directly.
-cat trace1.pftrace trace2.pftrace > merged.pftrace
+trace_processor util merge -o merged.tar trace1.pftrace trace2.pftrace
+trace_processor query merged.tar "SELECT count(*) FROM slice"
 ```
 
-When you need control over how the traces combine (keeping devices'
-data separate, aligning unsynchronized clocks, naming machines), use a
-trace manifest: see
-[Merging traces with Trace Processor](/docs/analysis/merging-traces.md).
+`util merge` writes a TAR that Trace Processor opens as a single merged
+trace, and dry-runs the result to warn if the traces would not merge
+cleanly (`--strict` makes that a hard error, handy in CI). Any ZIP or TAR
+of trace files opens the same way, so without a `trace_processor`
+dependency you can pack them yourself:
+`tar cf merged.tar trace1.pftrace trace2.pftrace`.
+
+Do not merge by concatenating the files with `cat`; that is not a merge,
+see [Trace merging](/docs/concepts/merging-traces.md).
+
+When you need control over how the traces combine (keeping devices' data
+separate, aligning unsynchronized clocks, naming machines), pass a trace
+manifest to `util merge` (`--manifest manifest.json`) or tar it into the
+archive yourself. See
+[Merging traces from the command line](/docs/analysis/merging-traces.md)
+for the details, including how to verify a merge placed every event.
 
 ## Export to a SQLite database
 

--- a/docs/getting-started/other-formats.md
+++ b/docs/getting-started/other-formats.md
@@ -1037,9 +1037,9 @@ and merge the traces inside onto a single timeline. An optional
 [trace manifest](/docs/reference/perfetto-manifest.md) file inside the
 archive controls how the traces are merged: which machine each file belongs
 to and how their clocks relate. See
-[Merging traces with Trace Processor](/docs/analysis/merging-traces.md) for
+[Merging traces from the command line](/docs/analysis/merging-traces.md) for
 how to build such archives and
-[Merging traces in the Perfetto UI](/docs/visualization/merging-traces.md)
+[Merging traces in the UI](/docs/visualization/merging-traces.md)
 for the interactive equivalent, which can also export the archive it builds.
 
 When merging traces produced from Linux `perf`, choose a merge-friendly clock

--- a/docs/getting-started/start-using-perfetto.md
+++ b/docs/getting-started/start-using-perfetto.md
@@ -170,7 +170,7 @@ state, Perfetto provides powerful insights.
     system trace) can be opened together as one merged trace on a shared
     timeline.
     - **Tutorial**:
-      [Merging traces in the Perfetto UI](/docs/visualization/merging-traces.md)
+      [Merging traces in the UI](/docs/visualization/merging-traces.md)
 
 ### {#android-optimizing-performance} Optimizing Performance & Addressing Latency
 

--- a/docs/learning-more/multi-machine-tracing.md
+++ b/docs/learning-more/multi-machine-tracing.md
@@ -41,7 +41,7 @@ you have over the producers:
    `PerfettoProducerBackendInitArgsSetMachineId()` in the C SDK). Merging
    the files later needs no configuration: every packet already says which
    machine it came from, and the traces align through their wall clocks.
-   See [Merging traces with Trace Processor](/docs/analysis/merging-traces.md#no-config).
+   See [Merging traces from the command line](/docs/analysis/merging-traces.md#no-config).
 
 3. **Record independently, merge afterwards.** Each machine records a
    normal trace; nothing is coordinated at recording time. Machine
@@ -247,7 +247,7 @@ machine through different dimensions.
 * [Multi-machine architecture](/docs/deployment/multi-machine-architecture.md) —
   the why: how `traced_relay`, machine identity, and cross-kernel clock
   sync fit together.
-* [Merging traces with Trace Processor](/docs/analysis/merging-traces.md) —
+* [Merging traces from the command line](/docs/analysis/merging-traces.md) —
   the post-hoc alternative: combine independently recorded traces onto one
   timeline when a live network path is not an option.
 * [PerfettoSQL: Getting Started](/docs/analysis/perfetto-sql-getting-started.md) —

--- a/docs/reference/perfetto-manifest.md
+++ b/docs/reference/perfetto-manifest.md
@@ -11,9 +11,9 @@ and attach [attributes](#attributes) annotating the archive.
 
 This page is the normative reference for the format. For a task-oriented
 guide to merging see
-[Merging traces with Trace Processor](/docs/analysis/merging-traces.md); for
+[Merging traces from the command line](/docs/analysis/merging-traces.md); for
 the underlying model see
-[How trace merging works](/docs/concepts/merging-traces.md).
+[Trace merging](/docs/concepts/merging-traces.md).
 
 The format is stable: `version` 1 is the current (and only) version and will
 remain supported. New capabilities are added as new fields within version 1;
@@ -104,7 +104,7 @@ key, containing:
 
 Files present in the archive but not listed in `files` are still imported;
 they just get no overrides and follow the default merging rules described in
-[How trace merging works](/docs/concepts/merging-traces.md).
+[Trace merging](/docs/concepts/merging-traces.md).
 
 ## {#trace-time} trace_time
 
@@ -318,9 +318,9 @@ and its test suite in
 
 ## Next steps
 
-- [Merging traces with Trace Processor](/docs/analysis/merging-traces.md):
+- [Merging traces from the command line](/docs/analysis/merging-traces.md):
   building and querying merged archives.
-- [Merging traces in the Perfetto UI](/docs/visualization/merging-traces.md):
+- [Merging traces in the UI](/docs/visualization/merging-traces.md):
   the interactive merge dialog, which generates this format for you.
-- [How trace merging works](/docs/concepts/merging-traces.md): machines,
+- [Trace merging](/docs/concepts/merging-traces.md): machines,
   the clock graph, and the automatic placement rules.

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -46,7 +46,7 @@
     - [Buffers and Dataflow](concepts/buffers.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
     - [Trace Configuration](concepts/config.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
     - [Clock Synchronization](concepts/clock-sync.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
-    - [How trace merging works](concepts/merging-traces.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Trace merging](concepts/merging-traces.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md) {.tag-android .tag-linux .tag-cpp-rust}
 
   - [Recording](#)
@@ -93,7 +93,7 @@
   - [Visualization](#)
 
     - [Perfetto UI](visualization/perfetto-ui.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
-    - [Merging traces in the Perfetto UI](visualization/merging-traces.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Merging traces in the UI](visualization/merging-traces.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Data Explorer](visualization/data-explorer.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Opening Large Traces](visualization/large-traces.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
@@ -126,7 +126,7 @@
       - [Python Library](analysis/trace-processor-python.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
       - [Batch Trace Processor](analysis/batch-trace-processor.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
 
-    - [Merging traces with Trace Processor](analysis/merging-traces.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Merging traces from the command line](analysis/merging-traces.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Trace Summarization](analysis/trace-summary.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Converting from Perfetto](quickstart/traceconv.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
 

--- a/docs/visualization/merging-traces.md
+++ b/docs/visualization/merging-traces.md
@@ -1,4 +1,4 @@
-# Merging traces in the Perfetto UI
+# Merging traces in the UI
 
 The Perfetto UI can open several trace files at once and merge them onto a
 single shared timeline: traces from two devices, an app trace next to a
@@ -8,9 +8,9 @@ each belongs to, and warns before opening if any events would not fit on the
 shared timeline.
 
 For merging in scripts or CI, see
-[Merging traces with Trace Processor](/docs/analysis/merging-traces.md).
+[Merging traces from the command line](/docs/analysis/merging-traces.md).
 For the underlying model, see
-[How trace merging works](/docs/concepts/merging-traces.md).
+[Trace merging](/docs/concepts/merging-traces.md).
 
 ## When to use it
 
@@ -146,9 +146,9 @@ The dialog's footer helps bootstrap exactly that:
 
 ## Next steps
 
-- [Merging traces with Trace Processor](/docs/analysis/merging-traces.md):
+- [Merging traces from the command line](/docs/analysis/merging-traces.md):
   the same merges from the command line, scripts and CI.
 - [Trace manifest format](/docs/reference/perfetto-manifest.md): what
   "Copy manifest" produces, field by field.
-- [How trace merging works](/docs/concepts/merging-traces.md): clocks,
+- [Trace merging](/docs/concepts/merging-traces.md): clocks,
   machines and the placement rules behind the dialog.

--- a/docs/visualization/perfetto-ui.md
+++ b/docs/visualization/perfetto-ui.md
@@ -14,7 +14,7 @@ sidebar to open a local trace file.
 
 Selecting or dropping several files at once merges them onto a single shared
 timeline via a configuration dialog: see
-[Merging traces in the Perfetto UI](/docs/visualization/merging-traces.md).
+[Merging traces in the UI](/docs/visualization/merging-traces.md).
 
 ## Navigating the Timeline
 


### PR DESCRIPTION
The "Merge traces" section of the command-line analysis cookbook suggested
merging traces by concatenating them with `cat`. Concatenation is not a
merge: the recordings are read as one file, so nothing relates or
attributes their clocks, per-trace state collides between files, and
non-protobuf traces can't be concatenated at all. The right tool is
`trace_processor util merge`.