### PR TITLE
base: fix Windows subprocess format signedness

### DIFF
--- a/src/base/subprocess_windows.cc
+++ b/src/base/subprocess_windows.cc
@@ -201,7 +201,7 @@ void Subprocess::StdoutErrThread(MovableState* s) {
     if (!res) {
       auto err = GetLastError();
       if (err != ERROR_BROKEN_PIPE)
-        PERFETTO_PLOG("Subprocess ReadFile(stdouterr) failed %ld", err);
+        PERFETTO_PLOG("Subprocess ReadFile(stdouterr) failed %lx", err);
     }
 
     if (rsize > 0) {


### PR DESCRIPTION
`GetLastError()` returns a `DWORD` (`unsigned long`), but the subprocess read failure path formatted it with `%ld`. The new clang-cl uprev diagnoses that signedness mismatch under `-Werror`.

Use `%lx`, matching the other Windows error-code logging in this file.

The reported Windows build failure was not rerun locally because the Windows toolchain is unavailable on this macOS checkout.