### PR TITLE
perfetto: sharpen SQL and heap dump guidance in AI skills

### DIFF
--- a/ai/skills/perfetto/infra-references/querying.md
+++ b/ai/skills/perfetto/infra-references/querying.md
@@ -224,35 +224,51 @@ reference linked above.
 - **Alias Precision.** Always prefix column names with table or view alias,
   that is: `{alias}.{column_name}`.
 
+- **Avoid Custom SQL Functions (Performance):** Avoid creating custom
+  functions via `CREATE PERFETTO FUNCTION` for large datasets or per-row
+  computations, as scalar/table function calls in SQLite/Perfetto incur
+  substantial per-row execution overhead. Instead, prefer direct SQL queries,
+  inline expressions, CTEs, or precomputed stdlib views/tables.
+
 ## Common Analysis Patterns
 
-- **Calculating Time Overlaps & CPU Time:**
-  1.  **Primary Method (MANDATORY):** Always search the standard library first
-    before writing custom interval logic. For example, to find the exact CPU
-    execution time of a slice, do not calculate it manually; instead, search
-    the docs and use the `slices.cpu_time` module.
-  2.  **Fallback Method (Use ONLY if you have verified no stdlib module or
-    `SPAN_JOIN` applies):** If you must calculate custom overlap durations
-    between two different sets of time intervals `[start1, end1]` and
-    `[start2, end2]`:
-  - **Condition:** The intervals overlap if `start1 < end2` and `start2
-      < end1`.
-  - **Duration:** The overlap duration is calculated as `MIN(end1, end2)
-    - MAX(start1, start2)`.
-  - **Important:** Incomplete Perfetto slices have a duration of -1
-    (`dur = -1`). Always calculate the effective end time using `ts +
-      IIF(dur = -1, trace_end() - ts, dur)` before applying this logic.
+- **Time Overlaps & Intersections (SPAN_JOIN):**
+  - **Concept:** `SPAN_JOIN` is a custom operator table that computes the time-interval
+    intersection of spans from two tables or views. A "span" is any row with `ts`
+    (timestamp) and `dur` (duration) columns. The output virtual table contains the
+    intersected `ts` and `dur` representing the exact overlapping time window, along with
+    all columns from both input tables.
+  - **Partitioning:** An optional partition column can be specified on neither, either,
+    or both tables (`PARTITIONED col`). If specified on both, the column name must match.
+    Partition columns **must be integers** (e.g. `cpu`, `upid`, `utid`, `track_id`).
+    String columns are *not* supported directly; convert to integers with `HASH(str_col)`
+    if necessary.
+  - **No Internal Overlaps:** Spans within the same input table and partition **must not
+    overlap**. `SPAN_JOIN` assumes non-overlapping slices per partition; if internal
+    intervals overlap, incorrect rows will silently be produced. Ensure input tables are
+    cleanly partitioned and materialized via `CREATE PERFETTO TABLE`.
+  - **Syntax & Idempotency:** Because `SPAN_JOIN` creates an SQLite virtual table,
+    `CREATE OR REPLACE` is not supported. Always drop first:
+    ```sql
+    DROP TABLE IF EXISTS sched_with_frequency;
+    CREATE VIRTUAL TABLE sched_with_frequency
+    USING SPAN_JOIN(sp_sched PARTITIONED cpu, sp_frequency PARTITIONED cpu);
+    ```
+  - **Variants:** `SPAN_LEFT_JOIN` (left outer interval intersection) and `SPAN_OUTER_JOIN`
+    (full outer interval intersection) are also available.
+  - **Fallback (When `SPAN_JOIN` is not applicable):** If computing custom overlap durations
+    between two interval sets `[start1, end1]` and `[start2, end2]` manually:
+    - **Condition:** Overlap if `start1 < end2 AND start2 < end1`.
+    - **Duration:** `MIN(end1, end2) - MAX(start1, start2)`.
+    - **Incomplete Slices:** Handle `dur = -1` via `ts + IIF(dur = -1, trace_end() - ts, dur)`.
 - **Window Size:** When looking for events around a specific timestamp, start
   with 100ms as the window size.
 - **Total Duration:** To calculate the total time spent in slices matching a
