### PR TITLE
tp: scan SQL queries into batches

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16010,6 +16010,7 @@ filegroup {
         "src/base/thread_checker_unittest.cc",
         "src/base/thread_task_runner_unittest.cc",
         "src/base/time_unittest.cc",
+        "src/base/type_set_unittest.cc",
         "src/base/unix_socket_unittest.cc",
         "src/base/utils_unittest.cc",
         "src/base/uuid_unittest.cc",
@@ -17792,7 +17793,6 @@ filegroup {
         "src/trace_processor/core/util/slab_unittest.cc",
         "src/trace_processor/core/util/sort_unittest.cc",
         "src/trace_processor/core/util/span_unittest.cc",
-        "src/trace_processor/core/util/type_set_unittest.cc",
     ],
 }
 
@@ -18877,6 +18877,22 @@ filegroup {
     name: "perfetto_src_trace_processor_perfetto_sql_engine_unittests",
     srcs: [
         "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection_unittest.cc",
+    ],
+}
+
+// GN: //src/trace_processor/perfetto_sql/exec:exec
+filegroup {
+    name: "perfetto_src_trace_processor_perfetto_sql_exec_exec",
+    srcs: [
+        "src/trace_processor/perfetto_sql/exec/sql_scan.cc",
+    ],
+}
+
+// GN: //src/trace_processor/perfetto_sql/exec:unittests
+filegroup {
+    name: "perfetto_src_trace_processor_perfetto_sql_exec_unittests",
+    srcs: [
+        "src/trace_processor/perfetto_sql/exec/sql_scan_unittest.cc",
     ],
 }
 
