### PR TITLE
tp: allow scalar <-> enum extension transitions in DescriptorPool

### DIFF
--- a/src/trace_processor/util/descriptors.cc
+++ b/src/trace_processor/util/descriptors.cc
@@ -114,10 +114,13 @@ base::Status CheckExtensionField(
                            field.name().c_str());
   }
 
-  const bool is_msg_or_enum =
-      field.type() == FieldDescriptorProto::TYPE_MESSAGE ||
-      field.type() == FieldDescriptorProto::TYPE_ENUM;
-  if (is_msg_or_enum &&
+  const bool both_messages =
+      field.type() == FieldDescriptorProto::TYPE_MESSAGE &&
+      existing_field->type() == FieldDescriptorProto::TYPE_MESSAGE;
+  const bool both_enums =
+      field.type() == FieldDescriptorProto::TYPE_ENUM &&
+      existing_field->type() == FieldDescriptorProto::TYPE_ENUM;
+  if ((both_messages || both_enums) &&
       field.raw_type_name() != existing_field->raw_type_name()) {
     // Same tag, same fundamental type, but the message/enum is named
     // differently (e.g. a package rename during an out-of-tree migration).
@@ -493,6 +496,9 @@ base::Status DescriptorPool::AddFromFileDescriptorSet(
   // Fourth pass: verify deferred type checks are structurally compatible
   // now that all field types have been resolved.
   for (const auto& check : extension_type_checks) {
+    if (check.existing_raw_type.empty() || check.new_raw_type.empty()) {
+      continue;
+    }
     std::optional<uint32_t> opt_existing_idx =
         ResolveShortType(check.extendee_full_name, check.existing_raw_type);
     std::optional<uint32_t> opt_new_idx =

--- a/src/trace_processor/util/descriptors_unittest.cc
+++ b/src/trace_processor/util/descriptors_unittest.cc
@@ -820,5 +820,112 @@ TEST(DescriptorsTest, FlagSetToViews) {
   EXPECT_THAT(out, testing::IsEmpty());
 }
 
+// Re-declaring a scalar int32 extension as an enum (same wire type kVarInt)
+// must be accepted without triggering an assertion failure or structural check
+// crash.
+TEST(DescriptorsTest, ScalarToEnumExtensionReDeclarationAllowed) {
+  // Pass 1: Base descriptor where ext_field (tag 10) is TYPE_INT32
+  protozero::HeapBuffered<FileDescriptorSet> fds1;
+  auto* file1 = fds1->add_file();
+  file1->set_name("base.proto");
+  file1->set_package("test");
+
+  auto* base_msg = file1->add_message_type();
+  base_msg->set_name("BaseMessage");
+
+  auto* ext1 = file1->add_extension();
+  ext1->set_name("ext_field");
+  ext1->set_number(10);
+  ext1->set_label(FieldDescriptorProto::LABEL_OPTIONAL);
+  ext1->set_type(FieldDescriptorProto::TYPE_INT32);
+  ext1->set_extendee(".test.BaseMessage");
+
+  DescriptorPool pool;
+  std::vector<uint8_t> fds1_bytes = fds1.SerializeAsArray();
+  ASSERT_TRUE(
+      pool.AddFromFileDescriptorSet(fds1_bytes.data(), fds1_bytes.size()).ok());
+
+  // Pass 2: Incoming descriptor where ext_field (tag 10) is re-declared as
+  // TYPE_ENUM
+  protozero::HeapBuffered<FileDescriptorSet> fds2;
+  auto* file2 = fds2->add_file();
+  file2->set_name("extension.proto");
+  file2->set_package("test");
+
+  auto* enum_type = file2->add_enum_type();
+  enum_type->set_name("MyEnum");
+  auto* val0 = enum_type->add_value();
+  val0->set_name("VAL_0");
+  val0->set_number(0);
+
+  auto* ext2 = file2->add_extension();
+  ext2->set_name("ext_field");
+  ext2->set_number(10);
+  ext2->set_label(FieldDescriptorProto::LABEL_OPTIONAL);
+  ext2->set_type(FieldDescriptorProto::TYPE_ENUM);
+  ext2->set_type_name(".test.MyEnum");
+  ext2->set_extendee(".test.BaseMessage");
+
+  std::vector<uint8_t> fds2_bytes = fds2.SerializeAsArray();
+  auto status = pool.AddFromFileDescriptorSet(
+      fds2_bytes.data(), fds2_bytes.size(), /*skip_prefixes=*/{},
+      /*merge_existing_messages=*/true);
+
+  EXPECT_TRUE(status.ok()) << status.message();
+  auto base_idx = pool.FindDescriptorIdx(".test.BaseMessage");
+  ASSERT_TRUE(base_idx.has_value());
+  EXPECT_NE(pool.descriptors()[base_idx.value()].FindFieldByTag(10), nullptr);
+}
+
+// Re-declaring an enum extension as a scalar int32 (same wire type kVarInt)
+// must also be accepted.
+TEST(DescriptorsTest, EnumToScalarExtensionReDeclarationAllowed) {
+  protozero::HeapBuffered<FileDescriptorSet> fds1;
+  auto* file1 = fds1->add_file();
+  file1->set_name("base.proto");
+  file1->set_package("test");
+
+  auto* base_msg = file1->add_message_type();
+  base_msg->set_name("BaseMessage");
+
+  auto* enum_type = file1->add_enum_type();
+  enum_type->set_name("MyEnum");
+  auto* val0 = enum_type->add_value();
+  val0->set_name("VAL_0");
+  val0->set_number(0);
+
+  auto* ext1 = file1->add_extension();
+  ext1->set_name("ext_field");
+  ext1->set_number(10);
+  ext1->set_label(FieldDescriptorProto::LABEL_OPTIONAL);
+  ext1->set_type(FieldDescriptorProto::TYPE_ENUM);
+  ext1->set_type_name(".test.MyEnum");
+  ext1->set_extendee(".test.BaseMessage");
+
+  DescriptorPool pool;
+  std::vector<uint8_t> fds1_bytes = fds1.SerializeAsArray();
+  ASSERT_TRUE(
+      pool.AddFromFileDescriptorSet(fds1_bytes.data(), fds1_bytes.size()).ok());
+
+  protozero::HeapBuffered<FileDescriptorSet> fds2;
+  auto* file2 = fds2->add_file();
+  file2->set_name("extension.proto");
+  file2->set_package("test");
+
+  auto* ext2 = file2->add_extension();
+  ext2->set_name("ext_field");
+  ext2->set_number(10);
+  ext2->set_label(FieldDescriptorProto::LABEL_OPTIONAL);
+  ext2->set_type(FieldDescriptorProto::TYPE_INT32);
+  ext2->set_extendee(".test.BaseMessage");
+
+  std::vector<uint8_t> fds2_bytes = fds2.SerializeAsArray();
+  auto status = pool.AddFromFileDescriptorSet(
+      fds2_bytes.data(), fds2_bytes.size(), /*skip_prefixes=*/{},
+      /*merge_existing_messages=*/true);
+
+  EXPECT_TRUE(status.ok()) << status.message();
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor


### PR DESCRIPTION
When merging an incoming FileDescriptorSet (such as on-device ExtensionDescriptor packets emitted during trace recording), an extension field may transition between a scalar integer (e.g. int32) and an enum. Both share the same protobuf wire type (kVarInt) and decode identically.

However, CheckExtensionField previously checked if the incoming field was a message or enum (is_msg_or_enum), but neglected to verify whether the existing field was also a message or enum. As a result, when an int32 extension field (with an empty raw_type_name) was re-declared as an enum, it queued a deferred structural check with an empty existing_raw_type. In the fourth pass, this triggered an assertion abort in ResolveShortType:
PERFETTO_CHECK(!short_type.empty()).

Fix this by ensuring deferred structural compatibility checks are only enqueued when both fields are messages or both fields are enums. Also defensively guard the fourth pass in AddFromFileDescriptorSet against empty type names.

Bug: 494586279
Test: perfetto_unittests --gtest_filter="DescriptorsTest.*"
