### PR TITLE
tp: overhaul error handling and diagnostics for the shell and bundle

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -251,18 +251,44 @@ out/linux_msan/perfetto_unittests --gtest_brief=1 --gtest_filter="<TestSuiteName
 
 ## Creating Pull Requests
 
+**Always use stacked pull requests (PRs) with GitHub, via the `gh stack`
+CLI extension — do not open PRs with `gh pr create` directly.** A stack is a
+chain of dependent PRs, one per branch, each based on the branch below it
+(see the `gh-stack` skill in `.pi/skills/gh-stack/SKILL.md` for the full
+workflow). Perfetto uses stacks for all incremental review.
+
+1.  **Create the first branch of a new stack** (off the latest remote trunk):
+
+    ```bash
+    gh stack init dev/$USER/<name-of-branch>
+    ```
+
+    This creates the branch from the remote default branch and checks it out.
+
+2.  **Add a dependent branch** (a second PR that builds on the first):
+
+    ```bash
+    gh stack add dev/$USER/<name-of-branch>
+    ```
+
+3.  **Commit** with the normal `git add` / `git commit` workflow, then push
+    and open the PRs:
+
+    ```bash
+    gh stack submit --auto
+    ```
+
+Notes:
+
+- To keep the working tree clean while creating branches, `git stash` your
+  changes before `gh stack init` / `gh stack add` and `git stash pop` after.
+- Before pushing a stack, run `tools/run_presubmit` on each changed branch.
+- To change a lower layer of an existing stack, navigate to it
+  (`gh stack down` or `gh stack checkout <branch>`), commit there, then run
+  `gh stack rebase --upstack` to propagate the change up the stack.
+
 **Note:** This is the default PR workflow. If the user has their own way of
 creating and managing pull requests, follow that and skip this section.
-
-When creating a pull request, follow these steps:
-
-1.  **Create a new branch:**
-    Use the command `git checkout -b dev/$USER/<name-of-branch>` to create a new branch for your pull request.
-
-2.  **Create a stacked/dependent pull request:**
-    To create a pull request that depends on another, use the command `git checkout -b dev/$USER/<name-of-branch> <name-of-parent-branch>`.
-
-**Note:** The `git checkout` command only creates and switches to a new branch. The normal `git add` and `git commit` workflow should be used to add changes to the branch.
 
 ## Commit Messages
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -251,44 +251,18 @@ out/linux_msan/perfetto_unittests --gtest_brief=1 --gtest_filter="<TestSuiteName
 
 ## Creating Pull Requests
 
-**Always use stacked pull requests (PRs) with GitHub, via the `gh stack`
-CLI extension — do not open PRs with `gh pr create` directly.** A stack is a
-chain of dependent PRs, one per branch, each based on the branch below it
-(see the `gh-stack` skill in `.pi/skills/gh-stack/SKILL.md` for the full
-workflow). Perfetto uses stacks for all incremental review.
-
-1.  **Create the first branch of a new stack** (off the latest remote trunk):
-
-    ```bash
-    gh stack init dev/$USER/<name-of-branch>
-    ```
-
-    This creates the branch from the remote default branch and checks it out.
-
-2.  **Add a dependent branch** (a second PR that builds on the first):
-
-    ```bash
-    gh stack add dev/$USER/<name-of-branch>
-    ```
-
-3.  **Commit** with the normal `git add` / `git commit` workflow, then push
-    and open the PRs:
-
-    ```bash
-    gh stack submit --auto
-    ```
-
-Notes:
-
-- To keep the working tree clean while creating branches, `git stash` your
-  changes before `gh stack init` / `gh stack add` and `git stash pop` after.
-- Before pushing a stack, run `tools/run_presubmit` on each changed branch.
-- To change a lower layer of an existing stack, navigate to it
-  (`gh stack down` or `gh stack checkout <branch>`), commit there, then run
-  `gh stack rebase --upstack` to propagate the change up the stack.
-
 **Note:** This is the default PR workflow. If the user has their own way of
 creating and managing pull requests, follow that and skip this section.
+
+When creating a pull request, follow these steps:
+
+1.  **Create a new branch:**
+    Use the command `git checkout -b dev/$USER/<name-of-branch>` to create a new branch for your pull request.
+
+2.  **Create a stacked/dependent pull request:**
+    To create a pull request that depends on another, use the command `git checkout -b dev/$USER/<name-of-branch> <name-of-parent-branch>`.
+
+**Note:** The `git checkout` command only creates and switches to a new branch. The normal `git add` and `git commit` workflow should be used to add changes to the branch.
 
 ## Commit Messages
 

--- a/docs/learning-more/symbolization.md
+++ b/docs/learning-more/symbolization.md
@@ -228,6 +228,40 @@ gauge demand and prioritise.
 
 ### Troubleshooting
 