@@ -24237,6 +24253,8 @@ cc_test {
         ":perfetto_src_trace_processor_metrics_unittests",
         ":perfetto_src_trace_processor_perfetto_sql_engine_engine",
         ":perfetto_src_trace_processor_perfetto_sql_engine_unittests",
+        ":perfetto_src_trace_processor_perfetto_sql_exec_exec",
+        ":perfetto_src_trace_processor_perfetto_sql_exec_unittests",
         ":perfetto_src_trace_processor_perfetto_sql_generator_generator",
         ":perfetto_src_trace_processor_perfetto_sql_generator_unittests",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",

--- a/BUILD
+++ b/BUILD
@@ -1438,6 +1438,7 @@ perfetto_filegroup(
         "include/perfetto/ext/base/thread_checker.h",
         "include/perfetto/ext/base/thread_task_runner.h",
         "include/perfetto/ext/base/thread_utils.h",
+        "include/perfetto/ext/base/type_set.h",
         "include/perfetto/ext/base/unix_socket.h",
         "include/perfetto/ext/base/unix_task_runner.h",
         "include/perfetto/ext/base/utils.h",
@@ -2585,7 +2586,6 @@ perfetto_filegroup(
         "src/trace_processor/core/util/slab.h",
         "src/trace_processor/core/util/sort.h",
         "src/trace_processor/core/util/span.h",
-        "src/trace_processor/core/util/type_set.h",
     ],
 )
 

--- a/include/perfetto/ext/base/BUILD.gn
+++ b/include/perfetto/ext/base/BUILD.gn
@@ -67,6 +67,7 @@ source_set("base") {
     "thread_checker.h",
     "thread_task_runner.h",
     "thread_utils.h",
+    "type_set.h",
     "unix_task_runner.h",
     "utils.h",
     "uuid.h",

--- a/include/perfetto/ext/base/type_set.h
+++ b/include/perfetto/ext/base/type_set.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_TRACE_PROCESSOR_CORE_UTIL_TYPE_SET_H_
-#define SRC_TRACE_PROCESSOR_CORE_UTIL_TYPE_SET_H_
+#ifndef INCLUDE_PERFETTO_EXT_BASE_TYPE_SET_H_
+#define INCLUDE_PERFETTO_EXT_BASE_TYPE_SET_H_
 
 #include <array>
 #include <cstddef>
@@ -28,7 +28,7 @@
 
 #include "perfetto/base/logging.h"
 
-namespace perfetto::trace_processor::core {
+namespace perfetto::base {
 
 // TypeSet: memory-efficient type hierarchy system with explicit ownership.
 //
@@ -112,6 +112,17 @@ class TypeSet {
   template <typename OtherTypeSet>
   OtherTypeSet Upcast() const {
     return UpcastImpl(static_cast<OtherTypeSet*>(nullptr));
+  }
+
+  // Converts to a TypeSet whose types correspond one to one, by position, to
+  // this one's. The caller is responsible for that correspondence: nothing
+  // here can check that the types at each index mean the same thing, so pin
+  // the pairing with static_asserts at the call site.
+  template <typename OtherTypeSet>
+  OtherTypeSet MapByIndex() const {
+    static_assert(OtherTypeSet::kSize == kSize,
+                  "Both TypeSets must have the same number of types");
+    return OtherTypeSet(type_idx_);
   }
 
   // Attempts to convert to a more specific TypeSet.
@@ -231,6 +242,6 @@ class TypeSet {
   uint32_t type_idx_;
 };
 
-}  // namespace perfetto::trace_processor::core
+}  // namespace perfetto::base
 
-#endif  // SRC_TRACE_PROCESSOR_CORE_UTIL_TYPE_SET_H_
+#endif  // INCLUDE_PERFETTO_EXT_BASE_TYPE_SET_H_

--- a/src/base/BUILD.gn
+++ b/src/base/BUILD.gn
@@ -260,6 +260,7 @@ perfetto_unittest_source_set("unittests") {
     "temp_file_unittest.cc",
     "thread_checker_unittest.cc",
     "time_unittest.cc",
+    "type_set_unittest.cc",
     "utils_unittest.cc",
     "uuid_unittest.cc",
     "weak_ptr_unittest.cc",

--- a/src/base/type_set_unittest.cc
+++ b/src/base/type_set_unittest.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "src/trace_processor/core/util/type_set.h"
+#include "perfetto/ext/base/type_set.h"
 
 #include <string>
 #include <type_traits>
@@ -23,7 +23,7 @@
 
 #include "test/gtest_and_gmock.h"
 
-namespace perfetto::trace_processor::core::dataframe {
+namespace perfetto::base {
 namespace {
 
 // Basic type tags for testing
@@ -64,6 +64,15 @@ TEST(TypeSet, Index) {
   // Check that index values are preserved for same types in different sets
   TypeSet<C, B, A> c_first(A{});
   EXPECT_EQ(c_first.index(), 2u);
+}
+
+TEST(TypeSet, MapByIndex) {
+  // Maps to the type at the same position, not the same type.
+  using ABC = TypeSet<A, B, C>;
+  using DEC = TypeSet<D, E, C>;
+  EXPECT_TRUE(ABC(A{}).MapByIndex<DEC>().Is<D>());
+  EXPECT_TRUE(ABC(B{}).MapByIndex<DEC>().Is<E>());
+  EXPECT_TRUE(ABC(C{}).MapByIndex<DEC>().Is<C>());
 }
 
 TEST(TypeSet, IsMethod) {
@@ -269,4 +278,4 @@ TEST(TypeSet, ComplexHierarchy) {
 }
 
 }  // namespace
-}  // namespace perfetto::trace_processor::core::dataframe
+}  // namespace perfetto::base

--- a/src/perfetto_sql/analysis/relation.cc
+++ b/src/perfetto_sql/analysis/relation.cc
@@ -439,8 +439,9 @@ base::StatusOr<std::vector<ColumnLineage>> RelationAnalyzer::Impl::Relation(
   if (std::optional<LeafRelation> relation = catalog_.FindLeafRelation(name)) {
     std::vector<ColumnLineage> out;
     out.reserve(relation->columns.size());
-    for (std::string_view column : relation->columns) {
-      out.push_back({column, {{relation->name, column}}});
+    for (const LeafColumn& column : relation->columns) {
+      out.push_back(
+          {column.name, {{relation->name, column.name, column.type}}});
     }
     return out;
   }
@@ -513,6 +514,17 @@ base::StatusOr<std::vector<ColumnLineage>> RelationAnalyzer::Impl::Relation(
 }
 
 Catalog::~Catalog() = default;
+
+std::optional<ColumnType> ColumnLineage::type() const {
+  std::optional<ColumnType> result;
+  for (const ColumnOrigin& origin : origins) {
+    if (!origin.type || (result && !(*result == *origin.type))) {
+      return std::nullopt;
+    }
+    result = origin.type;
+  }
+  return result;
+}
 
 RelationLineage::RelationLineage(std::unique_ptr<Storage> storage)
     : storage_(std::move(storage)) {}

--- a/src/perfetto_sql/analysis/relation.h
+++ b/src/perfetto_sql/analysis/relation.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/base/type_set.h"
 
 struct SyntaqliteParser;
 
@@ -36,10 +37,26 @@ struct SqlNode {
   uint32_t id;
 };
 
+// How a leaf relation column is stored, as declared by the catalog. Mirrors
+// the storage vocabulary of the engine behind the catalog without depending
+// on it.
+struct Id {};
+struct Uint32 {};
+struct Int32 {};
+struct Int64 {};
+struct Double {};
+struct String {};
+using ColumnType = base::TypeSet<Id, Uint32, Int32, Int64, Double, String>;
+
 // A leaf relation whose columns can be used as lineage origins.
+struct LeafColumn {
+  std::string_view name;
+  // Nothing when the catalog does not know how the column is stored.
+  std::optional<ColumnType> type;
+};
 struct LeafRelation {
   std::string_view name;
-  std::vector<std::string_view> columns;
+  std::vector<LeafColumn> columns;
 };
 
 // Supplies the schema objects referenced by parsed queries. Returned leaf
@@ -57,7 +74,10 @@ class Catalog {
 struct ColumnOrigin {
   std::string_view relation_name;
   std::string_view column_name;
+  std::optional<ColumnType> type;
 
+  // Two origins naming the same column always store it the same way, so the
+  // type does not participate.
   bool operator==(const ColumnOrigin& other) const {
     return relation_name == other.relation_name &&
            column_name == other.column_name;
@@ -69,6 +89,10 @@ struct ColumnLineage {
   // Empty when the expression cannot be traced to a known leaf column. USING
   // columns and compound queries can have more than one origin.
   std::vector<ColumnOrigin> origins;
+
+  // The type every origin agrees on, or nothing when the column has no
+  // origins, an origin is untyped, or the origins disagree.
+  std::optional<ColumnType> type() const;
 };
 
 // The lineage of a query result considered as a relation. All strings are

--- a/src/perfetto_sql/analysis/relation_unittest.cc
+++ b/src/perfetto_sql/analysis/relation_unittest.cc
@@ -61,7 +61,7 @@ class TestCatalog : public Catalog {
     result.name = name;
     result.columns.reserve(leaf->columns.size());
     for (const std::string& column : leaf->columns) {
-      result.columns.push_back(column);
+      result.columns.push_back({column, std::nullopt});
     }
     return result;
   }

--- a/src/perfetto_sql/syntaqlite/BUILD.gn
+++ b/src/perfetto_sql/syntaqlite/BUILD.gn
@@ -36,6 +36,7 @@ source_set("syntaqlite") {
   assert_no_deps = [ "../../trace_processor/*" ]
   visibility = [
     "..:intrinsic_macro_expansion",
+    "../../trace_processor/perfetto_sql/exec:*",
     "../../trace_processor/perfetto_sql/lineage:*",
     "../../trace_processor/perfetto_sql/parser:*",
     "../../trace_processor/perfetto_sql/tokenizer",

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -471,6 +471,7 @@ perfetto_unittest_source_set("unittests") {
     deps += [
       "../perfetto_sql/analysis:unittests",
       "perfetto_sql/engine:unittests",
+      "perfetto_sql/exec:unittests",
       "perfetto_sql/lineage:unittests",
       "perfetto_sql/parser:unittests",
       "perfetto_sql/tokenizer:unittests",

--- a/src/trace_processor/core/common/duplicate_types.h
+++ b/src/trace_processor/core/common/duplicate_types.h
@@ -17,7 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_COMMON_DUPLICATE_TYPES_H_
 #define SRC_TRACE_PROCESSOR_CORE_COMMON_DUPLICATE_TYPES_H_
 
-#include "src/trace_processor/core/util/type_set.h"
+#include "perfetto/ext/base/type_set.h"
 
 namespace perfetto::trace_processor::core {
 
@@ -29,7 +29,7 @@ struct NoDuplicates {};
 struct HasDuplicates {};
 
 // TypeSet of all possible column duplicate states.
-using DuplicateState = core::TypeSet<NoDuplicates, HasDuplicates>;
+using DuplicateState = base::TypeSet<NoDuplicates, HasDuplicates>;
 
 }  // namespace perfetto::trace_processor::core
 

--- a/src/trace_processor/core/common/null_types.h
+++ b/src/trace_processor/core/common/null_types.h
@@ -17,7 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_COMMON_NULL_TYPES_H_
 #define SRC_TRACE_PROCESSOR_CORE_COMMON_NULL_TYPES_H_
 
-#include "src/trace_processor/core/util/type_set.h"
+#include "perfetto/ext/base/type_set.h"
 
 namespace perfetto::trace_processor::core {
 
@@ -43,7 +43,7 @@ struct SparseNullWithPopcountUntilFinalization {};
 struct DenseNull {};
 
 // TypeSet of all possible column nullability states.
-using Nullability = core::TypeSet<NonNull,
+using Nullability = base::TypeSet<NonNull,
                                   SparseNull,
                                   SparseNullWithPopcountAlways,
                                   SparseNullWithPopcountUntilFinalization,

--- a/src/trace_processor/core/common/op_types.h
+++ b/src/trace_processor/core/common/op_types.h
@@ -17,7 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_COMMON_OP_TYPES_H_
 #define SRC_TRACE_PROCESSOR_CORE_COMMON_OP_TYPES_H_
 
-#include "src/trace_processor/core/util/type_set.h"
+#include "perfetto/ext/base/type_set.h"
 
 namespace perfetto::trace_processor::core {
 
@@ -56,31 +56,31 @@ struct In {};
 
 // TypeSet of all possible operations for filter conditions.
 using Op =
-    core::TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex, IsNotNull, IsNull, In>;
+    base::TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex, IsNotNull, IsNull, In>;
 
 // Subsets of Op describing which operations a given kind of value or access
 // path supports. Used to pick how a filter is evaluated.
 
 // Set of operations applicable to non-null values.
-using NonNullOp = core::TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex>;
+using NonNullOp = base::TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex>;
 
 // Set of operations applicable to non-string values.
-using NonStringOp = core::TypeSet<Eq, Ne, Lt, Le, Gt, Ge>;
+using NonStringOp = base::TypeSet<Eq, Ne, Lt, Le, Gt, Ge>;
 
 // Set of operations applicable to string values.
-using StringOp = core::TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex>;
+using StringOp = base::TypeSet<Eq, Ne, Lt, Le, Gt, Ge, Glob, Regex>;
 
 // Set of operations applicable to only string values.
-using OnlyStringOp = core::TypeSet<Glob, Regex>;
+using OnlyStringOp = base::TypeSet<Glob, Regex>;
 
 // Set of operations applicable to ranges.
-using RangeOp = core::TypeSet<Eq, Lt, Le, Gt, Ge>;
+using RangeOp = base::TypeSet<Eq, Lt, Le, Gt, Ge>;
 
 // Set of inequality operations (Lt, Le, Gt, Ge).
-using InequalityOp = core::TypeSet<Lt, Le, Gt, Ge>;
+using InequalityOp = base::TypeSet<Lt, Le, Gt, Ge>;
 
 // Set of null operations (IsNotNull, IsNull).
-using NullOp = core::TypeSet<IsNotNull, IsNull>;
+using NullOp = base::TypeSet<IsNotNull, IsNull>;
 
 }  // namespace perfetto::trace_processor::core
 

--- a/src/trace_processor/core/common/sort_types.h
+++ b/src/trace_processor/core/common/sort_types.h
@@ -19,7 +19,7 @@
 
 #include <cstdint>
 
-#include "src/trace_processor/core/util/type_set.h"
+#include "perfetto/ext/base/type_set.h"
 
 namespace perfetto::trace_processor::core {
 
@@ -46,7 +46,7 @@ struct Sorted {};
 struct Unsorted {};
 
 // TypeSet of all possible column sort states.
-using SortState = core::TypeSet<IdSorted, SetIdSorted, Sorted, Unsorted>;
+using SortState = base::TypeSet<IdSorted, SetIdSorted, Sorted, Unsorted>;
 
 // Defines the direction for sorting.
 enum class SortDirection : uint32_t {

--- a/src/trace_processor/core/common/storage_types.h
+++ b/src/trace_processor/core/common/storage_types.h
@@ -19,8 +19,8 @@
 
 #include <cstdint>
 
+#include "perfetto/ext/base/type_set.h"
 #include "src/trace_processor/containers/string_pool.h"
-#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::core {
 
@@ -64,20 +64,20 @@ struct Null {
 };
 
 // TypeSet of all possible storage value types.
-using StorageType = core::TypeSet<Id, Uint32, Int32, Int64, Double, String>;
+using StorageType = base::TypeSet<Id, Uint32, Int32, Int64, Double, String>;
 
 // Subsets of StorageType grouping the value types which share a filtering or
 // storage strategy.
 
 // Set of content types that aren't string-based.
-using NonStringType = core::TypeSet<Id, Uint32, Int32, Int64, Double>;
+using NonStringType = base::TypeSet<Id, Uint32, Int32, Int64, Double>;
 
 // Set of content types that are numeric in nature.
-using IntegerOrDoubleType = core::TypeSet<Uint32, Int32, Int64, Double>;
+using IntegerOrDoubleType = base::TypeSet<Uint32, Int32, Int64, Double>;
 
 // Set of content types which are backed by real storage, i.e. everything
 // except Id, whose value is the row index itself.
-using NonIdStorageType = core::TypeSet<Uint32, Int32, Int64, Double, String>;
+using NonIdStorageType = base::TypeSet<Uint32, Int32, Int64, Double, String>;
 
 // Maps a C++ type to its corresponding storage type tag.
 // E.g., TypeTagFor<int64_t>::type = Int64

--- a/src/trace_processor/core/dataframe/bytecode_lowering.cc
+++ b/src/trace_processor/core/dataframe/bytecode_lowering.cc
@@ -27,6 +27,7 @@
 
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/small_vector.h"
+#include "perfetto/ext/base/type_set.h"
 #include "perfetto/ext/base/variant.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/core/common/storage_types.h"
@@ -43,7 +44,6 @@
 #include "src/trace_processor/core/util/range.h"
 #include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
-#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::core::dataframe {
 
@@ -64,9 +64,9 @@ enum RegType : uint32_t {
 };
 
 // TypeSet of all possible sparse nullability states.
-using SparseNullTypes = TypeSet<SparseNull,
-                                SparseNullWithPopcountAlways,
-                                SparseNullWithPopcountUntilFinalization>;
+using SparseNullTypes = base::TypeSet<SparseNull,
+                                      SparseNullWithPopcountAlways,
+                                      SparseNullWithPopcountUntilFinalization>;
 
 // Gets the appropriate bound modifier and range operation type
 // for a given range operation.

--- a/src/trace_processor/core/dataframe/query_plan.h
+++ b/src/trace_processor/core/dataframe/query_plan.h
@@ -32,6 +32,7 @@
 #include "perfetto/ext/base/base64.h"
 #include "perfetto/ext/base/small_vector.h"
 #include "perfetto/ext/base/string_view.h"
+#include "perfetto/ext/base/type_set.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/core/dataframe/dataframe_register_cache.h"
 #include "src/trace_processor/core/dataframe/specs.h"
@@ -44,7 +45,6 @@
 #include "src/trace_processor/core/util/range.h"
 #include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
-#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::core::dataframe {
 
@@ -59,16 +59,16 @@ struct RegisterInit {
   struct SmallValueEqBitvector {};
   struct SmallValueEqPopcount {};
 
-  using Type = TypeSet<Id,
-                       Uint32,
-                       Int32,
-                       Int64,
-                       Double,
-                       String,
-                       NullBitvector,
-                       IndexVector,
-                       SmallValueEqBitvector,
-                       SmallValueEqPopcount>;
+  using Type = base::TypeSet<Id,
+                             Uint32,
+                             Int32,
+                             Int64,
+                             Double,
+                             String,
+                             NullBitvector,
+                             IndexVector,
+                             SmallValueEqBitvector,
+                             SmallValueEqPopcount>;
   uint32_t dest_register = 0;
   Type kind{Id{}};
   uint16_t source_index = 0;  // col_index or index_id depending on kind

--- a/src/trace_processor/core/dataframe/specs.h
+++ b/src/trace_processor/core/dataframe/specs.h
@@ -11,6 +11,7 @@
 #include <variant>
 #include <vector>
 
+#include "perfetto/ext/base/type_set.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/common/duplicate_types.h"
 #include "src/trace_processor/core/common/null_types.h"
@@ -18,7 +19,6 @@
 #include "src/trace_processor/core/common/sort_types.h"
 #include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/core/common/value_fetcher.h"
-#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::core::dataframe {
 

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -16,6 +16,7 @@ import("../../../../gn/test.gni")
 
 source_set("exec") {
   sources = [
+    "column_chunk.h",
     "column_view.cc",
     "column_view.h",
     "dataframe_scan.cc",

--- a/src/trace_processor/core/exec/column_chunk.h
+++ b/src/trace_processor/core/exec/column_chunk.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_CHUNK_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_CHUNK_H_
+
+#include <cstdint>
+#include <variant>
+
+#include "perfetto/ext/base/variant.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// kMaxBatchRows rows of one column: the buffer matching the column's type,
+// plus which of its rows hold a value.
+struct ColumnChunk {
+  std::variant<FlexVector<uint32_t>,
+               FlexVector<int32_t>,
+               FlexVector<int64_t>,
+               FlexVector<double>,
+               FlexVector<StringPool::Id>,
+               FlexVector<Variant>>
+      values{FlexVector<uint32_t>()};
+  BitVector validity;
+
+  // The chunk's values, made to hold kMaxBatchRows of T the first time they
+  // are used.
+  template <typename T>
+  FlexVector<T>& Values() {
+    // The default alternative is an empty vector, so holding the right type
+    // is not enough to have room in it.
+    if (!std::holds_alternative<FlexVector<T>>(values) ||
+        base::unchecked_get<FlexVector<T>>(values).size() < kMaxBatchRows) {
+      values = FlexVector<T>::CreateWithSize(kMaxBatchRows);
+    }
+    return base::unchecked_get<FlexVector<T>>(values);
+  }
+
+  // The chunk's values, which must already hold T.
+  template <typename T>
+  const FlexVector<T>& Values() const {
+    return base::unchecked_get<FlexVector<T>>(values);
+  }
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_CHUNK_H_

--- a/src/trace_processor/core/exec/row_store.cc
+++ b/src/trace_processor/core/exec/row_store.cc
@@ -29,6 +29,7 @@
 #include "perfetto/ext/base/status_macros.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_chunk.h"
 #include "src/trace_processor/core/exec/column_view.h"
 #include "src/trace_processor/core/exec/row_batch.h"
 #include "src/trace_processor/core/exec/row_selection.h"
@@ -38,44 +39,18 @@
 #include "src/trace_processor/core/util/span.h"
 
 namespace perfetto::trace_processor::core::exec {
-
-// kChunkRows rows of one column.
-struct RowStore::Chunk {
-  std::variant<FlexVector<uint32_t>,
-               FlexVector<int32_t>,
-               FlexVector<int64_t>,
-               FlexVector<double>,
-               FlexVector<StringPool::Id>,
-               FlexVector<Variant>>
-      values{FlexVector<uint32_t>()};
-  BitVector validity;
-};
-
 namespace {
 
-using Chunk = RowStore::Chunk;
 constexpr uint32_t kChunkRows = RowStore::kChunkRows;
 
-// The chunk's values, made to hold kChunkRows of T the first time it is used.
-template <typename T, typename V>
-FlexVector<T>& Values(V& values) {
-  // The default alternative is an empty vector, so holding the right type is
-  // not enough to have room in it.
-  if (!std::holds_alternative<FlexVector<T>>(values) ||
-      std::get<FlexVector<T>>(values).size() < kChunkRows) {
-    values = FlexVector<T>::CreateWithSize(kChunkRows);
-  }
-  return std::get<FlexVector<T>>(values);
-}
-
 // Copies `count` of `column`'s rows, starting at its row `from`, to `at`.
-template <typename T, typename V>
+template <typename T>
 void Copy(const ColumnView& column,
           uint32_t from,
           uint32_t at,
           uint32_t count,
-          V& values) {
-  T* dest = Values<T>(values).data() + at;
+          ColumnChunk& chunk) {
+  T* dest = chunk.Values<T>().data() + at;
   const auto* data = static_cast<const T*>(column.data());
   RowSelection selection = column.selection();
   if (selection.is_range()) {
@@ -89,13 +64,12 @@ void Copy(const ColumnView& column,
 }
 
 // An Id column has no storage: its value is the row it sits at.
-template <typename V>
 void CopyIds(const ColumnView& column,
              uint32_t from,
              uint32_t at,
              uint32_t count,
-             V& values) {
-  uint32_t* dest = Values<uint32_t>(values).data() + at;
+             ColumnChunk& chunk) {
+  uint32_t* dest = chunk.Values<uint32_t>().data() + at;
   RowSelection selection = column.selection();
   if (selection.is_range()) {
     uint32_t offset = selection.offset() + from;
@@ -139,21 +113,21 @@ void CopyValidity(const ColumnView& column,
 // Picks the rows `rows` names out of `chunks`, laying them out from zero. A
 // gather cannot be a view because the rows come from more than one chunk.
 template <typename T>
-void Gather(const std::vector<std::unique_ptr<Chunk>>& chunks,
+void Gather(const std::vector<std::unique_ptr<ColumnChunk>>& chunks,
             Span<const uint32_t> rows,
-            Chunk& into) {
-  T* dest = Values<T>(into.values).data();
+            ColumnChunk& into) {
+  T* dest = into.Values<T>().data();
   for (uint32_t i = 0; i < rows.size(); ++i) {
-    const Chunk& chunk = *chunks[rows[i] / kChunkRows];
-    dest[i] = std::get<FlexVector<T>>(chunk.values)[rows[i] % kChunkRows];
+    const ColumnChunk& chunk = *chunks[rows[i] / kChunkRows];
+    dest[i] = chunk.Values<T>()[rows[i] % kChunkRows];
   }
 }
 
-void GatherValidity(const std::vector<std::unique_ptr<Chunk>>& chunks,
+void GatherValidity(const std::vector<std::unique_ptr<ColumnChunk>>& chunks,
                     Span<const uint32_t> rows,
-                    Chunk& into) {
+                    ColumnChunk& into) {
   for (uint32_t i = 0; i < rows.size(); ++i) {
-    const Chunk& chunk = *chunks[rows[i] / kChunkRows];
+    const ColumnChunk& chunk = *chunks[rows[i] / kChunkRows];
     if (chunk.validity.is_set(rows[i] % kChunkRows)) {
       into.validity.set(i);
     }
@@ -165,12 +139,12 @@ void GatherValidity(const std::vector<std::unique_ptr<Chunk>>& chunks,
 RowStore::RowStore() = default;
 RowStore::~RowStore() = default;
 
-RowStore::Chunk& RowStore::ChunkAt(Column& column, uint32_t index) const {
+ColumnChunk& RowStore::ChunkAt(Column& column, uint32_t index) const {
   if (column.chunks.size() <= index) {
     column.chunks.resize(index + 1);
   }
   if (!column.chunks[index]) {
-    column.chunks[index] = std::make_unique<Chunk>();
+    column.chunks[index] = std::make_unique<ColumnChunk>();
   }
   return *column.chunks[index];
 }
@@ -225,21 +199,21 @@ void RowStore::AppendColumn(Column& into,
     uint32_t index = row / kChunkRows;
     uint32_t at = row % kChunkRows;
     uint32_t run = std::min(count - done, kChunkRows - at);
-    Chunk& chunk = ChunkAt(into, index);
+    ColumnChunk& chunk = ChunkAt(into, index);
     if (variant) {
-      Copy<Variant>(from, done, at, run, chunk.values);
+      Copy<Variant>(from, done, at, run, chunk);
     } else if (from.type().Is<Id>()) {
-      CopyIds(from, done, at, run, chunk.values);
+      CopyIds(from, done, at, run, chunk);
     } else if (type.Is<Uint32>()) {
-      Copy<uint32_t>(from, done, at, run, chunk.values);
+      Copy<uint32_t>(from, done, at, run, chunk);
     } else if (type.Is<Int32>()) {
-      Copy<int32_t>(from, done, at, run, chunk.values);
+      Copy<int32_t>(from, done, at, run, chunk);
     } else if (type.Is<Int64>()) {
-      Copy<int64_t>(from, done, at, run, chunk.values);
+      Copy<int64_t>(from, done, at, run, chunk);
     } else if (type.Is<Double>()) {
-      Copy<double>(from, done, at, run, chunk.values);
+      Copy<double>(from, done, at, run, chunk);
     } else {
-      Copy<StringPool::Id>(from, done, at, run, chunk.values);
+      Copy<StringPool::Id>(from, done, at, run, chunk);
     }
     if (nullable) {
       if (chunk.validity.size() == 0) {
@@ -273,22 +247,22 @@ base::Status RowStore::Append(const RowBatch& batch) {
   return base::OkStatus();
 }
 
-ColumnView RowStore::ViewOf(const Column& column, const Chunk& chunk) const {
+ColumnView RowStore::ViewOf(const Column& column,
+                            const ColumnChunk& chunk) const {
   if (column.variant) {
-    return ColumnView::Variants(
-        std::get<FlexVector<Variant>>(chunk.values).data());
+    return ColumnView::Variants(chunk.Values<Variant>().data());
   }
   const void* data = nullptr;
   if (column.type.Is<Uint32>()) {
-    data = std::get<FlexVector<uint32_t>>(chunk.values).data();
+    data = chunk.Values<uint32_t>().data();
   } else if (column.type.Is<Int32>()) {
-    data = std::get<FlexVector<int32_t>>(chunk.values).data();
+    data = chunk.Values<int32_t>().data();
   } else if (column.type.Is<Int64>()) {
-    data = std::get<FlexVector<int64_t>>(chunk.values).data();
+    data = chunk.Values<int64_t>().data();
   } else if (column.type.Is<Double>()) {
-    data = std::get<FlexVector<double>>(chunk.values).data();
+    data = chunk.Values<double>().data();
   } else {
-    data = std::get<FlexVector<StringPool::Id>>(chunk.values).data();
+    data = chunk.Values<StringPool::Id>().data();
   }
   return ColumnView::Reference(column.type, data,
                                column.nullable ? &chunk.validity : nullptr);
@@ -319,9 +293,9 @@ void RowStore::View(RowBatch* batch, Span<const uint32_t> rows) {
   batch->Reset();
   for (Column& column : columns_) {
     if (!column.gathered) {
-      column.gathered = std::make_unique<Chunk>();
+      column.gathered = std::make_unique<ColumnChunk>();
     }
-    Chunk& into = *column.gathered;
+    ColumnChunk& into = *column.gathered;
     if (column.variant) {
       Gather<Variant>(column.chunks, rows, into);
     } else if (column.type.Is<Uint32>()) {
@@ -354,7 +328,7 @@ void RowStore::Clear() {
   size_ = 0;
   for (Column& column : columns_) {
     column.nullable = false;
-    for (const std::unique_ptr<Chunk>& chunk : column.chunks) {
+    for (const std::unique_ptr<ColumnChunk>& chunk : column.chunks) {
       if (chunk) {
         chunk->validity.clear();
       }

--- a/src/trace_processor/core/exec/row_store.h
+++ b/src/trace_processor/core/exec/row_store.h
@@ -23,6 +23,7 @@
 
 #include "perfetto/base/status.h"
 #include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_chunk.h"
 #include "src/trace_processor/core/exec/column_view.h"
 #include "src/trace_processor/core/exec/row_batch.h"
 #include "src/trace_processor/core/exec/row_selection.h"
@@ -73,24 +74,20 @@ class RowStore {
   // Drops all the rows but keeps the allocated chunks.
   void Clear();
 
-  // kChunkRows rows of one column. Defined in the .cc and opaque here: it is
-  // public only so file-local helpers there can name it.
-  struct Chunk;
-
  private:
   struct Column {
     StorageType type{Uint32{}};
     bool variant = false;
     bool nullable = false;
-    std::vector<std::unique_ptr<Chunk>> chunks;
+    std::vector<std::unique_ptr<ColumnChunk>> chunks;
     // Where a gathered view puts the values it picks out.
-    std::unique_ptr<Chunk> gathered;
+    std::unique_ptr<ColumnChunk> gathered;
   };
 
   base::Status ValidateColumn(const Column&, const ColumnView&) const;
   void AppendColumn(Column&, const ColumnView&, uint32_t count);
-  ColumnView ViewOf(const Column&, const Chunk&) const;
-  Chunk& ChunkAt(Column&, uint32_t index) const;
+  ColumnView ViewOf(const Column&, const ColumnChunk&) const;
+  ColumnChunk& ChunkAt(Column&, uint32_t index) const;
 
   std::vector<Column> columns_;
   bool initialized_ = false;

--- a/src/trace_processor/core/interpreter/interpreter_types.h
+++ b/src/trace_processor/core/interpreter/interpreter_types.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/type_set.h"
 #include "perfetto/ext/base/variant.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/common/null_types.h"
@@ -32,7 +33,6 @@
 #include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/flex_vector.h"
 #include "src/trace_processor/core/util/slab.h"
-#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::core::interpreter {
 
@@ -46,7 +46,7 @@ struct BeginBound {};
 struct EndBound {};
 
 // Which bounds should be modified by a range operation.
-using BoundModifier = TypeSet<BothBounds, BeginBound, EndBound>;
+using BoundModifier = base::TypeSet<BothBounds, BeginBound, EndBound>;
 
 // Represents a filter operation where we are performing an equality operation
 // on a sorted column.
@@ -62,7 +62,7 @@ struct UpperBound {};
 
 // Set of operations that can be applied to a sorted column.
 using EqualRangeLowerBoundUpperBound =
-    TypeSet<EqualRange, LowerBound, UpperBound>;
+    base::TypeSet<EqualRange, LowerBound, UpperBound>;
 
 // Type tag indicating nulls should be placed at the start during
 // partitioning/sorting.
@@ -73,7 +73,7 @@ struct NullsAtStart {};
 struct NullsAtEnd {};
 
 // TypeSet defining the possible placement locations for nulls.
-using NullsLocation = TypeSet<NullsAtStart, NullsAtEnd>;
+using NullsLocation = base::TypeSet<NullsAtStart, NullsAtEnd>;
 
 // Type tag for finding the minimum value.
 struct MinOp {};
@@ -82,11 +82,12 @@ struct MinOp {};
 struct MaxOp {};
 
 // TypeSet combining Min and Max operations.
-using MinMaxOp = TypeSet<MinOp, MaxOp>;
+using MinMaxOp = base::TypeSet<MinOp, MaxOp>;
 
 // TypeSet which collapses all of the sparse nullability types into a single
 // type.
-using SparseNullCollapsedNullability = TypeSet<NonNull, SparseNull, DenseNull>;
+using SparseNullCollapsedNullability =
+    base::TypeSet<NonNull, SparseNull, DenseNull>;
 
 // Handle for referring to a filter value during query execution.
 struct FilterValueHandle {

--- a/src/trace_processor/core/plugin/plugin.h
+++ b/src/trace_processor/core/plugin/plugin.h
@@ -23,8 +23,8 @@
 #include <utility>
 #include <vector>
 
+#include "perfetto/ext/base/type_set.h"
 #include "src/trace_processor/core/plugin/registration.h"
-#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor {
 
@@ -125,7 +125,7 @@ class Plugin : public PluginBase {
   template <typename T>
   T* dependency() {
     return static_cast<T*>(
-        resolved_deps_[core::TypeSet<Deps...>::template GetTypeIndex<T>()]);
+        resolved_deps_[base::TypeSet<Deps...>::template GetTypeIndex<T>()]);
   }
 };
 

--- a/src/trace_processor/core/tree/tree.h
+++ b/src/trace_processor/core/tree/tree.h
@@ -98,7 +98,7 @@ struct Tree {
   struct Column {
     // Null-typed columns have no payload at all; their null_bv marks every
     // row as null and their data is never read.
-    using Type = TypeSet<Int64, Double, String, Null>;
+    using Type = base::TypeSet<Int64, Double, String, Null>;
 
     // Creates a null-typed column of |rows| rows: no payload, every row null.
     static Column CreateNull(uint32_t rows) {

--- a/src/trace_processor/core/util/BUILD.gn
+++ b/src/trace_processor/core/util/BUILD.gn
@@ -24,7 +24,6 @@ source_set("util") {
     "slab.h",
     "sort.h",
     "span.h",
-    "type_set.h",
   ]
   deps = [
     "../../../../gn:default_deps",
@@ -43,7 +42,6 @@ perfetto_unittest_source_set("unittests") {
     "slab_unittest.cc",
     "sort_unittest.cc",
     "span_unittest.cc",
-    "type_set_unittest.cc",
   ]
   deps = [
     ":util",

--- a/src/trace_processor/perfetto_sql/exec/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/exec/BUILD.gn
@@ -14,37 +14,41 @@
 
 import("../../../../gn/test.gni")
 
-source_set("connection_catalog") {
+source_set("exec") {
   sources = [
-    "connection_catalog.cc",
-    "connection_catalog.h",
-    "type_mapping.h",
+    "sql_scan.cc",
+    "sql_scan.h",
   ]
   deps = [
     "../../../../gn:default_deps",
     "../../../../gn:sqlite",
     "../../../base",
     "../../../perfetto_sql/analysis",
+    "../../../perfetto_sql/syntaqlite",
+    "../../containers",
     "../../core/common",
-    "../../core/dataframe",
+    "../../core/exec",
+    "../../core/util",
     "../../sqlite",
-    "../engine",
+    "../lineage:connection_catalog",
   ]
 }
 
 perfetto_unittest_source_set("unittests") {
   testonly = true
-  sources = [ "connection_catalog_unittest.cc" ]
+  sources = [ "sql_scan_unittest.cc" ]
   deps = [
-    ":connection_catalog",
+    ":exec",
     "../../../../gn:default_deps",
     "../../../../gn:gtest_and_gmock",
     "../../../base",
     "../../../perfetto_sql/analysis",
-    "../../../perfetto_sql/syntaqlite",
     "../../containers",
     "../../core/common",
+    "../../core/exec",
+    "../../core/exec:test_utils",
+    "../../core/util",
     "../../sqlite",
-    "../engine",
+    "../lineage:connection_catalog",
   ]
 }

--- a/src/trace_processor/perfetto_sql/exec/sql_scan.cc
+++ b/src/trace_processor/perfetto_sql/exec/sql_scan.cc
@@ -1,0 +1,350 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/perfetto_sql/exec/sql_scan.h"
+
+#include <sqlite3.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/perfetto_sql/analysis/relation.h"
+#include "src/perfetto_sql/syntaqlite/syntaqlite_perfetto.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_chunk.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/perfetto_sql/lineage/type_mapping.h"
+#include "src/trace_processor/sqlite/sql_source.h"
+#include "src/trace_processor/sqlite/sqlite_connection.h"
+
+namespace perfetto::trace_processor::exec {
+namespace {
+
+namespace analysis = ::perfetto::perfetto_sql::analysis;
+
+using core::Double;
+using core::Int64;
+using core::StorageType;
+using core::String;
+using core::exec::ColumnChunk;
+using core::exec::ColumnView;
+using core::exec::kMaxBatchRows;
+using core::exec::RowBatch;
+using core::exec::RowSelection;
+using core::exec::Variant;
+struct ParserDeleter {
+  void operator()(SyntaqliteParser* parser) const {
+    syntaqlite_parser_destroy(parser);
+  }
+};
+using ScopedParser = std::unique_ptr<SyntaqliteParser, ParserDeleter>;
+
+// The types lineage established, lined up with the query's columns. If the two
+// disagree on the number of columns they are not describing the same query, so
+// no type is claimed for any of them.
+std::vector<std::optional<StorageType>> ResolveTypes(
+    const SqlSource& sql,
+    uint32_t count,
+    const analysis::Catalog& catalog) {
+  std::vector<std::optional<StorageType>> types(count);
+  ScopedParser parser(syntaqlite_parser_create_perfetto(nullptr));
+  syntaqlite_parser_reset(parser.get(), sql.sql().data(),
+                          static_cast<uint32_t>(sql.sql().size()));
+  if (syntaqlite_parser_next(parser.get()) != SYNTAQLITE_PARSE_OK) {
+    return types;
+  }
+  analysis::RelationAnalyzer analyzer(catalog);
+  auto resolved = analyzer.AnalyzeQuery(
+      {parser.get(), syntaqlite_result_root(parser.get())});
+  if (!resolved.ok() || resolved->columns().size() != count) {
+    return types;
+  }
+  for (uint32_t i = 0; i < count; ++i) {
+    std::optional<analysis::ColumnType> type = resolved->columns()[i].type();
+    if (!type) {
+      continue;
+    }
+    StorageType storage = lineage::ToStorageType(*type);
+    // An Id has no storage of its own: its value is the row it sits at. A
+    // query result has no such rows to point at, so materialise it at the
+    // narrowest width which holds one.
+    if (storage.Is<core::Id>()) {
+      storage = StorageType{core::Uint32{}};
+    }
+    types[i] = storage;
+  }
+  return types;
+}
+
+}  // namespace
+
+base::StatusOr<std::unique_ptr<SqlScan>> SqlScan::Create(
+    SqliteConnection* connection,
+    SqlSource sql,
+    StringPool* pool,
+    const analysis::Catalog& catalog) {
+  // Prepared here only to read the column names, then discarded: a statement
+  // belongs to one execution, but the columns belong to the query.
+  SqliteConnection::PreparedStatement statement =
+      connection->PrepareStatement(sql);
+  RETURN_IF_ERROR(statement.status());
+
+  sqlite3_stmt* stmt = statement.sqlite_stmt();
+  auto count = static_cast<uint32_t>(sqlite3_column_count(stmt));
+  std::vector<std::string> names;
+  names.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    const char* name = sqlite3_column_name(stmt, static_cast<int>(i));
+    names.emplace_back(name ? name : "");
+  }
+  std::vector<std::optional<StorageType>> types =
+      ResolveTypes(sql, count, catalog);
+  return std::unique_ptr<SqlScan>(new SqlScan(
+      connection, std::move(sql), std::move(names), std::move(types), pool));
+}
+
+SqlScan::SqlScan(SqliteConnection* connection,
+                 SqlSource sql,
+                 std::vector<std::string> names,
+                 std::vector<std::optional<StorageType>> types,
+                 StringPool* pool)
+    : connection_(connection),
+      sql_(std::move(sql)),
+      names_(std::move(names)),
+      types_(std::move(types)),
+      pool_(pool) {}
+
+SqlScan::~SqlScan() = default;
+SqlScan::State::~State() = default;
+
+std::unique_ptr<core::exec::OperatorState> SqlScan::MakeState() const {
+  auto state = std::make_unique<State>();
+  Prepare(*state);
+  state->columns.reserve(names_.size());
+  state->data.reserve(names_.size());
+  for (uint32_t i = 0; i < names_.size(); ++i) {
+    auto column = std::make_shared<ColumnChunk>();
+    void* data = nullptr;
+    if (!types_[i]) {
+      data = column->Values<Variant>().data();
+    } else {
+      switch (types_[i]->index()) {
+        case StorageType::GetTypeIndex<core::Uint32>():
+          data = column->Values<uint32_t>().data();
+          break;
+        case StorageType::GetTypeIndex<core::Int32>():
+          data = column->Values<int32_t>().data();
+          break;
+        case StorageType::GetTypeIndex<Int64>():
+          data = column->Values<int64_t>().data();
+          break;
+        case StorageType::GetTypeIndex<Double>():
+          data = column->Values<double>().data();
+          break;
+        case StorageType::GetTypeIndex<String>():
+          data = column->Values<StringPool::Id>().data();
+          break;
+        default:
+          // An Id was already materialised as a Uint32 by ResolveTypes.
+          PERFETTO_FATAL("Unreachable");
+      }
+      column->validity = core::BitVector::CreateWithSize(kMaxBatchRows);
+    }
+    state->columns.push_back(std::move(column));
+    state->data.push_back(data);
+  }
+  return state;
+}
+
+void SqlScan::Prepare(State& state) const {
+  state.statement.emplace(connection_->PrepareStatement(sql_));
+  state.status = state.statement->status();
+  state.done = false;
+  if (!state.status.ok()) {
+    return;
+  }
+  sqlite3_stmt* stmt = state.statement->sqlite_stmt();
+  uint32_t count = static_cast<uint32_t>(sqlite3_column_count(stmt));
+  if (count != names_.size()) {
+    state.status =
+        base::ErrStatus("SQL source: result shape changed between executions");
+    return;
+  }
+  for (uint32_t i = 0; i < count; ++i) {
+    const char* name = sqlite3_column_name(stmt, static_cast<int>(i));
+    if (names_[i] != (name ? name : "")) {
+      state.status = base::ErrStatus(
+          "SQL source: result shape changed between executions");
+      return;
+    }
+  }
+}
+
+base::Status SqlScan::status(const core::exec::OperatorState& state) const {
+  return state.Cast<const State>().status;
+}
+
+void SqlScan::Rewind(core::exec::OperatorState& state) const {
+  Prepare(state.Cast<State>());
+}
+
+bool SqlScan::ReadValue(State& s,
+                        sqlite3_stmt* stmt,
+                        uint32_t index,
+                        uint32_t row) const {
+  auto col = static_cast<int>(index);
+  if (!types_[index]) {
+    auto* data = static_cast<Variant*>(s.data[index]);
+    switch (sqlite3_column_type(stmt, col)) {
+      case SQLITE_INTEGER:
+        data[row] = Variant::Int64(sqlite3_column_int64(stmt, col));
+        return true;
+      case SQLITE_FLOAT:
+        data[row] = Variant::Double(sqlite3_column_double(stmt, col));
+        return true;
+      case SQLITE_TEXT:
+        data[row] = Variant::String(pool_->InternString(
+            reinterpret_cast<const char*>(sqlite3_column_text(stmt, col))));
+        return true;
+      case SQLITE_NULL:
+        data[row] = Variant::Null();
+        return true;
+      default:
+        s.status = base::ErrStatus(
+            "SQL source: column '%s' holds a blob, which a pipeline cannot "
+            "carry",
+            names_[index].c_str());
+        return false;
+    }
+  }
+  switch (types_[index]->index()) {
+    case StorageType::GetTypeIndex<core::Uint32>():
+      return ReadTypedValue<uint32_t, SQLITE_INTEGER>(s, stmt, index, row);
+    case StorageType::GetTypeIndex<core::Int32>():
+      return ReadTypedValue<int32_t, SQLITE_INTEGER>(s, stmt, index, row);
+    case StorageType::GetTypeIndex<Int64>():
+      return ReadTypedValue<int64_t, SQLITE_INTEGER>(s, stmt, index, row);
+    case StorageType::GetTypeIndex<Double>():
+      return ReadTypedValue<double, SQLITE_FLOAT>(s, stmt, index, row);
+    case StorageType::GetTypeIndex<String>():
+      return ReadTypedValue<StringPool::Id, SQLITE_TEXT>(s, stmt, index, row);
+    default:
+      // An Id was already materialised as a Uint32 by ResolveTypes.
+      PERFETTO_FATAL("Unreachable");
+  }
+}
+
+template <typename T, int SqliteType>
+bool SqlScan::ReadTypedValue(State& s,
+                             sqlite3_stmt* stmt,
+                             uint32_t index,
+                             uint32_t row) const {
+  auto col = static_cast<int>(index);
+  auto* data = static_cast<T*>(s.data[index]);
+  int type = sqlite3_column_type(stmt, col);
+  if (PERFETTO_LIKELY(type == SqliteType)) {
+    if constexpr (std::is_same_v<T, StringPool::Id>) {
+      data[row] = pool_->InternString(
+          reinterpret_cast<const char*>(sqlite3_column_text(stmt, col)));
+    } else if constexpr (std::is_same_v<T, double>) {
+      data[row] = sqlite3_column_double(stmt, col);
+    } else {
+      data[row] = static_cast<T>(sqlite3_column_int64(stmt, col));
+    }
+    s.columns[index]->validity.set(row);
+    return true;
+  }
+  if (type == SQLITE_NULL) {
+    // The row is null, but write the slot anyway. A flat column's storage is
+    // readable at every row, so a reader summing it needs no per-row branch and
+    // never sees a value left over from the previous batch.
+    if constexpr (std::is_same_v<T, StringPool::Id>) {
+      data[row] = StringPool::Id::Null();
+    } else {
+      data[row] = T{};
+    }
+    return true;
+  }
+  // Only reachable if the type lineage established turned out to be wrong.
+  s.status = base::ErrStatus(
+      "SQL source: column '%s' does not hold what it was traced back to",
+      names_[index].c_str());
+  return false;
+}
+
+bool SqlScan::GetData(RowBatch& out, core::exec::OperatorState& state) const {
+  State& s = state.Cast<State>();
+  if (s.done || !s.status.ok()) {
+    return false;
+  }
+  for (const std::shared_ptr<ColumnChunk>& column : s.columns) {
+    if (column->validity.size() != 0) {
+      column->validity.ClearAllBits();
+    }
+  }
+  sqlite3_stmt* stmt = s.statement->sqlite_stmt();
+  uint32_t count = 0;
+  while (count < kMaxBatchRows && s.statement->Step()) {
+    for (uint32_t i = 0; i < s.columns.size(); ++i) {
+      if (!ReadValue(s, stmt, i, count)) {
+        return false;
+      }
+    }
+    ++count;
+  }
+  if (!s.statement->status().ok()) {
+    s.status = s.statement->status();
+    return false;
+  }
+  s.done = count < kMaxBatchRows;
+  if (count == 0) {
+    return false;
+  }
+
+  out.Reset();
+  for (uint32_t i = 0; i < s.columns.size(); ++i) {
+    const std::shared_ptr<ColumnChunk>& column = s.columns[i];
+    if (!types_[i]) {
+      out.AddColumn(
+          ColumnView::Variants(static_cast<const Variant*>(s.data[i])), column);
+    } else {
+      out.AddColumn(
+          ColumnView::Reference(*types_[i], s.data[i], &column->validity),
+          column);
+    }
+  }
+  out.Compose(RowSelection::Range(0), count);
+  out.SetCardinality(count);
+  return true;
+}
+
+}  // namespace perfetto::trace_processor::exec

--- a/src/trace_processor/perfetto_sql/exec/sql_scan.h
+++ b/src/trace_processor/perfetto_sql/exec/sql_scan.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_EXEC_SQL_SCAN_H_
+#define SRC_TRACE_PROCESSOR_PERFETTO_SQL_EXEC_SQL_SCAN_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/perfetto_sql/analysis/relation.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_chunk.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/sqlite/sql_source.h"
+#include "src/trace_processor/sqlite/sqlite_connection.h"
+
+struct sqlite3_stmt;
+
+namespace perfetto::trace_processor::exec {
+
+// Reads a pipeline's rows from a SQL query.
+//
+// Promises nothing about the order the rows arrive in, because SQLite does
+// not.
+//
+// Each column carries its type per row unless the query can be traced back to
+// a dataframe column, which is the only way to establish a type. SQLite's
+// declared types establish nothing: an INTEGER column holds text if something
+// puts text in it.
+class SqlScan : public core::exec::Source {
+ public:
+  // The catalog is where column types come from: any column it cannot trace
+  // back is a variant.
+  static base::StatusOr<std::unique_ptr<SqlScan>> Create(
+      SqliteConnection*,
+      SqlSource,
+      StringPool*,
+      const perfetto_sql::analysis::Catalog&);
+  ~SqlScan() override;
+
+  // The query's columns, in the order a batch carries them.
+  const std::vector<std::string>& column_names() const { return names_; }
+
+  // The type of column `i`, or nothing when the column carries a type per
+  // row.
+  std::optional<core::StorageType> column_type(uint32_t i) const {
+    return types_[i];
+  }
+
+  std::unique_ptr<core::exec::OperatorState> MakeState() const override;
+  bool GetData(core::exec::RowBatch& out,
+               core::exec::OperatorState&) const override;
+  void Rewind(core::exec::OperatorState&) const override;
+  base::Status status(const core::exec::OperatorState&) const override;
+
+ private:
+  struct State : core::exec::OperatorState {
+    ~State() override;
+    std::optional<SqliteConnection::PreparedStatement> statement;
+    // Shared so a batch can keep the values alive.
+    std::vector<std::shared_ptr<core::exec::ColumnChunk>> columns;
+    // Each column's value buffer, resolved out of its chunk once.
+    std::vector<void*> data;
+    bool done = false;
+    base::Status status = base::OkStatus();
+  };
+
+  SqlScan(SqliteConnection*,
+          SqlSource,
+          std::vector<std::string>,
+          std::vector<std::optional<core::StorageType>>,
+          StringPool*);
+  void Prepare(State&) const;
+
+  bool ReadValue(State&, sqlite3_stmt*, uint32_t index, uint32_t row) const;
+  template <typename T, int SqliteType>
+  bool ReadTypedValue(State&,
+                      sqlite3_stmt*,
+                      uint32_t index,
+                      uint32_t row) const;
+
+  SqliteConnection* connection_;
+  SqlSource sql_;
+  std::vector<std::string> names_;
+  std::vector<std::optional<core::StorageType>> types_;
+  StringPool* pool_;
+};
+
+}  // namespace perfetto::trace_processor::exec
+
+#endif  // SRC_TRACE_PROCESSOR_PERFETTO_SQL_EXEC_SQL_SCAN_H_

--- a/src/trace_processor/perfetto_sql/exec/sql_scan_unittest.cc
+++ b/src/trace_processor/perfetto_sql/exec/sql_scan_unittest.cc
@@ -1,0 +1,441 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/perfetto_sql/exec/sql_scan.h"
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_cursor.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/test_utils.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/perfetto_sql/lineage/type_mapping.h"
+#include "src/trace_processor/sqlite/sql_source.h"
+#include "src/trace_processor/sqlite/sqlite_connection.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::exec {
+namespace {
+
+using core::BitVector;
+using core::Double;
+using core::Int64;
+using core::StorageType;
+using core::String;
+using core::exec::ColumnView;
+using core::exec::kMaxBatchRows;
+using core::exec::RowBatch;
+using core::exec::RowCursor;
+using core::exec::Variant;
+
+// Drives a plan the way an executor does: creates the state, owns the batch.
+class Execution {
+ public:
+  explicit Execution(const core::exec::Source& source)
+      : source_(source), state_(source.MakeState()) {}
+
+  RowBatch* Next() {
+    return source_.GetData(batch_, *state_) ? &batch_ : nullptr;
+  }
+  void Rewind() { source_.Rewind(*state_); }
+  base::Status status() const { return source_.status(*state_); }
+
+ private:
+  const core::exec::Source& source_;
+  std::unique_ptr<core::exec::OperatorState> state_;
+  RowBatch batch_;
+};
+
+std::vector<int64_t> ReadInts(const RowBatch& batch, uint32_t index) {
+  std::vector<int64_t> out;
+  for (const Variant& cell :
+       core::exec::test::ReadColumn<Variant>(batch, index)) {
+    out.push_back(cell.AsInt64());
+  }
+  return out;
+}
+
+struct TestColumn {
+  std::string name;
+  core::StorageType type;
+};
+
+TestColumn Typed(std::string name, core::StorageType type) {
+  return {std::move(name), type};
+}
+
+class TestCatalog : public lineage::analysis::Catalog {
+ public:
+  void Add(std::string name, std::vector<TestColumn> columns) {
+    dataframes_[std::move(name)] = std::move(columns);
+  }
+
+  std::optional<lineage::analysis::LeafRelation> FindLeafRelation(
+      std::string_view name) const override {
+    auto dataframe = dataframes_.find(std::string(name));
+    if (dataframe == dataframes_.end()) {
+      return std::nullopt;
+    }
+    lineage::analysis::LeafRelation relation;
+    relation.name = name;
+    for (const TestColumn& column : dataframe->second) {
+      relation.columns.push_back(
+          {column.name, lineage::ToAnalysisType(column.type)});
+    }
+    return relation;
+  }
+
+  std::optional<std::string> FindViewSql(std::string_view) const override {
+    return std::nullopt;
+  }
+
+ private:
+  std::map<std::string, std::vector<TestColumn>> dataframes_;
+};
+
+class SqlScanTest : public ::testing::Test {
+ protected:
+  SqlScanTest()
+      : connection_(SqliteConnection::CreateConnectionToNewDatabase()) {}
+
+  void Exec(const std::string& sql) {
+    auto statement =
+        connection_->PrepareStatement(SqlSource::FromExecuteQuery(sql));
+    ASSERT_TRUE(statement.status().ok()) << statement.status().c_message();
+    while (statement.Step()) {
+    }
+    ASSERT_TRUE(statement.status().ok()) << statement.status().c_message();
+  }
+
+  base::StatusOr<std::unique_ptr<SqlScan>> Scan(
+      const std::string& sql,
+      const lineage::analysis::Catalog& catalog) {
+    return SqlScan::Create(connection_.get(), SqlSource::FromExecuteQuery(sql),
+                           &pool_, catalog);
+  }
+
+  // An empty catalog traces nothing, so every column is a variant.
+  base::StatusOr<std::unique_ptr<SqlScan>> Scan(const std::string& sql) {
+    return Scan(sql, empty_catalog_);
+  }
+
+  StringPool pool_;
+  std::unique_ptr<SqliteConnection> connection_;
+  TestCatalog empty_catalog_;
+};
+
+TEST_F(SqlScanTest, AQuerysColumnsAreKnownBeforeItsRows) {
+  auto scan = Scan("SELECT 1 AS a, 'x' AS b");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  EXPECT_THAT((*scan)->column_names(), testing::ElementsAre("a", "b"));
+}
+
+TEST_F(SqlScanTest, AQuerysRowsArriveAsABatch) {
+  auto scan = Scan(
+      "SELECT a FROM ("
+      "SELECT 2 AS ord, 20 AS a UNION ALL "
+      "SELECT 3, 30 UNION ALL SELECT 1, 10) ORDER BY ord");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  EXPECT_EQ(batch->size(), 3u);
+  EXPECT_THAT(ReadInts(*batch, 0), testing::ElementsAre(10, 20, 30));
+  EXPECT_EQ(run.Next(), nullptr);
+  EXPECT_TRUE(run.status().ok());
+}
+
+// One column holding three different types and a null, which SQLite allows.
+TEST_F(SqlScanTest, OneColumnCanHoldMoreThanOneType) {
+  auto scan = Scan(
+      "SELECT value FROM ("
+      "SELECT 1 AS ord, 7 AS value UNION ALL SELECT 2, 1.5 "
+      "UNION ALL SELECT 3, 'hello' UNION ALL SELECT 4, NULL) ORDER BY ord");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  std::vector<Variant> cells = core::exec::test::ReadColumn<Variant>(*batch, 0);
+  ASSERT_EQ(cells.size(), 4u);
+  EXPECT_EQ(cells[0].AsInt64(), 7);
+  EXPECT_EQ(cells[1].AsDouble(), 1.5);
+  EXPECT_EQ(pool_.Get(cells[2].AsString()).ToStdString(), "hello");
+  EXPECT_EQ(cells[3].type, Variant::Type::kNull);
+  EXPECT_TRUE(run.status().ok());
+}
+
+// A declared type is not binding in SQLite, so it is not trusted here.
+TEST_F(SqlScanTest, ADeclaredTypeIsNotBelieved) {
+  Exec("CREATE TABLE t(i INTEGER)");
+  Exec("INSERT INTO t VALUES(1), ('not a number')");
+  auto scan = Scan("SELECT i FROM t");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  std::vector<Variant> cells = core::exec::test::ReadColumn<Variant>(*batch, 0);
+  ASSERT_EQ(cells.size(), 2u);
+  EXPECT_EQ(cells[0].AsInt64(), 1);
+  EXPECT_EQ(pool_.Get(cells[1].AsString()).ToStdString(), "not a number");
+  EXPECT_TRUE(run.status().ok());
+}
+
+TEST_F(SqlScanTest, AColumnWhichIsNeverAnythingIsAColumnOfNulls) {
+  auto scan = Scan("SELECT NULL AS a UNION ALL SELECT NULL");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  for (const Variant& cell : core::exec::test::ReadColumn<Variant>(*batch, 0)) {
+    EXPECT_EQ(cell.type, Variant::Type::kNull);
+  }
+}
+
+TEST_F(SqlScanTest, MoreRowsThanFitInABatchArriveInSeveral) {
+  Exec(
+      "CREATE TABLE t AS WITH RECURSIVE r(x) AS ("
+      "  SELECT 0 UNION ALL SELECT x + 1 FROM r WHERE x < 4999"
+      ") SELECT x FROM r");
+  auto scan = Scan("SELECT x FROM t ORDER BY x");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+
+  std::vector<int64_t> seen;
+  std::vector<uint32_t> sizes;
+  while (RowBatch* batch = run.Next()) {
+    sizes.push_back(batch->size());
+    for (int64_t value : ReadInts(*batch, 0)) {
+      seen.push_back(value);
+    }
+  }
+  ASSERT_TRUE(run.status().ok()) << run.status().c_message();
+  EXPECT_THAT(sizes, testing::ElementsAre(kMaxBatchRows, kMaxBatchRows, 904u));
+  ASSERT_EQ(seen.size(), 5000u);
+  for (uint32_t i = 0; i < seen.size(); ++i) {
+    ASSERT_EQ(seen[i], int64_t{i});
+  }
+}
+
+TEST_F(SqlScanTest, AQueryWhichDoesNotRunIsReported) {
+  auto scan = Scan("SELECT * FROM not_a_table");
+  EXPECT_FALSE(scan.ok());
+}
+
+TEST_F(SqlScanTest, AQueryWhichFailsPartWayThroughIsReported) {
+  auto scan =
+      Scan("SELECT 1 AS a UNION ALL SELECT abs(-9223372036854775807 - 1)");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+  while (run.Next()) {
+  }
+  EXPECT_FALSE(run.status().ok());
+}
+
+TEST_F(SqlScanTest, ABlobIsReportedRatherThanCarried) {
+  auto scan = Scan("SELECT x'0102' AS a");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+
+  EXPECT_EQ(run.Next(), nullptr);
+  EXPECT_FALSE(run.status().ok());
+  EXPECT_THAT(run.status().message(), testing::HasSubstr("blob"));
+}
+
+TEST_F(SqlScanTest, RewindClearsThePreviousExecutionError) {
+  auto scan = Scan("SELECT x'0102' AS a");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+  ASSERT_EQ(run.Next(), nullptr);
+  ASSERT_FALSE(run.status().ok());
+
+  run.Rewind();
+  EXPECT_TRUE(run.status().ok());
+  EXPECT_EQ(run.Next(), nullptr);
+  EXPECT_FALSE(run.status().ok());
+}
+
+TEST_F(SqlScanTest, EachExecutionValidatesItsResultShape) {
+  Exec("CREATE TABLE t(a INTEGER)");
+  Exec("INSERT INTO t VALUES(1)");
+  auto scan = Scan("SELECT * FROM t");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Exec("ALTER TABLE t ADD COLUMN b TEXT");
+
+  Execution run(**scan);
+  EXPECT_EQ(run.Next(), nullptr);
+  EXPECT_FALSE(run.status().ok());
+  EXPECT_THAT(run.status().message(), testing::HasSubstr("shape changed"));
+}
+
+TEST_F(SqlScanTest, AScanCanBeRunAgain) {
+  auto scan = Scan("SELECT 1 AS a UNION ALL SELECT 2");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+
+  auto drain = [&] {
+    std::vector<int64_t> out;
+    while (RowBatch* batch = run.Next()) {
+      for (int64_t value : ReadInts(*batch, 0)) {
+        out.push_back(value);
+      }
+    }
+    return out;
+  };
+  std::vector<int64_t> first = drain();
+  run.Rewind();
+  EXPECT_EQ(drain(), first);
+}
+
+TEST_F(SqlScanTest, AQueryReachesARowCursor) {
+  auto scan = Scan(
+      "SELECT a FROM (SELECT 2 AS ord, 6 AS a UNION ALL "
+      "SELECT 3, 7 UNION ALL SELECT 1, 5) ORDER BY ord");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  RowCursor cursor(**scan);
+  std::vector<int64_t> values;
+  for (bool more = cursor.Open(); more; more = cursor.Next()) {
+    values.push_back(cursor.Value<Variant>(0).AsInt64());
+  }
+  EXPECT_THAT(values, testing::ElementsAre(5, 6, 7));
+}
+
+// A column which can be traced back to a dataframe needs neither a variant nor
+// an assertion: it comes out flat.
+TEST_F(SqlScanTest, AColumnFollowedBackToADataframeComesOutFlat) {
+  Exec("CREATE TABLE df(id INTEGER, name TEXT)");
+  Exec("INSERT INTO df VALUES(7, 'hello'), (8, NULL)");
+  TestCatalog catalog;
+  catalog.Add("df", {Typed("id", core::StorageType{core::Int64{}}),
+                     Typed("name", core::StorageType{core::String{}})});
+
+  auto scan = Scan("SELECT id, name FROM df ORDER BY id", catalog);
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  ASSERT_TRUE((*scan)->column_type(0).has_value());
+  EXPECT_TRUE((*scan)->column_type(0)->Is<core::Int64>());
+  EXPECT_TRUE((*scan)->column_type(1)->Is<core::String>());
+
+  Execution run(**scan);
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  EXPECT_EQ(batch->column(0).kind(), ColumnView::Kind::kFlat);
+  const auto* ids = static_cast<const int64_t*>(batch->column(0).data());
+  EXPECT_EQ(ids[0], 7);
+  EXPECT_EQ(ids[1], 8);
+  const BitVector* validity = batch->column(1).validity();
+  ASSERT_NE(validity, nullptr);
+  EXPECT_TRUE(validity->is_set(0));
+  EXPECT_FALSE(validity->is_set(1));
+  std::vector<StringPool::Id> names =
+      core::exec::test::ReadColumn<StringPool::Id>(*batch, 1);
+  EXPECT_EQ(pool_.Get(names[0]).ToStdString(), "hello");
+}
+
+TEST_F(SqlScanTest, MixedNumericCompoundResultsStayVariants) {
+  Exec("CREATE TABLE ints(value INTEGER)");
+  Exec("INSERT INTO ints VALUES(7)");
+  Exec("CREATE TABLE doubles(value REAL)");
+  Exec("INSERT INTO doubles VALUES(1.5)");
+  TestCatalog catalog;
+  catalog.Add("ints", {Typed("value", StorageType{Int64{}})});
+  catalog.Add("doubles", {Typed("value", StorageType{Double{}})});
+
+  auto scan = Scan(
+      "SELECT value FROM ("
+      "SELECT 1 AS ord, value FROM ints UNION ALL "
+      "SELECT 2, value FROM doubles) ORDER BY ord",
+      catalog);
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  EXPECT_FALSE((*scan)->column_type(0).has_value());
+  Execution run(**scan);
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  std::vector<Variant> values =
+      core::exec::test::ReadColumn<Variant>(*batch, 0);
+  ASSERT_EQ(values.size(), 2u);
+  EXPECT_EQ(values[0].AsInt64(), 7);
+  EXPECT_EQ(values[1].AsDouble(), 1.5);
+}
+
+// An expression cannot be traced back, so it stays a variant even when the
+// column beside it does not.
+TEST_F(SqlScanTest, OnlyTheColumnsWhichCanBeFollowedComeOutFlat) {
+  Exec("CREATE TABLE df(id INTEGER)");
+  Exec("INSERT INTO df VALUES(7)");
+  TestCatalog catalog;
+  catalog.Add("df", {Typed("id", core::StorageType{core::Int64{}})});
+
+  auto scan = Scan("SELECT id, id * 2 AS doubled FROM df", catalog);
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  EXPECT_TRUE((*scan)->column_type(0).has_value());
+  EXPECT_FALSE((*scan)->column_type(1).has_value());
+
+  Execution run(**scan);
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  EXPECT_EQ(batch->column(0).kind(), ColumnView::Kind::kFlat);
+  EXPECT_EQ(batch->column(1).kind(), ColumnView::Kind::kVariant);
+}
+
+// Without a catalog nothing can be traced back.
+TEST_F(SqlScanTest, WithoutACatalogEveryColumnIsAVariant) {
+  Exec("CREATE TABLE df(id INTEGER)");
+  auto scan = Scan("SELECT id FROM df");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  EXPECT_FALSE((*scan)->column_type(0).has_value());
+}
+
+// A flat column's storage is readable at every row, so a reader which sums it
+// without checking validity gets zero rather than a value left over from the
+// previous batch.
+TEST_F(SqlScanTest, ANullSlotOfAFlatColumnHoldsZero) {
+  Exec("CREATE TABLE df(id INTEGER)");
+  Exec("INSERT INTO df VALUES(7), (NULL)");
+  TestCatalog catalog;
+  catalog.Add("df", {Typed("id", core::StorageType{core::Int64{}})});
+
+  auto scan = Scan("SELECT id FROM df ORDER BY id IS NULL", catalog);
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  Execution run(**scan);
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  ASSERT_EQ(batch->size(), 2u);
+
+  const auto* ids = static_cast<const int64_t*>(batch->column(0).data());
+  EXPECT_EQ(ids[0], 7);
+  EXPECT_EQ(ids[1], 0);
+  EXPECT_FALSE(batch->column(0).validity()->is_set(1));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::exec

--- a/src/trace_processor/perfetto_sql/lineage/connection_catalog.cc
+++ b/src/trace_processor/perfetto_sql/lineage/connection_catalog.cc
@@ -18,7 +18,6 @@
 
 #include <sqlite3.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -27,9 +26,9 @@
 
 #include "perfetto/ext/base/string_utils.h"
 #include "src/perfetto_sql/analysis/relation.h"
-#include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
+#include "src/trace_processor/perfetto_sql/lineage/type_mapping.h"
 #include "src/trace_processor/sqlite/sql_source.h"
 
 namespace perfetto::trace_processor::lineage {
@@ -77,9 +76,11 @@ std::optional<analysis::LeafRelation> ConnectionCatalog::FindLeafRelation(
   }
   analysis::LeafRelation relation;
   relation.name = name;
-  relation.columns.reserve(dataframe->column_names().size());
-  for (const std::string& column : dataframe->column_names()) {
-    relation.columns.push_back(column);
+  const std::vector<std::string>& columns = dataframe->column_names();
+  relation.columns.reserve(columns.size());
+  for (uint32_t i = 0; i < columns.size(); ++i) {
+    relation.columns.push_back(
+        {columns[i], ToAnalysisType(dataframe->column_type(i))});
   }
   return relation;
 }
@@ -95,33 +96,6 @@ std::optional<std::string> ConnectionCatalog::FindViewSql(
   sqlite3_stmt* stmt = res->stmt.sqlite_stmt();
   const auto* sql = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
   return sql ? std::make_optional(std::string(sql)) : std::nullopt;
-}
-
-std::optional<core::StorageType> ConnectionCatalog::ColumnType(
-    const analysis::ColumnLineage& column) const {
-  std::optional<core::StorageType> result;
-  for (const analysis::ColumnOrigin& origin : column.origins) {
-    const dataframe::Dataframe* dataframe =
-        connection_->GetDataframeOrNull(origin.relation_name);
-    if (!dataframe) {
-      return std::nullopt;
-    }
-    const std::vector<std::string>& names = dataframe->column_names();
-    auto found =
-        std::find_if(names.begin(), names.end(), [&](const auto& name) {
-          return base::CaseInsensitiveEqual(name, origin.column_name);
-        });
-    if (found == names.end()) {
-      return std::nullopt;
-    }
-    core::StorageType type =
-        dataframe->column_type(static_cast<uint32_t>(found - names.begin()));
-    if (result && !(*result == type)) {
-      return std::nullopt;
-    }
-    result = type;
-  }
-  return result;
 }
 
 }  // namespace perfetto::trace_processor::lineage

--- a/src/trace_processor/perfetto_sql/lineage/connection_catalog.h
+++ b/src/trace_processor/perfetto_sql/lineage/connection_catalog.h
@@ -22,15 +22,14 @@
 #include <string_view>
 
 #include "src/perfetto_sql/analysis/relation.h"
-#include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
 
 namespace perfetto::trace_processor::lineage {
 
 namespace analysis = ::perfetto::perfetto_sql::analysis;
 
-// Adapts the dataframes and SQLite views of a live connection to the reusable
-// PerfettoSQL relation analyzer.
+// Adapts one trace processor connection to semantic analysis. Serves each
+// dataframe as a leaf relation whose columns carry their storage type.
 class ConnectionCatalog final : public analysis::Catalog {
  public:
   explicit ConnectionCatalog(PerfettoSqlConnection*);
@@ -38,11 +37,6 @@ class ConnectionCatalog final : public analysis::Catalog {
   std::optional<analysis::LeafRelation> FindLeafRelation(
       std::string_view name) const override;
   std::optional<std::string> FindViewSql(std::string_view name) const override;
-
-  // Maps all origins of a result column back to dataframe storage. Returns
-  // nothing unless every origin has the same storage type.
-  std::optional<core::StorageType> ColumnType(
-      const analysis::ColumnLineage&) const;
 
  private:
   PerfettoSqlConnection* connection_;

--- a/src/trace_processor/perfetto_sql/lineage/connection_catalog_unittest.cc
+++ b/src/trace_processor/perfetto_sql/lineage/connection_catalog_unittest.cc
@@ -30,6 +30,7 @@
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
+#include "src/trace_processor/perfetto_sql/lineage/type_mapping.h"
 #include "src/trace_processor/sqlite/sql_source.h"
 #include "test/gtest_and_gmock.h"
 
@@ -66,7 +67,9 @@ class ConnectionCatalogTest : public ::testing::Test {
     std::vector<std::optional<core::StorageType>> types;
     types.reserve(lineage.columns().size());
     for (const analysis::ColumnLineage& column : lineage.columns()) {
-      types.push_back(catalog_.ColumnType(column));
+      std::optional<analysis::ColumnType> type = column.type();
+      types.push_back(type ? std::make_optional(ToStorageType(*type))
+                           : std::nullopt);
     }
     return types;
   }

--- a/src/trace_processor/perfetto_sql/lineage/type_mapping.h
+++ b/src/trace_processor/perfetto_sql/lineage/type_mapping.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_LINEAGE_TYPE_MAPPING_H_
+#define SRC_TRACE_PROCESSOR_PERFETTO_SQL_LINEAGE_TYPE_MAPPING_H_
+
+#include "src/perfetto_sql/analysis/relation.h"
+#include "src/trace_processor/core/common/storage_types.h"
+
+namespace perfetto::trace_processor::lineage {
+
+namespace analysis = ::perfetto::perfetto_sql::analysis;
+
+// Maps between dataframe storage types and the analysis column type
+// vocabulary. Semantic analysis cannot depend on trace processor, so only
+// this side can know both sets. The vocabularies mirror each other position
+// by position, pinned here, which makes each mapping an identity on the
+// index.
+static_assert(analysis::ColumnType::kSize == core::StorageType::kSize,
+              "The analysis vocabulary must mirror StorageType");
+static_assert(analysis::ColumnType::GetTypeIndex<analysis::Id>() ==
+              core::StorageType::GetTypeIndex<core::Id>());
+static_assert(analysis::ColumnType::GetTypeIndex<analysis::Uint32>() ==
+              core::StorageType::GetTypeIndex<core::Uint32>());
+static_assert(analysis::ColumnType::GetTypeIndex<analysis::Int32>() ==
+              core::StorageType::GetTypeIndex<core::Int32>());
+static_assert(analysis::ColumnType::GetTypeIndex<analysis::Int64>() ==
+              core::StorageType::GetTypeIndex<core::Int64>());
+static_assert(analysis::ColumnType::GetTypeIndex<analysis::Double>() ==
+              core::StorageType::GetTypeIndex<core::Double>());
+static_assert(analysis::ColumnType::GetTypeIndex<analysis::String>() ==
+              core::StorageType::GetTypeIndex<core::String>());
+
+inline analysis::ColumnType ToAnalysisType(core::StorageType type) {
+  return type.MapByIndex<analysis::ColumnType>();
+}
+
+inline core::StorageType ToStorageType(analysis::ColumnType type) {
+  return type.MapByIndex<core::StorageType>();
+}
+
+}  // namespace perfetto::trace_processor::lineage
+
+#endif  // SRC_TRACE_PROCESSOR_PERFETTO_SQL_LINEAGE_TYPE_MAPPING_H_

--- a/src/trace_processor/plugins/flamegraph/flamegraph.h
+++ b/src/trace_processor/plugins/flamegraph/flamegraph.h
@@ -24,10 +24,10 @@
 
 #include "perfetto/ext/base/regex.h"
 #include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/base/type_set.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/tree/tree.h"
 #include "src/trace_processor/core/util/slab.h"
-#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::flamegraph {
 
@@ -52,14 +52,14 @@ struct Config {
   struct BottomUp {};
   struct Pivot {};
   struct FromFrame {};
-  using View = core::TypeSet<TopDown, BottomUp, Pivot, FromFrame>;
+  using View = base::TypeSet<TopDown, BottomUp, Pivot, FromFrame>;
 
   // Views anchored on frames matching |view_pattern|.
-  using PatternViews = core::TypeSet<Pivot, FromFrame>;
+  using PatternViews = base::TypeSet<Pivot, FromFrame>;
   // Views which build the downward (descendant) half of the output.
-  using DownwardViews = core::TypeSet<TopDown, Pivot, FromFrame>;
+  using DownwardViews = base::TypeSet<TopDown, Pivot, FromFrame>;
   // Views which build the upward (ancestor) half of the output.
-  using UpwardViews = core::TypeSet<BottomUp, Pivot>;
+  using UpwardViews = base::TypeSet<BottomUp, Pivot>;
 
   enum class Aggregate {
     kSum,


### PR DESCRIPTION
Queries which filter, join, group, or compute still need SQLite. SqlScan steps
a prepared statement and fills RowBatch instances instead of exposing the
row-at-a-time cursor to the rest of the pipeline.

Lineage decides how each result column is stored. Columns traced to a
dataframe come out flat at the proven type. Other columns use Variant because
SQLite may return a different type on each row.

Preparing, stepping, and rewinding the statement all follow the Source status
contract. Type validation is left to the operator which knows how a column
will be used.