### PR TITLE
ui: Make Memscope process search box fill available width

### DIFF
--- a/ui/src/plugins/dev.perfetto.Memscope/styles.scss
+++ b/ui/src/plugins/dev.perfetto.Memscope/styles.scss
@@ -69,6 +69,10 @@
   align-items: stretch;
   gap: 8px;
   padding: 8px;
+
+  .pf-text-input {
+    flex: 1;
+  }
 }
 
 .pf-memscope-device-list {


### PR DESCRIPTION
Small visual tweak to Memscope - makes the process search box stretch horizontally to fill the remaining space in the header above the table.