### PR TITLE
tp: load Arrow validity buffers with a memcpy

### DIFF
--- a/src/trace_processor/core/dataframe/arrow_deserializer.cc
+++ b/src/trace_processor/core/dataframe/arrow_deserializer.cc
@@ -107,14 +107,9 @@ base::StatusOr<BitVector> ReadValidityBuffer(BodyReader* reader,
 
   ASSIGN_OR_RETURN(TraceBlobView bitmap,
                    reader->ReadExact(ValidityBufferSize(rows)));
-  BitVector validity = BitVector::CreateWithSize(rows, false);
-  int64_t nulls = rows;
-  for (uint32_t row = 0; row < rows; ++row) {
-    if (bitmap.data()[BitmapByteIndex(row)] & BitmapMask(row)) {
-      validity.set(row);
-      --nulls;
-    }
-  }
+  BitVector validity = BitVector::CreateFromBitmap(bitmap.data(), rows);
+  int64_t nulls = static_cast<int64_t>(rows) -
+                  static_cast<int64_t>(validity.CountSetBits());
   return nulls == expected_nulls
              ? base::StatusOr<BitVector>(std::move(validity))
              : base::StatusOr<BitVector>(InvalidFile());

--- a/src/trace_processor/core/dataframe/arrow_serializer.cc
+++ b/src/trace_processor/core/dataframe/arrow_serializer.cc
@@ -173,11 +173,8 @@ class BufferedOutput {
 };
 
 int64_t CountNulls(uint32_t rows, const BitVector& validity) {
-  int64_t nulls = 0;
-  for (uint32_t row = 0; row < rows; ++row) {
-    nulls += !validity.is_set(row);
-  }
-  return nulls;
+  PERFETTO_DCHECK(validity.size() == rows);
+  return rows - static_cast<int64_t>(validity.CountSetBits());
 }
 
 // Maps Arrow's logical row index to dataframe's physical storage index. Dense

--- a/src/trace_processor/core/util/bit_vector.h
+++ b/src/trace_processor/core/util/bit_vector.h
@@ -82,6 +82,36 @@ struct BitVector {
     return BitVector(std::move(words), size);
   }
 
+  // Allocates a new BitVector of `size` bits from a packed bitmap of
+  // ceil(size / 8) bytes holding bit i at byte i / 8, bit i % 8. This is the
+  // layout of the words below, so the bitmap is taken verbatim.
+  static BitVector CreateFromBitmap(const uint8_t* bitmap, uint64_t size) {
+    static_assert(PERFETTO_IS_LITTLE_ENDIAN());
+    if (size == 0) {
+      return {};
+    }
+    auto words = FlexVector<uint64_t>::CreateWithSize((size + 63u) / 64u);
+    size_t bitmap_bytes = static_cast<size_t>((size + 7u) / 8u);
+    size_t word_bytes = words.size() * sizeof(uint64_t);
+    memcpy(words.data(), bitmap, bitmap_bytes);
+    memset(reinterpret_cast<uint8_t*>(words.data()) + bitmap_bytes, 0,
+           word_bytes - bitmap_bytes);
+    // Bits past `size` are unspecified in the source bitmap.
+    if (size % 64u != 0u) {
+      words.back() &= (1ull << (size % 64u)) - 1ull;
+    }
+    return BitVector(std::move(words), size);
+  }
+
+  // Returns the number of set bits in the vector.
+  PERFETTO_ALWAYS_INLINE uint64_t CountSetBits() const {
+    uint64_t count = 0;
+    for (uint64_t i = 0; i < (size_ + 63ull) / 64ull; ++i) {
+      count += static_cast<uint64_t>(PERFETTO_POPCOUNT(words_[i]));
+    }
+    return count;
+  }
+
   // Adds a bit to the end of the vector.
   //
   // bit: The boolean value to add to the end of the BitVector.


### PR DESCRIPTION
`ReadValidityBuffer` walked every row to rebuild the null bitmap one bit at a
time, which on a heap profile is tens of millions of iterations for every
nullable column.

Arrow's validity buffer already has the layout `BitVector` stores — bit *i* in
word *i/64* at position *i%64*, little-endian — so it can be taken verbatim with
a memcpy, and the null count falls out of a popcount over the words. Both are
added to `BitVector` as `CreateFromBitmap` and `CountSetBits`, and the
serializer's `CountNulls` uses the latter in place of its own per-row loop.

Reimporting a 2.26GB archive goes from 2.67s to 2.45s.

Bits past the end of the bitmap are unspecified in the source, so
`CreateFromBitmap` masks the tail of the last word; the existing round-trip
tests cover the non-multiple-of-64 row counts that exercise it.

Second of a three-PR stack, based on #7059.
