### PR TITLE
build: add `perfetto_use_system_zstd` flag

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -461,15 +461,26 @@ if (enable_perfetto_zlib) {
   }
 }
 
-config("system_zstd_config") {
-  libs = [ "zstd" ]
-}
-
 # Zstd is used both by trace_processor and by the tracing service.
 if (enable_perfetto_zstd) {
+  # pkg_deps selects the appropriate pkg-config based on current_toolchain and
+  # this is a no-op if |perfetto_use_pkgconfig| is false.
+  pkg_config("pkgconfig_zstd") {
+    pkg_deps = [ "libzstd" ]
+  }
+
+  config("system_zstd") {
+    if (perfetto_use_pkgconfig) {
+      configs = [ ":pkgconfig_zstd" ]
+    } else {
+      # Fallback if pkg-config isn't enabled.
+      libs = [ "libzstd" ]
+    }
+  }
+
   group("zstd") {
     if (perfetto_use_system_zstd) {
-      public_configs = [ "//gn:system_zstd_config" ]
+      public_configs = [ ":system_zstd" ]
     } else if (perfetto_root_path == "//") {
       public_configs = [ "//buildtools:zstd_config" ]
       public_deps = [ "//buildtools:zstd" ]

--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -461,10 +461,16 @@ if (enable_perfetto_zlib) {
   }
 }
 
+config("system_zstd_config") {
+  libs = [ "zstd" ]
+}
+
 # Zstd is used both by trace_processor and by the tracing service.
 if (enable_perfetto_zstd) {
   group("zstd") {
-    if (perfetto_root_path == "//") {
+    if (perfetto_use_system_zstd) {
+      public_configs = [ "//gn:system_zstd_config" ]
+    } else if (perfetto_root_path == "//") {
       public_configs = [ "//buildtools:zstd_config" ]
       public_deps = [ "//buildtools:zstd" ]
     } else {

--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -489,6 +489,10 @@ declare_args() {
 
   perfetto_use_system_zlib = false
 
+  # Used by NixOS system builds. Uses the system version of zstd
+  # from pkg-config instead of the hermetic one.
+  perfetto_use_system_zstd = false
+
   # Set by the amalgamated SDK build. Defaults the optional zlib/re2 features
   # to off; the consumer opts in via perfetto_sdk_config.h (see build_config.h).
   perfetto_amalgamated_sdk = false


### PR DESCRIPTION
Similar to https://github.com/google/perfetto/pull/7217, I was working on the 57.2 branch, and realized when trying to update to 58.2 that zstd needs the same treatment.