### PR TITLE
Revert "Update test RegsFake to get ready for update to remove memory allocations in libunwindstack (#7106)"

### DIFF
--- a/src/profiling/perf/frame_pointer_unwinder_unittest.cc
+++ b/src/profiling/perf/frame_pointer_unwinder_unittest.cc
@@ -30,7 +30,7 @@ namespace {
 
 class RegsFake : public unwindstack::Regs {
  public:
-  explicit RegsFake(uint16_t total_regs)
+  RegsFake(uint16_t total_regs)
       : unwindstack::Regs(
             total_regs,
             unwindstack::Regs::Location(unwindstack::Regs::LOCATION_UNKNOWN,
@@ -41,8 +41,7 @@ class RegsFake : public unwindstack::Regs {
 
   unwindstack::ArchEnum Arch() { return fake_arch_; }
   unwindstack::ArchEnum Arch() const { return fake_arch_; }
-  void* RawData() { return fake_data_.get(); }
-  const void* RawData() const { return fake_data_.get(); }
+  void* RawData() override { return fake_data_.get(); }
   uint64_t pc() { return fake_pc_; }
   uint64_t pc() const { return fake_pc_; }
   uint64_t sp() { return fake_sp_; }
@@ -72,8 +71,7 @@ class RegsFake : public unwindstack::Regs {
   bool SetPcFromReturnAddress(unwindstack::Memory*) override { return false; }
 
   void IterateRegisters(std::function<void(const char*, uint64_t)>) {}
-  void IterateRegisters(
-      const std::function<void(const char*, uint64_t)>&) const {}
+  void IterateRegisters(std::function<void(const char*, uint64_t)>) const {}
 
   bool StepIfSignalHandler(uint64_t,
                            unwindstack::Elf*,


### PR DESCRIPTION
This reverts commit 74c623214251abbcdce9b84d5ddd3d74c3bbc936.

Not compatible with current state of internal gerrit (needs a pending libunwindstack change, afaict). So reverting to unblock the flow of other patches. We should instead make the libunwindstack changes on gerrit and cherry-pick upstream afterwards.