### PR TITLE
ui: Fix Day Explorer flamegraph root selection for selected tracks

### DIFF
--- a/ui/src/plugins/com.android.DayExplorer/index.ts
+++ b/ui/src/plugins/com.android.DayExplorer/index.ts
@@ -212,31 +212,17 @@ export default class DayExplorerPlugin implements PerfettoPlugin {
             ),
             descendants(track_id) AS (
               SELECT track_id FROM selected_roots
-              UNION ALL
+              UNION
               SELECT child.track_id
               FROM day_explorer_ui_hierarchy child
               JOIN descendants parent ON child.parent_id = parent.track_id
-            ),
-            ancestors(track_id, parent_id) AS (
-              SELECT track_id, parent_id 
-              FROM day_explorer_ui_hierarchy 
-              WHERE track_id IN (SELECT track_id FROM selected_roots)
-              UNION ALL
-              SELECT parent.track_id, parent.parent_id
-              FROM day_explorer_ui_hierarchy parent
-              JOIN ancestors child ON child.parent_id = parent.track_id
-            ),
-            all_nodes(track_id) AS (
-              SELECT track_id FROM descendants
-              UNION
-              SELECT track_id FROM ancestors
             ),
             total_energy AS (
               SELECT track_id, parent_id, display_name, SUM(energy_uws) AS energy_uws
               FROM day_explorer_ui_hierarchy_per_ts
               WHERE ts >= ${currentSelection.start}
                 AND ts <= ${currentSelection.end}
-                AND track_id IN (SELECT track_id FROM all_nodes)
+                AND track_id IN (SELECT track_id FROM descendants)
               GROUP BY 1, 2, 3
             ),
             with_child AS (


### PR DESCRIPTION
Previously, computeDayExplorerFlameGraph traversed recursively upwards through ancestors to top-level roots (`on`, `off`, `[Label] ...`). This caused top-level table roots to always render at Depth 1 in the flamegraph, nesting the user's selected track deep within the hierarchy.

This patch removes the `ancestors` and `all_nodes` CTEs and restricts the recursive hierarchy query to `descendants` only. As a result, the selected tracks correctly become the Depth 1 roots of the flamegraph with their subtrees nested underneath. Also changes the descendants recursive step from UNION ALL to UNION to prevent duplicate nodes on overlapping selections.

Bug: 482033855