-  specific name pattern (for example, `*{name_pattern}*`), you must sum their
-  durations. **Why it's useful**: This helps quantify the total impact of a
-  specific function or feature on performance across multiple calls. Here is
-  an example query (note the safe handling of incomplete slices):
+  specific name pattern (for example, `*{name_pattern}*`), sum their durations:
   ```sql
   SELECT
-  count(*) as total_count,
-  sum(IIF(slice.dur = -1, trace_end() - slice.ts, slice.dur)) / 1000000.0 as total_dur_ms
+    count(*) as total_count,
+    sum(IIF(slice.dur = -1, trace_end() - slice.ts, slice.dur)) / 1000000.0 as total_dur_ms
   FROM slice
   WHERE slice.name GLOB '*{name_pattern}*';
   ```
@@ -260,6 +276,33 @@ reference linked above.
   - Classify CPU core clusters (big, mid, little) with `INCLUDE PERFETTO MODULE android.cpu.cluster_type;` (`android_cpu_cluster_mapping`) and calculate time-weighted frequency via `INCLUDE PERFETTO MODULE linux.cpu.frequency;`.
 - **Binder Transaction Analysis:**
   - Query cross-process Binder calls using stdlib views like `android_binder_txns` or `android_binder_metrics_by_process` (`INCLUDE PERFETTO MODULE android.binder;`), grouping by process names (`client_process`, `server_process`, `process_name`).
+- **Low Memory Killer (LMK) & Process Memory Analysis:**
+  - Identify killed processes and timestamps with `INCLUDE PERFETTO MODULE android.memory.lmk;` (`android_lmk_events`).
+  - Query process RSS and swap changes over time with `INCLUDE PERFETTO MODULE linux.memory.process;` (`memory_rss_and_swap_per_process`).
+- **Wakeup Chain & Thread Scheduling Analysis:**
+  - To trace which threads woke each other up leading into a slice execution, locate the slice via `slices.with_context` (`thread_slice`), correlate with `thread_state` where `state = 'R'` (Runnable state preceding execution), and recursively traverse `waker_utid`, joining out to `thread.name`:
+    ```sql
+    INCLUDE PERFETTO MODULE slices.with_context;
+
+    WITH RECURSIVE wakeup_chain(depth, utid, waker_utid, ts) AS (
+      -- Base: find the runnable state preceding the target slice
+      SELECT 0 AS depth, s.utid, ts.waker_utid, ts.ts
+      FROM thread_slice s
+      JOIN thread_state ts ON s.utid = ts.utid AND ts.state = 'R'
+        AND ts.ts + ts.dur = s.ts
+      WHERE s.is_main_thread = 1 AND s.name GLOB '*Choreographer*'
+      UNION ALL
+      -- Recurse: find the runnable state of the waker thread
+      SELECT c.depth + 1, c.waker_utid, prev.waker_utid, prev.ts
+      FROM wakeup_chain c
+      JOIN thread_state prev ON c.waker_utid = prev.utid AND prev.state = 'R'
+        AND prev.ts + prev.dur = c.ts
+      WHERE c.depth < 3 AND c.waker_utid IS NOT NULL
+    )
+    SELECT c.depth, t.name AS thread_name
+    FROM wakeup_chain c
+    JOIN thread t ON c.utid = t.utid;
+    ```
 
 ## Analytical Workflow (Standard Operating Procedure)
 

--- a/ai/skills/perfetto/workflows/android_memory/heap_dump.md
+++ b/ai/skills/perfetto/workflows/android_memory/heap_dump.md
@@ -210,23 +210,22 @@ Dive), a high-quality summary for the user MUST contain:
 1.  **Orienting Context:** The process name and timestamp of the heap dump.
 2.  **Primary Leak Signatures:** The top retaining class chains by
     cumulative/dominated memory size.
