### PR TITLE
tp: record responsible thread on process-scoped counters

### DIFF
--- a/src/trace_processor/importers/common/event_tracker.cc
+++ b/src/trace_processor/importers/common/event_tracker.cc
@@ -30,7 +30,8 @@
 namespace perfetto::trace_processor {
 
 EventTracker::EventTracker(TraceProcessorContext* context)
-    : context_(context) {}
+    : context_(context),
+      thread_arg_key_(context->storage->InternString("utid")) {}
 
 EventTracker::~EventTracker() = default;
 
@@ -39,7 +40,11 @@ void EventTracker::PushProcessCounterForThread(ProcessCounterForThread pcounter,
                                                double value,
                                                UniqueTid utid) {
   const auto& counter = context_->storage->counter_table();
-  auto opt_id = PushCounter(timestamp, value, kInvalidTrackId);
+  auto opt_id = PushCounter(timestamp, value, kInvalidTrackId,
+                            [this, utid](ArgsTracker::BoundInserter* inserter) {
+                              inserter->AddArg(thread_arg_key_,
+                                               Variadic::UnsignedInteger(utid));
+                            });
   if (opt_id) {
     PendingUpidResolutionCounter pending;
     pending.row = counter[*opt_id].ToRowNumber().row_number();

--- a/src/trace_processor/importers/common/event_tracker.h
+++ b/src/trace_processor/importers/common/event_tracker.h
@@ -96,6 +96,10 @@ class EventTracker {
   std::vector<PendingUpidResolutionCounter> pending_upid_resolution_counter_;
 
   TraceProcessorContext* const context_;
+
+  // "utid" arg recording the thread responsible for a process-scoped counter
+  // change (e.g. rss_stat), which otherwise only survives as the upid.
+  const StringId thread_arg_key_;
 };
 }  // namespace perfetto::trace_processor
 

--- a/test/trace_processor/diff_tests/tables/tests.py
+++ b/test/trace_processor/diff_tests/tables/tests.py
@@ -729,7 +729,7 @@ class Tables(TestSuite):
         """,
         out=Csv("""
         "utid_count","end_utid_count"
-        89,0
+        336,0
         """))
 
   def test_machine(self):


### PR DESCRIPTION
Counters delivered in thread context but attributed to a process (rss_stat, oom_score_adj, mm_event, ...) go through PushProcessCounterForThread, which resolves the emitting utid to a upid and drops the thread. The thread is often the signal you want ("which thread grew the process's anon RSS"), so record it as a "utid" arg on each counter sample.

The counter stays process-scoped; the responsible thread now survives in counter.arg_set_id, is queryable via EXTRACT_ARG, and shows in the UI details panel with no UI change -- mirroring the utid/end_utid args already attached to async slices in systrace_parser.
