### PR TITLE
perfetto: expose PerfettoSDK Java libs to ART modules

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1069,6 +1069,10 @@ cc_library {
         "-DPERFETTO_SDK_SHLIB_IMPLEMENTATION",
         "-DZLIB_IMPLEMENTATION",
     ],
+    apex_available: [
+        "//apex_available:anyapex",
+        "//apex_available:platform",
+    ],
     min_sdk_version: "30",
     target: {
         android: {
@@ -1414,6 +1418,11 @@ cc_library_shared {
     header_libs: [
         "jni_headers",
     ],
+    apex_available: [
+        "//apex_available:anyapex",
+        "//apex_available:platform",
+    ],
+    min_sdk_version: "31",
     target: {
         android: {
             shared_libs: [
@@ -1453,9 +1462,11 @@ cc_library_shared {
     header_libs: [
         "jni_headers",
     ],
-    visibility: [
-        ":__subpackages__",
+    apex_available: [
+        "//apex_available:anyapex",
+        "//apex_available:platform",
     ],
+    min_sdk_version: "31",
 }
 
 // GN: //src/java_sdk/main/cpp:perfetto_example_jni_lib
@@ -27264,5 +27275,59 @@ filegroup {
     name: "perfetto_cpp_blob_emitter",
     srcs: [
         "python/tools/cpp_blob_emitter.py",
+    ],
+}
+
+cc_library_static {
+    name: "libperfetto_jni_static",
+    apex_available: [
+        "//apex_available:anyapex",
+        "//apex_available:platform",
+    ],
+    min_sdk_version: "31",
+    srcs: [
+        ":perfetto_include_perfetto_public_abi_base",
+        ":perfetto_include_perfetto_public_abi_public",
+        ":perfetto_include_perfetto_public_base",
+        ":perfetto_include_perfetto_public_protos_protos",
+        ":perfetto_include_perfetto_public_protozero",
+        ":perfetto_include_perfetto_public_public",
+        ":perfetto_src_android_sdk_jni_libperfetto_jni_src",
+        ":perfetto_src_android_sdk_nativehelper_nativehelper",
+        ":perfetto_src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni",
+        ":perfetto_src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni_public",
+    ],
+    host_supported: true,
+    cflags: [
+        "-DLIBCORE_INTEGRATION",
+        "-DPERFETTO_JNI_JARJAR_PREFIX=dalvik/system/",
+    ],
+    defaults: [
+        "perfetto_defaults",
+    ],
+    header_libs: [
+        "jni_headers",
+    ],
+}
+
+filegroup {
+    name: "perfetto_jarjar_rules_files",
+    srcs: ["src/android_sdk/java/main/perfetto-sdk-libcore-jarjar-rules.txt"],
+}
+
+// GN: //src/android_sdk/java/main:perfetto_trace_lib_libcore_java
+filegroup {
+    name: "perfetto_trace_lib_libcore_java",
+
+    srcs: [
+        // From "perfetto_trace_lib_java_defaults":
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrack.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java",
+    ],
+    visibility: [
+        "//visibility:public",
     ],
 }

--- a/Android.bp.extras
+++ b/Android.bp.extras
@@ -389,3 +389,57 @@ filegroup {
         "python/tools/cpp_blob_emitter.py",
     ],
 }
+
+cc_library_static {
+    name: "libperfetto_jni_static",
+    apex_available: [
+        "//apex_available:anyapex",
+        "//apex_available:platform",
+    ],
+    min_sdk_version: "31",
+    srcs: [
+        ":perfetto_include_perfetto_public_abi_base",
+        ":perfetto_include_perfetto_public_abi_public",
+        ":perfetto_include_perfetto_public_base",
+        ":perfetto_include_perfetto_public_protos_protos",
+        ":perfetto_include_perfetto_public_protozero",
+        ":perfetto_include_perfetto_public_public",
+        ":perfetto_src_android_sdk_jni_libperfetto_jni_src",
+        ":perfetto_src_android_sdk_nativehelper_nativehelper",
+        ":perfetto_src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni",
+        ":perfetto_src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni_public",
+    ],
+    host_supported: true,
+    cflags: [
+        "-DLIBCORE_INTEGRATION",
+        "-DPERFETTO_JNI_JARJAR_PREFIX=dalvik/system/",
+    ],
+    defaults: [
+        "perfetto_defaults",
+    ],
+    header_libs: [
+        "jni_headers",
+    ],
+}
+
+filegroup {
+    name: "perfetto_jarjar_rules_files",
+    srcs: ["src/android_sdk/java/main/perfetto-sdk-libcore-jarjar-rules.txt"],
+}
+
+// GN: //src/android_sdk/java/main:perfetto_trace_lib_libcore_java
+filegroup {
+    name: "perfetto_trace_lib_libcore_java",
+
+    srcs: [
+        // From "perfetto_trace_lib_java_defaults":
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrack.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java",
+    ],
+    visibility: [
+        "//visibility:public",
+    ],
+}

--- a/src/android_sdk/java/main/perfetto-sdk-libcore-jarjar-rules.txt
+++ b/src/android_sdk/java/main/perfetto-sdk-libcore-jarjar-rules.txt
@@ -1,0 +1,2 @@
+rule dev.perfetto.sdk.** dalvik.system.dev.perfetto.sdk.@1
+zap com.google.errorprone.annotations.**

--- a/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrace.cc
+++ b/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrace.cc
@@ -180,7 +180,13 @@ int register_dev_perfetto_sdk_PerfettoTrace(JNIEnv* env) {
 }  // namespace jni
 }  // namespace perfetto
 
-JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void*) {
+#ifdef LIBCORE_INTEGRATION
+// If building for Libcore, give it a unique name so we can call it manually
+extern "C" jint JNI_OnLoad_Perfetto(JavaVM* vm, void* reserved) {
+#else
+// If building as a standalone library, keep the standard name
+JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+#endif
   JNIEnv* env;
   if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
     return JNI_ERR;

--- a/src/android_sdk/perfetto_sdk_for_jni/tracing_sdk.cc
+++ b/src/android_sdk/perfetto_sdk_for_jni/tracing_sdk.cc
@@ -15,7 +15,6 @@
  */
 
 #include "src/android_sdk/perfetto_sdk_for_jni/tracing_sdk.h"
-
 #include <sys/types.h>
 
 #include <cstdarg>

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -371,6 +371,8 @@ additional_args = {
         }),
     ],
     'libperfetto_c': [
+        ('apex_available',
+         {'//apex_available:platform', '//apex_available:anyapex'}),
         ('min_sdk_version', '30'),
         ('export_include_dirs', {'include'}),
         # Exports the SDK ABI symbols from the .so (see
@@ -434,8 +436,16 @@ additional_args = {
         # Framework should use 'perfetto_trace_lib_framework_java' instead.
         ('visibility', {':__subpackages__'}),
     ],
-    # Framework should use 'libperfetto_framework_jni' instead.
-    'libperfetto_jni': [('visibility', {':__subpackages__'}),],
+    'libperfetto_framework_jni': [
+        ('apex_available',
+         {'//apex_available:platform', '//apex_available:anyapex'}),
+        ('min_sdk_version', '31'),
+    ],
+    'libperfetto_jni': [
+        ('apex_available',
+         {'//apex_available:platform', '//apex_available:anyapex'}),
+        ('min_sdk_version', '31'),
+    ],
 }
 
 


### PR DESCRIPTION
Expose Perfetto Java SDK and JNI libraries for Libcore / ART integration:
- Add jarjar rules for dalvik.system.dev.perfetto.sdk.
- Conditionally expose JNI_OnLoad_Perfetto when LIBCORE_INTEGRATION is defined.
- Add libperfetto_jni_static, perfetto_jarjar_rules_files, and perfetto_trace_lib_libcore_java targets in Android.bp.extras.
- Update tools/gen_android_bp to set apex_available and min_sdk_version on SDK libraries.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
