### PR TITLE
build: add `perfetto_use_system_re2` flag

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -532,8 +532,27 @@ if (enable_perfetto_pcre2) {
 }
 
 if (enable_perfetto_re2) {
+  # pkg_deps selects the appropriate pkg-config based on current_toolchain and
+  # this is a no-op if |perfetto_use_pkgconfig| is false.
+  pkg_config("pkgconfig_re2") {
+    pkg_deps = [ "re2" ]
+  }
+
+  config("system_re2") {
+    # The system re2 is built against abseil, so its headers need this.
+    defines = [ "RE2_USE_ABSL" ]
+    if (perfetto_use_pkgconfig) {
+      configs = [ ":pkgconfig_re2" ]
+    } else {
+      # Fallback if pkg-config isn't enabled.
+      libs = [ "re2" ]
+    }
+  }
+
   group("re2") {
-    if (perfetto_root_path == "//") {
+    if (perfetto_use_system_re2) {
+      public_configs = [ ":system_re2" ]
+    } else if (perfetto_root_path == "//") {
       public_deps = [ "//buildtools:re2" ]
     } else {
       # This part will be overridden by the various build generators (Android.bp,

--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -483,6 +483,10 @@ declare_args() {
   # from /usr/include instead of the hermetic one.
   perfetto_use_system_protobuf = false
 
+  # Used by NixOS system builds. Uses the system version of re2
+  # from pkg-config instead of the hermetic one.
+  perfetto_use_system_re2 = false
+
   # Used by CrOS system builds. Uses the system version of sqlite
   # from /usr/include instead of the hermetic one.
   perfetto_use_system_sqlite = false


### PR DESCRIPTION
I'm trying to package Perfetto into NixOS / nixpkgs (https://github.com/NixOS/nixpkgs/pull/553888), and one of the requirement on that system is that downloading things at build time is not allowed, so I'd need a flag to use the system re2.

Given the patch is simple enough, I figured I should send it upstream rather than floating it on Nix end.