### PR TITLE
tp: add a batch execution pipeline

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17700,6 +17700,35 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/core/exec:exec
+filegroup {
+    name: "perfetto_src_trace_processor_core_exec_exec",
+    srcs: [
+        "src/trace_processor/core/exec/column_view.cc",
+        "src/trace_processor/core/exec/operator.cc",
+        "src/trace_processor/core/exec/pipeline.cc",
+        "src/trace_processor/core/exec/row_batch.cc",
+        "src/trace_processor/core/exec/row_cursor.cc",
+        "src/trace_processor/core/exec/row_store.cc",
+    ],
+}
+
+// GN: //src/trace_processor/core/exec:test_utils
+filegroup {
+    name: "perfetto_src_trace_processor_core_exec_test_utils",
+}
+
+// GN: //src/trace_processor/core/exec:unittests
+filegroup {
+    name: "perfetto_src_trace_processor_core_exec_unittests",
+    srcs: [
+        "src/trace_processor/core/exec/operator_unittest.cc",
+        "src/trace_processor/core/exec/row_batch_unittest.cc",
+        "src/trace_processor/core/exec/row_store_unittest.cc",
+        "src/trace_processor/core/exec/variant_unittest.cc",
+    ],
+}
+
 // GN: //src/trace_processor/core/interpreter:bytecode_interpreter_test_utils
 filegroup {
     name: "perfetto_src_trace_processor_core_interpreter_bytecode_interpreter_test_utils",
@@ -24135,6 +24164,9 @@ cc_test {
         ":perfetto_src_trace_processor_core_common_common",
         ":perfetto_src_trace_processor_core_dataframe_dataframe",
         ":perfetto_src_trace_processor_core_dataframe_unittests",
+        ":perfetto_src_trace_processor_core_exec_exec",
+        ":perfetto_src_trace_processor_core_exec_test_utils",
+        ":perfetto_src_trace_processor_core_exec_unittests",
         ":perfetto_src_trace_processor_core_interpreter_bytecode_interpreter_test_utils",
         ":perfetto_src_trace_processor_core_interpreter_interpreter",
         ":perfetto_src_trace_processor_core_interpreter_unittests",

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -445,6 +445,7 @@ perfetto_unittest_source_set("unittests") {
     ":top_level_unittests",
     "containers:unittests",
     "core/dataframe:unittests",
+    "core/exec:unittests",
     "core/interpreter:unittests",
     "core/tree:unittests",
     "core/util:unittests",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -1,0 +1,67 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/test.gni")
+
+source_set("exec") {
+  sources = [
+    "column_view.cc",
+    "column_view.h",
+    "operator.cc",
+    "operator.h",
+    "pipeline.cc",
+    "pipeline.h",
+    "row_batch.cc",
+    "row_batch.h",
+    "row_cursor.cc",
+    "row_cursor.h",
+    "row_selection.h",
+    "row_store.cc",
+    "row_store.h",
+    "variant.h",
+  ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../base",
+    "../../containers",
+    "../common",
+    "../util",
+  ]
+}
+
+source_set("test_utils") {
+  testonly = true
+  sources = [ "test_utils.h" ]
+  deps = [ ":exec" ]
+}
+
+perfetto_unittest_source_set("unittests") {
+  testonly = true
+  sources = [
+    "operator_unittest.cc",
+    "row_batch_unittest.cc",
+    "row_store_unittest.cc",
+    "variant_unittest.cc",
+  ]
+  deps = [
+    ":exec",
+    ":test_utils",
+    "../../../../gn:default_deps",
+    "../../../../gn:gtest_and_gmock",
+    "../../../base",
+    "../../containers",
+    "../common",
+    "../util",
+  ]
+}

--- a/src/trace_processor/core/exec/column_view.cc
+++ b/src/trace_processor/core/exec/column_view.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/column_view.h"
+
+#include <cstdint>
+#include <limits>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// Returned by ResolveToRun when the rows are not contiguous.
+constexpr uint32_t kNoRun = std::numeric_limits<uint32_t>::max();
+
+// The physical row `count` logical rows start at, if they resolve to a
+// contiguous run. Worth checking because a run needs no index array and keeps
+// reads contiguous for every operator downstream.
+//
+// `resolve` is a template parameter so the loop carries no per-row branch on
+// how a row is reached.
+template <typename Resolve>
+uint32_t ResolveToRun(Resolve resolve, uint32_t count) {
+  uint32_t first = resolve(0);
+  uint32_t expected = first + 1;
+  for (uint32_t row = 1; row < count; ++row, ++expected) {
+    if (resolve(row) != expected) {
+      return kNoRun;
+    }
+  }
+  return first;
+}
+
+}  // namespace
+
+void ColumnView::Slice(RowSelection selection,
+                       uint32_t count,
+                       SelectionPool& pool) {
+  if (count == 0) {
+    return;
+  }
+  RowSelection current = selection_;
+
+  if (selection.is_range()) {
+    if (current.is_range()) {
+      selection_ = RowSelection::Range(current.offset() + selection.offset());
+      return;
+    }
+    // Slicing a prefix or suffix of an index array is just a subspan, so the
+    // column keeps the storage it already pointed at.
+    const uint32_t* begin = current.data() + selection.offset();
+    selection_ =
+        RowSelection::Indices(Span<const uint32_t>(begin, begin + count));
+    return;
+  }
+
+  const uint32_t* rows = selection.data();
+  if (current.is_range()) {
+    uint32_t base = current.offset();
+    uint32_t run = ResolveToRun(
+        [rows, base](uint32_t r) { return base + rows[r]; }, count);
+    if (run != kNoRun) {
+      selection_ = RowSelection::Range(run);
+      block_ = nullptr;
+      return;
+    }
+    // Rows counted from zero are exactly the caller's array, whose lifetime
+    // covers the batch.
+    if (base == 0) {
+      selection_ =
+          RowSelection::Indices(Span<const uint32_t>(rows, rows + count));
+      block_ = nullptr;
+      return;
+    }
+    uint32_t* out = pool.TakeBlock();
+    for (uint32_t row = 0; row < count; ++row) {
+      out[row] = base + rows[row];
+    }
+    selection_ = RowSelection::Indices(Span<const uint32_t>(out, out + count));
+    block_ = out;
+    return;
+  }
+
+  const uint32_t* indices = current.data();
+  uint32_t run = ResolveToRun(
+      [rows, indices](uint32_t r) { return indices[rows[r]]; }, count);
+  if (run != kNoRun) {
+    selection_ = RowSelection::Range(run);
+    block_ = nullptr;
+    return;
+  }
+  // A selection the batch already composed is narrowed in place: the ordinals
+  // only ever grow, so an ascending gather never reads a slot it has already
+  // written.
+  bool in_place = block_ != nullptr;
+  uint32_t* out = in_place ? block_ : pool.TakeBlock();
+  for (uint32_t row = 0; row < count; ++row) {
+    PERFETTO_DCHECK(!in_place || indices + rows[row] >= out + row);
+    out[row] = indices[rows[row]];
+  }
+  selection_ = RowSelection::Indices(Span<const uint32_t>(out, out + count));
+  block_ = out;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_VIEW_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_VIEW_H_
+
+#include <cstdint>
+#include <type_traits>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// One column of a RowBatch: a reference to storage the batch does not own,
+// plus the row selection currently applied to it.
+class ColumnView {
+ public:
+  enum class Kind : uint8_t {
+    kFlat,
+    kSequence,
+    // `data()` is a Variant array and `type()` is meaningless.
+    kVariant,
+  };
+
+  ColumnView() = default;
+
+  static ColumnView Reference(StorageType type,
+                              const void* data,
+                              const BitVector* validity = nullptr) {
+    ColumnView view;
+    view.type_ = type;
+    if (type.Is<Id>()) {
+      PERFETTO_DCHECK(data == nullptr && validity == nullptr);
+      view.kind_ = Kind::kSequence;
+      return view;
+    }
+    view.kind_ = Kind::kFlat;
+    view.data_ = data;
+    view.validity_ = validity;
+    return view;
+  }
+
+  // A column carrying a type per row rather than one for the whole column.
+  static ColumnView Variants(const Variant* data) {
+    ColumnView view;
+    view.kind_ = Kind::kVariant;
+    view.data_ = data;
+    return view;
+  }
+
+  Kind kind() const { return kind_; }
+  StorageType type() const { return type_; }
+  RowSelection selection() const { return selection_; }
+
+  // Composes `selection` with the selection already applied, materializing the
+  // result into a block of `pool` if one is needed. The ordinals in
+  // `selection` must be strictly increasing.
+  void Slice(RowSelection selection, uint32_t count, SelectionPool& pool);
+
+  // Points this column at physical rows the caller owns. Nothing is copied, so
+  // `rows` has to outlive the batch's current contents.
+  void SetBorrowedRows(Span<const uint32_t> rows) {
+    selection_ = RowSelection::Indices(rows);
+    block_ = nullptr;
+  }
+
+  // Forgets which batch's block this selection was composed into. A batch
+  // adopting a column from another batch must call this, or narrowing the
+  // column would write into the other batch's storage.
+  void DisownBlock() { block_ = nullptr; }
+
+  // Points this column at the run of physical rows starting at `offset`.
+  void SetRange(uint32_t offset) {
+    selection_ = RowSelection::Range(offset);
+    block_ = nullptr;
+  }
+
+  // Takes over the selection `other` just composed. Columns sharing a
+  // selection before a slice still share one afterwards, so only the first of
+  // them has to do the work.
+  void AdoptSelection(const ColumnView& other) {
+    selection_ = other.selection_;
+    block_ = other.block_;
+  }
+
+  // The value at logical row `row`, resolved through this column's own row
+  // view. Reading is per column because a computed column added by an operator
+  // sits in its own index space rather than its input's.
+  template <typename T>
+  PERFETTO_ALWAYS_INLINE T Value(uint32_t row) const {
+    uint32_t index = selection_.GetIndex(row);
+    if constexpr (std::is_arithmetic_v<T>) {
+      // A sequence column has no storage: the value is the row it sits at.
+      if (kind_ == Kind::kSequence) {
+        return static_cast<T>(index);
+      }
+    }
+    return static_cast<const T*>(data_)[index];
+  }
+
+  // The values this column reads from, before its selection is applied.
+  const void* data() const { return data_; }
+
+  // Which physical rows hold a value, or null when they all do.
+  const BitVector* validity() const { return validity_; }
+
+ private:
+  Kind kind_ = Kind::kFlat;
+  StorageType type_{Id{}};
+  RowSelection selection_ = RowSelection::Range();
+  // The batch block this column's selection was composed into, or null when
+  // the selection points at storage the batch does not own. Columns sharing a
+  // selection share the block behind it.
+  uint32_t* block_ = nullptr;
+  const void* data_ = nullptr;
+  const BitVector* validity_ = nullptr;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_VIEW_H_

--- a/src/trace_processor/core/exec/operator.cc
+++ b/src/trace_processor/core/exec/operator.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/operator.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+OperatorState::~OperatorState() = default;
+Operator::~Operator() = default;
+Source::~Source() = default;
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/operator.h
+++ b/src/trace_processor/core/exec/operator.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// The mutable state of one execution of a plan.
+//
+// Operators and Sources are plan nodes: they stay const while running and hold
+// no values. Everything which changes as a query runs lives here, created by
+// the plan node and owned by the executor. A plan can be run more than once or
+// concurrently, but it and its borrowed dependencies must outlive each run.
+class OperatorState {
+ public:
+  OperatorState() = default;
+  virtual ~OperatorState();
+
+  OperatorState(const OperatorState&) = delete;
+  OperatorState& operator=(const OperatorState&) = delete;
+
+  // Only ever called on a state this plan node created.
+  template <typename T>
+  T& Cast() {
+    return static_cast<T&>(*this);
+  }
+  template <typename T>
+  const T& Cast() const {
+    return static_cast<const T&>(*this);
+  }
+};
+
+enum class OpResult : uint8_t {
+  // `out` holds all the output for this input. An empty `out` means the input
+  // produced no rows.
+  kNeedMoreInput,
+  // `out` holds part of the output for this input. Call Execute() again with
+  // the same input for the rest.
+  kHaveMoreOutput,
+  // The operator failed; status() says why.
+  kError,
+};
+
+// A streaming step in a plan.
+//
+// One input batch can produce more than one output batch: an operator which
+// fans out returns kHaveMoreOutput and is called again with the same input.
+// This is why input and output are separate batches: the input has to survive
+// being read more than once.
+class Operator {
+ public:
+  virtual ~Operator();
+  Operator(const Operator&) = delete;
+  Operator& operator=(const Operator&) = delete;
+
+  virtual std::unique_ptr<OperatorState> MakeState() const {
+    return std::make_unique<OperatorState>();
+  }
+
+  virtual OpResult Execute(const RowBatch& in,
+                           RowBatch& out,
+                           OperatorState& state) const = 0;
+
+  // Resets `state` so the plan can be run again. An operator which carries
+  // nothing between batches has nothing to do here.
+  virtual void Rewind(OperatorState&) const {}
+
+  // Why Execute() returned kError.
+  virtual base::Status status(const OperatorState&) const {
+    return base::OkStatus();
+  }
+
+ protected:
+  Operator() = default;
+};
+
+// Produces the batches a plan runs over.
+class Source {
+ public:
+  virtual ~Source();
+  Source(const Source&) = delete;
+  Source& operator=(const Source&) = delete;
+
+  // A source wrapping another source creates that source's state too, so one
+  // call builds the whole chain.
+  virtual std::unique_ptr<OperatorState> MakeState() const = 0;
+
+  // Fills `out` and returns true, or returns false when no batches are left.
+  // The values in `out` stay valid until the next call.
+  virtual bool GetData(RowBatch& out, OperatorState& state) const = 0;
+
+  // Restarts from the first batch.
+  virtual void Rewind(OperatorState& state) const = 0;
+
+  // After GetData() returns false, distinguishes exhaustion from failure.
+  virtual base::Status status(const OperatorState&) const {
+    return base::OkStatus();
+  }
+
+ protected:
+  Source() = default;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_

--- a/src/trace_processor/core/exec/operator_unittest.cc
+++ b/src/trace_processor/core/exec/operator_unittest.cc
@@ -1,0 +1,374 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/pipeline.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_cursor.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/span.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using ::testing::ElementsAre;
+
+// A source shaped like a dataframe scan: an id column so every batch carries
+// its row indices, plus the values themselves.
+class ArraySource final : public Source {
+ public:
+  explicit ArraySource(std::vector<int64_t> values)
+      : values_(std::move(values)) {}
+
+  std::unique_ptr<OperatorState> MakeState() const override {
+    return std::make_unique<State>();
+  }
+  void Rewind(OperatorState& state) const override {
+    state.Cast<State>().emitted = 0;
+  }
+
+  bool GetData(RowBatch& out, OperatorState& state) const override {
+    State& s = state.Cast<State>();
+    auto rows = static_cast<uint32_t>(values_.size());
+    if (s.emitted == rows) {
+      return false;
+    }
+    uint32_t count = std::min(kMaxBatchRows, rows - s.emitted);
+    out.Reset();
+    out.AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
+    out.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values_.data()));
+    out.Compose(RowSelection::Range(s.emitted), count);
+    out.SetCardinality(count);
+    s.emitted += count;
+    return true;
+  }
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    uint32_t emitted = 0;
+  };
+
+  std::vector<int64_t> values_;
+};
+
+ArraySource::State::~State() = default;
+
+// Keeps every second row, standing in for a real operator. The rows it picks
+// are scratch for one execution, so they live in the state, not the plan.
+class DropOddRows final : public Operator {
+ public:
+  std::unique_ptr<OperatorState> MakeState() const override {
+    return std::make_unique<State>();
+  }
+
+  OpResult Execute(const RowBatch& in,
+                   RowBatch& out,
+                   OperatorState& state) const override {
+    uint32_t* selected = state.Cast<State>().selected;
+    uint32_t count = 0;
+    for (uint32_t row = 0; row < in.size(); row += 2) {
+      selected[count++] = row;
+    }
+    out.CopyFrom(in);
+    out.Slice(
+        RowSelection::Indices(Span<const uint32_t>(selected, selected + count)),
+        count);
+    return OpResult::kNeedMoreInput;
+  }
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    uint32_t selected[kMaxBatchRows];
+  };
+};
+
+DropOddRows::State::~State() = default;
+
+// Drives a plan the way an executor does: it creates the state and owns the
+// batch, leaving the plan const throughout.
+class Execution {
+ public:
+  explicit Execution(const Source& source)
+      : source_(source), state_(source.MakeState()) {}
+
+  RowBatch* Next() {
+    return source_.GetData(batch_, *state_) ? &batch_ : nullptr;
+  }
+  void Rewind() { source_.Rewind(*state_); }
+
+ private:
+  const Source& source_;
+  std::unique_ptr<OperatorState> state_;
+  RowBatch batch_;
+};
+
+std::vector<int64_t> Sequence(uint32_t count) {
+  std::vector<int64_t> values(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    values[i] = i;
+  }
+  return values;
+}
+
+// Reads a pipeline a row at a time, the way a consumer would.
+std::vector<uint32_t> Drain(const Pipeline& pipeline) {
+  std::vector<uint32_t> rows;
+  RowCursor cursor(pipeline);
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    rows.push_back(cursor.Value<uint32_t>(0));
+  }
+  return rows;
+}
+
+// Returns the same input twice, standing in for an operator whose output does
+// not fit in a single batch.
+class Twice final : public Operator {
+ public:
+  std::unique_ptr<OperatorState> MakeState() const override {
+    return std::make_unique<State>();
+  }
+
+  OpResult Execute(const RowBatch& in,
+                   RowBatch& out,
+                   OperatorState& state) const override {
+    State& s = state.Cast<State>();
+    out.CopyFrom(in);
+    s.again = !s.again;
+    return s.again ? OpResult::kHaveMoreOutput : OpResult::kNeedMoreInput;
+  }
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    bool again = false;
+  };
+};
+
+Twice::State::~State() = default;
+
+TEST(OperatorTest, SourceEmitsEveryRow) {
+  ArraySource source({10, 20, 30});
+  Pipeline pipeline(source, {});
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+}
+
+TEST(OperatorTest, SourceSplitsIntoBatches) {
+  ArraySource source(Sequence(kMaxBatchRows * 2 + 3));
+  Pipeline pipeline(source, {});
+
+  std::vector<uint32_t> rows = Drain(pipeline);
+  ASSERT_EQ(rows.size(), kMaxBatchRows * 2u + 3u);
+  EXPECT_EQ(rows.front(), 0u);
+  EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 2u);
+}
+
+TEST(OperatorTest, SourceIsReplayable) {
+  ArraySource source({10, 20, 30});
+  Pipeline pipeline(source, {});
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+}
+
+TEST(OperatorTest, OperatorNarrowsTheBatch) {
+  ArraySource source({10, 20, 30, 40, 50});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<DropOddRows>());
+  Pipeline pipeline(source, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 2, 4));
+}
+
+TEST(OperatorTest, OperatorsComposeWithinABatch) {
+  ArraySource source({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<DropOddRows>());
+  ops.push_back(std::make_unique<DropOddRows>());
+  Pipeline pipeline(source, std::move(ops));
+
+  // Keeping every second row twice leaves every fourth.
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 4, 8));
+}
+
+TEST(OperatorTest, NarrowingAComposedViewKeepsIt) {
+  ArraySource source(Sequence(17));
+  std::vector<std::unique_ptr<Operator>> ops;
+  for (int i = 0; i < 3; ++i) {
+    ops.push_back(std::make_unique<DropOddRows>());
+  }
+  Pipeline pipeline(source, std::move(ops));
+
+  // Keeping every second row three times leaves every eighth. The third
+  // operator narrows a selection the batch already composed, in place.
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 8, 16));
+}
+
+// The storage a batch composes its selections into belongs to the batch and is
+// reused by the next one, so a pipeline stops allocating once it is running.
+TEST(OperatorTest, ComposedViewsReuseTheBatchesStorage) {
+  ArraySource source(Sequence(kMaxBatchRows * 4));
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<DropOddRows>());
+  ops.push_back(std::make_unique<DropOddRows>());
+  Pipeline pipeline(source, std::move(ops));
+
+  Execution run(pipeline);
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  const uint32_t* block = batch->column(0).selection().data();
+  ASSERT_NE(block, nullptr) << "expected a composed view";
+  uint32_t batches = 1;
+  while ((batch = run.Next()) != nullptr) {
+    EXPECT_EQ(batch->column(0).selection().data(), block);
+    ++batches;
+  }
+  EXPECT_EQ(batches, 4u);
+}
+
+TEST(SinkTest, ReadsEveryRowOfEveryBatch) {
+  ArraySource source(Sequence(kMaxBatchRows * 2 + 7));
+  Pipeline pipeline(source, {});
+
+  std::vector<uint32_t> rows = Drain(pipeline);
+  ASSERT_EQ(rows.size(), kMaxBatchRows * 2u + 7u);
+  EXPECT_EQ(rows.front(), 0u);
+  EXPECT_EQ(rows[kMaxBatchRows], kMaxBatchRows);
+  EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 6u);
+}
+
+// An operator adding a computed column cannot put it in the index space its
+// input arrived in, so it uses its own. Reading either column has to go
+// through that column's own selection.
+TEST(SinkTest, ReadsColumnsWhichDoNotShareARowView) {
+  std::vector<int64_t> payload = {10, 11, 12, 13};
+  std::vector<int64_t> computed = {90, 91};
+
+  class TwoViewSource final : public Source {
+   public:
+    TwoViewSource(const std::vector<int64_t>* payload,
+                  const std::vector<int64_t>* computed)
+        : payload_(payload), computed_(computed) {}
+
+    std::unique_ptr<OperatorState> MakeState() const override {
+      return std::make_unique<State>();
+    }
+    void Rewind(OperatorState& state) const override {
+      state.Cast<State>().done = false;
+    }
+    bool GetData(RowBatch& batch_, OperatorState& state) const override {
+      State& s = state.Cast<State>();
+      if (s.done) {
+        return false;
+      }
+      s.done = true;
+      batch_.Reset();
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, payload_->data()));
+      // The payload is read from half way in; the computed column is a
+      // separate array read from the start.
+      batch_.Compose(RowSelection::Range(2), 2);
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, computed_->data()));
+      batch_.SetCardinality(2);
+      return true;
+    }
+
+   private:
+    struct State : OperatorState {
+      bool done = false;
+    };
+    const std::vector<int64_t>* payload_;
+    const std::vector<int64_t>* computed_;
+  };
+
+  TwoViewSource source(&payload, &computed);
+  RowCursor cursor(source);
+  std::vector<int64_t> read_payload;
+  std::vector<int64_t> read_computed;
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    read_payload.push_back(cursor.Value<int64_t>(0));
+    read_computed.push_back(cursor.Value<int64_t>(1));
+  }
+  EXPECT_THAT(read_payload, ElementsAre(12, 13));
+  EXPECT_THAT(read_computed, ElementsAre(90, 91));
+}
+
+TEST(SinkTest, ReportsEofWithoutOpen) {
+  ArraySource source({1, 2, 3});
+  Pipeline pipeline(source, {});
+  RowCursor cursor(pipeline);
+
+  EXPECT_TRUE(cursor.eof());
+}
+
+// A cursor which has reported eof has no batch left to move within, so
+// advancing again must keep saying so rather than resurrecting the cursor.
+TEST(SinkTest, AdvancingPastEofStaysAtEof) {
+  ArraySource source({1, 2});
+  Pipeline pipeline(source, {});
+  RowCursor cursor(pipeline);
+  cursor.Open();
+  cursor.Next();
+  cursor.Next();
+  ASSERT_TRUE(cursor.eof());
+  EXPECT_FALSE(cursor.Next());
+  EXPECT_TRUE(cursor.eof());
+}
+
+TEST(SinkTest, ReopeningRereadsFromTheStart) {
+  ArraySource source({4, 5, 6});
+  Pipeline pipeline(source, {});
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+}
+
+// One input batch can produce more than one output batch: the operator says
+// so and is called again with the same input.
+TEST(OperatorTest, AnOperatorCanFanOut) {
+  ArraySource source({10, 20, 30});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<Twice>());
+  Pipeline pipeline(source, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2, 0, 1, 2));
+}
+
+// The deepest operator with more output is drained before the one above it is
+// called again.
+TEST(OperatorTest, FanOutNestsInnermostFirst) {
+  ArraySource source({10, 20});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<Twice>());
+  ops.push_back(std::make_unique<Twice>());
+  Pipeline pipeline(source, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 0, 1, 0, 1, 0, 1));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/pipeline.cc
+++ b/src/trace_processor/core/exec/pipeline.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/pipeline.h"
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+Pipeline::Pipeline(const Source& source,
+                   std::vector<std::unique_ptr<Operator>> operators)
+    : source_(source), operators_(std::move(operators)) {}
+
+Pipeline::~Pipeline() = default;
+Pipeline::State::~State() = default;
+
+std::unique_ptr<OperatorState> Pipeline::MakeState() const {
+  auto state = std::make_unique<State>();
+  state->source = source_.MakeState();
+  state->operators.reserve(operators_.size());
+  for (const std::unique_ptr<Operator>& op : operators_) {
+    state->operators.push_back(op->MakeState());
+  }
+  state->batches.resize(operators_.size());
+  return state;
+}
+
+void Pipeline::Rewind(OperatorState& state) const {
+  State& s = state.Cast<State>();
+  s.pending.clear();
+  source_.Rewind(*s.source);
+  for (uint32_t i = 0; i < operators_.size(); ++i) {
+    operators_[i]->Rewind(*s.operators[i]);
+  }
+}
+
+base::Status Pipeline::status(const OperatorState& state) const {
+  const State& s = state.Cast<const State>();
+  for (uint32_t i = 0; i < operators_.size(); ++i) {
+    base::Status status = operators_[i]->status(*s.operators[i]);
+    if (!status.ok()) {
+      return status;
+    }
+  }
+  return source_.status(*s.source);
+}
+
+bool Pipeline::GetData(RowBatch& out, OperatorState& state) const {
+  State& s = state.Cast<State>();
+  if (operators_.empty()) {
+    return source_.GetData(out, *s.source);
+  }
+  // TODO(lalitm): nothing between batches checks for cancellation, so a
+  // long-running pipeline cannot be interrupted; check an interrupt flag here
+  // once one is plumbed through.
+  for (;;) {
+    uint32_t first;
+    if (s.pending.empty()) {
+      if (!source_.GetData(s.batches[0], *s.source)) {
+        return false;
+      }
+      first = 0;
+    } else {
+      first = s.pending.back();
+      s.pending.pop_back();
+    }
+    bool filled = true;
+    for (uint32_t i = first; i < operators_.size(); ++i) {
+      RowBatch& dst = i + 1 == operators_.size() ? out : s.batches[i + 1];
+      OpResult result =
+          operators_[i]->Execute(s.batches[i], dst, *s.operators[i]);
+      if (result == OpResult::kError) {
+        return false;
+      }
+      if (result == OpResult::kHaveMoreOutput) {
+        s.pending.push_back(i);
+      }
+      if (dst.size() == 0) {
+        filled = false;
+        break;
+      }
+    }
+    if (filled) {
+      return true;
+    }
+  }
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/pipeline.h
+++ b/src/trace_processor/core/exec/pipeline.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_PIPELINE_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_PIPELINE_H_
+
+#include <memory>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// A source followed by a chain of operators, itself exposed as a Source. Its
+// state holds the state of every node in the chain.
+class Pipeline : public Source {
+ public:
+  Pipeline(const Source&, std::vector<std::unique_ptr<Operator>>);
+  Pipeline(Source&&, std::vector<std::unique_ptr<Operator>>) = delete;
+  ~Pipeline() override;
+
+  std::unique_ptr<OperatorState> MakeState() const override;
+  bool GetData(RowBatch& out, OperatorState& state) const override;
+  void Rewind(OperatorState& state) const override;
+  base::Status status(const OperatorState& state) const override;
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    std::unique_ptr<OperatorState> source;
+    std::vector<std::unique_ptr<OperatorState>> operators;
+    // The input batch of each operator. The last operator writes directly
+    // into the caller's batch.
+    std::vector<RowBatch> batches;
+    // Operators with more output for the input they already hold, deepest
+    // last, since the deepest has to be drained first.
+    std::vector<uint32_t> pending;
+  };
+
+  const Source& source_;
+  std::vector<std::unique_ptr<Operator>> operators_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_PIPELINE_H_

--- a/src/trace_processor/core/exec/row_batch.cc
+++ b/src/trace_processor/core/exec/row_batch.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_batch.h"
+
+#include <cstdint>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+bool RowBatch::AdoptPhysicalRows(Span<const uint32_t> rows) {
+  auto count = static_cast<uint32_t>(rows.size());
+  if (count == 0) {
+    cardinality_ = 0;
+    return false;
+  }
+  PERFETTO_DCHECK(count <= cardinality_);
+  for (ColumnView& column : columns_) {
+    column.SetBorrowedRows(rows);
+  }
+  cardinality_ = count;
+  return true;
+}
+
+void RowBatch::Compose(RowSelection selection, uint32_t count) {
+  // Columns filled by one source share a selection, and composing one is a
+  // gather over the whole batch. Do it once per distinct selection and let the
+  // other columns adopt the result.
+  const ColumnView* composed = nullptr;
+  const uint32_t* composed_from_rows = nullptr;
+  uint32_t composed_from_offset = 0;
+  for (ColumnView& column : columns_) {
+    RowSelection current = column.selection();
+    if (composed && current.data() == composed_from_rows &&
+        current.offset() == composed_from_offset) {
+      column.AdoptSelection(*composed);
+      continue;
+    }
+    composed_from_rows = current.data();
+    composed_from_offset = current.offset();
+    column.Slice(selection, count, selections_);
+    composed = &column;
+  }
+}
+
+bool RowBatch::Slice(RowSelection selection, uint32_t count) {
+  PERFETTO_DCHECK(count <= cardinality_);
+#if PERFETTO_DCHECK_IS_ON()
+  for (uint32_t row = 0; row < count; ++row) {
+    PERFETTO_DCHECK(selection.GetIndex(row) < cardinality_);
+    PERFETTO_DCHECK(row == 0 ||
+                    selection.GetIndex(row - 1) < selection.GetIndex(row));
+  }
+#endif
+  if (count == 0) {
+    cardinality_ = 0;
+    return false;
+  }
+  if (count == cardinality_) {
+    return true;
+  }
+  Compose(selection, count);
+  cardinality_ = count;
+  return true;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_batch.h
+++ b/src/trace_processor/core/exec/row_batch.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// A batch of columns, all with the same number of rows.
+//
+// The values belong to whoever handed the batch over and stay valid until the
+// next pull from them. A batch also keeps alive any column it was given
+// ownership of, so such a column does not dangle if its producer goes away.
+class RowBatch {
+ public:
+  RowBatch() = default;
+
+  uint32_t size() const { return cardinality_; }
+  void SetCardinality(uint32_t count) {
+    PERFETTO_DCHECK(count <= kMaxBatchRows);
+    cardinality_ = count;
+  }
+
+  uint32_t column_count() const {
+    return static_cast<uint32_t>(columns_.size());
+  }
+  const ColumnView& column(uint32_t column) const { return columns_[column]; }
+  ColumnView& mutable_column(uint32_t column) { return columns_[column]; }
+
+  // Points this batch at `other`'s columns and cardinality. No values are
+  // copied.
+  void CopyFrom(const RowBatch& other) {
+    columns_ = other.columns_;
+    owners_ = other.owners_;
+    cardinality_ = other.cardinality_;
+    selections_.Reset();
+    for (ColumnView& column : columns_) {
+      column.DisownBlock();
+    }
+  }
+
+  // Replaces `column` and the owner keeping its values alive.
+  void SetColumn(uint32_t column,
+                 ColumnView view,
+                 std::shared_ptr<const void> owner = nullptr) {
+    // The view may carry the block of the batch it was composed in; narrowing
+    // it here must not write there.
+    view.DisownBlock();
+    columns_[column] = std::move(view);
+    owners_[column] = std::move(owner);
+  }
+  // Adds a column. `owner` keeps the values alive for as long as the batch
+  // does; pass null when the storage already outlives the batch.
+  void AddColumn(ColumnView column,
+                 std::shared_ptr<const void> owner = nullptr) {
+    // The view may carry the block of the batch it was composed in; narrowing
+    // it here must not write there.
+    column.DisownBlock();
+    columns_.push_back(std::move(column));
+    owners_.push_back(std::move(owner));
+  }
+
+  // Points every column at `rows`, which the caller continues to own.
+  bool AdoptPhysicalRows(Span<const uint32_t> rows);
+
+  // Invalidates the current contents, ready for the batch to be refilled.
+  void PrepareForFill() { selections_.Reset(); }
+
+  // Points every column at the `count` rows `selection` picks out.
+  void Compose(RowSelection selection, uint32_t count);
+
+  // Narrows to the `count` rows `selection` picks out, whose ordinals must be
+  // strictly increasing. Returns false when no rows remain.
+  bool Slice(RowSelection selection, uint32_t count);
+
+  // Removes every column.
+  void Reset() {
+    cardinality_ = 0;
+    columns_.clear();
+    owners_.clear();
+    selections_.Reset();
+  }
+
+ private:
+  uint32_t cardinality_ = 0;
+  std::vector<ColumnView> columns_;
+  // One per column; null for columns the batch does not own.
+  std::vector<std::shared_ptr<const void>> owners_;
+  SelectionPool selections_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_

--- a/src/trace_processor/core/exec/row_batch_unittest.cc
+++ b/src/trace_processor/core/exec/row_batch_unittest.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_batch.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/test_utils.h"
+#include "src/trace_processor/core/util/span.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using testing::ElementsAre;
+
+// A column composed inside one batch carries the block its indices were
+// materialized into. A batch adopting that column must not keep writing into
+// the block, or narrowing the adopter corrupts the batch it came from.
+TEST(RowBatchTest, AdoptingAComposedColumnLeavesTheOriginalAlone) {
+  std::vector<int64_t> values = {0, 1, 2, 3, 4, 5, 6, 7};
+  std::vector<uint32_t> picks = {0, 2, 4};
+  std::vector<uint32_t> narrower = {0, 2};
+
+  // A range not starting at zero followed by an indexed slice forces the
+  // indices into a block owned by `original`.
+  RowBatch original;
+  original.AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  original.Compose(RowSelection::Range(2), 5);
+  original.SetCardinality(5);
+  ASSERT_TRUE(original.Slice(RowSelection::Indices(Span<const uint32_t>(
+                                 picks.data(), picks.data() + 3)),
+                             3));
+  ASSERT_THAT(test::ReadColumn<int64_t>(original, 0), ElementsAre(2, 4, 6));
+
+  RowBatch adopter;
+  adopter.AddColumn(original.column(0));
+  adopter.SetCardinality(3);
+  ASSERT_TRUE(adopter.Slice(RowSelection::Indices(Span<const uint32_t>(
+                                narrower.data(), narrower.data() + 2)),
+                            2));
+
+  EXPECT_THAT(test::ReadColumn<int64_t>(adopter, 0), ElementsAre(2, 6));
+  EXPECT_THAT(test::ReadColumn<int64_t>(original, 0), ElementsAre(2, 4, 6));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_cursor.cc
+++ b/src/trace_processor/core/exec/row_cursor.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_cursor.h"
+
+#include "src/trace_processor/core/exec/operator.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+RowCursor::RowCursor(const Source& source)
+    : source_(source), state_(source.MakeState()) {}
+
+RowCursor::~RowCursor() = default;
+
+bool RowCursor::Pull() {
+  if (!source_.GetData(batch_, *state_)) {
+    index_ = 0;
+    size_ = 0;
+    return false;
+  }
+  index_ = 0;
+  size_ = batch_.size();
+  return true;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_cursor.h
+++ b/src/trace_processor/core/exec/row_cursor.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// Reads one execution of a plan a row at a time.
+//
+// This is the executor: it creates the state and owns the batch, which is what
+// lets the plan itself be const. A new batch is pulled only when the current
+// one is exhausted.
+class RowCursor {
+ public:
+  explicit RowCursor(const Source& source);
+  RowCursor(Source&&) = delete;
+  ~RowCursor();
+
+  // Rewinds and moves to the first row.
+  bool Open() {
+    source_.Rewind(*state_);
+    index_ = 0;
+    size_ = 0;
+    return Pull();
+  }
+
+  // Moves to the next row, pulling a new batch if this one is exhausted. At
+  // eof it stays put and keeps returning false.
+  bool Next() {
+    if (index_ == size_) {
+      return false;
+    }
+    return ++index_ != size_ || Pull();
+  }
+
+  bool eof() const { return index_ == size_; }
+
+  base::Status status() const { return source_.status(*state_); }
+
+  // The value of `column` at the current row.
+  template <typename T>
+  PERFETTO_ALWAYS_INLINE T Value(uint32_t column) const {
+    PERFETTO_DCHECK(index_ < size_);
+    return batch_.column(column).Value<T>(index_);
+  }
+
+  const RowBatch& batch() const { return batch_; }
+
+ private:
+  bool Pull();
+
+  const Source& source_;
+  std::unique_ptr<OperatorState> state_;
+  RowBatch batch_;
+  uint32_t index_ = 0;
+  uint32_t size_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_

--- a/src/trace_processor/core/exec/row_selection.h
+++ b/src/trace_processor/core/exec/row_selection.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_SELECTION_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_SELECTION_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// The maximum number of rows in a batch.
+inline constexpr uint32_t kMaxBatchRows = 2048;
+
+// Maps the logical rows of a batch to physical rows of the underlying
+// storage, either as a contiguous range or as an array of indices. An indexed
+// selection does not own that array.
+class RowSelection {
+ public:
+  static RowSelection Range(uint32_t offset = 0) {
+    return RowSelection(nullptr, offset);
+  }
+  static RowSelection Indices(Span<const uint32_t> rows) {
+    return RowSelection(rows.data(), 0);
+  }
+
+  uint32_t GetIndex(uint32_t row) const {
+    return rows_ ? rows_[row] : offset_ + row;
+  }
+  bool is_range() const { return rows_ == nullptr; }
+  const uint32_t* data() const { return rows_; }
+  uint32_t offset() const { return offset_; }
+
+ private:
+  RowSelection(const uint32_t* rows, uint32_t offset)
+      : rows_(rows), offset_(offset) {}
+
+  const uint32_t* rows_;
+  uint32_t offset_;
+};
+
+// The storage a batch composes its row selections into.
+//
+// Blocks are handed out for the life of one batch and reused by the next. A
+// batch needs one block per group of columns sharing a selection, so the pool
+// stops growing after the first batch.
+class SelectionPool {
+ public:
+  // Returns a block of kMaxBatchRows indices, valid for as long as the batch
+  // is. Growing the pool reallocates the vector of blocks, not the blocks.
+  uint32_t* TakeBlock() {
+    if (next_ == blocks_.size()) {
+      blocks_.push_back(FlexVector<uint32_t>::CreateWithSize(kMaxBatchRows));
+    }
+    return blocks_[next_++].data();
+  }
+
+  // Returns every block to the pool for the next batch to use.
+  void Reset() { next_ = 0; }
+
+ private:
+  std::vector<FlexVector<uint32_t>> blocks_;
+  uint32_t next_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_SELECTION_H_

--- a/src/trace_processor/core/exec/row_store.cc
+++ b/src/trace_processor/core/exec/row_store.cc
@@ -1,0 +1,365 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_store.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// kChunkRows rows of one column.
+struct RowStore::Chunk {
+  std::variant<FlexVector<uint32_t>,
+               FlexVector<int32_t>,
+               FlexVector<int64_t>,
+               FlexVector<double>,
+               FlexVector<StringPool::Id>,
+               FlexVector<Variant>>
+      values{FlexVector<uint32_t>()};
+  BitVector validity;
+};
+
+namespace {
+
+using Chunk = RowStore::Chunk;
+constexpr uint32_t kChunkRows = RowStore::kChunkRows;
+
+// The chunk's values, made to hold kChunkRows of T the first time it is used.
+template <typename T, typename V>
+FlexVector<T>& Values(V& values) {
+  // The default alternative is an empty vector, so holding the right type is
+  // not enough to have room in it.
+  if (!std::holds_alternative<FlexVector<T>>(values) ||
+      std::get<FlexVector<T>>(values).size() < kChunkRows) {
+    values = FlexVector<T>::CreateWithSize(kChunkRows);
+  }
+  return std::get<FlexVector<T>>(values);
+}
+
+// Copies `count` of `column`'s rows, starting at its row `from`, to `at`.
+template <typename T, typename V>
+void Copy(const ColumnView& column,
+          uint32_t from,
+          uint32_t at,
+          uint32_t count,
+          V& values) {
+  T* dest = Values<T>(values).data() + at;
+  const auto* data = static_cast<const T*>(column.data());
+  RowSelection selection = column.selection();
+  if (selection.is_range()) {
+    memcpy(dest, data + selection.offset() + from, count * sizeof(T));
+    return;
+  }
+  const uint32_t* rows = selection.data() + from;
+  for (uint32_t i = 0; i < count; ++i) {
+    dest[i] = data[rows[i]];
+  }
+}
+
+// An Id column has no storage: its value is the row it sits at.
+template <typename V>
+void CopyIds(const ColumnView& column,
+             uint32_t from,
+             uint32_t at,
+             uint32_t count,
+             V& values) {
+  uint32_t* dest = Values<uint32_t>(values).data() + at;
+  RowSelection selection = column.selection();
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset() + from;
+    for (uint32_t i = 0; i < count; ++i) {
+      dest[i] = offset + i;
+    }
+    return;
+  }
+  memcpy(dest, selection.data() + from, count * sizeof(uint32_t));
+}
+
+// Copies the validity of `count` of `column`'s rows, starting at its row
+// `from`, to `at`.
+void CopyValidity(const ColumnView& column,
+                  uint32_t from,
+                  uint32_t at,
+                  uint32_t count,
+                  BitVector& into) {
+  const BitVector* validity = column.validity();
+  if (!validity) {
+    for (uint32_t i = 0; i < count; ++i) {
+      into.set(at + i);
+    }
+    return;
+  }
+  RowSelection selection = column.selection();
+  if (selection.is_range()) {
+    into.SetBitsFrom(at, *validity, selection.offset() + from, count);
+    return;
+  }
+  const uint32_t* rows = selection.data() + from;
+  for (uint32_t i = 0; i < count; ++i) {
+    if (validity->is_set(rows[i])) {
+      into.set(at + i);
+    } else {
+      into.clear(at + i);
+    }
+  }
+}
+
+// Picks the rows `rows` names out of `chunks`, laying them out from zero. A
+// gather cannot be a view because the rows come from more than one chunk.
+template <typename T>
+void Gather(const std::vector<std::unique_ptr<Chunk>>& chunks,
+            Span<const uint32_t> rows,
+            Chunk& into) {
+  T* dest = Values<T>(into.values).data();
+  for (uint32_t i = 0; i < rows.size(); ++i) {
+    const Chunk& chunk = *chunks[rows[i] / kChunkRows];
+    dest[i] = std::get<FlexVector<T>>(chunk.values)[rows[i] % kChunkRows];
+  }
+}
+
+void GatherValidity(const std::vector<std::unique_ptr<Chunk>>& chunks,
+                    Span<const uint32_t> rows,
+                    Chunk& into) {
+  for (uint32_t i = 0; i < rows.size(); ++i) {
+    const Chunk& chunk = *chunks[rows[i] / kChunkRows];
+    if (chunk.validity.is_set(rows[i] % kChunkRows)) {
+      into.validity.set(i);
+    }
+  }
+}
+
+}  // namespace
+
+RowStore::RowStore() = default;
+RowStore::~RowStore() = default;
+
+RowStore::Chunk& RowStore::ChunkAt(Column& column, uint32_t index) const {
+  if (column.chunks.size() <= index) {
+    column.chunks.resize(index + 1);
+  }
+  if (!column.chunks[index]) {
+    column.chunks[index] = std::make_unique<Chunk>();
+  }
+  return *column.chunks[index];
+}
+
+base::Status RowStore::ValidateColumn(const Column& into,
+                                      const ColumnView& from) const {
+  if (!initialized_) {
+    return base::OkStatus();
+  }
+  bool variant = from.kind() == ColumnView::Kind::kVariant;
+  if (variant != into.variant) {
+    return base::ErrStatus("row store: a column changed shape");
+  }
+  if (variant) {
+    return base::OkStatus();
+  }
+  StorageType type = from.type().Is<Id>() ? StorageType{Uint32{}} : from.type();
+  if (!(type == into.type)) {
+    return base::ErrStatus(
+        "row store: a column arrived holding one type after holding another");
+  }
+  return base::OkStatus();
+}
+
+void RowStore::AppendColumn(Column& into,
+                            const ColumnView& from,
+                            uint32_t count) {
+  bool variant = from.kind() == ColumnView::Kind::kVariant;
+  StorageType type = from.type();
+  if (!variant && type.Is<Id>()) {
+    type = StorageType{Uint32{}};
+  }
+  bool nullable = into.nullable || from.validity() != nullptr;
+  if (nullable && !into.nullable) {
+    // Rows appended while the column was non-nullable are all valid, but only
+    // those: the unwritten tail of the last chunk has to stay clear because
+    // the validity copy can only ever set bits, never clear one set here.
+    for (uint32_t i = 0; i < into.chunks.size(); ++i) {
+      if (!into.chunks[i]) {
+        continue;
+      }
+      uint64_t filled =
+          std::min<uint64_t>(kChunkRows, size_ - uint64_t{i} * kChunkRows);
+      BitVector validity = BitVector::CreateWithSize(filled, true);
+      validity.resize(kChunkRows);
+      into.chunks[i]->validity = std::move(validity);
+    }
+  }
+
+  for (uint32_t done = 0; done < count;) {
+    uint32_t row = size_ + done;
+    uint32_t index = row / kChunkRows;
+    uint32_t at = row % kChunkRows;
+    uint32_t run = std::min(count - done, kChunkRows - at);
+    Chunk& chunk = ChunkAt(into, index);
+    if (variant) {
+      Copy<Variant>(from, done, at, run, chunk.values);
+    } else if (from.type().Is<Id>()) {
+      CopyIds(from, done, at, run, chunk.values);
+    } else if (type.Is<Uint32>()) {
+      Copy<uint32_t>(from, done, at, run, chunk.values);
+    } else if (type.Is<Int32>()) {
+      Copy<int32_t>(from, done, at, run, chunk.values);
+    } else if (type.Is<Int64>()) {
+      Copy<int64_t>(from, done, at, run, chunk.values);
+    } else if (type.Is<Double>()) {
+      Copy<double>(from, done, at, run, chunk.values);
+    } else {
+      Copy<StringPool::Id>(from, done, at, run, chunk.values);
+    }
+    if (nullable) {
+      if (chunk.validity.size() == 0) {
+        chunk.validity = BitVector::CreateWithSize(kChunkRows);
+      }
+      CopyValidity(from, done, at, run, chunk.validity);
+    }
+    done += run;
+  }
+  into.variant = variant;
+  into.type = type;
+  into.nullable = nullable;
+}
+
+base::Status RowStore::Append(const RowBatch& batch) {
+  if (!initialized_) {
+    columns_.resize(batch.column_count());
+  } else if (columns_.size() != batch.column_count()) {
+    return base::ErrStatus(
+        "row store: a batch of %u columns arrived after one of %u",
+        batch.column_count(), static_cast<uint32_t>(columns_.size()));
+  }
+  for (uint32_t col = 0; col < columns_.size(); ++col) {
+    RETURN_IF_ERROR(ValidateColumn(columns_[col], batch.column(col)));
+  }
+  for (uint32_t col = 0; col < columns_.size(); ++col) {
+    AppendColumn(columns_[col], batch.column(col), batch.size());
+  }
+  size_ += batch.size();
+  initialized_ = true;
+  return base::OkStatus();
+}
+
+ColumnView RowStore::ViewOf(const Column& column, const Chunk& chunk) const {
+  if (column.variant) {
+    return ColumnView::Variants(
+        std::get<FlexVector<Variant>>(chunk.values).data());
+  }
+  const void* data = nullptr;
+  if (column.type.Is<Uint32>()) {
+    data = std::get<FlexVector<uint32_t>>(chunk.values).data();
+  } else if (column.type.Is<Int32>()) {
+    data = std::get<FlexVector<int32_t>>(chunk.values).data();
+  } else if (column.type.Is<Int64>()) {
+    data = std::get<FlexVector<int64_t>>(chunk.values).data();
+  } else if (column.type.Is<Double>()) {
+    data = std::get<FlexVector<double>>(chunk.values).data();
+  } else {
+    data = std::get<FlexVector<StringPool::Id>>(chunk.values).data();
+  }
+  return ColumnView::Reference(column.type, data,
+                               column.nullable ? &chunk.validity : nullptr);
+}
+
+uint32_t RowStore::View(RowBatch* batch,
+                        uint32_t offset,
+                        uint32_t count) const {
+  PERFETTO_DCHECK(offset + count <= size_);
+  batch->Reset();
+  if (count == 0) {
+    return 0;
+  }
+  uint32_t at = offset % kChunkRows;
+  uint32_t served = std::min(count, kChunkRows - at);
+  for (const Column& column : columns_) {
+    ColumnView view = ViewOf(column, *column.chunks[offset / kChunkRows]);
+    view.SetRange(at);
+    batch->AddColumn(view);
+  }
+  batch->SetCardinality(served);
+  return served;
+}
+
+void RowStore::View(RowBatch* batch, Span<const uint32_t> rows) {
+  auto count = static_cast<uint32_t>(rows.size());
+  PERFETTO_DCHECK(count <= kChunkRows);
+  batch->Reset();
+  for (Column& column : columns_) {
+    if (!column.gathered) {
+      column.gathered = std::make_unique<Chunk>();
+    }
+    Chunk& into = *column.gathered;
+    if (column.variant) {
+      Gather<Variant>(column.chunks, rows, into);
+    } else if (column.type.Is<Uint32>()) {
+      Gather<uint32_t>(column.chunks, rows, into);
+    } else if (column.type.Is<Int32>()) {
+      Gather<int32_t>(column.chunks, rows, into);
+    } else if (column.type.Is<Int64>()) {
+      Gather<int64_t>(column.chunks, rows, into);
+    } else if (column.type.Is<Double>()) {
+      Gather<double>(column.chunks, rows, into);
+    } else {
+      Gather<StringPool::Id>(column.chunks, rows, into);
+    }
+    if (column.nullable) {
+      if (into.validity.size() == 0) {
+        into.validity = BitVector::CreateWithSize(kChunkRows);
+      } else {
+        into.validity.ClearAllBits();
+      }
+      GatherValidity(column.chunks, rows, into);
+    }
+    ColumnView view = ViewOf(column, into);
+    view.SetRange(0);
+    batch->AddColumn(view);
+  }
+  batch->SetCardinality(count);
+}
+
+void RowStore::Clear() {
+  size_ = 0;
+  for (Column& column : columns_) {
+    column.nullable = false;
+    for (const std::unique_ptr<Chunk>& chunk : column.chunks) {
+      if (chunk) {
+        chunk->validity.clear();
+      }
+    }
+  }
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_store.h
+++ b/src/trace_processor/core/exec/row_store.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_STORE_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_STORE_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// Owns a copy of rows taken from one or more RowBatches.
+//
+// A RowBatch only borrows its values: they stay valid until the next pull from
+// the source, which is free to overwrite them. An operator which needs rows
+// for longer than that must copy them into a RowStore. Views of the store
+// borrow in the same way: they are good until the store's next mutation, and
+// never longer than the store.
+//
+// Rows are held in fixed-size chunks rather than one growing array, so nothing
+// already appended is ever copied again. kChunkRows is a power of two, so a
+// row's chunk and its offset within it are a shift and a mask.
+class RowStore {
+ public:
+  static constexpr uint32_t kChunkRows = kMaxBatchRows;
+
+  RowStore();
+  ~RowStore();
+
+  // Appends every column of `batch`. The first call fixes the column count and
+  // the type of each column; later calls must match it.
+  base::Status Append(const RowBatch& batch);
+
+  uint32_t size() const { return size_; }
+  uint32_t column_count() const {
+    return static_cast<uint32_t>(columns_.size());
+  }
+  StorageType type(uint32_t column) const { return columns_[column].type; }
+  bool is_variant(uint32_t column) const { return columns_[column].variant; }
+
+  // Points `batch` at up to `count` rows from `offset` and returns how many it
+  // could serve. A run never spans two chunks, so a caller asking for more than
+  // the rest of a chunk gets the rest of the chunk.
+  uint32_t View(RowBatch* batch, uint32_t offset, uint32_t count) const;
+
+  // Points `batch` at the rows `rows` picks out, in that order. They can come
+  // from any chunk, which no single view can span, so the values are gathered
+  // into reused storage. The result stays valid until the next indexed View()
+  // on this store.
+  void View(RowBatch* batch, Span<const uint32_t> rows);
+
+  // Drops all the rows but keeps the allocated chunks.
+  void Clear();
+
+  // kChunkRows rows of one column. Defined in the .cc and opaque here: it is
+  // public only so file-local helpers there can name it.
+  struct Chunk;
+
+ private:
+  struct Column {
+    StorageType type{Uint32{}};
+    bool variant = false;
+    bool nullable = false;
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    // Where a gathered view puts the values it picks out.
+    std::unique_ptr<Chunk> gathered;
+  };
+
+  base::Status ValidateColumn(const Column&, const ColumnView&) const;
+  void AppendColumn(Column&, const ColumnView&, uint32_t count);
+  ColumnView ViewOf(const Column&, const Chunk&) const;
+  Chunk& ChunkAt(Column&, uint32_t index) const;
+
+  std::vector<Column> columns_;
+  bool initialized_ = false;
+  uint32_t size_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_STORE_H_

--- a/src/trace_processor/core/exec/row_store_unittest.cc
+++ b/src/trace_processor/core/exec/row_store_unittest.cc
@@ -1,0 +1,418 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_store.h"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/test_utils.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/span.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using testing::ElementsAre;
+
+// Points a batch at a single int64 column, the way a source would.
+void Fill(RowBatch* batch,
+          const std::vector<int64_t>& values,
+          uint32_t offset,
+          uint32_t count) {
+  batch->Reset();
+  batch->AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch->Compose(RowSelection::Range(offset), count);
+  batch->SetCardinality(count);
+}
+
+// Reads every row of the store back, a run at a time.
+std::vector<int64_t> ReadAll(const RowStore& store, uint32_t column);
+
+std::vector<int64_t> ReadAll(const RowStore& store, uint32_t column) {
+  RowBatch batch;
+  std::vector<int64_t> out;
+  for (uint32_t at = 0; at < store.size();) {
+    at += store.View(&batch, at, store.size() - at);
+    std::vector<int64_t> run = test::ReadColumn<int64_t>(batch, column);
+    out.insert(out.end(), run.begin(), run.end());
+  }
+  return out;
+}
+
+TEST(RowStoreTest, KeepsWhatSeveralBatchesCarried) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 2);
+  ASSERT_TRUE(store.Append(batch).ok());
+  Fill(&batch, values, 2, 3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  EXPECT_EQ(store.size(), 5u);
+  EXPECT_THAT(ReadAll(store, 0), ElementsAre(10, 11, 12, 13, 14));
+}
+
+// The reason a store exists: a source is free to overwrite the buffer a batch
+// was pointing at.
+TEST(RowStoreTest, SurvivesTheStorageItWasReadFromMovingOn) {
+  std::vector<int64_t> buffer = {1, 2, 3};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, buffer, 0, 3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  buffer = {99, 99, 99};
+  EXPECT_THAT(ReadAll(store, 0), ElementsAre(1, 2, 3));
+}
+
+// A batch narrowed to a scattering of rows is stored as those rows laid out
+// one after another, whatever the batch was pointing at.
+TEST(RowStoreTest, ReadsBackDenseWhateverArrived) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  std::vector<uint32_t> rows = {4, 0, 2};
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch.mutable_column(0).SetBorrowedRows(
+      Span<const uint32_t>(rows.data(), rows.data() + 3));
+  batch.SetCardinality(3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  EXPECT_THAT(ReadAll(store, 0), ElementsAre(14, 10, 12));
+}
+
+TEST(RowStoreTest, HandsBackARunOfItsRows) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 5);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  EXPECT_EQ(store.View(&out, 2, 3), 3u);
+  EXPECT_EQ(out.size(), 3u);
+  EXPECT_THAT(test::ReadColumn<int64_t>(out, 0), ElementsAre(12, 13, 14));
+}
+
+TEST(RowStoreTest, HandsBackTheRowsAnOrderPicksOut) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  std::vector<uint32_t> order = {4, 3, 0};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 5);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, Span<const uint32_t>(order.data(), order.data() + 3));
+  EXPECT_THAT(test::ReadColumn<int64_t>(out, 0), ElementsAre(14, 13, 10));
+}
+
+// Viewing twice must not accumulate columns in the batch.
+TEST(RowStoreTest, AViewReplacesTheOneBefore) {
+  std::vector<int64_t> values = {10, 11};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 2);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 0, 2);
+  store.View(&out, 0, 2);
+  EXPECT_EQ(out.column_count(), 1u);
+}
+
+TEST(RowStoreTest, KeepsWhichRowsHeldNothing) {
+  std::vector<int64_t> values = {10, 11, 12};
+  BitVector validity = BitVector::CreateWithSize(3);
+  validity.set(0);
+  validity.set(2);
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, values.data(), &validity));
+  batch.Compose(RowSelection::Range(0), 3);
+  batch.SetCardinality(3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 0, 3);
+  const BitVector* kept = out.column(0).validity();
+  ASSERT_NE(kept, nullptr);
+  EXPECT_TRUE(kept->is_set(0));
+  EXPECT_FALSE(kept->is_set(1));
+  EXPECT_TRUE(kept->is_set(2));
+}
+
+TEST(RowStoreTest, BackfillsEarlierChunksWhenNullabilityAppears) {
+  std::vector<int64_t> values(RowStore::kChunkRows, 1);
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, RowStore::kChunkRows);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  BitVector validity = BitVector::CreateWithSize(1);
+  int64_t null_value = 0;
+  batch.Reset();
+  batch.AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, &null_value, &validity));
+  batch.SetCardinality(1);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  ASSERT_EQ(store.View(&out, 0, RowStore::kChunkRows), RowStore::kChunkRows);
+  ASSERT_NE(out.column(0).validity(), nullptr);
+  EXPECT_EQ(out.column(0).validity()->CountSetBits(), RowStore::kChunkRows);
+  ASSERT_EQ(store.View(&out, RowStore::kChunkRows, 1), 1u);
+  EXPECT_FALSE(out.column(0).validity()->is_set(0));
+}
+
+// When nullability appears, only the rows a chunk actually holds are valid:
+// the unwritten tail of the last chunk must stay clear, or a null landing
+// there cannot turn its bit off (the validity copy only ever sets bits).
+TEST(RowStoreTest, ANullLandingInAPartlyFilledChunkStaysNull) {
+  std::vector<int64_t> values = {10, 11, 12};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  std::vector<int64_t> more = {20, 21};
+  BitVector validity = BitVector::CreateWithSize(2);
+  validity.set(0);
+  batch.Reset();
+  batch.AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, more.data(), &validity));
+  batch.Compose(RowSelection::Range(0), 2);
+  batch.SetCardinality(2);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  ASSERT_EQ(store.View(&out, 0, 5), 5u);
+  EXPECT_THAT(test::ReadNullableColumn<int64_t>(out, 0),
+              ElementsAre(10, 11, 12, 20, std::nullopt));
+}
+
+TEST(RowStoreTest, RejectsABatchBeforeMutatingAnyColumn) {
+  std::vector<int64_t> ints = {1, 2};
+  std::vector<double> doubles = {1.0, 2.0};
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Int64{}}, ints.data()));
+  batch.AddColumn(ColumnView::Reference(StorageType{Int64{}}, ints.data()));
+  batch.SetCardinality(1);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  BitVector validity = BitVector::CreateWithSize(2);
+  validity.set(1);
+  batch.Reset();
+  batch.AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, ints.data(), &validity));
+  batch.AddColumn(ColumnView::Reference(StorageType{Double{}}, doubles.data()));
+  batch.Compose(RowSelection::Range(1), 1);
+  batch.SetCardinality(1);
+  EXPECT_FALSE(store.Append(batch).ok());
+
+  RowBatch out;
+  ASSERT_EQ(store.View(&out, 0, 1), 1u);
+  EXPECT_EQ(out.column(0).validity(), nullptr);
+  EXPECT_EQ(store.size(), 1u);
+}
+
+TEST(RowStoreTest, AZeroColumnBatchFixesTheSchema) {
+  RowStore store;
+  RowBatch empty_schema;
+  empty_schema.SetCardinality(2);
+  ASSERT_TRUE(store.Append(empty_schema).ok());
+
+  std::vector<int64_t> values = {1};
+  RowBatch with_column;
+  Fill(&with_column, values, 0, 1);
+  EXPECT_FALSE(store.Append(with_column).ok());
+  EXPECT_EQ(store.size(), 2u);
+  EXPECT_EQ(store.column_count(), 0u);
+}
+
+TEST(RowStoreTest, ViewingAnEmptySuffixReturnsAnEmptyBatch) {
+  std::vector<int64_t> values(RowStore::kChunkRows);
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, RowStore::kChunkRows);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  EXPECT_EQ(store.View(&out, store.size(), 0), 0u);
+  EXPECT_EQ(out.size(), 0u);
+}
+
+// An Id column has no storage: its value is the row it sits at, so storing one
+// means materialising those rows.
+TEST(RowStoreTest, AnIdColumnBecomesTheRowsItStoodFor) {
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
+  batch.Compose(RowSelection::Range(7), 3);
+  batch.SetCardinality(3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 0, 3);
+  ASSERT_TRUE(out.column(0).type().Is<Uint32>());
+  const auto* data = static_cast<const uint32_t*>(out.column(0).data());
+  EXPECT_THAT(std::vector<uint32_t>(data, data + 3), ElementsAre(7u, 8u, 9u));
+}
+
+TEST(RowStoreTest, ABatchOfADifferentShapeIsReported) {
+  std::vector<int64_t> values = {1, 2};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 2);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch wider;
+  wider.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  wider.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  wider.Compose(RowSelection::Range(0), 2);
+  wider.SetCardinality(2);
+  EXPECT_FALSE(store.Append(wider).ok());
+}
+
+// Rows already appended are never copied again: each chunk is allocated once
+// and stays where it is, so the run a given row sits in keeps its address
+// however many batches arrive after it.
+TEST(RowStoreTest, FillingAChunkAtATimeDoesNotRecopyTheColumn) {
+  const uint32_t kRows = 200000, kChunk = 2048;
+  std::vector<int64_t> values(kChunk);
+  RowStore store;
+  RowBatch batch;
+  RowBatch first;
+  for (uint32_t done = 0; done < kRows; done += kChunk) {
+    Fill(&batch, values, 0, kChunk);
+    ASSERT_TRUE(store.Append(batch).ok());
+    if (done == 0) {
+      store.View(&first, 0, kChunk);
+    }
+  }
+  RowBatch again;
+  store.View(&again, 0, kChunk);
+  EXPECT_EQ(again.column(0).data(), first.column(0).data());
+}
+
+// A run never spans two chunks, so a caller asking for more than the rest of
+// one gets the rest of it and comes back for the next.
+TEST(RowStoreTest, ARunStopsAtTheEndOfAChunk) {
+  std::vector<int64_t> values(RowStore::kChunkRows);
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, RowStore::kChunkRows);
+  ASSERT_TRUE(store.Append(batch).ok());
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  EXPECT_EQ(store.View(&out, 1, store.size() - 1), RowStore::kChunkRows - 1);
+  EXPECT_EQ(store.View(&out, RowStore::kChunkRows,
+                       store.size() - RowStore::kChunkRows),
+            RowStore::kChunkRows);
+}
+
+// A batch which does not divide into the chunk size straddles a boundary, so
+// the copy has to split. Every batch size lands differently against it.
+TEST(RowStoreTest, BatchesWhichStraddleAChunkBoundary) {
+  const uint32_t kRows = RowStore::kChunkRows * 2 + 37;
+  std::vector<int64_t> values(RowStore::kChunkRows);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = 1000 + i;
+  }
+  for (uint32_t batch_rows : {1u, 7u, 700u, RowStore::kChunkRows}) {
+    RowStore store;
+    RowBatch batch;
+    std::vector<int64_t> expected;
+    for (uint32_t done = 0; done < kRows;) {
+      uint32_t n = std::min(batch_rows, kRows - done);
+      Fill(&batch, values, 0, n);
+      ASSERT_TRUE(store.Append(batch).ok());
+      for (uint32_t i = 0; i < n; ++i) {
+        expected.push_back(values[i]);
+      }
+      done += n;
+    }
+    ASSERT_EQ(store.size(), kRows) << "batch of " << batch_rows;
+    EXPECT_EQ(ReadAll(store, 0), expected) << "batch of " << batch_rows;
+  }
+}
+
+// A gather can name rows from any chunk, which no single view can span.
+TEST(RowStoreTest, GathersRowsFromSeveralChunks) {
+  const uint32_t kRows = RowStore::kChunkRows * 2 + 5;
+  std::vector<int64_t> values(RowStore::kChunkRows);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int64_t>(i);
+  }
+  RowStore store;
+  RowBatch batch;
+  std::vector<int64_t> all;
+  for (uint32_t done = 0; done < kRows;) {
+    uint32_t n = std::min(RowStore::kChunkRows, kRows - done);
+    Fill(&batch, values, 0, n);
+    ASSERT_TRUE(store.Append(batch).ok());
+    all.insert(all.end(), values.begin(), values.begin() + n);
+    done += n;
+  }
+  std::vector<uint32_t> order = {kRows - 1, 0, RowStore::kChunkRows,
+                                 RowStore::kChunkRows - 1, 3};
+  RowBatch out;
+  store.View(&out,
+             Span<const uint32_t>(order.data(), order.data() + order.size()));
+  std::vector<int64_t> expected;
+  for (uint32_t row : order) {
+    expected.push_back(all[row]);
+  }
+  EXPECT_EQ(test::ReadColumn<int64_t>(out, 0), expected);
+}
+
+TEST(RowStoreTest, KeepsAColumnWhoseTypeIsPerRow) {
+  StringPool pool;
+  std::vector<Variant> values = {Variant::Int64(7), Variant::Null(),
+                                 Variant::Double(1.5),
+                                 Variant::String(pool.InternString("hi"))};
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Variants(values.data()));
+  batch.Compose(RowSelection::Range(0), 4);
+  batch.SetCardinality(4);
+
+  RowStore store;
+  ASSERT_TRUE(store.Append(batch).ok());
+  ASSERT_TRUE(store.is_variant(0));
+
+  RowBatch out;
+  ASSERT_EQ(store.View(&out, 0, 4), 4u);
+  const auto* kept = static_cast<const Variant*>(out.column(0).data());
+  EXPECT_EQ(kept[0].AsInt64(), 7);
+  EXPECT_EQ(kept[1].type, Variant::Type::kNull);
+  EXPECT_EQ(kept[2].AsDouble(), 1.5);
+  EXPECT_EQ(pool.Get(kept[3].AsString()).ToStdString(), "hi");
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/test_utils.h
+++ b/src/trace_processor/core/exec/test_utils.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_TEST_UTILS_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_TEST_UTILS_H_
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec::test {
+
+template <typename T>
+std::vector<T> ReadColumn(const RowBatch& batch, uint32_t column) {
+  const ColumnView& view = batch.column(column);
+  std::vector<T> values;
+  values.reserve(batch.size());
+  for (uint32_t row = 0; row < batch.size(); ++row) {
+    values.push_back(view.Value<T>(row));
+  }
+  return values;
+}
+
+template <typename T>
+std::vector<std::optional<T>> ReadNullableColumn(const RowBatch& batch,
+                                                 uint32_t column) {
+  const ColumnView& view = batch.column(column);
+  const BitVector* validity = view.validity();
+  std::vector<std::optional<T>> values;
+  values.reserve(batch.size());
+  for (uint32_t row = 0; row < batch.size(); ++row) {
+    uint32_t index = view.selection().GetIndex(row);
+    if (validity && !validity->is_set(index)) {
+      values.emplace_back(std::nullopt);
+    } else {
+      values.emplace_back(view.Value<T>(row));
+    }
+  }
+  return values;
+}
+
+}  // namespace perfetto::trace_processor::core::exec::test
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_TEST_UTILS_H_

