### PR TITLE
tp: trace SQL columns to dataframes

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -18885,6 +18885,22 @@ filegroup {
     name: "perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",
 }
 
+// GN: //src/trace_processor/perfetto_sql/lineage:connection_catalog
+filegroup {
+    name: "perfetto_src_trace_processor_perfetto_sql_lineage_connection_catalog",
+    srcs: [
+        "src/trace_processor/perfetto_sql/lineage/connection_catalog.cc",
+    ],
+}
+
+// GN: //src/trace_processor/perfetto_sql/lineage:unittests
+filegroup {
+    name: "perfetto_src_trace_processor_perfetto_sql_lineage_unittests",
+    srcs: [
+        "src/trace_processor/perfetto_sql/lineage/connection_catalog_unittest.cc",
+    ],
+}
+
 // GN: //src/trace_processor/perfetto_sql/parser:parser
 filegroup {
     name: "perfetto_src_trace_processor_perfetto_sql_parser_parser",
@@ -24189,6 +24205,8 @@ cc_test {
         ":perfetto_src_trace_processor_perfetto_sql_generator_generator",
         ":perfetto_src_trace_processor_perfetto_sql_generator_unittests",
         ":perfetto_src_trace_processor_perfetto_sql_intrinsics_types_types",
+        ":perfetto_src_trace_processor_perfetto_sql_lineage_connection_catalog",
+        ":perfetto_src_trace_processor_perfetto_sql_lineage_unittests",
         ":perfetto_src_trace_processor_perfetto_sql_parser_parser",
         ":perfetto_src_trace_processor_perfetto_sql_parser_test_utils",
         ":perfetto_src_trace_processor_perfetto_sql_parser_unittests",

--- a/include/perfetto/ext/base/flat_hash_map.h
+++ b/include/perfetto/ext/base/flat_hash_map.h
@@ -22,6 +22,7 @@
 #include "perfetto/ext/base/bits.h"
 #include "perfetto/ext/base/flat_hash_map_v1.h"
 #include "perfetto/ext/base/murmur_hash.h"
+#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/public/compiler.h"
@@ -133,6 +134,29 @@ static constexpr uint8_t kTombstone = 0xFE;  // Deleted slot
 static constexpr int kDefaultLoadLimitPct = 75;
 
 }  // namespace flat_hash_map_v2_internal
+
+// Hash and equality functors which treat ASCII strings case-insensitively.
+// Pass as the Hasher/Eq parameters of FlatHashMapV2 for maps keyed by
+// case-insensitive identifiers (e.g. SQL object names). Transparent, so
+// lookups accept std::string_view or const char* without constructing a
+// std::string key.
+struct CaseInsensitiveHash {
+  using is_transparent = void;
+  uint64_t operator()(std::string_view value) const {
+    MurmurHashCombiner combiner;
+    for (char c : value) {
+      combiner.Combine(Lowercase(c));
+    }
+    return combiner.digest();
+  }
+};
+
+struct CaseInsensitiveEq {
+  using is_transparent = void;
+  bool operator()(std::string_view lhs, std::string_view rhs) const {
+    return CaseInsensitiveEqual(lhs, rhs);
+  }
+};
 
 template <typename Key,
           typename Value,

--- a/include/perfetto/ext/base/string_utils.h
+++ b/include/perfetto/ext/base/string_utils.h
@@ -182,7 +182,7 @@ bool Contains(const std::string& haystack, char needle);
 bool Contains(const std::vector<std::string>& haystack,
               const std::string& needle);
 size_t Find(const StringView& needle, const StringView& haystack);
-bool CaseInsensitiveEqual(const std::string& first, const std::string& second);
+bool CaseInsensitiveEqual(std::string_view first, std::string_view second);
 std::string Join(const std::vector<std::string>& parts,
                  const std::string& delim);
 std::vector<std::string> SplitString(const std::string& text,

--- a/src/base/string_utils.cc
+++ b/src/base/string_utils.cc
@@ -29,6 +29,7 @@
 #endif
 
 #include <cinttypes>
+#include <string_view>
 
 #include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
@@ -90,7 +91,7 @@ size_t Find(const StringView& needle, const StringView& haystack) {
   return std::string::npos;
 }
 
-bool CaseInsensitiveEqual(const std::string& first, const std::string& second) {
+bool CaseInsensitiveEqual(std::string_view first, std::string_view second) {
   return first.size() == second.size() &&
          std::equal(
              first.begin(), first.end(), second.begin(),

--- a/src/base/string_utils_unittest.cc
+++ b/src/base/string_utils_unittest.cc
@@ -17,6 +17,8 @@
 #include "perfetto/ext/base/string_utils.h"
 
 #include <optional>
+#include <string_view>
+
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto {
@@ -328,6 +330,10 @@ TEST(StringUtilsTest, CaseInsensitiveEqual) {
   EXPECT_TRUE(CaseInsensitiveEqual("abc", "ABC"));
   EXPECT_FALSE(CaseInsensitiveEqual("abc", "AB"));
   EXPECT_FALSE(CaseInsensitiveEqual("ab", "ABC"));
+  EXPECT_TRUE(
+      CaseInsensitiveEqual(std::string_view("aBc"), std::string_view("AbC")));
+  EXPECT_FALSE(
+      CaseInsensitiveEqual(std::string_view("abc"), std::string_view("ab")));
 }
 
 TEST(StringUtilsTest, SplitString) {

--- a/src/perfetto_sql/analysis/relation.cc
+++ b/src/perfetto_sql/analysis/relation.cc
@@ -17,14 +17,16 @@
 #include "src/perfetto_sql/analysis/relation.h"
 
 #include <algorithm>
-#include <cctype>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
+#include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/ext/base/string_utils.h"
@@ -36,6 +38,18 @@ namespace perfetto::perfetto_sql::analysis {
 namespace {
 
 constexpr int kMaxDepth = 32;
+struct ParserDeleter {
+  void operator()(SyntaqliteParser* parser) const {
+    syntaqlite_parser_destroy(parser);
+  }
+};
+using ScopedParser = std::unique_ptr<SyntaqliteParser, ParserDeleter>;
+
+struct OwnedView {
+  std::string sql;
+  ScopedParser parser;
+  uint32_t root = 0;
+};
 
 std::string_view Text(SyntaqliteParser* p, SyntaqliteTextSpan span) {
   return base::TrimWhitespace(SyntaqliteSpanText(p, span));
@@ -57,32 +71,23 @@ void AppendUniqueOrigins(std::vector<ColumnOrigin>* dst,
   }
 }
 
-std::optional<SymbolId> CommonOrigin(
+std::optional<std::string_view> CommonOrigin(
     const std::vector<ColumnLineage>& columns) {
   if (columns.empty() || columns.front().origins.empty()) {
     return std::nullopt;
   }
-  SymbolId first = columns.front().origins.front().relation;
+  std::string_view first = columns.front().origins.front().relation_name;
   for (const ColumnLineage& column : columns) {
     if (column.origins.empty()) {
       return std::nullopt;
     }
     for (const ColumnOrigin& origin : column.origins) {
-      if (origin.relation != first) {
+      if (origin.relation_name != first) {
         return std::nullopt;
       }
     }
   }
   return first;
-}
-
-bool CaseInsensitiveEqual(std::string_view left, std::string_view right) {
-  return left.size() == right.size() &&
-         std::equal(left.begin(), left.end(), right.begin(),
-                    [](char l, char r) {
-                      return std::tolower(static_cast<unsigned char>(l)) ==
-                             std::tolower(static_cast<unsigned char>(r));
-                    });
 }
 
 bool IsNatural(SyntaqliteJoinType type) {
@@ -95,7 +100,7 @@ bool IsNatural(SyntaqliteJoinType type) {
 bool ContainsName(const std::vector<std::string_view>& names,
                   std::string_view name) {
   return std::any_of(names.begin(), names.end(), [&](std::string_view n) {
-    return CaseInsensitiveEqual(n, name);
+    return base::CaseInsensitiveEqual(n, name);
   });
 }
 
@@ -108,6 +113,7 @@ class RelationLineage::Storage {
     for (ColumnLineage& column : columns_) {
       column.output_name = strings_.Append(column.output_name);
       for (ColumnOrigin& origin : column.origins) {
+        origin.relation_name = strings_.Append(origin.relation_name);
         origin.column_name = strings_.Append(origin.column_name);
       }
     }
@@ -117,7 +123,7 @@ class RelationLineage::Storage {
   }
 
   const std::vector<ColumnLineage>& columns() const { return columns_; }
-  std::optional<SymbolId> row_origin() const { return row_origin_; }
+  std::optional<std::string_view> row_origin() const { return row_origin_; }
 
  private:
   static size_t StringBytes(const std::vector<ColumnLineage>& columns) {
@@ -125,6 +131,7 @@ class RelationLineage::Storage {
     for (const ColumnLineage& column : columns) {
       bytes += column.output_name.size();
       for (const ColumnOrigin& origin : column.origins) {
+        bytes += origin.relation_name.size();
         bytes += origin.column_name.size();
       }
     }
@@ -133,15 +140,17 @@ class RelationLineage::Storage {
 
   internal::StringArena strings_;
   std::vector<ColumnLineage> columns_;
-  std::optional<SymbolId> row_origin_;
+  std::optional<std::string_view> row_origin_;
 };
 
 class RelationAnalyzer::Impl {
  public:
-  Impl(const Program& program, const Catalog& catalog)
-      : program_(program), catalog_(catalog) {}
+  explicit Impl(const Catalog& catalog) : catalog_(catalog) {}
 
-  void Begin() { preserves_rows_ = true; }
+  void Begin() {
+    preserves_rows_ = true;
+    views_.clear();
+  }
 
   base::StatusOr<std::vector<ColumnLineage>> Relation(std::string_view name,
                                                       int depth);
@@ -167,22 +176,25 @@ class RelationAnalyzer::Impl {
                        Scope* scope);
   base::StatusOr<std::vector<ColumnLineage>>
   SelectStmt(SyntaqliteParser* p, const SyntaqliteSelectStmt&, int depth);
-  ColumnLineage Lookup(const Scope&,
-                       std::string_view table,
-                       std::string_view column) const;
+  static ColumnLineage Lookup(const Scope&,
+                              std::string_view table,
+                              std::string_view column);
 
-  const Program& program_;
   const Catalog& catalog_;
+  // Lineage string_views point into each view's sql string and parse tree, so
+  // every OwnedView needs a stable address: growing a std::vector<OwnedView>
+  // would move the elements and moving `sql` can relocate its bytes (SSO).
+  std::vector<std::unique_ptr<OwnedView>> views_;
   bool preserves_rows_ = true;
 };
 
 ColumnLineage RelationAnalyzer::Impl::Lookup(const Scope& scope,
                                              std::string_view table,
-                                             std::string_view column) const {
+                                             std::string_view column) {
   ColumnLineage found;
   found.output_name = column;
   for (const ScopeRelation& relation : scope) {
-    if (!table.empty() && !CaseInsensitiveEqual(relation.name, table)) {
+    if (!table.empty() && !base::CaseInsensitiveEqual(relation.name, table)) {
       continue;
     }
     if (!relation.columns) {
@@ -190,7 +202,7 @@ ColumnLineage RelationAnalyzer::Impl::Lookup(const Scope& scope,
       return found;
     }
     for (const ColumnLineage& candidate : *relation.columns) {
-      if (!CaseInsensitiveEqual(candidate.output_name, column)) {
+      if (!base::CaseInsensitiveEqual(candidate.output_name, column)) {
         continue;
       }
       AppendUniqueOrigins(&found.origins, candidate.origins);
@@ -343,7 +355,8 @@ base::StatusOr<std::vector<ColumnLineage>> RelationAnalyzer::Impl::SelectStmt(
         }
       }
       for (const ScopeRelation& relation : scope) {
-        if (!table.empty() && !CaseInsensitiveEqual(relation.name, table)) {
+        if (!table.empty() &&
+            !base::CaseInsensitiveEqual(relation.name, table)) {
           continue;
         }
         if (!relation.columns) {
@@ -361,7 +374,7 @@ base::StatusOr<std::vector<ColumnLineage>> RelationAnalyzer::Impl::SelectStmt(
       continue;
     }
 
-    std::string_view alias = "";
+    std::string_view alias;
     if (const SyntaqliteNode* a = Node(p, column.alias)) {
       alias = Text(p, a->ident_name.source);
     }
@@ -376,7 +389,7 @@ base::StatusOr<std::vector<ColumnLineage>> RelationAnalyzer::Impl::SelectStmt(
       continue;
     }
     preserves_rows_ = false;
-    out.push_back({alias, {}});
+    out.emplace_back(ColumnLineage{alias, {}});
   }
   return out;
 }
@@ -405,7 +418,13 @@ RelationAnalyzer::Impl::Select(SyntaqliteParser* p, uint32_t id, int depth) {
         return base::ErrStatus("relation analysis: arms of differing widths");
       }
       for (uint32_t i = 0; i < left->size(); ++i) {
-        AppendUniqueOrigins(&(*left)[i].origins, (*right)[i].origins);
+        // An arm with no origins contributes rows that cannot be traced, so
+        // keeping only the other arm's origins would claim more than we know.
+        if ((*left)[i].origins.empty() || (*right)[i].origins.empty()) {
+          (*left)[i].origins.clear();
+        } else {
+          AppendUniqueOrigins(&(*left)[i].origins, (*right)[i].origins);
+        }
       }
       return std::move(*left);
     }
@@ -418,32 +437,41 @@ base::StatusOr<std::vector<ColumnLineage>> RelationAnalyzer::Impl::Relation(
     std::string_view name,
     int depth) {
   if (std::optional<LeafRelation> relation = catalog_.FindLeafRelation(name)) {
-    std::optional<SymbolId> symbol = program_.FindSymbol(name);
-    if (!symbol) {
-      return base::ErrStatus(
-          "relation analysis: leaf relation '%.*s' is not in the program",
-          static_cast<int>(name.size()), name.data());
-    }
     std::vector<ColumnLineage> out;
     out.reserve(relation->columns.size());
     for (std::string_view column : relation->columns) {
-      out.push_back({column, {{*symbol, column}}});
+      out.push_back({column, {{relation->name, column}}});
     }
     return out;
-  }
-  std::optional<ViewDefinition> view = catalog_.FindView(name);
-  if (!view) {
-    return base::ErrStatus("relation analysis: '%.*s' is not known",
-                           static_cast<int>(name.size()), name.data());
   }
   if (depth >= kMaxDepth) {
     return base::ErrStatus(
         "relation analysis: views nested too deeply at '%.*s'",
         static_cast<int>(name.size()), name.data());
   }
+  std::optional<std::string> sql = catalog_.FindViewSql(name);
+  if (!sql) {
+    return base::ErrStatus("relation analysis: '%.*s' is not known",
+                           static_cast<int>(name.size()), name.data());
+  }
 
-  SyntaqliteParser* p = view->statement.parser;
-  const SyntaqliteNode* node = Node(p, view->statement.id);
+  // TODO(lalitm): Cache parsed view definitions instead of allocating a parser
+  // for each resolved view; the query-time cost is acceptable for now.
+  auto view = std::make_unique<OwnedView>();
+  view->sql = std::move(*sql);
+  view->parser.reset(syntaqlite_parser_create_perfetto(nullptr));
+  syntaqlite_parser_reset(view->parser.get(), view->sql.data(),
+                          static_cast<uint32_t>(view->sql.size()));
+  if (syntaqlite_parser_next(view->parser.get()) != SYNTAQLITE_PARSE_OK) {
+    return base::ErrStatus("relation analysis: could not parse view '%.*s'",
+                           static_cast<int>(name.size()), name.data());
+  }
+  view->root = syntaqlite_result_root(view->parser.get());
+  OwnedView* owned = view.get();
+  views_.push_back(std::move(view));
+
+  SyntaqliteParser* p = owned->parser.get();
+  const SyntaqliteNode* node = Node(p, owned->root);
   if (!node) {
     return base::ErrStatus("relation analysis: empty view '%.*s'",
                            static_cast<int>(name.size()), name.data());
@@ -481,7 +509,7 @@ base::StatusOr<std::vector<ColumnLineage>> RelationAnalyzer::Impl::Relation(
       (*columns)[i].output_name = Text(p, column->column_ref.column);
     }
   }
-  return columns;
+  return {columns};
 }
 
 Catalog::~Catalog() = default;
@@ -498,13 +526,12 @@ const std::vector<ColumnLineage>& RelationLineage::columns() const {
   return storage_->columns();
 }
 
-std::optional<SymbolId> RelationLineage::row_origin() const {
+std::optional<std::string_view> RelationLineage::row_origin() const {
   return storage_->row_origin();
 }
 
-RelationAnalyzer::RelationAnalyzer(const Program& program,
-                                   const Catalog& catalog)
-    : impl_(std::make_unique<Impl>(program, catalog)) {}
+RelationAnalyzer::RelationAnalyzer(const Catalog& catalog)
+    : impl_(std::make_unique<Impl>(catalog)) {}
 
 RelationAnalyzer::~RelationAnalyzer() = default;
 

--- a/src/perfetto_sql/analysis/relation.h
+++ b/src/perfetto_sql/analysis/relation.h
@@ -20,11 +20,11 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <vector>
 
 #include "perfetto/ext/base/status_or.h"
-#include "src/perfetto_sql/analysis/program.h"
 
 struct SyntaqliteParser;
 
@@ -38,33 +38,29 @@ struct SqlNode {
 
 // A leaf relation whose columns can be used as lineage origins.
 struct LeafRelation {
+  std::string_view name;
   std::vector<std::string_view> columns;
 };
 
-// A view definition already parsed by the caller.
-struct ViewDefinition {
-  SqlNode statement;
-};
-
-// Supplies the schema objects referenced by parsed queries. Returned strings
-// and parse trees only need to remain valid for the duration of an Analyze
-// call.
+// Supplies the schema objects referenced by parsed queries. Returned leaf
+// strings only need to remain valid for the duration of an Analyze call.
 class Catalog {
  public:
   virtual ~Catalog();
 
   virtual std::optional<LeafRelation> FindLeafRelation(
       std::string_view name) const = 0;
-  virtual std::optional<ViewDefinition> FindView(
+  virtual std::optional<std::string> FindViewSql(
       std::string_view name) const = 0;
 };
 
 struct ColumnOrigin {
-  SymbolId relation;
+  std::string_view relation_name;
   std::string_view column_name;
 
   bool operator==(const ColumnOrigin& other) const {
-    return relation == other.relation && column_name == other.column_name;
+    return relation_name == other.relation_name &&
+           column_name == other.column_name;
   }
 };
 
@@ -90,7 +86,7 @@ class RelationLineage {
 
   // The leaf relation whose rows map directly to the output rows, or nothing
   // when the query filters, joins, groups, limits or computes values.
-  std::optional<SymbolId> row_origin() const;
+  std::optional<std::string_view> row_origin() const;
 
  private:
   class Storage;
@@ -105,7 +101,7 @@ class RelationLineage {
 // Computes relation and column lineage over caller-owned parse trees.
 class RelationAnalyzer {
  public:
-  RelationAnalyzer(const Program&, const Catalog&);
+  explicit RelationAnalyzer(const Catalog&);
   ~RelationAnalyzer();
 
   RelationAnalyzer(const RelationAnalyzer&) = delete;

--- a/src/perfetto_sql/analysis/relation_unittest.cc
+++ b/src/perfetto_sql/analysis/relation_unittest.cc
@@ -25,7 +25,6 @@
 #include <variant>
 #include <vector>
 
-#include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "src/perfetto_sql/syntaqlite/syntaqlite_perfetto.h"
 #include "test/gtest_and_gmock.h"
@@ -47,14 +46,7 @@ class TestCatalog : public Catalog {
   }
 
   void AddView(std::string name, std::string sql) {
-    auto source = std::make_unique<std::string>(std::move(sql));
-    ScopedParser parser(syntaqlite_parser_create_perfetto(nullptr));
-    syntaqlite_parser_reset(parser.get(), source->data(),
-                            static_cast<uint32_t>(source->size()));
-    PERFETTO_CHECK(syntaqlite_parser_next(parser.get()) == SYNTAQLITE_PARSE_OK);
-    uint32_t root = syntaqlite_result_root(parser.get());
-    relations_.Insert(std::move(name),
-                      ViewRelation{std::move(source), std::move(parser), root});
+    relations_.Insert(std::move(name), ViewRelation{std::move(sql)});
   }
 
   std::optional<LeafRelation> FindLeafRelation(
@@ -66,6 +58,7 @@ class TestCatalog : public Catalog {
       return std::nullopt;
     }
     LeafRelation result;
+    result.name = name;
     result.columns.reserve(leaf->columns.size());
     for (const std::string& column : leaf->columns) {
       result.columns.push_back(column);
@@ -73,13 +66,10 @@ class TestCatalog : public Catalog {
     return result;
   }
 
-  std::optional<ViewDefinition> FindView(std::string_view name) const override {
+  std::optional<std::string> FindViewSql(std::string_view name) const override {
     const Relation* relation = relations_.Find(std::string(name));
     const auto* view = relation ? std::get_if<ViewRelation>(relation) : nullptr;
-    if (!view || !view->source) {
-      return std::nullopt;
-    }
-    return ViewDefinition{{view->parser.get(), view->root}};
+    return view ? std::make_optional(view->sql) : std::nullopt;
   }
 
  private:
@@ -87,17 +77,14 @@ class TestCatalog : public Catalog {
     std::vector<std::string> columns;
   };
   struct ViewRelation {
-    std::unique_ptr<std::string> source;
-    ScopedParser parser;
-    uint32_t root;
+    std::string sql;
   };
   using Relation = std::variant<TestLeafRelation, ViewRelation>;
 
   base::FlatHashMap<std::string, Relation> relations_;
 };
 
-std::vector<std::string> Show(const RelationLineage& lineage,
-                              const Program& program) {
+std::vector<std::string> Show(const RelationLineage& lineage) {
   std::vector<std::string> out;
   for (const ColumnLineage& column : lineage.columns()) {
     std::string value(column.output_name);
@@ -106,7 +93,7 @@ std::vector<std::string> Show(const RelationLineage& lineage,
       if (i) {
         value += ",";
       }
-      value += program.symbol(column.origins[i].relation).name;
+      value += column.origins[i].relation_name;
       value += ".";
       value += column.origins[i].column_name;
     }
@@ -117,17 +104,9 @@ std::vector<std::string> Show(const RelationLineage& lineage,
 
 class RelationAnalyzerTest : public ::testing::Test {
  protected:
-  RelationAnalyzerTest() : program_(CreateProgram()) {
+  RelationAnalyzerTest() {
     catalog_.AddRelation("slice", {"id", "ts", "name"});
     catalog_.AddRelation("thread", {"utid", "name"});
-  }
-
-  static Program CreateProgram() {
-    ProgramBuilder builder;
-    ModuleId module = builder.AddModule("builtin", "");
-    builder.AddSymbol(module, "slice", SymbolKind::kTable);
-    builder.AddSymbol(module, "thread", SymbolKind::kTable);
-    return builder.Build();
   }
 
   base::StatusOr<RelationLineage> Analyze(const std::string& sql) {
@@ -137,7 +116,7 @@ class RelationAnalyzerTest : public ::testing::Test {
     if (syntaqlite_parser_next(parser.get()) != SYNTAQLITE_PARSE_OK) {
       return base::ErrStatus("could not parse test query");
     }
-    RelationAnalyzer analyzer(program_, catalog_);
+    RelationAnalyzer analyzer(catalog_);
     return analyzer.AnalyzeQuery(
         {parser.get(), syntaqlite_result_root(parser.get())});
   }
@@ -145,10 +124,9 @@ class RelationAnalyzerTest : public ::testing::Test {
   std::vector<std::string> Select(const std::string& sql) {
     auto result = Analyze(sql);
     EXPECT_TRUE(result.ok()) << sql << ": " << result.status().c_message();
-    return result.ok() ? Show(*result, program_) : std::vector<std::string>{};
+    return result.ok() ? Show(*result) : std::vector<std::string>{};
   }
 
-  Program program_;
   TestCatalog catalog_;
 };
 
@@ -160,16 +138,14 @@ TEST_F(RelationAnalyzerTest, ResolvesColumnsAndAliases) {
 TEST_F(RelationAnalyzerTest, ResultOutlivesParserAndAnalyzer) {
   auto lineage = Analyze("SELECT id AS slice_id FROM slice");
   ASSERT_TRUE(lineage.ok()) << lineage.status().c_message();
-  EXPECT_THAT(Show(*lineage, program_),
-              testing::ElementsAre("slice_id=slice.id"));
+  EXPECT_THAT(Show(*lineage), testing::ElementsAre("slice_id=slice.id"));
 }
 
-TEST_F(RelationAnalyzerTest, OriginsAreRelationSymbols) {
+TEST_F(RelationAnalyzerTest, OriginsNameLeafRelations) {
   auto result = Analyze("SELECT id AS harmless_name FROM slice");
   ASSERT_TRUE(result.ok());
   ASSERT_THAT(result->columns().front().origins, testing::SizeIs(1));
-  EXPECT_EQ(result->columns().front().origins.front().relation,
-            *program_.FindSymbol("slice"));
+  EXPECT_EQ(result->columns().front().origins.front().relation_name, "slice");
 }
 
 TEST_F(RelationAnalyzerTest, ExpressionsHaveUnknownOrigin) {
@@ -217,6 +193,13 @@ TEST_F(RelationAnalyzerTest, KeepsEveryOriginAcrossCompoundSelect) {
               testing::ElementsAre("id=slice.id,thread.utid"));
 }
 
+TEST_F(RelationAnalyzerTest, UntraceableCompoundArmPoisonsOrigins) {
+  EXPECT_THAT(Select("SELECT id FROM slice UNION ALL SELECT 123"),
+              testing::ElementsAre("id="));
+  EXPECT_THAT(Select("SELECT 123 AS id UNION ALL SELECT id FROM slice"),
+              testing::ElementsAre("id="));
+}
+
 TEST_F(RelationAnalyzerTest, UnknownRelationsAreConservative) {
   EXPECT_THAT(Select("SELECT id FROM unknown_table"),
               testing::ElementsAre("id="));
@@ -225,7 +208,8 @@ TEST_F(RelationAnalyzerTest, UnknownRelationsAreConservative) {
 TEST_F(RelationAnalyzerTest, IdentifiesRowOrigin) {
   auto result = Analyze("SELECT id, name FROM slice");
   ASSERT_TRUE(result.ok());
-  EXPECT_EQ(result->row_origin(), program_.FindSymbol("slice"));
+  EXPECT_EQ(result->row_origin(),
+            std::make_optional<std::string_view>("slice"));
 
   result = Analyze("SELECT s.id, t.utid FROM slice s, thread t");
   ASSERT_TRUE(result.ok());
@@ -235,15 +219,16 @@ TEST_F(RelationAnalyzerTest, IdentifiesRowOrigin) {
 TEST_F(RelationAnalyzerTest, DetectsRowPreservingViewChains) {
   catalog_.AddView("v1", "CREATE VIEW v1 AS SELECT id, name FROM slice");
   catalog_.AddView("v2", "CREATE VIEW v2 AS SELECT id AS a, name AS b FROM v1");
-  RelationAnalyzer analyzer(program_, catalog_);
+  RelationAnalyzer analyzer(catalog_);
   auto result = analyzer.AnalyzeRelation("v2");
   ASSERT_TRUE(result.ok());
-  EXPECT_EQ(result->row_origin(), program_.FindSymbol("slice"));
+  EXPECT_EQ(result->row_origin(),
+            std::make_optional<std::string_view>("slice"));
 }
 
 TEST_F(RelationAnalyzerTest, RejectsFilteredViewAsRowOrigin) {
   catalog_.AddView("v", "CREATE VIEW v AS SELECT id FROM slice WHERE ts > 5");
-  RelationAnalyzer analyzer(program_, catalog_);
+  RelationAnalyzer analyzer(catalog_);
   auto result = analyzer.AnalyzeRelation("v");
   ASSERT_TRUE(result.ok());
   EXPECT_EQ(result->row_origin(), std::nullopt);
@@ -252,7 +237,7 @@ TEST_F(RelationAnalyzerTest, RejectsFilteredViewAsRowOrigin) {
 TEST_F(RelationAnalyzerTest, RejectsOrderedViewAsRowOrigin) {
   catalog_.AddView("v",
                    "CREATE VIEW v AS SELECT id FROM slice ORDER BY ts DESC");
-  RelationAnalyzer analyzer(program_, catalog_);
+  RelationAnalyzer analyzer(catalog_);
   auto result = analyzer.AnalyzeRelation("v");
   ASSERT_TRUE(result.ok());
   EXPECT_EQ(result->row_origin(), std::nullopt);

--- a/src/perfetto_sql/syntaqlite/BUILD.gn
+++ b/src/perfetto_sql/syntaqlite/BUILD.gn
@@ -36,6 +36,7 @@ source_set("syntaqlite") {
   assert_no_deps = [ "../../trace_processor/*" ]
   visibility = [
     "..:intrinsic_macro_expansion",
+    "../../trace_processor/perfetto_sql/lineage:*",
     "../../trace_processor/perfetto_sql/parser:*",
     "../../trace_processor/perfetto_sql/tokenizer",
     "../../trace_processor/util:sql_module_doc_parser",

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -470,6 +470,7 @@ perfetto_unittest_source_set("unittests") {
     deps += [
       "../perfetto_sql/analysis:unittests",
       "perfetto_sql/engine:unittests",
+      "perfetto_sql/lineage:unittests",
       "perfetto_sql/parser:unittests",
       "perfetto_sql/tokenizer:unittests",
       "plugins/ancestor:unittests",

--- a/src/trace_processor/core/dataframe/dataframe.h
+++ b/src/trace_processor/core/dataframe/dataframe.h
@@ -276,6 +276,11 @@ class Dataframe {
   // Returns the column names of the dataframe.
   const std::vector<std::string>& column_names() const { return column_names_; }
 
+  // Returns the type of the values in `column`.
+  StorageType column_type(uint32_t column) const {
+    return column_ptrs_[column]->storage.type();
+  }
+
   // Returns the number of rows in the dataframe.
   uint32_t row_count() const { return row_count_; }
 

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <initializer_list>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -39,14 +40,14 @@
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
+#include "perfetto/public/compiler.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
-#include "src/trace_processor/core/dataframe/runtime_dataframe_builder.h"
-#include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/plugin/registration.h"
 #include "src/trace_processor/perfetto_sql/engine/created_function.h"
 #include "src/trace_processor/perfetto_sql/engine/dataframe_module.h"
+#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_database.h"
 #include "src/trace_processor/perfetto_sql/engine/runtime_table_function.h"
 #include "src/trace_processor/perfetto_sql/engine/sqlite_dataframe_builder.h"
 #include "src/trace_processor/perfetto_sql/engine/static_table_function_module.h"
@@ -880,7 +881,7 @@ PerfettoSqlConnection::ExecuteStatementsImpl(SqlSource sql_source,
 }
 
 const dataframe::Dataframe* PerfettoSqlConnection::GetDataframeOrNull(
-    const std::string& name) const {
+    std::string_view name) const {
   auto* state = dataframe_context_->GetStateByName(name);
   return state ? state->dataframe : nullptr;
 }

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
@@ -30,14 +30,13 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/flat_hash_map.h"
-#include "perfetto/ext/base/hash.h"
 #include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/small_vector.h"
 #include "perfetto/ext/base/status_or.h"
-#include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
 #include "src/trace_processor/core/plugin/plugin.h"
+#include "src/trace_processor/core/plugin/registration.h"
 #include "src/trace_processor/perfetto_sql/engine/dataframe_module.h"
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_database.h"
 #include "src/trace_processor/perfetto_sql/engine/runtime_table_function.h"
@@ -358,7 +357,7 @@ class PerfettoSqlConnection {
   }
 
   // Find dataframe registered with this connection with provided name.
-  const dataframe::Dataframe* GetDataframeOrNull(const std::string& name) const;
+  const dataframe::Dataframe* GetDataframeOrNull(std::string_view name) const;
 
   // Registers a function with the prototype |prototype| implemented by
   // executing the SQL statement |sql|.

--- a/src/trace_processor/perfetto_sql/lineage/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/lineage/BUILD.gn
@@ -1,0 +1,49 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../gn/test.gni")
+
+source_set("connection_catalog") {
+  sources = [
+    "connection_catalog.cc",
+    "connection_catalog.h",
+  ]
+  deps = [
+    "../../../../gn:default_deps",
+    "../../../../gn:sqlite",
+    "../../../base",
+    "../../../perfetto_sql/analysis",
+    "../../core/common",
+    "../../core/dataframe",
+    "../../sqlite",
+    "../engine",
+  ]
+}
+
+perfetto_unittest_source_set("unittests") {
+  testonly = true
+  sources = [ "connection_catalog_unittest.cc" ]
+  deps = [
+    ":connection_catalog",
+    "../../../../gn:default_deps",
+    "../../../../gn:gtest_and_gmock",
+    "../../../base",
+    "../../../perfetto_sql/analysis",
+    "../../../perfetto_sql/syntaqlite",
+    "../../containers",
+    "../../core/common",
+    "../../sqlite",
+    "../engine",
+  ]
+}

--- a/src/trace_processor/perfetto_sql/lineage/connection_catalog.cc
+++ b/src/trace_processor/perfetto_sql/lineage/connection_catalog.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/perfetto_sql/lineage/connection_catalog.h"
+
+#include <sqlite3.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "perfetto/ext/base/string_utils.h"
+#include "src/perfetto_sql/analysis/relation.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
+#include "src/trace_processor/sqlite/sql_source.h"
+
+namespace perfetto::trace_processor::lineage {
+namespace {
+
+// Finds the stored CREATE VIEW SQL for the view named $name. Temporary views
+// shadow database views of the same name, so their rows sort first. SQL
+// identifiers are case-insensitive but sqlite_master stores names with the
+// case the user typed at CREATE time, so both sides are lowercased.
+constexpr char kFindViewSql[] = R"(
+  SELECT sql FROM (
+    SELECT sql, 0 AS priority FROM sqlite_temp_master
+    WHERE type = 'view' AND lower(name) = lower($name)
+    UNION ALL
+    SELECT sql, 1 AS priority FROM sqlite_master
+    WHERE type = 'view' AND lower(name) = lower($name)
+  )
+  ORDER BY priority
+  LIMIT 1
+)";
+
+// Escapes |name| as a single-quoted SQL string literal.
+std::string Quoted(std::string_view name) {
+  std::string out = "'";
+  for (char c : name) {
+    if (c == '\'') {
+      out.push_back('\'');
+    }
+    out.push_back(c);
+  }
+  out.push_back('\'');
+  return out;
+}
+
+}  // namespace
+
+ConnectionCatalog::ConnectionCatalog(PerfettoSqlConnection* connection)
+    : connection_(connection) {}
+
+std::optional<analysis::LeafRelation> ConnectionCatalog::FindLeafRelation(
+    std::string_view name) const {
+  const dataframe::Dataframe* dataframe = connection_->GetDataframeOrNull(name);
+  if (!dataframe) {
+    return std::nullopt;
+  }
+  analysis::LeafRelation relation;
+  relation.name = name;
+  relation.columns.reserve(dataframe->column_names().size());
+  for (const std::string& column : dataframe->column_names()) {
+    relation.columns.push_back(column);
+  }
+  return relation;
+}
+
+std::optional<std::string> ConnectionCatalog::FindViewSql(
+    std::string_view name) const {
+  auto res = connection_->ExecuteUntilLastStatement(
+      SqlSource::FromTraceProcessorImplementation(
+          base::ReplaceAll(kFindViewSql, "$name", Quoted(name))));
+  if (!res.ok() || res->stmt.IsDone()) {
+    return std::nullopt;
+  }
+  sqlite3_stmt* stmt = res->stmt.sqlite_stmt();
+  const auto* sql = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+  return sql ? std::make_optional(std::string(sql)) : std::nullopt;
+}
+
+std::optional<core::StorageType> ConnectionCatalog::ColumnType(
+    const analysis::ColumnLineage& column) const {
+  std::optional<core::StorageType> result;
+  for (const analysis::ColumnOrigin& origin : column.origins) {
+    const dataframe::Dataframe* dataframe =
+        connection_->GetDataframeOrNull(origin.relation_name);
+    if (!dataframe) {
+      return std::nullopt;
+    }
+    const std::vector<std::string>& names = dataframe->column_names();
+    auto found =
+        std::find_if(names.begin(), names.end(), [&](const auto& name) {
+          return base::CaseInsensitiveEqual(name, origin.column_name);
+        });
+    if (found == names.end()) {
+      return std::nullopt;
+    }
+    core::StorageType type =
+        dataframe->column_type(static_cast<uint32_t>(found - names.begin()));
+    if (result && !(*result == type)) {
+      return std::nullopt;
+    }
+    result = type;
+  }
+  return result;
+}
+
+}  // namespace perfetto::trace_processor::lineage

--- a/src/trace_processor/perfetto_sql/lineage/connection_catalog.h
+++ b/src/trace_processor/perfetto_sql/lineage/connection_catalog.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_LINEAGE_CONNECTION_CATALOG_H_
+#define SRC_TRACE_PROCESSOR_PERFETTO_SQL_LINEAGE_CONNECTION_CATALOG_H_
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "src/perfetto_sql/analysis/relation.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
+
+namespace perfetto::trace_processor::lineage {
+
+namespace analysis = ::perfetto::perfetto_sql::analysis;
+
+// Adapts the dataframes and SQLite views of a live connection to the reusable
+// PerfettoSQL relation analyzer.
+class ConnectionCatalog final : public analysis::Catalog {
+ public:
+  explicit ConnectionCatalog(PerfettoSqlConnection*);
+
+  std::optional<analysis::LeafRelation> FindLeafRelation(
+      std::string_view name) const override;
+  std::optional<std::string> FindViewSql(std::string_view name) const override;
+
+  // Maps all origins of a result column back to dataframe storage. Returns
+  // nothing unless every origin has the same storage type.
+  std::optional<core::StorageType> ColumnType(
+      const analysis::ColumnLineage&) const;
+
+ private:
+  PerfettoSqlConnection* connection_;
+};
+
+}  // namespace perfetto::trace_processor::lineage
+
+#endif  // SRC_TRACE_PROCESSOR_PERFETTO_SQL_LINEAGE_CONNECTION_CATALOG_H_

--- a/src/trace_processor/perfetto_sql/lineage/connection_catalog_unittest.cc
+++ b/src/trace_processor/perfetto_sql/lineage/connection_catalog_unittest.cc
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/perfetto_sql/lineage/connection_catalog.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/perfetto_sql/analysis/relation.h"
+#include "src/perfetto_sql/syntaqlite/syntaqlite_perfetto.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h"
+#include "src/trace_processor/sqlite/sql_source.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::lineage {
+namespace {
+
+struct ParserDeleter {
+  void operator()(SyntaqliteParser* parser) const {
+    syntaqlite_parser_destroy(parser);
+  }
+};
+using ScopedParser = std::unique_ptr<SyntaqliteParser, ParserDeleter>;
+
+class ConnectionCatalogTest : public ::testing::Test {
+ protected:
+  void Exec(const std::string& sql) {
+    auto result = connection_->Execute(SqlSource::FromExecuteQuery(sql));
+    ASSERT_TRUE(result.ok()) << sql << ": " << result.status().c_message();
+  }
+
+  base::StatusOr<std::vector<std::optional<core::StorageType>>> Types(
+      const std::string& sql) {
+    ScopedParser parser(syntaqlite_parser_create_perfetto(nullptr));
+    syntaqlite_parser_reset(parser.get(), sql.data(),
+                            static_cast<uint32_t>(sql.size()));
+    if (syntaqlite_parser_next(parser.get()) != SYNTAQLITE_PARSE_OK) {
+      return base::ErrStatus("could not parse test query");
+    }
+
+    analysis::RelationAnalyzer analyzer(catalog_);
+    ASSIGN_OR_RETURN(analysis::RelationLineage lineage,
+                     analyzer.AnalyzeQuery(
+                         {parser.get(), syntaqlite_result_root(parser.get())}));
+    std::vector<std::optional<core::StorageType>> types;
+    types.reserve(lineage.columns().size());
+    for (const analysis::ColumnLineage& column : lineage.columns()) {
+      types.push_back(catalog_.ColumnType(column));
+    }
+    return types;
+  }
+
+  StringPool pool_;
+  std::unique_ptr<PerfettoSqlConnection> connection_ =
+      PerfettoSqlConnection::CreateConnectionToNewDatabase(&pool_, true);
+  ConnectionCatalog catalog_{connection_.get()};
+};
+
+TEST_F(ConnectionCatalogTest, ReadsDataframeStorageTypes) {
+  Exec(
+      "CREATE PERFETTO TABLE t AS "
+      "SELECT 1 AS id, 2.5 AS weight, 'x' AS name");
+
+  auto types = Types("SELECT id, weight, name FROM t");
+  ASSERT_TRUE(types.ok()) << types.status().c_message();
+  ASSERT_EQ(types->size(), 3u);
+  ASSERT_TRUE((*types)[0].has_value());
+  ASSERT_TRUE((*types)[1].has_value());
+  ASSERT_TRUE((*types)[2].has_value());
+  EXPECT_TRUE((*types)[0]->Is<core::Uint32>());
+  EXPECT_TRUE((*types)[1]->Is<core::Double>());
+  EXPECT_TRUE((*types)[2]->Is<core::String>());
+}
+
+TEST_F(ConnectionCatalogTest, ReadsReplacedDataframeSchema) {
+  Exec("CREATE PERFETTO TABLE t AS SELECT 1 AS value");
+  ASSERT_TRUE(Types("SELECT value FROM t").ok());
+  Exec("CREATE OR REPLACE PERFETTO TABLE t AS SELECT 'x' AS value");
+
+  auto types = Types("SELECT value FROM t");
+  ASSERT_TRUE(types.ok()) << types.status().c_message();
+  ASSERT_EQ(types->size(), 1u);
+  ASSERT_TRUE((*types)[0].has_value());
+  EXPECT_TRUE((*types)[0]->Is<core::String>());
+}
+
+TEST_F(ConnectionCatalogTest, UsesTemporaryViewDefinition) {
+  Exec("CREATE PERFETTO TABLE ints AS SELECT 1 AS value");
+  Exec("CREATE PERFETTO TABLE strings AS SELECT 'x' AS value");
+  Exec("CREATE VIEW v AS SELECT value FROM ints");
+  Exec("CREATE TEMP VIEW v AS SELECT value FROM strings");
+
+  auto types = Types("SELECT value FROM v");
+  ASSERT_TRUE(types.ok()) << types.status().c_message();
+  ASSERT_EQ(types->size(), 1u);
+  ASSERT_TRUE((*types)[0].has_value());
+  EXPECT_TRUE((*types)[0]->Is<core::String>());
+}
+
+TEST_F(ConnectionCatalogTest, RequiresEveryOriginToHaveTheSameType) {
+  Exec("CREATE PERFETTO TABLE ints AS SELECT 1 AS value");
+  Exec("CREATE PERFETTO TABLE more_ints AS SELECT 2 AS value");
+  Exec("CREATE PERFETTO TABLE strings AS SELECT 'x' AS value");
+
+  auto same = Types("SELECT value FROM ints JOIN more_ints USING(value)");
+  ASSERT_TRUE(same.ok()) << same.status().c_message();
+  ASSERT_EQ(same->size(), 1u);
+  ASSERT_TRUE((*same)[0].has_value());
+  EXPECT_TRUE((*same)[0]->Is<core::Uint32>());
+
+  auto different = Types("SELECT value FROM ints JOIN strings USING(value)");
+  ASSERT_TRUE(different.ok()) << different.status().c_message();
+  ASSERT_EQ(different->size(), 1u);
+  EXPECT_FALSE((*different)[0].has_value());
+}
+
+TEST_F(ConnectionCatalogTest, ResolvesTableNamesCaseInsensitively) {
+  Exec("CREATE PERFETTO TABLE t AS SELECT 1 AS id");
+
+  auto types = Types("SELECT id FROM T");
+  ASSERT_TRUE(types.ok()) << types.status().c_message();
+  ASSERT_EQ(types->size(), 1u);
+  ASSERT_TRUE((*types)[0].has_value());
+  EXPECT_TRUE((*types)[0]->Is<core::Uint32>());
+}
+
+TEST_F(ConnectionCatalogTest, ResolvesViewNamesCaseInsensitively) {
+  Exec("CREATE PERFETTO TABLE t AS SELECT 1 AS id");
+  Exec("CREATE VIEW v AS SELECT id FROM t");
+
+  auto types = Types("SELECT id FROM V");
+  ASSERT_TRUE(types.ok()) << types.status().c_message();
+  ASSERT_EQ(types->size(), 1u);
+  ASSERT_TRUE((*types)[0].has_value());
+  EXPECT_TRUE((*types)[0]->Is<core::Uint32>());
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::lineage

--- a/src/trace_processor/sqlite/committed_state_manager.h
+++ b/src/trace_processor/sqlite/committed_state_manager.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "perfetto/ext/base/flat_hash_map.h"
@@ -35,18 +36,23 @@ class CommittedStateManager {
   CommittedStateManager(const CommittedStateManager&) = delete;
   CommittedStateManager& operator=(const CommittedStateManager&) = delete;
 
-  std::shared_ptr<void> Load(const std::string& name) const {
+  std::shared_ptr<void> Load(std::string_view name) const {
     const auto* p = map_.Find(name);
     return p ? *p : nullptr;
   }
-  void Store(const std::string& name, std::shared_ptr<void> state) {
+  void Store(std::string_view name, std::shared_ptr<void> state) {
     map_.Erase(name);
-    map_.Insert(name, std::move(state));
+    map_.Insert(std::string(name), std::move(state));
   }
-  void Erase(const std::string& name) { map_.Erase(name); }
+  void Erase(std::string_view name) { map_.Erase(name); }
 
  private:
-  base::FlatHashMap<std::string, std::shared_ptr<void>> map_;
+  // SQL object names are case-insensitive, so the map must be too.
+  base::FlatHashMapV2<std::string,
+                      std::shared_ptr<void>,
+                      base::CaseInsensitiveHash,
+                      base::CaseInsensitiveEq>
+      map_;
 };
 
 }  // namespace perfetto::trace_processor::sqlite

--- a/src/trace_processor/sqlite/module_state_manager.cc
+++ b/src/trace_processor/sqlite/module_state_manager.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -132,7 +133,7 @@ void* ModuleStateManagerBase::GetState(PerVtabState* s) {
   return s->active_state.get();
 }
 
-void* ModuleStateManagerBase::GetStateByName(const std::string& name) {
+void* ModuleStateManagerBase::GetStateByName(std::string_view name) {
   auto* ptr = state_by_name_.Find(name);
   if (!ptr) {
     return nullptr;

--- a/src/trace_processor/sqlite/module_state_manager.h
+++ b/src/trace_processor/sqlite/module_state_manager.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -98,10 +99,13 @@ class ModuleStateManagerBase {
   static void OnRollbackTo(PerVtabState* state, int);
 
   static void* GetState(PerVtabState* s);
-  void* GetStateByName(const std::string& name);
+  void* GetStateByName(std::string_view name);
 
-  using StateMap =
-      base::FlatHashMap<std::string, std::unique_ptr<PerVtabState>>;
+  // SQL object names are case-insensitive, so the map must be too.
+  using StateMap = base::FlatHashMapV2<std::string,
+                                       std::unique_ptr<PerVtabState>,
+                                       base::CaseInsensitiveHash,
+                                       base::CaseInsensitiveEq>;
 
   StateMap state_by_name_;
   CommittedStateManager* committed_store_;
@@ -196,7 +200,7 @@ class ModuleStateManager : public ModuleStateManagerBase {
   // This function should only be called for speculative lookups from outside
   // the module implementation: use `GetState` inside the sqlite::Module
   // implementation.
-  typename Module::State* GetStateByName(const std::string& name) {
+  typename Module::State* GetStateByName(std::string_view name) {
     return static_cast<typename Module::State*>(
         ModuleStateManagerBase::GetStateByName(name));
   }

--- a/src/trace_processor/sqlite/module_state_manager_unittest.cc
+++ b/src/trace_processor/sqlite/module_state_manager_unittest.cc
@@ -35,6 +35,7 @@ class TestStateManager : public ModuleStateManagerBase {
       : ModuleStateManagerBase(store) {}
 
   using ModuleStateManagerBase::GetState;
+  using ModuleStateManagerBase::GetStateByName;
   using ModuleStateManagerBase::OnConnect;
   using ModuleStateManagerBase::OnCreate;
   using ModuleStateManagerBase::OnDestroy;
@@ -50,6 +51,20 @@ std::unique_ptr<void, void (*)(void*)> MakeErasedPayload(int v) {
 }
 
 const char* const kArgvVt[] = {"db", "module", "vt1"};
+
+// SQL names are case-insensitive: state registered under one case must be
+// found under any other.
+TEST(ModuleStateManagerTest, StateLookupIsCaseInsensitive) {
+  CommittedStateManager store;
+  TestStateManager manager(store);
+
+  const char* const argv[] = {"db", "module", "MyTable"};
+  base::ignore_result(manager.OnCreate(3, argv, MakeErasedPayload(7)));
+
+  auto* payload = static_cast<Payload*>(manager.GetStateByName("MYTABLE"));
+  ASSERT_NE(payload, nullptr);
+  EXPECT_EQ(payload->value, 7);
+}
 
 // A manager with no local state falls back to peer-committed state.
 TEST(ModuleStateManagerTest, ColdAttachReadsPeerCommittedState) {


### PR DESCRIPTION
SQLite declarations do not bind result types, so the executor needs semantic
column origins before it can select flat storage.

Reuse the shared PerfettoSQL relation analyzer for that work. The analyzer owns
parsing view definitions and reports canonical leaf relation names as origins.
Views are parsed on demand for now; a TODO records that caching those parsed
definitions would avoid repeated parser allocation if this becomes measurable.

The trace processor adapter is limited to three boundary operations:
- expose a live dataframe as a leaf relation;
- return SQLite's stored CREATE VIEW SQL;
- map resolved leaf columns to dataframe storage types.

Aliases, subqueries, joins, compound queries, and row-origin semantics remain
owned by `src/perfetto_sql/analysis`.