### PR TITLE
Cherry-pick #7023, #7028, #7037, and v58.2 to stable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,10 @@ Unreleased:
   SDK:
    *
 
+v58.2 - 2026-08-21:
+  Misc:
+    * Fixed additional Windows build and test failures.
+
 v58.1 - 2026-08-21:
   Misc:
     * Fixed builds on Windows.

--- a/include/perfetto/ext/base/file_utils.h
+++ b/include/perfetto/ext/base/file_utils.h
@@ -158,6 +158,22 @@ std::string Basename(const std::string& path);
 //   Dirname("C:\\Windows\\System32") => "C:\\Windows"
 std::string Dirname(const std::string& path);
 
+// Returns the length of the leading root component of a path: "/" on UNIX,
+// "C:\" or "\\" (UNC) on Windows. Returns 0 if the path is relative. Like
+// Basename() and Dirname(), both '/' and '\' are recognized on all platforms.
+// Stripping the returned prefix turns the path into a relative one.
+// Examples:
+//   PathRootPrefixLength("/usr/bin/ls") => 1
+//   PathRootPrefixLength("//usr/bin") => 2
+//   PathRootPrefixLength("C:\\Windows") => 3
+//   PathRootPrefixLength("C:foo") => 0 (relative to the current dir of drive
+//   C:) PathRootPrefixLength("foo/bar") => 0
+size_t PathRootPrefixLength(const std::string& path);
+
+// Returns true if the path starts with a root component. See
+// PathRootPrefixLength().
+bool IsAbsolutePath(const std::string& path);
+
 // Puts the path to all files under |dir_path| in |output|, recursively walking
 // subdirectories. File paths are relative to |dir_path|. Only files are
 // included, not directories. Path separator is always '/', even on windows (not

