### PR TITLE
perfetto: renumber recovered_trace_info field ID to 138

### DIFF
--- a/include/perfetto/public/protos/trace/trace_packet.pzc.h
+++ b/include/perfetto/public/protos/trace/trace_packet.pzc.h
@@ -576,7 +576,7 @@ PERFETTO_PB_FIELD(perfetto_protos_TracePacket,
                   MSG,
                   perfetto_protos_RecoveredTraceInfo,
                   recovered_trace_info,
-                  136);
+                  138);
 PERFETTO_PB_FIELD(perfetto_protos_TracePacket,
                   MSG,
                   perfetto_protos_TestEvent,

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -18271,7 +18271,7 @@ message UiState {
 // See the [Buffers and Dataflow](/docs/concepts/buffers.md) doc for details.
 //
 // Next reserved id: 14 (up to 15).
-// Next id: 137.
+// Next id: 139.
 message TracePacket {
   // Encapsulates the state and configuration of the ProtoVM instances running
   // when the trace was snapshotted. This allows TP to re-instantiate the VMs
@@ -18452,7 +18452,7 @@ message TracePacket {
 
     // Injected into TracePacket by perfetto post-reboot recovery to record
     // recovered trace metadata.
-    RecoveredTraceInfo recovered_trace_info = 136;
+    RecoveredTraceInfo recovered_trace_info = 138;
 
     // This field is only used for testing.
     // In previous versions of this proto this field had the id 268435455

--- a/protos/perfetto/trace/trace_packet.proto
+++ b/protos/perfetto/trace/trace_packet.proto
@@ -112,7 +112,7 @@ package perfetto.protos;
 // See the [Buffers and Dataflow](/docs/concepts/buffers.md) doc for details.
 //
 // Next reserved id: 14 (up to 15).
-// Next id: 137.
+// Next id: 139.
 message TracePacket {
   // Encapsulates the state and configuration of the ProtoVM instances running
   // when the trace was snapshotted. This allows TP to re-instantiate the VMs
@@ -293,7 +293,7 @@ message TracePacket {
 
     // Injected into TracePacket by perfetto post-reboot recovery to record
     // recovered trace metadata.
-    RecoveredTraceInfo recovered_trace_info = 136;
+    RecoveredTraceInfo recovered_trace_info = 138;
 
     // This field is only used for testing.
     // In previous versions of this proto this field had the id 268435455


### PR DESCRIPTION
Update RecoveredTraceInfo field ID in TracePacket from 136 to 138 and regenerate merged protos, C-SDK headers, and Python protobuf bindings.
