### PR TITLE
tp: cherry-pick #7059 onto canary

### DIFF
--- a/src/trace_processor/core/dataframe/arrow_deserializer.cc
+++ b/src/trace_processor/core/dataframe/arrow_deserializer.cc
@@ -120,46 +120,73 @@ base::StatusOr<BitVector> ReadValidityBuffer(BodyReader* reader,
              : base::StatusOr<BitVector>(InvalidFile());
 }
 
-// Reverses WriteUtf8Buffers: validate Arrow's offsets, intern each string, and
-// store the resulting StringPool IDs in dense or compact sparse storage.
-base::Status ReadUtf8Buffers(BodyReader* reader,
-                             uint32_t rows,
-                             bool nullable,
-                             bool sparse,
-                             const BitVector& validity,
-                             StringPool* pool,
-                             Storage* storage) {
+using Dictionary = FlexVector<StringPool::Id>;
+
+// Reverses ArrowSerializer::WriteDictionary.
+base::StatusOr<Dictionary> ReadDictionaryValues(BodyReader* reader,
+                                                uint32_t count,
+                                                StringPool* pool) {
+  RETURN_IF_ERROR(reader->ReadEmpty());
   ASSIGN_OR_RETURN(TraceBlobView offsets,
-                   reader->ReadExact(Utf8OffsetBufferSize(rows)));
+                   reader->ReadExact(Utf8OffsetBufferSize(count)));
   ASSIGN_OR_RETURN(TraceBlobView strings, reader->ReadVariableSize());
   if (Load<int32_t>(offsets.data(), 0) != 0) {
     return InvalidFile();
   }
-  auto& output = storage->unchecked_get<String>();
-  for (uint32_t row = 0; row < rows; ++row) {
-    int32_t start = Load<int32_t>(offsets.data(), row);
-    int32_t end = Load<int32_t>(offsets.data(), row + 1);
+  const char* bytes =
+      strings.size() ? reinterpret_cast<const char*>(strings.data()) : "";
+  Dictionary values = Dictionary::CreateWithCapacity(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    int32_t start = Load<int32_t>(offsets.data(), i);
+    int32_t end = Load<int32_t>(offsets.data(), i + 1);
     if (start < 0 || end < start ||
         static_cast<uint64_t>(end) > strings.size()) {
       return InvalidFile();
     }
-    if (!nullable || validity.is_set(row)) {
-      output.push_back(pool->InternString(base::StringView(
-          reinterpret_cast<const char*>(strings.data()) + start,
-          static_cast<size_t>(end - start))));
-    } else if (!sparse) {
-      output.push_back({});
-    }
+    values.push_back(pool->InternString(
+        base::StringView(bytes + start, static_cast<size_t>(end - start))));
   }
-  return Load<int32_t>(offsets.data(), rows) ==
-                 static_cast<int64_t>(strings.size())
-             ? base::OkStatus()
-             : InvalidFile();
+  if (static_cast<uint64_t>(Load<int32_t>(offsets.data(), count)) !=
+      strings.size()) {
+    return InvalidFile();
+  }
+  return std::move(values);
+}
+
+// Reverses ArrowSerializer::WriteDictionaryIndices.
+base::Status ReadDictionaryIndices(BodyReader* reader,
+                                   uint32_t rows,
+                                   uint32_t stored_rows,
+                                   bool nullable,
+                                   bool sparse,
+                                   const BitVector& validity,
+                                   const Dictionary& dictionary,
+                                   Storage* storage) {
+  ASSIGN_OR_RETURN(
+      TraceBlobView indices,
+      reader->ReadExact(static_cast<uint64_t>(rows) * sizeof(DictionaryIndex)));
+  auto& output = storage->unchecked_get<String>();
+  output.reserve(stored_rows);
+  for (uint32_t row = 0; row < rows; ++row) {
+    if (nullable && !validity.is_set(row)) {
+      if (!sparse) {
+        output.push_back({});
+      }
+      continue;
+    }
+    DictionaryIndex index = Load<DictionaryIndex>(indices.data(), row);
+    if (index < 0 || static_cast<uint64_t>(index) >= dictionary.size()) {
+      return InvalidFile();
+    }
+    output.push_back(dictionary[static_cast<uint32_t>(index)]);
+  }
+  return base::OkStatus();
 }
 
 template <typename T>
 void ReadNumericValues(const TraceBlobView& values,
                        uint32_t rows,
+                       uint32_t stored_rows,
                        bool sparse,
                        const BitVector& validity,
                        FlexVector<T>* output) {
@@ -173,6 +200,7 @@ void ReadNumericValues(const TraceBlobView& values,
   }
   // Arrow has one value slot per logical row. Sparse dataframe storage keeps
   // only valid values, so compact the Arrow buffer using its validity bitmap.
+  output->reserve(stored_rows);
   for (uint32_t row = 0; row < rows; ++row) {
     if (validity.is_set(row)) {
       output->push_back(Load<T>(values.data(), row));
@@ -182,6 +210,7 @@ void ReadNumericValues(const TraceBlobView& values,
 
 base::Status ReadNumericBuffer(BodyReader* reader,
                                uint32_t rows,
+                               uint32_t stored_rows,
                                bool sparse,
                                const BitVector& validity,
                                Storage* storage) {
@@ -189,16 +218,16 @@ base::Status ReadNumericBuffer(BodyReader* reader,
                    reader->ReadExact(static_cast<uint64_t>(rows) *
                                      NumericSize(storage->type())));
   if (storage->type().Is<core::Double>()) {
-    ReadNumericValues(values, rows, sparse, validity,
+    ReadNumericValues(values, rows, stored_rows, sparse, validity,
                       &storage->unchecked_get<Double>());
   } else if (storage->type().Is<core::Int64>()) {
-    ReadNumericValues(values, rows, sparse, validity,
+    ReadNumericValues(values, rows, stored_rows, sparse, validity,
                       &storage->unchecked_get<Int64>());
   } else if (storage->type().Is<core::Int32>()) {
-    ReadNumericValues(values, rows, sparse, validity,
+    ReadNumericValues(values, rows, stored_rows, sparse, validity,
                       &storage->unchecked_get<Int32>());
   } else {
-    ReadNumericValues(values, rows, sparse, validity,
+    ReadNumericValues(values, rows, stored_rows, sparse, validity,
                       &storage->unchecked_get<Uint32>());
   }
   return base::OkStatus();
@@ -219,13 +248,15 @@ void InstallValidity(Nullability nullability,
   }
 }
 
-struct LocatedRecordBatch {
+struct LocatedBatches {
+  std::vector<Block> dictionaries;
   Block block;
   size_t message_offset;
 };
 
-// Phase 1: validate the outer file framing and locate the only record batch.
-base::StatusOr<LocatedRecordBatch> LocateRecordBatch(
+// Phase 1: validate the outer file framing and locate the dictionary batches
+// and the only record batch.
+base::StatusOr<LocatedBatches> LocateBatches(
     const util::TraceBlobViewReader& data) {
   size_t base = data.start_offset();
   size_t file_size = data.end_offset() - base;
@@ -257,6 +288,9 @@ base::StatusOr<LocatedRecordBatch> LocateRecordBatch(
   auto footer = FlatBufferReader::GetRoot(footer_blob->data(), footer_size);
   auto blocks = footer ? footer->VecScalar<Block>(footer_field::kRecordBatches)
                        : util::FlatBufferScalarVec<Block>{};
+  auto dictionary_blocks =
+      footer ? footer->VecScalar<Block>(footer_field::kDictionaries)
+             : util::FlatBufferScalarVec<Block>{};
   if (!footer ||
       footer->Scalar<int16_t>(footer_field::kVersion, kMissingSignedValue) !=
           kMetadataV5 ||
@@ -277,10 +311,44 @@ base::StatusOr<LocatedRecordBatch> LocateRecordBatch(
   if (block_offset > footer_relative ||
       metadata_length > footer_relative - block_offset ||
       body_length > footer_relative - block_offset - metadata_length ||
-      block_offset + metadata_length + body_length != footer_relative) {
+      block_offset + metadata_length + body_length + kEndOfStreamSize !=
+          footer_relative) {
     return InvalidFile();
   }
-  return LocatedRecordBatch{block, base + static_cast<size_t>(block_offset)};
+
+  std::vector<Block> dictionaries;
+  dictionaries.reserve(dictionary_blocks.size());
+  for (uint32_t i = 0; i < dictionary_blocks.size(); ++i) {
+    Block dictionary = dictionary_blocks[i];
+    if (dictionary.offset < 0 || dictionary.metadata_length < 0 ||
+        static_cast<uint32_t>(dictionary.metadata_length) <
+            kMessagePrefixSize ||
+        dictionary.body_length < 0) {
+      return InvalidFile();
+    }
+    uint64_t offset = static_cast<uint64_t>(dictionary.offset);
+    uint64_t metadata = static_cast<uint32_t>(dictionary.metadata_length);
+    uint64_t body = static_cast<uint64_t>(dictionary.body_length);
+    if (offset > block_offset || metadata > block_offset - offset ||
+        body > block_offset - offset - metadata) {
+      return InvalidFile();
+    }
+    dictionaries.push_back(dictionary);
+  }
+  auto marker = data.SliceOff(
+      base + static_cast<size_t>(footer_relative - kEndOfStreamSize),
+      kEndOfStreamSize);
+  MessagePrefix end_of_stream{};
+  if (!marker) {
+    return InvalidFile();
+  }
+  memcpy(&end_of_stream, marker->data(), sizeof(end_of_stream));
+  if (end_of_stream.continuation != kContinuation ||
+      end_of_stream.metadata_size != 0) {
+    return InvalidFile();
+  }
+  return LocatedBatches{std::move(dictionaries), block,
+                        base + static_cast<size_t>(block_offset)};
 }
 
 struct RecordBatchMetadata {
@@ -291,16 +359,18 @@ struct RecordBatchMetadata {
   util::FlatBufferScalarVec<ArrowBuffer> buffers;
 };
 
-// Phase 2: parse and validate the record-batch metadata. Keeping |blob| in the
-// result preserves the backing storage referenced by the flatbuffer vectors.
-base::StatusOr<RecordBatchMetadata> ReadRecordBatchMetadata(
-    const util::TraceBlobViewReader& data,
-    const LocatedRecordBatch& located,
-    uint32_t expected_nodes,
-    uint32_t expected_buffers) {
-  uint64_t metadata_length =
-      static_cast<uint32_t>(located.block.metadata_length);
-  auto prefix = data.SliceOff(located.message_offset, kMessagePrefixSize);
+struct Message {
+  TraceBlobView blob;
+  FlatBufferReader message;
+  size_t body_offset;
+};
+
+base::StatusOr<Message> ReadMessage(const util::TraceBlobViewReader& data,
+                                    const Block& block,
+                                    size_t message_offset,
+                                    uint8_t expected_header) {
+  uint64_t metadata_length = static_cast<uint32_t>(block.metadata_length);
+  auto prefix = data.SliceOff(message_offset, kMessagePrefixSize);
   uint32_t continuation = 0;
   int32_t metadata_size = 0;
   if (prefix) {
@@ -315,25 +385,32 @@ base::StatusOr<RecordBatchMetadata> ReadRecordBatchMetadata(
   }
 
   uint32_t metadata_size_u32 = static_cast<uint32_t>(metadata_size);
-  auto metadata = data.SliceOff(located.message_offset + kMessagePrefixSize,
-                                metadata_size_u32);
+  auto metadata =
+      data.SliceOff(message_offset + kMessagePrefixSize, metadata_size_u32);
   auto message =
       metadata ? FlatBufferReader::GetRoot(metadata->data(), metadata_size_u32)
                : std::nullopt;
-  auto record_batch =
-      message ? message->Table(message_field::kHeader) : FlatBufferReader{};
   if (!message ||
       message->Scalar<int16_t>(message_field::kVersion, kMissingSignedValue) !=
           kMetadataV5 ||
-      message->Scalar<uint8_t>(message_field::kHeaderType) !=
-          kHeaderRecordBatch ||
-      !record_batch ||
+      message->Scalar<uint8_t>(message_field::kHeaderType) != expected_header ||
       message->Scalar<int64_t>(message_field::kBodyLength,
-                               kMissingSignedValue) !=
-          located.block.body_length) {
+                               kMissingSignedValue) != block.body_length) {
     return InvalidFile();
   }
+  return Message{std::move(*metadata), *message,
+                 message_offset + static_cast<size_t>(metadata_length)};
+}
 
+// Phase 2: validate the shape of a record batch against the layout the caller
+// derived from the dataframe spec.
+base::StatusOr<RecordBatchMetadata> ReadRecordBatch(
+    Message message,
+    const FlatBufferReader& record_batch,
+    int64_t body_length,
+    std::optional<uint32_t> expected_rows,
+    uint32_t expected_nodes,
+    uint32_t expected_buffers) {
   int64_t row_count = record_batch.Scalar<int64_t>(record_batch_field::kLength,
                                                    kMissingSignedValue);
   auto nodes = record_batch.VecScalar<FieldNode>(record_batch_field::kNodes);
@@ -345,27 +422,63 @@ base::StatusOr<RecordBatchMetadata> ReadRecordBatchMetadata(
   }
 
   uint32_t rows = static_cast<uint32_t>(row_count);
+  if (expected_rows && rows != *expected_rows) {
+    return InvalidFile();
+  }
   for (uint32_t i = 0; i < nodes.size(); ++i) {
     FieldNode node = nodes[i];
     if (node.length != rows || node.null_count < 0 || node.null_count > rows) {
       return InvalidFile();
     }
   }
-  uint64_t body_length = static_cast<uint64_t>(located.block.body_length);
   for (uint32_t i = 0; i < buffers.size(); ++i) {
     ArrowBuffer buffer = buffers[i];
+    uint64_t body = static_cast<uint64_t>(body_length);
     if (buffer.offset < 0 || buffer.length < 0 ||
-        static_cast<uint64_t>(buffer.offset) > body_length ||
+        static_cast<uint64_t>(buffer.offset) > body ||
         static_cast<uint64_t>(buffer.length) >
-            body_length - static_cast<uint64_t>(buffer.offset)) {
+            body - static_cast<uint64_t>(buffer.offset)) {
       return InvalidFile();
     }
   }
+  return RecordBatchMetadata{std::move(message.blob), rows, message.body_offset,
+                             nodes, buffers};
+}
 
-  size_t body_offset =
-      located.message_offset + static_cast<size_t>(metadata_length);
-  return RecordBatchMetadata{std::move(*metadata), rows, body_offset, nodes,
-                             buffers};
+base::StatusOr<std::vector<Dictionary>> ReadDictionaries(
+    const util::TraceBlobViewReader& data,
+    const LocatedBatches& located,
+    StringPool* pool) {
+  size_t base = data.start_offset();
+  std::vector<Dictionary> dictionaries;
+  dictionaries.reserve(located.dictionaries.size());
+  for (uint32_t i = 0; i < located.dictionaries.size(); ++i) {
+    const Block& block = located.dictionaries[i];
+    ASSIGN_OR_RETURN(
+        Message message,
+        ReadMessage(data, block, base + static_cast<size_t>(block.offset),
+                    kHeaderDictionaryBatch));
+    auto batch = message.message.Table(message_field::kHeader);
+    if (!batch ||
+        batch.Scalar<int64_t>(dictionary_batch_field::kId,
+                              kMissingSignedValue) != i ||
+        batch.Scalar<bool>(dictionary_batch_field::kIsDelta)) {
+      return InvalidFile();
+    }
+    auto record_batch = batch.Table(dictionary_batch_field::kData);
+    if (!record_batch) {
+      return InvalidFile();
+    }
+    ASSIGN_OR_RETURN(
+        RecordBatchMetadata values,
+        ReadRecordBatch(std::move(message), record_batch, block.body_length,
+                        std::nullopt, 1, kUtf8BufferCount));
+    BodyReader reader(data, values.body_offset, values.buffers);
+    ASSIGN_OR_RETURN(Dictionary dictionary,
+                     ReadDictionaryValues(&reader, values.rows, pool));
+    dictionaries.push_back(std::move(dictionary));
+  }
+  return std::move(dictionaries);
 }
 
 }  // namespace
@@ -386,29 +499,43 @@ base::StatusOr<Dataframe> DeserializeFromArrow(
   Dataframe dataframe(pool, static_cast<uint32_t>(column_names.size()),
                       column_names.data(), spec.column_specs.data());
 
-  // The dataframe spec supplies the schema. Derive the exact node and buffer
-  // counts for the supported layout before parsing file metadata.
+  // The dataframe spec supplies the schema. Derive the exact node, buffer and
+  // dictionary counts for the supported layout before parsing file metadata.
   uint32_t expected_nodes = 0;
   uint32_t expected_buffers = 0;
+  uint32_t expected_dictionaries = 0;
   for (const auto& column : dataframe.columns_) {
     if (!column->storage.type().Is<core::Id>()) {
       ++expected_nodes;
-      expected_buffers += column->storage.type().Is<core::String>()
-                              ? kUtf8BufferCount
-                              : kFixedWidthBufferCount;
+      expected_buffers += kFixedWidthBufferCount;
+      expected_dictionaries += column->storage.type().Is<core::String>();
     }
   }
 
-  ASSIGN_OR_RETURN(LocatedRecordBatch located, LocateRecordBatch(data));
-  ASSIGN_OR_RETURN(
-      RecordBatchMetadata batch,
-      ReadRecordBatchMetadata(data, located, expected_nodes, expected_buffers));
+  ASSIGN_OR_RETURN(LocatedBatches located, LocateBatches(data));
+  if (located.dictionaries.size() != expected_dictionaries) {
+    return InvalidFile();
+  }
+  ASSIGN_OR_RETURN(std::vector<Dictionary> dictionaries,
+                   ReadDictionaries(data, located, pool));
+  ASSIGN_OR_RETURN(Message message,
+                   ReadMessage(data, located.block, located.message_offset,
+                               kHeaderRecordBatch));
+  auto record_batch = message.message.Table(message_field::kHeader);
+  if (!record_batch) {
+    return InvalidFile();
+  }
+  ASSIGN_OR_RETURN(RecordBatchMetadata batch,
+                   ReadRecordBatch(std::move(message), record_batch,
+                                   located.block.body_length, std::nullopt,
+                                   expected_nodes, expected_buffers));
 
   // Phase 3: decode buffers in the same validity-then-values order used by the
   // serializer. Id columns are reconstructed from the record-batch row count
   // because they are implicit and therefore absent from Arrow.
   BodyReader reader(data, batch.body_offset, batch.buffers);
   uint32_t serialized_column = 0;
+  uint32_t dictionary_index = 0;
   for (uint32_t column_index = 0; column_index < dataframe.column_count();
        ++column_index) {
     auto& column = *dataframe.columns_[column_index];
@@ -423,12 +550,16 @@ base::StatusOr<Dataframe> DeserializeFromArrow(
     ASSIGN_OR_RETURN(
         BitVector validity,
         ReadValidityBuffer(&reader, batch.rows, node.null_count, nullable));
+    uint32_t stored_rows =
+        sparse ? batch.rows - static_cast<uint32_t>(node.null_count)
+               : batch.rows;
     if (column.storage.type().Is<core::String>()) {
-      RETURN_IF_ERROR(ReadUtf8Buffers(&reader, batch.rows, nullable, sparse,
-                                      validity, pool, &column.storage));
+      RETURN_IF_ERROR(ReadDictionaryIndices(
+          &reader, batch.rows, stored_rows, nullable, sparse, validity,
+          dictionaries[dictionary_index++], &column.storage));
     } else {
-      RETURN_IF_ERROR(ReadNumericBuffer(&reader, batch.rows, sparse, validity,
-                                        &column.storage));
+      RETURN_IF_ERROR(ReadNumericBuffer(&reader, batch.rows, stored_rows,
+                                        sparse, validity, &column.storage));
     }
     InstallValidity(nullability, std::move(validity), &column.null_storage);
   }

--- a/src/trace_processor/core/dataframe/arrow_deserializer_unittest.cc
+++ b/src/trace_processor/core/dataframe/arrow_deserializer_unittest.cc
@@ -122,6 +122,34 @@ util::FlatBufferReader MutableRecordBatch(std::vector<uint8_t>* bytes) {
   return record_batch;
 }
 
+TestBlock ReadDictionaryBlock(const std::vector<uint8_t>& bytes) {
+  size_t footer_offset = FooterOffset(bytes);
+  uint32_t footer_size =
+      static_cast<uint32_t>(bytes.size() - 10 - footer_offset);
+  auto footer = util::FlatBufferReader::GetRoot(bytes.data() + footer_offset,
+                                                footer_size);
+  EXPECT_TRUE(footer.has_value());
+  auto blocks = footer->VecScalar<TestBlock>(2);
+  EXPECT_EQ(blocks.size(), 1u);
+  return blocks[0];
+}
+
+util::FlatBufferReader MutableDictionaryRecordBatch(
+    std::vector<uint8_t>* bytes) {
+  TestBlock block = ReadDictionaryBlock(*bytes);
+  uint32_t metadata_size;
+  memcpy(&metadata_size, bytes->data() + block.offset + 4,
+         sizeof(metadata_size));
+  auto message = util::FlatBufferReader::GetRoot(
+      bytes->data() + block.offset + 8, metadata_size);
+  EXPECT_TRUE(message.has_value());
+  auto dictionary_batch = message->Table(2);
+  EXPECT_TRUE(static_cast<bool>(dictionary_batch));
+  auto record_batch = dictionary_batch.Table(1);
+  EXPECT_TRUE(static_cast<bool>(record_batch));
+  return record_batch;
+}
+
 inline constexpr auto kUint32NonNull = CreateTypedDataframeSpec(
     {"_auto_id", "val"},
     CreateTypedColumnSpec(Id{}, NonNull{}, IdSorted{}, NoDuplicates{}),
@@ -574,6 +602,17 @@ TEST(ArrowDeserializerTest, RejectsInconsistentBlockLength) {
   EXPECT_THAT(Deserialize(bytes, &pool, dst.CreateSpec()), IsError());
 }
 
+TEST(ArrowDeserializerTest, RejectsCorruptEndOfStreamMarker) {
+  StringPool pool;
+  auto src = MakeDataframe(kUint32NonNull, &pool, uint32_t{1});
+  std::vector<uint8_t> bytes = Serialize(src, pool);
+
+  uint32_t garbage = 0;
+  memcpy(bytes.data() + FooterOffset(bytes) - 8, &garbage, sizeof(garbage));
+  auto dst = Dataframe::CreateFromTypedSpec(kUint32NonNull, &pool);
+  EXPECT_THAT(Deserialize(bytes, &pool, dst.CreateSpec()), IsError());
+}
+
 TEST(ArrowDeserializerTest, RejectsInconsistentFieldNode) {
   StringPool pool;
   auto src = MakeDataframe(kUint32NonNull, &pool, uint32_t{1});
@@ -613,8 +652,8 @@ TEST(ArrowDeserializerTest, RejectsInvalidStringOffsets) {
   auto src = MakeDataframe(kStringNonNull, &pool, value);
   std::vector<uint8_t> bytes = Serialize(src, pool);
 
-  TestBlock block = ReadBlock(bytes);
-  auto record_batch = MutableRecordBatch(&bytes);
+  TestBlock block = ReadDictionaryBlock(bytes);
+  auto record_batch = MutableDictionaryRecordBatch(&bytes);
   uint8_t* buffer_data = MutableVectorData(&bytes, record_batch, 2);
   TestArrowBuffer offsets_buffer;
   memcpy(&offsets_buffer, buffer_data + sizeof(TestArrowBuffer),
@@ -623,6 +662,27 @@ TEST(ArrowDeserializerTest, RejectsInvalidStringOffsets) {
   memcpy(bytes.data() + block.offset + block.metadata_length +
              offsets_buffer.offset + sizeof(int32_t),
          &invalid_offset, sizeof(invalid_offset));
+
+  auto dst = Dataframe::CreateFromTypedSpec(kStringNonNull, &pool);
+  EXPECT_THAT(Deserialize(bytes, &pool, dst.CreateSpec()), IsError());
+}
+
+TEST(ArrowDeserializerTest, RejectsOutOfRangeDictionaryIndex) {
+  StringPool pool;
+  auto value = pool.InternString(base::StringView("value"));
+  auto src = MakeDataframe(kStringNonNull, &pool, value);
+  std::vector<uint8_t> bytes = Serialize(src, pool);
+
+  TestBlock block = ReadBlock(bytes);
+  auto record_batch = MutableRecordBatch(&bytes);
+  uint8_t* buffer_data = MutableVectorData(&bytes, record_batch, 2);
+  TestArrowBuffer indices_buffer;
+  memcpy(&indices_buffer, buffer_data + sizeof(TestArrowBuffer),
+         sizeof(indices_buffer));
+  int32_t invalid_index = 1;
+  memcpy(bytes.data() + block.offset + block.metadata_length +
+             indices_buffer.offset,
+         &invalid_index, sizeof(invalid_index));
 
   auto dst = Dataframe::CreateFromTypedSpec(kStringNonNull, &pool);
   EXPECT_THAT(Deserialize(bytes, &pool, dst.CreateSpec()), IsError());

--- a/src/trace_processor/core/dataframe/arrow_internal.h
+++ b/src/trace_processor/core/dataframe/arrow_internal.h
@@ -39,6 +39,7 @@ constexpr uint8_t kPaddedMagic[] = {'A', 'R', 'R', 'O', 'W', '1', 0, 0};
 constexpr uint32_t kContinuation = 0xFFFFFFFF;
 constexpr int16_t kMetadataV5 = 4;
 constexpr uint8_t kHeaderSchema = 1;
+constexpr uint8_t kHeaderDictionaryBatch = 2;
 constexpr uint8_t kHeaderRecordBatch = 3;
 constexpr uint8_t kTypeInt = 2;
 constexpr uint8_t kTypeFloatingPoint = 3;
@@ -49,15 +50,21 @@ constexpr int16_t kEndiannessLittle = 0;
 constexpr uint32_t kArrowAlignment = 8;
 constexpr uint32_t kBitsPerByte = 8;
 constexpr uint32_t kMessagePrefixSize = 8;
+constexpr uint32_t kEndOfStreamSize = kMessagePrefixSize;
 constexpr uint32_t kFooterSizeFieldSize = sizeof(uint32_t);
 constexpr uint32_t kFileTrailerSize = kFooterSizeFieldSize + sizeof(kMagic);
 constexpr uint32_t kMinimumFileSize =
     sizeof(kPaddedMagic) + kFooterSizeFieldSize + sizeof(kMagic);
 constexpr uint32_t kFixedWidthBufferCount = 2;  // Validity + values.
 constexpr uint32_t kUtf8BufferCount = 3;        // Validity + offsets + bytes.
-constexpr uint32_t kDictionaryBatchCount = 0;
 constexpr uint32_t kRecordBatchCount = 1;
 constexpr int64_t kMissingSignedValue = -1;
+
+// String columns are dictionary encoded: the record batch holds int32 indices
+// and the values live in a dictionary batch, mirroring how a dataframe stores
+// StringPool ids.
+constexpr int32_t kDictionaryIndexBits = 32;
+using DictionaryIndex = int32_t;
 
 // Field indices from the official Arrow flatbuffer schema.
 namespace int_field {
@@ -72,7 +79,18 @@ constexpr uint32_t kName = 0;
 constexpr uint32_t kNullable = 1;
 constexpr uint32_t kTypeType = 2;
 constexpr uint32_t kType = 3;
+constexpr uint32_t kDictionary = 4;
 }  // namespace field_field
+namespace dictionary_encoding_field {
+constexpr uint32_t kId = 0;
+constexpr uint32_t kIndexType = 1;
+constexpr uint32_t kIsOrdered = 2;
+}  // namespace dictionary_encoding_field
+namespace dictionary_batch_field {
+constexpr uint32_t kId = 0;
+constexpr uint32_t kData = 1;
+constexpr uint32_t kIsDelta = 2;
+}  // namespace dictionary_batch_field
 namespace schema_field {
 constexpr uint32_t kEndianness = 0;
 constexpr uint32_t kFields = 1;
@@ -134,8 +152,8 @@ inline uint64_t ValidityBufferSize(uint32_t rows) {
   return (static_cast<uint64_t>(rows) + kBitsPerByte - 1) / kBitsPerByte;
 }
 
-inline uint64_t Utf8OffsetBufferSize(uint32_t rows) {
-  return (static_cast<uint64_t>(rows) + 1) * sizeof(int32_t);
+inline uint64_t Utf8OffsetBufferSize(uint32_t values) {
+  return (static_cast<uint64_t>(values) + 1) * sizeof(int32_t);
 }
 
 inline size_t BitmapByteIndex(uint32_t row) {

--- a/src/trace_processor/core/dataframe/arrow_serializer.cc
+++ b/src/trace_processor/core/dataframe/arrow_serializer.cc
@@ -27,6 +27,7 @@
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
 #include "src/trace_processor/containers/string_pool.h"
@@ -44,6 +45,15 @@ struct ArrowSerializer::BodyPlan {
   uint64_t size = 0;
   std::vector<arrow_internal::FieldNode> nodes;
   std::vector<arrow_internal::ArrowBuffer> buffers;
+};
+
+struct ArrowSerializer::DictionaryPlan {
+  std::vector<StringPool::Id> values;
+  base::FlatHashMap<uint32_t, uint32_t> index_by_id;
+  uint32_t data_length = 0;
+  uint64_t body_size = 0;
+  std::vector<arrow_internal::ArrowBuffer> buffers;
+  std::vector<uint8_t> message;
 };
 
 namespace {
@@ -193,27 +203,6 @@ class StorageIndexMapper {
   uint32_t sparse_row_ = 0;
 };
 
-base::StatusOr<uint32_t> MeasureUtf8(uint32_t rows,
-                                     const Column& column,
-                                     const StringPool& pool,
-                                     const BitVector* validity,
-                                     bool sparse) {
-  const auto* ids = column.storage.unchecked_data<String>();
-  StorageIndexMapper mapper(validity, sparse);
-  uint32_t bytes = 0;
-  for (uint32_t row = 0; row < rows; ++row) {
-    if (mapper.HasValue(row)) {
-      size_t size = pool.Get(ids[mapper.Take(row)]).size();
-      if (size >
-          static_cast<uint32_t>(std::numeric_limits<int32_t>::max() - bytes)) {
-        return base::ErrStatus("String column is too large for Arrow Utf8");
-      }
-      bytes += static_cast<uint32_t>(size);
-    }
-  }
-  return bytes;
-}
-
 // Small subset of the Arrow flatbuffer schema used by this file.
 W::Offset BuildInt(W& w, int32_t width, bool is_signed) {
   w.StartTable();
@@ -233,15 +222,27 @@ W::Offset BuildUtf8(W& w) {
   return w.EndTable();
 }
 
+W::Offset BuildDictionaryEncoding(W& w, int64_t id) {
+  auto index_type = BuildInt(w, kDictionaryIndexBits, true);
+  w.StartTable();
+  w.FieldI64(dictionary_encoding_field::kId, id);
+  w.FieldOffset(dictionary_encoding_field::kIndexType, index_type);
+  return w.EndTable();
+}
+
 W::Offset BuildField(W& w,
                      const std::string& name,
                      StorageType type,
-                     bool nullable) {
+                     bool nullable,
+                     int64_t dictionary_id) {
   uint8_t arrow_type;
   W::Offset type_table;
+  W::Offset dictionary;
+  bool has_dictionary = type.Is<core::String>();
   if (type.Is<core::String>()) {
     arrow_type = kTypeUtf8;
     type_table = BuildUtf8(w);
+    dictionary = BuildDictionaryEncoding(w, dictionary_id);
   } else if (type.Is<core::Double>()) {
     arrow_type = kTypeFloatingPoint;
     type_table = BuildFloatingPoint(w);
@@ -257,6 +258,9 @@ W::Offset BuildField(W& w,
   w.FieldBool(field_field::kNullable, nullable);
   w.FieldU8(field_field::kTypeType, arrow_type);
   w.FieldOffset(field_field::kType, type_table);
+  if (has_dictionary) {
+    w.FieldOffset(field_field::kDictionary, dictionary);
+  }
   return w.EndTable();
 }
 
@@ -289,11 +293,27 @@ W::Offset BuildRecordBatch(W& w,
   return w.EndTable();
 }
 
-W::Offset BuildFooter(W& w, W::Offset schema, const Block& block) {
+W::Offset BuildDictionaryBatch(W& w,
+                               int64_t id,
+                               uint32_t length,
+                               const std::vector<ArrowBuffer>& buffers) {
+  std::vector<FieldNode> nodes{FieldNode{length, 0}};
+  auto data = BuildRecordBatch(w, length, nodes, buffers);
+  w.StartTable();
+  w.FieldI64(dictionary_batch_field::kId, id);
+  w.FieldOffset(dictionary_batch_field::kData, data);
+  return w.EndTable();
+}
+
+W::Offset BuildFooter(W& w,
+                      W::Offset schema,
+                      const std::vector<Block>& dictionary_blocks,
+                      const Block& block) {
   auto blocks = w.WriteVecStruct(&block, sizeof(block), kRecordBatchCount,
                                  alignof(int64_t));
-  auto dictionaries = w.WriteVecStruct(nullptr, sizeof(Block),
-                                       kDictionaryBatchCount, alignof(int64_t));
+  auto dictionaries = w.WriteVecStruct(
+      dictionary_blocks.data(), sizeof(Block),
+      static_cast<uint32_t>(dictionary_blocks.size()), alignof(int64_t));
   w.StartTable();
   w.FieldI16(footer_field::kVersion, kMetadataV5);
   w.FieldOffset(footer_field::kSchema, schema);
@@ -325,49 +345,21 @@ base::Status WriteValidityBuffer(uint32_t rows,
   return output.Finish();
 }
 
-// Arrow Utf8 stores an offset per logical row followed by one contiguous byte
-// buffer. Dataframe stores StringPool IDs, so this is where IDs are resolved
-// and their bytes are streamed in Arrow's representation.
-base::Status WriteUtf8Buffers(uint32_t rows,
-                              const Column& column,
-                              const StringPool& pool,
-                              const BitVector* validity,
-                              bool sparse,
-                              uint32_t string_bytes,
-                              FlexVector<uint8_t>* scratch,
-                              const ArrowSerializer::WriteFn& write) {
-  size_t offsets_bytes = static_cast<size_t>(Utf8OffsetBufferSize(rows));
-  const auto* ids = column.storage.unchecked_data<String>();
-  BufferedOutput output(scratch, write);
-
-  // Offset buffer. Resolving IDs here only reads string lengths; bytes are
-  // emitted in the second pass below.
-  StorageIndexMapper offset_mapper(validity, sparse);
+base::Status WriteUtf8OffsetBuffer(const std::vector<StringPool::Id>& values,
+                                   const StringPool& pool,
+                                   uint32_t data_length,
+                                   BufferedOutput* output) {
   int32_t offset = 0;
-  for (uint32_t row = 0; row < rows; ++row) {
-    RETURN_IF_ERROR(output.Append(&offset, sizeof(offset)));
-    if (offset_mapper.HasValue(row)) {
-      offset +=
-          static_cast<int32_t>(pool.Get(ids[offset_mapper.Take(row)]).size());
-    }
+  for (StringPool::Id id : values) {
+    RETURN_IF_ERROR(output->Append(&offset, sizeof(offset)));
+    offset += static_cast<int32_t>(pool.Get(id).size());
   }
-  RETURN_IF_ERROR(output.Append(&offset, sizeof(offset)));
-  RETURN_IF_ERROR(output.AppendPadding(
-      static_cast<size_t>(AlignToArrow(offsets_bytes)) - offsets_bytes));
-  PERFETTO_CHECK(static_cast<uint32_t>(offset) == string_bytes);
-
-  // Data buffer. Values already live in the StringPool, so stream those bytes
-  // directly instead of gathering the whole Arrow buffer in memory.
-  StorageIndexMapper string_mapper(validity, sparse);
-  for (uint32_t row = 0; row < rows; ++row) {
-    if (string_mapper.HasValue(row)) {
-      NullTermStringView value = pool.Get(ids[string_mapper.Take(row)]);
-      RETURN_IF_ERROR(output.Append(value.data(), value.size()));
-    }
-  }
-  RETURN_IF_ERROR(output.AppendPadding(
-      static_cast<size_t>(AlignToArrow(string_bytes)) - string_bytes));
-  return output.Finish();
+  RETURN_IF_ERROR(output->Append(&offset, sizeof(offset)));
+  PERFETTO_CHECK(static_cast<uint32_t>(offset) == data_length);
+  size_t bytes = static_cast<size_t>(
+      Utf8OffsetBufferSize(static_cast<uint32_t>(values.size())));
+  return output->AppendPadding(static_cast<size_t>(AlignToArrow(bytes)) -
+                               bytes);
 }
 
 base::Status WriteIdBuffer(uint32_t rows,
@@ -421,12 +413,66 @@ base::Status WriteNumericBuffer(uint32_t rows,
 ArrowSerializer::ArrowSerializer(IdColumnMode id_column_mode)
     : id_column_mode_(id_column_mode) {}
 
+ArrowSerializer::~ArrowSerializer() = default;
+
 void ArrowSerializer::Reset() {
   prepared_dataframe_ = nullptr;
   prepared_string_pool_ = nullptr;
   prepared_columns_.clear();
+  dictionaries_.clear();
   header_.clear();
+  batch_header_.clear();
   trailer_.clear();
+}
+
+// Collects the distinct StringPool ids of a column in first-appearance order
+// and lays out the dictionary batch which will carry their bytes.
+base::Status ArrowSerializer::PlanDictionary(uint32_t rows,
+                                             const Column& column,
+                                             const StringPool& pool,
+                                             const BitVector* validity,
+                                             bool sparse) {
+  constexpr uint32_t kMaxData =
+      static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+  constexpr size_t kMaxValues =
+      static_cast<size_t>(std::numeric_limits<DictionaryIndex>::max());
+
+  DictionaryPlan dictionary;
+  const auto* ids = column.storage.unchecked_data<String>();
+  StorageIndexMapper mapper(validity, sparse);
+  for (uint32_t row = 0; row < rows; ++row) {
+    if (!mapper.HasValue(row)) {
+      continue;
+    }
+    StringPool::Id id = ids[mapper.Take(row)];
+    auto [index, inserted] = dictionary.index_by_id.Insert(
+        id.raw_id(), static_cast<uint32_t>(dictionary.values.size()));
+    if (!inserted) {
+      continue;
+    }
+    if (dictionary.values.size() == kMaxValues) {
+      return base::ErrStatus("String column has too many distinct values");
+    }
+    size_t size = pool.Get(id).size();
+    if (size > kMaxData - dictionary.data_length) {
+      return base::ErrStatus("String column is too large for Arrow Utf8");
+    }
+    dictionary.data_length += static_cast<uint32_t>(size);
+    dictionary.values.push_back(id);
+  }
+
+  auto values = static_cast<uint32_t>(dictionary.values.size());
+  uint64_t cursor = 0;
+  dictionary.buffers.push_back({0, 0});
+  ASSIGN_OR_RETURN(auto offsets_buffer,
+                   AddBuffer(Utf8OffsetBufferSize(values), &cursor));
+  dictionary.buffers.push_back(offsets_buffer);
+  ASSIGN_OR_RETURN(auto data_buffer,
+                   AddBuffer(dictionary.data_length, &cursor));
+  dictionary.buffers.push_back(data_buffer);
+  dictionary.body_size = cursor;
+  dictionaries_.push_back(std::move(dictionary));
+  return base::OkStatus();
 }
 
 // Phase 1: derive the exact record-batch body layout from the dataframe. Arrow
@@ -463,18 +509,16 @@ base::Status ArrowSerializer::PlanBody(const Dataframe& dataframe,
     }
 
     if (type.Is<core::String>()) {
-      ASSIGN_OR_RETURN(
-          auto offsets_buffer,
-          AddBuffer(Utf8OffsetBufferSize(plan->rows), &body_cursor));
-      plan->buffers.push_back(offsets_buffer);
       const BitVector* validity =
           nullable ? &column.null_storage.GetNullBitVector() : nullptr;
-      ASSIGN_OR_RETURN(uint32_t string_bytes,
-                       MeasureUtf8(plan->rows, column, pool, validity, sparse));
-      prepared.string_data_length = string_bytes;
-      ASSIGN_OR_RETURN(auto string_buffer,
-                       AddBuffer(string_bytes, &body_cursor));
-      plan->buffers.push_back(string_buffer);
+      prepared.dictionary = static_cast<uint32_t>(dictionaries_.size());
+      RETURN_IF_ERROR(
+          PlanDictionary(plan->rows, column, pool, validity, sparse));
+      ASSIGN_OR_RETURN(
+          auto index_buffer,
+          AddBuffer(static_cast<uint64_t>(plan->rows) * sizeof(DictionaryIndex),
+                    &body_cursor));
+      plan->buffers.push_back(index_buffer);
     } else {
       ASSIGN_OR_RETURN(
           auto data_buffer,
@@ -497,8 +541,9 @@ base::Status ArrowSerializer::BuildFileFraming(const BodyPlan& plan) {
     std::vector<W::Offset> fields;
     fields.reserve(prepared_columns_.size());
     for (const auto& column : prepared_columns_) {
-      fields.push_back(
-          BuildField(w, column.name, column.storage_type, column.nullable));
+      fields.push_back(BuildField(w, column.name, column.storage_type,
+                                  column.nullable,
+                                  static_cast<int64_t>(column.dictionary)));
     }
     auto field_vector =
         w.WriteVecOffsets(fields.data(), static_cast<uint32_t>(fields.size()));
@@ -527,21 +572,48 @@ base::Status ArrowSerializer::BuildFileFraming(const BodyPlan& plan) {
     return base::ErrStatus("Arrow metadata is too large");
   }
 
+  Append(&header_, kPaddedMagic, sizeof(kPaddedMagic));
+  AppendMessage(&header_, schema, schema_size);
+
+  uint64_t cursor = header_.size();
+  std::vector<Block> dictionary_blocks;
+  dictionary_blocks.reserve(dictionaries_.size());
+  for (uint32_t i = 0; i < dictionaries_.size(); ++i) {
+    DictionaryPlan& dictionary = dictionaries_[i];
+    W writer;
+    auto values = static_cast<uint32_t>(dictionary.values.size());
+    std::vector<uint8_t> dictionary_metadata = FinishFlatbuffer(
+        &writer, BuildMessage(writer, kHeaderDictionaryBatch,
+                              BuildDictionaryBatch(writer, i, values,
+                                                   dictionary.buffers),
+                              static_cast<int64_t>(dictionary.body_size)));
+    auto size = static_cast<uint32_t>(AlignToArrow(dictionary_metadata.size()));
+    if (size > maximum_metadata_size) {
+      return base::ErrStatus("Arrow metadata is too large");
+    }
+    AppendMessage(&dictionary.message, dictionary_metadata, size);
+    dictionary_blocks.push_back(
+        Block{static_cast<int64_t>(cursor),
+              static_cast<int32_t>(kMessagePrefixSize + size),
+              {},
+              static_cast<int64_t>(dictionary.body_size)});
+    cursor += dictionary.message.size() + dictionary.body_size;
+  }
+
   W footer_writer;
-  Block block{static_cast<int64_t>(sizeof(kPaddedMagic) + kMessagePrefixSize +
-                                   schema_size),
+  Block block{static_cast<int64_t>(cursor),
               static_cast<int32_t>(kMessagePrefixSize + metadata_size),
               {},
               static_cast<int64_t>(plan.size)};
   std::vector<uint8_t> footer = FinishFlatbuffer(
-      &footer_writer,
-      BuildFooter(footer_writer, build_schema(footer_writer), block));
+      &footer_writer, BuildFooter(footer_writer, build_schema(footer_writer),
+                                  dictionary_blocks, block));
 
-  // Assemble framing separately from the body so Write() only needs to stream
-  // header, column buffers, and footer in that order.
-  Append(&header_, kPaddedMagic, sizeof(kPaddedMagic));
-  AppendMessage(&header_, schema, schema_size);
-  AppendMessage(&header_, batch_metadata, metadata_size);
+  AppendMessage(&batch_header_, batch_metadata, metadata_size);
+  // Readers which walk the message stream instead of the footer rely on the
+  // end-of-stream marker to stop before the footer.
+  AppendU32(&trailer_, kContinuation);
+  AppendU32(&trailer_, 0);
   Append(&trailer_, footer.data(), footer.size());
   AppendU32(&trailer_, static_cast<uint32_t>(footer.size()));
   Append(&trailer_, kMagic, sizeof(kMagic));
@@ -566,22 +638,70 @@ base::StatusOr<size_t> ArrowSerializer::Prepare(const Dataframe& dataframe,
 
   // Phase 3: validate the final platform-sized result and record the objects
   // whose identity and mutation count Write() must verify.
-  uint64_t total = header_.size() + plan.size + trailer_.size();
-  uint64_t max_output_size = std::numeric_limits<size_t>::max();
-  if (total < plan.size || total > max_output_size) {
+  constexpr uint64_t kMaxOutputSize = std::numeric_limits<size_t>::max();
+  uint64_t total = header_.size() + batch_header_.size() + trailer_.size();
+  for (const DictionaryPlan& dictionary : dictionaries_) {
+    uint64_t dictionary_size = dictionary.message.size() + dictionary.body_size;
+    if (dictionary_size > kMaxOutputSize - total) {
+      return base::ErrStatus("Dataframe is too large for an Arrow file");
+    }
+    total += dictionary_size;
+  }
+  if (plan.size > kMaxOutputSize - total) {
     return base::ErrStatus("Dataframe is too large for an Arrow file");
   }
+  total += plan.size;
   prepared_dataframe_ = &dataframe;
   prepared_string_pool_ = &pool;
   prepared_mutations_ = dataframe.mutations();
   return static_cast<size_t>(total);
 }
 
+base::Status ArrowSerializer::WriteDictionary(const DictionaryPlan& dictionary,
+                                              const StringPool& pool,
+                                              const WriteFn& write) {
+  BufferedOutput output(&scratch_, write);
+  RETURN_IF_ERROR(WriteUtf8OffsetBuffer(dictionary.values, pool,
+                                        dictionary.data_length, &output));
+  for (StringPool::Id id : dictionary.values) {
+    NullTermStringView value = pool.Get(id);
+    RETURN_IF_ERROR(output.Append(value.data(), value.size()));
+  }
+  RETURN_IF_ERROR(output.AppendPadding(static_cast<size_t>(
+      AlignToArrow(dictionary.data_length) - dictionary.data_length)));
+  return output.Finish();
+}
+
+base::Status ArrowSerializer::WriteDictionaryIndices(
+    uint32_t rows,
+    const Column& column,
+    bool sparse,
+    const BitVector* validity,
+    const DictionaryPlan& dictionary,
+    const WriteFn& write) {
+  const auto* ids = column.storage.unchecked_data<String>();
+  BufferedOutput output(&scratch_, write);
+  StorageIndexMapper mapper(validity, sparse);
+  for (uint32_t row = 0; row < rows; ++row) {
+    DictionaryIndex index = 0;
+    if (mapper.HasValue(row)) {
+      const uint32_t* found =
+          dictionary.index_by_id.Find(ids[mapper.Take(row)].raw_id());
+      PERFETTO_CHECK(found);
+      index = static_cast<DictionaryIndex>(*found);
+    }
+    RETURN_IF_ERROR(output.Append(&index, sizeof(index)));
+  }
+  size_t bytes = static_cast<size_t>(rows) * sizeof(DictionaryIndex);
+  RETURN_IF_ERROR(
+      output.AppendPadding(static_cast<size_t>(AlignToArrow(bytes)) - bytes));
+  return output.Finish();
+}
+
 // Phase 4: materialize the buffers planned by PlanBody(). Each logical column
-// is encoded as validity followed by either Utf8's offsets and bytes or one
-// fixed-width numeric buffer.
+// is encoded as validity followed by one fixed-width buffer holding either the
+// numeric values or the dictionary indices.
 base::Status ArrowSerializer::WriteBody(const Dataframe& dataframe,
-                                        const StringPool& pool,
                                         const WriteFn& write) {
   uint32_t rows = dataframe.row_count();
   for (const auto& prepared : prepared_columns_) {
@@ -596,9 +716,9 @@ base::Status ArrowSerializer::WriteBody(const Dataframe& dataframe,
     if (prepared.storage_type.Is<core::Id>()) {
       RETURN_IF_ERROR(WriteIdBuffer(rows, &scratch_, write));
     } else if (prepared.storage_type.Is<core::String>()) {
-      RETURN_IF_ERROR(WriteUtf8Buffers(rows, column, pool, validity, sparse,
-                                       prepared.string_data_length, &scratch_,
-                                       write));
+      RETURN_IF_ERROR(WriteDictionaryIndices(rows, column, sparse, validity,
+                                             dictionaries_[prepared.dictionary],
+                                             write));
     } else {
       RETURN_IF_ERROR(
           WriteNumericBuffer(rows, column, sparse, validity, &scratch_, write));
@@ -617,7 +737,13 @@ base::Status ArrowSerializer::Write(const Dataframe& dataframe,
     return base::ErrStatus("Dataframe changed after Arrow Prepare");
   }
   RETURN_IF_ERROR(Emit(write, header_.data(), header_.size()));
-  RETURN_IF_ERROR(WriteBody(dataframe, pool, write));
+  for (const DictionaryPlan& dictionary : dictionaries_) {
+    RETURN_IF_ERROR(
+        Emit(write, dictionary.message.data(), dictionary.message.size()));
+    RETURN_IF_ERROR(WriteDictionary(dictionary, pool, write));
+  }
+  RETURN_IF_ERROR(Emit(write, batch_header_.data(), batch_header_.size()));
+  RETURN_IF_ERROR(WriteBody(dataframe, write));
   return Emit(write, trailer_.data(), trailer_.size());
 }
 

--- a/src/trace_processor/core/dataframe/arrow_serializer.h
+++ b/src/trace_processor/core/dataframe/arrow_serializer.h
@@ -37,10 +37,10 @@ namespace perfetto::trace_processor::core::dataframe {
 // Serializes a Dataframe as a standard Arrow file containing one record batch.
 // The output can be read by full Arrow implementations such as PyArrow.
 //
-// Sparse columns are expanded to Arrow's dense logical layout, and StringPool
-// IDs are encoded as Arrow Utf8 offset and data buffers. Input dataframes must
-// be finalized so their column storage remains stable across the Prepare() and
-// Write() passes.
+// Sparse columns are expanded to Arrow's dense logical layout. String columns
+// are dictionary encoded, with the values written as a dictionary batch ahead
+// of the record batch. Input dataframes must be finalized so their column
+// storage remains stable across the Prepare() and Write() passes.
 class ArrowSerializer {
  public:
   enum class IdColumnMode {
@@ -54,6 +54,7 @@ class ArrowSerializer {
   using WriteFn = std::function<base::Status(const uint8_t*, size_t)>;
 
   explicit ArrowSerializer(IdColumnMode = IdColumnMode::kOmit);
+  ~ArrowSerializer();
 
   // Computes Arrow buffer metadata and the exact output size for a finalized
   // dataframe. Arrow places buffer lengths before buffer contents, so
@@ -68,22 +69,39 @@ class ArrowSerializer {
 
  private:
   struct BodyPlan;
+  struct DictionaryPlan;
   struct PreparedColumn {
     uint32_t dataframe_column;
     std::string name;
     bool nullable;
     StorageType storage_type;
-    uint32_t string_data_length = 0;
+    uint32_t dictionary = 0;
   };
 
   void Reset();
   base::Status PlanBody(const Dataframe&, const StringPool&, BodyPlan*);
+  base::Status PlanDictionary(uint32_t rows,
+                              const Column&,
+                              const StringPool&,
+                              const BitVector*,
+                              bool sparse);
   base::Status BuildFileFraming(const BodyPlan&);
-  base::Status WriteBody(const Dataframe&, const StringPool&, const WriteFn&);
+  base::Status WriteDictionary(const DictionaryPlan&,
+                               const StringPool&,
+                               const WriteFn&);
+  base::Status WriteDictionaryIndices(uint32_t rows,
+                                      const Column&,
+                                      bool sparse,
+                                      const BitVector*,
+                                      const DictionaryPlan&,
+                                      const WriteFn&);
+  base::Status WriteBody(const Dataframe&, const WriteFn&);
 
   std::vector<uint8_t> header_;
+  std::vector<uint8_t> batch_header_;
   std::vector<uint8_t> trailer_;
   std::vector<PreparedColumn> prepared_columns_;
+  std::vector<DictionaryPlan> dictionaries_;
   FlexVector<uint8_t> scratch_;
 
   const Dataframe* prepared_dataframe_ = nullptr;

--- a/src/trace_processor/core/dataframe/arrow_serializer_unittest.cc
+++ b/src/trace_processor/core/dataframe/arrow_serializer_unittest.cc
@@ -56,6 +56,12 @@ inline constexpr auto kStringNonNull = CreateTypedDataframeSpec(
     CreateTypedColumnSpec(Id{}, NonNull{}, IdSorted{}, NoDuplicates{}),
     CreateTypedColumnSpec(String{}, NonNull{}, Unsorted{}));
 
+inline constexpr auto kTwoStrings = CreateTypedDataframeSpec(
+    {"_auto_id", "first", "second"},
+    CreateTypedColumnSpec(Id{}, NonNull{}, IdSorted{}, NoDuplicates{}),
+    CreateTypedColumnSpec(String{}, NonNull{}, Unsorted{}),
+    CreateTypedColumnSpec(String{}, NonNull{}, Unsorted{}));
+
 inline constexpr auto kInt32Sparse = CreateTypedDataframeSpec(
     {"_auto_id", "val"},
     CreateTypedColumnSpec(Id{}, NonNull{}, IdSorted{}, NoDuplicates{}),
@@ -73,8 +79,17 @@ struct SerializedRecordBatch {
   util::FlatBufferScalarVec<ArrowBuffer> buffers;
 };
 
-std::optional<SerializedRecordBatch> ReadRecordBatch(
-    const std::vector<uint8_t>& bytes) {
+size_t FooterOffset(const std::vector<uint8_t>& bytes) {
+  using namespace arrow_internal;
+  uint32_t footer_size =
+      Load<uint32_t>(bytes.data() + bytes.size() - kFileTrailerSize, 0);
+  return bytes.size() - kFileTrailerSize - footer_size;
+}
+
+std::optional<SerializedRecordBatch> ReadBatch(
+    const std::vector<uint8_t>& bytes,
+    uint32_t footer_blocks_field,
+    uint32_t index) {
   using namespace arrow_internal;
   if (bytes.size() < kMinimumFileSize) {
     return std::nullopt;
@@ -84,17 +99,17 @@ std::optional<SerializedRecordBatch> ReadRecordBatch(
   if (footer_size > bytes.size() - kFileTrailerSize) {
     return std::nullopt;
   }
-  size_t footer_offset = bytes.size() - kFileTrailerSize - footer_size;
+  size_t footer_offset = FooterOffset(bytes);
   auto footer = util::FlatBufferReader::GetRoot(bytes.data() + footer_offset,
                                                 footer_size);
   if (!footer) {
     return std::nullopt;
   }
-  auto blocks = footer->VecScalar<Block>(footer_field::kRecordBatches);
-  if (blocks.size() != kRecordBatchCount) {
+  auto blocks = footer->VecScalar<Block>(footer_blocks_field);
+  if (index >= blocks.size()) {
     return std::nullopt;
   }
-  Block block = blocks[0];
+  Block block = blocks[index];
   if (block.offset < 0 || block.metadata_length < 0 ||
       static_cast<uint64_t>(block.offset) +
               static_cast<uint32_t>(block.metadata_length) >
@@ -109,8 +124,11 @@ std::optional<SerializedRecordBatch> ReadRecordBatch(
   auto message = util::FlatBufferReader::GetRoot(
       bytes.data() + message_offset + kMessagePrefixSize,
       static_cast<uint32_t>(prefix.metadata_size));
-  auto record_batch = message ? message->Table(message_field::kHeader)
-                              : util::FlatBufferReader{};
+  auto header = message ? message->Table(message_field::kHeader)
+                        : util::FlatBufferReader{};
+  auto record_batch = footer_blocks_field == footer_field::kDictionaries
+                          ? header.Table(dictionary_batch_field::kData)
+                          : header;
   if (!record_batch) {
     return std::nullopt;
   }
@@ -119,6 +137,32 @@ std::optional<SerializedRecordBatch> ReadRecordBatch(
       message_offset + static_cast<uint32_t>(block.metadata_length),
       record_batch.VecScalar<FieldNode>(record_batch_field::kNodes),
       record_batch.VecScalar<ArrowBuffer>(record_batch_field::kBuffers)};
+}
+
+std::optional<SerializedRecordBatch> ReadRecordBatch(
+    const std::vector<uint8_t>& bytes) {
+  return ReadBatch(bytes, arrow_internal::footer_field::kRecordBatches, 0);
+}
+
+std::optional<SerializedRecordBatch> ReadDictionaryBatch(
+    const std::vector<uint8_t>& bytes,
+    uint32_t index) {
+  return ReadBatch(bytes, arrow_internal::footer_field::kDictionaries, index);
+}
+
+// Reads the schema message, which is the first message in the file.
+util::FlatBufferReader ReadSchema(const std::vector<uint8_t>& bytes) {
+  using namespace arrow_internal;
+  MessagePrefix prefix =
+      Load<MessagePrefix>(bytes.data() + sizeof(kPaddedMagic), 0);
+  EXPECT_EQ(prefix.continuation, kContinuation);
+  auto message = util::FlatBufferReader::GetRoot(
+      bytes.data() + sizeof(kPaddedMagic) + kMessagePrefixSize,
+      static_cast<uint32_t>(prefix.metadata_size));
+  EXPECT_TRUE(message.has_value());
+  auto schema = message->Table(message_field::kHeader);
+  EXPECT_TRUE(static_cast<bool>(schema));
+  return schema;
 }
 
 template <typename T>
@@ -186,30 +230,97 @@ TEST(ArrowSerializerTest, WritesValidityAndDensifiesSparseNumericBuffer) {
   EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *batch, 1, 2), 33);
 }
 
-TEST(ArrowSerializerTest, WritesUtf8OffsetAndDataBuffers) {
+TEST(ArrowSerializerTest, WritesDictionaryIndicesAndValues) {
   StringPool pool;
   auto hello = pool.InternString(base::StringView("hello"));
   auto empty = pool.InternString(base::StringView(""));
   auto world = pool.InternString(base::StringView("world"));
-  auto source = MakeDataframe(kStringNonNull, &pool, hello, empty, world);
+  auto source =
+      MakeDataframe(kStringNonNull, &pool, hello, empty, world, hello);
+  std::vector<uint8_t> bytes = Serialize(source, pool);
+  auto batch = ReadRecordBatch(bytes);
+  auto dictionary = ReadDictionaryBatch(bytes, 0);
+
+  ASSERT_TRUE(batch);
+  ASSERT_EQ(batch->rows, 4);
+  ASSERT_EQ(batch->buffers.size(), 2u);
+  EXPECT_EQ(batch->buffers[0].length, 0);
+  EXPECT_EQ(batch->buffers[1].length,
+            static_cast<int64_t>(4 * sizeof(int32_t)));
+  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *batch, 1, 0), 0);
+  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *batch, 1, 1), 1);
+  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *batch, 1, 2), 2);
+  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *batch, 1, 3), 0);
+
+  ASSERT_TRUE(dictionary);
+  ASSERT_EQ(dictionary->rows, 3);
+  ASSERT_EQ(dictionary->buffers.size(), 3u);
+  EXPECT_EQ(dictionary->buffers[0].length, 0);
+  EXPECT_EQ(dictionary->buffers[1].length,
+            static_cast<int64_t>(4 * sizeof(int32_t)));
+  EXPECT_EQ(dictionary->buffers[2].length, 10);
+  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *dictionary, 1, 0), 0);
+  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *dictionary, 1, 1), 5);
+  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *dictionary, 1, 2), 5);
+  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *dictionary, 1, 3), 10);
+  ArrowBuffer strings = dictionary->buffers[2];
+  const char* string_data = reinterpret_cast<const char*>(
+      bytes.data() + dictionary->body_offset + strings.offset);
+  EXPECT_EQ(std::string_view(string_data, static_cast<size_t>(strings.length)),
+            "helloworld");
+}
+
+TEST(ArrowSerializerTest, WritesDictionaryEncodingInSchema) {
+  using namespace arrow_internal;
+  StringPool pool;
+  auto hello = pool.InternString(base::StringView("hello"));
+  auto source = MakeDataframe(kStringNonNull, &pool, hello);
+  std::vector<uint8_t> bytes = Serialize(source, pool);
+
+  auto fields = ReadSchema(bytes).VecTable(schema_field::kFields);
+  ASSERT_EQ(fields.size(), 1u);
+  EXPECT_EQ(fields[0].Scalar<uint8_t>(field_field::kTypeType), kTypeUtf8);
+  auto encoding = fields[0].Table(field_field::kDictionary);
+  ASSERT_TRUE(static_cast<bool>(encoding));
+  EXPECT_EQ(encoding.Scalar<int64_t>(dictionary_encoding_field::kId,
+                                     kMissingSignedValue),
+            0);
+  auto index_type = encoding.Table(dictionary_encoding_field::kIndexType);
+  ASSERT_TRUE(static_cast<bool>(index_type));
+  EXPECT_EQ(index_type.Scalar<int32_t>(int_field::kBitWidth),
+            kDictionaryIndexBits);
+  EXPECT_TRUE(index_type.Scalar<bool>(int_field::kIsSigned));
+}
+
+TEST(ArrowSerializerTest, WritesOneDictionaryPerStringColumn) {
+  StringPool pool;
+  auto a = pool.InternString(base::StringView("a"));
+  auto source = Dataframe::CreateFromTypedSpec(kTwoStrings, &pool);
+  source.InsertUnchecked(kTwoStrings, std::monostate{}, a, a);
+  std::vector<uint8_t> bytes = Serialize(source, pool);
+
+  ASSERT_TRUE(ReadDictionaryBatch(bytes, 0));
+  ASSERT_TRUE(ReadDictionaryBatch(bytes, 1));
+  EXPECT_FALSE(ReadDictionaryBatch(bytes, 2));
+  auto batch = ReadRecordBatch(bytes);
+  ASSERT_TRUE(batch);
+  EXPECT_EQ(batch->buffers.size(), 2u * arrow_internal::kFixedWidthBufferCount);
+}
+
+TEST(ArrowSerializerTest, WritesEndOfStreamMarkerBeforeFooter) {
+  using namespace arrow_internal;
+  StringPool pool;
+  auto source = MakeDataframe(kUint32NonNull, &pool, uint32_t{1});
   std::vector<uint8_t> bytes = Serialize(source, pool);
   auto batch = ReadRecordBatch(bytes);
 
   ASSERT_TRUE(batch);
-  ASSERT_EQ(batch->buffers.size(), 3u);
-  EXPECT_EQ(batch->buffers[0].length, 0);
-  EXPECT_EQ(batch->buffers[1].length,
-            static_cast<int64_t>(4 * sizeof(int32_t)));
-  EXPECT_EQ(batch->buffers[2].length, 10);
-  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *batch, 1, 0), 0);
-  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *batch, 1, 1), 5);
-  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *batch, 1, 2), 5);
-  EXPECT_EQ(ReadBodyValue<int32_t>(bytes, *batch, 1, 3), 10);
-  ArrowBuffer strings = batch->buffers[2];
-  const char* string_data = reinterpret_cast<const char*>(
-      bytes.data() + batch->body_offset + strings.offset);
-  EXPECT_EQ(std::string_view(string_data, static_cast<size_t>(strings.length)),
-            "helloworld");
+  size_t batch_end =
+      batch->body_offset + static_cast<size_t>(batch->block.body_length);
+  MessagePrefix marker = Load<MessagePrefix>(bytes.data() + batch_end, 0);
+  EXPECT_EQ(marker.continuation, kContinuation);
+  EXPECT_EQ(marker.metadata_size, 0);
+  EXPECT_EQ(batch_end + kEndOfStreamSize, FooterOffset(bytes));
 }
 
 TEST(ArrowSerializerTest, OmitsImplicitIdColumn) {


### PR DESCRIPTION
Cherry-pick of #7059 (e559c5c6249b565fa535a86d7e49840f61fe2dd2) onto
canary.

`ArrowSerializer` wrote string columns as Arrow `Utf8`, which expands
the StringPool dictionary into one copy of the bytes per row. On a heap
profile that made `heap_graph_reference.field_name` 2.5GB of bytes for
67k distinct values, overflowing `Utf8`'s int32 offsets and failing the
export outright.

This backports writing each string column as an Arrow dictionary batch
holding the distinct StringPool ids, with int32 indices in the record
batch, so the encoded size is proportional to the distinct values rather
than to the rows. On a 37.7MB heap profile the archive goes from 6.12GB
to 2.26GB and reimport from 5.80s to 2.67s.

First of a three-PR stack.
