### PR TITLE
perfetto: cut v58.0 in the CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,15 @@
 Unreleased:
   Tracing service and probes:
+   *
+  Trace Processor:
+   *
+  UI:
+   *
+  SDK:
+   *
+
+v58.0 - 2026-08-04:
+  Tracing service and probes:
     * Added optional recording of the state changes of other concurrent
       tracing sessions, as ConcurrentSessionEvent packets. Opt-in via
       TraceConfig.BuiltinDataSource.enable_concurrent_session_events. Trace
@@ -62,6 +72,16 @@ Unreleased:
       The wire format is unchanged; code referencing the generated
       `TrackEvent.Callstack` / `TrackEvent::Callstack` types must switch to
       `InlineCallstack`.
+    * Added `trace_processor_shell export arrow_tar`, which writes the static
+      tables as a tar of Arrow files for other tools. It is cross-version
+      compatible but cannot be loaded back into Trace Processor.
+    * Added `trace_processor_shell export perfetto`, which writes an archive
+      that a fresh Trace Processor of the same version can load, so a large
+      trace can be parsed once and reloaded instead of reparsed.
+    * Fixed Apple Instruments XML traces from Xcode 27 losing their call
+      stacks, which moved to a <tagged-backtrace> element.
+    * `regexp()` takes an optional third argument for matching flags: `i`
+      for case-insensitive matching, `c` for case-sensitive.
   UI:
     * Improved flamegraphs with clearer direction and filter controls, frame
       highlighting, and case-insensitive regular expression filtering.
@@ -80,6 +100,14 @@ Unreleased:
     * Update node to v22.23.1 and pnpm to 10.34.5.
     * Allow pivoting on arg values in slice aggregation table.
     * Bump to vite v8.1.5 and typescript v7.0.2, vastly improving build times.
+    * Area selections now have a "Contained traces" tab that lists the other
+      traces under the selection and merges the ones you check.
+    * Add memory tooling:
+      * Memscope: a live memory profiler that guides you through connecting
+        an Android/Linux device and recording memory traces.
+      * Memory overview: opens by default on traces containing smaps dumps
+        and shows a high-level breakdown of where memory is being used,
+        drawing on smaps, ART, and native memory data recorded in the trace.
   SDK:
     * Reworked the C SDK shared library export macros: static linking (the
       default) no longer needs any macros. Define
@@ -93,6 +121,22 @@ Unreleased:
       preferred trace clock, so callers no longer need to pick the OS
       specific clock themselves. Also added DataSourceTimestamp::now() in
       the Rust SDK.
+    * dev.perfetto.clock_sync signpost events now fire on iOS as well as
+      macOS, so iOS Instruments traces can be synced with Perfetto traces.
+  Tools:
+    * Deprecated `traceconv`. Please use `trace_processor_shell`, which does
+      the same conversions as subcommands. The downloadable wrapper now
+      fetches it; the standalone binary still ships for now.
+  AI:
+    * The skill now queries through trace_processor sessions by default:
+      load the trace once, then query a named session many times. The HTTP
+      server and Python client paths are gone.
+    * Added a TraceConfig reference and exemplar configs for agents writing
+      a custom recording config.
+    * Every analysis now ends by writing a markdown report with the
+      question, the findings and the queries that worked.
+    * Releases now include a skill zip for machines that cannot reach
+      github.com at install time.
 
 v57.2 - 2026-07-07:
   Trace Processor:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ Unreleased:
   SDK:
    *
 
-v58.0 - 2026-08-04:
+v58.0 - 2026-08-06:
   Tracing service and probes:
     * Added optional recording of the state changes of other concurrent
       tracing sessions, as ConcurrentSessionEvent packets. Opt-in via
@@ -23,31 +23,6 @@ v58.0 - 2026-08-04:
     * Replaced TraceConfig.notes and `perfetto --add-note` with
       TraceConfig.trace_attributes and `--add-attribute`.
   Trace Processor:
