### PR TITLE
perfetto: fix unittest failures on Windows and Fuchsia

### DIFF
--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -268,6 +268,10 @@ bool FlushFile(int fd) {
 
 bool SeekFile(int fd, uint64_t offset) {
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  if (fd < 0) {
+    errno = EBADF;
+    return false;
+  }
   if (offset > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
     errno = EOVERFLOW;
     return false;
@@ -285,6 +289,10 @@ bool SeekFile(int fd, uint64_t offset) {
 
 bool TruncateFile(int fd, uint64_t size) {
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  if (fd < 0) {
+    errno = EBADF;
+    return false;
+  }
   if (size > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
     errno = EOVERFLOW;
     return false;

--- a/src/trace_processor/local_file_system_unittest.cc
+++ b/src/trace_processor/local_file_system_unittest.cc
@@ -91,6 +91,8 @@ TEST(LocalFileSystemTest, RandomAccessReadWrite) {
   ASSERT_OK(file->Truncate(6));
   ASSERT_OK(file->GetSize(&size));
   EXPECT_EQ(size, 6u);
+
+  file.reset();
   ASSERT_OK(file_system->DeleteFile(path));
 }
 

--- a/src/trace_processor/sqlite/file_system_vfs_unittest.cc
+++ b/src/trace_processor/sqlite/file_system_vfs_unittest.cc
@@ -21,7 +21,6 @@
 #include <memory>
 #include <string>
 
-#include "perfetto/base/build_config.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/temp_file.h"
 #include "perfetto/trace_processor/io.h"
@@ -64,18 +63,11 @@ TEST(SqliteFileSystemVfsTest, CreatesReadableDatabase) {
   ASSERT_GE(contents.size(), 16u);
   EXPECT_EQ(contents.substr(0, 16), std::string("SQLite format 3\0", 16));
 
-  // Re-open the database and check it is readable. On Fuchsia this has to go
-  // through our VFS again: the default unix VFS needs fcntl() advisory locks,
-  // which Fuchsia doesn't implement (ENOSYS).
-  const char* read_vfs_name = nullptr;
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_FUCHSIA)
   ASSERT_OK_AND_ASSIGN(vfs, SqliteFileSystemVfs::Create(file_system));
-  read_vfs_name = vfs->name();
-#endif
   raw_db = nullptr;
-  ASSERT_EQ(sqlite3_open_v2(path.c_str(), &raw_db, SQLITE_OPEN_READONLY,
-                            read_vfs_name),
-            SQLITE_OK);
+  ASSERT_EQ(
+      sqlite3_open_v2(path.c_str(), &raw_db, SQLITE_OPEN_READONLY, vfs->name()),
+      SQLITE_OK);
   db.reset(raw_db);
   sqlite3_stmt* raw_stmt = nullptr;
   ASSERT_EQ(sqlite3_prepare_v2(db.get(), "SELECT value FROM data", -1,

--- a/src/trace_processor/sqlite/file_system_vfs_unittest.cc
+++ b/src/trace_processor/sqlite/file_system_vfs_unittest.cc
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 
+#include "perfetto/base/build_config.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/temp_file.h"
 #include "perfetto/trace_processor/io.h"
@@ -63,10 +64,18 @@ TEST(SqliteFileSystemVfsTest, CreatesReadableDatabase) {
   ASSERT_GE(contents.size(), 16u);
   EXPECT_EQ(contents.substr(0, 16), std::string("SQLite format 3\0", 16));
 
+  // Re-open the database and check it is readable. On Fuchsia this has to go
+  // through our VFS again: the default unix VFS needs fcntl() advisory locks,
+  // which Fuchsia doesn't implement (ENOSYS).
+  const char* read_vfs_name = nullptr;
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_FUCHSIA)
+  ASSERT_OK_AND_ASSIGN(vfs, SqliteFileSystemVfs::Create(file_system));
+  read_vfs_name = vfs->name();
+#endif
   raw_db = nullptr;
-  ASSERT_EQ(
-      sqlite3_open_v2(path.c_str(), &raw_db, SQLITE_OPEN_READONLY, nullptr),
-      SQLITE_OK);
+  ASSERT_EQ(sqlite3_open_v2(path.c_str(), &raw_db, SQLITE_OPEN_READONLY,
+                            read_vfs_name),
+            SQLITE_OK);
   db.reset(raw_db);
   sqlite3_stmt* raw_stmt = nullptr;
   ASSERT_EQ(sqlite3_prepare_v2(db.get(), "SELECT value FROM data", -1,

--- a/src/trace_processor/util/symbolizer/local_symbolizer_unittest.cc
+++ b/src/trace_processor/util/symbolizer/local_symbolizer_unittest.cc
@@ -240,7 +240,11 @@ TEST(LocalBinaryIndexerTest, BuildIdFromNoteSegment) {
 
   BinaryLookupResult result = indexer.FindBinary("", "AAAAAAAAAAAAAAAAAAAA");
   ASSERT_TRUE(result.ok());
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  EXPECT_EQ(result.binary->file_name, tmp.path() + "/root\\elf1");
+#else
   EXPECT_EQ(result.binary->file_name, tmp.path() + "/root/elf1");
+#endif
 }
 
 TEST(LocalBinaryIndexerTest, MachOBuildIdFromLoadCommands) {
@@ -253,7 +257,11 @@ TEST(LocalBinaryIndexerTest, MachOBuildIdFromLoadCommands) {
 
   BinaryLookupResult result = indexer.FindBinary("", build_id);
   ASSERT_TRUE(result.ok());
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  EXPECT_EQ(result.binary->file_name, tmp.path() + "/root\\macho");
+#else
   EXPECT_EQ(result.binary->file_name, tmp.path() + "/root/macho");
+#endif
   EXPECT_EQ(result.binary->load_info.p_vaddr, 0x1234u);
 }
 


### PR DESCRIPTION
Fixes the test failures blocking the Chromium autoroll:

- SeekFile()/TruncateFile(): reject negative fds on Windows. The CRT sends them to the invalid parameter handler, which Chromium's test harness turns into a crash.
- LocalFileSystemTest: close the file before deleting it, Windows cannot delete open files.
- LocalBinaryIndexerTest: expect "\" path separators on Windows, as produced by the directory walker.
- SqliteFileSystemVfsTest: read back through our VFS on Fuchsia. SQLite's default VFS needs fcntl() locks, which are ENOSYS there.
