### PR TITLE
Eliminate cuj_id remapping in android_jank_latency_cujs

### DIFF
--- a/src/trace_processor/metrics/sql/android/android_blocking_calls_cuj_metric.sql
+++ b/src/trace_processor/metrics/sql/android/android_blocking_calls_cuj_metric.sql
@@ -44,7 +44,8 @@ SELECT
     cuj_name,
     process_name,
     upid,
-    utid
+    utid,
+    cuj_type
 FROM android_cuj_blocking_calls;
 
 
@@ -59,10 +60,11 @@ SELECT
     upid,
     cuj_id,
     cuj_name,
+    cuj_type,
     process_name
 FROM
     blocking_call_slices_scoped_to_cujs
-GROUP BY name, upid, cuj_id, cuj_name, process_name
+GROUP BY name, upid, cuj_id, cuj_name, cuj_type, process_name
 ORDER BY cuj_id;
 
 
@@ -90,7 +92,7 @@ SELECT AndroidBlockingCallsCujMetric('cuj', (
                     ) ORDER BY b.total_dur_ns DESC, b.name
                 )
                 FROM android_blocking_calls_cuj_calls b
-                WHERE b.cuj_id = cuj.cuj_id and b.upid = cuj.upid
+                WHERE b.cuj_id = cuj.cuj_id AND b.cuj_type = cuj.cuj_type AND b.upid = cuj.upid
             )
         ) ORDER BY cuj.cuj_id ASC
     )

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
@@ -276,8 +276,6 @@ SELECT
   end_vsync,
   'jank' AS cuj_type
 FROM android_sysui_jank_cujs
-ORDER BY
-  id
 UNION ALL
 SELECT
   cuj_id,
@@ -297,7 +295,7 @@ SELECT
   NULL AS begin_vsync,
   NULL AS end_vsync,
   'latency' AS cuj_type
-FROM android_sysui_latency_cujs ORDER BY id;
+FROM android_sysui_latency_cujs ORDER BY cuj_id;
 
 -- Slices corresponding to critical blocking calls that occurred during a CUJ,
 -- clipped to the CUJ time boundaries.

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
@@ -276,6 +276,8 @@ SELECT
   end_vsync,
   'jank' AS cuj_type
 FROM android_sysui_jank_cujs
