### PR TITLE
tools/proto_merger: preserve upstream declaration order for fields

### DIFF
--- a/src/tools/proto_merger/proto_file_serializer_unittest.cc
+++ b/src/tools/proto_merger/proto_file_serializer_unittest.cc
@@ -645,8 +645,9 @@ TEST(ProtoFileSerializerTest, ReservedUpstreamFieldIsMarkedDeprecated) {
   {
     ProtoFile::Message message{};
     message.name = "Container";
-    message.fields.push_back(MakeField("int32", "active_field", 1));
+    message.fields.push_back(MakeField("int32", "active_field_ten", 10));
     message.fields.push_back(MakeField("string", "reserved_field", 2));
+    message.fields.push_back(MakeField("int32", "active_field_five", 5));
     message.fields.push_back(MakeField("bool", "truly_deleted_field", 3));
     input.messages.push_back(message);
   }
@@ -655,7 +656,8 @@ TEST(ProtoFileSerializerTest, ReservedUpstreamFieldIsMarkedDeprecated) {
   {
     ProtoFile::Message message{};
     message.name = "Container";
-    message.fields.push_back(MakeField("int32", "active_field", 1));
+    message.fields.push_back(MakeField("int32", "active_field_ten", 10));
+    message.fields.push_back(MakeField("int32", "active_field_five", 5));
 
     // Field 2 is marked reserved upstream (not in fields list)
     message.reserved_numbers.insert(2);
@@ -669,8 +671,12 @@ TEST(ProtoFileSerializerTest, ReservedUpstreamFieldIsMarkedDeprecated) {
 
   std::string out = ProtoFileToDotProto(merged);
 
-  // 1. active_field is present as normal
-  EXPECT_THAT(out, HasSubstr("int32 active_field = 1;"));
+  // 1. Active fields preserve upstream declaration order (10 before 5)
+  size_t pos_10 = out.find("int32 active_field_ten = 10;");
+  size_t pos_5 = out.find("int32 active_field_five = 5;");
+  EXPECT_NE(pos_10, std::string::npos);
+  EXPECT_NE(pos_5, std::string::npos);
+  EXPECT_LT(pos_10, pos_5);
 
   // 2. reserved_field is kept in active fields with [deprecated = true]
   EXPECT_THAT(out, HasSubstr("string reserved_field = 2 [deprecated = true];"));

--- a/src/tools/proto_merger/proto_merger.cc
+++ b/src/tools/proto_merger/proto_merger.cc
@@ -363,6 +363,7 @@ base::Status MergeField(const ProtoFile::Field& input,
 base::Status MergeFields(const std::vector<ProtoFile::Field>& input,
                          const std::vector<ProtoFile::Field>& upstream,
                          const std::set<int>& allowlist,
+                         const std::unordered_set<int>& reserved_numbers,
                          const std::set<std::string>& known_enums,
                          const std::set<std::string>& allowlisted_options,
                          std::vector<ProtoFile::Field>& out) {
@@ -386,11 +387,14 @@ base::Status MergeFields(const std::vector<ProtoFile::Field>& input,
     out.emplace_back(std::move(out_field));
   }
 
-  // Sort all fields by tag number so reserved/deprecated fields are in place.
-  std::sort(out.begin(), out.end(),
-            [](const ProtoFile::Field& a, const ProtoFile::Field& b) {
-              return a.number < b.number;
-            });
+  // Append reserved fields from input as deprecated fields.
+  for (const auto& input_field : input) {
+    if (reserved_numbers.count(input_field.number)) {
+      ProtoFile::Field deprecated_field = input_field;
+      MarkFieldAsDeprecated(deprecated_field);
+      out.emplace_back(std::move(deprecated_field));
+    }
+  }
 
   return base::OkStatus();
 }
@@ -471,7 +475,7 @@ base::Status Merge(const ProtoFile::Oneof& input,
   out.deleted_fields = ComputeDeletedByNumber(input.fields, upstream.fields);
 
   // Finish by merging the list of fields.
-  return MergeFields(input.fields, upstream.fields, allowlist, known_enums,
+  return MergeFields(input.fields, upstream.fields, allowlist, {}, known_enums,
                      allowlisted_options, out.fields);
 }
 
@@ -495,14 +499,8 @@ base::Status Merge(const ProtoFile::Message& input,
       ComputeDeletedByName(input.nested_messages, upstream.nested_messages);
   out.deleted_oneofs = ComputeDeletedByName(input.oneofs, upstream.oneofs);
 
-  // Check if fields in input are deprecated in upstream or deleted.
-  std::vector<ProtoFile::Field> missing_fields =
-      ComputeDeletedByNumber(input.fields, upstream.fields);
-  for (auto& field : missing_fields) {
-    if (upstream.reserved_numbers.count(field.number)) {
-      MarkFieldAsDeprecated(field);
-      out.fields.emplace_back(std::move(field));
-    } else {
+  for (auto& field : ComputeDeletedByNumber(input.fields, upstream.fields)) {
+    if (!upstream.reserved_numbers.count(field.number)) {
       out.deleted_fields.emplace_back(std::move(field));
     }
   }
@@ -526,7 +524,8 @@ base::Status Merge(const ProtoFile::Message& input,
 
   // Finish by merging the list of fields.
   return MergeFields(input.fields, upstream.fields, allowlist.fields,
-                     known_enums, allowlisted_options, out.fields);
+                     upstream.reserved_numbers, known_enums,
+                     allowlisted_options, out.fields);
 }
 
 }  // namespace


### PR DESCRIPTION
When adding support for preserving reserved fields as `[deprecated = true]` in #7036, `std::sort` was introduced to sort fields by tag number. 

However, fields in Perfetto protos are often grouped logically by feature/subsystem rather than in strict ascending numerical order. Sorting all fields caused massive unnecessary diffs when merging downstream protos (such as `perfetto_log.proto`) by rearranging unchanged active fields.

This change:
1. Removes `std::sort` from `MergeFields` so active fields preserve their exact upstream declaration order.
2. Passes `reserved_numbers` into `MergeFields` to cleanly append retained deprecated fields without disturbing active fields.
3. Filters `reserved_numbers` from `deleted_fields` in `Merge(Message)` to avoid duplicating deprecated fields in the commented-out deleted section.
4. Updates unit tests to verify that non-numerical declaration order is maintained.