### PR TITLE
cherry-pick #7096 #7107 #7108 onto canary

### DIFF
--- a/ai/skills/perfetto/infra-references/querying.md
+++ b/ai/skills/perfetto/infra-references/querying.md
@@ -69,10 +69,10 @@ calls. Default to a session.
 
 ## Discovering what's in the trace
 
-PerfettoSQL ships with **intrinsic table-functions** for browsing the
-loaded standard library — modules, tables/views, functions, macros. Use
-these to find what's available and to verify if a Standard Library module
-already provides the needed abstraction before drafting custom logic.
+PerfettoSQL provides a searchable intrinsic table containing every loaded
+standard-library module, table, view, function, table function, and macro. Use
+it to verify whether the Standard Library already provides the needed
+abstraction before drafting custom logic.
 
 **Mandatory Schema Check:** Do not guess column names or join keys. Always
 use a plain `LIMIT 0` query to read the exact column schema of any specific
@@ -85,24 +85,27 @@ table, view, or query result before drafting your query.
 > or stdlib modules** — they can change without notice.
 
 ```sql
--- 1. List every stdlib module currently available.
-SELECT package, module FROM __intrinsic_stdlib_modules ORDER BY 1, 2;
+-- Search every documented stdlib object. Start with one precise phrase or
+-- API-like term. In a regexp, `|` means alternatives: prefer
+-- `breadth.first|bfs`, not a broad expression such as `breadth|graph|search`.
+WITH search(pattern) AS (VALUES ('precise phrase|api_term'))
+SELECT o.qualified_name, o.object_type, o.short_description
+FROM __intrinsic_stdlib_objects AS o, search AS s
+WHERE o.exposed = 1
+  AND regexp(s.pattern, o.summary, 'i')
+ORDER BY regexp(s.pattern, o.qualified_name, 'i') DESC,
+         o.qualified_name
+LIMIT 10;
 
--- 2. List the tables/views a specific module exposes
---    (after INCLUDE PERFETTO MODULE).
-INCLUDE PERFETTO MODULE slices.with_context;
-SELECT name, type, exposed, description
-FROM __intrinsic_stdlib_tables('slices.with_context');
+-- Once a candidate is found, read one human-friendly document containing its
+-- identity, description, arguments, return value, and result columns.
+SELECT o.summary
+FROM __intrinsic_stdlib_objects AS o
+WHERE o.qualified_name =
+  'intervals.overlap.intervals_overlap_count_by_group';
 
--- 3. List functions / macros a module exposes.
-SELECT name, return_type, args
-FROM __intrinsic_stdlib_functions('slices.with_context');
-SELECT name, return_type, args
-FROM __intrinsic_stdlib_macros('android.memory.heap_graph.helpers');
-
--- 4. Read the column schema of any table, view, or query.
---    LIMIT 0 returns the result header with no row scan; trace_processor
---    prints "column N = <name>" lines for each column.
+-- Read the runtime schema of any table, view, or query. LIMIT 0 returns the
+-- result header with no row scan.
 SELECT * FROM slice LIMIT 0;
 SELECT * FROM thread_or_process_slice LIMIT 0;
 SELECT * FROM (SELECT ts, dur, name FROM slice WHERE dur > 0) LIMIT 0;
@@ -208,16 +211,16 @@ reference linked above.
   properties instead of manually joining the `args` table.
 - **JSON Parsing:** When dealing with JSON text, use standard SQLite JSON
   functions (for example, `json_extract()`) to extract values.
-- **String Matching (Always use GLOB).** Use `GLOB` instead of `LIKE`. `LIKE`
+- **String Matching (Avoid `LIKE`).** Use `GLOB` or `regexp()` instead of
+  `LIKE`. `LIKE`
   causes performance bottlenecks and treats underscores (`_`) as wildcards,
   leading to bugs.
   - **Exact matches:** Use `=`.
   - **Substring matches:** Use `GLOB` with `*` (for example, `name GLOB
     '*RenderThread*'`).
-  - **Case-insensitive matches:** Use `LOWER(name) GLOB` and make sure the
-    search string is fully lowercase (for example, `LOWER(name) GLOB
-    '*renderthread*'`). Use this when dealing with inconsistent trace
-    capitalization (for example, `WakeLock` versus `wakelock`).
+  - **Case-insensitive matches:** Use `regexp(pattern, input, 'i')`. It
+    performs a case-insensitive partial match without `LOWER()` or `*`
+    wildcards (for example, `regexp('renderthread', name, 'i')`).
 - **Alias Precision.** Always prefix column names with table or view alias,
   that is: `{alias}.{column_name}`.
 
@@ -260,14 +263,16 @@ To ensure accuracy and efficiency, follow these steps:
 
 1. **Research & Dissection:** Identify the core question and required data
    points.
-2. **Mandatory Schema Validation:** Locate relevant tables via
-   `__intrinsic_stdlib_tables`. Verify column names and types.
-   - **Intent Check:** You must verify if a stdlib module already provides
-   the needed abstraction before drafting manual arithmetic or custom joins.
-  - **IMPORTANT:** If your query requires calculating overlaps,
-   intersections, or boundaries between intervals, you MUST search the
-   `__intrinsic_*` tables globally (for example, `GLOB 'overlap*'`) before
-    writing `MIN()/MAX()` or `IIF(dur = -1...)` logic.
+2. **Mandatory Schema Validation:** Search `__intrinsic_stdlib_objects`
+   globally across modules, tables, views, functions, table functions, and
+   macros. Filter to `exposed = 1`. Use one precise case-insensitive regexp,
+   rank qualified-name matches first, and use `LIMIT 10`. Once a candidate is
+   found, read its `summary`; it contains all argument, column, return, and
+   descriptive metadata.
+   - **Intent Check:** You must verify if a stdlib object already provides the
+   needed abstraction before drafting manual arithmetic or custom joins.
+  - **IMPORTANT:** For overlaps, intersections, or interval boundaries, search
+   the global object table before writing custom timestamp arithmetic.
 3. **Draft & Validate Loop (Max 3 Iterations):**
   - [ ] **Draft:** Use only verified schemas. Ensure `INCLUDE PERFETTO
     MODULE` is present for non-prelude modules.
@@ -275,7 +280,8 @@ To ensure accuracy and efficiency, follow these steps:
     EXISTS` for virtual tables.
   - [ ] **Check Precision:** Are ALL columns prefixed with aliases (e.g.,
     `s.name`)? Are you joining on `utid`/`upid`?
-  - [ ] **String Matching:** Did you use `GLOB` or `=` instead of `LIKE`?
+  - [ ] **String Matching:** Did you use `=`, `GLOB`, or case-insensitive
+    `regexp(..., ..., 'i')` instead of `LIKE`?
   - [ ] **Span Join Check:** If using `SPAN_JOIN`, are tables `PARTITIONED`
     and materialized?
   - [ ] **Execute:** Run against the session:

--- a/src/trace_processor/importers/proto/linux_probes_parser.cc
+++ b/src/trace_processor/importers/proto/linux_probes_parser.cc
@@ -44,6 +44,19 @@ void LinuxProbesParser::ParseSystemdJournaldEvent(int64_t ts,
                                                   protozero::ConstBytes blob) {
   protos::pbzero::SystemdJournaldEvent::Decoder evt(blob);
 
+  // Flushes emit statistics in a dedicated journald event packet.
+  const bool is_stats = evt.has_num_failed() || evt.has_num_total();
+  if (evt.has_num_failed()) {
+    context_->stats_tracker->SetStats(stats::systemd_journal_num_failed,
+                                      static_cast<int64_t>(evt.num_failed()));
+  }
+  if (evt.has_num_total()) {
+    context_->stats_tracker->SetStats(stats::systemd_journal_num_total,
+                                      static_cast<int64_t>(evt.num_total()));
+  }
+  if (is_stats)
+    return;
+
   auto pid = evt.has_pid() ? static_cast<uint32_t>(evt.pid()) : 0u;
   auto tid = evt.has_tid() ? static_cast<uint32_t>(evt.tid()) : pid;
 
@@ -119,16 +132,6 @@ void LinuxProbesParser::ParseSystemdJournaldEvent(int64_t ts,
     if (transport_id) {
       inserter.AddArg(transport_key_id_, Variadic::String(*transport_id));
     }
-  }
-
-  if (evt.has_num_failed()) {
-    context_->stats_tracker->SetStats(stats::systemd_journal_num_failed,
-                                      static_cast<int64_t>(evt.num_failed()));
-  }
-
-  if (evt.has_num_total()) {
-    context_->stats_tracker->SetStats(stats::systemd_journal_num_total,
-                                      static_cast<int64_t>(evt.num_total()));
   }
 }
 

