### PR TITLE
ui: memscope: Don't truncate frames in native callstack snippet table

### DIFF
--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/native_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/native_section.ts
@@ -366,11 +366,7 @@ export class NativeSection implements m.ClassComponent<NativeSectionAttrs> {
       m(
         '.pf-memscope-stack',
         stackSnippet(s.frames).map((f) =>
-          m(
-            '.pf-memscope-stack__frame',
-            {title: f},
-            f.length > 60 ? `${f.slice(0, 58)}…` : f,
-          ),
+          m('.pf-memscope-stack__frame', {title: f}, f),
         ),
       ),
       formatBytes(s.unreleased),


### PR DESCRIPTION
Remove the aggressive 60-character truncation on individual stack frame
names in the top allocation call-stacks table in the memory overview
landing page.

Before:
<img width="976" height="322" alt="image" src="https://github.com/user-attachments/assets/ea3893cb-6d08-4317-b200-77f0b7b5ab73" />

After:
<img width="1079" height="322" alt="image" src="https://github.com/user-attachments/assets/a747d415-f96e-4d2a-97c5-72422563d3f9" />
