### PR TITLE
tp: Fix negative self_size in heap graph aggregation

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
@@ -104,7 +104,10 @@ AS (
         o.root_type,
         o.heap_type,
         count() AS self_count,
-        sum(o.self_size) AS self_size,
+        -- -1 is a placeholder sentinel (see HeapGraphTracker::GetOrInsertObject
+        -- in heap_graph_tracker.cc) for forward-referenced objects in
+        -- incomplete/non-finalized heap graphs (e.g. from packet loss).
+        sum(iif(o.self_size != -1, o.self_size, 0)) AS self_size,
         sum(o.native_size > 0) AS self_native_count,
         sum(o.native_size) AS self_native_size
       FROM $tab


### PR DESCRIPTION
Exclude the -1 placeholder sentinel when aggregating self_size in _heap_graph_path_hash_aggregate to avoid negative sizes in flamegraphs. 

Bug: b/548916242