### PR TITLE
ui: merge duplicate per-cpu/gpu tracks on multi-machine open

### DIFF
--- a/ui/src/plugins/com.android.CpuPerUid/index.ts
+++ b/ui/src/plugins/com.android.CpuPerUid/index.ts
@@ -17,7 +17,7 @@ import type {PerfettoPlugin} from '../../public/plugin';
 import {TrackNode} from '../../public/workspace';
 import {CounterTrack} from '../../components/tracks/counter_track';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
-import {NUM, STR} from '../../trace_processor/query_result';
+import {NUM, NUM_NULL, STR} from '../../trace_processor/query_result';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'com.android.CpuPerUid';
@@ -62,17 +62,28 @@ export default class implements PerfettoPlugin {
   async addSummaryCpuCounters(ctx: Trace): Promise<void> {
     const e = ctx.engine;
 
+    // One track per (machine, type, cluster), unioning duplicated rows.
     const tracks = await e.query(
-      `select distinct
-         id,
+      `select
+         machine_id as machineId,
          extract_arg(dimension_arg_set_id, 'type') as type,
-         extract_arg(dimension_arg_set_id, 'cluster') as cluster
+         extract_arg(dimension_arg_set_id, 'cluster') as cluster,
+         group_concat(id) as trackIds
        from track
        where type = 'android_cpu_per_uid_totals'
+       group by
+         machine_id,
+         extract_arg(dimension_arg_set_id, 'type'),
+         extract_arg(dimension_arg_set_id, 'cluster')
        order by type, cluster`,
     );
 
-    const it = tracks.iter({id: NUM, type: STR, cluster: NUM});
+    const it = tracks.iter({
+      machineId: NUM_NULL,
+      type: STR,
+      cluster: NUM,
+      trackIds: STR,
+    });
     if (it.valid()) {
       const group = new TrackNode({
         name: 'Summary',
@@ -82,13 +93,14 @@ export default class implements PerfettoPlugin {
 
       for (; it.valid(); it.next()) {
         const name = `${it.type} (${clusterName(it.cluster)})`;
+        const trackIds = it.trackIds.split(',').map(Number);
         await this.addCpuPerUidTrack(
           ctx,
           `select ts, value
           from counter
-          where track_id = ${it.id}`,
+          where track_id in (${trackIds.join(',')})`,
           name,
-          `/cpu_per_uid_summary_${it.type}_${it.cluster}`,
+          `/cpu_per_uid_summary_${it.machineId ?? 0}_${it.type}_${it.cluster}`,
           group,
           'cpu-per-uid-summary',
         );

--- a/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
+++ b/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
@@ -53,7 +53,7 @@ export default class implements PerfettoPlugin {
         group by uid
       )
       select
-        t.id as trackId,
+        group_concat(distinct t.id) as trackIds,
         t.uid as uid,
         t.gpu_id as gpuId,
         t.ugpu as ugpu,
@@ -65,11 +65,12 @@ export default class implements PerfettoPlugin {
       left join grouped_packages p using (uid)
       left join gpu g on g.id = t.ugpu
       left join machine m on m.id = t.machine_id
+      group by t.machine_id, ifnull(t.ugpu, t.gpu_id), t.uid
       order by t.gpu_id, lower(packageName)
     `);
 
     const it = result.iter({
-      trackId: NUM,
+      trackIds: STR,
       uid: NUM,
       gpuId: NUM,
       ugpu: NUM_NULL,
@@ -89,8 +90,10 @@ export default class implements PerfettoPlugin {
     // Cache the work-period group(s) by name so each is created only once.
     const groupsByName = new Map<string, TrackNode>();
     for (; it.valid(); it.next()) {
-      const {trackId, gpuId, uid, packageName} = it;
-      const uri = `/gpu_work_period_${gpuId}_${uid}`;
+      const {gpuId, uid, packageName} = it;
+      const trackIds = it.trackIds.split(',').map(Number);
+      const logicalGpu = it.ugpu ?? gpuId;
+      const uri = `/gpu_work_period_${it.machineId ?? 0}_${logicalGpu}_${uid}`;
       const track = await SliceTrack.createMaterialized({
         trace: ctx,
         uri,
@@ -98,7 +101,7 @@ export default class implements PerfettoPlugin {
           src: `
             select ts, dur, name
             from slice
-            where track_id = ${trackId}
+            where track_id in (${trackIds.join(',')})
           `,
           schema: {
             ts: LONG,
@@ -110,7 +113,7 @@ export default class implements PerfettoPlugin {
       ctx.tracks.registerTrack({
         uri,
         tags: {
-          trackIds: [trackId],
+          trackIds,
           kinds: [SLICE_TRACK_KIND],
         },
         renderer: track,

--- a/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
@@ -73,8 +73,9 @@ interface MipmapTables extends AsyncDisposable {
 
 interface Config {
   cpu: number;
-  freqTrackId: number;
-  idleTrackId?: number;
+  // A merged trace can contribute several rows per CPU; union them.
+  freqTrackIds: ReadonlyArray<number>;
+  idleTrackIds: ReadonlyArray<number>;
   maximumValue: number;
 }
 
@@ -150,7 +151,10 @@ export class CpuFreqTrack implements TrackRenderer {
 
     let rawFreqIdleTableName: string;
 
-    if (this.config.idleTrackId === undefined) {
+    const freqTrackIds = this.config.freqTrackIds.join(',');
+    const idleTrackIds = this.config.idleTrackIds.join(',');
+
+    if (this.config.idleTrackIds.length === 0) {
       const rawFreqIdleView = await createView({
         engine: this.trace.engine,
         as: `
@@ -158,7 +162,7 @@ export class CpuFreqTrack implements TrackRenderer {
           from counter_leading_intervals!((
             select id, ts, track_id, value
             from counter
-            where track_id = ${this.config.freqTrackId}
+            where track_id in (${freqTrackIds})
           ))
         `,
       });
@@ -172,7 +176,7 @@ export class CpuFreqTrack implements TrackRenderer {
           from counter_leading_intervals!((
             select id, ts, track_id, value
             from counter
-           where track_id = ${this.config.freqTrackId}
+           where track_id in (${freqTrackIds})
           ))
         `,
       });
@@ -188,7 +192,7 @@ export class CpuFreqTrack implements TrackRenderer {
           from counter_leading_intervals!((
             select id, ts, track_id, value
             from counter
-            where track_id = ${this.config.idleTrackId}
+            where track_id in (${idleTrackIds})
           ))
         `,
       });
@@ -393,8 +397,8 @@ export class CpuFreqTrack implements TrackRenderer {
     const tableResult = this.tableSlot.use({
       // Key is constant - tables only need to be created once
       key: {
-        freqTrackId: this.config.freqTrackId,
-        idleTrackId: this.config.idleTrackId,
+        freqTrackIds: this.config.freqTrackIds,
+        idleTrackIds: this.config.idleTrackIds,
       },
       compute: () => this.createMipmapTables(),
     });

--- a/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {NUM, NUM_NULL, STR_NULL} from '../../trace_processor/query_result';
+import {NUM, NUM_NULL, STR, STR_NULL} from '../../trace_processor/query_result';
 import {CpuFreqTrack} from './cpu_freq_track';
 import {Anchor} from '../../widgets/anchor';
 import {Icons} from '../../base/semantic_icons';
@@ -32,27 +32,31 @@ export default class implements PerfettoPlugin {
 
     // Find the list of CPU frequency track ids and their corresponding CPU idle
     // track ids if they exist
+    // One track per logical CPU, unioning rows a merged trace may duplicate.
     const tracksResult = await engine.query(`
       SELECT
-        track.id AS freqTrackId,
-        t2.id AS idleTrackId,
         cpu.ucpu AS ucpu,
         track.machine_id AS machineId,
         machine.name AS machineName,
         machine.label_index AS machineLabelIndex,
-        track.cpu AS cpu
+        track.cpu AS cpu,
+        group_concat(DISTINCT track.id) AS freqTrackIds,
+        (
+          SELECT group_concat(DISTINCT t2.id)
+          FROM cpu_counter_track t2
+          WHERE t2.type = 'cpu_idle'
+            AND t2.cpu = track.cpu
+            AND t2.machine_id = track.machine_id
+        ) AS idleTrackIds
       FROM cpu_counter_track track
       JOIN cpu
         ON track.cpu = cpu.cpu
        AND track.machine_id = cpu.machine_id
-      LEFT JOIN cpu_counter_track t2
-        ON track.cpu = t2.cpu
-       AND track.machine_id = t2.machine_id
-       AND t2.type = 'cpu_idle'
       LEFT JOIN machine
         ON machine.id = track.machine_id
       WHERE
         track.type = 'cpu_frequency'
+      GROUP BY cpu.ucpu
       ORDER BY ucpu
     `);
 
@@ -76,40 +80,36 @@ export default class implements PerfettoPlugin {
 
     for (
       const it = tracksResult.iter({
-        freqTrackId: NUM,
+        freqTrackIds: STR,
         machineId: NUM,
         machineName: STR_NULL,
         machineLabelIndex: NUM_NULL,
         cpu: NUM,
         ucpu: NUM,
-        idleTrackId: NUM_NULL,
+        idleTrackIds: STR_NULL,
       });
       it.valid();
       it.next()
     ) {
-      const {
-        freqTrackId,
-        idleTrackId,
-        machineId,
-        machineName,
-        machineLabelIndex,
-        cpu,
-        ucpu,
-      } = it;
+      const {machineId, machineName, machineLabelIndex, cpu, ucpu} = it;
+      const freqTrackIds = it.freqTrackIds.split(',').map(Number);
+      const idleTrackIds =
+        it.idleTrackIds === null ? [] : it.idleTrackIds.split(',').map(Number);
       const uri = `/cpu_freq_cpu${ucpu}`;
 
       ctx.tracks.registerTrack({
         uri,
         tags: {
           cpu: ucpu,
+          trackIds: freqTrackIds,
         },
         renderer: new CpuFreqTrack(
           {
             // Coloring based Cpu number, same for all machines.
             cpu,
             maximumValue: maxCpuFreq,
-            freqTrackId,
-            idleTrackId: idleTrackId ?? undefined,
+            freqTrackIds,
+            idleTrackIds,
           },
           ctx,
         ),

--- a/ui/src/plugins/dev.perfetto.Gpu/index.ts
+++ b/ui/src/plugins/dev.perfetto.Gpu/index.ts
@@ -31,20 +31,20 @@ class GpuFreqTrack extends TraceProcessorCounterTrack {
   constructor(
     trace: Trace,
     uri: string,
-    freqTrackId: number,
+    freqTrackIds: ReadonlyArray<number>,
     trackName: string,
   ) {
     super({
       trace,
       uri,
       unit: 'Hz',
-      trackId: freqTrackId,
+      trackId: freqTrackIds[0],
       trackName,
       rootTable: 'counter',
       sqlSource: `
       select id, ts, value * 1000 as value, arg_set_id
       from counter
-      where track_id = ${freqTrackId}
+      where track_id in (${freqTrackIds.join(',')})
     `,
     });
   }
@@ -177,9 +177,10 @@ export default class GpuPlugin implements PerfettoPlugin {
   }
 
   private async addGpuFreq(ctx: Trace) {
+    // One track per logical GPU, unioning rows a merged trace may duplicate.
     const result = await ctx.engine.query(`
       select
-        gct.id,
+        group_concat(distinct gct.id) as freqTrackIds,
         gct.gpu_id as gpuId,
         gct.machine_id as machineId,
         m.name as machineName,
@@ -191,15 +192,16 @@ export default class GpuPlugin implements PerfettoPlugin {
       left join gpu g on gct.ugpu = g.id
       left join machine m on m.id = gct.machine_id
       where gct.name = 'gpufreq'
+      group by gct.machine_id, ifnull(gct.ugpu, gct.gpu_id)
       order by machineId, gct.ugpu
     `);
 
     const tracks: Array<{
-      id: number;
+      freqTrackIds: number[];
       gpu: Gpu;
     }> = [];
     const it = result.iter({
-      id: NUM,
+      freqTrackIds: STR,
       gpuId: NUM,
       machineId: NUM,
       machineName: STR_NULL,
@@ -209,7 +211,7 @@ export default class GpuPlugin implements PerfettoPlugin {
     });
     for (; it.valid(); it.next()) {
       tracks.push({
-        id: it.id,
+        freqTrackIds: it.freqTrackIds.split(',').map(Number),
         gpu: new Gpu(
           it.ugpu ?? it.gpuId,
           it.gpuId,
@@ -234,16 +236,16 @@ export default class GpuPlugin implements PerfettoPlugin {
       parent = gpuGroup;
     }
 
-    for (const {id, gpu} of tracks) {
-      const uri = `/gpu_frequency_${gpu.ugpu}`;
+    for (const {freqTrackIds, gpu} of tracks) {
+      const uri = `/gpu_frequency_${gpu.machine}_${gpu.ugpu}`;
       const name = `${gpu.displayName} Frequency${gpu.maybeMachineLabel()}`;
       ctx.tracks.registerTrack({
         uri,
         tags: {
           kinds: [COUNTER_TRACK_KIND],
-          trackIds: [id],
+          trackIds: freqTrackIds,
         },
-        renderer: new GpuFreqTrack(ctx, uri, id, name),
+        renderer: new GpuFreqTrack(ctx, uri, freqTrackIds, name),
       });
       parent.addChildInOrder(
         new TrackNode({


### PR DESCRIPTION
A merged trace can contain several track rows for one logical entity: two traces on the same machine each intern their own cpu_frequency, gpufreq, cpu-per-uid totals and gpu work-period tracks. Keying a track URI off a single row's dimension made registerTrack() throw RegistryError on the duplicate; keying it off the row id avoided the crash but split one CPU/GPU into several tracks.

Follow the Sched plugin: enumerate the logical entity (grouping by machine plus its machine-unique key) and have the single resulting track query across all of that entity's track ids. This removes the collision and unions the rows into one contiguous track, keeping distinct machines separate.

  CpuFreq       group by ucpu; union freq/idle track ids
  Gpu frequency group by (machine, ugpu|gpu_id); union track ids
  GpuWorkPeriod group by (machine, ugpu|gpu_id, uid); union track ids
  CpuPerUid     group by (machine, type, cluster); union track ids

Sched, CpuidleTimeInState, CoarseCpu, LinuxPerf and the Gpu counter/slice tracks already enumerate distinct keys or suffix the track id, so they are unaffected.
