### PR TITLE
tp: add missing stdint.h include in symbolizer elf.h

### DIFF
--- a/src/trace_processor/util/symbolizer/elf.h
+++ b/src/trace_processor/util/symbolizer/elf.h
@@ -18,6 +18,7 @@
 #define SRC_TRACE_PROCESSOR_UTIL_SYMBOLIZER_ELF_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
 // We cannot just include elf.h, as that only exists on Linux, and we want to
 // allow symbolization on other platforms as well. As we only need a small


### PR DESCRIPTION
- g3 import fails: uint32_t & friends are unknown types

