### PR TITLE
tp: say what a row batch is and where rows are kept

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17604,6 +17604,7 @@ filegroup {
         "src/trace_processor/core/exec/pipeline.cc",
         "src/trace_processor/core/exec/row_batch.cc",
         "src/trace_processor/core/exec/row_cursor.cc",
+        "src/trace_processor/core/exec/row_store.cc",
     ],
 }
 
@@ -17612,6 +17613,7 @@ filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
         "src/trace_processor/core/exec/operator_unittest.cc",
+        "src/trace_processor/core/exec/row_store_unittest.cc",
     ],
 }
 

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -28,6 +28,8 @@ source_set("exec") {
     "row_cursor.cc",
     "row_cursor.h",
     "row_selection.h",
+    "row_store.cc",
+    "row_store.h",
   ]
   deps = [
     "../../../../gn:default_deps",
@@ -40,7 +42,10 @@ source_set("exec") {
 
 perfetto_unittest_source_set("unittests") {
   testonly = true
-  sources = [ "operator_unittest.cc" ]
+  sources = [
+    "operator_unittest.cc",
+    "row_store_unittest.cc",
+  ]
   deps = [
     ":exec",
     "../../../../gn:default_deps",

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -69,6 +69,12 @@ class ColumnView {
     block_ = nullptr;
   }
 
+  // Points this column at the run of physical rows starting at `offset`.
+  void SetRange(uint32_t offset) {
+    selection_ = RowSelection::Range(offset);
+    block_ = nullptr;
+  }
+
   // Takes over the row view `other` just computed. Columns of one batch that
   // shared a view before slicing still share it afterwards, so only the first
   // of them has to compose it.
@@ -76,6 +82,12 @@ class ColumnView {
     selection_ = other.selection_;
     block_ = other.block_;
   }
+
+  // The values this column reads from, before its row view is applied.
+  const void* data() const { return data_; }
+
+  // Which physical rows hold a value, or null when every row does.
+  const BitVector* validity() const { return validity_; }
 
  private:
   Kind kind_ = Kind::kFlat;

--- a/src/trace_processor/core/exec/operator_unittest.cc
+++ b/src/trace_processor/core/exec/operator_unittest.cc
@@ -62,7 +62,7 @@ std::vector<uint32_t> Drain(PullPipeline& pipeline) {
   pipeline.Reset();
   RowCursor cursor(pipeline);
   for (cursor.Open(); !cursor.eof(); cursor.Next()) {
-    rows.push_back(cursor.row());
+    rows.push_back(cursor.row(0));
   }
   return rows;
 }
@@ -210,6 +210,56 @@ TEST(SinkTest, ReadsEveryRowOfEveryBatch) {
   EXPECT_EQ(rows.front(), 0u);
   EXPECT_EQ(rows[kMaxBatchRows], kMaxBatchRows);
   EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 6u);
+}
+
+// An operator which adds a computed column cannot put it in the index space
+// its input arrived in, so it adds it in its own. A cursor has to follow each
+// column's own view to read either of them.
+TEST(SinkTest, ReadsColumnsWhichDoNotShareARowView) {
+  std::vector<int64_t> payload = {10, 11, 12, 13};
+  std::vector<int64_t> computed = {90, 91};
+
+  class TwoViewSource final : public Source {
+   public:
+    TwoViewSource(const std::vector<int64_t>* payload,
+                  const std::vector<int64_t>* computed)
+        : payload_(payload), computed_(computed) {}
+
+    RowBatch* Next() override {
+      if (done_) {
+        return nullptr;
+      }
+      done_ = true;
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, payload_->data()));
+      // The payload is read from half way in; the computed column is its own
+      // array read from the start.
+      batch_.Compose(RowSelection::Range(2), 2);
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, computed_->data()));
+      batch_.SetCardinality(2);
+      return &batch_;
+    }
+
+   private:
+    const std::vector<int64_t>* payload_;
+    const std::vector<int64_t>* computed_;
+    RowBatch batch_;
+    bool done_ = false;
+  };
+
+  TwoViewSource source(&payload, &computed);
+  RowCursor cursor(source);
+  std::vector<int64_t> read_payload;
+  std::vector<int64_t> read_computed;
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    read_payload.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(0).data())[cursor.row(0)]);
+    read_computed.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(1).data())[cursor.row(1)]);
+  }
+  EXPECT_THAT(read_payload, ElementsAre(12, 13));
+  EXPECT_THAT(read_computed, ElementsAre(90, 91));
 }
 
 TEST(SinkTest, ReportsEofWithoutOpen) {

--- a/src/trace_processor/core/exec/row_batch.h
+++ b/src/trace_processor/core/exec/row_batch.h
@@ -27,9 +27,22 @@
 
 namespace perfetto::trace_processor::core::exec {
 
-class RowBatchPool;
-
 // A rectangular batch of columns with one shared cardinality.
+//
+// A batch owns nothing. Its columns are views over values belonging to the
+// operator that produced it, which fixes both halves of the question:
+//
+//   Who owns these values?   Whatever handed you the batch.
+//   How long are they good?  Until you ask it for the next batch, and never
+//                            past its lifetime.
+//
+// So a batch is a borrow with the same terms everywhere, and an operator that
+// needs rows for longer than that copies them into a RowStore of its own.
+// Everything an operator hands out is read from something it holds, which is
+// why a batch does not outlive it: nothing here is shared, reference counted,
+// or kept alive behind the reader's back, and a reader that wants values to
+// survive the operator that made them copies them, as it would from any other
+// view.
 class RowBatch {
  public:
   RowBatch() = default;
@@ -66,15 +79,14 @@ class RowBatch {
   // false when no rows remain.
   bool Slice(RowSelection selection, uint32_t count);
 
- private:
-  friend class RowBatchPool;
-
+  // Drops the columns, so the batch can be pointed at something else.
   void Reset() {
     cardinality_ = 0;
     columns_.clear();
     selections_.Reset();
   }
 
+ private:
   uint32_t cardinality_ = 0;
   std::vector<ColumnView> columns_;
   SelectionPool selections_;

--- a/src/trace_processor/core/exec/row_cursor.cc
+++ b/src/trace_processor/core/exec/row_cursor.cc
@@ -18,7 +18,6 @@
 
 #include "src/trace_processor/core/exec/operator.h"
 #include "src/trace_processor/core/exec/row_batch.h"
-#include "src/trace_processor/core/exec/row_selection.h"
 
 namespace perfetto::trace_processor::core::exec {
 
@@ -27,17 +26,14 @@ RowCursor::RowCursor(Source& source) : source_(source) {}
 RowCursor::~RowCursor() = default;
 
 bool RowCursor::Pull() {
-  RowBatch* batch = source_.Next();
-  if (!batch) {
+  batch_ = source_.Next();
+  if (!batch_) {
     index_ = 0;
     size_ = 0;
     return false;
   }
-  RowSelection selection = batch->column(0).selection();
-  rows_ = selection.is_range() ? nullptr : selection.data();
-  offset_ = selection.offset();
   index_ = 0;
-  size_ = batch->size();
+  size_ = batch_->size();
   return true;
 }
 

--- a/src/trace_processor/core/exec/row_cursor.h
+++ b/src/trace_processor/core/exec/row_cursor.h
@@ -22,6 +22,7 @@
 #include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
 
 namespace perfetto::trace_processor::core::exec {
 
@@ -49,11 +50,21 @@ class RowCursor {
 
   bool eof() const { return index_ == size_; }
 
-  // The row being read. Every column of a batch shares one row view, so which
-  // column it is read from does not matter.
-  PERFETTO_ALWAYS_INLINE uint32_t row() const {
+  // The physical row `column` is read at.
+  //
+  // Resolved per column rather than once for the batch: an operator which adds
+  // a computed column has nowhere to put it in the index space its input
+  // arrived in, so it adds the column in its own. Columns of one batch
+  // therefore agree on how many rows there are and need agree on nothing else.
+  PERFETTO_ALWAYS_INLINE uint32_t row(uint32_t column) const {
     PERFETTO_DCHECK(index_ < size_);
-    return rows_ ? rows_[index_] : offset_ + index_;
+    return batch_->column(column).selection().GetIndex(index_);
+  }
+
+  // The batch being read, for a consumer which wants the columns themselves.
+  const RowBatch& batch() const {
+    PERFETTO_DCHECK(batch_);
+    return *batch_;
   }
 
  private:
@@ -61,9 +72,7 @@ class RowCursor {
   bool Pull();
 
   Source& source_;
-  // The batch's rows, or null when they are the contiguous run from `offset_`.
-  const uint32_t* rows_ = nullptr;
-  uint32_t offset_ = 0;
+  RowBatch* batch_ = nullptr;
   uint32_t index_ = 0;
   uint32_t size_ = 0;
 };

--- a/src/trace_processor/core/exec/row_store.cc
+++ b/src/trace_processor/core/exec/row_store.cc
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_store.h"
+
+#include <cstdint>
+#include <cstring>
+#include <variant>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// Grows a column to hold `size` values. Reserving first is the whole of it:
+// resize allocates exactly what it is asked for, so a store filled a chunk at
+// a time would otherwise reallocate and copy the column on every chunk, and
+// filling it would cost a multiple of what the column is worth.
+template <typename T, typename Variant>
+FlexVector<T>& Ensure(Variant& values, uint32_t size) {
+  if (!std::holds_alternative<FlexVector<T>>(values)) {
+    values = FlexVector<T>();
+  }
+  auto& vec = std::get<FlexVector<T>>(values);
+  if (vec.size() < size) {
+    vec.reserve(size);
+    vec.resize(size);
+  }
+  return vec;
+}
+
+// Copies the `count` values `column` resolves to. A range resolves to a run,
+// which copies whole; anything else is one gather. Neither walks a row view a
+// value at a time.
+template <typename T, typename Variant>
+void Copy(const ColumnView& column,
+          uint32_t at,
+          uint32_t count,
+          Variant& values) {
+  FlexVector<T>& out = Ensure<T>(values, at + count);
+  const auto* data = static_cast<const T*>(column.data());
+  RowSelection selection = column.selection();
+  T* dest = out.data() + at;
+  if (selection.is_range()) {
+    memcpy(dest, data + selection.offset(), count * sizeof(T));
+    return;
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    dest[i] = data[rows[i]];
+  }
+}
+
+// An Id column's value is the row it sits at, so copying one means writing
+// down the rows it stood for.
+template <typename Variant>
+void CopyIds(const ColumnView& column,
+             uint32_t at,
+             uint32_t count,
+             Variant& values) {
+  FlexVector<uint32_t>& out = Ensure<uint32_t>(values, at + count);
+  RowSelection selection = column.selection();
+  uint32_t* dest = out.data() + at;
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      dest[i] = offset + i;
+    }
+    return;
+  }
+  memcpy(dest, selection.data(), count * sizeof(uint32_t));
+}
+
+}  // namespace
+
+base::Status RowStore::AppendColumn(Column& into,
+                                    const ColumnView& from,
+                                    uint32_t count) {
+  StorageType type = from.type();
+  if (type.Is<Id>()) {
+    CopyIds(from, size_, count, into.values);
+    type = StorageType{Uint32{}};
+  } else if (type.Is<Uint32>()) {
+    Copy<uint32_t>(from, size_, count, into.values);
+  } else if (type.Is<Int32>()) {
+    Copy<int32_t>(from, size_, count, into.values);
+  } else if (type.Is<Int64>()) {
+    Copy<int64_t>(from, size_, count, into.values);
+  } else if (type.Is<Double>()) {
+    Copy<double>(from, size_, count, into.values);
+  } else {
+    Copy<StringPool::Id>(from, size_, count, into.values);
+  }
+  if (size_ != 0 && !(type == into.type)) {
+    return base::ErrStatus(
+        "row store: a column arrived holding one type after holding another");
+  }
+  into.type = type;
+
+  const BitVector* validity = from.validity();
+  if (!validity && !into.nullable) {
+    return base::OkStatus();
+  }
+  uint32_t end = size_ + count;
+  if (into.validity.size() < end) {
+    into.validity.reserve(end);
+    into.validity.resize(end);
+  }
+  if (!into.nullable) {
+    // Everything already here came from a column with nothing missing.
+    for (uint32_t i = 0; i < size_; ++i) {
+      into.validity.set(i);
+    }
+    into.nullable = true;
+  }
+  if (!validity) {
+    for (uint32_t i = 0; i < count; ++i) {
+      into.validity.set(size_ + i);
+    }
+    return base::OkStatus();
+  }
+  RowSelection selection = from.selection();
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      into.validity.change(size_ + i, validity->is_set(offset + i));
+    }
+    return base::OkStatus();
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    into.validity.change(size_ + i, validity->is_set(rows[i]));
+  }
+  return base::OkStatus();
+}
+
+base::Status RowStore::Append(const RowBatch& batch) {
+  uint32_t count = batch.size();
+  if (count == 0) {
+    return base::OkStatus();
+  }
+  if (columns_.empty()) {
+    columns_.resize(batch.column_count());
+  } else if (columns_.size() != batch.column_count()) {
+    return base::ErrStatus(
+        "row store: a batch of %u columns arrived after one of %u",
+        batch.column_count(), static_cast<uint32_t>(columns_.size()));
+  }
+  for (uint32_t col = 0; col < columns_.size(); ++col) {
+    RETURN_IF_ERROR(AppendColumn(columns_[col], batch.column(col), count));
+  }
+  size_ += count;
+  return base::OkStatus();
+}
+
+Span<const int64_t> RowStore::Int64Column(uint32_t column) const {
+  const Column& held = columns_[column];
+  PERFETTO_DCHECK(held.type.Is<Int64>());
+  const FlexVector<int64_t>& values =
+      std::get<FlexVector<int64_t>>(held.values);
+  return Span<const int64_t>(values.data(), values.data() + size_);
+}
+
+ColumnView RowStore::ViewOf(const Column& column) const {
+  const void* data = nullptr;
+  if (column.type.Is<Uint32>()) {
+    data = std::get<FlexVector<uint32_t>>(column.values).data();
+  } else if (column.type.Is<Int32>()) {
+    data = std::get<FlexVector<int32_t>>(column.values).data();
+  } else if (column.type.Is<Int64>()) {
+    data = std::get<FlexVector<int64_t>>(column.values).data();
+  } else if (column.type.Is<Double>()) {
+    data = std::get<FlexVector<double>>(column.values).data();
+  } else {
+    data = std::get<FlexVector<StringPool::Id>>(column.values).data();
+  }
+  return ColumnView::Reference(column.type, data,
+                               column.nullable ? &column.validity : nullptr);
+}
+
+void RowStore::View(RowBatch* batch, uint32_t offset, uint32_t count) const {
+  batch->Reset();
+  for (const Column& column : columns_) {
+    ColumnView view = ViewOf(column);
+    view.SetRange(offset);
+    batch->AddColumn(view);
+  }
+  batch->SetCardinality(count);
+}
+
+void RowStore::View(RowBatch* batch, Span<const uint32_t> rows) const {
+  batch->Reset();
+  for (const Column& column : columns_) {
+    ColumnView view = ViewOf(column);
+    view.SetBorrowedRows(rows);
+    batch->AddColumn(view);
+  }
+  batch->SetCardinality(static_cast<uint32_t>(rows.size()));
+}
+
+void RowStore::Clear() {
+  size_ = 0;
+  for (Column& column : columns_) {
+    column.nullable = false;
+  }
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_store.h
+++ b/src/trace_processor/core/exec/row_store.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_STORE_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_STORE_H_
+
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// The rows an operator keeps.
+//
+// A batch is a borrow: its values belong to the operator that handed it over
+// and are good until that operator is asked for the next one. An operator
+// that needs rows for longer than that -- every breaker, by definition --
+// copies them here.
+//
+// This is the only way to keep rows. An operator holds a store or it holds
+// nothing, so the memory a query needs at once is the sum of its stores, and
+// finding it is reading the operators' member lists rather than hunting for
+// whichever scratch vectors somebody declared. It is also what makes the
+// lifetime answerable: a store dies with its operator, so batches read from
+// it are good for exactly as long as batches read from anything else.
+//
+// The copy is not the price of the rule -- it is the price of keeping rows at
+// all, and it is paid once, here. What it buys back is that the columns land
+// dense from row zero: a fold reads one flat span per column, and a computed
+// column can sit beside them in the same index space.
+//
+// The copy is not the price of this rule -- it is the price of keeping rows
+// at all, and it is paid once, here, rather than piecemeal into whatever
+// scratch vectors an operator felt like declaring. What it buys back is that
+// the columns land dense from row zero: a fold reads one flat span per
+// column, and a computed column can sit beside them in the same index space.
+class RowStore {
+ public:
+  // Copies every column of `batch` onto the end. The first append fixes the
+  // shape; a later one which disagrees is an error rather than a surprise.
+  base::Status Append(const RowBatch& batch);
+
+  uint32_t size() const { return size_; }
+  uint32_t column_count() const {
+    return static_cast<uint32_t>(columns_.size());
+  }
+  StorageType type(uint32_t column) const { return columns_[column].type; }
+
+  // A column read back whole. The rows are dense from zero, so a pass over a
+  // column is a walk over an array and not a walk over a row view.
+  Span<const int64_t> Int64Column(uint32_t column) const;
+
+  // Points `batch` at `count` rows from `offset`, replacing whatever it held.
+  // The caller is free to add its own columns afterwards.
+  void View(RowBatch* batch, uint32_t offset, uint32_t count) const;
+
+  // The same, for the rows `rows` picks out.
+  void View(RowBatch* batch, Span<const uint32_t> rows) const;
+
+  // Forgets the rows. The buffers stay, so a store which is filled again is
+  // filled into what it already had.
+  void Clear();
+
+ private:
+  struct Column {
+    StorageType type{Uint32{}};
+    std::variant<FlexVector<uint32_t>,
+                 FlexVector<int32_t>,
+                 FlexVector<int64_t>,
+                 FlexVector<double>,
+                 FlexVector<StringPool::Id>>
+        values{FlexVector<uint32_t>()};
+    BitVector validity;
+    bool nullable = false;
+  };
+
+  base::Status AppendColumn(Column& into, const ColumnView& from, uint32_t n);
+  ColumnView ViewOf(const Column& column) const;
+
+  // Fixed in size once the first batch has arrived, so a view of one column
+  // stays good while the others are appended to.
+  std::vector<Column> columns_;
+  uint32_t size_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_STORE_H_

--- a/src/trace_processor/core/exec/row_store_unittest.cc
+++ b/src/trace_processor/core/exec/row_store_unittest.cc
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_store.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/span.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using testing::ElementsAre;
+
+// Points a batch at one int64 column, the way a source would.
+void Fill(RowBatch* batch,
+          const std::vector<int64_t>& values,
+          uint32_t offset,
+          uint32_t count) {
+  batch->Reset();
+  batch->AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch->Compose(RowSelection::Range(offset), count);
+  batch->SetCardinality(count);
+}
+
+std::vector<int64_t> ReadInt64(const RowBatch& batch, uint32_t column) {
+  const ColumnView& view = batch.column(column);
+  const auto* data = static_cast<const int64_t*>(view.data());
+  std::vector<int64_t> out;
+  for (uint32_t i = 0; i < batch.size(); ++i) {
+    out.push_back(data[view.selection().GetIndex(i)]);
+  }
+  return out;
+}
+
+TEST(RowStoreTest, KeepsWhatSeveralBatchesCarried) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 2);
+  ASSERT_TRUE(store.Append(batch).ok());
+  Fill(&batch, values, 2, 3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  EXPECT_EQ(store.size(), 5u);
+  EXPECT_THAT(store.Int64Column(0), ElementsAre(10, 11, 12, 13, 14));
+}
+
+// The whole reason a store exists: a source is free to write over the buffer
+// a batch was pointing at.
+TEST(RowStoreTest, SurvivesTheStorageItWasReadFromMovingOn) {
+  std::vector<int64_t> buffer = {1, 2, 3};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, buffer, 0, 3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  buffer = {99, 99, 99};
+  EXPECT_THAT(store.Int64Column(0), ElementsAre(1, 2, 3));
+}
+
+// A column read back whole is dense from zero however the batches which
+// filled it were sliced, which is what lets a fold be a walk over an array.
+TEST(RowStoreTest, ReadsBackDenseWhateverArrived) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  std::vector<uint32_t> rows = {4, 0, 2};
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch.mutable_column(0).SetBorrowedRows(
+      Span<const uint32_t>(rows.data(), rows.data() + 3));
+  batch.SetCardinality(3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  EXPECT_THAT(store.Int64Column(0), ElementsAre(14, 10, 12));
+}
+
+TEST(RowStoreTest, HandsBackARunOfItsRows) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 5);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 2, 3);
+  EXPECT_EQ(out.size(), 3u);
+  EXPECT_THAT(ReadInt64(out, 0), ElementsAre(12, 13, 14));
+}
+
+TEST(RowStoreTest, HandsBackTheRowsAnOrderPicksOut) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  std::vector<uint32_t> order = {4, 3, 0};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 5);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, Span<const uint32_t>(order.data(), order.data() + 3));
+  EXPECT_THAT(ReadInt64(out, 0), ElementsAre(14, 13, 10));
+}
+
+// Viewing twice must not stack the columns up.
+TEST(RowStoreTest, AViewReplacesTheOneBefore) {
+  std::vector<int64_t> values = {10, 11};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 2);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 0, 2);
+  store.View(&out, 0, 2);
+  EXPECT_EQ(out.column_count(), 1u);
+}
+
+TEST(RowStoreTest, KeepsWhichRowsHeldNothing) {
+  std::vector<int64_t> values = {10, 11, 12};
+  BitVector validity = BitVector::CreateWithSize(3);
+  validity.set(0);
+  validity.set(2);
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, values.data(), &validity));
+  batch.Compose(RowSelection::Range(0), 3);
+  batch.SetCardinality(3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 0, 3);
+  const BitVector* kept = out.column(0).validity();
+  ASSERT_NE(kept, nullptr);
+  EXPECT_TRUE(kept->is_set(0));
+  EXPECT_FALSE(kept->is_set(1));
+  EXPECT_TRUE(kept->is_set(2));
+}
+
+// An Id column has no storage: its value is the row it sits at, so keeping
+// one means writing those rows down.
+TEST(RowStoreTest, AnIdColumnBecomesTheRowsItStoodFor) {
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
+  batch.Compose(RowSelection::Range(7), 3);
+  batch.SetCardinality(3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 0, 3);
+  ASSERT_TRUE(out.column(0).type().Is<Uint32>());
+  const auto* data = static_cast<const uint32_t*>(out.column(0).data());
+  EXPECT_THAT(std::vector<uint32_t>(data, data + 3), ElementsAre(7u, 8u, 9u));
+}
+
+TEST(RowStoreTest, ABatchOfADifferentShapeIsReported) {
+  std::vector<int64_t> values = {1, 2};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 2);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch wider;
+  wider.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  wider.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  wider.Compose(RowSelection::Range(0), 2);
+  wider.SetCardinality(2);
+  EXPECT_FALSE(store.Append(wider).ok());
+}
+
+// Filling a store a chunk at a time must cost the column, not a multiple of
+// it. Counting how often the buffer moves is how that stays true without the
+// test depending on a clock: growing geometrically moves it a handful of
+// times, growing by exactly what was asked for moves it once per chunk.
+TEST(RowStoreTest, FillingAChunkAtATimeDoesNotRecopyTheColumn) {
+  const uint32_t kRows = 200000, kChunk = 2048;
+  std::vector<int64_t> values(kChunk);
+  RowStore store;
+  RowBatch batch;
+  const void* data = nullptr;
+  uint32_t moves = 0;
+  for (uint32_t done = 0; done < kRows; done += kChunk) {
+    Fill(&batch, values, 0, kChunk);
+    ASSERT_TRUE(store.Append(batch).ok());
+    const void* now = store.Int64Column(0).data();
+    moves += now != data;
+    data = now;
+  }
+  EXPECT_EQ(store.size(), ((kRows + kChunk - 1) / kChunk) * kChunk);
+  EXPECT_LT(moves, 20u) << "the column is being recopied on every chunk";
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/util/bit_vector.h
+++ b/src/trace_processor/core/util/bit_vector.h
@@ -281,6 +281,11 @@ struct BitVector {
 
   // Resizes the vector to the specified size. If shrinking, bits past the new
   // size are cleared. If growing, new bits are set to the given value.
+  // Makes room for `new_size` bits without changing the size. Growth here is
+  // geometric where resize allocates exactly what was asked for, so anything
+  // filling a bit vector a chunk at a time has to come through here first.
+  void reserve(uint64_t new_size) { words_.reserve((new_size + 63) / 64); }
+
   void resize(uint64_t new_size, bool value = false) {
     uint64_t new_words = (new_size + 63) / 64;
     words_.resize(new_words);


### PR DESCRIPTION
Who owns the values a pipeline is carrying was never written down, and
the answer was drifting: some columns pointed into a source's storage,
some into a batch's, and an operator that wanted rows for longer than a
batch lasts declared whatever vectors it felt like. That is the sort of
thing which is fine until two operators disagree about it.

There are two rules and this is both of them.

A batch owns nothing. Its columns are views over storage belonging to
whatever produced them, so a batch is good until the next pull from that
source and not one instruction longer.

An operator that needs the rows after that copies them into a RowStore
it names as a member. There is no other way to keep rows, so the memory
a query holds is the sum of its stores, and finding it is reading the
operators' member lists.

Two things follow. Columns of one batch stop having to agree about which
rows they mean: a cursor took the row view from column zero and applied
it to the rest, which quietly reads a computed column off the end of
itself, because the space its input arrived in belongs to the storage
the input was read from. And a store reads back dense from row zero, so
a fold over a column is a walk over an array and a computed column can
sit beside it in the same space.