### PR TITLE
tp: keep an operator's rows in a store rather than in vectors

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17595,6 +17595,27 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/core/exec:exec
+filegroup {
+    name: "perfetto_src_trace_processor_core_exec_exec",
+    srcs: [
+        "src/trace_processor/core/exec/column_view.cc",
+        "src/trace_processor/core/exec/from.cc",
+        "src/trace_processor/core/exec/operator.cc",
+        "src/trace_processor/core/exec/pipeline.cc",
+        "src/trace_processor/core/exec/row_batch.cc",
+        "src/trace_processor/core/exec/row_cursor.cc",
+    ],
+}
+
+// GN: //src/trace_processor/core/exec:unittests
+filegroup {
+    name: "perfetto_src_trace_processor_core_exec_unittests",
+    srcs: [
+        "src/trace_processor/core/exec/operator_unittest.cc",
+    ],
+}
+
 // GN: //src/trace_processor/core/interpreter:bytecode_interpreter_test_utils
 filegroup {
     name: "perfetto_src_trace_processor_core_interpreter_bytecode_interpreter_test_utils",
@@ -23953,6 +23974,8 @@ cc_test {
         ":perfetto_src_trace_processor_core_common_common",
         ":perfetto_src_trace_processor_core_dataframe_dataframe",
         ":perfetto_src_trace_processor_core_dataframe_unittests",
+        ":perfetto_src_trace_processor_core_exec_exec",
+        ":perfetto_src_trace_processor_core_exec_unittests",
         ":perfetto_src_trace_processor_core_interpreter_bytecode_interpreter_test_utils",
         ":perfetto_src_trace_processor_core_interpreter_interpreter",
         ":perfetto_src_trace_processor_core_interpreter_unittests",

--- a/Android.bp
+++ b/Android.bp
@@ -17605,6 +17605,7 @@ filegroup {
         "src/trace_processor/core/exec/pipeline.cc",
         "src/trace_processor/core/exec/row_batch.cc",
         "src/trace_processor/core/exec/row_cursor.cc",
+        "src/trace_processor/core/exec/row_store.cc",
     ],
 }
 
@@ -17613,6 +17614,7 @@ filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
         "src/trace_processor/core/exec/operator_unittest.cc",
+        "src/trace_processor/core/exec/row_store_unittest.cc",
     ],
 }
 

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -444,6 +444,7 @@ perfetto_unittest_source_set("unittests") {
     ":top_level_unittests",
     "containers:unittests",
     "core/dataframe:unittests",
+    "core/exec:unittests",
     "core/interpreter:unittests",
     "core/tree:unittests",
     "core/util:unittests",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -29,6 +29,8 @@ source_set("exec") {
     "row_cursor.cc",
     "row_cursor.h",
     "row_selection.h",
+    "row_store.cc",
+    "row_store.h",
   ]
   deps = [
     "../../../../gn:default_deps",
@@ -41,7 +43,10 @@ source_set("exec") {
 
 perfetto_unittest_source_set("unittests") {
   testonly = true
-  sources = [ "operator_unittest.cc" ]
+  sources = [
+    "operator_unittest.cc",
+    "row_store_unittest.cc",
+  ]
   deps = [
     ":exec",
     "../../../../gn:default_deps",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -1,0 +1,54 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/test.gni")
+
+source_set("exec") {
+  sources = [
+    "column_view.cc",
+    "column_view.h",
+    "from.cc",
+    "from.h",
+    "operator.cc",
+    "operator.h",
+    "pipeline.cc",
+    "pipeline.h",
+    "row_batch.cc",
+    "row_batch.h",
+    "row_cursor.cc",
+    "row_cursor.h",
+    "row_selection.h",
+  ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../base",
+    "../../containers",
+    "../common",
+    "../util",
+  ]
+}
+
+perfetto_unittest_source_set("unittests") {
+  testonly = true
+  sources = [ "operator_unittest.cc" ]
+  deps = [
+    ":exec",
+    "../../../../gn:default_deps",
+    "../../../../gn:gtest_and_gmock",
+    "../../../base",
+    "../../containers",
+    "../common",
+    "../util",
+  ]
+}

--- a/src/trace_processor/core/exec/column_view.cc
+++ b/src/trace_processor/core/exec/column_view.cc
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/column_view.h"
+
+#include <cstdint>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// Whether `count` rows resolved through `resolve` land on a contiguous run,
+// and where that run starts. `resolve` is a template parameter so the walk
+// carries no per-row branch on how the rows are reached.
+template <typename Resolve>
+bool IsContiguousRun(Resolve resolve, uint32_t count, uint32_t* first) {
+  *first = resolve(0);
+  uint32_t expected = *first + 1;
+  for (uint32_t row = 1; row < count; ++row, ++expected) {
+    if (resolve(row) != expected) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+void ColumnView::Slice(RowSelection selection,
+                       uint32_t count,
+                       SelectionPool& pool) {
+  if (count == 0) {
+    return;
+  }
+  RowSelection current = selection_;
+
+  if (selection.is_range()) {
+    if (current.is_range()) {
+      selection_ = RowSelection::Range(current.offset() + selection.offset());
+      return;
+    }
+    // Slicing a prefix or suffix of an index array is a subspan, so the view
+    // keeps the storage it already pointed at.
+    const uint32_t* begin = current.data() + selection.offset();
+    selection_ =
+        RowSelection::Indices(Span<const uint32_t>(begin, begin + count));
+    return;
+  }
+
+  const uint32_t* rows = selection.data();
+  uint32_t first;
+  if (current.is_range()) {
+    uint32_t base = current.offset();
+    if (IsContiguousRun([rows, base](uint32_t r) { return base + rows[r]; },
+                        count, &first)) {
+      selection_ = RowSelection::Range(first);
+      block_ = nullptr;
+      return;
+    }
+    // Rows counted from zero are already exactly the caller's array, whose
+    // lifetime covers the batch.
+    if (base == 0) {
+      selection_ =
+          RowSelection::Indices(Span<const uint32_t>(rows, rows + count));
+      block_ = nullptr;
+      return;
+    }
+    uint32_t* out = pool.TakeBlock();
+    for (uint32_t row = 0; row < count; ++row) {
+      out[row] = base + rows[row];
+    }
+    selection_ = RowSelection::Indices(Span<const uint32_t>(out, out + count));
+    block_ = out;
+    return;
+  }
+
+  const uint32_t* indices = current.data();
+  if (IsContiguousRun([rows, indices](uint32_t r) { return indices[rows[r]]; },
+                      count, &first)) {
+    selection_ = RowSelection::Range(first);
+    block_ = nullptr;
+    return;
+  }
+  // A view the batch already composed narrows onto itself: ordinals only ever
+  // grow, so an ascending gather never reads a slot it has already written.
+  uint32_t* out = block_;
+  if (out) {
+    for (uint32_t row = 0; row < count; ++row) {
+      PERFETTO_DCHECK(indices + rows[row] >= out + row);
+    }
+  } else {
+    out = pool.TakeBlock();
+  }
+  for (uint32_t row = 0; row < count; ++row) {
+    out[row] = indices[rows[row]];
+  }
+  selection_ = RowSelection::Indices(Span<const uint32_t>(out, out + count));
+  block_ = out;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -69,6 +69,12 @@ class ColumnView {
     block_ = nullptr;
   }
 
+  // Points this column at the run of physical rows starting at `offset`.
+  void SetRange(uint32_t offset) {
+    selection_ = RowSelection::Range(offset);
+    block_ = nullptr;
+  }
+
   // Takes over the row view `other` just computed. Columns of one batch that
   // shared a view before slicing still share it afterwards, so only the first
   // of them has to compose it.
@@ -79,6 +85,9 @@ class ColumnView {
 
   // The values this column reads from, before its row view is applied.
   const void* data() const { return data_; }
+
+  // Which physical rows hold a value, or null when every row does.
+  const BitVector* validity() const { return validity_; }
 
  private:
   Kind kind_ = Kind::kFlat;

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_VIEW_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_VIEW_H_
+
+#include <cstdint>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// One column of a RowBatch: a reference to storage the batch does not own,
+// plus the logical-to-physical row view currently applied.
+class ColumnView {
+ public:
+  enum class Kind : uint8_t {
+    kFlat,
+    kSequence,
+  };
+
+  ColumnView() = default;
+
+  static ColumnView Reference(StorageType type,
+                              const void* data,
+                              const BitVector* validity = nullptr) {
+    ColumnView view;
+    view.type_ = type;
+    if (type.Is<Id>()) {
+      PERFETTO_DCHECK(data == nullptr && validity == nullptr);
+      view.kind_ = Kind::kSequence;
+      return view;
+    }
+    view.kind_ = Kind::kFlat;
+    view.data_ = data;
+    view.validity_ = validity;
+    return view;
+  }
+
+  Kind kind() const { return kind_; }
+  StorageType type() const { return type_; }
+  RowSelection selection() const { return selection_; }
+
+  // Composes `selection` with the current logical-to-physical row view,
+  // materializing the result into a block of `pool` if it needs one. The
+  // ordinals in `selection` must be strictly increasing.
+  void Slice(RowSelection selection, uint32_t count, SelectionPool& pool);
+
+  // Points this column at physical rows the caller owns. Nothing is copied, so
+  // `rows` must outlive the batch's current contents.
+  void SetBorrowedRows(Span<const uint32_t> rows) {
+    selection_ = RowSelection::Indices(rows);
+    block_ = nullptr;
+  }
+
+  // Takes over the row view `other` just computed. Columns of one batch that
+  // shared a view before slicing still share it afterwards, so only the first
+  // of them has to compose it.
+  void AdoptSelection(const ColumnView& other) {
+    selection_ = other.selection_;
+    block_ = other.block_;
+  }
+
+  // The values this column reads from, before its row view is applied.
+  const void* data() const { return data_; }
+
+ private:
+  Kind kind_ = Kind::kFlat;
+  StorageType type_{Id{}};
+  RowSelection selection_ = RowSelection::Range();
+  // The batch's block this column's view was composed into, or null when the
+  // view references other storage. Columns that share a view share the block
+  // behind it.
+  uint32_t* block_ = nullptr;
+  const void* data_ = nullptr;
+  const BitVector* validity_ = nullptr;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_COLUMN_VIEW_H_

--- a/src/trace_processor/core/exec/from.cc
+++ b/src/trace_processor/core/exec/from.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/from.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+From::From(std::vector<ColumnView> columns, RowSelection rows, uint32_t count)
+    : columns_(std::move(columns)), rows_(rows), count_(count) {}
+
+From::~From() = default;
+From::State::~State() = default;
+
+std::unique_ptr<OperatorState> From::MakeState() const {
+  return std::make_unique<State>();
+}
+
+void From::Rewind(OperatorState& state) const {
+  state.Cast<State>().emitted = 0;
+}
+
+bool From::GetData(RowBatch& out, OperatorState& state) const {
+  State& s = state.Cast<State>();
+  if (s.emitted == count_) {
+    return false;
+  }
+  uint32_t count = std::min(kMaxBatchRows, count_ - s.emitted);
+  RowSelection selection = RowSelection::Range(rows_.GetIndex(s.emitted));
+  if (!rows_.is_range()) {
+    const uint32_t* begin = rows_.data() + s.emitted;
+    selection =
+        RowSelection::Indices(Span<const uint32_t>(begin, begin + count));
+  }
+  out.Reset();
+  for (const ColumnView& column : columns_) {
+    out.AddColumn(column);
+  }
+  out.Compose(selection, count);
+  out.SetCardinality(count);
+  s.emitted += count;
+  return true;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/from.h
+++ b/src/trace_processor/core/exec/from.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_FROM_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_FROM_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// Implements FROM by referencing the selected source rows, one batch at a
+// time. The rows it references stand still, so there is nothing to keep and
+// the state is a count of how far through them the execution is.
+class From : public Source {
+ public:
+  From(std::vector<ColumnView> columns, RowSelection rows, uint32_t count);
+  ~From() override;
+
+  std::unique_ptr<OperatorState> MakeState() const override;
+  bool GetData(RowBatch& out, OperatorState& state) const override;
+  void Rewind(OperatorState& state) const override;
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    uint32_t emitted = 0;
+  };
+
+  // The columns as constructed, each holding the row view a batch starts from.
+  std::vector<ColumnView> columns_;
+  RowSelection rows_;
+  uint32_t count_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_FROM_H_

--- a/src/trace_processor/core/exec/operator.cc
+++ b/src/trace_processor/core/exec/operator.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/operator.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+OperatorState::~OperatorState() = default;
+Operator::~Operator() = default;
+Source::~Source() = default;
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/operator.h
+++ b/src/trace_processor/core/exec/operator.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// Everything one execution of a plan is up to.
+//
+// A plan says what to do and never changes while it is being done; a state is
+// where a particular doing of it has got to. Splitting them is what makes the
+// ownership question have one answer: a plan holds no values, every value a
+// query holds is in some state, and the states belong to whoever is running
+// the plan rather than to the plan.
+//
+// It is also what makes a plan reusable. Running the same plan twice, or
+// twice at once, is two states and one plan, so nothing has to be rebuilt and
+// nothing can be left over from last time.
+class OperatorState {
+ public:
+  OperatorState() = default;
+  virtual ~OperatorState();
+
+  OperatorState(const OperatorState&) = delete;
+  OperatorState& operator=(const OperatorState&) = delete;
+
+  // An operator only ever sees a state it made itself, so it may say which
+  // one that was.
+  template <typename T>
+  T& Cast() {
+    return static_cast<T&>(*this);
+  }
+  template <typename T>
+  const T& Cast() const {
+    return static_cast<const T&>(*this);
+  }
+};
+
+enum class OpResult : uint8_t {
+  // The batch continues to the next operator.
+  kContinue,
+  // The batch has no rows left; the rest of the pipeline skips it.
+  kDrop,
+};
+
+// A streaming step in a plan. An operator may add columns or select rows, but
+// it always updates one batch in place and produces at most one output batch
+// for each input batch.
+class Operator {
+ public:
+  virtual ~Operator();
+  Operator(const Operator&) = delete;
+  Operator& operator=(const Operator&) = delete;
+
+  // Made once per execution, before the first batch.
+  virtual std::unique_ptr<OperatorState> MakeState() const {
+    return std::make_unique<OperatorState>();
+  }
+
+  virtual OpResult Execute(RowBatch& batch, OperatorState& state) const = 0;
+
+ protected:
+  Operator() = default;
+};
+
+// Produces the batches a plan runs over.
+class Source {
+ public:
+  virtual ~Source();
+  Source(const Source&) = delete;
+  Source& operator=(const Source&) = delete;
+
+  // Made once per execution. A source whose input is another source makes
+  // that one's state too and holds it, so one call builds a whole chain.
+  virtual std::unique_ptr<OperatorState> MakeState() const = 0;
+
+  // Fills `out` with the next batch, or returns false when there are none
+  // left. The values it is filled with belong to `state` and are good until
+  // the next call, so a caller that wants them for longer copies them.
+  virtual bool GetData(RowBatch& out, OperatorState& state) const = 0;
+
+  // Winds `state` back to the first batch so it can be replayed.
+  virtual void Rewind(OperatorState& state) const = 0;
+
+  // Distinguishes normal exhaustion from an error after GetData() says there
+  // is nothing more.
+  virtual base::Status status(const OperatorState&) const {
+    return base::OkStatus();
+  }
+
+ protected:
+  Source() = default;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_OPERATOR_H_

--- a/src/trace_processor/core/exec/operator_unittest.cc
+++ b/src/trace_processor/core/exec/operator_unittest.cc
@@ -1,0 +1,323 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/from.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/pipeline.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_cursor.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/span.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using ::testing::ElementsAre;
+
+// A source shaped like a dataframe scan: an identity column so every batch
+// carries row indices, plus the values themselves.
+class TestSource {
+ public:
+  explicit TestSource(std::vector<int64_t> values)
+      : values_(std::move(values)) {}
+
+  std::unique_ptr<From> Create() {
+    std::vector<ColumnView> columns;
+    columns.push_back(
+        ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
+    columns.push_back(
+        ColumnView::Reference(StorageType{Int64{}}, values_.data(), nullptr));
+    return std::make_unique<From>(std::move(columns), RowSelection::Range(0),
+                                  static_cast<uint32_t>(values_.size()));
+  }
+
+ private:
+  std::vector<int64_t> values_;
+};
+
+// Reads a pipeline the way a consumer would, a row at a time.
+std::vector<uint32_t> Drain(const PullPipeline& pipeline) {
+  std::vector<uint32_t> rows;
+  RowCursor cursor(pipeline);
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    rows.push_back(cursor.row(0));
+  }
+  return rows;
+}
+
+std::vector<int64_t> Sequence(uint32_t count) {
+  std::vector<int64_t> values(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    values[i] = i;
+  }
+  return values;
+}
+
+// Keeps every second row, standing in for a real operator. The rows it picks
+// are scratch for one execution, so they live in its state and not in it.
+class DropOddRows final : public Operator {
+ public:
+  std::unique_ptr<OperatorState> MakeState() const override {
+    return std::make_unique<State>();
+  }
+
+  OpResult Execute(RowBatch& batch, OperatorState& state) const override {
+    uint32_t* selected = state.Cast<State>().selected;
+    uint32_t count = 0;
+    for (uint32_t row = 0; row < batch.size(); row += 2) {
+      selected[count++] = row;
+    }
+    return batch.Slice(RowSelection::Indices(
+                           Span<const uint32_t>(selected, selected + count)),
+                       count)
+               ? OpResult::kContinue
+               : OpResult::kDrop;
+  }
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    uint32_t selected[kMaxBatchRows];
+  };
+};
+
+DropOddRows::State::~State() = default;
+
+// Drives a plan the way an executor does: it makes the state and owns the
+// batch, and the plan stays const throughout.
+class Execution {
+ public:
+  explicit Execution(const Source& source)
+      : source_(source), state_(source.MakeState()) {}
+
+  RowBatch* Next() {
+    return source_.GetData(batch_, *state_) ? &batch_ : nullptr;
+  }
+  void Rewind() { source_.Rewind(*state_); }
+
+ private:
+  const Source& source_;
+  std::unique_ptr<OperatorState> state_;
+  RowBatch batch_;
+};
+
+TEST(OperatorTest, SourceEmitsEveryRow) {
+  TestSource source({10, 20, 30});
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+}
+
+TEST(OperatorTest, SourceSplitsIntoBatches) {
+  TestSource source(Sequence(kMaxBatchRows * 2 + 3));
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  std::vector<uint32_t> rows = Drain(pipeline);
+  ASSERT_EQ(rows.size(), kMaxBatchRows * 2u + 3u);
+  EXPECT_EQ(rows.front(), 0u);
+  EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 2u);
+}
+
+TEST(OperatorTest, SourceIsReplayable) {
+  TestSource source({10, 20, 30});
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+}
+
+// A source owns one batch and refills it, so a long pipeline allocates no
+// per-batch state at all.
+TEST(OperatorTest, SourceReusesOneBatch) {
+  TestSource source(Sequence(kMaxBatchRows * 20));
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  Execution run(pipeline);
+  RowBatch* first = run.Next();
+  ASSERT_NE(first, nullptr);
+  const void* values = first->column(1).data();
+  uint32_t batches = 1;
+  while (RowBatch* batch = run.Next()) {
+    EXPECT_EQ(batch, first) << "the executor's batch was replaced";
+    EXPECT_EQ(batch->column(1).data(), values) << "the source copied values";
+    ++batches;
+  }
+  EXPECT_EQ(batches, 20u);
+}
+
+TEST(OperatorTest, OperatorNarrowsTheBatch) {
+  TestSource source({10, 20, 30, 40, 50});
+  std::unique_ptr<From> from = source.Create();
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<DropOddRows>());
+  PullPipeline pipeline(*from, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 2, 4));
+}
+
+TEST(OperatorTest, OperatorsComposeWithinABatch) {
+  TestSource source({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  std::unique_ptr<From> from = source.Create();
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<DropOddRows>());
+  ops.push_back(std::make_unique<DropOddRows>());
+  PullPipeline pipeline(*from, std::move(ops));
+
+  // Keeping every second row twice keeps every fourth.
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 4, 8));
+}
+
+TEST(OperatorTest, NarrowingAComposedViewKeepsIt) {
+  TestSource source(Sequence(17));
+  std::unique_ptr<From> from = source.Create();
+  std::vector<std::unique_ptr<Operator>> ops;
+  for (int i = 0; i < 3; ++i) {
+    ops.push_back(std::make_unique<DropOddRows>());
+  }
+  PullPipeline pipeline(*from, std::move(ops));
+
+  // Keeping every second row three times keeps every eighth. The third
+  // operator narrows a view the batch already composed, onto itself.
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 8, 16));
+}
+
+// The storage a batch composes its views into belongs to the batch and is
+// handed back for the next one, so a pipeline stops allocating once it is
+// running.
+TEST(OperatorTest, ComposedViewsReuseTheBatchesStorage) {
+  TestSource source(Sequence(kMaxBatchRows * 4));
+  std::unique_ptr<From> from = source.Create();
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<DropOddRows>());
+  ops.push_back(std::make_unique<DropOddRows>());
+  PullPipeline pipeline(*from, std::move(ops));
+
+  Execution run(pipeline);
+  RowBatch* batch = run.Next();
+  ASSERT_NE(batch, nullptr);
+  const uint32_t* block = batch->column(0).selection().data();
+  ASSERT_NE(block, nullptr) << "expected a composed view";
+  uint32_t batches = 1;
+  while ((batch = run.Next()) != nullptr) {
+    EXPECT_EQ(batch->column(0).selection().data(), block);
+    ++batches;
+  }
+  EXPECT_EQ(batches, 4u);
+}
+
+TEST(SinkTest, ReadsEveryRowOfEveryBatch) {
+  TestSource source(Sequence(kMaxBatchRows * 2 + 7));
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  std::vector<uint32_t> rows = Drain(pipeline);
+  ASSERT_EQ(rows.size(), kMaxBatchRows * 2u + 7u);
+  EXPECT_EQ(rows.front(), 0u);
+  EXPECT_EQ(rows[kMaxBatchRows], kMaxBatchRows);
+  EXPECT_EQ(rows.back(), kMaxBatchRows * 2u + 6u);
+}
+
+// An operator which adds a computed column cannot put it in the index space
+// its input arrived in, so it adds it in its own. A cursor has to follow each
+// column's own view to read either of them.
+TEST(SinkTest, ReadsColumnsWhichDoNotShareARowView) {
+  std::vector<int64_t> payload = {10, 11, 12, 13};
+  std::vector<int64_t> computed = {90, 91};
+
+  class TwoViewSource final : public Source {
+   public:
+    TwoViewSource(const std::vector<int64_t>* payload,
+                  const std::vector<int64_t>* computed)
+        : payload_(payload), computed_(computed) {}
+
+    std::unique_ptr<OperatorState> MakeState() const override {
+      return std::make_unique<State>();
+    }
+    void Rewind(OperatorState& state) const override {
+      state.Cast<State>().done = false;
+    }
+    bool GetData(RowBatch& batch_, OperatorState& state) const override {
+      State& s = state.Cast<State>();
+      if (s.done) {
+        return false;
+      }
+      s.done = true;
+      batch_.Reset();
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, payload_->data()));
+      // The payload is read from half way in; the computed column is its own
+      // array read from the start.
+      batch_.Compose(RowSelection::Range(2), 2);
+      batch_.AddColumn(
+          ColumnView::Reference(StorageType{Int64{}}, computed_->data()));
+      batch_.SetCardinality(2);
+      return true;
+    }
+
+   private:
+    struct State : OperatorState {
+      bool done = false;
+    };
+    const std::vector<int64_t>* payload_;
+    const std::vector<int64_t>* computed_;
+  };
+
+  TwoViewSource source(&payload, &computed);
+  RowCursor cursor(source);
+  std::vector<int64_t> read_payload;
+  std::vector<int64_t> read_computed;
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    read_payload.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(0).data())[cursor.row(0)]);
+    read_computed.push_back(static_cast<const int64_t*>(
+        cursor.batch().column(1).data())[cursor.row(1)]);
+  }
+  EXPECT_THAT(read_payload, ElementsAre(12, 13));
+  EXPECT_THAT(read_computed, ElementsAre(90, 91));
+}
+
+TEST(SinkTest, ReportsEofWithoutOpen) {
+  TestSource source({1, 2, 3});
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+  RowCursor cursor(pipeline);
+
+  EXPECT_TRUE(cursor.eof());
+}
+
+TEST(SinkTest, ReopeningRereadsFromTheStart) {
+  TestSource source({4, 5, 6});
+  std::unique_ptr<From> from = source.Create();
+  PullPipeline pipeline(*from, {});
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/pipeline.cc
+++ b/src/trace_processor/core/exec/pipeline.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/pipeline.h"
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+PullPipeline::PullPipeline(const Source& source,
+                           std::vector<std::unique_ptr<Operator>> operators)
+    : source_(source), operators_(std::move(operators)) {}
+
+PullPipeline::~PullPipeline() = default;
+PullPipeline::State::~State() = default;
+
+std::unique_ptr<OperatorState> PullPipeline::MakeState() const {
+  auto state = std::make_unique<State>();
+  state->source = source_.MakeState();
+  state->operators.reserve(operators_.size());
+  for (const std::unique_ptr<Operator>& op : operators_) {
+    state->operators.push_back(op->MakeState());
+  }
+  return state;
+}
+
+void PullPipeline::Rewind(OperatorState& state) const {
+  source_.Rewind(*state.Cast<State>().source);
+}
+
+base::Status PullPipeline::status(const OperatorState& state) const {
+  return source_.status(*state.Cast<const State>().source);
+}
+
+bool PullPipeline::GetData(RowBatch& out, OperatorState& state) const {
+  State& s = state.Cast<State>();
+  while (source_.GetData(out, *s.source)) {
+    bool dropped = false;
+    for (uint32_t i = 0; i < operators_.size(); ++i) {
+      if (operators_[i]->Execute(out, *s.operators[i]) == OpResult::kDrop) {
+        dropped = true;
+        break;
+      }
+    }
+    if (!dropped) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/pipeline.h
+++ b/src/trace_processor/core/exec/pipeline.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_PIPELINE_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_PIPELINE_H_
+
+#include <memory>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// A source and a straight line of streaming operators, exposed as a Source.
+//
+// Its state holds the states of everything in it, so making one state builds
+// the whole line and dropping it takes the whole line down. That is what an
+// executor owns: the plan is separately owned and outlives any run of it.
+class PullPipeline : public Source {
+ public:
+  PullPipeline(const Source&, std::vector<std::unique_ptr<Operator>>);
+  ~PullPipeline() override;
+
+  std::unique_ptr<OperatorState> MakeState() const override;
+  bool GetData(RowBatch& out, OperatorState& state) const override;
+  void Rewind(OperatorState& state) const override;
+  base::Status status(const OperatorState& state) const override;
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    std::unique_ptr<OperatorState> source;
+    std::vector<std::unique_ptr<OperatorState>> operators;
+  };
+
+  const Source& source_;
+  std::vector<std::unique_ptr<Operator>> operators_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_PIPELINE_H_

--- a/src/trace_processor/core/exec/row_batch.cc
+++ b/src/trace_processor/core/exec/row_batch.cc
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_batch.h"
+
+#include <cstdint>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+bool RowBatch::AdoptPhysicalRows(Span<const uint32_t> rows) {
+  auto count = static_cast<uint32_t>(rows.size());
+  if (count == 0) {
+    cardinality_ = 0;
+    return false;
+  }
+  PERFETTO_DCHECK(count <= cardinality_);
+  for (ColumnView& column : columns_) {
+    column.SetBorrowedRows(rows);
+  }
+  cardinality_ = count;
+  return true;
+}
+
+void RowBatch::Compose(RowSelection selection, uint32_t count) {
+  // Columns filled by one source share a logical-to-physical view, and
+  // composing it is a gather over the whole batch. Do that once per distinct
+  // view and let the rest of the columns adopt the result.
+  const ColumnView* composed = nullptr;
+  const uint32_t* composed_from_rows = nullptr;
+  uint32_t composed_from_offset = 0;
+  for (ColumnView& column : columns_) {
+    RowSelection current = column.selection();
+    if (composed && current.data() == composed_from_rows &&
+        current.offset() == composed_from_offset) {
+      column.AdoptSelection(*composed);
+      continue;
+    }
+    composed_from_rows = current.data();
+    composed_from_offset = current.offset();
+    column.Slice(selection, count, selections_);
+    composed = &column;
+  }
+}
+
+bool RowBatch::Slice(RowSelection selection, uint32_t count) {
+  PERFETTO_DCHECK(count <= cardinality_);
+  for (uint32_t row = 0; row < count; ++row) {
+    PERFETTO_DCHECK(selection.GetIndex(row) < cardinality_);
+    PERFETTO_DCHECK(row == 0 ||
+                    selection.GetIndex(row - 1) < selection.GetIndex(row));
+  }
+  if (count == 0) {
+    cardinality_ = 0;
+    return false;
+  }
+  if (count == cardinality_) {
+    return true;
+  }
+  Compose(selection, count);
+  cardinality_ = count;
+  return true;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_batch.h
+++ b/src/trace_processor/core/exec/row_batch.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// A rectangular batch of columns with one shared cardinality.
+class RowBatch {
+ public:
+  RowBatch() = default;
+
+  uint32_t size() const { return cardinality_; }
+  void SetCardinality(uint32_t count) {
+    PERFETTO_DCHECK(count <= kMaxBatchRows);
+    cardinality_ = count;
+  }
+
+  uint32_t column_count() const {
+    return static_cast<uint32_t>(columns_.size());
+  }
+  const ColumnView& column(uint32_t column) const { return columns_[column]; }
+  ColumnView& mutable_column(uint32_t column) { return columns_[column]; }
+  void AddColumn(ColumnView column) { columns_.push_back(std::move(column)); }
+
+  // Points every column at `rows`, which the caller continues to own. Only
+  // valid while the columns still share the source's contiguous view, and
+  // while `rows` stays valid until the batch is next filled.
+  bool AdoptPhysicalRows(Span<const uint32_t> rows);
+
+  // Returns the storage the batch composed its row views into. A source calls
+  // this before refilling; from here the previous contents, and any indices
+  // taken from them, are no longer valid.
+  void PrepareForFill() { selections_.Reset(); }
+
+  // Points every column at the `count` rows `selection` picks out. Sources use
+  // this to fill a batch once they have restored the columns' starting views;
+  // operators narrow a filled one with Slice.
+  void Compose(RowSelection selection, uint32_t count);
+
+  // Applies strictly increasing logical row ordinals to every column. Returns
+  // false when no rows remain.
+  bool Slice(RowSelection selection, uint32_t count);
+
+  // Drops the columns, so the batch can be pointed at something else. The
+  // executor owns the batch and hands it to a source to be filled, so
+  // emptying it is the caller's to do.
+  void Reset() {
+    cardinality_ = 0;
+    columns_.clear();
+    selections_.Reset();
+  }
+
+ private:
+  uint32_t cardinality_ = 0;
+  std::vector<ColumnView> columns_;
+  SelectionPool selections_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_BATCH_H_

--- a/src/trace_processor/core/exec/row_batch.h
+++ b/src/trace_processor/core/exec/row_batch.h
@@ -28,6 +28,21 @@
 namespace perfetto::trace_processor::core::exec {
 
 // A rectangular batch of columns with one shared cardinality.
+//
+// A batch owns nothing. Its columns are views over values belonging to the
+// operator that produced it, which fixes both halves of the question:
+//
+//   Who owns these values?   Whatever handed you the batch.
+//   How long are they good?  Until you ask it for the next batch, and never
+//                            past its lifetime.
+//
+// So a batch is a borrow with the same terms everywhere, and an operator that
+// needs rows for longer than that copies them into a RowStore of its own.
+// Everything an operator hands out is read from something it holds, which is
+// why a batch does not outlive it: nothing here is shared, reference counted,
+// or kept alive behind the reader's back, and a reader that wants values to
+// survive the operator that made them copies them, as it would from any other
+// view.
 class RowBatch {
  public:
   RowBatch() = default;
@@ -64,9 +79,7 @@ class RowBatch {
   // false when no rows remain.
   bool Slice(RowSelection selection, uint32_t count);
 
-  // Drops the columns, so the batch can be pointed at something else. The
-  // executor owns the batch and hands it to a source to be filled, so
-  // emptying it is the caller's to do.
+  // Drops the columns, so the batch can be pointed at something else.
   void Reset() {
     cardinality_ = 0;
     columns_.clear();

--- a/src/trace_processor/core/exec/row_cursor.cc
+++ b/src/trace_processor/core/exec/row_cursor.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_cursor.h"
+
+#include "src/trace_processor/core/exec/operator.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+RowCursor::RowCursor(const Source& source)
+    : source_(source), state_(source.MakeState()) {}
+
+RowCursor::~RowCursor() = default;
+
+bool RowCursor::Pull() {
+  if (!source_.GetData(batch_, *state_)) {
+    index_ = 0;
+    size_ = 0;
+    return false;
+  }
+  index_ = 0;
+  size_ = batch_.size();
+  return true;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_cursor.h
+++ b/src/trace_processor/core/exec/row_cursor.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// One execution of a plan, read a row at a time.
+//
+// This is the executor: it owns the plan's state and the batch the rows
+// arrive in, which is why the plan itself can be const. A consumer drives it,
+// so batches are pulled only when the current one runs out and a consumer
+// that stops early stops paying.
+class RowCursor {
+ public:
+  explicit RowCursor(const Source& source);
+  ~RowCursor();
+
+  // Reads up to the first row, rewinding first. Returns false if there is
+  // none.
+  bool Open() {
+    source_.Rewind(*state_);
+    index_ = 0;
+    size_ = 0;
+    return Pull();
+  }
+
+  // Reads up to the next row, pulling a batch if the current one is exhausted.
+  bool Next() { return ++index_ != size_ || Pull(); }
+
+  bool eof() const { return index_ == size_; }
+
+  base::Status status() const { return source_.status(*state_); }
+
+  // The physical row `column` is read at.
+  //
+  // Resolved per column rather than once for the batch: an operator which
+  // adds a computed column has nowhere to put it in the index space its input
+  // arrived in, so it adds the column in its own. Columns of one batch
+  // therefore agree on how many rows there are and need agree on nothing else.
+  PERFETTO_ALWAYS_INLINE uint32_t row(uint32_t column) const {
+    PERFETTO_DCHECK(index_ < size_);
+    return batch_.column(column).selection().GetIndex(index_);
+  }
+
+  // The batch being read, for a consumer which wants the columns themselves.
+  const RowBatch& batch() const { return batch_; }
+
+ private:
+  bool Pull();
+
+  const Source& source_;
+  std::unique_ptr<OperatorState> state_;
+  RowBatch batch_;
+  uint32_t index_ = 0;
+  uint32_t size_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_CURSOR_H_

--- a/src/trace_processor/core/exec/row_selection.h
+++ b/src/trace_processor/core/exec/row_selection.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_SELECTION_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_SELECTION_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// The most rows a batch carries, and so the most a row view ever covers.
+inline constexpr uint32_t kMaxBatchRows = 2048;
+
+// A lightweight view of logical-to-physical row indices. Indexed selections
+// do not own their storage.
+class RowSelection {
+ public:
+  static RowSelection Range(uint32_t offset = 0) {
+    return RowSelection(nullptr, offset);
+  }
+  static RowSelection Indices(Span<const uint32_t> rows) {
+    return RowSelection(rows.data(), 0);
+  }
+
+  uint32_t GetIndex(uint32_t row) const {
+    return rows_ ? rows_[row] : offset_ + row;
+  }
+  bool is_range() const { return rows_ == nullptr; }
+  const uint32_t* data() const { return rows_; }
+  uint32_t offset() const { return offset_; }
+
+ private:
+  RowSelection(const uint32_t* rows, uint32_t offset)
+      : rows_(rows), offset_(offset) {}
+
+  const uint32_t* rows_;
+  uint32_t offset_;
+};
+
+// The storage a batch composes its row views into.
+//
+// Blocks are a fixed size and are handed out for the life of one batch; the
+// batch after it takes the same blocks back. A batch needs one block per group
+// of columns that share a view, so the pool stops growing once a query has run
+// its first batch.
+class SelectionPool {
+ public:
+  // A block of kMaxBatchRows indices. Its address stays valid for as long as
+  // the batch does: growing the pool reallocates the vector, not the blocks it
+  // owns.
+  uint32_t* TakeBlock() {
+    if (next_ == blocks_.size()) {
+      blocks_.push_back(FlexVector<uint32_t>::CreateWithSize(kMaxBatchRows));
+    }
+    return blocks_[next_++].data();
+  }
+
+  // Hands every block back for the next batch to use.
+  void Reset() { next_ = 0; }
+
+ private:
+  std::vector<FlexVector<uint32_t>> blocks_;
+  uint32_t next_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_SELECTION_H_

--- a/src/trace_processor/core/exec/row_store.cc
+++ b/src/trace_processor/core/exec/row_store.cc
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_store.h"
+
+#include <cstdint>
+#include <cstring>
+#include <variant>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+// Grows a column to hold `size` values. Reserving first is the whole of it:
+// resize allocates exactly what it is asked for, so a store filled a chunk at
+// a time would otherwise reallocate and copy the column on every chunk, and
+// filling it would cost a multiple of what the column is worth.
+template <typename T, typename Variant>
+FlexVector<T>& Ensure(Variant& values, uint32_t size) {
+  if (!std::holds_alternative<FlexVector<T>>(values)) {
+    values = FlexVector<T>();
+  }
+  auto& vec = std::get<FlexVector<T>>(values);
+  if (vec.size() < size) {
+    vec.reserve(size);
+    vec.resize(size);
+  }
+  return vec;
+}
+
+// Copies the `count` values `column` resolves to. A range resolves to a run,
+// which copies whole; anything else is one gather. Neither walks a row view a
+// value at a time.
+template <typename T, typename Variant>
+void Copy(const ColumnView& column,
+          uint32_t at,
+          uint32_t count,
+          Variant& values) {
+  FlexVector<T>& out = Ensure<T>(values, at + count);
+  const auto* data = static_cast<const T*>(column.data());
+  RowSelection selection = column.selection();
+  T* dest = out.data() + at;
+  if (selection.is_range()) {
+    memcpy(dest, data + selection.offset(), count * sizeof(T));
+    return;
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    dest[i] = data[rows[i]];
+  }
+}
+
+// An Id column's value is the row it sits at, so copying one means writing
+// down the rows it stood for.
+template <typename Variant>
+void CopyIds(const ColumnView& column,
+             uint32_t at,
+             uint32_t count,
+             Variant& values) {
+  FlexVector<uint32_t>& out = Ensure<uint32_t>(values, at + count);
+  RowSelection selection = column.selection();
+  uint32_t* dest = out.data() + at;
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      dest[i] = offset + i;
+    }
+    return;
+  }
+  memcpy(dest, selection.data(), count * sizeof(uint32_t));
+}
+
+}  // namespace
+
+base::Status RowStore::AppendColumn(Column& into,
+                                    const ColumnView& from,
+                                    uint32_t count) {
+  StorageType type = from.type();
+  if (type.Is<Id>()) {
+    CopyIds(from, size_, count, into.values);
+    type = StorageType{Uint32{}};
+  } else if (type.Is<Uint32>()) {
+    Copy<uint32_t>(from, size_, count, into.values);
+  } else if (type.Is<Int32>()) {
+    Copy<int32_t>(from, size_, count, into.values);
+  } else if (type.Is<Int64>()) {
+    Copy<int64_t>(from, size_, count, into.values);
+  } else if (type.Is<Double>()) {
+    Copy<double>(from, size_, count, into.values);
+  } else {
+    Copy<StringPool::Id>(from, size_, count, into.values);
+  }
+  if (size_ != 0 && !(type == into.type)) {
+    return base::ErrStatus(
+        "row store: a column arrived holding one type after holding another");
+  }
+  into.type = type;
+
+  const BitVector* validity = from.validity();
+  if (!validity && !into.nullable) {
+    return base::OkStatus();
+  }
+  uint32_t end = size_ + count;
+  if (into.validity.size() < end) {
+    into.validity.reserve(end);
+    into.validity.resize(end);
+  }
+  if (!into.nullable) {
+    // Everything already here came from a column with nothing missing.
+    for (uint32_t i = 0; i < size_; ++i) {
+      into.validity.set(i);
+    }
+    into.nullable = true;
+  }
+  if (!validity) {
+    for (uint32_t i = 0; i < count; ++i) {
+      into.validity.set(size_ + i);
+    }
+    return base::OkStatus();
+  }
+  RowSelection selection = from.selection();
+  if (selection.is_range()) {
+    uint32_t offset = selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      into.validity.change(size_ + i, validity->is_set(offset + i));
+    }
+    return base::OkStatus();
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    into.validity.change(size_ + i, validity->is_set(rows[i]));
+  }
+  return base::OkStatus();
+}
+
+base::Status RowStore::Append(const RowBatch& batch) {
+  uint32_t count = batch.size();
+  if (count == 0) {
+    return base::OkStatus();
+  }
+  if (columns_.empty()) {
+    columns_.resize(batch.column_count());
+  } else if (columns_.size() != batch.column_count()) {
+    return base::ErrStatus(
+        "row store: a batch of %u columns arrived after one of %u",
+        batch.column_count(), static_cast<uint32_t>(columns_.size()));
+  }
+  for (uint32_t col = 0; col < columns_.size(); ++col) {
+    RETURN_IF_ERROR(AppendColumn(columns_[col], batch.column(col), count));
+  }
+  size_ += count;
+  return base::OkStatus();
+}
+
+Span<const int64_t> RowStore::Int64Column(uint32_t column) const {
+  const Column& held = columns_[column];
+  PERFETTO_DCHECK(held.type.Is<Int64>());
+  const FlexVector<int64_t>& values =
+      std::get<FlexVector<int64_t>>(held.values);
+  return Span<const int64_t>(values.data(), values.data() + size_);
+}
+
+ColumnView RowStore::ViewOf(const Column& column) const {
+  const void* data = nullptr;
+  if (column.type.Is<Uint32>()) {
+    data = std::get<FlexVector<uint32_t>>(column.values).data();
+  } else if (column.type.Is<Int32>()) {
+    data = std::get<FlexVector<int32_t>>(column.values).data();
+  } else if (column.type.Is<Int64>()) {
+    data = std::get<FlexVector<int64_t>>(column.values).data();
+  } else if (column.type.Is<Double>()) {
+    data = std::get<FlexVector<double>>(column.values).data();
+  } else {
+    data = std::get<FlexVector<StringPool::Id>>(column.values).data();
+  }
+  return ColumnView::Reference(column.type, data,
+                               column.nullable ? &column.validity : nullptr);
+}
+
+void RowStore::View(RowBatch* batch, uint32_t offset, uint32_t count) const {
+  batch->Reset();
+  for (const Column& column : columns_) {
+    ColumnView view = ViewOf(column);
+    view.SetRange(offset);
+    batch->AddColumn(view);
+  }
+  batch->SetCardinality(count);
+}
+
+void RowStore::View(RowBatch* batch, Span<const uint32_t> rows) const {
+  batch->Reset();
+  for (const Column& column : columns_) {
+    ColumnView view = ViewOf(column);
+    view.SetBorrowedRows(rows);
+    batch->AddColumn(view);
+  }
+  batch->SetCardinality(static_cast<uint32_t>(rows.size()));
+}
+
+void RowStore::Clear() {
+  size_ = 0;
+  for (Column& column : columns_) {
+    column.nullable = false;
+  }
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/row_store.h
+++ b/src/trace_processor/core/exec/row_store.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_STORE_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_STORE_H_
+
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// The rows an operator keeps.
+//
+// A batch is a borrow: its values belong to the operator that handed it over
+// and are good until that operator is asked for the next one. An operator
+// that needs rows for longer than that -- every breaker, by definition --
+// copies them here.
+//
+// This is the only way to keep rows. An operator holds a store or it holds
+// nothing, so the memory a query needs at once is the sum of its stores, and
+// finding it is reading the operators' member lists rather than hunting for
+// whichever scratch vectors somebody declared. It is also what makes the
+// lifetime answerable: a store dies with its operator, so batches read from
+// it are good for exactly as long as batches read from anything else.
+//
+// The copy is not the price of the rule -- it is the price of keeping rows at
+// all, and it is paid once, here. What it buys back is that the columns land
+// dense from row zero: a fold reads one flat span per column, and a computed
+// column can sit beside them in the same index space.
+//
+// The copy is not the price of this rule -- it is the price of keeping rows
+// at all, and it is paid once, here, rather than piecemeal into whatever
+// scratch vectors an operator felt like declaring. What it buys back is that
+// the columns land dense from row zero: a fold reads one flat span per
+// column, and a computed column can sit beside them in the same index space.
+class RowStore {
+ public:
+  // Copies every column of `batch` onto the end. The first append fixes the
+  // shape; a later one which disagrees is an error rather than a surprise.
+  base::Status Append(const RowBatch& batch);
+
+  uint32_t size() const { return size_; }
+  uint32_t column_count() const {
+    return static_cast<uint32_t>(columns_.size());
+  }
+  StorageType type(uint32_t column) const { return columns_[column].type; }
+
+  // A column read back whole. The rows are dense from zero, so a pass over a
+  // column is a walk over an array and not a walk over a row view.
+  Span<const int64_t> Int64Column(uint32_t column) const;
+
+  // Points `batch` at `count` rows from `offset`, replacing whatever it held.
+  // The caller is free to add its own columns afterwards.
+  void View(RowBatch* batch, uint32_t offset, uint32_t count) const;
+
+  // The same, for the rows `rows` picks out.
+  void View(RowBatch* batch, Span<const uint32_t> rows) const;
+
+  // Forgets the rows. The buffers stay, so a store which is filled again is
+  // filled into what it already had.
+  void Clear();
+
+ private:
+  struct Column {
+    StorageType type{Uint32{}};
+    std::variant<FlexVector<uint32_t>,
+                 FlexVector<int32_t>,
+                 FlexVector<int64_t>,
+                 FlexVector<double>,
+                 FlexVector<StringPool::Id>>
+        values{FlexVector<uint32_t>()};
+    BitVector validity;
+    bool nullable = false;
+  };
+
+  base::Status AppendColumn(Column& into, const ColumnView& from, uint32_t n);
+  ColumnView ViewOf(const Column& column) const;
+
+  // Fixed in size once the first batch has arrived, so a view of one column
+  // stays good while the others are appended to.
+  std::vector<Column> columns_;
+  uint32_t size_ = 0;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ROW_STORE_H_

--- a/src/trace_processor/core/exec/row_store_unittest.cc
+++ b/src/trace_processor/core/exec/row_store_unittest.cc
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/row_store.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/span.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using testing::ElementsAre;
+
+// Points a batch at one int64 column, the way a source would.
+void Fill(RowBatch* batch,
+          const std::vector<int64_t>& values,
+          uint32_t offset,
+          uint32_t count) {
+  batch->Reset();
+  batch->AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch->Compose(RowSelection::Range(offset), count);
+  batch->SetCardinality(count);
+}
+
+std::vector<int64_t> ReadInt64(const RowBatch& batch, uint32_t column) {
+  const ColumnView& view = batch.column(column);
+  const auto* data = static_cast<const int64_t*>(view.data());
+  std::vector<int64_t> out;
+  for (uint32_t i = 0; i < batch.size(); ++i) {
+    out.push_back(data[view.selection().GetIndex(i)]);
+  }
+  return out;
+}
+
+TEST(RowStoreTest, KeepsWhatSeveralBatchesCarried) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 2);
+  ASSERT_TRUE(store.Append(batch).ok());
+  Fill(&batch, values, 2, 3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  EXPECT_EQ(store.size(), 5u);
+  EXPECT_THAT(store.Int64Column(0), ElementsAre(10, 11, 12, 13, 14));
+}
+
+// The whole reason a store exists: a source is free to write over the buffer
+// a batch was pointing at.
+TEST(RowStoreTest, SurvivesTheStorageItWasReadFromMovingOn) {
+  std::vector<int64_t> buffer = {1, 2, 3};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, buffer, 0, 3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  buffer = {99, 99, 99};
+  EXPECT_THAT(store.Int64Column(0), ElementsAre(1, 2, 3));
+}
+
+// A column read back whole is dense from zero however the batches which
+// filled it were sliced, which is what lets a fold be a walk over an array.
+TEST(RowStoreTest, ReadsBackDenseWhateverArrived) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  std::vector<uint32_t> rows = {4, 0, 2};
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch.mutable_column(0).SetBorrowedRows(
+      Span<const uint32_t>(rows.data(), rows.data() + 3));
+  batch.SetCardinality(3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  EXPECT_THAT(store.Int64Column(0), ElementsAre(14, 10, 12));
+}
+
+TEST(RowStoreTest, HandsBackARunOfItsRows) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 5);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 2, 3);
+  EXPECT_EQ(out.size(), 3u);
+  EXPECT_THAT(ReadInt64(out, 0), ElementsAre(12, 13, 14));
+}
+
+TEST(RowStoreTest, HandsBackTheRowsAnOrderPicksOut) {
+  std::vector<int64_t> values = {10, 11, 12, 13, 14};
+  std::vector<uint32_t> order = {4, 3, 0};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 5);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, Span<const uint32_t>(order.data(), order.data() + 3));
+  EXPECT_THAT(ReadInt64(out, 0), ElementsAre(14, 13, 10));
+}
+
+// Viewing twice must not stack the columns up.
+TEST(RowStoreTest, AViewReplacesTheOneBefore) {
+  std::vector<int64_t> values = {10, 11};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 2);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 0, 2);
+  store.View(&out, 0, 2);
+  EXPECT_EQ(out.column_count(), 1u);
+}
+
+TEST(RowStoreTest, KeepsWhichRowsHeldNothing) {
+  std::vector<int64_t> values = {10, 11, 12};
+  BitVector validity = BitVector::CreateWithSize(3);
+  validity.set(0);
+  validity.set(2);
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(
+      ColumnView::Reference(StorageType{Int64{}}, values.data(), &validity));
+  batch.Compose(RowSelection::Range(0), 3);
+  batch.SetCardinality(3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 0, 3);
+  const BitVector* kept = out.column(0).validity();
+  ASSERT_NE(kept, nullptr);
+  EXPECT_TRUE(kept->is_set(0));
+  EXPECT_FALSE(kept->is_set(1));
+  EXPECT_TRUE(kept->is_set(2));
+}
+
+// An Id column has no storage: its value is the row it sits at, so keeping
+// one means writing those rows down.
+TEST(RowStoreTest, AnIdColumnBecomesTheRowsItStoodFor) {
+  RowStore store;
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
+  batch.Compose(RowSelection::Range(7), 3);
+  batch.SetCardinality(3);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch out;
+  store.View(&out, 0, 3);
+  ASSERT_TRUE(out.column(0).type().Is<Uint32>());
+  const auto* data = static_cast<const uint32_t*>(out.column(0).data());
+  EXPECT_THAT(std::vector<uint32_t>(data, data + 3), ElementsAre(7u, 8u, 9u));
+}
+
+TEST(RowStoreTest, ABatchOfADifferentShapeIsReported) {
+  std::vector<int64_t> values = {1, 2};
+  RowStore store;
+  RowBatch batch;
+  Fill(&batch, values, 0, 2);
+  ASSERT_TRUE(store.Append(batch).ok());
+
+  RowBatch wider;
+  wider.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  wider.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  wider.Compose(RowSelection::Range(0), 2);
+  wider.SetCardinality(2);
+  EXPECT_FALSE(store.Append(wider).ok());
+}
+
+// Filling a store a chunk at a time must cost the column, not a multiple of
+// it. Counting how often the buffer moves is how that stays true without the
+// test depending on a clock: growing geometrically moves it a handful of
+// times, growing by exactly what was asked for moves it once per chunk.
+TEST(RowStoreTest, FillingAChunkAtATimeDoesNotRecopyTheColumn) {
+  const uint32_t kRows = 200000, kChunk = 2048;
+  std::vector<int64_t> values(kChunk);
+  RowStore store;
+  RowBatch batch;
+  const void* data = nullptr;
+  uint32_t moves = 0;
+  for (uint32_t done = 0; done < kRows; done += kChunk) {
+    Fill(&batch, values, 0, kChunk);
+    ASSERT_TRUE(store.Append(batch).ok());
+    const void* now = store.Int64Column(0).data();
+    moves += now != data;
+    data = now;
+  }
+  EXPECT_EQ(store.size(), ((kRows + kChunk - 1) / kChunk) * kChunk);
+  EXPECT_LT(moves, 20u) << "the column is being recopied on every chunk";
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/util/bit_vector.h
+++ b/src/trace_processor/core/util/bit_vector.h
@@ -281,6 +281,11 @@ struct BitVector {
 
   // Resizes the vector to the specified size. If shrinking, bits past the new
   // size are cleared. If growing, new bits are set to the given value.
+  // Makes room for `new_size` bits without changing the size. Growth here is
+  // geometric where resize allocates exactly what was asked for, so anything
+  // filling a bit vector a chunk at a time has to come through here first.
+  void reserve(uint64_t new_size) { words_.reserve((new_size + 63) / 64); }
+
   void resize(uint64_t new_size, bool value = false) {
     uint64_t new_words = (new_size + 63) / 64;
     words_.resize(new_words);

--- a/src/trace_processor/core/util/span.h
+++ b/src/trace_processor/core/util/span.h
@@ -17,8 +17,10 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_UTIL_SPAN_H_
 #define SRC_TRACE_PROCESSOR_CORE_UTIL_SPAN_H_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 #include <vector>
 
 #include "perfetto/base/logging.h"
@@ -37,6 +39,40 @@ struct Span {
 
   Span() = default;
   Span(T* _b, T* _e) : b(_b), e(_e) {}
+
+  template <typename U,
+            size_t N,
+            std::enable_if_t<std::is_convertible_v<U*, T*>, int> = 0>
+  Span(U (&values)[N]) : Span(values, values + N) {}
+
+  template <typename U,
+            size_t N,
+            std::enable_if_t<std::is_convertible_v<U*, T*>, int> = 0>
+  Span(std::array<U, N>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U,
+            size_t N,
+            std::enable_if_t<std::is_convertible_v<const U*, T*>, int> = 0>
+  Span(const std::array<U, N>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U,
+            typename Allocator,
+            std::enable_if_t<std::is_convertible_v<U*, T*>, int> = 0>
+  Span(std::vector<U, Allocator>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U,
+            typename Allocator,
+            std::enable_if_t<std::is_convertible_v<const U*, T*>, int> = 0>
+  Span(const std::vector<U, Allocator>& values)
+      : Span(values.data(), values.data() + values.size()) {}
+
+  template <typename U, size_t N>
+  Span(std::array<U, N>&&) = delete;
+  template <typename U, typename Allocator>
+  Span(std::vector<U, Allocator>&&) = delete;
 
   T* begin() const { return b; }
   T* end() const { return e; }
@@ -59,6 +95,16 @@ Span<T> MakeMutableSpan(T (&values)[N]) {
 template <typename T, size_t N>
 Span<const T> MakeSpan(const T (&values)[N]) {
   return Span<const T>(values, values + N);
+}
+
+template <typename T, size_t N>
+Span<T> MakeMutableSpan(std::array<T, N>& values) {
+  return Span<T>(values.data(), values.data() + values.size());
+}
+
+template <typename T, size_t N>
+Span<const T> MakeSpan(const std::array<T, N>& values) {
+  return Span<const T>(values.data(), values.data() + values.size());
 }
 
 template <typename T>

--- a/src/trace_processor/core/util/span_unittest.cc
+++ b/src/trace_processor/core/util/span_unittest.cc
@@ -16,6 +16,7 @@
 
 #include "src/trace_processor/core/util/span.h"
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -28,12 +29,22 @@ namespace {
 
 TEST(SpanTest, CreatesFromVector) {
   std::vector<uint32_t> values{1, 2, 3};
-  Span<const uint32_t> span = MakeSpan(values);
+  Span<const uint32_t> span = values;
   EXPECT_THAT(span, testing::ElementsAre(1u, 2u, 3u));
   EXPECT_THAT(span.subspan(1, 2), testing::ElementsAre(2u, 3u));
 
-  Span<uint32_t> mutable_span = MakeMutableSpan(values);
+  Span<uint32_t> mutable_span = values;
   mutable_span.b[1] = 4;
+  EXPECT_EQ(values[1], 4u);
+}
+
+TEST(SpanTest, CreatesFromArray) {
+  std::array<uint32_t, 3> values{1, 2, 3};
+  Span<const uint32_t> values_span = values;
+  EXPECT_THAT(values_span, testing::ElementsAre(1u, 2u, 3u));
+
+  Span<uint32_t> mutable_values = values;
+  mutable_values[1] = 4;
   EXPECT_EQ(values[1], 4u);
 }
 


### PR DESCRIPTION
A plan holds no values and a batch is a borrow, which leaves the
question of where the values are. They are in a state, and this is the
one thing a state keeps rows in.

The alternative is what was happening before: whichever operator needed
rows for longer than a batch lasts declared whatever vectors it felt
like, so the same column ended up stored twice under different names and
the memory a query needed at once was not findable without reading every
operator. A store makes it one thing, once, in one place.

Growing it is the whole of why it is a class rather than a vector.
Resize allocates exactly what it is asked for and only reserve grows
geometrically, so filling a column a chunk at a time reallocates and
recopies the column on every chunk -- quadratic, and invisible until the
input is big. Two million rows of one column took 2.7 seconds and now
take 23 milliseconds. The test for it counts how often the buffer moves
rather than how long it takes, so it does not depend on a clock.

The rows read back dense from row zero, so a fold over a column is a
walk over an array, and a column computed from them can sit beside them
in the same index space.