### PR TITLE
tp: fix size_t overflow in non-TracePacket field skip path

### DIFF
--- a/src/trace_processor/importers/proto/proto_trace_tokenizer.h
+++ b/src/trace_processor/importers/proto/proto_trace_tokenizer.h
@@ -117,8 +117,16 @@ class ProtoTraceTokenizer {
                                start_offset);
             }
 
+            const size_t header_overhead =
+                static_cast<size_t>(varint_end - tag_start);
+            const size_t kMaxSize = std::numeric_limits<size_t>::max();
+            if (PERFETTO_UNLIKELY(varint > kMaxSize - header_overhead)) {
+              return base::ErrStatus(
+                  "Oversized length-delimited field @ 0x%zx (ERR:tp-corrupt)",
+                  start_offset);
+            }
             size_t size_incl_header =
-                static_cast<size_t>(varint_end - tag_start) + varint;
+                header_overhead + static_cast<size_t>(varint);
             if (size_incl_header > avail) {
               return base::OkStatus();
             }


### PR DESCRIPTION
## Security Fix: size_t overflow → infinite loop in non-TracePacket field skip path

### Root Cause

In `src/trace_processor/importers/proto/proto_trace_tokenizer.h` (lines 120–125),
the `kLengthDelimited` skip branch computes:

```cpp
size_t size_incl_header =
    static_cast<size_t>(varint_end - tag_start) + varint;
if (size_incl_header > avail) {
  return base::OkStatus();
}
PERFETTO_CHECK(reader_.PopFrontBytes(size_incl_header));
```

When `varint` is near `SIZE_MAX` (e.g. `0xFFFFFFFFFFFFFFF5`), the addition
wraps `size_t` to zero. The guard evaluates `0 > avail` as false,
`PopFrontBytes(0)` is a no-op, and the outer `while(true)` spins indefinitely
at 100% CPU with no exit path.

### Impact

A 13-byte crafted trace file triggers the infinite loop in both
`trace_processor_shell` (full process hang) and `ui.perfetto.dev`
(Web Worker stuck, trace loading permanently blocked).

```bash
# PoC — generates the trigger file
printf '\x0A\x00\x12\xF5\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01' > poc.pb
```

### Fix

Added an explicit overflow pre-check before the addition, returning
`ErrStatus` on malformed input — consistent with other corrupt-trace
handling throughout this file. The same pattern guards against both
`SIZE_MAX` wrapping on 64-bit and `UINT32_MAX` wrapping on 32-bit.

### Testing

The fix causes the tokenizer to return `ErrStatus("Oversized length-delimited
field")` for the PoC input, terminating cleanly instead of looping.