### PR TITLE
ui: Fix flicker when selecting between track events

### DIFF
--- a/ui/src/base/zoned_interaction_handler.ts
+++ b/ui/src/base/zoned_interaction_handler.ts
@@ -154,11 +154,13 @@ export class ZonedInteractionHandler implements Disposable {
   private zones: ReadonlyArray<Zone> = [];
   private currentGesture?: InProgressGesture;
   private shiftHeld = false;
+  private shouldClick = false;
 
   constructor(readonly target: HTMLElement) {
     this.bindEvent(this.target, 'mousedown', this.onMouseDown.bind(this));
     this.bindEvent(document, 'mousemove', this.onMouseMove.bind(this));
     this.bindEvent(document, 'mouseup', this.onMouseUp.bind(this));
+    this.bindEvent(document, 'click', this.onClick.bind(this));
     this.bindEvent(document, 'keydown', this.onKeyDown.bind(this));
     this.bindEvent(document, 'keyup', this.onKeyUp.bind(this));
     this.bindEvent(this.target, 'wheel', this.handleWheel.bind(this));
@@ -202,6 +204,9 @@ export class ZonedInteractionHandler implements Disposable {
   }
 
   private onMouseDown(e: MouseEvent) {
+    // Clear shouldClick flag in case onclick was cancelled
+    this.shouldClick = false;
+
     const mousePositionClient = new Vector2D({x: e.clientX, y: e.clientY});
     const mouse = mousePositionClient.sub(this.target.getBoundingClientRect());
     const zone = this.findZone(
@@ -273,13 +278,29 @@ export class ZonedInteractionHandler implements Disposable {
         } else {
           // Check we're still the zone the click was started in
           if (this.hitTestZone(zone, mouse)) {
-            this.handleClick(this.target, e);
+            // This is a click (rather than a drag) - set a flag so that the
+            // onClick callback can be called from the onclick dom event rather
+            // than here in the mouseup event.
+            this.shouldClick = true;
           }
         }
       }
 
       this.currentGesture = undefined;
       this.updateCursor();
+    }
+  }
+
+  private onClick(e: MouseEvent) {
+    // If the onMouseUp event left the shouldClick flag set then we should emit
+    // a click event here, as long as no other handler further up the bubble
+    // chain has called e.preventDefault() in the meantime.
+    if (this.shouldClick) {
+      this.shouldClick = false;
+
+      if (!e.defaultPrevented) {
+        this.handleClick(this.target, e);
+      }
     }
   }
 

--- a/ui/src/base/zoned_interaction_handler_unittest.ts
+++ b/ui/src/base/zoned_interaction_handler_unittest.ts
@@ -40,6 +40,10 @@ describe('ZonedInteractionHandler', () => {
     simulateMouseEvent('mousemove', x, y);
   }
 
+  function click(x: number, y: number) {
+    simulateMouseEvent('click', x, y);
+  }
+
   function simulateMouseEvent(kind: string, x: number, y: number) {
     div.dispatchEvent(
       new MouseEvent(kind, {
@@ -85,6 +89,7 @@ describe('ZonedInteractionHandler', () => {
     // Simulate a mouse click
     mousedown(50, 50);
     mouseup(50, 50);
+    click(50, 50);
 
     expect(handleMouseClick).toHaveBeenCalled();
 
@@ -93,6 +98,7 @@ describe('ZonedInteractionHandler', () => {
     // Simulate a mouse down then a mouseup outside the zone
     mousedown(50, 50);
     mouseup(80, 80);
+    click(80, 80);
 
     expect(handleMouseClick).not.toHaveBeenCalled();
   });
@@ -204,18 +210,21 @@ describe('ZonedInteractionHandler', () => {
     // Attempt click without holding the modifier key
     mousedown(50, 50);
     mouseup(50, 50);
+    click(50, 50);
     expect(handleMouseClick).not.toHaveBeenCalled();
 
     // Simulate holding down the shift key and clicking
     document.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true}));
     mousedown(50, 50);
     mouseup(50, 50);
+    click(50, 50);
     expect(handleMouseClick).toHaveBeenCalled();
 
     // Simulate releasing the shift key
     document.dispatchEvent(new KeyboardEvent('keyup', {shiftKey: false}));
     mousedown(50, 50);
     mouseup(50, 50);
+    click(50, 50);
     expect(handleMouseClick).toHaveBeenCalledTimes(1); // No additional call
   });
 
@@ -274,6 +283,7 @@ describe('ZonedInteractionHandler', () => {
     // inside the zone with the click event handler.
     mousedown(30, 30);
     mouseup(50, 50);
+    click(50, 50);
 
     expect(handleMouseClick).toHaveBeenCalled();
   });
@@ -292,6 +302,7 @@ describe('ZonedInteractionHandler', () => {
     // Simulate a mouse click where the cursor has moved outside of the zone.
     mousedown(50, 50);
     mouseup(80, 80);
+    click(80, 80);
 
     expect(handleMouseClick).not.toHaveBeenCalled();
   });

--- a/ui/src/widgets/track_shell.ts
+++ b/ui/src/widgets/track_shell.ts
@@ -407,14 +407,14 @@ export class TrackShell implements m.ClassComponent<TrackShellAttrs> {
             return;
           }
 
-          // Returns true if something was selected, so stop propagation.
+          // Returns true if something was selected, so prevent default.
           if (
             onTrackContentClick?.(
               currentTargetOffset(e),
               getTargetContainerSize(e),
             )
           ) {
-            e.stopPropagation();
+            e.preventDefault();
           }
         },
         ondblclick: (e: MouseEvent) => {
@@ -424,7 +424,7 @@ export class TrackShell implements m.ClassComponent<TrackShellAttrs> {
               getTargetContainerSize(e),
             )
           ) {
-            e.stopPropagation();
+            e.preventDefault();
           }
         },
       },


### PR DESCRIPTION
Clicking between different track events on the timeline would result in a brief flicker in the details panel.

Root cause: There's a bug in the interaction between ZonedInteractionHandler and the TrackShell component(s). Track event clicks are triggered from a DOM click event listener in the TrackShell, and backdrop clicks (to clear the selection) are handled in an underlying component controlled by a ZonedInteractionHandler, which handles drag events, among other things.

Clicks on the backdrop are derived from the mouseup events rather than click events. However this means that calling `e.stopPropagation()` in one of the TrackShells doesn't prevent the 'click' event on the backdrop. Thus, every time the user clicks an event, the selection is first cleared (backdrop click), then immediately set to the new event. This causes the details panel to show 'Empty selection' while the details of the new track event are loaded, rather than continuing to show the previously selected events details.

This fix defers the virtual click event from the ZonedInteractionHandler to the actual DOM click event so it can be blocked by the TrackShell properly. We also switch to `e.preventDefault()` in the track shell so that the underlying backdrop can continue to receive the click event which helps with state management, checking the `e.defaultPrevented` flag to check whether or not to do anything.