### PR TITLE
perfetto: fix tempfile behavior on Windows tests

### DIFF
--- a/src/base/temp_file.cc
+++ b/src/base/temp_file.cc
@@ -74,14 +74,14 @@ TempFile TempFile::Create() {
   TempFile temp_file;
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
   temp_file.path_ = GetTempFilePathWin();
-  // Several tests want to read-back the temp file while still open. On Windows,
-  // that requires FILE_SHARE_READ. FILE_SHARE_READ is NOT settable when using
-  // the POSIX-compat equivalent function _open(). Hence the CreateFileA +
-  // _open_osfhandle dance here.
+  // TempFile exposes both a descriptor and a path. Match POSIX by allowing the
+  // path to be reopened while the descriptor remains open. These sharing flags
+  // are not settable through _open(), hence the CreateFileA +
+  // _open_osfhandle dance.
   HANDLE h =
       ::CreateFileA(temp_file.path_.c_str(), GENERIC_READ | GENERIC_WRITE,
-                    FILE_SHARE_DELETE | FILE_SHARE_READ, nullptr, CREATE_ALWAYS,
-                    FILE_ATTRIBUTE_TEMPORARY, nullptr);
+                    FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY, nullptr);
   PERFETTO_CHECK(PlatformHandleChecker::IsValid(h));
   // According to MSDN, when using _open_osfhandle the caller must not call
   // CloseHandle(). Ownership is moved to the file descriptor, which then needs

--- a/src/base/temp_file_unittest.cc
+++ b/src/base/temp_file_unittest.cc
@@ -15,6 +15,7 @@
  */
 
 #include "perfetto/ext/base/temp_file.h"
+#include "perfetto/ext/base/file_utils.h"
 
 #include <sys/stat.h>
 
