### PR TITLE
ui: Handle null navigator.keyboard

### DIFF
--- a/ui/src/base/keyboard_layout_map.ts
+++ b/ui/src/base/keyboard_layout_map.ts
@@ -18,7 +18,13 @@ export interface KeyboardLayoutMap {
 }
 
 interface Keyboard {
-  getLayoutMap(): KeyboardLayoutMap;
+  getLayoutMap(): Promise<KeyboardLayoutMap>;
+}
+
+declare global {
+  interface Navigator {
+    readonly keyboard?: Keyboard | null;
+  }
 }
 
 export class NotSupportedError extends Error {}
@@ -27,16 +33,12 @@ export class NotSupportedError extends Error {}
 // This function is merely a wrapper around the keyboard API, which throws a
 // specific error when used in browsers that don't support it.
 export async function nativeKeyboardLayoutMap(): Promise<KeyboardLayoutMap> {
-  // Browser's that don't support the Keyboard API won't have a keyboard
-  // property in their window.navigator object.
-  // Note: it seems this is also what Chrome does when the website is accessed
-  // through an insecure connection.
-  if ('keyboard' in window.navigator) {
-    // Typescript's dom library doesn't know about this feature, so we must
-    // take some liberties when it comes to relaxing types
-    const keyboard = window.navigator.keyboard as Keyboard;
-    return await keyboard.getLayoutMap();
-  } else {
+  // Browsers that don't support the Keyboard API either omit the keyboard
+  // property from navigator or expose it with a null value. The latter can
+  // also happen when the page does not meet the API's security requirements.
+  const keyboard = window.navigator.keyboard;
+  if (!keyboard) {
     throw new NotSupportedError('Keyboard API is not supported');
   }
+  return keyboard.getLayoutMap();
 }


### PR DESCRIPTION
## Problem
<img width="898" height="636" alt="Screenshot 2026-08-23 at 23 05 46" src="https://github.com/user-attachments/assets/cff9851d-82f4-40c4-9cde-d39f2e3964af" />

In some browsers, the `keyboard` property exists on `navigator` but its value is `null`.

The existing property-presence check succeeds and then calls `getLayoutMap()` on `null`, crashing the Perfetto home page:

> TypeError: Cannot read properties of null (reading 'getLayoutMap')

Observed with Perfetto UI v58.2 on Chrome 150 on macOS.

## Fix

Declare `navigator.keyboard` as nullable and check its value before calling `getLayoutMap()`.

Unsupported environments now throw the existing `NotSupportedError`, allowing the UI to use its fallback keyboard layout.

I solved it with declare global because I saw they've been used in other parts, could be fixed with cast but ugly, or runtime guard which's verbose..

Additionally getLayoutMap() genuinely returns a Promise<KeyboardLayoutMap> according to the [Keyboard Map specification](https://wicg.github.io/keyboard-map/#keyboard-interface), this is the reason I changed it.