-    * Added an embedder-provided filesystem interface. The interface is
-      disabled by default; trace_processor_shell allows SQL file access only
-      with --allow-sql-file-access. SQL file writes no longer require --dev,
-      and the integer file descriptor form of EXPORT_JSON has been removed.
-    * Introduced common stack_sample, stack_sample_session,
-      stack_sample_task_context, stack_sample_execution_context,
-      stack_sample_async_context, stack_sample_counter_track and
-      stack_sample_counter tables shared by all callstack profiler sources.
-      Async contexts preserve their structural parent relationships. The Linux
-      perf-specific perf_sample, perf_session and perf_counter_track tables
-      continue to expose all perf data, including counter-only samples.
-    * Chrome streaming profiles, legacy V8 cpu profiles, gecko profiles,
-      simpleperf proto traces, perf script text and macOS Instruments
-      traces now also populate profiler_sample; cpu_profile_stack_sample
-      and instruments_sample keep their schemas as views over it.
-    * The StackSample packet's counter descriptors now materialize as
-      counter tracks (scoped per profiler session, or per session and
-      cpu via the new CounterDescriptor.scope field, mirroring
-      perf_event scoping), with per-sample values as counter rows linked
-      through the counter set, exactly like linux perf counters.
-    * Fixed malformed TrackEvent timestamps overflowing into large positive
-      values, which could crash the UI.
-    * Added a client-server mode to `trace_processor_shell`: start a server
-      over a unix socket (`server unix`) or WebSocket (`server http`) and
-      connect a thin client with `--remote`.
     * Added trace merging: a ZIP or TAR archive containing several traces
       imports as one merged trace on a single timeline, with per-machine
       attribution. An optional `perfetto_manifest` JSON file in the archive
@@ -55,16 +30,35 @@ v58.0 - 2026-08-04:
       See https://perfetto.dev/docs/analysis/merging-traces.
     * Added `trace_processor_shell util merge`: packs traces and an optional
       manifest into a merged-trace archive and sanity-checks the result.
-    * Trace attributes can now also come from the trace config.
-    * perfetto_manifest files can annotate an archive via `attributes`.
-    * Added a transport-neutral stack sampling format: the new
-      TracePacket.stack_sample attributes a callstack to a thread, process or
-      async context (goroutine, fiber, ...), measured against an explicit
-      counter timebase (wall-time, cycles, bytes, ...) with optional follower
-      counters. Callstacks can be interned or fully inline; per-sequence
-      StackSampleDefaults declare the profiler source and common counters.
-      Samples are parsed into the stack sample tables and share the existing
-      stack_profile_* callstack tables.
+    * Added a client-server mode to `trace_processor_shell`: start a server
+      over a unix socket (`server unix`) or WebSocket (`server http`) and
+      connect a thin client with `--remote`.
+    * Added a common stack sampling format that any profiler can emit: the
+      new TracePacket.stack_sample attributes a callstack to a thread,
+      process or async context (goroutine, fiber, ...), measured against an
+      explicit counter timebase (wall-time, cycles, bytes, ...) with
+      optional follower counters. Callstacks can be interned or fully
+      inline; per-sequence StackSampleDefaults declare the profiler source
+      and common counters. Samples are parsed into the stack sample tables
+      and share the existing stack_profile_* callstack tables.
+    * Introduced common stack_sample, stack_sample_session,
+      stack_sample_task_context, stack_sample_execution_context,
+      stack_sample_async_context, stack_sample_counter_track and
+      stack_sample_counter tables shared by all callstack profiler sources.
+      Async contexts keep their parent relationships. The Linux perf-specific
+      perf_sample, perf_session and perf_counter_track tables continue to
+      expose all perf data, including counter-only samples.
+    * Added `trace_processor_shell export arrow_tar`, which writes the
+      built-in tables as a tar of Arrow files for other tools to read. The
+      format is stable across versions, but the archive cannot be loaded
+      back into Trace Processor.
+    * Added `trace_processor_shell export perfetto`, which writes an archive
+      that another Trace Processor of the same version can load, so a large
+      trace only has to be parsed once.
+    * Added an embedder-provided filesystem interface. The interface is
+      disabled by default; trace_processor_shell allows SQL file access only
+      with --allow-sql-file-access. SQL file writes no longer require --dev,
+      and the integer file descriptor form of EXPORT_JSON has been removed.
     * Breaking change: the inline callstack message `TrackEvent.Callstack`
       moved to the top-level `InlineCallstack` message in
       trace/profiling/inline_callstack.proto, so track events and stack