+ORDER BY
+  id
 UNION ALL
 SELECT
   cuj_id,

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
@@ -215,7 +215,9 @@ WHERE
 
 -- Table tracking all jank/latency CUJs information.
 CREATE PERFETTO TABLE android_jank_latency_cujs(
-  -- Unique incremental ID for each CUJ.
+  -- CUJ ID inherited directly from the underlying jank/latency source without
+  -- remapping. Note that this ID is not globally unique across this table (jank and
+  -- latency CUJs can share the same numeric ID).
   cuj_id LONG,
   -- An alias for cuj_id for compatibility purposes.
   id LONG,
@@ -225,7 +227,7 @@ CREATE PERFETTO TABLE android_jank_latency_cujs(
   process_name STRING,
   -- Name of the CUJ slice.
   cuj_slice_name STRING,
-  -- Name of the CUJ without the 'J<' prefix.
+  -- Name of the CUJ without the 'J<' or 'L<' prefix.
   cuj_name STRING,
   -- Id of the CUJ slice in perfetto. Keeping the slice id column as part of this table
   -- as provision to lookup the actual CUJ slice ts and dur. The ts and dur in this table
@@ -256,25 +258,9 @@ CREATE PERFETTO TABLE android_jank_latency_cujs(
   cuj_type STRING
 )
 AS
-WITH
-  combined_cujs AS (
-    SELECT *, "jank" AS cuj_type, cuj_id AS original_cuj_id
-    FROM android_sysui_jank_cujs
-    UNION ALL
-    SELECT
-      *,
-      -- upid is used as the ui_thread as it's the tid of the main thread.
-      upid AS ui_thread,
-      NULL AS layer_id,
-      NULL AS begin_vsync,
-      NULL AS end_vsync,
-      "latency" AS cuj_type,
-      cuj_id AS original_cuj_id
-    FROM android_sysui_latency_cujs
-  )
 SELECT
-  row_number() OVER (ORDER BY cuj_type, original_cuj_id) AS cuj_id,
-  row_number() OVER (ORDER BY cuj_type, original_cuj_id) AS id,
+  cuj_id,
+  cuj_id AS id,
   upid,
   process_name,
   cuj_slice_name,
@@ -288,8 +274,28 @@ SELECT
   layer_id,
   begin_vsync,
   end_vsync,
-  cuj_type
-FROM combined_cujs;
+  'jank' AS cuj_type
+FROM android_sysui_jank_cujs
+UNION ALL
+SELECT
+  cuj_id,
+  cuj_id AS id,
+  upid,
+  process_name,
+  cuj_slice_name,
+  cuj_name,
+  slice_id,
+  ts,
+  ts_end,
+  dur,
+  state,
+  -- upid is used as the ui_thread as it's the tid of the main thread.
+  upid AS ui_thread,
+  NULL AS layer_id,
+  NULL AS begin_vsync,
+  NULL AS end_vsync,
+  'latency' AS cuj_type
+FROM android_sysui_latency_cujs;
 
 -- Slices corresponding to critical blocking calls that occurred during a CUJ,
 -- clipped to the CUJ time boundaries.
@@ -313,7 +319,9 @@ CREATE PERFETTO TABLE android_cuj_blocking_calls(
   -- Process upid.
   upid JOINID(process.id),
   -- Thread utid.
-  utid JOINID(thread.id)
+  utid JOINID(thread.id),
+  -- Type of CUJ, i.e. jank or latency.
+  cuj_type STRING
 )
 AS
 SELECT
@@ -326,7 +334,8 @@ SELECT
   cuj.cuj_name,
   s.process_name,
   s.upid,
-  s.utid
+  s.utid,
+  cuj.cuj_type
 FROM _android_critical_blocking_calls AS s
 JOIN android_jank_latency_cujs AS cuj
   ON s.ts + s.dur > cuj.ts

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
@@ -295,7 +295,7 @@ SELECT
   NULL AS begin_vsync,
   NULL AS end_vsync,
   'latency' AS cuj_type
-FROM android_sysui_latency_cujs;
+FROM android_sysui_latency_cujs ORDER BY id;
 
 -- Slices corresponding to critical blocking calls that occurred during a CUJ,
 -- clipped to the CUJ time boundaries.

--- a/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
+++ b/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
@@ -77,10 +77,10 @@ class SystemUICujs(TestSuite):
         out=Csv("""
         "process_name","cuj_slice_name","cuj_name","ts","ts_end","dur","state","begin_vsync","end_vsync","cuj_type"
         "com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",27000000,65000000,38000000,"completed",20,30,"jank"
-        "com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",85000000,89000000,4000000,"completed",60,70,"jank"
-        "com.google.android.apps.nexuslauncher","J<CUJ_NAME>","CUJ_NAME",121000000,143000000,22000000,"completed",80,90,"jank"
         "com.android.systemui","L<IGNORED_CUJ_1>","IGNORED_CUJ_1",150000000,155000000,5000000,"completed","[NULL]","[NULL]","latency"
+        "com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",85000000,89000000,4000000,"completed",60,70,"jank"
         "com.android.systemui","L<IGNORED_CUJ_2>","IGNORED_CUJ_2",156000000,160000000,4000000,"completed","[NULL]","[NULL]","latency"
+        "com.google.android.apps.nexuslauncher","J<CUJ_NAME>","CUJ_NAME",121000000,143000000,22000000,"completed",80,90,"jank"
         """))
 
   def test_android_sysui_latency_cujs_state(self):

--- a/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
+++ b/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
@@ -54,6 +54,25 @@ class SystemUICujs(TestSuite):
         2,1,"com.android.systemui","L<IGNORED_CUJ_2>","IGNORED_CUJ_2",65,156000000,160000000,4000000,"completed"
         """))
 
+  def test_android_jank_latency_cujs(self):
+    return DiffTestBlueprint(
+        trace=Path(
+            '../../metrics/android/android_blocking_calls_cuj_per_frame_metric.py'
+        ),
+        query="""
+        INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
+        SELECT *
+        FROM android_jank_latency_cujs;
+        """,
+        out=Csv("""
+        "cuj_id","id","upid","process_name","cuj_slice_name","cuj_name","slice_id","ts","ts_end","dur","state","ui_thread","layer_id","begin_vsync","end_vsync","cuj_type"
+        1,1,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",4,27000000,65000000,38000000,"completed",3,0,20,30,"jank"
+        2,2,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",31,85000000,89000000,4000000,"completed",3,2,60,70,"jank"
+        3,3,2,"com.google.android.apps.nexuslauncher","J<CUJ_NAME>","CUJ_NAME",45,121000000,143000000,22000000,"completed",7,1,80,90,"jank"
+        1,1,1,"com.android.systemui","L<IGNORED_CUJ_1>","IGNORED_CUJ_1",60,150000000,155000000,5000000,"completed",1,"[NULL]","[NULL]","[NULL]","latency"
+        2,2,1,"com.android.systemui","L<IGNORED_CUJ_2>","IGNORED_CUJ_2",65,156000000,160000000,4000000,"completed",1,"[NULL]","[NULL]","[NULL]","latency"
+        """))
+
   def test_android_sysui_latency_cujs_state(self):
     return DiffTestBlueprint(
         trace=Path('latency_cujs_state_trace.py'),
@@ -68,4 +87,38 @@ class SystemUICujs(TestSuite):
         "CUJ_CANCELED","canceled"
         "CUJ_COMPLETED","completed"
         "CUJ_TIMEOUT","timeout"
+        """))
+
+  def test_android_cuj_blocking_calls(self):
+    return DiffTestBlueprint(
+        trace=Path(
+            '../../metrics/android/android_blocking_calls_cuj_per_frame_metric.py'
+        ),
+        query="""
+        INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
+        SELECT *
+        FROM android_cuj_blocking_calls
+        ORDER BY cuj_id, cuj_type, name, ts;
+        """,
+        out=Csv("""
+        "slice_id","name","ts","dur","ts_end","cuj_id","cuj_name","process_name","upid","utid","cuj_type"
+        13,"CreateGraphicsPipeline",27100000,800000,27900000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        11,"DrawFrames",27000000,1000000,28000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        22,"DrawFrames",44000000,1000000,45000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        26,"DrawFrames",61000000,1000000,62000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        15,"Texture upload",27200000,100000,27300000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        20,"animation",30000000,2000000,32000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
+        29,"animation",62000000,2000000,64000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
+        12,"binder transaction",27000000,500000,27500000,1,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
+        18,"binder transaction",27500000,2500000,30000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
+        14,"drawLayer",27100000,100000,27200000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        14,"drawLayer [TestLayer]",27100000,100000,27200000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        17,"flush commands",27400000,100000,27500000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        16,"flush layers",27300000,100000,27400000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        19,"queueBuffer",27500000,100000,27600000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        36,"DrawFrames",85000000,1000000,86000000,2,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
+        39,"binder transaction",86000000,2500000,88500000,2,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
+        50,"DrawFrames",121000000,800000,121800000,3,"CUJ_NAME","com.google.android.apps.nexuslauncher",2,6,"jank"
+        58,"DrawFrames",142000000,500000,142500000,3,"CUJ_NAME","com.google.android.apps.nexuslauncher",2,6,"jank"
+        54,"animation",127000000,11000000,138000000,3,"CUJ_NAME","com.google.android.apps.nexuslauncher",2,7,"jank"
         """))

