### PR TITLE
wattson: Add support to extract SoC model from devicetree on Linux

### DIFF
--- a/include/perfetto/ext/base/android_utils.h
+++ b/include/perfetto/ext/base/android_utils.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "perfetto/base/build_config.h"
 
@@ -57,6 +58,7 @@ struct SystemInfo {
   std::string android_storage_model;
   std::string android_ram_model;
   std::string android_serial_console;
+  std::vector<std::string> device_tree_compatibles;
 };
 
 // Returns the device's utsname information.

--- a/protos/perfetto/common/system_info.proto
+++ b/protos/perfetto/common/system_info.proto
@@ -25,7 +25,7 @@ message Utsname {
   optional string machine = 4;
 }
 
-// Next id: 18
+// Next id: 19
 message SystemInfo {
   optional Utsname utsname = 1;
   optional string android_build_fingerprint = 2;
@@ -38,6 +38,12 @@ message SystemInfo {
 
   // The SoC model from which trace is collected
   optional string android_soc_model = 9;
+
+  // Device tree compatible strings for Linux devices. This field is populated
+  // from the firmware file /sys/firmware/devicetree/base/compatible on the
+  // target device. The ordering matches the ordering in the device tree.
+  // Introduced after 26Q3 in Sept 2026 and is not supported on older versions.
+  repeated string device_tree_compatibles = 18;
 
   // The guest SoC model from which trace is collected in case of VMs
   optional string android_guest_soc_model = 13;

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -6103,7 +6103,7 @@ message Utsname {
   optional string machine = 4;
 }
 
-// Next id: 18
+// Next id: 19
 message SystemInfo {
   optional Utsname utsname = 1;
   optional string android_build_fingerprint = 2;
@@ -6116,6 +6116,12 @@ message SystemInfo {
 
   // The SoC model from which trace is collected
   optional string android_soc_model = 9;
+
+  // Device tree compatible strings for Linux devices. This field is populated
+  // from the firmware file /sys/firmware/devicetree/base/compatible on the
+  // target device. The ordering matches the ordering in the device tree.
+  // Introduced after 26Q3 in Sept 2026 and is not supported on older versions.
+  repeated string device_tree_compatibles = 18;
 
   // The guest SoC model from which trace is collected in case of VMs
   optional string android_guest_soc_model = 13;

--- a/src/base/android_utils.cc
+++ b/src/base/android_utils.cc
@@ -15,6 +15,8 @@
  */
 
 #include "perfetto/ext/base/android_utils.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/string_splitter.h"
 
 #include "perfetto/base/build_config.h"
 
@@ -119,7 +121,24 @@ SystemInfo GetSystemInfo() {
     info.system_ram_bytes = static_cast<uint64_t>(pages) * (*info.page_size);
   }
 #endif
+
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX_BUT_NOT_QNX)
+  // Extract the device compatible strings from the device tree (if available)
+  const std::string path = "/sys/firmware/devicetree/base/compatible";
+  std::string device_compatible_data;
+  if (ReadFile(path, &device_compatible_data)) {
+    for (base::StringSplitter ss(std::move(device_compatible_data), '\0');
+         ss.Next();) {
+      info.device_tree_compatibles.emplace_back(ss.cur_token(),
+                                                ss.cur_token_size());
+      PERFETTO_DLOG("Found linux device compatible: %s", ss.cur_token());
+    }
+  } else {
+    PERFETTO_DLOG("No linux device compatible found in path: %s", path.c_str());
+  }
+#endif
 #endif  // !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
   info.android_build_fingerprint = GetAndroidProp("ro.build.fingerprint");
   if (info.android_build_fingerprint.empty()) {

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -80,6 +80,7 @@
 #include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "protos/perfetto/common/perf_events.pbzero.h"
 #include "protos/perfetto/common/sys_stats_counters.pbzero.h"
+#include "protos/perfetto/common/system_info.pbzero.h"
 #include "protos/perfetto/common/trace_attributes.pbzero.h"
 #include "protos/perfetto/config/trace_config.pbzero.h"
 #include "protos/perfetto/trace/android/packages_list.pbzero.h"
@@ -3183,6 +3184,30 @@ TEST_F(ProtoTraceParserTest, NonEmptyCpuInfo) {
   EXPECT_STREQ(context_.storage->GetString(cpu_table[0].processor()).c_str(),
                "ARMv8 Processor rev 0 (v8l)");
   EXPECT_EQ(cpu_table[0].capacity(), 1024u);
+}
+
+TEST_F(ProtoTraceParserTest, SystemInfoDeviceTreeCompatible) {
+  auto* packet = trace_->add_packet();
+  packet->set_trusted_packet_sequence_id(1);
+  packet->set_timestamp(1000);
+  auto* sys_info = packet->set_system_info();
+  sys_info->add_device_tree_compatibles("google,gs101-oriole");
+  sys_info->add_device_tree_compatibles("google,gs101");
+
+  ASSERT_TRUE(Tokenize().ok());
+  context_.sorter->ExtractEventsForced();
+
+  const auto& metadata_table = context_.storage->metadata_table();
+  std::vector<std::string> compatibles;
+  StringId key_id = context_.storage->InternString("device_tree_compatible");
+  for (uint32_t i = 0; i < metadata_table.row_count(); ++i) {
+    if (metadata_table[i].name() == key_id) {
+      compatibles.push_back(
+          context_.storage->GetString(*metadata_table[i].str_value()).c_str());
+    }
+  }
+  EXPECT_THAT(compatibles,
+              testing::ElementsAre("google,gs101-oriole", "google,gs101"));
 }
 
 }  // namespace

--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -1100,6 +1100,12 @@ void SystemProbesParser::ParseSystemInfo(ConstBytes blob) {
             context_->storage->InternString(packet.android_serial_console())));
   }
 
+  for (auto it = packet.device_tree_compatibles(); it; ++it) {
+    context_->metadata_tracker->AppendMetadata(
+        metadata::device_tree_compatible,
+        Variadic::String(context_->storage->InternString(it->as_string())));
+  }
+
   page_size_ = packet.page_size();
   if (!page_size_) {
     page_size_ = 4096;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
@@ -114,6 +114,51 @@ WITH
   )
 SELECT * FROM data;
 
+CREATE PERFETTO TABLE _linux_soc_compatible_map AS
+WITH
+  data(soc_compatible, wattson_device) AS (
+    SELECT *
+    FROM (
+      VALUES
+        ("google,gs101", "Tensor"),
+        ("google,zuma-pro", "Tensor G4"),
+        ("google,lga", "Tensor G5"),
+        ("google,malibu", "Tensor G6"),
+        ("qcom,sm8750", "SM8750")
+    ) AS _values
+  )
+SELECT * FROM data;
+
+CREATE PERFETTO TABLE _linux_board_compatible_map AS
+WITH
+  data(board_compatible, wattson_device) AS (
+    SELECT *
+    FROM (
+      VALUES
+        ("google,gs101-oriole", "Tensor"),
+        ("google,gs101-raven", "Tensor"),
+        ("google,GS101 Oriole", "Tensor"),
+        ("google,GS101 Raven", "Tensor"),
+        ("google,GS101 BLUEJAY", "Tensor"),
+        ("google,ZUMA PRO CAIMAN", "Tensor G4"),
+        ("google,ZUMA PRO KOMODO", "Tensor G4"),
+        ("google,ZUMA PRO TOKAY", "Tensor G4"),
+        ("google,ZUMA PRO TEGU", "Tensor G4"),
+        ("google,ZUMA PRO COMET", "Tensor G4"),
+        ("google,ZUMA PRO STALLION", "Tensor G4"),
+        ("google,lga-frankel", "Tensor G5"),
+        ("google,lga-blazer", "Tensor G5"),
+        ("google,lga-mustang", "Tensor G5"),
+        ("google,lga-rango", "Tensor G5"),
+        ("google,malibu-cubs", "Tensor G6"),
+        ("google,malibu-grizzly", "Tensor G6"),
+        ("google,malibu-kodiak", "Tensor G6"),
+        ("qcom,sm8750-mtp", "SM8750"),
+        ("qcom,sm8750-qrd", "SM8750")
+    ) AS _values
+  )
+SELECT * FROM data;
+
 CREATE PERFETTO TABLE _wattson_device_map AS
 WITH
   data(device, wattson_device) AS (
@@ -139,6 +184,15 @@ SELECT * FROM data;
 
 CREATE PERFETTO TABLE _wattson_device AS
 WITH
+  dt_compatibles AS (
+    SELECT id, str_value AS compatible
+    FROM metadata
+    WHERE
+      name = 'device_tree_compatible'
+      AND (machine_id = 0 OR machine_id IS NULL)
+    ORDER BY
+      id DESC
+  ),
   soc_model AS (
     SELECT
       coalesce(
@@ -168,6 +222,26 @@ WITH
           FROM _wattson_device_map AS map
           JOIN android_device_name AS ad
             ON ad.name = map.device
+        ),
+        -- First check the Linux device tree SoC compatibles
+        (
+          SELECT map.wattson_device
+          FROM dt_compatibles AS dt
+          JOIN _linux_soc_compatible_map AS map
+            ON dt.compatible = map.soc_compatible
+          ORDER BY
+            dt.id DESC
+          LIMIT 1
+        ),
+        -- Then check the Linux device tree board compatibles
+        (
+          SELECT map.wattson_device
+          FROM dt_compatibles AS dt
+          JOIN _linux_board_compatible_map AS map
+            ON dt.compatible = map.board_compatible
+          ORDER BY
+            dt.id DESC
+          LIMIT 1
         )
       ) AS name
   )

--- a/src/trace_processor/storage/metadata.h
+++ b/src/trace_processor/storage/metadata.h
@@ -81,6 +81,7 @@ namespace metadata {
   F(android_serial_console,            KeyType::kSingle,  Variadic::kString, Scope::kMachine),         \
   F(android_soc_model,                 KeyType::kSingle,  Variadic::kString, Scope::kMachine),         \
   F(android_storage_model,             KeyType::kSingle,  Variadic::kString, Scope::kMachine),         \
+  F(device_tree_compatible,            KeyType::kMulti,   Variadic::kString, Scope::kMachine),         \
   F(system_machine,                    KeyType::kSingle,  Variadic::kString, Scope::kMachine),         \
   F(system_name,                       KeyType::kSingle,  Variadic::kString, Scope::kMachine),         \
   F(system_ram_bytes,                  KeyType::kSingle,  Variadic::kInt,    Scope::kMachine),         \

--- a/src/traced_relay/relay_service.cc
+++ b/src/traced_relay/relay_service.cc
@@ -133,6 +133,9 @@ void SetSystemInfo(protos::gen::InitRelayRequest* request) {
     info->set_android_storage_model(sys_info.android_storage_model);
   if (!sys_info.android_ram_model.empty())
     info->set_android_ram_model(sys_info.android_ram_model);
+  for (const auto& compatible : sys_info.device_tree_compatibles) {
+    info->add_device_tree_compatibles(compatible);
+  }
 }
 
 }  // Anonymous namespace.

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -4204,6 +4204,9 @@ void TracingServiceImpl::EmitSystemInfo(std::vector<TracePacket>* packets) {
     info->set_android_storage_model(sys_info.android_storage_model);
   if (!sys_info.android_ram_model.empty())
     info->set_android_ram_model(sys_info.android_ram_model);
+  for (const auto& compatible : sys_info.device_tree_compatibles) {
+    info->add_device_tree_compatibles(compatible);
+  }
   if (!sys_info.android_serial_console.empty())
     info->set_android_serial_console(sys_info.android_serial_console);
 

--- a/test/trace_processor/diff_tests/stdlib/wattson/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/wattson/tests.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from python.generators.diff_tests.testing import Csv, Path, DataPath
+from python.generators.diff_tests.testing import Csv, Path, DataPath, TextProto
 from python.generators.diff_tests.testing import DiffTestBlueprint
 from python.generators.diff_tests.testing import TestSuite
 
@@ -31,6 +31,125 @@ class WattsonStdlib(TestSuite):
             "name"
             "monaco"
             """))
+
+  # Test that Wattson device is resolved from Linux devicetree compatible metadata.
+  def test_wattson_linux_device_name(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          system_info {
+            utsname {
+              sysname: "Linux"
+              release: "6.1.0"
+              machine: "aarch64"
+            }
+            device_tree_compatibles: "google,gs101-oriole"
+            device_tree_compatibles: "google,gs101"
+          }
+          trusted_uid: 158158
+          trusted_packet_sequence_id: 1
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE wattson.device_infos;
+        SELECT name FROM _wattson_device;
+        """,
+        out=Csv("""
+        "name"
+        "Tensor"
+        """))
+
+  # Test that Wattson device is resolved from SoC compatible when board is unknown.
+  def test_wattson_linux_device_soc_fallback(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          system_info {
+            utsname {
+              sysname: "Linux"
+              release: "6.1.0"
+              machine: "aarch64"
+            }
+            device_tree_compatibles: "vendor,unknown-board"
+            device_tree_compatibles: "google,gs101"
+          }
+          trusted_uid: 158158
+          trusted_packet_sequence_id: 1
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE wattson.device_infos;
+        SELECT name FROM _wattson_device;
+        """,
+        out=Csv("""
+        "name"
+        "Tensor"
+        """))
+
+  # Test that Wattson device is resolved from board compatible fallback.
+  def test_wattson_linux_device_board_fallback(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          system_info {
+            utsname {
+              sysname: "Linux"
+              release: "6.1.0"
+              machine: "aarch64"
+            }
+            device_tree_compatibles: "google,GS101 BLUEJAY"
+          }
+          trusted_uid: 158158
+          trusted_packet_sequence_id: 1
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE wattson.device_infos;
+        SELECT name FROM _wattson_device;
+        """,
+        out=Csv("""
+        "name"
+        "Tensor"
+        """))
+
+  # Test that Wattson device ignores devicetree compatibles from remote machines.
+  def test_wattson_linux_device_multi_machine(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          system_info {
+            utsname {
+              sysname: "Linux"
+              release: "6.1.0"
+              machine: "aarch64"
+            }
+            device_tree_compatibles: "google,gs101"
+          }
+          trusted_uid: 158158
+          trusted_packet_sequence_id: 1
+        }
+        packet {
+          machine_id: 1001
+          system_info {
+            utsname {
+              sysname: "Linux"
+              release: "6.6.0"
+              machine: "aarch64"
+            }
+            device_tree_compatibles: "qcom,sm8750-mtp"
+          }
+          trusted_uid: 158158
+          trusted_packet_sequence_id: 2
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE wattson.device_infos;
+        SELECT name FROM _wattson_device;
+        """,
+        out=Csv("""
+        "name"
+        "Tensor"
+        """))
 
   # Tests intermediate table
   def test_wattson_intermediate_table(self):


### PR DESCRIPTION
On Android, the `ro.soc.model` system property is used to identify the target's SoC which the wattson stdlib uses to determine if a given target supports Wattson. Since Linux distributions don't use system properties, this patch introduces a new SystemInfo attribute -- linux_device. For arm64 Linux devices, we can populate the linux_device attribute with the Device Tree base compatible. This attribute is then passed through via the metadata to allow the Wattson stdlib to create a mapping between the linux_device and wattson_device properies.

With this change, you can successfully collect Wattson metrics on supported devices running Linux. As an example, use tracebox on your Linux target like this:

  $ tracebox --txt -c wattson.cfg --background-wait -o trace.pb

Bug: 446195032
Test: collect trace on Pixel 6 with Linux and verify Wattson track
Test: verify power metrics wattson_markers_rails,wattson_markers_threads