### PR TITLE
tp: sort a stream of tree rows which arrives in no order at all

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -18771,6 +18771,22 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/perfetto_sql/exec:exec
+filegroup {
+    name: "perfetto_src_trace_processor_perfetto_sql_exec_exec",
+    srcs: [
+        "src/trace_processor/perfetto_sql/exec/sql_scan.cc",
+    ],
+}
+
+// GN: //src/trace_processor/perfetto_sql/exec:unittests
+filegroup {
+    name: "perfetto_src_trace_processor_perfetto_sql_exec_unittests",
+    srcs: [
+        "src/trace_processor/perfetto_sql/exec/sql_scan_unittest.cc",
+    ],
+}
+
 // GN: //src/trace_processor/perfetto_sql/generator:gen_cc_perfetto_sql_descriptor
 genrule {
     name: "perfetto_src_trace_processor_perfetto_sql_generator_gen_cc_perfetto_sql_descriptor",
@@ -24050,6 +24066,8 @@ cc_test {
         ":perfetto_src_trace_processor_metrics_unittests",
         ":perfetto_src_trace_processor_perfetto_sql_engine_engine",
         ":perfetto_src_trace_processor_perfetto_sql_engine_unittests",
+        ":perfetto_src_trace_processor_perfetto_sql_exec_exec",
+        ":perfetto_src_trace_processor_perfetto_sql_exec_unittests",
         ":perfetto_src_trace_processor_perfetto_sql_generator_generator",
         ":perfetto_src_trace_processor_perfetto_sql_generator_unittests",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",

--- a/Android.bp
+++ b/Android.bp
@@ -17612,6 +17612,7 @@ filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
         "src/trace_processor/core/exec/operator_unittest.cc",
+        "src/trace_processor/core/exec/row_batch_pool_unittest.cc",
     ],
 }
 

--- a/Android.bp
+++ b/Android.bp
@@ -17608,6 +17608,7 @@ filegroup {
         "src/trace_processor/core/exec/row_cursor.cc",
         "src/trace_processor/core/exec/sink.cc",
         "src/trace_processor/core/exec/tree_accumulate.cc",
+        "src/trace_processor/core/exec/tree_order.cc",
     ],
 }
 
@@ -17619,6 +17620,7 @@ filegroup {
         "src/trace_processor/core/exec/owned_column_unittest.cc",
         "src/trace_processor/core/exec/row_batch_pool_unittest.cc",
         "src/trace_processor/core/exec/tree_accumulate_unittest.cc",
+        "src/trace_processor/core/exec/tree_order_unittest.cc",
     ],
 }
 

--- a/Android.bp
+++ b/Android.bp
@@ -17599,12 +17599,15 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_core_exec_exec",
     srcs: [
+        "src/trace_processor/core/exec/breaker.cc",
         "src/trace_processor/core/exec/column_view.cc",
         "src/trace_processor/core/exec/from.cc",
         "src/trace_processor/core/exec/owned_column.cc",
         "src/trace_processor/core/exec/pipeline.cc",
         "src/trace_processor/core/exec/row_batch.cc",
         "src/trace_processor/core/exec/row_cursor.cc",
+        "src/trace_processor/core/exec/sink.cc",
+        "src/trace_processor/core/exec/tree_accumulate.cc",
     ],
 }
 
@@ -17615,6 +17618,7 @@ filegroup {
         "src/trace_processor/core/exec/operator_unittest.cc",
         "src/trace_processor/core/exec/owned_column_unittest.cc",
         "src/trace_processor/core/exec/row_batch_pool_unittest.cc",
+        "src/trace_processor/core/exec/tree_accumulate_unittest.cc",
     ],
 }
 

