### PR TITLE
tp: build flamegraphs whose frames are all unnamed

### DIFF
--- a/src/trace_processor/plugins/experimental_flamegraph/flamegraph_construction_algorithms.cc
+++ b/src/trace_processor/plugins/experimental_flamegraph/flamegraph_construction_algorithms.cc
@@ -585,6 +585,15 @@ std::unique_ptr<tables::ExperimentalFlamegraphTable> BuildHeapGraphFlamegraph(
                  self_alloc_count_col && cumulative_alloc_count_col &&
                  self_alloc_size_col && cumulative_alloc_size_col);
 
+  // A string column holding no values at all is typed Null and carries no
+  // payload, so its data must not be read: every row is the null string.
+  auto string_at = [](const core::Tree::Column* column,
+                      uint32_t row) -> StringPool::Id {
+    return column->type.Is<core::Null>()
+               ? StringPool::Id::Null()
+               : column->unchecked_data<StringPool::Id>()[row];
+  };
+
   for (uint32_t row = 0; row < result.row_count; ++row) {
     tables::ExperimentalFlamegraphTable::Row alloc_row{};
     alloc_row.ts = ts;
@@ -593,8 +602,8 @@ std::unique_ptr<tables::ExperimentalFlamegraphTable> BuildHeapGraphFlamegraph(
     const int64_t depth = depth_col->unchecked_data<int64_t>()[row];
     PERFETTO_DCHECK(depth > 0);
     alloc_row.depth = static_cast<uint32_t>(depth - 1);
-    alloc_row.name = name_col->unchecked_data<StringPool::Id>()[row];
-    alloc_row.map_name = map_name_col->unchecked_data<StringPool::Id>()[row];
+    alloc_row.name = string_at(name_col, row);
+    alloc_row.map_name = string_at(map_name_col, row);
     alloc_row.count = self_count_col->unchecked_data<int64_t>()[row];
     alloc_row.cumulative_count =
         cumulative_count_col->unchecked_data<int64_t>()[row];

--- a/src/trace_processor/plugins/flamegraph/flamegraph.cc
+++ b/src/trace_processor/plugins/flamegraph/flamegraph.cc
@@ -628,8 +628,14 @@ class FlamegraphBuilder {
 };
 
 bool IsValidConfig(const core::Tree& input, const Config& config) {
-  if (!config.name || !config.name->type.Is<core::String>() ||
-      config.value_columns.empty()) {
+  // A name column holding no values at all is typed Null rather than String
+  // (e.g. a heap graph whose class names were all stripped). Every frame is
+  // then unnamed, which is an unhelpful but perfectly well-formed flamegraph,
+  // so accept it instead of failing the whole build.
+  const bool name_is_valid =
+      config.name && (config.name->type.Is<core::String>() ||
+                      config.name->type.Is<core::Null>());
+  if (!name_is_valid || config.value_columns.empty()) {
     return false;
   }
   for (const core::Tree::Column* value : config.value_columns) {
@@ -804,7 +810,12 @@ void FlamegraphBuilder::AnalyzePaths() {
       frame_match_index;
   base::FlatHashMapV2<StringPool::Id, uint32_t> name_match_index;
   std::vector<FilterMatches> match_pool;
-  const StringPool::Id* names = config_.name->unchecked_data<StringPool::Id>();
+  // A Null-typed name column carries no payload, so its data must not be
+  // read; every row reads as unnamed instead.
+  const bool name_is_null_typed = config_.name->type.Is<core::Null>();
+  const StringPool::Id* names =
+      name_is_null_typed ? nullptr
+                         : config_.name->unchecked_data<StringPool::Id>();
 
   for (uint32_t row = 0; row < input_.row_count; ++row) {
     // Tree guarantees parents precede children, so inheritance is an O(1)
@@ -826,8 +837,9 @@ void FlamegraphBuilder::AnalyzePaths() {
       bool inserted;
       StringPool::Id matched_name;
       if (config_.grouping_columns.empty()) {
-        const bool is_null = config_.name->null_bv.size() > 0 &&
-                             !config_.name->null_bv.is_set(row);
+        const bool is_null =
+            name_is_null_typed || (config_.name->null_bv.size() > 0 &&
+                                   !config_.name->null_bv.is_set(row));
         matched_name = is_null ? StringPool::Id() : names[row];
         std::tie(index, inserted) =
             name_match_index.Insert(matched_name, next_index);

--- a/src/trace_processor/plugins/flamegraph/flamegraph_function.cc
+++ b/src/trace_processor/plugins/flamegraph/flamegraph_function.cc
@@ -135,7 +135,11 @@ base::StatusOr<flamegraph::Config> ResolveConfig(const core::Tree& source,
   }
   ASSIGN_OR_RETURN(config.name,
                    ResolveColumn(source, "flamegraph: name", "name"));
-  if (!config.name->type.Is<core::String>()) {
+  // Null is the type of a column with no values at all: every frame is
+  // unnamed, which the builder handles the same way it handles a string
+  // column whose rows happen to all be null.
+  if (!config.name->type.Is<core::String>() &&
+      !config.name->type.Is<core::Null>()) {
     return base::ErrStatus("flamegraph: name column must be a string");
   }
   for (const std::string& name : query.grouping_columns) {

--- a/src/trace_processor/plugins/flamegraph/flamegraph_unittest.cc
+++ b/src/trace_processor/plugins/flamegraph/flamegraph_unittest.cc
@@ -229,6 +229,44 @@ TEST(FlamegraphTest, AllNullAggregates) {
   }
 }
 
+// A name column holding no values at all is typed Null rather than String,
+// e.g. a heap graph whose class names were all stripped. Every frame is then
+// unnamed, which is still a well-formed flamegraph.
+TEST(FlamegraphTest, AllNullNames) {
+  StringPool pool;
+  core::Tree input =
+      MakeTree(&pool, {{"main", std::nullopt, 1}, {"a", 0, 2}, {"b", 0, 3}});
+  input.columns[0] = core::Tree::Column::CreateNull(3);
+  Config config = MakeConfig(input, pool);
+
+  auto result = Build(input, config);
+  ASSERT_TRUE(result.ok());
+  // Both children are unnamed, so they merge into a single child frame.
+  ASSERT_EQ(result->row_count, 2u);
+  EXPECT_EQ(Value<int64_t>(*result, "cumulative_value", 0), 6);
+  EXPECT_EQ(Value<int64_t>(*result, "cumulative_value", 1), 5);
+  auto name = result->Find("name");
+  ASSERT_TRUE(name);
+  ASSERT_TRUE((*name)->null_bv.size() > 0);
+  for (uint32_t row = 0; row < result->row_count; ++row) {
+    EXPECT_FALSE((*name)->null_bv.is_set(row));
+  }
+}
+
+// Filters read the name of every frame, which must not touch the absent
+// payload of a Null-typed column. Nothing can match, so nothing is retained.
+TEST(FlamegraphTest, AllNullNamesWithFilters) {
+  StringPool pool;
+  core::Tree input = MakeTree(&pool, {{"main", std::nullopt, 1}, {"a", 0, 2}});
+  input.columns[0] = core::Tree::Column::CreateNull(2);
+  Config config = MakeConfig(input, pool);
+  config.show_stack_filters.push_back(base::Regex::CreateOrCheck("^main$"));
+
+  auto result = Build(input, config);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result->row_count, 0u);
+}
+
 TEST(FlamegraphTest, BottomUp) {
   StringPool pool;
   core::Tree input =


### PR DESCRIPTION
A heap graph whose class names were all stripped yields a name column
holding nothing but nulls. The tree layer types that column Null rather
than String, and the flamegraph builder demanded String, so the whole
flamegraph was rejected as an invalid configuration.

The data is perfectly renderable: the UI already coalesces the missing
names to "unknown". Rejecting it instead silently reduced traceconv's
Java heap pprof for those traces to a profile with no samples in it.

Accept a Null name column, as aggregate columns already do. The builder
and experimental_flamegraph must then both avoid reading the payload a
Null column does not have.

