### PR TITLE
ui: fix ts/dur deep-link selection for GPU slices

### DIFF
--- a/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
@@ -418,6 +418,10 @@ export default class implements PerfettoPlugin {
           trace: ctx,
           uri,
           dataset: t.dataset,
+          // Root table for SQL-event resolution: without it these tracks
+          // are invisible to selectSqlEvent(), so ts/dur deep links into
+          // GPU streams zoom but never select the slice.
+          rootTableName: 'slice',
           detailsPanel: () => new ThreadSliceDetailsPanel(ctx),
         }),
       });

--- a/ui/src/trace_processor/dataset.ts
+++ b/ui/src/trace_processor/dataset.ts
@@ -491,7 +491,14 @@ function getJoinSignature(dataset: SourceDataset): string {
   if (!dataset.joins) {
     return '';
   }
-  return Object.keys(dataset.joins).sort().join(',');
+  // The signature must identify the join definition, not just its alias:
+  // two datasets whose 'depth' joins point at different tables must not be
+  // merged, or the merged query joins every row through one table and
+  // silently drops the rows only present in the others.
+  return Object.entries(dataset.joins)
+    .map(([id, join]) => `${id}:${join.from}:${join.unique ?? false}`)
+    .sort()
+    .join(',');
 }
 
 function mergeFilters(filters: InFilter[]): InFilter | undefined {

--- a/ui/src/trace_processor/dataset_unittest.ts
+++ b/ui/src/trace_processor/dataset_unittest.ts
@@ -396,6 +396,39 @@ FROM (slice)
 WHERE id IN (123, 456)`);
 });
 
+test('union dataset does not merge datasets whose joins differ', () => {
+  // Mirrors the multi-track slice tracks created for grouped/split tracks:
+  // each track's dataset joins its own layout-depth table under the same
+  // 'depth' alias. Merging them would join every row through one table and
+  // silently drop the rows only present in the others.
+  const makeDepthDataset = (table: string, trackIds: number[]) =>
+    new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM, depth: NUM},
+      select: {
+        id: 'id',
+        depth: {join: 'depth', expr: 'depth.depth'},
+      },
+      joins: {
+        depth: {from: `${table} USING (id)`, unique: true},
+      },
+      filter: {
+        col: 'track_id',
+        in: trackIds,
+      },
+    });
+
+  const dataset = UnionDataset.create([
+    makeDepthDataset('__depth_1', [1, 2]),
+    makeDepthDataset('__depth_2', [3, 4]),
+  ]);
+
+  const query = dataset.query();
+  expect(query).toContain('__depth_1');
+  expect(query).toContain('__depth_2');
+  expect(query).toContain('UNION ALL');
+});
+
 test('union dataset batches large numbers of unions', () => {
   const datasets = [];
   for (let i = 0; i < 800; i++) {


### PR DESCRIPTION
Deep links carrying `ts`/`dur` query params (`dev.perfetto.DeeplinkQuerystring`) zoom to the right viewport but silently fail to select the target slice on GPU traces. Two independent causes:

**1. `UnionDataset.query()` merges datasets whose joins differ.**
Datasets are grouped for merging by source table and join *alias* only (`getJoinSignature`). The UI tracks created for grouped/split trace-processor tracks (e.g. GPU hardware queues whose overlapping slices TrackCompressor splits into parallel tracks) each join their own `experimental_slice_layout` depth table under the shared `depth` alias. The merge keeps only one of those join definitions (`Object.assign`), so the merged branch inner-joins every row through a single depth table and silently drops all rows that only exist in the other groups. `resolveSqlEvents()` then finds no track for the slice and `selectSqlEvent()` drops the selection without feedback. Any trace with two or more split tracks is affected.

Fix: include the join definition (from clause + unique flag) in the signature so only datasets with identical joins are merged. Refining the key can only prevent merges, so identically-joined datasets keep merging exactly as before; only the previously-corrupted case changes (each dataset becomes its own UNION branch, which is the definitional semantics).

**2. `dev.perfetto.GpuByProcess` tracks are invisible to SQL-event resolution.**
The plugin registers its per-process leaf tracks without `rootTableName`, so even a successfully found slice cannot resolve to them. Fix: pass `rootTableName: 'slice'`, matching the id namespace the track's details panel (`ThreadSliceDetailsPanel`) already assumes for these datasets (`gpu_slice` ids are `slice` ids).

**Testing**

- New unit test (`union dataset does not merge datasets whose joins differ`) fails without the `dataset.ts` fix and passes with it; the other union-merge tests pass in both states (no behavior change for legitimate merges).
- `ui/run-unittests`: 148 files, 2537 passed / 1 skipped.
- `ui/prettier --check` and `ui/eslint` clean on touched files.
- End-to-end: on a real GPU trace (GpuRenderStageEvent kernels, one hardware queue split into 4 tracks by TrackCompressor), a deep link with `visStart/visEnd/ts/dur` previously zoomed correctly but selected nothing; with this change the slice is selected, the track auto-reveals, and the details panel shows the target kernel.
