### PR TITLE
perfetto: expose drop_count in C and C++ SDKs

### DIFF
--- a/contrib/rust-sdk/perfetto-sys/src/bindings.rs
+++ b/contrib/rust-sdk/perfetto-sys/src/bindings.rs
@@ -324,6 +324,9 @@ unsafe extern "C" {
         user_arg: *mut ::std::os::raw::c_void,
     );
 }
+unsafe extern "C" {
+    pub fn PerfettoDsTracerImplGetDropCount(tracer: *mut PerfettoDsTracerImpl) -> u64;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct PerfettoHeapBuffer {

--- a/include/perfetto/public/abi/data_source_abi.h
+++ b/include/perfetto/public/abi/data_source_abi.h
@@ -408,6 +408,17 @@ PERFETTO_SDK_EXPORT void PerfettoDsTracerImplFlush(
     PerfettoDsTracerOnFlushCb cb,
     void* user_arg);
 
+// Returns the number of times `tracer` entered a mode in which it started
+// dropping data (e.g. because the shared memory buffer was exhausted and the
+// buffer exhausted policy is PERFETTO_DS_BUFFER_EXHAUSTED_POLICY_DROP).
+//
+// Note that this does *not* necessarily correspond to the number of dropped
+// packets, as multiple packets can be dropped on each entry into the drop
+// mode. A non-zero (or increased) value indicates that some data written on
+// this tracer was lost.
+PERFETTO_SDK_EXPORT uint64_t
+PerfettoDsTracerImplGetDropCount(struct PerfettoDsTracerImpl* tracer);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/perfetto/public/data_source.h
+++ b/include/perfetto/public/data_source.h
@@ -302,4 +302,18 @@ static inline void PerfettoDsTracerFlush(
   PerfettoDsTracerImplFlush(iterator->impl.tracer, cb, ctx);
 }
 
+// Returns the number of times the data source instance pointed by `iterator`
+// entered a mode in which it started dropping data (e.g. because the shared
+// memory buffer was exhausted and the buffer exhausted policy is
+// PERFETTO_DS_BUFFER_EXHAUSTED_POLICY_DROP).
+//
+// Note that this does *not* necessarily correspond to the number of dropped
+// packets, as multiple packets can be dropped on each entry into the drop
+// mode. A non-zero (or increased) value indicates that some data written on
+// this thread was lost.
+static inline uint64_t PerfettoDsTracerGetDropCount(
+    struct PerfettoDsTracerIterator* iterator) {
+  return PerfettoDsTracerImplGetDropCount(iterator->impl.tracer);
+}
+
 #endif  // INCLUDE_PERFETTO_PUBLIC_DATA_SOURCE_H_

--- a/include/perfetto/tracing/data_source.h
+++ b/include/perfetto/tracing/data_source.h
@@ -359,6 +359,15 @@ class DataSource : public DataSourceBase {
     // This can be useful for splitting protos that might grow very large.
     uint64_t written() { return tls_inst_->trace_writer->written(); }
 
+    // Returns the number of times the trace writer for the current thread and
+    // data source instance entered a mode in which it started dropping data
+    // (e.g. because the shared memory buffer was exhausted and the buffer
+    // exhausted policy is kDrop). Note that this does *not* necessarily
+    // correspond to the number of dropped packets, as multiple packets can be
+    // dropped on each entry into the drop mode. A non-zero (or increased)
+    // value indicates that some data written on this thread was lost.
+    uint64_t drop_count() { return tls_inst_->trace_writer->drop_count(); }
+
     // Returns a RAII handle to access the data source instance, guaranteeing
     // that it won't be deleted on another thread (because of trace stopping)
     // while accessing it from within the Trace() lambda.

--- a/src/shared_lib/data_source.cc
+++ b/src/shared_lib/data_source.cc
@@ -611,6 +611,13 @@ void PerfettoDsTracerImplFlush(struct PerfettoDsTracerImpl* tracer,
   tls_inst->trace_writer->Flush(fn);
 }
 
+uint64_t PerfettoDsTracerImplGetDropCount(struct PerfettoDsTracerImpl* tracer) {
+  auto* tls_inst =
+      reinterpret_cast<DataSourceInstanceThreadLocalState*>(tracer);
+
+  return tls_inst->trace_writer->drop_count();
+}
+
 uint32_t PerfettoDsGetDefaultClockId() {
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE) && \
     !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)

--- a/src/shared_lib/test/api_integrationtest.cc
+++ b/src/shared_lib/test/api_integrationtest.cc
@@ -883,6 +883,61 @@ TEST_F(SharedLibDataSourceTest, FlushCb) {
   EXPECT_TRUE(notification.IsNotified());
 }
 
+TEST_F(SharedLibDataSourceTest, DropCount) {
+  TracingSession tracing_session =
+      TracingSession::Builder().set_data_source_name(kDataSourceName2).Build();
+  WaitableEvent on_flush_started;
+  WaitableEvent on_flush_unblocked;
+  EXPECT_CALL(ds2_callbacks_, OnFlush(_, _, _, _, _))
+      .WillOnce([&] {
+        on_flush_started.Notify();
+        on_flush_unblocked.WaitForNotification();
+      })
+      .WillRepeatedly([] {});
+
+  // Block the internal perfetto thread inside the OnFlush callback. The
+  // in-process tracing service runs on the same thread, so it cannot free
+  // shared memory buffer chunks while blocked: writing enough data below is
+  // guaranteed to exhaust the buffer and cause data loss.
+  PerfettoTracingSessionFlushAsync(tracing_session.session(), 0, nullptr,
+                                   nullptr);
+  on_flush_started.WaitForNotification();
+
+  uint64_t initial_drop_count = 0;
+  uint64_t final_drop_count = 0;
+  PERFETTO_DS_TRACE(data_source_2, ctx) {
+    initial_drop_count = PerfettoDsTracerGetDropCount(&ctx);
+    // Write way more data than the shared memory buffer can hold (the default
+    // shared memory buffer size is 256 KiB).
+    std::string large_str(1024, 'x');
+    for (size_t i = 0; i < 2048; i++) {
+      struct PerfettoDsRootTracePacket trace_packet;
+      PerfettoDsTracerPacketBegin(&ctx, &trace_packet);
+      {
+        struct perfetto_protos_TestEvent for_testing;
+        perfetto_protos_TracePacket_begin_for_testing(&trace_packet.msg,
+                                                      &for_testing);
+        {
+          struct perfetto_protos_TestEvent_TestPayload payload;
+          perfetto_protos_TestEvent_begin_payload(&for_testing, &payload);
+          perfetto_protos_TestEvent_TestPayload_set_cstr_str(&payload,
+                                                             large_str.c_str());
+          perfetto_protos_TestEvent_end_payload(&for_testing, &payload);
+        }
+        perfetto_protos_TracePacket_end_for_testing(&trace_packet.msg,
+                                                    &for_testing);
+      }
+      PerfettoDsTracerPacketEnd(&ctx, &trace_packet);
+    }
+    final_drop_count = PerfettoDsTracerGetDropCount(&ctx);
+  }
+  on_flush_unblocked.Notify();
+  tracing_session.StopBlocking();
+
+  EXPECT_EQ(initial_drop_count, 0u);
+  EXPECT_GT(final_drop_count, 0u);
+}
+
 TEST_F(SharedLibDataSourceTest, LifetimeCallbacks) {
   void* const kInstancePtr = reinterpret_cast<void*>(0x44);
   testing::InSequence seq;

--- a/src/tracing/test/api_integrationtest.cc
+++ b/src/tracing/test/api_integrationtest.cc
@@ -5371,6 +5371,53 @@ TEST_P(PerfettoApiTest, OnFlushAsync) {
           Property(&perfetto::protos::gen::TestEvent::str, "on-flush"))));
 }
 
