### PR TITLE
tp: stdlib: Fix event time and action in android_input_events

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/input.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/input.sql
@@ -71,14 +71,12 @@ WITH
     SELECT
       name,
       str_split(str_split(str_split(name, 'id=', 1), ',', 0), ')', 0) AS input_event_id,
-      str_split(str_split(name, 'eventTime=', 1), ')', 0) AS event_time_str,
       ts AS read_time
     FROM slice
     WHERE
       name GLOB 'UnwantedInteractionBlocker::notifyMotion*'
   )
-SELECT name, input_event_id, cast_int!(event_time_str) AS event_time, read_time
-FROM _extracted_input_read_args;
+SELECT name, input_event_id, read_time FROM _extracted_input_read_args;
 
 CREATE PERFETTO TABLE _event_seq_to_input_event_id AS
 WITH
@@ -130,7 +128,8 @@ SELECT
   cast_int!(t.upid) AS upid,
   t.process_name,
   str_split(s.name, '=', 3) AS extracted_input_event_id,
-  str_split(str_split(parent.name, '_', 1), ' ', 0) AS event_action,
+  str_split(str_split(parent.name, ' ', 2), ' ', 0) AS event_action,
+  cast_int!(str_split(str_split(s.name, ' ', 2), '=', 1)) AS event_time,
   parent.ts AS consume_time,
   parent.ts + parent.dur AS finish_time
 FROM slice AS s
@@ -201,6 +200,7 @@ CREATE PERFETTO TABLE _input_event_id_to_android_frame AS
 SELECT
   dev.extracted_input_event_id AS input_event_id,
   dev.event_action,
+  dev.event_time,
   dev.consume_time,
   dev.finish_time,
   dev.utid,
@@ -237,7 +237,6 @@ CREATE PERFETTO TABLE _first_non_dropped_frame_after_input AS
 SELECT
   _input_read_time.input_event_id,
   _input_read_time.read_time,
-  _input_read_time.event_time,
   (
     SELECT surface_flinger_ts + surface_flinger_dur
     FROM _app_frame_to_surface_flinger_frame AS sf_frames
@@ -250,6 +249,7 @@ SELECT
   _input_event_id_to_android_frame.frame_id,
   event_seq,
   event_action,
+  event_time,
   _input_event_id_to_android_frame.is_speculative_match
 FROM _input_event_id_to_android_frame
 RIGHT JOIN _event_seq_to_input_event_id
@@ -414,7 +414,7 @@ SELECT
   receive.track_id AS receive_track_id,
   frame.frame_id,
   frame.is_speculative_match AS is_speculative_frame,
-  read_time.event_time
+  frame.event_time
 FROM dispatch
 JOIN receive
   ON receive.dispatch_event_channel = dispatch.event_channel

--- a/test/trace_processor/diff_tests/stdlib/android/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/android/tests.py
@@ -1352,15 +1352,17 @@ class AndroidStdlib(TestSuite):
         upid,
         pid,
         process_name,
-        event_type
+        event_type,
+        event_action,
+        event_time
         FROM android_input_events
         WHERE end_to_end_latency_dur IS NOT NULL
         ORDER BY dispatch_ts
       """,
         out=Csv("""
-        "total_latency_dur","handling_latency_dur","dispatch_latency_dur","end_to_end_latency_dur","tid","thread_name","upid","pid","process_name","event_type"
-        3422992,2937418,363000,51007097,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION"
-        2139405,1956366,81387,50642855,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION"
+        "total_latency_dur","handling_latency_dur","dispatch_latency_dur","end_to_end_latency_dur","tid","thread_name","upid","pid","process_name","event_type","event_action","event_time"
+        3422992,2937418,363000,51007097,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION","HOVER_MOVE",12394215174000
+        2139405,1956366,81387,50642855,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION","SCROLL",12394215174000
       """))
 
   def test_job_scheduler_events(self):


### PR DESCRIPTION
This fixes the association of event_time and event_action to reflect the most up to date format of trace events to ensure these values are populated in the table.

Bug: 540736430
Bug: 482994760