### PR TITLE
perfetto: attach offline-installable AI skill zip to releases

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -200,6 +200,14 @@ jobs:
             --skills-src "$SKILLS_SRC"
           git worktree remove --force /tmp/release-tag-tree
 
+          # Attach a copy-paste installable skill zip to the release for
+          # offline installs (#6515). Unzipping yields a `perfetto/` skill
+          # directory to drop into any agent's skills directory.
+          (cd /tmp/ai-agents-tree/plugins/perfetto/skills && \
+            zip -qr /tmp/perfetto-ai-skill.zip perfetto)
+          gh release upload "$VERSION" /tmp/perfetto-ai-skill.zip \
+            --repo "$REPO" --clobber
+
           BRANCH="dev/github-bot/ai-agents-bundle"
           REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
 

--- a/docs/getting-started/using-ai.md
+++ b/docs/getting-started/using-ai.md
@@ -42,6 +42,34 @@ install into that agent's default directory.
 To share the setup with your team, point `--target` at a per-agent directory
 in your repo (for example `.claude/skills/`) and commit the result.
 
+### Offline install
+
+Machines that can't reach github.com at install time can use the
+`perfetto-ai-skill.zip` asset attached to each
+[GitHub release](https://github.com/google/perfetto/releases): download it
+where you have connectivity, copy it across, and unzip it into your agent's
+skills directory (for example `.claude/skills/`). It contains a single
+`perfetto/` skill folder with `SKILL.md` inside — no installer needed.
+
+The bundled `bin/trace_processor` wrapper downloads the native
+`trace_processor` binary on first use and caches it in
+`~/.local/share/perfetto/prebuilts/` under the name
+`trace_processor_shell-<first 16 hex chars of its sha256>`. On a fully
+offline machine, seed that cache yourself: download your platform's prebuilt
+zip from the same release page (for example `linux-amd64.zip`, containing
+`trace_processor_shell`), then run:
+
+```sh
+mkdir -p ~/.local/share/perfetto/prebuilts
+SHA=$(sha256sum trace_processor_shell | cut -c1-16)
+cp trace_processor_shell ~/.local/share/perfetto/prebuilts/trace_processor_shell-$SHA
+```
+
+The wrapper trusts any file already present under that name, so the binary
+must come from the same release. On Windows the cache directory is
+`%USERPROFILE%\.local\share\perfetto\prebuilts` and the file is
+`trace_processor_shell.exe-<sha256 prefix>`.
+
 ## Update
 
 Updating uses the same mechanism as installing:


### PR DESCRIPTION
There is no way to install the AI skill on a machine that can't reach
github.com at install time: every supported install path (plugin
marketplaces, the fallback installer, OpenCode `skills.urls`) fetches
from github.com or the `ai-agents` branch. Issue #6515 asks for a
publishable artifact with the skill content that can be copied over and
used offline.
