### PR TITLE
tp: recycle row batches through a pool

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17612,6 +17612,7 @@ filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
         "src/trace_processor/core/exec/operator_unittest.cc",
+        "src/trace_processor/core/exec/row_batch_pool_unittest.cc",
     ],
 }
 

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -25,6 +25,7 @@ source_set("exec") {
     "pipeline.h",
     "row_batch.cc",
     "row_batch.h",
+    "row_batch_pool.h",
     "row_cursor.cc",
     "row_cursor.h",
     "row_selection.h",
@@ -40,7 +41,10 @@ source_set("exec") {
 
 perfetto_unittest_source_set("unittests") {
   testonly = true
-  sources = [ "operator_unittest.cc" ]
+  sources = [
+    "operator_unittest.cc",
+    "row_batch_pool_unittest.cc",
+  ]
   deps = [
     ":exec",
     "../../../../gn:default_deps",

--- a/src/trace_processor/core/exec/row_batch_pool.h
+++ b/src/trace_processor/core/exec/row_batch_pool.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_POOL_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_POOL_H_
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+class RowBatchPool;
+
+// A row batch borrowed from a pool and returned when it goes out of scope. The
+// pool must outlive every row batch borrowed from it.
+class PooledRowBatch {
+ public:
+  PooledRowBatch() = default;
+  PooledRowBatch(RowBatchPool* pool, std::unique_ptr<RowBatch> chunk)
+      : pool_(pool), chunk_(std::move(chunk)) {}
+  PooledRowBatch(PooledRowBatch&&) noexcept;
+  PooledRowBatch& operator=(PooledRowBatch&&) noexcept;
+  PooledRowBatch(const PooledRowBatch&) = delete;
+  PooledRowBatch& operator=(const PooledRowBatch&) = delete;
+  ~PooledRowBatch();
+
+  explicit operator bool() const { return chunk_ != nullptr; }
+  RowBatch& operator*() const { return *chunk_; }
+  RowBatch* operator->() const { return chunk_.get(); }
+
+  // Returns the batch to its pool early.
+  void Release();
+
+ private:
+  RowBatchPool* pool_ = nullptr;
+  std::unique_ptr<RowBatch> chunk_;
+};
+
+// Recycles row batches across a running pipeline.
+class RowBatchPool {
+ public:
+  PooledRowBatch Acquire() {
+    if (free_.empty()) {
+      ++allocations_;
+      return PooledRowBatch(this, std::make_unique<RowBatch>());
+    }
+    std::unique_ptr<RowBatch> chunk = std::move(free_.back());
+    free_.pop_back();
+    return PooledRowBatch(this, std::move(chunk));
+  }
+
+  void Return(std::unique_ptr<RowBatch> chunk) {
+    PERFETTO_DCHECK(chunk);
+    chunk->Reset();
+    free_.push_back(std::move(chunk));
+  }
+
+  // Row batches the pool has had to allocate. In a steady state this stops
+  // growing, which is what the pool exists to guarantee.
+  uint32_t allocations() const { return allocations_; }
+  uint32_t free_count() const { return static_cast<uint32_t>(free_.size()); }
+
+ private:
+  uint32_t allocations_ = 0;
+  std::vector<std::unique_ptr<RowBatch>> free_;
+};
+
+inline PooledRowBatch::PooledRowBatch(PooledRowBatch&& other) noexcept
+    : pool_(other.pool_), chunk_(std::move(other.chunk_)) {
+  other.pool_ = nullptr;
+}
+
+inline PooledRowBatch& PooledRowBatch::operator=(
+    PooledRowBatch&& other) noexcept {
+  if (this != &other) {
+    Release();
+    pool_ = other.pool_;
+    chunk_ = std::move(other.chunk_);
+    other.pool_ = nullptr;
+  }
+  return *this;
+}
+
+inline PooledRowBatch::~PooledRowBatch() {
+  Release();
+}
+
+inline void PooledRowBatch::Release() {
+  if (chunk_ && pool_) {
+    pool_->Return(std::move(chunk_));
+  }
+  chunk_.reset();
+  pool_ = nullptr;
+}
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_POOL_H_

--- a/src/trace_processor/core/exec/row_batch_pool_unittest.cc
+++ b/src/trace_processor/core/exec/row_batch_pool_unittest.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_batch_pool.h"
+
+#include <utility>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+TEST(RowBatchPoolTest, AReleasedBatchIsHandedOutAgain) {
+  RowBatchPool pool;
+  {
+    PooledRowBatch batch = pool.Acquire();
+    ASSERT_TRUE(batch);
+    EXPECT_EQ(pool.allocations(), 1u);
+  }
+  EXPECT_EQ(pool.free_count(), 1u);
+
+  PooledRowBatch again = pool.Acquire();
+  EXPECT_EQ(pool.allocations(), 1u);
+  EXPECT_EQ(pool.free_count(), 0u);
+}
+
+// The point of the pool: an operator which holds several batches at once
+// stops allocating once it has as many as it ever needs at one time.
+TEST(RowBatchPoolTest, HoldingSeveralAtOnceAllocatesOnlyAsManyAsAreHeld) {
+  RowBatchPool pool;
+  {
+    std::vector<PooledRowBatch> held;
+    for (int i = 0; i < 4; ++i) {
+      held.push_back(pool.Acquire());
+    }
+    EXPECT_EQ(pool.allocations(), 4u);
+  }
+  for (int round = 0; round < 10; ++round) {
+    std::vector<PooledRowBatch> held;
+    for (int i = 0; i < 4; ++i) {
+      held.push_back(pool.Acquire());
+    }
+  }
+  EXPECT_EQ(pool.allocations(), 4u);
+}
+
+// A batch handed back carries nothing over from its last use, or an operator
+// would read the previous query's columns.
+TEST(RowBatchPoolTest, ABatchComesBackEmpty) {
+  RowBatchPool pool;
+  {
+    PooledRowBatch batch = pool.Acquire();
+    batch->AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr));
+    batch->SetCardinality(7);
+    ASSERT_EQ(batch->column_count(), 1u);
+  }
+  PooledRowBatch again = pool.Acquire();
+  EXPECT_EQ(again->column_count(), 0u);
+  EXPECT_EQ(again->size(), 0u);
+}
+
+TEST(RowBatchPoolTest, MovingABatchMovesWhoReturnsIt) {
+  RowBatchPool pool;
+  {
+    PooledRowBatch batch = pool.Acquire();
+    PooledRowBatch moved = std::move(batch);
+    EXPECT_FALSE(batch);
+    EXPECT_TRUE(moved);
+    EXPECT_EQ(pool.free_count(), 0u);
+  }
+  // Returned once, by whichever of them still held it.
+  EXPECT_EQ(pool.free_count(), 1u);
+  EXPECT_EQ(pool.allocations(), 1u);
+}
+
+TEST(RowBatchPoolTest, ABatchCanBeGivenBackEarly) {
+  RowBatchPool pool;
+  PooledRowBatch batch = pool.Acquire();
+  batch.Release();
+  EXPECT_FALSE(batch);
+  EXPECT_EQ(pool.free_count(), 1u);
+  batch.Release();
+  EXPECT_EQ(pool.free_count(), 1u);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec


### PR DESCRIPTION
An operator which holds several chunks at once -- anything that has to
see every row before it can emit one -- cannot borrow the source's,
because a source refills its chunk on the next pull. It needs chunks of
its own, and allocating one per chunk of input makes the amount of
allocation a property of the input size rather than of the query.

A pool makes it a property of the query: an operator holding four
chunks at a time allocates four, whatever it is run over. Batches come
back reset, so nothing carries over from one query into the next.