### PR TITLE
perfetto: fix remaining -Wformat-signedness errors after clang uprev

### DIFF
--- a/src/trace_processor/importers/fuchsia/fuchsia_trace_parser.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_trace_parser.cc
@@ -764,13 +764,13 @@ void FuchsiaTraceParser::Parse(int64_t, FuchsiaRecord fr) {
           break;
         }
         default:
-          PERFETTO_DLOG("Skipping unknown scheduler event type %d", event_type);
+          PERFETTO_DLOG("Skipping unknown scheduler event type %u", event_type);
           break;
       }
       break;
     }
     default: {
-      PERFETTO_DFATAL("Unknown record type %d in FuchsiaTraceParser",
+      PERFETTO_DFATAL("Unknown record type %u in FuchsiaTraceParser",
                       record_type);
       break;
     }

--- a/src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.cc
@@ -569,7 +569,7 @@ void FuchsiaTraceTokenizer::ParseRecord(TraceBlobView tbv) {
           break;
         }
         default: {
-          PERFETTO_DLOG("Skipping Kernel Object record with type %d", obj_type);
+          PERFETTO_DLOG("Skipping Kernel Object record with type %u", obj_type);
           break;
         }
       }
@@ -718,14 +718,14 @@ void FuchsiaTraceTokenizer::ParseRecord(TraceBlobView tbv) {
           break;
         }
         default:
-          PERFETTO_DLOG("Skipping unknown scheduler event type %d", event_type);
+          PERFETTO_DLOG("Skipping unknown scheduler event type %u", event_type);
           break;
       }
 
       break;
     }
     default: {
-      PERFETTO_DLOG("Skipping record of unknown type %d", record_type);
+      PERFETTO_DLOG("Skipping record of unknown type %u", record_type);
       break;
     }
   }

--- a/src/trace_processor/importers/proto/chrome_string_lookup.cc
+++ b/src/trace_processor/importers/proto/chrome_string_lookup.cc
@@ -271,7 +271,7 @@ StringId ChromeStringLookup::GetProcessName(int32_t process_type) const {
   if (process_name_it != chrome_process_name_ids_.end())
     return process_name_it->second;
 
-  PERFETTO_DLOG("GetProcessName error: Unknown Chrome process type %u",
+  PERFETTO_DLOG("GetProcessName error: Unknown Chrome process type %d",
                 process_type);
   return kNullStringId;
 }
@@ -281,7 +281,7 @@ StringId ChromeStringLookup::GetThreadName(int32_t thread_type) const {
   if (thread_name_it != chrome_thread_name_ids_.end())
     return thread_name_it->second;
 
-  PERFETTO_DLOG("GetThreadName error: Unknown Chrome thread type %u",
+  PERFETTO_DLOG("GetThreadName error: Unknown Chrome thread type %d",
                 thread_type);
   return kNullStringId;
 }

--- a/src/tracing/internal/tracing_muxer_impl.cc
+++ b/src/tracing/internal/tracing_muxer_impl.cc
@@ -2536,7 +2536,7 @@ TracingMuxerImpl::CreateStartupTracingSession(
               "Setting up data source %s for startup tracing with target "
               "buffer reservation %" PRIi32,
               rds.descriptor.name().c_str(),
-              backend.producer->last_startup_target_buffer_reservation_ + 1u);
+              backend.producer->last_startup_target_buffer_reservation_ + 1);
           auto ds = SetupDataSourceImpl(
               rds, backend_id,
               backend.producer->connection_id_.load(std::memory_order_relaxed),

--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -1302,8 +1302,8 @@ void TraceBufferV2::DumpForTesting() {
       PERFETTO_DLOG(
           "[%06zu-%06zu] size=%05u(%05u) id=%05u pr_wr=%08x flags=%08x", rd,
           rd + c->outer_size(), c->payload_size,
-          c->payload_size - c->payload_avail, c->chunk_id, c->pri_wri_id,
-          c->flags);
+          static_cast<unsigned>(c->payload_size - c->payload_avail),
+          c->chunk_id, c->pri_wri_id, c->flags);
       rd += c->outer_size();
       continue;
     }

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -5259,10 +5259,11 @@ TEST_F(TracingServiceImplTest, TraceWriterStats) {
     for (const auto& wri : packet.trace_stats().writer_stats()) {
       for (size_t i = 0; i < wri.chunk_payload_histogram_counts().size() - 1;
            i++) {
-        PERFETTO_DLOG("Seq=%" PRIu64 ", %" PRIu64 " : %" PRIu64,
-                      wri.sequence_id(),
-                      packet.trace_stats().chunk_payload_histogram_def()[i],
-                      wri.chunk_payload_histogram_counts()[i]);
+        PERFETTO_DLOG(
+            "Seq=%" PRIu64 ", %" PRIu64 " : %" PRIu64, wri.sequence_id(),
+            static_cast<uint64_t>(
+                packet.trace_stats().chunk_payload_histogram_def()[i]),
+            wri.chunk_payload_histogram_counts()[i]);
       }
 
       switch (wri.sequence_id()) {


### PR DESCRIPTION
Fix signed/unsigned printf mismatches:

- fuchsia trace parser/tokenizer: %d -> %u for uint32_t record/event types
- chrome_string_lookup: %u -> %d for int32_t process/thread types
- tracing_muxer_impl: drop stray "u" suffix that flipped an int32_t to unsigned
- trace_buffer_v2: cast uint16_t subtraction result before %u
- tracing_service_impl_unittest: cast int64 proto field before PRIu64

