### PR TITLE
ui: Fix table name in PinAndroidPerfMetrics cujScopedTrackConfig

### DIFF
--- a/ui/src/plugins/com.android.PinAndroidPerfMetrics/handlers/pinCujScoped.ts
+++ b/ui/src/plugins/com.android.PinAndroidPerfMetrics/handlers/pinCujScoped.ts
@@ -98,7 +98,7 @@ class PinCujScopedJank implements MetricHandler {
         f.ts AS ts,
         f.dur as dur,
         f.jank_score as jank_score
-      FROM android_jank_cuj_frame f LEFT JOIN android_jank_cuj cuj USING (cuj_id)
+      FROM _android_jank_cuj_frame f LEFT JOIN android_jank_cuj cuj USING (cuj_id)
       WHERE cuj.process_name = "${processName}"
       AND cuj_name = "${cuj}" ${jankTypeFilter}
     `;


### PR DESCRIPTION
Update the query in pinCujScoped.ts to use _android_jank_cuj_frame instead of android_jank_cuj_frame, which was causing queries to fail with "no such table: android_jank_cuj_frame".
