### PR TITLE
ui: Return getGridConfig from aggregator probe step

### DIFF
--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -53,6 +53,12 @@ export interface AggregationData {
 
 export interface Aggregation {
   /**
+   * Defines how the datagrid that displays the aggregated data looks, including
+   * what to pivot on and the column definitions.
+   */
+  getGridConfig(): AggregatorGridConfig;
+
+  /**
    * Creates a view for the aggregated data corresponding to the selected area.
    *
    * The dataset provided will be filtered based on the `trackKind` and `schema`
@@ -111,10 +117,6 @@ export interface Aggregator {
 
   // Returns the name of this aggregation tag. Called every render cycle.
   getTabName(): string;
-
-  // Return the grid configuration for this aggregation panel. Called every
-  // render cycle.
-  getGridConfig(): AggregatorGridConfig;
 
   // Optional controls to render in the top bar of the aggregation panel.
   renderTopbarControls?(): m.Children;
@@ -232,9 +234,7 @@ export function createAggregationTab(
   let data: AggregationData | undefined;
   let dataSource: SQLDataSource | undefined;
   let dataGridApi: DataGridApi | undefined;
-
-  function createInitialState(): DataGridModel {
-    const config = aggregator.getGridConfig();
+  function createInitialState(config: AggregatorGridConfig): DataGridModel {
     return {
       columns: config.initialColumns,
       pivot: config.initialPivot,
@@ -242,9 +242,10 @@ export function createAggregationTab(
     };
   }
 
-  // DataGrid state managed by the adapter
-  const initialDataModel: DataGridModel = createInitialState();
-  let dataModel: DataGridModel = initialDataModel;
+  // Mutable datagrid model state - initialized the first time we get a config,
+  // and only ever modified by the user so that the config is retained over
+  // selection changes.
+  let dataModel: DataGridModel | undefined;
 
   return {
     id: aggregator.id,
@@ -260,6 +261,11 @@ export function createAggregationTab(
         currentSelection = selection;
         aggregation = aggregator.probe(selection);
 
+        // Snapshot the grid config if we don't have one yet
+        if (aggregation && !dataModel) {
+          dataModel = createInitialState(aggregation.getGridConfig());
+        }
+
         // Kick off a new load of the data
         limiter.schedule(async () => {
           // Clear previous data to prevent queries against a stale or partially
@@ -268,8 +274,8 @@ export function createAggregationTab(
           dataSource = undefined;
           data = undefined;
           if (aggregation) {
-            data = await aggregation?.prepareData(trace.engine);
-            const gridConfig = aggregator.getGridConfig();
+            const gridConfig = aggregation.getGridConfig();
+            data = await aggregation.prepareData(trace.engine);
             const sqlConfig = gridConfig.sqlConfig?.(data) ?? {
               tableOrSubquery: data.tableName,
             };
@@ -282,7 +288,7 @@ export function createAggregationTab(
         });
       }
 
-      if (!aggregation) {
+      if (!aggregation || !dataModel) {
         // Hides the tab
         return undefined;
       }
@@ -307,23 +313,24 @@ export function createAggregationTab(
         pivot: dataModel.pivot,
         filters: dataModel.filters,
         onColumnsChanged: (c) => {
-          dataModel = {...dataModel, columns: c};
+          dataModel = {...dataModel!, columns: c};
         },
         onPivotChanged: (p) => {
-          dataModel = {...dataModel, pivot: p};
+          dataModel = {...dataModel!, pivot: p};
         },
         onFiltersChanged: (f) => {
-          dataModel = {...dataModel, filters: f};
+          dataModel = {...dataModel!, filters: f};
         },
       };
 
+      const aggr = aggregation;
       return {
         isLoading: false,
         content: m(AggregationPanel, {
           controls: aggregator.renderTopbarControls?.(),
           key: aggregator.id,
           dataSource,
-          gridConfig: aggregator.getGridConfig(),
+          gridConfig: aggregation.getGridConfig(),
           barChartData: data?.barChartData,
           onReady: (api: DataGridApi) => {
             dataGridApi = api;
@@ -331,7 +338,7 @@ export function createAggregationTab(
           dataGridState,
           onClearGridState: () => {
             // Just wipe out the local data model to reset to initial state
-            dataModel = initialDataModel;
+            dataModel = createInitialState(aggr.getGridConfig());
           },
         }),
         buttons:

--- a/ui/src/plugins/com.android.AndroidLog/log_selection_aggregator.ts
+++ b/ui/src/plugins/com.android.AndroidLog/log_selection_aggregator.ts
@@ -42,6 +42,7 @@ export class AndroidLogSelectionAggregator implements Aggregator {
       .filter((u): u is number => u !== undefined);
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         let whereClause = `al.ts >= ${area.start} AND al.ts <= ${area.end}`;
         if (utids.length > 0) {
@@ -75,7 +76,7 @@ export class AndroidLogSelectionAggregator implements Aggregator {
     return 'Android Logs';
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(): AggregatorGridConfig {
     return {
       schema: {
         id: {

--- a/ui/src/plugins/dev.perfetto.EntityStateResidency/entity_state_residency_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.EntityStateResidency/entity_state_residency_selection_aggregator.ts
@@ -41,6 +41,7 @@ export class EntityStateResidencySelectionAggregator implements Aggregator {
     }
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         const duration = area.end - area.start;
         const durationSec = Duration.toSeconds(duration);
@@ -79,7 +80,7 @@ export class EntityStateResidencySelectionAggregator implements Aggregator {
     };
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(): AggregatorGridConfig {
     return {
       schema: {
         entity_name: {title: 'Entity', columnType: 'text'},

--- a/ui/src/plugins/dev.perfetto.Frames/frame_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/frame_selection_aggregator.ts
@@ -44,6 +44,7 @@ export class FrameSelectionAggregator implements Aggregator {
     if (!dataset) return undefined;
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         await using iiTable = await createIITable(
           engine,
@@ -70,7 +71,7 @@ export class FrameSelectionAggregator implements Aggregator {
     return 'Frames';
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(): AggregatorGridConfig {
     return {
       schema: {
         jank_type: {title: 'Jank Type', columnType: 'text'},

--- a/ui/src/plugins/dev.perfetto.PowerRails/power_counter_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.PowerRails/power_counter_selection_aggregator.ts
@@ -48,6 +48,7 @@ export class PowerCounterSelectionAggregator implements Aggregator {
     if (trackIds.length === 0) return undefined;
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         const duration = area.end - area.start;
         const durationSec = Duration.toSeconds(duration);
@@ -81,7 +82,7 @@ export class PowerCounterSelectionAggregator implements Aggregator {
     };
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(): AggregatorGridConfig {
     return {
       schema: {
         name: {title: 'Rail Name', columnType: 'text'},

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_by_process_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_by_process_selection_aggregator.ts
@@ -54,8 +54,6 @@ export class CpuSliceByProcessSelectionAggregator implements Aggregator {
   readonly id = 'cpu_by_process_aggregation';
 
   private readonly trace: Trace;
-  private trackDatasetMap?: Map<Dataset, Track>;
-  private unionDataset?: UnionDatasetWithLineage<DatasetSchema>;
 
   constructor(trace: Trace) {
     this.trace = trace;
@@ -75,29 +73,34 @@ export class CpuSliceByProcessSelectionAggregator implements Aggregator {
 
     if (cpuTracks.length === 0) return undefined;
 
+    // Build track-to-dataset mapping
+    const trackDatasetMap = new Map<Dataset, Track>();
+    const datasets: Dataset[] = [];
+    for (const track of cpuTracks) {
+      const dataset = track.renderer.getDataset?.();
+      if (dataset) {
+        datasets.push(dataset);
+        trackDatasetMap.set(dataset, track);
+      }
+    }
+
+    // Create union dataset with lineage tracking
+    const unionDataset = UnionDatasetWithLineage.create(datasets);
+
     return {
+      getGridConfig: () => {
+        return this.getGridConfig((groupId, partition) =>
+          this.resolveTrack(groupId, partition, trackDatasetMap, unionDataset),
+        );
+      },
       prepareData: async (engine: Engine) => {
-        // Build track-to-dataset mapping
-        this.trackDatasetMap = new Map();
-        const datasets: Dataset[] = [];
-        for (const track of cpuTracks) {
-          const dataset = track.renderer.getDataset?.();
-          if (dataset) {
-            datasets.push(dataset);
-            this.trackDatasetMap.set(dataset, track);
-          }
-        }
-
-        // Create union dataset with lineage tracking
-        this.unionDataset = UnionDatasetWithLineage.create(datasets);
-
         // Query with needed columns for II table
         const iiQuerySchema = {
           ...CPU_SLICE_SPEC,
           __groupid: NUM,
           __partition: UNKNOWN,
         };
-        const sql = this.unionDataset.query(iiQuerySchema);
+        const sql = unionDataset.query(iiQuerySchema);
 
         // Create interval-intersect table for time filtering
         await using iiTable = await createIITable(
@@ -131,7 +134,9 @@ export class CpuSliceByProcessSelectionAggregator implements Aggregator {
     return 'CPU by process';
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(
+    resolveTrack: (groupId: number, partition: SqlValue) => Track | undefined,
+  ): AggregatorGridConfig {
     return {
       schema: {
         id_with_lineage: {
@@ -151,7 +156,7 @@ export class CpuSliceByProcessSelectionAggregator implements Aggregator {
             const {id, groupid, partition} = parsed;
 
             // Resolve track from lineage
-            const track = this.resolveTrack(groupid, partition);
+            const track = resolveTrack(groupid, partition);
             if (!track) {
               return String(id);
             }
@@ -211,8 +216,10 @@ export class CpuSliceByProcessSelectionAggregator implements Aggregator {
   private resolveTrack(
     groupId: number,
     partition: SqlValue,
+    trackDatasetMap: Map<Dataset, Track>,
+    unionDataset?: UnionDatasetWithLineage<DatasetSchema>,
   ): Track | undefined {
-    if (!this.trackDatasetMap || !this.unionDataset) return undefined;
+    if (!unionDataset) return undefined;
 
     // Ensure partition is a valid SqlValue
     const partitionValue =
@@ -224,13 +231,13 @@ export class CpuSliceByProcessSelectionAggregator implements Aggregator {
         ? partition
         : null;
 
-    const datasets = this.unionDataset.resolveLineage({
+    const datasets = unionDataset.resolveLineage({
       __groupid: groupId,
       __partition: partitionValue,
     });
 
     for (const dataset of datasets) {
-      const track = this.trackDatasetMap.get(dataset);
+      const track = trackDatasetMap.get(dataset);
       if (track) return track;
     }
 

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_selection_aggregator.ts
@@ -55,8 +55,6 @@ export class CpuSliceSelectionAggregator implements Aggregator {
   readonly id = 'cpu_aggregation';
 
   private readonly trace: Trace;
-  private trackDatasetMap?: Map<Dataset, Track>;
-  private unionDataset?: UnionDatasetWithLineage<DatasetSchema>;
 
   constructor(trace: Trace) {
     this.trace = trace;
@@ -76,29 +74,33 @@ export class CpuSliceSelectionAggregator implements Aggregator {
 
     if (cpuTracks.length === 0) return undefined;
 
+    // Build track-to-dataset mapping synchronously
+    const trackDatasetMap = new Map<Dataset, Track>();
+    const datasets: Dataset[] = [];
+    for (const track of cpuTracks) {
+      const dataset = track.renderer.getDataset?.();
+      if (dataset) {
+        datasets.push(dataset);
+        trackDatasetMap.set(dataset, track);
+      }
+    }
+
+    // Create union dataset with lineage tracking
+    const unionDataset = UnionDatasetWithLineage.create(datasets);
+
     return {
+      getGridConfig: () =>
+        this.getGridConfig((groupId, partition) =>
+          this.resolveTrack(groupId, partition, trackDatasetMap, unionDataset),
+        ),
       prepareData: async (engine: Engine) => {
-        // Build track-to-dataset mapping
-        this.trackDatasetMap = new Map();
-        const datasets: Dataset[] = [];
-        for (const track of cpuTracks) {
-          const dataset = track.renderer.getDataset?.();
-          if (dataset) {
-            datasets.push(dataset);
-            this.trackDatasetMap.set(dataset, track);
-          }
-        }
-
-        // Create union dataset with lineage tracking
-        this.unionDataset = UnionDatasetWithLineage.create(datasets);
-
         // Query with needed columns for II table
         const iiQuerySchema = {
           ...CPU_SLICE_SPEC,
           __groupid: NUM,
           __partition: UNKNOWN,
         };
-        const sql = this.unionDataset.query(iiQuerySchema);
+        const sql = unionDataset.query(iiQuerySchema);
 
         // Create interval-intersect table for time filtering
         await using iiTable = await createIITable(
@@ -137,7 +139,9 @@ export class CpuSliceSelectionAggregator implements Aggregator {
     return `CPU by thread`;
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(
+    resolveTrack: (groupId: number, partition: SqlValue) => Track | undefined,
+  ): AggregatorGridConfig {
     return {
       schema: {
         id_with_lineage: {
@@ -157,7 +161,7 @@ export class CpuSliceSelectionAggregator implements Aggregator {
             const {id, groupid, partition} = parsed;
 
             // Resolve track from lineage
-            const track = this.resolveTrack(groupid, partition);
+            const track = resolveTrack(groupid, partition);
             if (!track) {
               return String(id);
             }
@@ -223,8 +227,10 @@ export class CpuSliceSelectionAggregator implements Aggregator {
   private resolveTrack(
     groupId: number,
     partition: SqlValue,
+    trackDatasetMap: Map<Dataset, Track>,
+    unionDataset?: UnionDatasetWithLineage<DatasetSchema>,
   ): Track | undefined {
-    if (!this.trackDatasetMap || !this.unionDataset) return undefined;
+    if (!unionDataset) return undefined;
 
     // Ensure partition is a valid SqlValue
     const partitionValue =
@@ -236,13 +242,13 @@ export class CpuSliceSelectionAggregator implements Aggregator {
         ? partition
         : null;
 
-    const datasets = this.unionDataset.resolveLineage({
+    const datasets = unionDataset.resolveLineage({
       __groupid: groupId,
       __partition: partitionValue,
     });
 
     for (const dataset of datasets) {
-      const track = this.trackDatasetMap.get(dataset);
+      const track = trackDatasetMap.get(dataset);
       if (track) return track;
     }
 

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_by_cpu_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_by_cpu_aggregator.ts
@@ -60,6 +60,7 @@ export class ThreadStateByCpuAggregator implements Aggregator {
     if (!dataset) return undefined;
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         await using iiTable = await createIITable(
           engine,
@@ -118,7 +119,7 @@ export class ThreadStateByCpuAggregator implements Aggregator {
     };
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(): AggregatorGridConfig {
     return {
       schema: {
         process_name: {title: 'Process', columnType: 'text'},

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_selection_aggregator.ts
@@ -62,8 +62,6 @@ export class ThreadStateSelectionAggregator implements Aggregator {
   readonly id = 'thread_state_aggregation';
 
   private readonly trace: Trace;
-  private trackDatasetMap?: Map<Dataset, Track>;
-  private unionDataset?: UnionDatasetWithLineage<DatasetSchema>;
 
   constructor(trace: Trace) {
     this.trace = trace;
@@ -83,29 +81,33 @@ export class ThreadStateSelectionAggregator implements Aggregator {
 
     if (threadStateTracks.length === 0) return undefined;
 
+    // Build track-to-dataset mapping synchronously
+    const trackDatasetMap = new Map<Dataset, Track>();
+    const datasets: Dataset[] = [];
+    for (const track of threadStateTracks) {
+      const dataset = track.renderer.getDataset?.();
+      if (dataset) {
+        datasets.push(dataset);
+        trackDatasetMap.set(dataset, track);
+      }
+    }
+
+    // Create union dataset with lineage tracking
+    const unionDataset = UnionDatasetWithLineage.create(datasets);
+
     return {
+      getGridConfig: () =>
+        this.getGridConfig((groupId, partition) =>
+          this.resolveTrack(groupId, partition, trackDatasetMap, unionDataset),
+        ),
       prepareData: async (engine: Engine) => {
-        // Build track-to-dataset mapping
-        this.trackDatasetMap = new Map();
-        const datasets: Dataset[] = [];
-        for (const track of threadStateTracks) {
-          const dataset = track.renderer.getDataset?.();
-          if (dataset) {
-            datasets.push(dataset);
-            this.trackDatasetMap.set(dataset, track);
-          }
-        }
-
-        // Create union dataset with lineage tracking
-        this.unionDataset = UnionDatasetWithLineage.create(datasets);
-
         // Query with needed columns for II table
         const iiQuerySchema = {
           ...THREAD_STATE_SPEC,
           __groupid: NUM,
           __partition: UNKNOWN,
         };
-        const sql = this.unionDataset.query(iiQuerySchema);
+        const sql = unionDataset.query(iiQuerySchema);
 
         // Create interval-intersect table for time filtering
         await using iiTable = await createIITable(
@@ -170,7 +172,9 @@ export class ThreadStateSelectionAggregator implements Aggregator {
     };
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(
+    resolveTrack: (groupId: number, partition: SqlValue) => Track | undefined,
+  ): AggregatorGridConfig {
     return {
       schema: {
         id_with_lineage: {
@@ -190,7 +194,7 @@ export class ThreadStateSelectionAggregator implements Aggregator {
             const {id, groupid, partition} = parsed;
 
             // Resolve track from lineage
-            const track = this.resolveTrack(groupid, partition);
+            const track = resolveTrack(groupid, partition);
             if (!track) {
               return String(id);
             }
@@ -262,8 +266,10 @@ export class ThreadStateSelectionAggregator implements Aggregator {
   private resolveTrack(
     groupId: number,
     partition: SqlValue,
+    trackDatasetMap: Map<Dataset, Track>,
+    unionDataset?: UnionDatasetWithLineage<DatasetSchema>,
   ): Track | undefined {
-    if (!this.trackDatasetMap || !this.unionDataset) return undefined;
+    if (!unionDataset) return undefined;
 
     // Ensure partition is a valid SqlValue
     const partitionValue =
@@ -275,13 +281,13 @@ export class ThreadStateSelectionAggregator implements Aggregator {
         ? partition
         : null;
 
-    const datasets = this.unionDataset.resolveLineage({
+    const datasets = unionDataset.resolveLineage({
       __groupid: groupId,
       __partition: partitionValue,
     });
 
     for (const dataset of datasets) {
-      const track = this.trackDatasetMap.get(dataset);
+      const track = trackDatasetMap.get(dataset);
       if (track) return track;
     }
 

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_selection_aggregator.ts
@@ -35,6 +35,7 @@ export class CounterSelectionAggregator implements Aggregator {
     if (trackIds.length === 0) return undefined;
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         const duration = area.end - area.start;
         const durationSec = Duration.toSeconds(duration);
@@ -129,7 +130,7 @@ export class CounterSelectionAggregator implements Aggregator {
     };
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(): AggregatorGridConfig {
     return {
       schema: {
         name: {title: 'Name', columnType: 'text'},

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
@@ -65,11 +65,6 @@ export class SliceSelectionAggregator implements Aggregator {
   readonly id = 'slice_aggregation';
 
   private readonly trace: Trace;
-  // Store track-to-dataset mapping for lineage resolution
-  private trackDatasetMap?: Map<Dataset, Track>;
-  // Store union datasets for lineage resolution
-  private sliceUnionDataset?: UnionDatasetWithLineage<DatasetSchema>;
-  private slicelikeUnionDataset?: UnionDatasetWithLineage<DatasetSchema>;
 
   constructor(trace: Trace) {
     this.trace = trace;
@@ -95,30 +90,66 @@ export class SliceSelectionAggregator implements Aggregator {
       return undefined;
     }
 
-    return {
-      prepareData: async (engine: Engine) => {
-        const unionQueries: string[] = [];
-        await using trash = new AsyncDisposableStack();
-        this.trackDatasetMap = new Map();
+    const unionQueries: string[] = [];
+    const trackDatasetMap = new Map<Dataset, Track>();
 
-        if (sliceTracks.length > 0) {
-          const {query, unionDataset, trackDatasetMap} =
-            await this.buildSliceQuery(engine, sliceTracks, area, trash);
+    const sliceDatasets: Dataset[] = [];
+    for (const track of sliceTracks) {
+      const dataset = track.renderer.getDataset?.();
+      if (dataset) {
+        sliceDatasets.push(dataset);
+        trackDatasetMap.set(dataset, track);
+      }
+    }
+    const sliceUnionDataset =
+      sliceDatasets.length > 0
+        ? UnionDatasetWithLineage.create(sliceDatasets)
+        : undefined;
+
+    const slicelikeDatasets: Dataset[] = [];
+    for (const track of slicelikeTracks) {
+      const dataset = track.renderer.getDataset?.();
+      if (dataset) {
+        slicelikeDatasets.push(dataset);
+        trackDatasetMap.set(dataset, track);
+      }
+    }
+    const slicelikeUnionDataset =
+      slicelikeDatasets.length > 0
+        ? UnionDatasetWithLineage.create(slicelikeDatasets)
+        : undefined;
+
+    return {
+      getGridConfig: () =>
+        this.getGridConfig((groupId, partition) =>
+          this.resolveTrack(
+            groupId,
+            partition,
+            trackDatasetMap,
+            sliceUnionDataset,
+            slicelikeUnionDataset,
+          ),
+        ),
+      prepareData: async (engine: Engine) => {
+        await using trash = new AsyncDisposableStack();
+
+        if (sliceUnionDataset) {
+          const query = await this.buildSliceQuery(
+            engine,
+            sliceUnionDataset,
+            area,
+            trash,
+          );
           unionQueries.push(query);
-          this.sliceUnionDataset = unionDataset;
-          for (const [dataset, track] of trackDatasetMap.entries()) {
-            this.trackDatasetMap.set(dataset, track);
-          }
         }
 
-        if (slicelikeTracks.length > 0) {
-          const {query, unionDataset, trackDatasetMap} =
-            await this.buildSlicelikeQuery(
-              engine,
-              slicelikeTracks,
-              area,
-              trash,
-            );
+        if (slicelikeUnionDataset) {
+          const query = await this.buildSlicelikeQuery(
+            engine,
+            slicelikeUnionDataset,
+            area,
+            trash,
+          );
           // Offset group IDs to avoid collision with slice groups
           const groupOffset = sliceTracks.length > 0 ? 1 : 0;
           const offsetQuery = query.replace(
@@ -126,10 +157,6 @@ export class SliceSelectionAggregator implements Aggregator {
             `__groupid + ${groupOffset} as __groupid`,
           );
           unionQueries.push(offsetQuery);
-          this.slicelikeUnionDataset = unionDataset;
-          for (const [dataset, track] of trackDatasetMap.entries()) {
-            this.trackDatasetMap.set(dataset, track);
-          }
         }
 
         await engine.query(`
@@ -143,35 +170,19 @@ export class SliceSelectionAggregator implements Aggregator {
           FROM (${unionQueries.join(' UNION ALL ')})
         `);
 
-        return {tableName: this.id};
+        return {
+          tableName: this.id,
+        };
       },
     };
   }
 
   private async buildSliceQuery(
     engine: Engine,
-    tracks: Track[],
+    unionDataset: UnionDatasetWithLineage<DatasetSchema>,
     area: AreaSelection,
     trash: AsyncDisposableStack,
-  ): Promise<{
-    query: string;
-    unionDataset: UnionDatasetWithLineage<DatasetSchema>;
-    trackDatasetMap: Map<Dataset, Track>;
-  }> {
-    // Build track-to-dataset mapping
-    const trackDatasetMap = new Map<Dataset, Track>();
-    const datasets: Dataset[] = [];
-    for (const track of tracks) {
-      const dataset = track.renderer.getDataset?.();
-      if (dataset) {
-        datasets.push(dataset);
-        trackDatasetMap.set(dataset, track);
-      }
-    }
-
-    // Create union dataset with lineage tracking
-    const unionDataset = UnionDatasetWithLineage.create(datasets);
-
+  ): Promise<string> {
     // Query with only needed columns for II table (ts, dur, id)
     const iiQuerySchema = {
       ...SLICE_WITH_PARENT_SPEC,
@@ -203,49 +214,27 @@ export class SliceSelectionAggregator implements Aggregator {
     });
     trash.use(childDurTable);
 
-    return {
-      query: `
-        SELECT
-          id,
-          name,
-          ts,
-          dur,
-          dur - COALESCE(child_dur, 0) AS self_dur,
-          arg_set_id,
-          __groupid,
-          __partition
-        FROM ${iiTable.name}
-        LEFT JOIN ${childDurTable.name} USING(id)
-      `,
-      unionDataset,
-      trackDatasetMap,
-    };
+    return `
+      SELECT
+        id,
+        name,
+        ts,
+        dur,
+        dur - COALESCE(child_dur, 0) AS self_dur,
+        arg_set_id,
+        __groupid,
+        __partition
+      FROM ${iiTable.name}
+      LEFT JOIN ${childDurTable.name} USING(id)
+    `;
   }
 
   private async buildSlicelikeQuery(
     engine: Engine,
-    tracks: Track[],
+    unionDataset: UnionDatasetWithLineage<DatasetSchema>,
     area: AreaSelection,
     trash: AsyncDisposableStack,
-  ): Promise<{
-    query: string;
-    unionDataset: UnionDatasetWithLineage<DatasetSchema>;
-    trackDatasetMap: Map<Dataset, Track>;
-  }> {
-    // Build track-to-dataset mapping
-    const trackDatasetMap = new Map<Dataset, Track>();
-    const datasets: Dataset[] = [];
-    for (const track of tracks) {
-      const dataset = track.renderer.getDataset?.();
-      if (dataset) {
-        datasets.push(dataset);
-        trackDatasetMap.set(dataset, track);
-      }
-    }
-
-    // Create union dataset with lineage tracking
-    const unionDataset = UnionDatasetWithLineage.create(datasets);
-
+  ): Promise<string> {
     // Query with only needed columns for II table (ts, dur, id)
     const iiQuerySchema = {
       ...SLICELIKE_SPEC,
@@ -263,29 +252,27 @@ export class SliceSelectionAggregator implements Aggregator {
     );
     trash.use(iiTable);
 
-    return {
-      query: `
-        SELECT
-          id,
-          name,
-          ts,
-          dur,
-          dur AS self_dur,
-          arg_set_id,
-          __groupid,
-          __partition
-        FROM ${iiTable.name}
-      `,
-      unionDataset,
-      trackDatasetMap,
-    };
+    return `
+      SELECT
+        id,
+        name,
+        ts,
+        dur,
+        dur AS self_dur,
+        arg_set_id,
+        __groupid,
+        __partition
+      FROM ${iiTable.name}
+    `;
   }
 
   getTabName() {
     return 'Slices';
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(
+    resolveTrack: (groupId: number, partition: SqlValue) => Track | undefined,
+  ): AggregatorGridConfig {
     return {
       schema: {
         id_with_lineage: {
@@ -305,7 +292,7 @@ export class SliceSelectionAggregator implements Aggregator {
             const {id, groupid, partition} = parsed;
 
             // Resolve track from lineage
-            const track = this.resolveTrack(groupid, partition);
+            const track = resolveTrack(groupid, partition);
             if (!track) {
               return String(id);
             }
@@ -382,9 +369,10 @@ export class SliceSelectionAggregator implements Aggregator {
   private resolveTrack(
     groupId: number,
     partition: SqlValue,
+    trackDatasetMap: Map<Dataset, Track>,
+    sliceUnionDataset?: UnionDatasetWithLineage<DatasetSchema>,
+    slicelikeUnionDataset?: UnionDatasetWithLineage<DatasetSchema>,
   ): Track | undefined {
-    if (!this.trackDatasetMap) return undefined;
-
     // Ensure partition is a valid SqlValue
     const partitionValue =
       partition === null ||
@@ -396,27 +384,27 @@ export class SliceSelectionAggregator implements Aggregator {
         : null;
 
     // Try slice union dataset first
-    if (this.sliceUnionDataset) {
-      const datasets = this.sliceUnionDataset.resolveLineage({
+    if (sliceUnionDataset) {
+      const datasets = sliceUnionDataset.resolveLineage({
         __groupid: groupId,
         __partition: partitionValue,
       });
       for (const dataset of datasets) {
-        const track = this.trackDatasetMap.get(dataset);
+        const track = trackDatasetMap.get(dataset);
         if (track) return track;
       }
     }
 
     // Try slicelike union dataset (with group offset)
-    if (this.slicelikeUnionDataset) {
-      const sliceGroupCount = this.sliceUnionDataset ? 1 : 0;
+    if (slicelikeUnionDataset) {
+      const sliceGroupCount = sliceUnionDataset ? 1 : 0;
       const adjustedGroupId = groupId - sliceGroupCount;
-      const datasets = this.slicelikeUnionDataset.resolveLineage({
+      const datasets = slicelikeUnionDataset.resolveLineage({
         __groupid: adjustedGroupId,
         __partition: partitionValue,
       });
       for (const dataset of datasets) {
-        const track = this.trackDatasetMap.get(dataset);
+        const track = trackDatasetMap.get(dataset);
         if (track) return track;
       }
     }

--- a/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
@@ -47,6 +47,7 @@ export class WattsonEstimateSelectionAggregator implements Aggregator {
     if (estimateTracks.length === 0) return undefined;
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         await engine.query(`drop view if exists ${this.id};`);
         const query = this.getEstimateTracksQuery(area, estimateTracks);
@@ -118,7 +119,7 @@ export class WattsonEstimateSelectionAggregator implements Aggregator {
     return String(value);
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(): AggregatorGridConfig {
     const powerUnits = this.scaleNumericData ? 'µW' : 'mW';
     const energyUnits = this.scaleNumericData ? 'µWs' : 'mWs';
 

--- a/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
@@ -36,6 +36,7 @@ abstract class WattsonBasePackageSelectionAggregator implements Aggregator {
     if (probeResult === undefined) return undefined;
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         await engine.query(`drop view if exists ${this.id};`);
         const duration = area.end - area.start;
@@ -90,7 +91,7 @@ abstract class WattsonBasePackageSelectionAggregator implements Aggregator {
     return String(value);
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  protected getGridConfig(): AggregatorGridConfig {
     const powerUnits = this.powerUnits();
     const energyUnits = `${powerUnits}s`;
     const idleCost = this.hasIdleCost();

--- a/ui/src/plugins/org.kernel.Wattson/process_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/process_aggregator.ts
@@ -39,6 +39,7 @@ export class WattsonProcessSelectionAggregator implements Aggregator {
     if (selectedCpus.length === 0) return undefined;
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         await engine.query(`drop view if exists ${this.id};`);
 
@@ -95,7 +96,7 @@ export class WattsonProcessSelectionAggregator implements Aggregator {
     return String(value);
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(): AggregatorGridConfig {
     const powerUnits = this.scaleNumericData ? 'µW' : 'mW';
     const energyUnits = this.scaleNumericData ? 'µWs' : 'mWs';
 

--- a/ui/src/plugins/org.kernel.Wattson/thread_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/thread_aggregator.ts
@@ -53,6 +53,7 @@ export class WattsonThreadSelectionAggregator implements Aggregator {
     }
 
     return {
+      getGridConfig: () => this.getGridConfig(),
       prepareData: async (engine: Engine) => {
         await engine.query(`drop view if exists ${this.id};`);
         const duration = area.end - area.start;
@@ -164,7 +165,7 @@ export class WattsonThreadSelectionAggregator implements Aggregator {
     });
   }
 
-  getGridConfig(): AggregatorGridConfig {
+  private getGridConfig(): AggregatorGridConfig {
     const powerUnits = this.scaleNumericData ? 'µW' : 'mW';
     const energyUnits = this.scaleNumericData ? 'µWs' : 'mWs';
 


### PR DESCRIPTION
Move getGridConfig() from the root Aggregator interface to be returned on the Aggregation object by probe() (or AggregationData by prepareData()).

This is much more convenient when data from the probe step needs to be cached and used for the grid config - e.g when track lineage needs to be retained. Instead of storing this data in mutable member variables on the class, this data can now be const and simply captured in a closure.