### PR TITLE
tp: avoid using heap_graph_object when heap_graph would do the job

### DIFF
--- a/src/trace_processor/importers/art_hprof/art_hprof_parser.cc
+++ b/src/trace_processor/importers/art_hprof/art_hprof_parser.cc
@@ -86,6 +86,10 @@ base::Status ArtHprofParser::OnPushDataToSorter() {
   }
 
   int64_t ts = static_cast<int64_t>(graph.GetTimestamp());
+  tables::HeapGraphTable::Row heap_graph_row;
+  heap_graph_row.ts = ts;
+  heap_graph_row.upid = upid;
+  context_->storage->mutable_heap_graph_table()->Insert(heap_graph_row);
 
   PopulateClasses(graph);
   PopulateObjects(graph, ts, upid);

--- a/test/trace_processor/diff_tests/parser/art_hprof/tests.py
+++ b/test/trace_processor/diff_tests/parser/art_hprof/tests.py
@@ -65,6 +65,17 @@ class ArtHprofParser(TestSuite):
           25919
         '''))
 
+  def test_art_hprof_heap_graph_metadata(self):
+    return DiffTestBlueprint(
+        trace=DataPath('test-dump.hprof'),
+        query="""
+          SELECT id, ts, upid FROM heap_graph
+        """,
+        out=Csv('''
+          "id","ts","upid"
+          0,1740172787560,1
+        '''))
+
   def test_art_hprof_object_examples_smoke(self):
     return DiffTestBlueprint(
         trace=DataPath('test-dump.hprof'),

--- a/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
@@ -42,7 +42,7 @@ export default class implements PerfettoPlugin {
     });
 
     const res = await ctx.engine.query(
-      'SELECT count(*) AS cnt FROM heap_graph_object LIMIT 1',
+      'SELECT count(*) AS cnt FROM heap_graph LIMIT 1',
     );
     if (res.iter({cnt: NUM}).cnt === 0) return;
 

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -62,14 +62,13 @@ export interface HeapDump {
 export async function loadDumpsList(engine: Engine): Promise<HeapDump[]> {
   const res = await engine.query(`
     SELECT
-      o.upid AS upid,
-      o.graph_sample_ts AS ts,
+      g.upid AS upid,
+      g.ts AS ts,
       coalesce(p.cmdline, p.name) AS pname,
       p.pid AS pid
-    FROM heap_graph_object o
+    FROM heap_graph g
     JOIN process p USING (upid)
-    GROUP BY o.upid, o.graph_sample_ts
-    ORDER BY o.graph_sample_ts ASC
+    ORDER BY g.ts ASC
   `);
   const result: HeapDump[] = [];
   for (

--- a/ui/src/plugins/dev.perfetto.Memscope/index.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/index.ts
@@ -132,7 +132,7 @@ export default class implements PerfettoPlugin {
     const result = await trace.engine.query(`
       SELECT
         EXISTS(SELECT 1 FROM profiler_smaps) AS hasSmapsSnapshots,
-        EXISTS(SELECT 1 FROM heap_graph_object) AS hasHeapDumps
+        EXISTS(SELECT 1 FROM heap_graph) AS hasHeapDumps
     `);
     const row = result.firstRow({
       hasSmapsSnapshots: NUM,

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/landing_page.ts
@@ -220,9 +220,9 @@ async function loadProcessMemoryStats(engine: Engine): Promise<ProcWithMem> {
       p.pid,
       COALESCE(p.cmdline, p.name, '<unknown>') AS procName,
       (
-        SELECT count(DISTINCT graph_sample_ts)
-        FROM heap_graph_object o
-        WHERE o.upid = p.upid
+        SELECT count(*)
+        FROM heap_graph g
+        WHERE g.upid = p.upid
       ) AS heapDumps,
       (
         SELECT count(DISTINCT ts)

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
@@ -173,8 +173,8 @@ async function loadBitmapRetainer(
     const res = await trace.engine.query(`
       WITH RECURSIVE
       last_ts AS (
-        SELECT MAX(graph_sample_ts) AS ts
-        FROM heap_graph_object WHERE upid = ${upid}
+        SELECT MAX(ts) AS ts
+        FROM heap_graph WHERE upid = ${upid}
       ),
       ck AS (
         SELECT c.id,

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/java_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/java_section.ts
@@ -80,8 +80,7 @@ interface DumpStats {
   readonly reachableHeapSize: number;
   readonly reachableNativeSize: number;
   readonly reachableObjCount: number;
-  // MIN(heap_graph_object.id) for this dump — the HeapProfile track event id
-  // used to select the dump on the timeline.
+  // heap_graph.id, used to select the dump on the HeapProfile track.
   readonly eventId: number;
 }
 
@@ -111,14 +110,11 @@ async function loadJavaData(trace: Trace, upid: number): Promise<JavaData> {
   await trace.engine.query(
     'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;',
   );
-  // MIN(object id) per dump — the HeapProfile track event id for that dump
-  // (mirrors how dev.perfetto.HeapProfile builds its timeline events).
   const eventIdByTs = new Map<bigint, number>();
   const eventRes = await trace.engine.query(`
-    SELECT graph_sample_ts AS ts, MIN(id) AS event_id
-    FROM heap_graph_object
+    SELECT ts, id AS event_id
+    FROM heap_graph
     WHERE upid = ${upid}
-    GROUP BY graph_sample_ts
   `);
   for (
     const it = eventRes.iter({ts: LONG, event_id: NUM});
@@ -275,8 +271,8 @@ async function loadRetainers(
     const res = await trace.engine.query(`
       WITH
       last_ts AS (
-        SELECT MAX(graph_sample_ts) AS ts
-        FROM heap_graph_object WHERE upid = ${upid}
+        SELECT MAX(ts) AS ts
+        FROM heap_graph WHERE upid = ${upid}
       ),
       ck AS (
         -- Classify by the *wrapped* name: a class object is named


### PR DESCRIPTION
Since we introduced the heap_graph table as the denormalized table to
keep track of information about heap graphs, we should just use it when
looking for information about the number/ts/upid etc of the heap dump.
