### PR TITLE
docs: document trace_processor export formats

### DIFF
--- a/docs/analysis/trace-processor-python.md
+++ b/docs/analysis/trace-processor-python.md
@@ -284,6 +284,31 @@ with TraceProcessor(trace='trace.perfetto-trace') as tp:
     print(summary)
 ```
 
+### Export
+
+The `export()` function writes the parsed trace data to a file, streaming
+directly to disk. The format is one of `arrow_tar` or `perfetto`:
+
+```python
+from perfetto.trace_processor import TraceProcessor
+
+tp = TraceProcessor(trace='trace.perfetto-trace')
+
+# Version-coupled archive, loadable by the same version of trace processor.
+tp.export('archive.tar', 'perfetto')
+
+# Static tables as a tar of standard Arrow files.
+tp.export('tables.tar', 'arrow_tar')
+```
+
+`perfetto` can be loaded back by a fresh trace processor instance from the
+same version (a different version may load it, but this is not guaranteed).
+`arrow_tar` produces one standard [Apache Arrow](https://arrow.apache.org/)
+file per statically registered table, for analysis with pandas, Polars or
+pyarrow; it cannot be loaded back into trace processor. The Python API
+supports these two formats; to export to SQLite, use the
+[`export` shell subcommand](/docs/analysis/trace-processor.md#subcommand-export).
+
 ### Metatracing
 
 Metatracing allows you to trace the performance of `trace_processor` itself.

--- a/docs/analysis/trace-processor.md
+++ b/docs/analysis/trace-processor.md
@@ -148,7 +148,7 @@ Commands:
   interactive   Interactive SQL shell (default if no command is given).
   server        Start an RPC server.
   summarize     Compute a trace summary from specs and/or built-in metrics.
-  export        Export a trace to a database file.
+  export        Export trace data (sqlite, arrow_tar, perfetto).
   metrics       Run v1 metrics (deprecated; use 'summarize --metrics-v2').
   convert       Convert trace format.
 
@@ -290,6 +290,46 @@ Flags:
 
 Spec files are detected as binary or text by extension (`.pb` for binary,
 `.textproto` for text), with content sniffing as a fallback.
+
+#### {#subcommand-export} `export`: write trace data to a file
+
+`export` writes the parsed trace data to a file. The format is the first
+positional argument, the output path is given with `-o`:
+
+```bash
+# Version-coupled archive, loadable by the same version of trace processor.
+trace_processor export perfetto -o archive.tar trace.pftrace
+
+# Static tables as standard Arrow files in a tar.
+trace_processor export arrow_tar -o tables.tar trace.pftrace
+
+# Static tables and views as a SQLite database.
+trace_processor export sqlite -o trace.db trace.pftrace
+```
+
+Formats:
+
+- **`perfetto`**: a version-coupled archive of the non-empty static tables.
+  A fresh trace processor instance from the same version can load it back as
+  a trace; a different version may load it, but this is not guaranteed. The
+  only format that can be reloaded.
+- **`arrow_tar`**: a tar of standard [Apache Arrow](https://arrow.apache.org/)
+  files, one per statically registered table, including empty tables and
+  implicit ID columns. Stable and forwards-compatible across versions, for
+  external consumers (e.g. pandas, Polars, pyarrow). Cannot be loaded back
+  into trace processor.
+- **`sqlite`**: the statically registered tables plus the trace's views, as
+  a SQLite database readable by any SQLite tool.
+
+Flags:
+
+- `-o, --output FILE`: output file path (required).
+
+All three formats export the statically registered tables; only `sqlite` also
+includes views. Runtime tables created during the session (e.g.
+`CREATE PERFETTO TABLE`) are not exported. Exports stream to disk, so memory
+use stays bounded for large traces. For task-oriented recipes, see
+[Export trace data](/docs/getting-started/command-line-analysis.md#export-trace-data).
 
 #### {#global-flags} Global flags (apply to every subcommand)
 

--- a/docs/getting-started/command-line-analysis.md
+++ b/docs/getting-started/command-line-analysis.md
@@ -99,14 +99,33 @@ archive yourself. See
 [Merging traces from the command line](/docs/analysis/merging-traces.md)
 for the details, including how to verify a merge placed every event.
 
-## Export to a SQLite database
+## Export trace data
 
-To use tools that speak SQLite (or to hand the data to someone without
-Perfetto), export every trace processor table to a database file:
+`export` writes the parsed trace data to a file. The format is the first
+positional argument, `-o FILE` the output path:
 
 ```bash
+trace_processor export perfetto -o archive.tar trace.pftrace
+trace_processor export arrow_tar -o tables.tar trace.pftrace
 trace_processor export sqlite -o trace.db trace.pftrace
 ```
+
+- **`perfetto`**: a version-coupled archive of the static tables. A fresh
+  trace processor instance from the same version can load it back as a trace;
+  a different version may load it, but this is not guaranteed. The only
+  format that can be reloaded.
+- **`arrow_tar`**: one standard [Apache Arrow](https://arrow.apache.org/)
+  file per statically registered table, packed in a tar. Stable across trace
+  processor versions, for analysis with pandas, Polars or pyarrow. Cannot be
+  loaded back into trace processor.
+- **`sqlite`**: the statically registered tables plus the trace's views, as
+  a SQLite database file that any SQLite tool can open.
+
+All three formats export the statically registered tables; only `sqlite` also
+includes views. Runtime tables created during the session (e.g.
+`CREATE PERFETTO TABLE`) are not exported. See the
+[Trace Processor reference](/docs/analysis/trace-processor.md#subcommand-export)
+for the flag and format details.
 
 ## Convert to another trace format
 
@@ -121,7 +140,8 @@ trace_processor convert text trace.pftrace trace.txt
 
 Run `trace_processor convert --help` for the full format list, and see
 [Converting from Perfetto](/docs/quickstart/traceconv.md) for more on the
-underlying traceconv tool.
+underlying traceconv tool. `convert` translates the trace itself; to dump the
+parsed tables instead, see [Export trace data](#export-trace-data) above.
 
 ## Next steps
 

--- a/docs/getting-started/converting.md
+++ b/docs/getting-started/converting.md
@@ -1323,6 +1323,25 @@ FROM metadata
 WHERE name GLOB 'trace_attribute.*';
 ```
 
