### PR TITLE
Remove invalid utf-8 chars from aflag events

### DIFF
--- a/src/trace_processor/importers/proto/android_probes_parser.cc
+++ b/src/trace_processor/importers/proto/android_probes_parser.cc
@@ -782,14 +782,21 @@ StringId AndroidProbesParser::ToFlagTypeId(int32_t type) {
 }
 
 void AndroidProbesParser::ParseAndroidAflags(int64_t ts, ConstBytes blob) {
+  auto sanitize_and_intern = [&](base::StringView sv) {
+    if (!base::CheckAsciiAndRemoveInvalidUTF8(sv, temp_string_utf8_)) {
+      sv = base::StringView(temp_string_utf8_);
+    }
+    return context_->storage->InternString(sv);
+  };
+
   protos::pbzero::AndroidAflags::Decoder decoder(blob.data, blob.size);
   if (decoder.has_error()) {
     context_->import_logs_tracker->RecordCollectionLog(
         stats::android_aflags_errors, ts,
         [&](ArgsTracker::BoundInserter& inserter) {
-          inserter.AddArg(context_->storage->InternString("error"),
-                          Variadic::String(context_->storage->InternString(
-                              decoder.error())));
+          inserter.AddArg(
+              context_->storage->InternString("error"),
+              Variadic::String(sanitize_and_intern(decoder.error())));
         });
     return;
   }
@@ -799,13 +806,13 @@ void AndroidProbesParser::ParseAndroidAflags(int64_t ts, ConstBytes blob) {
 
     tables::AndroidAflagsTable::Row row;
     row.ts = ts;
-    row.package = context_->storage->InternString(flag.pkg());
-    row.name = context_->storage->InternString(flag.name());
-    row.flag_namespace = context_->storage->InternString(flag.flag_namespace());
-    row.container = context_->storage->InternString(flag.container());
-    row.value = context_->storage->InternString(flag.value());
+    row.package = sanitize_and_intern(flag.pkg());
+    row.name = sanitize_and_intern(flag.name());
+    row.flag_namespace = sanitize_and_intern(flag.flag_namespace());
+    row.container = sanitize_and_intern(flag.container());
+    row.value = sanitize_and_intern(flag.value());
     if (flag.has_staged_value()) {
-      row.staged_value = context_->storage->InternString(flag.staged_value());
+      row.staged_value = sanitize_and_intern(flag.staged_value());
     }
     row.permission = ToPermissionId(flag.permission());
     row.value_picked_from = ToValuePickedFromId(flag.value_picked_from());

--- a/src/trace_processor/importers/proto/android_probes_parser.h
+++ b/src/trace_processor/importers/proto/android_probes_parser.h
@@ -18,6 +18,7 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_ANDROID_PROBES_PARSER_H_
 
 #include <cstdint>
+#include <string>
 
 #include "perfetto/protozero/field.h"
 
@@ -94,6 +95,8 @@ class AndroidProbesParser {
   const StringId aflags_integer_id_;
   const StringId aflags_unspecified_id_;
   const StringId android_logcat_;
+  // Temp string used to store strings after removing non-UTF-8 chars.
+  std::string temp_string_utf8_;
 };
 }  // namespace perfetto::trace_processor
 

--- a/test/trace_processor/diff_tests/parser/android/tests_aflags.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_aflags.py
@@ -73,35 +73,3 @@ class AndroidAflags(TestSuite):
         "ts","name","severity","display_value"
         2000,"android_aflags_errors","error","Failed to read aflags"
         """))
-
-  def test_android_aflags_invalid_utf8(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r"""
-        packet {
-          trusted_packet_sequence_id: 1
-          timestamp: 1000
-          android_aflags {
-            flags {
-              pkg: "com.android.settings\xc0\x80"
-              name: "my_\xd0\xc0flag"
-              flag_namespace: "settings_\xe0\xa4\xc0ns"
-              container: "system\xf0\x9f\x98\xc0"
-              value: "enabled\xf8\x80\x80\x80\x80"
-              staged_value: "disabled\xc0\x80"
-              permission: FLAG_PERMISSION_READ_WRITE
-              value_picked_from: VALUE_PICKED_FROM_LOCAL
-              storage_backend: FLAG_STORAGE_BACKEND_ACONFIGD
-              type: FLAG_TYPE_BOOLEAN
-            }
-          }
-        }
-        """),
-        query="""
-        INCLUDE PERFETTO MODULE android.aflags;
-        SELECT ts, package, name, flag_namespace, container, value, staged_value, permission, value_picked_from, storage_backend, type
-        FROM android_aflags;
-        """,
-        out=Csv("""
-        "ts","package","name","flag_namespace","container","value","staged_value","permission","value_picked_from","storage_backend","type"
-        1000,"com.android.settings","my_flag","settings_ns","system","enabled","disabled","read-write","local","aconfigd","boolean"
-        """))

--- a/test/trace_processor/diff_tests/parser/android/tests_aflags.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_aflags.py
@@ -73,3 +73,35 @@ class AndroidAflags(TestSuite):
         "ts","name","severity","display_value"
         2000,"android_aflags_errors","error","Failed to read aflags"
         """))
+
+  def test_android_aflags_invalid_utf8(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 1000
+          android_aflags {
+            flags {
+              pkg: "com.android.settings\xc0\x80"
+              name: "my_\xd0\xc0flag"
+              flag_namespace: "settings_\xe0\xa4\xc0ns"
+              container: "system\xf0\x9f\x98\xc0"
+              value: "enabled\xf8\x80\x80\x80\x80"
+              staged_value: "disabled\xc0\x80"
+              permission: FLAG_PERMISSION_READ_WRITE
+              value_picked_from: VALUE_PICKED_FROM_LOCAL
+              storage_backend: FLAG_STORAGE_BACKEND_ACONFIGD
+              type: FLAG_TYPE_BOOLEAN
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE android.aflags;
+        SELECT ts, package, name, flag_namespace, container, value, staged_value, permission, value_picked_from, storage_backend, type
+        FROM android_aflags;
+        """,
+        out=Csv("""
+        "ts","package","name","flag_namespace","container","value","staged_value","permission","value_picked_from","storage_backend","type"
+        1000,"com.android.settings","my_flag","settings_ns","system","enabled","disabled","read-write","local","aconfigd","boolean"
+        """))


### PR DESCRIPTION
Remove invalid utf-8 chars from aflag events

Similar to systrace_parser, check ascii and remove invalid utf8 characters to avoid issues in parsing metric outputs.