### PR TITLE
sdk: Loading JNI in corresponding classes

### DIFF
--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java
@@ -12,6 +12,10 @@ import java.util.Set;
 @SuppressWarnings(
     "AndroidJdkLibsChecker") // Suppress warning about 'java.lang.ref.Cleaner' in google3.
 public class PerfettoNativeMemoryCleaner {
+  static {
+    System.loadLibrary("perfetto_framework_jni");
+  }
+
   private final AllocationStats mAllocationStats;
   private final Cleaner mCleaner = SystemCleaner.cleaner();
 

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
@@ -35,6 +35,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class PerfettoTrace {
   private static final String TAG = "PerfettoTrace";
 
+  static {
+    System.loadLibrary("perfetto_framework_jni");
+  }
+
   // Keep in sync with C++
   private static final int PERFETTO_TE_TYPE_SLICE_BEGIN = 1;
   private static final int PERFETTO_TE_TYPE_SLICE_END = 2;

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
@@ -26,6 +26,10 @@ import java.util.concurrent.atomic.AtomicLong;
  * @hide
  */
 final class PerfettoTrackEventExtra {
+  static {
+    System.loadLibrary("perfetto_framework_jni");
+  }
+
   private final long mPtr;
 
   PerfettoTrackEventExtra(PerfettoNativeMemoryCleaner memoryCleaner) {


### PR DESCRIPTION
libperfetto_framework_jni registers JNI methods in these three classes:

* PerfettoNativeMemoryCleaner
* PerfettoTrace
* PerfettoTrackEventExtra

Hence the JNI should be loaded in these classes, not in ZygoteInit.preloadSharedLibraries() which can be skipped with --enable-lazy-preload.
