### PR TITLE
tp: make flamegraph diff tests order-independent

### DIFF
--- a/test/trace_processor/diff_tests/parser/profiling/heap_graph_flamegraph_system-server-heap-graph.out
+++ b/test/trace_processor/diff_tests/parser/profiling/heap_graph_flamegraph_system-server-heap-graph.out
@@ -1,11 +1,11 @@
-"id","depth","name","map_name","count","cumulative_count","size","cumulative_size","parent_id"
-0,0,"android.app.LoadedApk$ServiceDispatcher$DeathMonitor [ROOT_JNI_GLOBAL]","JAVA",32,789,640,54860,"[NULL]"
-1,1,"android.app.LoadedApk$ServiceDispatcher","JAVA",31,683,1395,51674,0
-2,2,"android.app.ActivityThread$H","JAVA",1,1,32,32,1
-3,2,"android.app.LoadedApk$ServiceDispatcher$InnerConnection","JAVA",31,62,868,1612,1
-4,3,"java.lang.ref.WeakReference","JAVA",31,31,744,744,3
-5,2,"android.util.ArrayMap","JAVA",31,125,775,3519,1
-6,3,"java.lang.Object[]","JAVA",31,63,1364,1876,5
-7,4,"android.app.LoadedApk$ServiceDispatcher$ConnectionInfo","JAVA",32,32,512,512,6
-8,3,"int[]","JAVA",31,31,868,868,5
-9,2,"android.app.ServiceConnectionLeaked","JAVA",31,145,868,22009,1
+"depth","name","map_name","count","cumulative_count","size","cumulative_size"
+0,"com.android.server.pm.PackageManagerService [ROOT_JNI_GLOBAL]","JAVA",1,109541,450,5749404
+1,"com.android.server.pm.ComponentResolver","JAVA",1,60095,37,3281092
+0,"java.lang.String [ROOT_INTERNED_STRING]","JAVA",41197,41197,1845640,1845640
+2,"com.android.server.pm.ComponentResolver$ActivityIntentResolver","JAVA",1,31934,52,1768143
+3,"android.util.ArrayMap","JAVA",8,18910,200,1261878
+4,"java.lang.Object[]","JAVA",7,18895,52020,1235626
+1,"com.android.server.pm.Settings","JAVA",1,29766,140,1170047
+0,"java.lang.Class<android.icu.text.Transliterator> [ROOT_STICKY_CLASS]","JAVA",1,12552,163,1120275
+1,"android.icu.text.TransliteratorRegistry","JAVA",1,12545,20,1119648
+2,"java.util.Collections$SynchronizedMap","JAVA",2,10614,56,1063424

--- a/test/trace_processor/diff_tests/parser/profiling/tests_heap_graph.py
+++ b/test/trace_processor/diff_tests/parser/profiling/tests_heap_graph.py
@@ -422,15 +422,13 @@ class ProfilingHeapGraph(TestSuite):
         trace=DataPath('system-server-heap-graph-new.pftrace'),
         query="""
         SELECT
-          id,
           depth,
           name,
           map_name,
           count,
           cumulative_count,
           size,
-          cumulative_size,
-          parent_id
+          cumulative_size
         FROM experimental_flamegraph(
           'graph',
           (SELECT max(graph_sample_ts) FROM heap_graph_object),
@@ -439,6 +437,7 @@ class ProfilingHeapGraph(TestSuite):
           NULL,
           NULL
         )
+        ORDER BY cumulative_size DESC, name
         LIMIT 10;
         """,
         out=Path('heap_graph_flamegraph_system-server-heap-graph.out'))
