### PR TITLE
 base: use intptr_t for ssize_t on Windows 

### DIFF
--- a/include/perfetto/ext/base/sys_types.h
+++ b/include/perfetto/ext/base/sys_types.h
@@ -41,11 +41,7 @@ using gid_t = int;
 using pid_t = int;
 #endif  // !GCC
 
-#if defined(_WIN64)
-using ssize_t = int64_t;
-#else
-using ssize_t = long;
-#endif  // _WIN64
+using ssize_t = intptr_t;
 
 #endif  // __MINGW32__
 


### PR DESCRIPTION
Use intptr_t for Perfetto's Windows ssize_t definition. This preserves the width and value range on all Windows architectures and makes the definition compatible with common embedders.

Electron has carried this downstream fix for Win32 builds since 2022.