-3.  **Code-Grounded Hypothesis & Philosophical Advice:**
-    - You MUST search the workspace codebase for the application source code
-      matching the process name or leaky class names to understand the
-      architectural intent and lifecycle of the suspected classes.
-    - Use that source code to assist in generating a grounded hypothesis for the
-      leak. If you cannot find the source code, explicitly inform the user that
-      the source code cannot be found, so the exact leak mechanism cannot be
-      definitively verified.
+3.  **Code-Grounded Hypothesis & Architectural Recommendations:**
+    - Search the workspace codebase for the application source code matching the
+      process name or leaky class names to understand the lifecycle and ownership
+      of suspected classes.
+    - Formulate a grounded hypothesis for the leak based on source code and heap
+      references. If source code is not available, state findings based on the
+      heap dump data.
     - If `class_name` is a primitive array like `byte[]` and the path begins
-      with `[ROOT_JNI_GLOBAL]`, advise the user they likely have a JNI global
-      reference leak.
-    - Provide expert philosophical advice on the architectural approach to take
-      (e.g., decoupling static singletons, adopting weak references, or clearing
-      listeners in `onDestroy`).
-4.  **Actionable Implementation Plan:** Reference specific locations in the
-    codebase (filenames and line numbers) showing the leak and create a concrete
-    implementation plan for fixing it.
+      with `[ROOT_JNI_GLOBAL]`, advise the user of a likely JNI global reference
+      leak.
+    - Provide concrete architectural recommendations (e.g., clearing listeners
+      in `onDestroy`, avoiding static references to Activities/Contexts, or using
+      `WeakReference`).
+4.  **Actionable Implementation Plan:** Reference specific code locations
+    (filenames and line numbers) where possible and provide a concrete plan for
+    fixing or mitigating the leak.
 
 Always keep the underlying SQL and object IDs available so the user can audit.
 Do not make claims about what the code is doing without inspecting the

--- a/ai/skills/perfetto/workflows/android_memory/heap_dump_cluster.md
+++ b/ai/skills/perfetto/workflows/android_memory/heap_dump_cluster.md
@@ -55,9 +55,9 @@ distinct.
 ## Step 2 — Execute the Clustering Script
 
 Invoke the provided standalone Python clustering script
-(`$SKILL_ROOT/workflows/android_memory/scripts/cluster_paths.py`) on the CSV data. The script performs TF-IDF
-vectorization, computes Silhouette scores to find the optimal $K$, and assigns
-cluster IDs.
+(`$SKILL_ROOT/workflows/android_memory/scripts/cluster_paths.py`) on the CSV data.
+Do not write custom clustering algorithms from scratch — this script already implements
+the TF-IDF vectorization, Silhouette score calculation for optimal $K$, and K-Means clustering.
 
 ```bash
 python3 $SKILL_ROOT/workflows/android_memory/scripts/cluster_paths.py --process_name <process_name> --input_file <path_to_input.csv> --output_file <path_to_clustered_output.csv>


### PR DESCRIPTION
The querying reference told agents to reach for the stdlib first but never explained SPAN_JOIN itself, so agents kept hand-rolling interval arithmetic and hitting the operator's unwritten rules: integer-only partition columns, no overlapping spans within a partition, and no CREATE OR REPLACE for virtual tables. Documenting those up front, along with the per-row cost of custom PerfettoSQL functions, removes the most common sources of silently wrong or needlessly slow queries.

Add recipes for the two investigations that come up repeatedly and have no obvious entry point in the stdlib: LMK plus process memory, and walking a wakeup chain back through waker_utid.

On the heap dump side, the report template asked for "philosophical advice" and made source lookup mandatory, which pushed agents into vague prose or a dead end when the source isn't in the workspace. Ask for concrete architectural recommendations instead, and let the report stand on heap data alone when the code isn't there. The clustering workflow now says outright not to reimplement the script.