### PR TITLE
tp: make an operator a plan and move what it is doing out of it

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17601,6 +17601,7 @@ filegroup {
     srcs: [
         "src/trace_processor/core/exec/column_view.cc",
         "src/trace_processor/core/exec/from.cc",
+        "src/trace_processor/core/exec/operator.cc",
         "src/trace_processor/core/exec/pipeline.cc",
         "src/trace_processor/core/exec/row_batch.cc",
         "src/trace_processor/core/exec/row_cursor.cc",

--- a/Android.bp
+++ b/Android.bp
@@ -17595,6 +17595,26 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/core/exec:exec
+filegroup {
+    name: "perfetto_src_trace_processor_core_exec_exec",
+    srcs: [
+        "src/trace_processor/core/exec/column_view.cc",
+        "src/trace_processor/core/exec/from.cc",
+        "src/trace_processor/core/exec/pipeline.cc",
+        "src/trace_processor/core/exec/row_batch.cc",
+        "src/trace_processor/core/exec/row_cursor.cc",
+    ],
+}
+
+// GN: //src/trace_processor/core/exec:unittests
+filegroup {
+    name: "perfetto_src_trace_processor_core_exec_unittests",
+    srcs: [
+        "src/trace_processor/core/exec/operator_unittest.cc",
+    ],
+}
+
 // GN: //src/trace_processor/core/interpreter:bytecode_interpreter_test_utils
 filegroup {
     name: "perfetto_src_trace_processor_core_interpreter_bytecode_interpreter_test_utils",
@@ -23953,6 +23973,8 @@ cc_test {
         ":perfetto_src_trace_processor_core_common_common",
         ":perfetto_src_trace_processor_core_dataframe_dataframe",
         ":perfetto_src_trace_processor_core_dataframe_unittests",
+        ":perfetto_src_trace_processor_core_exec_exec",
+        ":perfetto_src_trace_processor_core_exec_unittests",
         ":perfetto_src_trace_processor_core_interpreter_bytecode_interpreter_test_utils",
         ":perfetto_src_trace_processor_core_interpreter_interpreter",
         ":perfetto_src_trace_processor_core_interpreter_unittests",

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -444,6 +444,7 @@ perfetto_unittest_source_set("unittests") {
     ":top_level_unittests",
     "containers:unittests",
     "core/dataframe:unittests",
+    "core/exec:unittests",
     "core/interpreter:unittests",
     "core/tree:unittests",
     "core/util:unittests",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -20,6 +20,7 @@ source_set("exec") {
     "column_view.h",
     "from.cc",
     "from.h",
+    "operator.cc",
     "operator.h",
     "pipeline.cc",
     "pipeline.h",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -1,0 +1,53 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/test.gni")
+
+source_set("exec") {
+  sources = [
+    "column_view.cc",
+    "column_view.h",
+    "from.cc",
+    "from.h",
+    "operator.h",
+    "pipeline.cc",
+    "pipeline.h",
+    "row_batch.cc",
+    "row_batch.h",
+    "row_cursor.cc",
+    "row_cursor.h",
+    "row_selection.h",
+  ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../base",
+    "../../containers",
+    "../common",
+    "../util",
+  ]
+}
+
+perfetto_unittest_source_set("unittests") {
+  testonly = true
+  sources = [ "operator_unittest.cc" ]
+  deps = [
+    ":exec",
+    "../../../../gn:default_deps",
+    "../../../../gn:gtest_and_gmock",
+    "../../../base",
+    "../../containers",
+    "../common",
+    "../util",
+  ]
+}

--- a/src/trace_processor/core/exec/column_view.cc
+++ b/src/trace_processor/core/exec/column_view.cc
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/column_view.h"
+
+#include <cstdint>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// Whether `count` rows resolved through `resolve` land on a contiguous run,
+// and where that run starts. `resolve` is a template parameter so the walk
+// carries no per-row branch on how the rows are reached.
+template <typename Resolve>
+bool IsContiguousRun(Resolve resolve, uint32_t count, uint32_t* first) {
+  *first = resolve(0);
+  uint32_t expected = *first + 1;
+  for (uint32_t row = 1; row < count; ++row, ++expected) {
+    if (resolve(row) != expected) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+void ColumnView::Slice(RowSelection selection,
+                       uint32_t count,
+                       SelectionPool& pool) {
+  if (count == 0) {
+    return;
+  }
+  RowSelection current = selection_;
+
+  if (selection.is_range()) {
+    if (current.is_range()) {
+      selection_ = RowSelection::Range(current.offset() + selection.offset());
+      return;
+    }
+    // Slicing a prefix or suffix of an index array is a subspan, so the view
+    // keeps the storage it already pointed at.
+    const uint32_t* begin = current.data() + selection.offset();
+    selection_ =
+        RowSelection::Indices(Span<const uint32_t>(begin, begin + count));
+    return;
+  }
+
+  const uint32_t* rows = selection.data();
+  uint32_t first;
+  if (current.is_range()) {
+    uint32_t base = current.offset();
+    if (IsContiguousRun([rows, base](uint32_t r) { return base + rows[r]; },
+                        count, &first)) {
+      selection_ = RowSelection::Range(first);
+      block_ = nullptr;
+      return;
+    }
+    // Rows counted from zero are already exactly the caller's array, whose
+    // lifetime covers the batch.
+    if (base == 0) {
+      selection_ =
+          RowSelection::Indices(Span<const uint32_t>(rows, rows + count));
+      block_ = nullptr;
+      return;
+    }
+    uint32_t* out = pool.TakeBlock();
+    for (uint32_t row = 0; row < count; ++row) {
+      out[row] = base + rows[row];
+    }
+    selection_ = RowSelection::Indices(Span<const uint32_t>(out, out + count));
+    block_ = out;
+    return;
+  }
+
+  const uint32_t* indices = current.data();
+  if (IsContiguousRun([rows, indices](uint32_t r) { return indices[rows[r]]; },
+                      count, &first)) {
+    selection_ = RowSelection::Range(first);
+    block_ = nullptr;
+    return;
+  }
+  // A view the batch already composed narrows onto itself: ordinals only ever
+  // grow, so an ascending gather never reads a slot it has already written.
+  uint32_t* out = block_;
+  if (out) {
+    for (uint32_t row = 0; row < count; ++row) {
+      PERFETTO_DCHECK(indices + rows[row] >= out + row);
+    }
+  } else {
+    out = pool.TakeBlock();
+  }
+  for (uint32_t row = 0; row < count; ++row) {
+    out[row] = indices[rows[row]];
+  }
+  selection_ = RowSelection::Indices(Span<const uint32_t>(out, out + count));
+  block_ = out;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -77,6 +77,9 @@ class ColumnView {
     block_ = other.block_;
   }
 
+  // The values this column reads from, before its row view is applied.
+  const void* data() const { return data_; }
+
  private:
   Kind kind_ = Kind::kFlat;
   StorageType type_{Id{}};

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_VIEW_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_VIEW_H_
+
+#include <cstdint>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// One column of a RowBatch: a reference to storage the batch does not own,
+// plus the logical-to-physical row view currently applied.
+class ColumnView {
+ public:
+  enum class Kind : uint8_t {
+    kFlat,
+    kSequence,
+  };
+
+  ColumnView() = default;
+
+  static ColumnView Reference(StorageType type,
+                              const void* data,
+                              const BitVector* validity = nullptr) {
+    ColumnView view;
+    view.type_ = type;
+    if (type.Is<Id>()) {
+      PERFETTO_DCHECK(data == nullptr && validity == nullptr);
+      view.kind_ = Kind::kSequence;
+      return view;
+    }
+    view.kind_ = Kind::kFlat;
+    view.data_ = data;
+    view.validity_ = validity;
+    return view;
+  }
+
+  Kind kind() const { return kind_; }
+  StorageType type() const { return type_; }
+  RowSelection selection() const { return selection_; }
+
+  // Composes `selection` with the current logical-to-physical row view,
+  // materializing the result into a block of `pool` if it needs one. The
+  // ordinals in `selection` must be strictly increasing.
+  void Slice(RowSelection selection, uint32_t count, SelectionPool& pool);
+
+  // Points this column at physical rows the caller owns. Nothing is copied, so
+  // `rows` must outlive the batch's current contents.
+  void SetBorrowedRows(Span<const uint32_t> rows) {
+    selection_ = RowSelection::Indices(rows);
+    block_ = nullptr;
+  }
+
+  // Takes over the row view `other` just computed. Columns of one batch that
+  // shared a view before slicing still share it afterwards, so only the first
+  // of them has to compose it.
+  void AdoptSelection(const ColumnView& other) {
+    selection_ = other.selection_;
+    block_ = other.block_;
+  }
+
+ private:
+  Kind kind_ = Kind::kFlat;
+  StorageType type_{Id{}};
+  RowSelection selection_ = RowSelection::Range();
+  // The batch's block this column's view was composed into, or null when the
+  // view references other storage. Columns that share a view share the block
+  // behind it.
+  uint32_t* block_ = nullptr;
+  const void* data_ = nullptr;
+  const BitVector* validity_ = nullptr;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_VIEW_H_

--- a/src/trace_processor/core/exec/from.cc
+++ b/src/trace_processor/core/exec/from.cc
@@ -18,10 +18,12 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
 
 #include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
 #include "src/trace_processor/core/exec/row_batch.h"
 #include "src/trace_processor/core/exec/row_selection.h"
 #include "src/trace_processor/core/util/span.h"
@@ -29,33 +31,39 @@
 namespace perfetto::trace_processor::core::exec {
 
 From::From(std::vector<ColumnView> columns, RowSelection rows, uint32_t count)
-    : columns_(std::move(columns)), rows_(rows), count_(count) {
-  for (const ColumnView& column : columns_) {
-    batch_.AddColumn(column);
-  }
+    : columns_(std::move(columns)), rows_(rows), count_(count) {}
+
+From::~From() = default;
+From::State::~State() = default;
+
+std::unique_ptr<OperatorState> From::MakeState() const {
+  return std::make_unique<State>();
 }
 
-RowBatch* From::Next() {
-  if (emitted_ == count_) {
-    return nullptr;
+void From::Rewind(OperatorState& state) const {
+  state.Cast<State>().emitted = 0;
+}
+
+bool From::GetData(RowBatch& out, OperatorState& state) const {
+  State& s = state.Cast<State>();
+  if (s.emitted == count_) {
+    return false;
   }
-  uint32_t count = std::min(kMaxBatchRows, count_ - emitted_);
-  RowSelection selection = RowSelection::Range(rows_.GetIndex(emitted_));
+  uint32_t count = std::min(kMaxBatchRows, count_ - s.emitted);
+  RowSelection selection = RowSelection::Range(rows_.GetIndex(s.emitted));
   if (!rows_.is_range()) {
-    const uint32_t* begin = rows_.data() + emitted_;
+    const uint32_t* begin = rows_.data() + s.emitted;
     selection =
         RowSelection::Indices(Span<const uint32_t>(begin, begin + count));
   }
-  batch_.PrepareForFill();
-  for (uint32_t i = 0; i < columns_.size(); ++i) {
-    // Operators only replace a column's row view, so restoring the views is
-    // all a reused batch needs before being filled again.
-    batch_.mutable_column(i).AdoptSelection(columns_[i]);
+  out.Reset();
+  for (const ColumnView& column : columns_) {
+    out.AddColumn(column);
   }
-  batch_.Compose(selection, count);
-  batch_.SetCardinality(count);
-  emitted_ += count;
-  return &batch_;
+  out.Compose(selection, count);
+  out.SetCardinality(count);
+  s.emitted += count;
+  return true;
 }
 
 }  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/from.cc
+++ b/src/trace_processor/core/exec/from.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/from.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+From::From(std::vector<ColumnView> columns, RowSelection rows, uint32_t count)
+    : columns_(std::move(columns)), rows_(rows), count_(count) {
+  for (const ColumnView& column : columns_) {
+    batch_.AddColumn(column);
+  }
+}
+
+RowBatch* From::Next() {
+  if (emitted_ == count_) {
+    return nullptr;
+  }
+  uint32_t count = std::min(kMaxBatchRows, count_ - emitted_);
+  RowSelection selection = RowSelection::Range(rows_.GetIndex(emitted_));
+  if (!rows_.is_range()) {
+    const uint32_t* begin = rows_.data() + emitted_;
+    selection =
+        RowSelection::Indices(Span<const uint32_t>(begin, begin + count));
+  }
+  batch_.PrepareForFill();
+  for (uint32_t i = 0; i < columns_.size(); ++i) {
+    // Operators only replace a column's row view, so restoring the views is
+    // all a reused batch needs before being filled again.
+    batch_.mutable_column(i).AdoptSelection(columns_[i]);
+  }
+  batch_.Compose(selection, count);
+  batch_.SetCardinality(count);
+  emitted_ += count;
+  return &batch_;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/from.h
+++ b/src/trace_processor/core/exec/from.h
@@ -18,6 +18,7 @@
 #define SRC_TRACE_PROCESSOR_CORE_EXEC_FROM_H_
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "src/trace_processor/core/exec/column_view.h"
@@ -28,21 +29,27 @@
 namespace perfetto::trace_processor::core::exec {
 
 // Implements FROM by referencing the selected source rows, one batch at a
-// time.
+// time. The rows it references stand still, so there is nothing to keep and
+// the state is a count of how far through them the execution is.
 class From : public Source {
  public:
   From(std::vector<ColumnView> columns, RowSelection rows, uint32_t count);
+  ~From() override;
 
-  void Reset() override { emitted_ = 0; }
-  RowBatch* Next() override;
+  std::unique_ptr<OperatorState> MakeState() const override;
+  bool GetData(RowBatch& out, OperatorState& state) const override;
+  void Rewind(OperatorState& state) const override;
 
  private:
+  struct State : OperatorState {
+    ~State() override;
+    uint32_t emitted = 0;
+  };
+
   // The columns as constructed, each holding the row view a batch starts from.
   std::vector<ColumnView> columns_;
-  RowBatch batch_;
   RowSelection rows_;
   uint32_t count_;
-  uint32_t emitted_ = 0;
 };
 
 }  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/from.h
+++ b/src/trace_processor/core/exec/from.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_FROM_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_FROM_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// Implements FROM by referencing the selected source rows, one batch at a
+// time.
+class From : public Source {
+ public:
+  From(std::vector<ColumnView> columns, RowSelection rows, uint32_t count);
+
+  void Reset() override { emitted_ = 0; }
+  RowBatch* Next() override;
+
+ private:
+  // The columns as constructed, each holding the row view a batch starts from.
+  std::vector<ColumnView> columns_;
+  RowBatch batch_;
+  RowSelection rows_;
+  uint32_t count_;
+  uint32_t emitted_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_FROM_H_

--- a/src/trace_processor/core/exec/operator.cc
+++ b/src/trace_processor/core/exec/operator.cc
@@ -14,26 +14,12 @@
  * limitations under the License.
  */
 
-#include "src/trace_processor/core/exec/row_cursor.h"
-
 #include "src/trace_processor/core/exec/operator.h"
 
 namespace perfetto::trace_processor::core::exec {
 
-RowCursor::RowCursor(const Source& source)
-    : source_(source), state_(source.MakeState()) {}
-
-RowCursor::~RowCursor() = default;
-
-bool RowCursor::Pull() {
-  if (!source_.GetData(batch_, *state_)) {
-    index_ = 0;
-    size_ = 0;
-    return false;
-  }
-  index_ = 0;
-  size_ = batch_.size();
-  return true;
-}
+OperatorState::~OperatorState() = default;
+Operator::~Operator() = default;
+Source::~Source() = default;
 
 }  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/operator.h
+++ b/src/trace_processor/core/exec/operator.h
@@ -18,11 +18,43 @@
 #define SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_
 
 #include <cstdint>
+#include <memory>
 
 #include "perfetto/base/status.h"
 #include "src/trace_processor/core/exec/row_batch.h"
 
 namespace perfetto::trace_processor::core::exec {
+
+// Everything one execution of a plan is up to.
+//
+// A plan says what to do and never changes while it is being done; a state is
+// where a particular doing of it has got to. Splitting them is what makes the
+// ownership question have one answer: a plan holds no values, every value a
+// query holds is in some state, and the states belong to whoever is running
+// the plan rather than to the plan.
+//
+// It is also what makes a plan reusable. Running the same plan twice, or
+// twice at once, is two states and one plan, so nothing has to be rebuilt and
+// nothing can be left over from last time.
+class OperatorState {
+ public:
+  OperatorState() = default;
+  virtual ~OperatorState();
+
+  OperatorState(const OperatorState&) = delete;
+  OperatorState& operator=(const OperatorState&) = delete;
+
+  // An operator only ever sees a state it made itself, so it may say which
+  // one that was.
+  template <typename T>
+  T& Cast() {
+    return static_cast<T&>(*this);
+  }
+  template <typename T>
+  const T& Cast() const {
+    return static_cast<const T&>(*this);
+  }
+};
 
 enum class OpResult : uint8_t {
   // The batch continues to the next operator.
@@ -31,43 +63,50 @@ enum class OpResult : uint8_t {
   kDrop,
 };
 
-// A streaming step in a pipeline. An operator may add columns or select rows,
-// but it always updates one batch in place and produces at most one output
-// batch for each input batch.
+// A streaming step in a plan. An operator may add columns or select rows, but
+// it always updates one batch in place and produces at most one output batch
+// for each input batch.
 class Operator {
  public:
   virtual ~Operator();
   Operator(const Operator&) = delete;
   Operator& operator=(const Operator&) = delete;
 
-  // Called once per execution, before the first batch, so an operator built
-  // once per query plan can pick up values that change between executions.
-  virtual void Open() {}
+  // Made once per execution, before the first batch.
+  virtual std::unique_ptr<OperatorState> MakeState() const {
+    return std::make_unique<OperatorState>();
+  }
 
-  virtual OpResult Execute(RowBatch& batch) = 0;
+  virtual OpResult Execute(RowBatch& batch, OperatorState& state) const = 0;
 
  protected:
   Operator() = default;
 };
 
-// Produces the batches a pipeline runs over.
+// Produces the batches a plan runs over.
 class Source {
  public:
   virtual ~Source();
   Source(const Source&) = delete;
   Source& operator=(const Source&) = delete;
 
-  // Rewinds to the first batch so the source can be replayed.
-  virtual void Reset() {}
+  // Made once per execution. A source whose input is another source makes
+  // that one's state too and holds it, so one call builds a whole chain.
+  virtual std::unique_ptr<OperatorState> MakeState() const = 0;
 
-  // The next batch, or null when exhausted. The batch stays owned by the
-  // source and remains valid until the next Next() call, as do any row
-  // indices borrowed from it.
-  virtual RowBatch* Next() = 0;
+  // Fills `out` with the next batch, or returns false when there are none
+  // left. The values it is filled with belong to `state` and are good until
+  // the next call, so a caller that wants them for longer copies them.
+  virtual bool GetData(RowBatch& out, OperatorState& state) const = 0;
 
-  // Distinguishes normal exhaustion from an error after Next() returns no
-  // batch. In-memory sources retain the default OK status.
-  virtual base::Status status() const { return base::OkStatus(); }
+  // Winds `state` back to the first batch so it can be replayed.
+  virtual void Rewind(OperatorState& state) const = 0;
+
+  // Distinguishes normal exhaustion from an error after GetData() says there
+  // is nothing more.
+  virtual base::Status status(const OperatorState&) const {
+    return base::OkStatus();
+  }
 
  protected:
   Source() = default;

--- a/src/trace_processor/core/exec/operator.h
+++ b/src/trace_processor/core/exec/operator.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_
+
+#include <cstdint>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+enum class OpResult : uint8_t {
+  // The batch continues to the next operator.
+  kContinue,
+  // The batch has no rows left; the rest of the pipeline skips it.
+  kDrop,
+};
+
+// A streaming step in a pipeline. An operator may add columns or select rows,
+// but it always updates one batch in place and produces at most one output
+// batch for each input batch.
+class Operator {
+ public:
+  virtual ~Operator();
+  Operator(const Operator&) = delete;
+  Operator& operator=(const Operator&) = delete;
+
+  // Called once per execution, before the first batch, so an operator built
+  // once per query plan can pick up values that change between executions.
+  virtual void Open() {}
+
+  virtual OpResult Execute(RowBatch& batch) = 0;
+
+ protected:
+  Operator() = default;
+};
+
+// Produces the batches a pipeline runs over.
+class Source {
+ public:
+  virtual ~Source();
+  Source(const Source&) = delete;
+  Source& operator=(const Source&) = delete;
+
+  // Rewinds to the first batch so the source can be replayed.
+  virtual void Reset() {}
+
+  // The next batch, or null when exhausted. The batch stays owned by the
+  // source and remains valid until the next Next() call, as do any row
+  // indices borrowed from it.
+  virtual RowBatch* Next() = 0;
+
+  // Distinguishes normal exhaustion from an error after Next() returns no
+  // batch. In-memory sources retain the default OK status.
+  virtual base::Status status() const { return base::OkStatus(); }
+
+ protected:
+  Source() = default;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_

--- a/src/trace_processor/core/exec/operator_unittest.cc
+++ b/src/trace_processor/core/exec/operator_unittest.cc
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/from.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/pipeline.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_cursor.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/span.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using ::testing::ElementsAre;
+
+// A source shaped like a dataframe scan: an identity column so every batch
+// carries row indices, plus the values themselves.
+class TestSource {
+ public:
+  explicit TestSource(std::vector<int64_t> values)
+      : values_(std::move(values)) {}
+
+  std::unique_ptr<From> Create() {
+    std::vector<ColumnView> columns;
+    columns.push_back(
+        ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
+    columns.push_back(
+        ColumnView::Reference(StorageType{Int64{}}, values_.data(), nullptr));
+    return std::make_unique<From>(std::move(columns), RowSelection::Range(0),
+                                  static_cast<uint32_t>(values_.size()));
+  }
+
+ private:
+  std::vector<int64_t> values_;
+};
+
+// Reads a pipeline the way a consumer would, a row at a time.
+std::vector<uint32_t> Drain(PullPipeline& pipeline) {
+  std::vector<uint32_t> rows;
+  pipeline.Reset();
+  RowCursor cursor(pipeline);
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    rows.push_back(cursor.row());
+  }
+  return rows;
+}
+
+std::vector<int64_t> Sequence(uint32_t count) {
+  std::vector<int64_t> values(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    values[i] = i;
+  }
+  return values;
+}
+
+// Keeps every second row, standing in for a real operator.
+class DropOddRows final : public Operator {
+ public:
+  OpResult Execute(RowBatch& batch) override {
+    uint32_t count = 0;
+    for (uint32_t row = 0; row < batch.size(); row += 2) {
+      selected_[count++] = row;
+    }
+    return batch.Slice(RowSelection::Indices(
+                           Span<const uint32_t>(selected_, selected_ + count)),
+                       count)
+               ? OpResult::kContinue
+               : OpResult::kDrop;
+  }
+
+ private:
+  uint32_t selected_[kMaxBatchRows];
+};
+
+TEST(OperatorTest, SourceEmitsEveryRow) {
+  TestSource source({10, 20, 30});
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+}
+
+TEST(OperatorTest, SourceSplitsIntoBatches) {
+  TestSource source(Sequence(kMaxBatchRows * 2 + 3));
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  std::vector<uint32_t> rows = Drain(pipeline);
+  ASSERT_EQ(rows.size(), kMaxBatchRows * 2u + 3u);
+  EXPECT_EQ(rows.front(), 0u);
+  EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 2u);
+}
+
+TEST(OperatorTest, SourceIsReplayable) {
+  TestSource source({10, 20, 30});
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+}
+
+// A source owns one batch and refills it, so a long pipeline allocates no
+// per-batch state at all.
+TEST(OperatorTest, SourceReusesOneBatch) {
+  TestSource source(Sequence(kMaxBatchRows * 20));
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  pipeline.Reset();
+  RowBatch* first = pipeline.Next();
+  ASSERT_NE(first, nullptr);
+  uint32_t batches = 1;
+  while (RowBatch* batch = pipeline.Next()) {
+    EXPECT_EQ(batch, first) << "source handed out a different batch";
+    ++batches;
+  }
+  EXPECT_EQ(batches, 20u);
+}
+
+TEST(OperatorTest, OperatorNarrowsTheBatch) {
+  TestSource source({10, 20, 30, 40, 50});
+  std::unique_ptr<From> from = source.Create();
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<DropOddRows>());
+  PullPipeline pipeline(*from, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 2, 4));
+}
+
+TEST(OperatorTest, OperatorsComposeWithinABatch) {
+  TestSource source({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  std::unique_ptr<From> from = source.Create();
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<DropOddRows>());
+  ops.push_back(std::make_unique<DropOddRows>());
+  PullPipeline pipeline(*from, std::move(ops));
+
+  // Keeping every second row twice keeps every fourth.
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 4, 8));
+}
+
+TEST(OperatorTest, NarrowingAComposedViewKeepsIt) {
+  TestSource source(Sequence(17));
+  std::unique_ptr<From> from = source.Create();
+  std::vector<std::unique_ptr<Operator>> ops;
+  for (int i = 0; i < 3; ++i) {
+    ops.push_back(std::make_unique<DropOddRows>());
+  }
+  PullPipeline pipeline(*from, std::move(ops));
+
+  // Keeping every second row three times keeps every eighth. The third
+  // operator narrows a view the batch already composed, onto itself.
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 8, 16));
+}
+
+// The storage a batch composes its views into belongs to the batch and is
+// handed back for the next one, so a pipeline stops allocating once it is
+// running.
+TEST(OperatorTest, ComposedViewsReuseTheBatchesStorage) {
+  TestSource source(Sequence(kMaxBatchRows * 4));
+  std::unique_ptr<From> from = source.Create();
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<DropOddRows>());
+  ops.push_back(std::make_unique<DropOddRows>());
+  PullPipeline pipeline(*from, std::move(ops));
+
+  pipeline.Reset();
+  RowBatch* batch = pipeline.Next();
+  ASSERT_NE(batch, nullptr);
+  const uint32_t* block = batch->column(0).selection().data();
+  ASSERT_NE(block, nullptr) << "expected a composed view";
+  uint32_t batches = 1;
+  while ((batch = pipeline.Next()) != nullptr) {
+    EXPECT_EQ(batch->column(0).selection().data(), block);
+    ++batches;
+  }
+  EXPECT_EQ(batches, 4u);
+}
+
+TEST(SinkTest, ReadsEveryRowOfEveryBatch) {
+  TestSource source(Sequence(kMaxBatchRows * 2 + 7));
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  std::vector<uint32_t> rows = Drain(pipeline);
+  ASSERT_EQ(rows.size(), kMaxBatchRows * 2u + 7u);
+  EXPECT_EQ(rows.front(), 0u);
+  EXPECT_EQ(rows[kMaxBatchRows], kMaxBatchRows);
+  EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 6u);
+}
+
+TEST(SinkTest, ReportsEofWithoutOpen) {
+  TestSource source({1, 2, 3});
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+  RowCursor cursor(pipeline);
+
+  EXPECT_TRUE(cursor.eof());
+}
+
+TEST(SinkTest, ReopeningRereadsFromTheStart) {
+  TestSource source({4, 5, 6});
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/operator_unittest.cc
+++ b/src/trace_processor/core/exec/operator_unittest.cc
@@ -57,12 +57,11 @@ class TestSource {
 };
 
 // Reads a pipeline the way a consumer would, a row at a time.
-std::vector<uint32_t> Drain(PullPipeline& pipeline) {
+std::vector<uint32_t> Drain(const PullPipeline& pipeline) {
   std::vector<uint32_t> rows;
-  pipeline.Reset();
   RowCursor cursor(pipeline);
   for (cursor.Open(); !cursor.eof(); cursor.Next()) {
-    rows.push_back(cursor.row());
+    rows.push_back(cursor.row(0));
   }
   return rows;
 }
@@ -75,23 +74,52 @@ std::vector<int64_t> Sequence(uint32_t count) {
   return values;
 }
 
-// Keeps every second row, standing in for a real operator.
+// Keeps every second row, standing in for a real operator. The rows it picks
+// are scratch for one execution, so they live in its state and not in it.
 class DropOddRows final : public Operator {
  public:
-  OpResult Execute(RowBatch& batch) override {
+  std::unique_ptr<OperatorState> MakeState() const override {
+    return std::make_unique<State>();
+  }
+
+  OpResult Execute(RowBatch& batch, OperatorState& state) const override {
+    uint32_t* selected = state.Cast<State>().selected;
     uint32_t count = 0;
     for (uint32_t row = 0; row < batch.size(); row += 2) {
-      selected_[count++] = row;
+      selected[count++] = row;
     }
     return batch.Slice(RowSelection::Indices(
-                           Span<const uint32_t>(selected_, selected_ + count)),
+                           Span<const uint32_t>(selected, selected + count)),
                        count)
                ? OpResult::kContinue
                : OpResult::kDrop;
   }
 
  private:
-  uint32_t selected_[kMaxBatchRows];
+  struct State : OperatorState {
+    ~State() override;
+    uint32_t selected[kMaxBatchRows];
+  };
+};
+
+DropOddRows::State::~State() = default;
+
+// Drives a plan the way an executor does: it makes the state and owns the
+// batch, and the plan stays const throughout.
+class Execution {
+ public:
+  explicit Execution(const Source& source)
+      : source_(source), state_(source.MakeState()) {}
+
+  RowBatch* Next() {
+    return source_.GetData(batch_, *state_) ? &batch_ : nullptr;
+  }
+  void Rewind() { source_.Rewind(*state_); }
+
+ private:
+  const Source& source_;
+  std::unique_ptr<OperatorState> state_;
+  RowBatch batch_;
 };
 
 TEST(OperatorTest, SourceEmitsEveryRow) {
@@ -129,12 +157,14 @@ TEST(OperatorTest, SourceReusesOneBatch) {
   std::unique_ptr<From> from = source.Create();
   PullPipeline pipeline(*from, {});
 
-  pipeline.Reset();
-  RowBatch* first = pipeline.Next();
+  Execution run(pipeline);
+  RowBatch* first = run.Next();
   ASSERT_NE(first, nullptr);
+  const void* values = first->column(1).data();
   uint32_t batches = 1;
-  while (RowBatch* batch = pipeline.Next()) {
-    EXPECT_EQ(batch, first) << "source handed out a different batch";
+  while (RowBatch* batch = run.Next()) {
+    EXPECT_EQ(batch, first) << "the executor's batch was replaced";
+    EXPECT_EQ(batch->column(1).data(), values) << "the source copied values";
     ++batches;
   }
   EXPECT_EQ(batches, 20u);
@@ -187,13 +217,13 @@ TEST(OperatorTest, ComposedViewsReuseTheBatchesStorage) {
   ops.push_back(std::make_unique<DropOddRows>());
   PullPipeline pipeline(*from, std::move(ops));
 
-  pipeline.Reset();
-  RowBatch* batch = pipeline.Next();
+  Execution run(pipeline);
+  RowBatch* batch = run.Next();
   ASSERT_NE(batch, nullptr);
   const uint32_t* block = batch->column(0).selection().data();
   ASSERT_NE(block, nullptr) << "expected a composed view";
   uint32_t batches = 1;
-  while ((batch = pipeline.Next()) != nullptr) {
+  while ((batch = run.Next()) != nullptr) {
     EXPECT_EQ(batch->column(0).selection().data(), block);
     ++batches;
   }
@@ -210,6 +240,65 @@ TEST(SinkTest, ReadsEveryRowOfEveryBatch) {
   EXPECT_EQ(rows.front(), 0u);
   EXPECT_EQ(rows[kMaxBatchRows], kMaxBatchRows);
   EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 6u);
+}
+
+// An operator which adds a computed column cannot put it in the index space
+// its input arrived in, so it adds it in its own. A cursor has to follow each
+// column's own view to read either of them.
+TEST(SinkTest, ReadsColumnsWhichDoNotShareARowView) {
+  std::vector<int64_t> payload = {10, 11, 12, 13};
+  std::vector<int64_t> computed = {90, 91};
+
+  class TwoViewSource final : public Source {
+   public:
+    TwoViewSource(const std::vector<int64_t>* payload,
+                  const std::vector<int64_t>* computed)
+        : payload_(payload), computed_(computed) {}
+
+    std::unique_ptr<OperatorState> MakeState() const override {
+      return std::make_unique<State>();
+    }
+    void Rewind(OperatorState& state) const override {
+      state.Cast<State>().done = false;
+    }
+    bool GetData(RowBatch& batch_, OperatorState& state) const override {
+      State& s = state.Cast<State>();
+      if (s.done) {
+        return false;
+      }
+      s.done = true;
+      batch_.Reset();
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, payload_->data()));
+      // The payload is read from half way in; the computed column is its own
+      // array read from the start.
+      batch_.Compose(RowSelection::Range(2), 2);
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, computed_->data()));
+      batch_.SetCardinality(2);
+      return true;
+    }
+
+   private:
+    struct State : OperatorState {
+      bool done = false;
+    };
+    const std::vector<int64_t>* payload_;
+    const std::vector<int64_t>* computed_;
+  };
+
+  TwoViewSource source(&payload, &computed);
+  RowCursor cursor(source);
+  std::vector<int64_t> read_payload;
+  std::vector<int64_t> read_computed;
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    read_payload.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(0).data())[cursor.row(0)]);
+    read_computed.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(1).data())[cursor.row(1)]);
+  }
+  EXPECT_THAT(read_payload, ElementsAre(12, 13));
+  EXPECT_THAT(read_computed, ElementsAre(90, 91));
 }
 
 TEST(SinkTest, ReportsEofWithoutOpen) {

--- a/src/trace_processor/core/exec/pipeline.cc
+++ b/src/trace_processor/core/exec/pipeline.cc
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/pipeline.h"
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// Whether the batch still has rows for the consumer once every operator has
+// seen it.
+bool ExecuteOperators(RowBatch& batch,
+                      const std::vector<std::unique_ptr<Operator>>& operators) {
+  if (batch.size() == 0) {
+    return false;
+  }
+  for (const std::unique_ptr<Operator>& op : operators) {
+    if (op->Execute(batch) == OpResult::kDrop || batch.size() == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+Operator::~Operator() = default;
+Source::~Source() = default;
+
+PullPipeline::PullPipeline(Source& source,
+                           std::vector<std::unique_ptr<Operator>> operators)
+    : source_(source), operators_(std::move(operators)) {}
+
+PullPipeline::~PullPipeline() = default;
+
+void PullPipeline::Reset() {
+  source_.Reset();
+  for (const std::unique_ptr<Operator>& op : operators_) {
+    op->Open();
+  }
+}
+
+RowBatch* PullPipeline::Next() {
+  for (RowBatch* batch = source_.Next(); batch; batch = source_.Next()) {
+    if (ExecuteOperators(*batch, operators_)) {
+      return batch;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/pipeline.cc
+++ b/src/trace_processor/core/exec/pipeline.cc
@@ -16,7 +16,7 @@
 
 #include "src/trace_processor/core/exec/pipeline.h"
 
-#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -26,48 +26,47 @@
 #include "src/trace_processor/core/exec/row_batch.h"
 
 namespace perfetto::trace_processor::core::exec {
-namespace {
 
-// Whether the batch still has rows for the consumer once every operator has
-// seen it.
-bool ExecuteOperators(RowBatch& batch,
-                      const std::vector<std::unique_ptr<Operator>>& operators) {
-  if (batch.size() == 0) {
-    return false;
-  }
-  for (const std::unique_ptr<Operator>& op : operators) {
-    if (op->Execute(batch) == OpResult::kDrop || batch.size() == 0) {
-      return false;
-    }
-  }
-  return true;
-}
-
-}  // namespace
-
-Operator::~Operator() = default;
-Source::~Source() = default;
-
-PullPipeline::PullPipeline(Source& source,
+PullPipeline::PullPipeline(const Source& source,
                            std::vector<std::unique_ptr<Operator>> operators)
     : source_(source), operators_(std::move(operators)) {}
 
 PullPipeline::~PullPipeline() = default;
+PullPipeline::State::~State() = default;
 
-void PullPipeline::Reset() {
-  source_.Reset();
+std::unique_ptr<OperatorState> PullPipeline::MakeState() const {
+  auto state = std::make_unique<State>();
+  state->source = source_.MakeState();
+  state->operators.reserve(operators_.size());
   for (const std::unique_ptr<Operator>& op : operators_) {
-    op->Open();
+    state->operators.push_back(op->MakeState());
   }
+  return state;
 }
 
-RowBatch* PullPipeline::Next() {
-  for (RowBatch* batch = source_.Next(); batch; batch = source_.Next()) {
-    if (ExecuteOperators(*batch, operators_)) {
-      return batch;
+void PullPipeline::Rewind(OperatorState& state) const {
+  source_.Rewind(*state.Cast<State>().source);
+}
+
+base::Status PullPipeline::status(const OperatorState& state) const {
+  return source_.status(*state.Cast<const State>().source);
+}
+
+bool PullPipeline::GetData(RowBatch& out, OperatorState& state) const {
+  State& s = state.Cast<State>();
+  while (source_.GetData(out, *s.source)) {
+    bool dropped = false;
+    for (uint32_t i = 0; i < operators_.size(); ++i) {
+      if (operators_[i]->Execute(out, *s.operators[i]) == OpResult::kDrop) {
+        dropped = true;
+        break;
+      }
+    }
+    if (!dropped) {
+      return true;
     }
   }
-  return nullptr;
+  return false;
 }
 
 }  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/pipeline.h
+++ b/src/trace_processor/core/exec/pipeline.h
@@ -27,20 +27,28 @@
 namespace perfetto::trace_processor::core::exec {
 
 // A source and a straight line of streaming operators, exposed as a Source.
+//
+// Its state holds the states of everything in it, so making one state builds
+// the whole line and dropping it takes the whole line down. That is what an
+// executor owns: the plan is separately owned and outlives any run of it.
 class PullPipeline : public Source {
  public:
-  PullPipeline(Source& source, std::vector<std::unique_ptr<Operator>>);
+  PullPipeline(const Source&, std::vector<std::unique_ptr<Operator>>);
   ~PullPipeline() override;
 
-  void Reset() override;
-
-  RowBatch* Next() override;
-
-  // The status of the underlying source.
-  base::Status status() const override { return source_.status(); }
+  std::unique_ptr<OperatorState> MakeState() const override;
+  bool GetData(RowBatch& out, OperatorState& state) const override;
+  void Rewind(OperatorState& state) const override;
+  base::Status status(const OperatorState& state) const override;
 
  private:
-  Source& source_;
+  struct State : OperatorState {
+    ~State() override;
+    std::unique_ptr<OperatorState> source;
+    std::vector<std::unique_ptr<OperatorState>> operators;
+  };
+
+  const Source& source_;
   std::vector<std::unique_ptr<Operator>> operators_;
 };
 

--- a/src/trace_processor/core/exec/pipeline.h
+++ b/src/trace_processor/core/exec/pipeline.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_PIPELINE_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_PIPELINE_H_
+
+#include <memory>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// A source and a straight line of streaming operators, exposed as a Source.
+class PullPipeline : public Source {
+ public:
+  PullPipeline(Source& source, std::vector<std::unique_ptr<Operator>>);
+  ~PullPipeline() override;
+
+  void Reset() override;
+
+  RowBatch* Next() override;
+
+  // The status of the underlying source.
+  base::Status status() const override { return source_.status(); }
+
+ private:
+  Source& source_;
+  std::vector<std::unique_ptr<Operator>> operators_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_PIPELINE_H_

--- a/src/trace_processor/core/exec/row_batch.cc
+++ b/src/trace_processor/core/exec/row_batch.cc
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_batch.h"
+
+#include <cstdint>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+bool RowBatch::AdoptPhysicalRows(Span<const uint32_t> rows) {
+  auto count = static_cast<uint32_t>(rows.size());
+  if (count == 0) {
+    cardinality_ = 0;
+    return false;
+  }
+  PERFETTO_DCHECK(count <= cardinality_);
+  for (ColumnView& column : columns_) {
+    column.SetBorrowedRows(rows);
+  }
+  cardinality_ = count;
+  return true;
+}
+
+void RowBatch::Compose(RowSelection selection, uint32_t count) {
+  // Columns filled by one source share a logical-to-physical view, and
+  // composing it is a gather over the whole batch. Do that once per distinct
+  // view and let the rest of the columns adopt the result.
+  const ColumnView* composed = nullptr;
+  const uint32_t* composed_from_rows = nullptr;
+  uint32_t composed_from_offset = 0;
+  for (ColumnView& column : columns_) {
+    RowSelection current = column.selection();
+    if (composed && current.data() == composed_from_rows &&
+        current.offset() == composed_from_offset) {
+      column.AdoptSelection(*composed);
+      continue;
+    }
+    composed_from_rows = current.data();
+    composed_from_offset = current.offset();
+    column.Slice(selection, count, selections_);
+    composed = &column;
+  }
+}
+
+bool RowBatch::Slice(RowSelection selection, uint32_t count) {
+  PERFETTO_DCHECK(count <= cardinality_);
+  for (uint32_t row = 0; row < count; ++row) {
+    PERFETTO_DCHECK(selection.GetIndex(row) < cardinality_);
+    PERFETTO_DCHECK(row == 0 ||
+                    selection.GetIndex(row - 1) < selection.GetIndex(row));
+  }
+  if (count == 0) {
+    cardinality_ = 0;
+    return false;
+  }
+  if (count == cardinality_) {
+    return true;
+  }
+  Compose(selection, count);
+  cardinality_ = count;
+  return true;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_batch.h
+++ b/src/trace_processor/core/exec/row_batch.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+class RowBatchPool;
+
+// A rectangular batch of columns with one shared cardinality.
+class RowBatch {
+ public:
+  RowBatch() = default;
+
+  uint32_t size() const { return cardinality_; }
+  void SetCardinality(uint32_t count) {
+    PERFETTO_DCHECK(count <= kMaxBatchRows);
+    cardinality_ = count;
+  }
+
+  uint32_t column_count() const {
+    return static_cast<uint32_t>(columns_.size());
+  }
+  const ColumnView& column(uint32_t column) const { return columns_[column]; }
+  ColumnView& mutable_column(uint32_t column) { return columns_[column]; }
+  void AddColumn(ColumnView column) { columns_.push_back(std::move(column)); }
+
+  // Points every column at `rows`, which the caller continues to own. Only
+  // valid while the columns still share the source's contiguous view, and
+  // while `rows` stays valid until the batch is next filled.
+  bool AdoptPhysicalRows(Span<const uint32_t> rows);
+
+  // Returns the storage the batch composed its row views into. A source calls
+  // this before refilling; from here the previous contents, and any indices
+  // taken from them, are no longer valid.
+  void PrepareForFill() { selections_.Reset(); }
+
+  // Points every column at the `count` rows `selection` picks out. Sources use
+  // this to fill a batch once they have restored the columns' starting views;
+  // operators narrow a filled one with Slice.
+  void Compose(RowSelection selection, uint32_t count);
+
+  // Applies strictly increasing logical row ordinals to every column. Returns
+  // false when no rows remain.
+  bool Slice(RowSelection selection, uint32_t count);
+
+ private:
+  friend class RowBatchPool;
+
+  void Reset() {
+    cardinality_ = 0;
+    columns_.clear();
+    selections_.Reset();
+  }
+
+  uint32_t cardinality_ = 0;
+  std::vector<ColumnView> columns_;
+  SelectionPool selections_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_

--- a/src/trace_processor/core/exec/row_batch.h
+++ b/src/trace_processor/core/exec/row_batch.h
@@ -27,8 +27,6 @@
 
 namespace perfetto::trace_processor::core::exec {
 
-class RowBatchPool;
-
 // A rectangular batch of columns with one shared cardinality.
 class RowBatch {
  public:
@@ -66,15 +64,16 @@ class RowBatch {
   // false when no rows remain.
   bool Slice(RowSelection selection, uint32_t count);
 
- private:
-  friend class RowBatchPool;
-
+  // Drops the columns, so the batch can be pointed at something else. The
+  // executor owns the batch and hands it to a source to be filled, so
+  // emptying it is the caller's to do.
   void Reset() {
     cardinality_ = 0;
     columns_.clear();
     selections_.Reset();
   }
 
+ private:
   uint32_t cardinality_ = 0;
   std::vector<ColumnView> columns_;
   SelectionPool selections_;

--- a/src/trace_processor/core/exec/row_cursor.cc
+++ b/src/trace_processor/core/exec/row_cursor.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_cursor.h"
+
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+RowCursor::RowCursor(Source& source) : source_(source) {}
+
+RowCursor::~RowCursor() = default;
+
+bool RowCursor::Pull() {
+  RowBatch* batch = source_.Next();
+  if (!batch) {
+    index_ = 0;
+    size_ = 0;
+    return false;
+  }
+  RowSelection selection = batch->column(0).selection();
+  rows_ = selection.is_range() ? nullptr : selection.data();
+  offset_ = selection.offset();
+  index_ = 0;
+  size_ = batch->size();
+  return true;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_cursor.h
+++ b/src/trace_processor/core/exec/row_cursor.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_
+
+#include <cstdint>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/operator.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// The end of a pipeline, for a consumer that drives the loop itself: it asks
+// for a row, reads what it wants from that row, then asks for the next one.
+//
+// Batches are pulled only when the current one runs out, so a consumer that
+// stops early stops paying. Operators cannot do this: once handed a batch,
+// they run to the end of it.
+class RowCursor {
+ public:
+  explicit RowCursor(Source& source);
+  ~RowCursor();
+
+  // Reads up to the first row of a pipeline the caller has just rewound.
+  // Returns false if there is none.
+  bool Open() {
+    index_ = 0;
+    size_ = 0;
+    return Pull();
+  }
+
+  // Reads up to the next row, pulling a batch if the current one is exhausted.
+  bool Next() { return ++index_ != size_ || Pull(); }
+
+  bool eof() const { return index_ == size_; }
+
+  // The row being read. Every column of a batch shares one row view, so which
+  // column it is read from does not matter.
+  PERFETTO_ALWAYS_INLINE uint32_t row() const {
+    PERFETTO_DCHECK(index_ < size_);
+    return rows_ ? rows_[index_] : offset_ + index_;
+  }
+
+ private:
+  // Reads the next batch into the row view. Returns false at the end.
+  bool Pull();
+
+  Source& source_;
+  // The batch's rows, or null when they are the contiguous run from `offset_`.
+  const uint32_t* rows_ = nullptr;
+  uint32_t offset_ = 0;
+  uint32_t index_ = 0;
+  uint32_t size_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_

--- a/src/trace_processor/core/exec/row_cursor.h
+++ b/src/trace_processor/core/exec/row_cursor.h
@@ -18,27 +18,31 @@
 #define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_
 
 #include <cstdint>
+#include <memory>
 
 #include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
 #include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
 
 namespace perfetto::trace_processor::core::exec {
 
-// The end of a pipeline, for a consumer that drives the loop itself: it asks
-// for a row, reads what it wants from that row, then asks for the next one.
+// One execution of a plan, read a row at a time.
 //
-// Batches are pulled only when the current one runs out, so a consumer that
-// stops early stops paying. Operators cannot do this: once handed a batch,
-// they run to the end of it.
+// This is the executor: it owns the plan's state and the batch the rows
+// arrive in, which is why the plan itself can be const. A consumer drives it,
+// so batches are pulled only when the current one runs out and a consumer
+// that stops early stops paying.
 class RowCursor {
  public:
-  explicit RowCursor(Source& source);
+  explicit RowCursor(const Source& source);
   ~RowCursor();
 
-  // Reads up to the first row of a pipeline the caller has just rewound.
-  // Returns false if there is none.
+  // Reads up to the first row, rewinding first. Returns false if there is
+  // none.
   bool Open() {
+    source_.Rewind(*state_);
     index_ = 0;
     size_ = 0;
     return Pull();
@@ -49,21 +53,28 @@ class RowCursor {
 
   bool eof() const { return index_ == size_; }
 
-  // The row being read. Every column of a batch shares one row view, so which
-  // column it is read from does not matter.
-  PERFETTO_ALWAYS_INLINE uint32_t row() const {
+  base::Status status() const { return source_.status(*state_); }
+
+  // The physical row `column` is read at.
+  //
+  // Resolved per column rather than once for the batch: an operator which
+  // adds a computed column has nowhere to put it in the index space its input
+  // arrived in, so it adds the column in its own. Columns of one batch
+  // therefore agree on how many rows there are and need agree on nothing else.
+  PERFETTO_ALWAYS_INLINE uint32_t row(uint32_t column) const {
     PERFETTO_DCHECK(index_ < size_);
-    return rows_ ? rows_[index_] : offset_ + index_;
+    return batch_.column(column).selection().GetIndex(index_);
   }
 
+  // The batch being read, for a consumer which wants the columns themselves.
+  const RowBatch& batch() const { return batch_; }
+
  private:
-  // Reads the next batch into the row view. Returns false at the end.
   bool Pull();
 
-  Source& source_;
-  // The batch's rows, or null when they are the contiguous run from `offset_`.
-  const uint32_t* rows_ = nullptr;
-  uint32_t offset_ = 0;
+  const Source& source_;
+  std::unique_ptr<OperatorState> state_;
+  RowBatch batch_;
   uint32_t index_ = 0;
   uint32_t size_ = 0;
 };

--- a/src/trace_processor/core/exec/row_selection.h
+++ b/src/trace_processor/core/exec/row_selection.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_SELECTION_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_SELECTION_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// The most rows a batch carries, and so the most a row view ever covers.
+inline constexpr uint32_t kMaxBatchRows = 2048;
+
+// A lightweight view of logical-to-physical row indices. Indexed selections
+// do not own their storage.
+class RowSelection {
+ public:
+  static RowSelection Range(uint32_t offset = 0) {
+    return RowSelection(nullptr, offset);
+  }
+  static RowSelection Indices(Span<const uint32_t> rows) {
+    return RowSelection(rows.data(), 0);
+  }
+
+  uint32_t GetIndex(uint32_t row) const {
+    return rows_ ? rows_[row] : offset_ + row;
+  }
+  bool is_range() const { return rows_ == nullptr; }
+  const uint32_t* data() const { return rows_; }
+  uint32_t offset() const { return offset_; }
+
+ private:
+  RowSelection(const uint32_t* rows, uint32_t offset)
+      : rows_(rows), offset_(offset) {}
+
+  const uint32_t* rows_;
+  uint32_t offset_;
+};
+
+// The storage a batch composes its row views into.
+//
+// Blocks are a fixed size and are handed out for the life of one batch; the
+// batch after it takes the same blocks back. A batch needs one block per group
+// of columns that share a view, so the pool stops growing once a query has run
+// its first batch.
+class SelectionPool {
+ public:
+  // A block of kMaxBatchRows indices. Its address stays valid for as long as
+  // the batch does: growing the pool reallocates the vector, not the blocks it
+  // owns.
+  uint32_t* TakeBlock() {
+    if (next_ == blocks_.size()) {
+      blocks_.push_back(FlexVector<uint32_t>::CreateWithSize(kMaxBatchRows));
+    }
+    return blocks_[next_++].data();
+  }
+
+  // Hands every block back for the next batch to use.
+  void Reset() { next_ = 0; }
+
+ private:
+  std::vector<FlexVector<uint32_t>> blocks_;
+  uint32_t next_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_SELECTION_H_

--- a/src/trace_processor/core/exec/sink.h
+++ b/src/trace_processor/core/exec/sink.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_SINK_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_SINK_H_
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// The end a plan is pushed into, for a step which is told about batches
+// rather than asking for them.
+//
+// Whatever it accumulates is in the state it is handed, not in itself, so a
+// sink is as reusable as any other plan node.
+class Sink {
+ public:
+  virtual ~Sink();
+  Sink(const Sink&) = delete;
+  Sink& operator=(const Sink&) = delete;
+
+  virtual base::Status Consume(RowBatch& batch, OperatorState& state) const = 0;
+
+  // No more batches are coming.
+  virtual base::Status Finish(OperatorState& state) const = 0;
+
+ protected:
+  Sink() = default;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_SINK_H_

--- a/src/trace_processor/core/util/span.h
+++ b/src/trace_processor/core/util/span.h
@@ -17,8 +17,10 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_UTIL_SPAN_H_
 #define SRC_TRACE_PROCESSOR_CORE_UTIL_SPAN_H_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 #include <vector>
 
 #include "perfetto/base/logging.h"
@@ -37,6 +39,40 @@ struct Span {
 
   Span() = default;
   Span(T* _b, T* _e) : b(_b), e(_e) {}
+
+  template <typename U,
+            size_t N,
+            std::enable_if_t<std::is_convertible_v<U*, T*>, int> = 0>
+  Span(U (&values)[N]) : Span(values, values + N) {}
+
+  template <typename U,
+            size_t N,
+            std::enable_if_t<std::is_convertible_v<U*, T*>, int> = 0>
+  Span(std::array<U, N>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U,
+            size_t N,
+            std::enable_if_t<std::is_convertible_v<const U*, T*>, int> = 0>
+  Span(const std::array<U, N>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U,
+            typename Allocator,
+            std::enable_if_t<std::is_convertible_v<U*, T*>, int> = 0>
+  Span(std::vector<U, Allocator>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U,
+            typename Allocator,
+            std::enable_if_t<std::is_convertible_v<const U*, T*>, int> = 0>
+  Span(const std::vector<U, Allocator>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U, size_t N>
+  Span(std::array<U, N>&&) = delete;
+  template <typename U, typename Allocator>
+  Span(std::vector<U, Allocator>&&) = delete;
 
   T* begin() const { return b; }
   T* end() const { return e; }
@@ -59,6 +95,16 @@ Span<T> MakeMutableSpan(T (&values)[N]) {
 template <typename T, size_t N>
 Span<const T> MakeSpan(const T (&values)[N]) {
   return Span<const T>(values, values + N);
+}
+
+template <typename T, size_t N>
+Span<T> MakeMutableSpan(std::array<T, N>& values) {
+  return Span<T>(values.data(), values.data() + values.size());
+}
+
+template <typename T, size_t N>
+Span<const T> MakeSpan(const std::array<T, N>& values) {
+  return Span<const T>(values.data(), values.data() + values.size());
 }
 
 template <typename T>

--- a/src/trace_processor/core/util/span_unittest.cc
+++ b/src/trace_processor/core/util/span_unittest.cc
@@ -16,6 +16,7 @@
 
 #include "src/trace_processor/core/util/span.h"
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -28,12 +29,22 @@ namespace {
 
 TEST(SpanTest, CreatesFromVector) {
   std::vector<uint32_t> values{1, 2, 3};
-  Span<const uint32_t> span = MakeSpan(values);
+  Span<const uint32_t> span = values;
   EXPECT_THAT(span, testing::ElementsAre(1u, 2u, 3u));
   EXPECT_THAT(span.subspan(1, 2), testing::ElementsAre(2u, 3u));
 
-  Span<uint32_t> mutable_span = MakeMutableSpan(values);
+  Span<uint32_t> mutable_span = values;
   mutable_span.b[1] = 4;
+  EXPECT_EQ(values[1], 4u);
+}
+
+TEST(SpanTest, CreatesFromArray) {
+  std::array<uint32_t, 3> values{1, 2, 3};
+  Span<const uint32_t> values_span = values;
+  EXPECT_THAT(values_span, testing::ElementsAre(1u, 2u, 3u));
+
+  Span<uint32_t> mutable_values = values;
+  mutable_values[1] = 4;
   EXPECT_EQ(values[1], 4u);
 }
 


### PR DESCRIPTION
An operator held what it was in the middle of doing: how far through its
input it had got, the buffers it was filling, the batch it was handing
out. That makes an operator a thing you can only use once, ties the
lifetime of a query's values to the lifetime of the objects describing
the query, and leaves no answer to the question of who owns what beyond
"whoever happens to have declared it".

So an operator is now a plan and nothing else. It is const while it
runs, holds no values, and answers one question about itself: what state
does an execution of you need. The state is made by the operator, owned
by whatever is running it, and holds everything that changes -- which
for a source that materialises rows is also the values, and for a
breaker will be everything it has buffered.

The consequences are the point. A plan can be run twice, or twice at
once, and the two runs cannot see each other. Dropping a plan cannot
invalidate a running query's data, because the plan never had any.
Where the memory went is answerable by looking at the states rather than
at the objects. And a batch stops being something a source hands out and
becomes something the executor owns and asks to have filled, so the
answer to how long a batch is good for stops depending on which operator
produced it.

The cursor is the executor: it makes the state, owns the batch, and
holds the plan by const reference. Rewriting it also fixes the row view
it was handing out, which came from column zero and was applied to every
other column -- fine until an operator adds a computed column, which has
nowhere to go in the index space its input arrived in. Columns of one
batch now agree on how many rows there are and on nothing else.