--- a/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
+++ b/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
@@ -61,16 +61,26 @@ class SystemUICujs(TestSuite):
         ),
         query="""
         INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
-        SELECT *
+        SELECT
+          process_name,
+          cuj_slice_name,
+          cuj_name,
+          ts,
+          ts_end,
+          dur,
+          state,
+          begin_vsync,
+          end_vsync,
+          cuj_type
         FROM android_jank_latency_cujs;
         """,
         out=Csv("""
-        "cuj_id","id","upid","process_name","cuj_slice_name","cuj_name","slice_id","ts","ts_end","dur","state","ui_thread","layer_id","begin_vsync","end_vsync","cuj_type"
-        1,1,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",4,27000000,65000000,38000000,"completed",3,0,20,30,"jank"
-        2,2,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",31,85000000,89000000,4000000,"completed",3,2,60,70,"jank"
-        3,3,2,"com.google.android.apps.nexuslauncher","J<CUJ_NAME>","CUJ_NAME",45,121000000,143000000,22000000,"completed",7,1,80,90,"jank"
-        1,1,1,"com.android.systemui","L<IGNORED_CUJ_1>","IGNORED_CUJ_1",60,150000000,155000000,5000000,"completed",1,"[NULL]","[NULL]","[NULL]","latency"
-        2,2,1,"com.android.systemui","L<IGNORED_CUJ_2>","IGNORED_CUJ_2",65,156000000,160000000,4000000,"completed",1,"[NULL]","[NULL]","[NULL]","latency"
+        "process_name","cuj_slice_name","cuj_name","ts","ts_end","dur","state","begin_vsync","end_vsync","cuj_type"
+        "com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",27000000,65000000,38000000,"completed",20,30,"jank"
+        "com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",85000000,89000000,4000000,"completed",60,70,"jank"
+        "com.google.android.apps.nexuslauncher","J<CUJ_NAME>","CUJ_NAME",121000000,143000000,22000000,"completed",80,90,"jank"
+        "com.android.systemui","L<IGNORED_CUJ_1>","IGNORED_CUJ_1",150000000,155000000,5000000,"completed","[NULL]","[NULL]","latency"
+        "com.android.systemui","L<IGNORED_CUJ_2>","IGNORED_CUJ_2",156000000,160000000,4000000,"completed","[NULL]","[NULL]","latency"
         """))
 
   def test_android_sysui_latency_cujs_state(self):
