### PR TITLE
perfetto: bump CHANGELOG to v58.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,10 @@ Unreleased:
   SDK:
    *
 
+v58.2 - 2026-08-21:
+  Misc:
+    * Fixed additional Windows build and test failures.
+
 v58.1 - 2026-08-21:
   Misc:
     * Fixed builds on Windows.


### PR DESCRIPTION
Cut v58.2 for the additional Windows build, test, and path-handling fixes being promoted to canary and stable.

Tests were not run; changelog-only change.