@@ -482,7 +481,6 @@ class ProfilingHeapGraph(TestSuite):
         trace=DataPath('system-server-native-profile'),
         query="""
         SELECT
-          id,
           ts,
           depth,
           name,
@@ -495,7 +493,6 @@ class ProfilingHeapGraph(TestSuite):
           cumulative_alloc_count,
           alloc_size,
           cumulative_alloc_size,
-          parent_id,
           source_file,
           line_number
         FROM experimental_flamegraph(
@@ -506,20 +503,21 @@ class ProfilingHeapGraph(TestSuite):
           NULL,
           NULL
         )
+        ORDER BY depth, name, map_name, cumulative_size, cumulative_count
         LIMIT 10;
         """,
         out=Csv('''
-          "id","ts","depth","name","map_name","count","cumulative_count","size","cumulative_size","alloc_count","cumulative_alloc_count","alloc_size","cumulative_alloc_size","parent_id","source_file","line_number"
-          0,605908369259172,0,"__start_thread","/apex/com.android.runtime/lib64/bionic/libc.so",0,8,0,84848,0,210,0,1084996,"[NULL]","[NULL]","[NULL]"
-          1,605908369259172,1,"_ZL15__pthread_startPv","/apex/com.android.runtime/lib64/bionic/libc.so",0,8,0,84848,0,210,0,1084996,0,"[NULL]","[NULL]"
-          2,605908369259172,2,"_ZN7android14AndroidRuntime15javaThreadShellEPv","/system/lib64/libandroid_runtime.so",0,5,0,27704,0,77,0,348050,1,"[NULL]","[NULL]"
-          3,605908369259172,3,"_ZN7android6Thread11_threadLoopEPv","/system/lib64/libutils.so",0,5,0,27704,0,77,0,348050,2,"[NULL]","[NULL]"
-          4,605908369259172,4,"_ZN7android10PoolThread10threadLoopEv","/system/lib64/libbinder.so",0,1,0,4096,0,64,0,279182,3,"[NULL]","[NULL]"
-          5,605908369259172,5,"_ZN7android14IPCThreadState14joinThreadPoolEb","/system/lib64/libbinder.so",0,1,0,4096,0,64,0,279182,4,"[NULL]","[NULL]"
-          6,605908369259172,6,"_ZN7android14IPCThreadState20getAndExecuteCommandEv","/system/lib64/libbinder.so",0,1,0,4096,0,64,0,279182,5,"[NULL]","[NULL]"
-          7,605908369259172,7,"_ZN7android14IPCThreadState14executeCommandEi","/system/lib64/libbinder.so",0,1,0,4096,0,64,0,279182,6,"[NULL]","[NULL]"
-          8,605908369259172,8,"_ZN7android7BBinder8transactEjRKNS_6ParcelEPS1_j","/system/lib64/libbinder.so",0,1,0,4096,0,64,0,279182,7,"[NULL]","[NULL]"
-          9,605908369259172,9,"_ZN11JavaBBinder10onTransactEjRKN7android6ParcelEPS1_j","/system/lib64/libandroid_runtime.so",0,0,0,0,0,60,0,262730,8,"[NULL]","[NULL]"
+          "ts","depth","name","map_name","count","cumulative_count","size","cumulative_size","alloc_count","cumulative_alloc_count","alloc_size","cumulative_alloc_size","source_file","line_number"
+          605908369259172,0,"__libc_init","/apex/com.android.runtime/lib64/bionic/libc.so",0,0,0,0,0,7,0,29012,"[NULL]","[NULL]"
+          605908369259172,0,"__start_thread","/apex/com.android.runtime/lib64/bionic/libc.so",0,8,0,84848,0,210,0,1084996,"[NULL]","[NULL]"
+          605908369259172,1,"_ZL15__pthread_startPv","/apex/com.android.runtime/lib64/bionic/libc.so",0,8,0,84848,0,210,0,1084996,"[NULL]","[NULL]"
+          605908369259172,1,"main","/system/bin/app_process64",0,0,0,0,0,7,0,29012,"[NULL]","[NULL]"
+          605908369259172,2,"_ZN3art6Thread14CreateCallbackEPv","/apex/com.android.art/lib64/libart.so",0,3,0,57144,0,133,0,736946,"[NULL]","[NULL]"
+          605908369259172,2,"_ZN7android14AndroidRuntime15javaThreadShellEPv","/system/lib64/libandroid_runtime.so",0,5,0,27704,0,77,0,348050,"[NULL]","[NULL]"
+          605908369259172,2,"_ZN7android14AndroidRuntime5startEPKcRKNS_6VectorINS_7String8EEEb","/system/lib64/libandroid_runtime.so",0,0,0,0,0,7,0,29012,"[NULL]","[NULL]"
+          605908369259172,3,"_ZN3art35InvokeVirtualOrInterfaceWithJValuesIPNS_9ArtMethodEEENS_6JValueERKNS_33ScopedObjectAccessAlreadyRunnableEP8_jobjectT_PK6jvalue","/apex/com.android.art/lib64/libart.so",0,3,0,57144,0,133,0,736946,"[NULL]","[NULL]"
+          605908369259172,3,"_ZN7_JNIEnv20CallStaticVoidMethodEP7_jclassP10_jmethodIDz","/system/lib64/libandroid_runtime.so",0,0,0,0,0,7,0,29012,"[NULL]","[NULL]"
+          605908369259172,3,"_ZN7android6Thread11_threadLoopEPv","/system/lib64/libutils.so",0,5,0,27704,0,77,0,348050,"[NULL]","[NULL]"
         '''))
 
   def test_heap_profile_tracker_new_stack(self):

