### PR TITLE
ui: cherry-pick #7042 onto canary

### DIFF
--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -177,6 +177,8 @@ class ErrorDialogComponent implements m.ClassComponent<ErrorDetails> {
       this.traceData = traceSource.file;
       // this.traceSize = this.traceData.size;
     } else if (traceSource.type === 'ARRAY_BUFFER') {
+      // Never upload local-only traces (e.g. from postMessage) to GCS.
+      if (traceSource.localOnly) return;
       this.traceData = traceSource.buffer;
       // this.traceSize = this.traceData.byteLength;
     } else {

--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -138,6 +138,9 @@ export function parsePostedTrace(
   } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
     return {
       title: 'External trace',
+      // A bare buffer gives the sender no way to opt into sharing, so default
+      // to local-only (matching the wrapped path).
+      localOnly: true,
       buffer: toArrayBuffer(data),
     };
   } else {

--- a/ui/src/frontend/post_message_handler_unittest.ts
+++ b/ui/src/frontend/post_message_handler_unittest.ts
@@ -71,6 +71,11 @@ describe('parsePostedTrace', () => {
       expect(result?.buffer).toBeInstanceOf(ArrayBuffer);
     });
 
+    test('is local-only by default (no way to opt into sharing)', () => {
+      const result = parsePostedTrace(new ArrayBuffer());
+      expect(result?.localOnly).toBe(true);
+    });
+
     test('view is snipped to the view, not the underlying buffer', () => {
       // A 10-byte view starting at offset 2 of a 16-byte buffer.
       const underlying = new Uint8Array(16);


### PR DESCRIPTION
Cherry-pick of #7042 (a06f0659851f22611a5f886bc44349e08beeb240) onto canary.

Bare ArrayBuffers received over postMessage have no origin-provided
download URL, so treating them as shareable allowed GCS upload of
traces the sender never intended to leave the machine. This backports
the fix that defaults them to local-only.