### PR TITLE
trace_processor: Add support for tracking string system properties

### DIFF
--- a/src/trace_processor/importers/proto/android_probes_parser.cc
+++ b/src/trace_processor/importers/proto/android_probes_parser.cc
@@ -604,6 +604,15 @@ void AndroidProbesParser::ParseAndroidSystemProperty(int64_t ts,
       continue;
     }
 
+    if (name == "debug.tracing.wallpaper.package_name" ||
+        name == "debug.tracing.wallpaper.class_name") {
+      StringId name_id = context_->storage->InternString(name);
+      StringId value_id = context_->storage->InternString(kv.value());
+      context_->metadata_tracker->SetDynamicMetadata(
+          name_id, Variadic::String(value_id));
+      continue;
+    }
+
     std::optional<int32_t> state =
         base::StringToInt32(kv.value().ToStdString());
     if (!state) {


### PR DESCRIPTION
Currently Android system properties that evaluate to strings (rather than numbers) are silently dropped during trace_processor ingestion.

This modifies the android_probes_parser to catch values that fail StringToInt32 conversion and emit them instead as an instantaneous (0-duration) slice dynamically utilizing a sysprop_string dimension track named after the property name (e.g., debug.wallpaper.package_name).

This natively extends Perfetto's android_system_property capabilities without requiring upstream proto changes and exposes string states seamlessly to SQL.

Bug: 415757470
Test: built trace_processor