--- a/test/trace_processor/diff_tests/parser/profiling/tests_llvm_symbolizer.py
+++ b/test/trace_processor/diff_tests/parser/profiling/tests_llvm_symbolizer.py
@@ -34,7 +34,6 @@ class ProfilingLlvmSymbolizer(TestSuite):
         trace=DataPath('callstack_sampling.pftrace'),
         query="""
         SELECT
-          ef.id,
           ef.ts,
           ef.depth,
           ef.name,
@@ -47,7 +46,6 @@ class ProfilingLlvmSymbolizer(TestSuite):
           cumulative_alloc_count,
           alloc_size,
           cumulative_alloc_size,
-          ef.parent_id,
           ef.source_file,
           ef.line_number
         FROM process
@@ -60,20 +58,22 @@ class ProfilingLlvmSymbolizer(TestSuite):
           NULL
         ) ef
         WHERE pid = 1728
+        ORDER BY ef.depth, ef.name, ef.map_name, ef.cumulative_size,
+                 ef.cumulative_count
         LIMIT 10;
         """,
         out=Csv('''
-          "id","ts","depth","name","map_name","count","cumulative_count","size","cumulative_size","alloc_count","cumulative_alloc_count","alloc_size","cumulative_alloc_size","parent_id","source_file","line_number"
-          0,7689491063351,0,"__start_thread","/apex/com.android.runtime/lib64/bionic/libc.so",0,560,0,560,0,0,0,0,"[NULL]","[NULL]","[NULL]"
-          1,7689491063351,1,"_ZL15__pthread_startPv","/apex/com.android.runtime/lib64/bionic/libc.so",0,560,0,560,0,0,0,0,0,"[NULL]","[NULL]"
-          2,7689491063351,2,"_ZN3art6Thread14CreateCallbackEPv","/apex/com.android.art/lib64/libart.so",0,301,0,301,0,0,0,0,1,"[NULL]","[NULL]"
-          3,7689491063351,3,"_ZN3art35InvokeVirtualOrInterfaceWithJValuesIPNS_9ArtMethodEEENS_6JValueERKNS_33ScopedObjectAccessAlreadyRunnableEP8_jobjectT_PK6jvalue","/apex/com.android.art/lib64/libart.so",0,301,0,301,0,0,0,0,2,"[NULL]","[NULL]"
-          4,7689491063351,4,"_ZN3art9ArtMethod6InvokeEPNS_6ThreadEPjjPNS_6JValueEPKc","/apex/com.android.art/lib64/libart.so",0,301,0,301,0,0,0,0,3,"[NULL]","[NULL]"
-          5,7689491063351,5,"art_quick_invoke_stub","/apex/com.android.art/lib64/libart.so",0,301,0,301,0,0,0,0,4,"[NULL]","[NULL]"
-          6,7689491063351,6,"android.os.HandlerThread.run","/system/framework/arm64/boot-framework.oat",0,43,0,43,0,0,0,0,5,"[NULL]","[NULL]"
-          7,7689491063351,7,"android.os.Looper.loop","/system/framework/arm64/boot-framework.oat",0,43,0,43,0,0,0,0,6,"[NULL]","[NULL]"
-          8,7683950792832,8,"android.os.Looper.loopOnce","/system/framework/arm64/boot-framework.oat",1,43,1,43,0,0,0,0,7,"[NULL]","[NULL]"
-          9,7689491063351,9,"android.os.Handler.dispatchMessage","/system/framework/arm64/boot-framework.oat",0,35,0,35,0,0,0,0,8,"[NULL]","[NULL]"
+          "ts","depth","name","map_name","count","cumulative_count","size","cumulative_size","alloc_count","cumulative_alloc_count","alloc_size","cumulative_alloc_size","source_file","line_number"
+          7689491063351,0,"ERROR INVALID_MAP","/ERROR",0,1,0,1,0,0,0,0,"[NULL]","[NULL]"
+          7689491063351,0,"__libc_init","/apex/com.android.runtime/lib64/bionic/libc.so",0,10,0,10,0,0,0,0,"[NULL]","[NULL]"
+          7689491063351,0,"__start_thread","/apex/com.android.runtime/lib64/bionic/libc.so",0,560,0,560,0,0,0,0,"[NULL]","[NULL]"
+          7689491063351,0,"clone","/apex/com.android.runtime/lib64/bionic/libc.so",0,1,0,1,0,0,0,0,"[NULL]","[NULL]"
+          7689491063351,1,"","",0,1,0,1,0,0,0,0,"[NULL]","[NULL]"
+          7689491063351,1,"_ZL15__pthread_startPv","/apex/com.android.runtime/lib64/bionic/libc.so",0,560,0,560,0,0,0,0,"[NULL]","[NULL]"
+          7689491063351,1,"__bionic_clone","/apex/com.android.runtime/lib64/bionic/libc.so",0,1,0,1,0,0,0,0,"[NULL]","[NULL]"
+          7689491063351,1,"main","/system/bin/app_process64",0,10,0,10,0,0,0,0,"[NULL]","[NULL]"
+          7689491063351,1,"main","/system/bin/surfaceflinger",0,0,0,0,0,0,0,0,"[NULL]","[NULL]"
+          7689491063351,2,"_ZN13thread_data_t10trampolineEPKS_","/system/lib64/libutils.so",0,246,0,246,0,0,0,0,"[NULL]","[NULL]"
         '''))
 
   def test_callstack_sampling_flamegraph_multi_process(self):


### PR DESCRIPTION
Makes the experimental_flamegraph diff-test goldens independent of the pipeline's internal row order, so future reorderings don't churn them with pure reordering noise.

Three tests (system-server heap graph, system-server native profile, perf callstack sampling) used a bare `LIMIT 10`, pinning whatever rows the pipeline emitted first. They now:

- `ORDER BY` stable value columns (`cumulative_size DESC, name` for the heap graph, `depth, name, map_name, ...` for the callstack trees), and
- drop `id`/`parent_id` from the SELECT, which are emit-order row ids rather than data.

Verified that the new system-server golden is byte-identical on all value columns between the legacy implementation and the shared-pipeline implementation (#7048), so this lands on its own and the migration needs no golden change.