### PR TITLE
tp: speed up SQLite joins on ID columns

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17604,6 +17604,7 @@ filegroup {
     srcs: [
         "src/trace_processor/core/interpreter/bytecode_builder.cc",
         "src/trace_processor/core/interpreter/bytecode_interpreter_impl.cc",
+        "src/trace_processor/core/interpreter/bytecode_optimizer.cc",
         "src/trace_processor/core/interpreter/bytecode_to_string.cc",
     ],
 }

--- a/BUILD
+++ b/BUILD
@@ -2495,6 +2495,8 @@ perfetto_filegroup(
         "src/trace_processor/core/interpreter/bytecode_interpreter_impl.cc",
         "src/trace_processor/core/interpreter/bytecode_interpreter_impl.h",
         "src/trace_processor/core/interpreter/bytecode_interpreter_state.h",
+        "src/trace_processor/core/interpreter/bytecode_optimizer.cc",
+        "src/trace_processor/core/interpreter/bytecode_optimizer.h",
         "src/trace_processor/core/interpreter/bytecode_registers.h",
         "src/trace_processor/core/interpreter/bytecode_to_string.cc",
         "src/trace_processor/core/interpreter/bytecode_to_string.h",

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ Unreleased:
   Tracing service and probes:
    *
   Trace Processor:
-   *
+    * Improved performance of SQLite joins using ID columns.
   UI:
     * Double-clicking a timeline slice now selects and zooms into it.
   SDK:

--- a/src/trace_processor/core/dataframe/cursor.h
+++ b/src/trace_processor/core/dataframe/cursor.h
@@ -31,6 +31,7 @@
 #include "src/trace_processor/core/dataframe/query_plan.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/dataframe/types.h"
+#include "src/trace_processor/core/interpreter/bytecode_instructions.h"
 #include "src/trace_processor/core/interpreter/bytecode_interpreter.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
 

--- a/src/trace_processor/core/dataframe/cursor_impl.h
+++ b/src/trace_processor/core/dataframe/cursor_impl.h
@@ -29,11 +29,8 @@ namespace perfetto::trace_processor::core::dataframe {
 template <typename FilterValueFetcherImpl>
 void Cursor<FilterValueFetcherImpl>::Execute(
     FilterValueFetcherImpl& filter_value_fetcher) {
-  using S = Span<uint32_t>;
-  interpreter_.Execute(filter_value_fetcher);
-
-  const auto& span =
-      *interpreter_.template GetRegisterValue<S>(params_.output_register);
+  auto span =
+      interpreter_.Execute(filter_value_fetcher, params_.output_register);
   pos_ = span.b;
   end_ = span.e;
 }

--- a/src/trace_processor/core/dataframe/dataframe_unittest.cc
+++ b/src/trace_processor/core/dataframe/dataframe_unittest.cc
@@ -173,11 +173,41 @@ TEST_F(DataframeBytecodeTest, SingleFilter) {
              NoDuplicates{}});
   std::vector<FilterSpec> filters = {{0, 0, Eq{}, std::nullopt}};
   RunBytecodeTest(cols, filters, {}, {}, {}, R"(
-    InitRange: [size=0, dest_register=Register(0)]
-    CastFilterValue<Id>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
-    SortedFilter<Id, EqualRange>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
-    AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
-    Iota: [source_register=Register(0), update_register=Register(4)]
+    SingleRowQuery: [row_count=0, id_fval_handle=FilterValue(0), predicate_count=0]
+  )");
+}
+
+TEST_F(DataframeBytecodeTest, FusesMultipleSingleRowEqualities) {
+  std::vector<Column> cols = MakeColumnVector(
+      Column{Storage::Id{}, NullStorage::NonNull{}, IdSorted{}, NoDuplicates{}},
+      Column{Storage::Uint32{}, NullStorage::NonNull{}, Unsorted{},
+             HasDuplicates{}},
+      Column{Storage::Int64{}, NullStorage::NonNull{}, Unsorted{},
+             HasDuplicates{}});
+  std::vector<FilterSpec> filters = {
+      {0, 0, Eq{}, std::nullopt},
+      {1, 1, Eq{}, std::nullopt},
+      {2, 2, Eq{}, std::nullopt},
+  };
+  RunBytecodeTest(cols, filters, {}, {}, {}, R"(
+    SingleRowQuery: [row_count=0, id_fval_handle=FilterValue(0), predicate_count=2]
+    SingleRowEqPredicate: [fval_handle=FilterValue(1), storage_register=Register(6), storage_type=0]
+    SingleRowEqPredicate: [fval_handle=FilterValue(2), storage_register=Register(8), storage_type=2]
+  )");
+}
+
+TEST_F(DataframeBytecodeTest, FusesIdAndNonNullEquality) {
+  std::vector<Column> cols = MakeColumnVector(
+      Column{Storage::Id{}, NullStorage::NonNull{}, IdSorted{}, NoDuplicates{}},
+      Column{Storage::Uint32{}, NullStorage::NonNull{}, Unsorted{},
+             HasDuplicates{}});
+  std::vector<FilterSpec> filters = {
+      {0, 0, Eq{}, std::nullopt},
+      {1, 1, Eq{}, std::nullopt},
+  };
+  RunBytecodeTest(cols, filters, {}, {}, {}, R"(
+    SingleRowQuery: [row_count=0, id_fval_handle=FilterValue(0), predicate_count=1]
+    SingleRowEqPredicate: [fval_handle=FilterValue(1), storage_register=Register(6), storage_type=0]
   )");
 }
 
@@ -1615,6 +1645,123 @@ TEST(DataframeTest, TypedCursorSetMultipleTimes) {
     cursor.SetCellUnchecked<1>(kSpec, 20u);
     ASSERT_EQ(cursor.GetCellUnchecked<1>(kSpec), 20u);
   }
