### PR TITLE
tp: Report buffer overwrites in long traces as a data loss

### DIFF
--- a/docs/concepts/buffers.md
+++ b/docs/concepts/buffers.md
@@ -261,6 +261,22 @@ traced_buf_chunks_di                    0 info                 trace       0
 traced_buf_chunks_ov                    0 data_loss            trace       0
 ```
 
+When using [streaming mode] an overwrite is also a data loss: the overwritten
+data is never written into the file, so the trace has a gap. This data is
+available in the `stats` table, one entry per affected central buffer, where
+`idx` is the buffer and `value` is the number of bytes it overwrote:
+
+```sql
+> select * from stats where name = 'long_trace_mode_bytes_overwritten'
+name                 idx                  severity             source  value
+-------------------- -------------------- -------------------- ------- -----
+long_trace_mode_byte                    0 data_loss            trace    2048
+```
+
+Traces with a `file_write_period_ms` of a day or more do not get this stat: a
+write that far out never really happens, so the buffer is a plain ring buffer
+again. Traceur does this because detached mode forces `write_into_file` on it.
+
 Summary: the best way to detect and debug data losses is to use Trace Processor
 and issue the query:
 `select * from stats where severity = 'data_loss' and value != 0`

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -1287,7 +1287,30 @@ void ProtoTraceReader::OnEventsFullyExtracted() {
   using Config = protos::pbzero::TraceConfig;
   Config::Decoder trace_config(trace_config_raw_.data(),
                                trace_config_raw_.size());
-  if (!trace_config.write_into_file() || trace_config.flush_period_ms()) {
+  if (!trace_config.write_into_file()) {
+    return;
+  }
+
+  // Overwritten data never reached the file, so it counts as a data loss.
+  // A period of a day or more means "still a ring-buffer trace", the same
+  // cutoff as is_long_trace in tracing_service_impl.cc. In practice that is
+  // Traceur, which only uses write_into_file for detached mode.
+  constexpr uint32_t kMinRingBufferIntentPeriodMs = 24 * 60 * 60 * 1000;
+  if (trace_config.file_write_period_ms() < kMinRingBufferIntentPeriodMs) {
+    int buffer_index = 0;
+    for (auto it = trace_config.buffers(); it; ++it, ++buffer_index) {
+      std::optional<int64_t> bytes_overwritten =
+          context_->stats_tracker->GetIndexedStats(
+              stats::traced_buf_bytes_overwritten, buffer_index);
+      if (bytes_overwritten.value_or(0) > 0) {
+        context_->stats_tracker->SetIndexedStats(
+            stats::long_trace_mode_bytes_overwritten, buffer_index,
+            *bytes_overwritten);
+      }
+    }
+  }
+
+  if (trace_config.flush_period_ms()) {
     return;
   }
 

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -678,6 +678,12 @@ namespace perfetto::trace_processor::stats {
       "uses a `DISCARD` buffer. This configuration is strongly discouraged "   \
       "and can cause mysterious data loss in the trace. Please use "           \
       "`RING_BUFFER` buffers instead."),                                       \
+  F(long_trace_mode_bytes_overwritten,    kIndexed, kDataLoss, kTrace, Scope::kMachineAndTrace,         \
+      "Number of bytes this buffer overwrote while the trace was collected "   \
+      "in streaming mode (`write_into_file` with a periodic "                  \
+      "`file_write_period_ms`). The overwritten bytes were never written "     \
+      "out, so they are missing from the trace file. Consider a larger "       \
+      "buffer or a shorter `file_write_period_ms`."),                          \
    F(hprof_string_counter,                 kSingle,  kInfo,   kAnalysis, Scope::kMachineAndTrace,       \
          "Number of strings encountered."),                                    \
    F(hprof_class_counter,                  kSingle,  kInfo,   kAnalysis, Scope::kMachineAndTrace,       \

--- a/test/trace_processor/diff_tests/parser/parsing/tests_traced_stats.py
+++ b/test/trace_processor/diff_tests/parser/parsing/tests_traced_stats.py
@@ -263,3 +263,67 @@ class ParsingTracedStats(TestSuite):
         "traced_buf_data_loss_smb_full",0,1
         "traced_buf_data_loss_writer_abort",0,1
         """))
+
+  # Check that overwrites in a `write_into_file` trace map to
+  # `long_trace_mode_bytes_overwritten`, one row per affected buffer with the
+  # bytes it overwrote. Buffer 1 overwrote nothing, so it gets no row.
+  def test_long_trace_mode_bytes_overwritten(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          trace_config {
+            write_into_file: true
+            file_write_period_ms: 5000
+            buffers { size_kb: 1024 }
+            buffers { size_kb: 1024 fill_policy: RING_BUFFER }
+          }
+        }
+        packet {
+          trusted_uid: 9999
+          trusted_packet_sequence_id: 1
+          trace_stats {
+            buffer_stats { bytes_written: 4096 bytes_overwritten: 2048 }
+            buffer_stats { bytes_written: 4096 bytes_overwritten: 0 }
+          }
+        }
+        """),
+        query="""
+          SELECT idx, value
+          FROM stats
+          WHERE name = 'long_trace_mode_bytes_overwritten'
+          ORDER BY idx;
+        """,
+        out=Csv("""
+        "idx","value"
+        0,2048
+        """))
+
+  # Check that a 7 day `file_write_period_ms` produces no stat: the client is
+  # asking for ring-buffer behavior (see RecordLongTraceModeOverwrites).
+  def test_long_trace_mode_bytes_overwritten_ring_buffer_intent(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          trace_config {
+            write_into_file: true
+            file_write_period_ms: 604800000
+            buffers { size_kb: 1024 }
+          }
+        }
+        packet {
+          trusted_uid: 9999
+          trusted_packet_sequence_id: 1
+          trace_stats {
+            buffer_stats { bytes_written: 4096 bytes_overwritten: 2048 }
+          }
+        }
+        """),
+        query="""
+          SELECT count(*) AS stat_rows
+          FROM stats
+          WHERE name = 'long_trace_mode_bytes_overwritten';
+        """,
+        out=Csv("""
+        "stat_rows"
+        0
+        """))


### PR DESCRIPTION
With write_into_file the central buffer is only a staging area for the next periodic write, so anything overwritten before then never reaches the file and leaves a hole in it. That is a real data loss, unlike in a plain ring-buffer trace where overwriting is how things work.

- Adds the long_trace_mode_bytes_overwritten stat (severity data_loss, indexed by buffer), whose value is the number of bytes that buffer overwrote in that mode. idx identifies the buffer and value carries the magnitude, so both are visible wherever data_loss stats are shown without joining against anything else.
- Only traces with a file_write_period_ms shorter than a day count. Traceur asks for write_into_file with a 7 day period to mean "still a ring-buffer trace", and is left out by that threshold.

Bug: 489774614
