### PR TITLE
perfetto: expose PerfettoSDK Java libs to ART modules

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1069,6 +1069,10 @@ cc_library {
         "-DPERFETTO_SDK_SHLIB_IMPLEMENTATION",
         "-DZLIB_IMPLEMENTATION",
     ],
+    apex_available: [
+        "//apex_available:anyapex",
+        "//apex_available:platform",
+    ],
     min_sdk_version: "30",
     target: {
         android: {
@@ -1414,6 +1418,11 @@ cc_library_shared {
     header_libs: [
         "jni_headers",
     ],
+    apex_available: [
+        "//apex_available:anyapex",
+        "//apex_available:platform",
+    ],
+    min_sdk_version: "apex_inherit",
     target: {
         android: {
             shared_libs: [
@@ -1475,6 +1484,45 @@ cc_library_shared {
     ],
     header_libs: [
         "jni_headers",
+    ],
+}
+
+// GN: //src/android_sdk/jni:libperfetto_libcore_jni
+cc_library_static {
+    name: "libperfetto_libcore_jni",
+    srcs: [
+        ":perfetto_include_perfetto_public_abi_base",
+        ":perfetto_include_perfetto_public_abi_public",
+        ":perfetto_include_perfetto_public_base",
+        ":perfetto_include_perfetto_public_protos_protos",
+        ":perfetto_include_perfetto_public_protozero",
+        ":perfetto_include_perfetto_public_public",
+        ":perfetto_src_android_sdk_jni_libperfetto_libcore_jni_src",
+        ":perfetto_src_android_sdk_nativehelper_nativehelper",
+        ":perfetto_src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni",
+        ":perfetto_src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni_public",
+    ],
+    shared_libs: [
+        "libperfetto_c",
+    ],
+    host_supported: true,
+    defaults: [
+        "perfetto_defaults",
+    ],
+    cflags: [
+        "-DPERFETTO_JNI_ART_STATIC_INTEGRATION",
+        "-DPERFETTO_JNI_JARJAR_PREFIX=dalvik/system/",
+    ],
+    header_libs: [
+        "jni_headers",
+    ],
+    apex_available: [
+        "//apex_available:anyapex",
+        "//apex_available:platform",
+    ],
+    min_sdk_version: "apex_inherit",
+    visibility: [
+        "//libcore:__subpackages__",
     ],
 }
 
@@ -15799,6 +15847,16 @@ filegroup {
     ],
 }
 
+// GN: //src/android_sdk/jni:libperfetto_libcore_jni_src
+filegroup {
+    name: "perfetto_src_android_sdk_jni_libperfetto_libcore_jni_src",
+    srcs: [
+        "src/android_sdk/jni/dev_perfetto_sdk_PerfettoNativeMemoryCleaner.cc",
+        "src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrace.cc",
+        "src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrackEventExtra.cc",
+    ],
+}
+
 // GN: //src/android_sdk/nativehelper:nativehelper
 filegroup {
     name: "perfetto_src_android_sdk_nativehelper_nativehelper",
@@ -23284,6 +23342,22 @@ java_defaults {
     },
 }
 
+// GN: //src/android_sdk/java/main:perfetto_trace_lib
+filegroup {
+    name: "perfetto_trace_lib_libcore_java",
+    srcs: [
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeLibrary.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrack.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java",
+    ],
+    visibility: [
+        "//libcore:__subpackages__",
+    ],
+}
+
 // GN: //protos/perfetto/trace:perfetto_trace_protos
 cc_library_static {
     name: "perfetto_trace_protos",
@@ -27264,5 +27338,13 @@ filegroup {
     name: "perfetto_cpp_blob_emitter",
     srcs: [
         "python/tools/cpp_blob_emitter.py",
+    ],
+}
+
+filegroup {
+    name: "perfetto_sdk_libcore_jarjar_rules",
+    srcs: ["src/android_sdk/java/main/perfetto-sdk-libcore-jarjar-rules.txt"],
+    visibility: [
+        "//libcore:__subpackages__",
     ],
 }

--- a/Android.bp.extras
+++ b/Android.bp.extras
@@ -389,3 +389,11 @@ filegroup {
         "python/tools/cpp_blob_emitter.py",
     ],
 }
+
+filegroup {
+    name: "perfetto_sdk_libcore_jarjar_rules",
+    srcs: ["src/android_sdk/java/main/perfetto-sdk-libcore-jarjar-rules.txt"],
+    visibility: [
+        "//libcore:__subpackages__",
+    ],
+}

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeLibrary.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeLibrary.java
@@ -19,21 +19,28 @@ package dev.perfetto.sdk;
 /**
  * Loads the JNI library backing the native methods in this package.
  *
- * <p>These sources are built twice. The platform build jarjars them into {@code
- * com.android.internal.dev.perfetto.sdk} and pairs them with {@code libperfetto_framework_jni}; the
- * standalone SDK build keeps them in {@code dev.perfetto.sdk} and pairs them with {@code
- * libperfetto_jni}. Both libraries are compiled from the same sources and differ only in the class
- * names their {@code JNI_OnLoad} registers against, aborting if those classes are absent, so the
- * variant has to be picked from the package the classes actually landed in.
+ * <p>These sources are built in multiple variants. The platform framework build jarjars them into
+ * {@code com.android.internal.dev.perfetto.sdk} and pairs them with {@code
+ * libperfetto_framework_jni}; the standalone SDK build keeps them in {@code dev.perfetto.sdk} and
+ * pairs them with {@code libperfetto_jni}. The Libcore build jarjars them into {@code
+ * dalvik.system.dev.perfetto.sdk} and links them statically into the runtime, where JNI registration
+ * occurs at startup.
  *
  * @hide
  */
 final class PerfettoNativeLibrary {
   private static final String FRAMEWORK_PREFIX = "com.android.internal.";
+  private static final String LIBCORE_PREFIX = "dalvik.system.";
 
   /** Loads the JNI library matching this build. Repeat calls are no-ops. */
   static void load() {
-    boolean isFramework = PerfettoNativeLibrary.class.getName().startsWith(FRAMEWORK_PREFIX);
+    String className = PerfettoNativeLibrary.class.getName();
+    if (className.startsWith(LIBCORE_PREFIX)) {
+      // In Libcore, native methods are statically linked into the runtime
+      // and registered at startup.
+      return;
+    }
+    boolean isFramework = className.startsWith(FRAMEWORK_PREFIX);
     System.loadLibrary(isFramework ? "perfetto_framework_jni" : "perfetto_jni");
   }
 }

--- a/src/android_sdk/java/main/perfetto-sdk-libcore-jarjar-rules.txt
+++ b/src/android_sdk/java/main/perfetto-sdk-libcore-jarjar-rules.txt
@@ -1,0 +1,5 @@
+rule dev.perfetto.sdk.** dalvik.system.dev.perfetto.sdk.@1
+
+# ErrorProne annotations are not supported in Libcore; zap them to avoid
+# bundling compile-time annotations and prevent bootclasspath conflicts.
+zap com.google.errorprone.annotations.**

--- a/src/android_sdk/jni/BUILD.gn
+++ b/src/android_sdk/jni/BUILD.gn
@@ -72,6 +72,16 @@ source_set("libperfetto_framework_jni_src") {
            [ "-DPERFETTO_JNI_JARJAR_PREFIX=com/android/internal/" ]
 }
 
+source_set("libperfetto_libcore_jni_src") {
+  sources = SOURCE_SET_SOURCES
+  deps = SOURCE_SET_DEPS
+  include_dirs = SOURCE_SET_INCLUDE_DIRS
+  cflags = SOURCE_SET_HOST_CFLAGS + [
+             "-DPERFETTO_JNI_ART_STATIC_INTEGRATION",
+             "-DPERFETTO_JNI_JARJAR_PREFIX=dalvik/system/",
+           ]
+}
+
 perfetto_android_jni_library("libperfetto_jni") {
   deps = [
     ":libperfetto_jni_src",
@@ -89,4 +99,12 @@ perfetto_android_jni_library("libperfetto_framework_jni") {
     "../../shared_lib:libperfetto_c",
   ]
   binary_name = "libperfetto_framework_jni.so"
+}
+
+static_library("libperfetto_libcore_jni") {
+  deps = [
+    ":libperfetto_libcore_jni_src",
+    "../../../gn:default_deps",
+    "../../shared_lib:libperfetto_c",
+  ]
 }

--- a/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrace.cc
+++ b/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrace.cc
@@ -180,7 +180,14 @@ int register_dev_perfetto_sdk_PerfettoTrace(JNIEnv* env) {
 }  // namespace jni
 }  // namespace perfetto
 
-JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void*) {
+#ifdef PERFETTO_JNI_ART_STATIC_INTEGRATION
+// If building for ART static integration (e.g. Libcore), give it a unique name
+// so we can call it manually
+extern "C" jint JNI_OnLoad_Perfetto(JavaVM* vm, void* /*reserved*/) {
+#else
+// If building as a standalone library, keep the standard name
+JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* /*reserved*/) {
+#endif
   JNIEnv* env;
   if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
     return JNI_ERR;

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -79,6 +79,7 @@ default_targets = [
     '//src/java_sdk/test:perfetto_java_sdk_instrumentation_test',
     '//src/android_sdk/java/main:perfetto_trace_lib',
     '//src/android_sdk/jni:libperfetto_framework_jni',
+    '//src/android_sdk/jni:libperfetto_libcore_jni',
     '//src/android_sdk/java/test:perfetto_trace_instrumentation_test',
     '//test/cts:perfetto_cts_deps',
     '//test/cts:perfetto_cts_jni_deps',
@@ -122,6 +123,7 @@ target_host_supported = [
     '//:libperfetto_client_experimental',
     '//protos/perfetto/trace:perfetto_trace_protos',
     '//src/android_sdk/jni:libperfetto_framework_jni',
+    '//src/android_sdk/jni:libperfetto_libcore_jni',
     '//src/shared_lib:libperfetto_c',
     '//src/trace_processor:demangle',
     '//src/trace_processor:trace_processor',
@@ -371,6 +373,8 @@ additional_args = {
         }),
     ],
     'libperfetto_c': [
+        ('apex_available',
+         {'//apex_available:platform', '//apex_available:anyapex'}),
         ('min_sdk_version', '30'),
         ('export_include_dirs', {'include'}),
         # Exports the SDK ABI symbols from the .so (see
@@ -434,8 +438,23 @@ additional_args = {
         # Framework should use 'perfetto_trace_lib_framework_java' instead.
         ('visibility', {':__subpackages__'}),
     ],
+    'perfetto_trace_lib_libcore_java': [
+        ('visibility', {'//libcore:__subpackages__'}),
+    ],
+    'libperfetto_framework_jni': [
+        ('apex_available',
+         {'//apex_available:platform', '//apex_available:anyapex'}),
+        ('min_sdk_version', 'apex_inherit'),
+    ],
     # Framework should use 'libperfetto_framework_jni' instead.
     'libperfetto_jni': [('visibility', {':__subpackages__'}),],
+    'libperfetto_libcore_jni': [
+        ('apex_available',
+         {'//apex_available:platform', '//apex_available:anyapex'}),
+        ('min_sdk_version', 'apex_inherit'),
+        ('header_libs', {'jni_headers'}),
+        ('visibility', {'//libcore:__subpackages__'}),
+    ],
 }
 
 
@@ -1405,6 +1424,15 @@ class AndroidJavaSDKModulesGenerator:
         java_copy_module.jarjar_rules = gn_utils.label_to_path(
             target.android_bp_copy_java_target_jarjar)
         self.blueprint.add_module(java_copy_module)
+
+      libcore_filegroup_name = bp_module_name + '_libcore_java'
+      libcore_filegroup = Module('filegroup', libcore_filegroup_name,
+                                 target.name)
+      libcore_filegroup.srcs = [
+          gn_utils.label_to_path(src) for src in target.sources
+      ]
+      _add_additional_args(libcore_filegroup)
+      self.blueprint.add_module(libcore_filegroup)
 
       module.static_libs.add(java_library_module_name)
     else:


### PR DESCRIPTION
Expose Perfetto Java SDK and JNI libraries for Libcore / ART integration:
- Add jarjar rules for dalvik.system.dev.perfetto.sdk.
- Conditionally expose JNI_OnLoad_Perfetto when LIBCORE_INTEGRATION is defined.
- Add libperfetto_jni_static, perfetto_jarjar_rules_files, and perfetto_trace_lib_libcore_java targets in Android.bp.extras.
- Update tools/gen_android_bp to set apex_available and min_sdk_version on SDK libraries.
