### PR TITLE
ui: Add joinable track fields to thread slice aggregation

### DIFF
--- a/ui/src/components/widgets/datagrid/sql_data_source.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source.ts
@@ -18,7 +18,6 @@ import {
   AsyncMemo,
   AtomicTaskQueue,
 } from '../../../base/async_memo';
-import {maybeUndefined} from '../../../base/utils';
 import {shortUuid} from '../../../base/uuid';
 import type {Engine} from '../../../trace_processor/engine';
 import {
@@ -198,20 +197,34 @@ export class SQLDataSource implements DataSource {
     return this.parameterKeysSlot.use({
       key: prefix,
       compute: async () => {
-        const colDef = maybeUndefined(this.sqlSchema.columns?.[prefix]);
-        if (
-          !colDef ||
-          !('expression' in colDef) ||
-          !colDef.parameterKeysQuery
-        ) {
+        const resolver = new SQLSchemaResolver(this.sqlSchema);
+        const resolved = resolver.resolveParameterizedColumn(prefix);
+        if (!resolved) {
           return [];
         }
 
-        const baseTableOrSubquery = this.sqlSchema.tableOrSubquery;
-        const resolver = new SQLSchemaResolver(this.sqlSchema);
-        const baseAlias = resolver.getBaseAlias();
+        const {colDef, targetAlias} = resolved;
+        if (!colDef.parameterKeysQuery) {
+          return [];
+        }
 
-        const query = colDef.parameterKeysQuery(baseTableOrSubquery, baseAlias);
+        const baseTable = resolver.getBaseTableOrSubquery();
+        const baseAlias = resolver.getBaseAlias();
+        const joins = resolver.getJoins();
+
+        let tableOrSubquery: string;
+        if (joins.length === 0) {
+          tableOrSubquery = baseTable;
+        } else {
+          const joinClauses = resolver.buildJoinClauses();
+          tableOrSubquery = `
+            SELECT ${targetAlias}.*
+            FROM (${baseTable}) AS ${baseAlias}
+            ${joinClauses}
+          `;
+        }
+
+        const query = colDef.parameterKeysQuery(tableOrSubquery, baseAlias);
         const queryResult = await this.engine.query(query);
         const keys: string[] = [];
         for (let it = queryResult.iter({key: UNKNOWN}); it.valid(); it.next()) {

--- a/ui/src/components/widgets/datagrid/sql_schema.ts
+++ b/ui/src/components/widgets/datagrid/sql_schema.ts
@@ -382,6 +382,52 @@ export class SQLSchemaResolver {
   }
 
   /**
+   * Resolves a parameterized column by path, accumulating any necessary joins.
+   * Returns the colDef and the target table alias (e.g. 't0' or 'base').
+   */
+  resolveParameterizedColumn(
+    path: string,
+  ): {colDef: SQLExpressionDef; targetAlias: string} | undefined {
+    const parts = splitPath(path);
+    return this.resolveParamPath(parts, this.schema, this.baseAlias);
+  }
+
+  private resolveParamPath(
+    parts: string[],
+    schema: SQLTableSchema,
+    currentAlias: string,
+  ): {colDef: SQLExpressionDef; targetAlias: string} | undefined {
+    if (parts.length === 0) {
+      return undefined;
+    }
+
+    const [first, ...rest] = parts;
+    const colDef = maybeUndefined(schema.columns?.[first]);
+    if (!colDef) {
+      return undefined;
+    }
+
+    if ('schema' in colDef) {
+      const targetSchema = colDef.schema;
+      const joinAlias = this.getOrCreateJoin(
+        currentAlias,
+        targetSchema.tableOrSubquery,
+        colDef.foreignKey,
+        targetSchema.primaryKey ?? 'id',
+        colDef.innerJoin ?? false,
+      );
+
+      return this.resolveParamPath(rest, targetSchema, joinAlias);
+    }
+
+    if ('expression' in colDef && colDef.parameterized && rest.length === 0) {
+      return {colDef, targetAlias: currentAlias};
+    }
+
+    return undefined;
+  }
+
+  /**
    * Resets the resolver state, clearing all accumulated joins.
    */
   reset(): void {

--- a/ui/src/components/widgets/datagrid/sql_schema_unittest.ts
+++ b/ui/src/components/widgets/datagrid/sql_schema_unittest.ts
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, expect, test} from 'vitest';
+import {type SQLTableSchema, SQLSchemaResolver} from './sql_schema';
+
+describe('SQLSchemaResolver.resolveParameterizedColumn', () => {
+  const trackSqlSchema: SQLTableSchema = {
+    tableOrSubquery: 'track',
+    columns: {
+      dimension_arg_set_id: {
+        expression: (alias, key) =>
+          `extract_arg(${alias}.dimension_arg_set_id, '${key}')`,
+        parameterized: true,
+        parameterKeysQuery: (tableOrSubquery, alias) =>
+          `SELECT DISTINCT args.key FROM (${tableOrSubquery}) AS ${alias}`,
+      },
+      parent_id: {
+        foreignKey: 'parent_id',
+        get schema() {
+          return trackSqlSchema;
+        },
+      },
+    },
+  };
+
+  const rootSchema: SQLTableSchema = {
+    tableOrSubquery: 'slice',
+    columns: {
+      args: {
+        expression: (alias, key) =>
+          `extract_arg(${alias}.arg_set_id, '${key}')`,
+        parameterized: true,
+        parameterKeysQuery: (tableOrSubquery, alias) =>
+          `SELECT DISTINCT args.key FROM (${tableOrSubquery}) AS ${alias}`,
+      },
+      track: {
+        foreignKey: 'track_id',
+        schema: trackSqlSchema,
+      },
+    },
+  };
+
+  test('finds top-level parameterized column', () => {
+    const resolver = new SQLSchemaResolver(rootSchema);
+    const result = resolver.resolveParameterizedColumn('args');
+    expect(result).toBeDefined();
+    expect(result?.targetAlias).toBe('base');
+    expect(result?.colDef.parameterized).toBe(true);
+    expect(resolver.getJoins().length).toBe(0);
+  });
+
+  test('finds nested parameterized column and accumulates joins', () => {
+    const resolver = new SQLSchemaResolver(rootSchema);
+    const result = resolver.resolveParameterizedColumn(
+      'track.dimension_arg_set_id',
+    );
+    expect(result).toBeDefined();
+    expect(result?.targetAlias).toBe('t0');
+    expect(result?.colDef.parameterized).toBe(true);
+    expect(resolver.buildJoinClauses()).toBe(
+      'LEFT JOIN (track) AS t0 ON t0.id = base.track_id',
+    );
+  });
+
+  test('finds recursively joined parameterized column and accumulates joins', () => {
+    const resolver = new SQLSchemaResolver(rootSchema);
+    const result = resolver.resolveParameterizedColumn(
+      'track.parent_id.dimension_arg_set_id',
+    );
+    expect(result).toBeDefined();
+    expect(result?.targetAlias).toBe('t1');
+    expect(result?.colDef.parameterized).toBe(true);
+    expect(resolver.buildJoinClauses()).toBe(
+      'LEFT JOIN (track) AS t0 ON t0.id = base.track_id\nLEFT JOIN (track) AS t1 ON t1.id = t0.parent_id',
+    );
+  });
+
+  test('returns undefined for non-existent path', () => {
+    const resolver = new SQLSchemaResolver(rootSchema);
+    expect(resolver.resolveParameterizedColumn('nonexistent')).toBeUndefined();
+    expect(
+      resolver.resolveParameterizedColumn('track.nonexistent'),
+    ).toBeUndefined();
+  });
+
+  test('returns undefined for non-parameterized column', () => {
+    const schemaWithPlain: SQLTableSchema = {
+      tableOrSubquery: 'track',
+      columns: {
+        id: {},
+      },
+    };
+    const resolver = new SQLSchemaResolver(schemaWithPlain);
+    expect(resolver.resolveParameterizedColumn('id')).toBeUndefined();
+  });
+});
+
+describe('SQLSchemaResolver.resolveColumnPath', () => {
+  const trackSqlSchema: SQLTableSchema = {
+    tableOrSubquery: 'track',
+    columns: {
+      dimension_arg_set_id: {
+        expression: (alias, key) =>
+          `extract_arg(${alias}.dimension_arg_set_id, '${key}')`,
+        parameterized: true,
+      },
+      parent_id: {
+        foreignKey: 'parent_id',
+        get schema() {
+          return trackSqlSchema;
+        },
+      },
+    },
+  };
+
+  const rootSchema: SQLTableSchema = {
+    tableOrSubquery: 'slice',
+    columns: {
+      track: {
+        foreignKey: 'track_id',
+        schema: trackSqlSchema,
+      },
+    },
+  };
+
+  test('resolves nested parameterized column with join', () => {
+    const resolver = new SQLSchemaResolver(rootSchema);
+    const expr = resolver.resolveColumnPath('track.dimension_arg_set_id.foo');
+    expect(expr).toBe("extract_arg(t0.dimension_arg_set_id, 'foo')");
+    expect(resolver.buildJoinClauses()).toBe(
+      'LEFT JOIN (track) AS t0 ON t0.id = base.track_id',
+    );
+  });
+
+  test('resolves recursive join parameterized column', () => {
+    const resolver = new SQLSchemaResolver(rootSchema);
+    const expr = resolver.resolveColumnPath(
+      'track.parent_id.dimension_arg_set_id.bar',
+    );
+    expect(expr).toBe("extract_arg(t1.dimension_arg_set_id, 'bar')");
+    expect(resolver.buildJoinClauses()).toBe(
+      'LEFT JOIN (track) AS t0 ON t0.id = base.track_id\nLEFT JOIN (track) AS t1 ON t1.id = t0.parent_id',
+    );
+  });
+});

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/thread_slice_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/thread_slice_aggregator.ts
@@ -38,6 +38,81 @@ import {getOrCreate} from '../../base/utils';
 import {MenuItem, PopupMenu} from '../../widgets/menu';
 import {SLICE_TRACK_KIND} from '../../public/track_kinds';
 
+const TRACK_SCHEMA: ColumnSchema = {
+  id: {
+    title: 'ID',
+    columnType: 'identifier',
+  },
+  name: {
+    title: 'Name',
+    columnType: 'text',
+  },
+  type: {
+    title: 'Type',
+    columnType: 'text',
+  },
+  dimension_arg_set_id: {
+    title: 'Dimension Arg Set ID',
+    parameterized: true,
+  },
+  parent_id: {
+    title: 'Parent',
+    get schema() {
+      return TRACK_SCHEMA;
+    },
+  },
+  source_arg_set_id: {
+    title: 'Source Arg Set ID',
+    parameterized: true,
+  },
+  machine_id: {
+    title: 'Machine ID',
+    columnType: 'identifier',
+  },
+  track_group_id: {
+    title: 'Track Group ID',
+    columnType: 'identifier',
+  },
+};
+
+const TRACK_SQL_SCHEMA: SQLTableSchema = {
+  tableOrSubquery: 'track',
+  columns: {
+    dimension_arg_set_id: {
+      expression: (alias, key) =>
+        `extract_arg(${alias}.dimension_arg_set_id, '${key}')`,
+      parameterized: true,
+      parameterKeysQuery: (tableOrSubquery, alias) => `
+        SELECT DISTINCT args.key
+        FROM (${tableOrSubquery}) AS ${alias}
+        JOIN args ON args.arg_set_id = ${alias}.dimension_arg_set_id
+        WHERE args.key IS NOT NULL
+        ORDER BY args.key
+        LIMIT 1000
+      `,
+    },
+    parent_id: {
+      foreignKey: 'parent_id',
+      get schema() {
+        return TRACK_SQL_SCHEMA;
+      },
+    },
+    source_arg_set_id: {
+      expression: (alias, key) =>
+        `extract_arg(${alias}.source_arg_set_id, '${key}')`,
+      parameterized: true,
+      parameterKeysQuery: (tableOrSubquery, alias) => `
+        SELECT DISTINCT args.key
+        FROM (${tableOrSubquery}) AS ${alias}
+        JOIN args ON args.arg_set_id = ${alias}.source_arg_set_id
+        WHERE args.key IS NOT NULL
+        ORDER BY args.key
+        LIMIT 1000
+      `,
+    },
+  },
+};
+
 export class ThreadSliceAggregator implements Aggregator {
   readonly id = 'thread_slice_aggregator';
 
@@ -283,6 +358,10 @@ export class ThreadSliceAggregator implements Aggregator {
         title: 'Args',
         parameterized: true,
       },
+      track: {
+        title: 'Track',
+        schema: TRACK_SCHEMA,
+      },
       thread: {
         title: 'Thread',
         schema: {
@@ -338,6 +417,10 @@ export class ThreadSliceAggregator implements Aggregator {
       sqlConfig: ({sqlTable}): SQLTableSchema => ({
         tableOrSubquery: sqlTable.get().name,
         columns: {
+          track: {
+            foreignKey: 'track_id',
+            schema: TRACK_SQL_SCHEMA,
+          },
           thread: {
             foreignKey: 'utid',
             schema: {


### PR DESCRIPTION
This allows adding columns from the track table (joined using track_id) including parameterised args using `dimension_arg_set_id` and `source_arg_set_id`.

<img width="729" height="443" alt="image" src="https://github.com/user-attachments/assets/010aafee-287f-4578-88b0-ebe5cb2ba003" />
