### PR TITLE
perfetto: pick JNI lib name matching SDK build variant

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -23205,6 +23205,7 @@ java_library {
 java_defaults {
     name: "perfetto_trace_lib_java_defaults",
     srcs: [
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeLibrary.java",
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java",
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java",
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrack.java",

--- a/BUILD
+++ b/BUILD
@@ -6880,6 +6880,7 @@ perfetto_android_binary(
 perfetto_android_library(
     name = "src_android_sdk_java_main_perfetto_trace_lib",
     srcs = [
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeLibrary.java",
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java",
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java",
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrack.java",

--- a/src/android_sdk/java/main/BUILD.gn
+++ b/src/android_sdk/java/main/BUILD.gn
@@ -5,6 +5,7 @@ assert(enable_perfetto_android_java_sdk)
 
 perfetto_android_library("perfetto_trace_lib") {
   sources = [
+    "dev/perfetto/sdk/PerfettoNativeLibrary.java",
     "dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java",
     "dev/perfetto/sdk/PerfettoTrace.java",
     "dev/perfetto/sdk/PerfettoTrack.java",

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeLibrary.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeLibrary.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.perfetto.sdk;
+
+/**
+ * Loads the JNI library backing the native methods in this package.
+ *
+ * <p>These sources are built twice. The platform build jarjars them into {@code
+ * com.android.internal.dev.perfetto.sdk} and pairs them with {@code libperfetto_framework_jni}; the
+ * standalone SDK build keeps them in {@code dev.perfetto.sdk} and pairs them with {@code
+ * libperfetto_jni}. Both libraries are compiled from the same sources and differ only in the class
+ * names their {@code JNI_OnLoad} registers against, aborting if those classes are absent, so the
+ * variant has to be picked from the package the classes actually landed in.
+ *
+ * @hide
+ */
+final class PerfettoNativeLibrary {
+  private static final String FRAMEWORK_PREFIX = "com.android.internal.";
+
+  /** Loads the JNI library matching this build. Repeat calls are no-ops. */
+  static void load() {
+    boolean isFramework = PerfettoNativeLibrary.class.getName().startsWith(FRAMEWORK_PREFIX);
+    System.loadLibrary(isFramework ? "perfetto_framework_jni" : "perfetto_jni");
+  }
+}

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java
@@ -13,7 +13,7 @@ import java.util.Set;
     "AndroidJdkLibsChecker") // Suppress warning about 'java.lang.ref.Cleaner' in google3.
 public class PerfettoNativeMemoryCleaner {
   static {
-    System.loadLibrary("perfetto_framework_jni");
+    PerfettoNativeLibrary.load();
   }
 
   private final AllocationStats mAllocationStats;

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
@@ -36,7 +36,7 @@ public final class PerfettoTrace {
   private static final String TAG = "PerfettoTrace";
 
   static {
-    System.loadLibrary("perfetto_framework_jni");
+    PerfettoNativeLibrary.load();
   }
 
   // Keep in sync with C++

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 final class PerfettoTrackEventExtra {
   static {
-    System.loadLibrary("perfetto_framework_jni");
+    PerfettoNativeLibrary.load();
   }
 
   private final long mPtr;

--- a/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
+++ b/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
@@ -83,7 +83,6 @@ public class PerfettoTraceTest {
 
   @Before
   public void setUp() {
-    System.loadLibrary("perfetto_jni");
     PerfettoTrace.registerWithDebugChecks(true);
     // 'var unused' suppress error-prone warning
     var unused = FOO_CATEGORY.register();


### PR DESCRIPTION
The Java SDK sources are built twice, against two different .so names:

* platform: jarjar'd to com.android.internal.dev.perfetto.sdk, needs
  libperfetto_framework_jni
* standalone: stays dev.perfetto.sdk, needs libperfetto_jni

https://github.com/google/perfetto/commit/60f2040a8ef4514df1b419293928dd29c4b43b2b hardcoded "perfetto_framework_jni" in the shared sources, so
the standalone consumers now ask for an .so they don't ship:

* perfetto_trace_instrumentation_test and run_android_sdk_host_test both
  die in <clinit> with UnsatisfiedLinkError (http://cl/964137299)
* shipping the framework .so there instead won't work either: its
  JNI_OnLoad looks up the com.android.internal.* names, misses, and
  LOG_ALWAYS_FATALs

Pick the variant from the package the classes actually landed in:

* via Class.getName(), not a string literal, so jarjar leaves it alone
* the load stays in the classes owning the native methods, keeping the
  point of https://github.com/google/perfetto/commit/60f2040a8ef4514df1b419293928dd29c4b43b2b: out of ZygoteInit.preloadSharedLibraries(),
  which --enable-lazy-preload skips
* drop the now-redundant loadLibrary() from PerfettoTraceTest.setUp

Test: https://android-build.corp.google.com/abtd/run/L11400030167989902/?referrer=email
Test: http://sponge2/37af1f39-7a0d-4c39-a066-e1ced37634b6