### PR TITLE
Add stack_sampling_debug_ids to ETW config

### DIFF
--- a/protos/perfetto/config/etw/etw_config.proto
+++ b/protos/perfetto/config/etw/etw_config.proto
@@ -50,4 +50,15 @@ message EtwConfig {
   // Provides events relating to multiple kinds of IO including disk, cache, and
   // network.
   repeated string system_io_provider_events = 7;
+
+  // A debug ID that uniquely identifies an image (i.e., executable) for
+  // symbolization when stack sampling.
+  message DebugId {
+    // The full path to the image file.
+    optional string path = 1;
+    // The unique identifier for the image file.
+    optional string debug_id = 2;
+  }
+  // Debug IDs for images whose stack samples should be symbolized.
+  repeated DebugId stack_sampling_debug_ids = 8;
 }


### PR DESCRIPTION
This change adds `stack_sampling_debug_ids` to Perfetto's ETW config. This will enable the consumer to pass information needed for symbolization (specifically, file paths and debug IDs) to the producer, to be added to the trace.

Please see the companion Chromium change for an example of its use: [etw-stackwalk: send debug GUIDs from browser](https://chromium-review.git.corp.google.com/c/chromium/src/+/7793565)