### PR TITLE
tp: let a batch own the values it carries

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17601,6 +17601,7 @@ filegroup {
     srcs: [
         "src/trace_processor/core/exec/column_view.cc",
         "src/trace_processor/core/exec/from.cc",
+        "src/trace_processor/core/exec/owned_column.cc",
         "src/trace_processor/core/exec/pipeline.cc",
         "src/trace_processor/core/exec/row_batch.cc",
         "src/trace_processor/core/exec/row_cursor.cc",
@@ -17612,6 +17613,7 @@ filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
         "src/trace_processor/core/exec/operator_unittest.cc",
+        "src/trace_processor/core/exec/owned_column_unittest.cc",
         "src/trace_processor/core/exec/row_batch_pool_unittest.cc",
     ],
 }

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -21,6 +21,8 @@ source_set("exec") {
     "from.cc",
     "from.h",
     "operator.h",
+    "owned_column.cc",
+    "owned_column.h",
     "pipeline.cc",
     "pipeline.h",
     "row_batch.cc",
@@ -43,6 +45,7 @@ perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
     "operator_unittest.cc",
+    "owned_column_unittest.cc",
     "row_batch_pool_unittest.cc",
   ]
   deps = [

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -80,6 +80,9 @@ class ColumnView {
   // The values this column reads from, before its row view is applied.
   const void* data() const { return data_; }
 
+  // Which physical rows hold a value, or null when every row does.
+  const BitVector* validity() const { return validity_; }
+
  private:
   Kind kind_ = Kind::kFlat;
   StorageType type_{Id{}};

--- a/src/trace_processor/core/exec/owned_column.cc
+++ b/src/trace_processor/core/exec/owned_column.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/owned_column.h"
+
+#include <cstdint>
+#include <cstring>
+#include <variant>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+template <typename T, typename Variant>
+FlexVector<T>& Ensure(Variant& values, uint32_t size) {
+  if (!std::holds_alternative<FlexVector<T>>(values)) {
+    values = FlexVector<T>();
+  }
+  auto& vec = std::get<FlexVector<T>>(values);
+  if (vec.size() < size) {
+    vec.resize(size);
+  }
+  return vec;
+}
+
+// Copies the `count` values `column` resolves to. A range resolves to a run,
+// which copies whole; anything else is one gather, and neither walks a row
+// view a value at a time.
+template <typename T, typename Variant>
+void Copy(const ColumnView& column,
+          uint32_t at,
+          uint32_t count,
+          Variant& values) {
+  FlexVector<T>& out = Ensure<T>(values, at + count);
+  const auto* data = static_cast<const T*>(column.data());
+  RowSelection selection = column.selection();
+  T* dest = out.data() + at;
+  if (selection.is_range()) {
+    memcpy(dest, data + selection.offset(), count * sizeof(T));
+    return;
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    dest[i] = data[rows[i]];
+  }
+}
+
+// An Id column's value is the row it sits at, so copying one means writing
+// down the rows it stood for.
+template <typename Variant>
+void CopyIds(const ColumnView& column,
+             uint32_t at,
+             uint32_t count,
+             Variant& values) {
+  FlexVector<uint32_t>& out = Ensure<uint32_t>(values, at + count);
+  RowSelection selection = column.selection();
+  uint32_t* dest = out.data() + at;
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      dest[i] = offset + i;
+    }
+    return;
+  }
+  memcpy(dest, selection.data(), count * sizeof(uint32_t));
+}
+
+}  // namespace
+
+void OwnedColumn::Fill(const ColumnView& column, uint32_t count) {
+  Clear();
+  Append(column, count);
+}
+
+void OwnedColumn::Append(const ColumnView& column, uint32_t count) {
+  StorageType type = column.type();
+  uint32_t at = size_;
+  if (type.Is<Id>()) {
+    CopyIds(column, at, count, values_);
+    type = StorageType{Uint32{}};
+  } else if (type.Is<Uint32>()) {
+    Copy<uint32_t>(column, at, count, values_);
+  } else if (type.Is<Int32>()) {
+    Copy<int32_t>(column, at, count, values_);
+  } else if (type.Is<Int64>()) {
+    Copy<int64_t>(column, at, count, values_);
+  } else if (type.Is<Double>()) {
+    Copy<double>(column, at, count, values_);
+  } else {
+    Copy<StringPool::Id>(column, at, count, values_);
+  }
+  PERFETTO_DCHECK(at == 0 || type == type_);
+  type_ = type;
+  size_ = at + count;
+
+  const BitVector* validity = column.validity();
+  if (!validity && !nullable_) {
+    return;
+  }
+  if (validity_.size() < size_) {
+    validity_.resize(size_);
+  }
+  if (!nullable_) {
+    // Everything already here arrived from a column with nothing missing.
+    for (uint32_t i = 0; i < at; ++i) {
+      validity_.set(i);
+    }
+    nullable_ = true;
+  }
+  if (!validity) {
+    for (uint32_t i = 0; i < count; ++i) {
+      validity_.set(at + i);
+    }
+    return;
+  }
+  RowSelection selection = column.selection();
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      validity_.change(at + i, validity->is_set(offset + i));
+    }
+    return;
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    validity_.change(at + i, validity->is_set(rows[i]));
+  }
+}
+
+ColumnView OwnedColumn::View() const {
+  const void* data = nullptr;
+  if (type_.Is<Uint32>()) {
+    data = std::get<FlexVector<uint32_t>>(values_).data();
+  } else if (type_.Is<Int32>()) {
+    data = std::get<FlexVector<int32_t>>(values_).data();
+  } else if (type_.Is<Int64>()) {
+    data = std::get<FlexVector<int64_t>>(values_).data();
+  } else if (type_.Is<Double>()) {
+    data = std::get<FlexVector<double>>(values_).data();
+  } else {
+    data = std::get<FlexVector<StringPool::Id>>(values_).data();
+  }
+  return ColumnView::Reference(type_, data, nullable_ ? &validity_ : nullptr);
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/owned_column.h
+++ b/src/trace_processor/core/exec/owned_column.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_OWNED_COLUMN_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_OWNED_COLUMN_H_
+
+#include <cstdint>
+#include <variant>
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// A copy of a column's values, kept by whoever needs them to outlive the
+// storage they were read from.
+//
+// A column view is a view: it costs pointers, not values, and a batch built
+// from one is only good for as long as what it points at stands still. That
+// covers a source reading durable storage and does not cover a source which
+// materialises into buffers it refills, so whether to copy cannot be decided
+// once for the model. It is decided per column, by the operator, which is the
+// only thing that knows how long it needs the values for.
+//
+// The copy is dense from row zero, so an operator which owns its input is also
+// an operator which can add a computed column to it without the two ending up
+// in different index spaces.
+class OwnedColumn {
+ public:
+  // Copies `count` values out of `column`, resolved through its row view,
+  // replacing whatever was here. An Id column materialises as the row numbers
+  // it stood for.
+  void Fill(const ColumnView& column, uint32_t count);
+
+  // The same, onto the end of what is already here, for building one column
+  // out of a stream of chunks.
+  void Append(const ColumnView& column, uint32_t count);
+
+  // Forgets the values, keeping the buffers.
+  void Clear() { size_ = 0; }
+
+  uint32_t size() const { return size_; }
+
+  // A view of what was copied.
+  ColumnView View() const;
+
+ private:
+  using Values = std::variant<FlexVector<uint32_t>,
+                              FlexVector<int32_t>,
+                              FlexVector<int64_t>,
+                              FlexVector<double>,
+                              FlexVector<StringPool::Id>>;
+
+  StorageType type_{Uint32{}};
+  Values values_{FlexVector<uint32_t>()};
+  BitVector validity_;
+  uint32_t size_ = 0;
+  bool nullable_ = false;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_OWNED_COLUMN_H_

--- a/src/trace_processor/core/exec/owned_column_unittest.cc
+++ b/src/trace_processor/core/exec/owned_column_unittest.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/owned_column.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/span.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using testing::ElementsAre;
+
+template <typename T>
+std::vector<T> Read(const ColumnView& column, uint32_t count) {
+  const auto* data = static_cast<const T*>(column.data());
+  std::vector<T> out;
+  for (uint32_t i = 0; i < count; ++i) {
+    out.push_back(data[column.selection().GetIndex(i)]);
+  }
+  return out;
+}
+
+TEST(OwnedColumnTest, CopiesTheRunARangePicksOut) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  ColumnView view = ColumnView::Reference(StorageType{Int64{}}, values.data());
+  view.selection();
+
+  RowBatch batch;
+  batch.AddColumn(view);
+  batch.Compose(RowSelection::Range(2), 3);
+
+  OwnedColumn owned;
+  owned.Fill(batch.column(0), 3);
+  EXPECT_THAT(Read<int64_t>(owned.View(), 3), ElementsAre(12, 13, 14));
+}
+
+TEST(OwnedColumnTest, GathersTheRowsAnIndexSelectionPicksOut) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  std::vector<uint32_t> rows = {4, 1, 3};
+  ColumnView view = ColumnView::Reference(StorageType{Int64{}}, values.data());
+  view.SetBorrowedRows(Span<const uint32_t>(rows.data(), rows.data() + 3));
+
+  OwnedColumn owned;
+  owned.Fill(view, 3);
+  EXPECT_THAT(Read<int64_t>(owned.View(), 3), ElementsAre(14, 11, 13));
+}
+
+// An Id column has no storage: its value is the row it sits at, so a copy of
+// one has to write those rows down.
+TEST(OwnedColumnTest, AnIdColumnBecomesTheRowsItStoodFor) {
+  ColumnView view = ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr);
+  RowBatch batch;
+  batch.AddColumn(view);
+  batch.Compose(RowSelection::Range(7), 3);
+
+  OwnedColumn owned;
+  owned.Fill(batch.column(0), 3);
+  EXPECT_TRUE(owned.View().type().Is<Uint32>());
+  EXPECT_THAT(Read<uint32_t>(owned.View(), 3), ElementsAre(7u, 8u, 9u));
+}
+
+TEST(OwnedColumnTest, KeepsWhichRowsHeldNothing) {
+  std::vector<int64_t> values = {10, 11, 12, 13};
+  BitVector validity = BitVector::CreateWithSize(4);
+  validity.set(0);
+  validity.set(3);
+  ColumnView view =
+      ColumnView::Reference(StorageType{Int64{}}, values.data(), &validity);
+
+  OwnedColumn owned;
+  owned.Fill(view, 4);
+  const BitVector* copied = owned.View().validity();
+  ASSERT_NE(copied, nullptr);
+  EXPECT_TRUE(copied->is_set(0));
+  EXPECT_FALSE(copied->is_set(1));
+  EXPECT_FALSE(copied->is_set(2));
+  EXPECT_TRUE(copied->is_set(3));
+}
+
+// The whole point: a source which refills its buffers leaves a view pointing
+// at whatever it wrote next. A copy does not care.
+TEST(OwnedColumnTest, SurvivesTheStorageItWasReadFromMovingOn) {
+  std::vector<int64_t> buffer = {1, 2, 3};
+  ColumnView view = ColumnView::Reference(StorageType{Int64{}}, buffer.data());
+
+  OwnedColumn owned;
+  owned.Fill(view, 3);
+  buffer = {99, 99, 99};
+  EXPECT_THAT(Read<int64_t>(owned.View(), 3), ElementsAre(1, 2, 3));
+}
+
+TEST(OwnedColumnTest, CopiesEveryTypeABatchCarries) {
+  std::vector<double> doubles = {1.5, 2.5};
+  ColumnView double_view =
+      ColumnView::Reference(StorageType{Double{}}, doubles.data());
+  OwnedColumn owned_double;
+  owned_double.Fill(double_view, 2);
+  EXPECT_THAT(Read<double>(owned_double.View(), 2), ElementsAre(1.5, 2.5));
+
+  std::vector<uint32_t> uints = {7, 8};
+  ColumnView uint_view =
+      ColumnView::Reference(StorageType{Uint32{}}, uints.data());
+  OwnedColumn owned_uint;
+  owned_uint.Fill(uint_view, 2);
+  EXPECT_THAT(Read<uint32_t>(owned_uint.View(), 2), ElementsAre(7u, 8u));
+}
+
+// A batch that owns its values is also a batch whose columns start dense from
+// row zero, which is what lets a computed column be added beside them.
+TEST(OwnedColumnTest, AnOwnedColumnIsDenseFromRowZero) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  ColumnView view = ColumnView::Reference(StorageType{Int64{}}, values.data());
+
+  RowBatch source;
+  source.AddColumn(view);
+  source.Compose(RowSelection::Range(3), 2);
+
+  RowBatch held;
+  held.AddOwnedColumn(source.column(0), 2);
+  held.SetCardinality(2);
+  EXPECT_TRUE(held.column(0).selection().is_range());
+  EXPECT_EQ(held.column(0).selection().offset(), 0u);
+  EXPECT_THAT(Read<int64_t>(held.column(0), 2), ElementsAre(13, 14));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_batch.cc
+++ b/src/trace_processor/core/exec/row_batch.cc
@@ -17,9 +17,11 @@
 #include "src/trace_processor/core/exec/row_batch.h"
 
 #include <cstdint>
