### PR TITLE
tp: add SQLite VFS backed by abstract I/O

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20709,6 +20709,7 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_sqlite_sqlite",
     srcs: [
+        "src/trace_processor/sqlite/file_system_vfs.cc",
         "src/trace_processor/sqlite/module_state_manager.cc",
         "src/trace_processor/sqlite/sql_source.cc",
         "src/trace_processor/sqlite/sqlite_connection.cc",
@@ -20720,6 +20721,7 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_sqlite_unittests",
     srcs: [
+        "src/trace_processor/sqlite/file_system_vfs_unittest.cc",
         "src/trace_processor/sqlite/module_state_manager_unittest.cc",
         "src/trace_processor/sqlite/sql_source_unittest.cc",
         "src/trace_processor/sqlite/sqlite_utils_unittest.cc",

--- a/BUILD
+++ b/BUILD
@@ -5542,6 +5542,8 @@ perfetto_filegroup(
     name = "src_trace_processor_sqlite_sqlite",
     srcs = [
         "src/trace_processor/sqlite/committed_state_manager.h",
+        "src/trace_processor/sqlite/file_system_vfs.cc",
+        "src/trace_processor/sqlite/file_system_vfs.h",
         "src/trace_processor/sqlite/module_state_manager.cc",
         "src/trace_processor/sqlite/module_state_manager.h",
         "src/trace_processor/sqlite/scoped_db.h",

--- a/include/perfetto/ext/base/file_utils.h
+++ b/include/perfetto/ext/base/file_utils.h
@@ -19,6 +19,7 @@
 
 #include <fcntl.h>  // For mode_t & O_RDONLY/RDWR. Exists also on Windows.
 #include <stddef.h>
+#include <stdint.h>
 
 #include <functional>
 #include <memory>
@@ -99,6 +100,16 @@ ScopedFstream OpenFstream(const std::string& path, const std::string& mode);
 int PERFETTO_EXPORT_COMPONENT CloseFile(int fd);
 
 bool FlushFile(int fd);
+
+// Moves the file offset to |offset| bytes from the beginning of the file.
+// Returns false if |offset| cannot be represented by the platform or the seek
+// fails.
+bool SeekFile(int fd, uint64_t offset);
+
+// Changes the size of an open file to |size| bytes.
+// Returns false if |size| cannot be represented by the platform or truncation
+// fails.
+bool TruncateFile(int fd, uint64_t size);
 
 // Returns true if mkdir succeeds, false if it fails (see errno in that case).
 // `mode` is the permission bits for the new directory; it is ignored on

--- a/include/perfetto/trace_processor/io.h
+++ b/include/perfetto/trace_processor/io.h
@@ -18,6 +18,7 @@
 #define INCLUDE_PERFETTO_TRACE_PROCESSOR_IO_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -26,7 +27,8 @@
 
 namespace perfetto::trace_processor::io {
 
-// A synchronous writable file. Each instance is used from a single thread.
+// A synchronous random-access file. Each instance is used from a single thread
+// and implementations do not need to support concurrent calls.
 class PERFETTO_EXPORT_COMPONENT File {
  public:
   File();
@@ -35,10 +37,35 @@ class PERFETTO_EXPORT_COMPONENT File {
   File(const File&) = delete;
   File& operator=(const File&) = delete;
 
-  virtual base::Status Write(const void* data, size_t size) = 0;
+  // Reads up to |size| bytes starting at |offset|. A short read indicates EOF.
+  virtual base::Status ReadAt(uint64_t offset,
+                              void* data,
+                              size_t size,
+                              size_t* bytes_read) = 0;
+
+  // Writes all |size| bytes starting at |offset|.
+  virtual base::Status WriteAt(uint64_t offset,
+                               const void* data,
+                               size_t size) = 0;
+
+  virtual base::Status Truncate(uint64_t size) = 0;
+  virtual base::Status GetSize(uint64_t* size) = 0;
+  virtual base::Status Flush() = 0;
 };
 
-// A synchronous filesystem used by Trace Processor features which write named
+enum class FileAccess {
+  kReadOnly,
+  kWriteOnly,
+  kReadWrite,
+};
+
+struct FileOpenOptions {
+  FileAccess access = FileAccess::kReadOnly;
+  bool create = false;
+  bool truncate = false;
+};
+
+// A synchronous filesystem used by Trace Processor features which need named
 // files. Paths are opaque to Trace Processor and interpreted by the embedder.
 // Implementations must be thread-safe, although each returned File is only
 // used from one thread.
@@ -50,10 +77,14 @@ class PERFETTO_EXPORT_COMPONENT FileSystem {
   FileSystem(const FileSystem&) = delete;
   FileSystem& operator=(const FileSystem&) = delete;
 
-  // Opens |path| for writing, creating it if needed and replacing any existing
-  // contents. On success, stores the opened file in |file|.
+  // Opens |path| with the given |options|. On success, stores the opened
+  // random-access file in |file|.
   virtual base::Status OpenFile(const std::string& path,
+                                const FileOpenOptions& options,
                                 std::unique_ptr<File>* file) = 0;
+
+  virtual base::Status DeleteFile(const std::string& path) = 0;
+  virtual base::Status FileExists(const std::string& path, bool* exists) = 0;
 };
 
 }  // namespace perfetto::trace_processor::io

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -267,24 +267,28 @@ bool FlushFile(int fd) {
 }
 
 bool SeekFile(int fd, uint64_t offset) {
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
   if (offset > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
     errno = EOVERFLOW;
     return false;
   }
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
   return _lseeki64(fd, static_cast<int64_t>(offset), SEEK_SET) != -1;
 #else
+  if (offset > static_cast<uint64_t>(std::numeric_limits<off_t>::max())) {
+    errno = EOVERFLOW;
+    return false;
+  }
   return lseek(fd, static_cast<off_t>(offset), SEEK_SET) !=
          static_cast<off_t>(-1);
 #endif
 }
 
 bool TruncateFile(int fd, uint64_t size) {
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
   if (size > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
     errno = EOVERFLOW;
     return false;
   }
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
   int result = _chsize_s(fd, size);
   if (result != 0) {
     errno = result;
@@ -292,7 +296,11 @@ bool TruncateFile(int fd, uint64_t size) {
   }
   return true;
 #else
-  return ftruncate(fd, static_cast<off_t>(size)) == 0;
+  if (size > static_cast<uint64_t>(std::numeric_limits<off_t>::max())) {
+    errno = EOVERFLOW;
+    return false;
+  }
+  return PERFETTO_EINTR(ftruncate(fd, static_cast<off_t>(size))) == 0;
 #endif
 }
 

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <limits>
 #include <optional>
 #include <string>
 #include <vector>
@@ -262,6 +263,36 @@ bool FlushFile(int fd) {
   return !PERFETTO_EINTR(_commit(fd));
 #else
   return !PERFETTO_EINTR(fsync(fd));
+#endif
+}
+
+bool SeekFile(int fd, uint64_t offset) {
+  if (offset > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+    errno = EOVERFLOW;
+    return false;
+  }
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  return _lseeki64(fd, static_cast<int64_t>(offset), SEEK_SET) != -1;
+#else
+  return lseek(fd, static_cast<off_t>(offset), SEEK_SET) !=
+         static_cast<off_t>(-1);
+#endif
+}
+
+bool TruncateFile(int fd, uint64_t size) {
+  if (size > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+    errno = EOVERFLOW;
+    return false;
+  }
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  int result = _chsize_s(fd, size);
+  if (result != 0) {
+    errno = result;
+    return false;
+  }
+  return true;
+#else
+  return ftruncate(fd, static_cast<off_t>(size)) == 0;
 #endif
 }
 

--- a/src/base/utils_unittest.cc
+++ b/src/base/utils_unittest.cc
@@ -364,6 +364,28 @@ TEST(UtilsTest, CopyFileContents) {
 #endif
 }
 
+TEST(UtilsTest, SeekFile) {
+  TempFile file = TempFile::Create();
+  ASSERT_EQ(WriteAll(*file, "abcdef", 6), 6);
+
+  ASSERT_TRUE(SeekFile(*file, 3));
+  char data[3] = {};
+  ASSERT_EQ(Read(*file, data, sizeof(data)), 3);
+  EXPECT_EQ(std::string(data, sizeof(data)), "def");
+}
+
+TEST(UtilsTest, TruncateFile) {
+  TempFile file = TempFile::Create();
+  ASSERT_EQ(WriteAll(*file, "abcdef", 6), 6);
+
+  ASSERT_TRUE(TruncateFile(*file, 3));
+  EXPECT_EQ(GetFileSize(*file), 3u);
+
+  std::string contents;
+  ASSERT_TRUE(ReadFile(file.path(), &contents));
+  EXPECT_EQ(contents, "abc");
+}
+
 TEST(UtilsTest, GetFileSize) {
   TempFile file = TempFile::Create();
   // Explicitly set the string size, we want to write all data to the file.

--- a/src/base/utils_unittest.cc
+++ b/src/base/utils_unittest.cc
@@ -384,6 +384,22 @@ TEST(UtilsTest, TruncateFile) {
   std::string contents;
   ASSERT_TRUE(ReadFile(file.path(), &contents));
   EXPECT_EQ(contents, "abc");
+
+  ASSERT_TRUE(TruncateFile(*file, 8));
+  EXPECT_EQ(GetFileSize(*file), 8u);
+  contents.clear();
+  ASSERT_TRUE(ReadFile(file.path(), &contents));
+  EXPECT_EQ(contents, std::string("abc\0\0\0\0\0", 8));
+}
+
+TEST(UtilsTest, SeekAndTruncateFileErrors) {
+  EXPECT_FALSE(SeekFile(-1, 0));
+  EXPECT_FALSE(TruncateFile(-1, 0));
+
+  constexpr uint64_t kTooLarge = std::numeric_limits<uint64_t>::max();
+  TempFile file = TempFile::Create();
+  EXPECT_FALSE(SeekFile(*file, kTooLarge));
+  EXPECT_FALSE(TruncateFile(*file, kTooLarge));
 }
 
 TEST(UtilsTest, GetFileSize) {

--- a/src/trace_processor/local_file_system.cc
+++ b/src/trace_processor/local_file_system.cc
@@ -19,6 +19,7 @@
 #include <cerrno>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -31,47 +32,159 @@ namespace {
 
 class LocalFile final : public File {
  public:
-  LocalFile(std::string path, base::ScopedFile file)
-      : path_(std::move(path)), file_(std::move(file)) {}
+  LocalFile(std::string path, base::ScopedFile fd)
+      : path_(std::move(path)), fd_(std::move(fd)) {}
 
-  base::Status Write(const void* data, size_t size) override {
-    ssize_t written = base::WriteAll(file_.get(), data, size);
-    if (written < 0) {
+  base::Status ReadAt(uint64_t offset,
+                      void* data,
+                      size_t size,
+                      size_t* bytes_read) override {
+    if (!base::SeekFile(fd_.get(), offset)) {
+      return base::ErrStatus("Failed to seek file %s: %s", path_.c_str(),
+                             strerror(errno));
+    }
+    size_t total = 0;
+    auto* dst = static_cast<uint8_t*>(data);
+    while (total < size) {
+      ssize_t read = base::Read(fd_.get(), dst + total, size - total);
+      if (read < 0) {
+        return base::ErrStatus("Failed to read file %s: %s", path_.c_str(),
+                               strerror(errno));
+      }
+      if (read == 0) {
+        break;
+      }
+      total += static_cast<size_t>(read);
+    }
+    *bytes_read = total;
+    return base::OkStatus();
+  }
+
+  base::Status WriteAt(uint64_t offset,
+                       const void* data,
+                       size_t size) override {
+    if (!base::SeekFile(fd_.get(), offset)) {
+      return base::ErrStatus("Failed to seek file %s: %s", path_.c_str(),
+                             strerror(errno));
+    }
+    if (base::WriteAll(fd_.get(), data, size) != static_cast<ssize_t>(size)) {
       return base::ErrStatus("Failed to write file %s: %s", path_.c_str(),
                              strerror(errno));
     }
-    if (static_cast<size_t>(written) != size) {
-      return base::ErrStatus("Short write to file %s: wrote %zu of %zu bytes",
-                             path_.c_str(), static_cast<size_t>(written), size);
+    return base::OkStatus();
+  }
+
+  base::Status Truncate(uint64_t size) override {
+    if (!base::TruncateFile(fd_.get(), size)) {
+      return base::ErrStatus("Failed to truncate file %s: %s", path_.c_str(),
+                             strerror(errno));
+    }
+    return base::OkStatus();
+  }
+
+  base::Status GetSize(uint64_t* size) override {
+    std::optional<uint64_t> result = base::GetFileSize(fd_.get());
+    if (!result) {
+      return base::ErrStatus("Failed to get size of file %s: %s", path_.c_str(),
+                             strerror(errno));
+    }
+    *size = *result;
+    return base::OkStatus();
+  }
+
+  base::Status Flush() override {
+    if (!base::FlushFile(fd_.get())) {
+      return base::ErrStatus("Failed to flush file %s: %s", path_.c_str(),
+                             strerror(errno));
     }
     return base::OkStatus();
   }
 
  private:
   std::string path_;
-  base::ScopedFile file_;
+  base::ScopedFile fd_;
+};
+
+class NoopFileSystem final : public FileSystem {
+ public:
+  base::Status OpenFile(const std::string&,
+                        const FileOpenOptions&,
+                        std::unique_ptr<File>*) override {
+    return base::ErrStatus("File I/O is not supported");
+  }
+
+  base::Status DeleteFile(const std::string&) override {
+    return base::ErrStatus("File I/O is not supported");
+  }
+
+  base::Status FileExists(const std::string&, bool*) override {
+    return base::ErrStatus("File I/O is not supported");
+  }
 };
 
 class LocalFileSystem final : public FileSystem {
  public:
   base::Status OpenFile(const std::string& path,
+                        const FileOpenOptions& options,
                         std::unique_ptr<File>* file) override {
-    file->reset();
-    base::ScopedFile scoped_file =
-        base::OpenFile(path, O_CREAT | O_WRONLY | O_TRUNC, 0600);
-    if (!scoped_file) {
+    if ((options.create || options.truncate) &&
+        options.access == FileAccess::kReadOnly) {
+      return base::ErrStatus(
+          "Creating or truncating a file requires write access");
+    }
+
+    int flags = 0;
+    switch (options.access) {
+      case FileAccess::kReadOnly:
+        flags = O_RDONLY;
+        break;
+      case FileAccess::kWriteOnly:
+        flags = O_WRONLY;
+        break;
+      case FileAccess::kReadWrite:
+        flags = O_RDWR;
+        break;
+    }
+    if (options.create) {
+      flags |= O_CREAT;
+    }
+    if (options.truncate) {
+      flags |= O_TRUNC;
+    }
+
+    base::ScopedFile fd = base::OpenFile(path, flags, 0600);
+    if (!fd) {
       return base::ErrStatus("Failed to open file %s: %s", path.c_str(),
                              strerror(errno));
     }
-    file->reset(new LocalFile(path, std::move(scoped_file)));
+    file->reset(new LocalFile(path, std::move(fd)));
+    return base::OkStatus();
+  }
+
+  base::Status DeleteFile(const std::string& path) override {
+    if (!base::Unlink(path.c_str())) {
+      return base::ErrStatus("Failed to delete file %s: %s", path.c_str(),
+                             strerror(errno));
+    }
+    return base::OkStatus();
+  }
+
+  base::Status FileExists(const std::string& path, bool* exists) override {
+    *exists = base::FileExists(path);
     return base::OkStatus();
   }
 };
 
 }  // namespace
 
-std::unique_ptr<FileSystem> CreateLocalFileSystem() {
-  return std::make_unique<LocalFileSystem>();
+FileSystem* CreateLocalFileSystem() {
+  static LocalFileSystem* file_system = new LocalFileSystem();
+  return file_system;
+}
+
+FileSystem* CreateNoopFileSystem() {
+  static NoopFileSystem* file_system = new NoopFileSystem();
+  return file_system;
 }
 
 }  // namespace perfetto::trace_processor::io

--- a/src/trace_processor/local_file_system.h
+++ b/src/trace_processor/local_file_system.h
@@ -23,7 +23,13 @@
 
 namespace perfetto::trace_processor::io {
 
-std::unique_ptr<FileSystem> CreateLocalFileSystem();
+// Returns a process-wide filesystem backed by the native filesystem.
+FileSystem* CreateLocalFileSystem();
+
+// Returns a process-wide filesystem which rejects every operation. Embedders
+// without file I/O use this explicitly rather than accidentally falling
+// through to process filesystem calls.
+FileSystem* CreateNoopFileSystem();
 
 }  // namespace perfetto::trace_processor::io
 

--- a/src/trace_processor/local_file_system_unittest.cc
+++ b/src/trace_processor/local_file_system_unittest.cc
@@ -22,6 +22,7 @@
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/temp_file.h"
 #include "perfetto/trace_processor/basic_types.h"
+#include "src/base/test/status_matchers.h"
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto::trace_processor::io {
@@ -32,11 +33,14 @@ TEST(LocalFileSystemTest, WritesAndReplacesFile) {
   std::string path = dir.path() + "/output";
   auto file_system = CreateLocalFileSystem();
 
+  FileOpenOptions options;
+  options.access = FileAccess::kWriteOnly;
+  options.create = true;
+  options.truncate = true;
   {
     std::unique_ptr<File> file;
-    base::Status status = file_system->OpenFile(path, &file);
-    ASSERT_TRUE(status.ok()) << status.c_message();
-    ASSERT_TRUE(file->Write("abc", 3).ok());
+    ASSERT_OK(file_system->OpenFile(path, options, &file));
+    ASSERT_OK(file->WriteAt(0, "abc", 3));
   }
 
   std::string contents;
@@ -45,15 +49,77 @@ TEST(LocalFileSystemTest, WritesAndReplacesFile) {
 
   {
     std::unique_ptr<File> file;
-    base::Status status = file_system->OpenFile(path, &file);
-    ASSERT_TRUE(status.ok()) << status.c_message();
-    ASSERT_TRUE(file->Write("d", 1).ok());
+    ASSERT_OK(file_system->OpenFile(path, options, &file));
+    ASSERT_OK(file->WriteAt(0, "d", 1));
   }
 
   contents.clear();
   ASSERT_TRUE(base::ReadFile(path, &contents));
   EXPECT_EQ(contents, "d");
-  ASSERT_TRUE(base::Unlink(path.c_str()));
+  ASSERT_OK(file_system->DeleteFile(path));
+}
+
+TEST(LocalFileSystemTest, RandomAccessReadWrite) {
+  base::TempDir dir = base::TempDir::Create();
+  std::string path = dir.path() + "/output";
+  auto file_system = CreateLocalFileSystem();
+
+  FileOpenOptions options;
+  options.access = FileAccess::kReadWrite;
+  options.create = true;
+  options.truncate = true;
+  std::unique_ptr<File> file;
+  ASSERT_OK(file_system->OpenFile(path, options, &file));
+  ASSERT_OK(file->WriteAt(10, "hello", 5));
+  ASSERT_OK(file->WriteAt(0, "start ", 6));
+  ASSERT_OK(file->Flush());
+  uint64_t size = 0;
+  ASSERT_OK(file->GetSize(&size));
+  EXPECT_EQ(size, 15u);
+
+  char buffer[16] = {};
+  size_t read = 0;
+  ASSERT_OK(file->ReadAt(10, buffer, 7, &read));
+  EXPECT_EQ(read, 5u);
+  EXPECT_EQ(std::string(buffer, 5), "hello");
+  // The gap between the two writes is a sparse hole read back as zeros.
+  ASSERT_OK(file->ReadAt(0, buffer, 10, &read));
+  EXPECT_EQ(read, 10u);
+  EXPECT_EQ(std::string(buffer, 6), "start ");
+  EXPECT_EQ(std::string(buffer + 6, 4), std::string(4, '\0'));
+
+  ASSERT_OK(file->Truncate(6));
+  ASSERT_OK(file->GetSize(&size));
+  EXPECT_EQ(size, 6u);
+  ASSERT_OK(file_system->DeleteFile(path));
+}
+
+TEST(LocalFileSystemTest, RejectsReadOnlyCreate) {
+  base::TempDir dir = base::TempDir::Create();
+  std::string path = dir.path() + "/output";
+  auto file_system = CreateLocalFileSystem();
+
+  FileOpenOptions options;
+  options.access = FileAccess::kReadOnly;
+  options.create = true;
+  std::unique_ptr<File> file;
+  EXPECT_THAT(file_system->OpenFile(path, options, &file),
+              base::gtest_matchers::IsError());
+}
+
+TEST(LocalFileSystemTest, NoopFileSystemRejectsAllOperations) {
+  auto file_system = CreateNoopFileSystem();
+
+  FileOpenOptions options;
+  options.access = FileAccess::kReadWrite;
+  options.create = true;
+  std::unique_ptr<File> file;
+  EXPECT_THAT(file_system->OpenFile("path", options, &file),
+              base::gtest_matchers::IsError());
+  EXPECT_THAT(file_system->DeleteFile("path"), base::gtest_matchers::IsError());
+  bool exists = false;
+  EXPECT_THAT(file_system->FileExists("path", &exists),
+              base::gtest_matchers::IsError());
 }
 
 TEST(FileSystemConfigTest, DisabledByDefault) {

--- a/src/trace_processor/plugins/utils_functions/utils_functions.cc
+++ b/src/trace_processor/plugins/utils_functions/utils_functions.cc
@@ -85,8 +85,9 @@ class FileOutputWriter final : public json::OutputWriter {
     if (!status_.ok() || buffer_.empty()) {
       return status_;
     }
-    status_ = file_->Write(buffer_.data(), buffer_.size());
+    status_ = file_->WriteAt(offset_, buffer_.data(), buffer_.size());
     if (status_.ok()) {
+      offset_ += buffer_.size();
       buffer_.clear();
     }
     return status_;
@@ -95,6 +96,7 @@ class FileOutputWriter final : public json::OutputWriter {
   static constexpr size_t kBufferSize = 64 * 1024;
 
   std::unique_ptr<io::File> file_;
+  uint64_t offset_ = 0;
   std::string buffer_;
   base::Status status_ = base::OkStatus();
 };
@@ -130,9 +132,13 @@ void ExportJson::Step(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
   if (!file_system) {
     return sqlite::utils::SetError(ctx, "EXPORT_JSON: File I/O is disabled");
   }
+  io::FileOpenOptions options;
+  options.access = io::FileAccess::kWriteOnly;
+  options.create = true;
+  options.truncate = true;
   std::unique_ptr<io::File> file;
   base::Status open_status =
-      file_system->OpenFile(sqlite::value::Text(argv[0]), &file);
+      file_system->OpenFile(sqlite::value::Text(argv[0]), options, &file);
   if (!open_status.ok()) {
     return sqlite::utils::SetError(
         ctx, base::ErrStatus("EXPORT_JSON: %s", open_status.c_message()));
@@ -296,9 +302,13 @@ void FileWrite::Step(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
         ctx, "__intrinsic_file_write: File I/O is disabled");
   }
 
+  io::FileOpenOptions options;
+  options.access = io::FileAccess::kWriteOnly;
+  options.create = true;
+  options.truncate = true;
   std::unique_ptr<io::File> file;
   base::Status open_status =
-      file_system->OpenFile(sqlite::value::Text(argv[0]), &file);
+      file_system->OpenFile(sqlite::value::Text(argv[0]), options, &file);
   if (!open_status.ok()) {
     return sqlite::utils::SetError(
         ctx,
@@ -311,7 +321,7 @@ void FileWrite::Step(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
   // Make sure to call last as sqlite::value::Bytes can invalidate pointer
   // returned.
   const void* data = sqlite::value::Blob(argv[1]);
-  base::Status status = file->Write(data, len);
+  base::Status status = file->WriteAt(0, data, len);
   if (!status.ok()) {
     return sqlite::utils::SetError(
         ctx, base::ErrStatus("__intrinsic_file_write: %s", status.c_message()));

--- a/src/trace_processor/shell/subcommand_flags_unittest.cc
+++ b/src/trace_processor/shell/subcommand_flags_unittest.cc
@@ -115,8 +115,16 @@ struct OutputPath {
 class TestFileSystem final : public io::FileSystem {
  public:
   base::Status OpenFile(const std::string&,
-                        std::unique_ptr<io::File>* file) override {
-    file->reset();
+                        const io::FileOpenOptions&,
+                        std::unique_ptr<io::File>*) override {
+    return base::ErrStatus("not implemented");
+  }
+
+  base::Status DeleteFile(const std::string&) override {
+    return base::ErrStatus("not implemented");
+  }
+
+  base::Status FileExists(const std::string&, bool*) override {
     return base::ErrStatus("not implemented");
   }
 };

--- a/src/trace_processor/sqlite/BUILD.gn
+++ b/src/trace_processor/sqlite/BUILD.gn
@@ -19,6 +19,8 @@ assert(enable_perfetto_trace_processor_sqlite)
 source_set("sqlite") {
   sources = [
     "committed_state_manager.h",
+    "file_system_vfs.cc",
+    "file_system_vfs.h",
     "module_state_manager.cc",
     "module_state_manager.h",
     "scoped_db.h",
@@ -36,6 +38,7 @@ source_set("sqlite") {
     "../../../gn:sqlite",
     "../../../include/perfetto/trace_processor",
     "../../../include/perfetto/trace_processor:basic_types",
+    "../../../include/perfetto/trace_processor:io",
     "../../../protos/perfetto/trace/ftrace:zero",
     "../../../protos/perfetto/trace_processor:zero",
     "../../base",
@@ -53,16 +56,20 @@ source_set("sqlite") {
 perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
+    "file_system_vfs_unittest.cc",
     "module_state_manager_unittest.cc",
     "sql_source_unittest.cc",
     "sqlite_utils_unittest.cc",
   ]
   deps = [
     ":sqlite",
+    "../:local_file_system",
     "../../../gn:default_deps",
     "../../../gn:gtest_and_gmock",
     "../../../gn:sqlite",
+    "../../../include/perfetto/ext/base",
     "../../../include/perfetto/trace_processor:basic_types",
+    "../../../include/perfetto/trace_processor:io",
     "../../base",
     "../../base:test_support",
     "../containers",

--- a/src/trace_processor/sqlite/file_system_vfs.cc
+++ b/src/trace_processor/sqlite/file_system_vfs.cc
@@ -1,0 +1,380 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/sqlite/file_system_vfs.h"
+
+#include <sqlite3.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <new>
+#include <string>
+#include <utility>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/trace_processor/io.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+std::atomic<uint64_t> g_next_vfs_id{0};
+
+struct OpenFile {
+  sqlite3_file sqlite_file{};
+  std::unique_ptr<io::File> file;
+  io::FileSystem* file_system = nullptr;
+  std::string path;
+  bool delete_on_close = false;
+};
+
+OpenFile* ToOpenFile(sqlite3_file* file) {
+  return reinterpret_cast<OpenFile*>(file);
+}
+
+int Close(sqlite3_file* sqlite_file) {
+  OpenFile* file = ToOpenFile(sqlite_file);
+  file->file.reset();
+  if (file->delete_on_close) {
+    base::ignore_result(file->file_system->DeleteFile(file->path));
+  }
+  file->~OpenFile();
+  return SQLITE_OK;
+}
+
+int Read(sqlite3_file* sqlite_file,
+         void* data,
+         int size,
+         sqlite3_int64 offset) {
+  if (size < 0 || offset < 0) {
+    return SQLITE_IOERR_READ;
+  }
+  OpenFile* file = ToOpenFile(sqlite_file);
+  size_t bytes_read = 0;
+  if (!file->file
+           ->ReadAt(static_cast<uint64_t>(offset), data,
+                    static_cast<size_t>(size), &bytes_read)
+           .ok()) {
+    return SQLITE_IOERR_READ;
+  }
+  if (bytes_read != static_cast<size_t>(size)) {
+    auto* bytes = static_cast<uint8_t*>(data);
+    std::fill(bytes + bytes_read, bytes + size, 0);
+    return SQLITE_IOERR_SHORT_READ;
+  }
+  return SQLITE_OK;
+}
+
+int Write(sqlite3_file* sqlite_file,
+          const void* data,
+          int size,
+          sqlite3_int64 offset) {
+  if (size < 0 || offset < 0) {
+    return SQLITE_IOERR_WRITE;
+  }
+  base::Status status = ToOpenFile(sqlite_file)
+                            ->file->WriteAt(static_cast<uint64_t>(offset), data,
+                                            static_cast<size_t>(size));
+  return status.ok() ? SQLITE_OK : SQLITE_IOERR_WRITE;
+}
+
+int Truncate(sqlite3_file* sqlite_file, sqlite3_int64 size) {
+  if (size < 0) {
+    return SQLITE_IOERR_TRUNCATE;
+  }
+  base::Status status =
+      ToOpenFile(sqlite_file)->file->Truncate(static_cast<uint64_t>(size));
+  return status.ok() ? SQLITE_OK : SQLITE_IOERR_TRUNCATE;
+}
+
+int Sync(sqlite3_file* sqlite_file, int) {
+  return ToOpenFile(sqlite_file)->file->Flush().ok() ? SQLITE_OK
+                                                     : SQLITE_IOERR_FSYNC;
+}
+
+int FileSize(sqlite3_file* sqlite_file, sqlite3_int64* size) {
+  uint64_t result = 0;
+  if (!ToOpenFile(sqlite_file)->file->GetSize(&result).ok() ||
+      result >
+          static_cast<uint64_t>(std::numeric_limits<sqlite3_int64>::max())) {
+    return SQLITE_IOERR_FSTAT;
+  }
+  *size = static_cast<sqlite3_int64>(result);
+  return SQLITE_OK;
+}
+
+int Lock(sqlite3_file*, int) {
+  return SQLITE_OK;
+}
+
+int Unlock(sqlite3_file*, int) {
+  return SQLITE_OK;
+}
+
+int CheckReservedLock(sqlite3_file*, int* result) {
+  *result = 0;
+  return SQLITE_OK;
+}
+
+int FileControl(sqlite3_file*, int, void*) {
+  return SQLITE_NOTFOUND;
+}
+
+int SectorSize(sqlite3_file*) {
+  return 4096;
+}
+
+int DeviceCharacteristics(sqlite3_file*) {
+  return 0;
+}
+
+const sqlite3_io_methods kIoMethods = {
+    1,
+    &Close,
+    &Read,
+    &Write,
+    &Truncate,
+    &Sync,
+    &FileSize,
+    &Lock,
+    &Unlock,
+    &CheckReservedLock,
+    &FileControl,
+    &SectorSize,
+    &DeviceCharacteristics,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+};
+
+}  // namespace
+
+class SqliteFileSystemVfs::Impl {
+ public:
+  // |file_system| is borrowed and must outlive this VFS.
+  explicit Impl(io::FileSystem* file_system)
+      : file_system_(file_system),
+        name_("perfetto_file_system_" +
+              std::to_string(g_next_vfs_id.fetch_add(1))) {
+    parent_ = sqlite3_vfs_find(nullptr);
+    vfs_.iVersion = 1;
+    vfs_.szOsFile = static_cast<int>(sizeof(OpenFile));
+    vfs_.mxPathname = parent_ ? parent_->mxPathname : 1024;
+    vfs_.zName = name_.c_str();
+    vfs_.pAppData = this;
+    vfs_.xOpen = &Open;
+    vfs_.xDelete = &Delete;
+    vfs_.xAccess = &Access;
+    vfs_.xFullPathname = &FullPathname;
+    vfs_.xDlOpen = &DlOpen;
+    vfs_.xDlError = &DlError;
+    vfs_.xDlSym = &DlSym;
+    vfs_.xDlClose = &DlClose;
+    vfs_.xRandomness = &Randomness;
+    vfs_.xSleep = &Sleep;
+    vfs_.xCurrentTime = &CurrentTime;
+    vfs_.xGetLastError = &GetLastError;
+  }
+
+  base::Status Register() {
+    if (sqlite3_vfs_register(&vfs_, 0) != SQLITE_OK) {
+      return base::ErrStatus("Failed to register SQLite file system VFS");
+    }
+    registered_ = true;
+    return base::OkStatus();
+  }
+
+  ~Impl() {
+    if (registered_) {
+      sqlite3_vfs_unregister(&vfs_);
+    }
+  }
+
+  const char* name() const { return name_.c_str(); }
+
+ private:
+  static Impl* From(sqlite3_vfs* vfs) {
+    return static_cast<Impl*>(vfs->pAppData);
+  }
+
+  static int Open(sqlite3_vfs* vfs,
+                  const char* path,
+                  sqlite3_file* sqlite_file,
+                  int flags,
+                  int* out_flags) {
+    Impl* self = From(vfs);
+    std::string actual_path =
+        path ? path
+             : self->name_ + "_temp_" + std::to_string(self->next_temp_id_++);
+
+    if ((flags & SQLITE_OPEN_EXCLUSIVE) && (flags & SQLITE_OPEN_CREATE)) {
+      bool exists = false;
+      if (!self->file_system_->FileExists(actual_path, &exists).ok() ||
+          exists) {
+        return SQLITE_CANTOPEN;
+      }
+    }
+
+    io::FileOpenOptions options;
+    if (flags & SQLITE_OPEN_READONLY) {
+      options.access = io::FileAccess::kReadOnly;
+    } else {
+      options.access = io::FileAccess::kReadWrite;
+    }
+    options.create = (flags & SQLITE_OPEN_CREATE) != 0;
+
+    std::unique_ptr<io::File> opened;
+    if (!self->file_system_->OpenFile(actual_path, options, &opened).ok()) {
+      return SQLITE_CANTOPEN;
+    }
+
+    auto* file = new (sqlite_file) OpenFile();
+    file->file = std::move(opened);
+    file->file_system = self->file_system_;
+    file->path = std::move(actual_path);
+    file->delete_on_close = (flags & SQLITE_OPEN_DELETEONCLOSE) != 0;
+    file->sqlite_file.pMethods = &kIoMethods;
+    if (out_flags) {
+      *out_flags = flags;
+    }
+    return SQLITE_OK;
+  }
+
+  static int Delete(sqlite3_vfs* vfs, const char* path, int) {
+    if (!path) {
+      return SQLITE_IOERR_DELETE;
+    }
+    return From(vfs)->file_system_->DeleteFile(path).ok() ? SQLITE_OK
+                                                          : SQLITE_IOERR_DELETE;
+  }
+
+  static int Access(sqlite3_vfs* vfs, const char* path, int, int* result) {
+    if (!path) {
+      return SQLITE_IOERR_ACCESS;
+    }
+    bool exists = false;
+    if (!From(vfs)->file_system_->FileExists(path, &exists).ok()) {
+      return SQLITE_IOERR_ACCESS;
+    }
+    *result = exists ? 1 : 0;
+    return SQLITE_OK;
+  }
+
+  static int FullPathname(sqlite3_vfs*,
+                          const char* path,
+                          int output_size,
+                          char* output) {
+    if (!path || output_size <= 0 ||
+        strlen(path) >= static_cast<size_t>(output_size)) {
+      return SQLITE_CANTOPEN;
+    }
+    memcpy(output, path, strlen(path) + 1);
+    return SQLITE_OK;
+  }
+
+  static void* DlOpen(sqlite3_vfs* vfs, const char* path) {
+    sqlite3_vfs* parent = From(vfs)->parent_;
+    return parent && parent->xDlOpen ? parent->xDlOpen(parent, path) : nullptr;
+  }
+
+  static void DlError(sqlite3_vfs* vfs, int size, char* error) {
+    sqlite3_vfs* parent = From(vfs)->parent_;
+    if (parent && parent->xDlError) {
+      parent->xDlError(parent, size, error);
+    } else if (size > 0) {
+      error[0] = '\0';
+    }
+  }
+
+  static void (*DlSym(sqlite3_vfs* vfs, void* handle, const char* symbol))() {
+    sqlite3_vfs* parent = From(vfs)->parent_;
+    return parent && parent->xDlSym ? parent->xDlSym(parent, handle, symbol)
+                                    : nullptr;
+  }
+
+  static void DlClose(sqlite3_vfs* vfs, void* handle) {
+    sqlite3_vfs* parent = From(vfs)->parent_;
+    if (parent && parent->xDlClose) {
+      parent->xDlClose(parent, handle);
+    }
+  }
+
+  static int Randomness(sqlite3_vfs* vfs, int size, char* output) {
+    sqlite3_vfs* parent = From(vfs)->parent_;
+    if (parent && parent->xRandomness) {
+      return parent->xRandomness(parent, size, output);
+    }
+    memset(output, 0, static_cast<size_t>(size));
+    return size;
+  }
+
+  static int Sleep(sqlite3_vfs* vfs, int microseconds) {
+    sqlite3_vfs* parent = From(vfs)->parent_;
+    return parent && parent->xSleep ? parent->xSleep(parent, microseconds)
+                                    : microseconds;
+  }
+
+  static int CurrentTime(sqlite3_vfs* vfs, double* time) {
+    sqlite3_vfs* parent = From(vfs)->parent_;
+    return parent && parent->xCurrentTime ? parent->xCurrentTime(parent, time)
+                                          : SQLITE_ERROR;
+  }
+
+  static int GetLastError(sqlite3_vfs* vfs, int size, char* error) {
+    sqlite3_vfs* parent = From(vfs)->parent_;
+    return parent && parent->xGetLastError
+               ? parent->xGetLastError(parent, size, error)
+               : 0;
+  }
+
+  // Borrowed; must outlive the VFS (see io.h platform contract).
+  io::FileSystem* file_system_ = nullptr;
+  std::string name_;
+  sqlite3_vfs* parent_ = nullptr;
+  sqlite3_vfs vfs_{};
+  uint64_t next_temp_id_ = 0;
+  bool registered_ = false;
+};
+
+base::StatusOr<std::unique_ptr<SqliteFileSystemVfs>>
+SqliteFileSystemVfs::Create(io::FileSystem* file_system) {
+  if (!file_system) {
+    return base::ErrStatus("SQLite file system is null");
+  }
+  auto impl = std::make_unique<Impl>(file_system);
+  RETURN_IF_ERROR(impl->Register());
+  return std::unique_ptr<SqliteFileSystemVfs>(
+      new SqliteFileSystemVfs(std::move(impl)));
+}
+
+SqliteFileSystemVfs::SqliteFileSystemVfs(std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl)) {}
+SqliteFileSystemVfs::~SqliteFileSystemVfs() = default;
+
+const char* SqliteFileSystemVfs::name() const {
+  return impl_->name();
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/sqlite/file_system_vfs.h
+++ b/src/trace_processor/sqlite/file_system_vfs.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SQLITE_FILE_SYSTEM_VFS_H_
+#define SRC_TRACE_PROCESSOR_SQLITE_FILE_SYSTEM_VFS_H_
+
+#include <memory>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_or.h"
+
+namespace perfetto::trace_processor {
+
+namespace io {
+class FileSystem;
+}  // namespace io
+
+// A scoped SQLite VFS backed by a Trace Processor FileSystem. Each instance has
+// a unique SQLite VFS name and must outlive every SQLite database opened on it.
+class SqliteFileSystemVfs {
+ public:
+  static base::StatusOr<std::unique_ptr<SqliteFileSystemVfs>> Create(
+      io::FileSystem*);
+
+  ~SqliteFileSystemVfs();
+
+  SqliteFileSystemVfs(const SqliteFileSystemVfs&) = delete;
+  SqliteFileSystemVfs& operator=(const SqliteFileSystemVfs&) = delete;
+
+  const char* name() const;
+
+ private:
+  class Impl;
+
+  explicit SqliteFileSystemVfs(std::unique_ptr<Impl>);
+
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_SQLITE_FILE_SYSTEM_VFS_H_

--- a/src/trace_processor/sqlite/file_system_vfs_unittest.cc
+++ b/src/trace_processor/sqlite/file_system_vfs_unittest.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/sqlite/file_system_vfs.h"
+
+#include <sqlite3.h>
+
+#include <memory>
+#include <string>
+
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/temp_file.h"
+#include "perfetto/trace_processor/io.h"
+#include "src/base/test/status_matchers.h"
+#include "src/trace_processor/local_file_system.h"
+#include "src/trace_processor/sqlite/scoped_db.h"
+#include "src/trace_processor/sqlite/sqlite_connection.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+TEST(SqliteFileSystemVfsTest, CreatesReadableDatabase) {
+  // Ensure SQLite is initialized before registering another VFS.
+  auto initialization_connection =
+      SqliteConnection::CreateConnectionToNewDatabase();
+  ASSERT_NE(initialization_connection, nullptr);
+
+  base::TempDir dir = base::TempDir::Create();
+  std::string path = dir.path() + "/database.sqlite";
+  auto file_system = io::CreateLocalFileSystem();
+  ASSERT_OK_AND_ASSIGN(auto vfs, SqliteFileSystemVfs::Create(file_system));
+
+  sqlite3* raw_db = nullptr;
+  ASSERT_EQ(
+      sqlite3_open_v2(path.c_str(), &raw_db,
+                      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, vfs->name()),
+      SQLITE_OK);
+  ScopedDb db(raw_db);
+  ASSERT_EQ(sqlite3_exec(db.get(),
+                         "CREATE TABLE data(value INTEGER);"
+                         "INSERT INTO data VALUES(42);",
+                         nullptr, nullptr, nullptr),
+            SQLITE_OK);
+  db.reset();
+  vfs.reset();
+
+  std::string contents;
+  ASSERT_TRUE(base::ReadFile(path, &contents));
+  ASSERT_GE(contents.size(), 16u);
+  EXPECT_EQ(contents.substr(0, 16), std::string("SQLite format 3\0", 16));
+
+  raw_db = nullptr;
+  ASSERT_EQ(
+      sqlite3_open_v2(path.c_str(), &raw_db, SQLITE_OPEN_READONLY, nullptr),
+      SQLITE_OK);
+  db.reset(raw_db);
+  sqlite3_stmt* raw_stmt = nullptr;
+  ASSERT_EQ(sqlite3_prepare_v2(db.get(), "SELECT value FROM data", -1,
+                               &raw_stmt, nullptr),
+            SQLITE_OK);
+  ScopedStmt stmt(raw_stmt);
+  ASSERT_EQ(sqlite3_step(stmt.get()), SQLITE_ROW);
+  EXPECT_EQ(sqlite3_column_int64(stmt.get(), 0), 42);
+  stmt.reset();
+  db.reset();
+
+  ASSERT_OK(file_system->DeleteFile(path));
+}
+
+TEST(SqliteFileSystemVfsTest, NoopFileSystemCannotOpenDatabase) {
+  auto initialization_connection =
+      SqliteConnection::CreateConnectionToNewDatabase();
+  ASSERT_NE(initialization_connection, nullptr);
+  auto noop_file_system = io::CreateNoopFileSystem();
+  ASSERT_OK_AND_ASSIGN(auto vfs, SqliteFileSystemVfs::Create(noop_file_system));
+  sqlite3* raw_db = nullptr;
+  EXPECT_NE(
+      sqlite3_open_v2("database", &raw_db,
+                      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, vfs->name()),
+      SQLITE_OK);
+  if (raw_db) {
+    sqlite3_close(raw_db);
+  }
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/trace_database_integrationtest.cc
+++ b/src/trace_processor/trace_database_integrationtest.cc
@@ -65,17 +65,42 @@ constexpr size_t kMaxChunkSize = 4ul * 1024 * 1024;
 
 class FailingFile final : public io::File {
  public:
-  base::Status Write(const void*, size_t) override {
+  base::Status ReadAt(uint64_t, void*, size_t, size_t*) override {
+    return base::ErrStatus("injected read failure");
+  }
+
+  base::Status WriteAt(uint64_t, const void*, size_t) override {
     return base::ErrStatus("injected write failure");
+  }
+
+  base::Status Truncate(uint64_t) override {
+    return base::ErrStatus("injected truncate failure");
+  }
+
+  base::Status GetSize(uint64_t*) override {
+    return base::ErrStatus("injected size failure");
+  }
+
+  base::Status Flush() override {
+    return base::ErrStatus("injected flush failure");
   }
 };
 
 class FailingWriteFileSystem final : public io::FileSystem {
  public:
   base::Status OpenFile(const std::string&,
+                        const io::FileOpenOptions&,
                         std::unique_ptr<io::File>* file) override {
     file->reset(new FailingFile());
     return base::OkStatus();
+  }
+
+  base::Status DeleteFile(const std::string&) override {
+    return base::ErrStatus("injected delete failure");
+  }
+
+  base::Status FileExists(const std::string&, bool*) override {
+    return base::ErrStatus("injected exists failure");
   }
 };
 
@@ -83,10 +108,24 @@ class CountingFile final : public io::File {
  public:
   explicit CountingFile(size_t* write_count) : write_count_(write_count) {}
 
-  base::Status Write(const void*, size_t) override {
+  base::Status ReadAt(uint64_t, void*, size_t, size_t*) override {
+    return base::ErrStatus("not supported");
+  }
+
+  base::Status WriteAt(uint64_t, const void*, size_t) override {
     ++*write_count_;
     return base::OkStatus();
   }
+
+  base::Status Truncate(uint64_t) override {
+    return base::ErrStatus("not supported");
+  }
+
+  base::Status GetSize(uint64_t*) override {
+    return base::ErrStatus("not supported");
+  }
+
+  base::Status Flush() override { return base::ErrStatus("not supported"); }
 
  private:
   size_t* write_count_;
@@ -95,9 +134,18 @@ class CountingFile final : public io::File {
 class CountingFileSystem final : public io::FileSystem {
  public:
   base::Status OpenFile(const std::string&,
+                        const io::FileOpenOptions&,
                         std::unique_ptr<io::File>* file) override {
     file->reset(new CountingFile(&write_count_));
     return base::OkStatus();
+  }
+
+  base::Status DeleteFile(const std::string&) override {
+    return base::ErrStatus("not supported");
+  }
+
+  base::Status FileExists(const std::string&, bool*) override {
+    return base::ErrStatus("not supported");
   }
 
   size_t write_count() const { return write_count_; }
@@ -194,7 +242,7 @@ TEST(TraceProcessorCustomConfigTest, ExportJsonRequiresPlatformFileSystem) {
 
 TEST(TraceProcessorCustomConfigTest, ExportJsonRejectsIntegerFileDescriptor) {
   auto file_system = io::CreateLocalFileSystem();
-  FileSystemPlatform platform(file_system.get());
+  FileSystemPlatform platform(file_system);
   Config config;
   config.enable_sql_file_access = true;
   auto processor = TraceProcessor::CreateInstance(config, &platform);
@@ -212,7 +260,7 @@ TEST(TraceProcessorCustomConfigTest, ExportJsonUsesConfiguredFileSystem) {
   ASSERT_EQ(path.find('\''), std::string::npos);
 
   auto file_system = io::CreateLocalFileSystem();
-  FileSystemPlatform platform(file_system.get());
+  FileSystemPlatform platform(file_system);
   Config config;
   config.enable_sql_file_access = true;
   auto processor = TraceProcessor::CreateInstance(config, &platform);
@@ -231,7 +279,7 @@ TEST(TraceProcessorCustomConfigTest,
      RpcImplicitResetPreservesSqlFileAccessGrant) {
   base::TempDir dir = base::TempDir::Create();
   auto file_system = io::CreateLocalFileSystem();
-  FileSystemPlatform platform(file_system.get());
+  FileSystemPlatform platform(file_system);
   Config config;
   config.enable_sql_file_access = true;
   auto processor = TraceProcessor::CreateInstance(config, &platform);
@@ -300,7 +348,7 @@ TEST(TraceProcessorCustomConfigTest,
   ASSERT_EQ(path.find('\''), std::string::npos);
 
   auto file_system = io::CreateLocalFileSystem();
-  FileSystemPlatform platform(file_system.get());
+  FileSystemPlatform platform(file_system);
   Config config;
   config.enable_sql_file_access = true;
   auto processor = TraceProcessor::CreateInstance(config, &platform);

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -759,7 +759,7 @@ class DefaultPlatformInterface : public TraceProcessorShell::PlatformInterface {
     if (!file_system_) {
       file_system_ = io::CreateLocalFileSystem();
     }
-    return file_system_.get();
+    return file_system_;
   }
 
   base::Status OnTraceProcessorCreated(TraceProcessor*) override {
@@ -783,7 +783,7 @@ class DefaultPlatformInterface : public TraceProcessorShell::PlatformInterface {
   }
 
  private:
-  std::unique_ptr<io::FileSystem> file_system_;
+  io::FileSystem* file_system_ = nullptr;
 };
 
 DefaultPlatformInterface::~DefaultPlatformInterface() = default;


### PR DESCRIPTION
Add a random-access FileSystem interface and a SQLite VFS backed by it.

Use process-wide local and no-op filesystem implementations, with reusable seek and truncate utilities.