+`trace_processor bundle` always produces a bundle containing at least the
+original trace. When it cannot add all the enrichment it wants, it prints a
+summary of what is missing and how to fix it, then still exits successfully
+&mdash; so check the output of the command even when it succeeds. It exits
+non-zero only for genuine failures (unreadable input, unwritable output, or
+an explicitly-provided `--proguard-map` that cannot be read).
+
+Common messages and what they mean:
+
+- **`N frames could not be symbolized and will appear as "unknown"`** with a
+  `hint: use --symbol-paths ...` line: the tool searched the auto-discovered
+  paths (plus any `--symbol-paths` / `PERFETTO_BINARY_PATH` you gave) but
+  found no binary with a matching Build ID. Follow the hint, or re-run with
+  `--verbose` to see every path that was tried.
+
+- **`N frames ... no build IDs in trace, symbol lookup requires build IDs`**:
+  the trace's mappings have no Build ID, so symbols cannot be matched even
+  with the right binaries. Rebuild the binaries with Build IDs (linker flag
+  `-Wl,--build-id`) and re-record.
+
+- **`Kernel function names: this trace contains function_graph events ...`**:
+  the trace contains kernel addresses from `function_graph` (or similar
+  ftrace events) recorded **without** `symbolize_ksyms`. These cannot be
+  symbolized offline; re-record with `symbolize_ksyms: true`. See
+  [Kernel ftrace events](#ftrace).
+
+- **`no symbol paths were searched`**: automatic discovery was disabled
+  (`--no-auto-symbol-paths`) and no explicit paths were given. Pass
+  `--symbol-paths` with the directories to search.
+
+- **`failed to open output file ...`**: the output path could not be created
+  (e.g. the parent directory does not exist or is not writable). Check the
+  path.
+
 #### Could not find library
 
 When symbolizing a profile you may see messages like:

--- a/docs/learning-more/symbolization.md
+++ b/docs/learning-more/symbolization.md
@@ -239,7 +239,7 @@ Common messages and what they mean:
 
 - **`N frames could not be symbolized and will appear as "unknown"`** with a
   `hint: use --symbol-paths ...` line: the tool searched the auto-discovered
-  paths (plus any `--symbol-paths` / `PERFETTO_BINARY_PATH` you gave) but
+  paths (plus any `--symbol-paths` you gave) but
   found no binary with a matching Build ID. Follow the hint, or re-run with
   `--verbose` to see every path that was tried.
 
@@ -272,7 +272,7 @@ Could not find /data/app/invalid.app-wFgo3GRaod02wSvPZQ==/lib/arm64/somelib.so
 ```
 
 Check that `somelib.so` exists somewhere under one of the search paths
-(`--symbol-paths`, `PERFETTO_BINARY_PATH`, or an auto-discovered location). Then
+(`--symbol-paths` or an auto-discovered location). Then
 compare the Build ID on disk to the one reported in the message using
 `readelf -n /path/to/somelib.so`. If they do not match, the copy on disk is a
 different build than the one on device and cannot be used.

--- a/gn/perfetto_integrationtests.gni
+++ b/gn/perfetto_integrationtests.gni
@@ -50,6 +50,8 @@ if (enable_perfetto_trace_processor && perfetto_build_standalone &&
   perfetto_integrationtests_targets +=
       [ "src/trace_processor:integrationtests" ]
   perfetto_integrationtests_targets += [ "src/traceconv:integrationtests" ]
+  perfetto_integrationtests_targets +=
+      [ "src/trace_processor/shell:integrationtests" ]
   perfetto_integrationtests_data_targets +=
       [ "protos/perfetto/trace:test_extensions_slim_descriptor" ]
 }

--- a/include/perfetto/ext/base/file_utils.h
+++ b/include/perfetto/ext/base/file_utils.h
@@ -115,6 +115,9 @@ bool Unlink(const char* path);
 // Wrapper around access(path, F_OK).
 bool FileExists(const std::string& path);
 
+// Returns true if the path exists and is a directory.
+bool DirectoryExists(const std::string& path);
+
 // Gets the extension for a filename. If the file has two extensions, returns
 // only the last one (foo.pb.gz => .gz). Returns empty string if there is no
 // extension.

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -347,6 +347,16 @@ bool FileExists(const std::string& path) {
 #endif
 }
 
+bool DirectoryExists(const std::string& path) {
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  DWORD attrs = GetFileAttributesA(path.c_str());
+  return attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY);
+#else
+  struct stat st;
+  return stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+#endif
+}
+
 // Declared in base/platform_handle.h.
 int ClosePlatformHandle(PlatformHandle handle) {
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -353,7 +353,13 @@ bool DirectoryExists(const std::string& path) {
   return attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY);
 #else
   struct stat st;
-  return stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+  if (stat(path.c_str(), &st) != 0) {
+    return false;
+  }
+  // MSan's stat() interceptor on glibc 2.35+ does not mark the output buffer
+  // as initialized (the syscall goes through statx).
+  PERFETTO_MSAN_UNPOISON(&st, sizeof(st));
+  return S_ISDIR(st.st_mode);
 #endif
 }
 

--- a/src/trace_processor/importers/proto/proto_trace_tokenizer.h
+++ b/src/trace_processor/importers/proto/proto_trace_tokenizer.h
@@ -155,7 +155,9 @@ class ProtoTraceTokenizer {
           }
           default:
             return base::ErrStatus(
-                "Unknown field type @ 0x%zx (ERR:tp-corrupt)", start_offset);
+                "Unknown field type @ 0x%zx; the trace is corrupt or was "
+                "produced by a newer version of Perfetto (ERR:tp-corrupt)",
+                start_offset);
         }
       }
 

--- a/src/trace_processor/read_trace_internal.cc
+++ b/src/trace_processor/read_trace_internal.cc
@@ -591,8 +591,10 @@ base::Status ReadTraceUnfinalized(
 #endif  // PERFETTO_HAS_MMAP()
   if (bytes_read == 0) {
     base::ScopedFile fd(base::OpenFile(filename, O_RDONLY));
-    if (!fd)
-      return base::ErrStatus("Could not open trace file (path: %s)", filename);
+    if (!fd) {
+      return base::ErrStatus("could not open trace file (errno: %d, %s)", errno,
+                             strerror(errno));
+    }
     RETURN_IF_ERROR(
         ReadTraceUsingRead(tp, *fd, &bytes_read, progress_callback));
   }

--- a/src/trace_processor/read_trace_internal.cc
+++ b/src/trace_processor/read_trace_internal.cc
@@ -592,8 +592,8 @@ base::Status ReadTraceUnfinalized(
   if (bytes_read == 0) {
     base::ScopedFile fd(base::OpenFile(filename, O_RDONLY));
     if (!fd) {
-      return base::ErrStatus("could not open trace file (errno: %d, %s)", errno,
-                             strerror(errno));
+      return base::ErrStatus("could not open trace file %s (errno: %d, %s)",
+                             filename, errno, strerror(errno));
     }
     RETURN_IF_ERROR(
         ReadTraceUsingRead(tp, *fd, &bytes_read, progress_callback));

--- a/src/trace_processor/shell/BUILD.gn
+++ b/src/trace_processor/shell/BUILD.gn
@@ -145,4 +145,3 @@ if (enable_perfetto_integration_tests) {
     ]
   }
 }
-

--- a/src/trace_processor/shell/BUILD.gn
+++ b/src/trace_processor/shell/BUILD.gn
@@ -64,6 +64,7 @@ source_set("shell") {
     "../../traceconv:gen_cc_android_extension_descriptor",
     "../../traceconv:gen_cc_trace_descriptor",
     "../../traceconv:lib",
+    "../../traceconv:utils",
     "../metrics",
     "../rpc",
     "../rpc:lifecycle",
@@ -126,3 +127,22 @@ source_set("unittests") {
     "../../base",
   ]
 }
+if (enable_perfetto_integration_tests) {
+  source_set("integrationtests") {
+    testonly = true
+    sources = [ "bundle_integrationtest.cc" ]
+    deps = [
+      "..:trace_processor_shell_lib",
+      "../../../gn:default_deps",
+      "../../../gn:gtest_and_gmock",
+      "../../../include/perfetto/ext/base",
+      "../../../include/perfetto/ext/trace_processor:trace_processor_shell",
+      "../../../protos/perfetto/trace:cpp",
+      "../../../protos/perfetto/trace/ftrace:cpp",
+      "../../../protos/perfetto/trace/interned_data:cpp",
+      "../../../protos/perfetto/trace/profiling:cpp",
+      "../../base:test_support",
+    ]
+  }
+}
+

--- a/src/trace_processor/shell/bundle_integrationtest.cc
+++ b/src/trace_processor/shell/bundle_integrationtest.cc
@@ -100,7 +100,7 @@ std::map<std::string, std::string> ReadTarMembers(const std::string& path) {
   return out;
 }
 
-class TraceconvBundleTest : public ::testing::Test {
+class TraceconvShellBundleTest : public ::testing::Test {
  protected:
   void SetUp() override {
     input_trace_ = base::GetTestDataPath(
@@ -137,7 +137,7 @@ class TraceconvBundleTest : public ::testing::Test {
 // The bundle should contain the unmodified input trace plus a parseable
 // deobfuscation.pb whose `deobfuscation_mapping` reflects the supplied
 // mapping.txt (package, class, method names).
-TEST_F(TraceconvBundleTest, BundleWithProguardMap) {
+TEST_F(TraceconvShellBundleTest, BundleWithProguardMap) {
   base::TempFile mapping = WriteTempFile(
       "com.example.Foo -> a.a:\n"
       "    void bar() -> b\n");
@@ -183,7 +183,7 @@ TEST_F(TraceconvBundleTest, BundleWithProguardMap) {
 
 // Repeating --proguard-map should produce one DeobfuscationMapping per input
 // map, each tagged with the right package name.
-TEST_F(TraceconvBundleTest, BundleWithRepeatedProguardMaps) {
+TEST_F(TraceconvShellBundleTest, BundleWithRepeatedProguardMaps) {
   base::TempFile map1 = WriteTempFile("com.example.Foo -> a.a:\n");
   base::TempFile map2 = WriteTempFile("com.example.Bar -> b.b:\n");
 
@@ -208,7 +208,7 @@ TEST_F(TraceconvBundleTest, BundleWithRepeatedProguardMaps) {
 
 // --proguard-map without `pkg=` is accepted; the package name ends up empty
 // in the emitted mapping but the class mapping is still present.
-TEST_F(TraceconvBundleTest, BundleWithProguardMapNoPackage) {
+TEST_F(TraceconvShellBundleTest, BundleWithProguardMapNoPackage) {
   base::TempFile mapping = WriteTempFile("com.example.Foo -> a.a:\n");
 
   ArgvInvoker invoker;
@@ -234,7 +234,7 @@ TEST_F(TraceconvBundleTest, BundleWithProguardMapNoPackage) {
 }
 
 // Explicit --proguard-map pointing at a missing file must fail the command.
-TEST_F(TraceconvBundleTest, BundleWithMissingProguardMapFails) {
+TEST_F(TraceconvShellBundleTest, BundleWithMissingProguardMapFails) {
   ArgvInvoker invoker;
   invoker.Add("trace_processor_shell");
   invoker.Add("bundle");
@@ -248,7 +248,7 @@ TEST_F(TraceconvBundleTest, BundleWithMissingProguardMapFails) {
 }
 
 // --proguard-map with no following argument is a usage error.
-TEST_F(TraceconvBundleTest, BundleProguardMapMissingArgFails) {
+TEST_F(TraceconvShellBundleTest, BundleProguardMapMissingArgFails) {
   ArgvInvoker invoker;
   invoker.Add("trace_processor_shell");
   invoker.Add("bundle");
@@ -261,7 +261,7 @@ TEST_F(TraceconvBundleTest, BundleProguardMapMissingArgFails) {
 // and produces a DeobfuscationMapping for the specified package. (In the
 // test environment there are no Gradle layouts to auto-discover either
 // way, so this asserts the explicit path keeps working.)
-TEST_F(TraceconvBundleTest, BundleNoAutoProguardMapsWithExplicit) {
+TEST_F(TraceconvShellBundleTest, BundleNoAutoProguardMapsWithExplicit) {
   base::TempFile mapping = WriteTempFile("com.example.Foo -> a.a:\n");
 
   ArgvInvoker invoker;
@@ -376,7 +376,7 @@ class ScopedStderrCapture {
 // (the trace alone is bundled) but must tell the user why the names are hex
 // and how to fix it.
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-TEST_F(TraceconvBundleTest, BundleFuncgraphWithoutKallsymsGuidesUser) {
+TEST_F(TraceconvShellBundleTest, BundleFuncgraphWithoutKallsymsGuidesUser) {
   base::TempFile trace =
       WriteTempFile(BuildFuncgraphTrace(/*with_ksyms=*/false));
 
@@ -406,7 +406,7 @@ TEST_F(TraceconvBundleTest, BundleFuncgraphWithoutKallsymsGuidesUser) {
 
 // When symbolize_ksyms WAS enabled the names resolve fine: the bundle should
 // succeed without the kernel warning.
-TEST_F(TraceconvBundleTest, BundleFuncgraphWithKallsymsSucceedsQuietly) {
+TEST_F(TraceconvShellBundleTest, BundleFuncgraphWithKallsymsSucceedsQuietly) {
   base::TempFile trace =
       WriteTempFile(BuildFuncgraphTrace(/*with_ksyms=*/true));
 
@@ -427,7 +427,7 @@ TEST_F(TraceconvBundleTest, BundleFuncgraphWithKallsymsSucceedsQuietly) {
 // A trace with no profiled data at all (e.g. a pure atrace/systrace trace)
 // has nothing to enrich; bundling it must succeed, not fail with a cryptic
 // message.
-TEST_F(TraceconvBundleTest, BundleTraceWithoutProfileDataSucceeds) {
+TEST_F(TraceconvShellBundleTest, BundleTraceWithoutProfileDataSucceeds) {
   base::TempFile trace = WriteTempFile("");
 
   ArgvInvoker invoker;
@@ -445,7 +445,7 @@ TEST_F(TraceconvBundleTest, BundleTraceWithoutProfileDataSucceeds) {
 // (with the trace), and the user gets a summary of what could not be
 // symbolized plus a hint on how to fix it.
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-TEST_F(TraceconvBundleTest, BundleUnsymbolizedFramesSucceedsWithWarning) {
+TEST_F(TraceconvShellBundleTest, BundleUnsymbolizedFramesSucceedsWithWarning) {
   ArgvInvoker invoker;
   invoker.Add("trace_processor_shell");
   invoker.Add("bundle");
@@ -472,7 +472,7 @@ TEST_F(TraceconvBundleTest, BundleUnsymbolizedFramesSucceedsWithWarning) {
 // With --no-auto-symbol-paths and no explicit paths, no symbol source is
 // configured at all: the user must be told how to provide one.
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-TEST_F(TraceconvBundleTest, BundleNoSymbolPathsConfiguredExplainsFix) {
+TEST_F(TraceconvShellBundleTest, BundleNoSymbolPathsConfiguredExplainsFix) {
   ArgvInvoker invoker;
   invoker.Add("trace_processor_shell");
   invoker.Add("bundle");
@@ -494,7 +494,7 @@ TEST_F(TraceconvBundleTest, BundleNoSymbolPathsConfiguredExplainsFix) {
 
 // An unwritable output path must produce a graceful, descriptive error
 // instead of crashing the process.
-TEST_F(TraceconvBundleTest, BundleUnwritableOutputFailsGracefully) {
+TEST_F(TraceconvShellBundleTest, BundleUnwritableOutputFailsGracefully) {
   ArgvInvoker invoker;
   invoker.Add("trace_processor_shell");
   invoker.Add("bundle");
@@ -508,7 +508,7 @@ TEST_F(TraceconvBundleTest, BundleUnwritableOutputFailsGracefully) {
 }
 
 // An input path that is a directory must produce a helpful message.
-TEST_F(TraceconvBundleTest, BundleInputIsDirectoryFailsHelpfully) {
+TEST_F(TraceconvShellBundleTest, BundleInputIsDirectoryFailsHelpfully) {
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
   GTEST_SKIP() << "directory-vs-file validation differs on Windows";
 #endif
@@ -523,7 +523,7 @@ TEST_F(TraceconvBundleTest, BundleInputIsDirectoryFailsHelpfully) {
 
 // A broken input symlink must be called out as a broken link, not as a
 // missing file.
-TEST_F(TraceconvBundleTest, BundleBrokenSymlinkInputFailsHelpfully) {
+TEST_F(TraceconvShellBundleTest, BundleBrokenSymlinkInputFailsHelpfully) {
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
   GTEST_SKIP() << "symlink tests are POSIX-only";
 #endif
@@ -544,7 +544,7 @@ TEST_F(TraceconvBundleTest, BundleBrokenSymlinkInputFailsHelpfully) {
 
 // A garbage (non-trace) input file must fail with a clear "not a trace"
 // style error rather than a bare failure.
-TEST_F(TraceconvBundleTest, BundleMalformedInputFailsWithReason) {
+TEST_F(TraceconvShellBundleTest, BundleMalformedInputFailsWithReason) {
   base::TempFile trace = WriteTempFile(
       "this is definitely not a perfetto trace, just some text bytes");
 
@@ -562,7 +562,7 @@ TEST_F(TraceconvBundleTest, BundleMalformedInputFailsWithReason) {
 // `bundle --symbol-paths a b trace out.tar`). The shell must reject this
 // with a hint instead of silently treating the extra paths as the input and
 // output files.
-TEST_F(TraceconvBundleTest, BundleRejectsSymbolPathsAsSeparateArgs) {
+TEST_F(TraceconvShellBundleTest, BundleRejectsSymbolPathsAsSeparateArgs) {
   ArgvInvoker invoker;
   invoker.Add("trace_processor_shell");
   invoker.Add("bundle");

--- a/src/trace_processor/shell/bundle_integrationtest.cc
+++ b/src/trace_processor/shell/bundle_integrationtest.cc
@@ -1,0 +1,580 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "perfetto/ext/trace_processor/trace_processor_shell.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/build_config.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/temp_file.h"
+#include "protos/perfetto/trace/ftrace/ftrace.gen.h"
+#include "protos/perfetto/trace/ftrace/ftrace_event.gen.h"
+#include "protos/perfetto/trace/ftrace/ftrace_event_bundle.gen.h"
+#include "protos/perfetto/trace/interned_data/interned_data.gen.h"
+#include "protos/perfetto/trace/profiling/deobfuscation.gen.h"
+#include "protos/perfetto/trace/profiling/profile_common.gen.h"
+#include "protos/perfetto/trace/trace.gen.h"
+#include "protos/perfetto/trace/trace_packet.gen.h"
+#include "src/base/test/utils.h"
+#include "test/gtest_and_gmock.h"
+
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+#include <unistd.h>
+#endif
+
+namespace perfetto::trace_processor {
+namespace {
+
+using testing::HasSubstr;
+using testing::UnorderedElementsAre;
+
+// Helper: builds an argv from owned strings and invokes the shell's `bundle`
+// subcommand via TraceProcessorShellMain.
+class ArgvInvoker {
+ public:
+  void Add(const std::string& arg) { args_.push_back(arg); }
+  int Run() {
+    std::vector<char*> argv;
+    for (auto& s : args_) {
+      argv.push_back(s.data());
+    }
+    return TraceProcessorShellMain(static_cast<int>(argv.size()), argv.data());
+  }
+
+ private:
+  std::vector<std::string> args_;
+};
+
+base::TempFile WriteTempFile(const std::string& content) {
+  auto f = base::TempFile::Create();
+  PERFETTO_CHECK(base::WriteAll(f.fd(), content.data(), content.size()) ==
+                 static_cast<ssize_t>(content.size()));
+  return f;
+}
+
+// Parses a USTAR archive into a map of filename -> file content.
+// USTAR layout: each file is a 512-byte header (name at offset 0, size as
+// octal ASCII at offset 124) followed by the content padded to 512 bytes;
+// the archive ends with at least two zero-filled blocks.
+std::map<std::string, std::string> ReadTarMembers(const std::string& path) {
+  std::string bytes;
+  PERFETTO_CHECK(base::ReadFile(path, &bytes));
+  std::map<std::string, std::string> out;
+  size_t pos = 0;
+  while (pos + 512 <= bytes.size()) {
+    const char* header = bytes.data() + pos;
+    // Zero-name header -> end-of-archive marker.
+    if (header[0] == '\0') {
+      break;
+    }
+    std::string name(header, strnlen(header, 100));
+    // Size is null/space terminated octal ASCII at offset 124, up to 11 digits.
+    char size_buf[13] = {};
+    memcpy(size_buf, header + 124, 12);
+    size_t size = static_cast<size_t>(strtoul(size_buf, nullptr, 8));
+    pos += 512;
+    PERFETTO_CHECK(pos + size <= bytes.size());
+    out.emplace(std::move(name), bytes.substr(pos, size));
+    // Content is padded to a 512-byte boundary.
+    pos += ((size + 511) / 512) * 512;
+  }
+  return out;
+}
+
+class TraceconvBundleTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    input_trace_ = base::GetTestDataPath(
+        "test/data/heapprofd_standalone_client_example-trace");
+    output_path_ = temp_dir_.path() + "/bundle.tar";
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+    GTEST_SKIP() << "do not run traceconv tests on Android target";
+#endif
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+    GTEST_SKIP() << "TarWriter is not supported on Windows";
+#endif
+  }
+
+  void TearDown() override { remove(output_path_.c_str()); }
+
+  // Collects every package_name found in a deobfuscation.pb proto stream.
+  static std::set<std::string> PackageNames(const std::string& deob_bytes) {
+    protos::gen::Trace trace;
+    PERFETTO_CHECK(trace.ParseFromString(deob_bytes));
+    std::set<std::string> names;
+    for (const auto& pkt : trace.packet()) {
+      if (pkt.has_deobfuscation_mapping()) {
+        names.insert(pkt.deobfuscation_mapping().package_name());
+      }
+    }
+    return names;
+  }
+
+  base::TempDir temp_dir_ = base::TempDir::Create();
+  std::string input_trace_;
+  std::string output_path_;
+};
+
+// The bundle should contain the unmodified input trace plus a parseable
+// deobfuscation.pb whose `deobfuscation_mapping` reflects the supplied
+// mapping.txt (package, class, method names).
+TEST_F(TraceconvBundleTest, BundleWithProguardMap) {
+  base::TempFile mapping = WriteTempFile(
+      "com.example.Foo -> a.a:\n"
+      "    void bar() -> b\n");
+
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add("--proguard-map");
+  invoker.Add("com.example=" + mapping.path());
+  invoker.Add(input_trace_);
+  invoker.Add(output_path_);
+
+  ASSERT_EQ(invoker.Run(), 0);
+
+  auto members = ReadTarMembers(output_path_);
+  ASSERT_EQ(members.size(), 2u);
+
+  // trace.perfetto must be a byte-for-byte copy of the input trace.
+  std::string input_bytes;
+  ASSERT_TRUE(base::ReadFile(input_trace_, &input_bytes));
+  auto trace_it = members.find("trace.perfetto");
+  ASSERT_NE(trace_it, members.end());
+  EXPECT_EQ(trace_it->second, input_bytes);
+
+  // deobfuscation.pb parses as a Trace proto containing one
+  // DeobfuscationMapping for package "com.example" with our class + method.
+  auto deob_it = members.find("deobfuscation.pb");
+  ASSERT_NE(deob_it, members.end());
+  protos::gen::Trace deob;
+  ASSERT_TRUE(deob.ParseFromString(deob_it->second));
+  ASSERT_EQ(deob.packet().size(), 1u);
+  ASSERT_TRUE(deob.packet()[0].has_deobfuscation_mapping());
+  const auto& dm = deob.packet()[0].deobfuscation_mapping();
+  EXPECT_EQ(dm.package_name(), "com.example");
+  ASSERT_EQ(dm.obfuscated_classes().size(), 1u);
+  const auto& cls = dm.obfuscated_classes()[0];
+  EXPECT_EQ(cls.obfuscated_name(), "a.a");
+  EXPECT_EQ(cls.deobfuscated_name(), "com.example.Foo");
+  ASSERT_EQ(cls.obfuscated_methods().size(), 1u);
+  EXPECT_EQ(cls.obfuscated_methods()[0].obfuscated_name(), "b");
+}
+
+// Repeating --proguard-map should produce one DeobfuscationMapping per input
+// map, each tagged with the right package name.
+TEST_F(TraceconvBundleTest, BundleWithRepeatedProguardMaps) {
+  base::TempFile map1 = WriteTempFile("com.example.Foo -> a.a:\n");
+  base::TempFile map2 = WriteTempFile("com.example.Bar -> b.b:\n");
+
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add("--proguard-map");
+  invoker.Add("com.example.one=" + map1.path());
+  invoker.Add("--proguard-map");
+  invoker.Add("com.example.two=" + map2.path());
+  invoker.Add(input_trace_);
+  invoker.Add(output_path_);
+
+  ASSERT_EQ(invoker.Run(), 0);
+
+  auto members = ReadTarMembers(output_path_);
+  ASSERT_TRUE(members.count("deobfuscation.pb"));
+  EXPECT_THAT(PackageNames(members["deobfuscation.pb"]),
+              UnorderedElementsAre("com.example.one", "com.example.two"));
+}
+
+// --proguard-map without `pkg=` is accepted; the package name ends up empty
+// in the emitted mapping but the class mapping is still present.
+TEST_F(TraceconvBundleTest, BundleWithProguardMapNoPackage) {
+  base::TempFile mapping = WriteTempFile("com.example.Foo -> a.a:\n");
+
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add("--proguard-map");
+  invoker.Add(mapping.path());
+  invoker.Add(input_trace_);
+  invoker.Add(output_path_);
+
+  ASSERT_EQ(invoker.Run(), 0);
+
+  auto members = ReadTarMembers(output_path_);
+  ASSERT_TRUE(members.count("deobfuscation.pb"));
+  protos::gen::Trace deob;
+  ASSERT_TRUE(deob.ParseFromString(members["deobfuscation.pb"]));
+  ASSERT_EQ(deob.packet().size(), 1u);
+  const auto& dm = deob.packet()[0].deobfuscation_mapping();
+  EXPECT_EQ(dm.package_name(), "");
+  ASSERT_EQ(dm.obfuscated_classes().size(), 1u);
+  EXPECT_EQ(dm.obfuscated_classes()[0].deobfuscated_name(), "com.example.Foo");
+}
+
+// Explicit --proguard-map pointing at a missing file must fail the command.
+TEST_F(TraceconvBundleTest, BundleWithMissingProguardMapFails) {
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add("--proguard-map");
+  invoker.Add("com.example=/nonexistent/mapping.txt");
+  invoker.Add(input_trace_);
+  invoker.Add(output_path_);
+
+  EXPECT_NE(invoker.Run(), 0);
+}
+
+// --proguard-map with no following argument is a usage error.
+TEST_F(TraceconvBundleTest, BundleProguardMapMissingArgFails) {
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--proguard-map");
+
+  EXPECT_NE(invoker.Run(), 0);
+}
+
+// With --no-auto-proguard-maps, an explicit --proguard-map still propagates
+// and produces a DeobfuscationMapping for the specified package. (In the
+// test environment there are no Gradle layouts to auto-discover either
+// way, so this asserts the explicit path keeps working.)
+TEST_F(TraceconvBundleTest, BundleNoAutoProguardMapsWithExplicit) {
+  base::TempFile mapping = WriteTempFile("com.example.Foo -> a.a:\n");
+
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add("--no-auto-proguard-maps");
+  invoker.Add("--proguard-map");
+  invoker.Add("com.example=" + mapping.path());
+  invoker.Add(input_trace_);
+  invoker.Add(output_path_);
+
+  ASSERT_EQ(invoker.Run(), 0);
+
+  auto members = ReadTarMembers(output_path_);
+  ASSERT_TRUE(members.count("deobfuscation.pb"));
+  EXPECT_THAT(PackageNames(members["deobfuscation.pb"]),
+              UnorderedElementsAre("com.example"));
+}
+
+// --- Edge-case feedback tests ---
+//
+// These assert that the bundle command gives *useful* feedback in the
+// situations users actually hit (see https://github.com/google/perfetto/
+// issues/6927), rather than a bare "failed to create bundle."
+
+// Builds a minimal trace with a single function_graph entry/exit event on
+// cpu 0 (the idle thread). If |with_ksyms| is true, the trace also embeds a
+// kernel symbol map (as traced_probes does when FtraceConfig.symbolize_ksyms
+// is enabled), so the function resolves to its name; otherwise it stays a
+// raw hex address that cannot be symbolized offline.
+std::string BuildFuncgraphTrace(bool with_ksyms) {
+  protos::gen::Trace trace;
+
+  if (with_ksyms) {
+    auto* packet = trace.add_packet();
+    packet->set_timestamp(100);
+    packet->set_trusted_uid(0);
+    packet->set_trusted_packet_sequence_id(2);
+    packet->set_sequence_flags(
+        protos::gen::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
+    auto* sym = packet->mutable_interned_data()->add_kernel_symbols();
+    sym->set_iid(42);
+    sym->set_str("my_kernel_func");
+  }
+
+  auto* packet = trace.add_packet();
+  packet->set_timestamp(1000);
+  packet->set_trusted_uid(0);
+  packet->set_trusted_packet_sequence_id(2);
+  auto* bundle = packet->mutable_ftrace_events();
+  bundle->set_cpu(0);
+  auto* entry = bundle->add_event();
+  entry->set_timestamp(1000);
+  entry->set_pid(0);
+  entry->mutable_funcgraph_entry()->set_depth(0);
+  entry->mutable_funcgraph_entry()->set_func(42);
+  auto* exit_evt = bundle->add_event();
+  exit_evt->set_timestamp(1000);
+  exit_evt->set_pid(0);
+  auto* exit_fg = exit_evt->mutable_funcgraph_exit();
+  exit_fg->set_calltime(1000);
+  exit_fg->set_depth(0);
+  exit_fg->set_func(42);
+  exit_fg->set_overrun(0);
+  exit_fg->set_rettime(2000);
+
+  return trace.SerializeAsString();
+}
+
+// Redirects stderr to a temp file for the lifetime of the object so tests
+// can assert on the shell's diagnostics. POSIX only (the tests that use it
+// are not compiled on Windows; see the #if guards around them below).
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+class ScopedStderrCapture {
+ public:
+  ScopedStderrCapture() {
+    fflush(stderr);
+    saved_fd_ = dup(STDERR_FILENO);
+    PERFETTO_CHECK(saved_fd_ >= 0);
+    char tmpl[] = "/tmp/perfetto_stderr_XXXXXX";
+    capture_fd_ = mkstemp(tmpl);
+    PERFETTO_CHECK(capture_fd_ >= 0);
+    path_ = tmpl;
+    PERFETTO_CHECK(dup2(capture_fd_, STDERR_FILENO) == STDERR_FILENO);
+  }
+
+  ~ScopedStderrCapture() {
+    fflush(stderr);
+    dup2(saved_fd_, STDERR_FILENO);
+    close(saved_fd_);
+    close(capture_fd_);
+    unlink(path_.c_str());
+  }
+
+  std::string Get() const {
+    fflush(stderr);
+    std::string out;
+    PERFETTO_CHECK(base::ReadFile(path_, &out));
+    return out;
+  }
+
+ private:
+  int saved_fd_ = -1;
+  int capture_fd_ = -1;
+  std::string path_;
+};
+#endif  // !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+
+// A function_graph trace recorded WITHOUT symbolize_ksyms contains raw kernel
+// addresses that cannot be symbolized offline. The bundle must still succeed
+// (the trace alone is bundled) but must tell the user why the names are hex
+// and how to fix it.
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+TEST_F(TraceconvBundleTest, BundleFuncgraphWithoutKallsymsGuidesUser) {
+  base::TempFile trace =
+      WriteTempFile(BuildFuncgraphTrace(/*with_ksyms=*/false));
+
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add(trace.path());
+  invoker.Add(output_path_);
+
+  ScopedStderrCapture capture;
+  ASSERT_EQ(invoker.Run(), 0);
+  std::string stderr_text = capture.Get();
+
+  // The trace is bundled even though nothing could be symbolized.
+  auto members = ReadTarMembers(output_path_);
+  ASSERT_TRUE(members.count("trace.perfetto"));
+  EXPECT_EQ(members.size(), 1u);
+
+  // The user must be pointed at symbolize_ksyms, with the config and doc.
+  EXPECT_THAT(stderr_text, HasSubstr("symbolize_ksyms: true"));
+  EXPECT_THAT(stderr_text, HasSubstr("function_graph"));
+  EXPECT_THAT(stderr_text, HasSubstr("re-record"));
+  EXPECT_THAT(stderr_text, HasSubstr("symbolization#ftrace"));
+}
+#endif  // !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+
+// When symbolize_ksyms WAS enabled the names resolve fine: the bundle should
+// succeed without the kernel warning.
+TEST_F(TraceconvBundleTest, BundleFuncgraphWithKallsymsSucceedsQuietly) {
+  base::TempFile trace =
+      WriteTempFile(BuildFuncgraphTrace(/*with_ksyms=*/true));
+
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add(trace.path());
+  invoker.Add(output_path_);
+
+  ASSERT_EQ(invoker.Run(), 0);
+
+  auto members = ReadTarMembers(output_path_);
+  ASSERT_TRUE(members.count("trace.perfetto"));
+  EXPECT_EQ(members.size(), 1u);
+}
+
+// A trace with no profiled data at all (e.g. a pure atrace/systrace trace)
+// has nothing to enrich; bundling it must succeed, not fail with a cryptic
+// message.
+TEST_F(TraceconvBundleTest, BundleTraceWithoutProfileDataSucceeds) {
+  base::TempFile trace = WriteTempFile("");
+
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add(trace.path());
+  invoker.Add(output_path_);
+
+  ASSERT_EQ(invoker.Run(), 0);
+  EXPECT_EQ(ReadTarMembers(output_path_).size(), 1u);
+}
+
+// A trace with unsymbolized user-space frames: the bundle is still produced
+// (with the trace), and the user gets a summary of what could not be
+// symbolized plus a hint on how to fix it.
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+TEST_F(TraceconvBundleTest, BundleUnsymbolizedFramesSucceedsWithWarning) {
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  // Note: no --no-auto-symbol-paths here, so the symbolizer searches the
+  // mappings' absolute paths (which don't exist in this environment) and
+  // reports them as "no matching symbols".
+  invoker.Add(input_trace_);
+  invoker.Add(output_path_);
+
+  ScopedStderrCapture capture;
+  ASSERT_EQ(invoker.Run(), 0);
+  std::string stderr_text = capture.Get();
+
+  auto members = ReadTarMembers(output_path_);
+  ASSERT_TRUE(members.count("trace.perfetto"));
+  // No symbols were found, so no symbols.pb member is expected.
+  EXPECT_FALSE(members.count("symbols.pb"));
+
+  EXPECT_THAT(stderr_text, HasSubstr("could not be symbolized"));
+  EXPECT_THAT(stderr_text, HasSubstr("--symbol-paths"));
+}
+#endif  // !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+
+// With --no-auto-symbol-paths and no explicit paths, no symbol source is
+// configured at all: the user must be told how to provide one.
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+TEST_F(TraceconvBundleTest, BundleNoSymbolPathsConfiguredExplainsFix) {
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add(input_trace_);
+  invoker.Add(output_path_);
+
+  ScopedStderrCapture capture;
+  ASSERT_EQ(invoker.Run(), 0);
+  std::string stderr_text = capture.Get();
+
+  EXPECT_THAT(stderr_text, HasSubstr("no symbol paths were searched"));
+  EXPECT_THAT(stderr_text, HasSubstr("--symbol-paths"));
+  // PERFETTO_BINARY_PATH is a hidden feature and must not be surfaced in
+  // bundle's guidance.
+  EXPECT_THAT(stderr_text, Not(HasSubstr("PERFETTO_BINARY_PATH")));
+}
+#endif  // !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+
+// An unwritable output path must produce a graceful, descriptive error
+// instead of crashing the process.
+TEST_F(TraceconvBundleTest, BundleUnwritableOutputFailsGracefully) {
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add(input_trace_);
+  invoker.Add(temp_dir_.path() + "/no_such_dir/out.tar");
+
+  // Previously this crashed with a PERFETTO_CHECK deep in the tar writer;
+  // now it must return a normal error.
+  EXPECT_NE(invoker.Run(), 0);
+}
+
+// An input path that is a directory must produce a helpful message.
+TEST_F(TraceconvBundleTest, BundleInputIsDirectoryFailsHelpfully) {
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  GTEST_SKIP() << "directory-vs-file validation differs on Windows";
+#endif
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add(temp_dir_.path());
+  invoker.Add(output_path_);
+
+  EXPECT_EQ(invoker.Run(), 1);
+}
+
+// A broken input symlink must be called out as a broken link, not as a
+// missing file.
+TEST_F(TraceconvBundleTest, BundleBrokenSymlinkInputFailsHelpfully) {
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  GTEST_SKIP() << "symlink tests are POSIX-only";
+#endif
+  std::string link_path = temp_dir_.path() + "/dangling.pftrace";
+  PERFETTO_CHECK(symlink("/nonexistent/target.pftrace", link_path.c_str()) ==
+                 0);
+
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add(link_path);
+  invoker.Add(output_path_);
+
+  EXPECT_NE(invoker.Run(), 0);
+  // Clean up so the TempDir destructor can remove the directory.
+  unlink(link_path.c_str());
+}
+
+// A garbage (non-trace) input file must fail with a clear "not a trace"
+// style error rather than a bare failure.
+TEST_F(TraceconvBundleTest, BundleMalformedInputFailsWithReason) {
+  base::TempFile trace = WriteTempFile(
+      "this is definitely not a perfetto trace, just some text bytes");
+
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add(trace.path());
+  invoker.Add(output_path_);
+
+  EXPECT_NE(invoker.Run(), 0);
+}
+
+// Regression test for the classic misuse where each --symbol-paths directory
+// is passed as a separate positional argument (e.g.
+// `bundle --symbol-paths a b trace out.tar`). The shell must reject this
+// with a hint instead of silently treating the extra paths as the input and
+// output files.
+TEST_F(TraceconvBundleTest, BundleRejectsSymbolPathsAsSeparateArgs) {
+  ArgvInvoker invoker;
+  invoker.Add("trace_processor_shell");
+  invoker.Add("bundle");
+  invoker.Add("--no-auto-symbol-paths");
+  invoker.Add("--symbol-paths");
+  invoker.Add("/path/one");
+  invoker.Add("/path/two");
+  invoker.Add(input_trace_);
+  invoker.Add(output_path_);
+
+  EXPECT_NE(invoker.Run(), 0);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/shell/bundle_subcommand.cc
+++ b/src/trace_processor/shell/bundle_subcommand.cc
@@ -20,13 +20,47 @@
 #include <string>
 #include <vector>
 
+#include "perfetto/base/build_config.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/scoped_file.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "src/trace_processor/shell/subcommand.h"
 #include "src/traceconv/trace_to_bundle.h"
 
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <cerrno>
+#endif
+
 namespace perfetto::trace_processor::shell {
+namespace {
+
+// Returns a human-readable description of a symlink problem with `path`, or
+// an empty string if the path is either not a symlink or is a symlink whose
+// target resolves. Used to distinguish a broken/dangling link or a link loop
+// from a plain missing file, which would otherwise be reported as "does not
+// exist".
+std::string SymlinkProblemDescription(const std::string& path) {
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  return "";
+#else
+  struct stat st;
+  if (lstat(path.c_str(), &st) != 0 || !S_ISLNK(st.st_mode)) {
+    return "";
+  }
+  if (stat(path.c_str(), &st) != 0) {
+    if (errno == ELOOP) {
+      return "symbolic link loop (the link ultimately points to itself)";
+    }
+    return "broken symbolic link (its target does not exist)";
+  }
+  return "";
+#endif
+}
+
+}  // namespace
 
 const char* BundleSubcommand::name() const {
   return "bundle";
@@ -70,7 +104,16 @@ std::vector<FlagSpec> BundleSubcommand::GetFlags() {
 base::Status BundleSubcommand::Run(const SubcommandContext& ctx) {
   if (ctx.positional_args.size() < 2) {
     return base::ErrStatus(
-        "bundle requires both an input and an output file path.");
+        "bundle requires both an input and an output file path, got %zu "
+        "argument(s).",
+        ctx.positional_args.size());
+  }
+  if (ctx.positional_args.size() > 2) {
+    return RejectExtraPositionals(
+        ctx, "bundle", 2,
+        "Note: --symbol-paths takes a single comma-separated list of paths, "
+        "e.g. --symbol-paths path1,path2,path3; do not pass each path as a "
+        "separate argument.");
   }
   const std::string& input_file = ctx.positional_args[0];
   const std::string& output_file = ctx.positional_args[1];
@@ -84,8 +127,53 @@ base::Status BundleSubcommand::Run(const SubcommandContext& ctx) {
         "bundle does not support stdout output; provide a file path.");
   }
   if (!base::FileExists(input_file)) {
-    return base::ErrStatus("Input file does not exist: %s", input_file.c_str());
+    std::string symlink_problem = SymlinkProblemDescription(input_file);
+    if (!symlink_problem.empty()) {
+      return base::ErrStatus(
+          "bundle: input file '%s' is a %s. Fix the symlink and try again.",
+          input_file.c_str(), symlink_problem.c_str());
+    }
+    return base::ErrStatus(
+        "bundle: input file '%s' does not exist. Check the path and try "
+        "again.",
+        input_file.c_str());
   }
+  if (base::DirectoryExists(input_file)) {
+    return base::ErrStatus(
+        "bundle: input path '%s' is a directory, expected a trace file. If "
+        "you are trying to bundle a directory of traces, point at the "
+        "individual files instead.",
+        input_file.c_str());
+  }
+  if (base::DirectoryExists(output_file)) {
+    return base::ErrStatus(
+        "bundle: output path '%s' is a directory, expected a file path for "
+        "the bundle (e.g. %s.bundle.tar).",
+        output_file.c_str(), input_file.c_str());
+  }
+  std::string symlink_problem = SymlinkProblemDescription(output_file);
+  if (!symlink_problem.empty()) {
+    return base::ErrStatus(
+        "bundle: output path '%s' is a %s. Fix the symlink and try again.",
+        output_file.c_str(), symlink_problem.c_str());
+  }
+
+  // Fail fast on output paths that cannot be created, before spending time
+  // reading the (potentially huge) trace. The TarWriter re-opens with O_TRUNC
+  // once the trace has been read successfully.
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  {
+    base::ScopedFile probe =
+        base::OpenFile(output_file, O_CREAT | O_WRONLY, 0644);
+    if (!probe) {
+      return base::ErrStatus(
+          "bundle: cannot create output file '%s' (errno: %d, %s). Check "
+          "that the parent directory exists and is writable, then try "
+          "again.",
+          output_file.c_str(), errno, strerror(errno));
+    }
+  }
+#endif
 
   trace_to_text::BundleContext context;
   if (!symbol_paths_.empty())
@@ -110,9 +198,13 @@ base::Status BundleSubcommand::Run(const SubcommandContext& ctx) {
     context.home_dir = val;
   context.root_dir = "/";
 
-  if (trace_to_text::TraceToBundle(input_file, output_file, context) != 0)
-    return base::ErrStatus("bundle: failed to create bundle.");
-  return base::OkStatus();
+  base::Status status =
+      trace_to_text::TraceToBundle(input_file, output_file, context);
+  if (status.ok()) {
+    fprintf(stdout, "Wrote %s.\n", output_file.c_str());
+    fflush(stdout);
+  }
+  return status;
 }
 
 }  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/bundle_subcommand.cc
+++ b/src/trace_processor/shell/bundle_subcommand.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "perfetto/base/build_config.h"
+#include "perfetto/base/compiler.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/scoped_file.h"
@@ -47,7 +48,13 @@ std::string SymlinkProblemDescription(const std::string& path) {
   return "";
 #else
   struct stat st;
-  if (lstat(path.c_str(), &st) != 0 || !S_ISLNK(st.st_mode)) {
+  if (lstat(path.c_str(), &st) != 0) {
+    return "";
+  }
+  // MSan's stat() interceptor on glibc 2.35+ does not mark the output buffer
+  // as initialized (the syscall goes through statx).
+  PERFETTO_MSAN_UNPOISON(&st, sizeof(st));
+  if (!S_ISLNK(st.st_mode)) {
     return "";
   }
   if (stat(path.c_str(), &st) != 0) {

--- a/src/trace_processor/shell/common_flags.cc
+++ b/src/trace_processor/shell/common_flags.cc
@@ -15,6 +15,7 @@
  */
 
 #include "src/trace_processor/shell/common_flags.h"
+#include "src/traceconv/utils.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -440,8 +441,11 @@ base::StatusOr<base::TimeNanos> LoadTraceFile(
         size_mb = static_cast<double>(parsed_size) / 1E6;
         fprintf(stderr, "\rLoading trace: %.2f MB\r", size_mb);
       });
+  // Terminate the in-place progress line so errors/logs below start on a
+  // fresh line.
+  trace_to_text::EndProgressLine();
   if (!load_status.ok()) {
-    return base::ErrStatus("Could not read trace file (path: %s): %s",
+    return base::ErrStatus("failed to read trace file (path: %s): %s",
                            trace_file.c_str(), load_status.c_message());
   }
 
@@ -491,7 +495,7 @@ base::StatusOr<base::TimeNanos> LoadTraceFile(
   if (!maybe_map.empty()) {
     if (is_proto_trace) {
       tp->Flush();
-      profiling::ReadProguardMapsToDeobfuscationPackets(
+      auto deob_status = profiling::ReadProguardMapsToDeobfuscationPackets(
           maybe_map, [tp](const std::string& trace_proto) {
             std::unique_ptr<uint8_t[]> buf(new uint8_t[trace_proto.size()]);
             memcpy(buf.get(), trace_proto.data(), trace_proto.size());
@@ -502,6 +506,9 @@ base::StatusOr<base::TimeNanos> LoadTraceFile(
               return;
             }
           });
+      if (!deob_status.ok()) {
+        PERFETTO_ELOG("Failed to deobfuscate: %s", deob_status.c_message());
+      }
     } else {
       PERFETTO_ELOG("Skipping deobfuscation for non-proto trace");
     }

--- a/src/trace_processor/shell/convert_helpers.cc
+++ b/src/trace_processor/shell/convert_helpers.cc
@@ -82,7 +82,7 @@ base::Status OpenConversionOutput(const std::string& path,
   return base::OkStatus();
 }
 
-int TextToTrace(std::istream* input, std::ostream* output) {
+base::Status TextToTrace(std::istream* input, std::ostream* output) {
   std::string trace_text(std::istreambuf_iterator<char>{*input},
                          std::istreambuf_iterator<char>{});
   std::vector<uint8_t> descriptors;
@@ -96,14 +96,13 @@ int TextToTrace(std::istream* input, std::ostream* output) {
       protozero::TextToProto(descriptors.data(), descriptors.size(),
                              ".perfetto.protos.Trace", "trace", trace_text);
   if (!proto_status.ok()) {
-    PERFETTO_ELOG("Failed to parse trace: %s",
-                  proto_status.status().c_message());
-    return 1;
+    return base::ErrStatus("failed to parse trace text: %s",
+                           proto_status.status().c_message());
   }
   const std::vector<uint8_t>& trace_proto = proto_status.value();
   output->write(reinterpret_cast<const char*>(trace_proto.data()),
                 static_cast<int64_t>(trace_proto.size()));
-  return 0;
+  return base::OkStatus();
 }
 
 }  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/convert_helpers.h
+++ b/src/trace_processor/shell/convert_helpers.h
@@ -46,9 +46,8 @@ base::Status OpenConversionOutput(const std::string& path,
                                   std::ostream** out_stream);
 
 // Converts a text-format trace proto read from |input| into a binary trace
-// written to |output|. Returns 0 on success, non-zero on failure (matching the
-// other conversion entry points).
-int TextToTrace(std::istream* input, std::ostream* output);
+// written to |output|.
+base::Status TextToTrace(std::istream* input, std::ostream* output);
 
 }  // namespace perfetto::trace_processor::shell
 

--- a/src/trace_processor/shell/convert_helpers_unittest.cc
+++ b/src/trace_processor/shell/convert_helpers_unittest.cc
@@ -104,7 +104,7 @@ TEST(ConvertHelpersTest, OpenConversionOutputBadPathFails) {
 TEST(ConvertHelpersTest, TextToTraceEmptyInputSucceeds) {
   std::istringstream in("");
   std::ostringstream out;
-  EXPECT_EQ(TextToTrace(&in, &out), 0);
+  EXPECT_TRUE(TextToTrace(&in, &out).ok());
   // An empty trace serializes to zero bytes.
   EXPECT_TRUE(out.str().empty());
 }
@@ -112,14 +112,14 @@ TEST(ConvertHelpersTest, TextToTraceEmptyInputSucceeds) {
 TEST(ConvertHelpersTest, TextToTraceValidProtoSucceeds) {
   std::istringstream in("packet { timestamp: 42 }");
   std::ostringstream out;
-  EXPECT_EQ(TextToTrace(&in, &out), 0);
+  EXPECT_TRUE(TextToTrace(&in, &out).ok());
   EXPECT_FALSE(out.str().empty());
 }
 
 TEST(ConvertHelpersTest, TextToTraceInvalidProtoFails) {
   std::istringstream in("this is not a valid trace proto }}}");
   std::ostringstream out;
-  EXPECT_EQ(TextToTrace(&in, &out), 1);
+  EXPECT_FALSE(TextToTrace(&in, &out).ok());
 }
 
 }  // namespace

--- a/src/trace_processor/shell/convert_subcommand.cc
+++ b/src/trace_processor/shell/convert_subcommand.cc
@@ -91,6 +91,7 @@ std::vector<FlagSpec> ConvertSubcommand::GetFlags() {
 }
 
 base::Status ConvertSubcommand::Run(const SubcommandContext& ctx) {
+  RETURN_IF_ERROR(RejectExtraPositionals(ctx, "convert", 3));
   if (ctx.positional_args.empty())
     return base::ErrStatus("convert: a format must be specified.");
 
@@ -161,16 +162,15 @@ base::Status ConvertSubcommand::Run(const SubcommandContext& ctx) {
   RETURN_IF_ERROR(
       OpenConversionOutput(output_path, binary_output, &output_file, &output));
 
-  int ret = 0;
   if (format == "json") {
-    ret = trace_to_text::TraceToJson(input, output, /*compress=*/false,
-                                     truncate_keep, full_sort_);
+    RETURN_IF_ERROR(trace_to_text::TraceToJson(
+        input, output, /*compress=*/false, truncate_keep, full_sort_));
   } else if (format == "systrace") {
-    ret = trace_to_text::TraceToSystrace(input, output, /*ctrace=*/false,
-                                         truncate_keep, full_sort_);
+    RETURN_IF_ERROR(trace_to_text::TraceToSystrace(
+        input, output, /*ctrace=*/false, truncate_keep, full_sort_));
   } else if (format == "ctrace") {
-    ret = trace_to_text::TraceToSystrace(input, output, /*ctrace=*/true,
-                                         truncate_keep, full_sort_);
+    RETURN_IF_ERROR(trace_to_text::TraceToSystrace(
+        input, output, /*ctrace=*/true, truncate_keep, full_sort_));
   } else if (format == "text" || format == "profile" || format == "firefox") {
     if (truncate_keep != trace_to_text::Keep::kAll) {
       return base::ErrStatus("--truncate is unsupported for the '%s' format.",
@@ -183,26 +183,23 @@ base::Status ConvertSubcommand::Run(const SubcommandContext& ctx) {
     if (format == "text") {
       trace_to_text::TraceToTextOptions options;
       options.skip_unknown_fields = skip_unknown_;
-      ret = trace_to_text::TraceToText(input, output, options) ? 0 : 1;
+      RETURN_IF_ERROR(trace_to_text::TraceToText(input, output, options));
     } else if (format == "profile") {
       if (!output_path.empty()) {
         return base::ErrStatus(
             "output file is not supported for 'profile', use --output-dir "
             "instead.");
       }
-      ret = trace_to_text::TraceToProfile(input, pid, timestamps,
-                                          !no_annotations_, output_dir_,
-                                          profile_type, verbose_);
+      RETURN_IF_ERROR(trace_to_text::TraceToProfile(
+          input, pid, timestamps, !no_annotations_, output_dir_, profile_type,
+          verbose_));
     } else {  // firefox
-      ret = trace_to_text::TraceToFirefoxProfile(input, output) ? 0 : 1;
+      RETURN_IF_ERROR(trace_to_text::TraceToFirefoxProfile(input, output));
     }
   } else {
     return base::ErrStatus("convert: unknown format '%s'.", format.c_str());
   }
 
-  if (ret != 0)
-    return base::ErrStatus("convert: conversion of '%s' failed.",
-                           format.c_str());
   return base::OkStatus();
 }
 

--- a/src/trace_processor/shell/export_subcommand.cc
+++ b/src/trace_processor/shell/export_subcommand.cc
@@ -64,6 +64,7 @@ std::vector<FlagSpec> ExportSubcommand::GetFlags() {
 }
 
 base::Status ExportSubcommand::Run(const SubcommandContext& ctx) {
+  RETURN_IF_ERROR(RejectExtraPositionals(ctx, "export", 2));
   // First positional arg is the format.
   if (ctx.positional_args.empty()) {
     return base::ErrStatus(

--- a/src/trace_processor/shell/metrics_subcommand.cc
+++ b/src/trace_processor/shell/metrics_subcommand.cc
@@ -68,6 +68,7 @@ std::vector<FlagSpec> MetricsSubcommand::GetFlags() {
 }
 
 base::Status MetricsSubcommand::Run(const SubcommandContext& ctx) {
+  RETURN_IF_ERROR(RejectExtraPositionals(ctx, "metrics", 1));
   if (metric_names_.empty()) {
     return base::ErrStatus("metrics: --run is required");
   }

--- a/src/trace_processor/shell/query_subcommand.cc
+++ b/src/trace_processor/shell/query_subcommand.cc
@@ -168,6 +168,7 @@ std::vector<FlagSpec> QuerySubcommand::GetFlags() {
 }
 
 base::Status QuerySubcommand::Run(const SubcommandContext& ctx) {
+  RETURN_IF_ERROR(RejectExtraPositionals(ctx, "query", 2));
   // With --remote, the trace is already loaded server-side, so there is no
   // trace-file positional: the first positional (if any) is the SQL.
   std::string trace_file;

--- a/src/trace_processor/shell/server_subcommand.cc
+++ b/src/trace_processor/shell/server_subcommand.cc
@@ -226,6 +226,7 @@ base::Status KillServer(const std::string& addr) {
 }  // namespace
 
 base::Status ServerSubcommand::Run(const SubcommandContext& ctx) {
+  RETURN_IF_ERROR(RejectExtraPositionals(ctx, "server", 2));
   // First positional arg is the mode.
   if (ctx.positional_args.empty()) {
     return base::ErrStatus(

--- a/src/trace_processor/shell/subcommand.cc
+++ b/src/trace_processor/shell/subcommand.cc
@@ -21,9 +21,36 @@
 #include <unordered_set>
 #include <vector>
 
+#include "perfetto/ext/base/string_utils.h"
+
 namespace perfetto::trace_processor::shell {
 
 Subcommand::~Subcommand() = default;
+
+base::Status RejectExtraPositionals(const SubcommandContext& ctx,
+                                    const char* subcommand,
+                                    size_t max_positionals,
+                                    const char* hint) {
+  if (ctx.positional_args.size() <= max_positionals)
+    return base::OkStatus();
+
+  std::string extra;
+  for (size_t i = max_positionals; i < ctx.positional_args.size(); ++i) {
+    if (!extra.empty())
+      extra += " ";
+    extra += "'" + ctx.positional_args[i] + "'";
+  }
+  base::Status status = base::ErrStatus(
+      "%s: expected at most %zu positional argument(s), got %zu: %s. Extra "
+      "arguments are rejected to catch mistakes, e.g. passing each path "
+      "intended for a value-taking flag as a separate argument; use a "
+      "comma-separated list for those instead.",
+      subcommand, max_positionals, ctx.positional_args.size(), extra.c_str());
+  if (hint) {
+    status = base::ErrStatus("%s %s", status.c_message(), hint);
+  }
+  return status;
+}
 
 FindSubcommandResult FindSubcommandInArgs(
     int argc,

--- a/src/trace_processor/shell/subcommand.h
+++ b/src/trace_processor/shell/subcommand.h
@@ -69,6 +69,17 @@ struct SubcommandContext {
   std::vector<std::string> positional_args;
 };
 
+// Returns an error if `ctx.positional_args` has more than `max_positionals`
+// entries. Extra positional arguments are almost always a mistake (e.g.
+// passing each path intended for a value-taking flag such as --symbol-paths
+// as a separate argument); rejecting them surfaces the typo instead of
+// silently misinterpreting the command line. |hint|, if non-null, is
+// appended to the error message.
+base::Status RejectExtraPositionals(const SubcommandContext& ctx,
+                                    const char* subcommand,
+                                    size_t max_positionals,
+                                    const char* hint = nullptr);
+
 // Base class for all subcommands (query, export, serve, etc.).
 class Subcommand {
  public:

--- a/src/trace_processor/shell/subcommand_flags_unittest.cc
+++ b/src/trace_processor/shell/subcommand_flags_unittest.cc
@@ -31,6 +31,10 @@
 #include "perfetto/trace_processor/io.h"
 #include "src/trace_processor/shell/bundle_subcommand.h"
 #include "src/trace_processor/shell/convert_subcommand.h"
+#include "src/trace_processor/shell/export_subcommand.h"
+#include "src/trace_processor/shell/metrics_subcommand.h"
+#include "src/trace_processor/shell/query_subcommand.h"
+#include "src/trace_processor/shell/server_subcommand.h"
 #include "src/trace_processor/shell/subcommand.h"
 #include "src/trace_processor/shell/util_subcommand.h"
 #include "test/gtest_and_gmock.h"
@@ -306,6 +310,71 @@ TEST(BundleSubcommandTest, RequiresInputAndOutput) {
   BundleSubcommand bundle;
   EXPECT_FALSE(bundle.Run(CtxWithPositionals({})).ok());
   EXPECT_FALSE(bundle.Run(CtxWithPositionals({"only_input"})).ok());
+}
+
+// Passing more than two positional args is almost always a mistake (e.g.
+// each --symbol-paths dir passed as a separate argument); reject it with a
+// hint instead of silently misinterpreting the args.
+TEST(BundleSubcommandTest, RejectsTooManyPositionals) {
+  BundleSubcommand bundle;
+  base::Status s = bundle.Run(
+      CtxWithPositionals({"dir1", "dir2", "input.pftrace", "out.tar"}));
+  EXPECT_FALSE(s.ok());
+  EXPECT_THAT(s.message(), HasSubstr("expected at most 2 positional"));
+  EXPECT_THAT(s.message(), HasSubstr("--symbol-paths"));
+}
+
+// Every fixed-arity subcommand must reject extra positional arguments instead
+// of silently ignoring them (which used to misparse command lines such as
+// `bundle --symbol-paths a b trace out.tar`).
+TEST(RejectExtraPositionalsTest, RejectsAcrossSubcommands) {
+  struct Case {
+    std::unique_ptr<Subcommand> cmd;
+    std::vector<std::string> args;
+    const char* expected;
+  };
+  std::vector<Case> cases;
+  {
+    auto cmd = std::make_unique<ConvertSubcommand>();
+    cases.push_back({std::move(cmd),
+                     {"json", "in.pb", "out.json", "extra"},
+                     "expected at most 3 positional"});
+  }
+  {
+    auto cmd = std::make_unique<QuerySubcommand>();
+    cases.push_back({std::move(cmd),
+                     {"trace.pb", "select 1", "extra"},
+                     "expected at most 2 positional"});
+  }
+  {
+    auto cmd = std::make_unique<UtilSubcommand>();
+    cases.push_back({std::move(cmd),
+                     {"symbolize", "in.pb", "out", "extra"},
+                     "expected at most 3 positional"});
+  }
+  {
+    auto cmd = std::make_unique<ExportSubcommand>();
+    cases.push_back({std::move(cmd),
+                     {"sqlite", "trace.pb", "extra"},
+                     "expected at most 2 positional"});
+  }
+  {
+    auto cmd = std::make_unique<ServerSubcommand>();
+    cases.push_back({std::move(cmd),
+                     {"stdio", "trace.pb", "extra"},
+                     "expected at most 2 positional"});
+  }
+  {
+    auto cmd = std::make_unique<MetricsSubcommand>();
+    cases.push_back({std::move(cmd),
+                     {"trace.pb", "extra"},
+                     "expected at most 1 positional"});
+  }
+  for (auto& c : cases) {
+    base::Status s = c.cmd->Run(CtxWithPositionals(c.args));
+    EXPECT_FALSE(s.ok()) << c.args[0];
+    EXPECT_THAT(s.message(), HasSubstr(c.expected)) << c.args[0];
+  }
 }
 
 TEST(BundleSubcommandTest, RejectsStdinInput) {

--- a/src/trace_processor/shell/util_subcommand.cc
+++ b/src/trace_processor/shell/util_subcommand.cc
@@ -197,8 +197,11 @@ base::Status UtilSubcommand::Run(const SubcommandContext& ctx) {
   }
   const std::string& util = ctx.positional_args[0];
   if (util == "merge") {
+    // merge accepts any number of input traces, so skip the positional count
+    // check (the other utilities take at most [input] [output]).
     return RunMerge(ctx);
   }
+  RETURN_IF_ERROR(RejectExtraPositionals(ctx, "util", 3));
   const std::string input_path =
       ctx.positional_args.size() > 1 ? ctx.positional_args[1] : "";
   const std::string output_path =
@@ -222,18 +225,15 @@ base::Status UtilSubcommand::Run(const SubcommandContext& ctx) {
   RETURN_IF_ERROR(OpenConversionOutput(output_path, /*binary_output=*/true,
                                        &output_file, &output));
 
-  int ret;
   if (util == "symbolize") {
-    ret = trace_to_text::SymbolizeProfile(input, output, verbose_);
+    RETURN_IF_ERROR(trace_to_text::SymbolizeProfile(input, output, verbose_));
   } else if (util == "deobfuscate") {
-    ret = trace_to_text::DeobfuscateProfile(input, output);
+    RETURN_IF_ERROR(trace_to_text::DeobfuscateProfile(input, output));
   } else if (util == "decompress_packets") {
-    ret = trace_to_text::UnpackCompressedPackets(input, output) ? 0 : 1;
+    RETURN_IF_ERROR(trace_to_text::UnpackCompressedPackets(input, output));
   } else {  // text_to_binary
-    ret = TextToTrace(input, output);
+    RETURN_IF_ERROR(TextToTrace(input, output));
   }
-  if (ret != 0)
-    return base::ErrStatus("util: '%s' failed.", util.c_str());
   return base::OkStatus();
 }
 

--- a/src/trace_processor/trace_processor_storage_impl.cc
+++ b/src/trace_processor/trace_processor_storage_impl.cc
@@ -65,11 +65,12 @@ base::Status WrapParseError(const base::Status& status) {
   if (strstr(status.c_message(), "(ERR:fmt)") != nullptr) {
     return status;
   }
-  bool corrupt = strstr(status.c_message(), "(ERR:tp-corrupt)") != nullptr;
-  return base::ErrStatus("Trace parse failure (%s) (ERR:tp-parse). %s",
-                         status.c_message(),
-                         corrupt ? "The trace file is corrupt."
-                                 : "The trace file could not be parsed.");
+  // Keep the specific reason from the inner status; the trailing (ERR:tp-parse)
+  // marker is how the UI classifies the failure. The CLI strips these markers
+  // before displaying (see shell_utils.cc), so no redundant "the trace file is
+  // corrupt" sentence is appended here -- the inner message already says why.
+  return base::ErrStatus("Trace parse failure: %s (ERR:tp-parse)",
+                         status.c_message());
 }
 
 }  // namespace

--- a/src/trace_processor/util/deobfuscation/deobfuscator.cc
+++ b/src/trace_processor/util/deobfuscation/deobfuscator.cc
@@ -18,6 +18,8 @@
 
 #include <stdlib.h>
 
+#include <cerrno>
+#include <cstring>
 #include <optional>
 #include <set>
 
@@ -451,22 +453,25 @@ void MakeDeobfuscationPackets(
   callback(trace.SerializeAsString());
 }
 
-bool ReadProguardMapsToDeobfuscationPackets(
+base::Status ReadProguardMapsToDeobfuscationPackets(
     const std::vector<ProguardMap>& maps,
     std::function<void(std::string)> fn) {
   for (const ProguardMap& map : maps) {
     const char* filename = map.filename.c_str();
     base::ScopedFstream f = base::OpenFstream(filename, base::kFopenReadFlag);
     if (!f) {
-      PERFETTO_ELOG("Failed to open %s", filename);
-      return false;
+      return base::ErrStatus("failed to open ProGuard map %s (errno: %d, %s)",
+                             filename, errno, strerror(errno));
     }
     profiling::ProguardParser parser;
     std::string contents;
-    PERFETTO_CHECK(base::ReadFileStream(*f, &contents));
+    if (!base::ReadFileStream(*f, &contents)) {
+      return base::ErrStatus("failed to read ProGuard map %s", filename);
+    }
     if (!parser.AddLines(std::move(contents))) {
-      PERFETTO_ELOG("Failed to parse %s", filename);
-      return false;
+      return base::ErrStatus(
+          "failed to parse ProGuard map %s (not a valid mapping.txt)",
+          filename);
     }
     std::map<std::string, profiling::ObfuscatedClass> obfuscation_map =
         parser.ConsumeMapping();
@@ -476,7 +481,7 @@ bool ReadProguardMapsToDeobfuscationPackets(
     // profile.
     MakeDeobfuscationPackets(map.package, obfuscation_map, fn);
   }
-  return true;
+  return base::OkStatus();
 }
 
 std::vector<ProguardMap> GetPerfettoProguardMapPath() {

--- a/src/trace_processor/util/deobfuscation/deobfuscator.h
+++ b/src/trace_processor/util/deobfuscation/deobfuscator.h
@@ -107,7 +107,7 @@ void MakeDeobfuscationPackets(
 
 std::vector<ProguardMap> GetPerfettoProguardMapPath();
 
-bool ReadProguardMapsToDeobfuscationPackets(
+base::Status ReadProguardMapsToDeobfuscationPackets(
     const std::vector<ProguardMap>& maps,
     std::function<void(std::string)> fn);
 

--- a/src/trace_processor/util/symbolizer/local_symbolizer.cc
+++ b/src/trace_processor/util/symbolizer/local_symbolizer.cc
@@ -89,7 +89,6 @@ template <typename E>
 typename E::Phdr* FindFirstExecutableSegment(void* mem, size_t size) {
   const typename E::Ehdr* ehdr = static_cast<typename E::Ehdr*>(mem);
   if (!InRange(mem, size, ehdr, sizeof(typename E::Ehdr))) {
-    PERFETTO_ELOG("Corrupted ELF.");
     return nullptr;
   }
   // Note debug-symbols-only ELF files might not have any program header at all,
@@ -100,7 +99,6 @@ typename E::Phdr* FindFirstExecutableSegment(void* mem, size_t size) {
   for (size_t i = 0; i < ehdr->e_phnum; ++i) {
     typename E::Phdr* phdr = GetPhdr<E>(mem, ehdr, i);
     if (!InRange(mem, size, phdr, sizeof(typename E::Phdr))) {
-      PERFETTO_ELOG("Corrupted ELF.");
       return nullptr;
     }
     if (phdr->p_type == PT_LOAD && phdr->p_flags & PF_X) {
@@ -114,13 +112,11 @@ template <typename E>
 std::optional<std::string> GetElfBuildId(void* mem, size_t size) {
   const typename E::Ehdr* ehdr = static_cast<typename E::Ehdr*>(mem);
   if (!InRange(mem, size, ehdr, sizeof(typename E::Ehdr))) {
-    PERFETTO_ELOG("Corrupted ELF.");
     return std::nullopt;
   }
   for (size_t i = 0; i < ehdr->e_shnum; ++i) {
     typename E::Shdr* shdr = GetShdr<E>(mem, ehdr, i);
     if (!InRange(mem, size, shdr, sizeof(typename E::Shdr))) {
-      PERFETTO_ELOG("Corrupted ELF.");
       return std::nullopt;
     }
 
@@ -133,13 +129,11 @@ std::optional<std::string> GetElfBuildId(void* mem, size_t size) {
           reinterpret_cast<typename E::Nhdr*>(static_cast<char*>(mem) + offset);
 
       if (!InRange(mem, size, nhdr, sizeof(typename E::Nhdr))) {
-        PERFETTO_ELOG("Corrupted ELF.");
         return std::nullopt;
       }
       if (nhdr->n_type == NT_GNU_BUILD_ID && nhdr->n_namesz == 4) {
         char* name = reinterpret_cast<char*>(nhdr) + sizeof(*nhdr);
         if (!InRange(mem, size, name, 4)) {
-          PERFETTO_ELOG("Corrupted ELF.");
           return std::nullopt;
         }
         if (memcmp(name, "GNU", 3) == 0) {
@@ -147,7 +141,6 @@ std::optional<std::string> GetElfBuildId(void* mem, size_t size) {
                               base::AlignUp<4>(nhdr->n_namesz);
 
           if (!InRange(mem, size, value, nhdr->n_descsz)) {
-            PERFETTO_ELOG("Corrupted ELF.");
             return std::nullopt;
           }
           return std::string(value, nhdr->n_descsz);
@@ -326,10 +319,14 @@ std::optional<BinaryInfo> GetBinaryInfo(const char* fname, size_t size) {
   return std::nullopt;
 }
 
-// Helper function to process a single binary file and add it to the index
+// Helper function to process a single binary file and add it to the index.
+// Increments *corrupt_file_count when a file looks like ELF/Mach-O but cannot
+// be parsed (corrupt or truncated): callers aggregate this into a single log
+// line instead of spamming one message per file.
 void ProcessBinaryFile(const char* fname,
                        size_t size,
-                       std::map<std::string, FoundBinary>& result) {
+                       std::map<std::string, FoundBinary>& result,
+                       uint32_t* corrupt_file_count) {
   static_assert(EI_MAG3 + 1 == sizeof(kMachO64Magic));
   char magic[EI_MAG3 + 1];
   // Scope file access. On windows OpenFile opens an exclusive lock.
@@ -352,7 +349,8 @@ void ProcessBinaryFile(const char* fname,
   }
   std::optional<BinaryInfo> binary_info = GetBinaryInfo(fname, size);
   if (!binary_info) {
-    PERFETTO_DLOG("Failed to extract binary info from %s.", fname);
+    // Passed the magic check but failed to parse: corrupt or truncated.
+    ++(*corrupt_file_count);
     return;
   }
   if (!binary_info->build_id) {
@@ -394,17 +392,26 @@ std::map<std::string, FoundBinary> BuildIdIndex(
     std::vector<std::string> dirs,
     std::vector<std::string> files) {
   std::map<std::string, FoundBinary> result;
+  uint32_t corrupt_file_count = 0;
 
   // Process directories
   if (!dirs.empty()) {
-    WalkDirectories(std::move(dirs), [&result](const char* fname, size_t size) {
-      ProcessBinaryFile(fname, size, result);
+    WalkDirectories(std::move(dirs), [&result, &corrupt_file_count](
+                                         const char* fname, size_t size) {
+      ProcessBinaryFile(fname, size, result, &corrupt_file_count);
     });
   }
 
   // Process individual files
   for (const std::string& file_path : files) {
-    ProcessBinaryFile(file_path.c_str(), 0, result);
+    ProcessBinaryFile(file_path.c_str(), 0, result, &corrupt_file_count);
+  }
+
+  if (corrupt_file_count > 0) {
+    PERFETTO_LOG(
+        "Skipped %u file(s) that look like ELF/Mach-O but could not be "
+        "parsed (corrupt or truncated) while indexing symbol paths.",
+        corrupt_file_count);
   }
 
   return result;

--- a/src/trace_processor/util/symbolizer/local_symbolizer.cc
+++ b/src/trace_processor/util/symbolizer/local_symbolizer.cc
@@ -404,7 +404,16 @@ std::map<std::string, FoundBinary> BuildIdIndex(
 
   // Process individual files
   for (const std::string& file_path : files) {
-    ProcessBinaryFile(file_path.c_str(), 0, result, &corrupt_file_count);
+    std::optional<uint64_t> file_size = base::GetFileSize(file_path);
+    if (!file_size.has_value()) {
+      continue;
+    }
+    // Unlike WalkDirectories we don't have the size on hand here; pass the
+    // real size so GetBinaryInfo can actually parse the file. A size of 0
+    // would make it bail out early and miscount every valid file as corrupt.
+    size_t size = static_cast<size_t>(
+        std::min<uint64_t>(std::numeric_limits<size_t>::max(), *file_size));
+    ProcessBinaryFile(file_path.c_str(), size, result, &corrupt_file_count);
   }
 
   if (corrupt_file_count > 0) {

--- a/src/trace_processor/util/symbolizer/local_symbolizer_unittest.cc
+++ b/src/trace_processor/util/symbolizer/local_symbolizer_unittest.cc
@@ -139,6 +139,22 @@ TEST(LocalBinaryIndexerTest, NOMSAN_SimpleTree) {
 #endif
 }
 
+// A valid ELF passed as an individual file (rather than discovered via a
+// directory walk) must be indexed. Previously the size passed for such files
+// was 0, which made GetBinaryInfo bail out and silently dropped them (and,
+// after the corrupt-file aggregation, miscounted them as corrupt).
+TEST(LocalBinaryIndexerTest, IndividualFilesAreIndexed) {
+  base::TmpDirTree tmp;
+  tmp.AddDir("root");
+  tmp.AddFile("root/elf1", CreateElfWithBuildId("AAAAAAAAAAAAAAAAAAAA"));
+
+  LocalBinaryIndexer indexer({}, {tmp.AbsolutePath("root/elf1")});
+
+  BinaryLookupResult result = indexer.FindBinary("", "AAAAAAAAAAAAAAAAAAAA");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.binary->file_name, tmp.AbsolutePath("root/elf1"));
+}
+
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) ||   \
     PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID) || \
     PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE)

--- a/src/trace_processor/util/symbolizer/symbolize_database.cc
+++ b/src/trace_processor/util/symbolizer/symbolize_database.cc
@@ -432,7 +432,12 @@ SymbolizerResult SymbolizeDatabase(trace_processor::TraceProcessor* tp,
       !config.find_symbol_paths.empty() || !config.breakpad_paths.empty();
   if (!has_any_paths) {
     result.error = SymbolizerError::kSymbolizerNotAvailable;
-    result.error_details = "No symbol paths or breakpad paths provided";
+    result.error_details =
+        "no symbol paths were searched. This happens when automatic path "
+        "discovery is disabled and no paths are provided. Pass "
+        "--symbol-paths PATH1,PATH2,... to point at the unstripped binaries "
+        "or Breakpad symbol files, or drop --no-auto-symbol-paths to search "
+        "the standard locations.";
     return result;
   }
 

--- a/src/trace_processor/util/tar_writer.cc
+++ b/src/trace_processor/util/tar_writer.cc
@@ -17,6 +17,7 @@
 #include "src/trace_processor/util/tar_writer.h"
 
 #include <fcntl.h>
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -133,7 +134,15 @@ TarHeader MakeTarHeader(const std::string& filename, size_t file_size) {
   return header;
 }
 
-// Writes to a file descriptor. Backs the path/ScopedFile constructors.
+}  // namespace
+
+// --- TarWriterSink ---
+
+TarWriterSink::~TarWriterSink() = default;
+
+namespace {
+
+// Writes to a file descriptor. Backs the ScopedFile constructor.
 class FdTarWriterSink : public TarWriterSink {
  public:
   explicit FdTarWriterSink(base::ScopedFile fd) : fd_(std::move(fd)) {
@@ -156,11 +165,21 @@ class FdTarWriterSink : public TarWriterSink {
   base::ScopedFile fd_;
 };
 
+// Returns the same error for every operation. Used when the output path
+// could not be opened, so that callers get a useful error instead of a
+// PERFETTO_CHECK crash when they attempt the first write.
+class FailedTarWriterSink : public TarWriterSink {
+ public:
+  explicit FailedTarWriterSink(base::Status error) : error_(std::move(error)) {}
+
+  base::Status Write(const void*, size_t) override { return error_; }
+  base::Status WriteFromFd(int, size_t) override { return error_; }
+
+ private:
+  base::Status error_;
+};
+
 }  // namespace
-
-// --- TarWriterSink ---
-
-TarWriterSink::~TarWriterSink() = default;
 
 // --- BufferTarWriterSink ---
 
@@ -188,9 +207,27 @@ base::Status BufferTarWriterSink::WriteFromFd(int fd, size_t len) {
 
 // --- TarWriter ---
 
+namespace {
+
+// Opens the output path for writing. On failure returns a sink that makes
+// every subsequent TarWriter operation fail with a descriptive error
+// (instead of crashing on a PERFETTO_CHECK as the old code did).
+std::unique_ptr<TarWriterSink> OpenOutputSink(const std::string& output_path) {
+  base::ScopedFile fd =
+      base::OpenFile(output_path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+  if (fd) {
+    return std::unique_ptr<TarWriterSink>(new FdTarWriterSink(std::move(fd)));
+  }
+  return std::unique_ptr<TarWriterSink>(new FailedTarWriterSink(
+      base::ErrStatus("Failed to open output file '%s' for writing (errno: "
+                      "%d, %s)",
+                      output_path.c_str(), errno, strerror(errno))));
+}
+
+}  // namespace
+
 TarWriter::TarWriter(const std::string& output_path)
-    : TarWriter(
-          base::OpenFile(output_path, O_CREAT | O_WRONLY | O_TRUNC, 0644)) {}
+    : TarWriter(OpenOutputSink(output_path)) {}
 
 TarWriter::TarWriter(base::ScopedFile output_file)
     : TarWriter(std::unique_ptr<TarWriterSink>(

--- a/src/trace_processor/util/tar_writer_unittest.cc
+++ b/src/trace_processor/util/tar_writer_unittest.cc
@@ -568,5 +568,22 @@ TEST_F(TarWriterTest, CustomSinkFinalizeErrorPropagates) {
   EXPECT_OK(writer.Finalize());
 }
 
+// An output path that cannot be opened (e.g. the parent directory does not
+// exist) must produce a descriptive error from the first write instead of
+// crashing on a PERFETTO_CHECK deep in the sink constructor, and teardown
+// must not crash either.
+TEST_F(TarWriterTest, DisableWindows(UnopenableOutputPathFailsGracefully)) {
+  TarWriter writer("/nonexistent_dir_xyz/out.tar");
+
+  auto status = writer.AddFile("f.txt", "content");
+  EXPECT_THAT(status, IsError());
+  EXPECT_THAT(status.message(), HasSubstr("Failed to open output file"));
+  EXPECT_THAT(status.message(), HasSubstr("/nonexistent_dir_xyz/out.tar"));
+
+  // The failed write poisons the writer: finalization is a no-op and the
+  // destructor does not crash.
+  EXPECT_OK(writer.Finalize());
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/trace_enrichment/trace_enrichment.cc
+++ b/src/trace_processor/util/trace_enrichment/trace_enrichment.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "perfetto/ext/base/file_utils.h"
+#include "perfetto/trace_processor/iterator.h"
 #include "perfetto/trace_processor/trace_processor.h"
 #include "src/trace_processor/util/deobfuscation/deobfuscator.h"
 #include "src/trace_processor/util/symbolizer/symbolize_database.h"
@@ -128,6 +129,52 @@ std::vector<std::string> DiscoverSymbolPaths(
   return paths;
 }
 
+// Returns a warning (empty string if nothing to report) when the trace
+// contains kernel addresses that cannot be symbolized offline.
+//
+// Kernel function names in ftrace events (e.g. function_graph tracing,
+// workqueue_execute_start, sched_blocked_reason) come from the on-device
+// kallsyms map, which is only captured at record time when the ftrace config
+// sets FtraceConfig.symbolize_ksyms. Perfetto deliberately does not store
+// absolute kernel addresses in traces (to protect KASLR), so these addresses
+// cannot be resolved after the fact. If the map was not captured, the events
+// only contain raw hex addresses and the only fix is to re-record the trace
+// with `symbolize_ksyms: true`.
+std::string GetKernelSymbolizationWarning(TraceProcessor* tp) {
+  // Count function_graph slices whose names are raw hex addresses (i.e. the
+  // kernel symbol map was not captured at record time). With symbolize_ksyms
+  // enabled these names are the actual function names instead.
+  Iterator it = tp->ExecuteQuery(R"(
+    SELECT COUNT(*)
+    FROM slice s
+    JOIN track t ON s.track_id = t.id
+    WHERE t.type IN ('thread_funcgraph', 'cpu_funcgraph')
+      AND s.name GLOB '0x*'
+  )");
+  if (!it.Next() || it.Get(0).AsLong() == 0) {
+    return "";
+  }
+
+  return R"(Kernel function names: this trace contains function_graph events
+whose kernel function names were not captured at record time, so they appear
+as raw hex addresses. These cannot be symbolized offline: Perfetto does not
+store absolute kernel addresses in traces (to protect KASLR), so the only fix
+is to re-record the trace with `symbolize_ksyms: true` in the ftrace config:
+
+  data_sources: {
+    config {
+      name: "linux.ftrace"
+      ftrace_config {
+        symbolize_ksyms: true
+        # ... your ftrace_events / function_graph config ...
+      }
+    }
+  }
+
+See https://perfetto.dev/docs/learning-more/symbolization#ftrace for details.
+)";
+}
+
 }  // namespace
 
 EnrichmentResult EnrichTrace(TraceProcessor* tp,
@@ -174,6 +221,11 @@ EnrichmentResult EnrichTrace(TraceProcessor* tp,
     }
   }
 
+  // === Kernel ftrace events that cannot be symbolized offline ===
+  // Do this even when symbolization itself was skipped: the user needs this
+  // feedback regardless of whether any symbol paths were configured.
+  result.details += GetKernelSymbolizationWarning(tp);
+
   // === Java Deobfuscation ===
   bool explicit_maps_failed = false;
   {
@@ -199,34 +251,38 @@ EnrichmentResult EnrichTrace(TraceProcessor* tp,
     std::vector<std::string> failed_explicit_maps;
     for (size_t i = 0; i < maps.size(); ++i) {
       bool is_explicit = i < explicit_count;
-      bool success = profiling::ReadProguardMapsToDeobfuscationPackets(
+      auto map_status = profiling::ReadProguardMapsToDeobfuscationPackets(
           {maps[i]}, [&result](const std::string& packet) {
             result.deobfuscation_data += packet;
           });
-      if (!success && is_explicit) {
+      if (!map_status.ok() && is_explicit) {
         explicit_maps_failed = true;
-        failed_explicit_maps.push_back(maps[i].filename);
+        failed_explicit_maps.push_back(maps[i].filename + ": " +
+                                       map_status.message());
       }
     }
 
     // Add deobfuscation failures to details if any explicit maps failed.
     if (!failed_explicit_maps.empty()) {
-      result.details += "Deobfuscation: failed to read ProGuard map(s):\n";
+      result.details +=
+          "Deobfuscation: failed to read the following explicitly-provided "
+          "ProGuard/R8 map(s):\n";
       for (const auto& path : failed_explicit_maps) {
         result.details += "  - " + path + "\n";
       }
+      result.details +=
+          "Check that each file exists and is a valid mapping.txt produced "
+          "by R8/ProGuard for the build that ran on the device.\n";
     }
   }
 
-  // Determine overall status.
-  if (explicit_maps_failed) {
-    result.error = EnrichmentError::kExplicitMapsFailed;
-  } else if (result.native_symbols.empty() &&
-             result.deobfuscation_data.empty()) {
-    result.error = EnrichmentError::kAllFailed;
-  } else {
-    result.error = EnrichmentError::kOk;
-  }
+  // Determine overall status. Only explicitly-provided resources that fail
+  // to load are hard errors. Everything else (symbols not found, kernel
+  // addresses that cannot be resolved offline, etc.) is advisory: the bundle
+  // is still produced, with the details above explaining what was and wasn't
+  // possible and how to fix it.
+  result.error = explicit_maps_failed ? EnrichmentError::kExplicitMapsFailed
+                                      : EnrichmentError::kOk;
 
   return result;
 }

--- a/src/trace_processor/util/trace_enrichment/trace_enrichment.h
+++ b/src/trace_processor/util/trace_enrichment/trace_enrichment.h
@@ -68,13 +68,12 @@ struct EnrichmentConfig {
 };
 
 // Error codes for enrichment operations.
+// Only kExplicitMapsFailed is a hard failure: it means an explicitly-provided
+// ProGuard/R8 map could not be read. All other outcomes still produce a
+// bundle; `details` explains what could not be enriched and how to fix it.
 enum class EnrichmentError {
   kOk,
-  kPartialSuccess,      // Some optional enrichment failed
-  kExplicitMapsFailed,  // Explicitly provided ProGuard maps couldn't be read
-  kSymbolizerNotAvailable,
-  kDeobfuscationFailed,
-  kAllFailed,
+  kExplicitMapsFailed,
 };
 
 // Result of enrichment operation.

--- a/src/traceconv/deobfuscate_profile.cc
+++ b/src/traceconv/deobfuscate_profile.cc
@@ -19,6 +19,7 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/scoped_file.h"
+#include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/string_splitter.h"
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/trace_processor/trace_processor.h"
@@ -29,22 +30,21 @@
 namespace perfetto {
 namespace trace_to_text {
 
-int DeobfuscateProfile(std::istream* input, std::ostream* output) {
+base::Status DeobfuscateProfile(std::istream* input, std::ostream* output) {
   base::ignore_result(input);
   base::ignore_result(output);
   auto maybe_map = profiling::GetPerfettoProguardMapPath();
   if (maybe_map.empty()) {
-    PERFETTO_ELOG("No PERFETTO_PROGUARD_MAP specified.");
-    return 1;
+    return base::ErrStatus(
+        "no PERFETTO_PROGUARD_MAP specified: set it to a "
+        "colon-separated list of package=path entries pointing at the "
+        "ProGuard/R8 mapping.txt files and try again");
   }
-  if (!profiling::ReadProguardMapsToDeobfuscationPackets(
-          maybe_map, [output](const std::string& trace_proto) {
-            *output << trace_proto;
-          })) {
-    return 1;
-  }
+  RETURN_IF_ERROR(profiling::ReadProguardMapsToDeobfuscationPackets(
+      maybe_map,
+      [output](const std::string& trace_proto) { *output << trace_proto; }));
 
-  return 0;
+  return base::OkStatus();
 }
 
 }  // namespace trace_to_text

--- a/src/traceconv/deobfuscate_profile.h
+++ b/src/traceconv/deobfuscate_profile.h
@@ -19,10 +19,12 @@
 
 #include <iostream>
 
+#include "perfetto/base/status.h"
+
 namespace perfetto {
 namespace trace_to_text {
 
-int DeobfuscateProfile(std::istream* input, std::ostream* output);
+base::Status DeobfuscateProfile(std::istream* input, std::ostream* output);
 
 }
 }  // namespace perfetto

--- a/src/traceconv/symbolize_profile.cc
+++ b/src/traceconv/symbolize_profile.cc
@@ -31,7 +31,9 @@ namespace trace_to_text {
 
 // Ingest profile, and emit a symbolization table for each sequence. This can
 // be prepended to the profile to attach the symbol information.
-int SymbolizeProfile(std::istream* input, std::ostream* output, bool verbose) {
+base::Status SymbolizeProfile(std::istream* input,
+                              std::ostream* output,
+                              bool verbose) {
   profiling::SymbolizerConfig sym_config;
 
   const char* breakpad_dir = getenv("BREAKPAD_SYMBOL_DIR");
@@ -50,29 +52,35 @@ int SymbolizeProfile(std::istream* input, std::ostream* output, bool verbose) {
   if (sym_config.index_symbol_paths.empty() &&
       sym_config.find_symbol_paths.empty() &&
       sym_config.breakpad_paths.empty()) {
-    PERFETTO_FATAL("No symbol paths configured");
+    return base::ErrStatus(
+        "no symbol paths configured: set the PERFETTO_BINARY_PATH "
+        "environment variable to a colon-separated list of directories "
+        "containing the unstripped binaries (or BREAKPAD_SYMBOL_DIR for "
+        "Breakpad symbol files) and try again");
   }
 
   trace_processor::Config config;
   std::unique_ptr<trace_processor::TraceProcessor> tp =
       trace_processor::TraceProcessor::CreateInstance(config);
 
-  if (!ReadTraceUnfinalized(tp.get(), input))
-    PERFETTO_FATAL("Failed to read trace.");
+  if (!ReadTraceUnfinalized(tp.get(), input)) {
+    return base::ErrStatus("failed to read trace");
+  }
 
   tp->Flush();
   if (auto status = tp->NotifyEndOfFile(); !status.ok()) {
-    PERFETTO_FATAL("%s", status.c_message());
+    return base::ErrStatus("failed to finalize trace: %s", status.c_message());
   }
 
   auto result =
       profiling::SymbolizeDatabaseAndLog(tp.get(), sym_config, verbose);
   if (result.error != profiling::SymbolizerError::kOk) {
-    PERFETTO_FATAL("Symbolization failed: %s", result.error_details.c_str());
+    return base::ErrStatus("symbolization failed: %s",
+                           result.error_details.c_str());
   }
   *output << result.symbols;
 
-  return 0;
+  return base::OkStatus();
 }
 
 }  // namespace trace_to_text

--- a/src/traceconv/symbolize_profile.h
+++ b/src/traceconv/symbolize_profile.h
@@ -19,10 +19,14 @@
 
 #include <iostream>
 
+#include "perfetto/base/status.h"
+
 namespace perfetto {
 namespace trace_to_text {
 
-int SymbolizeProfile(std::istream* input, std::ostream* output, bool verbose);
+base::Status SymbolizeProfile(std::istream* input,
+                              std::ostream* output,
+                              bool verbose);
 
 }  // namespace trace_to_text
 }  // namespace perfetto

--- a/src/traceconv/trace_to_bundle.cc
+++ b/src/traceconv/trace_to_bundle.cc
@@ -21,6 +21,7 @@
 
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
 #include "perfetto/trace_processor/read_trace.h"
 #include "perfetto/trace_processor/trace_processor.h"
 #include "src/trace_processor/util/tar_writer.h"
@@ -34,24 +35,35 @@
 
 namespace perfetto::trace_to_text {
 
-int TraceToBundle(const std::string& input_file_path,
-                  const std::string& output_file_path,
-                  const BundleContext& context) {
+base::Status TraceToBundle(const std::string& input_file_path,
+                           const std::string& output_file_path,
+                           const BundleContext& context) {
   auto tp = trace_processor::TraceProcessor::CreateInstance({});
-  auto status = trace_processor::ReadTrace(tp.get(), input_file_path.c_str());
-  if (!status.ok()) {
-    PERFETTO_ELOG("Failed to read trace: %s", status.c_message());
-    return 1;
-  }
 
-  // Add original trace file directly (memory efficient).
+  // Report reading progress to stderr, like the interactive shell does, so
+  // long-running bundles don't look frozen.
+  double loaded_mb = 0;
+  auto status = trace_processor::ReadTrace(
+      tp.get(), input_file_path.c_str(), [&loaded_mb](uint64_t parsed_size) {
+        loaded_mb = static_cast<double>(parsed_size) / 1E6;
+        fprintf(stderr, "\rReading trace: %.2f MB", loaded_mb);
+      });
+  if (!status.ok()) {
+    fprintf(stderr, "\n");
+    return base::ErrStatus("failed to read trace: %s", status.c_message());
+  }
+  fprintf(stderr, "\rRead trace: %.2f MB.\n", loaded_mb);
+
+  // Add original trace file directly (memory efficient). If the output path
+  // cannot be opened, TarWriter fails gracefully and this propagates a
+  // descriptive error instead of crashing.
+  fprintf(stderr, "Adding trace to bundle...\n");
   trace_processor::util::TarWriter tar(output_file_path);
   auto add_trace_status =
       tar.AddFileFromPath("trace.perfetto", input_file_path);
   if (!add_trace_status.ok()) {
-    PERFETTO_ELOG("Failed to add trace to TAR archive: %s",
-                  add_trace_status.c_message());
-    return 1;
+    return base::ErrStatus("failed to create bundle: %s",
+                           add_trace_status.c_message());
   }
 
   // Build enrichment configuration from context.
@@ -76,16 +88,17 @@ int TraceToBundle(const std::string& input_file_path,
   }
 
   // Perform trace enrichment (symbolization + deobfuscation).
+  fprintf(stderr, "Symbolizing and deobfuscating...\n");
   auto enrich_result =
       trace_processor::util::EnrichTrace(tp.get(), enrich_config);
+  fprintf(stderr, "Enrichment done.\n");
 
   // Add symbols if available.
   if (!enrich_result.native_symbols.empty()) {
     auto add_status = tar.AddFile("symbols.pb", enrich_result.native_symbols);
     if (!add_status.ok()) {
-      PERFETTO_ELOG("Failed to add symbols to TAR archive: %s",
-                    add_status.c_message());
-      return 1;
+      return base::ErrStatus("failed to add symbols to bundle: %s",
+                             add_status.c_message());
     }
   }
 
@@ -94,9 +107,8 @@ int TraceToBundle(const std::string& input_file_path,
     auto add_status =
         tar.AddFile("deobfuscation.pb", enrich_result.deobfuscation_data);
     if (!add_status.ok()) {
-      PERFETTO_ELOG("Failed to add deobfuscation data to TAR: %s",
-                    add_status.c_message());
-      return 1;
+      return base::ErrStatus("failed to add deobfuscation data to bundle: %s",
+                             add_status.c_message());
     }
   }
 
@@ -105,15 +117,21 @@ int TraceToBundle(const std::string& input_file_path,
     fprintf(stderr, "%s", enrich_result.details.c_str());
   }
 
-  // Explicit user-provided paths must succeed.
+  // Explicitly-provided resources that fail to load are the only hard
+  // errors: the user asked for them, so silently producing a bundle without
+  // them would hide the problem. Everything else (no matching symbols found,
+  // kernel addresses that cannot be symbolized offline, ...) is advisory and
+  // has already been printed above; the bundle is still produced with the
+  // trace and whatever enrichment was possible.
   if (enrich_result.error ==
-          trace_processor::util::EnrichmentError::kExplicitMapsFailed ||
-      enrich_result.error ==
-          trace_processor::util::EnrichmentError::kAllFailed) {
-    return 1;
+      trace_processor::util::EnrichmentError::kExplicitMapsFailed) {
+    return base::ErrStatus(
+        "bundle: one or more explicitly-provided ProGuard/R8 maps could not "
+        "be read; see the details above. Refusing to produce a bundle without "
+        "the requested deobfuscation data.");
   }
 
-  return 0;
+  return base::OkStatus();
 }
 
 }  // namespace perfetto::trace_to_text

--- a/src/traceconv/trace_to_bundle.h
+++ b/src/traceconv/trace_to_bundle.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+#include "perfetto/base/status.h"
+
 namespace perfetto::trace_to_text {
 
 // ProGuard/R8 mapping specification.
@@ -61,10 +63,14 @@ struct BundleContext {
 // Creates a bundle from the input trace with symbolization,
 // deobfuscation, and potentially other enhancements. Outputs a TAR file
 // containing everything needed for the trace to be self-contained.
-// Returns 0 on success, non-zero on failure.
-int TraceToBundle(const std::string& input_file_path,
-                  const std::string& output_file_path,
-                  const BundleContext& context);
+//
+// Returns OkStatus() if the bundle was created, even when some enrichment
+// was not possible (the details are printed to stderr). Returns an error
+// only for genuine failures: unreadable input, unwritable output, or an
+// explicitly-provided ProGuard/R8 map that could not be read.
+base::Status TraceToBundle(const std::string& input_file_path,
+                           const std::string& output_file_path,
+                           const BundleContext& context);
 
 }  // namespace perfetto::trace_to_text
 

--- a/src/traceconv/trace_to_firefox.cc
+++ b/src/traceconv/trace_to_firefox.cc
@@ -63,13 +63,13 @@ std::unique_ptr<trace_processor::TraceProcessor> LoadTrace(
 
 }  // namespace
 
-bool TraceToFirefoxProfile(std::istream* input, std::ostream* output) {
+base::Status TraceToFirefoxProfile(std::istream* input, std::ostream* output) {
   auto tp = LoadTrace(input);
   if (!tp) {
-    return false;
+    return base::ErrStatus("failed to read trace");
   }
   ExportFirefoxProfile(*tp, output);
-  return true;
+  return base::OkStatus();
 }
 
 }  // namespace trace_to_text

--- a/src/traceconv/trace_to_firefox.h
+++ b/src/traceconv/trace_to_firefox.h
@@ -19,13 +19,15 @@
 
 #include <iostream>
 
+#include "perfetto/base/status.h"
+
 namespace perfetto {
 namespace trace_to_text {
 
 // Exports trace as as Firefox Profile. More details here:
 // https://firefox-source-docs.mozilla.org/tools/profiler/code-overview.html
 // https://github.com/firefox-devtools/profiler/blob/main/src/types/profile.js
-bool TraceToFirefoxProfile(std::istream* input, std::ostream* output);
+base::Status TraceToFirefoxProfile(std::istream* input, std::ostream* output);
 
 }  // namespace trace_to_text
 }  // namespace perfetto

--- a/src/traceconv/trace_to_json.cc
+++ b/src/traceconv/trace_to_json.cc
@@ -67,6 +67,7 @@ bool ExportUserspaceEvents(trace_processor::TraceProcessor* tp,
 
   TraceWriterOutputWriter output(writer);
   base::Status status = trace_processor::json::ExportJson(tp, &output);
+  EndProgressLine();
   if (!status.ok()) {
     PERFETTO_ELOG("Could not convert userspace events: %s", status.c_message());
     return false;
@@ -80,11 +81,11 @@ bool ExportUserspaceEvents(trace_processor::TraceProcessor* tp,
 
 }  // namespace
 
-int TraceToJson(std::istream* input,
-                std::ostream* output,
-                bool compress,
-                Keep truncate_keep,
-                bool full_sort) {
+base::Status TraceToJson(std::istream* input,
+                         std::ostream* output,
+                         bool compress,
+                         Keep truncate_keep,
+                         bool full_sort) {
   std::unique_ptr<TraceWriter> trace_writer(
       compress ? new DeflateTraceWriter(output) : new TraceWriter(output));
 
@@ -96,9 +97,9 @@ int TraceToJson(std::istream* input,
       trace_processor::TraceProcessor::CreateInstance(config);
 
   if (!ReadTraceUnfinalized(tp.get(), input))
-    return 1;
+    return base::ErrStatus("failed to read trace");
   if (auto status = tp->NotifyEndOfFile(); !status.ok()) {
-    return 1;
+    return base::ErrStatus("failed to finalize trace: %s", status.c_message());
   }
 
   // TODO(eseckler): Support truncation of userspace event data.
@@ -106,17 +107,21 @@ int TraceToJson(std::istream* input,
     // ExportJson streams directly to |trace_writer|, so emitting an empty
     // trace header here would corrupt any output already written. Report the
     // conversion failure instead of silently dropping userspace events.
-    return 1;
+    return base::ErrStatus(
+        "failed to convert userspace events (see errors above)");
   }
   trace_writer->Write(",\n");
 
   int ret = ExtractSystrace(tp.get(), trace_writer.get(),
                             /*wrapped_in_json=*/true, truncate_keep);
-  if (ret)
-    return ret;
+  if (ret) {
+    EndProgressLine();
+    return base::ErrStatus("failed to convert ftrace events");
+  }
 
   trace_writer->Write(kTraceFooter);
-  return 0;
+  EndProgressLine();
+  return base::OkStatus();
 }
 
 }  // namespace trace_to_text

--- a/src/traceconv/trace_to_json.cc
+++ b/src/traceconv/trace_to_json.cc
@@ -64,6 +64,7 @@ bool ExportUserspaceEvents(trace_processor::TraceProcessor* tp,
                            TraceWriter* writer) {
   fprintf(stderr, "Converting userspace events%c", kProgressChar);
   fflush(stderr);
+  MarkProgressLine();
 
   TraceWriterOutputWriter output(writer);
   base::Status status = trace_processor::json::ExportJson(tp, &output);

--- a/src/traceconv/trace_to_json.cc
+++ b/src/traceconv/trace_to_json.cc
@@ -62,9 +62,7 @@ class TraceWriterOutputWriter final
 
 bool ExportUserspaceEvents(trace_processor::TraceProcessor* tp,
                            TraceWriter* writer) {
-  fprintf(stderr, "Converting userspace events%c", kProgressChar);
-  fflush(stderr);
-  MarkProgressLine();
+  ProgressLine("Converting userspace events");
 
   TraceWriterOutputWriter output(writer);
   base::Status status = trace_processor::json::ExportJson(tp, &output);

--- a/src/traceconv/trace_to_json.h
+++ b/src/traceconv/trace_to_json.h
@@ -19,16 +19,17 @@
 
 #include <iostream>
 
+#include "perfetto/base/status.h"
 #include "src/traceconv/trace_to_systrace.h"
 
 namespace perfetto {
 namespace trace_to_text {
 
-int TraceToJson(std::istream* input,
-                std::ostream* output,
-                bool compress,
-                Keep truncate_keep,
-                bool full_sort);
+base::Status TraceToJson(std::istream* input,
+                         std::ostream* output,
+                         bool compress,
+                         Keep truncate_keep,
+                         bool full_sort);
 
 }  // namespace trace_to_text
 }  // namespace perfetto

--- a/src/traceconv/trace_to_pprof_integrationtest.cc
+++ b/src/traceconv/trace_to_pprof_integrationtest.cc
@@ -43,11 +43,13 @@ pprof::PprofProfileReader ConvertTraceToPprof(
   base::TempDir temp_dir = base::TempDir::Create();
   std::string out_dirname = temp_dir.path();
 
-  trace_to_text::TraceToProfile(&file_istream, /*pid=*/0,
-                                /*timestamps=*/{},
-                                /*annotate_frames=*/false, out_dirname,
-                                /*conversion_mode=*/std::nullopt,
-                                /*verbose=*/false);
+  auto profile_status =
+      trace_to_text::TraceToProfile(&file_istream, /*pid=*/0,
+                                    /*timestamps=*/{},
+                                    /*annotate_frames=*/false, out_dirname,
+                                    /*conversion_mode=*/std::nullopt,
+                                    /*verbose=*/false);
+  PERFETTO_CHECK(profile_status.ok());
   std::vector<std::string> filenames;
   base::ListFilesRecursive(out_dirname, filenames);
   // assumption: all test inputs contain exactly one profile
@@ -134,11 +136,12 @@ TEST_F(TraceToPprofTest, OutputDirectory) {
   base::TempDir temp_dir = base::TempDir::Create();
   std::string output_dir = temp_dir.path() + "/my_profiles";
 
-  trace_to_text::TraceToProfile(&file_istream, /*pid=*/0,
-                                /*timestamps=*/{},
-                                /*annotate_frames=*/false, output_dir,
-                                ConversionMode::kJavaHeapProfile,
-                                /*verbose=*/false);
+  auto profile_status = trace_to_text::TraceToProfile(
+      &file_istream, /*pid=*/0,
+      /*timestamps=*/{},
+      /*annotate_frames=*/false, output_dir, ConversionMode::kJavaHeapProfile,
+      /*verbose=*/false);
+  ASSERT_TRUE(profile_status.ok()) << profile_status.c_message();
 
   // Check files exist
   std::vector<std::string> filenames;

--- a/src/traceconv/trace_to_profile.cc
+++ b/src/traceconv/trace_to_profile.cc
@@ -236,7 +236,8 @@ base::Status TraceToProfile(std::istream* input,
                    GetDestinationDirectory(output_dir, dir_prefix));
   for (const auto& profile : profiles) {
     std::string filename = dst_dir + "/" + filename_fn(profile);
-    base::ScopedFile fd(base::OpenFile(filename, O_CREAT | O_WRONLY, 0700));
+    base::ScopedFile fd(
+        base::OpenFile(filename, O_CREAT | O_WRONLY | O_TRUNC, 0700));
     if (!fd) {
       return base::ErrStatus("failed to open %s (errno: %d, %s)",
                              filename.c_str(), errno, strerror(errno));

--- a/src/traceconv/trace_to_profile.cc
+++ b/src/traceconv/trace_to_profile.cc
@@ -18,6 +18,7 @@
 
 #include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <random>
 #include <string>
 #include <string_view>
@@ -26,6 +27,8 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/time.h"
 #include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
 #include "perfetto/profiling/pprof_builder.h"
 #include "perfetto/trace_processor/trace_processor.h"
 #include "src/trace_processor/util/deobfuscation/deobfuscator.h"
@@ -79,10 +82,13 @@ void MaybeDeobfuscate(trace_processor::TraceProcessor* tp) {
   if (maybe_map.empty()) {
     return;
   }
-  profiling::ReadProguardMapsToDeobfuscationPackets(
+  auto status = profiling::ReadProguardMapsToDeobfuscationPackets(
       maybe_map, [tp](const std::string& trace_proto) {
         IngestTraceOrDie(tp, trace_proto);
       });
+  if (!status.ok()) {
+    PERFETTO_ELOG("Failed to deobfuscate: %s", status.c_message());
+  }
   tp->Flush();
 }
 
@@ -99,8 +105,9 @@ std::string GetRandomString(size_t n) {
 // Creates the destination directory.
 // If |output_dir| is not empty, it is used as the destination directory.
 // Otherwise, a random temporary directory is created using
-// |fallback_dirname_prefix|.
-std::string GetDestinationDirectory(
+// |fallback_dirname_prefix|. Returns an error (instead of logging and
+// crashing) if the directory could not be created.
+base::StatusOr<std::string> GetDestinationDirectory(
     const std::string& output_dir,
     const std::string& fallback_dirname_prefix) {
   std::string dst_dir;
@@ -111,13 +118,16 @@ std::string GetDestinationDirectory(
               base::GetTimeFmt("%y%m%d%H%M%S") + GetRandomString(5);
   }
   if (!base::Mkdir(dst_dir) && errno != EEXIST) {
-    PERFETTO_FATAL("Failed to create output directory %s", dst_dir.c_str());
+    return base::ErrStatus(
+        "failed to create output directory %s (errno: %d, %s)", dst_dir.c_str(),
+        errno, strerror(errno));
   }
   return dst_dir;
 }
 
 std::optional<ConversionMode> DetectConversionMode(
-    trace_processor::TraceProcessor* tp) {
+    trace_processor::TraceProcessor* tp,
+    std::string* error_out) {
   auto it = tp->ExecuteQuery(R"(
   SELECT
     EXISTS (SELECT 1 FROM __intrinsic_heap_profile_allocation LIMIT 1),
@@ -132,11 +142,11 @@ std::optional<ConversionMode> DetectConversionMode(
 
   int64_t count = alloc_present + perf_present + graph_present;
   if (count == 0) {
-    PERFETTO_LOG("No profiles found.");
+    *error_out = "no profile found in the trace";
     return std::nullopt;
   } else if (count > 1) {
     std::string err_msg =
-        "More than one type of profile found in the trace, pass an explicit "
+        "more than one type of profile found in the trace, pass an explicit "
         "disambiguation flag:\n";
     if (alloc_present)
       err_msg += "  --alloc: allocator profile\n";
@@ -144,8 +154,7 @@ std::optional<ConversionMode> DetectConversionMode(
       err_msg += "  --perf: perf profile\n";
     if (graph_present)
       err_msg += "  --java-heap: java heap graph\n";
-
-    PERFETTO_ELOG("%s", err_msg.c_str());
+    *error_out = std::move(err_msg);
     return std::nullopt;
   }
   return alloc_present  ? ConversionMode::kHeapProfile
@@ -155,28 +164,29 @@ std::optional<ConversionMode> DetectConversionMode(
 
 }  // namespace
 
-int TraceToProfile(std::istream* input,
-                   uint64_t pid,
-                   const std::vector<uint64_t>& timestamps,
-                   bool annotate_frames,
-                   const std::string& output_dir,
-                   std::optional<ConversionMode> explicit_mode,
-                   bool verbose) {
+base::Status TraceToProfile(std::istream* input,
+                            uint64_t pid,
+                            const std::vector<uint64_t>& timestamps,
+                            bool annotate_frames,
+                            const std::string& output_dir,
+                            std::optional<ConversionMode> explicit_mode,
+                            bool verbose) {
   // Pre-parse trace.
   trace_processor::Config config;
   std::unique_ptr<trace_processor::TraceProcessor> tp =
       trace_processor::TraceProcessor::CreateInstance(config);
   if (!ReadTraceUnfinalized(tp.get(), input))
-    return -1;
+    return base::ErrStatus("failed to read trace");
   tp->Flush();
 
   // Detect type of profile.
-  std::optional<ConversionMode> mode = explicit_mode.has_value()
-                                           ? explicit_mode
-                                           : DetectConversionMode(tp.get());
+  std::string mode_error;
+  std::optional<ConversionMode> mode =
+      explicit_mode.has_value() ? explicit_mode
+                                : DetectConversionMode(tp.get(), &mode_error);
 
   if (!mode.has_value()) {
-    return -1;
+    return base::ErrStatus("convert profile: %s", mode_error.c_str());
   }
 
   int file_idx = 0;
@@ -210,7 +220,7 @@ int TraceToProfile(std::istream* input,
   MaybeSymbolize(tp.get(), verbose);
   MaybeDeobfuscate(tp.get());
   if (auto status = tp->NotifyEndOfFile(); !status.ok()) {
-    return -1;
+    return base::ErrStatus("failed to finalize trace: %s", status.c_message());
   }
 
   // Generate profiles.
@@ -218,22 +228,27 @@ int TraceToProfile(std::istream* input,
   TraceToPprof(tp.get(), &profiles, *mode, ToConversionFlags(annotate_frames),
                pid, timestamps);
   if (profiles.empty()) {
-    return 0;
+    return base::OkStatus();
   }
 
   // Write profiles to files.
-  std::string dst_dir = GetDestinationDirectory(output_dir, dir_prefix);
+  ASSIGN_OR_RETURN(std::string dst_dir,
+                   GetDestinationDirectory(output_dir, dir_prefix));
   for (const auto& profile : profiles) {
     std::string filename = dst_dir + "/" + filename_fn(profile);
     base::ScopedFile fd(base::OpenFile(filename, O_CREAT | O_WRONLY, 0700));
-    if (!fd)
-      PERFETTO_FATAL("Failed to open %s", filename.c_str());
-    PERFETTO_CHECK(base::WriteAll(*fd, profile.serialized.c_str(),
-                                  profile.serialized.size()) ==
-                   static_cast<ssize_t>(profile.serialized.size()));
+    if (!fd) {
+      return base::ErrStatus("failed to open %s (errno: %d, %s)",
+                             filename.c_str(), errno, strerror(errno));
+    }
+    if (base::WriteAll(*fd, profile.serialized.c_str(),
+                       profile.serialized.size()) !=
+        static_cast<ssize_t>(profile.serialized.size())) {
+      return base::ErrStatus("failed to write %s", filename.c_str());
+    }
   }
   PERFETTO_LOG("Wrote profiles to %s", dst_dir.c_str());
-  return 0;
+  return base::OkStatus();
 }
 
 }  // namespace trace_to_text

--- a/src/traceconv/trace_to_profile.h
+++ b/src/traceconv/trace_to_profile.h
@@ -23,19 +23,19 @@
 #include <string>
 #include <vector>
 
+#include "perfetto/base/status.h"
 #include "perfetto/profiling/pprof_builder.h"
 
 namespace perfetto {
 namespace trace_to_text {
 
-// 0: success
-int TraceToProfile(std::istream* input,
-                   uint64_t pid,
-                   const std::vector<uint64_t>& timestamps,
-                   bool annotate_frames,
-                   const std::string& output_dir,
-                   std::optional<ConversionMode> conversion_mode,
-                   bool verbose);
+base::Status TraceToProfile(std::istream* input,
+                            uint64_t pid,
+                            const std::vector<uint64_t>& timestamps,
+                            bool annotate_frames,
+                            const std::string& output_dir,
+                            std::optional<ConversionMode> conversion_mode,
+                            bool verbose);
 
 }  // namespace trace_to_text
 }  // namespace perfetto

--- a/src/traceconv/trace_to_systrace.cc
+++ b/src/traceconv/trace_to_systrace.cc
@@ -124,8 +124,7 @@ class QueryWriter {
       callback(&iterator, &line_writer);
 
       if (global_writer_.pos() + line_writer.pos() >= kFlushThreshold) {
-        fprintf(stderr, "Writing row %" PRIu32 "%c", rows, kProgressChar);
-        MarkProgressLine();
+        ProgressLine("Writing row %" PRIu32, rows);
         auto str = global_writer_.GetStringView();
         trace_writer_->Write(str.data(), str.size());
         global_writer_.Clear();
@@ -179,9 +178,7 @@ int ExtractRawEvents(TraceWriter* trace_writer,
     return 0;
   }
 
-  fprintf(stderr, "Converting ftrace events%c", kProgressChar);
-  fflush(stderr);
-  MarkProgressLine();
+  ProgressLine("Converting ftrace events");
 
   auto raw_callback = [wrapped_in_json](Iterator* it,
                                         base::DynamicStringWriter* writer) {

--- a/src/traceconv/trace_to_systrace.cc
+++ b/src/traceconv/trace_to_systrace.cc
@@ -125,6 +125,7 @@ class QueryWriter {
 
       if (global_writer_.pos() + line_writer.pos() >= kFlushThreshold) {
         fprintf(stderr, "Writing row %" PRIu32 "%c", rows, kProgressChar);
+        MarkProgressLine();
         auto str = global_writer_.GetStringView();
         trace_writer_->Write(str.data(), str.size());
         global_writer_.Clear();
@@ -180,6 +181,7 @@ int ExtractRawEvents(TraceWriter* trace_writer,
 
   fprintf(stderr, "Converting ftrace events%c", kProgressChar);
   fflush(stderr);
+  MarkProgressLine();
 
   auto raw_callback = [wrapped_in_json](Iterator* it,
                                         base::DynamicStringWriter* writer) {

--- a/src/traceconv/trace_to_systrace.cc
+++ b/src/traceconv/trace_to_systrace.cc
@@ -131,6 +131,7 @@ class QueryWriter {
       }
       global_writer_.AppendStringView(line_writer.GetStringView());
     }
+    EndProgressLine();
 
     // Check if we have an error in the iterator and print if so.
     auto status = iterator.Status();
@@ -263,11 +264,11 @@ int ExtractRawEvents(TraceWriter* trace_writer,
 
 }  // namespace
 
-int TraceToSystrace(std::istream* input,
-                    std::ostream* output,
-                    bool ctrace,
-                    Keep truncate_keep,
-                    bool full_sort) {
+base::Status TraceToSystrace(std::istream* input,
+                             std::ostream* output,
+                             bool ctrace,
+                             Keep truncate_keep,
+                             bool full_sort) {
   std::unique_ptr<TraceWriter> trace_writer(
       ctrace ? new DeflateTraceWriter(output) : new TraceWriter(output));
 
@@ -279,16 +280,22 @@ int TraceToSystrace(std::istream* input,
       trace_processor::TraceProcessor::CreateInstance(config);
 
   if (!ReadTraceUnfinalized(tp.get(), input))
-    return 1;
+    return base::ErrStatus("failed to read trace");
   if (auto status = tp->NotifyEndOfFile(); !status.ok()) {
-    return 1;
+    return base::ErrStatus("failed to finalize trace: %s", status.c_message());
   }
 
   if (ctrace)
     *output << "TRACE:\n";
 
-  return ExtractSystrace(tp.get(), trace_writer.get(),
-                         /*wrapped_in_json=*/false, truncate_keep);
+  int ret = ExtractSystrace(tp.get(), trace_writer.get(),
+                            /*wrapped_in_json=*/false, truncate_keep);
+  if (ret) {
+    EndProgressLine();
+    return base::ErrStatus("failed to convert ftrace events");
+  }
+  EndProgressLine();
+  return base::OkStatus();
 }
 
 int ExtractSystrace(trace_processor::TraceProcessor* tp,

--- a/src/traceconv/trace_to_systrace.h
+++ b/src/traceconv/trace_to_systrace.h
@@ -19,6 +19,8 @@
 
 #include <iostream>
 
+#include "perfetto/base/status.h"
+
 namespace perfetto {
 
 namespace trace_processor {
@@ -31,11 +33,11 @@ class TraceWriter;
 
 enum class Keep { kStart = 0, kEnd, kAll };
 
-int TraceToSystrace(std::istream* input,
-                    std::ostream* output,
-                    bool ctrace,
-                    Keep truncate_keep,
-                    bool full_sort);
+base::Status TraceToSystrace(std::istream* input,
+                             std::ostream* output,
+                             bool ctrace,
+                             Keep truncate_keep,
+                             bool full_sort);
 
 int ExtractSystrace(trace_processor::TraceProcessor*,
                     TraceWriter*,

--- a/src/traceconv/trace_to_text.cc
+++ b/src/traceconv/trace_to_text.cc
@@ -149,6 +149,7 @@ void OnlineTraceToText::Feed(const uint8_t* data, size_t len) {
       fprintf(stderr, "Processing trace: %8zu KB%c", bytes_processed_ / 1024,
               kProgressChar);
       fflush(stderr);
+      MarkProgressLine();
     }
     if (decoder.has_compressed_packets()) {
       PrintCompressedPackets(decoder.compressed_packets(),

--- a/src/traceconv/trace_to_text.cc
+++ b/src/traceconv/trace_to_text.cc
@@ -146,10 +146,7 @@ void OnlineTraceToText::Feed(const uint8_t* data, size_t len) {
     protos::pbzero::TracePacket::Decoder decoder(token.start, token.len);
     bytes_processed_ += token.len;
     if ((packet_++ & 0x3f) == 0) {
-      fprintf(stderr, "Processing trace: %8zu KB%c", bytes_processed_ / 1024,
-              kProgressChar);
-      fflush(stderr);
-      MarkProgressLine();
+      ProgressLine("Processing trace: %8zu KB", bytes_processed_ / 1024);
     }
     if (decoder.has_compressed_packets()) {
       PrintCompressedPackets(decoder.compressed_packets(),

--- a/src/traceconv/trace_to_text.cc
+++ b/src/traceconv/trace_to_text.cc
@@ -61,6 +61,7 @@ class OnlineTraceToText {
   OnlineTraceToText& operator=(const OnlineTraceToText&) = delete;
   void Feed(const uint8_t* data, size_t len);
   bool ok() const { return ok_; }
+  const std::string& error() const { return error_; }
 
  private:
   std::string TracePacketToText(protozero::ConstBytes packet,
@@ -69,6 +70,7 @@ class OnlineTraceToText {
                               util::CompressionType type);
 
   bool ok_ = true;
+  std::string error_;
   std::ostream* output_;
   protozero::ProtoRingBuffer ring_buffer_;
   DescriptorPool pool_;
@@ -127,7 +129,7 @@ void OnlineTraceToText::Feed(const uint8_t* data, size_t len) {
   while (true) {
     auto token = ring_buffer_.ReadMessage();
     if (token.fatal_framing_error) {
-      PERFETTO_ELOG("Failed to tokenize trace packet");
+      error_ = "failed to tokenize trace packet (corrupt or truncated)";
       ok_ = false;
       return;
     }
@@ -176,7 +178,7 @@ class InputReader {
       return false;
     input_->read(reinterpret_cast<char*>(data), std::streamsize(len_limit));
     if (input_->bad() || (input_->fail() && !input_->eof())) {
-      PERFETTO_ELOG("Failed while reading trace");
+      error_ = "failed while reading trace";
       ok_ = false;
       return false;
     }
@@ -184,17 +186,19 @@ class InputReader {
     return true;
   }
   bool ok() const { return ok_; }
+  const std::string& error() const { return error_; }
 
  private:
   std::istream* input_;
   bool ok_ = true;
+  std::string error_;
 };
 
 }  // namespace
 
-bool TraceToText(std::istream* input,
-                 std::ostream* output,
-                 const TraceToTextOptions& options) {
+base::Status TraceToText(std::istream* input,
+                         std::ostream* output,
+                         const TraceToTextOptions& options) {
   constexpr size_t kMaxMsgSize = protozero::ProtoRingBuffer::kMaxMsgSize;
   std::unique_ptr<uint8_t[]> buffer(new uint8_t[kMaxMsgSize]);
   uint32_t buffer_len = 0;
@@ -215,7 +219,10 @@ bool TraceToText(std::istream* input,
     std::unique_ptr<util::Decompressor> decompressor =
         util::CreateDecompressor(codec);
     if (!decompressor) {
-      return false;  // The codec isn't enabled in this build.
+      // The codec isn't enabled in this build.
+      return base::ErrStatus(
+          "cannot decode compressed packets: the codec is not enabled in the "
+          "build config");
     }
 
     using ResultCode = util::Decompressor::ResultCode;
@@ -231,13 +238,17 @@ bool TraceToText(std::istream* input,
       for (;;) {
         auto res = decompressor->ExtractOutput(out, sizeof(out));
         if (res.ret == ResultCode::kError) {
-          PERFETTO_ELOG("Failed to decompress, trace is likely corrupt");
-          return false;
+          EndProgressLine();
+          return base::ErrStatus(
+              "failed to decompress, trace is likely corrupt");
         }
         if (res.bytes_written > 0)
           online_trace_to_text.Feed(out, res.bytes_written);
-        if (!online_trace_to_text.ok())
-          return false;
+        if (!online_trace_to_text.ok()) {
+          EndProgressLine();
+          return base::ErrStatus("failed to convert trace to text: %s",
+                                 online_trace_to_text.error().c_str());
+        }
         code = res.ret;
         if (res.ret == ResultCode::kOk)
           continue;  // More output buffered; keep draining.
@@ -257,20 +268,36 @@ bool TraceToText(std::istream* input,
              buffer_len > 0);
 
     if (code != ResultCode::kEof) {
-      PERFETTO_ELOG("Compressed stream incomplete, trace is likely corrupt");
-      return false;
+      EndProgressLine();
+      return base::ErrStatus(
+          "compressed stream incomplete, trace is likely corrupt");
     }
-    return input_reader.ok();
+    if (!input_reader.ok()) {
+      EndProgressLine();
+      return base::ErrStatus("failed to read trace: %s",
+                             input_reader.error().c_str());
+    }
+    EndProgressLine();
+    return base::OkStatus();
   } else if (type == trace_processor::CompressedTraceType::kProto) {
     do {
       online_trace_to_text.Feed(buffer.get(), buffer_len);
-      if (!online_trace_to_text.ok())
-        return false;
+      if (!online_trace_to_text.ok()) {
+        EndProgressLine();
+        return base::ErrStatus("failed to convert trace to text: %s",
+                               online_trace_to_text.error().c_str());
+      }
     } while (input_reader.Read(buffer.get(), &buffer_len, kMaxMsgSize));
-    return input_reader.ok();
+    if (!input_reader.ok()) {
+      EndProgressLine();
+      return base::ErrStatus("failed to read trace: %s",
+                             input_reader.error().c_str());
+    }
+    EndProgressLine();
+    return base::OkStatus();
   } else {
-    PERFETTO_ELOG("Unrecognised file.");
-    return false;
+    return base::ErrStatus(
+        "unrecognised file: the input does not look like a Perfetto trace");
   }
 }
 

--- a/src/traceconv/trace_to_text.h
+++ b/src/traceconv/trace_to_text.h
@@ -19,6 +19,8 @@
 
 #include <iostream>
 
+#include "perfetto/base/status.h"
+
 namespace perfetto {
 namespace trace_to_text {
 
@@ -27,10 +29,10 @@ struct TraceToTextOptions {
   bool skip_unknown_fields = false;
 };
 
-// Returns true in case of success.
-bool TraceToText(std::istream* input,
-                 std::ostream* output,
-                 const TraceToTextOptions& options);
+// Returns OkStatus() on success.
+base::Status TraceToText(std::istream* input,
+                         std::ostream* output,
+                         const TraceToTextOptions& options);
 
 }  // namespace trace_to_text
 }  // namespace perfetto

--- a/src/traceconv/trace_to_text_integrationtest.cc
+++ b/src/traceconv/trace_to_text_integrationtest.cc
@@ -55,7 +55,7 @@ TEST(TraceToText, DISABLED_Basic) {
       std::ofstream output_f(tmp_file, std::ios::out | std::ios::binary);
       TraceToTextOptions options;
       options.skip_unknown_fields = true;
-      EXPECT_TRUE(TraceToText(&input_f, &output_f, options));
+      EXPECT_TRUE(TraceToText(&input_f, &output_f, options).ok());
       PERFETTO_LOG("Processed %s", filename);
     }
     EXPECT_EQ(0xCD794377594BC7DCull, FileHash(tmp_file));

--- a/src/traceconv/trace_unpack.cc
+++ b/src/traceconv/trace_unpack.cc
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <vector>
 
+#include "perfetto/base/status.h"
 #include "perfetto/trace_processor/read_trace.h"
 #include "src/traceconv/utils.h"
 
@@ -28,18 +29,19 @@ namespace trace_to_text {
 
 // Naive: puts multiple copies of the trace in memory, but good enough for
 // manual workflows.
-bool UnpackCompressedPackets(std::istream* input, std::ostream* output) {
+base::Status UnpackCompressedPackets(std::istream* input,
+                                     std::ostream* output) {
   std::vector<char> packed(std::istreambuf_iterator<char>{*input},
                            std::istreambuf_iterator<char>{});
   std::vector<uint8_t> unpacked;
   auto status = trace_processor::DecompressTrace(
       reinterpret_cast<uint8_t*>(packed.data()), packed.size(), &unpacked);
   if (!status.ok())
-    return false;
+    return status;
 
   TraceWriter trace_writer(output);
   trace_writer.Write(reinterpret_cast<char*>(unpacked.data()), unpacked.size());
-  return true;
+  return base::OkStatus();
 }
 
 }  // namespace trace_to_text

--- a/src/traceconv/trace_unpack.h
+++ b/src/traceconv/trace_unpack.h
@@ -19,12 +19,14 @@
 
 #include <iostream>
 
+#include "perfetto/base/status.h"
+
 namespace perfetto {
 namespace trace_to_text {
 
 // Serialised trace with compressed_packets -> serialised trace with those
 // packets in their decompressed form. Mostly for use with protoprofile.
-bool UnpackCompressedPackets(std::istream* input, std::ostream* output);
+base::Status UnpackCompressedPackets(std::istream* input, std::ostream* output);
 
 }  // namespace trace_to_text
 }  // namespace perfetto

--- a/src/traceconv/traceconv.cc
+++ b/src/traceconv/traceconv.cc
@@ -330,9 +330,9 @@ int Main(int argc, char** argv) {
   }
 
   if (format == "json")
-    return ToExitCode(trace_to_text::TraceToJson(
-        input_stream, output_stream, /*compress=*/false, truncate_keep,
-        full_sort));
+    return ToExitCode(trace_to_text::TraceToJson(input_stream, output_stream,
+                                                 /*compress=*/false,
+                                                 truncate_keep, full_sort));
 
   if (format == "systrace")
     return ToExitCode(trace_to_text::TraceToSystrace(
@@ -393,8 +393,8 @@ int Main(int argc, char** argv) {
         trace_to_text::DeobfuscateProfile(input_stream, output_stream));
 
   if (format == "firefox")
-    return ToExitCode(trace_to_text::TraceToFirefoxProfile(input_stream,
-                                                           output_stream));
+    return ToExitCode(
+        trace_to_text::TraceToFirefoxProfile(input_stream, output_stream));
 
   if (format == "decompress_packets")
     return ToExitCode(

--- a/src/traceconv/traceconv.cc
+++ b/src/traceconv/traceconv.cc
@@ -55,6 +55,14 @@
 namespace perfetto::traceconv {
 namespace {
 
+// Maps a base::Status to the process exit code, logging the failure reason.
+int ToExitCode(const base::Status& status) {
+  if (status.ok())
+    return 0;
+  PERFETTO_ELOG("%s", status.c_message());
+  return 1;
+}
+
 int Usage(const char* argv0) {
   fprintf(stderr, R"(
 Trace format conversion tool.
@@ -322,19 +330,19 @@ int Main(int argc, char** argv) {
   }
 
   if (format == "json")
-    return trace_to_text::TraceToJson(input_stream, output_stream,
-                                      /*compress=*/false, truncate_keep,
-                                      full_sort);
+    return ToExitCode(trace_to_text::TraceToJson(
+        input_stream, output_stream, /*compress=*/false, truncate_keep,
+        full_sort));
 
   if (format == "systrace")
-    return trace_to_text::TraceToSystrace(input_stream, output_stream,
-                                          /*ctrace=*/false, truncate_keep,
-                                          full_sort);
+    return ToExitCode(trace_to_text::TraceToSystrace(
+        input_stream, output_stream, /*ctrace=*/false, truncate_keep,
+        full_sort));
 
   if (format == "ctrace")
-    return trace_to_text::TraceToSystrace(input_stream, output_stream,
-                                          /*ctrace=*/true, truncate_keep,
-                                          full_sort);
+    return ToExitCode(trace_to_text::TraceToSystrace(
+        input_stream, output_stream, /*ctrace=*/true, truncate_keep,
+        full_sort));
 
   if (truncate_keep != trace_to_text::Keep::kAll) {
     PERFETTO_ELOG(
@@ -353,8 +361,8 @@ int Main(int argc, char** argv) {
   if (format == "text") {
     trace_to_text::TraceToTextOptions options;
     options.skip_unknown_fields = skip_unknown_fields;
-    return trace_to_text::TraceToText(input_stream, output_stream, options) ? 0
-                                                                            : 1;
+    return ToExitCode(
+        trace_to_text::TraceToText(input_stream, output_stream, options));
   }
 
   if (format == "profile") {
@@ -364,30 +372,33 @@ int Main(int argc, char** argv) {
           "instead");
       return Usage(argv[0]);
     }
-    return trace_to_text::TraceToProfile(input_stream, pid, timestamps,
-                                         !profile_no_annotations, output_dir,
-                                         profile_type, verbose);
+    return ToExitCode(trace_to_text::TraceToProfile(
+        input_stream, pid, timestamps, !profile_no_annotations, output_dir,
+        profile_type, verbose));
   }
 
   if (format == "java_heap_profile") {
     // legacy alias for "profile --java-heap"
-    return trace_to_text::TraceToProfile(
+    return ToExitCode(trace_to_text::TraceToProfile(
         input_stream, pid, timestamps, !profile_no_annotations, output_dir,
-        trace_to_text::ConversionMode::kJavaHeapProfile, verbose);
+        trace_to_text::ConversionMode::kJavaHeapProfile, verbose));
   }
 
   if (format == "symbolize")
-    return trace_to_text::SymbolizeProfile(input_stream, output_stream,
-                                           verbose);
+    return ToExitCode(
+        trace_to_text::SymbolizeProfile(input_stream, output_stream, verbose));
 
   if (format == "deobfuscate")
-    return trace_to_text::DeobfuscateProfile(input_stream, output_stream);
+    return ToExitCode(
+        trace_to_text::DeobfuscateProfile(input_stream, output_stream));
 
   if (format == "firefox")
-    return trace_to_text::TraceToFirefoxProfile(input_stream, output_stream);
+    return ToExitCode(trace_to_text::TraceToFirefoxProfile(input_stream,
+                                                           output_stream));
 
   if (format == "decompress_packets")
-    return trace_to_text::UnpackCompressedPackets(input_stream, output_stream);
+    return ToExitCode(
+        trace_to_text::UnpackCompressedPackets(input_stream, output_stream));
 
   if (format == "bundle") {
     // Bundle mode requires both input and output file paths
@@ -430,7 +441,8 @@ int Main(int argc, char** argv) {
       context.home_dir = val;
     }
     context.root_dir = "/";
-    return trace_to_text::TraceToBundle(input_file, output_file, context);
+    return ToExitCode(
+        trace_to_text::TraceToBundle(input_file, output_file, context));
   }
 
   return Usage(argv[0]);

--- a/src/traceconv/utils.cc
+++ b/src/traceconv/utils.cc
@@ -66,6 +66,7 @@ bool ReadTraceUnfinalized(trace_processor::TraceProcessor* tp,
       fprintf(stderr, "Loading trace %.2f MB%c",
               static_cast<double>(file_size) / 1.0e6, kProgressChar);
       fflush(stderr);
+      MarkProgressLine();
     }
 
     std::unique_ptr<uint8_t[]> buf(new uint8_t[kChunkSize]);
@@ -83,6 +84,7 @@ bool ReadTraceUnfinalized(trace_processor::TraceProcessor* tp,
   }
 
   fprintf(stderr, "Loaded trace%c", kProgressChar);
+  MarkProgressLine();
   EndProgressLine();
   return true;
 }

--- a/src/traceconv/utils.cc
+++ b/src/traceconv/utils.cc
@@ -83,7 +83,7 @@ bool ReadTraceUnfinalized(trace_processor::TraceProcessor* tp,
   }
 
   fprintf(stderr, "Loaded trace%c", kProgressChar);
-  fflush(stderr);
+  EndProgressLine();
   return true;
 }
 

--- a/src/traceconv/utils.cc
+++ b/src/traceconv/utils.cc
@@ -63,10 +63,8 @@ bool ReadTraceUnfinalized(trace_processor::TraceProcessor* tp,
 
   for (int i = 0;; i++) {
     if (i % kStderrRate == 0) {
-      fprintf(stderr, "Loading trace %.2f MB%c",
-              static_cast<double>(file_size) / 1.0e6, kProgressChar);
-      fflush(stderr);
-      MarkProgressLine();
+      ProgressLine("Loading trace %.2f MB",
+                   static_cast<double>(file_size) / 1.0e6);
     }
 
     std::unique_ptr<uint8_t[]> buf(new uint8_t[kChunkSize]);
@@ -83,8 +81,7 @@ bool ReadTraceUnfinalized(trace_processor::TraceProcessor* tp,
     tp->Parse(std::move(buf), static_cast<size_t>(rsize));
   }
 
-  fprintf(stderr, "Loaded trace%c", kProgressChar);
-  MarkProgressLine();
+  ProgressLine("Loaded trace");
   EndProgressLine();
   return true;
 }

--- a/src/traceconv/utils.h
+++ b/src/traceconv/utils.h
@@ -52,6 +52,17 @@ constexpr char kProgressChar = '\n';
 constexpr char kProgressChar = '\r';
 #endif
 
+// Terminates the current in-place progress line so that subsequent output
+// (errors, logs, results) starts on a fresh line instead of overwriting or
+// merging with the progress text. On WASM, progress updates already end with
+// a newline (see kProgressChar), so this is a no-op there.
+inline void EndProgressLine() {
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WASM)
+  fprintf(stderr, "\n");
+  fflush(stderr);
+#endif
+}
+
 bool ReadTraceUnfinalized(trace_processor::TraceProcessor* tp,
                           std::istream* input);
 void IngestTraceOrDie(trace_processor::TraceProcessor* tp,

--- a/src/traceconv/utils.h
+++ b/src/traceconv/utils.h
@@ -72,7 +72,9 @@ inline bool& IsProgressLineActive() {
 // with a newline. No-op on WASM where updates already end with '\n'.
 inline void ProgressLine(const char* fmt, ...) PERFETTO_PRINTF_FORMAT(1, 2);
 inline void ProgressLine(const char* fmt, ...) {
-#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WASM)
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WASM)
+  ::perfetto::base::ignore_result(fmt);
+#else
   va_list args;
   va_start(args, fmt);
   vfprintf(stderr, fmt, args);

--- a/src/traceconv/utils.h
+++ b/src/traceconv/utils.h
@@ -52,14 +52,41 @@ constexpr char kProgressChar = '\n';
 constexpr char kProgressChar = '\r';
 #endif
 
+// True while an in-place progress line (one ending in kProgressChar) has been
+// printed but not yet terminated. Kept TU-local: progress printing and the
+// matching EndProgressLine() always happen in the same translation unit.
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WASM)
+namespace {
+inline bool& IsProgressLineActive() {
+  static bool active = false;
+  return active;
+}
+}  // namespace
+#endif
+
+// Marks that an in-place progress line (ending in kProgressChar) has been
+// printed. Call right after printing a progress update so that the matching
+// EndProgressLine() terminates it. No-op on WASM where progress updates
+// already end with a newline.
+inline void MarkProgressLine() {
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WASM)
+  IsProgressLineActive() = true;
+#endif
+}
+
 // Terminates the current in-place progress line so that subsequent output
 // (errors, logs, results) starts on a fresh line instead of overwriting or
-// merging with the progress text. On WASM, progress updates already end with
-// a newline (see kProgressChar), so this is a no-op there.
+// merging with the progress text. No-op when no progress line is active, so
+// callers can invoke it unconditionally without producing stray blank lines.
+// On WASM, progress updates already end with a newline (see kProgressChar),
+// so this is a no-op there too.
 inline void EndProgressLine() {
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WASM)
-  fprintf(stderr, "\n");
-  fflush(stderr);
+  if (IsProgressLineActive()) {
+    fprintf(stderr, "\n");
+    fflush(stderr);
+    IsProgressLineActive() = false;
+  }
 #endif
 }
 

--- a/src/traceconv/utils.h
+++ b/src/traceconv/utils.h
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 
+#include <cstdarg>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -26,6 +27,7 @@
 #include <vector>
 
 #include "perfetto/base/build_config.h"
+#include "perfetto/base/compiler.h"
 #include "perfetto/ext/base/paged_memory.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_ZLIB)
@@ -52,9 +54,9 @@ constexpr char kProgressChar = '\n';
 constexpr char kProgressChar = '\r';
 #endif
 
-// True while an in-place progress line (one ending in kProgressChar) has been
-// printed but not yet terminated. Kept TU-local: progress printing and the
-// matching EndProgressLine() always happen in the same translation unit.
+// True while an in-place progress line has been printed but not yet
+// terminated with a newline. TU-local: all progress printing and the
+// matching EndProgressLine() live in the same translation unit.
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WASM)
 namespace {
 inline bool& IsProgressLineActive() {
@@ -64,12 +66,19 @@ inline bool& IsProgressLineActive() {
 }  // namespace
 #endif
 
-// Marks that an in-place progress line (ending in kProgressChar) has been
-// printed. Call right after printing a progress update so that the matching
-// EndProgressLine() terminates it. No-op on WASM where progress updates
-// already end with a newline.
-inline void MarkProgressLine() {
+// Prints an in-place progress update to stderr: the message followed by
+// kProgressChar (a '\r' so the next update overwrites it). Remembers that a
+// progress line is active so the matching EndProgressLine() terminates it
+// with a newline. No-op on WASM where updates already end with '\n'.
+inline void ProgressLine(const char* fmt, ...) PERFETTO_PRINTF_FORMAT(1, 2);
+inline void ProgressLine(const char* fmt, ...) {
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WASM)
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+  fputc(kProgressChar, stderr);
+  fflush(stderr);
   IsProgressLineActive() = true;
 #endif
 }

--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -408,12 +408,17 @@ function showTraceParseError(variant: TraceParseErrorVariant, message: string) {
 }
 
 // Pull the useful part out of a trace_processor parse error. The raw message
-// looks like: "Trace parse failure (<inner> (ERR:tp-corrupt)) (ERR:tp-parse).
-// The trace file is corrupt." We surface just <inner> without the markers,
-// falling back to the full message if the pattern doesn't match.
+// looks like: "Trace parse failure: <inner> (ERR:tp-corrupt) (ERR:tp-parse)".
+// We surface just <inner> without the markers, falling back to the full
+// message (with markers stripped) if the pattern doesn't match. The legacy
+// "Trace parse failure (<inner>) (ERR:tp-parse)" format is also handled for
+// older trace_processor servers.
 function extractTraceParseDetails(message: string): string {
-  const match = /Trace parse failure \((.*)\) \(ERR:tp-parse\)/s.exec(message);
-  const inner = match ? match[1] : message;
+  let inner = message.replace(/^Trace parse failure: /, '');
+  const legacy = /^Trace parse failure \((.*)\) \(ERR:tp-parse\)/s.exec(inner);
+  if (legacy) {
+    inner = legacy[1];
+  }
   return inner.replace(/\s*\(ERR:tp-(?:corrupt|parse)\)/g, '').trim();
 }
 


### PR DESCRIPTION
Issue: https://github.com/google/perfetto/issues/6927

`trace_processor bundle` (formerly `traceconv bundle`) gave cryptic or
misleading feedback when things went wrong:

- Traces with nothing to enrich (e.g. a pure atrace trace, or a
  function_graph trace recorded **with** `symbolize_ksyms`) failed with a
  bare `bundle: failed to create bundle.` and no explanation.
- A function_graph trace recorded **without** `symbolize_ksyms` got no
  feedback at all, even though its kernel addresses can never be
  symbolized offline.
- Unwritable output paths (missing parent dir, read-only, path-is-a-dir)
  crashed the whole process with a `PERFETTO_CHECK`.
- Extra positional arguments were silently ignored/misparsed (e.g. passing
  each `--symbol-paths` directory as a separate argument).
- Conversion failures produced double error messages (an internal
  `PERFETTO_ELOG` + a generic "conversion failed" wrapper), and several
  paths crashed with `PERFETTO_FATAL` on ordinary user error.

## Changes

- **bundle** now always produces the bundle and explains what could not be
  enriched, with actionable hints. It detects function_graph traces
  recorded without `symbolize_ksyms`, fails gracefully (instead of
  crashing) on unwritable output paths, and reports reading/enrichment
  progress.
- **CLI**: every fixed-arity subcommand (`bundle`, `convert`, `util`,
  `export`, `query`, `server`, `metrics`) now rejects extra positional
  arguments with a hint, instead of silently misinterpreting them.
- **traceconv**: the conversion entry points (`TraceToJson`,
  `TraceToSystrace`, `TraceToText`, `TraceToProfile`,
  `TraceToFirefoxProfile`, `UnpackCompressedPackets`, `SymbolizeProfile`,
  `DeobfuscateProfile`) now return descriptive `base::Status` errors
  instead of int/bool returns paired with internal `PERFETTO_ELOG`/`FATAL`,
  so failures are reported once with the actual reason.
- **TarWriter**: fails gracefully when the output path cannot be opened
  (also fixes the same crash in `util merge`).
- **Parse errors**: no longer append a redundant "The trace file is
  corrupt." sentence; the UI error-dialog extraction is updated for the
  new message format.