+#include <memory>
 
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/owned_column.h"
 #include "src/trace_processor/core/exec/row_selection.h"
 
 namespace perfetto::trace_processor::core::exec {
@@ -36,6 +38,15 @@ bool RowBatch::AdoptPhysicalRows(Span<const uint32_t> rows) {
   }
   cardinality_ = count;
   return true;
+}
+
+void RowBatch::AddOwnedColumn(const ColumnView& column, uint32_t count) {
+  if (owned_used_ == owned_.size()) {
+    owned_.push_back(std::make_unique<OwnedColumn>());
+  }
+  OwnedColumn& owned = *owned_[owned_used_++];
+  owned.Fill(column, count);
+  AddColumn(owned.View());
 }
 
 void RowBatch::Compose(RowSelection selection, uint32_t count) {

--- a/src/trace_processor/core/exec/row_batch.h
+++ b/src/trace_processor/core/exec/row_batch.h
@@ -18,11 +18,13 @@
 #define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
 
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/owned_column.h"
 #include "src/trace_processor/core/exec/row_selection.h"
 
 namespace perfetto::trace_processor::core::exec {
@@ -46,6 +48,15 @@ class RowBatch {
   const ColumnView& column(uint32_t column) const { return columns_[column]; }
   ColumnView& mutable_column(uint32_t column) { return columns_[column]; }
   void AddColumn(ColumnView column) { columns_.push_back(std::move(column)); }
+
+  // Copies `column`'s `count` values into storage this batch owns and adds a
+  // column reading them, dense from row zero.
+  //
+  // Optional, and the caller's call: a view costs nothing to add and is right
+  // whenever the storage behind it outlives the batch. This is for when it
+  // does not, which is any source that materialises into buffers it refills,
+  // and for an operator holding batches past the pull that produced them.
+  void AddOwnedColumn(const ColumnView& column, uint32_t count);
 
   // Points every column at `rows`, which the caller continues to own. Only
   // valid while the columns still share the source's contiguous view, and
@@ -73,11 +84,16 @@ class RowBatch {
     cardinality_ = 0;
     columns_.clear();
     selections_.Reset();
+    // The buffers stay: a pooled batch refills the ones it filled last time.
+    owned_used_ = 0;
   }
 
   uint32_t cardinality_ = 0;
   std::vector<ColumnView> columns_;
   SelectionPool selections_;
+  // Held by pointer so a column's view of one survives the vector growing.
+  std::vector<std::unique_ptr<OwnedColumn>> owned_;
+  uint32_t owned_used_ = 0;
 };
 
 }  // namespace perfetto::trace_processor::core::exec


### PR DESCRIPTION
A column view is a view, and a batch built from views is only good for
as long as the storage behind them stands still. That is true of a
source reading a dataframe and false of one that materialises rows into
buffers it refills, which is what reading from SQL will do. Anything
holding a batch past the pull that produced it -- every breaker, by
definition -- would be reading whatever the source wrote next.

Owning the values is optional and decided per column by the operator,
because the operator is the only thing that knows how long it needs them
for. A streaming step still adds views and pays nothing.

The copy lands dense from row zero, which settles a second question: an
operator adding a computed column has nowhere to put it while its
input's index space belongs to the storage that input was read from.
Once the payload is the operator's own, the computed column sits beside
it in the same space.