### PR TITLE
perfetto: update frameworks/base tracing protos

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -2982,6 +2982,7 @@ cc_test {
         ":perfetto_protos_perfetto_trace_translation_zero_gen",
         ":perfetto_protos_third_party_android_art_art_heap_graph_zero_gen",
         ":perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
@@ -3385,6 +3386,7 @@ cc_test {
         "perfetto_protos_perfetto_trace_translation_zero_gen_headers",
         "perfetto_protos_third_party_android_art_art_heap_graph_zero_gen_headers",
         "perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
@@ -13938,6 +13940,7 @@ genrule {
         "protos/third_party/android/android_extensions.proto",
         "protos/third_party/android/art/heap_graph.proto",
         "protos/third_party/android/connectivity/network_trace.proto",
+        "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.proto",
         "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_interned_data.proto",
         "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.proto",
         "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto",
@@ -14273,6 +14276,50 @@ genrule {
     ],
 }
 
+// GN: //protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_common_zero
+filegroup {
+    name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
+    srcs: [
+        "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.proto",
+    ],
+}
+
+// GN: //protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_common_zero
+genrule {
+    name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen",
+    srcs: [
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero)",
+    out: [
+        "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.pbzero.cc",
+    ],
+}
+
+// GN: //protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_common_zero
+genrule {
+    name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
+    srcs: [
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero)",
+    out: [
+        "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.pbzero.h",
+    ],
+    export_include_dirs: [
+        ".",
+        "protos",
+    ],
+}
+
 // GN: //protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_interned_data_zero
 filegroup {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
@@ -14411,6 +14458,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -14452,6 +14500,7 @@ genrule {
         ":perfetto_protos_perfetto_trace_system_info_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_perfetto_trace_translation_zero",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
     ],
@@ -14459,7 +14508,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.pbzero.cc",
     ],
@@ -14469,6 +14518,7 @@ genrule {
 genrule {
     name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
     srcs: [
+        ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
@@ -14510,6 +14560,7 @@ genrule {
         ":perfetto_protos_perfetto_trace_system_info_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
         ":perfetto_protos_perfetto_trace_translation_zero",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
     ],
@@ -14517,7 +14568,7 @@ genrule {
         "aprotoc",
         "protozero_plugin",
     ],
-    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero)",
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.pbzero.h",
     ],
@@ -14542,6 +14593,7 @@ genrule {
         ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_field_options_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     ],
     tools: [
@@ -14561,6 +14613,7 @@ genrule {
         ":libprotobuf-internal-descriptor-proto",
         ":perfetto_protos_perfetto_trace_field_options_zero",
         ":perfetto_protos_perfetto_trace_track_event_zero",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
     ],
     tools: [
@@ -20995,6 +21048,7 @@ cc_library_static {
         ":perfetto_protos_perfetto_trace_translation_zero_gen",
         ":perfetto_protos_third_party_android_art_art_heap_graph_zero_gen",
         ":perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
@@ -21265,6 +21319,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_translation_zero_gen_headers",
         "perfetto_protos_third_party_android_art_art_heap_graph_zero_gen_headers",
         "perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
@@ -21371,6 +21426,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_translation_zero_gen_headers",
         "perfetto_protos_third_party_android_art_art_heap_graph_zero_gen_headers",
         "perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
@@ -23831,6 +23887,7 @@ cc_test {
         ":perfetto_protos_perfetto_trace_translation_zero_gen",
         ":perfetto_protos_third_party_android_art_art_heap_graph_zero_gen",
         ":perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
@@ -24415,6 +24472,7 @@ cc_test {
         "perfetto_protos_perfetto_trace_translation_zero_gen_headers",
         "perfetto_protos_third_party_android_art_art_heap_graph_zero_gen_headers",
         "perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
@@ -25077,6 +25135,7 @@ cc_library_static {
         ":perfetto_protos_perfetto_trace_translation_zero_gen",
         ":perfetto_protos_third_party_android_art_art_heap_graph_zero_gen",
         ":perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
@@ -25329,6 +25388,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_translation_zero_gen_headers",
         "perfetto_protos_third_party_android_art_art_heap_graph_zero_gen_headers",
         "perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
@@ -25433,6 +25493,7 @@ cc_library_static {
         "perfetto_protos_perfetto_trace_translation_zero_gen_headers",
         "perfetto_protos_third_party_android_art_art_heap_graph_zero_gen_headers",
         "perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
@@ -25627,6 +25688,7 @@ cc_binary {
         ":perfetto_protos_perfetto_trace_system_info_zero_gen",
         ":perfetto_protos_perfetto_trace_track_event_zero_gen",
         ":perfetto_protos_perfetto_trace_translation_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen",
@@ -25686,6 +25748,7 @@ cc_binary {
         "perfetto_protos_perfetto_trace_system_info_zero_gen_headers",
         "perfetto_protos_perfetto_trace_track_event_zero_gen_headers",
         "perfetto_protos_perfetto_trace_translation_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen_headers",
@@ -25777,6 +25840,7 @@ cc_binary_host {
         ":perfetto_protos_perfetto_trace_translation_zero_gen",
         ":perfetto_protos_third_party_android_art_art_heap_graph_zero_gen",
         ":perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
@@ -26039,6 +26103,7 @@ cc_binary_host {
         "perfetto_protos_perfetto_trace_translation_zero_gen_headers",
         "perfetto_protos_third_party_android_art_art_heap_graph_zero_gen_headers",
         "perfetto_protos_third_party_android_connectivity_connectivity_network_trace_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",

--- a/BUILD
+++ b/BUILD
@@ -655,6 +655,7 @@ perfetto_cc_library(
                ":protos_perfetto_trace_translation_zero",
                ":protos_third_party_android_art_art_heap_graph_zero",
                ":protos_third_party_android_connectivity_connectivity_network_trace_zero",
+               ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
@@ -984,6 +985,7 @@ perfetto_cc_library(
                ":protos_perfetto_trace_translation_zero",
                ":protos_third_party_android_art_art_heap_graph_zero",
                ":protos_third_party_android_connectivity_connectivity_network_trace_zero",
+               ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
@@ -7445,6 +7447,7 @@ perfetto_proto_library(
         ":protos_third_party_android_android_extensions_protos",
         ":protos_third_party_android_art_art_heap_graph_protos",
         ":protos_third_party_android_connectivity_connectivity_network_trace_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_protos",
@@ -10055,6 +10058,7 @@ perfetto_proto_library(
         ":protos_perfetto_trace_translation_protos",
         ":protos_third_party_android_art_art_heap_graph_protos",
         ":protos_third_party_android_connectivity_connectivity_network_trace_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_protos",
@@ -10068,6 +10072,7 @@ perfetto_proto_library(
     exports = [
         ":protos_third_party_android_art_art_heap_graph_protos",
         ":protos_third_party_android_connectivity_connectivity_network_trace_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_protos",
@@ -10294,6 +10299,25 @@ perfetto_cc_protozero_library(
     ],
 )
 
+# GN target: //protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_common_source_set
+perfetto_proto_library(
+    name = "protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
+    srcs = [
+        "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.proto",
+    ],
+    visibility = [
+        PERFETTO_CONFIG.proto_library_visibility,
+    ],
+)
+
+# GN target: //protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_common_zero
+perfetto_cc_protozero_library(
+    name = "protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
+    deps = [
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
+    ],
+)
+
 # GN target: //protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_interned_data_source_set
 perfetto_proto_library(
     name = "protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
@@ -10452,10 +10476,12 @@ perfetto_proto_library(
         ":protos_perfetto_trace_system_info_protos",
         ":protos_perfetto_trace_track_event_protos",
         ":protos_perfetto_trace_translation_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
-    ],
+    ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_non_minimal_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
     ],
 )
@@ -10505,6 +10531,7 @@ perfetto_cc_protozero_library(
         ":protos_perfetto_trace_system_info_zero",
         ":protos_perfetto_trace_track_event_zero",
         ":protos_perfetto_trace_translation_zero",
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_protos",
     ],
@@ -10522,10 +10549,12 @@ perfetto_proto_library(
     deps = [
         ":protos_perfetto_trace_field_options_protos",
         ":protos_perfetto_trace_track_event_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
     ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_field_options_protos",
         ":protos_perfetto_trace_track_event_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
     ],
 )
 
@@ -10535,6 +10564,7 @@ perfetto_cc_protozero_library(
     deps = [
         ":protos_perfetto_trace_field_options_zero",
         ":protos_perfetto_trace_track_event_zero",
+        ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_protos",
     ],
 )
@@ -11783,6 +11813,7 @@ perfetto_cc_library(
                ":protos_perfetto_trace_translation_zero",
                ":protos_third_party_android_art_art_heap_graph_zero",
                ":protos_third_party_android_connectivity_connectivity_network_trace_zero",
+               ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
@@ -12116,6 +12147,7 @@ perfetto_cc_binary(
                ":protos_perfetto_trace_translation_zero",
                ":protos_third_party_android_art_art_heap_graph_zero",
                ":protos_third_party_android_connectivity_connectivity_network_trace_zero",
+               ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",

--- a/protos/third_party/android/BUILD.gn
+++ b/protos/third_party/android/BUILD.gn
@@ -24,6 +24,7 @@ perfetto_proto_library("android_extensions_@TYPE@") {
   public_deps = [
     "art:art_heap_graph_@TYPE@",
     "connectivity:connectivity_network_trace_@TYPE@",
+    "frameworks/base/proto/tracing:frameworks_base_common_@TYPE@",
     "frameworks/base/proto/tracing:frameworks_base_interned_data_@TYPE@",
     "frameworks/base/proto/tracing:frameworks_base_trace_packet_@TYPE@",
     "frameworks/base/proto/tracing:frameworks_base_track_event_@TYPE@",

--- a/protos/third_party/android/android_extensions.proto
+++ b/protos/third_party/android/android_extensions.proto
@@ -18,6 +18,9 @@ syntax = "proto2";
 
 package com.android.internal;
 
+// Common definitions.
+import public "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.proto";
+
 // TrackEvent extensions.
 import public "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto";
 import public "protos/third_party/android/frameworks/native/tracing/frameworks_native_track_event.proto";

--- a/protos/third_party/android/frameworks/base/proto/tracing/BUILD.gn
+++ b/protos/third_party/android/frameworks/base/proto/tracing/BUILD.gn
@@ -14,11 +14,16 @@
 
 import("../../../../../../../gn/proto_library.gni")
 
+perfetto_proto_library("frameworks_base_common_@TYPE@") {
+  sources = [ "frameworks_base_common.proto" ]
+}
+
 # Imports field_options.proto (a custom option), so it is protozero-only.
 perfetto_proto_library("frameworks_base_track_event_@TYPE@") {
   proto_generators = [ "zero" ]
   sources = [ "frameworks_base_track_event.proto" ]
   public_deps = [
+    ":frameworks_base_common_@TYPE@",
     "../../../../../../perfetto/trace:field_options_@TYPE@",
     "../../../../../../perfetto/trace/track_event:@TYPE@",
   ]
@@ -34,9 +39,12 @@ perfetto_proto_library("frameworks_base_interned_data_@TYPE@") {
 }
 
 perfetto_proto_library("frameworks_base_trace_packet_@TYPE@") {
+  proto_generators = [ "zero" ]
   sources = [ "frameworks_base_trace_packet.proto" ]
   public_deps = [
+    ":frameworks_base_common_@TYPE@",
     ":frameworks_base_interned_data_@TYPE@",
     "../../../../../../perfetto/trace:non_minimal_@TYPE@",
   ]
+  import_dirs = [ "${perfetto_protobuf_src_dir}" ]
 }

--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.proto
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// frameworks/base common tracing definitions. Source of truth lives at
+// frameworks/base/proto/tracing/ in the Android tree.
+
+syntax = "proto2";
+
+package com.android.internal;
+
+enum UnfreezeReason {
+  UFR_NONE = 0;
+  UFR_ACTIVITY = 1;
+  UFR_FINISH_RECEIVER = 2;
+  UFR_START_RECEIVER = 3;
+  UFR_BIND_SERVICE = 4;
+  UFR_UNBIND_SERVICE = 5;
+  UFR_START_SERVICE = 6;
+  UFR_GET_PROVIDER = 7;
+  UFR_REMOVE_PROVIDER = 8;
+  UFR_UI_VISIBILITY = 9;
+  UFR_ALLOWLIST = 10;
+  UFR_PROCESS_BEGIN = 11;
+  UFR_PROCESS_END = 12;
+  UFR_TRIM_MEMORY = 13;
+  UFR_PING = 15;
+  UFR_FILE_LOCKS = 16;
+  UFR_FILE_LOCK_CHECK_FAILURE = 17;
+  UFR_BINDER_TXNS = 18;
+  UFR_FEATURE_FLAGS = 19;
+  UFR_SHORT_FGS_TIMEOUT = 20;
+  UFR_SYSTEM_INIT = 21;
+  UFR_BACKUP = 22;
+  UFR_SHELL = 23;
+  UFR_REMOVE_TASK = 24;
+  UFR_UID_IDLE = 25;
+  UFR_STOP_SERVICE = 26;
+  UFR_EXECUTING_SERVICE = 27;
+  UFR_RESTRICTION_CHANGE = 28;
+  UFR_COMPONENT_DISABLED = 29;
+  UFR_OOM_ADJ_FOLLOW_UP = 30;
+  UFR_OOM_ADJ_RECONFIGURATION = 31;
+  UFR_OOM_ADJ_REASON_SERVICE_BINDER_CALL = 32;
+  UFR_OOM_ADJ_REASON_BATCH_UPDATE_REQUEST = 33;
+}

--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.proto
@@ -20,6 +20,7 @@
 syntax = "proto2";
 
 import public "protos/perfetto/trace/trace_packet.proto";
+import "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.proto";
 import "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_interned_data.proto";
 
 package com.android.internal;
@@ -106,10 +107,55 @@ message VideoFrameError {
   optional Reason reason = 2;
 }
 
+// Snapshot of all running process states written at trace stop.
+// See AndroidProcessStateChangedEvent in frameworks_base_track_event.proto
+message AndroidProcessStateSnapshot {
+  // A single process state entry.
+  message Record {
+    // Process ID.
+    optional int32 pid = 1;
+    // Package UID of the process.
+    optional int32 uid = 2;
+    // Process state (ActivityManager process state enum).
+    optional int32 proc_state = 3;
+    // OOM score adjustment value.
+    optional int32 oom_score = 4;
+    // Process capability flags.
+    optional int32 capability_flags = 5;
+    // Process name.
+    optional string process_name = 6;
+    // start sequence id which is assigned to a process during start update
+    optional int64 start_seq_id = 7;
+    // Process start elapsed realtime in milliseconds.
+    optional int64 start_time_ms = 8;
+  }
+  repeated Record record = 1;
+}
+
+// Snapshot of frozen process states written at trace stop.
+message AndroidFreezerStateSnapshot {
+  // A single freezer state entry for a frozen process.
+  message Record {
+    // Package UID of the process being frozen or unfrozen.
+    optional int32 uid = 1;
+    // Process ID of the process being frozen or unfrozen.
+    optional int32 pid = 2;
+    // Time in milliseconds since last unfrozen.
+    optional int64 unfrozen_dur_ms = 3;
+    // Time in milliseconds since last frozen.
+    optional int64 frozen_dur_ms = 4;
+    // Unfreeze reason.
+    optional UnfreezeReason unfreeze_reason = 5;
+  }
+  repeated Record record = 1;
+}
+
 message FrameworksBaseTracePacket {
   extend perfetto.protos.TracePacket {
     optional AppWakelockBundle app_wakelock_bundle = 116;
     optional VideoFrame video_frame = 1000;
     optional VideoFrameError video_frame_error = 1001;
+    optional AndroidProcessStateSnapshot android_process_state = 1002;
+    optional AndroidFreezerStateSnapshot android_freezer_state = 1003;
   }
 }

--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto
@@ -22,6 +22,7 @@ syntax = "proto2";
 
 import public "protos/perfetto/trace/track_event/track_event.proto";
 import "protos/perfetto/trace/field_options.proto";
+import "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.proto";
 
 package com.android.internal;
 
@@ -435,42 +436,6 @@ enum HostingTypeId {
   HOSTING_TYPE_BOUND_SERVICE = 16;
 }
 
-enum UnfreezeReason {
-  UFR_NONE = 0;
-  UFR_ACTIVITY = 1;
-  UFR_FINISH_RECEIVER = 2;
-  UFR_START_RECEIVER = 3;
-  UFR_BIND_SERVICE = 4;
-  UFR_UNBIND_SERVICE = 5;
-  UFR_START_SERVICE = 6;
-  UFR_GET_PROVIDER = 7;
-  UFR_REMOVE_PROVIDER = 8;
-  UFR_UI_VISIBILITY = 9;
-  UFR_ALLOWLIST = 10;
-  UFR_PROCESS_BEGIN = 11;
-  UFR_PROCESS_END = 12;
-  UFR_TRIM_MEMORY = 13;
-  UFR_PING = 15;
-  UFR_FILE_LOCKS = 16;
-  UFR_FILE_LOCK_CHECK_FAILURE = 17;
-  UFR_BINDER_TXNS = 18;
-  UFR_FEATURE_FLAGS = 19;
-  UFR_SHORT_FGS_TIMEOUT = 20;
-  UFR_SYSTEM_INIT = 21;
-  UFR_BACKUP = 22;
-  UFR_SHELL = 23;
-  UFR_REMOVE_TASK = 24;
-  UFR_UID_IDLE = 25;
-  UFR_STOP_SERVICE = 26;
-  UFR_EXECUTING_SERVICE = 27;
-  UFR_RESTRICTION_CHANGE = 28;
-  UFR_COMPONENT_DISABLED = 29;
-  UFR_OOM_ADJ_FOLLOW_UP = 30;
-  UFR_OOM_ADJ_RECONFIGURATION = 31;
-  UFR_OOM_ADJ_REASON_SERVICE_BINDER_CALL = 32;
-  UFR_OOM_ADJ_REASON_BATCH_UPDATE_REQUEST = 33;
-}
-
 enum TriggerType {
   TRIGGER_TYPE_UNKNOWN = 0;
   TRIGGER_TYPE_ALARM = 1;
@@ -770,6 +735,7 @@ message AndroidBinderDiedEvent {
   optional int64 start_seq_id = 4;
 }
 
+// See AndroidProcessStateSnapshot in frameworks_base_trace_packet.proto
 message AndroidProcessStateChangedEvent {
   // Uid of the package of the process changing state.
   optional int32 uid = 1;
@@ -974,9 +940,42 @@ message AndroidProcStateUpdateEvent {
            ".com.android.internal.ProcStateControllerInconsistentBehavior"];
 }
 
+message AndroidSelfBroadcastEvent {
+  // Sender/Receiver PID (since it's self-broadcast, they are the same)
+  optional int32 pid = 1;
+
+  // Sender/Receiver UID
+  optional int32 uid = 2;
+
+  // The action name of the broadcast.
+  optional string action_name = 3;
+
+  // The procstate of the process.
+  optional ProcessStateEnum process_state = 4;
+
+  // The type of the broadcast. It's a mask of BroadcastType.
+  optional int32 broadcast_type = 5;
+
+  // Flags set in the broadcast intent.
+  optional int32 intent_flags = 6;
+
+  // Number of registered receivers for this broadcast.
+  optional int32 registered_receiver_count = 7;
+
+  // Number of manifest receivers for this broadcast.
+  optional int32 manifest_receiver_count = 8;
+
+  // Delivery group policy set for the broadcast.
+  optional int32 delivery_group_policy = 9;
+
+  // Unique cookie for this broadcast, used to correlate server and client
+  // traces.
+  optional int64 trace_cookie = 10;
+}
+
 message FrameworksBaseTrackEvent {
   // Usable range: [2004, 2006], [2008, 2099]
-  // Next id: 2021
+  // Next id: 2022
   extend perfetto.protos.TrackEvent {
     // MessageQueue messages.
     optional AndroidMessageQueue message_queue = 2004;
@@ -1015,5 +1014,7 @@ message FrameworksBaseTrackEvent {
     optional AndroidProcStateSummaryEvent proc_state_summary_event = 2019;
     // ProcState update event.
     optional AndroidProcStateUpdateEvent proc_state_update_event = 2020;
+    // Self broadcast event.
+    optional AndroidSelfBroadcastEvent self_broadcast_event = 2021;
   }
 }


### PR DESCRIPTION
Add AndroidProcessStateSnapshot and AndroidFreezerStateSnapshot AndroidSelfBroadcastEvent trace packet extension protos. Extract UnfreezeReason enum into
frameworks_base_common.proto and register track event extensions.

Mirrors frameworks/base/proto/tracing/frameworks_base_track_event.proto in the upstream Android tree.

