### PR TITLE
tp: speed up SQLite joins on ID columns

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1346,6 +1346,7 @@ v32.0 - 2023-02-01:
       generates a UUID, even if TraceConfig.trace_uuid_msb/lsb is empty.
   Trace Processor:
     * Reduced native and WebAssembly Trace Processor binary size.
+    * Improved performance of SQLite joins using ID columns.
   UI:
     *
   SDK:

--- a/src/trace_processor/core/dataframe/cursor.h
+++ b/src/trace_processor/core/dataframe/cursor.h
@@ -86,7 +86,8 @@ class Cursor {
   //
   // Parameters:
   //   fvf: Fetches values for each filter spec.
-  PERFETTO_ALWAYS_INLINE void Execute(ValueFetcher&);
+  template <typename FilterValueFetcherImpl>
+  PERFETTO_ALWAYS_INLINE void Execute(FilterValueFetcherImpl&);
 
   // Returns the index of the row in the table this cursor is pointing to.
   PERFETTO_ALWAYS_INLINE uint32_t RowIndex() const { return *pos_; }

--- a/src/trace_processor/core/dataframe/cursor_impl.h
+++ b/src/trace_processor/core/dataframe/cursor_impl.h
@@ -26,11 +26,10 @@
 
 namespace perfetto::trace_processor::core::dataframe {
 
-inline void Cursor::Execute(ValueFetcher& filter_value_fetcher) {
-  using S = Span<uint32_t>;
-  interpreter_.Execute(filter_value_fetcher);
-
-  const auto& span = *interpreter_.GetRegisterValue<S>(params_.output_register);
+template <typename FilterValueFetcherImpl>
+void Cursor::Execute(FilterValueFetcherImpl& filter_value_fetcher) {
+  auto span =
+      interpreter_.Execute(filter_value_fetcher, params_.output_register);
   pos_ = span.b;
   end_ = span.e;
 }

--- a/src/trace_processor/core/dataframe/dataframe_unittest.cc
+++ b/src/trace_processor/core/dataframe/dataframe_unittest.cc
@@ -173,12 +173,60 @@ TEST_F(DataframeBytecodeTest, SingleFilter) {
              NoDuplicates{}});
   std::vector<FilterSpec> filters = {{0, 0, Eq{}, std::nullopt}};
   RunBytecodeTest(cols, filters, {}, {}, {}, R"(
-    InitRange: [size=0, dest_register=Register(0)]
-    CastFilterValue<Id>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
-    SortedFilter<Id, EqualRange>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
-    AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
-    Iota: [source_register=Register(0), update_register=Register(4)]
+    SingleRowQuery: [row_count=0, id_fval_handle=FilterValue(0), predicate_count=0]
   )");
+}
+
+TEST_F(DataframeBytecodeTest, SingleRowPredicatesAreLoweredFromBytecode) {
+  std::vector<Column> cols = MakeColumnVector(
+      Column{Storage::Id{}, NullStorage::NonNull{}, IdSorted{}, NoDuplicates{}},
+      Column{Storage::Uint32{}, NullStorage::NonNull{}, Unsorted{},
+             HasDuplicates{}},
+      Column{Storage::String{}, NullStorage::NonNull{}, Unsorted{},
+             HasDuplicates{}});
+  std::vector<FilterSpec> filters = {{0, 0, Eq{}, std::nullopt},
+                                     {1, 1, Eq{}, std::nullopt},
+                                     {2, 2, Eq{}, std::nullopt}};
+  auto df = MakeDatafame({"id", "value", "name"}, std::move(cols));
+  ASSERT_OK_AND_ASSIGN(Dataframe::QueryPlan plan,
+                       df->PlanQuery(filters, {}, {}, {}, 0x7));
+
+  const auto& bytecode = plan.GetImplForTesting().bytecode;
+  ASSERT_EQ(bytecode.size(), 3u);
+  ASSERT_EQ(bytecode[0].option,
+            interpreter::Index<interpreter::SingleRowQuery>());
+  const auto& query =
+      static_cast<const interpreter::SingleRowQuery&>(bytecode[0]);
+  EXPECT_EQ(query.arg<interpreter::SingleRowQuery::predicate_count>(), 2u);
+  ASSERT_EQ(bytecode[1].option,
+            interpreter::Index<interpreter::SingleRowEqPredicate>());
+  ASSERT_EQ(bytecode[2].option,
+            interpreter::Index<interpreter::SingleRowEqPredicate>());
+  const auto& first =
+      static_cast<const interpreter::SingleRowEqPredicate&>(bytecode[1]);
+  const auto& second =
+      static_cast<const interpreter::SingleRowEqPredicate&>(bytecode[2]);
+  EXPECT_EQ(first.arg<interpreter::SingleRowEqPredicate::storage_type>(),
+            interpreter::NonIdStorageType::GetTypeIndex<Uint32>());
+  EXPECT_EQ(second.arg<interpreter::SingleRowEqPredicate::storage_type>(),
+            interpreter::NonIdStorageType::GetTypeIndex<String>());
+}
+
+TEST_F(DataframeBytecodeTest, NullablePredicateUsesGeneralBytecode) {
+  std::vector<Column> cols = MakeColumnVector(
+      Column{Storage::Id{}, NullStorage::NonNull{}, IdSorted{}, NoDuplicates{}},
+      Column{Storage::Uint32{}, NullStorage::DenseNull{}, Unsorted{},
+             HasDuplicates{}});
+  std::vector<FilterSpec> filters = {{0, 0, Eq{}, std::nullopt},
+                                     {1, 1, Eq{}, std::nullopt}};
+  auto df = MakeDatafame({"id", "value"}, std::move(cols));
+  ASSERT_OK_AND_ASSIGN(Dataframe::QueryPlan plan,
+                       df->PlanQuery(filters, {}, {}, {}, 0x1));
+
+  const auto& bytecode = plan.GetImplForTesting().bytecode;
+  ASSERT_FALSE(bytecode.empty());
+  EXPECT_NE(bytecode.front().option,
+            interpreter::Index<interpreter::SingleRowQuery>());
 }
 
 // Test case with multiple filters
@@ -1583,6 +1631,55 @@ TEST(DataframeTest, TypedCursor) {
     cursor.Next();
     ASSERT_TRUE(cursor.Eof());
   }
+}
+
+TEST(DataframeTest, TypedCursorSingleRowPredicates) {
+  static constexpr auto kSpec = CreateTypedDataframeSpec(
+      {"id", "u32", "i32", "i64", "double", "string"},
+      CreateTypedColumnSpec(Id(), NonNull(), IdSorted()),
+      CreateTypedColumnSpec(Uint32(), NonNull(), Unsorted()),
+      CreateTypedColumnSpec(Int32(), NonNull(), Unsorted()),
+      CreateTypedColumnSpec(Int64(), NonNull(), Unsorted()),
+      CreateTypedColumnSpec(Double(), NonNull(), Unsorted()),
+      CreateTypedColumnSpec(String(), NonNull(), Unsorted()));
+  StringPool pool;
+  Dataframe df = Dataframe::CreateFromTypedSpec(kSpec, &pool);
+  df.InsertUnchecked(kSpec, std::monostate(), 10u, int32_t{-10}, int64_t{100},
+                     1.5, pool.InternString("a"));
+  df.InsertUnchecked(kSpec, std::monostate(), 20u, int32_t{-20}, int64_t{200},
+                     2.5, pool.InternString("b"));
+
+  TypedCursor cursor(&df,
+                     {{0, 0, Eq{}, {}},
+                      {1, 1, Eq{}, {}},
+                      {2, 2, Eq{}, {}},
+                      {3, 3, Eq{}, {}},
+                      {4, 4, Eq{}, {}},
+                      {5, 5, Eq{}, {}}},
+                     {});
+  auto set_values = [&cursor](int64_t id, const char* string_value) {
+    cursor.SetFilterValueUnchecked(0, id);
+    cursor.SetFilterValueUnchecked(1, int64_t{20});
+    cursor.SetFilterValueUnchecked(2, int64_t{-20});
+    cursor.SetFilterValueUnchecked(3, int64_t{200});
+    cursor.SetFilterValueUnchecked(4, 2.5);
+    cursor.SetFilterValueUnchecked(5, string_value);
+  };
+
+  set_values(1, "b");
+  cursor.ExecuteUnchecked();
+  ASSERT_FALSE(cursor.Eof());
+  EXPECT_EQ(cursor.GetCellUnchecked<0>(kSpec), 1u);
+  cursor.Next();
+  EXPECT_TRUE(cursor.Eof());
+
+  set_values(1, "a");
+  cursor.ExecuteUnchecked();
+  EXPECT_TRUE(cursor.Eof());
+
+  set_values(10, "b");
+  cursor.ExecuteUnchecked();
+  EXPECT_TRUE(cursor.Eof());
 }
 
 TEST(DataframeTest, TypedCursorSetMultipleTimes) {

--- a/src/trace_processor/core/dataframe/query_plan.cc
+++ b/src/trace_processor/core/dataframe/query_plan.cc
@@ -173,6 +173,168 @@ uint8_t GetDataSize(StorageType type) {
   }
 }
 
