### PR TITLE
ui: split postMessage trace sharing/downloading into shareable + downloadable

### DIFF
--- a/ui/src/core/cache_manager.ts
+++ b/ui/src/core/cache_manager.ts
@@ -96,7 +96,8 @@ export async function cacheTrace(
   let fileName = '';
   let url = '';
   let contentLength = 0;
-  let localOnly = false;
+  let shareable = true;
+  let downloadable = true;
   switch (traceSource.type) {
     case 'ARRAY_BUFFER':
       trace = traceSource.buffer;
@@ -104,7 +105,10 @@ export async function cacheTrace(
       fileName = traceSource.fileName ?? '';
       url = traceSource.url ?? '';
       contentLength = traceSource.buffer.byteLength;
-      localOnly = traceSource.localOnly || false;
+      // shareable/downloadable default to true when unset (mirroring
+      // load_trace.ts); the postMessage handler sets them explicitly.
+      shareable = traceSource.shareable ?? true;
+      downloadable = traceSource.downloadable ?? true;
       break;
     case 'FILE':
       trace = traceSource.file.stream();
@@ -119,7 +123,8 @@ export async function cacheTrace(
     ['x-trace-title', encodeURI(title)],
     ['x-trace-url', url],
     ['x-trace-filename', fileName],
-    ['x-trace-local-only', `${localOnly}`],
+    ['x-trace-shareable', `${shareable}`],
+    ['x-trace-downloadable', `${downloadable}`],
     ['content-type', 'application/octet-stream'],
     ['content-length', `${contentLength}`],
     [
@@ -154,6 +159,12 @@ export async function tryGetTrace(
   const response = await cacheMatch(`/_${TRACE_CACHE_NAME}/${traceUuid}`);
 
   if (!response) return undefined;
+
+  // Legacy entries only carry the |x-trace-local-only| header; derive both
+  // flags from it. Newer entries have the split headers.
+  const localOnly = response.headers.get('x-trace-local-only') === 'true';
+  const shareableHeader = response.headers.get('x-trace-shareable');
+  const downloadableHeader = response.headers.get('x-trace-downloadable');
   return {
     type: 'ARRAY_BUFFER',
     buffer: await response.arrayBuffer(),
@@ -161,7 +172,10 @@ export async function tryGetTrace(
     fileName: response.headers.get('x-trace-filename') ?? undefined,
     url: response.headers.get('x-trace-url') ?? undefined,
     uuid: traceUuid,
-    localOnly: response.headers.get('x-trace-local-only') === 'true',
+    shareable:
+      shareableHeader !== null ? shareableHeader === 'true' : !localOnly,
+    downloadable:
+      downloadableHeader !== null ? downloadableHeader === 'true' : !localOnly,
   };
 }
 

--- a/ui/src/core/fake_trace_impl.ts
+++ b/ui/src/core/fake_trace_impl.ts
@@ -103,6 +103,7 @@ export function createFakeTraceImpl(args: FakeTraceImplArgs = {}) {
     hasFtrace: false,
     uuid: '',
     cached: false,
+    shareable: false,
     downloadable: false,
   };
   AppImpl.instance.closeCurrentTrace();

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -650,11 +650,17 @@ async function getTraceInfo(
   updateStatus(app, 'Caching trace...');
   const cached = await cacheTrace(traceSource, uuid);
 
-  const downloadable =
-    (traceSource.type === 'ARRAY_BUFFER' && !traceSource.localOnly) ||
+  const shareable =
     traceSource.type === 'FILE' ||
     traceSource.type === 'URL' ||
-    traceSource.type === 'MULTIPLE_FILES';
+    traceSource.type === 'MULTIPLE_FILES' ||
+    (traceSource.type === 'ARRAY_BUFFER' && traceSource.shareable !== false);
+
+  const downloadable =
+    traceSource.type === 'FILE' ||
+    traceSource.type === 'URL' ||
+    traceSource.type === 'MULTIPLE_FILES' ||
+    (traceSource.type === 'ARRAY_BUFFER' && traceSource.downloadable !== false);
 
   return {
     ...traceTime,
@@ -668,6 +674,7 @@ async function getTraceInfo(
     hasFtrace,
     uuid,
     cached,
+    shareable,
     downloadable,
   };
 }

--- a/ui/src/core/trace_source.ts
+++ b/ui/src/core/trace_source.ts
@@ -68,8 +68,13 @@ export interface TraceArrayBufferSource {
   // with all other state fields).
   readonly uuid?: string;
 
-  // if |localOnly| is true then the trace should not be shared or downloaded.
-  readonly localOnly?: boolean;
+  // Whether the UI may share the trace externally (e.g. upload it to GCS
+  // as a permalink) and/or download it to disk. Both default to true when
+  // unset. The postMessage handler sets them explicitly to false unless the
+  // sender opts in (see post_message_handler.ts). These replace the legacy
+  // |localOnly| field.
+  readonly shareable?: boolean;
+  readonly downloadable?: boolean;
 
   // Allows to pass extra arguments to plugins. This can be read by plugins
   // onTraceLoad() and can be used to trigger plugin-specific-behaviours (e.g.

--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -177,8 +177,9 @@ class ErrorDialogComponent implements m.ClassComponent<ErrorDetails> {
       this.traceData = traceSource.file;
       // this.traceSize = this.traceData.size;
     } else if (traceSource.type === 'ARRAY_BUFFER') {
-      // Never upload local-only traces (e.g. from postMessage) to GCS.
-      if (traceSource.localOnly) return;
+      // Never upload traces the sender didn't allow sharing (e.g. pushed via
+      // postMessage) to GCS, not even for bug reports.
+      if (traceSource.shareable === false) return;
       this.traceData = traceSource.buffer;
       // this.traceSize = this.traceData.byteLength;
     } else {

--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -34,8 +34,11 @@ interface PostedTrace {
   // The hash of the app state to load from GCS after the trace is loaded
   appStateHash?: string;
 
-  // if |localOnly| is true then the trace should not be shared or downloaded.
-  localOnly?: boolean;
+  // Whether the UI may share the trace externally (e.g. upload it to GCS
+  // as a permalink) and/or download it to disk. Both default to false:
+  // traces pushed via postMessage are local-only unless the sender opts in.
+  shareable?: boolean;
+  downloadable?: boolean;
   keepApiOpen?: boolean;
 
   // Allows to pass extra arguments to plugins. This can be read by plugins
@@ -54,6 +57,12 @@ interface PostedTrace {
 // pure ArrayBuffer, so model that here. sanitizePostedTrace() normalizes it.
 interface RawPostedTrace extends Omit<PostedTrace, 'buffer'> {
   buffer: ArrayBuffer | ArrayBufferView;
+
+  // Legacy field: senders that predate the shareable/downloadable split may
+  // still pass |localOnly|. localOnly: false opts into both sharing and
+  // downloading; anything else (or absent) keeps the trace local-only.
+  // Translated in sanitizePostedTrace().
+  localOnly?: boolean;
 }
 
 interface PostedTraceWrapped {
@@ -138,9 +147,10 @@ export function parsePostedTrace(
   } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
     return {
       title: 'External trace',
-      // A bare buffer gives the sender no way to opt into sharing, so default
-      // to local-only (matching the wrapped path).
-      localOnly: true,
+      // A bare buffer gives the sender no way to opt into sharing or
+      // downloading, so both default to false (matching the wrapped path).
+      shareable: false,
+      downloadable: false,
       buffer: toArrayBuffer(data),
     };
   } else {
@@ -320,6 +330,10 @@ export function postMessageHandler(messageEvent: MessageEvent) {
 }
 
 function sanitizePostedTrace(postedTrace: RawPostedTrace): PostedTrace {
+  // Translate the legacy |localOnly| field. Absent localOnly defaults to true
+  // (local-only); localOnly: false opts into both sharing and downloading.
+  // Explicit shareable/downloadable fields win over the legacy field.
+  const localOnly = postedTrace.localOnly ?? true;
   const result: PostedTrace = {
     title: sanitizeString(postedTrace.title),
     // Senders routinely pass a view (e.g. Uint8Array) despite the static type;
@@ -328,7 +342,8 @@ function sanitizePostedTrace(postedTrace: RawPostedTrace): PostedTrace {
     keepApiOpen: postedTrace.keepApiOpen,
     // For external traces, we need to disable other features such as
     // downloading and sharing a trace, unless the caller allows it.
-    localOnly: postedTrace.localOnly ?? true,
+    shareable: postedTrace.shareable ?? !localOnly,
+    downloadable: postedTrace.downloadable ?? !localOnly,
     appStateHash: postedTrace.appStateHash,
     pluginArgs: postedTrace.pluginArgs,
   };

--- a/ui/src/frontend/post_message_handler_unittest.ts
+++ b/ui/src/frontend/post_message_handler_unittest.ts
@@ -73,7 +73,8 @@ describe('parsePostedTrace', () => {
 
     test('is local-only by default (no way to opt into sharing)', () => {
       const result = parsePostedTrace(new ArrayBuffer());
-      expect(result?.localOnly).toBe(true);
+      expect(result?.shareable).toBe(false);
+      expect(result?.downloadable).toBe(false);
     });
 
     test('view is snipped to the view, not the underlying buffer', () => {
@@ -98,6 +99,36 @@ describe('parsePostedTrace', () => {
       const buffer = new ArrayBuffer();
       const result = parsePostedTrace({perfetto: {buffer, title: 'foo'}});
       expect(result?.buffer).toBe(buffer);
+    });
+
+    test('defaults to local-only', () => {
+      const result = parsePostedTrace({
+        perfetto: {buffer: new ArrayBuffer(), title: 'foo'},
+      });
+      expect(result?.shareable).toBe(false);
+      expect(result?.downloadable).toBe(false);
+    });
+
+    test('legacy localOnly: false opts into sharing and downloading', () => {
+      const result = parsePostedTrace({
+        perfetto: {buffer: new ArrayBuffer(), title: 'foo', localOnly: false},
+      });
+      expect(result?.shareable).toBe(true);
+      expect(result?.downloadable).toBe(true);
+    });
+
+    test('explicit shareable/downloadable win over legacy localOnly', () => {
+      const result = parsePostedTrace({
+        perfetto: {
+          buffer: new ArrayBuffer(),
+          title: 'foo',
+          localOnly: false,
+          shareable: false,
+          downloadable: true,
+        },
+      });
+      expect(result?.shareable).toBe(false);
+      expect(result?.downloadable).toBe(true);
     });
 
     test('view converted to arraybuffer', () => {

--- a/ui/src/frontend/trace_share_utils.ts
+++ b/ui/src/frontend/trace_share_utils.ts
@@ -22,7 +22,7 @@ import {CopyableLink} from '../widgets/copyable_link';
 import {AppImpl} from '../core/app_impl';
 
 export function isShareable(trace: Trace) {
-  return AppImpl.instance.isInternalUser && trace.traceInfo.downloadable;
+  return AppImpl.instance.isInternalUser && trace.traceInfo.shareable;
 }
 
 const STATE_HASH_PLACEHOLDER = 'perfettoStateHashPlaceholder';

--- a/ui/src/public/trace_info.ts
+++ b/ui/src/public/trace_info.ts
@@ -49,6 +49,11 @@ export interface TraceInfo {
   // Wheteher the current trace has been successfully stored into cache storage.
   readonly cached: boolean;
 
+  // Whether the UI may re-share the current trace externally (e.g. upload
+  // it to GCS as a permalink). It is false when the trace was pushed via
+  // postMessage and the caller did not opt into sharing.
+  readonly shareable: boolean;
+
   // Returns true if the current trace can be downloaded via getTraceFile().
   // The trace isn't downloadable in the following cases:
   // - It comes from a source (e.g. HTTP+RPC) that doesn't support re-download


### PR DESCRIPTION
Split the postMessage `localOnly` flag into two independent properties:
`shareable` and `downloadable`.

- `shareable` gates **UI-side external sharing only**: whether the UI may
  re-share the trace to a third party (e.g. upload it to GCS as a
  permalink). It says nothing about how the sender itself distributes
  the trace.
- `downloadable` gates whether the trace may be downloaded to disk.

Senders can now opt into each capability separately. Backward compat:
`localOnly` is still accepted on the wire and translated — `localOnly:
false` sets both flags to true, anything else (or absent) sets both to
false. Explicit `shareable`/`downloadable` fields take precedence over
the legacy field.

Changes:
- `PostedTrace` / `TraceArrayBufferSource`: `localOnly` → `shareable` +
  `downloadable` (both default to true when unset for non-postMessage
  sources such as recordings).
- `TraceInfo`: new `shareable` field; `downloadable` now derives from the
  source flag.
- Share flow (`isShareable`) gates on `shareable` instead of
  `downloadable`.
- Trace cache stores both flags, falling back to the legacy
  `x-trace-local-only` header for entries written by older versions.
- Error dialog no longer offers to upload traces the sender did not
  allow sharing.
