### PR TITLE
tp: scan dataframes without SQLite

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17705,6 +17705,7 @@ filegroup {
     name: "perfetto_src_trace_processor_core_exec_exec",
     srcs: [
         "src/trace_processor/core/exec/column_view.cc",
+        "src/trace_processor/core/exec/dataframe_scan.cc",
         "src/trace_processor/core/exec/operator.cc",
         "src/trace_processor/core/exec/pipeline.cc",
         "src/trace_processor/core/exec/row_batch.cc",
@@ -17722,6 +17723,7 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
+        "src/trace_processor/core/exec/dataframe_scan_unittest.cc",
         "src/trace_processor/core/exec/operator_unittest.cc",
         "src/trace_processor/core/exec/row_batch_unittest.cc",
         "src/trace_processor/core/exec/row_store_unittest.cc",

--- a/src/trace_processor/core/dataframe/dataframe.h
+++ b/src/trace_processor/core/dataframe/dataframe.h
@@ -276,6 +276,9 @@ class Dataframe {
   // Returns the column names of the dataframe.
   const std::vector<std::string>& column_names() const { return column_names_; }
 
+  // Returns `column`'s values and which rows hold one, for reading them
+  // without going through a cursor.
+  const Column& column(uint32_t column) const { return *column_ptrs_[column]; }
   // Returns the type of the values in `column`.
   StorageType column_type(uint32_t column) const {
     return column_ptrs_[column]->storage.type();

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -18,6 +18,8 @@ source_set("exec") {
   sources = [
     "column_view.cc",
     "column_view.h",
+    "dataframe_scan.cc",
+    "dataframe_scan.h",
     "operator.cc",
     "operator.h",
     "pipeline.cc",
@@ -36,6 +38,7 @@ source_set("exec") {
     "../../../base",
     "../../containers",
     "../common",
+    "../dataframe",
     "../util",
   ]
 }
@@ -49,6 +52,7 @@ source_set("test_utils") {
 perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
+    "dataframe_scan_unittest.cc",
     "operator_unittest.cc",
     "row_batch_unittest.cc",
     "row_store_unittest.cc",
@@ -62,6 +66,7 @@ perfetto_unittest_source_set("unittests") {
     "../../../base",
     "../../containers",
     "../common",
+    "../dataframe",
     "../util",
   ]
 }

--- a/src/trace_processor/core/exec/column_view.h
+++ b/src/trace_processor/core/exec/column_view.h
@@ -48,8 +48,9 @@ class ColumnView {
     ColumnView view;
     view.type_ = type;
     if (type.Is<Id>()) {
-      PERFETTO_DCHECK(data == nullptr && validity == nullptr);
+      PERFETTO_DCHECK(data == nullptr);
       view.kind_ = Kind::kSequence;
+      view.validity_ = validity;
       return view;
     }
     view.kind_ = Kind::kFlat;

--- a/src/trace_processor/core/exec/dataframe_scan.cc
+++ b/src/trace_processor/core/exec/dataframe_scan.cc
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/dataframe_scan.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/dataframe/types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+// Lays a batch's worth of a column which does not store one value per row back
+// out so that it does. The buffer is a batch wide and reused, so a scan of a
+// sparse column costs one batch of work at a time rather than the whole column
+// up front.
+class DataframeScan::Expander {
+ public:
+  virtual ~Expander();
+
+  // Lays rows [from, from + count) out densely from zero and points `view` at
+  // them. Called with successive ranges starting at row zero.
+  virtual void Expand(uint32_t from, uint32_t count, ColumnView* view) = 0;
+
+  // Keeps the values alive for as long as a batch holds them.
+  virtual std::shared_ptr<const void> owner() const = 0;
+
+  virtual void Rewind() = 0;
+};
+
+DataframeScan::Expander::~Expander() = default;
+
+namespace {
+
+template <typename T>
+class ExpanderImpl final : public DataframeScan::Expander {
+ public:
+  ExpanderImpl(StorageType type, const T* packed, const BitVector* bits)
+      : type_(type), packed_(packed), bits_(bits) {
+    buffer_->values = FlexVector<T>::CreateWithSize(kMaxBatchRows);
+    buffer_->validity = BitVector::CreateWithSize(kMaxBatchRows);
+  }
+
+  void Expand(uint32_t from, uint32_t count, ColumnView* view) override {
+    PERFETTO_DCHECK(from == next_);
+    buffer_->validity.ClearAllBits();
+    for (uint32_t row = 0; row < count; ++row) {
+      if (bits_->is_set(from + row)) {
+        if constexpr (std::is_same_v<T, uint32_t>) {
+          buffer_->values[row] =
+              packed_ ? packed_[consumed_] : static_cast<uint32_t>(consumed_);
+        } else {
+          PERFETTO_DCHECK(packed_);
+          buffer_->values[row] = packed_[consumed_];
+        }
+        ++consumed_;
+        buffer_->validity.set(row);
+      } else {
+        // Written even for a null row, so the storage is readable everywhere.
+        buffer_->values[row] = T{};
+      }
+    }
+    next_ = from + count;
+    *view = ColumnView::Reference(type_, buffer_->values.data(),
+                                  &buffer_->validity);
+  }
+
+  std::shared_ptr<const void> owner() const override { return buffer_; }
+
+  void Rewind() override {
+    consumed_ = 0;
+    next_ = 0;
+  }
+
+ private:
+  struct Buffer {
+    FlexVector<T> values;
+    BitVector validity;
+  };
+
+  StorageType type_;
+  const T* packed_;
+  const BitVector* bits_;
+  std::shared_ptr<Buffer> buffer_ = std::make_shared<Buffer>();
+  // How many of the packed values have been read, which is how many rows
+  // before `next_` hold one.
+  uint32_t consumed_ = 0;
+  uint32_t next_ = 0;
+};
+
+// Builds either a view straight onto the dataframe's storage or, for a column
+// without a slot per row, the expander which fills one batch of it.
+template <typename T>
+void BuildColumn(const dataframe::Column& column,
+                 StorageType type,
+                 ColumnView* view,
+                 std::shared_ptr<const void>* owner,
+                 std::unique_ptr<DataframeScan::Expander>* expander) {
+  const T* data =
+      column.storage
+          .template unchecked_data<typename core::TypeTagFor<T>::type>();
+  const auto& nulls = column.null_storage;
+  if (nulls.nullability().template Is<core::NonNull>()) {
+    *view = ColumnView::Reference(type, data, nullptr);
+    return;
+  }
+  const BitVector& bits = nulls.GetNullBitVector();
+  if (nulls.nullability().template Is<core::DenseNull>()) {
+    // Already one slot per row, so the values can be read where they lie.
+    *view = ColumnView::Reference(type, data, &bits);
+    return;
+  }
+  auto impl = std::make_unique<ExpanderImpl<T>>(type, data, &bits);
+  *owner = impl->owner();
+  *expander = std::move(impl);
+}
+
+}  // namespace
+
+DataframeScan::DataframeScan(const dataframe::Dataframe& dataframe,
+                             std::vector<uint32_t> columns)
+    : dataframe_(&dataframe), columns_(std::move(columns)) {
+  PERFETTO_CHECK(dataframe.finalized());
+}
+
+DataframeScan::~DataframeScan() = default;
+DataframeScan::State::~State() = default;
+
+std::unique_ptr<OperatorState> DataframeScan::MakeState() const {
+  auto state = std::make_unique<State>();
+  state->columns.resize(columns_.size());
+  state->owners.resize(columns_.size());
+  state->expanders.resize(columns_.size());
+  for (uint32_t i = 0; i < columns_.size(); ++i) {
+    uint32_t index = columns_[i];
+    StorageType type = dataframe_->column_type(index);
+    if (type.Is<Id>()) {
+      const auto& nulls = dataframe_->column(index).null_storage;
+      if (nulls.nullability().Is<NonNull>()) {
+        state->columns[i] = ColumnView::Reference(type, nullptr, nullptr);
+      } else if (nulls.nullability().Is<DenseNull>()) {
+        state->columns[i] =
+            ColumnView::Reference(type, nullptr, &nulls.GetNullBitVector());
+      } else {
+        auto impl = std::make_unique<ExpanderImpl<uint32_t>>(
+            StorageType{Uint32{}}, nullptr, &nulls.GetNullBitVector());
+        state->owners[i] = impl->owner();
+        state->expanders[i] = std::move(impl);
+      }
+      continue;
+    }
+    const dataframe::Column& column = dataframe_->column(index);
+    if (type.Is<Uint32>()) {
+      BuildColumn<uint32_t>(column, type, &state->columns[i], &state->owners[i],
+                            &state->expanders[i]);
+    } else if (type.Is<Int32>()) {
+      BuildColumn<int32_t>(column, type, &state->columns[i], &state->owners[i],
+                           &state->expanders[i]);
+    } else if (type.Is<Int64>()) {
+      BuildColumn<int64_t>(column, type, &state->columns[i], &state->owners[i],
+                           &state->expanders[i]);
+    } else if (type.Is<Double>()) {
+      BuildColumn<double>(column, type, &state->columns[i], &state->owners[i],
+                          &state->expanders[i]);
+    } else {
+      BuildColumn<StringPool::Id>(column, type, &state->columns[i],
+                                  &state->owners[i], &state->expanders[i]);
+    }
+  }
+  return state;
+}
+
+void DataframeScan::Rewind(OperatorState& state) const {
+  State& s = state.Cast<State>();
+  s.emitted = 0;
+  for (const std::unique_ptr<Expander>& expander : s.expanders) {
+    if (expander) {
+      expander->Rewind();
+    }
+  }
+}
+
+bool DataframeScan::GetData(RowBatch& out, OperatorState& state) const {
+  State& s = state.Cast<State>();
+  uint32_t rows = dataframe_->row_count();
+  if (s.emitted == rows) {
+    return false;
+  }
+  uint32_t count = std::min(kMaxBatchRows, rows - s.emitted);
+  out.Reset();
+  for (uint32_t i = 0; i < s.columns.size(); ++i) {
+    ColumnView view = s.columns[i];
+    if (s.expanders[i]) {
+      // Expanded values are laid out from zero, so the column sits in its own
+      // index space rather than the dataframe's.
+      s.expanders[i]->Expand(s.emitted, count, &view);
+    } else {
+      view.SetRange(s.emitted);
+    }
+    out.AddColumn(view, s.owners[i]);
+  }
+  out.SetCardinality(count);
+  s.emitted += count;
+  return true;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/dataframe_scan.h
+++ b/src/trace_processor/core/exec/dataframe_scan.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_DATAFRAME_SCAN_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_DATAFRAME_SCAN_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// Reads a dataframe's rows without going through SQL.
+//
+// The batches point straight at the dataframe's own storage, so a query which
+// reads a table and does nothing else to it copies nothing. Deciding whether a
+// query is one of those belongs to whoever builds the plan: a relation which
+// filters, joins, groups or computes has work for SQLite to do and goes to
+// SqlScan instead.
+//
+// The exception is a column which does not store one value per row. Such a
+// column is expanded a batch at a time into a fixed-size buffer owned by the
+// execution, so a relation can be free for most of its columns and pay a
+// bounded amount for the rest. Nothing is materialised ahead of being asked
+// for, so a query which reads one batch and stops does one batch of work.
+//
+// The dataframe must be finalized and must outlive the scan.
+class DataframeScan : public Source {
+ public:
+  DataframeScan(const dataframe::Dataframe&, std::vector<uint32_t> columns);
+  ~DataframeScan() override;
+
+  std::unique_ptr<OperatorState> MakeState() const override;
+  bool GetData(RowBatch& out, OperatorState& state) const override;
+  void Rewind(OperatorState& state) const override;
+
+  // Fills one batch of a column which does not store one value per row.
+  // Defined in the .cc: an implementation detail with no callers outside it.
+  class Expander;
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    std::vector<ColumnView> columns;
+    // One per column: what keeps an expanded column alive, null where the
+    // column points at the dataframe's own storage.
+    std::vector<std::shared_ptr<const void>> owners;
+    // One per column, null unless the column has to be expanded.
+    std::vector<std::unique_ptr<Expander>> expanders;
+    uint32_t emitted = 0;
+  };
+
+  const dataframe::Dataframe* dataframe_;
+  std::vector<uint32_t> columns_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_DATAFRAME_SCAN_H_

--- a/src/trace_processor/core/exec/dataframe_scan_unittest.cc
+++ b/src/trace_processor/core/exec/dataframe_scan_unittest.cc
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/dataframe_scan.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h"
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/test_utils.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::Optional;
+
+// Bigger than an int32, so a column holding it is stored as an int64.
+constexpr int64_t kBig = int64_t{1} << 40;
+
+class DataframeScanTest : public ::testing::Test {
+ protected:
+  // A dataframe of one column, nullable where `present` says so. The values
+  // are big so that the builder picks int64 and the test can read it as one.
+  dataframe::Dataframe Build(const std::vector<int64_t>& values,
+                             const std::vector<bool>& present) {
+    dataframe::AdhocDataframeBuilder builder({"v"}, &pool_);
+    for (uint32_t i = 0; i < values.size(); ++i) {
+      if (present[i]) {
+        EXPECT_TRUE(builder.PushNonNull(0, values[i]));
+      } else {
+        builder.PushNull(0);
+      }
+    }
+    auto df = std::move(builder).Build();
+    EXPECT_TRUE(df.ok()) << df.status().c_message();
+    return std::move(*df);
+  }
+
+  std::vector<int64_t> Drain(const DataframeScan& scan, uint32_t column) {
+    std::unique_ptr<OperatorState> state = scan.MakeState();
+    RowBatch batch;
+    std::vector<int64_t> out;
+    while (scan.GetData(batch, *state)) {
+      std::vector<int64_t> values = test::ReadColumn<int64_t>(batch, column);
+      out.insert(out.end(), values.begin(), values.end());
+    }
+    return out;
+  }
+
+  StringPool pool_;
+};
+
+inline constexpr auto kAllTypes = dataframe::CreateTypedDataframeSpec(
+    {"id", "u32", "i32", "i64", "double", "string"},
+    dataframe::CreateTypedColumnSpec(Id{},
+                                     NonNull{},
+                                     IdSorted{},
+                                     NoDuplicates{}),
+    dataframe::CreateTypedColumnSpec(Uint32{}, NonNull{}, Unsorted{}),
+    dataframe::CreateTypedColumnSpec(Int32{}, NonNull{}, Unsorted{}),
+    dataframe::CreateTypedColumnSpec(Int64{}, NonNull{}, Unsorted{}),
+    dataframe::CreateTypedColumnSpec(Double{}, NonNull{}, Unsorted{}),
+    dataframe::CreateTypedColumnSpec(String{}, NonNull{}, Unsorted{}));
+
+inline constexpr auto kSparseId = dataframe::CreateTypedDataframeSpec(
+    {"id"},
+    dataframe::CreateTypedColumnSpec(Id{},
+                                     SparseNull{},
+                                     Unsorted{},
+                                     NoDuplicates{}));
+
+inline constexpr auto kDenseId = dataframe::CreateTypedDataframeSpec(
+    {"id"},
+    dataframe::CreateTypedColumnSpec(Id{},
+                                     DenseNull{},
+                                     Unsorted{},
+                                     NoDuplicates{}));
+
+TEST_F(DataframeScanTest, ReadsEveryStorageType) {
+  StringPool::Id first = pool_.InternString("first");
+  StringPool::Id second = pool_.InternString("second");
+  dataframe::Dataframe df =
+      dataframe::Dataframe::CreateFromTypedSpec(kAllTypes, &pool_);
+  df.InsertUnchecked(kAllTypes, std::monostate{}, uint32_t{7}, int32_t{-3},
+                     kBig, 1.5, first);
+  df.InsertUnchecked(kAllTypes, std::monostate{}, uint32_t{9}, int32_t{4},
+                     kBig + 1, 2.5, second);
+  df.Finalize();
+
+  DataframeScan scan(df, {0, 1, 2, 3, 4, 5});
+  std::unique_ptr<OperatorState> state = scan.MakeState();
+  RowBatch batch;
+  ASSERT_TRUE(scan.GetData(batch, *state));
+  EXPECT_TRUE(batch.column(0).type().Is<Id>());
+  EXPECT_TRUE(batch.column(1).type().Is<Uint32>());
+  EXPECT_TRUE(batch.column(2).type().Is<Int32>());
+  EXPECT_TRUE(batch.column(3).type().Is<Int64>());
+  EXPECT_TRUE(batch.column(4).type().Is<Double>());
+  EXPECT_TRUE(batch.column(5).type().Is<String>());
+  EXPECT_THAT(test::ReadColumn<uint32_t>(batch, 0), ElementsAre(0u, 1u));
+  EXPECT_THAT(test::ReadColumn<uint32_t>(batch, 1), ElementsAre(7u, 9u));
+  EXPECT_THAT(test::ReadColumn<int32_t>(batch, 2), ElementsAre(-3, 4));
+  EXPECT_THAT(test::ReadColumn<int64_t>(batch, 3), ElementsAre(kBig, kBig + 1));
+  EXPECT_THAT(test::ReadColumn<double>(batch, 4), ElementsAre(1.5, 2.5));
+  EXPECT_THAT(test::ReadColumn<StringPool::Id>(batch, 5),
+              ElementsAre(first, second));
+}
+
+TEST_F(DataframeScanTest, PreservesNullableIdSemantics) {
+  dataframe::Dataframe sparse =
+      dataframe::Dataframe::CreateFromTypedSpec(kSparseId, &pool_);
+  sparse.InsertUnchecked(kSparseId,
+                         std::optional<std::monostate>{std::monostate{}});
+  sparse.InsertUnchecked(kSparseId, std::optional<std::monostate>{});
+  sparse.InsertUnchecked(kSparseId,
+                         std::optional<std::monostate>{std::monostate{}});
+  sparse.Finalize();
+
+  DataframeScan sparse_scan(sparse, {0});
+  std::unique_ptr<OperatorState> sparse_state = sparse_scan.MakeState();
+  RowBatch batch;
+  ASSERT_TRUE(sparse_scan.GetData(batch, *sparse_state));
+  EXPECT_TRUE(batch.column(0).type().Is<Uint32>());
+  EXPECT_THAT(test::ReadNullableColumn<uint32_t>(batch, 0),
+              ElementsAre(Optional(0u), Eq(std::nullopt), Optional(1u)));
+
+  dataframe::Dataframe dense =
+      dataframe::Dataframe::CreateFromTypedSpec(kDenseId, &pool_);
+  dense.InsertUnchecked(kDenseId,
+                        std::optional<std::monostate>{std::monostate{}});
+  dense.InsertUnchecked(kDenseId, std::optional<std::monostate>{});
+  dense.InsertUnchecked(kDenseId,
+                        std::optional<std::monostate>{std::monostate{}});
+  dense.Finalize();
+
+  DataframeScan dense_scan(dense, {0});
+  std::unique_ptr<OperatorState> dense_state = dense_scan.MakeState();
+  ASSERT_TRUE(dense_scan.GetData(batch, *dense_state));
+  EXPECT_TRUE(batch.column(0).type().Is<Id>());
+  EXPECT_THAT(test::ReadNullableColumn<uint32_t>(batch, 0),
+              ElementsAre(Optional(0u), Eq(std::nullopt), Optional(2u)));
+}
+
+// The point of the operator: the batch reads the dataframe's own storage.
+TEST_F(DataframeScanTest, ReadsTheDataframesOwnStorage) {
+  dataframe::Dataframe df =
+      Build({kBig + 10, kBig + 20, kBig + 30}, {true, true, true});
+  DataframeScan scan(df, {0});
+
+  std::unique_ptr<OperatorState> state = scan.MakeState();
+  RowBatch batch;
+  ASSERT_TRUE(scan.GetData(batch, *state));
+  EXPECT_EQ(batch.size(), 3u);
+  EXPECT_EQ(batch.column(0).data(),
+            df.column(0).storage.unchecked_data<Int64>());
+}
+
+TEST_F(DataframeScanTest, HandsBackEveryRow) {
+  dataframe::Dataframe df =
+      Build({kBig + 10, kBig + 20, kBig + 30}, {true, true, true});
+  DataframeScan scan(df, {0});
+  EXPECT_THAT(Drain(scan, 0), ElementsAre(kBig + 10, kBig + 20, kBig + 30));
+}
+
+TEST_F(DataframeScanTest, SplitsIntoBatches) {
+  std::vector<int64_t> values(kMaxBatchRows * 2 + 5);
+  std::vector<bool> present(values.size(), true);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = kBig + i;
+  }
+  dataframe::Dataframe df = Build(values, present);
+  DataframeScan scan(df, {0});
+  EXPECT_EQ(Drain(scan, 0).size(), values.size());
+}
+
+// A column which does not store one value per row is laid back out once, so
+// the rest of the pipeline never has to know the difference.
+TEST_F(DataframeScanTest, AColumnWithoutASlotPerRowIsExpanded) {
+  dataframe::Dataframe df =
+      Build({kBig + 10, 0, kBig + 30}, {true, false, true});
+  DataframeScan scan(df, {0});
+
+  std::unique_ptr<OperatorState> state = scan.MakeState();
+  RowBatch batch;
+  ASSERT_TRUE(scan.GetData(batch, *state));
+  ASSERT_EQ(batch.size(), 3u);
+
+  const ColumnView& view = batch.column(0);
+  const auto* data = static_cast<const int64_t*>(view.data());
+  EXPECT_EQ(data[0], kBig + 10);
+  EXPECT_EQ(data[2], kBig + 30);
+  // Readable at every row, whether or not the row is null.
+  EXPECT_EQ(data[1], 0);
+  ASSERT_NE(view.validity(), nullptr);
+  EXPECT_TRUE(view.validity()->is_set(0));
+  EXPECT_FALSE(view.validity()->is_set(1));
+  EXPECT_TRUE(view.validity()->is_set(2));
+}
+
+// Expanding a batch at a time means picking up in the packed values where the
+// previous batch left off, which every batch after the first depends on.
+TEST_F(DataframeScanTest, AColumnWithoutASlotPerRowSpansBatches) {
+  std::vector<int64_t> values(kMaxBatchRows * 2 + 5);
+  std::vector<bool> present(values.size());
+  std::vector<int64_t> expected;
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    present[i] = i % 3 != 0;
+    values[i] = present[i] ? kBig + i : 0;
+    expected.push_back(values[i]);
+  }
+  dataframe::Dataframe df = Build(values, present);
+  DataframeScan scan(df, {0});
+  EXPECT_EQ(Drain(scan, 0), expected);
+}
+
+// Replaying has to wind the packed values back too, not just the row counter.
+TEST_F(DataframeScanTest, AColumnWithoutASlotPerRowIsReplayable) {
+  dataframe::Dataframe df =
+      Build({kBig + 10, 0, kBig + 30}, {true, false, true});
+  DataframeScan scan(df, {0});
+
+  std::unique_ptr<OperatorState> state = scan.MakeState();
+  RowBatch batch;
+  ASSERT_TRUE(scan.GetData(batch, *state));
+  ASSERT_FALSE(scan.GetData(batch, *state));
+
+  scan.Rewind(*state);
+  ASSERT_TRUE(scan.GetData(batch, *state));
+  const auto* data = static_cast<const int64_t*>(batch.column(0).data());
+  EXPECT_EQ(data[0], kBig + 10);
+  EXPECT_EQ(data[1], 0);
+  EXPECT_EQ(data[2], kBig + 30);
+}
+
+TEST_F(DataframeScanTest, IsReplayable) {
+  dataframe::Dataframe df = Build({kBig + 1, kBig + 2}, {true, true});
+  DataframeScan scan(df, {0});
+
+  std::unique_ptr<OperatorState> state = scan.MakeState();
+  RowBatch batch;
+  ASSERT_TRUE(scan.GetData(batch, *state));
+  EXPECT_FALSE(scan.GetData(batch, *state));
+  scan.Rewind(*state);
+  EXPECT_TRUE(scan.GetData(batch, *state));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec


### PR DESCRIPTION
A query which only reads a dataframe gives SQLite nothing to do. The values
already have storage types and are laid out the way a batch needs them.

DataframeScan returns views over the dataframe's storage without copying.
Columns without one slot per row are expanded one batch at a time into a
reused buffer, so they still look dense to downstream operators.

The planner only takes this path for passthrough dataframes. Filtering,
joining, grouping, and expressions still go through SQLite.