+}
+
+TEST(DataframeTest, TypedCursorSingleRowIdEquality) {
+  static constexpr auto kSpec = CreateTypedDataframeSpec(
+      {"id", "value"}, CreateTypedColumnSpec(Id(), NonNull(), IdSorted()),
+      CreateTypedColumnSpec(Uint32(), NonNull(), Unsorted()));
+  StringPool pool;
+  Dataframe df = Dataframe::CreateFromTypedSpec(kSpec, &pool);
+  df.InsertUnchecked(kSpec, std::monostate(), 10u);
+  df.InsertUnchecked(kSpec, std::monostate(), 20u);
+
+  TypedCursor cursor(&df, {FilterSpec{0, 0, Eq{}, {}}}, {});
+  cursor.SetFilterValueUnchecked(0, int64_t(1));
+  cursor.ExecuteUnchecked();
+  ASSERT_FALSE(cursor.Eof());
+  EXPECT_EQ(cursor.RowIndex(), 1u);
+  cursor.Next();
+  EXPECT_TRUE(cursor.Eof());
+
+  cursor.SetFilterValueUnchecked(0, int64_t(10));
+  cursor.ExecuteUnchecked();
+  EXPECT_TRUE(cursor.Eof());
+}
+
+TEST(DataframeTest, TypedCursorSingleRowIdAndNonNullEquality) {
+  static constexpr auto kSpec = CreateTypedDataframeSpec(
+      {"id", "value"}, CreateTypedColumnSpec(Id(), NonNull(), IdSorted()),
+      CreateTypedColumnSpec(Uint32(), NonNull(), Unsorted()));
+  StringPool pool;
+  Dataframe df = Dataframe::CreateFromTypedSpec(kSpec, &pool);
+  df.InsertUnchecked(kSpec, std::monostate(), 10u);
+  df.InsertUnchecked(kSpec, std::monostate(), 20u);
+  df.InsertUnchecked(kSpec, std::monostate(), 30u);
+
+  TypedCursor cursor(
+      &df, {FilterSpec{0, 0, Eq{}, {}}, FilterSpec{1, 1, Eq{}, {}}}, {});
+  cursor.SetFilterValueUnchecked(0, int64_t(1));
+  cursor.SetFilterValueUnchecked(1, int64_t(20));
+  cursor.ExecuteUnchecked();
+  ASSERT_FALSE(cursor.Eof());
+  EXPECT_EQ(cursor.RowIndex(), 1u);
+  cursor.Next();
+  EXPECT_TRUE(cursor.Eof());
+
+  cursor.SetFilterValueUnchecked(1, int64_t(30));
+  cursor.ExecuteUnchecked();
+  EXPECT_TRUE(cursor.Eof());
+
+  cursor.SetFilterValueUnchecked(0, int64_t(10));
+  cursor.ExecuteUnchecked();
+  EXPECT_TRUE(cursor.Eof());
+}
+
+TEST(DataframeTest, TypedCursorSingleRowIdAndNonNullEqualityAllTypes) {
+  static constexpr auto kSpec = CreateTypedDataframeSpec(
+      {"id", "u32", "i32", "i64", "double", "string"},
+      CreateTypedColumnSpec(Id(), NonNull(), IdSorted()),
+      CreateTypedColumnSpec(Uint32(), NonNull(), Unsorted()),
+      CreateTypedColumnSpec(Int32(), NonNull(), Unsorted()),
+      CreateTypedColumnSpec(Int64(), NonNull(), Unsorted()),
+      CreateTypedColumnSpec(Double(), NonNull(), Unsorted()),
+      CreateTypedColumnSpec(String(), NonNull(), Unsorted()));
+  StringPool pool;
+  Dataframe df = Dataframe::CreateFromTypedSpec(kSpec, &pool);
+  df.InsertUnchecked(kSpec, std::monostate(), 10u, -10, int64_t(100), 1.5,
+                     pool.InternString("a"));
+  df.InsertUnchecked(kSpec, std::monostate(), 20u, -20, int64_t(200), 2.5,
+                     pool.InternString("b"));
+
+  auto verify = [&](uint32_t column, auto value) {
+    TypedCursor cursor(
+        &df, {FilterSpec{0, 0, Eq{}, {}}, FilterSpec{column, 1, Eq{}, {}}}, {});
+    cursor.SetFilterValueUnchecked(0, int64_t(1));
+    cursor.SetFilterValueUnchecked(1, value);
+    cursor.ExecuteUnchecked();
+    ASSERT_FALSE(cursor.Eof());
+    EXPECT_EQ(cursor.RowIndex(), 1u);
+    cursor.Next();
+    EXPECT_TRUE(cursor.Eof());
+  };
+  verify(1, int64_t(20));
+  verify(2, int64_t(-20));
+  verify(3, int64_t(200));
+  verify(4, 2.5);
+  verify(5, "b");
+}
+
+TEST(DataframeTest, TypedCursorSingleRowMultipleEqualities) {
+  static constexpr auto kSpec = CreateTypedDataframeSpec(
+      {"id", "u32", "i64"}, CreateTypedColumnSpec(Id(), NonNull(), IdSorted()),
+      CreateTypedColumnSpec(Uint32(), NonNull(), Unsorted()),
+      CreateTypedColumnSpec(Int64(), NonNull(), Unsorted()));
+  StringPool pool;
+  Dataframe df = Dataframe::CreateFromTypedSpec(kSpec, &pool);
+  df.InsertUnchecked(kSpec, std::monostate(), 10u, int64_t(100));
+  df.InsertUnchecked(kSpec, std::monostate(), 20u, int64_t(200));
+
+  TypedCursor cursor(&df,
+                     {FilterSpec{0, 0, Eq{}, {}}, FilterSpec{1, 1, Eq{}, {}},
+                      FilterSpec{2, 2, Eq{}, {}}},
+                     {});
+  cursor.SetFilterValueUnchecked(0, int64_t(1));
+  cursor.SetFilterValueUnchecked(1, int64_t(20));
+  cursor.SetFilterValueUnchecked(2, int64_t(200));
+  cursor.ExecuteUnchecked();
+  ASSERT_FALSE(cursor.Eof());
+  EXPECT_EQ(cursor.RowIndex(), 1u);
+  cursor.Next();
+  EXPECT_TRUE(cursor.Eof());
+
+  cursor.SetFilterValueUnchecked(2, int64_t(100));
+  cursor.ExecuteUnchecked();
+  EXPECT_TRUE(cursor.Eof());
+
+  cursor.SetFilterValueUnchecked(0, int64_t(10));
+  cursor.ExecuteUnchecked();
+  EXPECT_TRUE(cursor.Eof());
 }
 
 TEST(DataframeTest, TypedCursorInFilter) {

--- a/src/trace_processor/core/dataframe/query_plan.cc
+++ b/src/trace_processor/core/dataframe/query_plan.cc
@@ -43,6 +43,7 @@
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_instructions.h"
+#include "src/trace_processor/core/interpreter/bytecode_optimizer.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
 #include "src/trace_processor/core/interpreter/interpreter_types.h"
 #include "src/trace_processor/core/util/bit_vector.h"
@@ -751,6 +752,7 @@ void QueryPlanBuilder::Output(const LimitSpec& limit, uint64_t cols_used) {
 }
 
 QueryPlanImpl QueryPlanBuilder::Build() && {
+  i::OptimizeBytecode(builder_.bytecode());
   plan_.bytecode = std::move(builder_.bytecode());
   plan_.params.register_count = builder_.register_count();
   return std::move(plan_);

--- a/src/trace_processor/core/interpreter/BUILD.gn
+++ b/src/trace_processor/core/interpreter/BUILD.gn
@@ -25,6 +25,8 @@ source_set("interpreter") {
     "bytecode_interpreter_impl.cc",
     "bytecode_interpreter_impl.h",
     "bytecode_interpreter_state.h",
+    "bytecode_optimizer.cc",
+    "bytecode_optimizer.h",
     "bytecode_registers.h",
     "bytecode_to_string.cc",
     "bytecode_to_string.h",

--- a/src/trace_processor/core/interpreter/bytecode_instructions.h
+++ b/src/trace_processor/core/interpreter/bytecode_instructions.h
@@ -568,6 +568,32 @@ struct LinearFilterEq : LinearFilterEqBase {
   static_assert(TS1::Contains<T>());
 };
 
+// Begins a scalar query whose Id equality predicate establishes that at most
+// one row can match. The following |predicate_count| bytecodes are
+// SingleRowEqPredicate records consumed by the scalar-query executor.
+struct SingleRowQuery : Bytecode {
+  static constexpr Cost kCost = FixedCost{10};
+
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(uint32_t,
+                                     row_count,
+                                     FilterValueHandle,
+                                     id_fval_handle,
+                                     uint32_t,
+                                     predicate_count);
+};
+
+// Describes an equality predicate evaluated against a zero-or-one-row
+// candidate. This is data for SingleRowQuery rather than an independently
+// dispatched instruction.
+struct SingleRowEqPredicate : Bytecode {
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(FilterValueHandle,
+                                     fval_handle,
+                                     ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     uint32_t,
+                                     storage_type);
+};
+
 // Filters rows based on a list of values (IN operator). Supports both indexed
 // and non-indexed modes:
 //   - Indexed: index_register points to a sorted permutation vector and
@@ -620,19 +646,28 @@ struct Reverse : Bytecode {
 };
 
 // Bytecode ops that require FilterValueFetcher access.
-#define PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(X) \
-  X(CastFilterValue<Id>)                        \
-  X(CastFilterValue<Uint32>)                    \
-  X(CastFilterValue<Int32>)                     \
-  X(CastFilterValue<Int64>)                     \
-  X(CastFilterValue<Double>)                    \
-  X(CastFilterValue<String>)                    \
-  X(CastFilterValueList<Id>)                    \
-  X(CastFilterValueList<Uint32>)                \
-  X(CastFilterValueList<Int32>)                 \
-  X(CastFilterValueList<Int64>)                 \
-  X(CastFilterValueList<Double>)                \
+#define PERFETTO_DATAFRAME_BYTECODE_GENERAL_FVF_LIST(X) \
+  X(CastFilterValue<Id>)                                \
+  X(CastFilterValue<Uint32>)                            \
+  X(CastFilterValue<Int32>)                             \
+  X(CastFilterValue<Int64>)                             \
+  X(CastFilterValue<Double>)                            \
+  X(CastFilterValue<String>)                            \
+  X(CastFilterValueList<Id>)                            \
+  X(CastFilterValueList<Uint32>)                        \
+  X(CastFilterValueList<Int32>)                         \
+  X(CastFilterValueList<Int64>)                         \
+  X(CastFilterValueList<Double>)                        \
   X(CastFilterValueList<String>)
+
+// Records consumed by the compact scalar-query executor rather than dispatched
+// as independent instructions.
+#define PERFETTO_DATAFRAME_BYTECODE_SINGLE_ROW_LIST(X) \
+  X(SingleRowQuery)                                    \
+  X(SingleRowEqPredicate)
+
+#define PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(X) \
+  PERFETTO_DATAFRAME_BYTECODE_GENERAL_FVF_LIST(X)
 
 // Bytecode ops that only need InterpreterState (no FilterValueFetcher).
 #define PERFETTO_DATAFRAME_BYTECODE_STATE_ONLY_LIST(X) \
@@ -783,8 +818,9 @@ struct Reverse : Bytecode {
   X(Reverse)
 
 // Combined list of all bytecode instruction types.
-#define PERFETTO_DATAFRAME_BYTECODE_LIST(X) \
-  PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(X)   \
+#define PERFETTO_DATAFRAME_BYTECODE_LIST(X)      \
+  PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(X)        \
+  PERFETTO_DATAFRAME_BYTECODE_SINGLE_ROW_LIST(X) \
   PERFETTO_DATAFRAME_BYTECODE_STATE_ONLY_LIST(X)
 
 #define PERFETTO_DATAFRAME_BYTECODE_VARIANT(...) __VA_ARGS__,

--- a/src/trace_processor/core/interpreter/bytecode_interpreter.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <type_traits>
 #include <utility>
 
@@ -28,6 +29,7 @@
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_interpreter_state.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
+#include "src/trace_processor/core/util/span.h"
 
 namespace perfetto::trace_processor::core::interpreter {
 
@@ -61,8 +63,10 @@ class Interpreter {
 
   // Executes the bytecode sequence, processing each bytecode instruction in
   // turn, and dispatching to the appropriate function in this class.
-  PERFETTO_ALWAYS_INLINE void Execute(
-      FilterValueFetcherImpl& filter_value_fetcher);
+  PERFETTO_ALWAYS_INLINE Span<uint32_t> Execute(
+      FilterValueFetcherImpl& filter_value_fetcher,
+      ReadHandle<Span<uint32_t>> output_register = ReadHandle<Span<uint32_t>>{
+          std::numeric_limits<uint32_t>::max()});
 
   // Returns the value of the specified register if it contains the expected
   // type. Returns nullptr if the register holds a different type or is empty.

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_impl.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_impl.h
@@ -701,6 +701,100 @@ inline PERFETTO_ALWAYS_INLINE void CastFilterValue(
   state.WriteToRegister(f.arg<B::write_register>(), result);
 }
 
+template <typename FilterValueFetcherImpl>
+inline PERFETTO_ALWAYS_INLINE bool CastSingleRowId(
+    FilterValueFetcherImpl& fetcher,
+    FilterValueHandle handle,
+    uint32_t& id) {
+  auto type = fetcher.GetValueType(handle.index);
+  auto validity = CastFilterValueToInteger<uint32_t, FilterValueFetcherImpl>(
+      handle, type, fetcher, NonStringOp{Eq{}}, id);
+  return validity == CastFilterValueResult::kValid;
+}
+
+template <typename T, typename FilterValueFetcherImpl>
+inline PERFETTO_ALWAYS_INLINE bool EvaluateSingleRowEqPredicate(
+    InterpreterState& state,
+    FilterValueFetcherImpl& fetcher,
+    const struct SingleRowEqPredicate& predicate,
+    uint32_t row) {
+  using B = struct SingleRowEqPredicate;
+  FilterValueHandle value_handle = predicate.arg<B::fval_handle>();
+  auto value_type = fetcher.GetValueType(value_handle.index);
+  const auto* data =
+      state.ReadStorageFromRegister<T>(predicate.arg<B::storage_register>());
+  if constexpr (IntegerOrDoubleType::Contains<T>()) {
+    using M = typename T::cpp_type;
+    M value;
+    auto validity = CastFilterValueToIntegerOrDouble<M, FilterValueFetcherImpl>(
+        value_handle, value_type, fetcher, NonStringOp{Eq{}}, value);
+    return validity == CastFilterValueResult::kValid &&
+           std::equal_to<>()(data[row], value);
+  } else if constexpr (std::is_same_v<T, String>) {
+    const char* value;
+    auto validity = CastFilterValueToString<FilterValueFetcherImpl>(
+        value_handle, value_type, fetcher, StringOp{Eq{}}, value);
+    if (validity != CastFilterValueResult::kValid) {
+      return false;
+    }
+    auto string_id = state.string_pool->GetId(base::StringView(value));
+    return string_id && data[row] == *string_id;
+  } else {
+    static_assert(
+        IntegerOrDoubleType::Contains<T>() || std::is_same_v<T, String>,
+        "Unsupported single-row filter type");
+  }
+}
+
+template <typename FilterValueFetcherImpl>
+inline PERFETTO_ALWAYS_INLINE Span<uint32_t> ExecuteSingleRowQuery(
+    InterpreterState& state,
+    FilterValueFetcherImpl& fetcher,
+    const struct SingleRowQuery& query) {
+  using B = struct SingleRowQuery;
+  uint32_t row = 0;
+  bool matches =
+      CastSingleRowId(fetcher, query.arg<B::id_fval_handle>(), row) &&
+      row < query.arg<B::row_count>();
+
+  const Bytecode* predicate_pc = static_cast<const Bytecode*>(&query) + 1;
+  uint32_t predicate_count = query.arg<B::predicate_count>();
+  for (uint32_t i = 0; matches && i < predicate_count; ++i) {
+    PERFETTO_DCHECK(predicate_pc[i].option == Index<SingleRowEqPredicate>());
+    const auto& predicate =
+        static_cast<const SingleRowEqPredicate&>(predicate_pc[i]);
+    bool predicate_matches = false;
+    switch (predicate.arg<SingleRowEqPredicate::storage_type>()) {
+      case NonIdStorageType::GetTypeIndex<Uint32>():
+        predicate_matches = EvaluateSingleRowEqPredicate<Uint32>(
+            state, fetcher, predicate, row);
+        break;
+      case NonIdStorageType::GetTypeIndex<Int32>():
+        predicate_matches =
+            EvaluateSingleRowEqPredicate<Int32>(state, fetcher, predicate, row);
+        break;
+      case NonIdStorageType::GetTypeIndex<Int64>():
+        predicate_matches =
+            EvaluateSingleRowEqPredicate<Int64>(state, fetcher, predicate, row);
+        break;
+      case NonIdStorageType::GetTypeIndex<Double>():
+        predicate_matches = EvaluateSingleRowEqPredicate<Double>(
+            state, fetcher, predicate, row);
+        break;
+      case NonIdStorageType::GetTypeIndex<String>():
+        predicate_matches = EvaluateSingleRowEqPredicate<String>(
+            state, fetcher, predicate, row);
+        break;
+      default:
+        PERFETTO_FATAL("Invalid single-row filter storage type");
+    }
+    matches = predicate_matches;
+  }
+  state.single_row_result = row;
+  return Span<uint32_t>{&state.single_row_result,
+                        &state.single_row_result + matches};
+}
+
 template <typename T, typename Op>
 inline PERFETTO_ALWAYS_INLINE void NonStringFilter(
     InterpreterState& state,
@@ -1710,11 +1804,6 @@ inline PERFETTO_ALWAYS_INLINE void FindMinMaxIndex(
 
 }  // namespace ops
 
-// Macros for generating case statements that dispatch to ops:: free functions.
-// Uses __VA_ARGS__ to handle template types with commas (e.g., SortedFilter<Id,
-// EqualRange>).
-
-// For ops that need state and fetcher:
 #define PERFETTO_OP_CASE_FVF(...)                                \
   case base::variant_index<BytecodeVariant, __VA_ARGS__>(): {    \
     ops::__VA_ARGS__(state_, fetcher,                            \
@@ -1722,25 +1811,39 @@ inline PERFETTO_ALWAYS_INLINE void FindMinMaxIndex(
     break;                                                       \
   }
 
-// For ops that only need state:
 #define PERFETTO_OP_CASE_STATE(...)                                      \
   case base::variant_index<BytecodeVariant, __VA_ARGS__>(): {            \
     ops::__VA_ARGS__(state_, static_cast<const __VA_ARGS__&>(bytecode)); \
     break;                                                               \
   }
 
-// Executes all bytecode instructions using free functions.
 template <typename FilterValueFetcherImpl>
-PERFETTO_ALWAYS_INLINE void Interpreter<FilterValueFetcherImpl>::Execute(
-    FilterValueFetcherImpl& fetcher) {
-  for (const auto& bytecode : state_.bytecode) {
+PERFETTO_ALWAYS_INLINE Span<uint32_t>
+Interpreter<FilterValueFetcherImpl>::Execute(
+    FilterValueFetcherImpl& fetcher,
+    ReadHandle<Span<uint32_t>> output_register) {
+  const Bytecode* pc = state_.bytecode.data();
+  const Bytecode* end = pc + state_.bytecode.size();
+  if (PERFETTO_LIKELY(pc != end && pc->option == Index<SingleRowQuery>())) {
+    const auto& query = static_cast<const SingleRowQuery&>(*pc);
+    PERFETTO_DCHECK(static_cast<size_t>(end - pc) ==
+                    query.arg<SingleRowQuery::predicate_count>() + 1);
+    return ops::ExecuteSingleRowQuery(state_, fetcher, query);
+  }
+
+  for (; pc != end; ++pc) {
+    const Bytecode& bytecode = *pc;
     switch (bytecode.option) {
-      PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(PERFETTO_OP_CASE_FVF)
+      PERFETTO_DATAFRAME_BYTECODE_GENERAL_FVF_LIST(PERFETTO_OP_CASE_FVF)
       PERFETTO_DATAFRAME_BYTECODE_STATE_ONLY_LIST(PERFETTO_OP_CASE_STATE)
       default:
         PERFETTO_ASSUME(false);
     }
   }
+  if (output_register.index == std::numeric_limits<uint32_t>::max()) {
+    return {};
+  }
+  return state_.ReadFromRegister(output_register);
 }
 
 #undef PERFETTO_OP_CASE_FVF

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_state.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_state.h
@@ -42,6 +42,8 @@ struct InterpreterState {
   base::SmallVector<RegValue, 16> registers;
   // Pointer to the string pool (for string operations)
   const StringPool* string_pool;
+  // Stable inline storage for zero-or-one-row query results.
+  uint32_t single_row_result = 0;
 
   /******************************************************************
    * Helper functions for accessing the interpreter state           *

--- a/src/trace_processor/core/interpreter/bytecode_optimizer.cc
+++ b/src/trace_processor/core/interpreter/bytecode_optimizer.cc
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/interpreter/bytecode_optimizer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/interpreter/bytecode_instructions.h"
+#include "src/trace_processor/core/util/range.h"
+#include "src/trace_processor/core/util/slab.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::interpreter {
+namespace {
+
+template <typename T>
+const T& As(const Bytecode& bytecode) {
+  return static_cast<const T&>(bytecode);
+}
+
+bool Is(const Bytecode& bytecode, uint32_t option) {
+  return bytecode.option == option;
+}
+
+bool HasCommonIdPrefix(const BytecodeVector& bytecode) {
+  if (bytecode.size() < 3 || !Is(bytecode[0], Index<InitRange>()) ||
+      !Is(bytecode[1], Index<CastFilterValue<Id>>()) ||
+      !Is(bytecode[2], Index<SortedFilter<Id, EqualRange>>())) {
+    return false;
+  }
+  const auto& init = As<InitRange>(bytecode[0]);
+  const auto& cast = As<CastFilterValue<Id>>(bytecode[1]);
+  const auto& filter = As<SortedFilter<Id, EqualRange>>(bytecode[2]);
+  return init.arg<InitRange::dest_register>().index ==
+             filter.arg<SortedFilterBase::update_register>().index &&
+         cast.arg<CastFilterValueBase::write_register>().index ==
+             filter.arg<SortedFilterBase::val_register>().index &&
+         cast.arg<CastFilterValueBase::op>().Is<Eq>() &&
+         filter.arg<SortedFilterBase::write_result_to>().Is<BothBounds>();
+}
+
+std::optional<uint32_t> GetFirstPredicateType(const Bytecode& cast,
+                                              const Bytecode& filter) {
+#define PERFETTO_MATCH_TYPE(type)                  \
+  if (Is(cast, Index<CastFilterValue<type>>()) &&  \
+      Is(filter, Index<LinearFilterEq<type>>())) { \
+    return NonIdStorageType::GetTypeIndex<type>(); \
+  }
+  PERFETTO_MATCH_TYPE(Uint32)
+  PERFETTO_MATCH_TYPE(Int32)
+  PERFETTO_MATCH_TYPE(Int64)
+  PERFETTO_MATCH_TYPE(Double)
+  PERFETTO_MATCH_TYPE(String)
+#undef PERFETTO_MATCH_TYPE
+  return std::nullopt;
+}
+
+std::optional<uint32_t> GetSubsequentPredicateType(const Bytecode& cast,
+                                                   const Bytecode& filter) {
+#define PERFETTO_MATCH_NUMERIC_TYPE(type)               \
+  if (Is(cast, Index<CastFilterValue<type>>()) &&       \
+      Is(filter, Index<NonStringFilter<type, Eq>>())) { \
+    return NonIdStorageType::GetTypeIndex<type>();      \
+  }
+  PERFETTO_MATCH_NUMERIC_TYPE(Uint32)
+  PERFETTO_MATCH_NUMERIC_TYPE(Int32)
+  PERFETTO_MATCH_NUMERIC_TYPE(Int64)
+  PERFETTO_MATCH_NUMERIC_TYPE(Double)
+#undef PERFETTO_MATCH_NUMERIC_TYPE
+  if (Is(cast, Index<CastFilterValue<String>>()) &&
+      Is(filter, Index<StringFilter<Eq>>())) {
+    return NonIdStorageType::GetTypeIndex<String>();
+  }
+  return std::nullopt;
+}
+
+void AppendPredicate(BytecodeVector& optimized,
+                     FilterValueHandle fval_handle,
+                     ReadHandle<StoragePtr> storage_register,
+                     uint32_t storage_type) {
+  optimized.emplace_back();
+  auto& predicate = static_cast<SingleRowEqPredicate&>(optimized.back());
+  predicate.option = Index<SingleRowEqPredicate>();
+  predicate.arg<SingleRowEqPredicate::fval_handle>() = fval_handle;
+  predicate.arg<SingleRowEqPredicate::storage_register>() = storage_register;
+  predicate.arg<SingleRowEqPredicate::storage_type>() = storage_type;
+}
+
+SingleRowQuery MakeSingleRowQuery(const BytecodeVector& bytecode,
+                                  uint32_t predicate_count) {
+  const auto& init = As<InitRange>(bytecode[0]);
+  const auto& id_cast = As<CastFilterValue<Id>>(bytecode[1]);
+  SingleRowQuery query;
+  query.option = Index<SingleRowQuery>();
+  query.arg<SingleRowQuery::row_count>() = init.arg<InitRange::size>();
+  query.arg<SingleRowQuery::id_fval_handle>() =
+      id_cast.arg<CastFilterValueBase::fval_handle>();
+  query.arg<SingleRowQuery::predicate_count>() = predicate_count;
+  return query;
+}
+
+bool TryFuseIdOnly(BytecodeVector& bytecode) {
+  if (bytecode.size() != 5 || !HasCommonIdPrefix(bytecode) ||
+      !Is(bytecode[3], Index<AllocateIndices>()) ||
+      !Is(bytecode[4], Index<Iota>())) {
+    return false;
+  }
+  const auto& init = As<InitRange>(bytecode[0]);
+  const auto& alloc = As<AllocateIndices>(bytecode[3]);
+  const auto& iota = As<Iota>(bytecode[4]);
+  if (alloc.arg<AllocateIndices::size>() > 1 ||
+      init.arg<InitRange::dest_register>().index !=
+          iota.arg<Iota::source_register>().index ||
+      alloc.arg<AllocateIndices::dest_span_register>().index !=
+          iota.arg<Iota::update_register>().index) {
+    return false;
+  }
+
+  BytecodeVector optimized;
+  optimized.emplace_back(MakeSingleRowQuery(bytecode, 0));
+  bytecode = std::move(optimized);
+  return true;
+}
+
+bool TryFuseIdAndColumnEq(BytecodeVector& bytecode) {
+  if (bytecode.size() < 6 || !HasCommonIdPrefix(bytecode) ||
+      !Is(bytecode[4], Index<AllocateIndices>())) {
+    return false;
+  }
+  std::optional<uint32_t> storage_type =
+      GetFirstPredicateType(bytecode[3], bytecode[5]);
+  if (!storage_type) {
+    return false;
+  }
+
+  const auto& init = As<InitRange>(bytecode[0]);
+  const auto& value_cast = As<CastFilterValueBase>(bytecode[3]);
+  const auto& alloc = As<AllocateIndices>(bytecode[4]);
+  const auto& filter = As<LinearFilterEqBase>(bytecode[5]);
+  if (alloc.arg<AllocateIndices::size>() > 1 ||
+      !value_cast.arg<CastFilterValueBase::op>().Is<Eq>() ||
+      init.arg<InitRange::dest_register>().index !=
+          filter.arg<LinearFilterEqBase::source_register>().index ||
+      value_cast.arg<CastFilterValueBase::write_register>().index !=
+          filter.arg<LinearFilterEqBase::filter_value_reg>().index ||
+      alloc.arg<AllocateIndices::dest_span_register>().index !=
+          filter.arg<LinearFilterEqBase::update_register>().index) {
+    return false;
+  }
+
+  auto output_register = alloc.arg<AllocateIndices::dest_span_register>();
+  BytecodeVector optimized;
+  optimized.emplace_back(MakeSingleRowQuery(bytecode, 0));
+  AppendPredicate(optimized, value_cast.arg<CastFilterValueBase::fval_handle>(),
+                  filter.arg<LinearFilterEqBase::storage_register>(),
+                  *storage_type);
+  for (size_t i = 6; i < bytecode.size(); i += 2) {
+    if (i + 1 >= bytecode.size()) {
+      return false;
+    }
+    storage_type = GetSubsequentPredicateType(bytecode[i], bytecode[i + 1]);
+    if (!storage_type) {
+      return false;
+    }
+    const auto& cast = As<CastFilterValueBase>(bytecode[i]);
+    if (!cast.arg<CastFilterValueBase::op>().Is<Eq>()) {
+      return false;
+    }
+
+    ReadHandle<StoragePtr> predicate_storage;
+    ReadHandle<CastFilterValueResult> predicate_value;
+    ReadHandle<Span<uint32_t>> predicate_source;
+    RwHandle<Span<uint32_t>> predicate_update;
+    if (*storage_type == NonIdStorageType::GetTypeIndex<String>()) {
+      const auto& predicate_filter = As<StringFilterBase>(bytecode[i + 1]);
+      predicate_storage =
+          predicate_filter.arg<StringFilterBase::storage_register>();
+      predicate_value = predicate_filter.arg<StringFilterBase::val_register>();
+      predicate_source =
+          predicate_filter.arg<StringFilterBase::source_register>();
+      predicate_update =
+          predicate_filter.arg<StringFilterBase::update_register>();
+    } else {
+      const auto& predicate_filter = As<NonStringFilterBase>(bytecode[i + 1]);
+      predicate_storage =
+          predicate_filter.arg<NonStringFilterBase::storage_register>();
+      predicate_value =
+          predicate_filter.arg<NonStringFilterBase::val_register>();
+      predicate_source =
+          predicate_filter.arg<NonStringFilterBase::source_register>();
+      predicate_update =
+          predicate_filter.arg<NonStringFilterBase::update_register>();
+    }
+    if (cast.arg<CastFilterValueBase::write_register>().index !=
+            predicate_value.index ||
+        output_register.index != predicate_source.index ||
+        output_register.index != predicate_update.index) {
+      return false;
+    }
+    AppendPredicate(optimized, cast.arg<CastFilterValueBase::fval_handle>(),
+                    predicate_storage, *storage_type);
+  }
+
+  auto& query = static_cast<SingleRowQuery&>(optimized.front());
+  query.arg<SingleRowQuery::predicate_count>() =
+      static_cast<uint32_t>(optimized.size() - 1);
+  bytecode = std::move(optimized);
+  return true;
+}
+
+}  // namespace
+
+void OptimizeBytecode(BytecodeVector& bytecode) {
+  if (TryFuseIdAndColumnEq(bytecode)) {
+    return;
+  }
+  TryFuseIdOnly(bytecode);
+}
+
+}  // namespace perfetto::trace_processor::core::interpreter

--- a/src/trace_processor/core/interpreter/bytecode_optimizer.h
+++ b/src/trace_processor/core/interpreter/bytecode_optimizer.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_INTERPRETER_BYTECODE_OPTIMIZER_H_
+#define SRC_TRACE_PROCESSOR_CORE_INTERPRETER_BYTECODE_OPTIMIZER_H_
+
+#include "src/trace_processor/core/interpreter/bytecode_core.h"
+
+namespace perfetto::trace_processor::core::interpreter {
+
+// Replaces common bytecode sequences with semantically equivalent fused
+// instructions. This runs once after query plan generation.
+void OptimizeBytecode(BytecodeVector& bytecode);
+
+}  // namespace perfetto::trace_processor::core::interpreter
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_INTERPRETER_BYTECODE_OPTIMIZER_H_

--- a/src/trace_processor/perfetto_sql/engine/dataframe_module.cc
+++ b/src/trace_processor/perfetto_sql/engine/dataframe_module.cc
@@ -20,7 +20,6 @@
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -29,6 +28,7 @@
 #include <utility>
 #include <vector>
 
+#include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "src/trace_processor/core/dataframe/cursor_impl.h"  // IWYU pragma: keep
@@ -448,38 +448,39 @@ int DataframeModule::Close(sqlite3_vtab_cursor* cursor) {
   return SQLITE_OK;
 }
 
+static PERFETTO_NO_INLINE void PrepareDataframeCursor(
+    DataframeModule::Cursor* cursor,
+    int idx_num,
+    const char* idx_str) {
+  auto plan = dataframe::Dataframe::QueryPlan::Deserialize(idx_str);
+  PERFETTO_TP_TRACE(
+      metatrace::Category::QUERY_DETAILED, "DATAFRAME_FILTER_PREPARE",
+      [&plan, idx_num](metatrace::Record* record) {
+        record->AddArg("idxNum",
+                       base::StackString<32>("%d", idx_num).string_view());
+        auto str = plan.BytecodeToString();
+        for (uint32_t i = 0; i < str.size(); ++i) {
+          base::StackString<32> c("bytecode[%u]", i);
+          record->AddArg(c.string_view(), str[i]);
+        }
+      });
+  auto* v = DataframeModule::GetVtab(cursor->pVtab);
+  auto* state = sqlite::ModuleStateManager<DataframeModule>::GetState(v->state);
+  state->dataframe->PrepareCursor(plan, cursor->df_cursor);
+  cursor->last_idx_str = idx_str;
+  cursor->id_col_idx = v->id_col_idx;
+}
+
 int DataframeModule::Filter(sqlite3_vtab_cursor* cur,
                             int idxNum,
                             const char* idxStr,
-                            int argc,
+                            int,
                             sqlite3_value** argv) {
   auto* c = GetCursor(cur);
-  if (idxStr != c->last_idx_str) {
-    auto plan = dataframe::Dataframe::QueryPlan::Deserialize(idxStr);
-    PERFETTO_TP_TRACE(
-        metatrace::Category::QUERY_DETAILED, "DATAFRAME_FILTER_PREPARE",
-        [&plan, idxNum](metatrace::Record* record) {
-          record->AddArg("idxNum",
-                         base::StackString<32>("%d", idxNum).string_view());
-          auto str = plan.BytecodeToString();
-          for (uint32_t i = 0; i < str.size(); ++i) {
-            base::StackString<32> c("bytecode[%u]", i);
-            record->AddArg(c.string_view(), str[i]);
-          }
-        });
-    auto* v = GetVtab(cur->pVtab);
-    auto* s = sqlite::ModuleStateManager<DataframeModule>::GetState(v->state);
-    s->dataframe->PrepareCursor(plan, c->df_cursor);
-    c->last_idx_str = idxStr;
-    c->id_col_idx = v->id_col_idx;
+  if (PERFETTO_UNLIKELY(idxStr != c->last_idx_str)) {
+    PrepareDataframeCursor(c, idxNum, idxStr);
   }
-  // SQLite's API claims it will never pass more than 16 arguments
-  // so assert that here as our std::array is fixed size.
-  PERFETTO_DCHECK(argc <= 16);
-  SqliteValueFetcher fetcher{{}, {}, argv};
-  memcpy(static_cast<void*>(fetcher.sqlite_value.data()),
-         static_cast<void*>(argv),
-         sizeof(sqlite3_value*) * static_cast<size_t>(argc));
+  SqliteValueFetcher fetcher(argv);
   c->df_cursor.Execute(fetcher);
   return SQLITE_OK;
 }

--- a/src/trace_processor/perfetto_sql/engine/dataframe_module.h
+++ b/src/trace_processor/perfetto_sql/engine/dataframe_module.h
@@ -17,9 +17,9 @@
 #ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_ENGINE_DATAFRAME_MODULE_H_
 #define SRC_TRACE_PROCESSOR_PERFETTO_SQL_ENGINE_DATAFRAME_MODULE_H_
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -60,6 +60,8 @@ struct DataframeModule : sqlite::Module<DataframeModule> {
     std::unique_ptr<State> temporary_create_state;
   };
   struct SqliteValueFetcher : dataframe::ValueFetcher {
+    explicit SqliteValueFetcher(sqlite3_value** values) : argv(values) {}
+
     using Type = sqlite::Type;
     static const Type kInt64 = sqlite::Type::kInteger;
     static const Type kDouble = sqlite::Type::kFloat;
@@ -67,25 +69,34 @@ struct DataframeModule : sqlite::Module<DataframeModule> {
     static const Type kNull = sqlite::Type::kNull;
 
     int64_t GetInt64Value(uint32_t idx) const {
-      return sqlite::value::Int64(sqlite_value[idx]);
+      return sqlite::value::Int64(GetValue(idx));
     }
     double GetDoubleValue(uint32_t idx) const {
-      return sqlite::value::Double(sqlite_value[idx]);
+      return sqlite::value::Double(GetValue(idx));
     }
     const char* GetStringValue(uint32_t idx) const {
-      return sqlite::value::Text(sqlite_value[idx]);
+      return sqlite::value::Text(GetValue(idx));
     }
     Type GetValueType(uint32_t idx) const {
-      return sqlite::value::Type(sqlite_value[idx]);
+      return sqlite::value::Type(GetValue(idx));
     }
+
     bool IteratorInit(uint32_t idx) {
-      return sqlite3_vtab_in_first(argv[idx], &sqlite_value[idx]) == SQLITE_OK;
+      iterator_index = idx;
+      return sqlite3_vtab_in_first(argv[idx], &iterator_value) == SQLITE_OK;
     }
     bool IteratorNext(uint32_t idx) {
-      return sqlite3_vtab_in_next(argv[idx], &sqlite_value[idx]) == SQLITE_OK;
+      return sqlite3_vtab_in_next(argv[idx], &iterator_value) == SQLITE_OK;
     }
-    std::array<sqlite3_value*, 16> sqlite_value;
+
+   private:
+    sqlite3_value* GetValue(uint32_t idx) const {
+      return idx == iterator_index ? iterator_value : argv[idx];
+    }
+
     sqlite3_value** argv;
+    sqlite3_value* iterator_value = nullptr;
+    uint32_t iterator_index = std::numeric_limits<uint32_t>::max();
   };
   struct SqliteResultCallback : dataframe::CellCallback {
     void OnCell(int64_t v) const { sqlite::result::Long(ctx, v); }

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_benchmark.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_benchmark.cc
@@ -14,9 +14,12 @@
 
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
 
+#include <cstdint>
 #include <memory>
+#include <string>
 
 #include <benchmark/benchmark.h>
+#include <sqlite3.h>
 
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/containers/string_pool.h"
@@ -38,6 +41,112 @@ void BM_Connection_Execute_TrivialSelect(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_Connection_Execute_TrivialSelect);
+
+struct PointQueryBenchmark {
+  PointQueryBenchmark() {
+    connection = PerfettoSqlConnection::CreateConnectionToNewDatabase(
+        &pool, /*enable_extra_checks=*/false);
+    auto result = connection->Execute(SqlSource::FromExecuteQuery(R"SQL(
+      CREATE PERFETTO TABLE point_query AS
+      WITH RECURSIVE seq(i) AS (
+        VALUES(0) UNION ALL SELECT i + 1 FROM seq WHERE i < 4095
+      )
+      SELECT
+        i AS id,
+        i % 17 AS value,
+        CASE i % 2 WHEN 0 THEN 'even' ELSE 'odd' END AS name
+      FROM seq
+    )SQL"));
+    PERFETTO_CHECK(result.ok());
+  }
+
+  SqliteConnection::PreparedStatement Prepare(const char* sql) {
+    auto statement =
+        connection->PrepareSqliteStatement(SqlSource::FromExecuteQuery(sql));
+    PERFETTO_CHECK(statement.ok());
+    return std::move(statement.value());
+  }
+
+  StringPool pool;
+  std::unique_ptr<PerfettoSqlConnection> connection;
+};
+
+enum class PointQueryMode {
+  kHit,
+  kSecondPredicateMiss,
+  kIdMiss,
+};
+
+void RunPointQueryBenchmark(benchmark::State& state,
+                            PointQueryMode mode,
+                            bool filter_value = true) {
+  constexpr uint32_t kLookupCount = 1024;
+  PointQueryBenchmark benchmark;
+  const char* id_expr = mode == PointQueryMode::kIdMiss ? "5000 + i" : "i";
+  const char* value_expr =
+      mode == PointQueryMode::kSecondPredicateMiss ? "(i + 1) % 17" : "i % 17";
+  std::string setup = R"SQL(
+    CREATE TABLE lookup(id INT, value INT);
+    WITH RECURSIVE seq(i) AS (
+      VALUES(0) UNION ALL SELECT i + 1 FROM seq WHERE i < 1023
+    )
+    INSERT INTO lookup SELECT )SQL" +
+                      std::string(id_expr) + ", " + value_expr + " FROM seq";
+  auto setup_result =
+      benchmark.connection->Execute(SqlSource::FromExecuteQuery(setup));
+  PERFETTO_CHECK(setup_result.ok());
+
+  // CROSS JOIN fixes the loop order: SQLite scans |lookup| and invokes the
+  // dataframe's xFilter once for each outer row, matching real join usage.
+  std::string query = R"SQL(
+    SELECT sum(p.id)
+    FROM lookup AS l CROSS JOIN point_query AS p
+    WHERE p.id = l.id
+  )SQL" + std::string(filter_value ? " AND p.value = l.value" : "");
+  auto statement = benchmark.Prepare(query.c_str());
+  sqlite3_stmt* stmt = statement.sqlite_stmt();
+
+  // Run once before timing so xFilter prepares and caches the query plan.
+  PERFETTO_CHECK(sqlite3_step(stmt) == SQLITE_ROW);
+  benchmark::DoNotOptimize(sqlite3_column_int64(stmt, 0));
+  PERFETTO_CHECK(sqlite3_step(stmt) == SQLITE_DONE);
+  PERFETTO_CHECK(sqlite3_reset(stmt) == SQLITE_OK);
+
+  for (auto _ : state) {
+    PERFETTO_CHECK(sqlite3_step(stmt) == SQLITE_ROW);
+    benchmark::DoNotOptimize(sqlite3_column_int64(stmt, 0));
+    PERFETTO_CHECK(sqlite3_step(stmt) == SQLITE_DONE);
+    PERFETTO_CHECK(sqlite3_reset(stmt) == SQLITE_OK);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          kLookupCount);
+}
+
+void BM_DataframeSqliteJoin_Id_Hit(benchmark::State& state) {
+  RunPointQueryBenchmark(state, PointQueryMode::kHit, false);
+}
+BENCHMARK(BM_DataframeSqliteJoin_Id_Hit);
+
+void BM_DataframeSqliteJoin_Id_IdMiss(benchmark::State& state) {
+  RunPointQueryBenchmark(state, PointQueryMode::kIdMiss, false);
+}
+BENCHMARK(BM_DataframeSqliteJoin_Id_IdMiss);
+
+void BM_DataframeSqliteJoin_IdAndUint32_Hit(benchmark::State& state) {
+  RunPointQueryBenchmark(state, PointQueryMode::kHit);
+}
+BENCHMARK(BM_DataframeSqliteJoin_IdAndUint32_Hit);
+
+void BM_DataframeSqliteJoin_IdAndUint32_SecondPredicateMiss(
+    benchmark::State& state) {
+  RunPointQueryBenchmark(state, PointQueryMode::kSecondPredicateMiss);
+}
+BENCHMARK(BM_DataframeSqliteJoin_IdAndUint32_SecondPredicateMiss);
+
+void BM_DataframeSqliteJoin_IdAndUint32_IdMiss(benchmark::State& state) {
+  RunPointQueryBenchmark(state, PointQueryMode::kIdMiss);
+}
+BENCHMARK(BM_DataframeSqliteJoin_IdAndUint32_IdMiss);
 
 // Re-entrant Execute(): the outer body uses a CREATE PERFETTO FUNCTION
 // whose body re-enters the engine via the runtime function machinery.

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_unittest.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_unittest.cc
@@ -132,6 +132,24 @@ TEST_F(PerfettoSqlConnectionTest, Table_Create) {
   ASSERT_TRUE(res.ok()) << res.status().c_message();
 }
 
+TEST_F(PerfettoSqlConnectionTest, Table_InFilter) {
+  auto res =
+      connection_->ExecuteUntilLastStatement(SqlSource::FromExecuteQuery(R"SQL(
+        CREATE PERFETTO TABLE foo AS
+        SELECT 0 AS id, 10 AS value UNION ALL
+        SELECT 1, 20 UNION ALL SELECT 2, 30 UNION ALL SELECT 3, 40;
+        SELECT group_concat(id) FROM (
+          SELECT id FROM foo WHERE value IN (20, 40) ORDER BY id
+        )
+      )SQL"));
+  ASSERT_TRUE(res.ok()) << res.status().c_message();
+  ASSERT_FALSE(res->stmt.IsDone());
+  ASSERT_STREQ(reinterpret_cast<const char*>(
+                   sqlite3_column_text(res->stmt.sqlite_stmt(), 0)),
+               "1,3");
+  ASSERT_FALSE(res->stmt.Step());
+}
+
 TEST_F(PerfettoSqlConnectionTest, Table_StringColumns) {
   auto res = connection_->Execute(SqlSource::FromExecuteQuery(
       "CREATE PERFETTO TABLE foo AS SELECT 'foo' AS bar"));


### PR DESCRIPTION
Speed up common SQLite joins against trace tables when an ID equality constraint means the joined side can return at most one row.

The query optimizer now emits a compact zero-or-one-row program for ID equality lookups, optionally followed by additional equality predicates. This avoids materializing intermediate ranges and allocating index storage, and lets failed predicates short-circuit immediately. The SQLite virtual-table path also avoids repeated argument copying and moves one-time cursor preparation off the hot path.

## Performance

Representative SQLite join benchmark with 1,024 lookups:

| Path | Before | After |
|---|---:|---:|
| Hit | ~67 us | ~58 us |
| Secondary predicate miss | ~49 us | ~39 us |
| ID miss | ~48 us | ~36 us |
