### PR TITLE
tp: speed up ART hprof import and cut its peak memory

### DIFF
--- a/src/trace_processor/importers/art_hprof/art_heap_graph.h
+++ b/src/trace_processor/importers/art_hprof/art_heap_graph.h
@@ -38,19 +38,11 @@ class HeapGraph {
   HeapGraph& operator=(HeapGraph&&) = default;
   ~HeapGraph() = default;
 
-  void AddObject(Object object) {
-    objects_[object.GetId()] = std::move(object);
+  void SetObjects(ObjectStore objs) { objects_ = std::move(objs); }
+  void SetClassFields(ClassFieldLayouts fields) {
+    class_fields_ = std::move(fields);
   }
-
-  void AddClass(ClassDefinition cls) { classes_[cls.GetId()] = std::move(cls); }
-
-  void AddString(uint64_t id, StringId interned_id) {
-    strings_[id] = interned_id;
-  }
-
-  void SetObjects(base::FlatHashMap<uint64_t, Object> objs) {
-    objects_ = std::move(objs);
-  }
+  void SetIdSize(uint32_t id_size) { id_size_ = id_size; }
   void SetClasses(base::FlatHashMap<uint64_t, ClassDefinition> cls) {
     classes_ = std::move(cls);
   }
@@ -58,9 +50,14 @@ class HeapGraph {
     strings_ = std::move(strs);
   }
 
-  const base::FlatHashMap<uint64_t, Object>& GetObjects() const {
-    return objects_;
+  const ObjectStore& GetObjects() const { return objects_; }
+
+  // Instance field layout of a class hierarchy, or nullptr if unknown.
+  const ClassFieldLayout* GetClassFields(uint64_t class_id) const {
+    return class_fields_.Find(class_id);
   }
+
+  uint32_t GetIdSize() const { return id_size_; }
 
   const base::FlatHashMap<uint64_t, ClassDefinition>& GetClasses() const {
     return classes_;
@@ -75,6 +72,7 @@ class HeapGraph {
     objects_.Clear();
     classes_.Clear();
     strings_.Clear();
+    class_fields_.Clear();
     heap_id_to_name_.Clear();
   }
 
@@ -114,11 +112,13 @@ class HeapGraph {
   }
 
  private:
-  base::FlatHashMap<uint64_t, Object> objects_;
+  ObjectStore objects_;
+  ClassFieldLayouts class_fields_;
   base::FlatHashMap<uint64_t, ClassDefinition> classes_;
   base::FlatHashMap<uint64_t, StringId> strings_;
   base::FlatHashMap<uint32_t, std::string> heap_id_to_name_;
   uint64_t timestamp_;
+  uint32_t id_size_ = 4;
 };
 }  // namespace perfetto::trace_processor::art_hprof
 

--- a/src/trace_processor/importers/art_hprof/art_heap_graph_builder.cc
+++ b/src/trace_processor/importers/art_hprof/art_heap_graph_builder.cc
@@ -15,7 +15,10 @@
  */
 
 #include "src/trace_processor/importers/art_hprof/art_heap_graph_builder.h"
+#include <algorithm>
 #include <cinttypes>
+#include "perfetto/ext/base/endian.h"
+#include "perfetto/trace_processor/trace_blob.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 
 namespace perfetto::trace_processor::art_hprof {
@@ -88,15 +91,18 @@ void HeapGraphBuilder::PushBlob(TraceBlobView&& blob) {
 
 HeapGraph HeapGraphBuilder::BuildGraph() {
   resolver_ = std::make_unique<HeapGraphResolver>(
-      context_, header_, objects_, classes_, roots_, string_class_id_, stats_);
+      context_, header_, objects_, classes_, roots_, class_fields_,
+      string_class_id_, stats_);
   resolver_->ResolveGraph();
 
   stats_.Write(context_);
   HeapGraph graph(header_.GetTimestamp());
 
+  graph.SetIdSize(header_.GetIdSize());
   graph.SetStrings(std::move(strings_));
   graph.SetClasses(std::move(classes_));
   graph.SetObjects(std::move(objects_));
+  graph.SetClassFields(std::move(class_fields_));
 
   return graph;
 }
@@ -106,8 +112,9 @@ void HeapGraphBuilder::Clear() {
   classes_.Clear();
   objects_.Clear();
   roots_.Clear();
+  class_fields_.Clear();
   resolver_.reset();
-  current_heap_.clear();
+  current_heap_ = StringId::Null();
 }
 
 bool HeapGraphBuilder::ParseHeader() {
@@ -435,7 +442,6 @@ bool HeapGraphBuilder::ParseClassStructure() {
   Object& class_obj = objects_[class_id];
   if (class_obj.GetId() == 0) {
     class_obj = Object(class_id, class_id, current_heap_, ObjectType::kClass);
-    class_obj.SetHeapType(current_heap_);
   }
 
   uint16_t static_field_count;
@@ -452,14 +458,14 @@ bool HeapGraphBuilder::ParseClassStructure() {
       return false;
 
     FieldType field_type = static_cast<FieldType>(type_value);
-    std::string field_name = LookupString(name_id);
+    StringId field_name = LookupStringId(name_id);
 
     switch (field_type) {
       case FieldType::kObject: {
         uint64_t target_id = 0;
         if (!iterator_->ReadId(target_id, header_.GetIdSize()))
           return false;
-        class_obj.AddPendingReference(field_name, std::nullopt, target_id);
+        class_obj.AddPendingReference(field_name, target_id);
         Field field(field_name, field_type, target_id);
         class_obj.AddField(std::move(field));
         break;
@@ -539,8 +545,8 @@ bool HeapGraphBuilder::ParseClassStructure() {
     if (!iterator_->ReadU1(type_value))
       return false;
 
-    std::string field_name = LookupString(name_id);
-    fields.emplace_back(field_name, static_cast<FieldType>(type_value));
+    fields.emplace_back(LookupStringId(name_id),
+                        static_cast<FieldType>(type_value));
   }
 
   cls->SetInstanceFields(std::move(fields));
@@ -568,8 +574,8 @@ bool HeapGraphBuilder::ParseInstanceObject() {
     return false;
   }
 
-  std::vector<uint8_t> data;
-  if (!iterator_->ReadBytes(data, data_length)) {
+  TraceBlobView data;
+  if (!iterator_->ReadView(data, data_length)) {
     return false;
   }
 
@@ -586,7 +592,6 @@ bool HeapGraphBuilder::ParseInstanceObject() {
   // Overwrite or create object
   Object obj(object_id, class_id, current_heap_, ObjectType::kInstance);
   obj.SetRawData(std::move(data));
-  obj.SetHeapType(current_heap_);
 
   if (was_root && root_type.has_value()) {
     obj.SetRootType(root_type.value());
@@ -618,28 +623,56 @@ bool HeapGraphBuilder::ParseObjectArrayObject() {
     return false;
   }
 
-  // Read elements
-  std::vector<uint64_t> elements;
-  elements.reserve(element_count);
-
-  for (uint32_t i = 0; i < element_count; i++) {
-    uint64_t element_id;
-    if (!iterator_->ReadId(element_id, header_.GetIdSize())) {
-      return false;
-    }
-    elements.push_back(element_id);
+  // The element ids are read straight out of the trace when references are
+  // resolved; no copy is made here.
+  TraceBlobView elements;
+  if (!iterator_->ReadView(
+          elements, static_cast<size_t>(element_count) * header_.GetIdSize())) {
+    return false;
   }
 
   Object obj{array_id, array_class_id, current_heap_, ObjectType::kObjectArray};
-  obj.SetArrayElements(std::move(elements));
+  obj.SetRawData(std::move(elements));
+  obj.SetArrayElementCount(element_count);
   obj.SetArrayElementType(FieldType::kObject);
-  obj.SetHeapType(current_heap_);
 
   objects_[array_id] = std::move(obj);
   stats_.object_array_count++;
 
   return true;
 }
+
+namespace {
+
+// HPROF stores array elements big endian; convert to native endianness in
+// place so the buffer can be handed to the storage as-is.
+template <typename T, typename Conv>
+void ConvertElements(uint8_t* data, size_t element_count, Conv conv) {
+  for (size_t i = 0; i < element_count; ++i) {
+    T value;
+    memcpy(&value, data + i * sizeof(T), sizeof(T));
+    value = conv(value);
+    memcpy(data + i * sizeof(T), &value, sizeof(T));
+  }
+}
+
+void ToNativeEndian(uint8_t* data, size_t element_count, size_t element_size) {
+  switch (element_size) {
+    case 2:
+      ConvertElements<uint16_t>(data, element_count, base::BE16ToHost);
+      break;
+    case 4:
+      ConvertElements<uint32_t>(data, element_count, base::BE32ToHost);
+      break;
+    case 8:
+      ConvertElements<uint64_t>(data, element_count, base::BE64ToHost);
+      break;
+    default:
+      break;
+  }
+}
+
+}  // namespace
 
 bool HeapGraphBuilder::ParsePrimitiveArrayObject() {
   uint64_t array_id;
@@ -665,31 +698,45 @@ bool HeapGraphBuilder::ParsePrimitiveArrayObject() {
 
   size_t type_size = GetFieldTypeSize(element_type, header_.GetIdSize());
 
-  size_t data_length = static_cast<size_t>(element_count) * type_size;
-  std::vector<uint8_t> data;
-  if (!iterator_->ReadBytes(data, data_length)) {
-    return false;
-  }
-
   uint64_t class_id = 0;
   size_t element_type_index = static_cast<size_t>(element_type);
   if (element_type_index >= prim_array_class_ids_.size()) {
     context_->stats_tracker->IncrementStats(
         stats::hprof_primitive_array_parsing_errors);
     return false;
-  } else {
-    class_id = prim_array_class_ids_[element_type_index];
-    if (class_id == 0) {
-      context_->stats_tracker->IncrementStats(
-          stats::hprof_primitive_array_parsing_errors);
-      return false;
-    }
+  }
+  class_id = prim_array_class_ids_[element_type_index];
+  if (class_id == 0) {
+    context_->stats_tracker->IncrementStats(
+        stats::hprof_primitive_array_parsing_errors);
+    return false;
   }
 
+  size_t data_length = static_cast<size_t>(element_count) * type_size;
+
   Object obj{array_id, class_id, current_heap_, ObjectType::kPrimitiveArray};
-  obj.SetRawData(std::move(data));
   obj.SetArrayElementType(element_type);
-  obj.SetHeapType(current_heap_);
+  obj.SetArrayDataBytes(static_cast<uint32_t>(data_length));
+
+  if (data_length > 0) {
+    // Array payloads are handed to the storage and live for as long as the
+    // trace is loaded, so they get an exactly sized buffer of their own: a
+    // view would pin the whole trace chunk it points into, however small the
+    // array is.
+    TraceBlob blob = TraceBlob::Allocate(data_length);
+    if (!iterator_->ReadInto(blob.data(), data_length)) {
+      return false;
+    }
+    if (element_type == FieldType::kBoolean) {
+      // Normalise to 0/1 to match the values exposed for boolean arrays.
+      for (size_t i = 0; i < data_length; ++i) {
+        blob.data()[i] = blob.data()[i] != 0 ? 1 : 0;
+      }
+    } else {
+      ToNativeEndian(blob.data(), element_count, type_size);
+    }
+    obj.SetArrayData(TraceBlobView(std::move(blob)), element_count);
+  }
 
   objects_[array_id] = std::move(obj);
   stats_.primitive_array_count++;
@@ -708,8 +755,17 @@ bool HeapGraphBuilder::ParseHeapName() {
     return false;
   }
 
-  current_heap_ = LookupString(name_string_id);
+  current_heap_ = LookupStringId(name_string_id);
   return true;
+}
+
+StringId HeapGraphBuilder::LookupStringId(uint64_t id) const {
+  auto it = strings_.Find(id);
+  if (!it) {
+    return context_->storage->InternString(
+        "[unknown string ID: " + std::to_string(id) + "]");
+  }
+  return *it;
 }
 
 std::string HeapGraphBuilder::LookupString(uint64_t id) const {

--- a/src/trace_processor/importers/art_hprof/art_heap_graph_builder.h
+++ b/src/trace_processor/importers/art_hprof/art_heap_graph_builder.h
@@ -17,6 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_ART_HPROF_ART_HEAP_GRAPH_BUILDER_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_ART_HPROF_ART_HEAP_GRAPH_BUILDER_H_
 
+#include "perfetto/ext/base/endian.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/art_hprof/art_heap_graph.h"
@@ -30,6 +31,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <string>
@@ -56,7 +58,10 @@ class ByteIterator {
   virtual bool ReadU4(uint32_t& value) = 0;
   virtual bool ReadId(uint64_t& value, uint32_t id_size) = 0;
   virtual bool ReadString(std::string& str, size_t length) = 0;
-  virtual bool ReadBytes(std::vector<uint8_t>& data, size_t length) = 0;
+  virtual bool ReadInto(uint8_t* dst, size_t length) = 0;
+  // Reads `length` bytes without copying them when they are contiguous in the
+  // underlying buffer.
+  virtual bool ReadView(TraceBlobView& view, size_t length) = 0;
   virtual bool SkipBytes(size_t count) = 0;
   virtual void PushBlob(TraceBlobView data) = 0;
 
@@ -106,9 +111,10 @@ class HeapGraphResolver {
  public:
   HeapGraphResolver(TraceProcessorContext* context,
                     HprofHeader& header,
-                    base::FlatHashMap<uint64_t, Object>& objects,
+                    ObjectStore& objects,
                     base::FlatHashMap<uint64_t, ClassDefinition>& classes,
                     base::FlatHashMap<uint64_t, HprofHeapRootTag>& roots,
+                    ClassFieldLayouts& class_fields,
                     uint64_t string_class_id,
                     DebugStats& stats);
 
@@ -119,29 +125,37 @@ class HeapGraphResolver {
   void MarkReachableObjects();
   void ExtractArrayElementReferences(Object& obj);
   bool ExtractObjectReferences(Object& obj, const ClassDefinition& cls);
-  void ExtractFieldValues(Object& obj, const ClassDefinition& cls);
-  void ExtractPrimitiveArrayValues(Object& obj);
-  std::optional<std::string> DecodeJavaString(const Object& string_obj) const;
+  std::optional<std::string> DecodeJavaString(const Object& string_obj);
   void DecodeJavaStrings();
-  const std::vector<Field>& GetClassHierarchyFields(uint64_t class_id);
-  void ComputeSelfSizes();
+  void BuildClassFieldLayouts();
   void CalculateNativeSizes();
 
   // Data references (not owned)
   TraceProcessorContext* context_;
   HprofHeader& header_;
-  base::FlatHashMap<uint64_t, Object>& objects_;
+  ObjectStore& objects_;
   base::FlatHashMap<uint64_t, HprofHeapRootTag>& roots_;
   base::FlatHashMap<uint64_t, ClassDefinition>& classes_;
+  ClassFieldLayouts& class_fields_;
   DebugStats& stats_;
 
-  // Cache for class hierarchy fields (avoids repeated hierarchy walks)
-  base::FlatHashMap<uint64_t, std::vector<Field>> field_cache_;
+  // Interned names of the fields the resolver needs to recognise. Comparing
+  // ids avoids string comparisons in the per-reference hot loops.
+  StringId referent_field_id_;
+  StringId string_value_field_id_;
+  StringId string_offset_field_id_;
+  StringId string_count_field_id_;
+  StringId cleaner_thunk_field_id_;
+  StringId cleaner_thunk_outer_field_id_;
+  StringId native_registry_size_field_id_;
 
   // Set during construction, used by DecodeJavaStrings().
   uint64_t string_class_id_;
   // Collected during ExtractAllObjectData() for efficient DecodeJavaStrings().
-  std::vector<uint64_t> string_object_ids_;
+  std::vector<ObjectIndex> string_object_indices_;
+  // (referent index, thunk index) of every sun.misc.Cleaner, collected during
+  // ExtractAllObjectData() and consumed by CalculateNativeSizes().
+  std::vector<std::pair<ObjectIndex, ObjectIndex>> cleaners_;
 };
 
 // Main parser class that builds a heap graph from HPROF data
@@ -215,6 +229,10 @@ class HeapGraphBuilder {
   // Look up a string by ID
   std::string LookupString(uint64_t id) const;
 
+  // Look up a string by ID, returning the interned id directly. Avoids the
+  // copy out of the string pool done by LookupString().
+  StringId LookupStringId(uint64_t id) const;
+
   void StoreString(uint64_t id, const std::string& str);
 
   // Convert JVM class name to Java format
@@ -230,12 +248,13 @@ class HeapGraphBuilder {
   HprofHeader header_;
 
   // Current heap name
-  std::string current_heap_;
+  StringId current_heap_;
 
   // Data collections
   base::FlatHashMap<uint64_t, StringId> strings_;
   base::FlatHashMap<uint64_t, ClassDefinition> classes_;
-  base::FlatHashMap<uint64_t, Object> objects_;
+  ObjectStore objects_;
+  ClassFieldLayouts class_fields_;
 
   // Type mapping and root tracking
   std::array<uint64_t, 12> prim_array_class_ids_ = {};
@@ -249,6 +268,124 @@ class HeapGraphBuilder {
   std::unique_ptr<HeapGraphResolver> resolver_;
   TraceProcessorContext* context_;
 };
+
+// Reads a big endian value of `length` bytes at `offset`. Out of bounds reads
+// yield 0 and are counted as field value errors.
+template <typename T>
+T ReadBigEndian(TraceProcessorContext* context,
+                const uint8_t* data,
+                size_t size,
+                size_t offset,
+                size_t length) {
+  if (offset + length > size) {
+    context->stats_tracker->IncrementStats(stats::hprof_field_value_errors);
+    return 0;
+  }
+  const uint8_t* p = data + offset;
+  switch (length) {
+    case 1:
+      return static_cast<T>(*p);
+    case 2: {
+      uint16_t value;
+      memcpy(&value, p, sizeof(value));
+      return static_cast<T>(base::BE16ToHost(value));
+    }
+    case 4: {
+      uint32_t value;
+      memcpy(&value, p, sizeof(value));
+      return static_cast<T>(base::BE32ToHost(value));
+    }
+    case 8: {
+      uint64_t value;
+      memcpy(&value, p, sizeof(value));
+      return static_cast<T>(base::BE64ToHost(value));
+    }
+    default:
+      break;
+  }
+  T result = 0;
+  for (size_t i = 0; i < length; ++i) {
+    result = static_cast<T>((result << 8) | static_cast<T>(p[i]));
+  }
+  return result;
+}
+
+template <typename T>
+T ReadBigEndian(TraceProcessorContext* context,
+                const uint8_t* data,
+                size_t size,
+                size_t offset) {
+  return ReadBigEndian<T>(context, data, size, offset, sizeof(T));
+}
+
+// Decodes the instance data of an object according to `fields`, the fully
+// qualified field layout of its class hierarchy, and invokes `fn` for each
+// field. Instance data is never materialised into Field objects on the heap:
+// the raw bytes stay the only copy until they are written to the tables.
+template <typename Fn>
+void ForEachFieldValue(TraceProcessorContext* context,
+                       const std::vector<Field>& fields,
+                       const uint8_t* data,
+                       size_t size,
+                       uint32_t id_size,
+                       Fn&& fn) {
+  size_t offset = 0;
+  for (const Field& field_def : fields) {
+    if (offset >= size) {
+      break;
+    }
+
+    Field field(field_def.GetName(), field_def.GetType());
+    switch (field_def.GetType()) {
+      case FieldType::kBoolean:
+        field.SetValue(data[offset] != 0);
+        offset += 1;
+        break;
+      case FieldType::kByte:
+        field.SetValue(data[offset]);
+        offset += 1;
+        break;
+      case FieldType::kChar:
+        field.SetValue(ReadBigEndian<uint16_t>(context, data, size, offset));
+        offset += 2;
+        break;
+      case FieldType::kShort:
+        field.SetValue(ReadBigEndian<int16_t>(context, data, size, offset));
+        offset += 2;
+        break;
+      case FieldType::kInt:
+        field.SetValue(ReadBigEndian<int32_t>(context, data, size, offset));
+        offset += 4;
+        break;
+      case FieldType::kLong:
+        field.SetValue(ReadBigEndian<int64_t>(context, data, size, offset));
+        offset += 8;
+        break;
+      case FieldType::kFloat: {
+        uint32_t raw = ReadBigEndian<uint32_t>(context, data, size, offset);
+        float value;
+        memcpy(&value, &raw, sizeof(float));
+        field.SetValue(value);
+        offset += 4;
+        break;
+      }
+      case FieldType::kDouble: {
+        uint64_t raw = ReadBigEndian<uint64_t>(context, data, size, offset);
+        double value;
+        memcpy(&value, &raw, sizeof(double));
+        field.SetValue(value);
+        offset += 8;
+        break;
+      }
+      case FieldType::kObject:
+        field.SetValue(
+            ReadBigEndian<uint64_t>(context, data, size, offset, id_size));
+        offset += id_size;
+        break;
+    }
+    fn(field);
+  }
+}
 
 inline size_t GetFieldTypeSize(FieldType type, size_t id_size) {
   switch (type) {

--- a/src/trace_processor/importers/art_hprof/art_heap_graph_resolver.cc
+++ b/src/trace_processor/importers/art_hprof/art_heap_graph_resolver.cc
@@ -15,64 +15,25 @@
  */
 
 #include <algorithm>
-#include <deque>
+#include <cstring>
 #include <string>
 #include <variant>
 
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/string_view.h"
 #include "src/trace_processor/importers/art_hprof/art_heap_graph_builder.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 
 namespace perfetto::trace_processor::art_hprof {
 
-template <typename T>
-T ReadBigEndian(TraceProcessorContext* context,
-                const std::vector<uint8_t>& data,
-                size_t offset,
-                size_t length) {
-  if (offset + length > data.size()) {
-    context->stats_tracker->IncrementStats(stats::hprof_field_value_errors);
-    return 0;
-  }
-
-  T result = 0;
-  for (size_t i = 0; i < length; ++i) {
-    result = static_cast<T>((result << 8) | static_cast<T>(data[offset + i]));
-  }
-  return result;
-}
-
-template <typename T>
-T ReadBigEndian(TraceProcessorContext* context,
-                const std::vector<uint8_t>& data,
-                size_t offset) {
-  return ReadBigEndian<T>(context, data, offset, sizeof(T));
-}
-
-template <typename T>
-void ExtractTypedArrayValues(TraceProcessorContext* context,
-                             Object& obj,
-                             const std::vector<uint8_t>& data,
-                             size_t element_count,
-                             size_t element_size) {
-  std::vector<T> values;
-  values.reserve(element_count);
-
-  for (size_t i = 0; i < element_count; ++i) {
-    size_t offset = i * element_size;
-    T value = ReadBigEndian<T>(context, data, offset);
-    values.push_back(value);
-  }
-
-  obj.SetArrayData(std::move(values));
-}
-
 HeapGraphResolver::HeapGraphResolver(
     TraceProcessorContext* context,
     HprofHeader& header,
-    base::FlatHashMap<uint64_t, Object>& objects,
+    ObjectStore& objects,
     base::FlatHashMap<uint64_t, ClassDefinition>& classes,
     base::FlatHashMap<uint64_t, HprofHeapRootTag>& roots,
+    ClassFieldLayouts& class_fields,
     uint64_t string_class_id,
     DebugStats& stats)
     : context_(context),
@@ -80,36 +41,100 @@ HeapGraphResolver::HeapGraphResolver(
       objects_(objects),
       roots_(roots),
       classes_(classes),
+      class_fields_(class_fields),
       stats_(stats),
+      referent_field_id_(
+          context->storage->InternString("java.lang.ref.Reference.referent")),
+      string_value_field_id_(
+          context->storage->InternString("java.lang.String.value")),
+      string_offset_field_id_(
+          context->storage->InternString("java.lang.String.offset")),
+      string_count_field_id_(
+          context->storage->InternString("java.lang.String.count")),
+      cleaner_thunk_field_id_(
+          context->storage->InternString("sun.misc.Cleaner.thunk")),
+      cleaner_thunk_outer_field_id_(context->storage->InternString(
+          "libcore.util.NativeAllocationRegistry$CleanerThunk.this$0")),
+      native_registry_size_field_id_(context->storage->InternString(
+          "libcore.util.NativeAllocationRegistry.size")),
       string_class_id_(string_class_id) {}
 
 void HeapGraphResolver::ResolveGraph() {
+  BuildClassFieldLayouts();
   ExtractAllObjectData();
-  field_cache_.Clear();
   DecodeJavaStrings();
   MarkReachableObjects();
-  ComputeSelfSizes();
   CalculateNativeSizes();
 }
 
 void HeapGraphResolver::ExtractAllObjectData() {
-  for (auto it = objects_.GetIterator(); it; ++it) {
-    auto& obj = it.value();
-    if (obj.GetObjectType() == ObjectType::kInstance ||
-        obj.GetObjectType() == ObjectType::kClass) {
-      auto cls = classes_.Find(obj.GetClassId());
-      if (cls) {
-        ExtractObjectReferences(obj, *cls);
-        ExtractFieldValues(obj, *cls);
+  // Match ahat's self_size computation:
+  //   Instances: CLASS_DUMP.instanceSize (not INSTANCE_DUMP.data_length).
+  //   Class objects: java.lang.Class.instanceSize + staticFieldsSize.
+  //   Arrays: CLASS_DUMP.instanceSize (header) + element_count * element_size.
+  uint32_t java_lang_class_size = 0;
+  uint64_t cleaner_class_id = 0;
+  for (auto it = classes_.GetIterator(); it; ++it) {
+    if (it.value().GetName() == "java.lang.Class") {
+      java_lang_class_size = it.value().GetInstanceSize();
+    } else if (it.value().GetName() == kSunMiscCleaner) {
+      cleaner_class_id = it.key();
+    }
+  }
+
+  const uint32_t id_size = header_.GetIdSize();
+  for (ObjectIndex i = 0; i < objects_.size(); ++i) {
+    auto& obj = objects_.at(i);
+    auto* cls = classes_.Find(obj.GetClassId());
+    switch (obj.GetObjectType()) {
+      case ObjectType::kInstance:
+      case ObjectType::kClass: {
+        if (cls) {
+          ExtractObjectReferences(obj, *cls);
+        }
+        if (obj.GetObjectType() == ObjectType::kClass) {
+          size_t size = java_lang_class_size;
+          for (const auto& field : obj.GetFields()) {
+            size += GetFieldTypeSize(field.GetType(), id_size);
+          }
+          obj.SetSelfSizeOverride(size);
+        } else if (cls) {
+          obj.SetSelfSizeOverride(cls->GetInstanceSize());
+        }
+        // Collect string objects for DecodeJavaStrings().
+        if (string_class_id_ != 0 && obj.GetClassId() == string_class_id_) {
+          string_object_indices_.push_back(i);
+        }
+        // Collect sun.misc.Cleaner objects for CalculateNativeSizes().
+        if (cleaner_class_id != 0 && obj.GetClassId() == cleaner_class_id) {
+          ObjectIndex referent = kInvalidObjectIndex;
+          ObjectIndex thunk = kInvalidObjectIndex;
+          for (const auto& ref : obj.GetReferences()) {
+            if (ref.field_name == referent_field_id_) {
+              referent = ref.target_index;
+            } else if (ref.field_name == cleaner_thunk_field_id_) {
+              thunk = ref.target_index;
+            }
+          }
+          if (referent != kInvalidObjectIndex && thunk != kInvalidObjectIndex) {
+            cleaners_.emplace_back(referent, thunk);
+          }
+        }
+        break;
       }
-      // Collect string object IDs for DecodeJavaStrings().
-      if (string_class_id_ != 0 && obj.GetClassId() == string_class_id_) {
-        string_object_ids_.push_back(obj.GetId());
-      }
-    } else if (obj.GetObjectType() == ObjectType::kObjectArray) {
-      ExtractArrayElementReferences(obj);
-    } else if (obj.GetObjectType() == ObjectType::kPrimitiveArray) {
-      ExtractPrimitiveArrayValues(obj);
+      case ObjectType::kObjectArray:
+        ExtractArrayElementReferences(obj);
+        if (cls) {
+          obj.SetSelfSizeOverride(cls->GetInstanceSize() +
+                                  obj.GetArrayElementCount() * id_size);
+        }
+        break;
+      case ObjectType::kPrimitiveArray:
+        if (cls) {
+          obj.SetSelfSizeOverride(cls->GetInstanceSize() +
+                                  obj.GetArrayDataBytes());
+        }
+        break;
     }
 
     uint64_t obj_id = obj.GetId();
@@ -123,88 +148,59 @@ void HeapGraphResolver::ExtractAllObjectData() {
 
 void HeapGraphResolver::MarkReachableObjects() {
   // BFS from roots to mark reachability and compute shortest-path
-  // root_distance. Skips "referent" fields from weak/phantom/finalizer
-  // reference types to match ahat's retained=SOFT behavior (soft referent
-  // edges are followed).
+  // root_distance. Edges flagged as weak/phantom/finalizer referents during
+  // extraction are not followed.
+  std::vector<ObjectIndex> queue;
 
-  // Pre-compute which class IDs are reference types by walking the hierarchy.
-  base::FlatHashMap<uint64_t, bool> ref_type_classes;
-  {
-    base::FlatHashMap<uint64_t, bool> base_refs;
-    for (auto it = classes_.GetIterator(); it; ++it) {
-      const auto& name = it.value().GetName();
-      if (name == "java.lang.ref.WeakReference" ||
-          name == "java.lang.ref.PhantomReference" ||
-          name == "java.lang.ref.FinalizerReference") {
-        base_refs[it.key()] = true;
-      }
-    }
-    for (auto it = classes_.GetIterator(); it; ++it) {
-      uint64_t current = it.key();
-      for (int depth = 0; depth < 100 && current != 0; ++depth) {
-        if (base_refs.Find(current)) {
-          ref_type_classes[it.key()] = true;
-          break;
-        }
-        auto* cls = classes_.Find(current);
-        if (!cls)
-          break;
-        current = cls->GetSuperClassId();
-      }
-    }
-  }
-
-  std::deque<uint64_t> queue;
-
-  for (auto it = objects_.GetIterator(); it; ++it) {
-    auto& obj = it.value();
+  for (ObjectIndex i = 0; i < objects_.size(); ++i) {
+    auto& obj = objects_.at(i);
     if (obj.IsRoot()) {
-      queue.push_back(it.key());
+      queue.push_back(i);
       obj.SetReachable();
       obj.SetRootDistance(0);
     }
   }
 
-  while (!queue.empty()) {
-    uint64_t current_id = queue.front();
-    queue.pop_front();
-
-    auto* obj = objects_.Find(current_id);
-    if (!obj) {
-      continue;
-    }
-
-    bool skip_referent = ref_type_classes.Find(obj->GetClassId()) != nullptr;
-    int32_t next_distance = obj->GetRootDistance() + 1;
-    for (const auto& ref : obj->GetReferences()) {
-      if (skip_referent &&
-          ref.field_name == "java.lang.ref.Reference.referent") {
+  for (size_t head = 0; head < queue.size(); ++head) {
+    Object& obj = objects_.at(queue[head]);
+    int32_t next_distance = obj.GetRootDistance() + 1;
+    for (const auto& ref : obj.GetReferences()) {
+      if (ref.target_index == kInvalidObjectIndex || ref.is_weak_referent) {
         continue;
       }
-      auto* target = objects_.Find(ref.target_id);
-      if (target && !target->IsReachable()) {
-        target->SetReachable();
-        target->SetRootDistance(next_distance);
-        queue.push_back(ref.target_id);
+      Object& target = objects_.at(ref.target_index);
+      if (!target.IsReachable()) {
+        target.SetReachable();
+        target.SetRootDistance(next_distance);
+        queue.push_back(ref.target_index);
       }
     }
   }
 }
 
 void HeapGraphResolver::ExtractArrayElementReferences(Object& obj) {
-  const auto& elements = obj.GetArrayElements();
+  const uint8_t* elements = obj.GetRawData();
+  size_t elements_size = obj.GetRawDataSize();
+  size_t count = obj.GetArrayElementCount();
+  uint32_t id_size = header_.GetIdSize();
   char buf[24];
-  for (size_t i = 0; i < elements.size(); ++i) {
-    uint64_t element_id = elements[i];
+  obj.ReserveReferences(count);
+  for (size_t i = 0; i < count; ++i) {
+    uint64_t element_id = ReadBigEndian<uint64_t>(
+        context_, elements, elements_size, i * id_size, id_size);
     if (element_id != 0) {
-      auto owned_obj = objects_.Find(element_id);
-      if (owned_obj) {
-        snprintf(buf, sizeof(buf), "[%zu]", i);
-        obj.AddReference(buf, owned_obj->GetClassId(), element_id);
+      ObjectIndex target = objects_.FindIndex(element_id);
+      if (target != kInvalidObjectIndex) {
+        size_t len = base::SprintfTrunc(buf, sizeof(buf), "[%zu]", i);
+        obj.AddReference(
+            context_->storage->InternString(base::StringView(buf, len)),
+            target);
         stats_.reference_count++;
       }
     }
   }
+  // The element ids are no longer needed once references have been created.
+  obj.ClearRawData();
 }
 
 bool HeapGraphResolver::ExtractObjectReferences(Object& obj,
@@ -212,217 +208,52 @@ bool HeapGraphResolver::ExtractObjectReferences(Object& obj,
   // Resolve pending static field references, qualifying names as
   // "ClassName.fieldName" to match the proto heap graph format.
   for (const auto& ref : obj.GetPendingReferences()) {
-    if (!ref.field_class_id) {
-      auto it = objects_.Find(ref.target_id);
-      if (it) {
-        std::string qualified = cls.GetName() + "." + ref.field_name;
-        obj.AddReference(qualified, it->GetClassId(), ref.target_id);
-        stats_.reference_count++;
-      }
+    ObjectIndex target = objects_.FindIndex(ref.target_id);
+    if (target != kInvalidObjectIndex) {
+      std::string qualified =
+          cls.GetName() + "." +
+          context_->storage->GetString(ref.field_name).ToStdString();
+      obj.AddReference(context_->storage->InternString(qualified), target);
+      stats_.reference_count++;
     }
   }
 
-  const std::vector<uint8_t>& data = obj.GetRawData();
-  if (data.empty()) {
+  const uint8_t* data = obj.GetRawData();
+  size_t data_size = obj.GetRawDataSize();
+  if (data_size == 0) {
     return true;
   }
 
-  const auto& fields = GetClassHierarchyFields(cls.GetId());
-  size_t offset = 0;
+  const auto* layout = class_fields_.Find(cls.GetId());
+  if (!layout) {
+    return true;
+  }
 
-  for (const auto& field : fields) {
-    if (offset >= data.size()) {
+  const uint32_t id_size = header_.GetIdSize();
+  obj.ReserveReferences(obj.GetReferences().size() +
+                        layout->object_fields.size());
+  for (const auto& field : layout->object_fields) {
+    if (field.offset >= data_size) {
       break;
     }
-
-    if (field.GetType() == FieldType::kObject) {
-      if (offset + header_.GetIdSize() <= data.size()) {
-        uint64_t target_id = ReadBigEndian<uint64_t>(context_, data, offset,
-                                                     header_.GetIdSize());
-        offset += header_.GetIdSize();
-
-        if (target_id != 0) {
-          uint64_t field_class_id = 0;
-          auto it = objects_.Find(target_id);
-          if (it) {
-            field_class_id = it->GetClassId();
-          }
-
-          obj.AddReference(field.GetName(), field_class_id, target_id);
-          stats_.reference_count++;
-        }
-      } else {
-        context_->stats_tracker->IncrementStats(stats::hprof_reference_errors);
-        break;
-      }
-    } else {
-      offset += GetFieldTypeSize(field.GetType(), header_.GetIdSize());
+    if (field.offset + id_size > data_size) {
+      context_->stats_tracker->IncrementStats(stats::hprof_reference_errors);
+      break;
+    }
+    uint64_t target_id = ReadBigEndian<uint64_t>(context_, data, data_size,
+                                                 field.offset, id_size);
+    if (target_id != 0) {
+      obj.AddReference(field.name, objects_.FindIndex(target_id),
+                       field.is_weak_referent);
+      stats_.reference_count++;
     }
   }
 
   return true;
 }
 
-void HeapGraphResolver::ExtractFieldValues(Object& obj,
-                                           const ClassDefinition& cls) {
-  if (obj.GetObjectType() != ObjectType::kInstance ||
-      obj.GetRawData().empty()) {
-    return;
-  }
-
-  const auto& fields = GetClassHierarchyFields(cls.GetId());
-  const auto& data = obj.GetRawData();
-  size_t offset = 0;
-  for (const auto& field_def : fields) {
-    if (offset >= data.size()) {
-      break;
-    }
-
-    Field field(field_def.GetName(), field_def.GetType());
-    switch (field_def.GetType()) {
-      case FieldType::kBoolean: {
-        bool value = data[offset] != 0;
-        field.SetValue(value);
-        offset += 1;
-        break;
-      }
-      case FieldType::kByte: {
-        uint8_t value = data[offset];
-        field.SetValue(value);
-        offset += 1;
-        break;
-      }
-      case FieldType::kChar: {
-        field.SetValue(ReadBigEndian<uint16_t>(context_, data, offset));
-        offset += 2;
-        break;
-      }
-      case FieldType::kShort: {
-        field.SetValue(ReadBigEndian<int16_t>(context_, data, offset));
-        offset += 2;
-        break;
-      }
-      case FieldType::kInt: {
-        field.SetValue(ReadBigEndian<int32_t>(context_, data, offset));
-        offset += 4;
-        break;
-      }
-      case FieldType::kLong: {
-        field.SetValue(ReadBigEndian<int64_t>(context_, data, offset));
-        offset += 8;
-        break;
-      }
-      case FieldType::kFloat: {
-        uint32_t raw = ReadBigEndian<uint32_t>(context_, data, offset);
-        float value;
-        std::memcpy(&value, &raw, sizeof(float));
-        field.SetValue(value);
-        offset += 4;
-        break;
-      }
-      case FieldType::kDouble: {
-        uint64_t raw = ReadBigEndian<uint64_t>(context_, data, offset);
-        double value;
-        std::memcpy(&value, &raw, sizeof(double));
-        field.SetValue(value);
-        offset += 8;
-        break;
-      }
-      case FieldType::kObject: {
-        uint64_t id = ReadBigEndian<uint64_t>(context_, data, offset,
-                                              header_.GetIdSize());
-        field.SetValue(id);
-        offset += header_.GetIdSize();
-        break;
-      }
-    }
-
-    obj.AddField(std::move(field));
-  }
-
-  obj.ClearRawData();
-}
-
-void HeapGraphResolver::ExtractPrimitiveArrayValues(Object& obj) {
-  if (obj.GetObjectType() != ObjectType::kPrimitiveArray ||
-      obj.GetRawData().empty()) {
-    return;
-  }
-
-  const FieldType element_type = obj.GetArrayElementType();
-  const auto& data = obj.GetRawData();
-  size_t element_size = GetFieldTypeSize(element_type, header_.GetIdSize());
-
-  if (element_size == 0 || data.size() % element_size != 0) {
-    return;
-  }
-
-  size_t element_count = data.size() / element_size;
-
-  switch (element_type) {
-    case FieldType::kBoolean: {
-      std::vector<bool> values;
-      values.reserve(element_count);
-      for (size_t i = 0; i < element_count; ++i) {
-        values.push_back(data[i] != 0);
-      }
-      obj.SetArrayData(std::move(values));
-      break;
-    }
-    case FieldType::kByte: {
-      std::vector<uint8_t> values(data.begin(), data.end());
-      obj.SetArrayData(std::move(values));
-      break;
-    }
-    case FieldType::kChar:
-      ExtractTypedArrayValues<uint16_t>(context_, obj, data, element_count,
-                                        element_size);
-      break;
-    case FieldType::kShort:
-      ExtractTypedArrayValues<int16_t>(context_, obj, data, element_count,
-                                       element_size);
-      break;
-    case FieldType::kInt:
-      ExtractTypedArrayValues<int32_t>(context_, obj, data, element_count,
-                                       element_size);
-      break;
-    case FieldType::kLong:
-      ExtractTypedArrayValues<int64_t>(context_, obj, data, element_count,
-                                       element_size);
-      break;
-    case FieldType::kFloat: {
-      std::vector<float> values;
-      values.reserve(element_count);
-      for (size_t i = 0; i < element_count; ++i) {
-        size_t offset = i * element_size;
-        uint32_t raw = ReadBigEndian<uint32_t>(context_, data, offset);
-        float value;
-        memcpy(&value, &raw, sizeof(float));
-        values.push_back(value);
-      }
-      obj.SetArrayData(std::move(values));
-      break;
-    }
-    case FieldType::kDouble: {
-      std::vector<double> values;
-      values.reserve(element_count);
-      for (size_t i = 0; i < element_count; ++i) {
-        size_t offset = i * element_size;
-        uint64_t raw = ReadBigEndian<uint64_t>(context_, data, offset);
-        double value;
-        memcpy(&value, &raw, sizeof(double));
-        values.push_back(value);
-      }
-      obj.SetArrayData(std::move(values));
-      break;
-    }
-    case FieldType::kObject:
-      break;
-  }
-}
-
 std::optional<std::string> HeapGraphResolver::DecodeJavaString(
-    const Object& string_obj) const {
+    const Object& string_obj) {
   auto cls = classes_.Find(string_obj.GetClassId());
   if (!cls || cls->GetName() != kJavaLangString)
     return std::nullopt;
@@ -431,21 +262,27 @@ std::optional<std::string> HeapGraphResolver::DecodeJavaString(
   std::optional<int32_t> offset_opt;
   std::optional<int32_t> count_opt;
 
-  for (const Field& f : string_obj.GetFields()) {
-    if (f.GetName() == "java.lang.String.value") {
-      if (auto v = f.GetValue<uint64_t>())
-        value_array_id = *v;
-    } else if (f.GetName() == "java.lang.String.offset") {
-      offset_opt = f.GetValue<int32_t>();
-    } else if (f.GetName() == "java.lang.String.count") {
-      count_opt = f.GetValue<int32_t>();
-    }
-  }
+  const auto* layout = class_fields_.Find(string_obj.GetClassId());
+  if (!layout)
+    return std::nullopt;
+
+  ForEachFieldValue(context_, layout->fields, string_obj.GetRawData(),
+                    string_obj.GetRawDataSize(), header_.GetIdSize(),
+                    [&](const Field& f) {
+                      if (f.GetName() == string_value_field_id_) {
+                        if (auto v = f.GetValue<uint64_t>())
+                          value_array_id = *v;
+                      } else if (f.GetName() == string_offset_field_id_) {
+                        offset_opt = f.GetValue<int32_t>();
+                      } else if (f.GetName() == string_count_field_id_) {
+                        count_opt = f.GetValue<int32_t>();
+                      }
+                    });
 
   if (value_array_id == 0)
     return std::nullopt;
 
-  auto array = objects_.Find(value_array_id);
+  const Object* array = objects_.Find(value_array_id);
   if (!array)
     return std::nullopt;
 
@@ -473,17 +310,21 @@ std::optional<std::string> HeapGraphResolver::DecodeJavaString(
     }
   };
 
-  const auto& array_data = array->GetArrayDataVariant();
+  const uint8_t* array_data = array->GetArrayData().data();
 
-  if (const auto* bytes = std::get_if<std::vector<uint8_t>>(&array_data)) {
+  if (array->GetArrayElementType() == FieldType::kByte) {
     for (int32_t i = 0; i < count; ++i)
-      result.push_back(
-          static_cast<char>((*bytes)[static_cast<size_t>(offset + i)]));
+      result.push_back(static_cast<char>(array_data[offset + i]));
     return result;
   }
-  if (const auto* chars = std::get_if<std::vector<uint16_t>>(&array_data)) {
-    for (int32_t i = 0; i < count; ++i)
-      append_utf8_from_utf16((*chars)[static_cast<size_t>(offset + i)]);
+  if (array->GetArrayElementType() == FieldType::kChar) {
+    for (int32_t i = 0; i < count; ++i) {
+      uint16_t ch;
+      memcpy(&ch,
+             array_data + static_cast<size_t>(offset + i) * sizeof(uint16_t),
+             sizeof(ch));
+      append_utf8_from_utf16(ch);
+    }
     return result;
   }
 
@@ -494,22 +335,43 @@ void HeapGraphResolver::DecodeJavaStrings() {
   if (string_class_id_ == 0)
     return;
 
-  for (uint64_t obj_id : string_object_ids_) {
-    auto* obj = objects_.Find(obj_id);
-    if (!obj)
-      continue;
-    auto decoded = DecodeJavaString(*obj);
+  for (ObjectIndex idx : string_object_indices_) {
+    Object& obj = objects_.at(idx);
+    auto decoded = DecodeJavaString(obj);
     if (decoded) {
-      obj->SetDecodedString(std::move(*decoded));
+      obj.SetDecodedString(context_->storage->InternString(*decoded));
     }
   }
 }
 
-const std::vector<Field>& HeapGraphResolver::GetClassHierarchyFields(
-    uint64_t class_id) {
-  auto* cached = field_cache_.Find(class_id);
-  if (cached) {
-    return *cached;
+void HeapGraphResolver::BuildClassFieldLayouts() {
+  // Reference subclasses whose "referent" edge must not be followed when
+  // computing reachability. Matches ahat's retained=SOFT behavior: soft
+  // referent edges are followed.
+  base::FlatHashMap<uint64_t, bool> weak_ref_classes;
+  {
+    base::FlatHashMap<uint64_t, bool> base_refs;
+    for (auto it = classes_.GetIterator(); it; ++it) {
+      const auto& name = it.value().GetName();
+      if (name == "java.lang.ref.WeakReference" ||
+          name == "java.lang.ref.PhantomReference" ||
+          name == "java.lang.ref.FinalizerReference") {
+        base_refs[it.key()] = true;
+      }
+    }
+    for (auto it = classes_.GetIterator(); it; ++it) {
+      uint64_t current = it.key();
+      for (int depth = 0; depth < 100 && current != 0; ++depth) {
+        if (base_refs.Find(current)) {
+          weak_ref_classes[it.key()] = true;
+          break;
+        }
+        auto* cls = classes_.Find(current);
+        if (!cls)
+          break;
+        current = cls->GetSuperClassId();
+      }
+    }
   }
 
   // HPROF instance data is laid out derived-class-first: the most-derived
@@ -517,65 +379,32 @@ const std::vector<Field>& HeapGraphResolver::GetClassHierarchyFields(
   // Field names are qualified as "ClassName.fieldName" to match the proto
   // heap graph format and allow MarkReachableObjects to recognize
   // "java.lang.ref.Reference.referent".
-  std::vector<Field> result;
-  uint64_t current_class_id = class_id;
-  while (current_class_id != 0) {
-    auto cls = classes_.Find(current_class_id);
-    if (!cls) {
-      break;
-    }
-    for (const auto& f : cls->GetInstanceFields()) {
-      result.emplace_back(cls->GetName() + "." + f.GetName(), f.GetType());
-    }
-    current_class_id = cls->GetSuperClassId();
-  }
-
-  field_cache_[class_id] = std::move(result);
-  return *field_cache_.Find(class_id);
-}
-
-void HeapGraphResolver::ComputeSelfSizes() {
-  // Match ahat's self_size computation:
-  //   Instances: CLASS_DUMP.instanceSize (not INSTANCE_DUMP.data_length).
-  //   Class objects: java.lang.Class.instanceSize + staticFieldsSize.
-  //   Arrays: CLASS_DUMP.instanceSize (header) + element_count * element_size.
-  std::optional<uint32_t> java_lang_class_size;
+  uint32_t id_size = header_.GetIdSize();
   for (auto it = classes_.GetIterator(); it; ++it) {
-    if (it.value().GetName() == "java.lang.Class") {
-      java_lang_class_size = it.value().GetInstanceSize();
-      break;
+    ClassFieldLayout layout;
+    bool is_weak_ref = weak_ref_classes.Find(it.key()) != nullptr;
+    uint32_t offset = 0;
+    uint64_t current_class_id = it.key();
+    while (current_class_id != 0) {
+      auto cls = classes_.Find(current_class_id);
+      if (!cls) {
+        break;
+      }
+      for (const auto& f : cls->GetInstanceFields()) {
+        std::string qualified =
+            cls->GetName() + "." +
+            context_->storage->GetString(f.GetName()).ToStdString();
+        StringId name = context_->storage->InternString(qualified);
+        layout.fields.emplace_back(name, f.GetType());
+        if (f.GetType() == FieldType::kObject) {
+          layout.object_fields.push_back(
+              {name, offset, is_weak_ref && name == referent_field_id_});
+        }
+        offset += static_cast<uint32_t>(GetFieldTypeSize(f.GetType(), id_size));
+      }
+      current_class_id = cls->GetSuperClassId();
     }
-  }
-
-  for (auto it = objects_.GetIterator(); it; ++it) {
-    auto& obj = it.value();
-    if (obj.GetObjectType() == ObjectType::kClass) {
-      // java.lang.Class.instanceSize + sum of static field sizes.
-      size_t size = java_lang_class_size.value_or(0);
-      for (const auto& field : obj.GetFields()) {
-        size += GetFieldTypeSize(field.GetType(), header_.GetIdSize());
-      }
-      obj.SetSelfSizeOverride(size);
-    } else if (obj.GetObjectType() == ObjectType::kInstance) {
-      auto* cls = classes_.Find(obj.GetClassId());
-      if (cls) {
-        obj.SetSelfSizeOverride(cls->GetInstanceSize());
-      }
-    } else if (obj.GetObjectType() == ObjectType::kObjectArray) {
-      auto* cls = classes_.Find(obj.GetClassId());
-      if (cls) {
-        size_t header = cls->GetInstanceSize();
-        size_t data = obj.GetArrayElements().size() * header_.GetIdSize();
-        obj.SetSelfSizeOverride(header + data);
-      }
-    } else if (obj.GetObjectType() == ObjectType::kPrimitiveArray) {
-      auto* cls = classes_.Find(obj.GetClassId());
-      if (cls) {
-        size_t header = cls->GetInstanceSize();
-        size_t data = obj.GetRawData().size();
-        obj.SetSelfSizeOverride(header + data);
-      }
-    }
+    class_fields_[it.key()] = std::move(layout);
   }
 }
 
@@ -601,88 +430,56 @@ void HeapGraphResolver::ComputeSelfSizes() {
 // Registry.size is attributed as the native_size of Object.
 // Matches ahat's AhatClassInstance.asRegisteredNativeAllocation().
 void HeapGraphResolver::CalculateNativeSizes() {
-  std::vector<std::pair<uint64_t, uint64_t>>
-      cleaners;  // (referent_id, thunk_id)
-
-  // Find sun.misc.Cleaner objects
-  for (auto it = objects_.GetIterator(); it; ++it) {
-    auto& obj = it.value();
-    auto cls = classes_.Find(obj.GetClassId());
-    if (!cls || cls->GetName() != kSunMiscCleaner) {
-      continue;
-    }
-
-    std::optional<uint64_t> referent_id;
-    std::optional<uint64_t> thunk_id;
-
-    for (const auto& ref : obj.GetReferences()) {
-      if (ref.field_name == "java.lang.ref.Reference.referent") {
-        referent_id = ref.target_id;
-      } else if (ref.field_name == "sun.misc.Cleaner.thunk") {
-        thunk_id = ref.target_id;
-      }
-    }
-
-    if (!referent_id || !thunk_id) {
-      continue;
-    }
-
-    cleaners.emplace_back(*referent_id, *thunk_id);
-  }
-
-  // Traverse cleaner chains to find NativeAllocationRegistry and attribute size
-  for (const auto& [referent_id, thunk_id] : cleaners) {
-    auto thunk = objects_.Find(thunk_id);
-    if (!thunk) {
-      continue;
-    }
+  // Traverse cleaner chains to find NativeAllocationRegistry and attribute
+  // size. The cleaners themselves were collected by ExtractAllObjectData().
+  for (const auto& [referent_idx, thunk_idx] : cleaners_) {
+    const Object& thunk = objects_.at(thunk_idx);
 
     // Verify thunk is a CleanerThunk (matches ahat check)
-    auto thunk_cls = classes_.Find(thunk->GetClassId());
+    auto thunk_cls = classes_.Find(thunk.GetClassId());
     if (!thunk_cls ||
         thunk_cls->GetName() != kNativeAllocationRegistryCleanerThunk) {
       continue;
     }
 
-    std::optional<uint64_t> registry_id;
-    for (const auto& ref : thunk->GetReferences()) {
-      if (ref.field_name ==
-          "libcore.util.NativeAllocationRegistry$CleanerThunk.this$0") {
-        registry_id = ref.target_id;
+    ObjectIndex registry_idx = kInvalidObjectIndex;
+    for (const auto& ref : thunk.GetReferences()) {
+      if (ref.field_name == cleaner_thunk_outer_field_id_) {
+        registry_idx = ref.target_index;
         break;
       }
     }
 
-    if (!registry_id) {
+    if (registry_idx == kInvalidObjectIndex) {
       continue;
     }
 
-    auto registry = objects_.Find(*registry_id);
-    if (!registry) {
-      continue;
-    }
+    const Object& registry = objects_.at(registry_idx);
 
     // Verify registry is a NativeAllocationRegistry (matches ahat check)
-    auto registry_cls = classes_.Find(registry->GetClassId());
+    auto registry_cls = classes_.Find(registry.GetClassId());
     if (!registry_cls || registry_cls->GetName() != kNativeAllocationRegistry) {
       continue;
     }
 
-    auto size_field =
-        registry->FindField("libcore.util.NativeAllocationRegistry.size");
-    if (!size_field) {
+    const auto* layout = class_fields_.Find(registry.GetClassId());
+    if (!layout) {
       continue;
     }
 
-    int64_t native_size = size_field->GetNumericValue();
+    int64_t native_size = 0;
+    ForEachFieldValue(context_, layout->fields, registry.GetRawData(),
+                      registry.GetRawDataSize(), header_.GetIdSize(),
+                      [&](const Field& f) {
+                        if (f.GetName() == native_registry_size_field_id_) {
+                          native_size = f.GetNumericValue();
+                        }
+                      });
     if (native_size <= 0) {
       continue;
     }
 
-    auto referent = objects_.Find(referent_id);
-    if (referent) {
-      referent->AddNativeSize(native_size);
-    }
+    objects_.at(referent_idx).AddNativeSize(native_size);
   }
 }
 }  // namespace perfetto::trace_processor::art_hprof

--- a/src/trace_processor/importers/art_hprof/art_hprof_model.h
+++ b/src/trace_processor/importers/art_hprof/art_hprof_model.h
@@ -18,8 +18,13 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_ART_HPROF_ART_HPROF_MODEL_H_
 
 #include "src/trace_processor/importers/art_hprof/art_hprof_types.h"
+#include "src/trace_processor/storage/trace_storage.h"
+
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
 
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -27,17 +32,6 @@
 #include <vector>
 
 namespace perfetto::trace_processor::art_hprof {
-using ArrayData = std::variant<std::monostate,         // Empty
-                               std::vector<bool>,      // Boolean array
-                               std::vector<uint8_t>,   // Byte array
-                               std::vector<uint16_t>,  // Char array
-                               std::vector<int16_t>,   // Short array
-                               std::vector<int32_t>,   // Int array
-                               std::vector<int64_t>,   // Long array
-                               std::vector<float>,     // Float array
-                               std::vector<double>,    // Double array
-                               std::vector<uint64_t>   // Object array
-                               >;
 
 // Field class with value storage using std::variant
 class Field {
@@ -54,12 +48,11 @@ class Field {
                                  uint64_t         // OBJECT (reference ID)
                                  >;
 
-  Field(std::string name, FieldType type)
-      : name_(std::move(name)), type_(type) {}
+  Field(StringId name, FieldType type) : name_(name), type_(type) {}
 
   template <typename T>
-  Field(std::string name, FieldType type, T value)
-      : name_(std::move(name)), type_(type), value_(value) {}
+  Field(StringId name, FieldType type, T value)
+      : name_(name), type_(type), value_(value) {}
 
   Field(const Field&) = default;
   Field& operator=(const Field&) = default;
@@ -67,7 +60,7 @@ class Field {
   Field& operator=(Field&&) = default;
   ~Field() = default;
 
-  const std::string& GetName() const { return name_; }
+  StringId GetName() const { return name_; }
   FieldType GetType() const { return type_; }
   bool HasValue() const {
     return !std::holds_alternative<std::monostate>(value_);
@@ -104,20 +97,41 @@ class Field {
   }
 
  private:
-  std::string name_;
+  StringId name_;
   FieldType type_;
   ValueType value_ = std::monostate{};
 };
 
+// Index of an object in the ObjectStore. Kept as a 32 bit index rather than
+// an hprof object id so that following a reference is an array lookup instead
+// of a hash map probe.
+using ObjectIndex = uint32_t;
+constexpr ObjectIndex kInvalidObjectIndex =
+    std::numeric_limits<ObjectIndex>::max();
+
 struct Reference {
-  std::string field_name;
-  std::optional<uint64_t> field_class_id;
+  StringId field_name;
+  // Index of the referred-to object, or kInvalidObjectIndex if the target is
+  // not present in the dump.
+  ObjectIndex target_index;
+  // Referent of a weak/phantom/finalizer reference: not followed when
+  // computing reachability.
+  bool is_weak_referent;
+
+  Reference(StringId name, ObjectIndex target, bool weak_referent = false)
+      : field_name(name),
+        target_index(target),
+        is_weak_referent(weak_referent) {}
+};
+
+// A static field reference seen while parsing, before the objects it points at
+// have been read.
+struct PendingReference {
+  StringId field_name;
   uint64_t target_id;
 
-  Reference(std::string_view name,
-            std::optional<uint64_t> class_id,
-            uint64_t target)
-      : field_name(name), field_class_id(class_id), target_id(target) {}
+  PendingReference(StringId name, uint64_t target)
+      : field_name(name), target_id(target) {}
 };
 
 class ClassDefinition {
@@ -161,23 +175,20 @@ class ClassDefinition {
 
 class Object {
  public:
-  Object(uint64_t id, uint64_t class_id, std::string heap, ObjectType type)
-      : id_(id),
-        class_id_(class_id),
-        type_(type),
-        heap_type_(std::move(heap)) {}
+  Object(uint64_t id, uint64_t class_id, StringId heap, ObjectType type)
+      : id_(id), class_id_(class_id), type_(type), heap_type_(heap) {}
 
   Object() = default;
 
-  Object(const Object&) = default;
-  Object& operator=(const Object&) = default;
+  Object(const Object&) = delete;
+  Object& operator=(const Object&) = delete;
   Object(Object&&) = default;
   Object& operator=(Object&&) = default;
   ~Object() = default;
 
   uint64_t GetId() const { return id_; }
   uint64_t GetClassId() const { return class_id_; }
-  const std::string& GetHeapType() const { return heap_type_; }
+  StringId GetHeapType() const { return heap_type_; }
   ObjectType GetObjectType() const { return type_; }
 
   void SetRootType(HprofHeapRootTag root_type) {
@@ -187,7 +198,7 @@ class Object {
 
   void SetReachable() { is_reachable_ = true; }
 
-  void SetHeapType(std::string heap_type) { heap_type_ = std::move(heap_type); }
+  void SetHeapType(StringId heap_type) { heap_type_ = heap_type; }
 
   bool IsRoot() const { return is_root_; }
   bool IsReachable() const { return is_reachable_; }
@@ -196,71 +207,61 @@ class Object {
   void SetRootDistance(int32_t d) { root_distance_ = d; }
   int32_t GetRootDistance() const { return root_distance_; }
 
-  void SetRawData(std::vector<uint8_t> data) { raw_data_ = std::move(data); }
+  // Instance data / object array element ids. This is a view onto the trace
+  // bytes themselves: on native builds, where the trace is mmapped, no copy
+  // of the data is ever made. It is released when the graph is torn down at
+  // the end of the import, so it never pins trace chunks beyond that.
+  void SetRawData(TraceBlobView data) { raw_data_ = std::move(data); }
 
-  const std::vector<uint8_t>& GetRawData() const { return raw_data_; }
-  void ClearRawData() { raw_data_ = {}; }
+  const uint8_t* GetRawData() const { return raw_data_.data(); }
+  size_t GetRawDataSize() const { return raw_data_.size(); }
+  const TraceBlobView& GetRawDataView() const { return raw_data_; }
+  void ClearRawData() { raw_data_ = TraceBlobView(); }
 
-  void ClearParsedData() {
-    fields_ = {};
-    references_ = {};
-    pending_references_ = {};
-    array_elements_ = {};
-    array_data_ = std::monostate{};
-    decoded_string_.reset();
+  void AddReference(StringId field_name,
+                    ObjectIndex target_index,
+                    bool is_weak_referent = false) {
+    references_.emplace_back(field_name, target_index, is_weak_referent);
   }
 
-  void AddReference(std::string_view field_name,
-                    std::optional<uint64_t> field_class_id,
-                    uint64_t target_id) {
-    references_.emplace_back(field_name, field_class_id, target_id);
-  }
+  void ReserveReferences(size_t count) { references_.reserve(count); }
 
-  void AddPendingReference(std::string_view field_name,
-                           std::optional<uint64_t> field_class_id,
-                           uint64_t target_id) {
-    pending_references_.emplace_back(field_name, field_class_id, target_id);
+  void AddPendingReference(StringId field_name, uint64_t target_id) {
+    pending_references_.emplace_back(field_name, target_id);
   }
 
   const std::vector<Reference>& GetReferences() const { return references_; }
 
-  const std::vector<Reference>& GetPendingReferences() const {
+  const std::vector<PendingReference>& GetPendingReferences() const {
     return pending_references_;
   }
 
   // Array-specific data
-  void SetArrayElements(std::vector<uint64_t> elements) {
-    array_elements_ = std::move(elements);
-  }
+  void SetArrayElementCount(uint32_t count) { array_element_count_ = count; }
 
   void SetArrayElementType(FieldType type) { array_element_type_ = type; }
 
-  const std::vector<uint64_t>& GetArrayElements() const {
-    return array_elements_;
-  }
+  // Size in bytes of the array payload as it appeared in the dump. Kept
+  // separately so the raw bytes can be dropped once they have been decoded.
+  void SetArrayDataBytes(uint32_t bytes) { array_data_bytes_ = bytes; }
+  uint32_t GetArrayDataBytes() const { return array_data_bytes_; }
 
   FieldType GetArrayElementType() const { return array_element_type_; }
 
-  void AddField(Field field) { fields_.push_back(std::move(field)); }
+  void AddField(Field field) { fields_.push_back(field); }
+
+  void ReserveFields(size_t count) { fields_.reserve(count); }
 
   const std::vector<Field>& GetFields() const { return fields_; }
-
-  const Field* FindField(const std::string& name) const {
-    for (const auto& field : fields_) {
-      if (field.GetName() == name) {
-        return &field;
-      }
-    }
-    return nullptr;
-  }
 
   int64_t GetNativeSize() const { return native_size_; }
 
   void AddNativeSize(int64_t size) { native_size_ += size; }
 
-  void SetDecodedString(std::string str) { decoded_string_ = std::move(str); }
-  const std::optional<std::string>& GetDecodedString() const {
-    return decoded_string_;
+  void SetDecodedString(StringId str) { decoded_string_ = str; }
+  std::optional<StringId> GetDecodedString() const {
+    return decoded_string_.is_null() ? std::nullopt
+                                     : std::make_optional(decoded_string_);
   }
 
   void SetSelfSizeOverride(size_t size) { self_size_override_ = size; }
@@ -268,37 +269,18 @@ class Object {
     return self_size_override_;
   }
 
-  template <typename T>
-  void SetArrayData(std::vector<T> data) {
+  // Primitive array payload, decoded to native endianness at parse time. This
+  // is the only copy of the data: it is handed to the storage as-is.
+  void SetArrayData(TraceBlobView data, uint32_t element_count) {
     array_data_ = std::move(data);
+    array_element_count_ = element_count;
   }
 
-  bool HasArrayData() const {
-    return !std::holds_alternative<std::monostate>(array_data_);
-  }
+  bool HasArrayData() const { return array_data_.size() > 0; }
 
-  template <typename T>
-  std::vector<T> GetArrayData() const {
-    const auto* data = std::get_if<std::vector<T>>(&array_data_);
-    if (data) {
-      return *data;
-    }
-    return {};
-  }
+  const TraceBlobView& GetArrayData() const { return array_data_; }
 
-  const ArrayData& GetArrayDataVariant() const { return array_data_; }
-
-  size_t GetArrayElementCount() const {
-    return std::visit(
-        [](const auto& val) -> size_t {
-          if constexpr (std::is_same_v<std::decay_t<decltype(val)>,
-                                       std::monostate>)
-            return 0;
-          else
-            return val.size();
-        },
-        array_data_);
-  }
+  size_t GetArrayElementCount() const { return array_element_count_; }
 
  private:
   uint64_t id_ = 0;
@@ -308,22 +290,88 @@ class Object {
   bool is_reachable_ = false;
   int32_t root_distance_ = -1;
   std::optional<HprofHeapRootTag> root_type_;
-  std::string heap_type_;
+  StringId heap_type_;
 
   // Data storage - used differently based on object type
-  std::vector<uint8_t> raw_data_;
+  TraceBlobView raw_data_;
   std::vector<Reference> references_;
-  std::vector<Reference> pending_references_;
-  std::vector<uint64_t> array_elements_;
+  std::vector<PendingReference> pending_references_;
+  uint32_t array_element_count_ = 0;
+  uint32_t array_data_bytes_ = 0;
   FieldType array_element_type_ = FieldType::kObject;
 
   int64_t native_size_ = 0;
   std::optional<size_t> self_size_override_;
-  std::optional<std::string> decoded_string_;
+  StringId decoded_string_ = StringId::Null();
 
   // Field values
   std::vector<Field> fields_;
-  ArrayData array_data_;
+  TraceBlobView array_data_;
+};
+
+// An object-typed field, at its fixed offset in the instance data.
+struct ObjectFieldRef {
+  StringId name;
+  uint32_t offset;
+  bool is_weak_referent;
+};
+
+// Fully qualified instance field layout of a class hierarchy. Computed once
+// per class, never per object.
+struct ClassFieldLayout {
+  // All fields, in the order they appear in the instance data.
+  std::vector<Field> fields;
+  // Just the object-typed fields, with their offsets precomputed so that
+  // reference extraction does not have to walk over the primitive ones.
+  std::vector<ObjectFieldRef> object_fields;
+};
+
+using ClassFieldLayouts = base::FlatHashMap<uint64_t, ClassFieldLayout>;
+
+// Stores all the objects in a dump contiguously, with a side map from hprof
+// object id to index. Keeping the (large) Object payloads out of the hash map
+// keeps probes cache friendly and avoids moving objects around on rehash.
+class ObjectStore {
+ public:
+  Object* Find(uint64_t id) {
+    ObjectIndex* idx = index_.Find(id);
+    return idx ? &objects_[*idx] : nullptr;
+  }
+
+  const Object* Find(uint64_t id) const {
+    const ObjectIndex* idx = index_.Find(id);
+    return idx ? &objects_[*idx] : nullptr;
+  }
+
+  ObjectIndex FindIndex(uint64_t id) const {
+    const ObjectIndex* idx = index_.Find(id);
+    return idx ? *idx : kInvalidObjectIndex;
+  }
+
+  // Returns the object with `id`, default constructing it if it does not
+  // exist yet.
+  Object& operator[](uint64_t id) {
+    auto res = index_.Insert(id, static_cast<ObjectIndex>(objects_.size()));
+    if (res.second) {
+      objects_.emplace_back();
+    }
+    return objects_[*res.first];
+  }
+
+  Object& at(ObjectIndex index) { return objects_[index]; }
+  const Object& at(ObjectIndex index) const { return objects_[index]; }
+
+  size_t size() const { return objects_.size(); }
+
+  void Clear() {
+    index_.Clear();
+    objects_.clear();
+    objects_.shrink_to_fit();
+  }
+
+ private:
+  base::FlatHashMap<uint64_t, ObjectIndex> index_;
+  std::vector<Object> objects_;
 };
 
 }  // namespace perfetto::trace_processor::art_hprof

--- a/src/trace_processor/importers/art_hprof/art_hprof_parser.cc
+++ b/src/trace_processor/importers/art_hprof/art_hprof_parser.cc
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/endian.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/string_view.h"
@@ -100,7 +101,7 @@ base::Status ArtHprofParser::OnPushDataToSorter() {
 
   class_map_.Clear();
   class_object_map_.Clear();
-  object_map_.Clear();
+  object_rows_ = {};
   class_name_map_.Clear();
   parser_->Clear();
 
@@ -110,11 +111,6 @@ base::Status ArtHprofParser::OnPushDataToSorter() {
 tables::HeapGraphClassTable::Id* ArtHprofParser::FindClassId(
     uint64_t class_id) const {
   return class_map_.Find(class_id);
-}
-
-tables::HeapGraphObjectTable::Id* ArtHprofParser::FindObjectId(
-    uint64_t obj_id) const {
-  return object_map_.Find(obj_id);
 }
 
 tables::HeapGraphClassTable::Id* ArtHprofParser::FindClassObjectId(
@@ -132,56 +128,73 @@ ArtHprofParser::TraceBlobViewIterator::TraceBlobViewIterator()
 
 ArtHprofParser::TraceBlobViewIterator::~TraceBlobViewIterator() = default;
 
-bool ArtHprofParser::TraceBlobViewIterator::ReadU1(uint8_t& value) {
-  auto slice = reader_.SliceOff(current_offset_, 1);
+const uint8_t* ArtHprofParser::TraceBlobViewIterator::Peek(size_t length) {
+  const uint8_t* ptr = reader_.ContiguousAt(current_offset_, length);
+  if (PERFETTO_LIKELY(ptr != nullptr)) {
+    return ptr;
+  }
+  // Slow path: the read straddles two chunks, so it has to be stitched
+  // together into the scratch buffer.
+  if (length > sizeof(scratch_))
+    return nullptr;
+  auto slice = reader_.SliceOff(current_offset_, length);
   if (!slice)
+    return nullptr;
+  std::memcpy(scratch_, slice->data(), length);
+  return scratch_;
+}
+
+bool ArtHprofParser::TraceBlobViewIterator::ReadU1(uint8_t& value) {
+  const uint8_t* d = Peek(1);
+  if (!d)
     return false;
-  value = *slice->data();
+  value = *d;
   current_offset_ += 1;
   return true;
 }
 
 bool ArtHprofParser::TraceBlobViewIterator::ReadU2(uint16_t& value) {
-  uint8_t b1;
-  uint8_t b2;
-  if (!ReadU1(b1) || !ReadU1(b2))
+  const uint8_t* d = Peek(2);
+  if (!d)
     return false;
-  value = static_cast<uint16_t>((static_cast<uint16_t>(b1) << 8) |
-                                static_cast<uint16_t>(b2));
+  uint16_t raw;
+  std::memcpy(&raw, d, sizeof(raw));
+  value = base::BE16ToHost(raw);
+  current_offset_ += 2;
   return true;
 }
 
 bool ArtHprofParser::TraceBlobViewIterator::ReadU4(uint32_t& value) {
-  uint8_t b1;
-  uint8_t b2;
-  uint8_t b3;
-  uint8_t b4;
-  if (!ReadU1(b1) || !ReadU1(b2) || !ReadU1(b3) || !ReadU1(b4))
+  const uint8_t* d = Peek(4);
+  if (!d)
     return false;
-  value = (static_cast<uint32_t>(b1) << 24) |
-          (static_cast<uint32_t>(b2) << 16) | (static_cast<uint32_t>(b3) << 8) |
-          static_cast<uint32_t>(b4);
+  uint32_t raw;
+  std::memcpy(&raw, d, sizeof(raw));
+  value = base::BE32ToHost(raw);
+  current_offset_ += 4;
   return true;
 }
 
 bool ArtHprofParser::TraceBlobViewIterator::ReadId(uint64_t& value,
                                                    uint32_t id_size) {
+  if (id_size != 4 && id_size != 8)
+    return false;
+
+  const uint8_t* d = Peek(id_size);
+  if (!d)
+    return false;
+
   if (id_size == 4) {
-    uint32_t id;
-    if (!ReadU4(id))
-      return false;
-    value = id;
-    return true;
+    uint32_t raw;
+    std::memcpy(&raw, d, sizeof(raw));
+    value = base::BE32ToHost(raw);
+  } else {
+    uint64_t raw;
+    std::memcpy(&raw, d, sizeof(raw));
+    value = base::BE64ToHost(raw);
   }
-  if (id_size == 8) {
-    uint32_t high;
-    uint32_t low;
-    if (!ReadU4(high) || !ReadU4(low))
-      return false;
-    value = (static_cast<uint64_t>(high) << 32) | low;
-    return true;
-  }
-  return false;
+  current_offset_ += id_size;
+  return true;
 }
 
 bool ArtHprofParser::TraceBlobViewIterator::ReadString(std::string& str,
@@ -196,23 +209,38 @@ bool ArtHprofParser::TraceBlobViewIterator::ReadString(std::string& str,
   return true;
 }
 
-bool ArtHprofParser::TraceBlobViewIterator::ReadBytes(
-    std::vector<uint8_t>& data,
-    size_t length) {
+bool ArtHprofParser::TraceBlobViewIterator::ReadView(TraceBlobView& view,
+                                                     size_t length) {
   auto slice = reader_.SliceOff(current_offset_, length);
   if (!slice)
     return false;
 
-  data.resize(length);
-  std::memcpy(data.data(), slice->data(), length);
+  view = std::move(*slice);
+  current_offset_ += length;
+  return true;
+}
+
+bool ArtHprofParser::TraceBlobViewIterator::ReadInto(uint8_t* dst,
+                                                     size_t length) {
+  if (const uint8_t* d = reader_.ContiguousAt(current_offset_, length)) {
+    std::memcpy(dst, d, length);
+    current_offset_ += length;
+    return true;
+  }
+  auto slice = reader_.SliceOff(current_offset_, length);
+  if (!slice)
+    return false;
+
+  std::memcpy(dst, slice->data(), length);
   current_offset_ += length;
   return true;
 }
 
 bool ArtHprofParser::TraceBlobViewIterator::SkipBytes(size_t count) {
-  auto slice = reader_.SliceOff(current_offset_, count);
-  if (!slice)
+  if (!reader_.ContiguousAt(current_offset_, count) &&
+      !reader_.SliceOff(current_offset_, count)) {
     return false;
+  }
 
   current_offset_ += count;
   return true;
@@ -226,12 +254,17 @@ bool ArtHprofParser::TraceBlobViewIterator::CanReadRecord() const {
   const size_t base_offset = current_offset_ + kRecordLengthOffset;
   uint8_t bytes[4];
 
-  auto slice = reader_.SliceOff(base_offset, 4);
-  if (!slice) {
-    return false;
+  const uint8_t* len_ptr = reader_.ContiguousAt(base_offset, 4);
+  std::optional<TraceBlobView> slice;
+  if (!len_ptr) {
+    slice = reader_.SliceOff(base_offset, 4);
+    if (!slice) {
+      return false;
+    }
+    len_ptr = slice->data();
   }
 
-  memcpy(bytes, slice->data(), 4);
+  memcpy(bytes, len_ptr, 4);
 
   uint32_t record_length = (static_cast<uint32_t>(bytes[0]) << 24) |
                            (static_cast<uint32_t>(bytes[1]) << 16) |
@@ -241,8 +274,9 @@ bool ArtHprofParser::TraceBlobViewIterator::CanReadRecord() const {
   // Check if we can read the full record (header + body) from the chunk.
   // If we can't we should fail so that we can receive another
   // chunk to continue.
-  return static_cast<bool>(
-      reader_.SliceOff(current_offset_, kRecordHeaderSize + record_length));
+  size_t record_size = kRecordHeaderSize + record_length;
+  return reader_.ContiguousAt(current_offset_, record_size) != nullptr ||
+         reader_.SliceOff(current_offset_, record_size).has_value();
 }
 
 void ArtHprofParser::TraceBlobViewIterator::PushBlob(TraceBlobView blob) {
@@ -339,7 +373,7 @@ void ArtHprofParser::PopulateClasses(const HeapGraph& graph) {
   // entries, so iterate classes instead of scanning all objects.
   for (auto it = graph.GetClasses().GetIterator(); it; ++it) {
     auto class_id = it.key();
-    auto* obj = graph.GetObjects().Find(class_id);
+    const auto* obj = graph.GetObjects().Find(class_id);
     if (!obj || obj->GetObjectType() != ObjectType::kClass) {
       continue;
     }
@@ -371,12 +405,14 @@ void ArtHprofParser::PopulateObjects(const HeapGraph& graph,
                                      int64_t ts,
                                      UniquePid upid) {
   auto& object_table = *context_->storage->mutable_heap_graph_object_table();
+  const auto& objects = graph.GetObjects();
 
   tables::HeapGraphClassTable::Id unknown_class_id;
 
-  for (auto it = graph.GetObjects().GetIterator(); it; ++it) {
-    auto obj_id = it.key();
-    auto& obj = it.value();
+  object_rows_.assign(objects.size(), kInvalidRow);
+
+  for (ObjectIndex i = 0; i < objects.size(); ++i) {
+    const auto& obj = objects.at(i);
 
     tables::HeapGraphClassTable::Id* type_id;
 
@@ -404,8 +440,7 @@ void ArtHprofParser::PopulateObjects(const HeapGraph& graph,
     object_row.reachable = obj.IsReachable();
     object_row.type_id = type_id ? *type_id : unknown_class_id;
 
-    StringId heap_type_id = context_->storage->InternString(obj.GetHeapType());
-    object_row.heap_type = heap_type_id;
+    object_row.heap_type = obj.GetHeapType();
 
     if (obj.IsRoot() && obj.GetRootType().has_value()) {
       std::string root_type_str =
@@ -419,7 +454,7 @@ void ArtHprofParser::PopulateObjects(const HeapGraph& graph,
 
     tables::HeapGraphObjectTable::Id table_id =
         object_table.Insert(object_row).id;
-    object_map_[obj_id] = table_id;
+    object_rows_[i] = table_id.value;
   }
 }
 
@@ -429,53 +464,54 @@ void ArtHprofParser::PopulateReferences(const HeapGraph& graph) {
       *context_->storage->mutable_heap_graph_reference_table();
 
   StringId unknown_type_id = context_->storage->InternString("unknown");
+  const auto& objects = graph.GetObjects();
 
-  for (auto it = graph.GetObjects().GetIterator(); it; ++it) {
-    auto obj_id = it.key();
-    auto& obj = it.value();
+  // Name of the class of each object, used as the field type name of every
+  // reference pointing at it.
+  const auto& class_table = context_->storage->heap_graph_class_table();
+  std::vector<StringId> class_names(objects.size(), unknown_type_id);
+  for (ObjectIndex i = 0; i < objects.size(); ++i) {
+    auto* cls_table_id = FindClassId(objects.at(i).GetClassId());
+    if (cls_table_id) {
+      class_names[i] = class_table[*cls_table_id].name();
+    }
+  }
+
+  for (ObjectIndex i = 0; i < objects.size(); ++i) {
+    const auto& obj = objects.at(i);
 
     const auto& refs = obj.GetReferences();
     if (refs.empty()) {
       continue;
     }
 
-    auto* owner_table_id = FindObjectId(obj_id);
-    if (!owner_table_id) {
+    if (object_rows_[i] == kInvalidRow) {
       continue;
     }
+    tables::HeapGraphObjectTable::Id owner_table_id(object_rows_[i]);
 
     // reference_set_id = row index of first reference for this object,
     // matching the proto importer's convention.
     uint32_t reference_set_id =
         static_cast<uint32_t>(reference_table.row_count());
-    object_table[*owner_table_id].set_reference_set_id(reference_set_id);
+    object_table[owner_table_id].set_reference_set_id(reference_set_id);
 
     for (const auto& ref : refs) {
-      tables::HeapGraphObjectTable::Id* owned_table_id = nullptr;
-      if (ref.target_id != 0) {
-        owned_table_id = FindObjectId(ref.target_id);
-      }
-
-      StringId field_name_id = context_->storage->InternString(ref.field_name);
-
+      std::optional<tables::HeapGraphObjectTable::Id> owned_table_id;
       StringId field_type_id = unknown_type_id;
-      if (ref.field_class_id.has_value() && *ref.field_class_id != 0) {
-        auto* cls_table_id = FindClassId(*ref.field_class_id);
-        if (cls_table_id) {
-          auto class_ref =
-              context_->storage->heap_graph_class_table()[*cls_table_id];
-          field_type_id = class_ref.name();
+      if (ref.target_index != kInvalidObjectIndex) {
+        if (object_rows_[ref.target_index] != kInvalidRow) {
+          owned_table_id =
+              tables::HeapGraphObjectTable::Id(object_rows_[ref.target_index]);
         }
+        field_type_id = class_names[ref.target_index];
       }
 
       tables::HeapGraphReferenceTable::Row reference_row;
       reference_row.reference_set_id = reference_set_id;
-      reference_row.owner_id = *owner_table_id;
-      reference_row.owned_id =
-          owned_table_id
-              ? std::optional<tables::HeapGraphObjectTable::Id>(*owned_table_id)
-              : std::nullopt;
-      reference_row.field_name = field_name_id;
+      reference_row.owner_id = owner_table_id;
+      reference_row.owned_id = owned_table_id;
+      reference_row.field_name = ref.field_name;
       reference_row.field_type_name = field_type_id;
 
       reference_table.Insert(reference_row);
@@ -512,46 +548,37 @@ const char* FieldTypeName(FieldType type) {
 void ArtHprofParser::PopulateFieldValues(const HeapGraph& graph) {
   auto& data_table = *context_->storage->mutable_heap_graph_object_data_table();
   auto& prim_table = *context_->storage->mutable_heap_graph_primitive_table();
+  auto& object_table = *context_->storage->mutable_heap_graph_object_table();
 
-  for (auto it = graph.GetObjects().GetIterator(); it; ++it) {
-    auto obj_id = it.key();
-    auto& obj = it.value();
+  const auto& objects = graph.GetObjects();
+  for (ObjectIndex i = 0; i < objects.size(); ++i) {
+    const auto& obj = objects.at(i);
 
-    auto* owner_table_id = FindObjectId(obj_id);
-    if (!owner_table_id)
+    if (object_rows_[i] == kInvalidRow)
       continue;
+    tables::HeapGraphObjectTable::Id owner_table_id(object_rows_[i]);
 
-    bool has_value_fields = false;
-    bool has_array_data = false;
+    bool has_array_data = obj.HasArrayData();
     bool has_string = obj.GetDecodedString().has_value();
 
-    if (obj.GetObjectType() == ObjectType::kInstance ||
-        obj.GetObjectType() == ObjectType::kClass) {
-      for (const auto& field : obj.GetFields()) {
-        if (field.GetType() != FieldType::kObject && field.HasValue()) {
-          has_value_fields = true;
-          break;
-        }
-      }
-    } else if (obj.GetObjectType() == ObjectType::kPrimitiveArray) {
-      has_array_data = obj.HasArrayData();
-    }
+    // Primitive fields are written as they are decoded; nothing is inserted
+    // for objects which have none, so this is safe to do before deciding
+    // whether the object needs a data row at all.
+    uint32_t field_set_id = static_cast<uint32_t>(prim_table.row_count());
+    uint32_t field_count =
+        InsertPrimitiveFields(graph, obj, field_set_id, prim_table);
 
-    if (!has_value_fields && !has_array_data && !has_string)
+    if (field_count == 0 && !has_array_data && !has_string)
       continue;
 
     tables::HeapGraphObjectDataTable::Row data_row;
 
     if (has_string) {
-      StringId str_id =
-          context_->storage->InternString(*obj.GetDecodedString());
-      data_row.value_string = str_id;
+      data_row.value_string = *obj.GetDecodedString();
     }
 
-    if (has_value_fields) {
-      uint32_t field_set_id = static_cast<uint32_t>(prim_table.row_count());
+    if (field_count > 0) {
       data_row.field_set_id = field_set_id;
-      InsertPrimitiveFields(obj, field_set_id, prim_table);
     }
 
     if (has_array_data) {
@@ -561,22 +588,23 @@ void ArtHprofParser::PopulateFieldValues(const HeapGraph& graph) {
     auto data_id = data_table.Insert(data_row).id;
 
     // Set reverse FK on the object table for direct lookup.
-    auto& object_table = *context_->storage->mutable_heap_graph_object_table();
-    object_table[*owner_table_id].set_object_data_id(data_id.value);
+    object_table[owner_table_id].set_object_data_id(data_id.value);
   }
 }
 
-void ArtHprofParser::InsertPrimitiveFields(
+uint32_t ArtHprofParser::InsertPrimitiveFields(
+    const HeapGraph& graph,
     const Object& obj,
     uint32_t field_set_id,
     tables::HeapGraphPrimitiveTable& prim_table) {
-  for (const auto& field : obj.GetFields()) {
+  uint32_t count = 0;
+  auto insert = [&](const Field& field) {
     if (field.GetType() == FieldType::kObject || !field.HasValue())
-      continue;
+      return;
 
     tables::HeapGraphPrimitiveTable::Row row;
     row.field_set_id = field_set_id;
-    row.field_name = context_->storage->InternString(field.GetName());
+    row.field_name = field.GetName();
     row.field_type =
         context_->storage->InternString(FieldTypeName(field.GetType()));
 
@@ -615,55 +643,53 @@ void ArtHprofParser::InsertPrimitiveFields(
     }
 
     prim_table.Insert(row);
+    ++count;
+  };
+
+  if (obj.GetObjectType() == ObjectType::kClass) {
+    // Class objects carry their static fields, parsed from the class dump.
+    for (const auto& field : obj.GetFields()) {
+      insert(field);
+    }
+  } else if (obj.GetObjectType() == ObjectType::kInstance) {
+    const auto* layout = graph.GetClassFields(obj.GetClassId());
+    if (layout) {
+      ForEachFieldValue(context_, layout->fields, obj.GetRawData(),
+                        obj.GetRawDataSize(), graph.GetIdSize(), insert);
+    }
   }
+  return count;
 }
 
 void ArtHprofParser::InsertArrayData(
     const Object& obj,
     tables::HeapGraphObjectDataTable::Row& data_row) {
-  std::vector<uint8_t> blob;
-  uint32_t element_count = 0;
-
-  std::visit(
-      [&](const auto& vec) {
-        using T = std::decay_t<decltype(vec)>;
-        if constexpr (!std::is_same_v<T, std::monostate>) {
-          element_count = static_cast<uint32_t>(vec.size());
-          using ElemT = typename T::value_type;
-          if constexpr (std::is_same_v<ElemT, bool>) {
-            blob.resize(vec.size());
-            for (size_t i = 0; i < vec.size(); ++i)
-              blob[i] = vec[i] ? 1 : 0;
-          } else {
-            blob.resize(vec.size() * sizeof(ElemT));
-            memcpy(blob.data(), vec.data(), blob.size());
-          }
-        }
-      },
-      obj.GetArrayDataVariant());
-
-  if (blob.empty())
+  const TraceBlobView& data = obj.GetArrayData();
+  if (data.size() == 0)
     return;
 
   int64_t hash = static_cast<int64_t>(
-      base::murmur_internal::MurmurHashBytes(blob.data(), blob.size()));
+      base::murmur_internal::MurmurHashBytes(data.data(), data.size()));
 
   StringId type_id =
       context_->storage->InternString(FieldTypeName(obj.GetArrayElementType()));
   auto* blobs = context_->storage->mutable_hprof_array_blobs();
   uint32_t blob_id = static_cast<uint32_t>(blobs->size());
 
-  // Copy the blob to avoid holding onto the potentially very large
-  // allocation of the trace object itself.
+  // Shares the buffer decoded at parse time rather than copying it again.
+  // That buffer is allocated per array and sized exactly to the array, so
+  // holding onto it here does not retain any of the trace's own memory: the
+  // parser deliberately does not hand out views into trace chunks for data
+  // that outlives the import.
   TraceStorage::HprofArrayBlob array_blob;
-  array_blob.data =
-      TraceBlobView(TraceBlob::CopyFrom(blob.data(), blob.size()));
+  array_blob.data = data.slice_off(0, data.size());
   array_blob.element_type = static_cast<uint8_t>(obj.GetArrayElementType());
-  array_blob.element_count = element_count;
+  array_blob.element_count = static_cast<uint32_t>(obj.GetArrayElementCount());
   blobs->push_back(std::move(array_blob));
 
   data_row.array_element_type = type_id;
-  data_row.array_element_count = element_count;
+  data_row.array_element_count =
+      static_cast<uint32_t>(obj.GetArrayElementCount());
   data_row.array_data_id = blob_id;
   data_row.array_data_hash = hash;
 }

--- a/src/trace_processor/importers/art_hprof/art_hprof_parser.h
+++ b/src/trace_processor/importers/art_hprof/art_hprof_parser.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -55,14 +56,16 @@ class ArtHprofParser : public ChunkedTraceReader {
   void PopulateObjects(const HeapGraph& graph, int64_t ts, UniquePid upid);
   void PopulateReferences(const HeapGraph& graph);
   void PopulateFieldValues(const HeapGraph& graph);
-  void InsertPrimitiveFields(const Object& obj,
-                             uint32_t field_set_id,
-                             tables::HeapGraphPrimitiveTable& prim_table);
+  // Writes the primitive field values of `obj` and returns how many rows were
+  // inserted.
+  uint32_t InsertPrimitiveFields(const HeapGraph& graph,
+                                 const Object& obj,
+                                 uint32_t field_set_id,
+                                 tables::HeapGraphPrimitiveTable& prim_table);
   void InsertArrayData(const Object& obj,
                        tables::HeapGraphObjectDataTable::Row& data_row);
 
   tables::HeapGraphClassTable::Id* FindClassId(uint64_t class_id) const;
-  tables::HeapGraphObjectTable::Id* FindObjectId(uint64_t obj_id) const;
   tables::HeapGraphClassTable::Id* FindClassObjectId(uint64_t obj_id) const;
   StringId InternClassName(const std::string& class_name);
 
@@ -75,7 +78,8 @@ class ArtHprofParser : public ChunkedTraceReader {
     bool ReadU4(uint32_t& value) override;
     bool ReadId(uint64_t& value, uint32_t id_size) override;
     bool ReadString(std::string& str, size_t length) override;
-    bool ReadBytes(std::vector<uint8_t>& data, size_t length) override;
+    bool ReadInto(uint8_t* dst, size_t length) override;
+    bool ReadView(TraceBlobView& view, size_t length) override;
     bool SkipBytes(size_t count) override;
     size_t GetPosition() const override;
     // Whether we can read an entire record from the existing chunk.
@@ -87,8 +91,13 @@ class ArtHprofParser : public ChunkedTraceReader {
     void Shrink() override;
 
    private:
+    // Returns a pointer to the next `length` bytes without advancing, using
+    // the scratch buffer only when they straddle two chunks.
+    const uint8_t* Peek(size_t length);
+
     util::TraceBlobViewReader reader_;
     size_t current_offset_ = 0;
+    uint8_t scratch_[8];
   };
 
   TraceProcessorContext* const context_;
@@ -100,7 +109,10 @@ class ArtHprofParser : public ChunkedTraceReader {
   base::FlatHashMap<uint64_t, tables::HeapGraphClassTable::Id> class_map_;
   base::FlatHashMap<uint64_t, tables::HeapGraphClassTable::Id>
       class_object_map_;
-  base::FlatHashMap<uint64_t, tables::HeapGraphObjectTable::Id> object_map_;
+  // Row id in the object table for each object in the heap graph, indexed by
+  // ObjectIndex. kInvalidRow for objects which were not inserted.
+  static constexpr uint32_t kInvalidRow = std::numeric_limits<uint32_t>::max();
+  std::vector<uint32_t> object_rows_;
   base::FlatHashMap<uint64_t, std::string> class_name_map_;
 };
 }  // namespace perfetto::trace_processor::art_hprof

--- a/src/trace_processor/tables/profiler_tables.py
+++ b/src/trace_processor/tables/profiler_tables.py
@@ -1130,7 +1130,8 @@ HEAP_GRAPH_OBJECT_TABLE = Table(
         C(
             'object_data_id',
             CppOptional(CppUint32()),
-            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
+            flags=ColumnFlag.DENSE,
+            cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE,
         ),
     ],
     tabledoc=TableDoc(

--- a/src/trace_processor/util/trace_blob_view_reader.h
+++ b/src/trace_processor/util/trace_blob_view_reader.h
@@ -183,6 +183,29 @@ class TraceBlobViewReader {
     return PopFrontUntil(start_offset() + bytes);
   }
 
+  // Returns a pointer to |length| contiguous bytes starting at |offset|, or
+  // nullptr if they are not entirely contained in the first buffered chunk.
+  //
+  // Unlike SliceOff() this does not create a TraceBlobView, so it does not
+  // touch the refcount of the underlying blob. Intended for readers which
+  // decode many small scalars and do not need to retain the data.
+  PERFETTO_ALWAYS_INLINE const uint8_t* ContiguousAt(size_t offset,
+                                                     size_t length) const {
+    if (PERFETTO_UNLIKELY(data_.empty())) {
+      return nullptr;
+    }
+    const Entry& entry = data_.front();
+    if (PERFETTO_UNLIKELY(offset < entry.start_offset)) {
+      return nullptr;
+    }
+    size_t rel_off = offset - entry.start_offset;
+    size_t size = entry.data.size();
+    if (PERFETTO_UNLIKELY(rel_off > size || length > size - rel_off)) {
+      return nullptr;
+    }
+    return entry.data.data() + rel_off;
+  }
+
   // Creates a TraceBlobView by slicing this reader starting at |offset| and
   // spanning |length| bytes.
   //


### PR DESCRIPTION
Loading a heap dump spends nearly all of its time after the last byte has
been read, which is why the UI sits at 100% for so long. Profiling an
82MB dump (~1M objects, 1.9M references) showed the cost is not in
parsing the file but in the object model built before anything reaches
the tables: a std::string for every field and reference name, copied per
object; a hash map keyed on hprof id whose values were ~250 byte objects,
so every probe and every rehash touched the whole payload; and several
copies of every instance and array payload.

Names are now interned once per class and carried as StringId, so the
reachability walk compares ids instead of strings and populating the
tables interns nothing. Objects live in a flat vector with a side index,
and references store the target's index, which turns following an edge
into an array lookup. Instance data and object array element ids are read
as views onto the trace rather than copied, and field values are decoded
from those bytes on demand instead of being materialised as a Field per
instance. Array payloads keep their own exactly sized buffer: they
outlive the import, and a view would pin whichever trace chunk it points
into for the rest of the session.

object_data_id becomes a dense null column. It is set for almost every
object, and each write to a sparse null column memmoves the tail of the
column, which alone accounted for a fifth of the import.

Import of the 82MB dump goes from 3.0s to 0.77s and peak RSS from 1.41GB
to 590MB. Table contents are unchanged; object rows are now numbered in
dump order rather than hash order.