### PR TITLE
perfetto: fix GetFileSize() compile break on Windows

### DIFF
--- a/include/perfetto/ext/base/file_utils.h
+++ b/include/perfetto/ext/base/file_utils.h
@@ -183,6 +183,13 @@ std::optional<uint64_t> GetFileSize(const std::string& path);
 // Returns the size of the open file |fd|, or nullopt in case of error.
 std::optional<uint64_t> GetFileSize(PlatformHandle fd);
 
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+// On Windows PlatformHandle is a HANDLE, not a file descriptor. This overload
+// accepts the CRT file descriptors returned by base::OpenFile(). On other
+// platforms PlatformHandle is an int, so the overload above already covers it.
+std::optional<uint64_t> GetFileSize(int fd);
+#endif
+
 // This class uses inotify (on Linux/Android) to watch for the creation of
 // files in the filesystem. When the specified file is created, it triggers a
 // callback function.

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -702,6 +702,12 @@ std::optional<uint64_t> GetFileSize(PlatformHandle fd) {
 #endif
 }
 
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+std::optional<uint64_t> GetFileSize(int fd) {
+  return GetFileSize(reinterpret_cast<PlatformHandle>(_get_osfhandle(fd)));
+}
+#endif
+
 // LinuxFileWatch
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX_BUT_NOT_QNX) || \


### PR DESCRIPTION
The Chromium roll (https://crrev.com/c/8215594) broke on the Windows bots.
Two recent changes call `base::GetFileSize()` with an int file descriptor:
the new SQLite VFS from #6997 and a test in `utils_unittest.cc`. That
compiles on POSIX, where `PlatformHandle` is an int, but on Windows it is
a `HANDLE`, so there is no matching overload and the build fails.

Add a Windows-only `GetFileSize(int fd)` overload that maps the CRT fd to
its `HANDLE` with `_get_osfhandle()` and calls the existing implementation.
The other fd helpers (`SeekFile`, `TruncateFile`, `FlushFile`) already
accept CRT fds on Windows, so this brings `GetFileSize()` in line with
them.

