### PR TITLE
[draft] tp+ui: support browsing and merging multi-pprof archives with FlamegraphCollection

### DIFF
--- a/src/trace_processor/importers/common/trace_file_tracker.h
+++ b/src/trace_processor/importers/common/trace_file_tracker.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -43,6 +44,15 @@ class TraceFileTracker {
   void SetSize(tables::TraceFileTable::Id id, uint64_t size);
   void StartParsing(tables::TraceFileTable::Id id, TraceImporterId trace_type);
   void DoneParsing(tables::TraceFileTable::Id id, size_t size);
+
+  // The file currently being parsed, so importers can attribute their rows
+  // to a source file.
+  std::optional<tables::TraceFileTable::Id> CurrentFile() const {
+    if (parsing_stack_.empty()) {
+      return std::nullopt;
+    }
+    return parsing_stack_.back();
+  }
 
  private:
   tables::TraceFileTable::Id AddFileImpl(StringId name);

--- a/src/trace_processor/importers/pprof/pprof_trace_reader.cc
+++ b/src/trace_processor/importers/pprof/pprof_trace_reader.cc
@@ -34,6 +34,7 @@
 #include "src/trace_processor/importers/common/create_mapping_params.h"
 #include "src/trace_processor/importers/common/mapping_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
+#include "src/trace_processor/importers/common/trace_file_tracker.h"
 #include "src/trace_processor/importers/common/virtual_memory_mapping.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/profiler_tables_py.h"
@@ -73,6 +74,11 @@ PprofTraceReader::PprofTraceReader(TraceProcessorContext* context)
 PprofTraceReader::~PprofTraceReader() = default;
 
 base::Status PprofTraceReader::Parse(TraceBlobView blob) {
+  // Capture the file here: ParseProfile() runs at an arbitrary
+  // push-to-sorter point, by which time the parsing stack may have popped.
+  if (!file_id_.has_value()) {
+    file_id_ = context_->trace_file_tracker->CurrentFile();
+  }
   buffer_.insert(buffer_.end(), blob.data(), blob.data() + blob.size());
   parsed_any_data_ = true;
   return base::OkStatus();
@@ -182,7 +188,11 @@ base::Status PprofTraceReader::ParseProfile() {
       }
     }
     if (!mapping) {
-      mapping = &context_->mapping_tracker->CreateDummyMapping("[unknown]");
+      // Interned so profiles in an archive share one mapping and their
+      // frames dedupe.
+      CreateMappingParams params;
+      params.name = "[unknown]";
+      mapping = &context_->mapping_tracker->InternMemoryMapping(params);
     }
 
     // Extract function information from the first line for frame name
@@ -213,6 +223,15 @@ base::Status PprofTraceReader::ParseProfile() {
     FrameId frame_id =
         mapping->InternFrame(rel_pc, storage->GetString(frame_name_id));
     location_to_frame[loc_decoder.id()] = frame_id;
+
+    // Frames interned by an earlier profile already carry their symbols.
+    {
+      auto frame_row =
+          (*storage->mutable_stack_profile_frame_table())[frame_id];
+      if (frame_row.symbol_set_id().has_value()) {
+        continue;
+      }
+    }
 
     // Create symbol table entries for all line entries (inlined functions)
     uint32_t symbol_set_id = storage->symbol_table().row_count();
@@ -283,6 +302,23 @@ base::Status PprofTraceReader::ParseProfile() {
     }
   }
 
+  // Scope each profile by its source file, so archive members stay
+  // distinguishable. Gzipped members parse under an unnamed decompression
+  // file, so walk up to the nearest named ancestor.
+  StringId scope_id = pprof_file_string_id_;
+  const auto& trace_files = context_->storage->trace_file_table();
+  auto cur = file_id_;
+  while (cur.has_value()) {
+    auto row = trace_files[*cur];
+    std::optional<StringId> name = row.name();
+    if (name.has_value() && !name->is_null() &&
+        storage->GetString(*name).size() > 0) {
+      scope_id = *name;
+      break;
+    }
+    cur = row.parent_id();
+  }
+
   // Parse sample types and create aggregate_profile entries
   std::vector<tables::AggregateProfileTable::Id> profile_ids;
   for (auto it = profile.sample_type(); it; ++it) {
@@ -298,7 +334,7 @@ base::Status PprofTraceReader::ParseProfile() {
     std::string type_str = storage->GetString(type_str_id).ToStdString();
     auto profile_id =
         storage->mutable_aggregate_profile_table()
-            ->Insert({pprof_file_string_id_,
+            ->Insert({scope_id,
                       storage->InternString(("pprof " + type_str).c_str()),
                       type_str_id, unit_str_id})
             .id;

--- a/src/trace_processor/importers/pprof/pprof_trace_reader.h
+++ b/src/trace_processor/importers/pprof/pprof_trace_reader.h
@@ -18,12 +18,14 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PPROF_PPROF_TRACE_READER_H_
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "perfetto/base/status.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/common/chunked_trace_reader.h"
 #include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/metadata_tables_py.h"
 
 namespace perfetto::trace_processor {
 
@@ -44,6 +46,9 @@ class PprofTraceReader : public ChunkedTraceReader {
   TraceProcessorContext* const context_;
   std::vector<uint8_t> buffer_;
   bool parsed_any_data_ = false;
+
+  // Captured on the first Parse(), when it is top of the parsing stack.
+  std::optional<tables::TraceFileTable::Id> file_id_;
 
   // Constant strings interned at construction time
   const StringId unknown_string_id_;

--- a/test/trace_processor/diff_tests/parser/pprof/tests_pprof.py
+++ b/test/trace_processor/diff_tests/parser/pprof/tests_pprof.py
@@ -13,10 +13,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gzip
+
 from python.generators.diff_tests.testing import Path, DataPath, Metric
 from python.generators.diff_tests.testing import Csv, Json, TextProto, BinaryProto, PprofTextproto
 from python.generators.diff_tests.testing import DiffTestBlueprint
 from python.generators.diff_tests.testing import TestSuite
+from python.generators.diff_tests.testing import Tar, Zip
+
+
+def _varint(n: int) -> bytes:
+  out = bytearray()
+  while True:
+    bits = n & 0x7f
+    n >>= 7
+    if n:
+      out.append(bits | 0x80)
+    else:
+      out.append(bits)
+      return bytes(out)
+
+
+def _field_varint(field_id: int, n: int) -> bytes:
+  return _varint(field_id << 3) + _varint(n)
+
+
+def _field_bytes(field_id: int, data: bytes) -> bytes:
+  return _varint((field_id << 3) | 2) + _varint(len(data)) + data
+
+
+def _mappingless_pprof() -> bytes:
+  """A minimal gzipped pprof whose single location has no mapping.
+
+  Locations without a resolvable mapping exercise the interned '[unknown]'
+  fallback mapping in the pprof reader. Layout (profile.proto field ids):
+  string_table(6), sample_type(1) {type(1), unit(2)}, function(5) {id(1),
+  name(2)}, location(4) {id(1), line(4) {function_id(1)}}, sample(2)
+  {location_id(1), value(2)}.
+  """
+  strings = [b'', b'cpu', b'nanoseconds', b'no_mapping_func']
+  value_type = _field_varint(1, 1) + _field_varint(2, 2)
+  function = _field_varint(1, 1) + _field_varint(2, 3)
+  line = _field_varint(1, 1)
+  location = _field_varint(1, 1) + _field_bytes(4, line)
+  sample = _field_varint(1, 1) + _field_varint(2, 100)
+  profile = (
+      _field_bytes(1, value_type) + _field_bytes(2, sample) +
+      _field_bytes(4, location) + _field_bytes(5, function) +
+      b''.join(_field_bytes(6, s) for s in strings))
+  return gzip.compress(profile)
 
 
 class PprofParser(TestSuite):
@@ -128,4 +173,90 @@ class PprofParser(TestSuite):
         "name","mapping_name","callsite_count"
         "foo","/proc/self/exe",1
         "main","/proc/self/exe",2
+        """))
+
+  # Each member of an archive is scoped by its file name (the reader walks
+  # past the unnamed gzip decompression layer to the nearest named ancestor).
+  def test_pprof_zip_archive_scopes(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'a.pprof': DataPath('pprof_simple_cpu.pprof'),
+            'b.pprof': DataPath('pprof_multi_metric.pprof'),
+        }),
+        query="""
+        SELECT scope, sample_type_type, sample_type_unit
+        FROM __intrinsic_aggregate_profile
+        ORDER BY scope, sample_type_type;
+        """,
+        out=Csv("""
+        "scope","sample_type_type","sample_type_unit"
+        "a.pprof","cpu","nanoseconds"
+        "b.pprof","allocations","count"
+        "b.pprof","cpu","nanoseconds"
+        """))
+
+  def test_pprof_tar_archive_scopes(self):
+    return DiffTestBlueprint(
+        trace=Tar({
+            'a.pprof': DataPath('pprof_simple_cpu.pprof'),
+            'b.pprof': DataPath('pprof_multi_metric.pprof'),
+        }),
+        query="""
+        SELECT scope, sample_type_type, sample_type_unit
+        FROM __intrinsic_aggregate_profile
+        ORDER BY scope, sample_type_type;
+        """,
+        out=Csv("""
+        "scope","sample_type_type","sample_type_unit"
+        "a.pprof","cpu","nanoseconds"
+        "b.pprof","allocations","count"
+        "b.pprof","cpu","nanoseconds"
+        """))
+
+  # The same profile imported twice from an archive must not duplicate
+  # frames, mappings or symbols: frames are interned per mapping and frames
+  # that already carry a symbol_set_id are not re-symbolized. Only the
+  # profiles/samples double.
+  def test_pprof_zip_duplicate_file_interning(self):
+    return DiffTestBlueprint(
+        trace=Zip({
+            'a.pprof': DataPath('pprof_simple_cpu.pprof'),
+            'b.pprof': DataPath('pprof_simple_cpu.pprof'),
+        }),
+        query="""
+        SELECT
+          (SELECT COUNT(DISTINCT scope) FROM __intrinsic_aggregate_profile)
+              AS scopes,
+          (SELECT COUNT(*) FROM __intrinsic_aggregate_sample) AS samples,
+          (SELECT COUNT(*) FROM stack_profile_frame) AS frames,
+          (SELECT COUNT(*) FROM stack_profile_mapping
+           WHERE name = '/proc/self/exe') AS exe_mappings,
+          (SELECT COUNT(*) FROM stack_profile_symbol) AS symbols;
+        """,
+        out=Csv("""
+        "scopes","samples","frames","exe_mappings","symbols"
+        2,6,3,1,3
+        """))
+
+  # Locations without a resolvable mapping all share one interned '[unknown]'
+  # fallback mapping, so identical frames dedupe across archive members.
+  def test_pprof_zip_unknown_mapping_interned(self):
+    pprof = _mappingless_pprof()
+    return DiffTestBlueprint(
+        trace=Zip({
+            'a.pprof': pprof,
+            'b.pprof': pprof,
+        }),
+        query="""
+        SELECT
+          (SELECT COUNT(*) FROM stack_profile_mapping
+           WHERE name = '[unknown]') AS unknown_mappings,
+          (SELECT COUNT(*) FROM stack_profile_frame) AS frames,
+          (SELECT COUNT(DISTINCT scope) FROM __intrinsic_aggregate_profile)
+              AS scopes,
+          (SELECT SUM(value) FROM __intrinsic_aggregate_sample) AS total;
+        """,
+        out=Csv("""
+        "unknown_mappings","frames","scopes","total"
+        1,1,2,200.000000
         """))

--- a/ui/src/components/flamegraph_collection.scss
+++ b/ui/src/components/flamegraph_collection.scss
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-flamegraph-collection {
+  height: 100%;
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+
+  // Height is set inline (drag-adjusted); the last row grows to fill.
+  &__row {
+    flex: 0 0 auto;
+    width: 100%;
+    min-height: 0;
+    overflow: hidden;
+
+    &--grow {
+      flex: 1 1 0;
+      min-height: 160px;
+    }
+  }
+
+  &__summary {
+    font-size: var(--pf-font-size-s);
+    color: var(--pf-color-text-muted);
+  }
+
+  &__grid {
+    height: 100%;
+    width: 100%;
+  }
+
+  &__flame {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+  }
+
+  &__flame-head {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--pf-color-border);
+  }
+
+  &__flame-nav {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  &__flame-pos {
+    min-width: 56px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    font-size: var(--pf-font-size-s);
+    color: var(--pf-color-text-muted);
+  }
+
+  &__flame-body {
+    flex: 1 1 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+
+    & > * {
+      flex: 1 1 0;
+      min-height: 0;
+    }
+  }
+
+  // Separates the Merge switch from what it is acting on.
+  &__head-divider {
+    width: 1px;
+    align-self: stretch;
+    margin: 2px 0;
+    background-color: var(--pf-color-border-secondary);
+  }
+
+  // The stepped entry's name.
+  &__flame-cell-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-family: var(--pf-font-monospace);
+    font-size: var(--pf-font-size-s);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // Clicking navigates the un-merged flamegraph to this entry.
+  &__entry {
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &--current {
+      color: var(--pf-color-primary);
+      font-weight: 600;
+    }
+  }
+}

--- a/ui/src/components/flamegraph_collection.ts
+++ b/ui/src/components/flamegraph_collection.ts
@@ -1,0 +1,586 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './flamegraph_collection.scss';
+import m from 'mithril';
+
+import {ensureExists} from '../base/assert';
+import {elementIsEditable} from '../base/dom_utils';
+import {Monitor} from '../base/monitor';
+import type {Trace} from '../public/trace';
+import type {Row, SqlValue} from '../trace_processor/query_result';
+import {Button} from '../widgets/button';
+import {EmptyState} from '../widgets/empty_state';
+import {displaySize, updateTreeExplorerState} from '../widgets/tree_explorer';
+import type {TreeExplorerState} from '../widgets/tree_explorer';
+import {ResizeHandle} from '../widgets/resize_handle';
+import {Switch} from '../widgets/switch';
+import {DataGrid} from './widgets/datagrid/datagrid';
+import type {ColumnSchema} from './widgets/datagrid/datagrid_schema';
+import {InMemoryDataSource} from './widgets/datagrid/in_memory_data_source';
+import type {Column, Filter} from './widgets/datagrid/model';
+import {TreeExplorerPanel} from './tree_explorer_panel';
+import type {TreeExplorerQueryMetric} from './tree_explorer_fetcher';
+
+// Fallback until the grid header has been measured.
+const MIN_GRID_HEIGHT = 64;
+const DEFAULT_GRID_HEIGHT = 300;
+
+// Held by the caller for the page's lifetime. Grid filters and columns are
+// view state here, not session state, so nothing is serialized.
+export interface FlamegraphCollectionState {
+  // Shared across entries, so stepping compares like with like.
+  readonly flamegraphState?: TreeExplorerState;
+  readonly merge: boolean;
+  readonly columns?: readonly Column[];
+  readonly filters: readonly Filter[];
+}
+
+export const DEFAULT_FLAMEGRAPH_COLLECTION_STATE: FlamegraphCollectionState = {
+  merge: true,
+  filters: [],
+};
+
+export interface FlamegraphCollectionColumn {
+  readonly field: string;
+  readonly title: string;
+  // 'id' renders a clickable entry name, 'numeric' a formatted quantity.
+  readonly kind: 'id' | 'numeric';
+  // 'ns', 'B', or '' for counts.
+  readonly unit?: string;
+}
+
+export interface FlamegraphCollectionAttrs {
+  readonly trace: Trace;
+
+  // One row per entry; extra fields are fine (e.g. one entryKey reads).
+  // Watched by identity: pass a new array to reload.
+  readonly rows: ReadonlyArray<Row>;
+  readonly columns: ReadonlyArray<FlamegraphCollectionColumn>;
+
+  // Stable identity of an entry.
+  readonly entryKey: (row: Row) => string;
+
+  // Metrics summing the given entries; [] means nothing to show. Metric ids
+  // must be stable across key sets, so the selected measure survives.
+  readonly metricsForKeys: (
+    keys: ReadonlyArray<string>,
+  ) => TreeExplorerQueryMetric[];
+
+  // Plural noun for UI strings, e.g. 'profiles'.
+  readonly entityName: string;
+
+  // Title rendered above the flamegraph in step mode. Defaults to the key.
+  readonly renderEntryTitle?: (key: string, row: Row) => m.Children;
+
+  readonly state: FlamegraphCollectionState;
+  readonly onStateChange: (state: FlamegraphCollectionState) => void;
+}
+
+// `resolveKey` recovers a rendered row's entry key: the id column may show a
+// label that isn't the key, and DataGrid passes renderers only the visible
+// columns. Unresolvable rows render inert.
+export function buildCollectionGridSchema(
+  columns: ReadonlyArray<FlamegraphCollectionColumn>,
+  resolveKey: (row: Row) => string | undefined,
+  currentKey: string | undefined,
+  onJump: (key: string) => void,
+): ColumnSchema {
+  const schema: ColumnSchema = {};
+  for (const c of columns) {
+    switch (c.kind) {
+      case 'id':
+        schema[c.field] = {
+          title: c.title,
+          columnType: 'identifier',
+          cellRenderer: (value: SqlValue, row: Row) => {
+            const key = resolveKey(row);
+            if (key === undefined) {
+              return String(value ?? '');
+            }
+            return m(
+              'span.pf-flamegraph-collection__entry' +
+                (key === currentKey
+                  ? '.pf-flamegraph-collection__entry--current'
+                  : ''),
+              {onclick: () => onJump(key)},
+              String(value),
+            );
+          },
+        };
+        break;
+      case 'numeric':
+        schema[c.field] = {
+          title: c.title,
+          columnType: 'quantitative',
+          cellRenderer: (value: SqlValue) =>
+            typeof value === 'number' ? displaySize(value, c.unit ?? '') : '',
+        };
+        break;
+    }
+  }
+  return schema;
+}
+
+// Recovers a renderer row's key by fingerprinting the full rows over the
+// visible columns. Ambiguous or incomplete rows yield undefined.
+export function buildEntryKeyResolver(
+  rows: ReadonlyArray<Row>,
+  gridColumns: ReadonlyArray<Column>,
+  entryKey: (row: Row) => string,
+): (row: Row) => string | undefined {
+  const byFingerprint = new Map<string, string | null>();
+  for (const row of rows) {
+    const fp = JSON.stringify(gridColumns.map((c) => String(row[c.field])));
+    const key = entryKey(row);
+    const existing = byFingerprint.get(fp);
+    if (existing === undefined) {
+      byFingerprint.set(fp, key);
+    } else if (existing !== key) {
+      byFingerprint.set(fp, null);
+    }
+  }
+  return (row: Row) => {
+    if (gridColumns.some((c) => !(c.id in row))) {
+      return undefined;
+    }
+    const fp = JSON.stringify(gridColumns.map((c) => String(row[c.id])));
+    return byFingerprint.get(fp) ?? undefined;
+  };
+}
+
+// A page navigated away from stays mounted behind a closed Gate, so a hidden
+// collection must ignore the keys.
+export function shouldHandleStepKey(
+  e: KeyboardEvent,
+  rootEl: HTMLElement | undefined,
+  merge: boolean,
+  entryCount: number,
+): boolean {
+  if (merge || entryCount <= 1) return false;
+  if (rootEl === undefined || rootEl.offsetParent === null) return false;
+  if (e.ctrlKey || e.metaKey || e.altKey) return false;
+  if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return false;
+  // Checkboxes are exempt (the Merge switch keeps focus after a click); a
+  // focused <select> uses arrows natively.
+  if (elementIsEditable(e.target)) return false;
+  return !(e.target instanceof HTMLElement && e.target.tagName === 'SELECT');
+}
+
+interface CollectionEntry {
+  readonly key: string;
+  readonly row: Row;
+  readonly metrics: TreeExplorerQueryMetric[];
+}
+
+// A filterable grid of entries over a flamegraph: the grid's filters pick the
+// working set, which merge mode sums and step mode walks one at a time.
+// Entries and their metrics come from the caller.
+export class FlamegraphCollection implements m.ClassComponent<FlamegraphCollectionAttrs> {
+  private attrs?: FlamegraphCollectionAttrs;
+
+  // Two sources: the DataGrid needs a long-lived one (raw rows would rebuild
+  // it every render), and the working set queries by field alias, not by the
+  // grid's column ids.
+  private gridSource?: InMemoryDataSource;
+  private querySource?: InMemoryDataSource;
+  private lastRows?: ReadonlyArray<Row>;
+
+  // Metric arrays must stay reference-stable or the flamegraph refetches.
+  private mergedMetrics?: TreeExplorerQueryMetric[];
+  private mergedCount = 0;
+  private perEntry?: ReadonlyArray<CollectionEntry>;
+  private entryIndex = 0;
+  // Set by jumpToEntry when leaving merge mode; consumed by the next rebuild.
+  private pendingJumpKey?: string;
+  // Keeps the shown entry's state reference-stable (see entryState()).
+  private shownState?: {
+    master?: TreeExplorerState;
+    key: string;
+    state: TreeExplorerState;
+  };
+  private readonly monitor = new Monitor([
+    () => this.attrs?.rows,
+    () => this.attrs?.columns,
+    () => this.attrs?.state.filters,
+    () => this.attrs?.state.merge,
+    // Sort only affects the un-merged view (step order); ignore it merged.
+    () => (this.attrs?.state.merge === false ? this.sortKey() : undefined),
+  ]);
+
+  private gridHeight = DEFAULT_GRID_HEIGHT;
+  private gridRowEl?: HTMLElement;
+  private rootEl?: HTMLElement;
+
+  oncreate({dom}: m.CVnodeDOM<FlamegraphCollectionAttrs>): void {
+    this.rootEl = dom as HTMLElement;
+    window.addEventListener('keydown', this.onKeyDown);
+  }
+
+  onremove(): void {
+    window.removeEventListener('keydown', this.onKeyDown);
+  }
+
+  view({attrs}: m.CVnode<FlamegraphCollectionAttrs>): m.Children {
+    this.attrs = attrs;
+    this.monitor.ifStateChanged(() => this.rebuild(attrs));
+
+    return m(
+      '.pf-flamegraph-collection',
+      m(
+        '.pf-flamegraph-collection__row',
+        {
+          style: {height: `${this.gridHeight}px`},
+          oncreate: (v: m.VnodeDOM) => {
+            this.gridRowEl = v.dom as HTMLElement;
+          },
+        },
+        this.renderGrid(attrs),
+      ),
+      m(ResizeHandle, {
+        onResize: (deltaPx: number) => {
+          this.gridHeight = Math.max(
+            this.minGridHeight(),
+            this.gridHeight + deltaPx,
+          );
+          if (this.gridRowEl) {
+            this.gridRowEl.style.height = `${this.gridHeight}px`;
+          }
+        },
+        onResizeEnd: () => m.redraw(),
+      }),
+      m(
+        '.pf-flamegraph-collection__row.pf-flamegraph-collection__row--grow',
+        this.renderFlamegraph(attrs),
+      ),
+    );
+  }
+
+  // The grid collapses to its chrome; only body rows shrink away.
+  private minGridHeight(): number {
+    const row = this.gridRowEl;
+    const header = row?.querySelector('.pf-grid__header');
+    if (!row || !header) return MIN_GRID_HEIGHT;
+    return (
+      header.getBoundingClientRect().bottom - row.getBoundingClientRect().top
+    );
+  }
+
+  private keyResolverCache?: {
+    rows: ReadonlyArray<Row>;
+    columnsKey: string;
+    resolve: (row: Row) => string | undefined;
+  };
+
+  private keyResolver(
+    attrs: FlamegraphCollectionAttrs,
+  ): (row: Row) => string | undefined {
+    const columns = this.columns(attrs);
+    const columnsKey = JSON.stringify(columns.map((c) => [c.id, c.field]));
+    const cache = this.keyResolverCache;
+    if (
+      cache !== undefined &&
+      cache.rows === attrs.rows &&
+      cache.columnsKey === columnsKey
+    ) {
+      return cache.resolve;
+    }
+    const resolve = buildEntryKeyResolver(attrs.rows, columns, attrs.entryKey);
+    this.keyResolverCache = {rows: attrs.rows, columnsKey, resolve};
+    return resolve;
+  }
+
+  private renderGrid(attrs: FlamegraphCollectionAttrs): m.Children {
+    this.ensureSources(attrs);
+    const current =
+      attrs.state.merge === false
+        ? this.perEntry?.[this.entryIndex]?.key
+        : undefined;
+    return m(DataGrid, {
+      className: 'pf-flamegraph-collection__grid',
+      fillHeight: true,
+      schema: buildCollectionGridSchema(
+        attrs.columns,
+        this.keyResolver(attrs),
+        current,
+        (key) => this.jumpToEntry(attrs, key),
+      ),
+      // Pivoting would regroup the grid only, silently desyncing it from the
+      // flamegraph, which reads the flat rows.
+      disablePivotControls: true,
+      data: ensureExists(this.gridSource),
+      columns: this.columns(attrs),
+      onColumnsChanged: (columns: readonly Column[]) =>
+        attrs.onStateChange({...attrs.state, columns: columns.slice()}),
+      filters: this.filters(attrs),
+      onFiltersChanged: (f: readonly Filter[]) =>
+        attrs.onStateChange({...attrs.state, filters: f.slice()}),
+    });
+  }
+
+  private renderFlamegraph(attrs: FlamegraphCollectionAttrs): m.Children {
+    const count = attrs.state.merge
+      ? this.mergedCount
+      : (this.perEntry?.length ?? 0);
+    const idx = this.clampIndex(this.perEntry?.length ?? 0);
+    const nav =
+      !attrs.state.merge && count > 0
+        ? m(
+            '.pf-flamegraph-collection__flame-nav',
+            m(Button, {
+              icon: 'chevron_left',
+              compact: true,
+              disabled: idx <= 0,
+              title: `Previous ${attrs.entityName}`,
+              onclick: () => this.stepEntry(-1),
+            }),
+            m('.pf-flamegraph-collection__flame-pos', `${idx + 1} / ${count}`),
+            m(Button, {
+              icon: 'chevron_right',
+              compact: true,
+              disabled: idx >= count - 1,
+              title: `Next ${attrs.entityName}`,
+              onclick: () => this.stepEntry(1),
+            }),
+          )
+        : null;
+    return m(
+      '.pf-flamegraph-collection__flame',
+      m(
+        '.pf-flamegraph-collection__flame-head',
+        m(Switch, {
+          label: 'Merge',
+          checked: attrs.state.merge,
+          onchange: () =>
+            attrs.onStateChange({...attrs.state, merge: !attrs.state.merge}),
+        }),
+        this.renderHeadLabel(attrs, idx, count),
+        nav,
+      ),
+      m(
+        '.pf-flamegraph-collection__flame-body',
+        attrs.state.merge
+          ? this.renderMergedFlame(attrs)
+          : this.renderEntryFlame(attrs, idx),
+      ),
+    );
+  }
+
+  // The head's middle slot: what the flamegraph is showing -- a description
+  // of the set when merging, the entry's name when stepping.
+  private renderHeadLabel(
+    attrs: FlamegraphCollectionAttrs,
+    idx: number,
+    count: number,
+  ): m.Children {
+    const divider = m('.pf-flamegraph-collection__head-divider');
+    if (attrs.state.merge) {
+      return [
+        divider,
+        m(
+          '.pf-flamegraph-collection__summary',
+          `${count} of ${attrs.rows.length} ${attrs.entityName}`,
+        ),
+      ];
+    }
+    const entry = this.perEntry?.[idx];
+    if (entry === undefined) return null;
+    return [
+      divider,
+      m(
+        '.pf-flamegraph-collection__flame-cell-title',
+        {title: entry.key},
+        attrs.renderEntryTitle?.(entry.key, entry.row) ?? entry.key,
+      ),
+    ];
+  }
+
+  private renderMergedFlame(attrs: FlamegraphCollectionAttrs): m.Children {
+    const metrics = this.mergedMetrics;
+    if (metrics === undefined) {
+      return this.renderEmpty(attrs);
+    }
+    return m(TreeExplorerPanel, {
+      trace: attrs.trace,
+      metrics,
+      state: updateTreeExplorerState(attrs.state.flamegraphState, metrics),
+      onStateChange: (s) =>
+        attrs.onStateChange({...attrs.state, flamegraphState: s}),
+    });
+  }
+
+  private renderEntryFlame(
+    attrs: FlamegraphCollectionAttrs,
+    idx: number,
+  ): m.Children {
+    const entry = this.perEntry?.[idx];
+    if (entry === undefined) {
+      return this.renderEmpty(attrs);
+    }
+    return m(TreeExplorerPanel, {
+      trace: attrs.trace,
+      metrics: entry.metrics,
+      state: this.entryState(attrs, entry),
+      onStateChange: (s) =>
+        attrs.onStateChange({...attrs.state, flamegraphState: s}),
+    });
+  }
+
+  private renderEmpty(attrs: FlamegraphCollectionAttrs): m.Children {
+    return m(EmptyState, {
+      icon: 'filter_alt',
+      title: `No ${attrs.entityName} match`,
+      detail: `Adjust the filters to select ${attrs.entityName}.`,
+    });
+  }
+
+  // The master state, with the metric swapped out if this entry lacks it.
+  // Cached to stay reference-stable.
+  private entryState(
+    attrs: FlamegraphCollectionAttrs,
+    entry: CollectionEntry,
+  ): TreeExplorerState {
+    const master = attrs.state.flamegraphState;
+    const cached = this.shownState;
+    if (
+      cached !== undefined &&
+      cached.master === master &&
+      cached.key === entry.key
+    ) {
+      return cached.state;
+    }
+    const state = updateTreeExplorerState(master, entry.metrics);
+    this.shownState = {master, key: entry.key, state};
+    return state;
+  }
+
+  private filters(attrs: FlamegraphCollectionAttrs): readonly Filter[] {
+    return attrs.state.filters;
+  }
+
+  private columns(attrs: FlamegraphCollectionAttrs): readonly Column[] {
+    const cols = attrs.state.columns;
+    if (cols !== undefined && cols.length > 0) {
+      return cols;
+    }
+    return attrs.columns.map((c) => ({id: c.field, field: c.field}));
+  }
+
+  private sortKey(): string | undefined {
+    const attrs = this.attrs;
+    if (attrs === undefined) return undefined;
+    const c = this.columns(attrs).find((c) => c.sort !== undefined);
+    return c && `${c.field}:${c.sort}`;
+  }
+
+  private ensureSources(attrs: FlamegraphCollectionAttrs): void {
+    if (this.lastRows !== attrs.rows) {
+      this.lastRows = attrs.rows;
+      this.gridSource = new InMemoryDataSource(attrs.rows);
+      this.querySource = new InMemoryDataSource(attrs.rows);
+      this.shownState = undefined;
+    }
+  }
+
+  // The filtered entries, in the grid's sort order, evaluated by the same
+  // DataGrid machinery. Projects every row field, so entryKey sees whole rows.
+  private workingRows(attrs: FlamegraphCollectionAttrs): ReadonlyArray<Row> {
+    this.ensureSources(attrs);
+    const sorted = this.columns(attrs).find((c) => c.sort !== undefined);
+    const fields = Object.keys(attrs.rows[0] ?? {});
+    const result = ensureExists(this.querySource).useRows({
+      mode: 'flat',
+      columns: fields.map((f) => ({field: f, alias: f})),
+      filters: this.filters(attrs),
+      sort: sorted?.sort
+        ? {alias: sorted.field, direction: sorted.sort}
+        : undefined,
+    });
+    return result.rows ?? [];
+  }
+
+  private clampIndex(count: number): number {
+    if (count <= 0) return 0;
+    this.entryIndex = Math.min(count - 1, Math.max(0, this.entryIndex));
+    return this.entryIndex;
+  }
+
+  private stepEntry(delta: number): void {
+    const n = this.perEntry?.length ?? 0;
+    if (n === 0) return;
+    this.entryIndex = Math.min(n - 1, Math.max(0, this.entryIndex + delta));
+    m.redraw();
+  }
+
+  // Leaves merge mode if needed; the rebuild that follows consumes the key.
+  private jumpToEntry(attrs: FlamegraphCollectionAttrs, key: string): void {
+    if (attrs.state.merge) {
+      this.pendingJumpKey = key;
+      attrs.onStateChange({...attrs.state, merge: false});
+    } else {
+      const idx = this.perEntry?.findIndex((p) => p.key === key) ?? -1;
+      if (idx >= 0) {
+        this.entryIndex = idx;
+      }
+    }
+    m.redraw();
+  }
+
+  private readonly onKeyDown = (e: KeyboardEvent): void => {
+    const merge = this.attrs?.state.merge ?? true;
+    const count = this.perEntry?.length ?? 0;
+    if (!shouldHandleStepKey(e, this.rootEl, merge, count)) return;
+    this.stepEntry(e.key === 'ArrowLeft' ? -1 : 1);
+    e.preventDefault();
+  };
+
+  // Merge on: one flamegraph over the working set. Off: one set per entry.
+  private rebuild(attrs: FlamegraphCollectionAttrs): void {
+    const rows = this.workingRows(attrs);
+
+    if (attrs.state.merge) {
+      this.perEntry = undefined;
+      const keys = rows.map((row) => attrs.entryKey(row));
+      const metrics = attrs.metricsForKeys(keys);
+      this.mergedMetrics = metrics.length > 0 ? metrics : undefined;
+      this.mergedCount = rows.length;
+      if (this.mergedMetrics !== undefined) {
+        // Reconcile once, so renders can reuse the result by reference.
+        const reconciled = updateTreeExplorerState(
+          attrs.state.flamegraphState,
+          this.mergedMetrics,
+        );
+        if (reconciled !== attrs.state.flamegraphState) {
+          attrs.onStateChange({...attrs.state, flamegraphState: reconciled});
+        }
+      }
+      return;
+    }
+
+    this.mergedMetrics = undefined;
+    const shownKey =
+      this.pendingJumpKey ?? this.perEntry?.[this.entryIndex]?.key;
+    this.pendingJumpKey = undefined;
+    this.perEntry = rows.flatMap((row) => {
+      const key = attrs.entryKey(row);
+      const metrics = attrs.metricsForKeys([key]);
+      return metrics.length > 0 ? [{key, row, metrics}] : [];
+    });
+    // Keep the shown entry selected across working-set changes.
+    const keep = this.perEntry.findIndex((p) => p.key === shownKey);
+    if (keep >= 0) {
+      this.entryIndex = keep;
+    }
+  }
+}

--- a/ui/src/components/flamegraph_collection_jsdomtest.ts
+++ b/ui/src/components/flamegraph_collection_jsdomtest.ts
@@ -1,0 +1,155 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+import type {Trace} from '../public/trace';
+import type {Row} from '../trace_processor/query_result';
+import type {TreeExplorerQueryMetric} from './tree_explorer_fetcher';
+import {
+  DEFAULT_FLAMEGRAPH_COLLECTION_STATE,
+  FlamegraphCollection,
+} from './flamegraph_collection';
+import type {
+  FlamegraphCollectionAttrs,
+  FlamegraphCollectionState,
+} from './flamegraph_collection';
+
+// What the collection hands its panel is invisible to the DOM, so these stub
+// TreeExplorerPanel and assert on its attrs. Anything visible is covered in a
+// real browser by aggregate_profiles_merge.test.ts.
+const panel = vi.hoisted(() => ({
+  renders: [] as Array<{metrics?: unknown}>,
+  last() {
+    return this.renders[this.renders.length - 1];
+  },
+}));
+
+vi.mock('./tree_explorer_panel', () => ({
+  TreeExplorerPanel: {
+    view: ({attrs}: m.CVnode<{metrics?: unknown}>) => {
+      panel.renders.push({metrics: attrs.metrics});
+      return m('.pf-test-fake-flamegraph-panel');
+    },
+  },
+}));
+
+const ROWS: Row[] = [
+  {c0: 'a.pprof', c1: 100},
+  {c0: 'b.pprof', c1: 25},
+];
+
+const COLUMNS = [
+  {field: 'c0', title: 'profile', kind: 'id'},
+  {field: 'c1', title: 'cpu (ns)', kind: 'numeric', unit: 'ns'},
+] as const;
+
+const metricFor = (keys: ReadonlyArray<string>): TreeExplorerQueryMetric => ({
+  name: 'cpu (ns)',
+  unit: 'ns',
+  statement: `select ... where key in (${keys.join(',')})`,
+});
+
+let container: HTMLElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  panel.renders.length = 0;
+});
+
+afterEach(() => {
+  m.render(container, null);
+  container.remove();
+});
+
+interface Harness {
+  rerender: () => void;
+  metricsForKeys: ReturnType<typeof vi.fn>;
+}
+
+// onStateChange stores the state for the next explicit rerender, as a real
+// caller would. Fresh vnodes each time: m.render no-ops on an identical one.
+function renderCollection(
+  initial?: Partial<FlamegraphCollectionState>,
+): Harness {
+  let state = {...DEFAULT_FLAMEGRAPH_COLLECTION_STATE, ...initial};
+  const metricsForKeys = vi.fn((keys: ReadonlyArray<string>) =>
+    keys.length > 0 ? [metricFor(keys)] : [],
+  );
+  const rerender = () =>
+    m.render(
+      container,
+      m(FlamegraphCollection, {
+        trace: {} as Trace,
+        rows: ROWS,
+        columns: COLUMNS,
+        entryKey: (row: Row) => String(row['c0']),
+        metricsForKeys,
+        entityName: 'profiles',
+        state,
+        onStateChange: (s: FlamegraphCollectionState) => {
+          state = s;
+        },
+      } satisfies FlamegraphCollectionAttrs),
+    );
+  rerender();
+  // Flush the reconciled flamegraph state written back on first rebuild.
+  rerender();
+  return {rerender, metricsForKeys};
+}
+
+describe('FlamegraphCollection', () => {
+  test('merged mode sums the whole working set into one panel', () => {
+    const h = renderCollection();
+    expect(h.metricsForKeys).toHaveBeenCalledWith(['a.pprof', 'b.pprof']);
+    expect(panel.last().metrics).toEqual([metricFor(['a.pprof', 'b.pprof'])]);
+  });
+
+  test('metric arrays stay reference-stable across no-op re-renders', () => {
+    // TreeExplorerPanel monitors `metrics` by identity: a fresh array per
+    // render would re-run the query on every redraw.
+    const h = renderCollection();
+    h.rerender();
+    h.rerender();
+    const sets = panel.renders.map((r) => r.metrics);
+    expect(sets.length).toBeGreaterThan(1);
+    for (const metrics of sets) {
+      expect(metrics).toBe(sets[0]);
+    }
+  });
+
+  test('step mode asks for one entry at a time', () => {
+    const h = renderCollection({merge: false});
+    expect(h.metricsForKeys).toHaveBeenCalledWith(['a.pprof']);
+    expect(h.metricsForKeys).toHaveBeenCalledWith(['b.pprof']);
+    expect(panel.last().metrics).toEqual([metricFor(['a.pprof'])]);
+  });
+
+  test('grid filters shrink the working set', () => {
+    const h = renderCollection({filters: [{field: 'c1', op: '>', value: 50}]});
+    expect(h.metricsForKeys).toHaveBeenLastCalledWith(['a.pprof']);
+  });
+
+  test('an empty working set renders an empty state, not a panel', () => {
+    // Reconciling a state against an empty metric set throws.
+    const h = renderCollection({filters: [{field: 'c1', op: '>', value: 1e9}]});
+    expect(h.metricsForKeys).toHaveBeenCalledWith([]);
+    expect(
+      container.querySelector('.pf-test-fake-flamegraph-panel'),
+    ).toBeNull();
+    expect(container.querySelector('.pf-empty-state')).toBeTruthy();
+  });
+});

--- a/ui/src/components/flamegraph_collection_unittest.ts
+++ b/ui/src/components/flamegraph_collection_unittest.ts
@@ -1,0 +1,175 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {describe, expect, test} from 'vitest';
+
+import {ensureExists} from '../base/assert';
+import type {Row, SqlValue} from '../trace_processor/query_result';
+import type {ColumnDef, ColumnSchema} from './widgets/datagrid/datagrid_schema';
+import {
+  buildCollectionGridSchema,
+  buildEntryKeyResolver,
+  shouldHandleStepKey,
+} from './flamegraph_collection';
+
+const COLUMNS = [
+  {field: 'c0', title: 'profile', kind: 'id'},
+  {field: 'c1', title: 'cpu (ns)', kind: 'numeric', unit: 'ns'},
+] as const;
+const GRID_COLUMNS = COLUMNS.map((c) => ({id: c.field, field: c.field}));
+const CURRENT = '.pf-flamegraph-collection__entry--current';
+
+// Defaults to the pprof case, where the key is the displayed identifier.
+function schemaFor(
+  resolveKey: (row: Row) => string | undefined = (row) => String(row['c0']),
+  currentKey?: string,
+  onJump: (key: string) => void = () => {},
+) {
+  return buildCollectionGridSchema(COLUMNS, resolveKey, currentKey, onJump);
+}
+
+// Renders one cell; `row` defaults to one carrying just that value.
+function cell(
+  schema: ColumnSchema,
+  field: string,
+  value: SqlValue,
+  row?: Row,
+): HTMLElement {
+  const render = ensureExists((schema[field] as ColumnDef).cellRenderer);
+  const el = document.createElement('div');
+  m.render(el, render(value, row ?? ({[field]: value} as Row)) as m.Children);
+  return el;
+}
+
+describe('buildCollectionGridSchema', () => {
+  test('maps column kinds onto grid column types', () => {
+    const schema = schemaFor();
+    expect(schema['c0']).toMatchObject({columnType: 'identifier'});
+    expect(schema['c1']).toMatchObject({columnType: 'quantitative'});
+  });
+
+  test('numeric cells format through displaySize with the column unit', () => {
+    const schema = schemaFor();
+    expect(cell(schema, 'c1', 1500000).textContent).toBe('1.50 ms');
+    expect(cell(schema, 'c1', null).textContent).toBe('');
+  });
+
+  test('id cells highlight and navigate by resolved key, not by label', () => {
+    // Consumers may show a label while keying entries by something else.
+    const rows = [
+      {key: 'utid=12', c0: 'traced_probes', c1: 5},
+      {key: 'utid=13', c0: 'surfaceflinger', c1: 7},
+    ];
+    const jumped: string[] = [];
+    const schema = schemaFor(
+      buildEntryKeyResolver(rows, GRID_COLUMNS, (row) => String(row['key'])),
+      'utid=12',
+      (key) => jumped.push(key),
+    );
+
+    const current = cell(schema, 'c0', rows[0].c0, rows[0]);
+    expect(current.textContent).toBe('traced_probes');
+    expect(current.querySelector(CURRENT)).toBeTruthy();
+
+    const other = cell(schema, 'c0', rows[1].c0, rows[1]);
+    expect(other.querySelector(CURRENT)).toBeNull();
+    other
+      .querySelector('span')
+      ?.dispatchEvent(new window.MouseEvent('click', {bubbles: true}));
+    expect(jumped).toEqual(['utid=13']);
+  });
+
+  test('id cells render unresolvable rows inert', () => {
+    // DataGrid renders its aggregate-totals row through the same renderer.
+    const schema = schemaFor(
+      () => undefined,
+      'utid=12',
+      () => {
+        throw new Error('unresolvable rows must not navigate');
+      },
+    );
+    const el = cell(schema, 'c0', 42, {} as Row);
+    expect(el.textContent).toBe('42');
+    expect(el.querySelector('.pf-flamegraph-collection__entry')).toBeNull();
+  });
+});
+
+describe('buildEntryKeyResolver', () => {
+  // Two entries share a label; two are identical across every column.
+  const resolve = buildEntryKeyResolver(
+    [
+      {key: 'utid=12', c0: 'foo 1', c1: 5},
+      {key: 'utid=13', c0: 'foo 1', c1: 7},
+      {key: 'utid=98', c0: 'dup', c1: 9},
+      {key: 'utid=99', c0: 'dup', c1: 9},
+    ],
+    GRID_COLUMNS,
+    (row) => String(row['key']),
+  );
+
+  test.each<[string, Row, string | undefined]>([
+    ['resolves a row to its key', {c0: 'foo 1', c1: 5}, 'utid=12'],
+    ['separates rows sharing a label', {c0: 'foo 1', c1: 7}, 'utid=13'],
+    ['drops unknown rows', {c0: 'bar', c1: 5}, undefined],
+    ['drops indistinguishable rows', {c0: 'dup', c1: 9}, undefined],
+    ['drops rows missing a column', {c0: 'foo 1'}, undefined],
+    ['drops the empty totals row', {}, undefined],
+  ])('%s', (_name, row, expected) => {
+    expect(resolve(row)).toBe(expected);
+  });
+
+  test('maps renderer aliases onto data fields', () => {
+    // Renderer rows are keyed by column id, data rows by column field.
+    const byAlias = buildEntryKeyResolver(
+      [{key: 'utid=12', raw: 'foo 1'}],
+      [{id: 'alias0', field: 'raw'}],
+      (row) => String(row['key']),
+    );
+    expect(byAlias({alias0: 'foo 1'})).toBe('utid=12');
+  });
+});
+
+describe('shouldHandleStepKey', () => {
+  const visible = {offsetParent: {}} as unknown as HTMLElement;
+  const hidden = {offsetParent: null} as unknown as HTMLElement;
+  const ev = (key: string, opts: {mod?: boolean; target?: unknown} = {}) =>
+    ({
+      key,
+      ctrlKey: opts.mod ?? false,
+      metaKey: false,
+      altKey: false,
+      target: opts.target,
+    }) as unknown as KeyboardEvent;
+
+  test.each<[string, KeyboardEvent, HTMLElement | undefined, boolean, number]>([
+    ['steps on left arrow', ev('ArrowLeft'), visible, false, 2],
+    ['steps on right arrow', ev('ArrowRight'), visible, false, 2],
+    ['steps outside form controls', ev('ArrowLeft', {target: document.createElement('div')}), visible, false, 2], // prettier-ignore
+  ])('%s', (_name, event, el, merge, count) => {
+    expect(shouldHandleStepKey(event, el, merge, count)).toBe(true);
+  });
+
+  test.each<[string, KeyboardEvent, HTMLElement | undefined, boolean, number]>([
+    ['ignores other keys', ev('a'), visible, false, 2],
+    ['ignores modifiers', ev('ArrowLeft', {mod: true}), visible, false, 2],
+    ['ignores merged mode', ev('ArrowLeft'), visible, true, 2],
+    ['ignores a lone entry', ev('ArrowLeft'), visible, false, 1],
+    ['ignores hidden collections', ev('ArrowLeft'), hidden, false, 2],
+    ['ignores unmounted collections', ev('ArrowLeft'), undefined, false, 2],
+    ['ignores typing in a form control', ev('ArrowLeft', {target: document.createElement('input')}), visible, false, 2], // prettier-ignore
+  ])('%s', (_name, event, el, merge, count) => {
+    expect(shouldHandleStepKey(event, el, merge, count)).toBe(false);
+  });
+});

--- a/ui/src/components/tree_explorer_fetcher.ts
+++ b/ui/src/components/tree_explorer_fetcher.ts
@@ -226,8 +226,24 @@ export class TreeExplorerFetcher implements AsyncDisposable {
       }
       trash.use(dependency.clone());
     }
+    await this.evictStaleTables(metrics);
     const table = await this.getMetricTable(metric);
     return await computeTree(this.trace.engine, table, state);
+  }
+
+  // Bounds the cache at |metrics| tables for callers that cycle through many
+  // metric sets. Safe because fetch() is the only path that creates or reads
+  // them and its callers serialize fetches on a query limiter.
+  private async evictStaleTables(
+    metrics: ReadonlyArray<TreeExplorerQueryMetric>,
+  ): Promise<void> {
+    for (let i = this.metricTables.length - 1; i >= 0; i--) {
+      const entry = this.metricTables[i];
+      if (!metrics.includes(entry.metric)) {
+        this.metricTables.splice(i, 1);
+        await entry.table[Symbol.asyncDispose]();
+      }
+    }
   }
 
   private async getMetricTable(

--- a/ui/src/components/tree_explorer_fetcher_unittest.ts
+++ b/ui/src/components/tree_explorer_fetcher_unittest.ts
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, expect, test} from 'vitest';
+
+import protos from '../protos';
+import {createQueryResult} from '../trace_processor/query_result';
+import type {QueryResult} from '../trace_processor/query_result';
+import type {Trace} from '../public/trace';
+import {createDefaultTreeExplorerState} from '../widgets/tree_explorer';
+import {TreeExplorerFetcher} from './tree_explorer_fetcher';
+import type {TreeExplorerQueryMetric} from './tree_explorer_fetcher';
+
+// What the operator query returns for a metric with no extra properties.
+const TREE_COLUMNS =
+  'id parentId depth name selfValue cumulativeValue parentCumulativeValue xStart xEnd'.split(
+    ' ',
+  );
+
+function fakeQueryResult(
+  columnNames: ReadonlyArray<string>,
+  varintRow?: ReadonlyArray<number>,
+): QueryResult {
+  const cells = varintRow ?? [];
+  const resProto = protos.QueryResult.create({
+    columnNames: columnNames.slice(),
+    batch: [
+      protos.QueryResult.CellsBatch.create({
+        cells: cells.map(
+          () => protos.QueryResult.CellsBatch.CellType.CELL_VARINT,
+        ),
+        varintCells: cells.slice(),
+        isLastBatch: true,
+      }),
+    ],
+  });
+  const res = createQueryResult({query: ''});
+  res.appendResultBatch(protos.QueryResult.encode(resProto).finish());
+  return res;
+}
+
+// A fake engine logging every statement, so tests can assert CREATE/DROPs.
+function fakeTrace(log: string[]): Trace {
+  const respond = (sql: string): QueryResult => {
+    log.push(sql);
+    if (sql.includes('__intrinsic_flamegraph_find')) {
+      return fakeQueryResult(['cumulative_value'], [0]);
+    }
+    if (sql.includes('cumulative_value > 0')) {
+      return fakeQueryResult(TREE_COLUMNS);
+    }
+    return fakeQueryResult([]);
+  };
+  const engine = {
+    query: async (sql: string) => respond(sql),
+    tryQuery: async (sql: string) => {
+      respond(sql);
+      return {ok: true};
+    },
+  };
+  return {engine} as unknown as Trace;
+}
+
+function metric(name: string): TreeExplorerQueryMetric {
+  return {
+    name,
+    unit: '',
+    statement: `select 0 as id, null as parentId, '${name}' as name, 0 as value`,
+  };
+}
+
+function creates(log: ReadonlyArray<string>): string[] {
+  return log.filter((sql) => sql.startsWith('CREATE VIRTUAL TABLE'));
+}
+
+function drops(log: ReadonlyArray<string>): string[] {
+  return log.filter((sql) => sql.startsWith('DROP TABLE'));
+}
+
+describe('TreeExplorerFetcher table cache', () => {
+  test('reuses the table for a metric already in the current set', async () => {
+    const log: string[] = [];
+    const fetcher = new TreeExplorerFetcher(fakeTrace(log));
+    const metrics = [metric('m1'), metric('m2')];
+    const state = createDefaultTreeExplorerState(metrics);
+
+    await fetcher.fetch(metrics, state);
+    expect(creates(log)).toHaveLength(1);
+
+    await fetcher.fetch(metrics, {...state, selectedMetricId: 'm2'});
+    expect(creates(log)).toHaveLength(2);
+    expect(drops(log)).toHaveLength(0);
+
+    await fetcher.fetch(metrics, state);
+    expect(creates(log)).toHaveLength(2);
+    expect(drops(log)).toHaveLength(0);
+  });
+
+  test('evicts tables for metrics absent from the new set', async () => {
+    const log: string[] = [];
+    const fetcher = new TreeExplorerFetcher(fakeTrace(log));
+    const metricsA = [metric('m1'), metric('m2')];
+    const stateA = createDefaultTreeExplorerState(metricsA);
+
+    await fetcher.fetch(metricsA, stateA);
+    await fetcher.fetch(metricsA, {...stateA, selectedMetricId: 'm2'});
+    expect(creates(log)).toHaveLength(2);
+
+    const metricsB = [metric('m3')];
+    await fetcher.fetch(metricsB, createDefaultTreeExplorerState(metricsB));
+    expect(creates(log)).toHaveLength(3);
+    expect(drops(log)).toHaveLength(2);
+
+    // The dropped names are exactly the ones created for the old set.
+    const createdNames = creates(log).map(
+      (sql) => sql.split(' ')[3], // CREATE VIRTUAL TABLE <name> USING ...
+    );
+    const droppedNames = drops(log).map(
+      (sql) => sql.split(' ')[4], // DROP TABLE IF EXISTS <name>
+    );
+    expect(droppedNames.sort()).toEqual(createdNames.slice(0, 2).sort());
+  });
+
+  test('disposal drops every cached table', async () => {
+    const log: string[] = [];
+    const fetcher = new TreeExplorerFetcher(fakeTrace(log));
+    const metrics = [metric('m1'), metric('m2')];
+    const state = createDefaultTreeExplorerState(metrics);
+
+    await fetcher.fetch(metrics, state);
+    await fetcher.fetch(metrics, {...state, selectedMetricId: 'm2'});
+
+    await fetcher[Symbol.asyncDispose]();
+    expect(drops(log)).toHaveLength(2);
+  });
+});

--- a/ui/src/plugins/dev.perfetto.AggregateProfiles/index.ts
+++ b/ui/src/plugins/dev.perfetto.AggregateProfiles/index.ts
@@ -15,51 +15,58 @@
 import './styles.scss';
 import m from 'mithril';
 
+import {
+  DEFAULT_FLAMEGRAPH_COLLECTION_STATE,
+  FlamegraphCollection,
+} from '../../components/flamegraph_collection';
+import type {
+  FlamegraphCollectionState,
+  FlamegraphCollectionColumn,
+} from '../../components/flamegraph_collection';
 import type {TreeExplorerQueryMetric} from '../../components/tree_explorer_fetcher';
 import type {PerfettoPlugin} from '../../public/plugin';
 import type {Trace} from '../../public/trace';
 import {NUM, STR} from '../../trace_processor/query_result';
+import type {Row} from '../../trace_processor/query_result';
+import {Anchor} from '../../widgets/anchor';
 import {AggregateProfilesPage} from './aggregate_profiles_page';
 import {
   type AggregateProfilesPageState,
   AGGREGATE_PROFILES_PAGE_STATE_SCHEMA,
+  type MergeColumn,
+  type MergeProfile,
+  type MergeProfileMetric,
+  type SampleType,
 } from './types';
 import type {Store} from '../../base/store';
 import {ensureExists} from '../../base/assert';
 
+interface LoadedProfiles {
+  readonly profiles: MergeProfile[];
+  readonly sampleTypes: SampleType[];
+  readonly columns: MergeColumn[];
+  readonly rows: Row[];
+}
+
+// A single profile gets a flamegraph with a metric selector; an archive of
+// many gets a FlamegraphCollection page that filters and merges them.
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.AggregateProfiles';
   private store?: Store<AggregateProfilesPageState>;
 
-  private migratePageState(init: unknown): AggregateProfilesPageState {
-    const result = AGGREGATE_PROFILES_PAGE_STATE_SCHEMA.safeParse(init);
-    return result.data ?? {};
-  }
-
   async onTraceLoad(trace: Trace): Promise<void> {
-    this.store = trace.mountStore('dev.perfetto.AggregateProfiles', (init) =>
-      this.migratePageState(init),
+    const scopes = await trace.engine.query(
+      'SELECT count(DISTINCT scope) AS n FROM __intrinsic_aggregate_profile',
     );
-    const profiles = await this.getProfiles(trace);
-    if (profiles.length === 0) {
+    const profileCount = scopes.firstRow({n: NUM}).n;
+    if (profileCount === 0) {
       return;
     }
-    const store = ensureExists(this.store);
-    trace.pages.registerPage({
-      route: '/aggregateprofiles',
-      render: () =>
-        m(AggregateProfilesPage, {
-          trace,
-          state: store.state,
-          onStateChange: (state: AggregateProfilesPageState) => {
-            store.edit((draft) => {
-              draft.selectedProfileId = state.selectedProfileId;
-              draft.flamegraphState = state.flamegraphState;
-            });
-          },
-          profiles,
-        }),
-    });
+    if (profileCount === 1) {
+      await this.registerSingleProfilePage(trace);
+    } else {
+      await this.registerMergePage(trace);
+    }
     trace.sidebar.addMenuItem({
       section: 'current_trace',
       sortOrder: 11,
@@ -76,9 +83,83 @@ export default class implements PerfettoPlugin {
       //  b) there is already some code in UI load time which navigates
       //     to the viewer page so we would always fail this check.
       // So for now just leave this as-is.
-      if (!hasAnyTracks && profiles.length > 0) {
+      if (!hasAnyTracks && profileCount > 0) {
         trace.navigate('#!/aggregateprofiles');
       }
+    });
+  }
+
+  private migratePageState(init: unknown): AggregateProfilesPageState {
+    const result = AGGREGATE_PROFILES_PAGE_STATE_SCHEMA.safeParse(init);
+    return result.data ?? {};
+  }
+
+  private async registerSingleProfilePage(trace: Trace): Promise<void> {
+    this.store = trace.mountStore('dev.perfetto.AggregateProfiles', (init) =>
+      this.migratePageState(init),
+    );
+    const profiles = await this.getProfiles(trace);
+    const store = ensureExists(this.store);
+    trace.pages.registerPage({
+      route: '/aggregateprofiles',
+      render: () =>
+        m(AggregateProfilesPage, {
+          trace,
+          state: store.state,
+          onStateChange: (state: AggregateProfilesPageState) => {
+            store.edit((draft) => {
+              draft.selectedProfileId = state.selectedProfileId;
+              draft.flamegraphState = state.flamegraphState;
+            });
+          },
+          profiles,
+        }),
+    });
+  }
+
+  private async registerMergePage(trace: Trace): Promise<void> {
+    const loaded = await loadMergeProfiles(trace);
+    // The expensive one-off every flamegraph query needs; do it at load.
+    await trace.engine.query(
+      'include perfetto module callstacks.stack_profile',
+    );
+    // Lives as long as the page is mounted, which is the rest of the session
+    // (a visited page stays mounted behind a Gate).
+    let state = DEFAULT_FLAMEGRAPH_COLLECTION_STATE;
+    const byScope = new Map(loaded.profiles.map((p) => [p.scope, p]));
+    // One metric per sample type, summing the given profiles.
+    const metricsForKeys = (keys: ReadonlyArray<string>) => {
+      const metrics: TreeExplorerQueryMetric[] = [];
+      for (const st of loaded.sampleTypes) {
+        const ids = keys
+          .map((k) => byScope.get(k)?.sampleTypes.get(st.key)?.aggId)
+          .filter((id): id is number => id !== undefined);
+        if (ids.length > 0) {
+          metrics.push(this.aggregateProfileMetric(st.key, st.unit, ids));
+        }
+      }
+      return metrics;
+    };
+    const columns: ReadonlyArray<FlamegraphCollectionColumn> = loaded.columns;
+    trace.pages.registerPage({
+      route: '/aggregateprofiles',
+      render: () =>
+        m(FlamegraphCollection, {
+          trace,
+          rows: loaded.rows,
+          columns,
+          entryKey: (row: Row) => String(row['c0']),
+          metricsForKeys,
+          entityName: 'profiles',
+          renderEntryTitle: (key: string) =>
+            key.startsWith('http://') || key.startsWith('https://')
+              ? m(Anchor, {href: key, target: '_blank'}, key)
+              : key,
+          state,
+          onStateChange: (s: FlamegraphCollectionState) => {
+            state = s;
+          },
+        }),
     });
   }
 
@@ -100,21 +181,17 @@ export default class implements PerfettoPlugin {
     return profiles;
   }
 
-  private async getProfileMetrics(
-    trace: Trace,
-    scope: string,
-  ): Promise<TreeExplorerQueryMetric[]> {
+  private async getProfileMetrics(trace: Trace, scope: string) {
     const result = await trace.engine.query(`
       SELECT
         id,
-        sample_type_type,
         sample_type_unit,
         sample_type_type || ' (' || sample_type_unit || ')' as display_name
       FROM __intrinsic_aggregate_profile
       WHERE scope = '${scope}'
       ORDER BY sample_type_type
     `);
-    const metrics: TreeExplorerQueryMetric[] = [];
+    const metrics = [];
     for (
       const it = result.iter({
         id: NUM,
@@ -124,54 +201,152 @@ export default class implements PerfettoPlugin {
       it.valid();
       it.next()
     ) {
-      metrics.push({
-        name: it.display_name,
-        unit: it.sample_type_unit,
-        nameColumnLabel: 'Symbol',
-        dependencySql: 'include perfetto module callstacks.stack_profile',
-        statement: `
-          WITH profile_samples AS MATERIALIZED (
-            SELECT callsite_id, sum(sample.value) AS sample_value
-            FROM __intrinsic_aggregate_sample sample
-            WHERE sample.aggregate_profile_id = ${it.id}
-            GROUP BY callsite_id
-          )
-          SELECT
-            c.id,
-            c.parent_id as parentId,
-            c.name,
-            c.mapping_name,
-            c.source_file || ':' || c.line_number as source_location,
-            cast_string!(c.inlined) AS inlined,
-            CASE WHEN c.is_leaf_function_in_callsite_frame
-              THEN coalesce(m.sample_value, 0)
-              ELSE 0
-            END AS value
-          FROM _callstacks_for_stack_profile_samples!(profile_samples) AS c
-          LEFT JOIN profile_samples AS m USING (callsite_id)
-        `,
-        unaggregatableProperties: [
-          {name: 'mapping_name', displayName: 'Mapping'},
-          {
-            name: 'inlined',
-            displayName: 'Inlined',
-            isVisible: () => false,
-          },
-        ],
-        aggregatableProperties: [
-          {
-            name: 'source_location',
-            displayName: 'Source Location',
-            mergeAggregation: 'ONE_OR_SUMMARY',
-          },
-        ],
-        optionalMarker: {
-          name: 'Inlined Function',
-          isVisible: (properties: ReadonlyMap<string, string>) =>
-            properties.get('inlined') === '1',
-        },
-      });
+      metrics.push(
+        this.aggregateProfileMetric(it.display_name, it.sample_type_unit, [
+          it.id,
+        ]),
+      );
     }
     return metrics;
   }
+
+  // Metric summing the given profiles. Callsites are interned globally, so one
+  // query merges same-stack samples across them.
+  private aggregateProfileMetric(
+    name: string,
+    unit: string,
+    aggIds: ReadonlyArray<number>,
+  ): TreeExplorerQueryMetric {
+    return {
+      name,
+      unit: displayUnit(unit),
+      nameColumnLabel: 'Symbol',
+      dependencySql: 'include perfetto module callstacks.stack_profile',
+      statement: `
+        WITH profile_samples AS MATERIALIZED (
+          SELECT callsite_id, sum(sample.value) AS sample_value
+          FROM __intrinsic_aggregate_sample sample
+          WHERE sample.aggregate_profile_id IN (${aggIds.join(',')})
+          GROUP BY callsite_id
+        )
+        SELECT
+          c.id,
+          c.parent_id as parentId,
+          c.name,
+          c.mapping_name,
+          c.source_file || ':' || c.line_number as source_location,
+          cast_string!(c.inlined) AS inlined,
+          CASE WHEN c.is_leaf_function_in_callsite_frame
+            THEN coalesce(m.sample_value, 0)
+            ELSE 0
+          END AS value
+        FROM _callstacks_for_stack_profile_samples!(profile_samples) AS c
+        LEFT JOIN profile_samples AS m USING (callsite_id)
+      `,
+      unaggregatableProperties: [
+        {name: 'mapping_name', displayName: 'Mapping'},
+        {name: 'inlined', displayName: 'Inlined', isVisible: () => false},
+      ],
+      aggregatableProperties: [
+        {
+          name: 'source_location',
+          displayName: 'Source Location',
+          mergeAggregation: 'ONE_OR_SUMMARY',
+        },
+      ],
+      optionalMarker: {
+        name: 'Inlined Function',
+        isVisible: (properties: ReadonlyMap<string, string>) =>
+          properties.get('inlined') === '1',
+      },
+    };
+  }
+}
+
+// Maps pprof units onto the flamegraph's vocabulary; displaySize scales
+// 'ns' and 'B'.
+function displayUnit(unit: string): string {
+  switch (unit.toLowerCase()) {
+    case 'nanoseconds':
+      return 'ns';
+    case 'bytes':
+      return 'B';
+    default:
+      return unit;
+  }
+}
+
+// Each profile's sample-type totals as grid rows. A grouped scan only: the
+// callstack tables are touched for the selected subset alone.
+async function loadMergeProfiles(trace: Trace): Promise<LoadedProfiles> {
+  const byScope = new Map<string, Map<string, MergeProfileMetric>>();
+  const sampleKinds = new Map<string, SampleType>();
+  const result = await trace.engine.query(`
+    SELECT
+      ap.scope AS scope,
+      ap.id AS agg_id,
+      ap.sample_type_type AS type,
+      ap.sample_type_unit AS unit,
+      coalesce(sum(s.value), 0) AS total,
+      count(s.id) AS n
+    FROM __intrinsic_aggregate_profile ap
+    LEFT JOIN __intrinsic_aggregate_sample s
+      ON s.aggregate_profile_id = ap.id
+    GROUP BY ap.id
+    ORDER BY ap.scope
+  `);
+  for (
+    const it = result.iter({
+      scope: STR,
+      agg_id: NUM,
+      type: STR,
+      unit: STR,
+      total: NUM,
+      n: NUM,
+    });
+    it.valid();
+    it.next()
+  ) {
+    const key = `${it.type} (${it.unit})`;
+    sampleKinds.set(key, {key, type: it.type, unit: it.unit});
+    let sampleTypes = byScope.get(it.scope);
+    if (sampleTypes === undefined) {
+      sampleTypes = new Map();
+      byScope.set(it.scope, sampleTypes);
+    }
+    sampleTypes.set(key, {aggId: it.agg_id, total: it.total, count: it.n});
+  }
+
+  const profiles: MergeProfile[] = Array.from(
+    byScope.entries(),
+    ([scope, sampleTypes]) => ({scope, sampleTypes}),
+  );
+
+  const columns: MergeColumn[] = [{field: 'c0', title: 'profile', kind: 'id'}];
+  for (const st of sampleKinds.values()) {
+    columns.push({
+      field: `c${columns.length}`,
+      title: st.key,
+      kind: 'numeric',
+      unit: displayUnit(st.unit),
+      sampleKey: st.key,
+    });
+  }
+
+  const rows: Row[] = profiles.map((p) => {
+    const row: Row = {c0: p.scope};
+    for (const c of columns) {
+      if (c.sampleKey !== undefined) {
+        row[c.field] = p.sampleTypes.get(c.sampleKey)?.total ?? null;
+      }
+    }
+    return row;
+  });
+
+  return {
+    profiles,
+    sampleTypes: Array.from(sampleKinds.values()),
+    columns,
+    rows,
+  };
 }

--- a/ui/src/plugins/dev.perfetto.AggregateProfiles/types.ts
+++ b/ui/src/plugins/dev.perfetto.AggregateProfiles/types.ts
@@ -30,3 +30,32 @@ export interface AggregateProfile {
   readonly displayName: string;
   readonly metrics: ReadonlyArray<TreeExplorerQueryMetric>;
 }
+
+// One (profile, sample-type) total. `aggId` is what the merge query filters
+// __intrinsic_aggregate_profile on.
+export interface MergeProfileMetric {
+  readonly aggId: number;
+  readonly total: number;
+  readonly count: number;
+}
+
+// One source pprof, keyed by its file scope.
+export interface MergeProfile {
+  readonly scope: string;
+  readonly sampleTypes: ReadonlyMap<string, MergeProfileMetric>;
+}
+
+export interface SampleType {
+  readonly key: string; // "cpu (nanoseconds)"
+  readonly type: string;
+  readonly unit: string;
+}
+
+// A collection column plus the sample type it totals.
+export interface MergeColumn {
+  readonly field: string; // positional grid field id ("c0", "c1", ...)
+  readonly title: string;
+  readonly kind: 'id' | 'numeric';
+  readonly unit?: string;
+  readonly sampleKey?: string; // for sample-type columns: the SampleType.key
+}


### PR DESCRIPTION

  ### Summary

  This PR adds support for importing, analyzing, and merging multi-pprof archives (e.g., .zip and .tar archives containing dozens or hundreds of .pprof files) across Trace Processor and the Perfetto UI. It
  introduces FlamegraphCollection, a reusable UI component pairing a filterable DataGrid with a linked flamegraph/tree explorer supporting both aggregated merge and step-through modes.
  ──────
  ### Key Changes

  #### Trace Processor: 

  - Archive Member Scoping:
      - Added TraceFileTracker::CurrentFile() ancestor chain walking to scope each pprof by its member file path (skipping unnamed gzip decompression layers), while standalone pprofs retain the default
      pprof_file scope.
      - Captured the file ID on the first Parse() call to ensure deterministic scope attribution regardless of sorter push/flush ordering.
  - Fallback Mapping Interning & Memory Optimization:
      - Interned dummy fallback mappings for mapping-less locations, allowing identical frames to intern globally across profiles.
      -Avoids explosion of dummy mappings/callsites (e.g. a 32 MB / 1,000-profile archive peak memory dropped from ~1.8 GB to ~647 MB, avoiding Wasm OOMs).


  #### Perfetto UI:

  - Reusable FlamegraphCollection Component (ui/src/components):
      - Pairs a DataGrid (with working-set filtering) with a TreeExplorerPanel.
      - Merge Mode: Aggregates the filtered working set into a single combined flamegraph in one query via globally interned callsites.
      - Step Mode: Allows stepping through individual entries one-by-one (via toolbar chevrons, arrow keys, or row clicks) with consistent view, filters, and metrics.
      - Resolves row selection using full entry keys rather than visible column labels, avoiding ambiguities with non-unique labels.
  - TreeExplorerFetcher Cache Eviction:
      - Bounded the persistent operator table cache to the active metric set, ensuring memory usage remains bounded when cycling through hundreds of profiles.
  - AggregateProfiles Plugin:
      - Adopted FlamegraphCollection to organize archives, mapping sample types to grid columns and flamegraph metrics. Profile-only traces land directly on the collection view via initialPage.

  ──────
  ### Testing

  - Trace Processor: Added parser diff tests (tests_pprof.py) verifying archive scoping, fallback mapping interning, and frame deduplication across archive members.
  - UI Unit / Component Tests: Added unit tests for TreeExplorerFetcher cache eviction and FlamegraphCollection state management / DOM interactions (_unittest.ts & _jsdomtest.ts).