### PR TITLE
tp: persist an id -> row index on Tree

### DIFF
--- a/src/trace_processor/core/tree/tree.h
+++ b/src/trace_processor/core/tree/tree.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "perfetto/base/logging.h"
+#include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/slab.h"
@@ -47,6 +48,52 @@ namespace perfetto::trace_processor::core {
 // ownership. Tree operators consume it and can reuse its allocations.
 struct Tree {
   static constexpr uint32_t kNullParent = std::numeric_limits<uint32_t>::max();
+
+  // Index mapping the tree's original node ids (the "id" column produced by
+  // BuildTree) to row indices, built once during construction so consumers
+  // can resolve ids to rows via FindRow without rebuilding the map.
+  //
+  // Storage is chosen to match the id shape: identity ids (id == row index)
+  // need no storage; a reasonably dense uint32 id range uses a direct index
+  // vector; arbitrary ids fall back to a hash map. The default state is
+  // identity: a tree without an id column has row indices as its ids by
+  // definition, so a default-constructed tree resolves ids correctly.
+  struct IdIndex {
+    bool identity_ids = true;
+    std::vector<uint32_t> dense;  // dense uint32 ids -> row, kNullParent absent
+    // Arbitrary ids -> row. Optional because FlatHashMap's constructor is
+    // explicit, which would break aggregate initialization of Tree.
+    std::optional<base::FlatHashMap<int64_t, uint32_t>> hash;
+
+    // Resolves an id to a row index within a table of |num_rows| rows, or
+    // kNullParent if absent (returned as a sentinel rather than wrapped in
+    // std::optional as this is on the hot path of consumers). |num_rows|
+    // bounds the identity case, where ids are the row indices themselves.
+    uint32_t Find(int64_t id, uint32_t num_rows) const {
+      if (identity_ids) {
+        if (id < 0 || static_cast<uint64_t>(id) >= num_rows) {
+          return kNullParent;
+        }
+        return static_cast<uint32_t>(id);
+      }
+      if (!dense.empty()) {
+        if (id < 0 || static_cast<uint64_t>(id) >= dense.size()) {
+          return kNullParent;
+        }
+        return dense[static_cast<uint32_t>(id)];
+      }
+      if (hash) {
+        const uint32_t* row = hash->Find(id);
+        return row ? *row : kNullParent;
+      }
+      return kNullParent;
+    }
+  };
+
+  IdIndex id_index;
+
+  // Resolves an original node id to its row index, or kNullParent if absent.
+  uint32_t FindRow(int64_t id) const { return id_index.Find(id, row_count); }
 
   struct Column {
     // Null-typed columns have no payload at all; their null_bv marks every

--- a/src/trace_processor/core/tree/tree_algorithms_unittest.cc
+++ b/src/trace_processor/core/tree/tree_algorithms_unittest.cc
@@ -150,5 +150,154 @@ TEST(TreeFromDataframeTest, RejectsCycle) {
   EXPECT_THAT(result.status().message(), testing::HasSubstr("cycle detected"));
 }
 
+TEST(TreeTest, DefaultConstructedTreeResolvesIdentityIds) {
+  // The index defaults to identity: an empty tree has no rows, so every id
+  // resolves to absent, and a tree without an id column would resolve row
+  // indices directly.
+  Tree tree;
+  ASSERT_TRUE(tree.id_index.identity_ids);
+  EXPECT_EQ(tree.FindRow(0), Tree::kNullParent);
+  EXPECT_EQ(tree.FindRow(-1), Tree::kNullParent);
+}
+
+TEST(TreeFromDataframeTest, FindRowIdentityIds) {
+  StringPool pool;
+  dataframe::AdhocDataframeBuilder::Options options;
+  options.types = {dataframe::AdhocColumnType::kInt64,
+                   dataframe::AdhocColumnType::kInt64};
+  options.nullability_type = dataframe::NullabilityType::kDenseNull;
+  dataframe::AdhocDataframeBuilder builder({"id", "parent_id"}, &pool, options);
+
+  // Ids equal their row index, so the index is identity and needs no storage.
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{0}));
+  builder.PushNull(1);
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{1}));
+  ASSERT_TRUE(builder.PushNonNull(1, int64_t{0}));
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{2}));
+  ASSERT_TRUE(builder.PushNonNull(1, int64_t{0}));
+
+  auto result = BuildTree(std::move(builder));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  Tree tree = std::move(result.value());
+  ASSERT_TRUE(tree.id_index.identity_ids);
+
+  EXPECT_EQ(tree.FindRow(0), 0u);
+  EXPECT_EQ(tree.FindRow(1), 1u);
+  EXPECT_EQ(tree.FindRow(2), 2u);
+  EXPECT_EQ(tree.FindRow(3), Tree::kNullParent);
+  EXPECT_EQ(tree.FindRow(-1), Tree::kNullParent);
+}
+
+TEST(TreeFromDataframeTest, FindRowDenseIds) {
+  StringPool pool;
+  dataframe::AdhocDataframeBuilder::Options options;
+  options.types = {dataframe::AdhocColumnType::kInt64,
+                   dataframe::AdhocColumnType::kInt64};
+  options.nullability_type = dataframe::NullabilityType::kDenseNull;
+  dataframe::AdhocDataframeBuilder builder({"id", "parent_id"}, &pool, options);
+
+  // A compact non-identity uint32 id range is stored as a direct index
+  // vector (max_id + 1 <= 2 * row_count).
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{1}));
+  builder.PushNull(1);
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{2}));
+  ASSERT_TRUE(builder.PushNonNull(1, int64_t{1}));
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{3}));
+  ASSERT_TRUE(builder.PushNonNull(1, int64_t{1}));
+
+  auto result = BuildTree(std::move(builder));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  Tree tree = std::move(result.value());
+  ASSERT_FALSE(tree.id_index.identity_ids);
+  ASSERT_FALSE(tree.id_index.dense.empty());
+
+  EXPECT_EQ(tree.FindRow(1), 0u);
+  EXPECT_EQ(tree.FindRow(2), 1u);
+  EXPECT_EQ(tree.FindRow(3), 2u);
+  EXPECT_EQ(tree.FindRow(0), Tree::kNullParent);  // absent id
+  EXPECT_EQ(tree.FindRow(4), Tree::kNullParent);  // beyond the dense range
+  EXPECT_EQ(tree.FindRow(-1), Tree::kNullParent);
+}
+
+TEST(TreeFromDataframeTest, FindRowHashIds) {
+  StringPool pool;
+  dataframe::AdhocDataframeBuilder::Options options;
+  options.types = {dataframe::AdhocColumnType::kInt64,
+                   dataframe::AdhocColumnType::kInt64};
+  options.nullability_type = dataframe::NullabilityType::kDenseNull;
+  dataframe::AdhocDataframeBuilder builder({"id", "parent_id"}, &pool, options);
+
+  // Sparse ids, including one beyond uint32, fall back to a hash map.
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{1000}));
+  builder.PushNull(1);
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{5000000000}));
+  ASSERT_TRUE(builder.PushNonNull(1, int64_t{1000}));
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{9000}));
+  ASSERT_TRUE(builder.PushNonNull(1, int64_t{1000}));
+
+  auto result = BuildTree(std::move(builder));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  Tree tree = std::move(result.value());
+  ASSERT_FALSE(tree.id_index.identity_ids);
+  ASSERT_TRUE(tree.id_index.dense.empty());
+  ASSERT_TRUE(tree.id_index.hash.has_value());
+
+  EXPECT_EQ(tree.FindRow(1000), 0u);
+  EXPECT_EQ(tree.FindRow(5000000000), 1u);
+  EXPECT_EQ(tree.FindRow(9000), 2u);
+  EXPECT_EQ(tree.FindRow(1001), Tree::kNullParent);
+  EXPECT_EQ(tree.FindRow(-1), Tree::kNullParent);
+}
+
+TEST(TreeFromDataframeTest, ReorderRebuildsIdIndex) {
+  StringPool pool;
+  dataframe::AdhocDataframeBuilder::Options options;
+  options.types = {dataframe::AdhocColumnType::kInt64,
+                   dataframe::AdhocColumnType::kInt64};
+  options.nullability_type = dataframe::NullabilityType::kDenseNull;
+  dataframe::AdhocDataframeBuilder builder({"id", "parent_id"}, &pool, options);
+
+  // Child rows precede their parents in the input, so the topological reorder
+  // invalidates the input-order index and it is rebuilt from the output id
+  // column.
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{5}));
+  ASSERT_TRUE(builder.PushNonNull(1, int64_t{3}));
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{3}));
+  builder.PushNull(1);
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{4}));
+  ASSERT_TRUE(builder.PushNonNull(1, int64_t{3}));
+
+  auto result = BuildTree(std::move(builder));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  Tree tree = std::move(result.value());
+  ASSERT_FALSE(tree.id_index.identity_ids);
+  ASSERT_FALSE(tree.id_index.dense.empty());
+
+  EXPECT_THAT(tree.columns[0].unchecked_span<int64_t>(),
+              testing::ElementsAre(3, 5, 4));
+  EXPECT_EQ(tree.FindRow(3), 0u);
+  EXPECT_EQ(tree.FindRow(5), 1u);
+  EXPECT_EQ(tree.FindRow(4), 2u);
+  EXPECT_EQ(tree.FindRow(6), Tree::kNullParent);
+}
+
+TEST(TreeFromDataframeTest, RejectsDuplicateIds) {
+  StringPool pool;
+  dataframe::AdhocDataframeBuilder::Options options;
+  options.types = {dataframe::AdhocColumnType::kInt64,
+                   dataframe::AdhocColumnType::kInt64};
+  options.nullability_type = dataframe::NullabilityType::kDenseNull;
+  dataframe::AdhocDataframeBuilder builder({"id", "parent_id"}, &pool, options);
+
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{2}));
+  builder.PushNull(1);
+  ASSERT_TRUE(builder.PushNonNull(0, int64_t{2}));
+  builder.PushNull(1);
+
+  auto result = BuildTree(std::move(builder));
+  ASSERT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), testing::HasSubstr("duplicate id"));
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor::core