--- a/src/trace_processor/core/exec/variant.h
+++ b/src/trace_processor/core/exec/variant.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_VARIANT_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_VARIANT_H_
+
+#include <cstdint>
+#include <type_traits>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/containers/string_pool.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// One value of a column whose type is per row rather than per column.
+struct Variant {
+  enum class Type : uint8_t { kNull, kInt64, kDouble, kString };
+
+  static Variant Null() {
+    Variant v;
+    v.type = Type::kNull;
+    v.int64_ = 0;
+    return v;
+  }
+  static Variant Int64(int64_t value) {
+    Variant v;
+    v.type = Type::kInt64;
+    v.int64_ = value;
+    return v;
+  }
+  static Variant Double(double value) {
+    Variant v;
+    v.type = Type::kDouble;
+    v.double_ = value;
+    return v;
+  }
+  static Variant String(StringPool::Id value) {
+    Variant v;
+    v.type = Type::kString;
+    v.string_ = value;
+    return v;
+  }
+
+  int64_t AsInt64() const {
+    PERFETTO_DCHECK(type == Type::kInt64);
+    return int64_;
+  }
+  double AsDouble() const {
+    PERFETTO_DCHECK(type == Type::kDouble);
+    return double_;
+  }
+  StringPool::Id AsString() const {
+    PERFETTO_DCHECK(type == Type::kString);
+    return string_;
+  }
+
+  // Deliberately carries no initializer: chunks of Variant are allocated as
+  // whole arrays without being written, which needs trivial construction. Use
+  // Null() for an initialized null value.
+  Type type;
+
+ private:
+  union {
+    int64_t int64_;
+    double double_;
+    StringPool::Id string_;
+  };
+};
+
+// See the comment on `type`.
+static_assert(std::is_trivially_constructible_v<Variant>);
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_VARIANT_H_

