### PR TITLE
tp: fix the strace importer on real -f and -T output

### DIFF
--- a/src/trace_processor/plugins/strace/strace_event.h
+++ b/src/trace_processor/plugins/strace/strace_event.h
@@ -50,6 +50,10 @@ struct alignas(8) StraceEvent {
   StringPool::Id syscall_name_id;
   std::optional<StringPool::Id> args_id;
   std::optional<StringPool::Id> return_value_id;
+  // Time spent in the syscall, when the trace was collected with
+  // `strace -T`. Unset otherwise, in which case complete calls become
+  // zero-duration slices as before.
+  std::optional<int64_t> duration_ns;
   StraceEventKind kind = StraceEventKind::kComplete;
 };
 

--- a/src/trace_processor/plugins/strace/strace_trace_parser.cc
+++ b/src/trace_processor/plugins/strace/strace_trace_parser.cc
@@ -70,9 +70,12 @@ void StraceTraceParser::Parse(int64_t ts, StraceEvent evt) {
   // resumes with their unfinished starts.
   switch (evt.kind) {
     case StraceEventKind::kComplete:
+      // With `-T` the line carries how long the call took; without it there
+      // is only the entry timestamp, so the slice stays a zero-duration
+      // marker rather than being stretched to the next event.
       context_->slice_tracker->Scoped(ts, track, category_id_,
-                                      evt.syscall_name_id, /*duration=*/0,
-                                      args_cb);
+                                      evt.syscall_name_id,
+                                      evt.duration_ns.value_or(0), args_cb);
       return;
     case StraceEventKind::kUnfinished:
       context_->slice_tracker->Begin(ts, track, category_id_,

--- a/src/trace_processor/plugins/strace/strace_trace_tokenizer.cc
+++ b/src/trace_processor/plugins/strace/strace_trace_tokenizer.cc
@@ -230,8 +230,7 @@ ParseStraceLineResult ParseStraceLine(std::string_view line) {
     size_t sp = rest.find(' ');
     if (sp != std::string_view::npos) {
       std::string_view head = rest.substr(0, sp);
-      bool all_digits =
-          !head.empty() && head.size() < 10 && IsAllDigits(head);
+      bool all_digits = !head.empty() && head.size() < 10 && IsAllDigits(head);
       if (all_digits) {
         auto pid = base::StringViewToNumber<uint32_t>(base::StringView(head));
         if (!pid)

--- a/src/trace_processor/plugins/strace/strace_trace_tokenizer.cc
+++ b/src/trace_processor/plugins/strace/strace_trace_tokenizer.cc
@@ -55,6 +55,17 @@ std::string_view ToStringView(const TraceBlobView& tbv) {
   return {reinterpret_cast<const char*>(tbv.data()), tbv.size()};
 }
 
+// Whether `s` consists only of ASCII digits. Vacuously true for an empty
+// `s`, matching a `for` loop over it that never finds a non-digit; callers
+// that require at least one digit check emptiness separately.
+bool IsAllDigits(std::string_view s) {
+  for (char c : s) {
+    if (!isdigit(static_cast<unsigned char>(c)))
+      return false;
+  }
+  return true;
+}
+
 // The largest number of whole seconds since the epoch for which
 // `seconds * kNsPerSec` cannot overflow int64_t. Anything larger is
 // rejected outright rather than silently saturating/overflowing; genuine
@@ -121,14 +132,8 @@ std::optional<int64_t> ParseSyscallDuration(std::string_view s) {
 
   if (whole.empty() || whole.size() > 10 || frac.size() > 9)
     return std::nullopt;
-  for (char c : whole) {
-    if (!isdigit(static_cast<unsigned char>(c)))
-      return std::nullopt;
-  }
-  for (char c : frac) {
-    if (!isdigit(static_cast<unsigned char>(c)))
-      return std::nullopt;
-  }
+  if (!IsAllDigits(whole) || !IsAllDigits(frac))
+    return std::nullopt;
 
   auto seconds = base::StringViewToInt64(base::StringView(whole));
   // A syscall duration is a wall-clock interval, so anything near the epoch
@@ -225,13 +230,8 @@ ParseStraceLineResult ParseStraceLine(std::string_view line) {
     size_t sp = rest.find(' ');
     if (sp != std::string_view::npos) {
       std::string_view head = rest.substr(0, sp);
-      bool all_digits = !head.empty() && head.size() < 10;
-      for (char c : head) {
-        if (!isdigit(static_cast<unsigned char>(c))) {
-          all_digits = false;
-          break;
-        }
-      }
+      bool all_digits =
+          !head.empty() && head.size() < 10 && IsAllDigits(head);
       if (all_digits) {
         auto pid = base::StringViewToNumber<uint32_t>(base::StringView(head));
         if (!pid)

--- a/src/trace_processor/plugins/strace/strace_trace_tokenizer.cc
+++ b/src/trace_processor/plugins/strace/strace_trace_tokenizer.cc
@@ -47,6 +47,10 @@ namespace {
 constexpr int64_t kNsPerSec = 1000LL * 1000 * 1000;
 constexpr int64_t kNsPerUs = 1000;
 
+// strace interleaves its own messages ("strace: Process 1234 attached", and
+// the errors it prints when it cannot attach) with the trace itself.
+constexpr std::string_view kDiagnosticPrefix = "strace: ";
+
 std::string_view ToStringView(const TraceBlobView& tbv) {
   return {reinterpret_cast<const char*>(tbv.data()), tbv.size()};
 }
@@ -102,6 +106,69 @@ std::optional<int64_t> ParseEpochTimestamp(std::string_view s) {
   return ns;
 }
 
+// Parses the "<seconds.fraction>" suffix `strace -T` appends to a completed
+// syscall line ("... = 0 <0.000123>") into nanoseconds. strace prints six
+// fractional digits by default and up to nine with `--syscall-times=ns`, so
+// the fraction is scaled by its digit count rather than assumed to be
+// microseconds. Returns std::nullopt if the suffix isn't a well-formed
+// duration, in which case the caller keeps the text as part of the return
+// value instead of dropping it.
+std::optional<int64_t> ParseSyscallDuration(std::string_view s) {
+  size_t dot = s.find('.');
+  std::string_view whole = s.substr(0, dot);
+  std::string_view frac =
+      dot == std::string_view::npos ? std::string_view() : s.substr(dot + 1);
+
+  if (whole.empty() || whole.size() > 10 || frac.size() > 9)
+    return std::nullopt;
+  for (char c : whole) {
+    if (!isdigit(static_cast<unsigned char>(c)))
+      return std::nullopt;
+  }
+  for (char c : frac) {
+    if (!isdigit(static_cast<unsigned char>(c)))
+      return std::nullopt;
+  }
+
+  auto seconds = base::StringViewToInt64(base::StringView(whole));
+  // A syscall duration is a wall-clock interval, so anything near the epoch
+  // range is garbage rather than a real measurement; reject it instead of
+  // overflowing the multiplication below.
+  if (!seconds || *seconds > kMaxEpochSeconds)
+    return std::nullopt;
+
+  int64_t ns = *seconds * kNsPerSec;
+  if (!frac.empty()) {
+    auto frac_value = base::StringViewToInt64(base::StringView(frac));
+    if (!frac_value)
+      return std::nullopt;
+    // Scale by the number of digits actually printed: ".5" is 500ms, while
+    // ".000500" is 500us.
+    int64_t scale = kNsPerSec;
+    for (size_t i = 0; i < frac.size(); ++i)
+      scale /= 10;
+    ns += *frac_value * scale;
+  }
+  return ns;
+}
+
+// Splits a trailing `strace -T` "<duration>" suffix off a return value.
+// `ret` is updated in place to the return value without the suffix.
+std::optional<int64_t> ExtractTrailingDuration(std::string_view* ret) {
+  std::string_view text = base::TrimWhitespace(*ret);
+  if (text.size() < 3 || text.back() != '>')
+    return std::nullopt;
+  size_t open = text.rfind('<');
+  if (open == std::string_view::npos)
+    return std::nullopt;
+  std::optional<int64_t> dur =
+      ParseSyscallDuration(text.substr(open + 1, text.size() - open - 2));
+  if (!dur)
+    return std::nullopt;
+  *ret = base::TrimWhitespace(text.substr(0, open));
+  return dur;
+}
+
 }  // namespace
 
 ParseStraceLineResult ParseStraceLine(std::string_view line) {
@@ -111,7 +178,41 @@ ParseStraceLineResult ParseStraceLine(std::string_view line) {
     return {};
   }
 
+  // strace's own diagnostics ("strace: Process 1234 attached", and the
+  // error messages it prints when it cannot attach) are interleaved with
+  // the trace. They must be recognised here: the timestamp parsing below
+  // would otherwise see the ':' in "strace:" and report them as `-t`/`-tt`
+  // output, which raises a spurious "re-run with -ttt" error on a trace
+  // that was in fact collected correctly.
+  if (rest.substr(0, kDiagnosticPrefix.size()) == kDiagnosticPrefix) {
+    return {};
+  }
+
   StraceLine out;
+
+  // Optional "[pid  1234] " prefix. strace prints the pid two different
+  // ways when following processes: a bare "1234 " prefix when writing to a
+  // file (-o/-ff), and this bracketed, right-aligned form when writing to
+  // stderr, which is what a piped or redirected capture contains.
+  {
+    constexpr std::string_view kPidPrefix = "[pid";
+    if (rest.substr(0, kPidPrefix.size()) == kPidPrefix) {
+      size_t close = rest.find(']', kPidPrefix.size());
+      if (close == std::string_view::npos)
+        return {};
+      std::string_view digits = base::TrimWhitespace(
+          rest.substr(kPidPrefix.size(), close - kPidPrefix.size()));
+      auto pid = base::StringViewToNumber<uint32_t>(base::StringView(digits));
+      if (!pid)
+        return {};
+      out.pid = *pid;
+      rest = base::TrimWhitespace(rest.substr(close + 1));
+      // "[pid 75] +++ exited with 0 +++" and its signal-delivery sibling
+      // are not syscall lines either, they just carry a pid prefix.
+      if (rest.empty() || rest[0] == '-' || rest[0] == '+')
+        return {};
+    }
+  }
 
   // Optional leading pid (present with -f/-ff): "1234 1700000000.000000 ...".
   // A bare digit run is ambiguous with an integral (no-fraction) `-ttt`
@@ -120,7 +221,7 @@ ParseStraceLineResult ParseStraceLine(std::string_view line) {
   // digits, while Linux's pid_max tops out at 4194304 (7 digits) even at
   // its highest configurable value. A 10+ digit run is therefore always the
   // timestamp, never a pid, and is left for the block below.
-  {
+  if (!out.pid) {
     size_t sp = rest.find(' ');
     if (sp != std::string_view::npos) {
       std::string_view head = rest.substr(0, sp);
@@ -209,15 +310,19 @@ ParseStraceLineResult ParseStraceLine(std::string_view line) {
   // single-line call ("foo(...) = ret").
   out.kind = resumed ? StraceEventKind::kResumed : StraceEventKind::kComplete;
 
-  // The return value itself may contain further parens (e.g. "-1 ENOENT (No
-  // such file or directory)"), so anchor on a ')' followed by whitespace and
-  // then '=' — not the last ')' in the line — to separate the call's own
-  // closing paren from its return value. strace right-aligns the '=' column
-  // with spaces (e.g. "close(2)        = 0"), so the gap between ')' and '='
-  // cannot be assumed to be exactly one space.
+  // The call's own closing paren is the last ')' that is followed by the
+  // '=' of the return value. Scanning forwards instead would stop at the
+  // first such ')', which is wrong whenever an argument contains one:
+  // wait4's status macros print "[{WIFEXITED(s) && WEXITSTATUS(s) == 0}]",
+  // and a string argument can contain ") =" verbatim. Anchoring on ')'
+  // rather than on the last ')' in the line keeps a parenthesised errno
+  // description ("-1 ENOENT (No such file or directory)") out of the args.
+  // strace right-aligns the '=' column with spaces (e.g.
+  // "close(2)        = 0"), so the gap between ')' and '=' cannot be
+  // assumed to be exactly one space.
   size_t close_paren = std::string_view::npos;
-  for (size_t pos = rest.find(')'); pos != std::string_view::npos;
-       pos = rest.find(')', pos + 1)) {
+  for (size_t pos = rest.rfind(')'); pos != std::string_view::npos;
+       pos = pos == 0 ? std::string_view::npos : rest.rfind(')', pos - 1)) {
     size_t after = pos + 1;
     while (after < rest.size() && base::IsSpace(rest[after]))
       ++after;
@@ -233,22 +338,39 @@ ParseStraceLineResult ParseStraceLine(std::string_view line) {
     size_t eq = rest.find('=');
     if (eq == std::string_view::npos)
       return {};
-    out.return_value = std::string(base::TrimWhitespace(rest.substr(eq + 1)));
+    std::string_view ret = rest.substr(eq + 1);
+    out.duration_ns = ExtractTrailingDuration(&ret);
+    out.return_value = std::string(base::TrimWhitespace(ret));
     return ParseStraceLineResult{std::move(out)};
   }
 
   out.args = std::string(base::TrimWhitespace(rest.substr(0, close_paren)));
   size_t eq = rest.find('=', close_paren + 1);
-  out.return_value = std::string(base::TrimWhitespace(rest.substr(eq + 1)));
+  std::string_view ret = rest.substr(eq + 1);
+  out.duration_ns = ExtractTrailingDuration(&ret);
+  out.return_value = std::string(base::TrimWhitespace(ret));
   return ParseStraceLineResult{std::move(out)};
 }
 
 bool IsStraceFormatTrace(const uint8_t* ptr, size_t size) {
   std::string_view str(reinterpret_cast<const char*>(ptr), size);
-  size_t nl = str.find('\n');
-  std::string_view first_line =
-      nl == std::string_view::npos ? str : str.substr(0, nl);
-  return ParseStraceLine(first_line).line.has_value();
+  // `strace -f -p <pid>` opens its output with "strace: Process <pid>
+  // attached" rather than a syscall line, so sniffing only the very first
+  // line would reject a perfectly valid trace. Skip strace's own
+  // diagnostics (and blank lines) and sniff the first real line instead.
+  for (;;) {
+    size_t nl = str.find('\n');
+    std::string_view line =
+        nl == std::string_view::npos ? str : str.substr(0, nl);
+    std::string_view trimmed = base::TrimWhitespace(line);
+    if (!trimmed.empty() &&
+        trimmed.substr(0, kDiagnosticPrefix.size()) != kDiagnosticPrefix) {
+      return ParseStraceLine(line).line.has_value();
+    }
+    if (nl == std::string_view::npos)
+      return false;
+    str = str.substr(nl + 1);
+  }
 }
 
 StraceTraceTokenizer::StraceTraceTokenizer(TraceProcessorContext* ctx)
@@ -314,6 +436,7 @@ base::Status StraceTraceTokenizer::Parse(TraceBlobView blob) {
           base::StringView(*parsed.return_value));
     }
     evt.kind = parsed.kind;
+    evt.duration_ns = parsed.duration_ns;
 
     stream_->Push(*trace_ts, evt);
   }

--- a/src/trace_processor/plugins/strace/strace_trace_tokenizer.h
+++ b/src/trace_processor/plugins/strace/strace_trace_tokenizer.h
@@ -38,7 +38,9 @@ namespace perfetto::trace_processor::strace_importer {
 // Examples of lines this is built from:
 //   1700000000.000000 openat(AT_FDCWD, "/etc/passwd", O_RDONLY) = 3
 //   1700000000.123456 read(3, "root:x:0:0"..., 1024) = 312
-//   1234 1700000000.000000 read(3, "root:x:0:0"..., 1024) = 312    (-f)
+//   1234 1700000000.000000 read(3, "root:x:0:0"..., 1024) = 312    (-f -o)
+//   [pid  1234] 1700000000.000000 read(3, "abc", 1024) = 3          (-f)
+//   1700000000.000000 read(3, "abc", 1024) = 3 <0.000123>           (-T)
 //   1700000000.000000 read(3,  <unfinished ...>
 //   1700000000.000500 <... read resumed> "root:x:0:0"..., 1024) = 312
 //
@@ -62,8 +64,14 @@ struct StraceLine {
   // line, whatever text follows "resumed>").
   std::string args;
   // The text after "= " at the end of a *complete* call, e.g. "3" or "-1
-  // ENOENT (No such file or directory)". Unset for unfinished calls.
+  // ENOENT (No such file or directory)". Unset for unfinished calls. The
+  // `strace -T` "<0.000123>" suffix, if any, is stripped into duration_ns
+  // rather than left in here.
   std::optional<std::string> return_value;
+  // Time spent inside the syscall, from `strace -T`'s "<seconds.fraction>"
+  // suffix. Unset when the trace was collected without `-T` (and always
+  // unset for an unfinished call, which strace has not timed yet).
+  std::optional<int64_t> duration_ns;
   StraceEventKind kind = StraceEventKind::kComplete;
 };
 

--- a/src/trace_processor/plugins/strace/strace_trace_tokenizer_unittest.cc
+++ b/src/trace_processor/plugins/strace/strace_trace_tokenizer_unittest.cc
@@ -69,6 +69,141 @@ TEST(StraceLineParserTest, PidPrefixFromDashF) {
   EXPECT_EQ(line->syscall, "read");
 }
 
+TEST(StraceLineParserTest, BracketedPidPrefix) {
+  // Writing to stderr (the default, and what a piped capture records)
+  // strace prints the pid as a right-aligned "[pid  1234]" prefix rather
+  // than the bare "1234 " form it uses with -o/-ff.
+  auto line = ParseStraceLine(
+                  R"([pid  1234] 1700000000.000000 read(3, "abc", 1024) = 3)")
+                  .line;
+  ASSERT_TRUE(line.has_value());
+  ASSERT_TRUE(line->pid.has_value());
+  EXPECT_EQ(*line->pid, 1234u);
+  EXPECT_EQ(line->syscall, "read");
+  EXPECT_EQ(line->args, R"(3, "abc", 1024)");
+  ASSERT_TRUE(line->return_value.has_value());
+  EXPECT_EQ(*line->return_value, "3");
+}
+
+TEST(StraceLineParserTest, BracketedPidPrefixOnResumedLine) {
+  auto line =
+      ParseStraceLine(
+          R"([pid    75] 1700000000.000500 <... execve resumed>) = 0 <0.000328>)")
+          .line;
+  ASSERT_TRUE(line.has_value());
+  ASSERT_TRUE(line->pid.has_value());
+  EXPECT_EQ(*line->pid, 75u);
+  EXPECT_EQ(line->syscall, "execve");
+  EXPECT_EQ(line->kind, StraceEventKind::kResumed);
+}
+
+TEST(StraceLineParserTest, BracketedPidPrefixOnNonSyscallLine) {
+  // Exit banners and signal deliveries carry the same pid prefix when
+  // following processes. They are still not syscall lines, and must not be
+  // mistaken for one (nor reported as a timestamp-format problem).
+  auto exited =
+      ParseStraceLine("[pid    75] 1700000000.000000 +++ exited with 0 +++");
+  EXPECT_FALSE(exited.line.has_value());
+  EXPECT_FALSE(exited.unsupported_timestamp_format);
+
+  auto signalled = ParseStraceLine(
+      "[pid    75] 1700000000.000000 --- SIGCHLD {si_signo=SIGCHLD} ---");
+  EXPECT_FALSE(signalled.line.has_value());
+  EXPECT_FALSE(signalled.unsupported_timestamp_format);
+}
+
+TEST(StraceLineParserTest, RejectsMalformedBracketedPid) {
+  EXPECT_FALSE(ParseStraceLine(R"([pid  abc] 1700000000.000000 read(3) = 3)")
+                   .line.has_value());
+  EXPECT_FALSE(ParseStraceLine(R"([pid  12 1700000000.000000 read(3) = 3)")
+                   .line.has_value());
+}
+
+TEST(StraceLineParserTest, StraceOwnDiagnosticLine) {
+  // strace interleaves its own messages with the trace. These are not
+  // syscall lines, and in particular the ':' in "strace:" must not make
+  // them look like `-t`/`-tt` output: that would raise a spurious
+  // "re-run with -ttt" error on a trace collected exactly as documented.
+  for (const char* diagnostic :
+       {"strace: Process 75 attached", "strace: Process 75 detached",
+        "strace: [ Process PID=75 runs in 32 bit mode. ]"}) {
+    auto result = ParseStraceLine(diagnostic);
+    EXPECT_FALSE(result.line.has_value()) << diagnostic;
+    EXPECT_FALSE(result.unsupported_timestamp_format) << diagnostic;
+  }
+}
+
+TEST(StraceLineParserTest, SyscallDurationFromDashT) {
+  auto line =
+      ParseStraceLine(
+          R"(1700000000.000000 clock_nanosleep(CLOCK_REALTIME, 0, {tv_sec=1}, NULL) = 0 <1.004879>)")
+          .line;
+  ASSERT_TRUE(line.has_value());
+  ASSERT_TRUE(line->duration_ns.has_value());
+  EXPECT_EQ(*line->duration_ns, 1004879000);
+  // The suffix belongs to the duration, not to the return value.
+  ASSERT_TRUE(line->return_value.has_value());
+  EXPECT_EQ(*line->return_value, "0");
+}
+
+TEST(StraceLineParserTest, SyscallDurationScalesByDigitCount) {
+  // Six digits is strace's default; `--syscall-times=ns` prints nine. The
+  // fraction is scaled by how many digits are actually there, so neither is
+  // silently off by a factor of 1000.
+  auto us =
+      ParseStraceLine(R"(1700000000.000000 close(3) = 0 <0.000123>)").line;
+  ASSERT_TRUE(us.has_value());
+  ASSERT_TRUE(us->duration_ns.has_value());
+  EXPECT_EQ(*us->duration_ns, 123000);
+
+  auto ns =
+      ParseStraceLine(R"(1700000000.000000 close(3) = 0 <0.000004321>)").line;
+  ASSERT_TRUE(ns.has_value());
+  ASSERT_TRUE(ns->duration_ns.has_value());
+  EXPECT_EQ(*ns->duration_ns, 4321);
+}
+
+TEST(StraceLineParserTest, DurationOnErrorReturnValue) {
+  auto line =
+      ParseStraceLine(
+          R"(1700000000.000000 wait4(-1, 0x0, WNOHANG, NULL) = -1 ECHILD (No child processes) <0.000027>)")
+          .line;
+  ASSERT_TRUE(line.has_value());
+  ASSERT_TRUE(line->duration_ns.has_value());
+  EXPECT_EQ(*line->duration_ns, 27000);
+  ASSERT_TRUE(line->return_value.has_value());
+  EXPECT_EQ(*line->return_value, "-1 ECHILD (No child processes)");
+}
+
+TEST(StraceLineParserTest, NoDurationWithoutDashT) {
+  auto line = ParseStraceLine(R"(1700000000.000000 close(3) = 0)").line;
+  ASSERT_TRUE(line.has_value());
+  EXPECT_FALSE(line->duration_ns.has_value());
+  ASSERT_TRUE(line->return_value.has_value());
+  EXPECT_EQ(*line->return_value, "0");
+}
+
+TEST(StraceLineParserTest, MalformedDurationStaysInReturnValue) {
+  // Anything that isn't a well-formed duration is left alone rather than
+  // silently dropped from the return value.
+  auto line =
+      ParseStraceLine(R"(1700000000.000000 fcntl(3, F_GETFL) = 0 <x>)").line;
+  ASSERT_TRUE(line.has_value());
+  EXPECT_FALSE(line->duration_ns.has_value());
+  ASSERT_TRUE(line->return_value.has_value());
+  EXPECT_EQ(*line->return_value, "0 <x>");
+}
+
+TEST(StraceLineParserTest, UnfinishedCallHasNoDuration) {
+  auto line =
+      ParseStraceLine(
+          R"([pid    74] 1700000000.000000 wait4(-1,  <unfinished ...>)")
+          .line;
+  ASSERT_TRUE(line.has_value());
+  EXPECT_EQ(line->kind, StraceEventKind::kUnfinished);
+  EXPECT_FALSE(line->duration_ns.has_value());
+}
+
 TEST(StraceLineParserTest, RejectsNegativeTimestampAfterPidPrefix) {
   // The leading '-' guard in ParseStraceLine only inspects the first
   // character of the whole line (to reject "--- SIGCHLD ... ---"), which is
@@ -177,6 +312,32 @@ TEST(StraceLineParserTest, ReturnValueContainingParens) {
   EXPECT_EQ(*line->return_value, "-1 ECONNREFUSED (Connection refused)");
 }
 
+TEST(StraceLineParserTest, ArgumentContainingClosingParenAndEquals) {
+  // wait4 prints its status through macros, so the argument list itself
+  // contains ") ==". Anchoring the return value on the first ")" followed
+  // by "=" would cut the line in the middle of the arguments.
+  auto line =
+      ParseStraceLine(
+          R"(1700000000.000000 wait4(-1, [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL) = 75)")
+          .line;
+  ASSERT_TRUE(line.has_value());
+  EXPECT_EQ(line->args, "-1, [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL");
+  ASSERT_TRUE(line->return_value.has_value());
+  EXPECT_EQ(*line->return_value, "75");
+}
+
+TEST(StraceLineParserTest, StringArgumentContainingParenEquals) {
+  auto line = ParseStraceLine(
+                  R"(1700000000.000000 write(1, "x) = y", 6) = 6 <0.000004>)")
+                  .line;
+  ASSERT_TRUE(line.has_value());
+  EXPECT_EQ(line->args, R"(1, "x) = y", 6)");
+  ASSERT_TRUE(line->return_value.has_value());
+  EXPECT_EQ(*line->return_value, "6");
+  ASSERT_TRUE(line->duration_ns.has_value());
+  EXPECT_EQ(*line->duration_ns, 4000);
+}
+
 TEST(StraceLineParserTest, ReturnValueColumnAlignedWithSpaces) {
   // strace right-aligns the '=' column across a trace with padding spaces
   // (so short calls like "close(2)" don't need to match the width of the
@@ -231,6 +392,22 @@ TEST(StraceLineParserTest, NonSyscallLineIsNotUnsupportedTimestampFormat) {
   // syscall line) must not be misclassified as the timestamp-format case.
   EXPECT_FALSE(ParseStraceLine(R"(--- SIGCHLD {si_signo=SIGCHLD} ---)")
                    .unsupported_timestamp_format);
+}
+
+TEST(StraceLineParserTest, IsStraceFormatTraceSkipsLeadingDiagnostics) {
+  // `strace -f -p <pid>` opens with an "attached" diagnostic rather than a
+  // syscall line; the trace is still strace output.
+  std::string trace =
+      "strace: Process 1234 attached\n"
+      "[pid  1234] 1700000000.000000 read(3, \"abc\", 1024) = 3 <0.000012>\n";
+  EXPECT_TRUE(IsStraceFormatTrace(
+      reinterpret_cast<const uint8_t*>(trace.data()), trace.size()));
+
+  // Skipping diagnostics must not turn an unrelated format into strace.
+  std::string not_strace =
+      "strace: Process 1234 attached\n{\"traceEvents\": []}";
+  EXPECT_FALSE(IsStraceFormatTrace(
+      reinterpret_cast<const uint8_t*>(not_strace.data()), not_strace.size()));
 }
 
 TEST(StraceLineParserTest, IsStraceFormatTraceSniffing) {

--- a/test/trace_processor/diff_tests/parser/strace/pid_prefix_durations.strace
+++ b/test/trace_processor/diff_tests/parser/strace/pid_prefix_durations.strace
@@ -1,0 +1,10 @@
+[pid    74] 1787734451.075961 execve("/usr/bin/sh", ["sh", "-c", "sleep 0.3"], 0xffffc6bf4618 /* 4 vars */) = 0 <0.001261>
+strace: Process 75 attached
+[pid    75] 1787734451.084425 execve("/usr/bin/sleep", ["sleep", "0.3"], 0xaaaacd792868 /* 4 vars */ <unfinished ...>
+[pid    74] 1787734451.084774 wait4(-1,  <unfinished ...>
+[pid    75] 1787734451.084796 <... execve resumed>) = 0 <0.000328>
+[pid    75] 1787734451.088553 clock_nanosleep(CLOCK_REALTIME, 0, {tv_sec=0, tv_nsec=300000001}, 0xfffff6d40e78) = 0 <0.305284>
+[pid    75] 1787734451.395296 +++ exited with 0 +++
+[pid    74] 1787734451.395359 <... wait4 resumed>[{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL) = 75 <0.310566>
+[pid    74] 1787734451.395906 --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=75, si_uid=0, si_status=0} ---
+[pid    74] 1787734451.396054 wait4(-1, 0xffffc28a5b9c, WNOHANG, NULL) = -1 ECHILD (No child processes) <0.000027>

--- a/test/trace_processor/diff_tests/parser/strace/tests.py
+++ b/test/trace_processor/diff_tests/parser/strace/tests.py
@@ -131,6 +131,71 @@ class StraceParser(TestSuite):
         2,2
         """))
 
+  def test_strace_bracketed_pid_and_durations(self):
+    # Lines taken from real strace 6.13 `-ttt -T -f` stderr output, where
+    # pids come as "[pid    75]" prefixes rather than the bare form strace
+    # uses with -o, and every completed call carries a "<seconds>" duration
+    # from -T. The root process's lines carry the prefix too, as they do
+    # when strace is attached to several processes (-p A -p B).
+    return DiffTestBlueprint(
+        trace=Path('pid_prefix_durations.strace'),
+        query="""
+        SELECT s.ts, s.dur, s.name, t.tid
+        FROM slice s
+        JOIN thread_track tt ON s.track_id = tt.id
+        JOIN thread t USING (utid)
+        ORDER BY s.ts;
+        """,
+        out=Csv("""
+        "ts","dur","name","tid"
+        1787734451075961000,1261000,"execve",74
+        1787734451084425000,371000,"execve",75
+        1787734451084774000,310585000,"wait4",74
+        1787734451088553000,305284000,"clock_nanosleep",75
+        1787734451396054000,27000,"wait4",74
+        """))
+
+  def test_strace_duration_stripped_from_return_value(self):
+    # The "<0.000027>" suffix belongs to the slice duration, not to the
+    # recorded return value.
+    return DiffTestBlueprint(
+        trace=Path('pid_prefix_durations.strace'),
+        query="""
+        SELECT a.string_value
+        FROM slice s
+        JOIN args a ON s.arg_set_id = a.arg_set_id
+        WHERE s.name = 'wait4' AND a.key = 'ret'
+        ORDER BY s.ts;
+        """,
+        out=Csv("""
+        "string_value"
+        "75"
+        "-1 ECHILD (No child processes)"
+        """))
+
+  def test_strace_bracketed_pid_non_syscall_lines(self):
+    # strace's own "Process N attached" diagnostic, the exit banner and the
+    # signal-delivery line are all skipped as ordinary non-syscall lines.
+    # In particular the ':' in "strace:" must not be read as a `-t`/`-tt`
+    # timestamp: that would raise a spurious "re-run with -ttt" error on a
+    # trace that already uses -ttt.
+    return DiffTestBlueprint(
+        trace=Path('pid_prefix_durations.strace'),
+        query="""
+        SELECT name, value
+        FROM stats
+        WHERE name IN ('strace_parse_failure',
+                        'strace_unsupported_timestamp_format',
+                        'strace_missing_pid')
+        ORDER BY name;
+        """,
+        out=Csv("""
+        "name","value"
+        "strace_missing_pid",0
+        "strace_parse_failure",3
+        "strace_unsupported_timestamp_format",0
+        """))
+
   def test_strace_unfinished_resumed(self):
     return DiffTestBlueprint(
         trace=Path('unfinished_resumed.strace'),


### PR DESCRIPTION
I ran a plain `strace -ttt -T -f sh -c "ls /usr/bin > /dev/null; sleep 0.05; echo done"` (strace 6.13) and fed the 228-line result to trace_processor. It produced zero slices and 152 parse failures. Four separate things are wrong, all in the tokenizer I contributed in #6588.

**`[pid N]` prefixes.** Writing to stderr, which is what a piped or redirected capture records, strace prints the pid as `[pid    75] ` rather than the bare `75 ` form it uses with `-o`. The tokenizer only knew the bare form, so every line belonging to a followed process failed to parse. Both forms are accepted now.

**strace's own diagnostics.** strace interleaves messages like `strace: Process 75 attached` with the trace. The `:` in `strace:` made the timestamp parser classify them as `-t`/`-tt` output, which raises `strace_unsupported_timestamp_format` telling the user to re-run with `-ttt` on a trace that already used `-ttt`. Those lines are recognised and skipped now, and format sniffing looks past them, so a log that opens with one (as `strace -f -p <pid>` does) is still detected as strace instead of failing type detection outright.

**Return value split.** The split ran forwards to the first `)` followed by `=`, which lands in the middle of the arguments whenever an argument contains one. wait4 prints its status through macros, so `<... wait4 resumed>[{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL) = 75` gave a return value of `= 0}], 0, NULL) = 75`. The scan runs backwards from the end of the line now, which also covers a string argument containing `) =` verbatim.

**`-T` durations.** `-T` prints how long each call took (`= 0 <1.004879>`) and that was ignored, so every completed call became a zero-duration slice with the timing glued onto the return value. The suffix becomes the slice duration now. Without `-T` slices stay zero-duration, exactly as before.

The same log imports as 139 slices across 3 threads, 135 of them with durations, after the change.

The new diff-test fixture is lines from that real strace 6.13 output rather than something hand-written, with the root process's lines given the same `[pid]` prefix strace uses when it is attached to several processes.

Ran `perfetto_trace_processor_unittests --gtest_filter="*Strace*"` (37 pass, 14 of them new), the full unit suite (2067 pass), `diff_test_trace_processor.py --name-filter ".*Strace.*"` (11 pass, 3 new) and the same for `(Systrace|Atrace|PerfText|Ftrace)` to confirm the sniffing change doesn't disturb the neighbouring text formats (28 pass). The repo's pre-push presubmit passes.

Written with Claude Code (Claude Opus 5); I reviewed and tested everything before submitting.
