### PR TITLE
ui: Fix parameterised aggregate columns in pivot tables

### DIFF
--- a/ui/src/components/widgets/datagrid/add_column_menu.ts
+++ b/ui/src/components/widgets/datagrid/add_column_menu.ts
@@ -424,6 +424,216 @@ function buildAggFuncItems(
   });
 }
 
+interface AggregateParamMenuItemAttrs {
+  // Label shown on this submenu's own menu item.
+  readonly label: m.Children;
+  // Optional icon shown alongside the label.
+  readonly icon?: string;
+  // Path prefix of the parameterized column (the key is appended to this).
+  readonly pathPrefix: string;
+  // Filter/column type of the parameterized column.
+  readonly filterType?: 'text' | 'quantitative' | 'identifier';
+  // Existing aggregates, used to disable already-added function/column pairs.
+  readonly existingAggregates: readonly AggregateColumn[] | undefined;
+  // Data source used to discover the available parameter keys.
+  readonly datasource: DataSource;
+  // Callback invoked with the chosen aggregate function and full column path.
+  readonly onSelect: (func: AggregateFunction, field: string) => void;
+}
+
+/**
+ * A menu item for a parameterized aggregate column that expands into a searchable
+ * list of keys available in the data source. Each key expands into the aggregate
+ * functions available for its type.
+ */
+class AggregateParamMenuItem implements m.ClassComponent<AggregateParamMenuItemAttrs> {
+  view({attrs}: m.Vnode<AggregateParamMenuItemAttrs>) {
+    const {
+      pathPrefix,
+      filterType,
+      existingAggregates,
+      datasource,
+      onSelect,
+      label,
+      icon,
+    } = attrs;
+    return m(MenuItem, {label, icon}, [
+      m(AggregateRecordPopup, {
+        pathPrefix,
+        filterType,
+        existingAggregates,
+        datasource,
+        onSelect,
+      }),
+    ]);
+  }
+}
+
+interface AggregateRecordPopupAttrs {
+  // Path prefix of the parameterized column (the key is appended to this).
+  readonly pathPrefix: string;
+  // Filter/column type of the parameterized column.
+  readonly filterType?: 'text' | 'quantitative' | 'identifier';
+  // Existing aggregates, used to disable already-added function/column pairs.
+  readonly existingAggregates: readonly AggregateColumn[] | undefined;
+  // Data source used to discover the available parameter keys.
+  readonly datasource: DataSource;
+  // Callback invoked with the chosen aggregate function and full column path.
+  readonly onSelect: (func: AggregateFunction, field: string) => void;
+}
+
+class AggregateRecordPopup implements m.ClassComponent<AggregateRecordPopupAttrs> {
+  private readonly MAX_VISIBLE_ITEMS = 100;
+  private searchQuery = '';
+
+  view({attrs}: m.Vnode<AggregateRecordPopupAttrs>): m.Children {
+    const {pathPrefix, filterType, existingAggregates, datasource, onSelect} =
+      attrs;
+
+    // Fetch available keys - this is only called when the submenu is visible
+    const {data: availableKeys, isPending} =
+      datasource.useParameterKeys(pathPrefix);
+
+    // Show loading state while fetching
+    if (isPending || availableKeys === undefined) {
+      return m('.pf-distinct-values-menu', [
+        m(MenuItem, {label: 'Loading...', disabled: true}),
+      ]);
+    }
+
+    // Use fuzzy search to filter and get highlighted segments
+    const fuzzyResults = (() => {
+      if (this.searchQuery === '') {
+        // No search - show all keys without highlighting
+        return availableKeys.map((key: string) => ({
+          key,
+          segments: [{matching: false, value: key}],
+        }));
+      } else {
+        // Fuzzy search with highlighting
+        return fuzzySearch(
+          availableKeys as string[],
+          (k: string) => k,
+          this.searchQuery,
+        ).map((result) => ({
+          key: result.item,
+          segments: result.segments,
+        }));
+      }
+    })();
+
+    // Limit the number of items rendered
+    const visibleResults = fuzzyResults.slice(0, this.MAX_VISIBLE_ITEMS);
+    const remainingCount = fuzzyResults.length - this.MAX_VISIBLE_ITEMS;
+
+    // Check if search query could be used as a custom key
+    const customKeyPath =
+      this.searchQuery.trim().length > 0
+        ? `${pathPrefix}.${this.searchQuery.trim()}`
+        : '';
+    const isCustomKeyInResults =
+      this.searchQuery.trim().length > 0 &&
+      availableKeys.includes(this.searchQuery.trim());
+
+    return m('.pf-distinct-values-menu', [
+      // Search input
+      m(
+        '.pf-distinct-values-menu__search',
+        {
+          onclick: (e: MouseEvent) => {
+            // Prevent menu from closing when clicking search box
+            e.stopPropagation();
+          },
+        },
+        m(TextInput, {
+          placeholder: 'Search or enter key name...',
+          value: this.searchQuery,
+          oninput: (e: InputEvent) => {
+            this.searchQuery = (e.target as HTMLInputElement).value;
+          },
+          onkeydown: (e: KeyboardEvent) => {
+            if (this.searchQuery !== '' && e.key === 'Escape') {
+              this.searchQuery = '';
+              e.stopPropagation(); // Prevent menu from closing
+            }
+          },
+        }),
+      ),
+      // List of available keys
+      m(
+        '.pf-distinct-values-menu__list',
+        fuzzyResults.length > 0
+          ? [
+              visibleResults.map(
+                (result: {
+                  key: string;
+                  segments: readonly {matching: boolean; value: string}[];
+                }) => {
+                  const keyPath = `${pathPrefix}.${result.key}`;
+
+                  // Render highlighted label
+                  const labelContent = result.segments.map(
+                    (segment: {matching: boolean; value: string}) => {
+                      if (segment.matching) {
+                        return m('strong.pf-fuzzy-match', segment.value);
+                      } else {
+                        return segment.value;
+                      }
+                    },
+                  );
+
+                  return m(
+                    MenuItem,
+                    {
+                      label: labelContent,
+                    },
+                    buildAggFuncItems(
+                      filterType,
+                      keyPath,
+                      existingAggregates,
+                      (func, field) => {
+                        onSelect(func, field);
+                        this.searchQuery = '';
+                      },
+                    ),
+                  );
+                },
+              ),
+              remainingCount > 0 &&
+                m(MenuItem, {
+                  label: `...and ${remainingCount} more`,
+                  disabled: true,
+                }),
+            ]
+          : m(EmptyState, {
+              title: 'No matches',
+            }),
+      ),
+      // Footer with "Add custom" option when search query doesn't match existing keys
+      this.searchQuery.trim().length > 0 &&
+        !isCustomKeyInResults &&
+        m('.pf-distinct-values-menu__footer', [
+          m(
+            MenuItem,
+            {
+              label: `Add "${this.searchQuery.trim()}"`,
+              icon: 'add',
+            },
+            buildAggFuncItems(
+              filterType,
+              customKeyPath,
+              existingAggregates,
+              (func, field) => {
+                onSelect(func, field);
+                this.searchQuery = '';
+              },
+            ),
+          ),
+        ]),
+    ]);
+  }
+}
+
 interface AggregateSchemaMenuItemAttrs {
   // Label shown on this submenu's own menu item.
   readonly label: m.Children;
@@ -437,6 +647,8 @@ interface AggregateSchemaMenuItemAttrs {
   readonly onSelect: (func: AggregateFunction, field: string) => void;
   // Existing aggregates, used to disable already-added function/column pairs.
   readonly existingAggregates: readonly AggregateColumn[] | undefined;
+  // Data source used to discover keys for parameterized columns.
+  readonly datasource: DataSource;
   // Extra items rendered before the column entries (e.g. the COUNT option at
   // the root of the menu).
   readonly leadingItems?: m.Children;
@@ -457,6 +669,7 @@ const AggregateSchemaMenuItem: m.Component<AggregateSchemaMenuItemAttrs> = {
       pathPrefix,
       onSelect,
       existingAggregates,
+      datasource,
       leadingItems,
     } = attrs;
     const menuItems: m.Children[] = [];
@@ -467,38 +680,36 @@ const AggregateSchemaMenuItem: m.Component<AggregateSchemaMenuItemAttrs> = {
 
     for (const [columnName, entry] of Object.entries(schema)) {
       const fullPath = pathPrefix ? `${pathPrefix}.${columnName}` : columnName;
+      const title = entry.title ?? columnName;
 
       if ('parameterized' in entry) {
-        // For parameterized columns, aggregate over the base column.
-        const title =
-          typeof entry.title === 'string' ? entry.title : columnName;
+        // Show available keys from datasource
         menuItems.push(
-          m(
-            MenuItem,
-            {label: `${title} (base)`},
-            buildAggFuncItems(
-              entry.filterType,
-              fullPath,
-              existingAggregates,
-              onSelect,
-            ),
-          ),
+          m(AggregateParamMenuItem, {
+            label: `${title}...`,
+            pathPrefix: fullPath,
+            filterType: entry.filterType,
+            existingAggregates,
+            datasource,
+            onSelect,
+          }),
         );
       } else if ('schema' in entry) {
         menuItems.push(
           m(AggregateSchemaMenuItem, {
-            label: entry.title ?? columnName,
+            label: title,
             schema: entry.schema,
             pathPrefix: fullPath,
             onSelect,
             existingAggregates,
+            datasource,
           }),
         );
       } else {
         menuItems.push(
           m(
             MenuItem,
-            {label: entry.title ?? columnName},
+            {label: title},
             buildAggFuncItems(
               entry.columnType,
               fullPath,
@@ -518,8 +729,9 @@ const AggregateSchemaMenuItem: m.Component<AggregateSchemaMenuItemAttrs> = {
   },
 };
 
-interface AggregateMenuAttrs {
+export interface AggregateMenuAttrs {
   readonly schema: ColumnSchema;
+  readonly datasource: DataSource;
   readonly onAddAggregate: (
     func: AggregateFunction | 'COUNT',
     field: string | undefined,
@@ -530,6 +742,9 @@ interface AggregateMenuAttrs {
 
   // Custom label (default: "Add aggregate")
   readonly label?: string;
+
+  // Optional icon (default: Icons.AddColumnRight)
+  readonly icon?: string;
 }
 
 /**
@@ -541,9 +756,11 @@ export class AggregateMenu implements m.ClassComponent<AggregateMenuAttrs> {
   view({attrs}: m.Vnode<AggregateMenuAttrs>): m.Children {
     const {
       schema,
+      datasource,
       onAddAggregate,
       existingAggregates,
       label = 'Add column',
+      icon = Icons.AddColumnRight,
     } = attrs;
 
     const countExists = isAggregateExists(
@@ -554,9 +771,10 @@ export class AggregateMenu implements m.ClassComponent<AggregateMenuAttrs> {
 
     return m(AggregateSchemaMenuItem, {
       label,
-      icon: Icons.AddColumnRight,
+      icon,
       schema,
       pathPrefix: '',
+      datasource,
       onSelect: (func, field) => onAddAggregate(func, field),
       existingAggregates,
       // COUNT option - doesn't need a field

--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -1972,6 +1972,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           groupByThisMenuItem,
           m(AggregateMenu, {
             schema,
+            datasource,
             existingAggregates: pivot.aggregates,
             onAddAggregate: (func, aggField) =>
               this.addAggregateColumn(func, aggField, attrs, i),

--- a/ui/src/components/widgets/datagrid/sql_data_source/pivot_unittest.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/pivot_unittest.ts
@@ -1,0 +1,180 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AtomicTaskQueue} from '../../../../base/async_memo';
+import type {Engine} from '../../../../trace_processor/engine';
+import type {PivotModel} from '../data_source';
+import type {SQLTableSchema} from '../sql_schema';
+import {SQLDataSourceGroupBy} from './group_by';
+import {SQLDataSourceRollupTree} from './rollup_tree';
+
+describe('SQLDataSourceGroupBy parameterized aggregates', () => {
+  const dummyEngine = {} as Engine;
+  const queue = new AtomicTaskQueue();
+
+  const trackSchema: SQLTableSchema = {
+    tableOrSubquery: 'track',
+    columns: {
+      id: {column: 'id'},
+      name: {column: 'name'},
+      dimension_arg_set_id: {
+        parameterized: true,
+        expression: (alias, key) =>
+          `extract_arg(${alias}.dimension_arg_set_id, ${JSON.stringify(key ?? null)})`,
+      },
+    },
+  };
+
+  const sliceSchema: SQLTableSchema = {
+    tableOrSubquery: 'slice',
+    columns: {
+      id: {column: 'id'},
+      name: {column: 'name'},
+      dur: {column: 'dur'},
+      args: {
+        parameterized: true,
+        expression: (alias, key) =>
+          `extract_arg(${alias}.arg_set_id, ${JSON.stringify(key ?? null)})`,
+      },
+      track: {
+        schema: trackSchema,
+        foreignKey: 'track_id',
+      },
+    },
+  };
+
+  test('generates query with parameterized aggregate on base table', () => {
+    const ds = new SQLDataSourceGroupBy(queue, dummyEngine, sliceSchema);
+    const model: PivotModel = {
+      mode: 'pivot',
+      groupDisplay: 'flat',
+      groupBy: [{field: 'name', alias: 'name_alias'}],
+      aggregates: [
+        {function: 'SUM', field: 'args.destination', alias: 'dest_sum'},
+      ],
+    };
+
+    const query = ds.getQuery(model);
+    expect(query).toContain(
+      'SUM(extract_arg(base.arg_set_id, "destination")) AS "dest_sum"',
+    );
+    expect(query).toContain('GROUP BY base.name');
+  });
+
+  test('generates query with parameterized aggregate on joined relation', () => {
+    const ds = new SQLDataSourceGroupBy(queue, dummyEngine, sliceSchema);
+    const model: PivotModel = {
+      mode: 'pivot',
+      groupDisplay: 'flat',
+      groupBy: [{field: 'name', alias: 'name_alias'}],
+      aggregates: [
+        {
+          function: 'MAX',
+          field: 'track.dimension_arg_set_id.key',
+          alias: 'track_dim_max',
+        },
+      ],
+    };
+
+    const query = ds.getQuery(model);
+    expect(query).toContain('LEFT JOIN (track) AS');
+    expect(query).toContain('MAX(extract_arg(');
+    expect(query).toContain('dimension_arg_set_id, "key")) AS "track_dim_max"');
+  });
+});
+
+describe('SQLDataSourceRollupTree parameterized aggregates', () => {
+  const dummyEngine = {} as Engine;
+  const queue = new AtomicTaskQueue();
+
+  const trackSchema: SQLTableSchema = {
+    tableOrSubquery: 'track',
+    columns: {
+      id: {column: 'id'},
+      name: {column: 'name'},
+      dimension_arg_set_id: {
+        parameterized: true,
+        expression: (alias, key) =>
+          `extract_arg(${alias}.dimension_arg_set_id, ${JSON.stringify(key ?? null)})`,
+      },
+    },
+  };
+
+  const sliceSchema: SQLTableSchema = {
+    tableOrSubquery: 'slice',
+    columns: {
+      id: {column: 'id'},
+      name: {column: 'name'},
+      dur: {column: 'dur'},
+      args: {
+        parameterized: true,
+        expression: (alias, key) =>
+          `extract_arg(${alias}.arg_set_id, ${JSON.stringify(key ?? null)})`,
+      },
+      track: {
+        schema: trackSchema,
+        foreignKey: 'track_id',
+      },
+    },
+  };
+
+  test('generates rollup table with parameterized aggregate on base table', () => {
+    const ds = new SQLDataSourceRollupTree(
+      'test_uuid',
+      queue,
+      dummyEngine,
+      sliceSchema,
+    );
+    const model: PivotModel = {
+      mode: 'pivot',
+      groupDisplay: 'tree',
+      groupBy: [{field: 'name', alias: 'name_alias'}],
+      aggregates: [
+        {function: 'SUM', field: 'args.destination', alias: 'dest_sum'},
+      ],
+    };
+
+    const query = ds.getQuery(model);
+    expect(query).toContain(
+      'SUM(extract_arg(base.arg_set_id, "destination")) AS __agg_0',
+    );
+    expect(query).toContain('FROM (slice) AS base');
+  });
+
+  test('generates rollup table with parameterized aggregate on joined relation', () => {
+    const ds = new SQLDataSourceRollupTree(
+      'test_uuid',
+      queue,
+      dummyEngine,
+      sliceSchema,
+    );
+    const model: PivotModel = {
+      mode: 'pivot',
+      groupDisplay: 'tree',
+      groupBy: [{field: 'name', alias: 'name_alias'}],
+      aggregates: [
+        {
+          function: 'MAX',
+          field: 'track.dimension_arg_set_id.key',
+          alias: 'track_dim_max',
+        },
+      ],
+    };
+
+    const query = ds.getQuery(model);
+    expect(query).toContain('LEFT JOIN (track) AS');
+    expect(query).toContain('MAX(extract_arg(');
+    expect(query).toContain('dimension_arg_set_id, "key")) AS __agg_0');
+  });
+});

--- a/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source/rollup_tree.ts
@@ -259,21 +259,18 @@ export class SQLDataSourceRollupTree {
   private useRollupTable(
     model: PivotModel,
   ): AsyncMemoResult<DisposableSqlEntity> {
-    const {groupBy, aggregates, filters = []} = model;
-
-    const sourceQuery = this.buildSourceQuery(filters);
-    const groupByColumns = groupBy.map((col) => col.field);
-    const aggregateExprs = this.buildAggregateExprs(aggregates);
+    const {sourceTable, groupByColumns, aggregateExprs} =
+      this.buildRollupQueryParts(model);
 
     return this.rollupTableSlot.use({
       key: {
-        sourceQuery,
+        sourceTable,
         groupByColumns,
         aggregateExprs,
       },
       compute: async () => {
         return await createRollupTable(this.engine, {
-          sourceTable: sourceQuery,
+          sourceTable,
           groupByColumns,
           aggregateExprs,
           tableName: this.rollupTableName,
@@ -291,14 +288,52 @@ export class SQLDataSourceRollupTree {
     return `rollup_${this.uuid}`;
   }
 
-  private buildAggregateExprs(aggregates: PivotModel['aggregates']): string[] {
-    return aggregates.map((agg) => {
+  private buildRollupQueryParts(model: PivotModel): {
+    sourceTable: string;
+    groupByColumns: string[];
+    aggregateExprs: string[];
+  } {
+    const {groupBy, aggregates, filters = []} = model;
+    const resolver = new SQLSchemaResolver(this.sqlSchema);
+
+    // Resolve all column paths in filters, groupBy, and aggregates to accumulate joins
+    if (filters.length > 0) {
+      for (const filter of filters) {
+        resolver.resolveColumnPath(filter.field);
+      }
+    }
+
+    const groupByColumns = groupBy.map((col) => {
+      return resolver.resolveColumnPath(col.field) ?? col.field;
+    });
+
+    const aggregateExprs = aggregates.map((agg) => {
       if (agg.function === 'COUNT') {
         return 'COUNT(*)';
       } else {
-        return sqlAggregateExpr(agg.function, agg.field);
+        const sqlExpr = resolver.resolveColumnPath(agg.field);
+        return sqlAggregateExpr(agg.function, sqlExpr ?? agg.field);
       }
     });
+
+    const baseTable = resolver.getBaseTableOrSubquery();
+    const baseAlias = resolver.getBaseAlias();
+    const joinClauses = resolver.buildJoinClauses();
+
+    let sourceTable = `(${baseTable}) AS ${baseAlias}`;
+    if (joinClauses) {
+      sourceTable += `\n${joinClauses}`;
+    }
+
+    if (filters.length > 0) {
+      const whereConditions = filters.map((filter) => {
+        const sqlExpr = resolver.resolveColumnPath(filter.field);
+        return filterToSql(filter, sqlExpr ?? filter.field);
+      });
+      sourceTable += `\nWHERE ${whereConditions.join(' AND ')}`;
+    }
+
+    return {sourceTable, groupByColumns, aggregateExprs};
   }
 
   /**
@@ -353,21 +388,13 @@ export class SQLDataSourceRollupTree {
    * created.
    */
   getQuery(model: PivotModel): string {
-    const {
-      groupBy,
-      aggregates,
-      filters = [],
-      expandedGroups,
-      collapsedGroups,
-    } = model;
-
-    const sourceQuery = this.buildSourceQuery(filters);
-    const groupByColumns = groupBy.map((col) => col.field);
-    const aggregateExprs = this.buildAggregateExprs(aggregates);
+    const {expandedGroups, collapsedGroups} = model;
+    const {sourceTable, groupByColumns, aggregateExprs} =
+      this.buildRollupQueryParts(model);
     const tableName = this.rollupTableName;
     const {columnAliases, aliasToColumn} = this.buildColumnAliases(
-      groupBy,
-      aggregates,
+      model.groupBy,
+      model.aggregates,
     );
     const {sortColumn, sortDirection} = this.resolveSort(
       model.sort,
@@ -389,7 +416,7 @@ export class SQLDataSourceRollupTree {
       `-- Materialize rollup table:`,
       `CREATE PERFETTO TABLE ${tableName} AS`,
       buildRollupTableCreateQuery(
-        sourceQuery,
+        sourceTable,
         groupByColumns,
         aggregateExprs,
       ).trim(),
@@ -397,33 +424,6 @@ export class SQLDataSourceRollupTree {
       `-- Traverse rollup table:`,
       traversalQuery.trim(),
     ].join('\n');
-  }
-
-  private buildSourceQuery(filters: PivotModel['filters']): string {
-    const resolver = new SQLSchemaResolver(this.sqlSchema);
-    const baseTable = resolver.getBaseTableOrSubquery();
-    const baseAlias = resolver.getBaseAlias();
-
-    let sql = `SELECT ${baseAlias}.* FROM (${baseTable}) AS ${baseAlias}`;
-
-    if (filters && filters.length > 0) {
-      for (const filter of filters) {
-        resolver.resolveColumnPath(filter.field);
-      }
-
-      const joinClauses = resolver.buildJoinClauses();
-      if (joinClauses) {
-        sql += `\n${joinClauses}`;
-      }
-
-      const whereConditions = filters.map((filter) => {
-        const sqlExpr = resolver.resolveColumnPath(filter.field);
-        return filterToSql(filter, sqlExpr ?? filter.field);
-      });
-      sql += `\nWHERE ${whereConditions.join(' AND ')}`;
-    }
-
-    return `(${sql})`;
   }
 
   dispose(): void {


### PR DESCRIPTION
Add support for adding parameterised columns (e.g. args) as aggregate columns in the DataGrid pivot mode. This currently works for groupby columns but not aggregates.