### PR TITLE
tp: add dur_without_trampoline to android_startups

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/startup/startups.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/startup/startups.sql
@@ -21,6 +21,8 @@ INCLUDE PERFETTO MODULE android.startup.startups_minsdk29;
 
 INCLUDE PERFETTO MODULE android.startup.startups_minsdk33;
 
+INCLUDE PERFETTO MODULE android.startup.startup_events;
+
 INCLUDE PERFETTO MODULE android.version;
 
 CREATE PERFETTO TABLE _android_startups_raw AS
@@ -153,6 +155,9 @@ CREATE PERFETTO VIEW android_startups(
   ts_end TIMESTAMP,
   -- Startup duration.
   dur DURATION,
+  -- Duration of the launch excluding a preceding trampoline. Equals `dur` when
+  -- there is no trampoline.
+  dur_without_trampoline DURATION,
   -- Package name.
   package STRING,
   -- Startup type.
@@ -164,6 +169,28 @@ SELECT
   r.ts,
   r.ts_end,
   r.dur,
+  coalesce(
+    (
+      SELECT le.dur
+      FROM _startup_events AS le
+      WHERE
+        le.package_name = r.package
+        AND le.ts >= r.ts
+        AND le.ts < r.ts_end
+        AND EXISTS (
+          SELECT 1
+          FROM _startup_events AS e
+          WHERE
+            e.ts >= r.ts
+            AND e.ts < r.ts_end
+            AND e.ts < le.ts
+        )
+      ORDER BY
+        le.ts DESC
+      LIMIT 1
+    ),
+    r.dur
+  ) AS dur_without_trampoline,
   r.package,
   coalesce(r.startup_type, max(p.startup_type)) AS startup_type
 FROM _android_startups_raw AS r

--- a/test/trace_processor/diff_tests/stdlib/android/startups_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/android/startups_tests.py
@@ -29,8 +29,8 @@ class Startups(TestSuite):
         SELECT * FROM android_startups;
         """,
         out=Csv("""
-        "startup_id","ts","ts_end","dur","package","startup_type"
-        0,186969441973689,186969489302704,47329015,"androidx.benchmark.integration.macrobenchmark.target","hot"
+        "startup_id","ts","ts_end","dur","dur_without_trampoline","package","startup_type"
+        0,186969441973689,186969489302704,47329015,47329015,"androidx.benchmark.integration.macrobenchmark.target","hot"
         """))
 
   def test_warm_startups(self):
@@ -41,8 +41,8 @@ class Startups(TestSuite):
         SELECT * FROM android_startups;
         """,
         out=Csv("""
-        "startup_id","ts","ts_end","dur","package","startup_type"
-        0,186982050780778,186982115528805,64748027,"androidx.benchmark.integration.macrobenchmark.target","warm"
+        "startup_id","ts","ts_end","dur","dur_without_trampoline","package","startup_type"
+        0,186982050780778,186982115528805,64748027,64748027,"androidx.benchmark.integration.macrobenchmark.target","warm"
         """))
 
   def test_cold_startups(self):
@@ -53,8 +53,8 @@ class Startups(TestSuite):
         SELECT * FROM android_startups;
         """,
         out=Csv("""
-        "startup_id","ts","ts_end","dur","package","startup_type"
-        0,186974938196632,186975083989042,145792410,"androidx.benchmark.integration.macrobenchmark.target","cold"
+        "startup_id","ts","ts_end","dur","dur_without_trampoline","package","startup_type"
+        0,186974938196632,186975083989042,145792410,145792410,"androidx.benchmark.integration.macrobenchmark.target","cold"
         """))
 
   def test_hot_startups_maxsdk28(self):
@@ -65,9 +65,9 @@ class Startups(TestSuite):
         SELECT * FROM android_startups;
         """,
         out=Csv("""
-        "startup_id","ts","ts_end","dur","package","startup_type"
-        0,779860286416,779893485322,33198906,"com.google.android.googlequicksearchbox","hot"
-        1,780778904571,780813944498,35039927,"androidx.benchmark.integration.macrobenchmark.target","hot"
+        "startup_id","ts","ts_end","dur","dur_without_trampoline","package","startup_type"
+        0,779860286416,779893485322,33198906,33198906,"com.google.android.googlequicksearchbox","hot"
+        1,780778904571,780813944498,35039927,35039927,"androidx.benchmark.integration.macrobenchmark.target","hot"
         """))
 
   def test_warm_startups_maxsdk28(self):
@@ -78,9 +78,9 @@ class Startups(TestSuite):
         SELECT * FROM android_startups;
         """,
         out=Csv("""
-        "startup_id","ts","ts_end","dur","package","startup_type"
-        0,799979565075,800014194731,34629656,"com.google.android.googlequicksearchbox","hot"
-        1,800868511677,800981929562,113417885,"androidx.benchmark.integration.macrobenchmark.target","[NULL]"
+        "startup_id","ts","ts_end","dur","dur_without_trampoline","package","startup_type"
+        0,799979565075,800014194731,34629656,34629656,"com.google.android.googlequicksearchbox","hot"
+        1,800868511677,800981929562,113417885,113417885,"androidx.benchmark.integration.macrobenchmark.target","[NULL]"
         """))
 
   def test_cold_startups_maxsdk28(self):
@@ -91,8 +91,8 @@ class Startups(TestSuite):
         SELECT * FROM android_startups;
         """,
         out=Csv("""
-        "startup_id","ts","ts_end","dur","package","startup_type"
-        0,791231114368,791501060868,269946500,"androidx.benchmark.integration.macrobenchmark.target","[NULL]"
+        "startup_id","ts","ts_end","dur","dur_without_trampoline","package","startup_type"
+        0,791231114368,791501060868,269946500,269946500,"androidx.benchmark.integration.macrobenchmark.target","[NULL]"
         """))
 
   def test_android_startup_time_to_display_hot_maxsdk28(self):


### PR DESCRIPTION
The launchingActivity# span (SDK 33+) coalesces a trampoline launch and the launch it redirects to, so android_startups.dur covers both. Add a dur_without_trampoline column: the duration of the launched package's own "launching:" slice when an earlier launch precedes it in the span, else dur. ts/dur are unchanged.
