### PR TITLE
ui: Fix memscope process profitability false negatives.

### DIFF
--- a/ui/src/plugins/dev.perfetto.Memscope/sessions/live_session.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/sessions/live_session.ts
@@ -22,6 +22,7 @@ import type {AdbDevice} from '../../dev.perfetto.RecordTraceV2/adb/adb_device';
 import {createAdbTracingSession} from '../../dev.perfetto.RecordTraceV2/adb/adb_tracing_session';
 import type {TracingSession} from '../../dev.perfetto.RecordTraceV2/interfaces/tracing_session';
 import type {TracedWebsocketTarget} from '../../dev.perfetto.RecordTraceV2/traced_over_websocket/traced_websocket_target';
+import {isDebuggableAndroidBuild} from '../utils';
 import type {ConnectionResult} from '../views/connection';
 import {download} from '../../../base/download_utils';
 import {ProfileSession, type ProfileState} from './profile_session';
@@ -712,9 +713,9 @@ async function extractSnapshotData(
     });
   }
 
-  // Check if device is userdebug.
+  // Check if device is userdebug / eng.
   const buildRow = buildResult.maybeFirstRow({fingerprint: STR});
-  const isUserDebug = buildRow?.fingerprint?.includes('userdebug') ?? false;
+  const isUserDebug = isDebuggableAndroidBuild(buildRow?.fingerprint);
 
   return {
     data: {

--- a/ui/src/plugins/dev.perfetto.Memscope/utils.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/utils.ts
@@ -104,4 +104,3 @@ export function isDebuggableAndroidBuild(fingerprint?: string): boolean {
   const variant = parseAndroidBuildVariant(fingerprint);
   return variant === 'userdebug' || variant === 'eng';
 }
-

--- a/ui/src/plugins/dev.perfetto.Memscope/utils.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/utils.ts
@@ -61,3 +61,47 @@ export function billboardBytes(bytes: number) {
   const [value, unit] = formatBytesIec(bytes).split(' ');
   return {value, unit};
 }
+
+export type AndroidBuildVariant = 'user' | 'userdebug' | 'eng' | 'unknown';
+
+/**
+ * Parses the build variant (e.g. 'user', 'userdebug', 'eng') from an Android build fingerprint.
+ *
+ * According to the Android CDD, the fingerprint format is:
+ * $(BRAND)/$(PRODUCT)/$(DEVICE):$(PLATFORM_VERSION)/$(BUILD_ID)/$(BUILD_NUMBER):$(TARGET_BUILD_VARIANT)/$(BUILD_VERSION_TAGS)
+ *
+ * The build variant is the token after the last ':' up to the following '/'.
+ */
+export function parseAndroidBuildVariant(
+  fingerprint?: string,
+): AndroidBuildVariant {
+  if (!fingerprint) return 'unknown';
+
+  const lastColon = fingerprint.lastIndexOf(':');
+  if (lastColon === -1) {
+    const match = fingerprint.match(/\b(userdebug|eng|user)\b/i);
+    return match ? (match[1].toLowerCase() as AndroidBuildVariant) : 'unknown';
+  }
+
+  const rest = fingerprint.substring(lastColon + 1);
+  const slash = rest.indexOf('/');
+  const variant = (slash === -1 ? rest : rest.substring(0, slash))
+    .toLowerCase()
+    .trim();
+
+  if (variant === 'userdebug' || variant === 'eng' || variant === 'user') {
+    return variant;
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Returns whether an Android build fingerprint corresponds to a debuggable build
+ * ('userdebug' or 'eng').
+ */
+export function isDebuggableAndroidBuild(fingerprint?: string): boolean {
+  const variant = parseAndroidBuildVariant(fingerprint);
+  return variant === 'userdebug' || variant === 'eng';
+}
+

--- a/ui/src/plugins/dev.perfetto.Memscope/utils_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/utils_unittest.ts
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  isDebuggableAndroidBuild,
-  parseAndroidBuildVariant,
-} from './utils';
-
+import {isDebuggableAndroidBuild, parseAndroidBuildVariant} from './utils';
 
 describe('parseAndroidBuildVariant', () => {
   it('identifies userdebug build from standard fingerprint', () => {
@@ -101,4 +97,3 @@ describe('isDebuggableAndroidBuild', () => {
     expect(isDebuggableAndroidBuild('')).toBe(false);
   });
 });
-

--- a/ui/src/plugins/dev.perfetto.Memscope/utils_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/utils_unittest.ts
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  isDebuggableAndroidBuild,
+  parseAndroidBuildVariant,
+} from './utils';
+
+
+describe('parseAndroidBuildVariant', () => {
+  it('identifies userdebug build from standard fingerprint', () => {
+    const fp =
+      'google/coral/coral:12/SP1A.210812.015/7679548:userdebug/dev-keys';
+    expect(parseAndroidBuildVariant(fp)).toBe('userdebug');
+  });
+
+  it('identifies eng build from standard fingerprint', () => {
+    const fp =
+      'google/tangorpro/tangorpro:VanillaIceCream/MAIN/eng.prabir.20240606.172326:eng/dev-keys';
+    expect(parseAndroidBuildVariant(fp)).toBe('eng');
+  });
+
+  it('identifies user build from standard fingerprint', () => {
+    const fp =
+      'google/oriole/oriole:14/AP1A.240405.002/11487190:user/release-keys';
+    expect(parseAndroidBuildVariant(fp)).toBe('user');
+  });
+
+  it('handles AOSP generic fingerprints', () => {
+    const fp = 'generic/aosp_arm64/arm64:14/UDC/1234:eng/test-keys';
+    expect(parseAndroidBuildVariant(fp)).toBe('eng');
+  });
+
+  it('handles fingerprint with build ID containing words like user or eng', () => {
+    const fp =
+      'Android/aosp_raven/raven:VanillaIceCream/MAIN/eng.user.20240101.000000:userdebug/test-keys';
+    expect(parseAndroidBuildVariant(fp)).toBe('userdebug');
+  });
+
+  it('handles uppercase and mixed case build variants', () => {
+    const fp = 'google/coral/coral:12/SP1A/123:USERDEBUG/dev-keys';
+    expect(parseAndroidBuildVariant(fp)).toBe('userdebug');
+  });
+
+  it('handles fingerprint without trailing tags', () => {
+    const fp = 'google/coral/coral:12/SP1A/123:userdebug';
+    expect(parseAndroidBuildVariant(fp)).toBe('userdebug');
+  });
+
+  it('falls back to substring matching when colons are absent', () => {
+    expect(parseAndroidBuildVariant('aosp_cf_x86_phone-userdebug')).toBe(
+      'userdebug',
+    );
+    expect(parseAndroidBuildVariant('linux-eng-build')).toBe('eng');
+  });
+
+  it('returns unknown for undefined, null, or empty string', () => {
+    expect(parseAndroidBuildVariant(undefined)).toBe('unknown');
+    expect(parseAndroidBuildVariant('')).toBe('unknown');
+  });
+
+  it('returns unknown for unrecognizable fingerprints', () => {
+    expect(
+      parseAndroidBuildVariant('custom/device/model:1.0/foo/bar:custom/tag'),
+    ).toBe('unknown');
+  });
+});
+
+describe('isDebuggableAndroidBuild', () => {
+  it('returns true for userdebug fingerprint', () => {
+    const fp =
+      'google/coral/coral:12/SP1A.210812.015/7679548:userdebug/dev-keys';
+    expect(isDebuggableAndroidBuild(fp)).toBe(true);
+  });
+
+  it('returns true for eng fingerprint', () => {
+    const fp =
+      'google/tangorpro/tangorpro:VanillaIceCream/MAIN/eng.prabir.20240606.172326:eng/dev-keys';
+    expect(isDebuggableAndroidBuild(fp)).toBe(true);
+  });
+
+  it('returns false for user fingerprint', () => {
+    const fp =
+      'google/oriole/oriole:14/AP1A.240405.002/11487190:user/release-keys';
+    expect(isDebuggableAndroidBuild(fp)).toBe(false);
+  });
+
+  it('returns false for undefined or empty string', () => {
+    expect(isDebuggableAndroidBuild(undefined)).toBe(false);
+    expect(isDebuggableAndroidBuild('')).toBe(false);
+  });
+});
+

--- a/ui/src/plugins/dev.perfetto.Memscope/views/tabs/processes.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/tabs/processes.ts
@@ -783,14 +783,14 @@ class ProcessTable implements m.ClassComponent<ProcessTableAttrs> {
       const canProfile = p.debuggable || isUserDebug;
       const profileButton = m(Button, {
         label: 'Profile',
+        icon: canProfile ? undefined : 'warning',
         rightIcon: 'arrow_forward',
         rounded: true,
         variant: ButtonVariant.Filled,
         intent: Intent.Primary,
-        disabled: !canProfile,
         tooltip: canProfile
           ? undefined
-          : 'Process is not debuggable. A userdebug or eng build is required to heap profile.',
+          : 'Process is not marked debuggable. Profiling may fail if the device is not a userdebug or eng build.',
         onclick: () =>
           session.startProfile(p.pid, p.processName).then(() => m.redraw()),
       });


### PR DESCRIPTION
In memscope, a process can be profiled if it has the profiled flag set in its manifest or the user is running a userdebug or eng build. However the current way of detecting the build type is poorly implemented and misses eng builds.

- Improve Android fingerprint parser to improve userdebug detection and to detect eng builds too + add some unit tests.
- Don't block the user from attempting to profile what we suspect are non-profilable processes - just show a warning but still allow the user to click through and start profiling.
