### PR TITLE
cherry-pick #7123 onto canary

### DIFF
--- a/src/trace_processor/core/dataframe/arrow_internal.h
+++ b/src/trace_processor/core/dataframe/arrow_internal.h
@@ -47,7 +47,7 @@ constexpr uint8_t kTypeUtf8 = 5;
 constexpr int16_t kPrecisionDouble = 2;
 constexpr int16_t kEndiannessLittle = 0;
 
-constexpr uint32_t kArrowAlignment = 8;
+constexpr uint32_t kArrowAlignment = 64;
 constexpr uint32_t kBitsPerByte = 8;
 constexpr uint32_t kMessagePrefixSize = 8;
 constexpr uint32_t kEndOfStreamSize = kMessagePrefixSize;
@@ -146,6 +146,20 @@ inline base::Status InvalidFile() {
 inline uint64_t AlignToArrow(uint64_t value) {
   constexpr uint64_t kMask = kArrowAlignment - 1;
   return (value + kMask) & ~kMask;
+}
+
+// A message body starts immediately after the message prefix and the padded
+// metadata, so the metadata padding is what decides whether the body lands on
+// an aligned file offset.
+inline uint64_t PaddedMetadataSize(uint64_t metadata_size) {
+  return AlignToArrow(metadata_size + kMessagePrefixSize) - kMessagePrefixSize;
+}
+
+// The schema message is the first message in the file, so its padding also has
+// to absorb the leading magic to keep every later message aligned.
+inline uint64_t PaddedSchemaMetadataSize(uint64_t metadata_size) {
+  constexpr uint64_t kLeading = sizeof(kPaddedMagic) + kMessagePrefixSize;
+  return AlignToArrow(metadata_size + kLeading) - kLeading;
 }
 
 inline uint64_t ValidityBufferSize(uint32_t rows) {

--- a/src/trace_processor/core/dataframe/arrow_serializer.cc
+++ b/src/trace_processor/core/dataframe/arrow_serializer.cc
@@ -559,9 +559,10 @@ base::Status ArrowSerializer::BuildFileFraming(const BodyPlan& plan) {
   std::vector<uint8_t> batch_metadata = FinishFlatbuffer(
       &batch_writer, BuildMessage(batch_writer, kHeaderRecordBatch, batch,
                                   static_cast<int64_t>(plan.size)));
-  uint32_t schema_size = static_cast<uint32_t>(AlignToArrow(schema.size()));
-  uint32_t metadata_size =
-      static_cast<uint32_t>(AlignToArrow(batch_metadata.size()));
+  auto schema_size =
+      static_cast<uint32_t>(PaddedSchemaMetadataSize(schema.size()));
+  auto metadata_size =
+      static_cast<uint32_t>(PaddedMetadataSize(batch_metadata.size()));
   uint32_t maximum_metadata_size = static_cast<uint32_t>(
       std::numeric_limits<int32_t>::max() - kMessagePrefixSize);
   if (schema_size > maximum_metadata_size ||
@@ -584,7 +585,8 @@ base::Status ArrowSerializer::BuildFileFraming(const BodyPlan& plan) {
                               BuildDictionaryBatch(writer, i, values,
                                                    dictionary.buffers),
                               static_cast<int64_t>(dictionary.body_size)));
-    auto size = static_cast<uint32_t>(AlignToArrow(dictionary_metadata.size()));
+    auto size =
+        static_cast<uint32_t>(PaddedMetadataSize(dictionary_metadata.size()));
     if (size > maximum_metadata_size) {
       return base::ErrStatus("Arrow metadata is too large");
     }

--- a/src/trace_processor/core/util/slab.h
+++ b/src/trace_processor/core/util/slab.h
@@ -62,14 +62,23 @@ class Slab {
   Slab(const Slab&) = delete;
   Slab& operator=(const Slab&) = delete;
 
+  // Alignment of every slab allocation. 64 bytes is the widest SIMD register
+  // we target and the alignment Arrow recommends for its buffers, so a slab
+  // and a buffer mapped out of an Arrow file are interchangeable.
+  static constexpr size_t kAlignment = 64;
+
   // Allocates a new slab with the specified number of elements.
   //
   // size: Number of elements to allocate space for.
   // Returns a new Slab object with the requested capacity.
   static Slab<T> Alloc(uint64_t size) {
-    return Slab(
-        static_cast<T*>(base::AlignedAlloc(alignof(T), size * sizeof(T))),
-        size);
+    static_assert(alignof(T) <= kAlignment, "T is over-aligned for a Slab");
+    // Allocations too small to hold a whole vector register cannot benefit
+    // from the wider alignment, and paying for it on the many tiny slabs the
+    // parser creates measurably costs memory.
+    uint64_t bytes = size * sizeof(T);
+    size_t alignment = bytes >= kAlignment ? kAlignment : alignof(T);
+    return Slab(static_cast<T*>(base::AlignedAlloc(alignment, bytes)), size);
   }
 
   // Shrinks the logical size without changing the underlying allocation.

--- a/src/trace_processor/core/util/slab_unittest.cc
+++ b/src/trace_processor/core/util/slab_unittest.cc
@@ -128,6 +128,25 @@ TEST(SlabTest, RangeBasedForLoop) {
   EXPECT_EQ(sum, 15);
 }
 
+// Allocations big enough to hold a vector register must be 64 byte aligned:
+// vectorized code and zero-copy mapping of Arrow buffers both depend on it.
+// glibc returns mmap-backed chunks at a 16 byte offset from the page, so this
+// does not come for free even on large allocations.
+TEST(SlabTest, LargeAllocationsAreAligned) {
+  constexpr size_t kAlign = Slab<uint8_t>::kAlignment;
+  for (uint64_t bytes : {64u, 256u, 4096u, 131072u, 1u << 22}) {
+    auto u8 = Slab<uint8_t>::Alloc(bytes);
+    auto u32 = Slab<uint32_t>::Alloc(bytes / sizeof(uint32_t));
+    auto i64 = Slab<int64_t>::Alloc(bytes / sizeof(int64_t));
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(u8.data()) % kAlign, 0u)
+        << "uint8 slab of " << bytes << " bytes";
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(u32.data()) % kAlign, 0u)
+        << "uint32 slab of " << bytes << " bytes";
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(i64.data()) % kAlign, 0u)
+        << "int64 slab of " << bytes << " bytes";
+  }
+}
+
 // Test with different data types
 TEST(SlabTest, DifferentDataTypes) {
   // Test with a larger type


### PR DESCRIPTION
Cherry-pick of `tp: align Arrow buffers and slabs to 64 bytes` (e5e5da7587, PR #7123) from main onto canary.