--- a/src/trace_processor/core/tree/tree_from_dataframe.cc
+++ b/src/trace_processor/core/tree/tree_from_dataframe.cc
@@ -127,31 +127,56 @@ Tree::Column GatherRawColumn(dataframe::AdhocDataframeBuilder::RawColumn& rc,
   return tc;
 }
 
-struct IdIndex {
-  std::optional<uint32_t> Find(int64_t id) const {
-    if (identity_ids) {
-      if (id < 0 || static_cast<uint64_t>(id) >= row_count) {
-        return std::nullopt;
-      }
-      return static_cast<uint32_t>(id);
-    }
-    if (dense_ids) {
-      if (id < 0 || static_cast<uint64_t>(id) >= dense_index.size()) {
-        return std::nullopt;
-      }
-      const uint32_t row = dense_index[static_cast<uint32_t>(id)];
-      return row == Tree::kNullParent ? std::nullopt : std::make_optional(row);
-    }
-    const uint32_t* row = hash_index->Find(id);
-    return row ? std::make_optional(*row) : std::nullopt;
-  }
+// Direct indexing is used while the dense vector is at least
+// 1 / kDenseIndexMaxSizeFactor full; sparser id ranges fall back to the hash
+// map to bound the memory wasted on empty slots.
+constexpr uint64_t kDenseIndexMaxSizeFactor = 2;
 
-  bool identity_ids;
-  bool dense_ids;
-  uint32_t row_count;
-  Span<const uint32_t> dense_index;
-  const base::FlatHashMap<int64_t, uint32_t>* hash_index;
-};
+// Builds an id -> row index matching storage to the id shape: identity ids
+// (id == row index) need no storage; a reasonably dense uint32 id range uses
+// a direct index vector; arbitrary int64 ids fall back to a hash map. Fails
+// on duplicate ids.
+base::StatusOr<Tree::IdIndex> BuildIdIndex(Span<const int64_t> ids,
+                                           uint32_t row_count) {
+  Tree::IdIndex result;
+  bool identity_ids = true;
+  bool uint32_ids = true;
+  uint32_t max_id = 0;
+  for (uint32_t i = 0; i < row_count; ++i) {
+    const int64_t id = ids[i];
+    identity_ids = identity_ids && id == i;
+    if (id < 0 ||
+        static_cast<uint64_t>(id) > std::numeric_limits<uint32_t>::max()) {
+      uint32_ids = false;
+    } else {
+      max_id = std::max(max_id, static_cast<uint32_t>(id));
+    }
+  }
+  result.identity_ids = identity_ids;
+  const bool dense_ids =
+      !identity_ids && uint32_ids &&
+      uint64_t(max_id) + 1 <= uint64_t(row_count) * kDenseIndexMaxSizeFactor;
+  if (dense_ids) {
+    result.dense.resize(uint64_t(max_id) + 1, Tree::kNullParent);
+    for (uint32_t i = 0; i < row_count; ++i) {
+      const uint32_t id = static_cast<uint32_t>(ids[i]);
+      if (result.dense[id] != Tree::kNullParent) {
+        return base::ErrStatus("tree: duplicate id");
+      }
+      result.dense[id] = i;
+    }
+  } else if (!identity_ids) {
+    result.hash.emplace();
+    for (uint32_t i = 0; i < row_count; ++i) {
+      auto [row, inserted] = result.hash->Insert(ids[i], i);
+      base::ignore_result(row);
+      if (!inserted) {
+        return base::ErrStatus("tree: duplicate id");
+      }
+    }
+  }
+  return std::move(result);
+}
 
 base::StatusOr<Tree> BuildFromRawColumns(
     std::vector<dataframe::AdhocDataframeBuilder::RawColumn> raw_cols);
