### PR TITLE
tp: Fallback unnamed classes to '' in heap graph aggregation

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
@@ -100,7 +100,7 @@ AS (
         o.upid,
         path_hash,
         parent_path_hash,
-        coalesce(c.deobfuscated_name, c.name) AS name,
+        coalesce(c.deobfuscated_name, c.name, '') AS name,
         o.root_type,
         o.heap_type,
         count() AS self_count,


### PR DESCRIPTION
Ensures non-NULL class names in _heap_graph_path_hash_aggregate, matching _heap_graph_class_name_hash.

