### PR TITLE
tp: ignore journald stats when parsing logs

### DIFF
--- a/src/trace_processor/importers/proto/linux_probes_parser.cc
+++ b/src/trace_processor/importers/proto/linux_probes_parser.cc
@@ -44,6 +44,19 @@ void LinuxProbesParser::ParseSystemdJournaldEvent(int64_t ts,
                                                   protozero::ConstBytes blob) {
   protos::pbzero::SystemdJournaldEvent::Decoder evt(blob);
 
+  // Flushes emit statistics in a dedicated journald event packet.
+  const bool is_stats = evt.has_num_failed() || evt.has_num_total();
+  if (evt.has_num_failed()) {
+    context_->stats_tracker->SetStats(stats::systemd_journal_num_failed,
+                                      static_cast<int64_t>(evt.num_failed()));
+  }
+  if (evt.has_num_total()) {
+    context_->stats_tracker->SetStats(stats::systemd_journal_num_total,
+                                      static_cast<int64_t>(evt.num_total()));
+  }
+  if (is_stats)
+    return;
+
   auto pid = evt.has_pid() ? static_cast<uint32_t>(evt.pid()) : 0u;
   auto tid = evt.has_tid() ? static_cast<uint32_t>(evt.tid()) : pid;
 
@@ -119,16 +132,6 @@ void LinuxProbesParser::ParseSystemdJournaldEvent(int64_t ts,
     if (transport_id) {
       inserter.AddArg(transport_key_id_, Variadic::String(*transport_id));
     }
-  }
-
-  if (evt.has_num_failed()) {
-    context_->stats_tracker->SetStats(stats::systemd_journal_num_failed,
-                                      static_cast<int64_t>(evt.num_failed()));
-  }
-
-  if (evt.has_num_total()) {
-    context_->stats_tracker->SetStats(stats::systemd_journal_num_total,
-                                      static_cast<int64_t>(evt.num_total()));
   }
 }
 

--- a/test/trace_processor/diff_tests/parser/linux/tests.py
+++ b/test/trace_processor/diff_tests/parser/linux/tests.py
@@ -61,3 +61,26 @@ class Linux(TestSuite):
         "ts","prio","tag","msg","uid","comm","systemd_unit","hostname","transport"
         1000000000,6,"myapp","hello world",1000,"myapp","myapp.service","myhost","journal"
         """))
+
+  def test_journald_stats_not_log(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 1000000000
+          journald_event {
+            num_total: 42
+            num_failed: 0
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE linux.systemd_journald;
+        SELECT
+          (SELECT count(*) FROM linux_systemd_journald_logs) AS log_count,
+          (SELECT value FROM stats WHERE name = 'systemd_journal_num_total') AS num_total,
+          (SELECT value FROM stats WHERE name = 'systemd_journal_num_failed') AS num_failed;
+        """,
+        out=Csv("""
+        "log_count","num_total","num_failed"
+        0,42,0
+        """))


### PR DESCRIPTION
Journald flushes emit statistics in dedicated `SystemdJournaldEvent`
packets. Trace Processor currently inserts those packets into the logs table
before processing their counters, producing empty priority-0 log entries.

Process the statistics first and return without inserting a log row. Add a
diff test which verifies that the counters are preserved while no log entry is
created.

Fixes #7086