+TEST_P(PerfettoApiTest, TraceContextDropCount) {
+  if (GetParam() == perfetto::kSystemBackend) {
+    GTEST_SKIP();
+  }
+  auto* data_source = &data_sources_["my_data_source"];
+  perfetto::TraceConfig cfg;
+  cfg.add_buffers()->set_size_kb(1024);
+  auto* ds_cfg = cfg.add_data_sources()->mutable_config();
+  ds_cfg->set_name("my_data_source");
+  auto* tracing_session = NewTrace(cfg);
+  tracing_session->get()->StartBlocking();
+
+  WaitableTestEvent on_flush_started;
+  WaitableTestEvent on_flush_unblocked;
+  data_source->on_flush_callback = [&](perfetto::FlushFlags) {
+    on_flush_started.Notify();
+    on_flush_unblocked.Wait();
+  };
+
+  // Block the internal perfetto thread inside the OnFlush callback. The
+  // in-process tracing service runs on the same thread, so it cannot free
+  // shared memory buffer chunks while blocked: writing enough data below is
+  // guaranteed to exhaust the buffer and cause data loss.
+  tracing_session->get()->Flush([](bool) {});
+  on_flush_started.Wait();
+
+  uint64_t initial_drop_count = 0;
+  uint64_t final_drop_count = 0;
+  MockDataSource::Trace([&](MockDataSource::TraceContext ctx) {
+    initial_drop_count = ctx.drop_count();
+    // Write way more data than the shared memory buffer can hold (the default
+    // shared memory buffer size is 256 KiB).
+    std::string large_str(1024, 'x');
+    for (size_t i = 0; i < 2048; i++) {
+      ctx.NewTracePacket()->set_for_testing()->set_str(large_str);
+    }
+    final_drop_count = ctx.drop_count();
+  });
+  on_flush_unblocked.Notify();
+
+  EXPECT_EQ(initial_drop_count, 0u);
+  EXPECT_GT(final_drop_count, 0u);
+
+  tracing_session->get()->StopBlocking();
+  data_source->on_stop.Wait();
+}
+
 // Regression test for b/139110180. Checks that GetDataSourceLocked() can be
 // called from OnStart() and OnStop() callbacks without deadlocking.
 TEST_P(PerfettoApiTest, GetDataSourceLockedFromCallbacks) {


### PR DESCRIPTION
Allows producers to detect at runtime whether trace data was lost due to shared memory buffer exhaustion. Adds TraceContext::drop_count() to the C++ SDK and PerfettoDsTracerGetDropCount() (backed by a new PerfettoDsTracerImplGetDropCount ABI export) to the C SDK, both forwarding the existing per-writer TraceWriterBase::drop_count() counter.