--- a/src/trace_processor/core/exec/variant_unittest.cc
+++ b/src/trace_processor/core/exec/variant_unittest.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/variant.h"
+
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// A default-constructed Variant is deliberately uninitialized (see the header)
+// so every value has to come from a factory, which carries its type.
+TEST(VariantTest, FactoriesCarryTheirType) {
+  EXPECT_EQ(Variant::Null().type, Variant::Type::kNull);
+  EXPECT_EQ(Variant::Int64(7).AsInt64(), 7);
+  EXPECT_EQ(Variant::Double(1.5).AsDouble(), 1.5);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/util/bit_vector.h
+++ b/src/trace_processor/core/util/bit_vector.h
@@ -17,6 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_UTIL_BIT_VECTOR_H_
 #define SRC_TRACE_PROCESSOR_CORE_UTIL_BIT_VECTOR_H_
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -268,6 +269,39 @@ struct BitVector {
   // The && qualifier allows reusing the existing words_ buffer in-place.
   BitVector Compact(const BitVector& keep) && { return CompactInPlace(keep); }
 
+  // Sets bits [at, at + count) from `src` bits [from, from + count). Bits in
+  // the destination range which are unset in the source are left alone, so the
+  // range has to start clear to be a copy rather than a merge.
+  //
+  // A partial first word, whole destination words, then a partial last word:
+  // each destination word costs one read-modify-write, where a bit at a time
+  // would serialise on it.
+  void SetBitsFrom(uint64_t at,
+                   const BitVector& src,
+                   uint64_t from,
+                   uint64_t count) {
+    PERFETTO_DCHECK(at + count <= size_);
+    PERFETTO_DCHECK(from + count <= src.size_);
+    if (count == 0) {
+      return;
+    }
+    uint64_t done = 0;
+    // Up to the destination's next word boundary.
+    if (at % 64 != 0) {
+      uint64_t n = std::min(count, 64 - at % 64);
+      words_[at / 64] |= src.ReadBits(from, n) << (at % 64);
+      done = n;
+    }
+    // Whole destination words.
+    for (; count - done >= 64; done += 64) {
+      words_[(at + done) / 64] |= src.ReadBits(from + done, 64);
+    }
+    // The tail short of a word.
+    if (done < count) {
+      words_[(at + done) / 64] |= src.ReadBits(from + done, count - done);
+    }
+  }
+
   // Clears all bits in the vector, resetting it to an empty state.
   void clear() {
     words_.clear();
@@ -278,6 +312,11 @@ struct BitVector {
   void ClearAllBits() {
     memset(words_.data(), 0, words_.size() * sizeof(uint64_t));
   }
+
+  // Makes room for `new_size` bits without changing the size. Growth here is
+  // geometric where resize allocates exactly what was asked for, so anything
+  // filling a bit vector a chunk at a time has to come through here first.
+  void reserve(uint64_t new_size) { words_.reserve((new_size + 63) / 64); }
 
   // Resizes the vector to the specified size. If shrinking, bits past the new
   // size are cleared. If growing, new bits are set to the given value.
@@ -315,6 +354,17 @@ struct BitVector {
   PERFETTO_ALWAYS_INLINE uint64_t size() const { return size_; }
 
  private:
+  // Reads `n` (1..=64) bits starting at `bit`, packed at the bottom of the
+  // returned word.
+  uint64_t ReadBits(uint64_t bit, uint64_t n) const {
+    uint64_t shift = bit % 64;
+    uint64_t value = words_[bit / 64] >> shift;
+    if (shift != 0 && shift + n > 64) {
+      value |= words_[bit / 64 + 1] << (64 - shift);
+    }
+    return n == 64 ? value : value & ((uint64_t{1} << n) - 1);
+  }
+
   // Software emulation of the x64 PEXT instruction. Extracts bits from |word|
   // at positions where |mask| has set bits, packing them into the low bits.
   // See https://www.felixcloutier.com/x86/pext for details.

--- a/src/trace_processor/core/util/bit_vector_unittest.cc
+++ b/src/trace_processor/core/util/bit_vector_unittest.cc
@@ -570,6 +570,49 @@ TEST(BitVectorTest, CompactSingleWord) {
   }
 }
 
+// Every alignment of source and destination against the word boundary, and a
+// count long enough to span several words.
+TEST(BitVectorTest, SetBitsFromEveryAlignment) {
+  constexpr uint64_t kSize = 400;
+  BitVector src = BitVector::CreateWithSize(kSize);
+  for (uint64_t i = 0; i < kSize; ++i) {
+    if (i % 7 == 0 || i % 11 == 3) {
+      src.set(i);
+    }
+  }
+  for (uint64_t from : {uint64_t{0}, uint64_t{1}, uint64_t{63}, uint64_t{64},
+                        uint64_t{65}, uint64_t{130}}) {
+    for (uint64_t at : {uint64_t{0}, uint64_t{1}, uint64_t{63}, uint64_t{64},
+                        uint64_t{65}, uint64_t{130}}) {
+      uint64_t count = kSize - std::max(from, at);
+      BitVector dst = BitVector::CreateWithSize(kSize);
+      dst.SetBitsFrom(at, src, from, count);
+      for (uint64_t i = 0; i < kSize; ++i) {
+        bool expected = i >= at && i < at + count && src.is_set(from + i - at);
+        EXPECT_EQ(dst.is_set(i), expected)
+            << "from=" << from << " at=" << at << " bit=" << i;
+      }
+    }
+  }
+}
+
+TEST(BitVectorTest, SetBitsFromMergesRatherThanOverwrites) {
+  BitVector src = BitVector::CreateWithSize(64);
+  BitVector dst = BitVector::CreateWithSize(64);
+  src.set(1);
+  dst.set(2);
+  dst.SetBitsFrom(0, src, 0, 64);
+  EXPECT_TRUE(dst.is_set(1));
+  EXPECT_TRUE(dst.is_set(2));
+}
+
+TEST(BitVectorTest, SetBitsFromNothing) {
+  BitVector src = BitVector::CreateWithSize(64, true);
+  BitVector dst = BitVector::CreateWithSize(64);
+  dst.SetBitsFrom(0, src, 0, 0);
+  EXPECT_EQ(dst.CountSetBits(), 0u);
+}
+
 TEST(BitVectorTest, CompactCrossWordBoundary) {
   // 128 bits: set bits at positions 63 and 64 (word boundary).
   // Keep only those two positions.

--- a/src/trace_processor/core/util/span.h
+++ b/src/trace_processor/core/util/span.h
@@ -17,8 +17,10 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_UTIL_SPAN_H_
 #define SRC_TRACE_PROCESSOR_CORE_UTIL_SPAN_H_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 #include <vector>
 
 #include "perfetto/base/logging.h"
@@ -37,6 +39,40 @@ struct Span {
 
   Span() = default;
   Span(T* _b, T* _e) : b(_b), e(_e) {}
+
+  template <typename U,
+            size_t N,
+            std::enable_if_t<std::is_convertible_v<U*, T*>, int> = 0>
+  Span(U (&values)[N]) : Span(values, values + N) {}
+
+  template <typename U,
+            size_t N,
+            std::enable_if_t<std::is_convertible_v<U*, T*>, int> = 0>
+  Span(std::array<U, N>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U,
+            size_t N,
+            std::enable_if_t<std::is_convertible_v<const U*, T*>, int> = 0>
+  Span(const std::array<U, N>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U,
+            typename Allocator,
+            std::enable_if_t<std::is_convertible_v<U*, T*>, int> = 0>
+  Span(std::vector<U, Allocator>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U,
+            typename Allocator,
+            std::enable_if_t<std::is_convertible_v<const U*, T*>, int> = 0>
+  Span(const std::vector<U, Allocator>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U, size_t N>
+  Span(std::array<U, N>&&) = delete;
+  template <typename U, typename Allocator>
+  Span(std::vector<U, Allocator>&&) = delete;
 
   T* begin() const { return b; }
   T* end() const { return e; }
@@ -59,6 +95,16 @@ Span<T> MakeMutableSpan(T (&values)[N]) {
 template <typename T, size_t N>
 Span<const T> MakeSpan(const T (&values)[N]) {
   return Span<const T>(values, values + N);
+}
+
+template <typename T, size_t N>
+Span<T> MakeMutableSpan(std::array<T, N>& values) {
+  return Span<T>(values.data(), values.data() + values.size());
+}
+
+template <typename T, size_t N>
+Span<const T> MakeSpan(const std::array<T, N>& values) {
+  return Span<const T>(values.data(), values.data() + values.size());
 }
 
 template <typename T>

--- a/src/trace_processor/core/util/span_unittest.cc
+++ b/src/trace_processor/core/util/span_unittest.cc
@@ -16,6 +16,7 @@
 
 #include "src/trace_processor/core/util/span.h"
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -28,12 +29,22 @@ namespace {
 
 TEST(SpanTest, CreatesFromVector) {
   std::vector<uint32_t> values{1, 2, 3};
-  Span<const uint32_t> span = MakeSpan(values);
+  Span<const uint32_t> span = values;
   EXPECT_THAT(span, testing::ElementsAre(1u, 2u, 3u));
   EXPECT_THAT(span.subspan(1, 2), testing::ElementsAre(2u, 3u));
 
-  Span<uint32_t> mutable_span = MakeMutableSpan(values);
+  Span<uint32_t> mutable_span = values;
   mutable_span.b[1] = 4;
+  EXPECT_EQ(values[1], 4u);
+}
+
+TEST(SpanTest, CreatesFromArray) {
+  std::array<uint32_t, 3> values{1, 2, 3};
+  Span<const uint32_t> values_span = values;
+  EXPECT_THAT(values_span, testing::ElementsAre(1u, 2u, 3u));
+
+  Span<uint32_t> mutable_values = values;
+  mutable_values[1] = 4;
   EXPECT_EQ(values[1], 4u);
 }
 


### PR DESCRIPTION
Trace processor moves rows one at a time through a cursor. That interface
works well for callers, but upstream it costs a virtual call and bounds check
per row and prevents operators from working over a run of values.

Add a batch pipeline alongside the cursor. RowBatch holds column views over
producer-owned storage, so filtering changes a selection instead of moving
values. Operators hold only plan data; mutable execution state is owned
separately, which makes plans safe to reuse.

Values normally live until the producer's next pull. RowStore copies them into
fixed-size chunks when an operator needs to keep them longer. Later changes add
sources and operators on top of these primitives.