### PR TITLE
tp: anchor TraceProcessor_PlatformInterface vtable in storage_minimal

### DIFF
--- a/src/trace_processor/trace_processor.cc
+++ b/src/trace_processor/trace_processor.cc
@@ -29,7 +29,6 @@
 namespace perfetto::trace_processor {
 
 TraceProcessor::MetatraceConfig::MetatraceConfig() = default;
-TraceProcessor_PlatformInterface::~TraceProcessor_PlatformInterface() = default;
 
 // static
 std::unique_ptr<TraceProcessor> TraceProcessor::CreateInstance(

--- a/src/trace_processor/virtual_destructors.cc
+++ b/src/trace_processor/virtual_destructors.cc
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
+#include "perfetto/trace_processor/trace_processor.h"
 #include "src/trace_processor/importers/common/chunked_trace_reader.h"
 
 namespace perfetto {
 namespace trace_processor {
 
 ChunkedTraceReader::~ChunkedTraceReader() {}
+
+// Anchored here: embedders linking only "storage_minimal" call
+// GetFileSystem() and still need the vtable.
+TraceProcessor_PlatformInterface::~TraceProcessor_PlatformInterface() = default;
 
 }  // namespace trace_processor
 }  // namespace perfetto


### PR DESCRIPTION
- The key function (out-of-line dtor) lived in trace_processor.cc, which is part of the ":lib" target only.
- trace_processor_context.cc is in ":storage_minimal" and calls the virtual GetFileSystem(), so embedders linking storage_minimal without lib had no vtable/typeinfo for the interface.
- This broke Chrome's UBSan vptr build, where the vptr check emits an explicit typeinfo reference: undefined symbol at link time.
- Move the dtor to virtual_destructors.cc, the existing anchor TU for storage_minimal.
