### PR TITLE
tp: update live_tid cache when reaffirming thread parent process

### DIFF
--- a/src/trace_processor/importers/common/process_tracker.cc
+++ b/src/trace_processor/importers/common/process_tracker.cc
@@ -166,6 +166,17 @@ UniqueTid ProcessTracker::GetOrCreateThreadWithParentInternal(
   auto opt_utid = GetThreadOrNull(tid, ps.pid());
   UniqueTid utid = opt_utid ? *opt_utid : StartNewThread(std::nullopt, tid);
 
+  // When an existing thread is reaffirmed with its parent process, update
+  // the live_tid_ cache and move it to the back of tids_ so subsequent
+  // bare lookups and RefreshLiveTid() calls resolve to this active thread.
+  if (opt_utid.has_value()) {
+    live_tid_[tid] = utid;
+    if (auto* vec = tids_.Find(tid); vec && vec->back() != utid) {
+      vec->erase(std::remove(vec->begin(), vec->end(), utid), vec->end());
+      vec->push_back(utid);
+    }
+  }
+
   auto td = thread_table[utid];
   PERFETTO_DCHECK(td.tid() == tid);
   // Ensure that the thread's machine ID matches the context's machine ID.

--- a/src/trace_processor/importers/common/process_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/process_tracker_unittest.cc
@@ -644,5 +644,33 @@ TEST_F(ProcessTrackerTest, IsThreadAliveTruthTable) {
   ASSERT_FALSE(context.process_tracker->IsThreadAlive(worker));
 }
 
+TEST_F(ProcessTrackerTest, ReaffirmedThreadUpdatesLiveTid) {
+  // 1. Process A (pid 100) has thread tid 500.
+  context.process_tracker->StartNewProcess(std::nullopt, std::nullopt,
+                                           /*pid=*/100, kNullStringId,
+                                           ThreadNamePriority::kFtrace);
+  UniqueTid utid_a =
+      context.process_tracker->UpdateThread(/*tid=*/500, /*pid=*/100);
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(500), utid_a);
+
+  // 2. Process B (pid 200) also claims thread tid 500.
+  context.process_tracker->StartNewProcess(std::nullopt, std::nullopt,
+                                           /*pid=*/200, kNullStringId,
+                                           ThreadNamePriority::kFtrace);
+  UniqueTid utid_b =
+      context.process_tracker->UpdateThread(/*tid=*/500, /*pid=*/200);
+  ASSERT_NE(utid_a, utid_b);
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(500), utid_b);
+
+  // 3. Process A reaffirms thread tid 500.
+  UniqueTid reaffirmed =
+      context.process_tracker->UpdateThread(/*tid=*/500, /*pid=*/100);
+  ASSERT_EQ(reaffirmed, utid_a);
+
+  // Bare lookup should now return utid_a again.
+  ASSERT_EQ(context.process_tracker->GetThreadOrNull(500), utid_a);
+  ASSERT_EQ(context.process_tracker->GetOrCreateThread(500), utid_a);
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor


### PR DESCRIPTION
When an existing thread is reaffirmed with its parent process in GetOrCreateThreadWithParentInternal(), update live_tid_[tid] and move the utid to the back of tids_[tid].

Background:
ProcessTracker tracks threads across time using two data structures:
- tids_[tid]: An ordered vector of all UniqueTids allocated for a tid, scanned backwards (from rbegin()) to prioritize newer incarnations.
- live_tid_[tid]: A fast-path cache mapping a tid to its active UniqueTid, queried by bare ftrace events (like sched_switch) that do not carry a parent PID.

Problem:
If a TID is recycled across processes—for instance, when a thread is created by Process A, then an out-of-order /proc dump associates that TID with Process B, and later a ProcessTree dump confirms the thread belongs to Process A:
1. Process A's reaffirmation matches the existing utid via GetThreadOrNull(tid, pid), so StartNewThread() is not called.
2. Because StartNewThread() was skipped, live_tid_[tid] was not updated and remained pointing to Process B's utid.
3. In addition, Process B's utid stayed at the back of tids_[tid], so any subsequent RefreshLiveTid() calls would also pick Process B.

Impact:
Subsequent bare lookups from sched_switch and sched_waking routed all CPU scheduling states to Process B. Furthermore, when the thread spawned worker threads via task_newtask, the child threads inherited Process B's upid, mistakenly parenting them to the wrong process.

Fix:
In GetOrCreateThreadWithParentInternal(), when an existing utid is matched for (tid, pid), explicitly update live_tid_[tid] to this utid and move it to the back of tids_[tid]. This ensures both direct lookups and RefreshLiveTid() correctly resolve to the active thread.

BUG: b/546056884