+// A small, typed cursor for capturing instructions and their arguments from a
+// bytecode sequence. Optimizations can build a replacement from the captures
+// without repeating query-planning decisions.
+class BytecodeCapture {
+ public:
+  BytecodeCapture(const i::BytecodeVector& bytecode,
+                  const std::vector<uint32_t>& max_row_counts)
+      : bytecode_(bytecode), max_row_counts_(max_row_counts) {
+    PERFETTO_DCHECK(bytecode_.size() == max_row_counts_.size());
+  }
+
+  template <typename B>
+  const B* Match() {
+    if (position_ == bytecode_.size() ||
+        bytecode_[position_].option != i::Index<B>()) {
+      return nullptr;
+    }
+    return &static_cast<const B&>(bytecode_[position_++]);
+  }
+
+  struct AnyMatch {
+    const i::Bytecode* bytecode;
+    uint32_t variant;
+  };
+
+  template <typename... B>
+  std::optional<AnyMatch> MatchAny() {
+    if (position_ == bytecode_.size()) {
+      return std::nullopt;
+    }
+    const uint32_t options[] = {i::Index<B>()...};
+    for (uint32_t variant = 0; variant < sizeof...(B); ++variant) {
+      if (bytecode_[position_].option == options[variant]) {
+        return AnyMatch{&bytecode_[position_++], variant};
+      }
+    }
+    return std::nullopt;
+  }
+
+  bool done() const { return position_ == bytecode_.size(); }
+  uint32_t max_row_count() const {
+    PERFETTO_DCHECK(position_ > 0);
+    return max_row_counts_[position_ - 1];
+  }
+
+ private:
+  const i::BytecodeVector& bytecode_;
+  const std::vector<uint32_t>& max_row_counts_;
+  uint32_t position_ = 0;
+};
+
+struct CapturedPredicateValue {
+  i::FilterValueHandle value;
+  uint32_t variant;
+  uint32_t storage_type;
+};
+
+void AppendSingleRowPredicate(i::BytecodeVector& bytecode,
+                              const CapturedPredicateValue& value,
+                              i::ReadHandle<i::StoragePtr> storage) {
+  bytecode.emplace_back();
+  using B = i::SingleRowEqPredicate;
+  auto& predicate = static_cast<B&>(bytecode.back());
+  predicate.option = i::Index<B>();
+  predicate.arg<B::fval_handle>() = value.value;
+  predicate.arg<B::storage_register>() = storage;
+  predicate.arg<B::storage_type>() = value.storage_type;
+}
+
+void TryLowerSingleRowQuery(i::BytecodeVector& bytecode,
+                            const std::vector<uint32_t>& max_row_counts) {
+  BytecodeCapture capture(bytecode, max_row_counts);
+  const auto* init = capture.Match<i::InitRange>();
+  const auto* id_value = capture.Match<i::CastFilterValue<Id>>();
+  const auto* id_filter = capture.Match<i::SortedFilter<Id, i::EqualRange>>();
+  if (!init || !id_value || !id_filter || capture.max_row_count() > 1 ||
+      id_filter->arg<i::SortedFilterBase::val_register>().index !=
+          id_value->arg<i::CastFilterValue<Id>::write_register>().index ||
+      id_filter->arg<i::SortedFilterBase::update_register>().index !=
+          init->arg<i::InitRange::dest_register>().index) {
+    return;
+  }
+
+  i::BytecodeVector lowered;
+  lowered.emplace_back();
+  using Query = i::SingleRowQuery;
+  auto& query = static_cast<Query&>(lowered.back());
+  query.option = i::Index<Query>();
+  query.arg<Query::row_count>() = init->arg<i::InitRange::size>();
+  query.arg<Query::id_fval_handle>() =
+      id_value->arg<i::CastFilterValue<Id>::fval_handle>();
+  query.arg<Query::predicate_count>() = 0;
+
+  std::optional<CapturedPredicateValue> pending_value;
+  while (!capture.done()) {
+    // These operations only change how the current rows are represented. Once
+    // cardinality is at most one, the scalar program does not need them.
+    if (capture.Match<i::AllocateIndices>() || capture.Match<i::Iota>()) {
+      continue;
+    }
+
+    auto cast =
+        capture.MatchAny<i::CastFilterValue<Uint32>, i::CastFilterValue<Int32>,
+                         i::CastFilterValue<Int64>, i::CastFilterValue<Double>,
+                         i::CastFilterValue<String>>();
+    if (cast) {
+      if (pending_value) {
+        return;
+      }
+      const auto& op =
+          static_cast<const i::CastFilterValueBase&>(*cast->bytecode);
+      static constexpr uint32_t kStorageTypes[] = {
+          i::NonIdStorageType::GetTypeIndex<Uint32>(),
+          i::NonIdStorageType::GetTypeIndex<Int32>(),
+          i::NonIdStorageType::GetTypeIndex<Int64>(),
+          i::NonIdStorageType::GetTypeIndex<Double>(),
+          i::NonIdStorageType::GetTypeIndex<String>()};
+      pending_value =
+          CapturedPredicateValue{op.arg<i::CastFilterValueBase::fval_handle>(),
+                                 cast->variant, kStorageTypes[cast->variant]};
+      continue;
+    }
+
+    // Both halves are ordered like NonIdStorageType: range filters followed
+    // by their span-filter equivalents.
+    auto filter = capture.MatchAny<
+        i::LinearFilterEq<Uint32>, i::LinearFilterEq<Int32>,
+        i::LinearFilterEq<Int64>, i::LinearFilterEq<Double>,
+        i::LinearFilterEq<String>, i::NonStringFilter<Uint32, Eq>,
+        i::NonStringFilter<Int32, Eq>, i::NonStringFilter<Int64, Eq>,
+        i::NonStringFilter<Double, Eq>, i::StringFilter<Eq>>();
+    constexpr uint32_t kTypeCount = i::NonIdStorageType::kSize;
+    if (!filter || !pending_value ||
+        filter->variant % kTypeCount != pending_value->variant) {
+      return;
+    }
+
+    i::ReadHandle<i::StoragePtr> storage;
+    if (filter->variant < kTypeCount) {
+      const auto& op =
+          static_cast<const i::LinearFilterEqBase&>(*filter->bytecode);
+      storage = op.arg<i::LinearFilterEqBase::storage_register>();
+    } else if (filter->variant == 2 * kTypeCount - 1) {
+      const auto& op =
+          static_cast<const i::StringFilterBase&>(*filter->bytecode);
+      storage = op.arg<i::StringFilterBase::storage_register>();
+    } else {
+      const auto& op =
+          static_cast<const i::NonStringFilterBase&>(*filter->bytecode);
+      storage = op.arg<i::NonStringFilterBase::storage_register>();
+    }
+    AppendSingleRowPredicate(lowered, *pending_value, storage);
+    pending_value.reset();
+  }
+  if (pending_value) {
+    return;
+  }
+  static_cast<Query&>(lowered.front()).arg<Query::predicate_count>() =
+      static_cast<uint32_t>(lowered.size() - 1);
+  bytecode = std::move(lowered);
+}
+
 i::SparseNullCollapsedNullability NullabilityToSparseNullCollapsedNullability(
     Nullability nullability) {
   switch (nullability.index()) {
@@ -256,9 +418,11 @@ QueryPlanBuilder::QueryPlanBuilder(
       indices_reg_(indices),
       builder_(builder),
       cache_(cache) {
-  // Setup the maximum and estimated row counts.
+  // Setup the maximum and estimated row counts. InitRange was emitted before
+  // constructing this builder, so record its output cardinality here.
   plan_.params.max_row_count = row_count;
   plan_.params.estimated_row_count = row_count;
+  bytecode_max_row_counts_.push_back(row_count);
 }
 
 base::StatusOr<QueryPlanImpl> QueryPlanBuilder::Build(
@@ -751,6 +915,8 @@ void QueryPlanBuilder::Output(const LimitSpec& limit, uint64_t cols_used) {
 }
 
 QueryPlanImpl QueryPlanBuilder::Build() && {
+  PERFETTO_CHECK(builder_.bytecode().size() == bytecode_max_row_counts_.size());
+  TryLowerSingleRowQuery(builder_.bytecode(), bytecode_max_row_counts_);
   plan_.bytecode = std::move(builder_.bytecode());
   plan_.params.register_count = builder_.register_count();
   return std::move(plan_);
@@ -1251,7 +1417,9 @@ PERFETTO_NO_INLINE i::Bytecode& QueryPlanBuilder::AddRawOpcode(
     const auto& c = base::unchecked_get<i::PostOperationLinearPerRowCost>(cost);
     plan_.params.estimated_cost += c.cost * plan_.params.estimated_cost;
   }
-  return builder_.AddRawOpcode(option);
+  i::Bytecode& bytecode = builder_.AddRawOpcode(option);
+  bytecode_max_row_counts_.push_back(plan_.params.max_row_count);
+  return bytecode;
 }
 
 void QueryPlanBuilder::SetGuaranteedToBeEmpty() {

--- a/src/trace_processor/core/dataframe/query_plan.h
+++ b/src/trace_processor/core/dataframe/query_plan.h
@@ -500,6 +500,11 @@ class QueryPlanBuilder {
   // Last scratch registers returned by GetOrCreateScratchSpanRegister.
   std::optional<Scratch> scratch_;
 
+  // Maximum row count after each emitted bytecode. This is retained so
+  // bytecode rewriting can use cardinality without reconstructing planner
+  // decisions.
+  std::vector<uint32_t> bytecode_max_row_counts_;
+
   // Row count before the first selective (equality/IN) filter was applied. Used
   // to avoid compounding the selectivity of multiple such filters: only the
   // most selective one determines the estimate.

--- a/src/trace_processor/core/interpreter/bytecode_instructions.h
+++ b/src/trace_processor/core/interpreter/bytecode_instructions.h
@@ -568,6 +568,29 @@ struct LinearFilterEq : LinearFilterEqBase {
   static_assert(TS1::Contains<T>());
 };
 
+// A compact program for queries whose Id equality predicate establishes that
+// at most one row can match. The following |predicate_count| bytecodes are
+// SingleRowEqPredicate records consumed by the single-row executor.
+struct SingleRowQuery : Bytecode {
+  static constexpr Cost kCost = FixedCost{10};
+
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(uint32_t,
+                                     row_count,
+                                     FilterValueHandle,
+                                     id_fval_handle,
+                                     uint32_t,
+                                     predicate_count);
+};
+
+struct SingleRowEqPredicate : Bytecode {
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(FilterValueHandle,
+                                     fval_handle,
+                                     ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     uint32_t,
+                                     storage_type);
+};
+
 // Filters rows based on a list of values (IN operator). Supports both indexed
 // and non-indexed modes:
 //   - Indexed: index_register points to a sorted permutation vector and
@@ -620,19 +643,26 @@ struct Reverse : Bytecode {
 };
 
 // Bytecode ops that require FilterValueFetcher access.
-#define PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(X) \
-  X(CastFilterValue<Id>)                        \
-  X(CastFilterValue<Uint32>)                    \
-  X(CastFilterValue<Int32>)                     \
-  X(CastFilterValue<Int64>)                     \
-  X(CastFilterValue<Double>)                    \
-  X(CastFilterValue<String>)                    \
-  X(CastFilterValueList<Id>)                    \
-  X(CastFilterValueList<Uint32>)                \
-  X(CastFilterValueList<Int32>)                 \
-  X(CastFilterValueList<Int64>)                 \
-  X(CastFilterValueList<Double>)                \
+#define PERFETTO_DATAFRAME_BYTECODE_GENERAL_FVF_LIST(X) \
+  X(CastFilterValue<Id>)                                \
+  X(CastFilterValue<Uint32>)                            \
+  X(CastFilterValue<Int32>)                             \
+  X(CastFilterValue<Int64>)                             \
+  X(CastFilterValue<Double>)                            \
+  X(CastFilterValue<String>)                            \
+  X(CastFilterValueList<Id>)                            \
+  X(CastFilterValueList<Uint32>)                        \
+  X(CastFilterValueList<Int32>)                         \
+  X(CastFilterValueList<Int64>)                         \
+  X(CastFilterValueList<Double>)                        \
   X(CastFilterValueList<String>)
+
+#define PERFETTO_DATAFRAME_BYTECODE_SINGLE_ROW_LIST(X) \
+  X(SingleRowQuery)                                    \
+  X(SingleRowEqPredicate)
+
+#define PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(X) \
+  PERFETTO_DATAFRAME_BYTECODE_GENERAL_FVF_LIST(X)
 
 // Bytecode ops that only need InterpreterState (no FilterValueFetcher).
 #define PERFETTO_DATAFRAME_BYTECODE_STATE_ONLY_LIST(X) \
@@ -783,8 +813,9 @@ struct Reverse : Bytecode {
   X(Reverse)
 
 // Combined list of all bytecode instruction types.
-#define PERFETTO_DATAFRAME_BYTECODE_LIST(X) \
-  PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(X)   \
+#define PERFETTO_DATAFRAME_BYTECODE_LIST(X)      \
+  PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(X)        \
+  PERFETTO_DATAFRAME_BYTECODE_SINGLE_ROW_LIST(X) \
   PERFETTO_DATAFRAME_BYTECODE_STATE_ONLY_LIST(X)
 
 #define PERFETTO_DATAFRAME_BYTECODE_VARIANT(...) __VA_ARGS__,

--- a/src/trace_processor/core/interpreter/bytecode_interpreter.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <type_traits>
 #include <utility>
 
@@ -28,6 +29,7 @@
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_interpreter_state.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
+#include "src/trace_processor/core/util/span.h"
 
 namespace perfetto::trace_processor::core::interpreter {
 
@@ -55,7 +57,11 @@ class Interpreter {
 
   // Executes the bytecode sequence, processing each bytecode instruction in
   // turn, and dispatching to the appropriate function in this class.
-  void Execute(ValueFetcher& filter_value_fetcher);
+  template <typename FilterValueFetcherImpl>
+  PERFETTO_ALWAYS_INLINE Span<uint32_t> Execute(
+      FilterValueFetcherImpl& filter_value_fetcher,
+      ReadHandle<Span<uint32_t>> output_register = ReadHandle<Span<uint32_t>>{
+          std::numeric_limits<uint32_t>::max()});
 
   // Returns the value of the specified register if it contains the expected
   // type. Returns nullptr if the register holds a different type or is empty.
@@ -76,6 +82,8 @@ class Interpreter {
   }
 
  private:
+  void ExecuteGeneralBytecode(ValueFetcher&);
+
   InterpreterState state_;
 };
 

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_impl.cc
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_impl.cc
@@ -354,7 +354,7 @@ namespace perfetto::trace_processor::core::interpreter {
     break;                                                               \
   }
 
-void Interpreter::Execute(ValueFetcher& fetcher) {
+void Interpreter::ExecuteGeneralBytecode(ValueFetcher& fetcher) {
   for (const auto& bytecode : state_.bytecode) {
     switch (bytecode.option) {
       PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(PERFETTO_OP_CASE_FVF)

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_impl.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_impl.h
@@ -701,6 +701,97 @@ inline PERFETTO_ALWAYS_INLINE void CastFilterValue(
   state.WriteToRegister(f.arg<B::write_register>(), result);
 }
 
+template <typename FilterValueFetcherImpl>
+inline PERFETTO_ALWAYS_INLINE bool CastSingleRowId(
+    FilterValueFetcherImpl& fetcher,
+    FilterValueHandle handle,
+    uint32_t& id) {
+  auto type = fetcher.GetValueType(handle.index);
+  auto validity = CastFilterValueToInteger<uint32_t, FilterValueFetcherImpl>(
+      handle, type, fetcher, NonStringOp{Eq{}}, id);
+  return validity == CastFilterValueResult::kValid;
+}
+
+template <typename T, typename FilterValueFetcherImpl>
+inline PERFETTO_ALWAYS_INLINE bool EvaluateSingleRowEqPredicate(
+    InterpreterState& state,
+    FilterValueFetcherImpl& fetcher,
+    const struct SingleRowEqPredicate& predicate,
+    uint32_t row) {
+  using B = struct SingleRowEqPredicate;
+  FilterValueHandle handle = predicate.arg<B::fval_handle>();
+  auto type = fetcher.GetValueType(handle.index);
+  const auto* data =
+      state.ReadStorageFromRegister<T>(predicate.arg<B::storage_register>());
+  if constexpr (IntegerOrDoubleType::Contains<T>()) {
+    using M = typename T::cpp_type;
+    M value;
+    auto validity = CastFilterValueToIntegerOrDouble<M, FilterValueFetcherImpl>(
+        handle, type, fetcher, NonStringOp{Eq{}}, value);
+    return validity == CastFilterValueResult::kValid &&
+           std::equal_to<>()(data[row], value);
+  } else if constexpr (std::is_same_v<T, String>) {
+    const char* value;
+    auto validity = CastFilterValueToString<FilterValueFetcherImpl>(
+        handle, type, fetcher, StringOp{Eq{}}, value);
+    if (validity != CastFilterValueResult::kValid) {
+      return false;
+    }
+    auto id = state.string_pool->GetId(base::StringView(value));
+    return id && data[row] == *id;
+  } else {
+    static_assert(IntegerOrDoubleType::Contains<T>() ||
+                  std::is_same_v<T, String>);
+  }
+}
+
+template <typename FilterValueFetcherImpl>
+inline PERFETTO_ALWAYS_INLINE Span<uint32_t> ExecuteSingleRowQuery(
+    InterpreterState& state,
+    FilterValueFetcherImpl& fetcher,
+    const struct SingleRowQuery& query) {
+  using B = struct SingleRowQuery;
+  uint32_t row = 0;
+  bool matches =
+      CastSingleRowId(fetcher, query.arg<B::id_fval_handle>(), row) &&
+      row < query.arg<B::row_count>();
+
+  const Bytecode* predicates = static_cast<const Bytecode*>(&query) + 1;
+  uint32_t predicate_count = query.arg<B::predicate_count>();
+  for (uint32_t i = 0; matches && i < predicate_count; ++i) {
+    PERFETTO_DCHECK(predicates[i].option == Index<SingleRowEqPredicate>());
+    const auto& predicate =
+        static_cast<const SingleRowEqPredicate&>(predicates[i]);
+    switch (predicate.arg<SingleRowEqPredicate::storage_type>()) {
+      case NonIdStorageType::GetTypeIndex<Uint32>():
+        matches = EvaluateSingleRowEqPredicate<Uint32>(state, fetcher,
+                                                       predicate, row);
+        break;
+      case NonIdStorageType::GetTypeIndex<Int32>():
+        matches =
+            EvaluateSingleRowEqPredicate<Int32>(state, fetcher, predicate, row);
+        break;
+      case NonIdStorageType::GetTypeIndex<Int64>():
+        matches =
+            EvaluateSingleRowEqPredicate<Int64>(state, fetcher, predicate, row);
+        break;
+      case NonIdStorageType::GetTypeIndex<Double>():
+        matches = EvaluateSingleRowEqPredicate<Double>(state, fetcher,
+                                                       predicate, row);
+        break;
+      case NonIdStorageType::GetTypeIndex<String>():
+        matches = EvaluateSingleRowEqPredicate<String>(state, fetcher,
+                                                       predicate, row);
+        break;
+      default:
+        PERFETTO_FATAL("Invalid single-row predicate type");
+    }
+  }
+  state.single_row_result = row;
+  return Span<uint32_t>{&state.single_row_result,
+                        &state.single_row_result + matches};
+}
+
 template <typename T, typename Op>
 inline PERFETTO_ALWAYS_INLINE void NonStringFilter(
     InterpreterState& state,
@@ -1709,6 +1800,26 @@ inline PERFETTO_ALWAYS_INLINE void FindMinMaxIndex(
 }
 
 }  // namespace ops
+
+template <typename FilterValueFetcherImpl>
+PERFETTO_ALWAYS_INLINE Span<uint32_t> Interpreter::Execute(
+    FilterValueFetcherImpl& fetcher,
+    ReadHandle<Span<uint32_t>> output_register) {
+  static_assert(std::is_base_of_v<ValueFetcher, FilterValueFetcherImpl>);
+  if (!state_.bytecode.empty() &&
+      state_.bytecode.front().option == Index<SingleRowQuery>()) {
+    const auto& query =
+        static_cast<const SingleRowQuery&>(state_.bytecode.front());
+    PERFETTO_DCHECK(state_.bytecode.size() ==
+                    query.arg<SingleRowQuery::predicate_count>() + 1);
+    return ops::ExecuteSingleRowQuery(state_, fetcher, query);
+  }
+  ExecuteGeneralBytecode(fetcher);
+  if (output_register.index == std::numeric_limits<uint32_t>::max()) {
+    return {};
+  }
+  return state_.ReadFromRegister(output_register);
+}
 
 }  // namespace perfetto::trace_processor::core::interpreter
 

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_state.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_state.h
@@ -42,6 +42,8 @@ struct InterpreterState {
   base::SmallVector<RegValue, 16> registers;
   // Pointer to the string pool (for string operations)
   const StringPool* string_pool;
+  // Backing storage for zero-or-one-row result spans.
+  uint32_t single_row_result = 0;
 
   /******************************************************************
    * Helper functions for accessing the interpreter state           *

--- a/src/trace_processor/perfetto_sql/engine/dataframe_module.cc
+++ b/src/trace_processor/perfetto_sql/engine/dataframe_module.cc
@@ -20,7 +20,6 @@
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -453,7 +452,7 @@ int DataframeModule::Close(sqlite3_vtab_cursor* cursor) {
 int DataframeModule::Filter(sqlite3_vtab_cursor* cur,
                             int idxNum,
                             const char* idxStr,
-                            int argc,
+                            int,
                             sqlite3_value** argv) {
   auto* c = GetCursor(cur);
   if (idxStr != c->last_idx_str) {
@@ -475,13 +474,7 @@ int DataframeModule::Filter(sqlite3_vtab_cursor* cur,
     c->last_idx_str = idxStr;
     c->id_col_idx = v->id_col_idx;
   }
-  // SQLite's API claims it will never pass more than 16 arguments
-  // so assert that here as our std::array is fixed size.
-  PERFETTO_DCHECK(argc <= 16);
   SqliteValueFetcher fetcher(argv);
-  memcpy(static_cast<void*>(fetcher.sqlite_value.data()),
-         static_cast<void*>(argv),
-         sizeof(sqlite3_value*) * static_cast<size_t>(argc));
   c->df_cursor.Execute(fetcher);
   return SQLITE_OK;
 }

--- a/src/trace_processor/perfetto_sql/engine/dataframe_module.h
+++ b/src/trace_processor/perfetto_sql/engine/dataframe_module.h
@@ -17,14 +17,15 @@
 #ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_ENGINE_DATAFRAME_MODULE_H_
 #define SRC_TRACE_PROCESSOR_PERFETTO_SQL_ENGINE_DATAFRAME_MODULE_H_
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "perfetto/base/logging.h"
 #include "src/trace_processor/containers/null_term_string_view.h"
 #include "src/trace_processor/core/dataframe/cursor.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
@@ -64,29 +65,38 @@ struct DataframeModule : sqlite::Module<DataframeModule> {
     ~SqliteValueFetcher() override;
 
     int64_t GetInt64Value(uint32_t idx) const override {
-      return sqlite::value::Int64(sqlite_value[idx]);
+      return sqlite::value::Int64(GetValue(idx));
     }
     double GetDoubleValue(uint32_t idx) const override {
-      return sqlite::value::Double(sqlite_value[idx]);
+      return sqlite::value::Double(GetValue(idx));
     }
     const char* GetStringValue(uint32_t idx) const override {
-      return sqlite::value::Text(sqlite_value[idx]);
+      return sqlite::value::Text(GetValue(idx));
     }
     Type GetValueType(uint32_t idx) const override {
       static_assert(static_cast<Type>(sqlite::Type::kInteger) == kInt64);
       static_assert(static_cast<Type>(sqlite::Type::kFloat) == kDouble);
       static_assert(static_cast<Type>(sqlite::Type::kText) == kString);
       static_assert(static_cast<Type>(sqlite::Type::kNull) == kNull);
-      return static_cast<Type>(sqlite::value::Type(sqlite_value[idx]));
+      return static_cast<Type>(sqlite::value::Type(GetValue(idx)));
     }
     bool IteratorInit(uint32_t idx) override {
-      return sqlite3_vtab_in_first(argv[idx], &sqlite_value[idx]) == SQLITE_OK;
+      iterator_index = idx;
+      return sqlite3_vtab_in_first(argv[idx], &iterator_value) == SQLITE_OK;
     }
     bool IteratorNext(uint32_t idx) override {
-      return sqlite3_vtab_in_next(argv[idx], &sqlite_value[idx]) == SQLITE_OK;
+      PERFETTO_DCHECK(idx == iterator_index);
+      return sqlite3_vtab_in_next(argv[idx], &iterator_value) == SQLITE_OK;
     }
-    std::array<sqlite3_value*, 16> sqlite_value;
+
+   private:
+    sqlite3_value* GetValue(uint32_t idx) const {
+      return idx == iterator_index ? iterator_value : argv[idx];
+    }
+
     sqlite3_value** argv;
+    sqlite3_value* iterator_value = nullptr;
+    uint32_t iterator_index = std::numeric_limits<uint32_t>::max();
   };
   struct SqliteResultCallback : dataframe::CellCallback {
     void OnCell(int64_t v) const { sqlite::result::Long(ctx, v); }

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_unittest.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_unittest.cc
@@ -132,6 +132,24 @@ TEST_F(PerfettoSqlConnectionTest, Table_Create) {
   ASSERT_TRUE(res.ok()) << res.status().c_message();
 }
 
+TEST_F(PerfettoSqlConnectionTest, Table_InFilter) {
+  auto result =
+      connection_->ExecuteUntilLastStatement(SqlSource::FromExecuteQuery(R"SQL(
+        CREATE PERFETTO TABLE foo AS
+        SELECT 0 AS id, 10 AS value UNION ALL
+        SELECT 1, 20 UNION ALL SELECT 2, 30 UNION ALL SELECT 3, 40;
+        SELECT group_concat(id) FROM (
+          SELECT id FROM foo WHERE value IN (20, 40) ORDER BY id
+        )
+      )SQL"));
+  ASSERT_TRUE(result.ok()) << result.status().c_message();
+  ASSERT_FALSE(result->stmt.IsDone());
+  ASSERT_STREQ(reinterpret_cast<const char*>(
+                   sqlite3_column_text(result->stmt.sqlite_stmt(), 0)),
+               "1,3");
+  ASSERT_FALSE(result->stmt.Step());
+}
+
 TEST_F(PerfettoSqlConnectionTest, Table_StringColumns) {
   auto res = connection_->Execute(SqlSource::FromExecuteQuery(
       "CREATE PERFETTO TABLE foo AS SELECT 'foo' AS bar"));


### PR DESCRIPTION
## Summary

Speed up common SQLite joins when an ID equality constraint means the joined side can return at most one row.

Query planning retains the maximum result cardinality after each emitted bytecode. A small typed rewrite cursor then walks the generated operations and their arguments. Once an ID equality establishes a zero-or-one-row range, range/span materialization operations can be removed and subsequent equality operations can be captured into a compact scalar program. Unsupported operations leave the original program unchanged.

The capture helper provides reusable `Match` and `MatchAny` operations, while the per-operation cardinality can guide future bytecode rewrites without reconstructing query-planning decisions.

The scalar program avoids intermediate range materialization and index allocation, and failed predicates short-circuit immediately. Repeated SQLite filtering also no longer copies a fixed-size argument array.

## Performance

Representative SQLite join benchmark with 1,024 lookups, relative to the preceding PR:

| Path | Before | After |
|---|---:|---:|
| ID hit | ~60 us | ~44 us |
| ID miss | ~41 us | ~30 us |
| ID + value hit | ~76 us | ~57 us |
| Value predicate miss | ~55 us | ~38 us |
| ID miss with value predicate | ~54 us | ~36 us |

Complete stack size:

- Stripped native: 15,278,944 to 15,219,280 bytes (-59,664 bytes)
- Raw release Wasm: 13,616,479 to 13,526,472 bytes (-90,007 bytes)

## Testing

- 180 focused interpreter, query, and SQLite connection tests
- Coverage for all supported scalar predicate types, multiple predicates, nullable fallback, and SQLite `IN`
- Native unit-test, benchmark, and Trace Processor shell builds
- GN dependency check
- Perfetto presubmit

This is the second PR in the stack and depends on #7097.