+## Exporting the data back out
+
+Once your trace is loaded, trace processor can write the parsed tables back
+out with the `export` subcommand:
+
+```bash
+trace_processor export perfetto -o archive.tar my_custom_trace.pftrace
+trace_processor export arrow_tar -o tables.tar my_custom_trace.pftrace
+trace_processor export sqlite -o trace.db my_custom_trace.pftrace
+```
+
+`perfetto` can be loaded back by a trace processor instance from the same
+version, `arrow_tar` targets external tools such as pandas, Polars or pyarrow,
+and `sqlite` produces a database any SQLite tool can open. For how to choose
+between the formats and the exact contents of each, see
+[Export trace data](/docs/getting-started/command-line-analysis.md#export-trace-data)
+and the
+[Trace Processor reference](/docs/analysis/trace-processor.md#subcommand-export).
+
 ## Next Steps
 
 You've now seen how to convert custom timestamped data into Perfetto traces
@@ -1352,6 +1371,9 @@ you can:
   [Trace Processor](/docs/analysis/getting-started.md) to query your custom
   trace data. Your custom tracks and events will populate standard tables like
   `slice`, `track`, `counter`, etc.
+- **Get the data back out:** Export the parsed tables with the
+  [`export` subcommand](/docs/getting-started/command-line-analysis.md#export-trace-data)
+  (SQLite, Arrow, or a reloadable Perfetto archive).
 - **Handle large datasets:** If you are generating very large traces and want to
   avoid high memory usage, learn how to stream data directly to a file in the
   [Advanced Guide's section on streaming](/docs/reference/synthetic-track-event.md#handling-large-traces-with-streaming).

--- a/docs/quickstart/traceconv.md
+++ b/docs/quickstart/traceconv.md
@@ -14,6 +14,11 @@ the `convert` subcommand of `trace_processor`.
 > see [Symbolization and deobfuscation](/docs/learning-more/symbolization.md)
 > instead (the `bundle` and `util` subcommands). This page covers only format
 > conversion.
+>
+> To dump trace processor's parsed *tables* (rather than the trace itself) as
+> SQLite, Arrow or a reloadable Perfetto archive, use the `export` subcommand
+> instead: see
+> [Export trace data](/docs/getting-started/command-line-analysis.md#export-trace-data).
 
 ## Prerequisites
 

--- a/docs/visualization/large-traces.md
+++ b/docs/visualization/large-traces.md
@@ -29,6 +29,27 @@ via a WebSocket or the built-in WebAssembly runtime that runs in the browser.
 NOTE: The classic `./trace_processor --httpd /path/to/trace.pftrace` invocation
 is still supported and behaves identically.
 
+## Re-using a parsed trace without re-parsing
+
+Parsing is the expensive part of working with a large trace. If you will load
+the same trace more than once (or hand it to another instance), export the
+parsed result once and load the archive instead:
+
+```bash
+./trace_processor export perfetto -o parsed.tar trace.pftrace
+./trace_processor query parsed.tar "SELECT count(*) FROM slice"
+```
+
+The `perfetto` format restores trace processor's static tables directly from
+the archive, skipping the packet ingestion and sorting of a full parse. It is
+version-coupled: load it with the same version of trace processor that
+produced it (a different version may work, but is not guaranteed).
+
+For repeated work on one machine, a background
+[session](/docs/getting-started/command-line-analysis.md#iterate-without-re-parsing-sessions)
+is the lighter-weight alternative; the `perfetto` archive is the portable
+one, e.g. to move a parsed trace between machines or into a batch job.
+
 ## Using more than one instance in parallel
 
 NOTE: this is a temporary workaround until getting to a better solution as


### PR DESCRIPTION
The `export` subcommand of `trace_processor` now supports three formats
(`perfetto`, `arrow_tar`, `sqlite`), and the Python API gained
`TraceProcessor.export()`, but the docs only mentioned the sqlite export
in a short recipe.

Document export everywhere it is relevant:

- command-line analysis cookbook: replace the "Export to a SQLite
  database" recipe with an "Export trace data" section covering all
  three formats as coequal options (`perfetto` is the only one that can
  be reloaded into trace processor)
- Trace Processor reference: add an `export` subcommand section with
  the format details and the `-o` flag
- Python API reference: document `TraceProcessor.export()`
- converting guide: add a short "Exporting the data back out" section
- large traces page: cover re-using a parsed trace without re-parsing
  via `export perfetto`
- traceconv page: distinguish `convert` (the trace itself) from
  `export` (the parsed tables)