### PR TITLE
tp: assert that a column is of a given type

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17599,6 +17599,7 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_core_exec_exec",
     srcs: [
+        "src/trace_processor/core/exec/assert_type.cc",
         "src/trace_processor/core/exec/column_view.cc",
         "src/trace_processor/core/exec/dataframe_scan.cc",
         "src/trace_processor/core/exec/operator.cc",
@@ -17616,6 +17617,7 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
+        "src/trace_processor/core/exec/assert_type_unittest.cc",
         "src/trace_processor/core/exec/dataframe_scan_unittest.cc",
         "src/trace_processor/core/exec/operator_unittest.cc",
         "src/trace_processor/core/exec/row_store_unittest.cc",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -16,6 +16,8 @@ import("../../../../gn/test.gni")
 
 source_set("exec") {
   sources = [
+    "assert_type.cc",
+    "assert_type.h",
     "column_view.cc",
     "column_view.h",
     "dataframe_scan.cc",
@@ -52,6 +54,7 @@ source_set("exec") {
 perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
+    "assert_type_unittest.cc",
     "dataframe_scan_unittest.cc",
     "operator_unittest.cc",
     "row_store_unittest.cc",

--- a/src/trace_processor/core/exec/assert_type.cc
+++ b/src/trace_processor/core/exec/assert_type.cc
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/assert_type.h"
+
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+const char* Name(Variant::Type type) {
+  switch (type) {
+    case Variant::Type::kNull:
+      return "a null";
+    case Variant::Type::kInt64:
+      return "an integer";
+    case Variant::Type::kDouble:
+      return "a float";
+    case Variant::Type::kString:
+      return "a string";
+  }
+  return "something";
+}
+
+const char* Name(StorageType type) {
+  if (type.Is<Int64>()) {
+    return "an integer";
+  }
+  return type.Is<Double>() ? "a float" : "a string";
+}
+
+// `resolve` is a template so the walk carries no per-row branch on how the
+// rows are reached.
+template <typename Resolve, typename Write>
+bool Walk(Resolve resolve, uint32_t count, Write write) {
+  for (uint32_t i = 0; i < count; ++i) {
+    if (!write(i, resolve(i))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Reads `count` values of a narrower integer column into `values.ints`.
+template <typename T>
+void WidenAs(const ColumnView& column,
+             uint32_t count,
+             FlexVector<int64_t>& out) {
+  const auto* data = static_cast<const T*>(column.data());
+  RowSelection selection = column.selection();
+  int64_t* dest = out.data();
+  if (selection.is_range()) {
+    const T* from = data + selection.offset();
+    for (uint32_t i = 0; i < count; ++i) {
+      dest[i] = from[i];
+    }
+    return;
+  }
+  const uint32_t* rows = selection.data();
+  for (uint32_t i = 0; i < count; ++i) {
+    dest[i] = data[rows[i]];
+  }
+}
+
+}  // namespace
+
+AssertType::AssertType(uint32_t column, StorageType type, std::string name)
+    : column_(column), type_(type), name_(std::move(name)) {}
+
+AssertType::~AssertType() = default;
+
+void AssertType::Widen(const ColumnView& column,
+                       uint32_t count,
+                       Values& values) const {
+  if (column.type().Is<Uint32>()) {
+    WidenAs<uint32_t>(column, count, values.ints);
+  } else {
+    WidenAs<int32_t>(column, count, values.ints);
+  }
+}
+AssertType::State::~State() = default;
+
+std::unique_ptr<OperatorState> AssertType::MakeState() const {
+  auto state = std::make_unique<State>();
+  if (type_.Is<Int64>()) {
+    state->values->ints.resize(kMaxBatchRows);
+  } else if (type_.Is<Double>()) {
+    state->values->doubles.resize(kMaxBatchRows);
+  } else {
+    state->values->strings.resize(kMaxBatchRows);
+  }
+  state->values->validity = BitVector::CreateWithSize(kMaxBatchRows);
+  return state;
+}
+
+base::Status AssertType::status(const OperatorState& state) const {
+  return state.Cast<const State>().status;
+}
+
+OpResult AssertType::Execute(const RowBatch& in,
+                             RowBatch& out,
+                             OperatorState& state) const {
+  State& s = state.Cast<State>();
+  out.CopyFrom(in);
+  const ColumnView& column = in.column(column_);
+  if (column.kind() != ColumnView::Kind::kVariant) {
+    if (column.type() == type_) {
+      return OpResult::kNeedMoreInput;
+    }
+    // A narrower integer widens to Int64 without losing anything.
+    if (type_.Is<Int64>() &&
+        (column.type().Is<Uint32>() || column.type().Is<Int32>())) {
+      Widen(column, in.size(), *s.values);
+      out.SetColumn(column_,
+                    ColumnView::Reference(type_, s.values->ints.data(),
+                                          column.validity()),
+                    s.values);
+      return OpResult::kNeedMoreInput;
+    }
+    s.status = base::ErrStatus("column '%s' is %s, not %s", name_.c_str(),
+                               Name(column.type()), Name(type_));
+    return OpResult::kError;
+  }
+
+  uint32_t count = in.size();
+  const auto* cells = static_cast<const Variant*>(column.data());
+  Values& values = *s.values;
+  values.validity.ClearAllBits();
+  auto write = [&](uint32_t row, const Variant& cell) {
+    if (cell.type == Variant::Type::kNull) {
+      // Written even though the row is null, so nothing downstream reads an
+      // uninitialised slot.
+      if (type_.Is<Int64>()) {
+        values.ints[row] = 0;
+      } else if (type_.Is<Double>()) {
+        values.doubles[row] = 0;
+      } else {
+        values.strings[row] = StringPool::Id::Null();
+      }
+      return true;
+    }
+    if (type_.Is<Int64>() && cell.type == Variant::Type::kInt64) {
+      values.ints[row] = cell.AsInt64();
+    } else if (type_.Is<Double>() && cell.type == Variant::Type::kDouble) {
+      values.doubles[row] = cell.AsDouble();
+    } else if (type_.Is<Double>() && cell.type == Variant::Type::kInt64) {
+      // Widening is a conversion only where it loses nothing.
+      int64_t value = cell.AsInt64();
+      auto widened = static_cast<double>(value);
+      if (static_cast<int64_t>(widened) != value) {
+        s.status = base::ErrStatus(
+            "column '%s' holds an integer too large to be a float",
+            name_.c_str());
+        return false;
+      }
+      values.doubles[row] = widened;
+    } else if (type_.Is<String>() && cell.type == Variant::Type::kString) {
+      values.strings[row] = cell.AsString();
+    } else {
+      s.status = base::ErrStatus("column '%s' holds %s, not %s", name_.c_str(),
+                                 Name(cell.type), Name(type_));
+      return false;
+    }
+    values.validity.set(row);
+    return true;
+  };
+
+  RowSelection selection = column.selection();
+  bool ok;
+  if (selection.is_range()) {
+    const Variant* from = cells + selection.offset();
+    ok = Walk([from](uint32_t i) -> const Variant& { return from[i]; }, count,
+              write);
+  } else {
+    const uint32_t* rows = selection.data();
+    ok = Walk(
+        [cells, rows](uint32_t i) -> const Variant& { return cells[rows[i]]; },
+        count, write);
+  }
+  if (!ok) {
+    return OpResult::kError;
+  }
+
+  const void* data = nullptr;
+  if (type_.Is<Int64>()) {
+    data = values.ints.data();
+  } else if (type_.Is<Double>()) {
+    data = values.doubles.data();
+  } else {
+    data = values.strings.data();
+  }
+  out.SetColumn(column_, ColumnView::Reference(type_, data, &values.validity),
+                s.values);
+  return OpResult::kNeedMoreInput;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/assert_type.h
+++ b/src/trace_processor/core/exec/assert_type.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ASSERT_TYPE_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ASSERT_TYPE_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// Turns a column whose values carry their own type into one of a single type,
+// failing on a row which disagrees.
+//
+// This is where a claim about a column's type is checked. A source reading
+// SQLite cannot make that claim -- a declared type there is not binding -- so
+// everything typed downstream of one goes through here first. An integer
+// widens to a float where it is exact; nothing else converts.
+class AssertType : public Operator {
+ public:
+  AssertType(uint32_t column, StorageType type, std::string name);
+  ~AssertType() override;
+
+  std::unique_ptr<OperatorState> MakeState() const override;
+  OpResult Execute(const RowBatch& in,
+                   RowBatch& out,
+                   OperatorState&) const override;
+  base::Status status(const OperatorState&) const override;
+
+ private:
+  struct Values {
+    FlexVector<int64_t> ints;
+    FlexVector<double> doubles;
+    FlexVector<StringPool::Id> strings;
+    BitVector validity;
+  };
+  struct State : OperatorState {
+    ~State() override;
+    std::shared_ptr<Values> values = std::make_shared<Values>();
+    base::Status status = base::OkStatus();
+  };
+
+  void Widen(const ColumnView&, uint32_t count, Values&) const;
+
+  uint32_t column_;
+  StorageType type_;
+  // For saying which column failed.
+  std::string name_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ASSERT_TYPE_H_

--- a/src/trace_processor/core/exec/assert_type_unittest.cc
+++ b/src/trace_processor/core/exec/assert_type_unittest.cc
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/assert_type.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using testing::ElementsAre;
+
+// The operator over one batch of variants.
+struct Asserted {
+  Asserted(std::vector<Variant> cells, StorageType type)
+      : op(0, type, "a"), state(op.MakeState()), values(std::move(cells)) {
+    batch.AddColumn(ColumnView::Variants(values.data()));
+    batch.Compose(RowSelection::Range(0), static_cast<uint32_t>(values.size()));
+    batch.SetCardinality(static_cast<uint32_t>(values.size()));
+  }
+
+  OpResult Execute() { return op.Execute(batch, out, *state); }
+  base::Status status() const { return op.status(*state); }
+
+  template <typename T>
+  std::vector<T> Read() {
+    const ColumnView& column = out.column(0);
+    const auto* data = static_cast<const T*>(column.data());
+    std::vector<T> read;
+    for (uint32_t i = 0; i < out.size(); ++i) {
+      read.push_back(data[column.selection().GetIndex(i)]);
+    }
+    return read;
+  }
+
+  AssertType op;
+  std::unique_ptr<OperatorState> state;
+  std::vector<Variant> values;
+  RowBatch batch;
+  RowBatch out;
+};
+
+TEST(AssertTypeTest, TurnsVariantsIntoAFlatColumn) {
+  Asserted run({Variant::Int64(7), Variant::Int64(8)}, StorageType{Int64{}});
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+
+  EXPECT_EQ(run.out.column(0).kind(), ColumnView::Kind::kFlat);
+  EXPECT_TRUE(run.out.column(0).type().Is<Int64>());
+  EXPECT_THAT(run.Read<int64_t>(), ElementsAre(7, 8));
+}
+
+TEST(AssertTypeTest, ANullIsARowWhichHoldsNothing) {
+  Asserted run({Variant::Int64(7), Variant::Null(), Variant::Int64(9)},
+               StorageType{Int64{}});
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+
+  const BitVector* validity = run.out.column(0).validity();
+  ASSERT_NE(validity, nullptr);
+  EXPECT_TRUE(validity->is_set(0));
+  EXPECT_FALSE(validity->is_set(1));
+  EXPECT_TRUE(validity->is_set(2));
+}
+
+TEST(AssertTypeTest, ARowWhichDisagreesIsReported) {
+  StringPool pool;
+  Asserted run({Variant::Int64(7), Variant::String(pool.InternString("no"))},
+               StorageType{Int64{}});
+  EXPECT_EQ(run.Execute(), OpResult::kError);
+  EXPECT_FALSE(run.status().ok());
+  EXPECT_THAT(run.status().message(), testing::HasSubstr("'a'"));
+  EXPECT_THAT(run.status().message(), testing::HasSubstr("a string"));
+}
+
+TEST(AssertTypeTest, AnIntegerWidensToAFloat) {
+  Asserted run({Variant::Int64(7), Variant::Double(1.5)},
+               StorageType{Double{}});
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+  EXPECT_THAT(run.Read<double>(), ElementsAre(7.0, 1.5));
+}
+
+TEST(AssertTypeTest, AnIntegerTooLargeToWidenIsReported) {
+  Asserted run({Variant::Int64((int64_t{1} << 53) + 1)}, StorageType{Double{}});
+  EXPECT_EQ(run.Execute(), OpResult::kError);
+  EXPECT_THAT(run.status().message(), testing::HasSubstr("too large"));
+}
+
+TEST(AssertTypeTest, KeepsStrings) {
+  StringPool pool;
+  Asserted run({Variant::String(pool.InternString("hi"))},
+               StorageType{String{}});
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+  EXPECT_EQ(pool.Get(run.Read<StringPool::Id>()[0]).ToStdString(), "hi");
+}
+
+// Reading through a row view rather than by position, which is what a batch
+// narrowed by an earlier operator hands over.
+TEST(AssertTypeTest, FollowsTheRowsTheBatchPicksOut) {
+  Asserted run({Variant::Int64(10), Variant::Int64(11), Variant::Int64(12)},
+               StorageType{Int64{}});
+  std::vector<uint32_t> rows = {2, 0};
+  run.batch.mutable_column(0).SetBorrowedRows(
+      Span<const uint32_t>(rows.data(), rows.data() + 2));
+  run.batch.SetCardinality(2);
+
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+  EXPECT_THAT(run.Read<int64_t>(), ElementsAre(12, 10));
+}
+
+// A column which is already the right type is left alone.
+TEST(AssertTypeTest, AFlatColumnOfTheRightTypePassesThrough) {
+  std::vector<int64_t> values = {1, 2};
+  AssertType op(0, StorageType{Int64{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch.Compose(RowSelection::Range(0), 2);
+  batch.SetCardinality(2);
+
+  RowBatch out;
+  EXPECT_EQ(op.Execute(batch, out, *state), OpResult::kNeedMoreInput);
+  EXPECT_EQ(out.column(0).data(), values.data());
+}
+
+TEST(AssertTypeTest, AFlatColumnOfTheWrongTypeIsReported) {
+  std::vector<double> values = {1.5};
+  AssertType op(0, StorageType{Int64{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Double{}}, values.data()));
+  batch.Compose(RowSelection::Range(0), 1);
+  batch.SetCardinality(1);
+
+  RowBatch out;
+  EXPECT_EQ(op.Execute(batch, out, *state), OpResult::kError);
+  EXPECT_FALSE(op.status(*state).ok());
+}
+
+// A dataframe's id column is narrower than an integer, and widening it loses
+// nothing.
+TEST(AssertTypeTest, ANarrowerIntegerWidens) {
+  std::vector<uint32_t> values = {7, 8, 9};
+  AssertType op(0, StorageType{Int64{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Uint32{}}, values.data()));
+  batch.Compose(RowSelection::Range(1), 2);
+  batch.SetCardinality(2);
+
+  RowBatch out;
+  ASSERT_EQ(op.Execute(batch, out, *state), OpResult::kNeedMoreInput);
+  ASSERT_TRUE(out.column(0).type().Is<Int64>());
+  const auto* data = static_cast<const int64_t*>(out.column(0).data());
+  EXPECT_EQ(data[0], 8);
+  EXPECT_EQ(data[1], 9);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec


### PR DESCRIPTION
A source reading SQLite cannot say what type a column is: a declared
type there is not binding, so every column it produces carries its type
per row. Everything downstream that wants a column of one type -- the
tree operators, and every operator after them -- has had no way to say
so, which left a query unable to reach any of them.

This is that way. It reads a variant column, checks every row against
the type asked for, and hands back a flat column of it, which is also
where a conversion belongs: an integer widens to a float where it is
exact and nothing else converts.

Failing here rather than at the source is the point. The source cannot
know what a column is for, and the operator that does know is not the
one reading SQLite.