### PR TITLE
tp: stdlib: Ensure irq_slices are non-negative

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/pixel/touch.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/pixel/touch.sql
@@ -85,7 +85,11 @@ WITH
       track_id = (SELECT id FROM track WHERE name = 'gti_th_irq_index' LIMIT 1)
   ),
   irq_slices AS (
-    SELECT id, ts, dur, track_id FROM slice WHERE name GLOB 'IRQ (*)'
+    SELECT id, ts, dur, track_id
+    FROM slice
+    WHERE
+      name GLOB 'IRQ (*)'
+      AND dur > 0
   )
 SELECT
   s.id AS th_slice_id,


### PR DESCRIPTION
This ensures interval intersect does not error on unfinished slices.

Bug: 454761692