--- a/Android.bp
+++ b/Android.bp
@@ -17601,6 +17601,7 @@ filegroup {
     srcs: [
         "src/trace_processor/core/exec/column_view.cc",
         "src/trace_processor/core/exec/from.cc",
+        "src/trace_processor/core/exec/owned_column.cc",
         "src/trace_processor/core/exec/pipeline.cc",
         "src/trace_processor/core/exec/row_batch.cc",
         "src/trace_processor/core/exec/row_cursor.cc",
@@ -17612,6 +17613,7 @@ filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
         "src/trace_processor/core/exec/operator_unittest.cc",
+        "src/trace_processor/core/exec/owned_column_unittest.cc",
         "src/trace_processor/core/exec/row_batch_pool_unittest.cc",
     ],
 }

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -469,6 +469,7 @@ perfetto_unittest_source_set("unittests") {
   if (enable_perfetto_trace_processor_sqlite) {
     deps += [
       "perfetto_sql/engine:unittests",
+      "perfetto_sql/exec:unittests",
       "perfetto_sql/parser:unittests",
       "perfetto_sql/tokenizer:unittests",
       "plugins/ancestor:unittests",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -37,6 +37,8 @@ source_set("exec") {
     "sink.h",
     "tree_accumulate.cc",
     "tree_accumulate.h",
+    "tree_order.cc",
+    "tree_order.h",
   ]
   deps = [
     "../../../../gn:default_deps",
@@ -54,6 +56,7 @@ perfetto_unittest_source_set("unittests") {
     "owned_column_unittest.cc",
     "row_batch_pool_unittest.cc",
     "tree_accumulate_unittest.cc",
+    "tree_order_unittest.cc",
   ]
   deps = [
     ":exec",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -25,6 +25,7 @@ source_set("exec") {
     "pipeline.h",
     "row_batch.cc",
     "row_batch.h",
+    "row_batch_pool.h",
     "row_cursor.cc",
     "row_cursor.h",
     "row_selection.h",
@@ -40,7 +41,10 @@ source_set("exec") {
 
 perfetto_unittest_source_set("unittests") {
   testonly = true
-  sources = [ "operator_unittest.cc" ]
+  sources = [
+    "operator_unittest.cc",
+    "row_batch_pool_unittest.cc",
+  ]
   deps = [
     ":exec",
     "../../../../gn:default_deps",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -16,6 +16,8 @@ import("../../../../gn/test.gni")
 
 source_set("exec") {
   sources = [
+    "breaker.cc",
+    "breaker.h",
     "column_view.cc",
     "column_view.h",
     "from.cc",
@@ -31,6 +33,10 @@ source_set("exec") {
     "row_cursor.cc",
     "row_cursor.h",
     "row_selection.h",
+    "sink.cc",
+    "sink.h",
+    "tree_accumulate.cc",
+    "tree_accumulate.h",
   ]
   deps = [
     "../../../../gn:default_deps",
@@ -47,6 +53,7 @@ perfetto_unittest_source_set("unittests") {
     "operator_unittest.cc",
     "owned_column_unittest.cc",
     "row_batch_pool_unittest.cc",
+    "tree_accumulate_unittest.cc",
   ]
   deps = [
     ":exec",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -21,6 +21,8 @@ source_set("exec") {
     "from.cc",
     "from.h",
     "operator.h",
+    "owned_column.cc",
+    "owned_column.h",
     "pipeline.cc",
     "pipeline.h",
     "row_batch.cc",
@@ -43,6 +45,7 @@ perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
     "operator_unittest.cc",
+    "owned_column_unittest.cc",
     "row_batch_pool_unittest.cc",
   ]
   deps = [

--- a/src/trace_processor/core/exec/breaker.cc
+++ b/src/trace_processor/core/exec/breaker.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/breaker.h"
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+Breaker::~Breaker() = default;
+
+void Breaker::Reset() {
+  source_.Reset();
+  Rewind();
+  filled_ = false;
+  status_ = base::OkStatus();
+}
+
+base::Status Breaker::Fill() {
+  while (RowBatch* chunk = source_.Next()) {
+    RETURN_IF_ERROR(Consume(*chunk));
+  }
+  RETURN_IF_ERROR(source_.status());
+  return Finish();
+}
+
+RowBatch* Breaker::Next() {
+  if (!filled_) {
+    filled_ = true;
+    status_ = Fill();
+    if (!status_.ok()) {
+      return nullptr;
+    }
+  }
+  return Emit();
+}
+
+base::Status Breaker::status() const {
+  return status_.ok() ? source_.status() : status_;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/breaker.h
+++ b/src/trace_processor/core/exec/breaker.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_BREAKER_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_BREAKER_H_
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/sink.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// A step which cannot answer until it has seen everything.
+//
+// A Sink while it fills and a Source once it is full, and both at once
+// in the type, because that is what it is: every chunk goes in before any
+// chunk comes out. An Operator cannot be this, because an
+// Operator is handed a chunk and answers for that chunk; a sort, a subtree
+// fold, or anything else whose first row depends on the last one has to be
+// something else, and this is that something.
+//
+// Saying so in the type is the point. Where the breakers are is where a
+// pipeline stops being a pipeline: the memory a query needs at once, and the
+// latency before its first row, are both decided by them and by nothing else.
+class Breaker : public Source, public Sink {
+ public:
+  ~Breaker() override;
+
+  void Reset() final;
+
+  // Fills on the first call, then hands over what it made, a chunk at a time.
+  RowBatch* Next() final;
+
+  base::Status status() const final;
+
+ protected:
+  explicit Breaker(Source& source) : source_(source) {}
+
+  // The next chunk of the answer, or null once there are none left.
+  virtual RowBatch* Emit() = 0;
+
+  // Drops whatever was built, so the whole thing can be run again.
+  virtual void Rewind() = 0;
+
+ private:
+  base::Status Fill();
+
+  Source& source_;
+  bool filled_ = false;
+  base::Status status_ = base::OkStatus();
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_BREAKER_H_

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -80,6 +80,9 @@ class ColumnView {
   // The values this column reads from, before its row view is applied.
   const void* data() const { return data_; }
 
+  // Which physical rows hold a value, or null when every row does.
+  const BitVector* validity() const { return validity_; }
+
  private:
   Kind kind_ = Kind::kFlat;
   StorageType type_{Id{}};

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -69,6 +69,12 @@ class ColumnView {
     block_ = nullptr;
   }
 
+  // Points this column at the run of physical rows starting at `offset`.
+  void SetRange(uint32_t offset) {
+    selection_ = RowSelection::Range(offset);
+    block_ = nullptr;
+  }
+
   // Takes over the row view `other` just computed. Columns of one batch that
   // shared a view before slicing still share it afterwards, so only the first
   // of them has to compose it.

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -77,6 +77,9 @@ class ColumnView {
     block_ = other.block_;
   }
 
+  // The values this column reads from, before its row view is applied.
+  const void* data() const { return data_; }
+
  private:
   Kind kind_ = Kind::kFlat;
   StorageType type_{Id{}};

--- a/src/trace_processor/core/exec/operator_unittest.cc
+++ b/src/trace_processor/core/exec/operator_unittest.cc
@@ -62,7 +62,7 @@ std::vector<uint32_t> Drain(PullPipeline& pipeline) {
   pipeline.Reset();
   RowCursor cursor(pipeline);
   for (cursor.Open(); !cursor.eof(); cursor.Next()) {
-    rows.push_back(cursor.row());
+    rows.push_back(cursor.row(0));
   }
   return rows;
 }
@@ -210,6 +210,56 @@ TEST(SinkTest, ReadsEveryRowOfEveryBatch) {
   EXPECT_EQ(rows.front(), 0u);
   EXPECT_EQ(rows[kMaxBatchRows], kMaxBatchRows);
   EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 6u);
+}
+
+// An operator which adds a computed column cannot put it in the index space
+// its input arrived in, so it adds it in its own. A cursor has to follow each
+// column's own view to read either of them.
+TEST(SinkTest, ReadsColumnsWhichDoNotShareARowView) {
+  std::vector<int64_t> payload = {10, 11, 12, 13};
+  std::vector<int64_t> computed = {90, 91};
+
+  class TwoViewSource final : public Source {
+   public:
+    TwoViewSource(const std::vector<int64_t>* payload,
+                  const std::vector<int64_t>* computed)
+        : payload_(payload), computed_(computed) {}
+
+    RowBatch* Next() override {
+      if (done_) {
+        return nullptr;
+      }
+      done_ = true;
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, payload_->data()));
+      // The payload is read from half way in; the computed column is its own
+      // array read from the start.
+      batch_.Compose(RowSelection::Range(2), 2);
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, computed_->data()));
+      batch_.SetCardinality(2);
+      return &batch_;
+    }
+
+   private:
+    const std::vector<int64_t>* payload_;
+    const std::vector<int64_t>* computed_;
+    RowBatch batch_;
+    bool done_ = false;
+  };
+
+  TwoViewSource source(&payload, &computed);
+  RowCursor cursor(source);
+  std::vector<int64_t> read_payload;
+  std::vector<int64_t> read_computed;
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    read_payload.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(0).data())[cursor.row(0)]);
+    read_computed.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(1).data())[cursor.row(1)]);
+  }
+  EXPECT_THAT(read_payload, ElementsAre(12, 13));
+  EXPECT_THAT(read_computed, ElementsAre(90, 91));
 }
 
 TEST(SinkTest, ReportsEofWithoutOpen) {

--- a/src/trace_processor/core/exec/owned_column.cc
+++ b/src/trace_processor/core/exec/owned_column.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/owned_column.h"
+
+#include <cstdint>
+#include <cstring>
+#include <variant>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+template <typename T, typename Variant>
+FlexVector<T>& Ensure(Variant& values, uint32_t size) {
+  if (!std::holds_alternative<FlexVector<T>>(values)) {
+    values = FlexVector<T>();
+  }
+  auto& vec = std::get<FlexVector<T>>(values);
+  if (vec.size() < size) {
+    vec.resize(size);
+  }
+  return vec;
+}
+
+// Copies the `count` values `column` resolves to. A range resolves to a run,
+// which copies whole; anything else is one gather, and neither walks a row
+// view a value at a time.
+template <typename T, typename Variant>
+void Copy(const ColumnView& column,
+          uint32_t at,
+          uint32_t count,
+          Variant& values) {
+  FlexVector<T>& out = Ensure<T>(values, at + count);
+  const auto* data = static_cast<const T*>(column.data());
+  RowSelection selection = column.selection();
+  T* dest = out.data() + at;
+  if (selection.is_range()) {
+    memcpy(dest, data + selection.offset(), count * sizeof(T));
+    return;
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    dest[i] = data[rows[i]];
+  }
+}
+
+// An Id column's value is the row it sits at, so copying one means writing
+// down the rows it stood for.
+template <typename Variant>
+void CopyIds(const ColumnView& column,
+             uint32_t at,
+             uint32_t count,
+             Variant& values) {
+  FlexVector<uint32_t>& out = Ensure<uint32_t>(values, at + count);
+  RowSelection selection = column.selection();
+  uint32_t* dest = out.data() + at;
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      dest[i] = offset + i;
+    }
+    return;
+  }
+  memcpy(dest, selection.data(), count * sizeof(uint32_t));
+}
+
+}  // namespace
+
+void OwnedColumn::Fill(const ColumnView& column, uint32_t count) {
+  Clear();
+  Append(column, count);
+}
+
+void OwnedColumn::Append(const ColumnView& column, uint32_t count) {
+  StorageType type = column.type();
+  uint32_t at = size_;
+  if (type.Is<Id>()) {
+    CopyIds(column, at, count, values_);
+    type = StorageType{Uint32{}};
+  } else if (type.Is<Uint32>()) {
+    Copy<uint32_t>(column, at, count, values_);
+  } else if (type.Is<Int32>()) {
+    Copy<int32_t>(column, at, count, values_);
+  } else if (type.Is<Int64>()) {
+    Copy<int64_t>(column, at, count, values_);
+  } else if (type.Is<Double>()) {
+    Copy<double>(column, at, count, values_);
+  } else {
+    Copy<StringPool::Id>(column, at, count, values_);
+  }
+  PERFETTO_DCHECK(at == 0 || type == type_);
+  type_ = type;
+  size_ = at + count;
+
+  const BitVector* validity = column.validity();
+  if (!validity && !nullable_) {
+    return;
+  }
+  if (validity_.size() < size_) {
+    validity_.resize(size_);
+  }
+  if (!nullable_) {
+    // Everything already here arrived from a column with nothing missing.
+    for (uint32_t i = 0; i < at; ++i) {
+      validity_.set(i);
+    }
+    nullable_ = true;
+  }
+  if (!validity) {
+    for (uint32_t i = 0; i < count; ++i) {
+      validity_.set(at + i);
+    }
+    return;
+  }
+  RowSelection selection = column.selection();
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      validity_.change(at + i, validity->is_set(offset + i));
+    }
+    return;
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    validity_.change(at + i, validity->is_set(rows[i]));
+  }
+}
+
+ColumnView OwnedColumn::View() const {
+  const void* data = nullptr;
+  if (type_.Is<Uint32>()) {
+    data = std::get<FlexVector<uint32_t>>(values_).data();
+  } else if (type_.Is<Int32>()) {
+    data = std::get<FlexVector<int32_t>>(values_).data();
+  } else if (type_.Is<Int64>()) {
+    data = std::get<FlexVector<int64_t>>(values_).data();
+  } else if (type_.Is<Double>()) {
+    data = std::get<FlexVector<double>>(values_).data();
+  } else {
+    data = std::get<FlexVector<StringPool::Id>>(values_).data();
+  }
+  return ColumnView::Reference(type_, data, nullable_ ? &validity_ : nullptr);
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/owned_column.h
+++ b/src/trace_processor/core/exec/owned_column.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_OWNED_COLUMN_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_OWNED_COLUMN_H_
+
+#include <cstdint>
+#include <variant>
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// A copy of a column's values, kept by whoever needs them to outlive the
+// storage they were read from.
+//
+// A column view is a view: it costs pointers, not values, and a batch built
+// from one is only good for as long as what it points at stands still. That
+// covers a source reading durable storage and does not cover a source which
+// materialises into buffers it refills, so whether to copy cannot be decided
+// once for the model. It is decided per column, by the operator, which is the
+// only thing that knows how long it needs the values for.
+//
+// The copy is dense from row zero, so an operator which owns its input is also
+// an operator which can add a computed column to it without the two ending up
+// in different index spaces.
+class OwnedColumn {
+ public:
+  // Copies `count` values out of `column`, resolved through its row view,
+  // replacing whatever was here. An Id column materialises as the row numbers
+  // it stood for.
+  void Fill(const ColumnView& column, uint32_t count);
+
+  // The same, onto the end of what is already here, for building one column
+  // out of a stream of chunks.
+  void Append(const ColumnView& column, uint32_t count);
+
+  // Forgets the values, keeping the buffers.
+  void Clear() { size_ = 0; }
+
+  uint32_t size() const { return size_; }
+
+  // A view of what was copied.
+  ColumnView View() const;
+
+ private:
+  using Values = std::variant<FlexVector<uint32_t>,
+                              FlexVector<int32_t>,
+                              FlexVector<int64_t>,
+                              FlexVector<double>,
+                              FlexVector<StringPool::Id>>;
+
+  StorageType type_{Uint32{}};
+  Values values_{FlexVector<uint32_t>()};
+  BitVector validity_;
+  uint32_t size_ = 0;
+  bool nullable_ = false;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_OWNED_COLUMN_H_

--- a/src/trace_processor/core/exec/owned_column_unittest.cc
+++ b/src/trace_processor/core/exec/owned_column_unittest.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/owned_column.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/span.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using testing::ElementsAre;
+
+template <typename T>
+std::vector<T> Read(const ColumnView& column, uint32_t count) {
+  const auto* data = static_cast<const T*>(column.data());
+  std::vector<T> out;
+  for (uint32_t i = 0; i < count; ++i) {
+    out.push_back(data[column.selection().GetIndex(i)]);
+  }
+  return out;
+}
+
+TEST(OwnedColumnTest, CopiesTheRunARangePicksOut) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  ColumnView view = ColumnView::Reference(StorageType{Int64{}}, values.data());
+  view.selection();
+
+  RowBatch batch;
+  batch.AddColumn(view);
+  batch.Compose(RowSelection::Range(2), 3);
+
+  OwnedColumn owned;
+  owned.Fill(batch.column(0), 3);
+  EXPECT_THAT(Read<int64_t>(owned.View(), 3), ElementsAre(12, 13, 14));
+}
+
+TEST(OwnedColumnTest, GathersTheRowsAnIndexSelectionPicksOut) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  std::vector<uint32_t> rows = {4, 1, 3};
+  ColumnView view = ColumnView::Reference(StorageType{Int64{}}, values.data());
+  view.SetBorrowedRows(Span<const uint32_t>(rows.data(), rows.data() + 3));
+
+  OwnedColumn owned;
+  owned.Fill(view, 3);
+  EXPECT_THAT(Read<int64_t>(owned.View(), 3), ElementsAre(14, 11, 13));
+}
+
+// An Id column has no storage: its value is the row it sits at, so a copy of
+// one has to write those rows down.
+TEST(OwnedColumnTest, AnIdColumnBecomesTheRowsItStoodFor) {
+  ColumnView view = ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr);
+  RowBatch batch;
+  batch.AddColumn(view);
+  batch.Compose(RowSelection::Range(7), 3);
+
+  OwnedColumn owned;
+  owned.Fill(batch.column(0), 3);
+  EXPECT_TRUE(owned.View().type().Is<Uint32>());
+  EXPECT_THAT(Read<uint32_t>(owned.View(), 3), ElementsAre(7u, 8u, 9u));
+}
+
+TEST(OwnedColumnTest, KeepsWhichRowsHeldNothing) {
+  std::vector<int64_t> values = {10, 11, 12, 13};
+  BitVector validity = BitVector::CreateWithSize(4);
+  validity.set(0);
+  validity.set(3);
+  ColumnView view =
+      ColumnView::Reference(StorageType{Int64{}}, values.data(), &validity);
+
+  OwnedColumn owned;
+  owned.Fill(view, 4);
+  const BitVector* copied = owned.View().validity();
+  ASSERT_NE(copied, nullptr);
+  EXPECT_TRUE(copied->is_set(0));
+  EXPECT_FALSE(copied->is_set(1));
+  EXPECT_FALSE(copied->is_set(2));
+  EXPECT_TRUE(copied->is_set(3));
+}
+
+// The whole point: a source which refills its buffers leaves a view pointing
+// at whatever it wrote next. A copy does not care.
+TEST(OwnedColumnTest, SurvivesTheStorageItWasReadFromMovingOn) {
+  std::vector<int64_t> buffer = {1, 2, 3};
+  ColumnView view = ColumnView::Reference(StorageType{Int64{}}, buffer.data());
+
+  OwnedColumn owned;
+  owned.Fill(view, 3);
+  buffer = {99, 99, 99};
+  EXPECT_THAT(Read<int64_t>(owned.View(), 3), ElementsAre(1, 2, 3));
+}
+
+TEST(OwnedColumnTest, CopiesEveryTypeABatchCarries) {
+  std::vector<double> doubles = {1.5, 2.5};
+  ColumnView double_view =
+      ColumnView::Reference(StorageType{Double{}}, doubles.data());
+  OwnedColumn owned_double;
+  owned_double.Fill(double_view, 2);
+  EXPECT_THAT(Read<double>(owned_double.View(), 2), ElementsAre(1.5, 2.5));
+
+  std::vector<uint32_t> uints = {7, 8};
+  ColumnView uint_view =
+      ColumnView::Reference(StorageType{Uint32{}}, uints.data());
+  OwnedColumn owned_uint;
+  owned_uint.Fill(uint_view, 2);
+  EXPECT_THAT(Read<uint32_t>(owned_uint.View(), 2), ElementsAre(7u, 8u));
+}
+
+// A batch that owns its values is also a batch whose columns start dense from
+// row zero, which is what lets a computed column be added beside them.
+TEST(OwnedColumnTest, AnOwnedColumnIsDenseFromRowZero) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  ColumnView view = ColumnView::Reference(StorageType{Int64{}}, values.data());
+
+  RowBatch source;
+  source.AddColumn(view);
+  source.Compose(RowSelection::Range(3), 2);
+
+  RowBatch held;
+  held.AddOwnedColumn(source.column(0), 2);
+  held.SetCardinality(2);
+  EXPECT_TRUE(held.column(0).selection().is_range());
+  EXPECT_EQ(held.column(0).selection().offset(), 0u);
+  EXPECT_THAT(Read<int64_t>(held.column(0), 2), ElementsAre(13, 14));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_batch.cc
+++ b/src/trace_processor/core/exec/row_batch.cc
@@ -17,9 +17,11 @@
 #include "src/trace_processor/core/exec/row_batch.h"
 
 #include <cstdint>
+#include <memory>
 
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/owned_column.h"
 #include "src/trace_processor/core/exec/row_selection.h"
 
 namespace perfetto::trace_processor::core::exec {
@@ -36,6 +38,15 @@ bool RowBatch::AdoptPhysicalRows(Span<const uint32_t> rows) {
   }
   cardinality_ = count;
   return true;
+}
+
+void RowBatch::AddOwnedColumn(const ColumnView& column, uint32_t count) {
+  if (owned_used_ == owned_.size()) {
+    owned_.push_back(std::make_unique<OwnedColumn>());
+  }
+  OwnedColumn& owned = *owned_[owned_used_++];
+  owned.Fill(column, count);
+  AddColumn(owned.View());
 }
 
 void RowBatch::Compose(RowSelection selection, uint32_t count) {

--- a/src/trace_processor/core/exec/row_batch.h
+++ b/src/trace_processor/core/exec/row_batch.h
@@ -18,11 +18,13 @@
 #define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
 
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/owned_column.h"
 #include "src/trace_processor/core/exec/row_selection.h"
 
 namespace perfetto::trace_processor::core::exec {
@@ -46,6 +48,15 @@ class RowBatch {
   const ColumnView& column(uint32_t column) const { return columns_[column]; }
   ColumnView& mutable_column(uint32_t column) { return columns_[column]; }
   void AddColumn(ColumnView column) { columns_.push_back(std::move(column)); }
+
+  // Copies `column`'s `count` values into storage this batch owns and adds a
+  // column reading them, dense from row zero.
+  //
+  // Optional, and the caller's call: a view costs nothing to add and is right
+  // whenever the storage behind it outlives the batch. This is for when it
+  // does not, which is any source that materialises into buffers it refills,
+  // and for an operator holding batches past the pull that produced them.
+  void AddOwnedColumn(const ColumnView& column, uint32_t count);
 
   // Points every column at `rows`, which the caller continues to own. Only
   // valid while the columns still share the source's contiguous view, and
@@ -73,11 +84,16 @@ class RowBatch {
     cardinality_ = 0;
     columns_.clear();
     selections_.Reset();
+    // The buffers stay: a pooled batch refills the ones it filled last time.
+    owned_used_ = 0;
   }
 
   uint32_t cardinality_ = 0;
   std::vector<ColumnView> columns_;
   SelectionPool selections_;
+  // Held by pointer so a column's view of one survives the vector growing.
+  std::vector<std::unique_ptr<OwnedColumn>> owned_;
+  uint32_t owned_used_ = 0;
 };
 
 }  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_batch_pool.h
+++ b/src/trace_processor/core/exec/row_batch_pool.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_POOL_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_POOL_H_
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+class RowBatchPool;
+
+// A row batch borrowed from a pool and returned when it goes out of scope. The
+// pool must outlive every row batch borrowed from it.
+class PooledRowBatch {
+ public:
+  PooledRowBatch() = default;
+  PooledRowBatch(RowBatchPool* pool, std::unique_ptr<RowBatch> chunk)
+      : pool_(pool), chunk_(std::move(chunk)) {}
+  PooledRowBatch(PooledRowBatch&&) noexcept;
+  PooledRowBatch& operator=(PooledRowBatch&&) noexcept;
+  PooledRowBatch(const PooledRowBatch&) = delete;
+  PooledRowBatch& operator=(const PooledRowBatch&) = delete;
+  ~PooledRowBatch();
+
+  explicit operator bool() const { return chunk_ != nullptr; }
+  RowBatch& operator*() const { return *chunk_; }
+  RowBatch* operator->() const { return chunk_.get(); }
+
+  // Returns the batch to its pool early.
+  void Release();
+
+ private:
+  RowBatchPool* pool_ = nullptr;
+  std::unique_ptr<RowBatch> chunk_;
+};
+
+// Recycles row batches across a running pipeline.
+class RowBatchPool {
+ public:
+  PooledRowBatch Acquire() {
+    if (free_.empty()) {
+      ++allocations_;
+      return PooledRowBatch(this, std::make_unique<RowBatch>());
+    }
+    std::unique_ptr<RowBatch> chunk = std::move(free_.back());
+    free_.pop_back();
+    return PooledRowBatch(this, std::move(chunk));
+  }
+
+  void Return(std::unique_ptr<RowBatch> chunk) {
+    PERFETTO_DCHECK(chunk);
+    chunk->Reset();
+    free_.push_back(std::move(chunk));
+  }
+
+  // Row batches the pool has had to allocate. In a steady state this stops
+  // growing, which is what the pool exists to guarantee.
+  uint32_t allocations() const { return allocations_; }
+  uint32_t free_count() const { return static_cast<uint32_t>(free_.size()); }
+
+ private:
+  uint32_t allocations_ = 0;
+  std::vector<std::unique_ptr<RowBatch>> free_;
+};
+
+inline PooledRowBatch::PooledRowBatch(PooledRowBatch&& other) noexcept
+    : pool_(other.pool_), chunk_(std::move(other.chunk_)) {
+  other.pool_ = nullptr;
+}
+
+inline PooledRowBatch& PooledRowBatch::operator=(
+    PooledRowBatch&& other) noexcept {
+  if (this != &other) {
+    Release();
+    pool_ = other.pool_;
+    chunk_ = std::move(other.chunk_);
+    other.pool_ = nullptr;
+  }
+  return *this;
+}
+
+inline PooledRowBatch::~PooledRowBatch() {
+  Release();
+}
+
+inline void PooledRowBatch::Release() {
+  if (chunk_ && pool_) {
+    pool_->Return(std::move(chunk_));
+  }
+  chunk_.reset();
+  pool_ = nullptr;
+}
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_POOL_H_

--- a/src/trace_processor/core/exec/row_batch_pool_unittest.cc
+++ b/src/trace_processor/core/exec/row_batch_pool_unittest.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_batch_pool.h"
+
+#include <utility>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+TEST(RowBatchPoolTest, AReleasedBatchIsHandedOutAgain) {
+  RowBatchPool pool;
+  {
+    PooledRowBatch batch = pool.Acquire();
+    ASSERT_TRUE(batch);
+    EXPECT_EQ(pool.allocations(), 1u);
+  }
+  EXPECT_EQ(pool.free_count(), 1u);
+
+  PooledRowBatch again = pool.Acquire();
+  EXPECT_EQ(pool.allocations(), 1u);
+  EXPECT_EQ(pool.free_count(), 0u);
+}
+
+// The point of the pool: an operator which holds several batches at once
+// stops allocating once it has as many as it ever needs at one time.
+TEST(RowBatchPoolTest, HoldingSeveralAtOnceAllocatesOnlyAsManyAsAreHeld) {
+  RowBatchPool pool;
+  {
+    std::vector<PooledRowBatch> held;
+    for (int i = 0; i < 4; ++i) {
+      held.push_back(pool.Acquire());
+    }
+    EXPECT_EQ(pool.allocations(), 4u);
+  }
+  for (int round = 0; round < 10; ++round) {
+    std::vector<PooledRowBatch> held;
+    for (int i = 0; i < 4; ++i) {
+      held.push_back(pool.Acquire());
+    }
+  }
+  EXPECT_EQ(pool.allocations(), 4u);
+}
+
+// A batch handed back carries nothing over from its last use, or an operator
+// would read the previous query's columns.
+TEST(RowBatchPoolTest, ABatchComesBackEmpty) {
+  RowBatchPool pool;
+  {
+    PooledRowBatch batch = pool.Acquire();
+    batch->AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr));
+    batch->SetCardinality(7);
+    ASSERT_EQ(batch->column_count(), 1u);
+  }
+  PooledRowBatch again = pool.Acquire();
+  EXPECT_EQ(again->column_count(), 0u);
+  EXPECT_EQ(again->size(), 0u);
+}
+
+TEST(RowBatchPoolTest, MovingABatchMovesWhoReturnsIt) {
+  RowBatchPool pool;
+  {
+    PooledRowBatch batch = pool.Acquire();
+    PooledRowBatch moved = std::move(batch);
+    EXPECT_FALSE(batch);
+    EXPECT_TRUE(moved);
+    EXPECT_EQ(pool.free_count(), 0u);
+  }
+  // Returned once, by whichever of them still held it.
+  EXPECT_EQ(pool.free_count(), 1u);
+  EXPECT_EQ(pool.allocations(), 1u);
+}
+
+TEST(RowBatchPoolTest, ABatchCanBeGivenBackEarly) {
+  RowBatchPool pool;
+  PooledRowBatch batch = pool.Acquire();
+  batch.Release();
+  EXPECT_FALSE(batch);
+  EXPECT_EQ(pool.free_count(), 1u);
+  batch.Release();
+  EXPECT_EQ(pool.free_count(), 1u);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_cursor.cc
+++ b/src/trace_processor/core/exec/row_cursor.cc
@@ -18,7 +18,6 @@
 
 #include "src/trace_processor/core/exec/operator.h"
 #include "src/trace_processor/core/exec/row_batch.h"
-#include "src/trace_processor/core/exec/row_selection.h"
 
 namespace perfetto::trace_processor::core::exec {
 
@@ -27,17 +26,14 @@ RowCursor::RowCursor(Source& source) : source_(source) {}
 RowCursor::~RowCursor() = default;
 
 bool RowCursor::Pull() {
-  RowBatch* batch = source_.Next();
-  if (!batch) {
+  batch_ = source_.Next();
+  if (!batch_) {
     index_ = 0;
     size_ = 0;
     return false;
   }
-  RowSelection selection = batch->column(0).selection();
-  rows_ = selection.is_range() ? nullptr : selection.data();
-  offset_ = selection.offset();
   index_ = 0;
-  size_ = batch->size();
+  size_ = batch_->size();
   return true;
 }
 

--- a/src/trace_processor/core/exec/row_cursor.h
+++ b/src/trace_processor/core/exec/row_cursor.h
@@ -22,6 +22,7 @@
 #include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
 
 namespace perfetto::trace_processor::core::exec {
 
@@ -49,11 +50,21 @@ class RowCursor {
 
   bool eof() const { return index_ == size_; }
 
-  // The row being read. Every column of a batch shares one row view, so which
-  // column it is read from does not matter.
-  PERFETTO_ALWAYS_INLINE uint32_t row() const {
+  // The physical row `column` is read at.
+  //
+  // Resolved per column rather than once for the batch: an operator which adds
+  // a computed column has nowhere to put it in the index space its input
+  // arrived in, so it adds the column in its own. Columns of one batch
+  // therefore agree on how many rows there are and need agree on nothing else.
+  PERFETTO_ALWAYS_INLINE uint32_t row(uint32_t column) const {
     PERFETTO_DCHECK(index_ < size_);
-    return rows_ ? rows_[index_] : offset_ + index_;
+    return batch_->column(column).selection().GetIndex(index_);
+  }
+
+  // The batch being read, for a consumer which wants the columns themselves.
+  const RowBatch& batch() const {
+    PERFETTO_DCHECK(batch_);
+    return *batch_;
   }
 
  private:
@@ -61,9 +72,7 @@ class RowCursor {
   bool Pull();
 
   Source& source_;
-  // The batch's rows, or null when they are the contiguous run from `offset_`.
-  const uint32_t* rows_ = nullptr;
-  uint32_t offset_ = 0;
+  RowBatch* batch_ = nullptr;
   uint32_t index_ = 0;
   uint32_t size_ = 0;
 };

--- a/src/trace_processor/core/exec/sink.cc
+++ b/src/trace_processor/core/exec/sink.cc
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/sink.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+Sink::~Sink() = default;
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/sink.h
+++ b/src/trace_processor/core/exec/sink.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_SINK_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_SINK_H_
+
+#include "perfetto/base/status.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+class RowBatch;
+
+// Somewhere a stream of chunks can be poured.
+//
+// Chunks are pushed into it. The opposite end of a Source, which has chunks
+// pulled out of it, and the half of a Breaker that faces its input.
+//
+// The two are separate so that being fed and being read are things a step can
+// do rather than things it is: a Breaker does both.
+class Sink {
+ public:
+  virtual ~Sink();
+
+  // Called with every chunk of the input, in order. The chunk belongs to
+  // whoever produced it and is refilled on the next pull, so anything worth
+  // keeping has to be kept here.
+  virtual base::Status Consume(RowBatch&) = 0;
+
+  // Called once, after the last chunk: everything is now known.
+  virtual base::Status Finish() = 0;
+
+ protected:
+  Sink() = default;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_SINK_H_

--- a/src/trace_processor/core/exec/tree_accumulate.cc
+++ b/src/trace_processor/core/exec/tree_accumulate.cc
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/tree_accumulate.h"
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// Resolves a chunk's column into contiguous memory.
+//
+// A range selection already is contiguous, so it is handed back as a pointer
+// into the storage the column references and nothing is copied; anything else
+// is gathered once, here. Reading through the selection a row at a time
+// inside the loop that follows would neither vectorize nor prefetch, which is
+// why the filters resolve their columns the same way before looping.
+const int64_t* Flatten(const ColumnView& column,
+                       uint32_t count,
+                       std::vector<int64_t>* scratch) {
+  const auto* data = static_cast<const int64_t*>(column.data());
+  RowSelection selection = column.selection();
+  if (selection.is_range()) {
+    return data + selection.offset();
+  }
+  scratch->resize(count);
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    (*scratch)[i] = data[rows[i]];
+  }
+  return scratch->data();
+}
+
+}  // namespace
+
+TreeAccumulateUp::TreeAccumulateUp(Source& source,
+                                   RowBatchPool* pool,
+                                   uint32_t parent_column,
+                                   uint32_t value_column)
+    : Breaker(source),
+      pool_(pool),
+      parent_column_(parent_column),
+      value_column_(value_column) {}
+
+TreeAccumulateUp::~TreeAccumulateUp() = default;
+
+void TreeAccumulateUp::Rewind() {
+  parents_.clear();
+  values_.clear();
+  sizes_.clear();
+  retained_.clear();
+  totals_.clear();
+  next_ = 0;
+}
+
+base::Status TreeAccumulateUp::Consume(RowBatch& chunk) {
+  uint32_t count = chunk.size();
+  std::vector<int64_t> parent_scratch;
+  std::vector<int64_t> value_scratch;
+  const int64_t* parent =
+      Flatten(chunk.column(parent_column_), count, &parent_scratch);
+  const int64_t* value =
+      Flatten(chunk.column(value_column_), count, &value_scratch);
+  parents_.insert(parents_.end(), parent, parent + count);
+  values_.insert(values_.end(), value, value + count);
+  sizes_.push_back(count);
+
+  // The chunk is kept by copying its values into a batch this operator owns.
+  // A view would be cheaper and would be wrong: the source is free to refill
+  // its buffers on the next pull, and one that materialises rows does exactly
+  // that. Owning them also lands every column dense from row zero, which is
+  // what lets the total be added beside them on the way out.
+  PooledRowBatch held = pool_->Acquire();
+  for (uint32_t col = 0; col < chunk.column_count(); ++col) {
+    held->AddOwnedColumn(chunk.column(col), count);
+  }
+  held->SetCardinality(count);
+  retained_.push_back(std::move(held));
+  return base::OkStatus();
+}
+
+base::Status TreeAccumulateUp::Finish() {
+  // Every parent precedes its children, so one pass backwards carries each
+  // node's subtree into its parent.
+  auto rows = static_cast<uint32_t>(parents_.size());
+  std::vector<int64_t> totals(values_.begin(), values_.end());
+  for (uint32_t row = rows; row-- > 0;) {
+    int64_t parent = parents_[row];
+    if (parent >= 0) {
+      totals[static_cast<uint32_t>(parent)] += totals[row];
+    }
+  }
+  uint32_t offset = 0;
+  totals_.reserve(sizes_.size());
+  for (uint32_t size : sizes_) {
+    totals_.emplace_back(totals.begin() + offset,
+                         totals.begin() + offset + size);
+    offset += size;
+  }
+  return base::OkStatus();
+}
+
+RowBatch* TreeAccumulateUp::Emit() {
+  if (next_ == retained_.size()) {
+    return nullptr;
+  }
+  size_t index = next_++;
+  RowBatch& chunk = *retained_[index];
+  // The column is added on the way out rather than on the way in, because
+  // until every row had gone past there was nothing to put in it.
+  chunk.AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, totals_[index].data()));
+  return &chunk;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/tree_accumulate.cc
+++ b/src/trace_processor/core/exec/tree_accumulate.cc
@@ -16,7 +16,9 @@
 
 #include "src/trace_processor/core/exec/tree_accumulate.h"
 
+#include <algorithm>
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -57,18 +59,22 @@ const int64_t* Flatten(const ColumnView& column,
 TreeAccumulateUp::TreeAccumulateUp(Source& source,
                                    RowBatchPool* pool,
                                    uint32_t parent_column,
-                                   uint32_t value_column)
+                                   uint32_t value_column,
+                                   std::optional<uint32_t> node_column)
     : Breaker(source),
       pool_(pool),
       parent_column_(parent_column),
-      value_column_(value_column) {}
+      value_column_(value_column),
+      node_column_(node_column) {}
 
 TreeAccumulateUp::~TreeAccumulateUp() = default;
 
 void TreeAccumulateUp::Rewind() {
   parents_.clear();
   values_.clear();
+  nodes_.clear();
   sizes_.clear();
+  node_count_ = 0;
   retained_.clear();
   totals_.clear();
   next_ = 0;
@@ -86,6 +92,23 @@ base::Status TreeAccumulateUp::Consume(RowBatch& chunk) {
   values_.insert(values_.end(), value, value + count);
   sizes_.push_back(count);
 
+  size_t base = nodes_.size();
+  if (node_column_) {
+    std::vector<int64_t> node_scratch;
+    const int64_t* node =
+        Flatten(chunk.column(*node_column_), count, &node_scratch);
+    nodes_.insert(nodes_.end(), node, node + count);
+  } else {
+    // No node column: the rows are their own numbers.
+    nodes_.resize(base + count);
+    for (uint32_t i = 0; i < count; ++i) {
+      nodes_[base + i] = static_cast<int64_t>(base) + i;
+    }
+  }
+  for (size_t i = base; i < nodes_.size(); ++i) {
+    node_count_ = std::max(node_count_, static_cast<uint32_t>(nodes_[i]) + 1);
+  }
+
   // The chunk is kept by copying its values into a batch this operator owns.
   // A view would be cheaper and would be wrong: the source is free to refill
   // its buffers on the next pull, and one that materialises rows does exactly
@@ -102,20 +125,29 @@ base::Status TreeAccumulateUp::Consume(RowBatch& chunk) {
 
 base::Status TreeAccumulateUp::Finish() {
   // Every parent precedes its children, so one pass backwards carries each
-  // node's subtree into its parent.
+  // node's subtree into its parent. The totals are held by node number, not
+  // by where the row sits, because the two are only the same when the rows
+  // arrived in this order rather than being put in it.
   auto rows = static_cast<uint32_t>(parents_.size());
-  std::vector<int64_t> totals(values_.begin(), values_.end());
+  std::vector<int64_t> totals(node_count_, 0);
+  for (uint32_t row = 0; row < rows; ++row) {
+    totals[static_cast<uint32_t>(nodes_[row])] = values_[row];
+  }
   for (uint32_t row = rows; row-- > 0;) {
     int64_t parent = parents_[row];
     if (parent >= 0) {
-      totals[static_cast<uint32_t>(parent)] += totals[row];
+      totals[static_cast<uint32_t>(parent)] +=
+          totals[static_cast<uint32_t>(nodes_[row])];
     }
   }
   uint32_t offset = 0;
   totals_.reserve(sizes_.size());
   for (uint32_t size : sizes_) {
-    totals_.emplace_back(totals.begin() + offset,
-                         totals.begin() + offset + size);
+    std::vector<int64_t> chunk(size);
+    for (uint32_t i = 0; i < size; ++i) {
+      chunk[i] = totals[static_cast<uint32_t>(nodes_[offset + i])];
+    }
+    totals_.push_back(std::move(chunk));
     offset += size;
   }
   return base::OkStatus();

--- a/src/trace_processor/core/exec/tree_accumulate.h
+++ b/src/trace_processor/core/exec/tree_accumulate.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_TREE_ACCUMULATE_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_TREE_ACCUMULATE_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/breaker.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_batch_pool.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// TREE ACCUMULATE UP over a stream of chunks.
+//
+// A breaker: a node's total is not known until the last of its descendants
+// has gone past, so every chunk goes in before any comes out.
+//
+// What it holds while it waits is the input, copied. A view of the input
+// would be cheaper and would be wrong: a source is free to refill its buffers
+// on the next pull, so a view is only good until the pull after the one that
+// produced it. The rows come back out with one column added.
+//
+// The parent column holds each row's parent as an ordinal into the stream, or
+// a negative value for a root, and every parent precedes its children. That
+// is what a tree looks like once it is rows; establishing it is the job of
+// whatever comes before this.
+class TreeAccumulateUp : public Breaker {
+ public:
+  TreeAccumulateUp(Source& source,
+                   RowBatchPool* pool,
+                   uint32_t parent_column,
+                   uint32_t value_column);
+  ~TreeAccumulateUp() override;
+
+ public:
+  base::Status Consume(RowBatch&) override;
+  base::Status Finish() override;
+
+ protected:
+  RowBatch* Emit() override;
+  void Rewind() override;
+
+ private:
+  RowBatchPool* pool_;
+  uint32_t parent_column_;
+  uint32_t value_column_;
+
+  // The two columns the fold reads, pulled out flat as the chunks go by.
+  std::vector<int64_t> parents_;
+  std::vector<int64_t> values_;
+  std::vector<uint32_t> sizes_;
+
+  std::vector<PooledRowBatch> retained_;
+  // One per retained chunk, in the same order: the totals that chunk's rows
+  // get, laid out so the added column reads them flat.
+  std::vector<std::vector<int64_t>> totals_;
+  size_t next_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_TREE_ACCUMULATE_H_

--- a/src/trace_processor/core/exec/tree_accumulate.h
+++ b/src/trace_processor/core/exec/tree_accumulate.h
@@ -18,6 +18,7 @@
 #define SRC_TRACE_PROCESSOR_CORE_EXEC_TREE_ACCUMULATE_H_
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "perfetto/base/status.h"
@@ -37,16 +38,22 @@ namespace perfetto::trace_processor::core::exec {
 // on the next pull, so a view is only good until the pull after the one that
 // produced it. The rows come back out with one column added.
 //
-// The parent column holds each row's parent as an ordinal into the stream, or
-// a negative value for a root, and every parent precedes its children. That
-// is what a tree looks like once it is rows; establishing it is the job of
-// whatever comes before this.
+// The parent column holds each row's parent as a node number, or a negative
+// value for a root, and every parent precedes its children. That is what a
+// tree looks like once it is rows; establishing it is the job of whatever
+// comes before this.
+//
+// Node numbers need not be stream positions, and are not whenever the rows
+// were put in this order rather than arriving in it. Without a node column
+// they are taken to be stream positions, which is what a source that was
+// already in order gives for free.
 class TreeAccumulateUp : public Breaker {
  public:
   TreeAccumulateUp(Source& source,
                    RowBatchPool* pool,
                    uint32_t parent_column,
-                   uint32_t value_column);
+                   uint32_t value_column,
+                   std::optional<uint32_t> node_column = std::nullopt);
   ~TreeAccumulateUp() override;
 
  public:
@@ -61,11 +68,14 @@ class TreeAccumulateUp : public Breaker {
   RowBatchPool* pool_;
   uint32_t parent_column_;
   uint32_t value_column_;
+  std::optional<uint32_t> node_column_;
 
-  // The two columns the fold reads, pulled out flat as the chunks go by.
+  // The columns the fold reads, pulled out flat as the chunks go by.
   std::vector<int64_t> parents_;
   std::vector<int64_t> values_;
+  std::vector<int64_t> nodes_;
   std::vector<uint32_t> sizes_;
+  uint32_t node_count_ = 0;
 
   std::vector<PooledRowBatch> retained_;
   // One per retained chunk, in the same order: the totals that chunk's rows

--- a/src/trace_processor/core/exec/tree_accumulate_unittest.cc
+++ b/src/trace_processor/core/exec/tree_accumulate_unittest.cc
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/tree_accumulate.h"
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_batch_pool.h"
+#include "src/trace_processor/core/exec/row_cursor.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// Hands out a parent column and a value column in chunks of a fixed size,
+// refilling one batch each time, which is what a real source does and what
+// makes holding onto its chunk the wrong thing to do.
+class ArraySource : public Source {
+ public:
+  ArraySource(const std::vector<int64_t>* parent,
+              const std::vector<int64_t>* value,
+              uint32_t chunk_rows)
+      : parent_(parent), value_(value), chunk_rows_(chunk_rows) {}
+
+  void Reset() override { offset_ = 0; }
+
+  RowBatch* Next() override {
+    auto rows = static_cast<uint32_t>(parent_->size());
+    if (offset_ == rows) {
+      return nullptr;
+    }
+    uint32_t count = std::min(chunk_rows_, rows - offset_);
+    batch_ = RowBatch();
+    batch_.AddColumn(
+        ColumnView::Reference(StorageType{Int64{}}, parent_->data()));
+    batch_.AddColumn(
+        ColumnView::Reference(StorageType{Int64{}}, value_->data()));
+    batch_.Compose(RowSelection::Range(offset_), count);
+    batch_.SetCardinality(count);
+    offset_ += count;
+    return &batch_;
+  }
+
+ private:
+  const std::vector<int64_t>* parent_;
+  const std::vector<int64_t>* value_;
+  uint32_t chunk_rows_;
+  uint32_t offset_ = 0;
+  RowBatch batch_;
+};
+
+// The definition, written out: a node's total is the sum over everything
+// whose parent chain reaches it.
+std::vector<int64_t> Reference(const std::vector<int64_t>& parent,
+                               const std::vector<int64_t>& value) {
+  std::vector<int64_t> totals(parent.size(), 0);
+  for (size_t node = 0; node < parent.size(); ++node) {
+    for (size_t row = 0; row < parent.size(); ++row) {
+      for (int64_t walk = static_cast<int64_t>(row); walk >= 0;
+           walk = parent[static_cast<size_t>(walk)]) {
+        if (static_cast<size_t>(walk) == node) {
+          totals[node] += value[row];
+          break;
+        }
+      }
+    }
+  }
+  return totals;
+}
+
+std::vector<int64_t> Totals(const std::vector<int64_t>& parent,
+                            const std::vector<int64_t>& value,
+                            uint32_t chunk_rows,
+                            RowBatchPool* pool) {
+  ArraySource source(&parent, &value, chunk_rows);
+  TreeAccumulateUp accumulate(source, pool, 0, 1);
+  std::vector<int64_t> out;
+  while (RowBatch* chunk = accumulate.Next()) {
+    // The added column is the last one; the ones it arrived with are still
+    // there, in the order they were in.
+    EXPECT_EQ(chunk->column_count(), 3u);
+    // Read through the column's own row view rather than by position: a
+    // column added on the way out need not sit in the same index space as
+    // the ones it was added beside, and reading it by position is how that
+    // going wrong stays invisible.
+    const ColumnView& column = chunk->column(2);
+    const auto* totals = static_cast<const int64_t*>(column.data());
+    for (uint32_t row = 0; row < chunk->size(); ++row) {
+      out.push_back(totals[column.selection().GetIndex(row)]);
+    }
+  }
+  EXPECT_TRUE(accumulate.status().ok()) << accumulate.status().message();
+  return out;
+}
+
+// A source which materialises its rows refills the same buffers on every
+// pull, so what a held view points at is whatever it wrote next. Holding on
+// to a chunk from one of these is the case a view cannot serve.
+class RefillingSource final : public Source {
+ public:
+  RefillingSource(const std::vector<int64_t>* parent,
+                  const std::vector<int64_t>* value,
+                  uint32_t chunk_rows)
+      : parent_(parent), value_(value), chunk_rows_(chunk_rows) {}
+
+  void Reset() override { offset_ = 0; }
+
+  RowBatch* Next() override {
+    auto rows = static_cast<uint32_t>(parent_->size());
+    if (offset_ == rows) {
+      return nullptr;
+    }
+    uint32_t count = std::min(chunk_rows_, rows - offset_);
+    parent_buffer_.assign(parent_->begin() + offset_,
+                          parent_->begin() + offset_ + count);
+    value_buffer_.assign(value_->begin() + offset_,
+                         value_->begin() + offset_ + count);
+    batch_ = RowBatch();
+    batch_.AddColumn(
+        ColumnView::Reference(StorageType{Int64{}}, parent_buffer_.data()));
+    batch_.AddColumn(
+        ColumnView::Reference(StorageType{Int64{}}, value_buffer_.data()));
+    batch_.Compose(RowSelection::Range(0), count);
+    batch_.SetCardinality(count);
+    offset_ += count;
+    return &batch_;
+  }
+
+ private:
+  const std::vector<int64_t>* parent_;
+  const std::vector<int64_t>* value_;
+  uint32_t chunk_rows_;
+  uint32_t offset_ = 0;
+  std::vector<int64_t> parent_buffer_;
+  std::vector<int64_t> value_buffer_;
+  RowBatch batch_;
+};
+
+// Parents come before their children, which is what the stage before this
+// one is for.
+std::vector<int64_t> RandomParents(std::mt19937& rng, uint32_t rows) {
+  std::vector<int64_t> parent(rows, -1);
+  for (uint32_t i = 1; i < rows; ++i) {
+    if (std::uniform_int_distribution<int>(0, 3)(rng) == 0) {
+      continue;
+    }
+    parent[i] = std::uniform_int_distribution<int64_t>(0, i - 1)(rng);
+  }
+  return parent;
+}
+
+TEST(TreeAccumulateUpChunkTest, MatchesTheDefinition) {
+  std::mt19937 rng(0xfeed);
+  RowBatchPool pool;
+  for (int trial = 0; trial < 50; ++trial) {
+    auto rows = std::uniform_int_distribution<uint32_t>(0, 60)(rng);
+    std::vector<int64_t> parent = RandomParents(rng, rows);
+    std::vector<int64_t> value(rows);
+    for (uint32_t i = 0; i < rows; ++i) {
+      value[i] = std::uniform_int_distribution<int64_t>(-100, 100)(rng);
+    }
+    EXPECT_EQ(Totals(parent, value, 8, &pool), Reference(parent, value))
+        << "trial " << trial;
+  }
+}
+
+// A subtree spans whatever chunks it happens to span, so the answer cannot
+// depend on where the boundaries fall.
+TEST(TreeAccumulateUpChunkTest, TheChunkSizeDoesNotChangeTheAnswer) {
+  std::mt19937 rng(7);
+  RowBatchPool pool;
+  std::vector<int64_t> parent = RandomParents(rng, 64);
+  std::vector<int64_t> value(64);
+  for (uint32_t i = 0; i < 64; ++i) {
+    value[i] = i + 1;
+  }
+  std::vector<int64_t> whole = Totals(parent, value, 1024, &pool);
+  for (uint32_t chunk_rows : {1u, 2u, 7u, 63u, 64u, 65u}) {
+    EXPECT_EQ(Totals(parent, value, chunk_rows, &pool), whole)
+        << "chunk size " << chunk_rows;
+  }
+}
+
+// What the pool is for: holding every chunk of a long input allocates as many
+// batches as the longest input needs, and running again allocates none.
+TEST(TreeAccumulateUpChunkTest, RunningAgainAllocatesNothing) {
+  std::mt19937 rng(11);
+  RowBatchPool pool;
+  std::vector<int64_t> parent = RandomParents(rng, 100);
+  std::vector<int64_t> value(100, 1);
+
+  Totals(parent, value, 10, &pool);
+  uint32_t after_first = pool.allocations();
+  EXPECT_EQ(after_first, 10u);
+
+  Totals(parent, value, 10, &pool);
+  EXPECT_EQ(pool.allocations(), after_first);
+}
+
+TEST(TreeAccumulateUpChunkTest, AnEmptyInputProducesNothing) {
+  RowBatchPool pool;
+  std::vector<int64_t> parent;
+  std::vector<int64_t> value;
+  EXPECT_TRUE(Totals(parent, value, 8, &pool).empty());
+}
+
+// The answer must not depend on whether the source's storage stands still.
+TEST(TreeAccumulateUpTest, ASourceWhichRefillsItsBuffersGivesTheSameAnswer) {
+  std::mt19937 rng(7);
+  std::vector<int64_t> parent = RandomParents(rng, 200);
+  std::vector<int64_t> value(parent.size());
+  for (uint32_t i = 0; i < value.size(); ++i) {
+    value[i] = std::uniform_int_distribution<int64_t>(-50, 50)(rng);
+  }
+
+  RowBatchPool pool;
+  std::vector<int64_t> expected = Totals(parent, value, 16, &pool);
+
+  RefillingSource source(&parent, &value, 16);
+  TreeAccumulateUp accumulate(source, &pool, 0, 1);
+  std::vector<int64_t> got;
+  std::vector<int64_t> payload;
+  while (RowBatch* chunk = accumulate.Next()) {
+    const ColumnView& totals_column = chunk->column(2);
+    const ColumnView& value_column = chunk->column(1);
+    const auto* totals = static_cast<const int64_t*>(totals_column.data());
+    const auto* values = static_cast<const int64_t*>(value_column.data());
+    for (uint32_t row = 0; row < chunk->size(); ++row) {
+      got.push_back(totals[totals_column.selection().GetIndex(row)]);
+      payload.push_back(values[value_column.selection().GetIndex(row)]);
+    }
+  }
+  ASSERT_TRUE(accumulate.status().ok()) << accumulate.status().message();
+  EXPECT_EQ(got, Reference(parent, value));
+  EXPECT_EQ(got, expected);
+  EXPECT_EQ(payload, value);
+}
+
+// The payload has to come back out beside the total, at the same rows.
+TEST(TreeAccumulateUpTest, ThePayloadComesBackOutBesideTheTotal) {
+  std::vector<int64_t> parent = {-1, 0, 0, 1, 1, 2, 2};
+  std::vector<int64_t> value = {1, 2, 3, 4, 5, 6, 7};
+
+  RowBatchPool pool;
+  RefillingSource source(&parent, &value, 2);
+  TreeAccumulateUp accumulate(source, &pool, 0, 1);
+
+  std::vector<int64_t> values_out;
+  std::vector<int64_t> totals_out;
+  RowCursor cursor(accumulate);
+  for (bool more = cursor.Open(); more; more = cursor.Next()) {
+    const RowBatch& chunk = cursor.batch();
+    values_out.push_back(
+        static_cast<const int64_t*>(chunk.column(1).data())[cursor.row(1)]);
+    totals_out.push_back(
+        static_cast<const int64_t*>(chunk.column(2).data())[cursor.row(2)]);
+  }
+  EXPECT_EQ(values_out, value);
+  EXPECT_EQ(totals_out, Reference(parent, value));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/tree_order.cc
+++ b/src/trace_processor/core/exec/tree_order.cc
@@ -1,0 +1,353 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/tree_order.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/owned_column.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// The column's `count` values, laid out flat. A range already is flat; an
+// index selection is gathered once rather than walked a value at a time.
+const int64_t* Flatten(const ColumnView& column,
+                       uint32_t count,
+                       std::vector<int64_t>* scratch) {
+  const auto* data = static_cast<const int64_t*>(column.data());
+  RowSelection selection = column.selection();
+  if (selection.is_range()) {
+    return data + selection.offset();
+  }
+  scratch->resize(count);
+  const uint32_t* rows = selection.data();
+  int64_t* out = scratch->data();
+  for (uint32_t i = 0; i < count; ++i) {
+    out[i] = data[rows[i]];
+  }
+  return out;
+}
+
+// Which of the column's `count` values are null, laid out flat, or null when
+// none of them are.
+const uint8_t* FlattenNulls(const ColumnView& column,
+                            uint32_t count,
+                            std::vector<uint8_t>* scratch) {
+  const BitVector* validity = column.validity();
+  if (!validity) {
+    return nullptr;
+  }
+  scratch->resize(count);
+  uint8_t* out = scratch->data();
+  RowSelection selection = column.selection();
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      out[i] = static_cast<uint8_t>(!validity->is_set(offset + i));
+    }
+    return out;
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    out[i] = static_cast<uint8_t>(!validity->is_set(rows[i]));
+  }
+  return out;
+}
+
+const char* Name(TreeRowOrder order) {
+  return order == TreeRowOrder::kParentFirst ? "TREE ORDER PARENT FIRST"
+                                             : "TREE ORDER CHILD FIRST";
+}
+
+}  // namespace
+
+TreeOrder::TreeOrder(Source& input, Spec spec)
+    : input_(input),
+      spec_(spec),
+      mode_(spec.input && *spec.input == spec.want ? Mode::kStreaming
+                                                   : Mode::kBuffering) {}
+
+TreeOrder::~TreeOrder() = default;
+
+uint32_t TreeOrder::Number(int64_t id) {
+  if (dense_) {
+    // Everything below `numbered_` was handed out in order, so an id in that
+    // range is already its own number.
+    if (id >= 0 && static_cast<uint64_t>(id) < numbered_) {
+      return static_cast<uint32_t>(id);
+    }
+    if (id == static_cast<int64_t>(numbered_)) {
+      return numbered_++;
+    }
+    // Not dense after all. Write down what identity had been saying, then
+    // carry on the slow way.
+    dense_ = false;
+    for (uint32_t n = 0; n < numbered_; ++n) {
+      numbers_.Insert(static_cast<int64_t>(n), n);
+    }
+  }
+  if (uint32_t* existing = numbers_.Find(id); existing) {
+    return *existing;
+  }
+  uint32_t assigned = numbered_++;
+  numbers_.Insert(id, assigned);
+  return assigned;
+}
+
+void TreeOrder::Note(uint32_t node, int64_t parent) {
+  if (has_row_.size() < numbered_) {
+    has_row_.resize(numbered_);
+  }
+  if (parent >= 0) {
+    // A parent already seen means children follow parents here; a parent not
+    // seen yet means they precede them. A row cannot be both, so between them
+    // the two orders are decided by the first row that is not a root.
+    if (has_row_.is_set(static_cast<uint32_t>(parent))) {
+      child_first_ = false;
+    } else {
+      parent_first_ = false;
+    }
+  }
+  has_row_.set(node);
+}
+
+bool TreeOrder::Consume(RowBatch& batch, bool retain) {
+  uint32_t count = batch.size();
+  if (count == 0) {
+    return true;
+  }
+  std::vector<int64_t> id_scratch;
+  std::vector<int64_t> parent_scratch;
+  std::vector<uint8_t> null_scratch;
+  const ColumnView& parent_column = batch.column(spec_.parent_column);
+  const int64_t* ids =
+      Flatten(batch.column(spec_.id_column), count, &id_scratch);
+  const int64_t* parents = Flatten(parent_column, count, &parent_scratch);
+  const uint8_t* parent_null =
+      FlattenNulls(parent_column, count, &null_scratch);
+
+  size_t base = nodes_.size();
+  nodes_.resize(base + count);
+  parents_.resize(base + count);
+  for (uint32_t i = 0; i < count; ++i) {
+    uint32_t node = Number(ids[i]);
+    int64_t parent = -1;
+    if (!parent_null || !parent_null[i]) {
+      parent = static_cast<int64_t>(Number(parents[i]));
+    }
+    Note(node, parent);
+    nodes_[base + i] = node;
+    parents_[base + i] = parent;
+  }
+
+  if (retain) {
+    if (store_.empty()) {
+      for (uint32_t col = 0; col < batch.column_count(); ++col) {
+        store_.push_back(std::make_unique<OwnedColumn>());
+      }
+    }
+    for (uint32_t col = 0; col < batch.column_count(); ++col) {
+      store_[col]->Append(batch.column(col), count);
+    }
+    total_ += count;
+  }
+  PERFETTO_DCHECK(batch.column_count() == spec_.input_columns);
+  return true;
+}
+
+bool TreeOrder::Fill() {
+  while (RowBatch* batch = input_.Next()) {
+    if (!Consume(*batch, /*retain=*/true)) {
+      return false;
+    }
+  }
+  if (!input_.status().ok()) {
+    status_ = input_.status();
+    return false;
+  }
+  if (has_row_.size() < numbered_) {
+    has_row_.resize(numbered_);
+  }
+  if (has_row_.CountSetBits() != numbered_) {
+    status_ = base::ErrStatus(
+        "%s: a row names a parent which is not itself a row in the input",
+        Name(spec_.want));
+    return false;
+  }
+
+  bool wanted =
+      spec_.want == TreeRowOrder::kParentFirst ? parent_first_ : child_first_;
+  bool other =
+      spec_.want == TreeRowOrder::kParentFirst ? child_first_ : parent_first_;
+  if (wanted) {
+    // Straight through: no order to read the rows back in, so none is built.
+    order_.clear();
+  } else if (other) {
+    // Backwards, which is the whole of turning a tree order into the other
+    // one and costs an array of row numbers rather than moving any values.
+    order_.resize(total_);
+    for (uint32_t row = 0; row < total_; ++row) {
+      order_[row] = total_ - 1 - row;
+    }
+  } else {
+    status_ = base::ErrStatus(
+        "%s: the rows arrive in neither tree order, which needs a sort",
+        Name(spec_.want));
+    return false;
+  }
+
+  for (const std::unique_ptr<OwnedColumn>& column : store_) {
+    batch_.AddColumn(column->View());
+  }
+  batch_.AddColumn(ColumnView::Reference(StorageType{Int64{}}, nodes_.data()));
+  batch_.AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, parents_.data()));
+  filled_ = true;
+  return true;
+}
+
+RowBatch* TreeOrder::NextStreaming() {
+  RowBatch* batch = input_.Next();
+  if (!batch) {
+    if (!input_.status().ok()) {
+      status_ = input_.status();
+      return nullptr;
+    }
+    if (has_row_.size() < numbered_) {
+      has_row_.resize(numbered_);
+    }
+    if (has_row_.CountSetBits() != numbered_) {
+      status_ = base::ErrStatus(
+          "%s: a row names a parent which is not itself a row in the input",
+          Name(spec_.want));
+    }
+    return nullptr;
+  }
+  uint32_t count = batch->size();
+  size_t base = nodes_.size();
+  if (!Consume(*batch, /*retain=*/false)) {
+    return nullptr;
+  }
+  bool holds =
+      spec_.want == TreeRowOrder::kParentFirst ? parent_first_ : child_first_;
+  if (!holds) {
+    status_ = base::ErrStatus(
+        "%s: was told the rows already arrive in this order and they do not",
+        Name(spec_.want));
+    return nullptr;
+  }
+
+  // Nothing is held, so the values behind the two columns are this batch's
+  // and are written over on the next pull.
+  batch_nodes_.assign(nodes_.begin() + static_cast<long>(base), nodes_.end());
+  batch_parents_.assign(parents_.begin() + static_cast<long>(base),
+                        parents_.end());
+  nodes_.resize(base);
+  parents_.resize(base);
+  batch->AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, batch_nodes_.data()));
+  batch->AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, batch_parents_.data()));
+  batch->SetCardinality(count);
+  return batch;
+}
+
+RowBatch* TreeOrder::NextBuffered() {
+  if (emitted_ == total_) {
+    return nullptr;
+  }
+  uint32_t count = std::min(kMaxBatchRows, total_ - emitted_);
+  for (uint32_t col = 0; col < batch_.column_count(); ++col) {
+    ColumnView& column = batch_.mutable_column(col);
+    if (order_.empty()) {
+      column.SetRange(emitted_);
+    } else {
+      const uint32_t* begin = order_.data() + emitted_;
+      column.SetBorrowedRows(Span<const uint32_t>(begin, begin + count));
+    }
+  }
+  batch_.SetCardinality(count);
+  emitted_ += count;
+  return &batch_;
+}
+
+RowBatch* TreeOrder::Next() {
+  if (!status_.ok()) {
+    return nullptr;
+  }
+  if (mode_ == Mode::kStreaming) {
+    return NextStreaming();
+  }
+  if (!filled_ && !Fill()) {
+    return nullptr;
+  }
+  return NextBuffered();
+}
+
+void TreeOrder::Reset() {
+  input_.Reset();
+  emitted_ = 0;
+  if (mode_ == Mode::kStreaming) {
+    dense_ = true;
+    numbered_ = 0;
+    numbers_.Clear();
+    has_row_.clear();
+    parent_first_ = true;
+    child_first_ = true;
+    nodes_.clear();
+    parents_.clear();
+  }
+  status_ = base::OkStatus();
+}
+
+TreeParentFirst::TreeParentFirst(Source& input,
+                                 uint32_t id_column,
+                                 uint32_t parent_column,
+                                 uint32_t input_columns,
+                                 std::optional<TreeRowOrder> arriving)
+    : TreeOrder(input,
+                Spec{id_column, parent_column, input_columns,
+                     TreeRowOrder::kParentFirst, arriving}) {}
+
+TreeParentFirst::~TreeParentFirst() = default;
+
+TreeChildFirst::TreeChildFirst(Source& input,
+                               uint32_t id_column,
+                               uint32_t parent_column,
+                               uint32_t input_columns,
+                               std::optional<TreeRowOrder> arriving)
+    : TreeOrder(input,
+                Spec{id_column, parent_column, input_columns,
+                     TreeRowOrder::kChildFirst, arriving}) {}
+
+TreeChildFirst::~TreeChildFirst() = default;
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/tree_order.cc
+++ b/src/trace_processor/core/exec/tree_order.cc
@@ -122,9 +122,10 @@ uint32_t TreeOrder::Number(int64_t id) {
   return assigned;
 }
 
-void TreeOrder::Note(uint32_t node, int64_t parent) {
+void TreeOrder::Note(uint32_t node, int64_t parent, uint32_t row) {
   if (has_row_.size() < numbered_) {
     has_row_.resize(numbered_);
+    row_of_node_.resize(numbered_);
   }
   if (parent >= 0) {
     // A parent already seen means children follow parents here; a parent not
@@ -137,6 +138,7 @@ void TreeOrder::Note(uint32_t node, int64_t parent) {
     }
   }
   has_row_.set(node);
+  row_of_node_[node] = row;
 }
 
 bool TreeOrder::Consume(RowBatch& batch, bool retain) {
@@ -163,7 +165,7 @@ bool TreeOrder::Consume(RowBatch& batch, bool retain) {
     if (!parent_null || !parent_null[i]) {
       parent = static_cast<int64_t>(Number(parents[i]));
     }
-    Note(node, parent);
+    Note(node, parent, static_cast<uint32_t>(base) + i);
     nodes_[base + i] = node;
     parents_[base + i] = parent;
   }
@@ -183,6 +185,58 @@ bool TreeOrder::Consume(RowBatch& batch, bool retain) {
   return true;
 }
 
+bool TreeOrder::Sort() {
+  // One list of children per node, laid out end to end rather than as a list
+  // of lists: a tree has exactly as many child entries as it has non-roots.
+  uint32_t nodes = numbered_;
+  std::vector<uint32_t> begin(nodes + 1, 0);
+  for (uint32_t row = 0; row < total_; ++row) {
+    int64_t parent = parents_[row];
+    if (parent >= 0) {
+      ++begin[static_cast<uint32_t>(parent) + 1];
+    }
+  }
+  for (uint32_t node = 0; node < nodes; ++node) {
+    begin[node + 1] += begin[node];
+  }
+  std::vector<uint32_t> next = begin;
+  std::vector<uint32_t> children(begin[nodes]);
+  for (uint32_t row = 0; row < total_; ++row) {
+    int64_t parent = parents_[row];
+    if (parent >= 0) {
+      children[next[static_cast<uint32_t>(parent)]++] =
+          static_cast<uint32_t>(nodes_[row]);
+    }
+  }
+
+  // Every root, then everything reachable from one, which is a parent-first
+  // order by construction: a node is only reached through its parent.
+  order_.clear();
+  order_.reserve(total_);
+  std::vector<uint32_t> pending;
+  for (uint32_t row = 0; row < total_; ++row) {
+    if (parents_[row] < 0) {
+      pending.push_back(static_cast<uint32_t>(nodes_[row]));
+    }
+  }
+  while (!pending.empty()) {
+    uint32_t node = pending.back();
+    pending.pop_back();
+    order_.push_back(row_of_node_[node]);
+    for (uint32_t i = begin[node]; i < begin[node + 1]; ++i) {
+      pending.push_back(children[i]);
+    }
+  }
+  if (order_.size() != total_) {
+    status_ = base::ErrStatus(
+        "%s: the rows are not a tree, because %u of them are in a cycle",
+        Name(spec_.want), total_ - static_cast<uint32_t>(order_.size()));
+    order_.clear();
+    return false;
+  }
+  return true;
+}
+
 bool TreeOrder::Fill() {
   while (RowBatch* batch = input_.Next()) {
     if (!Consume(*batch, /*retain=*/true)) {
@@ -195,6 +249,7 @@ bool TreeOrder::Fill() {
   }
   if (has_row_.size() < numbered_) {
     has_row_.resize(numbered_);
+    row_of_node_.resize(numbered_);
   }
   if (has_row_.CountSetBits() != numbered_) {
     status_ = base::ErrStatus(
@@ -218,10 +273,12 @@ bool TreeOrder::Fill() {
       order_[row] = total_ - 1 - row;
     }
   } else {
-    status_ = base::ErrStatus(
-        "%s: the rows arrive in neither tree order, which needs a sort",
-        Name(spec_.want));
-    return false;
+    if (!Sort()) {
+      return false;
+    }
+    if (spec_.want == TreeRowOrder::kChildFirst) {
+      std::reverse(order_.begin(), order_.end());
+    }
   }
 
   for (const std::unique_ptr<OwnedColumn>& column : store_) {

--- a/src/trace_processor/core/exec/tree_order.h
+++ b/src/trace_processor/core/exec/tree_order.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_TREE_ORDER_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_TREE_ORDER_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/owned_column.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// Which way round a stream of tree rows is.
+//
+// A fold up a tree and a fold down it want opposite orders, and each is a
+// single streaming pass in the one it wants. Neither order is the right one;
+// which to be in is a question about what comes next.
+enum class TreeRowOrder : uint8_t {
+  // Every parent precedes its children. What a fold downwards reads.
+  kParentFirst,
+  // Every child precedes its parent. What a fold upwards reads.
+  kChildFirst,
+};
+
+// Puts a stream of rows into a tree order and says where each row's parent is.
+//
+// Streams when the rows already arrive in the order asked for and inverts
+// when they arrive in the other. Which of the two it does is the whole cost
+// of the operator, so it says which, and
+// takes what the planner knows rather than guessing: an operator cannot start
+// emitting and change its mind, so `input` is the difference between passing
+// rows through and holding all of them.
+//
+// Two columns are appended: the row's own node number, and its parent's, or
+// -1 for a root. They are numbered densely from zero, which is what makes an
+// array indexed by node the right size when the ids arriving are a filtered
+// scattering of some table's. Ids that already arrive dense and in order are
+// left alone and cost nothing.
+class TreeOrder : public Source {
+ public:
+  struct Spec {
+    // The columns carrying identity and parentage. A null parent is a root.
+    uint32_t id_column = 0;
+    uint32_t parent_column = 1;
+
+    // How many columns arrive. Needed up front so that where the appended
+    // ones land is answerable before any row has been read, which is when
+    // whatever consumes them is built.
+    uint32_t input_columns = 2;
+
+    // The order to put the rows in.
+    TreeRowOrder want = TreeRowOrder::kParentFirst;
+
+    // The order the rows arrive in, when the planner knows it. Without it the
+    // rows have to be held, because by the time an out-of-order row proves
+    // the guess wrong the rows before it have already gone.
+    std::optional<TreeRowOrder> input;
+  };
+
+  TreeOrder(Source& input, Spec spec);
+  ~TreeOrder() override;
+
+  void Reset() override;
+  RowBatch* Next() override;
+  base::Status status() const override { return status_; }
+
+  // Where the two appended columns are in the batches this hands out.
+  uint32_t node_column() const { return spec_.input_columns; }
+  uint32_t parent_ordinal_column() const { return spec_.input_columns + 1; }
+
+  // Whether the rows were passed through rather than held. For tests and for
+  // anything that wants to explain where a query's memory went.
+  bool streamed() const { return mode_ == Mode::kStreaming; }
+
+ private:
+  enum class Mode : uint8_t {
+    // The planner said the rows already arrive in the order wanted.
+    kStreaming,
+    // Everything else: hold the rows, then work out how to hand them back.
+    kBuffering,
+  };
+
+  // Reads every row, holding what it reads. Sets `status_` and returns false
+  // if the rows are not a tree.
+  bool Fill();
+  bool Consume(RowBatch& batch, bool retain);
+  RowBatch* NextStreaming();
+  RowBatch* NextBuffered();
+
+  // The node number for `id`, assigning one if this is the first sighting.
+  uint32_t Number(int64_t id);
+
+  // Marks `node` as having had a row, and checks that row's place against
+  // what both orders require.
+  void Note(uint32_t node, int64_t parent);
+
+  Source& input_;
+  Spec spec_;
+  Mode mode_;
+  base::Status status_ = base::OkStatus();
+
+  // Node numbering. While the ids arriving are exactly 0, 1, 2, ... they are
+  // already node numbers and the map stays empty.
+  bool dense_ = true;
+  uint32_t numbered_ = 0;
+  base::FlatHashMap<int64_t, uint32_t> numbers_;
+
+  // Which nodes have had a row, by node number, and whether each order still
+  // holds for every row seen so far.
+  BitVector has_row_;
+  bool parent_first_ = true;
+  bool child_first_ = true;
+
+  // The appended columns' values, for every row in order of arrival.
+  std::vector<int64_t> nodes_;
+  std::vector<int64_t> parents_;
+
+  // Streaming: one batch's worth, refilled on every pull.
+  std::vector<int64_t> batch_nodes_;
+  std::vector<int64_t> batch_parents_;
+
+  // Buffering: the whole input, one column at a time, and the order to read
+  // it back in. An empty order means straight through.
+  std::vector<std::unique_ptr<OwnedColumn>> store_;
+  std::vector<uint32_t> order_;
+  RowBatch batch_;
+  uint32_t total_ = 0;
+  uint32_t emitted_ = 0;
+  bool filled_ = false;
+};
+
+// TREE ORDER PARENT FIRST: every parent precedes its children.
+class TreeParentFirst : public TreeOrder {
+ public:
+  TreeParentFirst(Source& input,
+                  uint32_t id_column,
+                  uint32_t parent_column,
+                  uint32_t input_columns,
+                  std::optional<TreeRowOrder> arriving = std::nullopt);
+  ~TreeParentFirst() override;
+};
+
+// TREE ORDER CHILD FIRST: every child precedes its parent.
+class TreeChildFirst : public TreeOrder {
+ public:
+  TreeChildFirst(Source& input,
+                 uint32_t id_column,
+                 uint32_t parent_column,
+                 uint32_t input_columns,
+                 std::optional<TreeRowOrder> arriving = std::nullopt);
+  ~TreeChildFirst() override;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_TREE_ORDER_H_

--- a/src/trace_processor/core/exec/tree_order.h
+++ b/src/trace_processor/core/exec/tree_order.h
@@ -46,9 +46,9 @@ enum class TreeRowOrder : uint8_t {
 
 // Puts a stream of rows into a tree order and says where each row's parent is.
 //
-// Streams when the rows already arrive in the order asked for and inverts
-// when they arrive in the other. Which of the two it does is the whole cost
-// of the operator, so it says which, and
+// Streams when the rows already arrive in the order asked for, inverts when
+// they arrive in the other, and sorts when they arrive in neither. Which of
+// the three it does is the whole cost of the operator, so it says which, and
 // takes what the planner knows rather than guessing: an operator cannot start
 // emitting and change its mind, so `input` is the difference between passing
 // rows through and holding all of them.
@@ -109,12 +109,16 @@ class TreeOrder : public Source {
   RowBatch* NextStreaming();
   RowBatch* NextBuffered();
 
+  // Works out an order in which every parent precedes its children. False,
+  // with `status_` set, if the rows are not a tree but a cycle.
+  bool Sort();
+
   // The node number for `id`, assigning one if this is the first sighting.
   uint32_t Number(int64_t id);
 
-  // Marks `node` as having had a row, and checks that row's place against
-  // what both orders require.
-  void Note(uint32_t node, int64_t parent);
+  // Marks `node` as having its row at `row`, and checks that row's place
+  // against what both orders require.
+  void Note(uint32_t node, int64_t parent, uint32_t row);
 
   Source& input_;
   Spec spec_;
@@ -127,9 +131,10 @@ class TreeOrder : public Source {
   uint32_t numbered_ = 0;
   base::FlatHashMap<int64_t, uint32_t> numbers_;
 
-  // Which nodes have had a row, by node number, and whether each order still
-  // holds for every row seen so far.
+  // Which nodes have had a row and where it was, by node number, and whether
+  // each order still holds for every row seen so far.
   BitVector has_row_;
+  std::vector<uint32_t> row_of_node_;
   bool parent_first_ = true;
   bool child_first_ = true;
 

--- a/src/trace_processor/core/exec/tree_order_unittest.cc
+++ b/src/trace_processor/core/exec/tree_order_unittest.cc
@@ -229,16 +229,82 @@ TEST(TreeOrderTest, AParentWhichIsNotARowIsReported) {
   EXPECT_THAT(order.status().message(), testing::HasSubstr("not itself a row"));
 }
 
-TEST(TreeOrderTest, RowsInNeitherOrderAreReported) {
-  // 1 before its parent 0, then 3 after its parent 2: neither order holds.
+// Every parent appears before all of its children.
+void ExpectParentFirst(const Output& out) {
+  std::vector<int64_t> seen;
+  for (uint32_t i = 0; i < out.node.size(); ++i) {
+    if (out.parent[i] >= 0) {
+      EXPECT_NE(std::find(seen.begin(), seen.end(), out.parent[i]), seen.end())
+          << "row " << i << " came before its parent";
+    }
+    seen.push_back(out.node[i]);
+  }
+}
+
+// Rows in neither order are neither passed through nor turned round: they
+// have to be put in an order which did not exist in the input.
+TEST(TreeOrderTest, RowsInNeitherOrderAreSorted) {
+  // 1 before its parent 0, then 3 after its parent 2.
   std::vector<Row> rows = {
       {1, 0, 101}, {0, std::nullopt, 100}, {2, 0, 102}, {3, 2, 103}};
   RowSource source(rows, 4);
   TreeParentFirst order(source, 0, 1, 3);
 
+  Output out = Drain(order);
+  ASSERT_TRUE(order.status().ok()) << order.status().message();
+  ExpectParentFirst(out);
+  std::vector<int64_t> payload = out.payload;
+  std::sort(payload.begin(), payload.end());
+  EXPECT_THAT(payload, ElementsAre(100, 101, 102, 103));
+}
+
+TEST(TreeOrderTest, ASortedStreamCanBeAskedForTheOtherWayRound) {
+  std::vector<Row> rows = {
+      {1, 0, 101}, {0, std::nullopt, 100}, {2, 0, 102}, {3, 2, 103}};
+  RowSource source(rows, 4);
+  TreeChildFirst order(source, 0, 1, 3);
+
+  Output out = Drain(order);
+  ASSERT_TRUE(order.status().ok()) << order.status().message();
+  std::reverse(out.node.begin(), out.node.end());
+  std::reverse(out.parent.begin(), out.parent.end());
+  ExpectParentFirst(out);
+}
+
+TEST(TreeOrderTest, ACycleIsReported) {
+  std::vector<Row> rows = {{0, 1, 100}, {1, 0, 101}};
+  RowSource source(rows, 2);
+  TreeParentFirst order(source, 0, 1, 3);
+
   Drain(order);
   EXPECT_FALSE(order.status().ok());
-  EXPECT_THAT(order.status().message(), testing::HasSubstr("needs a sort"));
+  EXPECT_THAT(order.status().message(), testing::HasSubstr("cycle"));
+}
+
+// A tree big enough to span batches, with its rows shuffled into no order at
+// all.
+TEST(TreeOrderTest, SortsATreeWhoseRowsAreShuffled) {
+  std::mt19937 rng(11);
+  std::vector<Row> rows;
+  rows.push_back({0, std::nullopt, 1000});
+  for (int64_t id = 1; id < 5000; ++id) {
+    int64_t parent = std::uniform_int_distribution<int64_t>(0, id - 1)(rng);
+    rows.push_back({id, parent, 1000 + id});
+  }
+  std::shuffle(rows.begin(), rows.end(), rng);
+
+  RowSource source(rows, 512);
+  TreeParentFirst order(source, 0, 1, 3);
+  Output out = Drain(order);
+  ASSERT_TRUE(order.status().ok()) << order.status().message();
+  ASSERT_EQ(out.node.size(), 5000u);
+  ExpectParentFirst(out);
+
+  std::vector<int64_t> payload = out.payload;
+  std::sort(payload.begin(), payload.end());
+  for (uint32_t i = 0; i < payload.size(); ++i) {
+    ASSERT_EQ(payload[i], 1000 + int64_t{i});
+  }
 }
 
 TEST(TreeOrderTest, TheChunkSizeDoesNotChangeTheAnswer) {
@@ -253,7 +319,7 @@ TEST(TreeOrderTest, TheChunkSizeDoesNotChangeTheAnswer) {
 }
 
 // The point of the operator: a fold up the tree reads what this hands it,
-// whichever way round the rows arrived.
+// whether the rows arrived in that order, the other one, or none.
 TEST(TreeOrderTest, WhatComesOutCanBeFoldedUp) {
   std::mt19937 rng(3);
   std::vector<Row> rows;
@@ -275,10 +341,12 @@ TEST(TreeOrderTest, WhatComesOutCanBeFoldedUp) {
     }
   }
 
-  for (bool backwards : {false, true}) {
+  for (int arrival = 0; arrival < 3; ++arrival) {
     std::vector<Row> input = rows;
-    if (backwards) {
+    if (arrival == 1) {
       std::reverse(input.begin(), input.end());
+    } else if (arrival == 2) {
+      std::shuffle(input.begin(), input.end(), rng);
     }
     RowSource source(input, 64);
     TreeParentFirst order(source, 0, 1, 3);
@@ -294,7 +362,7 @@ TEST(TreeOrderTest, WhatComesOutCanBeFoldedUp) {
       }
     }
     ASSERT_TRUE(fold.status().ok()) << fold.status().message();
-    EXPECT_EQ(got, want) << "backwards: " << backwards;
+    EXPECT_EQ(got, want) << "arrival: " << arrival;
   }
 }
 

--- a/src/trace_processor/core/exec/tree_order_unittest.cc
+++ b/src/trace_processor/core/exec/tree_order_unittest.cc
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/tree_order.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <random>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_batch_pool.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/tree_accumulate.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using testing::ElementsAre;
+
+// A row as the tests write one down: an id, a parent id or none, and a
+// payload to prove the row itself came back out with its number.
+struct Row {
+  int64_t id;
+  std::optional<int64_t> parent;
+  int64_t payload;
+};
+
+// Hands the rows over in chunks, refilling one batch each time.
+class RowSource final : public Source {
+ public:
+  RowSource(std::vector<Row> rows, uint32_t chunk_rows)
+      : rows_(std::move(rows)), chunk_rows_(chunk_rows) {}
+
+  void Reset() override { offset_ = 0; }
+
+  RowBatch* Next() override {
+    auto total = static_cast<uint32_t>(rows_.size());
+    if (offset_ == total) {
+      return nullptr;
+    }
+    uint32_t count = std::min(chunk_rows_, total - offset_);
+    ids_.resize(count);
+    parents_.resize(count);
+    payloads_.resize(count);
+    validity_ = BitVector::CreateWithSize(count);
+    for (uint32_t i = 0; i < count; ++i) {
+      const Row& row = rows_[offset_ + i];
+      ids_[i] = row.id;
+      payloads_[i] = row.payload;
+      parents_[i] = row.parent.value_or(0);
+      if (row.parent) {
+        validity_.set(i);
+      }
+    }
+    batch_ = RowBatch();
+    batch_.AddColumn(ColumnView::Reference(StorageType{Int64{}}, ids_.data()));
+    batch_.AddColumn(ColumnView::Reference(StorageType{Int64{}},
+                                           parents_.data(), &validity_));
+    batch_.AddColumn(
+        ColumnView::Reference(StorageType{Int64{}}, payloads_.data()));
+    batch_.Compose(RowSelection::Range(0), count);
+    batch_.SetCardinality(count);
+    offset_ += count;
+    return &batch_;
+  }
+
+ private:
+  std::vector<Row> rows_;
+  uint32_t chunk_rows_;
+  uint32_t offset_ = 0;
+  std::vector<int64_t> ids_;
+  std::vector<int64_t> parents_;
+  std::vector<int64_t> payloads_;
+  BitVector validity_;
+  RowBatch batch_;
+};
+
+// What came out: the payload, the node number and the parent's, in the order
+// the rows were handed over.
+struct Output {
+  std::vector<int64_t> payload;
+  std::vector<int64_t> node;
+  std::vector<int64_t> parent;
+};
+
+int64_t Read(const RowBatch& batch, uint32_t column, uint32_t row) {
+  const ColumnView& view = batch.column(column);
+  return static_cast<const int64_t*>(
+      view.data())[view.selection().GetIndex(row)];
+}
+
+Output Drain(TreeOrder& order) {
+  Output out;
+  while (RowBatch* batch = order.Next()) {
+    for (uint32_t row = 0; row < batch->size(); ++row) {
+      out.payload.push_back(Read(*batch, 2, row));
+      out.node.push_back(Read(*batch, order.node_column(), row));
+      out.parent.push_back(Read(*batch, order.parent_ordinal_column(), row));
+    }
+  }
+  return out;
+}
+
+// A root, its two children, and a grandchild, written parent first.
+std::vector<Row> ParentFirstRows() {
+  return {{0, std::nullopt, 100}, {1, 0, 101}, {2, 0, 102}, {3, 1, 103}};
+}
+
+// The same tree, written child first.
+std::vector<Row> ChildFirstRows() {
+  return {{3, 1, 103}, {2, 0, 102}, {1, 0, 101}, {0, std::nullopt, 100}};
+}
+
+TEST(TreeOrderTest, RowsAlreadyInOrderArePassedThrough) {
+  RowSource source(ParentFirstRows(), 2);
+  TreeParentFirst order(source, 0, 1, 3, TreeRowOrder::kParentFirst);
+
+  Output out = Drain(order);
+  ASSERT_TRUE(order.status().ok()) << order.status().message();
+  EXPECT_TRUE(order.streamed());
+  EXPECT_THAT(out.payload, ElementsAre(100, 101, 102, 103));
+  EXPECT_THAT(out.node, ElementsAre(0, 1, 2, 3));
+  EXPECT_THAT(out.parent, ElementsAre(-1, 0, 0, 1));
+}
+
+TEST(TreeOrderTest, RowsInTheOtherOrderAreTurnedRound) {
+  RowSource source(ChildFirstRows(), 2);
+  TreeParentFirst order(source, 0, 1, 3, TreeRowOrder::kChildFirst);
+
+  Output out = Drain(order);
+  ASSERT_TRUE(order.status().ok()) << order.status().message();
+  EXPECT_FALSE(order.streamed());
+  EXPECT_THAT(out.payload, ElementsAre(100, 101, 102, 103));
+  // Every parent is now handed over before its children.
+  for (uint32_t i = 0; i < out.node.size(); ++i) {
+    if (out.parent[i] < 0) {
+      continue;
+    }
+    auto seen =
+        std::find(out.node.begin(), out.node.begin() + i, out.parent[i]);
+    EXPECT_NE(seen, out.node.begin() + i) << "row " << i;
+  }
+}
+
+TEST(TreeOrderTest, ChildFirstTurnsRoundRowsWhichArriveParentFirst) {
+  RowSource source(ParentFirstRows(), 2);
+  TreeChildFirst order(source, 0, 1, 3, TreeRowOrder::kParentFirst);
+
+  Output out = Drain(order);
+  ASSERT_TRUE(order.status().ok()) << order.status().message();
+  EXPECT_FALSE(order.streamed());
+  EXPECT_THAT(out.payload, ElementsAre(103, 102, 101, 100));
+}
+
+TEST(TreeOrderTest, ChildFirstPassesThroughRowsWhichAlreadyAre) {
+  RowSource source(ChildFirstRows(), 2);
+  TreeChildFirst order(source, 0, 1, 3, TreeRowOrder::kChildFirst);
+
+  Output out = Drain(order);
+  ASSERT_TRUE(order.status().ok()) << order.status().message();
+  EXPECT_TRUE(order.streamed());
+  EXPECT_THAT(out.payload, ElementsAre(103, 102, 101, 100));
+}
+
+// Without being told, the rows have to be held: by the time a row proves a
+// guess wrong the rows before it have already gone.
+TEST(TreeOrderTest, WithoutBeingToldTheRowsAreHeld) {
+  RowSource source(ParentFirstRows(), 2);
+  TreeParentFirst order(source, 0, 1, 3);
+
+  Output out = Drain(order);
+  ASSERT_TRUE(order.status().ok()) << order.status().message();
+  EXPECT_FALSE(order.streamed());
+  EXPECT_THAT(out.payload, ElementsAre(100, 101, 102, 103));
+}
+
+TEST(TreeOrderTest, BeingToldWrongIsReported) {
+  RowSource source(ChildFirstRows(), 2);
+  TreeParentFirst order(source, 0, 1, 3, TreeRowOrder::kParentFirst);
+
+  Drain(order);
+  EXPECT_FALSE(order.status().ok());
+  EXPECT_THAT(order.status().message(), testing::HasSubstr("they do not"));
+}
+
+// Ids which are a scattering -- a filtered set, say -- are numbered densely,
+// so what is indexed by node number is the size of the input and not of
+// whatever the input was filtered from.
+TEST(TreeOrderTest, AScatteringOfIdsIsNumberedDensely) {
+  std::vector<Row> rows = {{500, std::nullopt, 100},
+                           {900, 500, 101},
+                           {700, 500, 102},
+                           {123, 900, 103}};
+  RowSource source(rows, 3);
+  TreeParentFirst order(source, 0, 1, 3, TreeRowOrder::kParentFirst);
+
+  Output out = Drain(order);
+  ASSERT_TRUE(order.status().ok()) << order.status().message();
+  EXPECT_THAT(out.node, ElementsAre(0, 1, 2, 3));
+  EXPECT_THAT(out.parent, ElementsAre(-1, 0, 0, 1));
+}
+
+TEST(TreeOrderTest, AParentWhichIsNotARowIsReported) {
+  std::vector<Row> rows = {{0, std::nullopt, 100}, {1, 42, 101}};
+  RowSource source(rows, 2);
+  TreeParentFirst order(source, 0, 1, 3);
+
+  Drain(order);
+  EXPECT_FALSE(order.status().ok());
+  EXPECT_THAT(order.status().message(), testing::HasSubstr("not itself a row"));
+}
+
+TEST(TreeOrderTest, RowsInNeitherOrderAreReported) {
+  // 1 before its parent 0, then 3 after its parent 2: neither order holds.
+  std::vector<Row> rows = {
+      {1, 0, 101}, {0, std::nullopt, 100}, {2, 0, 102}, {3, 2, 103}};
+  RowSource source(rows, 4);
+  TreeParentFirst order(source, 0, 1, 3);
+
+  Drain(order);
+  EXPECT_FALSE(order.status().ok());
+  EXPECT_THAT(order.status().message(), testing::HasSubstr("needs a sort"));
+}
+
+TEST(TreeOrderTest, TheChunkSizeDoesNotChangeTheAnswer) {
+  for (uint32_t chunk : {1u, 2u, 3u, 4u, 64u}) {
+    RowSource source(ChildFirstRows(), chunk);
+    TreeParentFirst order(source, 0, 1, 3, TreeRowOrder::kChildFirst);
+    Output out = Drain(order);
+    ASSERT_TRUE(order.status().ok()) << order.status().message();
+    EXPECT_THAT(out.payload, ElementsAre(100, 101, 102, 103))
+        << "chunk size " << chunk;
+  }
+}
+
+// The point of the operator: a fold up the tree reads what this hands it,
+// whichever way round the rows arrived.
+TEST(TreeOrderTest, WhatComesOutCanBeFoldedUp) {
+  std::mt19937 rng(3);
+  std::vector<Row> rows;
+  rows.push_back({0, std::nullopt, 1});
+  std::vector<int64_t> parent_of = {-1};
+  for (int64_t id = 1; id < 400; ++id) {
+    int64_t parent = std::uniform_int_distribution<int64_t>(0, id - 1)(rng);
+    parent_of.push_back(parent);
+    rows.push_back({id, parent, id + 1});
+  }
+
+  // What the answer is, by the definition: everything whose parent chain
+  // reaches a node.
+  std::vector<int64_t> want(rows.size(), 0);
+  for (uint32_t row = 0; row < rows.size(); ++row) {
+    for (int64_t walk = static_cast<int64_t>(row); walk >= 0;
+         walk = parent_of[static_cast<size_t>(walk)]) {
+      want[static_cast<size_t>(walk)] += static_cast<int64_t>(row) + 1;
+    }
+  }
+
+  for (bool backwards : {false, true}) {
+    std::vector<Row> input = rows;
+    if (backwards) {
+      std::reverse(input.begin(), input.end());
+    }
+    RowSource source(input, 64);
+    TreeParentFirst order(source, 0, 1, 3);
+    RowBatchPool pool;
+    TreeAccumulateUp fold(order, &pool, order.parent_ordinal_column(), 2,
+                          order.node_column());
+
+    std::vector<int64_t> got(rows.size(), 0);
+    while (RowBatch* batch = fold.Next()) {
+      for (uint32_t row = 0; row < batch->size(); ++row) {
+        auto id = Read(*batch, 0, row);
+        got[static_cast<size_t>(id)] = Read(*batch, 5, row);
+      }
+    }
+    ASSERT_TRUE(fold.status().ok()) << fold.status().message();
+    EXPECT_EQ(got, want) << "backwards: " << backwards;
+  }
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/perfetto_sql/exec/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/exec/BUILD.gn
@@ -1,0 +1,47 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/test.gni")
+
+source_set("exec") {
+  sources = [
+    "sql_scan.cc",
+    "sql_scan.h",
+  ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../../gn:sqlite",
+    "../../../base",
+    "../../containers",
+    "../../core/common",
+    "../../core/exec",
+    "../../core/util",
+    "../../sqlite",
+  ]
+}
+
+perfetto_unittest_source_set("unittests") {
+  testonly = true
+  sources = [ "sql_scan_unittest.cc" ]
+  deps = [
+    ":exec",
+    "../../../../gn:default_deps",
+    "../../../../gn:gtest_and_gmock",
+    "../../../base",
+    "../../containers",
+    "../../core/common",
+    "../../core/exec",
+    "../../sqlite",
+  ]
+}

--- a/src/trace_processor/perfetto_sql/exec/sql_scan.cc
+++ b/src/trace_processor/perfetto_sql/exec/sql_scan.cc
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/perfetto_sql/exec/sql_scan.h"
+
+#include <sqlite3.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/sqlite/sql_source.h"
+#include "src/trace_processor/sqlite/sqlite_connection.h"
+
+namespace perfetto::trace_processor::exec {
+namespace {
+
+using core::Double;
+using core::Int64;
+using core::StorageType;
+using core::String;
+using core::exec::ColumnView;
+using core::exec::kMaxBatchRows;
+using core::exec::RowBatch;
+using core::exec::RowSelection;
+
+const char* TypeName(StorageType type) {
+  if (type.Is<Int64>()) {
+    return "an integer";
+  }
+  if (type.Is<Double>()) {
+    return "a float";
+  }
+  return "a string";
+}
+
+}  // namespace
+
+base::StatusOr<std::unique_ptr<SqlScan>>
+SqlScan::Create(SqliteConnection* connection, SqlSource sql, StringPool* pool) {
+  SqliteConnection::PreparedStatement statement =
+      connection->PrepareStatement(std::move(sql));
+  RETURN_IF_ERROR(statement.status());
+
+  // The columns are known once the statement is prepared, before any row is
+  // read, which is what lets a stage resolve the names it was given first.
+  sqlite3_stmt* stmt = statement.sqlite_stmt();
+  auto count = static_cast<uint32_t>(sqlite3_column_count(stmt));
+  std::vector<std::string> names;
+  names.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    const char* name = sqlite3_column_name(stmt, static_cast<int>(i));
+    names.emplace_back(name ? name : "");
+  }
+  return std::unique_ptr<SqlScan>(
+      new SqlScan(std::move(statement), std::move(names), pool));
+}
+
+SqlScan::SqlScan(SqliteConnection::PreparedStatement statement,
+                 std::vector<std::string> names,
+                 StringPool* pool)
+    : statement_(std::move(statement)),
+      names_(std::move(names)),
+      pool_(pool),
+      columns_(names_.size()) {
+  for (Column& column : columns_) {
+    column.validity = core::BitVector::CreateWithSize(kMaxBatchRows);
+  }
+}
+
+SqlScan::~SqlScan() = default;
+
+void SqlScan::Reset() {
+  sqlite3_reset(statement_.sqlite_stmt());
+  done_ = false;
+}
+
+bool SqlScan::Settle(uint32_t index, StorageType type) {
+  Column& column = columns_[index];
+  if (column.type) {
+    if (*column.type == type) {
+      return true;
+    }
+    status_ = base::ErrStatus(
+        "SQL source: column '%s' holds %s after already holding %s; a "
+        "column's type is settled by its first value and cannot change",
+        names_[index].c_str(), TypeName(type), TypeName(*column.type));
+    return false;
+  }
+  column.type = type;
+  if (type.Is<Int64>()) {
+    column.ints.resize(kMaxBatchRows);
+  } else if (type.Is<Double>()) {
+    column.doubles.resize(kMaxBatchRows);
+  } else {
+    column.strings.resize(kMaxBatchRows);
+  }
+  return true;
+}
+
+bool SqlScan::ReadValue(sqlite3_stmt* stmt, uint32_t index, uint32_t row) {
+  Column& column = columns_[index];
+  auto col = static_cast<int>(index);
+  switch (sqlite3_column_type(stmt, col)) {
+    case SQLITE_NULL:
+      // The validity bit was cleared when the batch started.
+      return true;
+    case SQLITE_INTEGER:
+      if (!Settle(index, StorageType{Int64{}})) {
+        return false;
+      }
+      column.ints[row] = sqlite3_column_int64(stmt, col);
+      break;
+    case SQLITE_FLOAT:
+      if (!Settle(index, StorageType{Double{}})) {
+        return false;
+      }
+      column.doubles[row] = sqlite3_column_double(stmt, col);
+      break;
+    case SQLITE_TEXT:
+      if (!Settle(index, StorageType{String{}})) {
+        return false;
+      }
+      column.strings[row] = pool_->InternString(
+          reinterpret_cast<const char*>(sqlite3_column_text(stmt, col)));
+      break;
+    default:
+      status_ = base::ErrStatus(
+          "SQL source: column '%s' holds a blob, which a pipeline cannot "
+          "carry",
+          names_[index].c_str());
+      return false;
+  }
+  column.validity.set(row);
+  return true;
+}
+
+ColumnView SqlScan::MakeView(const Column& column) const {
+  const void* data = nullptr;
+  if (column.type->Is<Int64>()) {
+    data = column.ints.data();
+  } else if (column.type->Is<Double>()) {
+    data = column.doubles.data();
+  } else {
+    data = column.strings.data();
+  }
+  return ColumnView::Reference(*column.type, data, &column.validity);
+}
+
+RowBatch* SqlScan::Next() {
+  if (done_ || !status_.ok()) {
+    return nullptr;
+  }
+  for (Column& column : columns_) {
+    column.validity.ClearAllBits();
+  }
+
+  sqlite3_stmt* stmt = statement_.sqlite_stmt();
+  uint32_t count = 0;
+  while (count < kMaxBatchRows && statement_.Step()) {
+    for (uint32_t i = 0; i < columns_.size(); ++i) {
+      if (!ReadValue(stmt, i, count)) {
+        return nullptr;
+      }
+    }
+    ++count;
+  }
+  if (!statement_.status().ok()) {
+    status_ = statement_.status();
+    return nullptr;
+  }
+  done_ = count < kMaxBatchRows;
+  if (count == 0) {
+    return nullptr;
+  }
+
+  if (batch_.column_count() == 0) {
+    for (uint32_t i = 0; i < columns_.size(); ++i) {
+      // A column which never held a value still has to be some type for
+      // anything to read it; nothing will, because none of its rows are valid.
+      if (!columns_[i].type) {
+        Settle(i, StorageType{Int64{}});
+      }
+      pristine_.push_back(MakeView(columns_[i]));
+      batch_.AddColumn(pristine_.back());
+    }
+  }
+
+  batch_.PrepareForFill();
+  for (uint32_t i = 0; i < columns_.size(); ++i) {
+    // Operators only replace a column's row view, so restoring the views is
+    // all a reused batch needs before being filled again.
+    batch_.mutable_column(i).AdoptSelection(pristine_[i]);
+  }
+  batch_.Compose(RowSelection::Range(0), count);
+  batch_.SetCardinality(count);
+  return &batch_;
+}
+
+}  // namespace perfetto::trace_processor::exec

--- a/src/trace_processor/perfetto_sql/exec/sql_scan.h
+++ b/src/trace_processor/perfetto_sql/exec/sql_scan.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_EXEC_SQL_SCAN_H_
+#define SRC_TRACE_PROCESSOR_PERFETTO_SQL_EXEC_SQL_SCAN_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/sqlite/sql_source.h"
+#include "src/trace_processor/sqlite/sqlite_connection.h"
+
+struct sqlite3_stmt;
+
+namespace perfetto::trace_processor::exec {
+
+// A pipeline's rows, read from a SQL query.
+//
+// Where a pipeline meets everything which is already SQL. The query's rows
+// arrive a batch at a time, so nothing downstream can tell that SQLite
+// produced them, and nothing downstream has to be taught to.
+//
+// It promises nothing about the order rows arrive in, because SQLite promises
+// nothing either. Putting rows in an order is the business of whichever stage
+// needs one.
+class SqlScan : public core::exec::Source {
+ public:
+  static base::StatusOr<std::unique_ptr<SqlScan>> Create(SqliteConnection*,
+                                                         SqlSource,
+                                                         StringPool*);
+  ~SqlScan() override;
+
+  // The query's columns, in the order a batch carries them. Known before the
+  // first row, because a stage has to resolve the names it was given against
+  // something before it can start.
+  const std::vector<std::string>& column_names() const { return names_; }
+
+  void Reset() override;
+  core::exec::RowBatch* Next() override;
+  base::Status status() const override { return status_; }
+
+ private:
+  // One column's values for the batch being filled.
+  //
+  // A column's type is settled by the first non-null value seen in it and
+  // cannot change afterwards: by the time a second batch is read the first
+  // has gone downstream, and what has already left cannot be retyped. A
+  // column which is null the whole way through settles as an integer holding
+  // nothing.
+  //
+  // This is a stopgap. Inference exists because a bare query is all this is
+  // given; once a FROM stage is built from a logical plan it will be handed
+  // the column types and this will do as it is told.
+  struct Column {
+    std::optional<core::StorageType> type;
+    // Only the buffer matching `type` is ever allocated.
+    std::vector<int64_t> ints;
+    std::vector<double> doubles;
+    std::vector<StringPool::Id> strings;
+    core::BitVector validity;
+  };
+
+  SqlScan(SqliteConnection::PreparedStatement,
+          std::vector<std::string> names,
+          StringPool*);
+
+  // Reads one value into row `row` of column `index`. False on failure, with
+  // `status_` saying why.
+  bool ReadValue(sqlite3_stmt*, uint32_t index, uint32_t row);
+
+  // Settles column `index` on `type`, allocating its buffer, or fails if the
+  // column already settled on something else.
+  bool Settle(uint32_t index, core::StorageType type);
+
+  // The view of `column` a batch reads through.
+  core::exec::ColumnView MakeView(const Column& column) const;
+
+  SqliteConnection::PreparedStatement statement_;
+  std::vector<std::string> names_;
+  StringPool* pool_;
+
+  // Fixed at construction: a batch's columns point into these, so they must
+  // not move.
+  std::vector<Column> columns_;
+  // The columns as first built, each holding the row view a batch starts from.
+  std::vector<core::exec::ColumnView> pristine_;
+  core::exec::RowBatch batch_;
+
+  bool done_ = false;
+  base::Status status_ = base::OkStatus();
+};
+
+}  // namespace perfetto::trace_processor::exec
+
+#endif  // SRC_TRACE_PROCESSOR_PERFETTO_SQL_EXEC_SQL_SCAN_H_

--- a/src/trace_processor/perfetto_sql/exec/sql_scan_unittest.cc
+++ b/src/trace_processor/perfetto_sql/exec/sql_scan_unittest.cc
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/perfetto_sql/exec/sql_scan.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_cursor.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/sqlite/sql_source.h"
+#include "src/trace_processor/sqlite/sqlite_connection.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::exec {
+namespace {
+
+using core::Double;
+using core::Int64;
+using core::StorageType;
+using core::String;
+using core::exec::ColumnView;
+using core::exec::kMaxBatchRows;
+using core::exec::RowBatch;
+using core::exec::RowCursor;
+
+// Reads column `index` of `batch` as `T`, with null for the rows which hold
+// nothing.
+template <typename T>
+std::vector<std::optional<T>> Read(const RowBatch& batch, uint32_t index) {
+  const ColumnView& column = batch.column(index);
+  const auto* data = static_cast<const T*>(column.data());
+  std::vector<std::optional<T>> out;
+  for (uint32_t i = 0; i < batch.size(); ++i) {
+    uint32_t row = column.selection().GetIndex(i);
+    if (column.validity() && !column.validity()->is_set(row)) {
+      out.emplace_back();
+      continue;
+    }
+    out.push_back(data[row]);
+  }
+  return out;
+}
+
+class SqlScanTest : public ::testing::Test {
+ protected:
+  SqlScanTest()
+      : connection_(SqliteConnection::CreateConnectionToNewDatabase()) {}
+
+  void Exec(const std::string& sql) {
+    auto statement =
+        connection_->PrepareStatement(SqlSource::FromExecuteQuery(sql));
+    ASSERT_TRUE(statement.status().ok()) << statement.status().c_message();
+    while (statement.Step()) {
+    }
+    ASSERT_TRUE(statement.status().ok()) << statement.status().c_message();
+  }
+
+  base::StatusOr<std::unique_ptr<SqlScan>> Scan(const std::string& sql) {
+    return SqlScan::Create(connection_.get(), SqlSource::FromExecuteQuery(sql),
+                           &pool_);
+  }
+
+  StringPool pool_;
+  std::unique_ptr<SqliteConnection> connection_;
+};
+
+TEST_F(SqlScanTest, AQuerysColumnsAreKnownBeforeItsRows) {
+  auto scan = Scan("SELECT 1 AS a, 'x' AS b");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  EXPECT_THAT((*scan)->column_names(), testing::ElementsAre("a", "b"));
+}
+
+TEST_F(SqlScanTest, AQuerysRowsArriveAsABatch) {
+  auto scan = Scan("SELECT 10 AS a UNION ALL SELECT 20 UNION ALL SELECT 30");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  RowBatch* batch = (*scan)->Next();
+  ASSERT_NE(batch, nullptr);
+  EXPECT_EQ(batch->size(), 3u);
+  EXPECT_TRUE(batch->column(0).type().Is<Int64>());
+  EXPECT_THAT(Read<int64_t>(*batch, 0),
+              testing::ElementsAre(std::optional<int64_t>(10),
+                                   std::optional<int64_t>(20),
+                                   std::optional<int64_t>(30)));
+  EXPECT_EQ((*scan)->Next(), nullptr);
+  EXPECT_TRUE((*scan)->status().ok());
+}
+
+TEST_F(SqlScanTest, EachOfTheTypesAPipelineCarriesComesThrough) {
+  auto scan = Scan("SELECT 7 AS i, 1.5 AS d, 'hello' AS s");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  RowBatch* batch = (*scan)->Next();
+  ASSERT_NE(batch, nullptr);
+  ASSERT_EQ(batch->size(), 1u);
+  EXPECT_TRUE(batch->column(0).type().Is<Int64>());
+  EXPECT_TRUE(batch->column(1).type().Is<Double>());
+  EXPECT_TRUE(batch->column(2).type().Is<String>());
+  EXPECT_EQ(Read<int64_t>(*batch, 0)[0], std::optional<int64_t>(7));
+  EXPECT_EQ(Read<double>(*batch, 1)[0], std::optional<double>(1.5));
+
+  auto strings = Read<StringPool::Id>(*batch, 2);
+  ASSERT_TRUE(strings[0].has_value());
+  EXPECT_EQ(pool_.Get(*strings[0]).ToStdString(), "hello");
+}
+
+TEST_F(SqlScanTest, ANullIsARowWhichHoldsNothing) {
+  auto scan = Scan("SELECT 1 AS a UNION ALL SELECT NULL UNION ALL SELECT 3");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  RowBatch* batch = (*scan)->Next();
+  ASSERT_NE(batch, nullptr);
+  EXPECT_THAT(Read<int64_t>(*batch, 0),
+              testing::ElementsAre(std::optional<int64_t>(1), std::nullopt,
+                                   std::optional<int64_t>(3)));
+}
+
+TEST_F(SqlScanTest, AColumnWhichIsNeverAnythingIsAColumnOfNulls) {
+  auto scan = Scan("SELECT NULL AS a UNION ALL SELECT NULL");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  RowBatch* batch = (*scan)->Next();
+  ASSERT_NE(batch, nullptr);
+  EXPECT_THAT(Read<int64_t>(*batch, 0),
+              testing::ElementsAre(std::nullopt, std::nullopt));
+}
+
+TEST_F(SqlScanTest, MoreRowsThanFitInABatchArriveInSeveral) {
+  Exec(
+      "CREATE TABLE t AS WITH RECURSIVE r(x) AS ("
+      "  SELECT 0 UNION ALL SELECT x + 1 FROM r WHERE x < 4999"
+      ") SELECT x FROM r");
+  auto scan = Scan("SELECT x FROM t ORDER BY x");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  std::vector<int64_t> seen;
+  std::vector<uint32_t> sizes;
+  while (RowBatch* batch = (*scan)->Next()) {
+    sizes.push_back(batch->size());
+    for (const std::optional<int64_t>& value : Read<int64_t>(*batch, 0)) {
+      ASSERT_TRUE(value.has_value());
+      seen.push_back(*value);
+    }
+  }
+  ASSERT_TRUE((*scan)->status().ok()) << (*scan)->status().c_message();
+  EXPECT_THAT(sizes, testing::ElementsAre(kMaxBatchRows, kMaxBatchRows, 904u));
+  ASSERT_EQ(seen.size(), 5000u);
+  for (uint32_t i = 0; i < seen.size(); ++i) {
+    ASSERT_EQ(seen[i], int64_t{i});
+  }
+}
+
+TEST_F(SqlScanTest, AQueryWhichDoesNotRunIsReported) {
+  auto scan = Scan("SELECT * FROM not_a_table");
+  EXPECT_FALSE(scan.ok());
+}
+
+TEST_F(SqlScanTest, AQueryWhichFailsPartWayThroughIsReported) {
+  auto scan =
+      Scan("SELECT 1 AS a UNION ALL SELECT abs(-9223372036854775807 - 1)");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+  // A query which dies half way must not look like one which simply ended.
+  while ((*scan)->Next()) {
+  }
+  EXPECT_FALSE((*scan)->status().ok());
+}
+
+TEST_F(SqlScanTest, AColumnWhichChangesTypeIsReported) {
+  auto scan = Scan("SELECT 1 AS a UNION ALL SELECT 'two'");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  EXPECT_EQ((*scan)->Next(), nullptr);
+  EXPECT_FALSE((*scan)->status().ok());
+  EXPECT_THAT((*scan)->status().message(), testing::HasSubstr("'a'"));
+}
+
+TEST_F(SqlScanTest, ABlobIsReportedRatherThanCarried) {
+  auto scan = Scan("SELECT x'0102' AS a");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  EXPECT_EQ((*scan)->Next(), nullptr);
+  EXPECT_FALSE((*scan)->status().ok());
+  EXPECT_THAT((*scan)->status().message(), testing::HasSubstr("blob"));
+}
+
+TEST_F(SqlScanTest, AScanCanBeRunAgain) {
+  auto scan = Scan("SELECT 1 AS a UNION ALL SELECT 2");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  auto run = [&] {
+    std::vector<std::optional<int64_t>> out;
+    while (RowBatch* batch = (*scan)->Next()) {
+      for (const std::optional<int64_t>& value : Read<int64_t>(*batch, 0)) {
+        out.push_back(value);
+      }
+    }
+    return out;
+  };
+  std::vector<std::optional<int64_t>> first = run();
+  (*scan)->Reset();
+  EXPECT_EQ(run(), first);
+}
+
+// The point of being a Source: a query reaches the thing which reads rows
+// without either end knowing about the other.
+TEST_F(SqlScanTest, AQueryReachesARowCursor) {
+  auto scan = Scan("SELECT 5 AS a UNION ALL SELECT 6 UNION ALL SELECT 7");
+  ASSERT_TRUE(scan.ok()) << scan.status().c_message();
+
+  RowCursor cursor(**scan);
+  std::vector<uint32_t> rows;
+  for (bool more = cursor.Open(); more; more = cursor.Next()) {
+    rows.push_back(cursor.row(0));
+  }
+  EXPECT_THAT(rows, testing::ElementsAre(0u, 1u, 2u));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::exec


### PR DESCRIPTION
Streaming and turning round between them cover a stream that is already
in one of the two tree orders. A stream in neither is not a harder case
of the same thing: no reordering of chunks and no reversal of rows
produces an order that was not in the input, so the rows have to be put
in one.

What makes that affordable is that the rows are held anyway, and held as
one column each. Sorting them is another array of row numbers, exactly
like turning them round is, and handing a batch over stays a matter of
pointing every column at a slice of it. Nothing is moved for any of the
three.

A tree also has to be a tree, and a stream in no order is the first one
where that is worth checking properly: a walk from the roots reaches
every node exactly once, and any it does not reach are in a cycle.