--- a/include/perfetto/ext/base/file_utils.h
+++ b/include/perfetto/ext/base/file_utils.h
@@ -183,6 +183,13 @@ std::optional<uint64_t> GetFileSize(const std::string& path);
 // Returns the size of the open file |fd|, or nullopt in case of error.
 std::optional<uint64_t> GetFileSize(PlatformHandle fd);
 
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+// On Windows PlatformHandle is a HANDLE, not a file descriptor. This overload
+// accepts the CRT file descriptors returned by base::OpenFile(). On other
+// platforms PlatformHandle is an int, so the overload above already covers it.
+std::optional<uint64_t> GetFileSize(int fd);
+#endif
+
 // This class uses inotify (on Linux/Android) to watch for the creation of
 // files in the filesystem. When the specified file is created, it triggers a
 // callback function.

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -268,6 +268,10 @@ bool FlushFile(int fd) {
 
 bool SeekFile(int fd, uint64_t offset) {
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  if (fd < 0) {
+    errno = EBADF;
+    return false;
+  }
   if (offset > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
     errno = EOVERFLOW;
     return false;
@@ -285,6 +289,10 @@ bool SeekFile(int fd, uint64_t offset) {
 
 bool TruncateFile(int fd, uint64_t size) {
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  if (fd < 0) {
+    errno = EBADF;
+    return false;
+  }
   if (size > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
     errno = EOVERFLOW;
     return false;

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -702,6 +702,12 @@ std::optional<uint64_t> GetFileSize(PlatformHandle fd) {
 #endif
 }
 
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+std::optional<uint64_t> GetFileSize(int fd) {
+  return GetFileSize(reinterpret_cast<PlatformHandle>(_get_osfhandle(fd)));
+}
+#endif
+
 // LinuxFileWatch
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX_BUT_NOT_QNX) || \

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -627,6 +627,27 @@ std::string Dirname(const std::string& path) {
   return p.substr(0, last_sep);
 }
 
+size_t PathRootPrefixLength(const std::string& path) {
+  size_t pos = 0;
+  // Skip over a leading drive letter, e.g. "C:\foo".
+  bool has_drive_letter = path.size() >= 2 && path[1] == ':' &&
+                          ((path[0] >= 'a' && path[0] <= 'z') ||
+                           (path[0] >= 'A' && path[0] <= 'Z'));
+  if (has_drive_letter)
+    pos = 2;
+
+  size_t end = path.find_first_not_of("/\\", pos);
+  end = end == std::string::npos ? path.size() : end;
+
+  // A drive letter not followed by a separator ("C:foo") is relative to the
+  // current directory of that drive, not absolute.
+  return end > pos ? end : 0;
+}
+
+bool IsAbsolutePath(const std::string& path) {
+  return PathRootPrefixLength(path) != 0;
+}
+
 base::Status SetFilePermissions(const std::string& file_path,
                                 const std::string& group_name_or_id,
                                 const std::string& mode_bits) {

--- a/src/base/file_utils_unittest.cc
+++ b/src/base/file_utils_unittest.cc
@@ -59,6 +59,28 @@ TEST(FileUtilsTest, Basename) {
   EXPECT_EQ(Basename("foo/bar\\"), "bar");
 }
 
+TEST(FileUtilsTest, PathRootPrefixLength) {
+  EXPECT_EQ(PathRootPrefixLength("/usr/bin/ls"), 1u);
+  EXPECT_EQ(PathRootPrefixLength("/"), 1u);
+  EXPECT_EQ(PathRootPrefixLength("//usr//bin"), 2u);
+  EXPECT_EQ(PathRootPrefixLength("foo/bar"), 0u);
+  EXPECT_EQ(PathRootPrefixLength(""), 0u);
+
+  // Windows.
+  EXPECT_EQ(PathRootPrefixLength("C:\\Windows\\System32"), 3u);
+  EXPECT_EQ(PathRootPrefixLength("c:/Windows"), 3u);
+  EXPECT_EQ(PathRootPrefixLength("\\\\server\\share"), 2u);
+  // Relative to the current directory of drive C:, not absolute.
+  EXPECT_EQ(PathRootPrefixLength("C:foo"), 0u);
+  EXPECT_EQ(PathRootPrefixLength("C:"), 0u);
+  EXPECT_EQ(PathRootPrefixLength("1:\\foo"), 0u);
+
+  EXPECT_TRUE(IsAbsolutePath("/usr/bin/ls"));
+  EXPECT_TRUE(IsAbsolutePath("C:\\Windows"));
+  EXPECT_FALSE(IsAbsolutePath("foo/bar"));
+  EXPECT_FALSE(IsAbsolutePath(""));
+}
+
 TEST(FileUtilsTest, Dirname) {
   EXPECT_EQ(Dirname("/usr/bin/ls"), "/usr/bin");
   EXPECT_EQ(Dirname("/usr/bin"), "/usr");

--- a/src/base/subprocess_windows.cc
+++ b/src/base/subprocess_windows.cc
@@ -201,7 +201,7 @@ void Subprocess::StdoutErrThread(MovableState* s) {
     if (!res) {
       auto err = GetLastError();
       if (err != ERROR_BROKEN_PIPE)
-        PERFETTO_PLOG("Subprocess ReadFile(stdouterr) failed %ld", err);
+        PERFETTO_PLOG("Subprocess ReadFile(stdouterr) failed %lx", err);
     }
 
     if (rsize > 0) {

--- a/src/trace_processor/local_file_system_unittest.cc
+++ b/src/trace_processor/local_file_system_unittest.cc
@@ -91,6 +91,8 @@ TEST(LocalFileSystemTest, RandomAccessReadWrite) {
   ASSERT_OK(file->Truncate(6));
   ASSERT_OK(file->GetSize(&size));
   EXPECT_EQ(size, 6u);
+
+  file.reset();
   ASSERT_OK(file_system->DeleteFile(path));
 }
 

--- a/src/trace_processor/rpc/session_paths.cc
+++ b/src/trace_processor/rpc/session_paths.cc
@@ -65,16 +65,6 @@ constexpr const char* kAnimals[] = {
     "otter",  "falcon", "lynx",  "panda", "tapir", "heron", "ibex", "koala",
     "marten", "quokka", "raven", "shrew", "stork", "viper", "wren", "yak"};
 
-bool IsAbsolutePath(const std::string& p) {
-  if (p.empty())
-    return false;
-  if (p[0] == '/' || p[0] == '\\')
-    return true;
-  // Windows drive-letter path, e.g. "C:\foo" or "C:/foo".
-  return p.size() >= 3 && std::isalpha(static_cast<unsigned char>(p[0])) &&
-         p[1] == ':' && (p[2] == '\\' || p[2] == '/');
-}
-
 // Returns true if the substring after the last ':' is non-empty and all digits
 // (i.e. a "host:port" address).
 bool HasTrailingPort(const std::string& addr) {
@@ -168,7 +158,7 @@ base::Status ValidateAfUnixPathLength(const std::string& path) {
 }
 
 std::string MakeAbsolutePath(const std::string& path) {
-  if (path.empty() || IsAbsolutePath(path))
+  if (path.empty() || base::IsAbsolutePath(path))
     return path;
   char cwd[4096];
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
@@ -204,7 +194,7 @@ base::StatusOr<uint32_t> ParseDurationMs(const std::string& s) {
 }
 
 RemoteAddrKind ClassifyRemoteAddr(const std::string& addr) {
-  if (base::EndsWith(addr, ".sock") || IsAbsolutePath(addr))
+  if (base::EndsWith(addr, ".sock") || base::IsAbsolutePath(addr))
     return RemoteAddrKind::kUnixPath;
   if (addr.find("://") != std::string::npos || HasTrailingPort(addr))
     return RemoteAddrKind::kHttp;

--- a/src/trace_processor/sqlite/file_system_vfs_unittest.cc
+++ b/src/trace_processor/sqlite/file_system_vfs_unittest.cc
@@ -63,9 +63,10 @@ TEST(SqliteFileSystemVfsTest, CreatesReadableDatabase) {
   ASSERT_GE(contents.size(), 16u);
   EXPECT_EQ(contents.substr(0, 16), std::string("SQLite format 3\0", 16));
 
+  ASSERT_OK_AND_ASSIGN(vfs, SqliteFileSystemVfs::Create(file_system));
   raw_db = nullptr;
   ASSERT_EQ(
-      sqlite3_open_v2(path.c_str(), &raw_db, SQLITE_OPEN_READONLY, nullptr),
+      sqlite3_open_v2(path.c_str(), &raw_db, SQLITE_OPEN_READONLY, vfs->name()),
       SQLITE_OK);
   db.reset(raw_db);
   sqlite3_stmt* raw_stmt = nullptr;

--- a/src/trace_processor/util/symbolizer/local_symbolizer.cc
+++ b/src/trace_processor/util/symbolizer/local_symbolizer.cc
@@ -38,7 +38,6 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/scoped_file.h"
-#include "perfetto/ext/base/string_splitter.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/utils.h"
 #include "src/trace_processor/util/symbolizer/elf.h"
@@ -709,16 +708,20 @@ std::optional<FoundBinary> FindBinaryInRoot(
     std::vector<BinaryPathAttempt>& attempts) {
   constexpr char kApkPrefix[] = "base.apk!";
 
-  std::string filename;
-  std::string dirname;
+  std::optional<FoundBinary> result;
+  // Try a path relative to the symbol root and record the attempt.
+  auto try_path_in_root = [&](const std::string& rel_path) {
+    return TryPath(root_str + "/" + rel_path, build_id, result, attempts);
+  };
 
-  for (base::StringSplitter sp(abspath, '/'); sp.Next();) {
-    if (!dirname.empty()) {
-      dirname += "/";
-    }
-    dirname += filename;
-    filename = sp.cur_token();
-  }
+  // Strip the leading root (e.g. "/" or "C:\") before searching for the
+  // mapping under `root_str`. Treat both '/' and '\' as path separators.
+  std::string_view rel = abspath;
+  rel.remove_prefix(base::PathRootPrefixLength(abspath));
+  size_t last_sep = rel.find_last_of("/\\");
+  size_t file_pos = last_sep == std::string_view::npos ? 0 : last_sep + 1;
+
+  std::string filename(rel.substr(file_pos));
 
   // Return the first match for the following options:
   // * absolute path of library file relative to root.
@@ -740,42 +743,35 @@ std::optional<FoundBinary> FindBinaryInRoot(
   // * $ROOT/foo.so
   // * $ROOT/.build-id/ab/cd1234.debug
 
-  std::optional<FoundBinary> result;
-  std::string symbol_file;
+  // Directory of the mapping relative to the root, including the trailing '/'
+  // (empty if the mapping has no directory component). Native separators are
+  // normalized to '/', which is accepted on all platforms.
+  std::string dir(rel.substr(0, file_pos));
+  std::replace(dir.begin(), dir.end(), '\\', '/');
 
-  symbol_file = root_str + "/" + dirname + "/" + filename;
-  if (TryPath(symbol_file, build_id, result, attempts)) {
+  bool has_apk_prefix = base::StartsWith(filename, kApkPrefix);
+  std::string filename_without_apk_prefix =
+      has_apk_prefix ? filename.substr(sizeof(kApkPrefix) - 1) : std::string();
+
+  if (!dir.empty() && try_path_in_root(dir + filename)) {
     return result;
   }
-
-  if (base::StartsWith(filename, kApkPrefix)) {
-    symbol_file = root_str + "/" + dirname + "/" +
-                  filename.substr(sizeof(kApkPrefix) - 1);
-    if (TryPath(symbol_file, build_id, result, attempts)) {
-      return result;
-    }
-  }
-
-  symbol_file = root_str + "/" + filename;
-  if (TryPath(symbol_file, build_id, result, attempts)) {
+  if (!dir.empty() && has_apk_prefix &&
+      try_path_in_root(dir + filename_without_apk_prefix)) {
     return result;
   }
-
-  if (base::StartsWith(filename, kApkPrefix)) {
-    symbol_file = root_str + "/" + filename.substr(sizeof(kApkPrefix) - 1);
-    if (TryPath(symbol_file, build_id, result, attempts)) {
-      return result;
-    }
+  if (try_path_in_root(filename)) {
+    return result;
+  }
+  if (has_apk_prefix && try_path_in_root(filename_without_apk_prefix)) {
+    return result;
   }
 
   std::string hex_build_id = base::ToHex(build_id.c_str(), build_id.size());
-  std::string split_hex_build_id = SplitBuildID(hex_build_id);
-  if (!split_hex_build_id.empty()) {
-    symbol_file =
-        root_str + "/" + ".build-id" + "/" + split_hex_build_id + ".debug";
-    if (TryPath(symbol_file, build_id, result, attempts)) {
-      return result;
-    }
+  if (std::string build_id_path = SplitBuildID(hex_build_id);
+      !build_id_path.empty() &&
+      try_path_in_root(".build-id/" + build_id_path + ".debug")) {
+    return result;
   }
 
   return std::nullopt;
@@ -941,7 +937,7 @@ BinaryLookupResult LocalBinaryFinder::FindBinary(const std::string& abspath,
   BinaryLookupResult& result = p.first->second;
 
   // Try the absolute path first.
-  if (base::StartsWith(abspath, "/")) {
+  if (base::IsAbsolutePath(abspath)) {
     if (TryPath(abspath, build_id, result.binary, result.attempts)) {
       return result;
     }

--- a/src/trace_processor/util/symbolizer/local_symbolizer_unittest.cc
+++ b/src/trace_processor/util/symbolizer/local_symbolizer_unittest.cc
@@ -240,7 +240,11 @@ TEST(LocalBinaryIndexerTest, BuildIdFromNoteSegment) {
 
   BinaryLookupResult result = indexer.FindBinary("", "AAAAAAAAAAAAAAAAAAAA");
   ASSERT_TRUE(result.ok());
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  EXPECT_EQ(result.binary->file_name, tmp.path() + "/root\\elf1");
+#else
   EXPECT_EQ(result.binary->file_name, tmp.path() + "/root/elf1");
+#endif
 }
 
 TEST(LocalBinaryIndexerTest, MachOBuildIdFromLoadCommands) {
@@ -253,7 +257,11 @@ TEST(LocalBinaryIndexerTest, MachOBuildIdFromLoadCommands) {
 
   BinaryLookupResult result = indexer.FindBinary("", build_id);
   ASSERT_TRUE(result.ok());
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  EXPECT_EQ(result.binary->file_name, tmp.path() + "/root\\macho");
+#else
   EXPECT_EQ(result.binary->file_name, tmp.path() + "/root/macho");
+#endif
   EXPECT_EQ(result.binary->load_info.p_vaddr, 0x1234u);
 }
 


### PR DESCRIPTION
This PR backports the following Windows fixes and cuts v58.2:

https://github.com/google/perfetto/pull/7023: add the Windows GetFileSize(int) overload
https://github.com/google/perfetto/pull/7028: fix Windows/Fuchsia unit-test failures and reject invalid CRT file descriptors
https://github.com/google/perfetto/pull/7037: fix Windows path handling in the local symbolizer
https://github.com/google/perfetto/pull/7177: bump the changelog to v58.2
https://github.com/google/perfetto/pull/7178: fix Windows subprocess format signedness