### PR TITLE
ui: add contained-traces merge panel

### DIFF
--- a/ui/src/plugins/com.android.ContainedTraces/index.ts
+++ b/ui/src/plugins/com.android.ContainedTraces/index.ts
@@ -24,7 +24,7 @@ import {
 } from '../../trace_processor/query_result';
 import {SourceDataset, type Dataset} from '../../trace_processor/dataset';
 import SupportPlugin from '../com.android.AndroidLongBatterySupport';
-import {AsyncLimiter} from '../../base/async_limiter';
+import {AsyncMemo} from '../../base/async_memo';
 import {Duration, Time, type duration} from '../../base/time';
 import {DurationWidget} from '../../components/widgets/duration';
 import {selectTracksAndGetDataset} from '../../components/aggregation_adapter';
@@ -34,11 +34,10 @@ import {Button} from '../../widgets/button';
 import {Checkbox} from '../../widgets/checkbox';
 import {Anchor} from '../../widgets/anchor';
 import {Grid, GridCell, GridHeaderCell} from '../../widgets/grid';
-import {
-  type AreaSelection,
-  type AreaSelectionTab,
-  type ContentWithLoadingFlag,
-  areaSelectionsEqual,
+import type {
+  AreaSelection,
+  AreaSelectionTab,
+  ContentWithLoadingFlag,
 } from '../../public/selection';
 
 interface ContainedTrace {
@@ -77,11 +76,10 @@ class ContainedTracesTab implements AreaSelectionTab {
   readonly id = 'contained_traces_merge';
   readonly name = 'Contained traces';
 
-  private readonly limiter = new AsyncLimiter();
-  private previousSelection?: AreaSelection;
-  private rows: MergeRow[] = [];
-  private selected = new Set<string>();
-  private loading = false;
+  private readonly memo = new AsyncMemo<{
+    rows: MergeRow[];
+    selected: Set<string>;
+  }>();
 
   constructor(
     private readonly trace: Trace,
@@ -93,35 +91,39 @@ class ContainedTracesTab implements AreaSelectionTab {
       selection.tracks,
       CONTAINED_TRACE_SPEC,
     );
-    if (dataset === undefined) {
-      this.previousSelection = undefined;
-      return undefined;
-    }
+    if (dataset === undefined) return undefined;
 
-    if (
-      this.previousSelection === undefined ||
-      !areaSelectionsEqual(this.previousSelection, selection)
-    ) {
-      this.previousSelection = selection;
-      this.loading = true;
-      this.limiter.schedule(async () => {
-        this.rows = await this.queryRows(dataset, selection);
-        this.selected = new Set(this.rows.map((r) => r.uuid));
-        this.loading = false;
-        m.redraw();
-      });
-    }
+    const {data, isPending} = this.memo.use({
+      key: {
+        start: selection.start,
+        end: selection.end,
+        trackUris: selection.trackUris,
+      },
+      compute: async () => {
+        const rows = await this.queryRows(dataset, selection);
+        return {rows, selected: new Set(rows.map((r) => r.uuid))};
+      },
+    });
 
     return {
-      isLoading: this.loading,
+      isLoading: isPending,
       buttons: m(Button, {
         label: 'Merge selected traces',
         icon: Icons.ExternalLink,
-        disabled: this.selected.size === 0,
-        onclick: () =>
-          window.open(TRACE_UUIDS_URL + [...this.selected].join(','), '_blank'),
+        disabled: data === undefined || data.selected.size === 0,
+        onclick: () => {
+          if (data !== undefined) {
+            window.open(
+              TRACE_UUIDS_URL + [...data.selected].join(','),
+              '_blank',
+            );
+          }
+        },
       }),
-      content: this.renderGrid(),
+      content:
+        data === undefined
+          ? undefined
+          : this.renderGrid(data.rows, data.selected),
     };
   }
 
@@ -164,7 +166,10 @@ class ContainedTracesTab implements AreaSelectionTab {
     return rows;
   }
 
-  private renderGrid(): m.Children {
+  private renderGrid(
+    rows: ReadonlyArray<MergeRow>,
+    selected: Set<string>,
+  ): m.Children {
     return m(Grid, {
       columns: [
         {key: 'select'},
@@ -174,12 +179,18 @@ class ContainedTracesTab implements AreaSelectionTab {
         {key: 'track', header: m(GridHeaderCell, 'Track')},
         {key: 'dur', header: m(GridHeaderCell, 'Duration')},
       ],
-      rowData: this.rows.map((r) => [
+      rowData: rows.map((r) => [
         m(
           GridCell,
           m(Checkbox, {
-            checked: this.selected.has(r.uuid),
-            onchange: () => this.toggle(r.uuid),
+            checked: selected.has(r.uuid),
+            onchange: () => {
+              if (selected.has(r.uuid)) {
+                selected.delete(r.uuid);
+              } else {
+                selected.add(r.uuid);
+              }
+            },
           }),
         ),
         m(GridCell, r.isSelf ? m(Icon, {icon: Icons.Check}) : undefined),
@@ -196,14 +207,6 @@ class ContainedTracesTab implements AreaSelectionTab {
         m(GridCell, m(DurationWidget, {trace: this.trace, dur: r.dur})),
       ]),
     });
-  }
-
-  private toggle(uuid: string) {
-    if (this.selected.has(uuid)) {
-      this.selected.delete(uuid);
-    } else {
-      this.selected.add(uuid);
-    }
   }
 }
 

--- a/ui/src/plugins/com.android.ContainedTraces/index.ts
+++ b/ui/src/plugins/com.android.ContainedTraces/index.ts
@@ -12,12 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import type {Trace} from '../../public/trace';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import type {PerfettoPlugin} from '../../public/plugin';
-import {STR, LONG, LONG_NULL} from '../../trace_processor/query_result';
-import {SourceDataset} from '../../trace_processor/dataset';
+import {
+  STR,
+  STR_NULL,
+  LONG,
+  LONG_NULL,
+} from '../../trace_processor/query_result';
+import {SourceDataset, type Dataset} from '../../trace_processor/dataset';
 import SupportPlugin from '../com.android.AndroidLongBatterySupport';
+import {AsyncLimiter} from '../../base/async_limiter';
+import {Duration, Time, type duration} from '../../base/time';
+import {DurationWidget} from '../../components/widgets/duration';
+import {selectTracksAndGetDataset} from '../../components/aggregation_adapter';
+import {Icons} from '../../base/semantic_icons';
+import {Icon} from '../../widgets/icon';
+import {Button} from '../../widgets/button';
+import {Checkbox} from '../../widgets/checkbox';
+import {Anchor} from '../../widgets/anchor';
+import {Grid, GridCell, GridHeaderCell} from '../../widgets/grid';
+import {
+  type AreaSelection,
+  type AreaSelectionTab,
+  type ContentWithLoadingFlag,
+  areaSelectionsEqual,
+} from '../../public/selection';
 
 interface ContainedTrace {
   uuid: string;
@@ -26,6 +48,171 @@ interface ContainedTrace {
   // NB: these are millis.
   ts: number;
   dur: number;
+}
+
+interface MergeRow {
+  uuid: string;
+  name: string;
+  track: string;
+  dur: duration;
+  isSelf: boolean;
+}
+
+const TRACE_UUID_URL = 'http://go/trace-uuid/';
+const TRACE_UUIDS_URL = 'http://go/trace-uuids/';
+
+const CONTAINED_TRACE_SPEC = {
+  ts: LONG,
+  dur: LONG_NULL,
+  name: STR,
+  track: STR,
+  link: STR,
+};
+
+function traceName(t: ContainedTrace): string {
+  return t.trigger === '' ? 'Trace' : t.trigger;
+}
+
+class ContainedTracesTab implements AreaSelectionTab {
+  readonly id = 'contained_traces_merge';
+  readonly name = 'Contained traces';
+
+  private readonly limiter = new AsyncLimiter();
+  private previousSelection?: AreaSelection;
+  private rows: MergeRow[] = [];
+  private selected = new Set<string>();
+  private loading = false;
+
+  constructor(
+    private readonly trace: Trace,
+    private readonly selfUuid?: string,
+  ) {}
+
+  render(selection: AreaSelection): ContentWithLoadingFlag | undefined {
+    const dataset = selectTracksAndGetDataset(
+      selection.tracks,
+      CONTAINED_TRACE_SPEC,
+    );
+    if (dataset === undefined) {
+      this.previousSelection = undefined;
+      return undefined;
+    }
+
+    if (
+      this.previousSelection === undefined ||
+      !areaSelectionsEqual(this.previousSelection, selection)
+    ) {
+      this.previousSelection = selection;
+      this.loading = true;
+      this.limiter.schedule(async () => {
+        this.rows = await this.queryRows(dataset, selection);
+        this.selected = new Set(this.rows.map((r) => r.uuid));
+        this.loading = false;
+        m.redraw();
+      });
+    }
+
+    return {
+      isLoading: this.loading,
+      buttons: m(Button, {
+        label: 'Merge selected traces',
+        icon: Icons.ExternalLink,
+        disabled: this.selected.size === 0,
+        onclick: () =>
+          window.open(TRACE_UUIDS_URL + [...this.selected].join(','), '_blank'),
+      }),
+      content: this.renderGrid(),
+    };
+  }
+
+  private async queryRows(
+    dataset: Dataset,
+    selection: AreaSelection,
+  ): Promise<MergeRow[]> {
+    const rows: MergeRow[] = [];
+    if (this.selfUuid !== undefined) {
+      const {start, end} = this.trace.traceInfo;
+      rows.push({
+        uuid: this.selfUuid,
+        name: 'This trace',
+        track: '',
+        dur: Time.durationBetween(start, end),
+        isSelf: true,
+      });
+    }
+
+    const result = await this.trace.engine.query(`
+      select
+        replace(link, '${TRACE_UUID_URL}', '') as uuid,
+        name,
+        track,
+        coalesce(dur, 0) as dur
+      from (${dataset.query(CONTAINED_TRACE_SPEC)})
+      where ts < ${selection.end} and ts + coalesce(dur, 0) > ${selection.start}
+      order by ts
+    `);
+    const it = result.iter({uuid: STR, name: STR, track: STR, dur: LONG});
+    for (; it.valid(); it.next()) {
+      rows.push({
+        uuid: it.uuid,
+        name: it.name,
+        track: it.track,
+        dur: Duration.fromRaw(it.dur),
+        isSelf: false,
+      });
+    }
+    return rows;
+  }
+
+  private renderGrid(): m.Children {
+    return m(Grid, {
+      columns: [
+        {key: 'select'},
+        {key: 'self', header: m(GridHeaderCell, 'Self')},
+        {key: 'uuid', header: m(GridHeaderCell, 'Trace')},
+        {key: 'name', header: m(GridHeaderCell, 'Name')},
+        {key: 'track', header: m(GridHeaderCell, 'Track')},
+        {key: 'dur', header: m(GridHeaderCell, 'Duration')},
+      ],
+      rowData: this.rows.map((r) => [
+        m(
+          GridCell,
+          m(Checkbox, {
+            checked: this.selected.has(r.uuid),
+            onchange: () => this.toggle(r.uuid),
+          }),
+        ),
+        m(GridCell, r.isSelf ? m(Icon, {icon: Icons.Check}) : undefined),
+        m(
+          GridCell,
+          m(
+            Anchor,
+            {href: TRACE_UUID_URL + r.uuid, target: '_blank'},
+            TRACE_UUID_URL + r.uuid,
+          ),
+        ),
+        m(GridCell, r.name),
+        m(GridCell, r.track),
+        m(GridCell, m(DurationWidget, {trace: this.trace, dur: r.dur})),
+      ]),
+    });
+  }
+
+  private toggle(uuid: string) {
+    if (this.selected.has(uuid)) {
+      this.selected.delete(uuid);
+    } else {
+      this.selected.add(uuid);
+    }
+  }
+}
+
+async function selfTraceUuid(ctx: Trace): Promise<string | undefined> {
+  const result = await ctx.engine.query(
+    `select str_value from metadata where name = 'trace_uuid'`,
+  );
+  const it = result.iter({str_value: STR_NULL});
+  return it.valid() ? (it.str_value ?? undefined) : undefined;
 }
 
 export default class implements PerfettoPlugin {
@@ -60,8 +247,9 @@ export default class implements PerfettoPlugin {
               SELECT
                 CAST(${t.ts} * 1e6 AS int) AS ts,
                 CAST(${t.dur} * 1e6 AS int) AS dur,
-                '${t.trigger === '' ? 'Trace' : t.trigger}' AS name,
-                'http://go/trace-uuid/${t.uuid}' AS link
+                '${traceName(t)}' AS name,
+                '${t.subscription}' AS track,
+                '${TRACE_UUID_URL}${t.uuid}' AS link
               `,
             )
             .join(' UNION ALL '),
@@ -69,11 +257,16 @@ export default class implements PerfettoPlugin {
             ts: LONG,
             dur: LONG_NULL,
             name: STR,
+            track: STR,
             link: STR,
           },
         }),
         'Other traces',
       );
     }
+
+    ctx.selection.registerAreaSelectionTab(
+      new ContainedTracesTab(ctx, await selfTraceUuid(ctx)),
+    );
   }
 }


### PR DESCRIPTION
Add an area-selection tab to the ContainedTraces plugin that lists the contained ("other") traces under the selection in a grid (self flag, uuid link, name, track, duration) with per-row checkboxes, prepends the current trace as a "This trace" row (uuid from the trace_uuid metadata), and a "Merge selected traces" button that opens the checked uuids as go/trace-uuids/<uuids>.
