### PR TITLE
tp: split access-path selection out of dataframe bytecode emission

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17575,6 +17575,7 @@ filegroup {
         "src/trace_processor/core/dataframe/adhoc_dataframe_builder.cc",
         "src/trace_processor/core/dataframe/arrow_deserializer.cc",
         "src/trace_processor/core/dataframe/arrow_serializer.cc",
+        "src/trace_processor/core/dataframe/bytecode_lowering.cc",
         "src/trace_processor/core/dataframe/dataframe.cc",
         "src/trace_processor/core/dataframe/query_plan.cc",
         "src/trace_processor/core/dataframe/typed_cursor.cc",

--- a/BUILD
+++ b/BUILD
@@ -2467,6 +2467,8 @@ perfetto_filegroup(
         "src/trace_processor/core/dataframe/arrow_internal.h",
         "src/trace_processor/core/dataframe/arrow_serializer.cc",
         "src/trace_processor/core/dataframe/arrow_serializer.h",
+        "src/trace_processor/core/dataframe/bytecode_lowering.cc",
+        "src/trace_processor/core/dataframe/bytecode_lowering.h",
         "src/trace_processor/core/dataframe/cursor.h",
         "src/trace_processor/core/dataframe/cursor_impl.h",
         "src/trace_processor/core/dataframe/dataframe.cc",

--- a/src/trace_processor/core/common/op_types.h
+++ b/src/trace_processor/core/common/op_types.h
@@ -58,6 +58,30 @@ struct In {};
 using Op =
     core::TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex, IsNotNull, IsNull, In>;
 
+// Subsets of Op describing which operations a given kind of value or access
+// path supports. Used to pick how a filter is evaluated.
+
+// Set of operations applicable to non-null values.
+using NonNullOp = core::TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex>;
+
+// Set of operations applicable to non-string values.
+using NonStringOp = core::TypeSet<Eq, Ne, Lt, Le, Gt, Ge>;
+
+// Set of operations applicable to string values.
+using StringOp = core::TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex>;
+
+// Set of operations applicable to only string values.
+using OnlyStringOp = core::TypeSet<Glob, Regex>;
+
+// Set of operations applicable to ranges.
+using RangeOp = core::TypeSet<Eq, Lt, Le, Gt, Ge>;
+
+// Set of inequality operations (Lt, Le, Gt, Ge).
+using InequalityOp = core::TypeSet<Lt, Le, Gt, Ge>;
+
+// Set of null operations (IsNotNull, IsNull).
+using NullOp = core::TypeSet<IsNotNull, IsNull>;
+
 }  // namespace perfetto::trace_processor::core
 
 #endif  // SRC_TRACE_PROCESSOR_CORE_COMMON_OP_TYPES_H_

--- a/src/trace_processor/core/common/storage_types.h
+++ b/src/trace_processor/core/common/storage_types.h
@@ -66,6 +66,19 @@ struct Null {
 // TypeSet of all possible storage value types.
 using StorageType = core::TypeSet<Id, Uint32, Int32, Int64, Double, String>;
 
+// Subsets of StorageType grouping the value types which share a filtering or
+// storage strategy.
+
+// Set of content types that aren't string-based.
+using NonStringType = core::TypeSet<Id, Uint32, Int32, Int64, Double>;
+
+// Set of content types that are numeric in nature.
+using IntegerOrDoubleType = core::TypeSet<Uint32, Int32, Int64, Double>;
+
+// Set of content types which are backed by real storage, i.e. everything
+// except Id, whose value is the row index itself.
+using NonIdStorageType = core::TypeSet<Uint32, Int32, Int64, Double, String>;
+
 // Maps a C++ type to its corresponding storage type tag.
 // E.g., TypeTagFor<int64_t>::type = Int64
 template <typename CppType>

--- a/src/trace_processor/core/dataframe/BUILD.gn
+++ b/src/trace_processor/core/dataframe/BUILD.gn
@@ -23,6 +23,8 @@ source_set("dataframe") {
     "arrow_internal.h",
     "arrow_serializer.cc",
     "arrow_serializer.h",
+    "bytecode_lowering.cc",
+    "bytecode_lowering.h",
     "cursor.h",
     "cursor_impl.h",
     "dataframe.cc",

--- a/src/trace_processor/core/dataframe/bytecode_lowering.cc
+++ b/src/trace_processor/core/dataframe/bytecode_lowering.cc
@@ -1,0 +1,1148 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/dataframe/bytecode_lowering.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/small_vector.h"
+#include "perfetto/ext/base/variant.h"
+#include "perfetto/public/compiler.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/dataframe/query_plan.h"
+#include "src/trace_processor/core/dataframe/specs.h"
+#include "src/trace_processor/core/dataframe/types.h"
+#include "src/trace_processor/core/interpreter/bytecode_core.h"
+#include "src/trace_processor/core/interpreter/bytecode_instructions.h"
+#include "src/trace_processor/core/interpreter/bytecode_registers.h"
+#include "src/trace_processor/core/interpreter/interpreter_types.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/range.h"
+#include "src/trace_processor/core/util/slab.h"
+#include "src/trace_processor/core/util/span.h"
+#include "src/trace_processor/core/util/type_set.h"
+
+namespace perfetto::trace_processor::core::dataframe {
+
+namespace {
+
+namespace i = interpreter;
+
+// Assumed number of distinct values matched by an IN filter when the list size
+// is not known at plan time. Scales the single-value equality estimate. Matches
+// SQLite's own tuning constant for "x IN (SELECT ...)" (see whereLoopAddBtree).
+constexpr double kAssumedInListSize = 25;
+
+// Rows surviving a scalar equality filter on a HasDuplicates column with
+// `estimated_distinct` distinct values (0 = unknown). With a known count, a
+// uniform column keeps ~1/estimated_distinct of the rows; otherwise fall back
+// to the data-blind heuristic.
+double EqualityFilterRows(uint32_t row_count, uint32_t estimated_distinct) {
+  if (estimated_distinct > 0) {
+    return static_cast<double>(row_count) / estimated_distinct;
+  }
+  return row_count / (2 * log2(row_count));
+}
+
+// Register type identifiers for cache key encoding.
+// Used with DataframeRegisterCache::GetOrAllocate(reg_type, ptr)
+// to cache column/index-specific registers.
+enum RegType : uint32_t {
+  kStorageReg = 0,
+  kNullBvReg = 1,
+  kSmallValueEqBvReg = 2,
+  kSmallValueEqPopcountReg = 3,
+  kIndexReg = 4,
+  kRegTypeCount = 5,
+};
+
+// TypeSet of all possible sparse nullability states.
+using SparseNullTypes = TypeSet<SparseNull,
+                                SparseNullWithPopcountAlways,
+                                SparseNullWithPopcountUntilFinalization>;
+
+// Gets the appropriate bound modifier and range operation type
+// for a given range operation.
+std::pair<i::BoundModifier, i::EqualRangeLowerBoundUpperBound>
+GetSortedFilterArgs(const RangeOp& op) {
+  switch (op.index()) {
+    case RangeOp::GetTypeIndex<Eq>():
+      return std::make_pair(i::BothBounds{}, i::EqualRange{});
+    case RangeOp::GetTypeIndex<Lt>():
+      return std::make_pair(i::EndBound{}, i::LowerBound{});
+    case RangeOp::GetTypeIndex<Le>():
+      return std::make_pair(i::EndBound{}, i::UpperBound{});
+    case RangeOp::GetTypeIndex<Gt>():
+      return std::make_pair(i::BeginBound{}, i::UpperBound{});
+    case RangeOp::GetTypeIndex<Ge>():
+      return std::make_pair(i::BeginBound{}, i::LowerBound{});
+    default:
+      PERFETTO_FATAL("Unreachable");
+  }
+}
+
+// Helper to get byte size of storage types for layout calculation.
+uint8_t GetDataSize(StorageType type) {
+  switch (type.index()) {
+    case StorageType::GetTypeIndex<Id>():
+    case StorageType::GetTypeIndex<Uint32>():
+    case StorageType::GetTypeIndex<Int32>():
+    case StorageType::GetTypeIndex<String>():
+      return sizeof(uint32_t);
+    case StorageType::GetTypeIndex<Int64>():
+      return sizeof(int64_t);
+    case StorageType::GetTypeIndex<Double>():
+      return sizeof(double);
+    default:
+      PERFETTO_FATAL("Invalid storage type");
+  }
+}
+
+i::SparseNullCollapsedNullability NullabilityToSparseNullCollapsedNullability(
+    Nullability nullability) {
+  switch (nullability.index()) {
+    case Nullability::GetTypeIndex<NonNull>():
+      return NonNull{};
+    case Nullability::GetTypeIndex<DenseNull>():
+      return DenseNull{};
+    case Nullability::GetTypeIndex<SparseNull>():
+    case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
+    case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>():
+      return SparseNull{};
+    default:
+      PERFETTO_FATAL("Invalid nullability type");
+  }
+}
+
+}  // namespace
+
+BytecodeLowering::BytecodeLowering(
+    uint32_t row_count,
+    const std::vector<std::shared_ptr<Column>>& columns,
+    const std::vector<Index>& indexes)
+    : columns_(columns),
+      indexes_(indexes),
+      cache_(builder_),
+      indices_reg_(builder_.AllocateRegister<Range>()) {
+  // Setup the maximum and estimated row counts.
+  plan_.params.max_row_count = row_count;
+  plan_.params.estimated_row_count = row_count;
+
+  // Initialize with a range covering all rows.
+  using B = i::InitRange;
+  auto& ir = builder_.AddOpcode<B>(i::Index<B>());
+  ir.arg<B::size>() = row_count;
+  ir.arg<B::dest_register>() =
+      base::unchecked_get<i::RwHandle<Range>>(indices_reg_);
+}
+
+QueryPlanImpl BytecodeLowering::Build() && {
+  plan_.bytecode = std::move(builder_.bytecode());
+  plan_.params.register_count = builder_.register_count();
+  return std::move(plan_);
+}
+
+uint32_t BytecodeLowering::ReserveFilterValueSlot(FilterSpec& spec) {
+  uint32_t slot = plan_.params.filter_value_count++;
+  spec.value_index = slot;
+  return slot;
+}
+
+i::ReadHandle<i::CastFilterValueResult> BytecodeLowering::EmitCastFilterValue(
+    FilterSpec& spec,
+    const StorageType& type,
+    NonNullOp op) {
+  i::RwHandle<i::CastFilterValueResult> value_reg =
+      builder_.AllocateRegister<i::CastFilterValueResult>();
+  {
+    using B = i::CastFilterValueBase;
+    auto& bc =
+        AddOpcode<B>(i::Index<i::CastFilterValue>(type), UnchangedRowCount{});
+    bc.arg<B::fval_handle>() = {plan_.params.filter_value_count};
+    bc.arg<B::write_register>() = value_reg;
+    bc.arg<B::op>() = op;
+    spec.value_index = plan_.params.filter_value_count++;
+  }
+  return value_reg;
+}
+
+i::RwHandle<std::unique_ptr<i::CastFilterValueListResult>>
+BytecodeLowering::EmitCastFilterValueList(FilterSpec& spec,
+                                          const StorageType& type) {
+  i::RwHandle<std::unique_ptr<i::CastFilterValueListResult>> value =
+      builder_
+          .AllocateRegister<std::unique_ptr<i::CastFilterValueListResult>>();
+  {
+    using B = i::CastFilterValueListBase;
+    auto& bc = AddOpcode<B>(i::Index<i::CastFilterValueList>(type),
+                            UnchangedRowCount{});
+    bc.arg<B::fval_handle>() = {plan_.params.filter_value_count};
+    bc.arg<B::write_register>() = value;
+    bc.arg<B::op>() = Eq{};
+    spec.value_index = plan_.params.filter_value_count++;
+  }
+  return value;
+}
+
+void BytecodeLowering::EmitSortedFilter(
+    const FilterSpec& spec,
+    const StorageType& type,
+    const RangeOp& op,
+    const i::ReadHandle<i::CastFilterValueResult>& value) {
+  const auto& col = GetColumn(spec.col);
+
+  // We should have ordered the constraints such that we only reach this
+  // point with range indices.
+  PERFETTO_CHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
+  const auto& reg = base::unchecked_get<i::RwHandle<Range>>(indices_reg_);
+
+  const auto& [bound, erlbub] = GetSortedFilterArgs(op);
+  RowCountModifier modifier;
+  if (op.Is<Eq>()) {
+    modifier =
+        EqualityFilterRowCount{col.duplicate_state, col.estimated_distinct};
+  } else {
+    modifier = NonEqualityFilterRowCount{};
+  }
+  {
+    using B = i::SortedFilterBase;
+    auto& bc = AddOpcode<B>(i::Index<i::SortedFilter>(type, erlbub), modifier,
+                            i::SortedFilterBase::EstimateCost(type));
+    bc.arg<B::storage_register>() = StorageRegisterFor(spec.col, type);
+    bc.arg<B::val_register>() = value;
+    bc.arg<B::update_register>() = reg;
+    bc.arg<B::write_result_to>() = bound;
+  }
+}
+
+void BytecodeLowering::EmitSetIdSortedEq(
+    const FilterSpec& spec,
+    const i::ReadHandle<i::CastFilterValueResult>& value) {
+  const auto& col = GetColumn(spec.col);
+  PERFETTO_CHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
+  const auto& reg = base::unchecked_get<i::RwHandle<Range>>(indices_reg_);
+
+  using B = i::Uint32SetIdSortedEq;
+  auto& bc = AddOpcode<B>(RowCountModifier{
+      EqualityFilterRowCount{col.duplicate_state, col.estimated_distinct}});
+  bc.arg<B::storage_register>() =
+      StorageRegisterFor(spec.col, col.storage.type());
+  bc.arg<B::val_register>() = value;
+  bc.arg<B::update_register>() = reg;
+}
+
+void BytecodeLowering::EmitSmallValueEq(
+    const FilterSpec& spec,
+    const i::ReadHandle<i::CastFilterValueResult>& value) {
+  const auto& col = GetColumn(spec.col);
+  PERFETTO_CHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
+  const auto& reg = base::unchecked_get<i::RwHandle<Range>>(indices_reg_);
+
+  using B = i::SpecializedStorageSmallValueEq;
+  auto& bc = AddOpcode<B>(RowCountModifier{
+      EqualityFilterRowCount{col.duplicate_state, col.estimated_distinct}});
+  bc.arg<B::small_value_bv_register>() = SmallValueEqBvRegisterFor(spec.col);
+  bc.arg<B::small_value_popcount_register>() =
+      SmallValueEqPopcountRegisterFor(spec.col);
+  bc.arg<B::val_register>() = value;
+  bc.arg<B::update_register>() = reg;
+}
+
+void BytecodeLowering::EmitLinearFilterEq(
+    const FilterSpec& spec,
+    const NonIdStorageType& type,
+    const i::ReadHandle<i::CastFilterValueResult>& value) {
+  const auto& col = GetColumn(spec.col);
+  PERFETTO_DCHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
+  PERFETTO_DCHECK(col.null_storage.nullability().Is<NonNull>());
+  PERFETTO_DCHECK(spec.op.Is<Eq>());
+
+  using SpanReg = i::RwHandle<Span<uint32_t>>;
+  using SlabReg = i::RwHandle<Slab<uint32_t>>;
+  using RegRange = i::RwHandle<Range>;
+
+  auto range_reg = base::unchecked_get<RegRange>(indices_reg_);
+  SlabReg slab_reg = builder_.AllocateRegister<Slab<uint32_t>>();
+  SpanReg span_reg = builder_.AllocateRegister<Span<uint32_t>>();
+  {
+    using B = i::AllocateIndices;
+    auto& bc = AddOpcode<B>(UnchangedRowCount{});
+    bc.arg<B::size>() = plan_.params.max_row_count;
+    bc.arg<B::dest_slab_register>() = slab_reg;
+    bc.arg<B::dest_span_register>() = span_reg;
+  }
+  {
+    using B = i::LinearFilterEqBase;
+    B& bc = AddOpcode<B>(i::Index<i::LinearFilterEq>(type),
+                         RowCountModifier{EqualityFilterRowCount{
+                             col.duplicate_state, col.estimated_distinct}});
+    bc.arg<B::storage_register>() =
+        StorageRegisterFor(spec.col, type.Upcast<StorageType>());
+    bc.arg<B::filter_value_reg>() = value;
+    bc.arg<B::source_register>() = range_reg;
+    bc.arg<B::update_register>() = span_reg;
+  }
+  indices_reg_ = span_reg;
+}
+
+void BytecodeLowering::EmitNonStringFilter(
+    const FilterSpec& spec,
+    const NonStringType& type,
+    const NonStringOp& op,
+    const i::ReadHandle<i::CastFilterValueResult>& value) {
+  const auto& col = GetColumn(spec.col);
+  auto update = EnsureIndicesAreInSlab();
+  PruneNullIndices(spec.col, update, NullPruneScope::kResultRows);
+  auto source = TranslateNonNullIndices(spec.col, update, false);
+  {
+    using B = i::NonStringFilterBase;
+    B& bc = AddOpcode<B>(i::Index<i::NonStringFilter>(type, op),
+                         op.Is<Eq>()
+                             ? RowCountModifier{EqualityFilterRowCount{
+                                   col.duplicate_state, col.estimated_distinct}}
+                             : RowCountModifier{NonEqualityFilterRowCount{}});
+    bc.arg<B::storage_register>() =
+        StorageRegisterFor(spec.col, type.Upcast<StorageType>());
+    bc.arg<B::val_register>() = value;
+    bc.arg<B::source_register>() = source;
+    bc.arg<B::update_register>() = update;
+  }
+  MaybeReleaseScratchSpanRegister();
+}
+
+void BytecodeLowering::EmitStringFilter(
+    const FilterSpec& spec,
+    const StringOp& op,
+    const i::ReadHandle<i::CastFilterValueResult>& value) {
+  const auto& col = GetColumn(spec.col);
+  auto update = EnsureIndicesAreInSlab();
+  PruneNullIndices(spec.col, update, NullPruneScope::kResultRows);
+  auto source = TranslateNonNullIndices(spec.col, update, false);
+  {
+    using B = i::StringFilterBase;
+    B& bc = AddOpcode<B>(i::Index<i::StringFilter>(op),
+                         op.Is<Eq>()
+                             ? RowCountModifier{EqualityFilterRowCount{
+                                   col.duplicate_state, col.estimated_distinct}}
+                             : RowCountModifier{NonEqualityFilterRowCount{}});
+    bc.arg<B::storage_register>() = StorageRegisterFor(spec.col, String{});
+    bc.arg<B::val_register>() = value;
+    bc.arg<B::source_register>() = source;
+    bc.arg<B::update_register>() = update;
+  }
+  MaybeReleaseScratchSpanRegister();
+}
+
+void BytecodeLowering::EmitNullFilter(const FilterSpec& spec,
+                                      const NullOp& op) {
+  auto indices = EnsureIndicesAreInSlab();
+  using B = i::NullFilterBase;
+  B& bc =
+      AddOpcode<B>(i::Index<i::NullFilter>(op), NonEqualityFilterRowCount{});
+  bc.arg<B::null_bv_register>() = NullBitvectorRegisterFor(spec.col);
+  bc.arg<B::update_register>() = indices;
+}
+
+void BytecodeLowering::EmitScanFilterIn(
+    const FilterSpec& spec,
+    i::RwHandle<std::unique_ptr<i::CastFilterValueListResult>> values) {
+  const auto& col = GetColumn(spec.col);
+  auto update = EnsureIndicesAreInSlab();
+  PruneNullIndices(spec.col, update, NullPruneScope::kResultRows);
+  auto source = TranslateNonNullIndices(spec.col, update, false);
+  {
+    using B = i::FilterInBase;
+    B& bc = AddOpcode<B>(
+        i::Index<i::FilterIn>(col.storage.type(),
+                              i::SparseNullCollapsedNullability{NonNull{}}),
+        RowCountModifier{
+            InFilterRowCount{col.duplicate_state, col.estimated_distinct}});
+    bc.arg<B::storage_register>() =
+        StorageRegisterFor(spec.col, col.storage.type());
+    bc.arg<B::null_bv_register>() = {};
+    bc.arg<B::value_list_register>() = values;
+    bc.arg<B::index_register>() = {};
+    bc.arg<B::source_range_register>() = {};
+    bc.arg<B::source_register>() = source;
+    bc.arg<B::dest_register>() = update;
+  }
+  MaybeReleaseScratchSpanRegister();
+}
+
+void BytecodeLowering::EmitIndexedFilters(
+    std::vector<FilterSpec>& specs,
+    uint32_t index_idx,
+    const std::vector<uint32_t>& spec_idxs) {
+  i::RwHandle<Span<uint32_t>> source_reg = IndexRegisterFor(index_idx);
+  i::RwHandle<Span<uint32_t>> dest_reg =
+      builder_.AllocateRegister<Span<uint32_t>>();
+
+  // The current row range — used by FilterIn's scan fallback when the IN list
+  // is too large for binary search and the index is ignored.
+  PERFETTO_CHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
+  const auto& range_reg = base::unchecked_get<i::RwHandle<Range>>(indices_reg_);
+
+  // Allocate the output indices upfront. For In filters, FilterIn writes
+  // directly here and CopySpanIntersectingRange runs in-place (safe because
+  // its write pointer never advances past its read pointer). For Eq-only
+  // filters, dest_reg points into the source index and
+  // CopySpanIntersectingRange copies from there into this buffer.
+  i::RwHandle<Slab<uint32_t>> output_slab_reg =
+      builder_.AllocateRegister<Slab<uint32_t>>();
+  i::RwHandle<Span<uint32_t>> output_span_reg =
+      builder_.AllocateRegister<Span<uint32_t>>();
+  {
+    using B = i::AllocateIndices;
+    auto& bc = AddOpcode<B>(UnchangedRowCount{});
+    bc.arg<B::size>() = plan_.params.max_row_count;
+    bc.arg<B::dest_slab_register>() = output_slab_reg;
+    bc.arg<B::dest_span_register>() = output_span_reg;
+  }
+
+  for (uint32_t spec_idx : spec_idxs) {
+    FilterSpec& fs = specs[spec_idx];
+    const Column& column = GetColumn(fs.col);
+    auto non_id = column.storage.type().TryDowncast<NonIdStorageType>();
+    PERFETTO_CHECK(non_id);
+
+    if (fs.op.Is<In>()) {
+      // Emit IndexedFilterIn for In filters.
+      auto value_list_reg = EmitCastFilterValueList(fs, column.storage.type());
+      // IndexedFilterIn gathers results from non-contiguous ranges, so it
+      // cannot write into the source (which points to the persistent index
+      // permutation vector). Write directly into the output span allocated
+      // upfront; CopySpanIntersectingRange will then run in-place on it.
+      {
+        using B = i::FilterInBase;
+        auto null_bv_reg = EnsurePrefixPopcountFor(fs.col);
+        auto& bc = AddOpcode<B>(
+            i::Index<i::FilterIn>(non_id->Upcast<StorageType>(),
+                                  NullabilityToSparseNullCollapsedNullability(
+                                      column.null_storage.nullability())),
+            RowCountModifier{InFilterRowCount{column.duplicate_state,
+                                              column.estimated_distinct}},
+            i::LogPerRowCost{10});
+        bc.arg<B::storage_register>() =
+            StorageRegisterFor(fs.col, non_id->Upcast<StorageType>());
+        bc.arg<B::null_bv_register>() = null_bv_reg;
+        bc.arg<B::value_list_register>() = value_list_reg;
+        bc.arg<B::index_register>() = source_reg;
+        bc.arg<B::source_range_register>() = range_reg;
+        bc.arg<B::source_register>() = {};
+        bc.arg<B::dest_register>() = output_span_reg;
+      }
+      // Override dest_reg so subsequent filters use the output span.
+      dest_reg = output_span_reg;
+    } else {
+      // Emit IndexedFilterEq for Eq filters.
+      auto value_reg = EmitCastFilterValue(fs, column.storage.type(),
+                                           *fs.op.TryDowncast<NonNullOp>());
+      {
+        using B = i::IndexedFilterEqBase;
+        auto null_bv_reg = EnsurePrefixPopcountFor(fs.col);
+        auto& bc = AddOpcode<B>(
+            i::Index<i::IndexedFilterEq>(
+                *non_id, NullabilityToSparseNullCollapsedNullability(
+                             column.null_storage.nullability())),
+            RowCountModifier{EqualityFilterRowCount{
+                column.duplicate_state, column.estimated_distinct}});
+        bc.arg<B::storage_register>() =
+            StorageRegisterFor(fs.col, non_id->Upcast<StorageType>());
+        bc.arg<B::null_bv_register>() = null_bv_reg;
+        bc.arg<B::filter_value_reg>() = value_reg;
+        bc.arg<B::source_register>() = source_reg;
+        bc.arg<B::dest_register>() = dest_reg;
+      }
+    }
+    // After first filter, subsequent filters read from dest and write back to
+    // dest.
+    source_reg = dest_reg;
+  }
+
+  PERFETTO_CHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
+  const auto& indices_reg =
+      base::unchecked_get<i::RwHandle<Range>>(indices_reg_);
+
+  {
+    using B = i::CopySpanIntersectingRange;
+    auto& bc = AddOpcode<B>(UnchangedRowCount{});
+    bc.arg<B::source_register>() = dest_reg;
+    bc.arg<B::source_range_register>() = indices_reg;
+    bc.arg<B::update_register>() = output_span_reg;
+  }
+  indices_reg_ = output_span_reg;
+}
+
+void BytecodeLowering::EmitGuaranteedEmpty() {
+  i::RwHandle<Slab<uint32_t>> slab_reg =
+      builder_.AllocateRegister<Slab<uint32_t>>();
+  i::RwHandle<Span<uint32_t>> span_reg =
+      builder_.AllocateRegister<Span<uint32_t>>();
+  {
+    using B = i::AllocateIndices;
+    auto& bc = AddOpcode<B>(ZeroRowCount{});
+    bc.arg<B::size>() = 0;
+    bc.arg<B::dest_slab_register>() = slab_reg;
+    bc.arg<B::dest_span_register>() = span_reg;
+  }
+  indices_reg_ = span_reg;
+}
+
+void BytecodeLowering::EmitDistinct(const std::vector<DistinctSpec>& specs) {
+  std::vector<RowLayoutParams> row_layout_params;
+  row_layout_params.reserve(specs.size());
+  for (const auto& spec : specs) {
+    row_layout_params.push_back({spec.col, false});
+  }
+  uint16_t total_row_stride = CalculateRowLayoutStride(row_layout_params);
+  i::RwHandle<Span<uint32_t>> indices = EnsureIndicesAreInSlab();
+  auto buffer_reg =
+      CopyToRowLayout(total_row_stride, indices, {}, row_layout_params);
+  {
+    using B = i::Distinct;
+    auto& bc = AddOpcode<B>(NonEqualityFilterRowCount{});
+    bc.arg<B::buffer_register>() = buffer_reg;
+    bc.arg<B::total_row_stride>() = total_row_stride;
+    bc.arg<B::indices_register>() = indices;
+  }
+}
+
+void BytecodeLowering::EmitReverse() {
+  auto indices = EnsureIndicesAreInSlab();
+  using B = i::Reverse;
+  auto& op = AddOpcode<B>(UnchangedRowCount{});
+  op.arg<B::update_register>() = indices;
+}
+
+void BytecodeLowering::EmitSort(const std::vector<SortSpec>& sort_specs) {
+  // main_indices_span will be modified by the final sort operation.
+  // EnsureIndicesAreInSlab makes it an RwHandle.
+  i::RwHandle<Span<uint32_t>> indices = EnsureIndicesAreInSlab();
+
+  bool has_string_sort_keys = false;
+  for (const auto& spec : sort_specs) {
+    if (GetColumn(spec.col).storage.type().Is<String>()) {
+      has_string_sort_keys = true;
+      break;
+    }
+  }
+
+  using Map = i::StringIdToRankMap;
+  i::RwHandle<Map> string_rank_map;
+  if (has_string_sort_keys) {
+    string_rank_map = builder_.AllocateRegister<Map>();
+    {
+      using B = i::InitRankMap;
+      auto& op = AddOpcode<B>(UnchangedRowCount{});
+      op.arg<B::dest_register>() = string_rank_map;
+    }
+
+    // For each string column in the sort specification, collect its unique IDs.
+    // This involves preparing a temporary set of indices for that column which
+    // are non-null and translated to storage indices if originally sparse.
+    for (const auto& spec : sort_specs) {
+      const Column& col = GetColumn(spec.col);
+      if (!col.storage.type().Is<String>()) {
+        continue;
+      }
+
+      i::RwHandle<Span<uint32_t>> translated;
+      if (col.null_storage.nullability().Is<NonNull>()) {
+        // If the column is non-null, we can use the main indices directly.
+        translated = indices;
+      } else {
+        // Get a scratch register to prepare indices for this specific column.
+        // This ensures that the main_indices_span is not modified, allowing
+        // each string column to be processed independently from the original
+        // set of rows.
+        i::RwHandle<Span<uint32_t>> scratch =
+            GetOrCreateScratchSpanRegister(plan_.params.max_row_count);
+
+        // 1. Copy the current indices to our temporary scratch span.
+        {
+          auto& op = AddOpcode<i::StrideCopy>(UnchangedRowCount{});
+          op.arg<i::StrideCopy::source_register>() = indices;
+          op.arg<i::StrideCopy::update_register>() = scratch;
+          op.arg<i::StrideCopy::stride>() = 1;
+        }
+
+        // 2. Prune nulls from this temporary span in-place.
+        PruneNullIndices(spec.col, scratch, NullPruneScope::kScratchOnly);
+
+        // 3. Translate these non-null table indices to storage indices if
+        // necessary.
+        translated = TranslateNonNullIndices(spec.col, scratch, true);
+        PERFETTO_CHECK(translated.index == scratch.index);
+      }
+
+      // Collect IDs using the prepared (non-null, translated) indices.
+      {
+        using B = i::CollectIdIntoRankMap;
+        auto& op = AddOpcode<B>(UnchangedRowCount{});
+        op.arg<B::storage_register>() =
+            StorageRegisterFor(spec.col, col.storage.type());
+        op.arg<B::source_register>() = translated;
+        op.arg<B::rank_map_register>() = string_rank_map;
+      }
+
+      // Maybe release the scratch register if we used one.
+      MaybeReleaseScratchSpanRegister();
+    }
+
+    // Finalize ranks in the map (sorts keys, updates map values to ranks).
+    {
+      using B = i::FinalizeRanksInMap;
+      auto& op = AddOpcode<B>(UnchangedRowCount{});
+      op.arg<B::update_register>() = string_rank_map;
+    }
+  }
+
+  std::vector<RowLayoutParams> row_layout_params;
+  row_layout_params.reserve(sort_specs.size());
+  for (const auto& spec : sort_specs) {
+    row_layout_params.push_back(
+        {spec.col, columns_[spec.col]->storage.type().Is<String>(),
+         spec.direction == SortDirection::kDescending});
+  }
+  uint16_t total_row_stride = CalculateRowLayoutStride(row_layout_params);
+  auto buffer_reg = CopyToRowLayout(total_row_stride, indices, string_rank_map,
+                                    row_layout_params);
+  {
+    using B = i::SortRowLayout;
+    auto& op = AddOpcode<B>(UnchangedRowCount{});
+    op.arg<B::buffer_register>() = buffer_reg;
+    op.arg<B::total_row_stride>() = total_row_stride;
+    op.arg<B::indices_register>() = indices;
+  }
+}
+
+void BytecodeLowering::EmitMinMax(const SortSpec& sort_spec) {
+  uint32_t col_idx = sort_spec.col;
+  const auto& col = GetColumn(col_idx);
+  StorageType storage_type = col.storage.type();
+
+  i::MinMaxOp mmop = sort_spec.direction == SortDirection::kAscending
+                         ? i::MinMaxOp(i::MinOp{})
+                         : i::MinMaxOp(i::MaxOp{});
+
+  auto indices = EnsureIndicesAreInSlab();
+  using B = i::FindMinMaxIndexBase;
+  auto& op = AddOpcode<B>(i::Index<i::FindMinMaxIndex>(storage_type, mmop),
+                          OneRowCount{});
+  op.arg<B::update_register>() = indices;
+  op.arg<B::storage_register>() = StorageRegisterFor(col_idx, storage_type);
+}
+
+void BytecodeLowering::EmitOutput(const LimitSpec& limit, uint64_t cols_used) {
+  // Structure to track column and offset pairs
+  struct ColAndOffset {
+    uint32_t col;
+    uint32_t offset;
+  };
+
+  base::SmallVector<ColAndOffset, 24> null_cols;
+  plan_.params.output_per_row = 1;
+  for (uint32_t i = 0; i < columns_.size(); ++i) {
+    plan_.col_to_output_offset.emplace_back();
+  }
+
+  // Process each column that will be used in the output
+  for (uint32_t i = 0; i < columns_.size(); ++i) {
+    // Any column with index >= 64 uses the 64th bit in cols_used.
+    uint64_t mask = 1ULL << std::min(i, 63u);
+    if ((cols_used & mask) == 0) {
+      continue;
+    }
+    const auto& col = GetColumn(i);
+    switch (col.null_storage.nullability().index()) {
+      case Nullability::GetTypeIndex<SparseNull>():
+      case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
+      case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>():
+      case Nullability::GetTypeIndex<DenseNull>(): {
+        uint32_t offset = plan_.params.output_per_row++;
+        null_cols.emplace_back(ColAndOffset{i, offset});
+        plan_.col_to_output_offset[i] = offset;
+        break;
+      }
+      case Nullability::GetTypeIndex<NonNull>():
+        // For non-null columns, we can directly use the indices
+        plan_.col_to_output_offset[i] = 0;
+        break;
+      default:
+        PERFETTO_FATAL("Unreachable");
+    }
+  }
+
+  auto in_memory_indices = EnsureIndicesAreInSlab();
+  if (limit.limit || limit.offset) {
+    auto o = limit.offset.value_or(0);
+    auto l = limit.limit.value_or(std::numeric_limits<uint32_t>::max());
+    using B = i::LimitOffsetIndices;
+    auto& bc = AddOpcode<B>(LimitOffsetRowCount{l, o});
+    bc.arg<B::offset_value>() = o;
+    bc.arg<B::limit_value>() = l;
+    bc.arg<B::update_register>() = in_memory_indices;
+  }
+
+  i::RwHandle<Span<uint32_t>> storage_update_register;
+  if (plan_.params.output_per_row > 1) {
+    i::RwHandle<Slab<uint32_t>> slab_register =
+        builder_.AllocateRegister<Slab<uint32_t>>();
+    storage_update_register = builder_.AllocateRegister<Span<uint32_t>>();
+    {
+      using B = i::AllocateIndices;
+      auto& bc = AddOpcode<B>(UnchangedRowCount{});
+      bc.arg<B::size>() =
+          plan_.params.max_row_count * plan_.params.output_per_row;
+      bc.arg<B::dest_slab_register>() = slab_register;
+      bc.arg<B::dest_span_register>() = storage_update_register;
+    }
+    {
+      using B = i::StrideCopy;
+      auto& bc = AddOpcode<B>(UnchangedRowCount{});
+      bc.arg<B::source_register>() = in_memory_indices;
+      bc.arg<B::update_register>() = storage_update_register;
+      bc.arg<B::stride>() = plan_.params.output_per_row;
+    }
+    for (auto [col, offset] : null_cols) {
+      const auto& c = GetColumn(col);
+      switch (c.null_storage.nullability().index()) {
+        case Nullability::GetTypeIndex<SparseNull>():
+        case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
+        case Nullability::GetTypeIndex<
+            SparseNullWithPopcountUntilFinalization>(): {
+          using B = i::StrideTranslateAndCopySparseNullIndices;
+          auto null_bv_reg = EnsurePrefixPopcountFor(col);
+          auto& bc = AddOpcode<B>(UnchangedRowCount{});
+          bc.arg<B::update_register>() = storage_update_register;
+          bc.arg<B::null_bv_register>() = null_bv_reg;
+          bc.arg<B::offset>() = offset;
+          bc.arg<B::stride>() = plan_.params.output_per_row;
+          break;
+        }
+        case Nullability::GetTypeIndex<DenseNull>(): {
+          using B = i::StrideCopyDenseNullIndices;
+          auto& bc = AddOpcode<B>(UnchangedRowCount{});
+          bc.arg<B::update_register>() = storage_update_register;
+          bc.arg<B::null_bv_register>() = NullBitvectorRegisterFor(col);
+          bc.arg<B::offset>() = offset;
+          bc.arg<B::stride>() = plan_.params.output_per_row;
+          break;
+        }
+        case Nullability::GetTypeIndex<NonNull>():
+        default:
+          PERFETTO_FATAL("Unreachable");
+      }
+    }
+  } else {
+    PERFETTO_CHECK(null_cols.empty());
+    storage_update_register = in_memory_indices;
+  }
+  plan_.params.output_register = storage_update_register;
+}
+
+void BytecodeLowering::PruneNullIndices(uint32_t col,
+                                        i::RwHandle<Span<uint32_t>> indices,
+                                        NullPruneScope scope) {
+  switch (GetColumn(col).null_storage.nullability().index()) {
+    case Nullability::GetTypeIndex<SparseNull>():
+    case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
+    case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>():
+    case Nullability::GetTypeIndex<DenseNull>(): {
+      using B = i::NullFilter<IsNotNull>;
+      RowCountModifier rc = scope == NullPruneScope::kResultRows
+                                ? RowCountModifier{NonEqualityFilterRowCount{}}
+                                : RowCountModifier{UnchangedRowCount{}};
+      i::NullFilterBase& bc = AddOpcode<B>(rc);
+      bc.arg<B::null_bv_register>() = NullBitvectorRegisterFor(col);
+      bc.arg<B::update_register>() = indices;
+      break;
+    }
+    case Nullability::GetTypeIndex<NonNull>():
+      break;
+    default:
+      PERFETTO_FATAL("Unreachable");
+  }
+}
+
+i::RwHandle<Span<uint32_t>> BytecodeLowering::TranslateNonNullIndices(
+    uint32_t col,
+    i::RwHandle<Span<uint32_t>> table_indices_register,
+    bool in_place) {
+  switch (GetColumn(col).null_storage.nullability().index()) {
+    case Nullability::GetTypeIndex<SparseNull>():
+    case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
+    case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>(): {
+      auto update =
+          in_place ? table_indices_register
+                   : GetOrCreateScratchSpanRegister(plan_.params.max_row_count);
+      {
+        auto null_bv_reg = EnsurePrefixPopcountFor(col);
+        using B = i::TranslateSparseNullIndices;
+        auto& bc = AddOpcode<B>(UnchangedRowCount{});
+        bc.arg<B::null_bv_register>() = null_bv_reg;
+        bc.arg<B::source_register>() = table_indices_register;
+        bc.arg<B::update_register>() = update;
+      }
+      return update;
+    }
+    case Nullability::GetTypeIndex<DenseNull>():
+    case Nullability::GetTypeIndex<NonNull>():
+      return table_indices_register;
+    default:
+      PERFETTO_FATAL("Unreachable");
+  }
+}
+
+PERFETTO_NO_INLINE i::RwHandle<Span<uint32_t>>
+BytecodeLowering::EnsureIndicesAreInSlab() {
+  using SpanReg = i::RwHandle<Span<uint32_t>>;
+  using SlabReg = i::RwHandle<Slab<uint32_t>>;
+
+  if (PERFETTO_LIKELY(std::holds_alternative<SpanReg>(indices_reg_))) {
+    return base::unchecked_get<SpanReg>(indices_reg_);
+  }
+
+  using RegRange = i::RwHandle<Range>;
+  PERFETTO_DCHECK(std::holds_alternative<RegRange>(indices_reg_));
+  auto range_reg = base::unchecked_get<RegRange>(indices_reg_);
+
+  SlabReg slab_reg = builder_.AllocateRegister<Slab<uint32_t>>();
+  SpanReg span_reg = builder_.AllocateRegister<Span<uint32_t>>();
+  {
+    using B = i::AllocateIndices;
+    auto& bc = AddOpcode<B>(UnchangedRowCount{});
+    bc.arg<B::size>() = plan_.params.max_row_count;
+    bc.arg<B::dest_slab_register>() = slab_reg;
+    bc.arg<B::dest_span_register>() = span_reg;
+  }
+  {
+    using B = i::Iota;
+    auto& bc = AddOpcode<B>(UnchangedRowCount{});
+    bc.arg<B::source_register>() = range_reg;
+    bc.arg<B::update_register>() = span_reg;
+  }
+  indices_reg_ = span_reg;
+  return span_reg;
+}
+
+PERFETTO_NO_INLINE i::Bytecode& BytecodeLowering::AddRawOpcode(
+    uint32_t option,
+    RowCountModifier rc,
+    i::Cost cost) {
+  static constexpr uint32_t kFixedBytecodeCost = 5;
+  switch (cost.index()) {
+    case base::variant_index<i::Cost, i::FixedCost>(): {
+      const auto& c = base::unchecked_get<i::FixedCost>(cost);
+      plan_.params.estimated_cost += c.cost;
+      break;
+    }
+    case base::variant_index<i::Cost, i::LogPerRowCost>(): {
+      const auto& c = base::unchecked_get<i::LogPerRowCost>(cost);
+      plan_.params.estimated_cost +=
+          plan_.params.estimated_row_count == 0
+              ? kFixedBytecodeCost
+              : c.cost * log2(plan_.params.estimated_row_count);
+      break;
+    }
+    case base::variant_index<i::Cost, i::LinearPerRowCost>(): {
+      const auto& c = base::unchecked_get<i::LinearPerRowCost>(cost);
+      plan_.params.estimated_cost +=
+          plan_.params.estimated_row_count == 0
+              ? kFixedBytecodeCost
+              : c.cost * plan_.params.estimated_row_count;
+      break;
+    }
+    case base::variant_index<i::Cost, i::LogLinearPerRowCost>(): {
+      const auto& c = base::unchecked_get<i::LogLinearPerRowCost>(cost);
+      plan_.params.estimated_cost +=
+          plan_.params.estimated_row_count == 0
+              ? kFixedBytecodeCost
+              : c.cost * plan_.params.estimated_row_count *
+                    log2(plan_.params.estimated_row_count);
+      break;
+    }
+    case base::variant_index<i::Cost, i::PostOperationLinearPerRowCost>():
+      break;
+    default:
+      PERFETTO_FATAL("Unknown cost type");
+  }
+  switch (rc.index()) {
+    case base::variant_index<RowCountModifier, UnchangedRowCount>():
+      break;
+    case base::variant_index<RowCountModifier, NonEqualityFilterRowCount>():
+      if (plan_.params.estimated_row_count > 1) {
+        plan_.params.estimated_row_count = plan_.params.estimated_row_count / 2;
+      } else {
+        // Leave the estimated row count as is if it is already 1 or less.
+      }
+      break;
+    case base::variant_index<RowCountModifier, EqualityFilterRowCount>(): {
+      const auto& eq = base::unchecked_get<EqualityFilterRowCount>(rc);
+      if (eq.duplicate_state.Is<HasDuplicates>()) {
+        if (plan_.params.estimated_row_count > 1) {
+          if (!selective_filter_base_row_count_) {
+            selective_filter_base_row_count_ = plan_.params.estimated_row_count;
+          }
+          // Estimate against the pre-selective-filter row count and keep the
+          // most selective result: correlated filters on one scan shouldn't
+          // compound and collapse the estimate toward 1.
+          plan_.params.estimated_row_count =
+              std::min(plan_.params.estimated_row_count,
+                       std::max(1u, static_cast<uint32_t>(EqualityFilterRows(
+                                        *selective_filter_base_row_count_,
+                                        eq.estimated_distinct))));
+        } else {
+          // Leave the estimated row count as is if it is already 1 or less.
+        }
+      } else {
+        PERFETTO_CHECK(eq.duplicate_state.Is<NoDuplicates>());
+        plan_.params.estimated_row_count =
+            std::min(1u, plan_.params.estimated_row_count);
+        plan_.params.max_row_count = std::min(1u, plan_.params.max_row_count);
+      }
+      break;
+    }
+    case base::variant_index<RowCountModifier, InFilterRowCount>(): {
+      const auto& in = base::unchecked_get<InFilterRowCount>(rc);
+      if (in.duplicate_state.Is<HasDuplicates>() &&
+          plan_.params.estimated_row_count > 1) {
+        if (!selective_filter_base_row_count_) {
+          selective_filter_base_row_count_ = plan_.params.estimated_row_count;
+        }
+        // An IN is a union of equalities over the list values. The list size
+        // is unknown at plan time, so scale the single-value estimate by an
+        // assumed distinct-value count. As with equality, estimate against the
+        // pre-selective-filter row count and keep the most selective result.
+        double per_value = EqualityFilterRows(*selective_filter_base_row_count_,
+                                              in.estimated_distinct);
+        double new_count =
+            std::min(static_cast<double>(*selective_filter_base_row_count_),
+                     per_value * kAssumedInListSize);
+        plan_.params.estimated_row_count =
+            std::min(plan_.params.estimated_row_count,
+                     std::max(1u, static_cast<uint32_t>(new_count)));
+      }
+      break;
+    }
+    case base::variant_index<RowCountModifier, OneRowCount>():
+      plan_.params.estimated_row_count =
+          std::min(1u, plan_.params.estimated_row_count);
+      plan_.params.max_row_count = std::min(1u, plan_.params.max_row_count);
+      break;
+    case base::variant_index<RowCountModifier, ZeroRowCount>():
+      plan_.params.estimated_row_count = 0;
+      plan_.params.max_row_count = 0;
+      break;
+    case base::variant_index<RowCountModifier, LimitOffsetRowCount>(): {
+      const auto& lc = base::unchecked_get<LimitOffsetRowCount>(rc);
+
+      // Offset will cut out `offset` rows from the start of indices.
+      uint32_t remove_from_start =
+          std::min(plan_.params.max_row_count, lc.offset);
+      plan_.params.max_row_count -= remove_from_start;
+
+      // Limit will only preserve at most `limit` rows.
+      plan_.params.max_row_count =
+          std::min(lc.limit, plan_.params.max_row_count);
+
+      // The max row count is also the best possible estimate we can make for
+      // the row count.
+      plan_.params.estimated_row_count = plan_.params.max_row_count;
+      break;
+    }
+    default:
+      PERFETTO_FATAL("Unknown row count modifier type");
+  }
+  // Handle all the cost types which need to be calculated *post* the row
+  // estimate update.
+  if (cost.index() ==
+      base::variant_index<i::Cost, i::PostOperationLinearPerRowCost>()) {
+    const auto& c = base::unchecked_get<i::PostOperationLinearPerRowCost>(cost);
+    plan_.params.estimated_cost += c.cost * plan_.params.estimated_cost;
+  }
+  return builder_.AddRawOpcode(option);
+}
+
+i::RwHandle<i::StoragePtr> BytecodeLowering::StorageRegisterFor(
+    uint32_t col,
+    StorageType type) {
+  auto [reg, inserted] =
+      cache_.GetOrAllocate<i::StoragePtr>(kStorageReg, columns_[col].get());
+  if (inserted) {
+    plan_.register_inits.emplace_back(
+        RegisterInit{reg.index, type.Upcast<RegisterInit::Type>(),
+                     static_cast<uint16_t>(col)});
+  }
+  return reg;
+}
+
+i::ReadHandle<i::NullBitvector> BytecodeLowering::NullBitvectorRegisterFor(
+    uint32_t col) {
+  if (GetColumn(col).null_storage.nullability().Is<NonNull>()) {
+    return {};
+  }
+  auto [reg, inserted] =
+      cache_.GetOrAllocate<i::NullBitvector>(kNullBvReg, columns_[col].get());
+  if (inserted) {
+    plan_.register_inits.emplace_back(RegisterInit{
+        reg.index, RegisterInit::NullBitvector{}, static_cast<uint16_t>(col)});
+  }
+  return reg;
+}
+
+i::ReadHandle<i::NullBitvector> BytecodeLowering::EnsurePrefixPopcountFor(
+    uint32_t col) {
+  auto nbv_reg = NullBitvectorRegisterFor(col);
+  if (!GetColumn(col).null_storage.nullability().IsAnyOf<SparseNullTypes>()) {
+    return nbv_reg;
+  }
+  auto [it, inserted] = prefix_popcount_emitted_.Insert(col, true);
+  if (inserted) {
+    using B = i::PrefixPopcount;
+    auto& bc = AddOpcode<B>(UnchangedRowCount{});
+    bc.arg<B::null_bv_register>() =
+        i::RwHandle<i::NullBitvector>(nbv_reg.index);
+  }
+  return nbv_reg;
+}
+
+i::ReadHandle<const BitVector*> BytecodeLowering::SmallValueEqBvRegisterFor(
+    uint32_t col) {
+  auto [reg, inserted] = cache_.GetOrAllocate<const BitVector*>(
+      kSmallValueEqBvReg, columns_[col].get());
+  if (inserted) {
+    plan_.register_inits.emplace_back(
+        RegisterInit{reg.index, RegisterInit::SmallValueEqBitvector{},
+                     static_cast<uint16_t>(col)});
+  }
+  return reg;
+}
+
+i::ReadHandle<Span<const uint32_t>>
+BytecodeLowering::SmallValueEqPopcountRegisterFor(uint32_t col) {
+  auto [reg, inserted] = cache_.GetOrAllocate<Span<const uint32_t>>(
+      kSmallValueEqPopcountReg, columns_[col].get());
+  if (inserted) {
+    plan_.register_inits.emplace_back(
+        RegisterInit{reg.index, RegisterInit::SmallValueEqPopcount{},
+                     static_cast<uint16_t>(col)});
+  }
+  return reg;
+}
+
+i::RwHandle<Span<uint32_t>> BytecodeLowering::IndexRegisterFor(uint32_t pos) {
+  auto [reg, inserted] =
+      cache_.GetOrAllocate<Span<uint32_t>>(kIndexReg, &indexes_[pos]);
+  if (inserted) {
+    plan_.register_inits.emplace_back(RegisterInit{
+        reg.index, RegisterInit::IndexVector{}, static_cast<uint16_t>(pos)});
+  }
+  return reg;
+}
+
+i::RwHandle<Span<uint32_t>> BytecodeLowering::GetOrCreateScratchSpanRegister(
+    uint32_t size) {
+  auto scratch = builder_.GetOrCreateScratchRegisters(size);
+  {
+    using B = i::AllocateIndices;
+    auto& bc = AddOpcode<B>(UnchangedRowCount{});
+    bc.arg<B::size>() = size;
+    bc.arg<B::dest_slab_register>() = scratch.slab;
+    bc.arg<B::dest_span_register>() = scratch.span;
+  }
+  builder_.MarkScratchInUse(scratch);
+  scratch_ = scratch;
+  return scratch.span;
+}
+
+void BytecodeLowering::MaybeReleaseScratchSpanRegister() {
+  if (scratch_.has_value()) {
+    builder_.ReleaseScratch(*scratch_);
+    scratch_ = std::nullopt;
+  }
+}
+
+uint16_t BytecodeLowering::CalculateRowLayoutStride(
+    const std::vector<RowLayoutParams>& row_layout_params) {
+  PERFETTO_CHECK(!row_layout_params.empty());
+  uint16_t calculated_total_row_stride = 0;
+  for (const auto& param : row_layout_params) {
+    const Column& col = GetColumn(param.column);
+    bool is_non_null = col.null_storage.nullability().Is<NonNull>();
+    calculated_total_row_stride +=
+        (is_non_null ? 0u : 1u) + GetDataSize(col.storage.type());
+  }
+  return calculated_total_row_stride;
+}
+
+i::RwHandle<Slab<uint8_t>> BytecodeLowering::CopyToRowLayout(
+    uint16_t row_stride,
+    i::RwHandle<Span<uint32_t>> indices,
+    i::ReadHandle<i::StringIdToRankMap> rank_map,
+    const std::vector<RowLayoutParams>& row_layout_params) {
+  uint32_t buffer_size = plan_.params.max_row_count * row_stride;
+  i::RwHandle<Slab<uint8_t>> new_buffer_reg =
+      builder_.AllocateRegister<Slab<uint8_t>>();
+  {
+    using B = i::AllocateRowLayoutBuffer;
+    auto& op = AddOpcode<B>(UnchangedRowCount{});
+    op.arg<B::buffer_size>() = buffer_size;
+    op.arg<B::dest_buffer_register>() = new_buffer_reg;
+  }
+  uint16_t current_offset = 0;
+  for (const auto& param : row_layout_params) {
+    const Column& col = GetColumn(param.column);
+    const auto& nullability = col.null_storage.nullability();
+    auto null_bv_reg = EnsurePrefixPopcountFor(param.column);
+    {
+      using B = i::CopyToRowLayoutBase;
+      auto index = i::Index<i::CopyToRowLayout>(
+          col.storage.type(),
+          NullabilityToSparseNullCollapsedNullability(nullability));
+      auto& op = AddOpcode<B>(index, UnchangedRowCount{});
+      op.arg<B::storage_register>() =
+          StorageRegisterFor(param.column, col.storage.type());
+      op.arg<B::null_bv_register>() = null_bv_reg;
+      op.arg<B::source_indices_register>() = indices;
+      op.arg<B::dest_buffer_register>() = new_buffer_reg;
+      op.arg<B::rank_map_register>() = rank_map;
+      op.arg<B::row_layout_offset>() = current_offset;
+      op.arg<B::row_layout_stride>() = row_stride;
+      op.arg<B::invert_copied_bits>() = param.invert_copied_bits;
+    }
+    current_offset +=
+        (nullability.Is<NonNull>() ? 0u : 1u) + GetDataSize(col.storage.type());
+  }
+  PERFETTO_CHECK(current_offset == row_stride);
+  return new_buffer_reg;
+}
+
+template <typename T>
+T& BytecodeLowering::AddOpcode(RowCountModifier rc) {
+  return AddOpcode<T>(i::Index<T>(), rc, T::kCost);
+}
+
+}  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/dataframe/bytecode_lowering.h
+++ b/src/trace_processor/core/dataframe/bytecode_lowering.h
@@ -1,0 +1,342 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_DATAFRAME_BYTECODE_LOWERING_H_
+#define SRC_TRACE_PROCESSOR_CORE_DATAFRAME_BYTECODE_LOWERING_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/public/compiler.h"
+#include "src/trace_processor/core/dataframe/dataframe_register_cache.h"
+#include "src/trace_processor/core/dataframe/query_plan.h"
+#include "src/trace_processor/core/dataframe/specs.h"
+#include "src/trace_processor/core/dataframe/types.h"
+#include "src/trace_processor/core/interpreter/bytecode_builder.h"
+#include "src/trace_processor/core/interpreter/bytecode_core.h"
+#include "src/trace_processor/core/interpreter/bytecode_instructions.h"
+#include "src/trace_processor/core/interpreter/bytecode_registers.h"
+#include "src/trace_processor/core/interpreter/interpreter_types.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/range.h"
+#include "src/trace_processor/core/util/slab.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::dataframe {
+
+// Turns access-path decisions made by QueryPlanBuilder into bytecode.
+//
+// This class owns everything mechanical about emission: register allocation
+// and caching, scratch lifetimes, materializing a range into an index list,
+// pruning nulls, translating sparse-null indices, row layout buffers, and the
+// running row-count and cost estimates.
+//
+// It makes no access-path decisions of its own. Each Emit* method corresponds
+// to one strategy the planner has already chosen, and expands it into however
+// many bytecodes that strategy needs.
+class BytecodeLowering {
+ public:
+  BytecodeLowering(uint32_t row_count,
+                   const std::vector<std::shared_ptr<Column>>& columns,
+                   const std::vector<Index>& indexes);
+
+  // === State the planner needs to make decisions ===
+
+  // Whether the set of matching rows is still a contiguous range, as opposed
+  // to a materialized list of indices. Some strategies are only available
+  // while this holds.
+  bool IsIndicesRange() const {
+    return std::holds_alternative<interpreter::RwHandle<Range>>(indices_reg_);
+  }
+
+  uint32_t max_row_count() const { return plan_.params.max_row_count; }
+  uint32_t estimated_row_count() const {
+    return plan_.params.estimated_row_count;
+  }
+
+  // === Filter values ===
+
+  // Reserves the next filter value slot and records it on `spec`. Emits
+  // nothing; used by strategies which need SQLite to pass a value they do not
+  // themselves read.
+  uint32_t ReserveFilterValueSlot(FilterSpec& spec);
+
+  // Emits the cast of a scalar filter value, recording the slot on `spec`.
+  interpreter::ReadHandle<interpreter::CastFilterValueResult>
+  EmitCastFilterValue(FilterSpec& spec, const StorageType& type, NonNullOp op);
+
+  // Emits the cast of an IN list filter value, recording the slot on `spec`.
+  interpreter::RwHandle<std::unique_ptr<interpreter::CastFilterValueListResult>>
+  EmitCastFilterValueList(FilterSpec& spec, const StorageType& type);
+
+  // === Filter strategies ===
+
+  // Binary search over a sorted column, narrowing the range in place.
+  void EmitSortedFilter(
+      const FilterSpec& spec,
+      const StorageType& type,
+      const RangeOp& op,
+      const interpreter::ReadHandle<interpreter::CastFilterValueResult>& value);
+
+  // Equality on a SetId-sorted uint32 column.
+  void EmitSetIdSortedEq(
+      const FilterSpec& spec,
+      const interpreter::ReadHandle<interpreter::CastFilterValueResult>& value);
+
+  // Equality served by a column's SmallValueEq specialized storage.
+  void EmitSmallValueEq(
+      const FilterSpec& spec,
+      const interpreter::ReadHandle<interpreter::CastFilterValueResult>& value);
+
+  // Equality scan over a range, materializing the matches into an index list.
+  void EmitLinearFilterEq(
+      const FilterSpec& spec,
+      const NonIdStorageType& type,
+      const interpreter::ReadHandle<interpreter::CastFilterValueResult>& value);
+
+  // Scan filter over an index list for a non-string column.
+  void EmitNonStringFilter(
+      const FilterSpec& spec,
+      const NonStringType& type,
+      const NonStringOp& op,
+      const interpreter::ReadHandle<interpreter::CastFilterValueResult>& value);
+
+  // Scan filter over an index list for a string column.
+  void EmitStringFilter(
+      const FilterSpec& spec,
+      const StringOp& op,
+      const interpreter::ReadHandle<interpreter::CastFilterValueResult>& value);
+
+  // IS NULL / IS NOT NULL over an index list.
+  void EmitNullFilter(const FilterSpec& spec, const NullOp& op);
+
+  // IN over an index list, without an index to accelerate it.
+  void EmitScanFilterIn(
+      const FilterSpec& spec,
+      interpreter::RwHandle<
+          std::unique_ptr<interpreter::CastFilterValueListResult>> values);
+
+  // Applies a whole group of Eq/In filters through `index_idx`, chaining them
+  // so each reads the previous one's output. `spec_idxs` indexes into `specs`
+  // and is ordered by the index's own column order.
+  void EmitIndexedFilters(std::vector<FilterSpec>& specs,
+                          uint32_t index_idx,
+                          const std::vector<uint32_t>& spec_idxs);
+
+  // Replaces the row set with the empty set. Used when a filter cannot match.
+  void EmitGuaranteedEmpty();
+
+  // === Post-filter stages ===
+
+  void EmitDistinct(const std::vector<DistinctSpec>& specs);
+
+  // Reverses the row set. Used when the data is already sorted, but opposite
+  // to the requested direction.
+  void EmitReverse();
+
+  void EmitSort(const std::vector<SortSpec>& specs);
+
+  void EmitMinMax(const SortSpec& spec);
+
+  void EmitOutput(const LimitSpec& limit, uint64_t cols_used);
+
+  // Finalizes and returns the plan.
+  QueryPlanImpl Build() &&;
+
+ private:
+  // How a bytecode changes the row-count estimate. See AddRawOpcode.
+  struct UnchangedRowCount {};
+  struct NonEqualityFilterRowCount {};
+
+  // An equality filter with the given duplicate state and estimated
+  // distinct-value count (0 = unknown).
+  struct EqualityFilterRowCount {
+    DuplicateState duplicate_state;
+    uint32_t estimated_distinct = 0;
+  };
+
+  // An IN filter over a value list. Unlike a scalar equality, an IN matches
+  // multiple distinct values; since the list size is not known at plan time
+  // (the RHS may be a subquery), we assume it selects a fixed number of
+  // distinct values. `estimated_distinct` is the per-column distinct-value
+  // count (0 = unknown).
+  struct InFilterRowCount {
+    DuplicateState duplicate_state;
+    uint32_t estimated_distinct = 0;
+  };
+
+  struct OneRowCount {};
+  struct ZeroRowCount {};
+
+  // Produces `limit` rows starting at `offset`.
+  struct LimitOffsetRowCount {
+    uint32_t limit;
+    uint32_t offset;
+  };
+  using RowCountModifier = std::variant<UnchangedRowCount,
+                                        NonEqualityFilterRowCount,
+                                        InFilterRowCount,
+                                        EqualityFilterRowCount,
+                                        OneRowCount,
+                                        ZeroRowCount,
+                                        LimitOffsetRowCount>;
+
+  // Register holding the set of matching rows, either as a contiguous range
+  // or as a materialized list of indices.
+  using IndicesReg = std::variant<interpreter::RwHandle<Range>,
+                                  interpreter::RwHandle<Span<uint32_t>>>;
+
+  // Parameters for conversion to row layout.
+  struct RowLayoutParams {
+    // The column to be copied.
+    uint32_t column;
+
+    // Whether, instead of copying the string column, we should replace it
+    // with a rank of the string.
+    bool replace_string_with_rank = false;
+
+    // Whether the bits when copied should be inverted.
+    bool invert_copied_bits = false;
+  };
+
+  // Alias for scratch register type.
+  using Scratch = interpreter::BytecodeBuilder::ScratchRegisters;
+
+  // Whether the span being pruned holds the query's result rows, or only a
+  // temporary copy of them.
+  enum class NullPruneScope { kResultRows, kScratchOnly };
+
+  // Given a list of indices, prunes any indices that point to null rows
+  // in the given column. The indices are pruned in-place.
+  void PruneNullIndices(uint32_t col,
+                        interpreter::RwHandle<Span<uint32_t>> indices,
+                        NullPruneScope scope);
+
+  // Given a list of table indices pointing to *only* non-null rows,
+  // if necessary, translates them to the storage indices for the given column.
+  // If no translation is needed, the indices are returned as-is.
+  // If translation *is* needed, the value of `in_place` determines
+  // whether the translation is done in-place or whether the data is stored
+  // in the scratch register.
+  interpreter::RwHandle<Span<uint32_t>> TranslateNonNullIndices(
+      uint32_t col,
+      interpreter::RwHandle<Span<uint32_t>> indices_register,
+      bool in_place);
+
+  // Ensures indices are stored in a Slab, converting from Range if necessary.
+  PERFETTO_NO_INLINE interpreter::RwHandle<Span<uint32_t>>
+  EnsureIndicesAreInSlab();
+
+  // Adds a new bytecode instruction of type T to the plan.
+  template <typename T>
+  T& AddOpcode(RowCountModifier rc);
+
+  // Adds a new bytecode instruction of type T with the given option value.
+  template <typename T>
+  T& AddOpcode(uint32_t option, RowCountModifier rc) {
+    return static_cast<T&>(AddRawOpcode(option, rc, T::kCost));
+  }
+
+  // Adds a new bytecode instruction of type T with the given option value.
+  template <typename T>
+  T& AddOpcode(uint32_t option, RowCountModifier rc, interpreter::Cost cost) {
+    return static_cast<T&>(AddRawOpcode(option, rc, cost));
+  }
+
+  PERFETTO_NO_INLINE interpreter::Bytecode&
+  AddRawOpcode(uint32_t option, RowCountModifier rc, interpreter::Cost cost);
+
+  // Allocates a register for column data pointer and adds RegisterInit entry.
+  interpreter::RwHandle<interpreter::StoragePtr> StorageRegisterFor(
+      uint32_t col,
+      StorageType storage_type);
+
+  // Returns the index register for the given position.
+  interpreter::RwHandle<Span<uint32_t>> IndexRegisterFor(uint32_t pos);
+
+  // Returns the null bitvector register for the given column.
+  // For NonNull columns, returns an empty handle.
+  interpreter::ReadHandle<interpreter::NullBitvector> NullBitvectorRegisterFor(
+      uint32_t col);
+
+  // Returns the null bitvector register for the given column, ensuring a
+  // PrefixPopcount bytecode has been emitted for SparseNull columns.
+  // No-op for non-SparseNull columns or if already emitted.
+  interpreter::ReadHandle<interpreter::NullBitvector> EnsurePrefixPopcountFor(
+      uint32_t col);
+
+  // Returns the SmallValueEq bitvector register for the given column.
+  interpreter::ReadHandle<const BitVector*> SmallValueEqBvRegisterFor(
+      uint32_t col);
+
+  // Returns the SmallValueEq popcount register for the given column.
+  interpreter::ReadHandle<Span<const uint32_t>> SmallValueEqPopcountRegisterFor(
+      uint32_t col);
+
+  interpreter::RwHandle<Span<uint32_t>> GetOrCreateScratchSpanRegister(
+      uint32_t size);
+
+  void MaybeReleaseScratchSpanRegister();
+
+  uint16_t CalculateRowLayoutStride(
+      const std::vector<RowLayoutParams>& row_layout_params);
+
+  interpreter::RwHandle<Slab<uint8_t>> CopyToRowLayout(
+      uint16_t row_stride,
+      interpreter::RwHandle<Span<uint32_t>> indices,
+      interpreter::ReadHandle<interpreter::StringIdToRankMap> rank_map,
+      const std::vector<RowLayoutParams>& row_layout_params);
+
+  const Column& GetColumn(uint32_t idx) { return *columns_[idx]; }
+
+  // Reference to the columns being queried.
+  const std::vector<std::shared_ptr<Column>>& columns_;
+
+  // Reference to the indexes available.
+  const std::vector<Index>& indexes_;
+
+  // The query plan being built.
+  QueryPlanImpl plan_;
+
+  // Low-level bytecode builder for register allocation, bytecode storage,
+  // and scratch management.
+  interpreter::BytecodeBuilder builder_;
+
+  // Register cache for caching column/index registers.
+  DataframeRegisterCache cache_;
+
+  // Current register holding the set of matching indices.
+  IndicesReg indices_reg_;
+
+  // Tracks which columns have had PrefixPopcount bytecode emitted.
+  base::FlatHashMap<uint32_t, bool> prefix_popcount_emitted_;
+
+  // Last scratch registers returned by GetOrCreateScratchSpanRegister.
+  std::optional<Scratch> scratch_;
+
+  // Row count before the first selective (equality/IN) filter was applied. Used
+  // to avoid compounding the selectivity of multiple such filters: only the
+  // most selective one determines the estimate.
+  std::optional<uint32_t> selective_filter_base_row_count_;
+};
+
+}  // namespace perfetto::trace_processor::core::dataframe
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_DATAFRAME_BYTECODE_LOWERING_H_

--- a/src/trace_processor/core/dataframe/query_plan.cc
+++ b/src/trace_processor/core/dataframe/query_plan.cc
@@ -17,78 +17,32 @@
 #include "src/trace_processor/core/dataframe/query_plan.h"
 
 #include <algorithm>
-#include <cmath>
-#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
-#include "perfetto/ext/base/regex.h"
-#include "perfetto/ext/base/small_vector.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
-#include "perfetto/ext/base/variant.h"
-#include "perfetto/public/compiler.h"
 #include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/dataframe/bytecode_lowering.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
-#include "src/trace_processor/core/dataframe/dataframe_register_cache.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/dataframe/types.h"
-#include "src/trace_processor/core/interpreter/bytecode_builder.h"
-#include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_instructions.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
 #include "src/trace_processor/core/interpreter/interpreter_types.h"
-#include "src/trace_processor/core/util/bit_vector.h"
-#include "src/trace_processor/core/util/range.h"
-#include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
-#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::core::dataframe {
 
 namespace {
 
 namespace i = interpreter;
-
-// Assumed number of distinct values matched by an IN filter when the list size
-// is not known at plan time. Scales the single-value equality estimate. Matches
-// SQLite's own tuning constant for "x IN (SELECT ...)" (see whereLoopAddBtree).
-constexpr double kAssumedInListSize = 25;
-
-// Rows surviving a scalar equality filter on a HasDuplicates column with
-// `estimated_distinct` distinct values (0 = unknown). With a known count, a
-// uniform column keeps ~1/estimated_distinct of the rows; otherwise fall back
-// to the data-blind heuristic.
-double EqualityFilterRows(uint32_t row_count, uint32_t estimated_distinct) {
-  if (estimated_distinct > 0) {
-    return static_cast<double>(row_count) / estimated_distinct;
-  }
-  return row_count / (2 * log2(row_count));
-}
-
-// Register type identifiers for cache key encoding.
-// Used with DataframeRegisterCache::GetOrAllocate(reg_type, ptr)
-// to cache column/index-specific registers.
-enum RegType : uint32_t {
-  kStorageReg = 0,
-  kNullBvReg = 1,
-  kSmallValueEqBvReg = 2,
-  kSmallValueEqPopcountReg = 3,
-  kIndexReg = 4,
-  kRegTypeCount = 5,
-};
-
-// TypeSet of all possible sparse nullability states.
-using SparseNullTypes = TypeSet<SparseNull,
-                                SparseNullWithPopcountAlways,
-                                SparseNullWithPopcountUntilFinalization>;
 
 // Calculates filter preference score for ordering filters.
 // Lower scores are applied first for better efficiency.
@@ -113,15 +67,15 @@ uint32_t FilterPreference(const FilterSpec& fs, const Column& col) {
       op.Is<Eq>()) {
     return kSetIdSortedEq;
   }
-  if (n.Is<NonNull>() && ct.Is<Id>() && op.IsAnyOf<i::InequalityOp>()) {
+  if (n.Is<NonNull>() && ct.Is<Id>() && op.IsAnyOf<InequalityOp>()) {
     return kIdInequality;
   }
   if (n.Is<NonNull>() && col.sort_state.Is<Sorted>() &&
-      ct.IsAnyOf<i::IntegerOrDoubleType>() && op.Is<Eq>()) {
+      ct.IsAnyOf<IntegerOrDoubleType>() && op.Is<Eq>()) {
     return kNumericSortedEq;
   }
   if (n.Is<NonNull>() && col.sort_state.Is<Sorted>() &&
-      ct.IsAnyOf<i::IntegerOrDoubleType>() && op.IsAnyOf<i::InequalityOp>()) {
+      ct.IsAnyOf<IntegerOrDoubleType>() && op.IsAnyOf<InequalityOp>()) {
     return kNumericSortedInequality;
   }
   if (n.Is<NonNull>() && col.sort_state.Is<Sorted>() && ct.Is<String>() &&
@@ -129,64 +83,10 @@ uint32_t FilterPreference(const FilterSpec& fs, const Column& col) {
     return kStringSortedEq;
   }
   if (n.Is<NonNull>() && col.sort_state.Is<Sorted>() && ct.Is<String>() &&
-      op.IsAnyOf<i::InequalityOp>()) {
+      op.IsAnyOf<InequalityOp>()) {
     return kStringSortedInequality;
   }
   return kLeastPreferred;
-}
-
-// Gets the appropriate bound modifier and range operation type
-// for a given range operation.
-std::pair<i::BoundModifier, i::EqualRangeLowerBoundUpperBound>
-GetSortedFilterArgs(const i::RangeOp& op) {
-  switch (op.index()) {
-    case i::RangeOp::GetTypeIndex<Eq>():
-      return std::make_pair(i::BothBounds{}, i::EqualRange{});
-    case i::RangeOp::GetTypeIndex<Lt>():
-      return std::make_pair(i::EndBound{}, i::LowerBound{});
-    case i::RangeOp::GetTypeIndex<Le>():
-      return std::make_pair(i::EndBound{}, i::UpperBound{});
-    case i::RangeOp::GetTypeIndex<Gt>():
-      return std::make_pair(i::BeginBound{}, i::UpperBound{});
-    case i::RangeOp::GetTypeIndex<Ge>():
-      return std::make_pair(i::BeginBound{}, i::LowerBound{});
-    default:
-      PERFETTO_FATAL("Unreachable");
-  }
-}
-
-// Helper to get byte size of storage types for layout calculation.
-// Returns 0 for Id type as it's handled specially.
-uint8_t GetDataSize(StorageType type) {
-  switch (type.index()) {
-    case StorageType::GetTypeIndex<Id>():
-    case StorageType::GetTypeIndex<Uint32>():
-    case StorageType::GetTypeIndex<Int32>():
-    case StorageType::GetTypeIndex<String>():
-      return sizeof(uint32_t);
-    case StorageType::GetTypeIndex<Int64>():
-      return sizeof(int64_t);
-    case StorageType::GetTypeIndex<Double>():
-      return sizeof(double);
-    default:
-      PERFETTO_FATAL("Invalid storage type");
-  }
-}
-
-i::SparseNullCollapsedNullability NullabilityToSparseNullCollapsedNullability(
-    Nullability nullability) {
-  switch (nullability.index()) {
-    case Nullability::GetTypeIndex<NonNull>():
-      return NonNull{};
-    case Nullability::GetTypeIndex<DenseNull>():
-      return DenseNull{};
-    case Nullability::GetTypeIndex<SparseNull>():
-    case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
-    case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>():
-      return SparseNull{};
-    default:
-      PERFETTO_FATAL("Invalid nullability type");
-  }
 }
 
 struct BestIndex {
@@ -194,12 +94,12 @@ struct BestIndex {
   std::vector<uint32_t> best_index_specs;
 };
 std::optional<BestIndex> GetBestIndexForFilterSpecs(
-    const QueryPlanImpl::ExecutionParams& params,
+    uint32_t max_row_count,
     const std::vector<FilterSpec>& all_specs,
     const std::vector<uint8_t>& spec_already_handled,
     const std::vector<Index>& indexes) {
   // If we have very few rows, there's no point in using an index.
-  if (params.max_row_count <= 1) {
+  if (max_row_count <= 1) {
     return std::nullopt;
   }
   uint32_t best_index_idx = std::numeric_limits<uint32_t>::max();
@@ -245,21 +145,10 @@ std::optional<BestIndex> GetBestIndexForFilterSpecs(
 }  // namespace
 
 QueryPlanBuilder::QueryPlanBuilder(
-    i::BytecodeBuilder& builder,
-    DataframeRegisterCache& cache,
-    IndicesReg indices,
-    uint32_t row_count,
+    BytecodeLowering& lowering,
     const std::vector<std::shared_ptr<Column>>& columns,
     const std::vector<Index>& indexes)
-    : columns_(columns),
-      indexes_(indexes),
-      indices_reg_(indices),
-      builder_(builder),
-      cache_(cache) {
-  // Setup the maximum and estimated row counts.
-  plan_.params.max_row_count = row_count;
-  plan_.params.estimated_row_count = row_count;
-}
+    : columns_(columns), indexes_(indexes), lowering_(lowering) {}
 
 base::StatusOr<QueryPlanImpl> QueryPlanBuilder::Build(
     uint32_t row_count,
@@ -270,20 +159,8 @@ base::StatusOr<QueryPlanImpl> QueryPlanBuilder::Build(
     const std::vector<SortSpec>& sort_specs,
     const LimitSpec& limit_spec,
     uint64_t cols_used) {
-  i::BytecodeBuilder bytecode_builder;
-  DataframeRegisterCache cache(bytecode_builder);
-
-  // Initialize with a range covering all rows.
-  i::RwHandle<Range> range = bytecode_builder.AllocateRegister<Range>();
-  {
-    using B = i::InitRange;
-    auto& ir = bytecode_builder.AddOpcode<B>(i::Index<B>());
-    ir.arg<B::size>() = row_count;
-    ir.arg<B::dest_register>() = range;
-  }
-
-  QueryPlanBuilder builder(bytecode_builder, cache, range, row_count, columns,
-                           indexes);
+  BytecodeLowering lowering(row_count, columns, indexes);
+  QueryPlanBuilder builder(lowering, columns, indexes);
   RETURN_IF_ERROR(builder.Filter(specs));
   builder.Distinct(distinct);
   if (builder.CanUseMinMaxOptimization(sort_specs, limit_spec)) {
@@ -293,7 +170,243 @@ base::StatusOr<QueryPlanImpl> QueryPlanBuilder::Build(
     builder.Sort(sort_specs);
     builder.Output(limit_spec, cols_used);
   }
-  return std::move(builder).Build();
+  return std::move(lowering).Build();
+}
+
+base::Status QueryPlanBuilder::Filter(std::vector<FilterSpec>& specs) {
+  // Sort filters by efficiency (most selective/cheapest first)
+  std::stable_sort(specs.begin(), specs.end(),
+                   [this](const FilterSpec& a, const FilterSpec& b) {
+                     const auto& a_col = GetColumn(a.col);
+                     const auto& b_col = GetColumn(b.col);
+                     return FilterPreference(a, a_col) <
+                            FilterPreference(b, b_col);
+                   });
+
+  std::vector<uint8_t> specs_handled(specs.size(), false);
+
+  // Phase 1: Handle sorted constraints first
+  for (uint32_t i = 0; i < specs.size(); ++i) {
+    if (specs_handled[i]) {
+      continue;
+    }
+    FilterSpec& c = specs[i];
+    auto non_null_op = c.op.TryDowncast<NonNullOp>();
+    if (!non_null_op) {
+      continue;
+    }
+    const Column& col = GetColumn(c.col);
+    if (!TrySortedConstraint(c, col.storage.type(), *non_null_op)) {
+      continue;
+    }
+    specs_handled[i] = true;
+  }
+
+  // Phase 2: Handle constraints which can use an index.
+  std::optional<BestIndex> best_index = GetBestIndexForFilterSpecs(
+      lowering_.max_row_count(), specs, specs_handled, indexes_);
+  if (best_index) {
+    IndexConstraints(specs, specs_handled, best_index->best_index_idx,
+                     best_index->best_index_specs);
+  }
+
+  // Phase 3: Handle all remaining constraints.
+  for (uint32_t i = 0; i < specs.size(); ++i) {
+    if (specs_handled[i]) {
+      continue;
+    }
+    FilterSpec& c = specs[i];
+    const Column& col = GetColumn(c.col);
+    StorageType ct = col.storage.type();
+
+    if (c.op.Is<In>()) {
+      lowering_.EmitScanFilterIn(c, lowering_.EmitCastFilterValueList(c, ct));
+      continue;
+    }
+
+    // Get the non-null operation (all our ops are non-null at this point)
+    auto non_null_op = c.op.TryDowncast<NonNullOp>();
+    if (!non_null_op) {
+      NullConstraint(*c.op.TryDowncast<NullOp>(), c);
+      continue;
+    }
+
+    // Handle non-string data types
+    if (const auto& n = ct.TryDowncast<NonStringType>(); n) {
+      if (auto op = c.op.TryDowncast<NonStringOp>(); op) {
+        NonStringConstraint(c, *n, *op,
+                            lowering_.EmitCastFilterValue(c, ct, *non_null_op));
+      } else {
+        lowering_.EmitGuaranteedEmpty();
+      }
+      continue;
+    }
+
+    PERFETTO_CHECK(ct.Is<String>());
+    auto op = non_null_op->TryDowncast<StringOp>();
+    PERFETTO_CHECK(op);
+    RETURN_IF_ERROR(StringConstraint(
+        c, *op, lowering_.EmitCastFilterValue(c, ct, *non_null_op)));
+  }
+  return base::OkStatus();
+}
+
+bool QueryPlanBuilder::TrySortedConstraint(FilterSpec& fs,
+                                           const StorageType& ct,
+                                           const NonNullOp& op) {
+  const auto& col = GetColumn(fs.col);
+  const auto& nullability = col.null_storage.nullability();
+  if (!nullability.Is<NonNull>() || col.sort_state.Is<Unsorted>()) {
+    return false;
+  }
+  auto range_op = op.TryDowncast<RangeOp>();
+  if (!range_op) {
+    return false;
+  }
+
+  // We should have ordered the constraints such that we only reach this
+  // point with range indices.
+  PERFETTO_CHECK(lowering_.IsIndicesRange());
+
+  auto value_reg = lowering_.EmitCastFilterValue(fs, ct, op);
+
+  // Handle set id equality with a specialized opcode.
+  if (ct.Is<Uint32>() && col.sort_state.Is<SetIdSorted>() && op.Is<Eq>()) {
+    lowering_.EmitSetIdSortedEq(fs, value_reg);
+    return true;
+  }
+
+  if (col.specialized_storage.Is<SpecializedStorage::SmallValueEq>() &&
+      op.Is<Eq>()) {
+    lowering_.EmitSmallValueEq(fs, value_reg);
+    return true;
+  }
+
+  lowering_.EmitSortedFilter(fs, ct, *range_op, value_reg);
+  return true;
+}
+
+void QueryPlanBuilder::IndexConstraints(
+    std::vector<FilterSpec>& specs,
+    std::vector<uint8_t>& specs_handled,
+    uint32_t index_idx,
+    const std::vector<uint32_t>& filter_specs) {
+  lowering_.EmitIndexedFilters(specs, index_idx, filter_specs);
+  for (uint32_t spec_idx : filter_specs) {
+    specs_handled[spec_idx] = true;
+  }
+}
+
+void QueryPlanBuilder::NonStringConstraint(
+    const FilterSpec& c,
+    const NonStringType& type,
+    const NonStringOp& op,
+    const i::ReadHandle<i::CastFilterValueResult>& result) {
+  const auto& col = GetColumn(c.col);
+  if (lowering_.IsIndicesRange() && op.Is<Eq>() &&
+      col.null_storage.nullability().Is<NonNull>()) {
+    // Non null equality on an id column should have been handled earlier.
+    PERFETTO_CHECK(!type.Is<Id>());
+    auto non_id_type = type.TryDowncast<NonIdStorageType>();
+    PERFETTO_CHECK(non_id_type);
+    lowering_.EmitLinearFilterEq(c, *non_id_type, result);
+    return;
+  }
+  lowering_.EmitNonStringFilter(c, type, op, result);
+}
+
+base::Status QueryPlanBuilder::StringConstraint(
+    const FilterSpec& c,
+    const StringOp& op,
+    const i::ReadHandle<i::CastFilterValueResult>& result) {
+  const auto& col = GetColumn(c.col);
+  if (op.Is<Eq>() && lowering_.IsIndicesRange() &&
+      col.null_storage.nullability().Is<NonNull>()) {
+    lowering_.EmitLinearFilterEq(c, NonIdStorageType{String{}}, result);
+    return base::OkStatus();
+  }
+  lowering_.EmitStringFilter(c, op, result);
+  return base::OkStatus();
+}
+
+void QueryPlanBuilder::NullConstraint(const NullOp& op, FilterSpec& c) {
+  // Even if we don't need this to filter null/non-null, we add it so that
+  // the caller (i.e. SQLite) knows that we are able to handle the constraint.
+  lowering_.ReserveFilterValueSlot(c);
+
+  const auto& col = GetColumn(c.col);
+  uint32_t nullability_type_index = col.null_storage.nullability().index();
+  switch (nullability_type_index) {
+    case Nullability::GetTypeIndex<SparseNull>():
+    case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
+    case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>():
+    case Nullability::GetTypeIndex<DenseNull>():
+      lowering_.EmitNullFilter(c, op);
+      break;
+    case Nullability::GetTypeIndex<NonNull>():
+      if (op.Is<IsNull>()) {
+        lowering_.EmitGuaranteedEmpty();
+        return;
+      }
+      // Nothing to do as the column is non-null.
+      return;
+    default:
+      PERFETTO_FATAL("Unreachable");
+  }
+}
+
+void QueryPlanBuilder::Distinct(
+    const std::vector<DistinctSpec>& distinct_specs) {
+  if (distinct_specs.empty()) {
+    return;
+  }
+  lowering_.EmitDistinct(distinct_specs);
+}
+
+void QueryPlanBuilder::Sort(const std::vector<SortSpec>& sort_specs) {
+  if (sort_specs.empty()) {
+    return;
+  }
+
+  // Optimization: If there's a single sort constraint on a NonNull
+  // column that is already sorted accordingly, skip the sort operation.
+  if (sort_specs.size() == 1) {
+    const auto& single_spec = sort_specs[0];
+    const Column& col = GetColumn(single_spec.col);
+    if (col.null_storage.nullability().Is<NonNull>() &&
+        (col.sort_state.Is<Sorted>() || col.sort_state.Is<IdSorted>() ||
+         col.sort_state.Is<SetIdSorted>())) {
+      switch (single_spec.direction) {
+        case SortDirection::kAscending:
+          // The column is NonNull and already sorted as required.
+          return;
+        case SortDirection::kDescending:
+          // The column is NonNull and sorted in the reverse order. Just
+          // reverse the indices to get the correct order.
+          lowering_.EmitReverse();
+          return;
+      }
+    }
+  }
+  lowering_.EmitSort(sort_specs);
+}
+
+void QueryPlanBuilder::MinMax(const SortSpec& sort_spec) {
+  lowering_.EmitMinMax(sort_spec);
+}
+
+void QueryPlanBuilder::Output(const LimitSpec& limit, uint64_t cols_used) {
+  lowering_.EmitOutput(limit, cols_used);
+}
+
+bool QueryPlanBuilder::CanUseMinMaxOptimization(
+    const std::vector<SortSpec>& sort_specs,
+    const LimitSpec& limit_spec) {
+  return sort_specs.size() == 1 &&
+         GetColumn(sort_specs[0].col)
+             .null_storage.nullability()
+             .Is<NonNull>() &&
+         limit_spec.limit == 1 && limit_spec.offset.value_or(0) == 0;
 }
 
 i::RegValue QueryPlanImpl::GetRegisterInitValue(const RegisterInit& init,
@@ -359,1144 +472,6 @@ i::RegValue QueryPlanImpl::GetRegisterInitValue(const RegisterInit& init,
       PERFETTO_FATAL("Unhandled RegisterInit kind: %u",
                      static_cast<uint32_t>(init.kind.index()));
   }
-}
-
-base::Status QueryPlanBuilder::Filter(std::vector<FilterSpec>& specs) {
-  // Sort filters by efficiency (most selective/cheapest first)
-  std::stable_sort(specs.begin(), specs.end(),
-                   [this](const FilterSpec& a, const FilterSpec& b) {
-                     const auto& a_col = GetColumn(a.col);
-                     const auto& b_col = GetColumn(b.col);
-                     return FilterPreference(a, a_col) <
-                            FilterPreference(b, b_col);
-                   });
-
-  std::vector<uint8_t> specs_handled(specs.size(), false);
-
-  // Phase 1: Handle sorted constraints first
-  for (uint32_t i = 0; i < specs.size(); ++i) {
-    if (specs_handled[i]) {
-      continue;
-    }
-    FilterSpec& c = specs[i];
-    auto non_null_op = c.op.TryDowncast<i::NonNullOp>();
-    if (!non_null_op) {
-      continue;
-    }
-    const Column& col = GetColumn(c.col);
-    if (!TrySortedConstraint(c, col.storage.type(), *non_null_op)) {
-      continue;
-    }
-    specs_handled[i] = true;
-  }
-
-  // Phase 2: Handle constraints which can use an index.
-  std::optional<BestIndex> best_index =
-      GetBestIndexForFilterSpecs(plan_.params, specs, specs_handled, indexes_);
-  if (best_index) {
-    IndexConstraints(specs, specs_handled, best_index->best_index_idx,
-                     best_index->best_index_specs);
-  }
-
-  // Phase 3: Handle all remaining constraints.
-  for (uint32_t i = 0; i < specs.size(); ++i) {
-    if (specs_handled[i]) {
-      continue;
-    }
-    FilterSpec& c = specs[i];
-    const Column& col = GetColumn(c.col);
-    StorageType ct = col.storage.type();
-
-    if (c.op.Is<In>()) {
-      i::RwHandle<std::unique_ptr<i::CastFilterValueListResult>> value =
-          builder_.AllocateRegister<
-              std::unique_ptr<i::CastFilterValueListResult>>();
-      {
-        using B = i::CastFilterValueListBase;
-        auto& bc = AddOpcode<B>(i::Index<i::CastFilterValueList>(ct),
-                                UnchangedRowCount{});
-        bc.arg<B::fval_handle>() = {plan_.params.filter_value_count};
-        bc.arg<B::write_register>() = value;
-        bc.arg<B::op>() = Eq{};
-        c.value_index = plan_.params.filter_value_count++;
-      }
-      auto update = EnsureIndicesAreInSlab();
-      PruneNullIndices(c.col, update, NullPruneScope::kResultRows);
-      auto source = TranslateNonNullIndices(c.col, update, false);
-      {
-        using B = i::FilterInBase;
-        B& bc = AddOpcode<B>(
-            i::Index<i::FilterIn>(col.storage.type(),
-                                  i::SparseNullCollapsedNullability{NonNull{}}),
-            RowCountModifier{
-                InFilterRowCount{col.duplicate_state, col.estimated_distinct}});
-        bc.arg<B::storage_register>() =
-            StorageRegisterFor(c.col, col.storage.type());
-        bc.arg<B::null_bv_register>() = {};
-        bc.arg<B::value_list_register>() = value;
-        bc.arg<B::index_register>() = {};
-        bc.arg<B::source_range_register>() = {};
-        bc.arg<B::source_register>() = source;
-        bc.arg<B::dest_register>() = update;
-      }
-      MaybeReleaseScratchSpanRegister();
-      continue;
-    }
-
-    // Get the non-null operation (all our ops are non-null at this point)
-    auto non_null_op = c.op.TryDowncast<i::NonNullOp>();
-    if (!non_null_op) {
-      NullConstraint(*c.op.TryDowncast<i::NullOp>(), c);
-      continue;
-    }
-
-    // Handle non-string data types
-    if (const auto& n = ct.TryDowncast<i::NonStringType>(); n) {
-      if (auto op = c.op.TryDowncast<i::NonStringOp>(); op) {
-        NonStringConstraint(c, *n, *op, CastFilterValue(c, ct, *non_null_op));
-      } else {
-        SetGuaranteedToBeEmpty();
-      }
-      continue;
-    }
-
-    PERFETTO_CHECK(ct.Is<String>());
-    auto op = non_null_op->TryDowncast<i::StringOp>();
-    PERFETTO_CHECK(op);
-    RETURN_IF_ERROR(
-        StringConstraint(c, *op, CastFilterValue(c, ct, *non_null_op)));
-  }
-  return base::OkStatus();
-}
-
-void QueryPlanBuilder::Distinct(
-    const std::vector<DistinctSpec>& distinct_specs) {
-  if (distinct_specs.empty()) {
-    return;
-  }
-  std::vector<RowLayoutParams> row_layout_params;
-  row_layout_params.reserve(distinct_specs.size());
-  for (const auto& spec : distinct_specs) {
-    row_layout_params.push_back({spec.col, false});
-  }
-  uint16_t total_row_stride = CalculateRowLayoutStride(row_layout_params);
-  i::RwHandle<Span<uint32_t>> indices = EnsureIndicesAreInSlab();
-  auto buffer_reg =
-      CopyToRowLayout(total_row_stride, indices, {}, row_layout_params);
-  {
-    using B = i::Distinct;
-    auto& bc = AddOpcode<B>(NonEqualityFilterRowCount{});
-    bc.arg<B::buffer_register>() = buffer_reg;
-    bc.arg<B::total_row_stride>() = total_row_stride;
-    bc.arg<B::indices_register>() = indices;
-  }
-}
-
-void QueryPlanBuilder::Sort(const std::vector<SortSpec>& sort_specs) {
-  if (sort_specs.empty()) {
-    return;
-  }
-
-  // Optimization: If there's a single sort constraint on a NonNull
-  // column that is already sorted accordingly, skip the sort operation.
-  if (sort_specs.size() == 1) {
-    const auto& single_spec = sort_specs[0];
-    const Column& col = GetColumn(single_spec.col);
-    if (col.null_storage.nullability().Is<NonNull>() &&
-        (col.sort_state.Is<Sorted>() || col.sort_state.Is<IdSorted>() ||
-         col.sort_state.Is<SetIdSorted>())) {
-      switch (single_spec.direction) {
-        case SortDirection::kAscending:
-          // The column is NonNull and already sorted as required.
-          return;
-        case SortDirection::kDescending:
-          // The column is NonNull and sorted in the reverse order. Just
-          // reverse the indices to get the correct order.
-          {
-            auto indices = EnsureIndicesAreInSlab();
-            using B = i::Reverse;
-            auto& op = AddOpcode<B>(UnchangedRowCount{});
-            op.arg<B::update_register>() = indices;
-            return;
-          }
-      }
-    }
-  }
-
-  // main_indices_span will be modified by the final sort operation.
-  // EnsureIndicesAreInSlab makes it an RwHandle.
-  i::RwHandle<Span<uint32_t>> indices = EnsureIndicesAreInSlab();
-
-  bool has_string_sort_keys = false;
-  for (const auto& spec : sort_specs) {
-    if (GetColumn(spec.col).storage.type().Is<String>()) {
-      has_string_sort_keys = true;
-      break;
-    }
-  }
-
-  using Map = i::StringIdToRankMap;
-  i::RwHandle<Map> string_rank_map;
-  if (has_string_sort_keys) {
-    string_rank_map = builder_.AllocateRegister<Map>();
-    {
-      using B = i::InitRankMap;
-      auto& op = AddOpcode<B>(UnchangedRowCount{});
-      op.arg<B::dest_register>() = string_rank_map;
-    }
-
-    // For each string column in the sort specification, collect its unique IDs.
-    // This involves preparing a temporary set of indices for that column which
-    // are non-null and translated to storage indices if originally sparse.
-    for (const auto& spec : sort_specs) {
-      const Column& col = GetColumn(spec.col);
-      if (!col.storage.type().Is<String>()) {
-        continue;
-      }
-
-      i::RwHandle<Span<uint32_t>> translated;
-      if (col.null_storage.nullability().Is<NonNull>()) {
-        // If the column is non-null, we can use the main indices directly.
-        translated = indices;
-      } else {
-        // Get a scratch register to prepare indices for this specific column.
-        // This ensures that the main_indices_span is not modified, allowing
-        // each string column to be processed independently from the original
-        // set of rows.
-        i::RwHandle<Span<uint32_t>> scratch =
-            GetOrCreateScratchSpanRegister(plan_.params.max_row_count);
-
-        // 1. Copy the current indices to our temporary scratch span.
-        {
-          auto& op = AddOpcode<i::StrideCopy>(UnchangedRowCount{});
-          op.arg<i::StrideCopy::source_register>() = indices;
-          op.arg<i::StrideCopy::update_register>() = scratch;
-          op.arg<i::StrideCopy::stride>() = 1;
-        }
-
-        // 2. Prune nulls from this temporary span in-place.
-        PruneNullIndices(spec.col, scratch, NullPruneScope::kScratchOnly);
-
-        // 3. Translate these non-null table indices to storage indices if
-        // necessary.
-        translated = TranslateNonNullIndices(spec.col, scratch, true);
-        PERFETTO_CHECK(translated.index == scratch.index);
-      }
-
-      // Collect IDs using the prepared (non-null, translated) indices.
-      {
-        using B = i::CollectIdIntoRankMap;
-        auto& op = AddOpcode<B>(UnchangedRowCount{});
-        op.arg<B::storage_register>() =
-            StorageRegisterFor(spec.col, col.storage.type());
-        op.arg<B::source_register>() = translated;
-        op.arg<B::rank_map_register>() = string_rank_map;
-      }
-
-      // Maybe release the scratch register if we used one.
-      MaybeReleaseScratchSpanRegister();
-    }
-
-    // Finalize ranks in the map (sorts keys, updates map values to ranks).
-    // The argument name in the patch for FinalizeRanksInMap was
-    // 'update_register_register'.
-    {
-      using B = i::FinalizeRanksInMap;
-      auto& op = AddOpcode<B>(UnchangedRowCount{});
-      op.arg<B::update_register>() = string_rank_map;
-    }
-  }
-
-  std::vector<RowLayoutParams> row_layout_params;
-  row_layout_params.reserve(sort_specs.size());
-  for (const auto& spec : sort_specs) {
-    row_layout_params.push_back(
-        {spec.col, columns_[spec.col]->storage.type().Is<String>(),
-         spec.direction == SortDirection::kDescending});
-  }
-  uint16_t total_row_stride = CalculateRowLayoutStride(row_layout_params);
-  auto buffer_reg = CopyToRowLayout(total_row_stride, indices, string_rank_map,
-                                    row_layout_params);
-  {
-    using B = i::SortRowLayout;
-    auto& op = AddOpcode<B>(UnchangedRowCount{});
-    op.arg<B::buffer_register>() = buffer_reg;
-    op.arg<B::total_row_stride>() = total_row_stride;
-    op.arg<B::indices_register>() = indices;
-  }
-}
-
-void QueryPlanBuilder::MinMax(const SortSpec& sort_spec) {
-  uint32_t col_idx = sort_spec.col;
-  const auto& col = GetColumn(col_idx);
-  StorageType storage_type = col.storage.type();
-
-  i::MinMaxOp mmop = sort_spec.direction == SortDirection::kAscending
-                         ? i::MinMaxOp(i::MinOp{})
-                         : i::MinMaxOp(i::MaxOp{});
-
-  auto indices = EnsureIndicesAreInSlab();
-  using B = i::FindMinMaxIndexBase;
-  auto& op = AddOpcode<B>(i::Index<i::FindMinMaxIndex>(storage_type, mmop),
-                          OneRowCount{});
-  op.arg<B::update_register>() = indices;
-  op.arg<B::storage_register>() = StorageRegisterFor(col_idx, storage_type);
-}
-
-void QueryPlanBuilder::Output(const LimitSpec& limit, uint64_t cols_used) {
-  // Structure to track column and offset pairs
-  struct ColAndOffset {
-    uint32_t col;
-    uint32_t offset;
-  };
-
-  base::SmallVector<ColAndOffset, 24> null_cols;
-  plan_.params.output_per_row = 1;
-  for (uint32_t i = 0; i < columns_.size(); ++i) {
-    plan_.col_to_output_offset.emplace_back();
-  }
-
-  // Process each column that will be used in the output
-  for (uint32_t i = 0; i < columns_.size(); ++i) {
-    // Any column with index >= 64 uses the 64th bit in cols_used.
-    uint64_t mask = 1ULL << std::min(i, 63u);
-    if ((cols_used & mask) == 0) {
-      continue;
-    }
-    const auto& col = GetColumn(i);
-    switch (col.null_storage.nullability().index()) {
-      case Nullability::GetTypeIndex<SparseNull>():
-      case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
-      case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>():
-      case Nullability::GetTypeIndex<DenseNull>(): {
-        uint32_t offset = plan_.params.output_per_row++;
-        null_cols.emplace_back(ColAndOffset{i, offset});
-        plan_.col_to_output_offset[i] = offset;
-        break;
-      }
-      case Nullability::GetTypeIndex<NonNull>():
-        // For non-null columns, we can directly use the indices
-        plan_.col_to_output_offset[i] = 0;
-        break;
-      default:
-        PERFETTO_FATAL("Unreachable");
-    }
-  }
-
-  auto in_memory_indices = EnsureIndicesAreInSlab();
-  if (limit.limit || limit.offset) {
-    auto o = limit.offset.value_or(0);
-    auto l = limit.limit.value_or(std::numeric_limits<uint32_t>::max());
-    using B = i::LimitOffsetIndices;
-    auto& bc = AddOpcode<B>(LimitOffsetRowCount{l, o});
-    bc.arg<B::offset_value>() = o;
-    bc.arg<B::limit_value>() = l;
-    bc.arg<B::update_register>() = in_memory_indices;
-  }
-
-  i::RwHandle<Span<uint32_t>> storage_update_register;
-  if (plan_.params.output_per_row > 1) {
-    i::RwHandle<Slab<uint32_t>> slab_register =
-        builder_.AllocateRegister<Slab<uint32_t>>();
-    storage_update_register = builder_.AllocateRegister<Span<uint32_t>>();
-    {
-      using B = i::AllocateIndices;
-      auto& bc = AddOpcode<B>(UnchangedRowCount{});
-      bc.arg<B::size>() =
-          plan_.params.max_row_count * plan_.params.output_per_row;
-      bc.arg<B::dest_slab_register>() = slab_register;
-      bc.arg<B::dest_span_register>() = storage_update_register;
-    }
-    {
-      using B = i::StrideCopy;
-      auto& bc = AddOpcode<B>(UnchangedRowCount{});
-      bc.arg<B::source_register>() = in_memory_indices;
-      bc.arg<B::update_register>() = storage_update_register;
-      bc.arg<B::stride>() = plan_.params.output_per_row;
-    }
-    for (auto [col, offset] : null_cols) {
-      const auto& c = GetColumn(col);
-      switch (c.null_storage.nullability().index()) {
-        case Nullability::GetTypeIndex<SparseNull>():
-        case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
-        case Nullability::GetTypeIndex<
-            SparseNullWithPopcountUntilFinalization>(): {
-          using B = i::StrideTranslateAndCopySparseNullIndices;
-          auto null_bv_reg = EnsurePrefixPopcountFor(col);
-          auto& bc = AddOpcode<B>(UnchangedRowCount{});
-          bc.arg<B::update_register>() = storage_update_register;
-          bc.arg<B::null_bv_register>() = null_bv_reg;
-          bc.arg<B::offset>() = offset;
-          bc.arg<B::stride>() = plan_.params.output_per_row;
-          break;
-        }
-        case Nullability::GetTypeIndex<DenseNull>(): {
-          using B = i::StrideCopyDenseNullIndices;
-          auto& bc = AddOpcode<B>(UnchangedRowCount{});
-          bc.arg<B::update_register>() = storage_update_register;
-          bc.arg<B::null_bv_register>() = NullBitvectorRegisterFor(col);
-          bc.arg<B::offset>() = offset;
-          bc.arg<B::stride>() = plan_.params.output_per_row;
-          break;
-        }
-        case Nullability::GetTypeIndex<NonNull>():
-        default:
-          PERFETTO_FATAL("Unreachable");
-      }
-    }
-  } else {
-    PERFETTO_CHECK(null_cols.empty());
-    storage_update_register = in_memory_indices;
-  }
-  plan_.params.output_register = storage_update_register;
-}
-
-QueryPlanImpl QueryPlanBuilder::Build() && {
-  plan_.bytecode = std::move(builder_.bytecode());
-  plan_.params.register_count = builder_.register_count();
-  return std::move(plan_);
-}
-
-void QueryPlanBuilder::NonStringConstraint(
-    const FilterSpec& c,
-    const i::NonStringType& type,
-    const i::NonStringOp& op,
-    const i::ReadHandle<i::CastFilterValueResult>& result) {
-  const auto& col = GetColumn(c.col);
-  if (std::holds_alternative<i::RwHandle<Range>>(indices_reg_) && op.Is<Eq>() &&
-      col.null_storage.nullability().Is<NonNull>()) {
-    // Non null equality on an id column should have been handled earlier.
-    PERFETTO_CHECK(!type.Is<Id>());
-    auto non_id_type = type.TryDowncast<i::NonIdStorageType>();
-    PERFETTO_CHECK(non_id_type);
-    AddLinearFilterEqBytecode(c, result, *non_id_type);
-    return;
-  }
-  auto update = EnsureIndicesAreInSlab();
-  PruneNullIndices(c.col, update, NullPruneScope::kResultRows);
-  auto source = TranslateNonNullIndices(c.col, update, false);
-  {
-    using B = i::NonStringFilterBase;
-    B& bc = AddOpcode<B>(i::Index<i::NonStringFilter>(type, op),
-                         op.Is<Eq>()
-                             ? RowCountModifier{EqualityFilterRowCount{
-                                   col.duplicate_state, col.estimated_distinct}}
-                             : RowCountModifier{NonEqualityFilterRowCount{}});
-    bc.arg<B::storage_register>() =
-        StorageRegisterFor(c.col, type.Upcast<StorageType>());
-    bc.arg<B::val_register>() = result;
-    bc.arg<B::source_register>() = source;
-    bc.arg<B::update_register>() = update;
-  }
-  MaybeReleaseScratchSpanRegister();
-}
-
-base::Status QueryPlanBuilder::StringConstraint(
-    const FilterSpec& c,
-    const i::StringOp& op,
-    const i::ReadHandle<i::CastFilterValueResult>& result) {
-  const auto& col = GetColumn(c.col);
-  if (op.Is<Eq>() && std::holds_alternative<i::RwHandle<Range>>(indices_reg_) &&
-      col.null_storage.nullability().Is<NonNull>()) {
-    AddLinearFilterEqBytecode(c, result, i::NonIdStorageType{String{}});
-    return base::OkStatus();
-  }
-  auto update = EnsureIndicesAreInSlab();
-  PruneNullIndices(c.col, update, NullPruneScope::kResultRows);
-  auto source = TranslateNonNullIndices(c.col, update, false);
-  {
-    using B = i::StringFilterBase;
-    B& bc = AddOpcode<B>(i::Index<i::StringFilter>(op),
-                         op.Is<Eq>()
-                             ? RowCountModifier{EqualityFilterRowCount{
-                                   col.duplicate_state, col.estimated_distinct}}
-                             : RowCountModifier{NonEqualityFilterRowCount{}});
-    bc.arg<B::storage_register>() = StorageRegisterFor(c.col, String{});
-    bc.arg<B::val_register>() = result;
-    bc.arg<B::source_register>() = source;
-    bc.arg<B::update_register>() = update;
-  }
-  MaybeReleaseScratchSpanRegister();
-  return base::OkStatus();
-}
-
-void QueryPlanBuilder::NullConstraint(const i::NullOp& op, FilterSpec& c) {
-  // Even if we don't need this to filter null/non-null, we add it so that
-  // the caller (i.e. SQLite) knows that we are able to handle the constraint.
-  c.value_index = plan_.params.filter_value_count++;
-
-  const auto& col = GetColumn(c.col);
-  uint32_t nullability_type_index = col.null_storage.nullability().index();
-  switch (nullability_type_index) {
-    case Nullability::GetTypeIndex<SparseNull>():
-    case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
-    case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>():
-    case Nullability::GetTypeIndex<DenseNull>(): {
-      auto indices = EnsureIndicesAreInSlab();
-      {
-        using B = i::NullFilterBase;
-        B& bc = AddOpcode<B>(i::Index<i::NullFilter>(op),
-                             NonEqualityFilterRowCount{});
-        bc.arg<B::null_bv_register>() = NullBitvectorRegisterFor(c.col);
-        bc.arg<B::update_register>() = indices;
-      }
-      break;
-    }
-    case Nullability::GetTypeIndex<NonNull>():
-      if (op.Is<IsNull>()) {
-        SetGuaranteedToBeEmpty();
-        return;
-      }
-      // Nothing to do as the column is non-null.
-      return;
-    default:
-      PERFETTO_FATAL("Unreachable");
-  }
-}
-
-void QueryPlanBuilder::IndexConstraints(
-    std::vector<FilterSpec>& specs,
-    std::vector<uint8_t>& specs_handled,
-    uint32_t index_idx,
-    const std::vector<uint32_t>& filter_specs) {
-  i::RwHandle<Span<uint32_t>> source_reg = IndexRegisterFor(index_idx);
-  i::RwHandle<Span<uint32_t>> dest_reg =
-      builder_.AllocateRegister<Span<uint32_t>>();
-
-  // The current row range — used by FilterIn's scan fallback when the IN list
-  // is too large for binary search and the index is ignored.
-  PERFETTO_CHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
-  const auto& range_reg = base::unchecked_get<i::RwHandle<Range>>(indices_reg_);
-
-  // Allocate the output indices upfront. For In filters, FilterIn writes
-  // directly here and CopySpanIntersectingRange runs in-place (safe because
-  // its write pointer never advances past its read pointer). For Eq-only
-  // filters, dest_reg points into the source index and
-  // CopySpanIntersectingRange copies from there into this buffer.
-  i::RwHandle<Slab<uint32_t>> output_slab_reg =
-      builder_.AllocateRegister<Slab<uint32_t>>();
-  i::RwHandle<Span<uint32_t>> output_span_reg =
-      builder_.AllocateRegister<Span<uint32_t>>();
-  {
-    using B = i::AllocateIndices;
-    auto& bc = AddOpcode<B>(UnchangedRowCount{});
-    bc.arg<B::size>() = plan_.params.max_row_count;
-    bc.arg<B::dest_slab_register>() = output_slab_reg;
-    bc.arg<B::dest_span_register>() = output_span_reg;
-  }
-
-  for (uint32_t spec_idx : filter_specs) {
-    FilterSpec& fs = specs[spec_idx];
-    const Column& column = GetColumn(fs.col);
-    auto non_id = column.storage.type().TryDowncast<i::NonIdStorageType>();
-    PERFETTO_CHECK(non_id);
-
-    if (fs.op.Is<In>()) {
-      // Emit IndexedFilterIn for In filters.
-      StorageType ct = column.storage.type();
-      i::RwHandle<std::unique_ptr<i::CastFilterValueListResult>>
-          value_list_reg = builder_.AllocateRegister<
-              std::unique_ptr<i::CastFilterValueListResult>>();
-      {
-        using B = i::CastFilterValueListBase;
-        auto& bc = AddOpcode<B>(i::Index<i::CastFilterValueList>(ct),
-                                UnchangedRowCount{});
-        bc.arg<B::fval_handle>() = {plan_.params.filter_value_count};
-        bc.arg<B::write_register>() = value_list_reg;
-        bc.arg<B::op>() = Eq{};
-        fs.value_index = plan_.params.filter_value_count++;
-      }
-      // IndexedFilterIn gathers results from non-contiguous ranges, so it
-      // cannot write into the source (which points to the persistent index
-      // permutation vector). Write directly into the output span allocated
-      // upfront; CopySpanIntersectingRange will then run in-place on it.
-      {
-        using B = i::FilterInBase;
-        auto null_bv_reg = EnsurePrefixPopcountFor(fs.col);
-        auto& bc = AddOpcode<B>(
-            i::Index<i::FilterIn>(non_id->Upcast<StorageType>(),
-                                  NullabilityToSparseNullCollapsedNullability(
-                                      column.null_storage.nullability())),
-            RowCountModifier{InFilterRowCount{column.duplicate_state,
-                                              column.estimated_distinct}},
-            i::LogPerRowCost{10});
-        bc.arg<B::storage_register>() =
-            StorageRegisterFor(fs.col, non_id->Upcast<StorageType>());
-        bc.arg<B::null_bv_register>() = null_bv_reg;
-        bc.arg<B::value_list_register>() = value_list_reg;
-        bc.arg<B::index_register>() = source_reg;
-        bc.arg<B::source_range_register>() = range_reg;
-        bc.arg<B::source_register>() = {};
-        bc.arg<B::dest_register>() = output_span_reg;
-      }
-      // Override dest_reg so subsequent filters use the output span.
-      dest_reg = output_span_reg;
-    } else {
-      // Emit IndexedFilterEq for Eq filters.
-      auto value_reg = CastFilterValue(fs, column.storage.type(),
-                                       *fs.op.TryDowncast<i::NonNullOp>());
-      {
-        using B = i::IndexedFilterEqBase;
-        auto null_bv_reg = EnsurePrefixPopcountFor(fs.col);
-        auto& bc = AddOpcode<B>(
-            i::Index<i::IndexedFilterEq>(
-                *non_id, NullabilityToSparseNullCollapsedNullability(
-                             column.null_storage.nullability())),
-            RowCountModifier{EqualityFilterRowCount{
-                column.duplicate_state, column.estimated_distinct}});
-        bc.arg<B::storage_register>() =
-            StorageRegisterFor(fs.col, non_id->Upcast<StorageType>());
-        bc.arg<B::null_bv_register>() = null_bv_reg;
-        bc.arg<B::filter_value_reg>() = value_reg;
-        bc.arg<B::source_register>() = source_reg;
-        bc.arg<B::dest_register>() = dest_reg;
-      }
-    }
-    // After first filter, subsequent filters read from dest and write back to
-    // dest.
-    source_reg = dest_reg;
-    specs_handled[spec_idx] = true;
-  }
-
-  PERFETTO_CHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
-  const auto& indices_reg =
-      base::unchecked_get<i::RwHandle<Range>>(indices_reg_);
-
-  {
-    using B = i::CopySpanIntersectingRange;
-    auto& bc = AddOpcode<B>(UnchangedRowCount{});
-    bc.arg<B::source_register>() = dest_reg;
-    bc.arg<B::source_range_register>() = indices_reg;
-    bc.arg<B::update_register>() = output_span_reg;
-  }
-  indices_reg_ = output_span_reg;
-}
-
-bool QueryPlanBuilder::TrySortedConstraint(FilterSpec& fs,
-                                           const StorageType& ct,
-                                           const i::NonNullOp& op) {
-  const auto& col = GetColumn(fs.col);
-  const auto& nullability = col.null_storage.nullability();
-  if (!nullability.Is<NonNull>() || col.sort_state.Is<Unsorted>()) {
-    return false;
-  }
-  auto range_op = op.TryDowncast<i::RangeOp>();
-  if (!range_op) {
-    return false;
-  }
-
-  // We should have ordered the constraints such that we only reach this
-  // point with range indices.
-  PERFETTO_CHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
-  const auto& reg = base::unchecked_get<i::RwHandle<Range>>(indices_reg_);
-
-  auto value_reg = CastFilterValue(fs, ct, op);
-
-  // Handle set id equality with a specialized opcode.
-  if (ct.Is<Uint32>() && col.sort_state.Is<SetIdSorted>() && op.Is<Eq>()) {
-    using B = i::Uint32SetIdSortedEq;
-    auto& bc = AddOpcode<B>(RowCountModifier{
-        EqualityFilterRowCount{col.duplicate_state, col.estimated_distinct}});
-    bc.arg<B::storage_register>() = StorageRegisterFor(fs.col, ct);
-    bc.arg<B::val_register>() = value_reg;
-    bc.arg<B::update_register>() = reg;
-    return true;
-  }
-
-  if (col.specialized_storage.Is<SpecializedStorage::SmallValueEq>() &&
-      op.Is<Eq>()) {
-    using B = i::SpecializedStorageSmallValueEq;
-    auto& bc = AddOpcode<B>(RowCountModifier{
-        EqualityFilterRowCount{col.duplicate_state, col.estimated_distinct}});
-    bc.arg<B::small_value_bv_register>() = SmallValueEqBvRegisterFor(fs.col);
-    bc.arg<B::small_value_popcount_register>() =
-        SmallValueEqPopcountRegisterFor(fs.col);
-    bc.arg<B::val_register>() = value_reg;
-    bc.arg<B::update_register>() = reg;
-    return true;
-  }
-
-  const auto& [bound, erlbub] = GetSortedFilterArgs(*range_op);
-  RowCountModifier modifier;
-  if (op.Is<Eq>()) {
-    modifier =
-        EqualityFilterRowCount{col.duplicate_state, col.estimated_distinct};
-  } else {
-    modifier = NonEqualityFilterRowCount{};
-  }
-  {
-    using B = i::SortedFilterBase;
-    auto& bc = AddOpcode<B>(i::Index<i::SortedFilter>(ct, erlbub), modifier,
-                            i::SortedFilterBase::EstimateCost(ct));
-    bc.arg<B::storage_register>() = StorageRegisterFor(fs.col, ct);
-    bc.arg<B::val_register>() = value_reg;
-    bc.arg<B::update_register>() = reg;
-    bc.arg<B::write_result_to>() = bound;
-  }
-  return true;
-}
-
-void QueryPlanBuilder::PruneNullIndices(uint32_t col,
-                                        i::RwHandle<Span<uint32_t>> indices,
-                                        NullPruneScope scope) {
-  switch (GetColumn(col).null_storage.nullability().index()) {
-    case Nullability::GetTypeIndex<SparseNull>():
-    case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
-    case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>():
-    case Nullability::GetTypeIndex<DenseNull>(): {
-      using B = i::NullFilter<IsNotNull>;
-      RowCountModifier rc = scope == NullPruneScope::kResultRows
-                                ? RowCountModifier{NonEqualityFilterRowCount{}}
-                                : RowCountModifier{UnchangedRowCount{}};
-      i::NullFilterBase& bc = AddOpcode<B>(rc);
-      bc.arg<B::null_bv_register>() = NullBitvectorRegisterFor(col);
-      bc.arg<B::update_register>() = indices;
-      break;
-    }
-    case Nullability::GetTypeIndex<NonNull>():
-      break;
-    default:
-      PERFETTO_FATAL("Unreachable");
-  }
-}
-
-i::RwHandle<Span<uint32_t>> QueryPlanBuilder::TranslateNonNullIndices(
-    uint32_t col,
-    i::RwHandle<Span<uint32_t>> table_indices_register,
-    bool in_place) {
-  switch (GetColumn(col).null_storage.nullability().index()) {
-    case Nullability::GetTypeIndex<SparseNull>():
-    case Nullability::GetTypeIndex<SparseNullWithPopcountAlways>():
-    case Nullability::GetTypeIndex<SparseNullWithPopcountUntilFinalization>(): {
-      auto update =
-          in_place ? table_indices_register
-                   : GetOrCreateScratchSpanRegister(plan_.params.max_row_count);
-      {
-        auto null_bv_reg = EnsurePrefixPopcountFor(col);
-        using B = i::TranslateSparseNullIndices;
-        auto& bc = AddOpcode<B>(UnchangedRowCount{});
-        bc.arg<B::null_bv_register>() = null_bv_reg;
-        bc.arg<B::source_register>() = table_indices_register;
-        bc.arg<B::update_register>() = update;
-      }
-      return update;
-    }
-    case Nullability::GetTypeIndex<DenseNull>():
-    case Nullability::GetTypeIndex<NonNull>():
-      return table_indices_register;
-    default:
-      PERFETTO_FATAL("Unreachable");
-  }
-}
-
-PERFETTO_NO_INLINE i::RwHandle<Span<uint32_t>>
-QueryPlanBuilder::EnsureIndicesAreInSlab() {
-  using SpanReg = i::RwHandle<Span<uint32_t>>;
-  using SlabReg = i::RwHandle<Slab<uint32_t>>;
-
-  if (PERFETTO_LIKELY(std::holds_alternative<SpanReg>(indices_reg_))) {
-    return base::unchecked_get<SpanReg>(indices_reg_);
-  }
-
-  using RegRange = i::RwHandle<Range>;
-  PERFETTO_DCHECK(std::holds_alternative<RegRange>(indices_reg_));
-  auto range_reg = base::unchecked_get<RegRange>(indices_reg_);
-
-  SlabReg slab_reg = builder_.AllocateRegister<Slab<uint32_t>>();
-  SpanReg span_reg = builder_.AllocateRegister<Span<uint32_t>>();
-  {
-    using B = i::AllocateIndices;
-    auto& bc = AddOpcode<B>(UnchangedRowCount{});
-    bc.arg<B::size>() = plan_.params.max_row_count;
-    bc.arg<B::dest_slab_register>() = slab_reg;
-    bc.arg<B::dest_span_register>() = span_reg;
-  }
-  {
-    using B = i::Iota;
-    auto& bc = AddOpcode<B>(UnchangedRowCount{});
-    bc.arg<B::source_register>() = range_reg;
-    bc.arg<B::update_register>() = span_reg;
-  }
-  indices_reg_ = span_reg;
-  return span_reg;
-}
-
-PERFETTO_NO_INLINE i::Bytecode& QueryPlanBuilder::AddRawOpcode(
-    uint32_t option,
-    RowCountModifier rc,
-    i::Cost cost) {
-  static constexpr uint32_t kFixedBytecodeCost = 5;
-  switch (cost.index()) {
-    case base::variant_index<i::Cost, i::FixedCost>(): {
-      const auto& c = base::unchecked_get<i::FixedCost>(cost);
-      plan_.params.estimated_cost += c.cost;
-      break;
-    }
-    case base::variant_index<i::Cost, i::LogPerRowCost>(): {
-      const auto& c = base::unchecked_get<i::LogPerRowCost>(cost);
-      plan_.params.estimated_cost +=
-          plan_.params.estimated_row_count == 0
-              ? kFixedBytecodeCost
-              : c.cost * log2(plan_.params.estimated_row_count);
-      break;
-    }
-    case base::variant_index<i::Cost, i::LinearPerRowCost>(): {
-      const auto& c = base::unchecked_get<i::LinearPerRowCost>(cost);
-      plan_.params.estimated_cost +=
-          plan_.params.estimated_row_count == 0
-              ? kFixedBytecodeCost
-              : c.cost * plan_.params.estimated_row_count;
-      break;
-    }
-    case base::variant_index<i::Cost, i::LogLinearPerRowCost>(): {
-      const auto& c = base::unchecked_get<i::LogLinearPerRowCost>(cost);
-      plan_.params.estimated_cost +=
-          plan_.params.estimated_row_count == 0
-              ? kFixedBytecodeCost
-              : c.cost * plan_.params.estimated_row_count *
-                    log2(plan_.params.estimated_row_count);
-      break;
-    }
-    case base::variant_index<i::Cost, i::PostOperationLinearPerRowCost>():
-      break;
-    default:
-      PERFETTO_FATAL("Unknown cost type");
-  }
-  switch (rc.index()) {
-    case base::variant_index<RowCountModifier, UnchangedRowCount>():
-      break;
-    case base::variant_index<RowCountModifier, NonEqualityFilterRowCount>():
-      if (plan_.params.estimated_row_count > 1) {
-        plan_.params.estimated_row_count = plan_.params.estimated_row_count / 2;
-      } else {
-        // Leave the estimated row count as is if it is already 1 or less.
-      }
-      break;
-    case base::variant_index<RowCountModifier, EqualityFilterRowCount>(): {
-      const auto& eq = base::unchecked_get<EqualityFilterRowCount>(rc);
-      if (eq.duplicate_state.Is<HasDuplicates>()) {
-        if (plan_.params.estimated_row_count > 1) {
-          if (!selective_filter_base_row_count_) {
-            selective_filter_base_row_count_ = plan_.params.estimated_row_count;
-          }
-          // Estimate against the pre-selective-filter row count and keep the
-          // most selective result: correlated filters on one scan shouldn't
-          // compound and collapse the estimate toward 1.
-          plan_.params.estimated_row_count =
-              std::min(plan_.params.estimated_row_count,
-                       std::max(1u, static_cast<uint32_t>(EqualityFilterRows(
-                                        *selective_filter_base_row_count_,
-                                        eq.estimated_distinct))));
-        } else {
-          // Leave the estimated row count as is if it is already 1 or less.
-        }
-      } else {
-        PERFETTO_CHECK(eq.duplicate_state.Is<NoDuplicates>());
-        plan_.params.estimated_row_count =
-            std::min(1u, plan_.params.estimated_row_count);
-        plan_.params.max_row_count = std::min(1u, plan_.params.max_row_count);
-      }
-      break;
-    }
-    case base::variant_index<RowCountModifier, InFilterRowCount>(): {
-      const auto& in = base::unchecked_get<InFilterRowCount>(rc);
-      if (in.duplicate_state.Is<HasDuplicates>() &&
-          plan_.params.estimated_row_count > 1) {
-        if (!selective_filter_base_row_count_) {
-          selective_filter_base_row_count_ = plan_.params.estimated_row_count;
-        }
-        // An IN is a union of equalities over the list values. The list size
-        // is unknown at plan time, so scale the single-value estimate by an
-        // assumed distinct-value count. As with equality, estimate against the
-        // pre-selective-filter row count and keep the most selective result.
-        double per_value = EqualityFilterRows(*selective_filter_base_row_count_,
-                                              in.estimated_distinct);
-        double new_count =
-            std::min(static_cast<double>(*selective_filter_base_row_count_),
-                     per_value * kAssumedInListSize);
-        plan_.params.estimated_row_count =
-            std::min(plan_.params.estimated_row_count,
-                     std::max(1u, static_cast<uint32_t>(new_count)));
-      }
-      break;
-    }
-    case base::variant_index<RowCountModifier, OneRowCount>():
-      plan_.params.estimated_row_count =
-          std::min(1u, plan_.params.estimated_row_count);
-      plan_.params.max_row_count = std::min(1u, plan_.params.max_row_count);
-      break;
-    case base::variant_index<RowCountModifier, ZeroRowCount>():
-      plan_.params.estimated_row_count = 0;
-      plan_.params.max_row_count = 0;
-      break;
-    case base::variant_index<RowCountModifier, LimitOffsetRowCount>(): {
-      const auto& lc = base::unchecked_get<LimitOffsetRowCount>(rc);
-
-      // Offset will cut out `offset` rows from the start of indices.
-      uint32_t remove_from_start =
-          std::min(plan_.params.max_row_count, lc.offset);
-      plan_.params.max_row_count -= remove_from_start;
-
-      // Limit will only preserve at most `limit` rows.
-      plan_.params.max_row_count =
-          std::min(lc.limit, plan_.params.max_row_count);
-
-      // The max row count is also the best possible estimate we can make for
-      // the row count.
-      plan_.params.estimated_row_count = plan_.params.max_row_count;
-      break;
-    }
-    default:
-      PERFETTO_FATAL("Unknown row count modifier type");
-  }
-  // Handle all the cost types which need to be calculated *post* the row
-  // estimate update.
-  if (cost.index() ==
-      base::variant_index<i::Cost, i::PostOperationLinearPerRowCost>()) {
-    const auto& c = base::unchecked_get<i::PostOperationLinearPerRowCost>(cost);
-    plan_.params.estimated_cost += c.cost * plan_.params.estimated_cost;
-  }
-  return builder_.AddRawOpcode(option);
-}
-
-void QueryPlanBuilder::SetGuaranteedToBeEmpty() {
-  i::RwHandle<Slab<uint32_t>> slab_reg =
-      builder_.AllocateRegister<Slab<uint32_t>>();
-  i::RwHandle<Span<uint32_t>> span_reg =
-      builder_.AllocateRegister<Span<uint32_t>>();
-  {
-    using B = i::AllocateIndices;
-    auto& bc = AddOpcode<B>(ZeroRowCount{});
-    bc.arg<B::size>() = 0;
-    bc.arg<B::dest_slab_register>() = slab_reg;
-    bc.arg<B::dest_span_register>() = span_reg;
-  }
-  indices_reg_ = span_reg;
-}
-
-i::RwHandle<i::StoragePtr> QueryPlanBuilder::StorageRegisterFor(
-    uint32_t col,
-    StorageType type) {
-  auto [reg, inserted] =
-      cache_.GetOrAllocate<i::StoragePtr>(kStorageReg, columns_[col].get());
-  if (inserted) {
-    plan_.register_inits.emplace_back(
-        RegisterInit{reg.index, type.Upcast<RegisterInit::Type>(),
-                     static_cast<uint16_t>(col)});
-  }
-  return reg;
-}
-
-i::ReadHandle<i::NullBitvector> QueryPlanBuilder::NullBitvectorRegisterFor(
-    uint32_t col) {
-  if (GetColumn(col).null_storage.nullability().Is<NonNull>()) {
-    return {};
-  }
-  auto [reg, inserted] =
-      cache_.GetOrAllocate<i::NullBitvector>(kNullBvReg, columns_[col].get());
-  if (inserted) {
-    plan_.register_inits.emplace_back(RegisterInit{
-        reg.index, RegisterInit::NullBitvector{}, static_cast<uint16_t>(col)});
-  }
-  return reg;
-}
-
-i::ReadHandle<i::NullBitvector> QueryPlanBuilder::EnsurePrefixPopcountFor(
-    uint32_t col) {
-  auto nbv_reg = NullBitvectorRegisterFor(col);
-  if (!GetColumn(col).null_storage.nullability().IsAnyOf<SparseNullTypes>()) {
-    return nbv_reg;
-  }
-  auto [it, inserted] = prefix_popcount_emitted_.Insert(col, true);
-  if (inserted) {
-    using B = i::PrefixPopcount;
-    auto& bc = AddOpcode<B>(UnchangedRowCount{});
-    bc.arg<B::null_bv_register>() =
-        i::RwHandle<i::NullBitvector>(nbv_reg.index);
-  }
-  return nbv_reg;
-}
-
-i::ReadHandle<const BitVector*> QueryPlanBuilder::SmallValueEqBvRegisterFor(
-    uint32_t col) {
-  auto [reg, inserted] = cache_.GetOrAllocate<const BitVector*>(
-      kSmallValueEqBvReg, columns_[col].get());
-  if (inserted) {
-    plan_.register_inits.emplace_back(
-        RegisterInit{reg.index, RegisterInit::SmallValueEqBitvector{},
-                     static_cast<uint16_t>(col)});
-  }
-  return reg;
-}
-
-i::ReadHandle<Span<const uint32_t>>
-QueryPlanBuilder::SmallValueEqPopcountRegisterFor(uint32_t col) {
-  auto [reg, inserted] = cache_.GetOrAllocate<Span<const uint32_t>>(
-      kSmallValueEqPopcountReg, columns_[col].get());
-  if (inserted) {
-    plan_.register_inits.emplace_back(
-        RegisterInit{reg.index, RegisterInit::SmallValueEqPopcount{},
-                     static_cast<uint16_t>(col)});
-  }
-  return reg;
-}
-
-i::RwHandle<Span<uint32_t>> QueryPlanBuilder::IndexRegisterFor(uint32_t pos) {
-  auto [reg, inserted] =
-      cache_.GetOrAllocate<Span<uint32_t>>(kIndexReg, &indexes_[pos]);
-  if (inserted) {
-    plan_.register_inits.emplace_back(RegisterInit{
-        reg.index, RegisterInit::IndexVector{}, static_cast<uint16_t>(pos)});
-  }
-  return reg;
-}
-
-bool QueryPlanBuilder::CanUseMinMaxOptimization(
-    const std::vector<SortSpec>& sort_specs,
-    const LimitSpec& limit_spec) {
-  return sort_specs.size() == 1 &&
-         GetColumn(sort_specs[0].col)
-             .null_storage.nullability()
-             .Is<NonNull>() &&
-         limit_spec.limit == 1 && limit_spec.offset.value_or(0) == 0;
-}
-
-i::ReadHandle<i::CastFilterValueResult> QueryPlanBuilder::CastFilterValue(
-    FilterSpec& c,
-    const StorageType& ct,
-    i::NonNullOp op) {
-  i::RwHandle<i::CastFilterValueResult> value_reg =
-      builder_.AllocateRegister<i::CastFilterValueResult>();
-  {
-    using B = i::CastFilterValueBase;
-    auto& bc =
-        AddOpcode<B>(i::Index<i::CastFilterValue>(ct), UnchangedRowCount{});
-    bc.arg<B::fval_handle>() = {plan_.params.filter_value_count};
-    bc.arg<B::write_register>() = value_reg;
-    bc.arg<B::op>() = op;
-    c.value_index = plan_.params.filter_value_count++;
-  }
-  return value_reg;
-}
-
-i::RwHandle<Span<uint32_t>> QueryPlanBuilder::GetOrCreateScratchSpanRegister(
-    uint32_t size) {
-  auto scratch = builder_.GetOrCreateScratchRegisters(size);
-  {
-    using B = i::AllocateIndices;
-    auto& bc = AddOpcode<B>(UnchangedRowCount{});
-    bc.arg<B::size>() = size;
-    bc.arg<B::dest_slab_register>() = scratch.slab;
-    bc.arg<B::dest_span_register>() = scratch.span;
-  }
-  builder_.MarkScratchInUse(scratch);
-  scratch_ = scratch;
-  return scratch.span;
-}
-
-void QueryPlanBuilder::MaybeReleaseScratchSpanRegister() {
-  if (scratch_.has_value()) {
-    builder_.ReleaseScratch(*scratch_);
-    scratch_ = std::nullopt;
-  }
-}
-
-uint16_t QueryPlanBuilder::CalculateRowLayoutStride(
-    const std::vector<RowLayoutParams>& row_layout_params) {
-  PERFETTO_CHECK(!row_layout_params.empty());
-  uint16_t calculated_total_row_stride = 0;
-  for (const auto& param : row_layout_params) {
-    const Column& col = GetColumn(param.column);
-    bool is_non_null = col.null_storage.nullability().Is<NonNull>();
-    calculated_total_row_stride +=
-        (is_non_null ? 0u : 1u) + GetDataSize(col.storage.type());
-  }
-  return calculated_total_row_stride;
-}
-
-i::RwHandle<Slab<uint8_t>> QueryPlanBuilder::CopyToRowLayout(
-    uint16_t row_stride,
-    i::RwHandle<Span<uint32_t>> indices,
-    i::ReadHandle<i::StringIdToRankMap> rank_map,
-    const std::vector<RowLayoutParams>& row_layout_params) {
-  uint32_t buffer_size = plan_.params.max_row_count * row_stride;
-  i::RwHandle<Slab<uint8_t>> new_buffer_reg =
-      builder_.AllocateRegister<Slab<uint8_t>>();
-  {
-    using B = i::AllocateRowLayoutBuffer;
-    auto& op = AddOpcode<B>(UnchangedRowCount{});
-    op.arg<B::buffer_size>() = buffer_size;
-    op.arg<B::dest_buffer_register>() = new_buffer_reg;
-  }
-  uint16_t current_offset = 0;
-  for (const auto& param : row_layout_params) {
-    const Column& col = GetColumn(param.column);
-    const auto& nullability = col.null_storage.nullability();
-    auto null_bv_reg = EnsurePrefixPopcountFor(param.column);
-    {
-      using B = i::CopyToRowLayoutBase;
-      auto index = i::Index<i::CopyToRowLayout>(
-          col.storage.type(),
-          NullabilityToSparseNullCollapsedNullability(nullability));
-      auto& op = AddOpcode<B>(index, UnchangedRowCount{});
-      op.arg<B::storage_register>() =
-          StorageRegisterFor(param.column, col.storage.type());
-      op.arg<B::null_bv_register>() = null_bv_reg;
-      op.arg<B::source_indices_register>() = indices;
-      op.arg<B::dest_buffer_register>() = new_buffer_reg;
-      op.arg<B::rank_map_register>() = rank_map;
-      op.arg<B::row_layout_offset>() = current_offset;
-      op.arg<B::row_layout_stride>() = row_stride;
-      op.arg<B::invert_copied_bits>() = param.invert_copied_bits;
-    }
-    current_offset +=
-        (nullability.Is<NonNull>() ? 0u : 1u) + GetDataSize(col.storage.type());
-  }
-  PERFETTO_CHECK(current_offset == row_stride);
-  return new_buffer_reg;
-}
-
-void QueryPlanBuilder::AddLinearFilterEqBytecode(
-    const FilterSpec& c,
-    const i::ReadHandle<i::CastFilterValueResult>& filter_value_result_reg,
-    const i::NonIdStorageType& non_id_storage_type) {
-  const auto& col = GetColumn(c.col);
-  PERFETTO_DCHECK(std::holds_alternative<i::RwHandle<Range>>(indices_reg_));
-  PERFETTO_DCHECK(col.null_storage.nullability().Is<NonNull>());
-  PERFETTO_DCHECK(c.op.Is<Eq>());
-
-  using SpanReg = i::RwHandle<Span<uint32_t>>;
-  using SlabReg = i::RwHandle<Slab<uint32_t>>;
-  using RegRange = i::RwHandle<Range>;
-
-  auto range_reg = base::unchecked_get<RegRange>(indices_reg_);
-  SlabReg slab_reg = builder_.AllocateRegister<Slab<uint32_t>>();
-  SpanReg span_reg = builder_.AllocateRegister<Span<uint32_t>>();
-  {
-    using B = i::AllocateIndices;
-    auto& bc = AddOpcode<B>(UnchangedRowCount{});
-    bc.arg<B::size>() = plan_.params.max_row_count;
-    bc.arg<B::dest_slab_register>() = slab_reg;
-    bc.arg<B::dest_span_register>() = span_reg;
-  }
-
-  {
-    using B = i::LinearFilterEqBase;
-    B& bc = AddOpcode<B>(i::Index<i::LinearFilterEq>(non_id_storage_type),
-                         RowCountModifier{EqualityFilterRowCount{
-                             col.duplicate_state, col.estimated_distinct}});
-    bc.arg<B::storage_register>() =
-        StorageRegisterFor(c.col, non_id_storage_type.Upcast<StorageType>());
-    bc.arg<B::filter_value_reg>() = filter_value_result_reg;
-    bc.arg<B::source_register>() = range_reg;
-    bc.arg<B::update_register>() = span_reg;
-  }
-  indices_reg_ = span_reg;
-}
-
-template <typename T>
-T& QueryPlanBuilder::AddOpcode(RowCountModifier rc) {
-  return AddOpcode<T>(i::Index<T>(), rc, T::kCost);
 }
 
 }  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/dataframe/query_plan.h
+++ b/src/trace_processor/core/dataframe/query_plan.h
@@ -51,6 +51,7 @@
 namespace perfetto::trace_processor::core::dataframe {
 
 class Dataframe;
+class BytecodeLowering;
 
 // Specification for initializing a register before bytecode execution.
 // The plan contains abstract references (column indices, index IDs), and
@@ -228,16 +229,14 @@ struct QueryPlanImpl {
   base::SmallVector<RegisterInit, 16> register_inits;
 };
 
-// Builder class for creating query plans.
+// Chooses the access path for a query.
 //
-// QueryPlans contain the bytecode instructions and interpreter configuration
-// needed to execute a query.
+// This class makes all the decisions a query plan involves: the order filters
+// are applied in, which strategy serves each one, whether an index is worth
+// using, and whether a sort can be skipped. It makes no bytecode of its own;
+// each decision is handed to BytecodeLowering, which knows how to emit it.
 class QueryPlanBuilder {
  public:
-  // Represents register types for holding indices.
-  using IndicesReg = std::variant<interpreter::RwHandle<Range>,
-                                  interpreter::RwHandle<Span<uint32_t>>>;
-
   static base::StatusOr<QueryPlanImpl> Build(
       uint32_t row_count,
       const std::vector<std::shared_ptr<Column>>& columns,
@@ -249,57 +248,7 @@ class QueryPlanBuilder {
       uint64_t cols_used);
 
  private:
-  // Indicates that the bytecode does not change the estimated or maximum number
-  // of rows.
-  struct UnchangedRowCount {};
-
-  // Indicates that the bytecode is a non-equality filter.
-  struct NonEqualityFilterRowCount {};
-
-  // Indicates that the bytecode is a equality filter with given duplicate
-  // state and estimated distinct-value count (0 = unknown).
-  struct EqualityFilterRowCount {
-    DuplicateState duplicate_state;
-    uint32_t estimated_distinct = 0;
-  };
-
-  // Indicates that the bytecode is an IN filter over a value list. Unlike a
-  // scalar equality, an IN matches multiple distinct values; since the list
-  // size is not known at plan time (the RHS may be a subquery), we assume it
-  // selects a fixed number of distinct values. `estimated_distinct` is the
-  // per-column distinct-value count (0 = unknown).
-  struct InFilterRowCount {
-    DuplicateState duplicate_state;
-    uint32_t estimated_distinct = 0;
-  };
-
-  // Indicates that the bytecode produces *exactly* one row and the estimated
-  // and maximum should be set to 1.
-  struct OneRowCount {};
-
-  // Indicates that the bytecode produces *exactly* zero rows and the estimated
-  // and maximum should be set to 0.
-  struct ZeroRowCount {};
-
-  // Indicates that the bytecode produces `limit` rows starting at `offset`.
-  struct LimitOffsetRowCount {
-    uint32_t limit;
-    uint32_t offset;
-  };
-  using RowCountModifier = std::variant<UnchangedRowCount,
-                                        NonEqualityFilterRowCount,
-                                        EqualityFilterRowCount,
-                                        InFilterRowCount,
-                                        OneRowCount,
-                                        ZeroRowCount,
-                                        LimitOffsetRowCount>;
-
-  // Constructs a builder for the given indices and columns.
-  // cache is used for caching column/index registers.
-  QueryPlanBuilder(interpreter::BytecodeBuilder& builder,
-                   DataframeRegisterCache& cache,
-                   IndicesReg indices,
-                   uint32_t row_count,
+  QueryPlanBuilder(BytecodeLowering& lowering,
                    const std::vector<std::shared_ptr<Column>>& columns,
                    const std::vector<Index>& indexes);
 
@@ -325,26 +274,23 @@ class QueryPlanBuilder {
   // accessed.
   void Output(const LimitSpec&, uint64_t cols_used_bitmap);
 
-  // Finalizes and returns the built query plan.
-  QueryPlanImpl Build() &&;
-
   // Processes non-string filter constraints.
   void NonStringConstraint(
       const FilterSpec& c,
-      const interpreter::NonStringType& type,
-      const interpreter::NonStringOp& op,
+      const NonStringType& type,
+      const NonStringOp& op,
       const interpreter::ReadHandle<interpreter::CastFilterValueResult>&
           result);
 
   // Processes string filter constraints.
   base::Status StringConstraint(
       const FilterSpec& c,
-      const interpreter::StringOp& op,
+      const StringOp& op,
       const interpreter::ReadHandle<interpreter::CastFilterValueResult>&
           result);
 
   // Processes null filter constraints.
-  void NullConstraint(const interpreter::NullOp&, FilterSpec&);
+  void NullConstraint(const NullOp&, FilterSpec&);
 
   // Processes constraints which can be handled with an index.
   void IndexConstraints(std::vector<FilterSpec>&,
@@ -356,125 +302,7 @@ class QueryPlanBuilder {
   // Returns true if the optimization was applied.
   bool TrySortedConstraint(FilterSpec& fs,
                            const StorageType& ct,
-                           const interpreter::NonNullOp& op);
-
-  // Whether the span being pruned holds the query's result rows, or only a
-  // temporary copy of them.
-  enum class NullPruneScope { kResultRows, kScratchOnly };
-
-  // Given a list of indices, prunes any indices that point to null rows
-  // in the given column. The indices are pruned in-place, and the
-  // `indices_register` is updated to contain only non-null indices.
-  void PruneNullIndices(uint32_t col,
-                        interpreter::RwHandle<Span<uint32_t>> indices,
-                        NullPruneScope scope);
-
-  // Given a list of table indices pointing to *only* non-null rows,
-  // if necessary, translates them to the storage indices for the given column.
-  // If no translation is needed, the indices are returned as-is.
-  // If translation *is* needed, the value of `in_place` determines
-  // whether the translation is done in-place or whether the data is stored
-  // in the scratch register.
-  //
-  // Returns a register handle to the translated indices (either
-  // `indices_register` or the scratch register).
-  interpreter::RwHandle<Span<uint32_t>> TranslateNonNullIndices(
-      uint32_t col,
-      interpreter::RwHandle<Span<uint32_t>> indices_register,
-      bool in_place);
-
-  // Ensures indices are stored in a Slab, converting from Range if necessary.
-  PERFETTO_NO_INLINE interpreter::RwHandle<Span<uint32_t>>
-  EnsureIndicesAreInSlab();
-
-  // Adds a new bytecode instruction of type T to the plan.
-  template <typename T>
-  T& AddOpcode(RowCountModifier rc);
-
-  // Adds a new bytecode instruction of type T with the given option value.
-  template <typename T>
-  T& AddOpcode(uint32_t option, RowCountModifier rc) {
-    return static_cast<T&>(AddRawOpcode(option, rc, T::kCost));
-  }
-
-  // Adds a new bytecode instruction of type T with the given option value.
-  template <typename T>
-  T& AddOpcode(uint32_t option, RowCountModifier rc, interpreter::Cost cost) {
-    return static_cast<T&>(AddRawOpcode(option, rc, cost));
-  }
-
-  PERFETTO_NO_INLINE interpreter::Bytecode&
-  AddRawOpcode(uint32_t option, RowCountModifier rc, interpreter::Cost cost);
-
-  // Sets the result to an empty set. Use when a filter guarantees no matches.
-  void SetGuaranteedToBeEmpty();
-
-  // Allocates a register for column data pointer and adds RegisterInit entry.
-  // Returns a HandleBase that can be assigned to typed data_register fields.
-  interpreter::RwHandle<interpreter::StoragePtr> StorageRegisterFor(
-      uint32_t col,
-      StorageType storage_type);
-
-  // Returns the index register for the given position.
-  interpreter::RwHandle<Span<uint32_t>> IndexRegisterFor(uint32_t pos);
-
-  // Returns the null bitvector register for the given column.
-  // For NonNull columns, returns an empty handle.
-  interpreter::ReadHandle<interpreter::NullBitvector> NullBitvectorRegisterFor(
-      uint32_t col);
-
-  // Returns the null bitvector register for the given column, ensuring a
-  // PrefixPopcount bytecode has been emitted for SparseNull columns.
-  // No-op for non-SparseNull columns or if already emitted.
-  interpreter::ReadHandle<interpreter::NullBitvector> EnsurePrefixPopcountFor(
-      uint32_t col);
-
-  // Returns the SmallValueEq bitvector register for the given column.
-  interpreter::ReadHandle<const BitVector*> SmallValueEqBvRegisterFor(
-      uint32_t col);
-
-  // Returns the SmallValueEq popcount register for the given column.
-  interpreter::ReadHandle<Span<const uint32_t>> SmallValueEqPopcountRegisterFor(
-      uint32_t col);
-
-  interpreter::ReadHandle<interpreter::CastFilterValueResult> CastFilterValue(
-      FilterSpec& c,
-      const StorageType& ct,
-      interpreter::NonNullOp non_null_op);
-
-  interpreter::RwHandle<Span<uint32_t>> GetOrCreateScratchSpanRegister(
-      uint32_t size);
-
-  // Alias for scratch register type.
-  using Scratch = interpreter::BytecodeBuilder::ScratchRegisters;
-
-  // Parameters for conversion to row layout.
-  struct RowLayoutParams {
-    // The column to be copied.
-    uint32_t column;
-
-    // Whether, instead of copying the string column, we should replace it
-    // with a rank of the string.
-    bool replace_string_with_rank = false;
-
-    // Whether the bits when copied should be inverted.
-    bool invert_copied_bits = false;
-  };
-  uint16_t CalculateRowLayoutStride(
-      const std::vector<RowLayoutParams>& row_layout_params);
-
-  interpreter::RwHandle<Slab<uint8_t>> CopyToRowLayout(
-      uint16_t row_stride,
-      interpreter::RwHandle<Span<uint32_t>> indices,
-      interpreter::ReadHandle<interpreter::StringIdToRankMap> rank_map,
-      const std::vector<RowLayoutParams>& row_layout_params);
-
-  void MaybeReleaseScratchSpanRegister();
-
-  void AddLinearFilterEqBytecode(
-      const FilterSpec&,
-      const interpreter::ReadHandle<interpreter::CastFilterValueResult>&,
-      const interpreter::NonIdStorageType&);
+                           const NonNullOp& op);
 
   bool CanUseMinMaxOptimization(const std::vector<SortSpec>&, const LimitSpec&);
 
@@ -486,29 +314,8 @@ class QueryPlanBuilder {
   // Reference to the indexes available.
   const std::vector<Index>& indexes_;
 
-  // The query plan being built.
-  QueryPlanImpl plan_;
-
-  // Current register holding the set of matching indices.
-  IndicesReg indices_reg_;
-
-  // Low-level bytecode builder for register allocation, bytecode storage,
-  // and scratch management.
-  interpreter::BytecodeBuilder& builder_;
-
-  // Register cache for caching column/index registers across Filter() calls.
-  DataframeRegisterCache& cache_;
-
-  // Tracks which columns have had PrefixPopcount bytecode emitted.
-  base::FlatHashMap<uint32_t, bool> prefix_popcount_emitted_;
-
-  // Last scratch registers returned by GetOrCreateScratchSpanRegister.
-  std::optional<Scratch> scratch_;
-
-  // Row count before the first selective (equality/IN) filter was applied. Used
-  // to avoid compounding the selectivity of multiple such filters: only the
-  // most selective one determines the estimate.
-  std::optional<uint32_t> selective_filter_base_row_count_;
+  // Turns the decisions made here into bytecode.
+  BytecodeLowering& lowering_;
 };
 
 }  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/interpreter/interpreter_types.h
+++ b/src/trace_processor/core/interpreter/interpreter_types.h
@@ -36,36 +36,6 @@
 
 namespace perfetto::trace_processor::core::interpreter {
 
-// Type categories for column content and operations.
-// These define which operations can be applied to which content types.
-
-// Set of content types that aren't string-based.
-using NonStringType = TypeSet<Id, Uint32, Int32, Int64, Double>;
-
-// Set of content types that are numeric in nature.
-using IntegerOrDoubleType = TypeSet<Uint32, Int32, Int64, Double>;
-
-// Set of operations applicable to non-null values.
-using NonNullOp = TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex>;
-
-// Set of operations applicable to non-string values.
-using NonStringOp = TypeSet<Eq, Ne, Lt, Le, Gt, Ge>;
-
-// Set of operations applicable to string values.
-using StringOp = TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex>;
-
-// Set of operations applicable to only string values.
-using OnlyStringOp = TypeSet<Glob, Regex>;
-
-// Set of operations applicable to ranges.
-using RangeOp = TypeSet<Eq, Lt, Le, Gt, Ge>;
-
-// Set of inequality operations (Lt, Le, Gt, Ge).
-using InequalityOp = TypeSet<Lt, Le, Gt, Ge>;
-
-// Set of null operations (IsNotNull, IsNull).
-using NullOp = TypeSet<IsNotNull, IsNull>;
-
 // Indicates an operation applies to both bounds of a range.
 struct BothBounds {};
 
@@ -113,9 +83,6 @@ struct MaxOp {};
 
 // TypeSet combining Min and Max operations.
 using MinMaxOp = TypeSet<MinOp, MaxOp>;
-
-// TypeSet containing all the non-id storage types.
-using NonIdStorageType = TypeSet<Uint32, Int32, Int64, Double, String>;
 
 // TypeSet which collapses all of the sparse nullability types into a single
 // type.


### PR DESCRIPTION
Pure refactor, splitting query planning into two stages to allow for alternative lowering from logical plan other than
to bytecode.