@@ -72,16 +66,12 @@ v58.0 - 2026-08-04:
       The wire format is unchanged; code referencing the generated
       `TrackEvent.Callstack` / `TrackEvent::Callstack` types must switch to
       `InlineCallstack`.
-    * Added `trace_processor_shell export arrow_tar`, which writes the static
-      tables as a tar of Arrow files for other tools. It is cross-version
-      compatible but cannot be loaded back into Trace Processor.
-    * Added `trace_processor_shell export perfetto`, which writes an archive
-      that a fresh Trace Processor of the same version can load, so a large
-      trace can be parsed once and reloaded instead of reparsed.
-    * Fixed Apple Instruments XML traces from Xcode 27 losing their call
-      stacks, which moved to a <tagged-backtrace> element.
-    * `regexp()` takes an optional third argument for matching flags: `i`
-      for case-insensitive matching, `c` for case-sensitive.
+    * `regexp()` now takes an optional third argument for matching flags:
+      `i` for case-insensitive matching, `c` for case-sensitive.
+    * Fixed negative timestamps wrapping around to large positive values and
+      crashing the UI, a crash on empty CpuInfo packets, a hang when
+      skipping an oversized proto field, and Apple Instruments Xcode 27
+      traces losing their call stacks.
   UI:
     * Improved flamegraphs with clearer direction and filter controls, frame
       highlighting, and case-insensitive regular expression filtering.
@@ -100,8 +90,6 @@ v58.0 - 2026-08-04:
     * Update node to v22.23.1 and pnpm to 10.34.5.
     * Allow pivoting on arg values in slice aggregation table.
     * Bump to vite v8.1.5 and typescript v7.0.2, vastly improving build times.
-    * Area selections now have a "Contained traces" tab that lists the other
-      traces under the selection and merges the ones you check.
     * Add memory tooling:
       * Memscope: a live memory profiler that guides you through connecting
         an Android/Linux device and recording memory traces.
@@ -121,20 +109,23 @@ v58.0 - 2026-08-04:
       preferred trace clock, so callers no longer need to pick the OS
       specific clock themselves. Also added DataSourceTimestamp::now() in
       the Rust SDK.
-    * dev.perfetto.clock_sync signpost events now fire on iOS as well as
-      macOS, so iOS Instruments traces can be synced with Perfetto traces.
+    * `dev.perfetto.clock_sync` signpost events now fire on iOS as well as
+      macOS, so Instruments traces from iOS can be synchronized with
+      Perfetto traces.
   Tools:
     * Deprecated `traceconv`. Please use `trace_processor_shell`, which does
-      the same conversions as subcommands. The downloadable wrapper now
-      fetches it; the standalone binary still ships for now.
+      the same conversions as subcommands. The `traceconv` wrapper script
+      now fetches `trace_processor_shell` and runs it under the `traceconv`
+      name, so existing invocations keep working unchanged. The standalone
+      binary still ships for now.
   AI:
-    * The skill now queries through trace_processor sessions by default:
-      load the trace once, then query a named session many times. The HTTP
-      server and Python client paths are gone.
-    * Added a TraceConfig reference and exemplar configs for agents writing
-      a custom recording config.
-    * Every analysis now ends by writing a markdown report with the
-      question, the findings and the queries that worked.
+    * Much faster repeated queries with skills: the skill now loads a trace
+      once into a `trace_processor` session and reuses it, instead of
+      reparsing on every call.
+    * Added a `TraceConfig` reference and exemplar configs an agent can start
+      from when it needs a custom recording setup.
+    * Every analysis now ends by saving a markdown report with the question,
+      the findings and the queries that worked.
     * Releases now include a skill zip for machines that cannot reach
       github.com at install time.
 


### PR DESCRIPTION
Date the Unreleased block as v58.0 and open a fresh Unreleased block on top, ahead of cutting canary from main.

Also fill in entries for work that landed after the 2026-07-16 canary cut and was never written up: the Arrow and Perfetto table export formats, the traceconv deprecation, the Xcode 27 Instruments fix, the regexp() flags argument, the "Contained traces" UI tab, and clock_sync on iOS, plus a new AI section for the skill changes. The memory tooling entry is taken from #6983.

