### PR TITLE
tp: read a row cursor's rows per column

### DIFF
--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -77,6 +77,9 @@ class ColumnView {
     block_ = other.block_;
   }
 
+  // The values this column reads from, before its row view is applied.
+  const void* data() const { return data_; }
+
  private:
   Kind kind_ = Kind::kFlat;
   StorageType type_{Id{}};

--- a/src/trace_processor/core/exec/operator_unittest.cc
+++ b/src/trace_processor/core/exec/operator_unittest.cc
@@ -62,7 +62,7 @@ std::vector<uint32_t> Drain(PullPipeline& pipeline) {
   pipeline.Reset();
   RowCursor cursor(pipeline);
   for (cursor.Open(); !cursor.eof(); cursor.Next()) {
-    rows.push_back(cursor.row());
+    rows.push_back(cursor.row(0));
   }
   return rows;
 }
@@ -210,6 +210,56 @@ TEST(SinkTest, ReadsEveryRowOfEveryBatch) {
   EXPECT_EQ(rows.front(), 0u);
   EXPECT_EQ(rows[kMaxBatchRows], kMaxBatchRows);
   EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 6u);
+}
+
+// An operator which adds a computed column cannot put it in the index space
+// its input arrived in, so it adds it in its own. A cursor has to follow each
+// column's own view to read either of them.
+TEST(SinkTest, ReadsColumnsWhichDoNotShareARowView) {
+  std::vector<int64_t> payload = {10, 11, 12, 13};
+  std::vector<int64_t> computed = {90, 91};
+
+  class TwoViewSource final : public Source {
+   public:
+    TwoViewSource(const std::vector<int64_t>* payload,
+                  const std::vector<int64_t>* computed)
+        : payload_(payload), computed_(computed) {}
+
+    RowBatch* Next() override {
+      if (done_) {
+        return nullptr;
+      }
+      done_ = true;
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, payload_->data()));
+      // The payload is read from half way in; the computed column is its own
+      // array read from the start.
+      batch_.Compose(RowSelection::Range(2), 2);
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, computed_->data()));
+      batch_.SetCardinality(2);
+      return &batch_;
+    }
+
+   private:
+    const std::vector<int64_t>* payload_;
+    const std::vector<int64_t>* computed_;
+    RowBatch batch_;
+    bool done_ = false;
+  };
+
+  TwoViewSource source(&payload, &computed);
+  RowCursor cursor(source);
+  std::vector<int64_t> read_payload;
+  std::vector<int64_t> read_computed;
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    read_payload.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(0).data())[cursor.row(0)]);
+    read_computed.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(1).data())[cursor.row(1)]);
+  }
+  EXPECT_THAT(read_payload, ElementsAre(12, 13));
+  EXPECT_THAT(read_computed, ElementsAre(90, 91));
 }
 
 TEST(SinkTest, ReportsEofWithoutOpen) {

--- a/src/trace_processor/core/exec/row_cursor.cc
+++ b/src/trace_processor/core/exec/row_cursor.cc
@@ -18,7 +18,6 @@
 
 #include "src/trace_processor/core/exec/operator.h"
 #include "src/trace_processor/core/exec/row_batch.h"
-#include "src/trace_processor/core/exec/row_selection.h"
 
 namespace perfetto::trace_processor::core::exec {
 
@@ -27,17 +26,14 @@ RowCursor::RowCursor(Source& source) : source_(source) {}
 RowCursor::~RowCursor() = default;
 
 bool RowCursor::Pull() {
-  RowBatch* batch = source_.Next();
-  if (!batch) {
+  batch_ = source_.Next();
+  if (!batch_) {
     index_ = 0;
     size_ = 0;
     return false;
   }
-  RowSelection selection = batch->column(0).selection();
-  rows_ = selection.is_range() ? nullptr : selection.data();
-  offset_ = selection.offset();
   index_ = 0;
-  size_ = batch->size();
+  size_ = batch_->size();
   return true;
 }
 

--- a/src/trace_processor/core/exec/row_cursor.h
+++ b/src/trace_processor/core/exec/row_cursor.h
@@ -22,6 +22,7 @@
 #include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
 
 namespace perfetto::trace_processor::core::exec {
 
@@ -49,11 +50,21 @@ class RowCursor {
 
   bool eof() const { return index_ == size_; }
 
-  // The row being read. Every column of a batch shares one row view, so which
-  // column it is read from does not matter.
-  PERFETTO_ALWAYS_INLINE uint32_t row() const {
+  // The physical row `column` is read at.
+  //
+  // Resolved per column rather than once for the batch: an operator which adds
+  // a computed column has nowhere to put it in the index space its input
+  // arrived in, so it adds the column in its own. Columns of one batch
+  // therefore agree on how many rows there are and need agree on nothing else.
+  PERFETTO_ALWAYS_INLINE uint32_t row(uint32_t column) const {
     PERFETTO_DCHECK(index_ < size_);
-    return rows_ ? rows_[index_] : offset_ + index_;
+    return batch_->column(column).selection().GetIndex(index_);
+  }
+
+  // The batch being read, for a consumer which wants the columns themselves.
+  const RowBatch& batch() const {
+    PERFETTO_DCHECK(batch_);
+    return *batch_;
   }
 
  private:
@@ -61,9 +72,7 @@ class RowCursor {
   bool Pull();
 
   Source& source_;
-  // The batch's rows, or null when they are the contiguous run from `offset_`.
-  const uint32_t* rows_ = nullptr;
-  uint32_t offset_ = 0;
+  RowBatch* batch_ = nullptr;
   uint32_t index_ = 0;
   uint32_t size_ = 0;
 };


### PR DESCRIPTION
A cursor took the row view from column zero and applied it to every
other column, and RowBatch said in as many words that all of them shared
one. Nothing enforced it, and the first operator to want otherwise
breaks quietly: an operator which adds a computed column has nowhere to
put it in the index space its input arrived in, because that space
belongs to the storage the input was read from. It adds the column in
its own space, the two disagree, and the cursor reads the new column at
the old column's rows -- off the end of it, in release, with no
complaint.

Columns of one batch now agree on how many rows there are and on nothing
else. The cost is resolving a row per column instead of once per batch,
which a row-at-a-time reader can afford; what it buys is that adding a
column stops being a thing which happens to work when the offset is
zero.