### PR TITLE
profiling:x86_64: use stack pointer instead of frame address for heapprofd

### DIFF
--- a/src/profiling/memory/client.cc
+++ b/src/profiling/memory/client.cc
@@ -345,9 +345,6 @@ bool Client::IsPostFork() {
   return false;
 }
 
-#if (PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) ||   \
-     PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_X86_64)) && \
-    !PERFETTO_HAS_BUILTIN_STACK_ADDRESS()
 ssize_t Client::GetStackRegister(unwindstack::ArchEnum arch) {
   ssize_t reg_sp, reg_size;
   switch (arch) {
@@ -383,8 +380,6 @@ uintptr_t Client::GetStackAddress(char* reg_data, unwindstack::ArchEnum arch) {
     return reinterpret_cast<uintptr_t>(nullptr);
   return *reinterpret_cast<uintptr_t*>(&reg_data[reg]);
 }
-#endif /* (PERFETTO_ARCH_CPU_RISCV || PERFETTO_ARCH_CPU_X86_64) && \
-          !PERFETTO_HAS_BUILTIN_STACK_ADDRESS() */
 
 // The stack grows towards numerically smaller addresses, so the stack layout
 // of main calling malloc is as follows.
@@ -407,38 +402,26 @@ bool Client::RecordMalloc(uint32_t heap_id,
   }
 
   AllocMetadata metadata;
-  // By the difference between calling conventions, the frame pointer might
-  // include the current frame or not. So, using __builtin_frame_address()
-  // on specific architectures such as riscv and x86_64 can make stack unwinding
-  // fail. Thus, using __builtin_stack_address() or reading the stack pointer in
-  // register data directly instead of using __builtin_frame_address() on riscv
-  // and x86_64.
-#if PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) || \
-    PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_X86_64)
-#if PERFETTO_HAS_BUILTIN_STACK_ADDRESS()
-  const char* stackptr = reinterpret_cast<char*>(__builtin_stack_address());
   unwindstack::AsmGetRegs(metadata.register_data);
+
+#if PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_ARM64)
+  // On ARM64, the prologue allocates the callee-saved register block first and
+  // sets x29 (FP) to the base of that block. Starting the stack copy at FP
+  // captures all saved registers while omitting ~450 bytes of RecordMalloc's
+  // own local stack frame to save ring buffer space.
+  const char* stackptr = reinterpret_cast<char*>(__builtin_frame_address(0));
 #else
-  char* register_data = metadata.register_data;
-  unwindstack::AsmGetRegs(register_data);
-  const char* stackptr = reinterpret_cast<char*>(
-      GetStackAddress(register_data, unwindstack::Regs::CurrentArch()));
+  // On other architectures (such as x86_64 and RISC-V), callee-saved registers
+  // are pushed below the frame pointer (or calling conventions differ). We must
+  // copy from the sampled stack pointer (SP) to include all saved registers.
+  const char* stackptr = reinterpret_cast<char*>(GetStackAddress(
+      metadata.register_data, unwindstack::Regs::CurrentArch()));
   if (!stackptr) {
     PERFETTO_ELOG("Failed to get stack address.");
     shmem_.SetErrorState(SharedRingBuffer::kInvalidStackBounds);
     return false;
   }
-#endif /* PERFETTO_HAS_BUILTIN_STACK_ADDRESS() */
-#else
-  // On ARM/ARM64, active registers (such as the return address in LR) are
-  // captured directly in the register snapshot (metadata.register_data).
-  // Any stack-saved registers and caller frames reside at or above the Frame
-  // Pointer (FP), so capturing stack memory from __builtin_frame_address(0)
-  // upwards is sufficient.
-  const char* stackptr = reinterpret_cast<char*>(__builtin_frame_address(0));
-  unwindstack::AsmGetRegs(metadata.register_data);
-#endif /* PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) || \
-          PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_X86_64) */
+#endif
   const char* stackend = GetStackEnd(stackptr);
   if (!stackend) {
     PERFETTO_ELOG("Failed to find stackend.");

--- a/src/profiling/memory/client.cc
+++ b/src/profiling/memory/client.cc
@@ -401,7 +401,7 @@ bool Client::RecordMalloc(uint32_t heap_id,
     return postfork_return_value_;
   }
 
-  AllocMetadata metadata;
+  AllocMetadata metadata = {};
   unwindstack::AsmGetRegs(metadata.register_data);
 
 #if PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_ARM64)

--- a/src/profiling/memory/client.cc
+++ b/src/profiling/memory/client.cc
@@ -345,7 +345,8 @@ bool Client::IsPostFork() {
   return false;
 }
 
-#if PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) && \
+#if (PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) ||   \
+     PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_X86_64)) && \
     !PERFETTO_HAS_BUILTIN_STACK_ADDRESS()
 ssize_t Client::GetStackRegister(unwindstack::ArchEnum arch) {
   ssize_t reg_sp, reg_size;
@@ -382,7 +383,8 @@ uintptr_t Client::GetStackAddress(char* reg_data, unwindstack::ArchEnum arch) {
     return reinterpret_cast<uintptr_t>(nullptr);
   return *reinterpret_cast<uintptr_t*>(&reg_data[reg]);
 }
-#endif /* PERFETTO_ARCH_CPU_RISCV && !PERFETTO_HAS_BUILTIN_STACK_ADDRESS() */
+#endif /* (PERFETTO_ARCH_CPU_RISCV || PERFETTO_ARCH_CPU_X86_64) && \
+          !PERFETTO_HAS_BUILTIN_STACK_ADDRESS() */
 
 // The stack grows towards numerically smaller addresses, so the stack layout
 // of main calling malloc is as follows.
@@ -407,10 +409,12 @@ bool Client::RecordMalloc(uint32_t heap_id,
   AllocMetadata metadata;
   // By the difference between calling conventions, the frame pointer might
   // include the current frame or not. So, using __builtin_frame_address()
-  // on specific architectures such as riscv can make stack unwinding failed.
-  // Thus, using __builtin_stack_address() or reading the stack pointer in
-  // register data directly instead of using __builtin_frame_address() on riscv.
-#if PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV)
+  // on specific architectures such as riscv and x86_64 can make stack unwinding
+  // fail. Thus, using __builtin_stack_address() or reading the stack pointer in
+  // register data directly instead of using __builtin_frame_address() on riscv
+  // and x86_64.
+#if PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) || \
+    PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_X86_64)
 #if PERFETTO_HAS_BUILTIN_STACK_ADDRESS()
   const char* stackptr = reinterpret_cast<char*>(__builtin_stack_address());
   unwindstack::AsmGetRegs(metadata.register_data);
@@ -426,9 +430,15 @@ bool Client::RecordMalloc(uint32_t heap_id,
   }
 #endif /* PERFETTO_HAS_BUILTIN_STACK_ADDRESS() */
 #else
+  // On ARM/ARM64, active registers (such as the return address in LR) are
+  // captured directly in the register snapshot (metadata.register_data).
+  // Any stack-saved registers and caller frames reside at or above the Frame
+  // Pointer (FP), so capturing stack memory from __builtin_frame_address(0)
+  // upwards is sufficient.
   const char* stackptr = reinterpret_cast<char*>(__builtin_frame_address(0));
   unwindstack::AsmGetRegs(metadata.register_data);
-#endif /* PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) */
+#endif /* PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) || \
+          PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_X86_64) */
   const char* stackend = GetStackEnd(stackptr);
   if (!stackend) {
     PERFETTO_ELOG("Failed to find stackend.");

--- a/src/profiling/memory/client.h
+++ b/src/profiling/memory/client.h
@@ -118,12 +118,13 @@ class Client {
   bool IsConnected();
 
  private:
-#if PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) && \
+#if (PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) ||   \
+     PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_X86_64)) && \
     !PERFETTO_HAS_BUILTIN_STACK_ADDRESS()
