### PR TITLE
tp: Support self_count in __intrinsic_tree_dominator_summary

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/dominator_tree.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/dominator_tree.sql
@@ -58,7 +58,9 @@ FROM __intrinsic_table_ptr(
           'self_size',
           o.self_size,
           'native_size',
-          o.native_size
+          o.native_size,
+          'self_count',
+          1
         )
       )
     FROM _raw_heap_graph_dominator_tree AS p

--- a/src/trace_processor/plugins/tree_functions/tree_conversion.cc
+++ b/src/trace_processor/plugins/tree_functions/tree_conversion.cc
@@ -211,9 +211,15 @@ static base::StatusOr<dataframe::Dataframe> TreeDominatorSummaryImpl(
     return std::move(builder).Build();
   }
 
-  // Pre-initialize working vectors. Every node dominates itself (count=1,
-  // depth=1).
-  std::vector<int64_t> subtree_count(N, 1);
+  if (tree.columns.size() != 5) {
+    return base::ErrStatus(
+        "__intrinsic_tree_dominator_summary: expected tree with exactly 5 "
+        "columns (id, parent_id, self_size, native_size, self_count), got %zu",
+        tree.columns.size());
+  }
+
+  // Pre-initialize working vectors. Nodes start at depth=1.
+  std::vector<int64_t> subtree_count(N, 0);
   std::vector<int64_t> subtree_size_bytes(N, 0);
   std::vector<int64_t> subtree_native_size_bytes(N, 0);
   std::vector<int64_t> depth(N, 1);
@@ -221,6 +227,19 @@ static base::StatusOr<dataframe::Dataframe> TreeDominatorSummaryImpl(
   const auto* ids = tree.columns[0].unchecked_data<int64_t>();
   const auto* self_sizes = tree.columns[2].unchecked_data<int64_t>();
   const auto* native_sizes = tree.columns[3].unchecked_data<int64_t>();
+  const auto* counts = tree.columns[4].unchecked_data<int64_t>();
+
+  // Copy initial self-counts into subtree accumulators, skipping nulls if
+  // present.
+  if (tree.columns[4].null_bv.size() == 0) {
+    std::copy(counts, counts + N, subtree_count.begin());
+  } else {
+    for (uint32_t i = 0; i < N; ++i) {
+      if (tree.columns[4].null_bv.is_set(i)) {
+        subtree_count[i] = counts[i];
+      }
+    }
+  }
 
   // Copy initial self-sizes into subtree accumulators, skipping nulls if
   // present.


### PR DESCRIPTION
Allow `__intrinsic_tree_dominator_summary` to accept `self_count` as a fifth input column, aggregating per-node counts into `dominated_obj_count` during the bottom-up pass instead of assuming each node has a unit count. Update `heap_graph_dominator_tree` to supply a constant `self_count` of 1 to preserve existing behavior.