--- a/src/trace_processor/plugins/stdlib_docs/stdlib_docs.cc
+++ b/src/trace_processor/plugins/stdlib_docs/stdlib_docs.cc
@@ -16,10 +16,12 @@
 
 #include "src/trace_processor/plugins/stdlib_docs/stdlib_docs.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -48,15 +50,104 @@ template <typename Entry>
 std::string SerializeEntries(const std::vector<Entry>& entries) {
   return json::SerializeJson([&](json::JsonValueSerializer&& writer) {
     std::move(writer).WriteArray([&](json::JsonArraySerializer& array) {
-      for (const auto& e : entries) {
+      for (const auto& entry : entries) {
         array.AppendDict([&](json::JsonDictSerializer& dict) {
-          dict.AddString("name", e.name);
-          dict.AddString("type", e.type);
-          dict.AddString("description", e.description);
+          dict.AddString("name", entry.name);
+          dict.AddString("type", entry.type);
+          dict.AddString("description", entry.description);
         });
       }
     });
   });
+}
+
+template <typename Entry>
+void AppendSummaryEntries(const char* heading,
+                          const std::vector<Entry>& entries,
+                          std::string* summary) {
+  if (entries.empty()) {
+    return;
+  }
+  summary->append("\n").append(heading).append(":");
+  for (const auto& entry : entries) {
+    summary->append("\n- ")
+        .append(entry.name)
+        .append(" (")
+        .append(entry.type)
+        .append(")");
+    if (!entry.description.empty()) {
+      summary->append(": ").append(entry.description);
+    }
+  }
+}
+
+std::string_view ShortDescription(std::string_view description) {
+  size_t size = std::min<size_t>(description.size(), 160);
+  while (size > 0 && size < description.size() &&
+         (static_cast<uint8_t>(description[size]) & 0xc0) == 0x80) {
+    --size;
+  }
+  return description.substr(0, size);
+}
+
+std::string HumanizeName(std::string_view package,
+                         std::string_view module,
+                         std::string_view name) {
+  std::string humanized;
+  humanized.reserve(package.size() + module.size() + name.size() + 2);
+  humanized.append(package);
+  humanized.push_back(' ');
+  humanized.append(module);
+  if (!name.empty() && name != module) {
+    humanized.push_back(' ');
+    humanized.append(name);
+  }
+  for (char& c : humanized) {
+    if (c == '.' || c == '_') {
+      c = ' ';
+    }
+  }
+  return humanized;
+}
+
+template <typename Arg, typename Column>
+std::string BuildSummary(std::string_view package,
+                         std::string_view module,
+                         std::string_view name,
+                         std::string_view qualified_name,
+                         std::string_view object_type,
+                         bool exposed,
+                         std::string_view description,
+                         std::string_view return_type,
+                         std::string_view return_description,
+                         const std::vector<Arg>& args,
+                         const std::vector<Column>& columns) {
+  std::string summary;
+  summary.reserve(package.size() + module.size() + name.size() +
+                  description.size() + return_description.size() + 128);
+  summary.append("Package: ").append(package);
+  summary.append("\nModule: ").append(module);
+  if (object_type != "MODULE") {
+    summary.append("\nName: ").append(name);
+  }
+  summary.append("\nQualified name: ").append(qualified_name);
+  summary.append("\nSearch aliases: ")
+      .append(HumanizeName(package, module, name))
+      .append("\nKind: ")
+      .append(exposed ? "public " : "internal ");
+  summary.append(object_type);
+  if (!description.empty()) {
+    summary.append("\nDescription: ").append(description);
+  }
+  AppendSummaryEntries("Arguments", args, &summary);
+  if (!return_type.empty()) {
+    summary.append("\nReturns: ").append(return_type);
+    if (!return_description.empty()) {
+      summary.append(": ").append(return_description);
+    }
+  }
+  AppendSummaryEntries("Columns", columns, &summary);
+  return summary;
 }
 
 // Parses |module_key| in the caller-resolved |package|. The package must not
@@ -82,375 +173,117 @@ base::StatusOr<stdlib_doc::ParsedModule> ParseModule(
   return parsed;
 }
 
-// __intrinsic_stdlib_modules() — lists all (module, package) pairs.
-class StdlibDocsModules : public StaticTableFunction {
+// __intrinsic_stdlib_objects is a zero-argument, table-like intrinsic.
+class StdlibDocsObjects : public StaticTableFunction {
  public:
   class Cursor : public StaticTableFunction::Cursor {
    public:
-    explicit Cursor(StringPool*, const PerfettoSqlConnection*);
-    bool Run(const std::vector<SqlValue>& arguments) override;
+    Cursor(StringPool* pool, const PerfettoSqlConnection* connection)
+        : string_pool_(pool), engine_(connection), table_(pool) {}
 
-   private:
-    StringPool* string_pool_ = nullptr;
-    const PerfettoSqlConnection* engine_ = nullptr;
-    tables::StdlibDocsModulesTable table_;
-  };
-
-  explicit StdlibDocsModules(StringPool*, const PerfettoSqlConnection*);
-  std::unique_ptr<StaticTableFunction::Cursor> MakeCursor() override;
-  dataframe::DataframeSpec CreateSpec() override;
-  std::string TableName() override;
-  uint32_t GetArgumentCount() const override;
-
- private:
-  StringPool* string_pool_ = nullptr;
-  const PerfettoSqlConnection* engine_ = nullptr;
-};
-
-// __intrinsic_stdlib_tables(module) — table/view metadata for a module.
-class StdlibDocsTables : public StaticTableFunction {
- public:
-  class Cursor : public StaticTableFunction::Cursor {
-   public:
-    explicit Cursor(StringPool*, const PerfettoSqlConnection*);
-    bool Run(const std::vector<SqlValue>& arguments) override;
-
-   private:
-    StringPool* string_pool_ = nullptr;
-    const PerfettoSqlConnection* engine_ = nullptr;
-    tables::StdlibDocsTablesTable table_;
-  };
-
-  explicit StdlibDocsTables(StringPool*, const PerfettoSqlConnection*);
-  std::unique_ptr<StaticTableFunction::Cursor> MakeCursor() override;
-  dataframe::DataframeSpec CreateSpec() override;
-  std::string TableName() override;
-  uint32_t GetArgumentCount() const override;
-
- private:
-  StringPool* string_pool_ = nullptr;
-  const PerfettoSqlConnection* engine_ = nullptr;
-};
-
-// __intrinsic_stdlib_functions(module) — function metadata for a module.
-class StdlibDocsFunctions : public StaticTableFunction {
- public:
-  class Cursor : public StaticTableFunction::Cursor {
-   public:
-    explicit Cursor(StringPool*, const PerfettoSqlConnection*);
-    bool Run(const std::vector<SqlValue>& arguments) override;
-
-   private:
-    StringPool* string_pool_ = nullptr;
-    const PerfettoSqlConnection* engine_ = nullptr;
-    tables::StdlibDocsFunctionsTable table_;
-  };
-
-  explicit StdlibDocsFunctions(StringPool*, const PerfettoSqlConnection*);
-  std::unique_ptr<StaticTableFunction::Cursor> MakeCursor() override;
-  dataframe::DataframeSpec CreateSpec() override;
-  std::string TableName() override;
-  uint32_t GetArgumentCount() const override;
-
- private:
-  StringPool* string_pool_ = nullptr;
-  const PerfettoSqlConnection* engine_ = nullptr;
-};
-
-// __intrinsic_stdlib_macros(module) — macro metadata for a module.
-class StdlibDocsMacros : public StaticTableFunction {
- public:
-  class Cursor : public StaticTableFunction::Cursor {
-   public:
-    explicit Cursor(StringPool*, const PerfettoSqlConnection*);
-    bool Run(const std::vector<SqlValue>& arguments) override;
-
-   private:
-    StringPool* string_pool_ = nullptr;
-    const PerfettoSqlConnection* engine_ = nullptr;
-    tables::StdlibDocsMacrosTable table_;
-  };
-
-  explicit StdlibDocsMacros(StringPool*, const PerfettoSqlConnection*);
-  std::unique_ptr<StaticTableFunction::Cursor> MakeCursor() override;
-  dataframe::DataframeSpec CreateSpec() override;
-  std::string TableName() override;
-  uint32_t GetArgumentCount() const override;
-
- private:
-  StringPool* string_pool_ = nullptr;
-  const PerfettoSqlConnection* engine_ = nullptr;
-};
-// Calls callback(module_key, parsed) for each module matched by |arg|.
-// If |arg| is "*", all loaded modules are visited; otherwise exactly |arg|.
-// Returns the first parse failure encountered, if any.
-template <typename Fn>
-base::Status ForEachModule(const PerfettoSqlConnection* engine,
-                           const std::string& arg,
-                           Fn callback) {
-  if (arg == "*") {
-    for (const auto& kv : engine->GetModules()) {
-      const std::string& pkg = kv.first;
-      const std::string& mod = kv.second;
-      // The package name comes straight from the registry, so no re-derivation
-      // from the module key is needed (and would be wrong for dotted packages).
-      auto parsed_or = ParseModule(engine->FindPackage(pkg), mod);
-      if (!parsed_or.ok()) {
-        return parsed_or.status();
+    bool Run(const std::vector<SqlValue>& arguments) override {
+      PERFETTO_DCHECK(arguments.empty());
+      auto dataframe = GetDataframe();
+      if (!dataframe.ok()) {
+        return OnFailure(dataframe.status());
       }
-      callback(mod, *parsed_or);
+      return OnSuccess(*dataframe);
     }
-  } else {
-    auto parsed_or = ParseModule(engine->FindPackageForModule(arg), arg);
-    if (!parsed_or.ok()) {
-      return parsed_or.status();
+
+   private:
+    base::StatusOr<dataframe::Dataframe*> GetDataframe() {
+      table_.Clear();
+      const std::vector<stdlib_doc::Arg> no_args;
+      const std::vector<stdlib_doc::Column> no_columns;
+      for (const auto& package_and_module : engine_->GetModules()) {
+        const std::string& package = package_and_module.first;
+        const std::string& module = package_and_module.second;
+        auto parsed = ParseModule(engine_->FindPackage(package), module);
+        if (!parsed.ok()) {
+          return parsed.status();
+        }
+
+        auto insert = [&](std::string_view name,
+                          std::string_view qualified_name,
+                          std::string_view object_type, bool exposed,
+                          std::string_view description,
+                          std::string_view return_type,
+                          std::string_view return_description, const auto& args,
+                          const auto& columns) {
+          tables::StdlibDocsObjectsTable::Row row;
+          row.package = string_pool_->InternString(base::StringView(package));
+          row.module = string_pool_->InternString(base::StringView(module));
+          row.name = string_pool_->InternString(base::StringView(name));
+          row.qualified_name =
+              string_pool_->InternString(base::StringView(qualified_name));
+          row.object_type =
+              string_pool_->InternString(base::StringView(object_type));
+          row.exposed = exposed ? 1 : 0;
+          row.short_description = string_pool_->InternString(
+              base::StringView(ShortDescription(description)));
+          row.summary = string_pool_->InternString(base::StringView(
+              BuildSummary(package, module, name, qualified_name, object_type,
+                           exposed, description, return_type,
+                           return_description, args, columns)));
+          row.description =
+              string_pool_->InternString(base::StringView(description));
+          row.return_type =
+              string_pool_->InternString(base::StringView(return_type));
+          row.return_description =
+              string_pool_->InternString(base::StringView(return_description));
+          row.args = string_pool_->InternString(
+              base::StringView(SerializeEntries(args)));
+          row.cols = string_pool_->InternString(
+              base::StringView(SerializeEntries(columns)));
+          table_.Insert(row);
+        };
+
+        insert(module, module, "MODULE", true, "", "", "", no_args, no_columns);
+        for (const auto& table_view : parsed->table_views) {
+          insert(table_view.name, module + "." + table_view.name,
+                 table_view.type, table_view.exposed, table_view.description,
+                 "", "", no_args, table_view.columns);
+        }
+        for (const auto& function : parsed->functions) {
+          insert(function.name, module + "." + function.name,
+                 function.is_table_function ? "TABLE_FUNCTION" : "FUNCTION",
+                 function.exposed, function.description, function.return_type,
+                 function.return_description, function.args, function.columns);
+        }
+        for (const auto& macro : parsed->macros) {
+          insert(macro.name, module + "." + macro.name, "MACRO", macro.exposed,
+                 macro.description, macro.return_type, macro.return_description,
+                 macro.args, no_columns);
+        }
+      }
+
+      return &table_.dataframe();
     }
-    callback(arg, *parsed_or);
+
+    StringPool* string_pool_ = nullptr;
+    const PerfettoSqlConnection* engine_ = nullptr;
+    tables::StdlibDocsObjectsTable table_;
+  };
+
+  StdlibDocsObjects(StringPool* pool, const PerfettoSqlConnection* connection)
+      : string_pool_(pool), engine_(connection) {}
+
+  std::unique_ptr<StaticTableFunction::Cursor> MakeCursor() override {
+    return std::make_unique<Cursor>(string_pool_, engine_);
   }
-  return base::OkStatus();
-}
 
-// ============================================================================
-// StdlibDocsModules
-// ============================================================================
-
-StdlibDocsModules::Cursor::Cursor(StringPool* pool,
-                                  const PerfettoSqlConnection* connection)
-    : string_pool_(pool), engine_(connection), table_(pool) {}
-
-bool StdlibDocsModules::Cursor::Run(const std::vector<SqlValue>& arguments) {
-  PERFETTO_DCHECK(arguments.empty());
-  table_.Clear();
-  for (const auto& [pkg, mod] : engine_->GetModules()) {
-    tables::StdlibDocsModulesTable::Row row;
-    row.module = string_pool_->InternString(base::StringView(mod));
-    row.package = string_pool_->InternString(base::StringView(pkg));
-    table_.Insert(row);
+  dataframe::DataframeSpec CreateSpec() override {
+    return tables::StdlibDocsObjectsTable::kSpec.ToUntypedDataframeSpec();
   }
-  return OnSuccess(&table_.dataframe());
-}
 
-StdlibDocsModules::StdlibDocsModules(StringPool* pool,
-                                     const PerfettoSqlConnection* connection)
-    : string_pool_(pool), engine_(connection) {}
+  std::string TableName() override { return "__intrinsic_stdlib_objects"; }
 
-std::unique_ptr<StaticTableFunction::Cursor> StdlibDocsModules::MakeCursor() {
-  return std::make_unique<Cursor>(string_pool_, engine_);
-}
+  uint32_t GetArgumentCount() const override { return 0; }
 
-dataframe::DataframeSpec StdlibDocsModules::CreateSpec() {
-  return tables::StdlibDocsModulesTable::kSpec.ToUntypedDataframeSpec();
-}
-
-std::string StdlibDocsModules::TableName() {
-  return "__intrinsic_stdlib_modules";
-}
-
-uint32_t StdlibDocsModules::GetArgumentCount() const {
-  return 0;
-}
-
-// ============================================================================
-// StdlibDocsTables
-// ============================================================================
-
-StdlibDocsTables::Cursor::Cursor(StringPool* pool,
-                                 const PerfettoSqlConnection* connection)
-    : string_pool_(pool), engine_(connection), table_(pool) {}
-
-bool StdlibDocsTables::Cursor::Run(const std::vector<SqlValue>& arguments) {
-  PERFETTO_DCHECK(arguments.size() == 1);
-  table_.Clear();
-  if (arguments[0].is_null()) {
-    return OnSuccess(&table_.dataframe());
-  }
-  if (arguments[0].type != SqlValue::kString) {
-    return OnFailure(
-        base::ErrStatus("__intrinsic_stdlib_tables: module must be a string"));
-  }
-  std::string arg = arguments[0].AsString();
-  auto st = ForEachModule(
-      engine_, arg,
-      [&](const std::string& module_key,
-          const stdlib_doc::ParsedModule& parsed) {
-        StringPool::Id mod_id =
-            string_pool_->InternString(base::StringView(module_key));
-        for (const auto& tv : parsed.table_views) {
-          tables::StdlibDocsTablesTable::Row row;
-          row.module = mod_id;
-          row.name = string_pool_->InternString(base::StringView(tv.name));
-          row.type = string_pool_->InternString(base::StringView(tv.type));
-          row.description =
-              string_pool_->InternString(base::StringView(tv.description));
-          row.exposed = tv.exposed ? 1 : 0;
-          row.cols = string_pool_->InternString(
-              base::StringView(SerializeEntries(tv.columns)));
-          table_.Insert(row);
-        }
-      });
-  if (!st.ok()) {
-    return OnFailure(st);
-  }
-  return OnSuccess(&table_.dataframe());
-}
-
-StdlibDocsTables::StdlibDocsTables(StringPool* pool,
-                                   const PerfettoSqlConnection* connection)
-    : string_pool_(pool), engine_(connection) {}
-
-std::unique_ptr<StaticTableFunction::Cursor> StdlibDocsTables::MakeCursor() {
-  return std::make_unique<Cursor>(string_pool_, engine_);
-}
-
-dataframe::DataframeSpec StdlibDocsTables::CreateSpec() {
-  return tables::StdlibDocsTablesTable::kSpec.ToUntypedDataframeSpec();
-}
-
-std::string StdlibDocsTables::TableName() {
-  return "__intrinsic_stdlib_tables";
-}
-
-uint32_t StdlibDocsTables::GetArgumentCount() const {
-  return 1;
-}
-
-// ============================================================================
-// StdlibDocsFunctions
-// ============================================================================
-
-StdlibDocsFunctions::Cursor::Cursor(StringPool* pool,
-                                    const PerfettoSqlConnection* connection)
-    : string_pool_(pool), engine_(connection), table_(pool) {}
-
-bool StdlibDocsFunctions::Cursor::Run(const std::vector<SqlValue>& arguments) {
-  PERFETTO_DCHECK(arguments.size() == 1);
-  table_.Clear();
-  if (arguments[0].is_null()) {
-    return OnSuccess(&table_.dataframe());
-  }
-  if (arguments[0].type != SqlValue::kString) {
-    return OnFailure(base::ErrStatus(
-        "__intrinsic_stdlib_functions: module must be a string"));
-  }
-  std::string arg = arguments[0].AsString();
-  auto st = ForEachModule(
-      engine_, arg,
-      [&](const std::string& module_key,
-          const stdlib_doc::ParsedModule& parsed) {
-        StringPool::Id mod_id =
-            string_pool_->InternString(base::StringView(module_key));
-        for (const auto& fn : parsed.functions) {
-          tables::StdlibDocsFunctionsTable::Row row;
-          row.module = mod_id;
-          row.name = string_pool_->InternString(base::StringView(fn.name));
-          row.description =
-              string_pool_->InternString(base::StringView(fn.description));
-          row.exposed = fn.exposed ? 1 : 0;
-          row.is_table_function = fn.is_table_function ? 1 : 0;
-          row.return_type =
-              string_pool_->InternString(base::StringView(fn.return_type));
-          row.return_description = string_pool_->InternString(
-              base::StringView(fn.return_description));
-          row.args = string_pool_->InternString(
-              base::StringView(SerializeEntries(fn.args)));
-          row.cols = string_pool_->InternString(
-              base::StringView(SerializeEntries(fn.columns)));
-          table_.Insert(row);
-        }
-      });
-  if (!st.ok()) {
-    return OnFailure(st);
-  }
-  return OnSuccess(&table_.dataframe());
-}
-
-StdlibDocsFunctions::StdlibDocsFunctions(
-    StringPool* pool,
-    const PerfettoSqlConnection* connection)
-    : string_pool_(pool), engine_(connection) {}
-
-std::unique_ptr<StaticTableFunction::Cursor> StdlibDocsFunctions::MakeCursor() {
-  return std::make_unique<Cursor>(string_pool_, engine_);
-}
-
-dataframe::DataframeSpec StdlibDocsFunctions::CreateSpec() {
-  return tables::StdlibDocsFunctionsTable::kSpec.ToUntypedDataframeSpec();
-}
-
-std::string StdlibDocsFunctions::TableName() {
-  return "__intrinsic_stdlib_functions";
-}
-
-uint32_t StdlibDocsFunctions::GetArgumentCount() const {
-  return 1;
-}
-
-// ============================================================================
-// StdlibDocsMacros
-// ============================================================================
-
-StdlibDocsMacros::Cursor::Cursor(StringPool* pool,
-                                 const PerfettoSqlConnection* connection)
-    : string_pool_(pool), engine_(connection), table_(pool) {}
-
-bool StdlibDocsMacros::Cursor::Run(const std::vector<SqlValue>& arguments) {
-  PERFETTO_DCHECK(arguments.size() == 1);
-  table_.Clear();
-  if (arguments[0].is_null()) {
-    return OnSuccess(&table_.dataframe());
-  }
-  if (arguments[0].type != SqlValue::kString) {
-    return OnFailure(
-        base::ErrStatus("__intrinsic_stdlib_macros: module must be a string"));
-  }
-  std::string arg = arguments[0].AsString();
-  auto st = ForEachModule(
-      engine_, arg,
-      [&](const std::string& module_key,
-          const stdlib_doc::ParsedModule& parsed) {
-        StringPool::Id mod_id =
-            string_pool_->InternString(base::StringView(module_key));
-        for (const auto& macro : parsed.macros) {
-          tables::StdlibDocsMacrosTable::Row row;
-          row.module = mod_id;
-          row.name = string_pool_->InternString(base::StringView(macro.name));
-          row.description =
-              string_pool_->InternString(base::StringView(macro.description));
-          row.exposed = macro.exposed ? 1 : 0;
-          row.return_type =
-              string_pool_->InternString(base::StringView(macro.return_type));
-          row.return_description = string_pool_->InternString(
-              base::StringView(macro.return_description));
-          row.args = string_pool_->InternString(
-              base::StringView(SerializeEntries(macro.args)));
-          table_.Insert(row);
-        }
-      });
-  if (!st.ok()) {
-    return OnFailure(st);
-  }
-  return OnSuccess(&table_.dataframe());
-}
-
-StdlibDocsMacros::StdlibDocsMacros(StringPool* pool,
-                                   const PerfettoSqlConnection* connection)
-    : string_pool_(pool), engine_(connection) {}
-
-std::unique_ptr<StaticTableFunction::Cursor> StdlibDocsMacros::MakeCursor() {
-  return std::make_unique<Cursor>(string_pool_, engine_);
-}
-
-dataframe::DataframeSpec StdlibDocsMacros::CreateSpec() {
-  return tables::StdlibDocsMacrosTable::kSpec.ToUntypedDataframeSpec();
-}
-
-std::string StdlibDocsMacros::TableName() {
-  return "__intrinsic_stdlib_macros";
-}
-
-uint32_t StdlibDocsMacros::GetArgumentCount() const {
-  return 1;
-}
+ private:
+  StringPool* string_pool_ = nullptr;
+  const PerfettoSqlConnection* engine_ = nullptr;
+};
 
 class StdlibDocsPlugin : public Plugin<StdlibDocsPlugin> {
  public:
@@ -458,12 +291,10 @@ class StdlibDocsPlugin : public Plugin<StdlibDocsPlugin> {
 
   void RegisterStaticTableFunctions(
       PerfettoSqlConnection* connection,
-      std::vector<std::unique_ptr<StaticTableFunction>>& fns) override {
+      std::vector<std::unique_ptr<StaticTableFunction>>& functions) override {
     StringPool* pool = trace_context_->storage->mutable_string_pool();
-    fns.emplace_back(std::make_unique<StdlibDocsModules>(pool, connection));
-    fns.emplace_back(std::make_unique<StdlibDocsTables>(pool, connection));
-    fns.emplace_back(std::make_unique<StdlibDocsFunctions>(pool, connection));
-    fns.emplace_back(std::make_unique<StdlibDocsMacros>(pool, connection));
+    functions.emplace_back(
+        std::make_unique<StdlibDocsObjects>(pool, connection));
   }
 };
 

--- a/src/trace_processor/plugins/stdlib_docs/tables.py
+++ b/src/trace_processor/plugins/stdlib_docs/tables.py
@@ -18,43 +18,21 @@ from python.generators.trace_processor_table.public import CppString
 from python.generators.trace_processor_table.public import Purpose
 from python.generators.trace_processor_table.public import Table
 
-STDLIB_DOCS_MODULES_TABLE = Table(
+STDLIB_DOCS_OBJECTS_TABLE = Table(
     python_module=__file__,
-    class_name="StdlibDocsModulesTable",
+    class_name="StdlibDocsObjectsTable",
     purpose=Purpose.STATIC_TABLE_FUNCTION,
-    sql_name="__intrinsic_stdlib_modules",
+    sql_name="not_exposed_to_sql",
     columns=[
-        C("module", CppString()),
         C("package", CppString()),
-    ],
-)
-
-STDLIB_DOCS_TABLES_TABLE = Table(
-    python_module=__file__,
-    class_name="StdlibDocsTablesTable",
-    purpose=Purpose.STATIC_TABLE_FUNCTION,
-    sql_name="not_exposed_to_sql",
-    columns=[
         C("module", CppString()),
         C("name", CppString()),
-        C("type", CppString()),
-        C("description", CppString()),
+        C("qualified_name", CppString()),
+        C("object_type", CppString()),
         C("exposed", CppInt64()),
-        C("cols", CppString()),
-    ],
-)
-
-STDLIB_DOCS_FUNCTIONS_TABLE = Table(
-    python_module=__file__,
-    class_name="StdlibDocsFunctionsTable",
-    purpose=Purpose.STATIC_TABLE_FUNCTION,
-    sql_name="not_exposed_to_sql",
-    columns=[
-        C("module", CppString()),
-        C("name", CppString()),
+        C("short_description", CppString()),
+        C("summary", CppString()),
         C("description", CppString()),
-        C("exposed", CppInt64()),
-        C("is_table_function", CppInt64()),
         C("return_type", CppString()),
         C("return_description", CppString()),
         C("args", CppString()),
@@ -62,26 +40,4 @@ STDLIB_DOCS_FUNCTIONS_TABLE = Table(
     ],
 )
 
-STDLIB_DOCS_MACROS_TABLE = Table(
-    python_module=__file__,
-    class_name="StdlibDocsMacrosTable",
-    purpose=Purpose.STATIC_TABLE_FUNCTION,
-    sql_name="not_exposed_to_sql",
-    columns=[
-        C("module", CppString()),
-        C("name", CppString()),
-        C("description", CppString()),
-        C("exposed", CppInt64()),
-        C("return_type", CppString()),
-        C("return_description", CppString()),
-        C("args", CppString()),
-    ],
-)
-
-# Keep this list sorted.
-ALL_TABLES = [
-    STDLIB_DOCS_FUNCTIONS_TABLE,
-    STDLIB_DOCS_MACROS_TABLE,
-    STDLIB_DOCS_MODULES_TABLE,
-    STDLIB_DOCS_TABLES_TABLE,
-]
+ALL_TABLES = [STDLIB_DOCS_OBJECTS_TABLE]

--- a/src/trace_processor/trace_database_integrationtest.cc
+++ b/src/trace_processor/trace_database_integrationtest.cc
@@ -1219,24 +1219,25 @@ TEST_F(TraceProcessorIntegrationTest, PackagePrefixClash_NewIsPrefix) {
   ASSERT_THAT(status.message(), HasSubstr("clashes"));
 }
 
-TEST_F(TraceProcessorIntegrationTest, StdlibDocsWildcardDottedPackage) {
+TEST_F(TraceProcessorIntegrationTest, StdlibDocsObjectsDottedPackage) {
   ASSERT_OK(NotifyEndOfFile());
 
-  // A package whose *name* itself contains dots, owning a module beneath it.
-  // The stdlib docs table functions must resolve the owning package via the
-  // (package, module) pairs from the registry, not by splitting the module key
-  // on the first '.' (which would yield "dev" and fail to find the package).
+  // A package whose name itself contains dots, owning a module beneath it.
+  // Package ownership must come directly from the registry rather than from
+  // splitting the module key on the first dot.
   SqlPackage pkg;
   pkg.name = "dev.perfetto.test";
   pkg.modules.push_back({"dev.perfetto.test.common", "SELECT 1"});
   ASSERT_OK(Processor()->RegisterSqlPackage(pkg));
 
-  // The wildcard enumerates every registered module, including the dotted one.
-  // Before the fix this failed with "Module not found:
-  // dev.perfetto.test.common" and aborted the whole query.
-  auto it = Query("SELECT COUNT(*) AS c FROM __intrinsic_stdlib_tables('*')");
-  ASSERT_TRUE(it.Next());
-  ASSERT_OK(it.Status());
+  auto result = Query(
+      "SELECT COUNT(*) FROM __intrinsic_stdlib_objects "
+      "WHERE package = 'dev.perfetto.test' "
+      "AND module = 'dev.perfetto.test.common' "
+      "AND object_type = 'MODULE'");
+  ASSERT_TRUE(result.Next());
+  ASSERT_EQ(result.Get(0).AsLong(), 1);
+  ASSERT_OK(result.Status());
 }
 
 TEST_F(TraceProcessorIntegrationTest, PackageSameNameOverride) {

--- a/test/trace_processor/diff_tests/parser/linux/tests.py
+++ b/test/trace_processor/diff_tests/parser/linux/tests.py
@@ -61,3 +61,26 @@ class Linux(TestSuite):
         "ts","prio","tag","msg","uid","comm","systemd_unit","hostname","transport"
         1000000000,6,"myapp","hello world",1000,"myapp","myapp.service","myhost","journal"
         """))
+
+  def test_journald_stats_not_log(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 1000000000
+          journald_event {
+            num_total: 42
+            num_failed: 0
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE linux.systemd_journald;
+        SELECT
+          (SELECT count(*) FROM linux_systemd_journald_logs) AS log_count,
+          (SELECT value FROM stats WHERE name = 'systemd_journal_num_total') AS num_total,
+          (SELECT value FROM stats WHERE name = 'systemd_journal_num_failed') AS num_failed;
+        """,
+        out=Csv("""
+        "log_count","num_total","num_failed"
+        0,42,0
+        """))

--- a/test/trace_processor/diff_tests/syntax/stdlib_docs_tests.py
+++ b/test/trace_processor/diff_tests/syntax/stdlib_docs_tests.py
@@ -20,17 +20,18 @@ from python.generators.diff_tests.testing import TestSuite
 
 class StdlibDocs(TestSuite):
 
-  def test_stdlib_modules_slices(self):
+  def test_stdlib_objects_modules(self):
     return DiffTestBlueprint(
         trace=TextProto(r''),
         query="""
         SELECT module, package
-        FROM __intrinsic_stdlib_modules()
-        WHERE module IN (
-          'slices.with_context',
-          'slices.flat_slices',
-          'slices.hierarchy'
-        )
+        FROM __intrinsic_stdlib_objects
+        WHERE object_type = 'MODULE'
+          AND module IN (
+            'slices.with_context',
+            'slices.flat_slices',
+            'slices.hierarchy'
+          )
         ORDER BY module;
         """,
         out=Csv("""
@@ -40,276 +41,171 @@ class StdlibDocs(TestSuite):
         "slices.with_context","slices"
         """))
 
-  def test_stdlib_modules_nonempty(self):
+  def test_stdlib_objects_all_kinds(self):
     return DiffTestBlueprint(
         trace=TextProto(r''),
         query="""
-        SELECT COUNT(*) > 0 AS has_modules,
-               COUNT(DISTINCT package) > 0 AS has_packages
-        FROM __intrinsic_stdlib_modules();
+        SELECT object_type, COUNT(*) > 0 AS present
+        FROM __intrinsic_stdlib_objects
+        WHERE object_type IN ('MODULE', 'TABLE', 'VIEW', 'FUNCTION',
+                              'TABLE_FUNCTION', 'MACRO')
+        GROUP BY object_type
+        ORDER BY object_type;
         """,
         out=Csv("""
-        "has_modules","has_packages"
-        1,1
+        "object_type","present"
+        "FUNCTION",1
+        "MACRO",1
+        "MODULE",1
+        "TABLE",1
+        "TABLE_FUNCTION",1
+        "VIEW",1
         """))
 
-  def test_stdlib_tables_slices_with_context(self):
+  def test_stdlib_objects_self_join(self):
     return DiffTestBlueprint(
         trace=TextProto(r''),
         query="""
-        SELECT name, type, exposed
-        FROM __intrinsic_stdlib_tables('slices.with_context')
-        ORDER BY name;
+        SELECT module.qualified_name, function.qualified_name
+        FROM __intrinsic_stdlib_objects AS module
+        JOIN __intrinsic_stdlib_objects AS function
+          ON function.module = module.module
+        WHERE module.qualified_name = 'time.conversion'
+          AND function.qualified_name = 'time.conversion.time_from_ns';
         """,
         out=Csv("""
-        "name","type","exposed"
-        "process_slice","VIEW",1
-        "thread_or_process_slice","VIEW",1
-        "thread_slice","VIEW",1
+        "qualified_name","qualified_name"
+        "time.conversion","time.conversion.time_from_ns"
         """))
 
-  def test_stdlib_tables_include_internal(self):
+  def test_stdlib_objects_table(self):
     return DiffTestBlueprint(
         trace=TextProto(r''),
         query="""
-        SELECT name, type, exposed
-        FROM __intrinsic_stdlib_tables('slices.flat_slices')
-        WHERE name = '_slice_flattened';
+        SELECT qualified_name, object_type, exposed, short_description
+        FROM __intrinsic_stdlib_objects
+        WHERE module = 'slices.with_context'
+          AND name = 'thread_slice';
         """,
         out=Csv("""
-        "name","type","exposed"
+        "qualified_name","object_type","exposed","short_description"
+        "slices.with_context.thread_slice","VIEW",1,"All thread slices with data about thread, thread track and process."
+        """))
+
+  def test_stdlib_objects_internal_table(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r''),
+        query="""
+        SELECT name, object_type, exposed
+        FROM __intrinsic_stdlib_objects
+        WHERE module = 'slices.flat_slices'
+          AND name = '_slice_flattened';
+        """,
+        out=Csv("""
+        "name","object_type","exposed"
         "_slice_flattened","TABLE",0
         """))
 
-  def test_stdlib_tables_columns(self):
+  def test_stdlib_objects_columns(self):
     return DiffTestBlueprint(
         trace=TextProto(r''),
         query="""
         SELECT
           c.value ->> 'name' AS col_name,
-          c.value ->> 'type' AS col_type
-        FROM __intrinsic_stdlib_tables('slices.with_context') t,
-             json_each(t.cols) c
-        WHERE t.name = 'thread_slice'
-        LIMIT 4;
-        """,
-        out=Csv("""
-        "col_name","col_type"
-        "id","ID(slice.id)"
-        "ts","TIMESTAMP"
-        "dur","DURATION"
-        "category","STRING"
-        """))
-
-  def test_stdlib_tables_column_description(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT
-          c.value ->> 'name' AS col_name,
-          c.value ->> 'description' AS col_desc
-        FROM __intrinsic_stdlib_tables('slices.with_context') t,
-             json_each(t.cols) c
-        WHERE t.name = 'thread_slice'
+          c.value ->> 'type' AS col_type,
+          c.value ->> 'description' AS col_description
+        FROM __intrinsic_stdlib_objects AS o,
+             json_each(o.cols) AS c
+        WHERE o.qualified_name = 'slices.with_context.thread_slice'
           AND c.value ->> 'name' = 'tid';
         """,
         out=Csv("""
-        "col_name","col_desc"
-        "tid","Alias for `thread.tid`."
+        "col_name","col_type","col_description"
+        "tid","LONG","Alias for `thread.tid`."
         """))
 
-  def test_stdlib_tables_description(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT name, description
-        FROM __intrinsic_stdlib_tables('slices.with_context')
-        WHERE name = 'thread_slice';
-        """,
-        out=Csv("""
-        "name","description"
-        "thread_slice","All thread slices with data about thread, thread track and process."
-        """))
-
-  def test_stdlib_functions_scalar(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT name, is_table_function, return_type, exposed
-        FROM __intrinsic_stdlib_functions('time.conversion')
-        WHERE name = 'time_from_ns';
-        """,
-        out=Csv("""
-        "name","is_table_function","return_type","exposed"
-        "time_from_ns",0,"TIMESTAMP",1
-        """))
-
-  def test_stdlib_functions_args(self):
+  def test_stdlib_objects_function(self):
     return DiffTestBlueprint(
         trace=TextProto(r''),
         query="""
         SELECT
-          f.name,
-          a.value ->> 'name' AS arg_name,
-          a.value ->> 'type' AS arg_type,
-          a.value ->> 'description' AS arg_desc
-        FROM __intrinsic_stdlib_functions('time.conversion') f,
-             json_each(f.args) a
-        WHERE f.name = 'time_from_ns';
-        """,
-        out=Csv("""
-        "name","arg_name","arg_type","arg_desc"
-        "time_from_ns","nanos","LONG","Time duration in nanoseconds."
-        """))
-
-  def test_stdlib_functions_internal_table_function(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT name, is_table_function, return_type, exposed
-        FROM __intrinsic_stdlib_functions('slices.hierarchy')
-        WHERE name = '_slice_ancestor_and_self';
-        """,
-        out=Csv("""
-        "name","is_table_function","return_type","exposed"
-        "_slice_ancestor_and_self",1,"TABLE",0
-        """))
-
-  def test_stdlib_macros(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT name, return_type, exposed
-        FROM __intrinsic_stdlib_macros('intervals.intersect')
-        WHERE name = '_ii_df_agg';
-        """,
-        out=Csv("""
-        "name","return_type","exposed"
-        "_ii_df_agg","_ProjectionFragment",0
-        """))
-
-  def test_stdlib_macro_args(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT
-          m.name,
+          o.object_type,
+          o.return_type,
+          o.return_description,
           a.value ->> 'name' AS arg_name,
           a.value ->> 'type' AS arg_type
-        FROM __intrinsic_stdlib_macros('intervals.intersect') m,
-             json_each(m.args) a
-        WHERE m.name = '_ii_df_agg'
+        FROM __intrinsic_stdlib_objects AS o,
+             json_each(o.args) AS a
+        WHERE o.qualified_name = 'time.conversion.time_from_ns';
+        """,
+        out=Csv("""
+        "object_type","return_type","return_description","arg_name","arg_type"
+        "FUNCTION","TIMESTAMP","Time duration in nanoseconds.","nanos","LONG"
+        """))
+
+  def test_stdlib_objects_table_function(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r''),
+        query="""
+        SELECT object_type, return_type, exposed
+        FROM __intrinsic_stdlib_objects
+        WHERE qualified_name =
+          'slices.hierarchy._slice_ancestor_and_self';
+        """,
+        out=Csv("""
+        "object_type","return_type","exposed"
+        "TABLE_FUNCTION","TABLE",0
+        """))
+
+  def test_stdlib_objects_macro(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r''),
+        query="""
+        SELECT
+          o.return_type,
+          o.exposed,
+          a.value ->> 'name' AS arg_name,
+          a.value ->> 'type' AS arg_type
+        FROM __intrinsic_stdlib_objects AS o,
+             json_each(o.args) AS a
+        WHERE o.qualified_name = 'intervals.intersect._ii_df_agg'
         ORDER BY arg_name;
         """,
         out=Csv("""
-        "name","arg_name","arg_type"
-        "_ii_df_agg","x","ColumnName"
-        "_ii_df_agg","y","ColumnName"
+        "return_type","exposed","arg_name","arg_type"
+        "_ProjectionFragment",0,"x","ColumnName"
+        "_ProjectionFragment",0,"y","ColumnName"
         """))
 
-  def test_stdlib_tables_description_non_first_stmt(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT name, description
-        FROM __intrinsic_stdlib_tables('slices.with_context')
-        WHERE name = 'process_slice';
-        """,
-        out=Csv("""
-        "name","description"
-        "process_slice","All process slices with data about process track and process."
-        """))
-
-  def test_stdlib_tables_column_description_non_first_stmt(self):
+  def test_stdlib_objects_summary(self):
     return DiffTestBlueprint(
         trace=TextProto(r''),
         query="""
         SELECT
-          c.value ->> 'name' AS col_name,
-          c.value ->> 'description' AS col_desc
-        FROM __intrinsic_stdlib_tables('slices.with_context') t,
-             json_each(t.cols) c
-        WHERE t.name = 'process_slice'
-          AND c.value ->> 'name' = 'pid';
+          summary GLOB '*Kind: public FUNCTION*' AS has_kind,
+          summary GLOB '*Arguments:*nanos (LONG)*' AS has_arg,
+          summary GLOB '*Returns: TIMESTAMP*' AS has_return,
+          summary GLOB '*Search aliases: time time conversion time from ns*'
+            AS has_alias
+        FROM __intrinsic_stdlib_objects
+        WHERE qualified_name = 'time.conversion.time_from_ns';
         """,
         out=Csv("""
-        "col_name","col_desc"
-        "pid","Alias for `process.pid`."
+        "has_kind","has_arg","has_return","has_alias"
+        1,1,1,1
         """))
 
-  def test_stdlib_functions_return_description(self):
+  def test_stdlib_objects_case_insensitive_search(self):
     return DiffTestBlueprint(
         trace=TextProto(r''),
         query="""
-        SELECT name, return_description
-        FROM __intrinsic_stdlib_functions('time.conversion')
-        WHERE name = 'time_from_ns';
+        SELECT qualified_name
+        FROM __intrinsic_stdlib_objects
+        WHERE exposed = 1
+          AND regexp('TIME.TO.MS|MILLISECONDS', summary, 'i')
+          AND qualified_name = 'time.conversion.time_to_ms';
         """,
         out=Csv("""
-        "name","return_description"
-        "time_from_ns","Time duration in nanoseconds."
-        """))
-
-  def test_stdlib_functions_return_description_non_first_stmt(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT name, return_description
-        FROM __intrinsic_stdlib_functions('time.conversion')
-        WHERE name = 'time_from_us';
-        """,
-        out=Csv("""
-        "name","return_description"
-        "time_from_us","Time duration in nanoseconds."
-        """))
-
-  def test_stdlib_functions_args_non_first_stmt(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT
-          f.name,
-          a.value ->> 'name' AS arg_name,
-          a.value ->> 'type' AS arg_type,
-          a.value ->> 'description' AS arg_desc
-        FROM __intrinsic_stdlib_functions('time.conversion') f,
-             json_each(f.args) a
-        WHERE f.name = 'time_from_us';
-        """,
-        out=Csv("""
-        "name","arg_name","arg_type","arg_desc"
-        "time_from_us","micros","LONG","Time duration in microseconds."
-        """))
-
-  def test_stdlib_tables_null_module(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT COUNT(*) AS c FROM __intrinsic_stdlib_tables(NULL);
-        """,
-        out=Csv("""
-        "c"
-        0
-        """))
-
-  def test_stdlib_functions_null_module(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT COUNT(*) AS c FROM __intrinsic_stdlib_functions(NULL);
-        """,
-        out=Csv("""
-        "c"
-        0
-        """))
-
-  def test_stdlib_macros_null_module(self):
-    return DiffTestBlueprint(
-        trace=TextProto(r''),
-        query="""
-        SELECT COUNT(*) AS c FROM __intrinsic_stdlib_macros(NULL);
-        """,
-        out=Csv("""
-        "c"
-        0
+        "qualified_name"
+        "time.conversion.time_to_ms"
         """))

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_from_tp.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_from_tp.ts
@@ -99,130 +99,83 @@ function summaryDesc(desc: string): string {
   return trimmed;
 }
 
-// Queries the TP's __intrinsic_stdlib_* table functions and merges with the
+// Queries the TP's unified stdlib object catalog and merges it with the
 // pre-generated metadata JSON to build a SqlModules object.
-// Uses 4 parallel queries (one per entity type) instead of per-module queries.
 export async function loadSqlModulesFromTp(
   trace: Trace,
   metadata: StdlibMetadata,
 ): Promise<SqlModules> {
-  const engine = trace.engine;
-
-  const [modsResult, tablesResult, fnsResult, macrosResult] = await Promise.all(
-    [
-      engine.query('SELECT module, package FROM __intrinsic_stdlib_modules()'),
-      engine.query(
-        `SELECT module, name, type, description, exposed, cols
-           FROM __intrinsic_stdlib_tables('*')`,
-      ),
-      engine.query(
-        `SELECT module, name, description, exposed, is_table_function,
-                return_type, return_description, args, cols
-           FROM __intrinsic_stdlib_functions('*')`,
-      ),
-      engine.query(
-        `SELECT module, name, description, exposed,
-                return_type, return_description, args
-           FROM __intrinsic_stdlib_macros('*')`,
-      ),
-    ],
+  const result = await trace.engine.query(
+    `SELECT package, module, name, object_type, description, exposed,
+            return_type, return_description, args, cols
+       FROM __intrinsic_stdlib_objects`,
   );
 
-  // Build package → [module] map.
   const packageMap = new Map<string, string[]>();
-  const modsIter = modsResult.iter({module: STR, package: STR});
-  for (; modsIter.valid(); modsIter.next()) {
-    getOrCreate(packageMap, modsIter.package, () => []).push(modsIter.module);
-  }
-
-  // Group tables by module.
   const tablesByModule = new Map<string, DataObject[]>();
-  const tIter = tablesResult.iter({
-    module: STR,
-    name: STR,
-    type: STR,
-    description: STR,
-    exposed: LONG,
-    cols: STR,
-  });
-  for (; tIter.valid(); tIter.next()) {
-    if (!tIter.exposed) continue;
-    const modKey = tIter.module;
-    const tableMeta = metadata[modKey]?.tables?.[tIter.name];
-    const desc = tIter.description;
-    getOrCreate(tablesByModule, modKey, () => []).push({
-      name: tIter.name,
-      desc,
-      summary_desc: summaryDesc(desc),
-      type: tIter.type,
-      importance: tableMeta?.importance ?? null,
-      data_check_sql: tableMeta?.data_check_sql ?? null,
-      cols: parseEntries(tIter.cols).map((e) => toArgOrCol(e)),
-    });
-  }
-
-  // Group functions and table functions by module.
   const fnsByModule = new Map<string, FnObject[]>();
   const tblFnsByModule = new Map<string, TblFnObject[]>();
-  const fIter = fnsResult.iter({
+  const macrosByModule = new Map<string, MacroObject[]>();
+  const iter = result.iter({
+    package: STR,
     module: STR,
     name: STR,
+    object_type: STR,
     description: STR,
     exposed: LONG,
-    is_table_function: LONG,
     return_type: STR,
     return_description: STR,
     args: STR,
     cols: STR,
   });
-  for (; fIter.valid(); fIter.next()) {
-    if (!fIter.exposed) continue;
-    const modKey = fIter.module;
-    const desc = fIter.description;
-    const args = parseEntries(fIter.args).map((e) => toArgOrCol(e));
-    if (fIter.is_table_function) {
+  for (; iter.valid(); iter.next()) {
+    const modKey = iter.module;
+    if (iter.object_type === 'MODULE') {
+      getOrCreate(packageMap, iter.package, () => []).push(modKey);
+      continue;
+    }
+    if (iter.exposed === 0n) continue;
+
+    const desc = iter.description;
+    const args = parseEntries(iter.args).map((entry) => toArgOrCol(entry));
+    if (iter.object_type === 'TABLE' || iter.object_type === 'VIEW') {
+      const tableMeta = metadata[modKey]?.tables?.[iter.name];
+      getOrCreate(tablesByModule, modKey, () => []).push({
+        name: iter.name,
+        desc,
+        summary_desc: summaryDesc(desc),
+        type: iter.object_type,
+        importance: tableMeta?.importance ?? null,
+        data_check_sql: tableMeta?.data_check_sql ?? null,
+        cols: parseEntries(iter.cols).map((entry) => toArgOrCol(entry)),
+      });
+    } else if (iter.object_type === 'FUNCTION') {
+      getOrCreate(fnsByModule, modKey, () => []).push({
+        name: iter.name,
+        desc,
+        summary_desc: summaryDesc(desc),
+        return_type: iter.return_type,
+        return_desc: iter.return_description,
+        args,
+      });
+    } else if (iter.object_type === 'TABLE_FUNCTION') {
       getOrCreate(tblFnsByModule, modKey, () => []).push({
-        name: fIter.name,
+        name: iter.name,
         desc,
         summary_desc: summaryDesc(desc),
         args,
-        cols: parseEntries(fIter.cols).map((e) => toArgOrCol(e)),
+        cols: parseEntries(iter.cols).map((entry) => toArgOrCol(entry)),
       });
-    } else {
-      getOrCreate(fnsByModule, modKey, () => []).push({
-        name: fIter.name,
+    } else if (iter.object_type === 'MACRO') {
+      getOrCreate(macrosByModule, modKey, () => []).push({
+        name: iter.name,
         desc,
         summary_desc: summaryDesc(desc),
-        return_type: fIter.return_type,
-        return_desc: fIter.return_description,
+        return_type: iter.return_type,
+        return_desc: iter.return_description,
         args,
       });
     }
-  }
-
-  // Group macros by module.
-  const macrosByModule = new Map<string, MacroObject[]>();
-  const mIter = macrosResult.iter({
-    module: STR,
-    name: STR,
-    description: STR,
-    exposed: LONG,
-    return_type: STR,
-    return_description: STR,
-    args: STR,
-  });
-  for (; mIter.valid(); mIter.next()) {
-    if (!mIter.exposed) continue;
-    const modKey = mIter.module;
-    const desc = mIter.description;
-    getOrCreate(macrosByModule, modKey, () => []).push({
-      name: mIter.name,
-      desc,
-      summary_desc: summaryDesc(desc),
-      return_type: mIter.return_type,
-      return_desc: mIter.return_description,
-      args: parseEntries(mIter.args).map((e) => toArgOrCol(e)),
-    });
   }
 
   // Assemble the final docs structure.

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_from_tp_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_from_tp_unittest.ts
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import protos from '../../protos';
+import type {Trace} from '../../public/trace';
+import {createQueryResult} from '../../trace_processor/query_result';
+import {loadSqlModulesFromTp} from './sql_modules_from_tp';
+
+const CELL_TYPE = protos.QueryResult.CellsBatch.CellType;
+
+type ObjectRow = readonly [
+  packageName: string,
+  module: string,
+  name: string,
+  objectType: string,
+  description: string,
+  exposed: number,
+  returnType: string,
+  returnDescription: string,
+  args: string,
+  columns: string,
+];
+
+function makeQueryResult(rows: readonly ObjectRow[]) {
+  const strings = rows.flatMap((row) => [
+    row[0],
+    row[1],
+    row[2],
+    row[3],
+    row[4],
+    row[6],
+    row[7],
+    row[8],
+    row[9],
+  ]);
+  const cells = rows.flatMap(() => [
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_VARINT,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+    CELL_TYPE.CELL_STRING,
+  ]);
+  const batch = protos.QueryResult.CellsBatch.create({
+    cells,
+    stringCells: strings.join('\0'),
+    varintCells: rows.map((row) => row[5]),
+    isLastBatch: true,
+  });
+  const resultProto = protos.QueryResult.create({
+    columnNames: [
+      'package',
+      'module',
+      'name',
+      'object_type',
+      'description',
+      'exposed',
+      'return_type',
+      'return_description',
+      'args',
+      'cols',
+    ],
+    batch: [batch],
+  });
+  const result = createQueryResult({query: 'stdlib objects'});
+  result.appendResultBatch(protos.QueryResult.encode(resultProto).finish());
+  return result;
+}
+
+test('loads the unified stdlib object catalog', async () => {
+  const entry = (name: string, type: string) =>
+    JSON.stringify([{name, type, description: `${name} description`}]);
+  const result = makeQueryResult([
+    ['test', 'test.module', 'test.module', 'MODULE', '', 1, '', '', '[]', '[]'],
+    [
+      'test',
+      'test.module',
+      'test_table',
+      'TABLE',
+      'A test table.',
+      1,
+      '',
+      '',
+      '[]',
+      entry('value', 'LONG'),
+    ],
+    [
+      'test',
+      'test.module',
+      'test_function',
+      'FUNCTION',
+      'A test function.',
+      1,
+      'LONG',
+      'The result.',
+      entry('input', 'LONG'),
+      '[]',
+    ],
+    [
+      'test',
+      'test.module',
+      'test_table_function',
+      'TABLE_FUNCTION',
+      'A test table function.',
+      1,
+      'TABLE',
+      '',
+      entry('input', 'LONG'),
+      entry('output', 'STRING'),
+    ],
+    [
+      'test',
+      'test.module',
+      'test_macro',
+      'MACRO',
+      'A test macro.',
+      1,
+      'Expr',
+      'The expression.',
+      entry('input', 'Expr'),
+      '[]',
+    ],
+    [
+      'test',
+      'test.module',
+      '_internal_table',
+      'TABLE',
+      'Internal.',
+      0,
+      '',
+      '',
+      '[]',
+      '[]',
+    ],
+  ]);
+  const queries: string[] = [];
+  const trace = {
+    engine: {
+      query: async (sql: string) => {
+        queries.push(sql);
+        return result;
+      },
+    },
+  } as unknown as Trace;
+
+  const sqlModules = await loadSqlModulesFromTp(trace, {
+    'test.module': {
+      tags: ['test'],
+      includes: [],
+      data_check_sql: null,
+      tables: {
+        test_table: {importance: 'high', data_check_sql: null},
+      },
+    },
+  });
+
+  expect(queries).toHaveLength(1);
+  expect(queries[0]).toContain('FROM __intrinsic_stdlib_objects');
+  const module = sqlModules.listModules()[0];
+  expect(module.includeKey).toBe('test.module');
+  expect(module.tables.map((table) => table.name)).toEqual(['test_table']);
+  expect(module.tables[0].importance).toBe('high');
+  expect(module.tables[0].columns[0].name).toBe('value');
+  expect(module.functions[0].name).toBe('test_function');
+  expect(module.functions[0].returnType).toBe('LONG');
+  expect(module.tableFunctions[0].name).toBe('test_table_function');
+  expect(module.tableFunctions[0].returnCols[0].name).toBe('output');
+  expect(module.macros[0].name).toBe('test_macro');
+});


### PR DESCRIPTION
Cherry-picks of three commits from main onto canary:

- #7096 `tp: unify stdlib object discovery` (a9ae7e5d31)
- #7107 `tp: ignore journald stats when parsing logs` (a367067350)
- #7108 `ui: fix stdlib module loading` (454b4cfc45)