### PR TITLE
Normalize spaces and underscores in PinAndroidPerfMetrics

### DIFF
--- a/ui/src/plugins/com.android.PinAndroidPerfMetrics/handlers/pinBlockingCall.ts
+++ b/ui/src/plugins/com.android.PinAndroidPerfMetrics/handlers/pinBlockingCall.ts
@@ -93,20 +93,29 @@ class BlockingCallMetricHandler implements MetricHandler {
     }
   }
 
-  private blockingCallTrackConfig(metricData: BlockingCallMetricData) {
+  private blockingCallWhereClause(metricData: BlockingCallMetricData): string {
     const cuj = metricData.cujName;
     const processName = metricData.process;
     const blockingCallName = metricData.blockingCallName;
+    // Some lab pipelines replace spaces with underscores in metric names (e.g.
+    // 'drawLayer_[StatusBarIconView]'), whereas standardized slice names
+    // in PerfettoSQL tables retain spaces ('drawLayer [StatusBarIconView]').
+    const normalizedName = blockingCallName.replaceAll('_', ' ');
+    return `
+      process_name = "${processName}"
+      AND cuj_name = "${cuj}"
+      AND name IN ("${blockingCallName}", "${normalizedName}")
+    `;
+  }
 
+  private blockingCallTrackConfig(metricData: BlockingCallMetricData) {
     const blockingCallDuringCujQuery = `
       SELECT name, ts, dur
       FROM android_cuj_blocking_calls
-      WHERE process_name = "${processName}"
-          AND cuj_name = "${cuj}"
-          AND name = "${blockingCallName}"
+      WHERE ${this.blockingCallWhereClause(metricData)}
     `;
 
-    const trackName = 'Blocking calls in ' + processName;
+    const trackName = 'Blocking calls in ' + metricData.process;
     return {
       data: {
         sqlSource: blockingCallDuringCujQuery,
@@ -122,10 +131,6 @@ class BlockingCallMetricHandler implements MetricHandler {
     ctx: Trace,
     metricData: BlockingCallMetricData,
   ): Promise<QueryResult> {
-    const cuj = metricData.cujName;
-    const processName = metricData.process;
-    const blockingCallName = metricData.blockingCallName;
-
     // Fetch the frame_id of the frame with the max duration blocking call.
     return ctx.engine.query(`
       INCLUDE PERFETTO MODULE android.frame_blocking_calls.blocking_calls_aggregation;
@@ -133,10 +138,7 @@ class BlockingCallMetricHandler implements MetricHandler {
       SELECT
         frame_id
       FROM _blocking_calls_frame_cuj
-      WHERE
-        process_name = '${processName}'
-        AND name = '${blockingCallName}'
-        AND cuj_name = '${cuj}'
+      WHERE ${this.blockingCallWhereClause(metricData)}
       -- select frame_id for the metric with the maximum duration.
       ORDER BY dur DESC
       LIMIT 1`);

--- a/ui/src/plugins/com.android.PinAndroidPerfMetrics/handlers/pinBlockingCall_unittest.ts
+++ b/ui/src/plugins/com.android.PinAndroidPerfMetrics/handlers/pinBlockingCall_unittest.ts
@@ -83,6 +83,16 @@ const validMetricsTest: {
       aggregation: 'mean_dur_per_frame_ns-max',
     },
   },
+  {
+    inputMetric:
+      'perfetto_android_blocking_call_per_frame-cuj-name-com.android.systemui-name-NOTIFICATION_HEADS_UP_APPEAR-blocking_calls-name-drawLayer_[StatusBarIconView]-max_dur_per_frame_ns-mean',
+    expectedOutput: {
+      process: 'com.android.systemui',
+      cujName: 'NOTIFICATION_HEADS_UP_APPEAR',
+      blockingCallName: 'drawLayer_[StatusBarIconView]',
+      aggregation: 'max_dur_per_frame_ns-mean',
+    },
+  },
 ];
 
 const invalidMetricsTest: string[] = [


### PR DESCRIPTION
Some lab pipelines replace spaces with underscores in metric names (e.g. drawLayer_[StatusBarIconView]), whereas standardized blocking call names in PerfettoSQL tables retain spaces (drawLayer [StatusBarIconView]).

Update the blocking call name matching in PinAndroidPerfMetrics to match both exact names and normalized space/underscore variants, resolving zero-row matches when loading blocking call metrics from lab pipelines.
