### PR TITLE
Exclude waitForBufferRelease from DrawFrames blocking calls

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/critical_blocking_calls.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/critical_blocking_calls.sql
@@ -87,19 +87,59 @@ RETURNS BOOL
 AS
 SELECT _is_relevant_blocking_call_expr!($name);
 
+CREATE PERFETTO TABLE _android_critical_blocking_calls_draw_frames AS
+SELECT utid, id, ts, dur
+FROM thread_slice
+WHERE
+  name GLOB 'DrawFrames*'
+ORDER BY
+  ts;
+
+CREATE PERFETTO TABLE _android_critical_blocking_calls_wait_for_buffer_release
+AS
+SELECT utid, ts, dur
+FROM thread_slice
+WHERE
+  name = 'waitForBufferRelease'
+ORDER BY
+  ts;
+
 --Extract critical blocking calls from all processes.
 CREATE PERFETTO TABLE _android_critical_blocking_calls AS
+WITH
+  _wait_for_buffer_release_dur AS (
+    SELECT s.id, SUM(child.dur) AS dur
+    FROM _android_critical_blocking_calls_wait_for_buffer_release AS child
+    JOIN _android_critical_blocking_calls_draw_frames AS s
+      ON child.utid = s.utid
+      AND child.ts >= s.ts
+      AND child.ts < s.ts + s.dur
+    GROUP BY
+      s.id
+  )
 SELECT
   android_standardize_slice_name(s.name) AS name,
   s.ts,
-  s.dur,
+  iif(
+    wait_for_buffer_release.dur IS NULL
+    OR s.dur = -1,
+    s.dur,
+    MAX(s.dur - wait_for_buffer_release.dur, 0)
+  ) AS dur,
   s.id,
   s.process_name,
   thread.utid,
   s.upid,
-  s.ts + s.dur AS ts_end
+  s.ts
+  + iif(
+    wait_for_buffer_release.dur IS NULL
+    OR s.dur = -1,
+    s.dur,
+    MAX(s.dur - wait_for_buffer_release.dur, 0)
+  ) AS ts_end
 FROM thread_slice AS s
 JOIN thread USING (utid)
+LEFT JOIN _wait_for_buffer_release_dur AS wait_for_buffer_release USING (id)
 WHERE
   _is_relevant_blocking_call_expr!(s.name)
 UNION ALL

--- a/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.out
+++ b/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.out
@@ -119,10 +119,10 @@ android_blocking_calls_cuj_per_frame_metric {
     }
     blocking_calls {
       name: "DrawFrames"
-      max_dur_per_frame_ms: 1
-      max_dur_per_frame_ns: 1000000
+      max_dur_per_frame_ms: 0
+      max_dur_per_frame_ns: 800000
       mean_dur_per_frame_ms: 0
-      mean_dur_per_frame_ns: 750000
+      mean_dur_per_frame_ns: 650000
       max_cnt_per_frame: 1
       mean_cnt_per_frame: 1.000000
     }

--- a/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.py
+++ b/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.py
@@ -369,6 +369,13 @@ def add_blocking_call_crossing_frame_boundary(trace, cuj_name):
       tid=LAUNCHER_RTID,
       pid=LAUNCHER_PID)
 
+  trace.add_atrace_for_thread(
+      ts=121_500_000,
+      ts_end=121_700_000,
+      buf="waitForBufferRelease",
+      tid=LAUNCHER_RTID,
+      pid=LAUNCHER_PID)
+
   trace.add_frame(
       vsync=82,
       ts_do_frame=141_000_000,

--- a/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
+++ b/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
@@ -50,8 +50,8 @@ class SystemUICujs(TestSuite):
         """,
         out=Csv("""
         "cuj_id","upid","process_name","cuj_slice_name","cuj_name","slice_id","ts","ts_end","dur","state"
-        1,1,"com.android.systemui","L<IGNORED_CUJ_1>","IGNORED_CUJ_1",59,150000000,155000000,5000000,"completed"
-        2,1,"com.android.systemui","L<IGNORED_CUJ_2>","IGNORED_CUJ_2",64,156000000,160000000,4000000,"completed"
+        1,1,"com.android.systemui","L<IGNORED_CUJ_1>","IGNORED_CUJ_1",60,150000000,155000000,5000000,"completed"
+        2,1,"com.android.systemui","L<IGNORED_CUJ_2>","IGNORED_CUJ_2",65,156000000,160000000,4000000,"completed"
         """))
 
   def test_android_sysui_latency_cujs_state(self):


### PR DESCRIPTION
This recalculates the duration and end time for DrawFrames slices by explicitly subtracting the time spent in any child waitForBufferRelease slices. This helps stabilize metrics that are sensitive to EGL swap buffer overhead differences.

Bug: 540803616