@@ -69,6 +70,20 @@ TEST(TempFileTest, Create) {
   // Windows UCRT aborts when trying to write into a closed FD.
   ASSERT_EQ(-1, write(fd, "foo", 4));
 #endif
+}
+
+TEST(TempFileTest, ReopenForWriting) {
+  TempFile file = TempFile::Create();
+  ASSERT_EQ(WriteAll(file.fd(), "old", 3), 3);
+
+  ScopedFile reopened = OpenFile(file.path(), O_RDWR | O_TRUNC);
+  ASSERT_TRUE(reopened);
+  ASSERT_EQ(WriteAll(*reopened, "new", 3), 3);
+  reopened.reset();
+
+  std::string contents;
+  ASSERT_TRUE(ReadFile(file.path(), &contents));
+  EXPECT_EQ(contents, "new");
 }
 
 TEST(TempFileTest, CreateUnlinked) {

--- a/src/base/utils_unittest.cc
+++ b/src/base/utils_unittest.cc
@@ -428,8 +428,8 @@ TEST(UtilsTest, OpenFstreamTextModeNotSupported) {
 }
 
 TEST(UtilsTest, OpenFstreamAlwaysBinaryMode) {
-  auto tmp = TempDir::Create();
-  std::string tmp_path = tmp.path() + "/temp.txt";
+  TempFile file = TempFile::Create();
+  const std::string& tmp_path = file.path();
   // Explicitly set the string size, we want to write all data to the file.
   std::string payload("foo\nbar\0baz\r\nqux", 16);
   ASSERT_EQ(payload.size(), static_cast<size_t>(16));
@@ -449,7 +449,6 @@ TEST(UtilsTest, OpenFstreamAlwaysBinaryMode) {
       ASSERT_TRUE(ReadFile(tmp_path, &actual));
       ASSERT_EQ(actual, payload);
     }
-    ASSERT_EQ(remove(tmp_path.c_str()), 0);
   }
 
   {

--- a/src/protozero/filtering/filter_util_unittest.cc
+++ b/src/protozero/filtering/filter_util_unittest.cc
@@ -45,17 +45,17 @@ size_t TestDescriptorSize() {
 
 std::string FilterToText(FilterUtil& filter,
                          const std::optional<std::string>& bytecode = {}) {
-  std::string tmp_path = perfetto::base::TempFile::Create().path();
+  auto tmp_file = perfetto::base::TempFile::Create();
   {
     perfetto::base::ScopedFstream tmp_stream(
-        perfetto::base::OpenFstream(tmp_path, "w"));
+        perfetto::base::OpenFstream(tmp_file.path(), "w"));
     PERFETTO_CHECK(!!tmp_stream);
     filter.set_print_stream_for_testing(*tmp_stream);
     filter.PrintAsText(bytecode);
     filter.set_print_stream_for_testing(stdout);
   }
   std::string output;
-  PERFETTO_CHECK(perfetto::base::ReadFile(tmp_path, &output));
+  PERFETTO_CHECK(perfetto::base::ReadFile(tmp_file.path(), &output));
   // Make the output a bit more compact.
   auto re = perfetto::base::Regex::CreateOrCheck(" +");
   output = re.GlobalReplace(output, " ");

--- a/src/trace_processor/rpc/rpc.cc
+++ b/src/trace_processor/rpc/rpc.cc
@@ -834,15 +834,13 @@ base::Status Rpc::ExportSqlite(const ExportCallback& callback) {
   // database in a server-controlled temporary file and streams the bytes back
   // to the client. The client never names a path on the server, so this does
   // not expose the server's filesystem.
-  base::TempDir dir = base::TempDir::Create();
-  std::string path = dir.path() + "/export.db";
-  auto cleanup = base::OnScopeExit([&path] { base::Unlink(path.c_str()); });
+  base::TempFile file = base::TempFile::Create();
 
-  RpcExportOutput output(callback, path);
+  RpcExportOutput output(callback, file.path());
   RETURN_IF_ERROR(
       trace_processor_->Export(TraceProcessor::ExportFormat::kSqlite, &output));
 
-  base::ScopedFile fd = base::OpenFile(path, O_RDONLY);
+  base::ScopedFile fd = base::OpenFile(file.path(), O_RDONLY);
   if (!fd) {
     return base::ErrStatus("Failed to open exported SQLite database");
   }

--- a/src/trace_processor/shell/bundle_integrationtest.cc
+++ b/src/trace_processor/shell/bundle_integrationtest.cc
@@ -105,7 +105,7 @@ class TraceconvShellBundleTest : public ::testing::Test {
   void SetUp() override {
     input_trace_ = base::GetTestDataPath(
         "test/data/heapprofd_standalone_client_example-trace");
-    output_path_ = temp_dir_.path() + "/bundle.tar";
+    output_path_ = output_file_.path();
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
     GTEST_SKIP() << "do not run traceconv tests on Android target";
 #endif
@@ -113,8 +113,6 @@ class TraceconvShellBundleTest : public ::testing::Test {
     GTEST_SKIP() << "TarWriter is not supported on Windows";
 #endif
   }
-
-  void TearDown() override { remove(output_path_.c_str()); }
 
   // Collects every package_name found in a deobfuscation.pb proto stream.
   static std::set<std::string> PackageNames(const std::string& deob_bytes) {
@@ -130,6 +128,7 @@ class TraceconvShellBundleTest : public ::testing::Test {
   }
 
   base::TempDir temp_dir_ = base::TempDir::Create();
+  base::TempFile output_file_ = base::TempFile::Create();
   std::string input_trace_;
   std::string output_path_;
 };

--- a/src/trace_processor/shell/convert_helpers_unittest.cc
+++ b/src/trace_processor/shell/convert_helpers_unittest.cc
@@ -67,15 +67,12 @@ TEST(ConvertHelpersTest, OpenConversionInputMissingFileFails) {
 }
 
 TEST(ConvertHelpersTest, OpenConversionOutputWritesFile) {
-  // A path rather than a TempFile: on Windows an open TempFile lacks
-  // FILE_SHARE_WRITE, so reopening it for write hits a sharing violation.
-  base::TempDir dir = base::TempDir::Create();
-  std::string path = PathIn(dir, "out.bin");
+  base::TempFile file = base::TempFile::Create();
 
   std::ofstream owned;
   std::ostream* stream = nullptr;
-  base::Status s =
-      OpenConversionOutput(path, /*binary_output=*/true, &owned, &stream);
+  base::Status s = OpenConversionOutput(file.path(), /*binary_output=*/true,
+                                        &owned, &stream);
   ASSERT_TRUE(s.ok()) << s.c_message();
   ASSERT_NE(stream, nullptr);
 
@@ -84,10 +81,8 @@ TEST(ConvertHelpersTest, OpenConversionOutputWritesFile) {
   owned.close();
 
   std::string content;
-  ASSERT_TRUE(base::ReadFile(path, &content));
+  ASSERT_TRUE(base::ReadFile(file.path(), &content));
   EXPECT_EQ(content, "payload");
-
-  base::Unlink(path.c_str());  // TempDir's destructor needs an empty dir.
 }
 
 TEST(ConvertHelpersTest, OpenConversionOutputBadPathFails) {

--- a/src/trace_processor/shell/shell_utils_unittest.cc
+++ b/src/trace_processor/shell/shell_utils_unittest.cc
@@ -86,11 +86,7 @@ class FileSystemPlatform final : public TraceProcessor::PlatformInterface {
 // by a standalone SQLite connection and re-attached and queried by a trace
 // processor.
 TEST(ShellUtilsTest, DisableFuchsia(ExportTraceToDatabaseWritesToDisk)) {
-  base::TempDir dir = base::TempDir::Create();
-  std::string output = dir.path() + "/export.db";
-
-  auto remove_output =
-      base::OnScopeExit([&output] { base::Unlink(output.c_str()); });
+  base::TempFile output = base::TempFile::Create();
 
   FileSystemPlatform platform;
   auto tp = TraceProcessor::CreateInstance(Config(), &platform);
@@ -101,18 +97,18 @@ TEST(ShellUtilsTest, DisableFuchsia(ExportTraceToDatabaseWritesToDisk)) {
   int64_t expected_views = ScalarCount(
       tp.get(), "SELECT COUNT(*) FROM sqlite_master WHERE type='view'");
 
-  base::Status export_status = ExportTraceToDatabase(tp.get(), output);
+  base::Status export_status = ExportTraceToDatabase(tp.get(), output.path());
   ASSERT_TRUE(export_status.ok()) << export_status.c_message();
 
   std::string contents;
-  ASSERT_TRUE(base::ReadFile(output, &contents));
+  ASSERT_TRUE(base::ReadFile(output.path(), &contents));
   ASSERT_GT(contents.size(), 0u);
   ASSERT_EQ(contents.rfind("SQLite format 3", 0), 0u);
 
   // Read back with a standalone connection on the default (on-disk) VFS.
   PERFETTO_CHECK(sqlite3_initialize() == SQLITE_OK);
   sqlite3* db = nullptr;
-  ASSERT_EQ(sqlite3_open(output.c_str(), &db), SQLITE_OK);
+  ASSERT_EQ(sqlite3_open(output.path().c_str(), &db), SQLITE_OK);
   EXPECT_EQ(
       ScalarCount(db, "SELECT COUNT(*) FROM sqlite_master WHERE type='table'"),
       expected_tables);
@@ -124,8 +120,8 @@ TEST(ShellUtilsTest, DisableFuchsia(ExportTraceToDatabaseWritesToDisk)) {
   // Reload the exported database into a fresh trace processor and query it.
   auto reloaded = TraceProcessor::CreateInstance(Config());
   {
-    auto it = reloaded->ExecuteQuery("ATTACH DATABASE '" +
-                                     MakeAttachUri(output) + "' AS reimported");
+    auto it = reloaded->ExecuteQuery(
+        "ATTACH DATABASE '" + MakeAttachUri(output.path()) + "' AS reimported");
     EXPECT_FALSE(it.Next());
     ASSERT_TRUE(it.Status().ok()) << it.Status().c_message();
   }

--- a/src/trace_processor/shell/subcommand_flags_unittest.cc
+++ b/src/trace_processor/shell/subcommand_flags_unittest.cc
@@ -101,17 +101,6 @@ base::TempFile WriteTempFile(const std::string& content) {
   return f;
 }
 
-// A path for an output file the code under test creates. Not a TempFile: on
-// Windows an open TempFile lacks FILE_SHARE_WRITE, so reopening it for write
-// hits a sharing violation.
-struct OutputPath {
-  base::TempDir dir = base::TempDir::Create();
-  std::string path() const { return dir.path() + "/out"; }
-  ~OutputPath() {
-    base::Unlink(path().c_str());
-  }  // TempDir needs an empty dir.
-};
-
 class TestFileSystem final : public io::FileSystem {
  public:
   base::Status OpenFile(const std::string&,
@@ -418,7 +407,7 @@ TEST(ConvertSubcommandTest, RequiresFormat) {
 
 TEST(ConvertSubcommandTest, RejectsUnknownFormat) {
   base::TempFile input = WriteTempFile("ignored");
-  OutputPath output;
+  base::TempFile output = base::TempFile::Create();
 
   ConvertSubcommand convert;
   base::Status s =
@@ -431,7 +420,7 @@ TEST(ConvertSubcommandTest, RejectsUnknownFormat) {
 // in favour of `convert profile --java-heap`; `convert` must reject them all.
 TEST(ConvertSubcommandTest, RejectsFormatsMovedOrRemoved) {
   base::TempFile input = WriteTempFile("ignored");
-  OutputPath output;
+  base::TempFile output = base::TempFile::Create();
 
   for (const char* fmt :
        {"binary", "decompress_packets", "java_heap_profile"}) {
@@ -487,7 +476,7 @@ TEST(UtilSubcommandTest, RejectsUnknownUtility) {
 // must be converted to a non-empty binary trace.
 TEST(UtilSubcommandTest, TextToBinaryConvertsTextProto) {
   base::TempFile input = WriteTempFile("packet { timestamp: 42 }");
-  OutputPath output;
+  base::TempFile output = base::TempFile::Create();
 
   UtilSubcommand util;
   base::Status s = util.Run(

--- a/src/trace_processor/sqlite/file_system_vfs_unittest.cc
+++ b/src/trace_processor/sqlite/file_system_vfs_unittest.cc
@@ -39,8 +39,8 @@ TEST(SqliteFileSystemVfsTest, CreatesReadableDatabase) {
       SqliteConnection::CreateConnectionToNewDatabase();
   ASSERT_NE(initialization_connection, nullptr);
 
-  base::TempDir dir = base::TempDir::Create();
-  std::string path = dir.path() + "/database.sqlite";
+  base::TempFile file = base::TempFile::Create();
+  const std::string& path = file.path();
   auto file_system = io::CreateLocalFileSystem();
   ASSERT_OK_AND_ASSIGN(auto vfs, SqliteFileSystemVfs::Create(file_system));
 
@@ -78,8 +78,6 @@ TEST(SqliteFileSystemVfsTest, CreatesReadableDatabase) {
   EXPECT_EQ(sqlite3_column_int64(stmt.get(), 0), 42);
   stmt.reset();
   db.reset();
-
-  ASSERT_OK(file_system->DeleteFile(path));
 }
 
 TEST(SqliteFileSystemVfsTest, NoopFileSystemCannotOpenDatabase) {

--- a/src/trace_processor/trace_database_integrationtest.cc
+++ b/src/trace_processor/trace_database_integrationtest.cc
@@ -255,8 +255,8 @@ TEST(TraceProcessorCustomConfigTest, ExportJsonRejectsIntegerFileDescriptor) {
 }
 
 TEST(TraceProcessorCustomConfigTest, ExportJsonUsesConfiguredFileSystem) {
-  base::TempDir dir = base::TempDir::Create();
-  std::string path = dir.path() + "/trace.json";
+  base::TempFile file = base::TempFile::Create();
+  const std::string& path = file.path();
   ASSERT_EQ(path.find('\''), std::string::npos);
 
   auto file_system = io::CreateLocalFileSystem();
@@ -272,12 +272,11 @@ TEST(TraceProcessorCustomConfigTest, ExportJsonUsesConfiguredFileSystem) {
   std::string contents;
   ASSERT_TRUE(base::ReadFile(path, &contents));
   EXPECT_THAT(contents, HasSubstr("\"traceEvents\""));
-  ASSERT_TRUE(base::Unlink(path.c_str()));
 }
 
 TEST(TraceProcessorCustomConfigTest,
      RpcImplicitResetPreservesSqlFileAccessGrant) {
-  base::TempDir dir = base::TempDir::Create();
+  base::TempFile first_file = base::TempFile::Create();
   auto file_system = io::CreateLocalFileSystem();
   FileSystemPlatform platform(file_system);
   Config config;
@@ -292,16 +291,13 @@ TEST(TraceProcessorCustomConfigTest,
     EXPECT_OK(it.Status());
   };
 
-  std::string first_path = dir.path() + "/before_reset";
-  write_file(first_path);
-  ASSERT_TRUE(base::Unlink(first_path.c_str()));
+  write_file(first_file.path());
 
   ASSERT_OK(rpc.NotifyEndOfFile());
   ASSERT_OK(rpc.Parse(nullptr, 0));
 
-  std::string second_path = dir.path() + "/after_reset";
-  write_file(second_path);
-  ASSERT_TRUE(base::Unlink(second_path.c_str()));
+  base::TempFile second_file = base::TempFile::Create();
+  write_file(second_file.path());
 }
 
 TEST(TraceProcessorCustomConfigTest, ExportJsonPropagatesWriteFailure) {
@@ -343,8 +339,8 @@ TEST(TraceProcessorCustomConfigTest,
 
 TEST(TraceProcessorCustomConfigTest,
      IntrinsicFileWriteUsesConfiguredFileSystem) {
-  base::TempDir dir = base::TempDir::Create();
-  std::string path = dir.path() + "/file_write";
+  base::TempFile file = base::TempFile::Create();
+  const std::string& path = file.path();
   ASSERT_EQ(path.find('\''), std::string::npos);
 
   auto file_system = io::CreateLocalFileSystem();
@@ -362,7 +358,6 @@ TEST(TraceProcessorCustomConfigTest,
   std::string contents;
   ASSERT_TRUE(base::ReadFile(path, &contents));
   EXPECT_EQ(contents, std::string("\0\1\2\xff", 4));
-  ASSERT_TRUE(base::Unlink(path.c_str()));
 }
 
 namespace {

--- a/src/trace_redaction/trace_redactor_unittest.cc
+++ b/src/trace_redaction/trace_redactor_unittest.cc
@@ -225,9 +225,8 @@ TEST(TraceRedactorTest, EmptyTimelineReturnsError) {
 }
 
 TEST(TraceRedactorTest, SinglePassAppendsAugmentAtEnd) {
-  auto tmp_dir = base::TempDir::Create();
-  std::string input_file_path = tmp_dir.path() + "/input.pb";
-  std::string output_file_path = tmp_dir.path() + "/output.pb";
+  auto input_file = base::TempFile::Create();
+  auto output_file = base::TempFile::Create();
 
   protos::gen::Trace trace;
   {
@@ -246,11 +245,10 @@ TEST(TraceRedactorTest, SinglePassAppendsAugmentAtEnd) {
     packet->set_trusted_uid(1000);
   }
 
-  const auto input_fd =
-      base::OpenFile(input_file_path, O_RDWR | O_CREAT | O_TRUNC, 0666);
   std::string serialized = trace.SerializeAsString();
-  ASSERT_EQ(base::WriteAll(*input_fd, serialized.data(), serialized.size()),
-            static_cast<ssize_t>(serialized.size()));
+  ASSERT_EQ(
+      base::WriteAll(input_file.fd(), serialized.data(), serialized.size()),
+      static_cast<ssize_t>(serialized.size()));
 
   TraceRedactor redactor;
   redactor.emplace_collect<DummyCollect>();
@@ -259,10 +257,10 @@ TEST(TraceRedactorTest, SinglePassAppendsAugmentAtEnd) {
 
   Context context;
   context.package_uid = 1000;
-  ASSERT_OK(redactor.Redact(input_file_path, output_file_path, &context));
+  ASSERT_OK(redactor.Redact(input_file.path(), output_file.path(), &context));
 
   std::string output_content;
-  ASSERT_TRUE(base::ReadFile(output_file_path, &output_content));
+  ASSERT_TRUE(base::ReadFile(output_file.path(), &output_content));
 
   protos::pbzero::Trace::Decoder output_trace(output_content);
   std::vector<uint64_t> timestamps;
@@ -276,16 +274,11 @@ TEST(TraceRedactorTest, SinglePassAppendsAugmentAtEnd) {
   EXPECT_EQ(timestamps[0], 100u);
   EXPECT_EQ(timestamps[1], 300u);
   EXPECT_EQ(timestamps[2], 999u);
-
-  // Clean up temporary files
-  remove(input_file_path.c_str());
-  remove(output_file_path.c_str());
 }
 
 TEST(TraceRedactorTest, MultiPassPipelineExecution) {
-  auto tmp_dir = base::TempDir::Create();
-  std::string input_file_path = tmp_dir.path() + "/input.pb";
-  std::string output_file_path = tmp_dir.path() + "/output.pb";
+  auto input_file = base::TempFile::Create();
+  auto output_file = base::TempFile::Create();
 
   protos::gen::Trace trace;
   {
@@ -294,11 +287,10 @@ TEST(TraceRedactorTest, MultiPassPipelineExecution) {
     packet->set_trusted_uid(500);
   }
 
-  const auto input_fd =
-      base::OpenFile(input_file_path, O_RDWR | O_CREAT | O_TRUNC, 0666);
   std::string serialized = trace.SerializeAsString();
-  ASSERT_EQ(base::WriteAll(*input_fd, serialized.data(), serialized.size()),
-            static_cast<ssize_t>(serialized.size()));
+  ASSERT_EQ(
+      base::WriteAll(input_file.fd(), serialized.data(), serialized.size()),
+      static_cast<ssize_t>(serialized.size()));
 
   TraceRedactor redactor;
   auto* pass1 = redactor.add_pass();
@@ -310,10 +302,10 @@ TEST(TraceRedactorTest, MultiPassPipelineExecution) {
 
   Context context;
   context.package_uid = 500;
-  ASSERT_OK(redactor.Redact(input_file_path, output_file_path, &context));
+  ASSERT_OK(redactor.Redact(input_file.path(), output_file.path(), &context));
 
   std::string output_content;
-  ASSERT_TRUE(base::ReadFile(output_file_path, &output_content));
+  ASSERT_TRUE(base::ReadFile(output_file.path(), &output_content));
 
   protos::pbzero::Trace::Decoder output_trace(output_content);
   std::vector<uint64_t> timestamps;
@@ -328,16 +320,11 @@ TEST(TraceRedactorTest, MultiPassPipelineExecution) {
   EXPECT_EQ(timestamps[0], 10u);
   EXPECT_EQ(timestamps[1], 999u);
   EXPECT_EQ(timestamps[2], 999u);
-
-  // Clean up temporary files
-  remove(input_file_path.c_str());
-  remove(output_file_path.c_str());
 }
 
 TEST(TraceRedactorTest, ThreePassPipelineExecution) {
-  auto tmp_dir = base::TempDir::Create();
-  std::string input_file_path = tmp_dir.path() + "/input.pb";
-  std::string output_file_path = tmp_dir.path() + "/output.pb";
+  auto input_file = base::TempFile::Create();
+  auto output_file = base::TempFile::Create();
 
   protos::gen::Trace trace;
   {
@@ -351,11 +338,10 @@ TEST(TraceRedactorTest, ThreePassPipelineExecution) {
     packet->set_trusted_uid(999);  // Will be dropped by pass 2 transform
   }
 
-  const auto input_fd =
-      base::OpenFile(input_file_path, O_RDWR | O_CREAT | O_TRUNC, 0666);
   std::string serialized = trace.SerializeAsString();
-  ASSERT_EQ(base::WriteAll(*input_fd, serialized.data(), serialized.size()),
-            static_cast<ssize_t>(serialized.size()));
+  ASSERT_EQ(
+      base::WriteAll(input_file.fd(), serialized.data(), serialized.size()),
+      static_cast<ssize_t>(serialized.size()));
 
   TraceRedactor redactor;
 
@@ -375,10 +361,10 @@ TEST(TraceRedactorTest, ThreePassPipelineExecution) {
   pass3->emplace_augment<DummyAugmentTimestamp<300>>();
 
   Context context;
-  ASSERT_OK(redactor.Redact(input_file_path, output_file_path, &context));
+  ASSERT_OK(redactor.Redact(input_file.path(), output_file.path(), &context));
 
   std::string output_content;
-  ASSERT_TRUE(base::ReadFile(output_file_path, &output_content));
+  ASSERT_TRUE(base::ReadFile(output_file.path(), &output_content));
 
   protos::pbzero::Trace::Decoder output_trace(output_content);
   std::vector<uint64_t> timestamps;
@@ -398,10 +384,6 @@ TEST(TraceRedactorTest, ThreePassPipelineExecution) {
   EXPECT_EQ(timestamps[1], 100u);
   EXPECT_EQ(timestamps[2], 200u);
   EXPECT_EQ(timestamps[3], 300u);
-
-  // Clean up temporary files
-  remove(input_file_path.c_str());
-  remove(output_file_path.c_str());
 }
 
 }  // namespace perfetto::trace_redaction

--- a/src/traceconv/traceconv_bundle_integrationtest.cc
+++ b/src/traceconv/traceconv_bundle_integrationtest.cc
@@ -93,7 +93,7 @@ class TraceconvBundleTest : public ::testing::Test {
   void SetUp() override {
     input_trace_ = base::GetTestDataPath(
         "test/data/heapprofd_standalone_client_example-trace");
-    output_path_ = temp_dir_.path() + "/bundle.tar";
+    output_path_ = output_file_.path();
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
     GTEST_SKIP() << "do not run traceconv tests on Android target";
 #endif
@@ -101,8 +101,6 @@ class TraceconvBundleTest : public ::testing::Test {
     GTEST_SKIP() << "TarWriter is not supported on Windows";
 #endif
   }
-
-  void TearDown() override { remove(output_path_.c_str()); }
 
   // Collects every package_name found in a deobfuscation.pb proto stream.
   static std::set<std::string> PackageNames(const std::string& deob_bytes) {
@@ -117,7 +115,7 @@ class TraceconvBundleTest : public ::testing::Test {
     return names;
   }
 
-  base::TempDir temp_dir_ = base::TempDir::Create();
+  base::TempFile output_file_ = base::TempFile::Create();
   std::string input_trace_;
   std::string output_path_;
 };

--- a/src/tracing/test/api_test_support.cc
+++ b/src/tracing/test/api_test_support.cc
@@ -161,8 +161,8 @@ TestTempFile CreateTempFile() {
   PERFETTO_CHECK(_mktemp_s(temp_file.mutable_data(), temp_file.len() + 1) == 0);
   HANDLE handle =
       ::CreateFileA(temp_file.c_str(), GENERIC_READ | GENERIC_WRITE,
-                    FILE_SHARE_DELETE | FILE_SHARE_READ, nullptr, CREATE_ALWAYS,
-                    FILE_ATTRIBUTE_TEMPORARY, nullptr);
+                    FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY, nullptr);
   PERFETTO_CHECK(handle && handle != INVALID_HANDLE_VALUE);
   res.fd = _open_osfhandle(reinterpret_cast<intptr_t>(handle), 0);
   res.path = temp_file.ToStdString();

--- a/test/stress_test/stress_test.cc
+++ b/test/stress_test/stress_test.cc
@@ -64,9 +64,10 @@ namespace {
 // in our codebase.
 base::ScopedPlatformHandle OpenLogFile(const std::string& path) {
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-  return base::ScopedPlatformHandle(::CreateFileA(
-      path.c_str(), GENERIC_READ | GENERIC_WRITE,
-      FILE_SHARE_DELETE | FILE_SHARE_READ, nullptr, CREATE_ALWAYS, 0, nullptr));
+  return base::ScopedPlatformHandle(
+      ::CreateFileA(path.c_str(), GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    nullptr, CREATE_ALWAYS, 0, nullptr));
 #else
   return base::OpenFile(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
 #endif

--- a/test/trace_processor_shell_integrationtest.cc
+++ b/test/trace_processor_shell_integrationtest.cc
@@ -1010,11 +1010,8 @@ TEST(TraceProcessorShellIntegrationTest, ClassicBadTraceFileShowsOnlyError) {
 // This test requires llvm-symbolize on the PATH
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
 TEST(TraceProcessorShellIntegrationTest, ConvertBundleWithDebugOnlyLibraries) {
-  auto out_dir = base::TempDir::Create();
-  std::string out_path = out_dir.path() + "/bundle.tar";
-  // Clean up on every exit path (an early ASSERT included): TempDir's
-  // destructor aborts the binary if the dir isn't empty.
-  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
+  base::TempFile out_file = base::TempFile::Create();
+  const std::string& out_path = out_file.path();
 
   auto symbolize = [&](const std::string& in_file,
                        const std::string& symbol_path) {
@@ -1332,9 +1329,8 @@ TEST(TraceProcessorShellIntegrationTest, BundleWithProguardMap) {
   auto mapping = WriteTempFile(
       "com.example.Foo -> a.a:\n"
       "    void bar() -> b\n");
-  auto out_dir = base::TempDir::Create();
-  std::string out_path = out_dir.path() + "/bundle.tar";
-  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
+  base::TempFile out_file = base::TempFile::Create();
+  const std::string& out_path = out_file.path();
 
   auto result = RunShell({"bundle", "--no-auto-symbol-paths", "--proguard-map",
                           "com.example=" + mapping.path(), HeapprofdTracePath(),
@@ -1369,9 +1365,8 @@ TEST(TraceProcessorShellIntegrationTest, BundleWithProguardMap) {
 TEST(TraceProcessorShellIntegrationTest, BundleRepeatedProguardMap) {
   auto m1 = WriteTempFile("com.example.Foo -> a.a:\n");
   auto m2 = WriteTempFile("com.example.Bar -> b.b:\n");
-  auto out_dir = base::TempDir::Create();
-  std::string out_path = out_dir.path() + "/bundle.tar";
-  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
+  base::TempFile out_file = base::TempFile::Create();
+  const std::string& out_path = out_file.path();
 
   auto result = RunShell({"bundle", "--no-auto-symbol-paths", "--proguard-map",
                           "com.example.one=" + m1.path(), "--proguard-map",
@@ -1387,9 +1382,8 @@ TEST(TraceProcessorShellIntegrationTest, BundleRepeatedProguardMap) {
 }
 
 TEST(TraceProcessorShellIntegrationTest, BundleMissingProguardMapFails) {
-  auto out_dir = base::TempDir::Create();
-  std::string out_path = out_dir.path() + "/bundle.tar";
-  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
+  base::TempFile out_file = base::TempFile::Create();
+  const std::string& out_path = out_file.path();
 
   auto result = RunShell({"bundle", "--no-auto-symbol-paths", "--proguard-map",
                           "com.example=/nonexistent/mapping.txt",
@@ -1409,9 +1403,8 @@ TEST(TraceProcessorShellIntegrationTest, BundleHelpShowsProguardMap) {
 // the packet for the explicit package still appears in the bundle.
 TEST(TraceProcessorShellIntegrationTest, BundleNoAutoProguardMaps) {
   auto mapping = WriteTempFile("com.example.Foo -> a.a:\n");
-  auto out_dir = base::TempDir::Create();
-  std::string out_path = out_dir.path() + "/bundle.tar";
-  auto remove_bundle = base::OnScopeExit([&] { unlink(out_path.c_str()); });
+  base::TempFile out_file = base::TempFile::Create();
+  const std::string& out_path = out_file.path();
 
   auto result =
       RunShell({"bundle", "--no-auto-symbol-paths", "--no-auto-proguard-maps",
@@ -1518,6 +1511,53 @@ TEST(TraceProcessorShellIntegrationTest, StdioExport) {
   ASSERT_GT(tar_bytes.size(), 512u);
   ASSERT_EQ(std::string(tar_bytes.data(), 22), "perfetto_manifest.json");
   ASSERT_EQ(std::string(tar_bytes.data() + 257, 5), "ustar");
+}
+
+TEST(TraceProcessorShellIntegrationTest, StdioExportSqlite) {
+  TraceProcessorRpcStream req;
+
+  auto* rpc = req.add_msg();
+  rpc->set_append_trace_data(kSimpleSystrace.data(), kSimpleSystrace.size());
+  rpc->set_request(TraceProcessorRpc::TPM_APPEND_TRACE_DATA);
+
+  rpc = req.add_msg();
+  rpc->set_request(TraceProcessorRpc::TPM_FINALIZE_TRACE_DATA);
+
+  rpc = req.add_msg();
+  rpc->set_request(TraceProcessorRpc::TPM_EXPORT);
+  rpc->mutable_export_args()->set_format(protos::gen::ExportArgs::SQLITE);
+
+  base::Subprocess process(
+      {base::GetCurExecutableDir() + "/trace_processor_shell", "--stdiod"});
+  process.args.stdin_mode = base::Subprocess::InputMode::kBuffer;
+  process.args.stdout_mode = base::Subprocess::OutputMode::kBuffer;
+  process.args.stderr_mode = base::Subprocess::OutputMode::kInherit;
+  process.args.input = req.SerializeAsString();
+  process.Start();
+
+  ASSERT_TRUE(process.Wait(kDefaultTestTimeoutMs));
+
+  TraceProcessorRpcStream stream;
+  stream.ParseFromString(process.output());
+
+  ASSERT_GE(stream.msg_size(), 4);
+  ASSERT_EQ(stream.msg()[0].response(),
+            TraceProcessorRpc::TPM_APPEND_TRACE_DATA);
+  ASSERT_EQ(stream.msg()[1].response(),
+            TraceProcessorRpc::TPM_FINALIZE_TRACE_DATA);
+
+  std::string sqlite_bytes;
+  for (size_t i = 2; i < static_cast<size_t>(stream.msg_size()); ++i) {
+    const auto& msg = stream.msg()[i];
+    ASSERT_EQ(msg.response(), TraceProcessorRpc::TPM_EXPORT);
+    ASSERT_THAT(msg.export_result().error(), IsEmpty());
+    ASSERT_EQ(msg.export_result().has_more(),
+              i != static_cast<size_t>(stream.msg_size()) - 1);
+    sqlite_bytes += msg.export_result().data();
+  }
+
+  ASSERT_GE(sqlite_bytes.size(), 16u);
+  EXPECT_EQ(sqlite_bytes.substr(0, 16), std::string("SQLite format 3\0", 16));
 }
 
 }  // namespace


### PR DESCRIPTION
We were manually doing unlink/remove before. Fix this properly by adding
the necessary flag to tempfile to prevent this once and for all
