### PR TITLE
tp: fix -Wformat error on 32-bit Windows in local_file_system

### DIFF
--- a/src/trace_processor/local_file_system.cc
+++ b/src/trace_processor/local_file_system.cc
@@ -41,8 +41,8 @@ class LocalFile final : public File {
                              strerror(errno));
     }
     if (static_cast<size_t>(written) != size) {
-      return base::ErrStatus("Short write to file %s: wrote %zd of %zu bytes",
-                             path_.c_str(), written, size);
+      return base::ErrStatus("Short write to file %s: wrote %zu of %zu bytes",
+                             path_.c_str(), static_cast<size_t>(written), size);
     }
     return base::OkStatus();
   }


### PR DESCRIPTION
The Chromium autoroll https://crrev.com/c/8186998 fails to build win_chromium_compile_dbg_ng with:

```
error: format specifies type 'signed size_t' (aka 'int') but the argument has type 'ssize_t' (aka 'long') [-Werror,-Wformat]
   44 |       return base::ErrStatus("Short write to file %s: wrote %zd of %zu bytes",
      |                                                             ~~~
      |                                                             %zd
   45 |                              path_.c_str(), written, size);
      |                                             ^~~~~~~
```

On 32-bit Windows, size_t is 'unsigned int', so %zd expects 'int', while Perfetto typedefs ssize_t as 'long' (see
include/perfetto/ext/base/sys_types.h). 

Both are 32 bits but are distinct types, so clang-cl rejects the format.

The value is already known to be non-negative at that point (the written < 0 case returns above), so print it as a size_t with %zu, which is exact on every platform.