### PR TITLE
tp: reduce Trace Processor binary size

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17566,6 +17566,9 @@ filegroup {
 // GN: //src/trace_processor/core/common:common
 filegroup {
     name: "perfetto_src_trace_processor_core_common_common",
+    srcs: [
+        "src/trace_processor/core/common/value_fetcher.cc",
+    ],
 }
 
 // GN: //src/trace_processor/core/dataframe:dataframe

--- a/BUILD
+++ b/BUILD
@@ -2452,6 +2452,7 @@ perfetto_filegroup(
         "src/trace_processor/core/common/op_types.h",
         "src/trace_processor/core/common/sort_types.h",
         "src/trace_processor/core/common/storage_types.h",
+        "src/trace_processor/core/common/value_fetcher.cc",
         "src/trace_processor/core/common/value_fetcher.h",
     ],
 )

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1345,7 +1345,7 @@ v32.0 - 2023-02-01:
     * Added an explicit TraceUuid packet. The tracing service now always
       generates a UUID, even if TraceConfig.trace_uuid_msb/lsb is empty.
   Trace Processor:
-    *
+    * Reduced native and WebAssembly Trace Processor binary size.
   UI:
     *
   SDK:

--- a/src/trace_processor/core/common/BUILD.gn
+++ b/src/trace_processor/core/common/BUILD.gn
@@ -21,6 +21,7 @@ source_set("common") {
     "op_types.h",
     "sort_types.h",
     "storage_types.h",
+    "value_fetcher.cc",
     "value_fetcher.h",
   ]
   deps = [

--- a/src/trace_processor/core/common/value_fetcher.cc
+++ b/src/trace_processor/core/common/value_fetcher.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/common/value_fetcher.h"
+
+namespace perfetto::trace_processor::core {
+
+ValueFetcher::~ValueFetcher() = default;
+ErrorValueFetcher::~ErrorValueFetcher() = default;
+
+}  // namespace perfetto::trace_processor::core

--- a/src/trace_processor/core/common/value_fetcher.h
+++ b/src/trace_processor/core/common/value_fetcher.h
@@ -23,66 +23,44 @@
 
 namespace perfetto::trace_processor::core {
 
-// Fetcher for values from an aribtrary indexed source. The meaning of the index
-// in each of the *Value methods varies depending on where this class is used.
-//
-// Note: all the methods in this class are declared but not defined as this
-// class is simply an interface which needs to be subclassed and all
-// methods/variables implemented. The methods are intentionally not defined to
-// cause link errors if not implemented.
+// Fetches filter values from an arbitrary indexed source.
 struct ValueFetcher {
-  using Type = int;
-  static const Type kInt64;
-  static const Type kDouble;
-  static const Type kString;
-  static const Type kNull;
+  // These values match SQLite's fundamental type tags so SQLite-backed
+  // fetchers can return their source type without translating it.
+  using Type = uint8_t;
+  static constexpr Type kInt64 = 1;
+  static constexpr Type kDouble = 2;
+  static constexpr Type kString = 3;
+  static constexpr Type kBytes = 4;
+  static constexpr Type kNull = 5;
 
-  // Functions for operating on scalar values. The caller should know that
-  // the value at the give index is a scalar and not an iterator.
+  virtual ~ValueFetcher();
 
-  // Fetches an int64_t value at the given index.
-  int64_t GetInt64Value(uint32_t);
-  // Fetches a double value at the given index.
-  double GetDoubleValue(uint32_t);
-  // Fetches a string value at the given index.
-  const char* GetStringValue(uint32_t);
-  // Fetches the type of the value at the given index.
-  Type GetValueType(uint32_t);
+  virtual int64_t GetInt64Value(uint32_t) const = 0;
+  virtual double GetDoubleValue(uint32_t) const = 0;
+  virtual const char* GetStringValue(uint32_t) const = 0;
+  virtual Type GetValueType(uint32_t) const = 0;
 
-  // Functions for operating on iterators. The caller should know that
-  // the value at the given index is an iterator and not a scalar.
-
-  // Initializes the iterator at the given index. Returns true if the
-  // iterator has elements, false otherwise.
-  bool IteratorInit(uint32_t);
-  // Forwards the iterator to the next value and returns true if the iterator
-  // has more elements, false otherwise.
-  bool IteratorNext(uint32_t);
+  virtual bool IteratorInit(uint32_t) = 0;
+  virtual bool IteratorNext(uint32_t) = 0;
 };
 
-// ErrorValueFetcher is a dummy implementation of ValueFetcher that returns
-// an error value for all methods. This is used in cases where a
-// ValueFetcher is required but no actual data is available (e.g. where you are
-// iterating over a dataframe without filtering).
-struct ErrorValueFetcher : public ValueFetcher {
-  static const Type kInt64 = 0;
-  static const Type kDouble = 1;
-  static const Type kString = 2;
-  static const Type kNull = 3;
-  static int64_t GetInt64Value(uint32_t) {
+struct ErrorValueFetcher final : ValueFetcher {
+  ~ErrorValueFetcher() override;
+  int64_t GetInt64Value(uint32_t) const override {
     PERFETTO_FATAL("Dummy implementation; should not be called");
   }
-  static double GetDoubleValue(uint32_t) {
+  double GetDoubleValue(uint32_t) const override {
     PERFETTO_FATAL("Dummy implementation; should not be called");
   }
-  static const char* GetStringValue(uint32_t) {
+  const char* GetStringValue(uint32_t) const override {
     PERFETTO_FATAL("Dummy implementation; should not be called");
   }
-  static Type GetValueType(uint32_t) {
+  Type GetValueType(uint32_t) const override {
     PERFETTO_FATAL("Dummy implementation; should not be called");
   }
-  static bool IteratorInit(uint32_t) { PERFETTO_FATAL("Unsupported"); }
-  static bool IteratorNext(uint32_t) { PERFETTO_FATAL("Unsupported"); }
+  bool IteratorInit(uint32_t) override { PERFETTO_FATAL("Unsupported"); }
+  bool IteratorNext(uint32_t) override { PERFETTO_FATAL("Unsupported"); }
 };
 
 }  // namespace perfetto::trace_processor::core

--- a/src/trace_processor/core/dataframe/cursor.h
+++ b/src/trace_processor/core/dataframe/cursor.h
@@ -50,12 +50,8 @@ struct CellCallback {
 
 // Cursor provides a mechanism to iterate through dataframe query results
 // and access column values.
-template <typename FilterValueFetcherImpl>
 class Cursor {
  public:
-  static_assert(std::is_base_of_v<ValueFetcher, FilterValueFetcherImpl>,
-                "FilterValueFetcherImpl must be a subclass of ValueFetcher");
-
   Cursor() = default;
 
   // Initializes the cursor from a query plan and dataframe columns.
@@ -89,9 +85,8 @@ class Cursor {
   // This initializes the cursor's position to the first row of results.
   //
   // Parameters:
-  //   fvf: A subclass of `ValueFetcher` that defines the logic for fetching
-  //        filter values for each filter spec.
-  PERFETTO_ALWAYS_INLINE void Execute(FilterValueFetcherImpl&);
+  //   fvf: Fetches values for each filter spec.
+  PERFETTO_ALWAYS_INLINE void Execute(ValueFetcher&);
 
   // Returns the index of the row in the table this cursor is pointing to.
   PERFETTO_ALWAYS_INLINE uint32_t RowIndex() const { return *pos_; }
@@ -152,7 +147,7 @@ class Cursor {
 
  private:
   // Bytecode interpreter that executes the query.
-  interpreter::Interpreter<FilterValueFetcherImpl> interpreter_;
+  interpreter::Interpreter interpreter_;
   // Parameters for query execution.
   QueryPlanImpl::ExecutionParams params_;
   // Maps column indices to their output offsets in the result set.

--- a/src/trace_processor/core/dataframe/cursor_impl.h
+++ b/src/trace_processor/core/dataframe/cursor_impl.h
@@ -26,14 +26,11 @@
 
 namespace perfetto::trace_processor::core::dataframe {
 
-template <typename FilterValueFetcherImpl>
-void Cursor<FilterValueFetcherImpl>::Execute(
-    FilterValueFetcherImpl& filter_value_fetcher) {
+inline void Cursor::Execute(ValueFetcher& filter_value_fetcher) {
   using S = Span<uint32_t>;
   interpreter_.Execute(filter_value_fetcher);
 
-  const auto& span =
-      *interpreter_.template GetRegisterValue<S>(params_.output_register);
+  const auto& span = *interpreter_.GetRegisterValue<S>(params_.output_register);
   pos_ = span.b;
   end_ = span.e;
 }

--- a/src/trace_processor/core/dataframe/dataframe.h
+++ b/src/trace_processor/core/dataframe/dataframe.h
@@ -158,18 +158,13 @@ class Dataframe {
       const LimitSpec& limit_spec,
       uint64_t cols_used_bitmap) const;
 
-  // Prepares a cursor for executing the query plan. The template parameter
-  // `FilterValueFetcherImpl` is a subclass of `ValueFetcher` that defines the
-  // logic for fetching filter values for each filter specs specified when
-  // calling `PlanQuery`.
+  // Prepares a cursor for executing the query plan.
   //
   // Parameters:
   //   plan: The query plan to execute.
   //   c:    A reference to a std::optional that will be set to the prepared
   //         cursor.
-  template <typename FilterValueFetcherImpl>
-  void PrepareCursor(const QueryPlan& plan,
-                     Cursor<FilterValueFetcherImpl>& c) const {
+  void PrepareCursor(const QueryPlan& plan, Cursor& c) const {
     c.Initialize(plan.plan_, static_cast<uint32_t>(column_ptrs_.size()),
                  column_ptrs_.data(), indexes_.data(), string_pool_);
   }

--- a/src/trace_processor/core/dataframe/dataframe_test_utils.h
+++ b/src/trace_processor/core/dataframe/dataframe_test_utils.h
@@ -35,48 +35,40 @@
 
 namespace perfetto::trace_processor::core::dataframe {
 
-struct TestRowFetcher : ValueFetcher {
+struct TestRowFetcher final : ValueFetcher {
   using Value = std::variant<std::nullopt_t, int64_t, double, const char*>;
-  enum Type : uint8_t {
-    kNull,
-    kInt64,
-    kDouble,
-    kString,
-    kBytes,
-  };
-
   void SetRow(const std::vector<Value>& row_data) { current_row_ = &row_data; }
 
-  Type GetValueType(uint32_t index) {
+  Type GetValueType(uint32_t index) const override {
     PERFETTO_CHECK(current_row_ && index < current_row_->size());
     const auto& var = (*current_row_)[index];
     if (std::holds_alternative<std::nullopt_t>(var))
-      return Type::kNull;
+      return kNull;
     if (std::holds_alternative<int64_t>(var))
-      return Type::kInt64;
+      return kInt64;
     if (std::holds_alternative<double>(var))
-      return Type::kDouble;
+      return kDouble;
     if (std::holds_alternative<const char*>(var))
-      return Type::kString;
+      return kString;
     PERFETTO_FATAL("Invalid variant state");
   }
 
-  int64_t GetInt64Value(uint32_t index) {
+  int64_t GetInt64Value(uint32_t index) const override {
     PERFETTO_CHECK(current_row_ && index < current_row_->size());
     return std::get<int64_t>((*current_row_)[index]);
   }
 
-  double GetDoubleValue(uint32_t index) {
+  double GetDoubleValue(uint32_t index) const override {
     PERFETTO_CHECK(current_row_ && index < current_row_->size());
     return std::get<double>((*current_row_)[index]);
   }
 
-  const char* GetStringValue(uint32_t index) {
+  const char* GetStringValue(uint32_t index) const override {
     PERFETTO_CHECK(current_row_ && index < current_row_->size());
     return std::get<const char*>((*current_row_)[index]);
   }
-  static bool IteratorInit(uint32_t) { PERFETTO_FATAL("Unsupported"); }
-  static bool IteratorNext(uint32_t) { PERFETTO_FATAL("Unsupported"); }
+  bool IteratorInit(uint32_t) override { PERFETTO_FATAL("Unsupported"); }
+  bool IteratorNext(uint32_t) override { PERFETTO_FATAL("Unsupported"); }
 
  private:
   const std::vector<Value>* current_row_ = nullptr;
@@ -92,8 +84,7 @@ struct ValueVerifier : CellCallback {
                                     NullTermStringView,
                                     std::nullptr_t>;
 
-  template <typename Fetcher>
-  void Fetch(Cursor<Fetcher>* cursor, uint32_t col_count) {
+  void Fetch(Cursor* cursor, uint32_t col_count) {
     for (uint32_t i = 0; i < col_count; ++i) {
       cursor->Cell(i, *this);
     }
@@ -120,7 +111,7 @@ inline void VerifyData(
 
   // Heap allocate to avoid potential stack overflows due to large cursor
   // object.
-  auto cursor = std::make_unique<Cursor<TestRowFetcher>>();
+  auto cursor = std::make_unique<Cursor>();
   df.PrepareCursor(std::move(plan), *cursor);
 
   TestRowFetcher fetcher;

--- a/src/trace_processor/core/dataframe/runtime_dataframe_builder.h
+++ b/src/trace_processor/core/dataframe/runtime_dataframe_builder.h
@@ -112,13 +112,8 @@ class RuntimeDataframeBuilder {
 
   // Adds a row to the dataframe using data provided by the Fetcher.
   //
-  // Template Args:
-  //   ValueFetcherImpl: A concrete class derived from `ValueFetcher` that
-  //                     provides methods like `GetValueType(col_idx)` and
-  //                     `GetInt64Value(col_idx)`, `GetDoubleValue(col_idx)`,
-  //                     `GetStringValue(col_idx)` for the current row.
   // Args:
-  //   fetcher: A pointer to an instance of `ValueFetcherImpl`, configured
+  //   fetcher: A pointer to a `ValueFetcher`, configured
   //            to provide data for the row being added. The fetcher only
   //            needs to be valid for the duration of this call.
   // Returns:
@@ -138,35 +133,32 @@ class RuntimeDataframeBuilder {
   // 3) Performs strict type checking against the inferred type for subsequent
   //    rows. If a type mismatch occurs, sets an error status (retrievable via
   //    status()) and returns false.
-  template <typename ValueFetcherImpl>
-  bool AddRow(ValueFetcherImpl* fetcher) {
-    static_assert(std::is_base_of_v<ValueFetcher, ValueFetcherImpl>,
-                  "ValueFetcherImpl must inherit from ValueFetcher");
+  bool AddRow(ValueFetcher* fetcher) {
     PERFETTO_CHECK(status().ok());
 
     for (uint32_t i = 0; i < coulumn_count_; ++i) {
-      typename ValueFetcherImpl::Type fetched_type = fetcher->GetValueType(i);
+      ValueFetcher::Type fetched_type = fetcher->GetValueType(i);
       switch (fetched_type) {
-        case ValueFetcherImpl::kInt64:
+        case ValueFetcher::kInt64:
           if (!builder_.PushNonNull(i, fetcher->GetInt64Value(i))) {
             return false;
           }
           break;
-        case ValueFetcherImpl::kDouble:
+        case ValueFetcher::kDouble:
           if (!builder_.PushNonNull(i, fetcher->GetDoubleValue(i))) {
             return false;
           }
           break;
-        case ValueFetcherImpl::kString:
+        case ValueFetcher::kString:
           if (!builder_.PushNonNull(
                   i, pool_->InternString(fetcher->GetStringValue(i)))) {
             return false;
           }
           break;
-        case ValueFetcherImpl::kNull:
+        case ValueFetcher::kNull:
           builder_.PushNull(i);
           break;
-        case ValueFetcherImpl::kBytes:
+        case ValueFetcher::kBytes:
           PERFETTO_FATAL("Blob type not supported in Dataframe");
           break;
       }

--- a/src/trace_processor/core/dataframe/typed_cursor.cc
+++ b/src/trace_processor/core/dataframe/typed_cursor.cc
@@ -27,11 +27,13 @@
 
 namespace perfetto::trace_processor::core::dataframe {
 
+TypedCursor::Fetcher::~Fetcher() = default;
+
 void TypedCursor::ExecuteUnchecked() {
   if (PERFETTO_UNLIKELY(last_execution_mutation_count_ != GetMutations())) {
     PrepareCursorInternal();
   }
-  Fetcher fetcher{{}, filter_values_.data(), filter_value_list_states_.data()};
+  Fetcher fetcher(filter_values_.data(), filter_value_list_states_.data());
   cursor_.Execute(fetcher);
 }
 

--- a/src/trace_processor/core/dataframe/typed_cursor.h
+++ b/src/trace_processor/core/dataframe/typed_cursor.h
@@ -52,26 +52,25 @@ class TypedCursor {
     uint32_t current = 0;
   };
 
-  struct Fetcher : ValueFetcher {
-    using Type = size_t;
-    static const Type kInt64 = base::variant_index<FilterValue, int64_t>();
-    static const Type kDouble = base::variant_index<FilterValue, double>();
-    static const Type kString = base::variant_index<FilterValue, const char*>();
-    static const Type kNull =
-        base::variant_index<FilterValue, std::nullptr_t>();
-    int64_t GetInt64Value(uint32_t col) const {
+  struct Fetcher final : ValueFetcher {
+    Fetcher(FilterValue* values, FilterValueListState* list_states)
+        : filter_values_(values), filter_value_list_states_(list_states) {}
+    ~Fetcher() override;
+
+    int64_t GetInt64Value(uint32_t col) const override {
       return base::unchecked_get<int64_t>(filter_values_[col]);
     }
-    double GetDoubleValue(uint32_t col) const {
+    double GetDoubleValue(uint32_t col) const override {
       return base::unchecked_get<double>(filter_values_[col]);
     }
-    const char* GetStringValue(uint32_t col) const {
+    const char* GetStringValue(uint32_t col) const override {
       return base::unchecked_get<const char*>(filter_values_[col]);
     }
-    Type GetValueType(uint32_t col) const {
-      return filter_values_[col].index();
+    Type GetValueType(uint32_t col) const override {
+      static constexpr Type kTypes[] = {kNull, kInt64, kDouble, kString};
+      return kTypes[filter_values_[col].index()];
     }
-    bool IteratorInit(uint32_t col) {
+    bool IteratorInit(uint32_t col) override {
       FilterValueListState& s = filter_value_list_states_[col];
       s.current = 0;
       if (s.size == 0) {
@@ -80,7 +79,7 @@ class TypedCursor {
       filter_values_[col] = s.data[0];
       return true;
     }
-    bool IteratorNext(uint32_t col) {
+    bool IteratorNext(uint32_t col) override {
       FilterValueListState& s = filter_value_list_states_[col];
       ++s.current;
       if (s.current >= s.size) {
@@ -242,7 +241,7 @@ class TypedCursor {
   std::vector<FilterSpec> filter_specs_;
   std::vector<SortSpec> sort_specs_;
   bool mutable_;
-  Cursor<Fetcher> cursor_;
+  Cursor cursor_;
 
   core::Slab<uint32_t*> column_mutation_count_;
   uint32_t last_execution_mutation_count_ =

--- a/src/trace_processor/core/interpreter/bytecode_interpreter.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter.h
@@ -38,14 +38,8 @@ namespace perfetto::trace_processor::core::interpreter {
 // designed for high-performance data filtering and manipulation, with
 // specialized handling for different data types and comparison operations.
 //
-// This class is templated on a subclass of ValueFetcher, which is used to
-// fetch filter values for each filter spec.
-template <typename FilterValueFetcherImpl>
 class Interpreter {
  public:
-  static_assert(std::is_base_of_v<ValueFetcher, FilterValueFetcherImpl>,
-                "FilterValueFetcherImpl must be a subclass of ValueFetcher");
-
   Interpreter() = default;
 
   void Initialize(const BytecodeVector& bytecode,
@@ -61,8 +55,7 @@ class Interpreter {
 
   // Executes the bytecode sequence, processing each bytecode instruction in
   // turn, and dispatching to the appropriate function in this class.
-  PERFETTO_ALWAYS_INLINE void Execute(
-      FilterValueFetcherImpl& filter_value_fetcher);
+  void Execute(ValueFetcher& filter_value_fetcher);
 
   // Returns the value of the specified register if it contains the expected
   // type. Returns nullptr if the register holds a different type or is empty.

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_benchmark.cc
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_benchmark.cc
@@ -68,7 +68,7 @@ void BM_BytecodeInterpreter_LinearFilterEqUint32(benchmark::State& state) {
   )";
 
   StringPool spool;
-  Interpreter<Fetcher> interpreter;
+  Interpreter interpreter;
   interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 5, &spool);
 
   // Set up storage pointer in register
@@ -117,7 +117,7 @@ void BM_BytecodeInterpreter_LinearFilterEqString(benchmark::State& state) {
     LinearFilterEq<String>: [storage_register=Register(4), filter_value_reg=Register(0), source_register=Register(1), update_register=Register(2)]
   )";
 
-  Interpreter<Fetcher> interpreter;
+  Interpreter interpreter;
   interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 5, &spool);
 
   // Set up storage pointer in register
@@ -164,7 +164,7 @@ void BM_BytecodeInterpreter_InUint32(benchmark::State& state) {
   )";
 
   StringPool spool;
-  Interpreter<Fetcher> interpreter;
+  Interpreter interpreter;
   interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 5, &spool);
 
   StoragePtr storage_ptr{col.storage.unchecked_data<Uint32>(), Uint32{}};
@@ -207,7 +207,7 @@ void BM_BytecodeInterpreter_InId(benchmark::State& state) {
   )";
 
   StringPool spool;
-  Interpreter<Fetcher> interpreter;
+  Interpreter interpreter;
   interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 5, &spool);
 
   StoragePtr storage_ptr{nullptr, Id{}};
@@ -314,7 +314,7 @@ void BM_FilterIn_IndexedBinarySearch(benchmark::State& state) {
   )";
 
   StringPool spool;
-  Interpreter<Fetcher> interpreter;
+  Interpreter interpreter;
   interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 5, &spool);
 
   StoragePtr storage_ptr{setup.col.storage.unchecked_data<Uint32>(), Uint32{}};
@@ -363,7 +363,7 @@ void BM_FilterIn_IndexedLinearScan(benchmark::State& state) {
   )";
 
   StringPool spool;
-  Interpreter<Fetcher> interpreter;
+  Interpreter interpreter;
   interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 5, &spool);
 
   StoragePtr storage_ptr{setup.col.storage.unchecked_data<Uint32>(), Uint32{}};
@@ -413,7 +413,7 @@ static void BM_BytecodeInterpreter_SortUint32(benchmark::State& state) {
   )";
 
   StringPool spool;
-  Interpreter<Fetcher> interpreter;
+  Interpreter interpreter;
   interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 5, &spool);
 
   // Set up storage pointer in register
@@ -467,7 +467,7 @@ static void BM_BytecodeInterpreter_SortString(benchmark::State& state) {
     SortRowLayout: [buffer_register=Register(4), total_row_stride=4, indices_register=Register(2)]
   )";
 
-  Interpreter<Fetcher> interpreter;
+  Interpreter interpreter;
   interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 6, &spool);
 
   // Set up storage pointer in register

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_impl.cc
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_impl.cc
@@ -338,3 +338,34 @@ void StrideCopyDenseNullIndices(
 }
 
 }  // namespace perfetto::trace_processor::core::interpreter::ops
+
+namespace perfetto::trace_processor::core::interpreter {
+
+#define PERFETTO_OP_CASE_FVF(...)                                \
+  case base::variant_index<BytecodeVariant, __VA_ARGS__>(): {    \
+    ops::__VA_ARGS__(state_, fetcher,                            \
+                     static_cast<const __VA_ARGS__&>(bytecode)); \
+    break;                                                       \
+  }
+
+#define PERFETTO_OP_CASE_STATE(...)                                      \
+  case base::variant_index<BytecodeVariant, __VA_ARGS__>(): {            \
+    ops::__VA_ARGS__(state_, static_cast<const __VA_ARGS__&>(bytecode)); \
+    break;                                                               \
+  }
+
+void Interpreter::Execute(ValueFetcher& fetcher) {
+  for (const auto& bytecode : state_.bytecode) {
+    switch (bytecode.option) {
+      PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(PERFETTO_OP_CASE_FVF)
+      PERFETTO_DATAFRAME_BYTECODE_STATE_ONLY_LIST(PERFETTO_OP_CASE_STATE)
+      default:
+        PERFETTO_ASSUME(false);
+    }
+  }
+}
+
+#undef PERFETTO_OP_CASE_FVF
+#undef PERFETTO_OP_CASE_STATE
+
+}  // namespace perfetto::trace_processor::core::interpreter

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_impl.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_impl.h
@@ -1710,42 +1710,6 @@ inline PERFETTO_ALWAYS_INLINE void FindMinMaxIndex(
 
 }  // namespace ops
 
-// Macros for generating case statements that dispatch to ops:: free functions.
-// Uses __VA_ARGS__ to handle template types with commas (e.g., SortedFilter<Id,
-// EqualRange>).
-
-// For ops that need state and fetcher:
-#define PERFETTO_OP_CASE_FVF(...)                                \
-  case base::variant_index<BytecodeVariant, __VA_ARGS__>(): {    \
-    ops::__VA_ARGS__(state_, fetcher,                            \
-                     static_cast<const __VA_ARGS__&>(bytecode)); \
-    break;                                                       \
-  }
-
-// For ops that only need state:
-#define PERFETTO_OP_CASE_STATE(...)                                      \
-  case base::variant_index<BytecodeVariant, __VA_ARGS__>(): {            \
-    ops::__VA_ARGS__(state_, static_cast<const __VA_ARGS__&>(bytecode)); \
-    break;                                                               \
-  }
-
-// Executes all bytecode instructions using free functions.
-template <typename FilterValueFetcherImpl>
-PERFETTO_ALWAYS_INLINE void Interpreter<FilterValueFetcherImpl>::Execute(
-    FilterValueFetcherImpl& fetcher) {
-  for (const auto& bytecode : state_.bytecode) {
-    switch (bytecode.option) {
-      PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(PERFETTO_OP_CASE_FVF)
-      PERFETTO_DATAFRAME_BYTECODE_STATE_ONLY_LIST(PERFETTO_OP_CASE_STATE)
-      default:
-        PERFETTO_ASSUME(false);
-    }
-  }
-}
-
-#undef PERFETTO_OP_CASE_FVF
-#undef PERFETTO_OP_CASE_STATE
-
 }  // namespace perfetto::trace_processor::core::interpreter
 
 #endif  // SRC_TRACE_PROCESSOR_CORE_INTERPRETER_BYTECODE_INTERPRETER_IMPL_H_

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_test_utils.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_test_utils.h
@@ -51,39 +51,30 @@ namespace perfetto::trace_processor::core::interpreter {
 
 using FilterValue = std::variant<int64_t, double, const char*, std::nullptr_t>;
 
-struct Fetcher : ValueFetcher {
-  using Type = size_t;
-  [[maybe_unused]] static constexpr Type kInt64 =
-      base::variant_index<FilterValue, int64_t>();
-  [[maybe_unused]] static constexpr Type kDouble =
-      base::variant_index<FilterValue, double>();
-  [[maybe_unused]] static constexpr Type kString =
-      base::variant_index<FilterValue, const char*>();
-  [[maybe_unused]] static constexpr Type kNull =
-      base::variant_index<FilterValue, std::nullptr_t>();
-
-  int64_t GetInt64Value(uint32_t idx) const {
+struct Fetcher final : ValueFetcher {
+  int64_t GetInt64Value(uint32_t idx) const override {
     PERFETTO_CHECK(idx == 0);
     return std::get<int64_t>(value[i]);
   }
-  double GetDoubleValue(uint32_t idx) const {
+  double GetDoubleValue(uint32_t idx) const override {
     PERFETTO_CHECK(idx == 0);
     return std::get<double>(value[i]);
   }
-  const char* GetStringValue(uint32_t idx) const {
+  const char* GetStringValue(uint32_t idx) const override {
     PERFETTO_CHECK(idx == 0);
     return std::get<const char*>(value[i]);
   }
-  Type GetValueType(uint32_t idx) const {
+  Type GetValueType(uint32_t idx) const override {
     PERFETTO_CHECK(idx == 0);
-    return value[i].index();
+    static constexpr Type kTypes[] = {kInt64, kDouble, kString, kNull};
+    return kTypes[value[i].index()];
   }
-  bool IteratorInit(uint32_t idx) {
+  bool IteratorInit(uint32_t idx) override {
     PERFETTO_CHECK(idx == 0);
     i = 0;
     return i < value.size();
   }
-  bool IteratorNext(uint32_t idx) {
+  bool IteratorNext(uint32_t idx) override {
     PERFETTO_CHECK(idx == 0);
     i++;
     return i < value.size();

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_unittest.cc
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_unittest.cc
@@ -118,7 +118,7 @@ class BytecodeInterpreterTest : public testing::Test {
       const BytecodeVector& bytecode) {
     // Hardcode the register count to 128 for testing.
     static constexpr uint32_t kNumRegisters = 128;
-    interpreter_ = std::make_unique<Interpreter<Fetcher>>();
+    interpreter_ = std::make_unique<Interpreter>();
     interpreter_->Initialize(bytecode, kNumRegisters, &spool_);
   }
 
@@ -147,7 +147,7 @@ class BytecodeInterpreterTest : public testing::Test {
   }
 
   template <typename... Ts, uint32_t... Is>
-  void SetRegisterValuesForTesting(Interpreter<Fetcher>* interpreter,
+  void SetRegisterValuesForTesting(Interpreter* interpreter,
                                    std::integer_sequence<uint32_t, Is...>,
                                    Ts... values) {
     (interpreter->SetRegisterValue(WriteHandle<Ts>(Is), std::move(values)),
@@ -159,7 +159,7 @@ class BytecodeInterpreterTest : public testing::Test {
   std::vector<std::unique_ptr<dataframe::Column>> columns_vec_;
   std::vector<dataframe::Column*> column_ptrs_;
   std::vector<dataframe::Index> indexes_;
-  std::unique_ptr<Interpreter<Fetcher>> interpreter_;
+  std::unique_ptr<Interpreter> interpreter_;
 };
 
 TEST_F(BytecodeInterpreterTest, InitRange) {

--- a/src/trace_processor/perfetto_sql/engine/dataframe_module.cc
+++ b/src/trace_processor/perfetto_sql/engine/dataframe_module.cc
@@ -42,6 +42,8 @@
 
 namespace perfetto::trace_processor {
 
+DataframeModule::SqliteValueFetcher::~SqliteValueFetcher() = default;
+
 namespace {
 
 std::optional<dataframe::Op> SqliteOpToDataframeOp(int op) {
@@ -476,7 +478,7 @@ int DataframeModule::Filter(sqlite3_vtab_cursor* cur,
   // SQLite's API claims it will never pass more than 16 arguments
   // so assert that here as our std::array is fixed size.
   PERFETTO_DCHECK(argc <= 16);
-  SqliteValueFetcher fetcher{{}, {}, argv};
+  SqliteValueFetcher fetcher(argv);
   memcpy(static_cast<void*>(fetcher.sqlite_value.data()),
          static_cast<void*>(argv),
          sizeof(sqlite3_value*) * static_cast<size_t>(argc));

--- a/src/trace_processor/perfetto_sql/engine/dataframe_module.h
+++ b/src/trace_processor/perfetto_sql/engine/dataframe_module.h
@@ -59,29 +59,30 @@ struct DataframeModule : sqlite::Module<DataframeModule> {
         : sqlite::ModuleStateManager<DataframeModule>(store) {}
     std::unique_ptr<State> temporary_create_state;
   };
-  struct SqliteValueFetcher : dataframe::ValueFetcher {
-    using Type = sqlite::Type;
-    static const Type kInt64 = sqlite::Type::kInteger;
-    static const Type kDouble = sqlite::Type::kFloat;
-    static const Type kString = sqlite::Type::kText;
-    static const Type kNull = sqlite::Type::kNull;
+  struct SqliteValueFetcher final : dataframe::ValueFetcher {
+    explicit SqliteValueFetcher(sqlite3_value** values) : argv(values) {}
+    ~SqliteValueFetcher() override;
 
-    int64_t GetInt64Value(uint32_t idx) const {
+    int64_t GetInt64Value(uint32_t idx) const override {
       return sqlite::value::Int64(sqlite_value[idx]);
     }
-    double GetDoubleValue(uint32_t idx) const {
+    double GetDoubleValue(uint32_t idx) const override {
       return sqlite::value::Double(sqlite_value[idx]);
     }
-    const char* GetStringValue(uint32_t idx) const {
+    const char* GetStringValue(uint32_t idx) const override {
       return sqlite::value::Text(sqlite_value[idx]);
     }
-    Type GetValueType(uint32_t idx) const {
-      return sqlite::value::Type(sqlite_value[idx]);
+    Type GetValueType(uint32_t idx) const override {
+      static_assert(static_cast<Type>(sqlite::Type::kInteger) == kInt64);
+      static_assert(static_cast<Type>(sqlite::Type::kFloat) == kDouble);
+      static_assert(static_cast<Type>(sqlite::Type::kText) == kString);
+      static_assert(static_cast<Type>(sqlite::Type::kNull) == kNull);
+      return static_cast<Type>(sqlite::value::Type(sqlite_value[idx]));
     }
-    bool IteratorInit(uint32_t idx) {
+    bool IteratorInit(uint32_t idx) override {
       return sqlite3_vtab_in_first(argv[idx], &sqlite_value[idx]) == SQLITE_OK;
     }
-    bool IteratorNext(uint32_t idx) {
+    bool IteratorNext(uint32_t idx) override {
       return sqlite3_vtab_in_next(argv[idx], &sqlite_value[idx]) == SQLITE_OK;
     }
     std::array<sqlite3_value*, 16> sqlite_value;
@@ -104,7 +105,7 @@ struct DataframeModule : sqlite::Module<DataframeModule> {
     int best_idx_num = 0;
     uint32_t id_col_idx = 0;
   };
-  using DfCursor = dataframe::Cursor<SqliteValueFetcher>;
+  using DfCursor = dataframe::Cursor;
   struct Cursor : sqlite::Module<DataframeModule>::Cursor {
     const dataframe::Dataframe* dataframe;
     DfCursor df_cursor;

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_benchmark.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_benchmark.cc
@@ -14,9 +14,12 @@
 
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
 
+#include <cstdint>
 #include <memory>
+#include <string>
 
 #include <benchmark/benchmark.h>
+#include <sqlite3.h>
 
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/containers/string_pool.h"
@@ -38,6 +41,113 @@ void BM_Connection_Execute_TrivialSelect(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_Connection_Execute_TrivialSelect);
+
+class PointJoinBenchmark {
+ public:
+  PointJoinBenchmark()
+      : connection_(PerfettoSqlConnection::CreateConnectionToNewDatabase(
+            &pool_,
+            /*enable_extra_checks=*/false)) {
+    auto status = connection_->Execute(SqlSource::FromExecuteQuery(R"SQL(
+      CREATE PERFETTO TABLE point_table AS
+      WITH RECURSIVE sequence(id) AS (
+        VALUES(0)
+        UNION ALL
+        SELECT id + 1 FROM sequence WHERE id < 4095
+      )
+      SELECT id, id % 17 AS value FROM sequence
+    )SQL"));
+    PERFETTO_CHECK(status.ok());
+  }
+
+  PerfettoSqlConnection* connection() { return connection_.get(); }
+
+ private:
+  StringPool pool_;
+  std::unique_ptr<PerfettoSqlConnection> connection_;
+};
+
+enum class PointJoinResult {
+  kHit,
+  kValueMiss,
+  kIdMiss,
+};
+
+void RunPointJoinBenchmark(benchmark::State& state,
+                           PointJoinResult result,
+                           bool check_value = true) {
+  constexpr int64_t kLookupCount = 1024;
+  PointJoinBenchmark benchmark;
+
+  const char* id = result == PointJoinResult::kIdMiss ? "id + 5000" : "id";
+  const char* value =
+      result == PointJoinResult::kValueMiss ? "(id + 1) % 17" : "id % 17";
+  std::string setup = R"SQL(
+    CREATE TABLE lookup(id INTEGER, value INTEGER);
+    WITH RECURSIVE sequence(id) AS (
+      VALUES(0)
+      UNION ALL
+      SELECT id + 1 FROM sequence WHERE id < 1023
+    )
+    INSERT INTO lookup SELECT )SQL" +
+                      std::string(id) + ", " + value + " FROM sequence";
+  auto status =
+      benchmark.connection()->Execute(SqlSource::FromExecuteQuery(setup));
+  PERFETTO_CHECK(status.ok());
+
+  std::string query = R"SQL(
+    SELECT sum(point_table.id)
+    FROM lookup CROSS JOIN point_table
+    WHERE point_table.id = lookup.id
+  )SQL";
+  if (check_value) {
+    query += " AND point_table.value = lookup.value";
+  }
+  auto prepared = benchmark.connection()->PrepareSqliteStatement(
+      SqlSource::FromExecuteQuery(query));
+  PERFETTO_CHECK(prepared.ok());
+  sqlite3_stmt* stmt = prepared->sqlite_stmt();
+
+  // Exclude one-time virtual table planning from repeated execution.
+  PERFETTO_CHECK(sqlite3_step(stmt) == SQLITE_ROW);
+  benchmark::DoNotOptimize(sqlite3_column_int64(stmt, 0));
+  PERFETTO_CHECK(sqlite3_step(stmt) == SQLITE_DONE);
+  PERFETTO_CHECK(sqlite3_reset(stmt) == SQLITE_OK);
+
+  for (auto _ : state) {
+    PERFETTO_CHECK(sqlite3_step(stmt) == SQLITE_ROW);
+    benchmark::DoNotOptimize(sqlite3_column_int64(stmt, 0));
+    PERFETTO_CHECK(sqlite3_step(stmt) == SQLITE_DONE);
+    PERFETTO_CHECK(sqlite3_reset(stmt) == SQLITE_OK);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          kLookupCount);
+}
+
+void BM_SqliteJoin_Id_Hit(benchmark::State& state) {
+  RunPointJoinBenchmark(state, PointJoinResult::kHit, false);
+}
+BENCHMARK(BM_SqliteJoin_Id_Hit);
+
+void BM_SqliteJoin_Id_IdMiss(benchmark::State& state) {
+  RunPointJoinBenchmark(state, PointJoinResult::kIdMiss, false);
+}
+BENCHMARK(BM_SqliteJoin_Id_IdMiss);
+
+void BM_SqliteJoin_IdAndValue_Hit(benchmark::State& state) {
+  RunPointJoinBenchmark(state, PointJoinResult::kHit);
+}
+BENCHMARK(BM_SqliteJoin_IdAndValue_Hit);
+
+void BM_SqliteJoin_IdAndValue_ValueMiss(benchmark::State& state) {
+  RunPointJoinBenchmark(state, PointJoinResult::kValueMiss);
+}
+BENCHMARK(BM_SqliteJoin_IdAndValue_ValueMiss);
+
+void BM_SqliteJoin_IdAndValue_IdMiss(benchmark::State& state) {
+  RunPointJoinBenchmark(state, PointJoinResult::kIdMiss);
+}
+BENCHMARK(BM_SqliteJoin_IdAndValue_IdMiss);
 
 // Re-entrant Execute(): the outer body uses a CREATE PERFETTO FUNCTION
 // whose body re-enters the engine via the runtime function machinery.

--- a/src/trace_processor/perfetto_sql/engine/sqlite_dataframe_builder.cc
+++ b/src/trace_processor/perfetto_sql/engine/sqlite_dataframe_builder.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <utility>
 
+#include "perfetto/base/logging.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
 #include "src/trace_processor/core/dataframe/runtime_dataframe_builder.h"
@@ -28,34 +29,32 @@
 namespace perfetto::trace_processor {
 namespace {
 
-struct SqliteValueFetcher : public dataframe::ValueFetcher {
+struct SqliteValueFetcher final : public dataframe::ValueFetcher {
   SqliteValueFetcher(sqlite3_stmt* sql_stmt, bool null_blobs)
       : stmt(sql_stmt), blobs_as_null(null_blobs) {}
+  ~SqliteValueFetcher() override;
 
-  using Type = sqlite::Type;
-  static constexpr Type kInt64 = sqlite::Type::kInteger;
-  static constexpr Type kDouble = sqlite::Type::kFloat;
-  static constexpr Type kString = sqlite::Type::kText;
-  static constexpr Type kNull = sqlite::Type::kNull;
-  static constexpr Type kBytes = sqlite::Type::kBlob;
-
-  int64_t GetInt64Value(uint32_t column) const {
+  int64_t GetInt64Value(uint32_t column) const override {
     return sqlite::column::Int64(stmt, column);
   }
-  double GetDoubleValue(uint32_t column) const {
+  double GetDoubleValue(uint32_t column) const override {
     return sqlite::column::Double(stmt, column);
   }
-  const char* GetStringValue(uint32_t column) const {
+  const char* GetStringValue(uint32_t column) const override {
     return sqlite::column::Text(stmt, column);
   }
-  Type GetValueType(uint32_t column) const {
-    Type type = sqlite::column::Type(stmt, column);
+  Type GetValueType(uint32_t column) const override {
+    Type type = static_cast<Type>(sqlite::column::Type(stmt, column));
     return blobs_as_null && type == kBytes ? kNull : type;
   }
+  bool IteratorInit(uint32_t) override { PERFETTO_FATAL("Unsupported"); }
+  bool IteratorNext(uint32_t) override { PERFETTO_FATAL("Unsupported"); }
 
   sqlite3_stmt* stmt;
   bool blobs_as_null;
 };
+
+SqliteValueFetcher::~SqliteValueFetcher() = default;
 
 }  // namespace
 


### PR DESCRIPTION
## Summary

Reduce native and WebAssembly Trace Processor binary size by emitting the general query interpreter once instead of instantiating it for every filter-value source.

`ValueFetcher` is now a conventional runtime interface, and the interpreter, cursor, and runtime table builder no longer specialize their full implementations by fetcher type. SQLite's existing type tags are used directly, so this does not add a type-translation switch.

This PR also adds repeated SQLite point-join benchmarks for hit and miss paths.

## Size

Stripped native Trace Processor shell:

- Before: 15,278,944 bytes
- After: 15,212,240 bytes
- Reduction: 66,704 bytes

## Testing

- 176 focused interpreter, query, and SQLite connection tests
- Native unit-test, benchmark, and Trace Processor shell builds
- GN dependency check
- Perfetto presubmit

This is the first PR in a two-PR stack. The follow-up recovers and improves latency for common ID-based SQLite joins using semantic cardinality information.
