### PR TITLE
ui: fix stdlib module loading

### DIFF
--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_from_tp.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_from_tp.ts
@@ -99,130 +99,83 @@ function summaryDesc(desc: string): string {
   return trimmed;
 }
 
-// Queries the TP's __intrinsic_stdlib_* table functions and merges with the
+// Queries the TP's unified stdlib object catalog and merges it with the
 // pre-generated metadata JSON to build a SqlModules object.
-// Uses 4 parallel queries (one per entity type) instead of per-module queries.
 export async function loadSqlModulesFromTp(
   trace: Trace,
   metadata: StdlibMetadata,
 ): Promise<SqlModules> {
-  const engine = trace.engine;
-
-  const [modsResult, tablesResult, fnsResult, macrosResult] = await Promise.all(
-    [
-      engine.query('SELECT module, package FROM __intrinsic_stdlib_modules()'),
-      engine.query(
-        `SELECT module, name, type, description, exposed, cols
-           FROM __intrinsic_stdlib_tables('*')`,
-      ),
-      engine.query(
-        `SELECT module, name, description, exposed, is_table_function,
-                return_type, return_description, args, cols
-           FROM __intrinsic_stdlib_functions('*')`,
-      ),
-      engine.query(
-        `SELECT module, name, description, exposed,
-                return_type, return_description, args
-           FROM __intrinsic_stdlib_macros('*')`,
-      ),
-    ],
+  const result = await trace.engine.query(
+    `SELECT package, module, name, object_type, description, exposed,
+            return_type, return_description, args, cols
+       FROM __intrinsic_stdlib_objects`,
   );
 
-  // Build package → [module] map.
   const packageMap = new Map<string, string[]>();
-  const modsIter = modsResult.iter({module: STR, package: STR});
-  for (; modsIter.valid(); modsIter.next()) {
-    getOrCreate(packageMap, modsIter.package, () => []).push(modsIter.module);
-  }
-
-  // Group tables by module.
   const tablesByModule = new Map<string, DataObject[]>();
-  const tIter = tablesResult.iter({
-    module: STR,
-    name: STR,
-    type: STR,
-    description: STR,
-    exposed: LONG,
-    cols: STR,
-  });
-  for (; tIter.valid(); tIter.next()) {
-    if (!tIter.exposed) continue;
-    const modKey = tIter.module;
-    const tableMeta = metadata[modKey]?.tables?.[tIter.name];
-    const desc = tIter.description;
-    getOrCreate(tablesByModule, modKey, () => []).push({
-      name: tIter.name,
-      desc,
-      summary_desc: summaryDesc(desc),
-      type: tIter.type,
-      importance: tableMeta?.importance ?? null,
-      data_check_sql: tableMeta?.data_check_sql ?? null,
-      cols: parseEntries(tIter.cols).map((e) => toArgOrCol(e)),
-    });
-  }
-
-  // Group functions and table functions by module.
   const fnsByModule = new Map<string, FnObject[]>();
   const tblFnsByModule = new Map<string, TblFnObject[]>();
-  const fIter = fnsResult.iter({
+  const macrosByModule = new Map<string, MacroObject[]>();
+  const iter = result.iter({
+    package: STR,
     module: STR,
     name: STR,
+    object_type: STR,
     description: STR,
     exposed: LONG,
-    is_table_function: LONG,
     return_type: STR,
     return_description: STR,
     args: STR,
     cols: STR,
   });
-  for (; fIter.valid(); fIter.next()) {
-    if (!fIter.exposed) continue;
-    const modKey = fIter.module;
-    const desc = fIter.description;
-    const args = parseEntries(fIter.args).map((e) => toArgOrCol(e));
-    if (fIter.is_table_function) {
+  for (; iter.valid(); iter.next()) {
+    const modKey = iter.module;
+    if (iter.object_type === 'MODULE') {
+      getOrCreate(packageMap, iter.package, () => []).push(modKey);
+      continue;
+    }
+    if (iter.exposed === 0n) continue;
+
+    const desc = iter.description;
+    const args = parseEntries(iter.args).map((entry) => toArgOrCol(entry));
+    if (iter.object_type === 'TABLE' || iter.object_type === 'VIEW') {
+      const tableMeta = metadata[modKey]?.tables?.[iter.name];
+      getOrCreate(tablesByModule, modKey, () => []).push({
+        name: iter.name,
+        desc,
+        summary_desc: summaryDesc(desc),
+        type: iter.object_type,
+        importance: tableMeta?.importance ?? null,
+        data_check_sql: tableMeta?.data_check_sql ?? null,
+        cols: parseEntries(iter.cols).map((entry) => toArgOrCol(entry)),
+      });
+    } else if (iter.object_type === 'FUNCTION') {
+      getOrCreate(fnsByModule, modKey, () => []).push({
+        name: iter.name,
+        desc,
+        summary_desc: summaryDesc(desc),
+        return_type: iter.return_type,
+        return_desc: iter.return_description,
+        args,
+      });
+    } else if (iter.object_type === 'TABLE_FUNCTION') {
       getOrCreate(tblFnsByModule, modKey, () => []).push({
-        name: fIter.name,
+        name: iter.name,
         desc,
         summary_desc: summaryDesc(desc),
         args,
-        cols: parseEntries(fIter.cols).map((e) => toArgOrCol(e)),
+        cols: parseEntries(iter.cols).map((entry) => toArgOrCol(entry)),
       });
-    } else {
-      getOrCreate(fnsByModule, modKey, () => []).push({
-        name: fIter.name,
+    } else if (iter.object_type === 'MACRO') {
+      getOrCreate(macrosByModule, modKey, () => []).push({
+        name: iter.name,
         desc,
         summary_desc: summaryDesc(desc),
-        return_type: fIter.return_type,
-        return_desc: fIter.return_description,
+        return_type: iter.return_type,
+        return_desc: iter.return_description,
         args,
       });
     }
-  }
-
-  // Group macros by module.
-  const macrosByModule = new Map<string, MacroObject[]>();
-  const mIter = macrosResult.iter({
-    module: STR,
-    name: STR,
-    description: STR,
-    exposed: LONG,
-    return_type: STR,
-    return_description: STR,
-    args: STR,
-  });
-  for (; mIter.valid(); mIter.next()) {
-    if (!mIter.exposed) continue;
-    const modKey = mIter.module;
-    const desc = mIter.description;
-    getOrCreate(macrosByModule, modKey, () => []).push({
-      name: mIter.name,
-      desc,
-      summary_desc: summaryDesc(desc),
-      return_type: mIter.return_type,
-      return_desc: mIter.return_description,
-      args: parseEntries(mIter.args).map((e) => toArgOrCol(e)),
-    });
   }
 
   // Assemble the final docs structure.

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_from_tp_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_from_tp_unittest.ts
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import protos from '../../protos';
+import type {Trace} from '../../public/trace';
+import {createQueryResult} from '../../trace_processor/query_result';
+import {loadSqlModulesFromTp} from './sql_modules_from_tp';
+
+const CELL_TYPE = protos.QueryResult.CellsBatch.CellType;
+
+type ObjectRow = readonly [
+  packageName: string,
+  module: string,
+  name: string,
+  objectType: string,
+  description: string,
+  exposed: number,
+  returnType: string,
+  returnDescription: string,
+  args: string,
+  columns: string,
+];
+
+function makeQueryResult(rows: readonly ObjectRow[]) {
+  const strings = rows.flatMap((row) => [
+    row[0],
+    row[1],
+    row[2],
+    row[3],
+    row[4],
+    row[6],
+    row[7],
+    row[8],
+    row[9],
+  ]);
+  const cells = rows.flatMap(() => [
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_VARINT,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+  ]);
+  const batch = protos.QueryResult.CellsBatch.create({
+    cells,
+    stringCells: strings.join('\0'),
+    varintCells: rows.map((row) => row[5]),
+    isLastBatch: true,
+  });
+  const resultProto = protos.QueryResult.create({
+    columnNames: [
+      'package',
+      'module',
+      'name',
+      'object_type',
+      'description',
+      'exposed',
+      'return_type',
+      'return_description',
+      'args',
+      'cols',
+    ],
+    batch: [batch],
+  });
+  const result = createQueryResult({query: 'stdlib objects'});
+  result.appendResultBatch(protos.QueryResult.encode(resultProto).finish());
+  return result;
+}
+
+test('loads the unified stdlib object catalog', async () => {
+  const entry = (name: string, type: string) =>
+    JSON.stringify([{name, type, description: `${name} description`}]);
+  const result = makeQueryResult([
+    ['test', 'test.module', 'test.module', 'MODULE', '', 1, '', '', '[]', '[]'],
+    [
+      'test',
+      'test.module',
+      'test_table',
+      'TABLE',
+      'A test table.',
+      1,
+      '',
+      '',
+      '[]',
+      entry('value', 'LONG'),
+    ],
+    [
+      'test',
+      'test.module',
+      'test_function',
+      'FUNCTION',
+      'A test function.',
+      1,
+      'LONG',
+      'The result.',
+      entry('input', 'LONG'),
+      '[]',
+    ],
+    [
+      'test',
+      'test.module',
+      'test_table_function',
+      'TABLE_FUNCTION',
+      'A test table function.',
+      1,
+      'TABLE',
+      '',
+      entry('input', 'LONG'),
+      entry('output', 'STRING'),
+    ],
+    [
+      'test',
+      'test.module',
+      'test_macro',
+      'MACRO',
+      'A test macro.',
+      1,
+      'Expr',
+      'The expression.',
+      entry('input', 'Expr'),
+      '[]',
+    ],
+    [
+      'test',
+      'test.module',
+      '_internal_table',
+      'TABLE',
+      'Internal.',
+      0,
+      '',
+      '',
+      '[]',
+      '[]',
+    ],
+  ]);
+  const queries: string[] = [];
+  const trace = {
+    engine: {
+      query: async (sql: string) => {
+        queries.push(sql);
+        return result;
+      },
+    },
+  } as unknown as Trace;
+
+  const sqlModules = await loadSqlModulesFromTp(trace, {
+    'test.module': {
+      tags: ['test'],
+      includes: [],
+      data_check_sql: null,
+      tables: {
+        test_table: {importance: 'high', data_check_sql: null},
+      },
+    },
+  });
+
+  expect(queries).toHaveLength(1);
+  expect(queries[0]).toContain('FROM __intrinsic_stdlib_objects');
+  const module = sqlModules.listModules()[0];
+  expect(module.includeKey).toBe('test.module');
+  expect(module.tables.map((table) => table.name)).toEqual(['test_table']);
+  expect(module.tables[0].importance).toBe('high');
+  expect(module.tables[0].columns[0].name).toBe('value');
+  expect(module.functions[0].name).toBe('test_function');
+  expect(module.functions[0].returnType).toBe('LONG');
+  expect(module.tableFunctions[0].name).toBe('test_table_function');
+  expect(module.tableFunctions[0].returnCols[0].name).toBe('output');
+  expect(module.macros[0].name).toBe('test_macro');
+});


### PR DESCRIPTION
Follow-up to #7096, which replaced the separate stdlib metadata intrinsics with `__intrinsic_stdlib_objects`.

The SQL modules UI plugin still queried the removed intrinsics whenever a trace was opened, causing trace load to fail. 