@@ -96,29 +106,29 @@ class SystemUICujs(TestSuite):
         ),
         query="""
         INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
-        SELECT *
+        SELECT name, ts, dur, ts_end, cuj_name, process_name, cuj_type
         FROM android_cuj_blocking_calls
-        ORDER BY cuj_id, cuj_type, name, ts;
+        ORDER BY ts;
         """,
         out=Csv("""
-        "slice_id","name","ts","dur","ts_end","cuj_id","cuj_name","process_name","upid","utid","cuj_type"
-        13,"CreateGraphicsPipeline",27100000,800000,27900000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        11,"DrawFrames",27000000,1000000,28000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        22,"DrawFrames",44000000,1000000,45000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        26,"DrawFrames",61000000,1000000,62000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        15,"Texture upload",27200000,100000,27300000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        20,"animation",30000000,2000000,32000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
-        29,"animation",62000000,2000000,64000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
-        12,"binder transaction",27000000,500000,27500000,1,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
-        18,"binder transaction",27500000,2500000,30000000,1,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
-        14,"drawLayer",27100000,100000,27200000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        14,"drawLayer [TestLayer]",27100000,100000,27200000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        17,"flush commands",27400000,100000,27500000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        16,"flush layers",27300000,100000,27400000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        19,"queueBuffer",27500000,100000,27600000,1,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        36,"DrawFrames",85000000,1000000,86000000,2,"BACK_PANEL_ARROW","com.android.systemui",1,4,"jank"
-        39,"binder transaction",86000000,2500000,88500000,2,"BACK_PANEL_ARROW","com.android.systemui",1,3,"jank"
-        50,"DrawFrames",121000000,800000,121800000,3,"CUJ_NAME","com.google.android.apps.nexuslauncher",2,6,"jank"
-        58,"DrawFrames",142000000,500000,142500000,3,"CUJ_NAME","com.google.android.apps.nexuslauncher",2,6,"jank"
-        54,"animation",127000000,11000000,138000000,3,"CUJ_NAME","com.google.android.apps.nexuslauncher",2,7,"jank"
+        "name","ts","dur","ts_end","cuj_name","process_name","cuj_type"
+        "binder transaction",27000000,500000,27500000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "DrawFrames",27000000,1000000,28000000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "CreateGraphicsPipeline",27100000,800000,27900000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "drawLayer [TestLayer]",27100000,100000,27200000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "drawLayer",27100000,100000,27200000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "Texture upload",27200000,100000,27300000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "flush layers",27300000,100000,27400000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "flush commands",27400000,100000,27500000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "binder transaction",27500000,2500000,30000000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "queueBuffer",27500000,100000,27600000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "animation",30000000,2000000,32000000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "DrawFrames",44000000,1000000,45000000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "DrawFrames",61000000,1000000,62000000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "animation",62000000,2000000,64000000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "DrawFrames",85000000,1000000,86000000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "binder transaction",86000000,2500000,88500000,"BACK_PANEL_ARROW","com.android.systemui","jank"
+        "DrawFrames",121000000,800000,121800000,"CUJ_NAME","com.google.android.apps.nexuslauncher","jank"
+        "animation",127000000,11000000,138000000,"CUJ_NAME","com.google.android.apps.nexuslauncher","jank"
+        "DrawFrames",142000000,500000,142500000,"CUJ_NAME","com.google.android.apps.nexuslauncher","jank"
         """))


### PR DESCRIPTION
In android_jank_latency_cujs, remove the ROW_NUMBER() OVER (...) remapping and original_cuj_id column. Instead, make the table a direct UNION ALL of android_sysui_jank_cujs and android_sysui_latency_cujs, preserving the original cuj_id from the underlying jank and latency sources.

This ensures that only one place generates row_number() for Jank CUJs (_jank_cujs_slices) and only one place generates row_number() for Latency CUJs (android_sysui_latency_cujs). Duplicated cuj_id values across jank and latency rows in android_jank_latency_cujs are permitted.

If anyone does join on the table containing both latency and jank cujs, they are expected to also join on the cuj_type.

---- 

fully human part: In practise, this was not really an issue for jank cujs, even if they were accessed from `android_jank_latency_cujs`.. What was happening in `android_jank_latency_cujs` was that jank cuj were keeping the existing id, while latency cujs were remapped after them. We didn't really notice the problem as most of the infra we have is for jank cujs, and not for latency ones. In the blocking calls, the cuj id was not really used anywhere.