### PR TITLE
Ensure `object-src: 'none'` CSP directive is applied as intended

### DIFF
--- a/ui/src/bigtrace/index.ts
+++ b/ui/src/bigtrace/index.ts
@@ -60,7 +60,7 @@ function setupContentSecurityPolicy() {
     // wasm-unsafe-eval: the SQL formatter runs as WebAssembly; this allows
     // Wasm compilation without enabling JS eval().
     'script-src': [`'self'`, `'wasm-unsafe-eval'`],
-    'object-src': ['none'],
+    'object-src': [`'none'`],
     'connect-src': [
       `'self'`,
       'https://autopush-brush-googleapis.corp.google.com',

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -163,7 +163,7 @@ function setupContentSecurityPolicy() {
       'https://www.googletagmanager.com',
       'https://*.google-analytics.com',
     ],
-    'object-src': ['none'],
+    'object-src': [`'none'`],
     'connect-src': [
       `'self'`,
       'ws://127.0.0.1:8037', // For the adb websocket server.


### PR DESCRIPTION
[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/object-src#none) the single-quotes surrounding `'none'` are mandatory in the `object-src` CSP directive. Unlike the other CSP directives that take care to preserve these single-quotes when required (e.g. `'self'` in `connect-src`), the `object-src` was passing a plain `none` without quotes, which is treated as the bare hostname `none`.
