### PR TITLE
tp: validate variant column types

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17705,6 +17705,7 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_core_exec_exec",
     srcs: [
+        "src/trace_processor/core/exec/assert_type.cc",
         "src/trace_processor/core/exec/column_view.cc",
         "src/trace_processor/core/exec/dataframe_scan.cc",
         "src/trace_processor/core/exec/operator.cc",
@@ -17724,6 +17725,7 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
+        "src/trace_processor/core/exec/assert_type_unittest.cc",
         "src/trace_processor/core/exec/dataframe_scan_unittest.cc",
         "src/trace_processor/core/exec/operator_unittest.cc",
         "src/trace_processor/core/exec/row_batch_unittest.cc",

--- a/src/trace_processor/core/common/storage_types.h
+++ b/src/trace_processor/core/common/storage_types.h
@@ -75,6 +75,9 @@ using NonStringType = base::TypeSet<Id, Uint32, Int32, Int64, Double>;
 // Set of content types that are numeric in nature.
 using IntegerOrDoubleType = base::TypeSet<Uint32, Int32, Int64, Double>;
 
+// Set of content types which hold an integer.
+using IntegerType = base::TypeSet<Id, Uint32, Int32, Int64>;
+
 // Set of content types which are backed by real storage, i.e. everything
 // except Id, whose value is the row index itself.
 using NonIdStorageType = base::TypeSet<Uint32, Int32, Int64, Double, String>;

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -16,6 +16,8 @@ import("../../../../gn/test.gni")
 
 source_set("exec") {
   sources = [
+    "assert_type.cc",
+    "assert_type.h",
     "column_chunk.h",
     "column_view.cc",
     "column_view.h",
@@ -53,6 +55,7 @@ source_set("test_utils") {
 perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
+    "assert_type_unittest.cc",
     "dataframe_scan_unittest.cc",
     "operator_unittest.cc",
     "row_batch_unittest.cc",

--- a/src/trace_processor/core/exec/assert_type.cc
+++ b/src/trace_processor/core/exec/assert_type.cc
@@ -1,0 +1,318 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/assert_type.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_chunk.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/flex_vector.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+const char* Name(Variant::Type type) {
+  switch (type) {
+    case Variant::Type::kNull:
+      return "a null";
+    case Variant::Type::kInt64:
+      return "an integer";
+    case Variant::Type::kDouble:
+      return "a float";
+    case Variant::Type::kString:
+      return "a string";
+  }
+  return "something";
+}
+
+const char* Name(StorageType type) {
+  switch (type.index()) {
+    case StorageType::GetTypeIndex<Id>():
+    case StorageType::GetTypeIndex<Uint32>():
+    case StorageType::GetTypeIndex<Int32>():
+    case StorageType::GetTypeIndex<Int64>():
+      return "an integer";
+    case StorageType::GetTypeIndex<Double>():
+      return "a float";
+    case StorageType::GetTypeIndex<String>():
+      return "a string";
+    default:
+      PERFETTO_FATAL("Unreachable");
+  }
+}
+
+base::Status NotExact(const std::string& name) {
+  return base::ErrStatus(
+      "column '%s' holds an integer which a float cannot represent exactly",
+      name.c_str());
+}
+
+template <typename From, typename To>
+bool Cast(From value, To* out) {
+  *out = static_cast<To>(value);
+  return true;
+}
+
+// Fails when no double holds exactly `value`: either it lies outside the
+// range of a double or, above 2^53, its low bits would be rounded away.
+bool ExactDouble(int64_t value, double* out) {
+  constexpr double kInt64Limit = 0x1p63;
+  double widened = static_cast<double>(value);
+  if (widened >= kInt64Limit || widened < -kInt64Limit ||
+      static_cast<int64_t>(widened) != value) {
+    return false;
+  }
+  *out = widened;
+  return true;
+}
+
+// Copies the selected rows of a flat `column` into `out` through `convert`,
+// which returns false for a value it cannot convert. A null row is written as
+// zero so nothing downstream reads an uninitialised slot.
+template <typename From, typename To, typename Convert>
+bool WidenAs(const ColumnView& column,
+             uint32_t count,
+             Convert convert,
+             FlexVector<To>* out,
+             BitVector* out_validity) {
+  const BitVector* validity = column.validity();
+  out_validity->ClearAllBits();
+  for (uint32_t row = 0; row < count; ++row) {
+    uint32_t index = column.selection().GetIndex(row);
+    if (validity && !validity->is_set(index)) {
+      (*out)[row] = To{};
+      continue;
+    }
+    if (!convert(column.Value<From>(row), &(*out)[row])) {
+      return false;
+    }
+    out_validity->set(row);
+  }
+  return true;
+}
+
+// The variant counterpart of WidenAs: a row is null when its cell is.
+template <typename To, typename Convert>
+bool Fill(const ColumnView& column,
+          uint32_t count,
+          Convert convert,
+          FlexVector<To>* out,
+          BitVector* out_validity) {
+  out_validity->ClearAllBits();
+  for (uint32_t row = 0; row < count; ++row) {
+    Variant cell = column.Value<Variant>(row);
+    if (cell.type == Variant::Type::kNull) {
+      (*out)[row] = To{};
+      continue;
+    }
+    if (!convert(cell, &(*out)[row])) {
+      return false;
+    }
+    out_validity->set(row);
+  }
+  return true;
+}
+
+}  // namespace
+
+AssertType::AssertType(uint32_t column, AssertTypeTarget type, std::string name)
+    : column_(column),
+      target_(type),
+      type_(type.Upcast<StorageType>()),
+      name_(std::move(name)) {}
+
+AssertType::~AssertType() = default;
+
+AssertType::State::~State() = default;
+
+const void* AssertType::Data(const ColumnChunk& chunk) const {
+  switch (target_.index()) {
+    case AssertTypeTarget::GetTypeIndex<Int64>():
+      return chunk.Values<int64_t>().data();
+    case AssertTypeTarget::GetTypeIndex<Double>():
+      return chunk.Values<double>().data();
+    case AssertTypeTarget::GetTypeIndex<String>():
+      return chunk.Values<StringPool::Id>().data();
+    default:
+      PERFETTO_FATAL("Unreachable");
+  }
+}
+
+std::unique_ptr<OperatorState> AssertType::MakeState() const {
+  auto state = std::make_unique<State>();
+  switch (target_.index()) {
+    case AssertTypeTarget::GetTypeIndex<Int64>():
+      state->chunk.Values<int64_t>();
+      break;
+    case AssertTypeTarget::GetTypeIndex<Double>():
+      state->chunk.Values<double>();
+      break;
+    case AssertTypeTarget::GetTypeIndex<String>():
+      state->chunk.Values<StringPool::Id>();
+      break;
+    default:
+      PERFETTO_FATAL("Unreachable");
+  }
+  state->chunk.validity = BitVector::CreateWithSize(kMaxBatchRows);
+  return state;
+}
+
+base::Status AssertType::status(const OperatorState& state) const {
+  return state.Cast<const State>().status;
+}
+
+void AssertType::Rewind(OperatorState& state) const {
+  state.Cast<State>().status = base::OkStatus();
+}
+
+bool AssertType::Widen(const ColumnView& column,
+                       uint32_t count,
+                       State& state) const {
+  ColumnChunk& chunk = state.chunk;
+  StorageType from = column.type();
+  if (type_.Is<Int64>()) {
+    PERFETTO_DCHECK((from.IsAnyOf<base::TypeSet<Id, Uint32, Int32>>()));
+    if (from.Is<Int32>()) {
+      return WidenAs<int32_t>(column, count, Cast<int32_t, int64_t>,
+                              &chunk.Values<int64_t>(), &chunk.validity);
+    }
+    return WidenAs<uint32_t>(column, count, Cast<uint32_t, int64_t>,
+                             &chunk.Values<int64_t>(), &chunk.validity);
+  }
+  PERFETTO_DCHECK(type_.Is<Double>());
+  if (from.Is<Int32>()) {
+    return WidenAs<int32_t>(column, count, Cast<int32_t, double>,
+                            &chunk.Values<double>(), &chunk.validity);
+  }
+  if (from.Is<Int64>()) {
+    auto exact = [&](int64_t value, double* out) {
+      if (ExactDouble(value, out)) {
+        return true;
+      }
+      state.status = NotExact(name_);
+      return false;
+    };
+    return WidenAs<int64_t>(column, count, exact, &chunk.Values<double>(),
+                            &chunk.validity);
+  }
+  PERFETTO_DCHECK(from.Is<Id>() || from.Is<Uint32>());
+  return WidenAs<uint32_t>(column, count, Cast<uint32_t, double>,
+                           &chunk.Values<double>(), &chunk.validity);
+}
+
+OpResult AssertType::Execute(const RowBatch& in,
+                             RowBatch& out,
+                             OperatorState& state) const {
+  State& s = state.Cast<State>();
+  out.CopyFrom(in);
+  const ColumnView& column = in.column(column_);
+  ColumnChunk& chunk = s.chunk;
+  if (column.kind() != ColumnView::Kind::kVariant) {
+    if (column.type() == type_) {
+      return OpResult::kNeedMoreInput;
+    }
+    bool widen = column.type().IsAnyOf<IntegerType>() &&
+                 (type_.Is<Int64>() || type_.Is<Double>());
+    if (!widen) {
+      s.status = base::ErrStatus("column '%s' is %s, not %s", name_.c_str(),
+                                 Name(column.type()), Name(type_));
+      return OpResult::kError;
+    }
+    if (!Widen(column, in.size(), s)) {
+      return OpResult::kError;
+    }
+    // A column without validity has no nulls to remap, so stays non-null.
+    const BitVector* validity = column.validity() ? &chunk.validity : nullptr;
+    out.SetColumn(column_, ColumnView::Reference(type_, Data(chunk), validity));
+    return OpResult::kNeedMoreInput;
+  }
+
+  auto mismatch = [&](const Variant& cell) {
+    s.status = base::ErrStatus("column '%s' holds %s, not %s", name_.c_str(),
+                               Name(cell.type), Name(type_));
+    return false;
+  };
+  uint32_t count = in.size();
+  bool ok;
+  switch (target_.index()) {
+    case AssertTypeTarget::GetTypeIndex<Int64>():
+      ok = Fill(
+          column, count,
+          [&](const Variant& cell, int64_t* out) {
+            if (cell.type != Variant::Type::kInt64) {
+              return mismatch(cell);
+            }
+            *out = cell.AsInt64();
+            return true;
+          },
+          &chunk.Values<int64_t>(), &chunk.validity);
+      break;
+    case AssertTypeTarget::GetTypeIndex<Double>():
+      ok = Fill(
+          column, count,
+          [&](const Variant& cell, double* out) {
+            if (cell.type == Variant::Type::kDouble) {
+              *out = cell.AsDouble();
+              return true;
+            }
+            if (cell.type != Variant::Type::kInt64) {
+              return mismatch(cell);
+            }
+            if (ExactDouble(cell.AsInt64(), out)) {
+              return true;
+            }
+            s.status = NotExact(name_);
+            return false;
+          },
+          &chunk.Values<double>(), &chunk.validity);
+      break;
+    case AssertTypeTarget::GetTypeIndex<String>():
+      ok = Fill(
+          column, count,
+          [&](const Variant& cell, StringPool::Id* out) {
+            if (cell.type != Variant::Type::kString) {
+              return mismatch(cell);
+            }
+            *out = cell.AsString();
+            return true;
+          },
+          &chunk.Values<StringPool::Id>(), &chunk.validity);
+      break;
+    default:
+      PERFETTO_FATAL("Unreachable");
+  }
+  if (!ok) {
+    return OpResult::kError;
+  }
+  out.SetColumn(column_,
+                ColumnView::Reference(type_, Data(chunk), &chunk.validity));
+  return OpResult::kNeedMoreInput;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/assert_type.h
+++ b/src/trace_processor/core/exec/assert_type.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_ASSERT_TYPE_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_ASSERT_TYPE_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/type_set.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_chunk.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+using AssertTypeTarget = base::TypeSet<Int64, Double, String>;
+
+// Converts a column whose values carry their own type into a column of a
+// single type, failing on any row which disagrees.
+//
+// A source reading SQLite cannot promise a column's type, because a declared
+// type in SQLite is not binding. AssertType is needed for variant columns. A
+// flat column already of the requested type passes through unchanged; a flat
+// integer column of any other type is copied into a widened one. Integers
+// widen to a float only where the conversion is exact; nothing else converts.
+class AssertType : public Operator {
+ public:
+  AssertType(uint32_t column, AssertTypeTarget type, std::string name);
+  ~AssertType() override;
+
+  std::unique_ptr<OperatorState> MakeState() const override;
+  OpResult Execute(const RowBatch& in,
+                   RowBatch& out,
+                   OperatorState&) const override;
+  void Rewind(OperatorState&) const override;
+  base::Status status(const OperatorState&) const override;
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    // The converted column, holding values of the target type.
+    ColumnChunk chunk;
+    base::Status status = base::OkStatus();
+  };
+
+  // The buffer in `chunk` holding values of the target type.
+  const void* Data(const ColumnChunk& chunk) const;
+  bool Widen(const ColumnView&, uint32_t count, State&) const;
+
+  uint32_t column_;
+  AssertTypeTarget target_;
+  // `target_` as a StorageType, which is what a column carries.
+  StorageType type_;
+  // Used in the error message when a row disagrees.
+  std::string name_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_ASSERT_TYPE_H_

--- a/src/trace_processor/core/exec/assert_type_unittest.cc
+++ b/src/trace_processor/core/exec/assert_type_unittest.cc
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/assert_type.h"
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/test_utils.h"
+#include "src/trace_processor/core/exec/variant.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+using testing::Eq;
+using testing::Optional;
+
+using testing::ElementsAre;
+
+// Runs the operator over a single batch of variants.
+struct Asserted {
+  Asserted(std::vector<Variant> cells, AssertTypeTarget type)
+      : op(0, type, "a"), state(op.MakeState()), values(std::move(cells)) {
+    batch.AddColumn(ColumnView::Variants(values.data()));
+    batch.Compose(RowSelection::Range(0), static_cast<uint32_t>(values.size()));
+    batch.SetCardinality(static_cast<uint32_t>(values.size()));
+  }
+
+  OpResult Execute() { return op.Execute(batch, out, *state); }
+  base::Status status() const { return op.status(*state); }
+
+  template <typename T>
+  std::vector<T> Read() {
+    return test::ReadColumn<T>(out, 0);
+  }
+
+  AssertType op;
+  std::unique_ptr<OperatorState> state;
+  std::vector<Variant> values;
+  RowBatch batch;
+  RowBatch out;
+};
+
+TEST(AssertTypeTest, TurnsVariantsIntoAFlatColumn) {
+  Asserted run({Variant::Int64(7), Variant::Int64(8)},
+               AssertTypeTarget{Int64{}});
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+
+  EXPECT_EQ(run.out.column(0).kind(), ColumnView::Kind::kFlat);
+  EXPECT_TRUE(run.out.column(0).type().Is<Int64>());
+  EXPECT_THAT(run.Read<int64_t>(), ElementsAre(7, 8));
+}
+
+TEST(AssertTypeTest, ANullIsARowWhichHoldsNothing) {
+  Asserted run({Variant::Int64(7), Variant::Null(), Variant::Int64(9)},
+               AssertTypeTarget{Int64{}});
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+
+  const BitVector* validity = run.out.column(0).validity();
+  ASSERT_NE(validity, nullptr);
+  EXPECT_TRUE(validity->is_set(0));
+  EXPECT_FALSE(validity->is_set(1));
+  EXPECT_TRUE(validity->is_set(2));
+}
+
+TEST(AssertTypeTest, ARowWhichDisagreesIsReported) {
+  StringPool pool;
+  Asserted run({Variant::Int64(7), Variant::String(pool.InternString("no"))},
+               AssertTypeTarget{Int64{}});
+  EXPECT_EQ(run.Execute(), OpResult::kError);
+  EXPECT_FALSE(run.status().ok());
+  EXPECT_THAT(run.status().message(), testing::HasSubstr("'a'"));
+  EXPECT_THAT(run.status().message(), testing::HasSubstr("a string"));
+}
+
+TEST(AssertTypeTest, AnIntegerWidensToAFloat) {
+  Asserted run({Variant::Int64(7), Variant::Double(1.5)},
+               AssertTypeTarget{Double{}});
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+  EXPECT_THAT(run.Read<double>(), ElementsAre(7.0, 1.5));
+}
+
+TEST(AssertTypeTest, AnIntegerBeyondTheFloatRangeIsReported) {
+  Asserted run({Variant::Int64(std::numeric_limits<int64_t>::max())},
+               AssertTypeTarget{Double{}});
+  EXPECT_EQ(run.Execute(), OpResult::kError);
+  EXPECT_THAT(run.status().message(),
+              testing::HasSubstr("cannot represent exactly"));
+}
+
+// Above 2^53 a double keeps only the high bits, so a value with low bits set
+// has no exact float even though it is well within range.
+TEST(AssertTypeTest, AnIntegerAFloatWouldRoundIsReported) {
+  Asserted run({Variant::Int64((int64_t{1} << 53) + 1)},
+               AssertTypeTarget{Double{}});
+  EXPECT_EQ(run.Execute(), OpResult::kError);
+  EXPECT_THAT(run.status().message(),
+              testing::HasSubstr("cannot represent exactly"));
+}
+
+TEST(AssertTypeTest, KeepsStrings) {
+  StringPool pool;
+  Asserted run({Variant::String(pool.InternString("hi"))},
+               AssertTypeTarget{String{}});
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+  EXPECT_EQ(pool.Get(run.Read<StringPool::Id>()[0]).ToStdString(), "hi");
+}
+
+// Reading through a selection rather than by position, which is what a batch
+// narrowed by an earlier operator looks like.
+TEST(AssertTypeTest, FollowsTheRowsTheBatchPicksOut) {
+  Asserted run({Variant::Int64(10), Variant::Int64(11), Variant::Int64(12)},
+               AssertTypeTarget{Int64{}});
+  std::vector<uint32_t> rows = {2, 0};
+  run.batch.mutable_column(0).SetBorrowedRows(
+      Span<const uint32_t>(rows.data(), rows.data() + 2));
+  run.batch.SetCardinality(2);
+
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+  EXPECT_THAT(run.Read<int64_t>(), ElementsAre(12, 10));
+}
+
+// A column which is already the right type is left alone.
+TEST(AssertTypeTest, AFlatColumnOfTheRightTypePassesThrough) {
+  std::vector<int64_t> values = {1, 2};
+  AssertType op(0, AssertTypeTarget{Int64{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch.Compose(RowSelection::Range(0), 2);
+  batch.SetCardinality(2);
+
+  RowBatch out;
+  EXPECT_EQ(op.Execute(batch, out, *state), OpResult::kNeedMoreInput);
+  EXPECT_EQ(out.column(0).data(), values.data());
+}
+
+TEST(AssertTypeTest, AFlatColumnOfTheWrongTypeIsReported) {
+  std::vector<double> values = {1.5};
+  AssertType op(0, AssertTypeTarget{Int64{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Double{}}, values.data()));
+  batch.Compose(RowSelection::Range(0), 1);
+  batch.SetCardinality(1);
+
+  RowBatch out;
+  EXPECT_EQ(op.Execute(batch, out, *state), OpResult::kError);
+  EXPECT_FALSE(op.status(*state).ok());
+}
+
+TEST(AssertTypeTest, WideningASelectedFlatColumnRemapsValidity) {
+  std::vector<uint32_t> values = {7, 8, 9};
+  BitVector validity = BitVector::CreateWithSize(3);
+  validity.set(1);
+  AssertType op(0, AssertTypeTarget{Int64{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(
+      ColumnView::Reference(StorageType{Uint32{}}, values.data(), &validity));
+  batch.Compose(RowSelection::Range(1), 2);
+  batch.SetCardinality(2);
+
+  RowBatch out;
+  ASSERT_EQ(op.Execute(batch, out, *state), OpResult::kNeedMoreInput);
+  EXPECT_THAT(test::ReadNullableColumn<int64_t>(out, 0),
+              ElementsAre(Optional(8), Eq(std::nullopt)));
+  EXPECT_THAT(test::ReadColumn<int64_t>(out, 0), ElementsAre(8, 0));
+}
+
+TEST(AssertTypeTest, FlatIntegersWidenToDouble) {
+  std::vector<int64_t> values = {std::numeric_limits<int64_t>::min(), 42};
+  AssertType op(0, AssertTypeTarget{Double{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch.SetCardinality(2);
+
+  RowBatch out;
+  ASSERT_EQ(op.Execute(batch, out, *state), OpResult::kNeedMoreInput);
+  EXPECT_THAT(test::ReadColumn<double>(out, 0),
+              ElementsAre(static_cast<double>(values[0]), 42.0));
+}
+
+TEST(AssertTypeTest, AFlatIntegerAFloatWouldRoundIsReported) {
+  std::vector<int64_t> values = {(int64_t{1} << 53) + 1};
+  AssertType op(0, AssertTypeTarget{Double{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values.data()));
+  batch.SetCardinality(1);
+
+  RowBatch out;
+  EXPECT_EQ(op.Execute(batch, out, *state), OpResult::kError);
+  EXPECT_THAT(op.status(*state).message(),
+              testing::HasSubstr("cannot represent exactly"));
+}
+
+TEST(AssertTypeTest, WideningANonNullFlatColumnStaysNonNull) {
+  std::vector<uint32_t> values = {7, 8};
+  AssertType op(0, AssertTypeTarget{Int64{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Uint32{}}, values.data()));
+  batch.SetCardinality(2);
+
+  RowBatch out;
+  ASSERT_EQ(op.Execute(batch, out, *state), OpResult::kNeedMoreInput);
+  EXPECT_EQ(out.column(0).validity(), nullptr);
+  EXPECT_THAT(test::ReadColumn<int64_t>(out, 0), ElementsAre(7, 8));
+}
+
+TEST(AssertTypeTest, RewindClearsATypeError) {
+  StringPool pool;
+  Asserted run({Variant::String(pool.InternString("wrong"))},
+               AssertTypeTarget{Int64{}});
+  ASSERT_EQ(run.Execute(), OpResult::kError);
+  ASSERT_FALSE(run.status().ok());
+  run.op.Rewind(*run.state);
+  EXPECT_TRUE(run.status().ok());
+}
+
+TEST(AssertTypeTest, AReusedNullSlotIsCleared) {
+  Asserted run({Variant::Int64(7)}, AssertTypeTarget{Int64{}});
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+  EXPECT_THAT(run.Read<int64_t>(), ElementsAre(7));
+
+  run.values[0] = Variant::Null();
+  ASSERT_EQ(run.Execute(), OpResult::kNeedMoreInput);
+  EXPECT_THAT(run.Read<int64_t>(), ElementsAre(0));
+  EXPECT_FALSE(run.out.column(0).validity()->is_set(0));
+}
+
+TEST(AssertTypeTest, NarrowIntegerErrorsNameAnInteger) {
+  std::vector<uint32_t> values = {7};
+  AssertType op(0, AssertTypeTarget{String{}}, "a");
+  std::unique_ptr<OperatorState> state = op.MakeState();
+  RowBatch batch;
+  batch.AddColumn(ColumnView::Reference(StorageType{Uint32{}}, values.data()));
+  batch.SetCardinality(1);
+
+  RowBatch out;
+  ASSERT_EQ(op.Execute(batch, out, *state), OpResult::kError);
+  EXPECT_THAT(op.status(*state).message(), testing::HasSubstr("an integer"));
+  EXPECT_THAT(op.status(*state).message(), testing::HasSubstr("a string"));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec


### PR DESCRIPTION
A SqlScan column uses Variant when lineage cannot prove one storage type.
Typed operators need to check those values before reading them as a flat
column.

AssertType checks every selected row against the requested type and produces a
flat column. Nulls remain null. Narrow integers can widen when the conversion
is exact; other mismatches stop the pipeline and name the offending column.

This is an operator rather than part of SqlScan because the consumer, not the
source, decides what type a column must have.