@@ -203,46 +228,11 @@ base::StatusOr<Tree> BuildFromRawColumns(
   Tree result;
   result.row_count = row_count;
 
-  // Prefer indexes which avoid hashing. Identity ids need no storage; a
-  // reasonably dense uint32 range uses direct indexing; arbitrary int64 ids
-  // fall back to a hash map.
-  bool identity_ids = true;
-  bool uint32_ids = true;
-  uint32_t max_id = 0;
-  for (uint32_t i = 0; i < row_count; ++i) {
-    int64_t id = id_vec[i];
-    identity_ids = identity_ids && id == i;
-    if (id < 0 ||
-        static_cast<uint64_t>(id) > std::numeric_limits<uint32_t>::max()) {
-      uint32_ids = false;
-    } else {
-      max_id = std::max(max_id, static_cast<uint32_t>(id));
-    }
-  }
-  bool dense_ids = !identity_ids && uint32_ids &&
-                   uint64_t(max_id) + 1 <= uint64_t(row_count) * 2;
-  std::vector<uint32_t> dense_index;
-  base::FlatHashMap<int64_t, uint32_t> hash_index;
-  if (dense_ids) {
-    dense_index.resize(uint64_t(max_id) + 1, Tree::kNullParent);
-    for (uint32_t i = 0; i < row_count; ++i) {
-      uint32_t id = static_cast<uint32_t>(id_vec[i]);
-      if (dense_index[id] != Tree::kNullParent) {
-        return base::ErrStatus("tree: duplicate id");
-      }
-      dense_index[id] = i;
-    }
-  } else if (!identity_ids) {
-    for (uint32_t i = 0; i < row_count; ++i) {
-      auto [row, inserted] = hash_index.Insert(id_vec[i], i);
-      base::ignore_result(row);
-      if (!inserted) {
-        return base::ErrStatus("tree: duplicate id");
-      }
-    }
-  }
-  const IdIndex id_index{identity_ids, dense_ids, row_count,
-                         MakeSpan(dense_index), &hash_index};
+  // Id index over the input rows, used to resolve parent_id references during
+  // normalization. If the input already satisfies the ordering invariant it is
+  // persisted on the tree as-is; a topological reorder invalidates it, in
+  // which case it is rebuilt from the output-order id column below.
+  ASSIGN_OR_RETURN(auto id_index, BuildIdIndex(id_vec.span(), row_count));
 
   // Normalize parent_id to input row indices first. Track whether the input
   // already satisfies the Tree ordering invariant while doing so.
@@ -259,12 +249,12 @@ base::StatusOr<Tree> BuildFromRawColumns(
       if (pid_rc.null_bv.size() > 0 && !pid_rc.null_bv.is_set(row)) {
         continue;
       }
-      std::optional<uint32_t> parent = id_index.Find(pid_vec[row]);
-      if (PERFETTO_UNLIKELY(!parent)) {
+      const uint32_t parent = id_index.Find(pid_vec[row], row_count);
+      if (PERFETTO_UNLIKELY(parent == Tree::kNullParent)) {
         return base::ErrStatus("tree: parent_id not found in id column");
       }
-      input_parent[row] = *parent;
-      if (*parent >= row) {
+      input_parent[row] = parent;
+      if (parent >= row) {
         identity_order = false;
       }
     }
@@ -322,12 +312,19 @@ base::StatusOr<Tree> BuildFromRawColumns(
       result.names.push_back(std::move(rc.name));
       result.columns.push_back(MoveRawColumn(rc));
     }
+    result.id_index = std::move(id_index);
   } else {
     // Gather all columns (including id/parent_id) in topological order.
     for (auto& rc : raw_cols) {
       result.names.push_back(std::move(rc.name));
       result.columns.push_back(GatherRawColumn(rc, row_count, MakeSpan(order)));
     }
+    // The reorder invalidated the input-space index; rebuild it from the
+    // gathered id column, which is in output row order.
+    const auto* ids = result.columns[0].unchecked_data<int64_t>();
+    ASSIGN_OR_RETURN(
+        result.id_index,
+        BuildIdIndex(Span<const int64_t>(ids, ids + row_count), row_count));
   }
   return std::move(result);
 }


### PR DESCRIPTION
Builds an id -> row index once during tree construction (identity / dense vector / hash map depending on the id shape) so consumers can resolve node ids without rebuilding the map. Identity is the default, so trees without an id column resolve row indices directly.