-  // For specific architectures, such as riscv, different calling conventions
-  // make a difference in the meaning of the frame pointer. (see comments in
-  // client.cc) So, we want to use other method to get the stack address for
-  // specific architectures such as riscv.
+  // For specific architectures, such as riscv and x86_64, different calling
+  // conventions make a difference in the meaning of the frame pointer. (see
+  // comments in client.cc) So, we want to use other method to get the stack
+  // address for specific architectures such as riscv and x86_64.
   ssize_t GetStackRegister(unwindstack::ArchEnum arch);
   uintptr_t GetStackAddress(char* reg_data, unwindstack::ArchEnum arch);
 #endif

--- a/src/profiling/memory/client.h
+++ b/src/profiling/memory/client.h
@@ -118,16 +118,8 @@ class Client {
   bool IsConnected();
 
  private:
-#if (PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_RISCV) ||   \
-     PERFETTO_BUILDFLAG(PERFETTO_ARCH_CPU_X86_64)) && \
-    !PERFETTO_HAS_BUILTIN_STACK_ADDRESS()
-  // For specific architectures, such as riscv and x86_64, different calling
-  // conventions make a difference in the meaning of the frame pointer. (see
-  // comments in client.cc) So, we want to use other method to get the stack
-  // address for specific architectures such as riscv and x86_64.
   ssize_t GetStackRegister(unwindstack::ArchEnum arch);
   uintptr_t GetStackAddress(char* reg_data, unwindstack::ArchEnum arch);
-#endif
   const char* GetStackEnd(const char* stacktop);
   bool SendControlSocketByte() PERFETTO_WARN_UNUSED_RESULT;
   int64_t SendWireMessageWithRetriesIfBlocking(const WireMessage&)


### PR DESCRIPTION
On x86_64, the hardware call instruction pushes the return address directly to the stack at %rsp. When heapprofd intercepts allocations in Client::RecordMalloc, sampling the stack starting from __builtin_frame_address(0) can miss the bottom of the active frame [RSP, __builtin_frame_address(0)) (e.g. when the interceptor library is built with release optimizations where __builtin_frame_address(0) returns the caller's CFA).

During asynchronous unwinding, if the target thread or process exits shortly after an allocation (or under PERFETTO_HEAPPROFD_BLOCKING_INIT=1), heapprofd cannot fall back to reading /proc/<pid>/mem, leading to ERROR MEMORY_INVALID.

This change extends the stack pointer capture mechanism already used for RISC-V to x86_64 as well. It samples stack memory starting from the hardware stack pointer (RSP), ensuring 100% of the active frame is present in the shared memory snapshot buffer regardless of optimization or frame pointer flags.

Fixes: #4801
