### PR TITLE
ui: offer ART heap dumps as pprof from the flamegraph export menu

### DIFF
--- a/ui/src/components/tree_explorer_panel.ts
+++ b/ui/src/components/tree_explorer_panel.ts
@@ -21,6 +21,7 @@ import type {Trace} from '../public/trace';
 import {EmptyState} from '../widgets/empty_state';
 import {Spinner} from '../widgets/spinner';
 import {Flamegraph, buildFlamegraphExportString} from '../widgets/flamegraph';
+import type {ExportDownloadItem} from '../widgets/export_button';
 import {TreeExplorerFilterBar} from '../widgets/tree_explorer_filter_bar';
 import {TreeExplorerViewSwitcher} from '../widgets/tree_explorer_view_switcher';
 import {
@@ -62,6 +63,10 @@ export interface TreeExplorerPanelAttrs {
   // them to the inner `TreeExplorerFetcher`, which disposes them along with
   // itself on unmount or when the array reference changes.
   readonly dependencies?: ReadonlyArray<TreeExplorerFetcherDependency>;
+
+  // Host-provided downloads shown alongside the built-in exports of the
+  // displayed tree, for representations the panel cannot build itself.
+  readonly extraDownloadItems?: ReadonlyArray<ExportDownloadItem>;
 }
 
 // The batteries-included tree explorer: owns a `TreeExplorerFetcher` (created
@@ -176,6 +181,7 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
             : displayMode === 'tree'
               ? 'call_tree'
               : 'flamegraph',
+        extraDownloadItems: attrs.extraDownloadItems,
       }),
       this.renderView(attrs, shownState, highlightRegex),
     );

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -22,7 +22,10 @@ import {
 } from '../../components/tree_explorer_fetcher';
 import {TreeExplorerPanel} from '../../components/tree_explorer_panel';
 import {FlamegraphProfile} from '../../components/flamegraph_profile';
-import {convertTraceToPprofAndDownload} from '../../frontend/trace_converter';
+import {
+  type PprofProfileType,
+  convertTraceToPprofAndDownload,
+} from '../../frontend/trace_converter';
 import {Timestamp} from '../../components/widgets/timestamp';
 import type {
   TrackEventDetailsPanel,
@@ -30,8 +33,7 @@ import type {
 } from '../../public/details_panel';
 import type {Trace} from '../../public/trace';
 import {NUM} from '../../trace_processor/query_result';
-import {Button} from '../../widgets/button';
-import {MenuItem, PopupMenu} from '../../widgets/menu';
+import type {ExportDownloadItem} from '../../widgets/export_button';
 import {DetailsShell} from '../../widgets/details_shell';
 import {showModal} from '../../widgets/modal';
 import {incompleteFlamegraphModal} from './incomplete_flamegraph';
@@ -202,6 +204,10 @@ export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel
     private readonly tsEnd: time,
     private state: TreeExplorerState | undefined,
     private readonly onStateChange: (state: TreeExplorerState) => void,
+    // True when `ts`/`tsEnd` come from an area selection rather than from a
+    // single snapshot. traceconv can only convert a snapshot it can name by
+    // timestamp, so the pprof export is not offered in that case.
+    private readonly isAreaSelection: boolean,
     onNodeSelected?: (args: {
       pathHashes: string;
       isDominator: boolean;
@@ -264,28 +270,11 @@ export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel
             }),
             renderOomeDetails(this.oomeDetails),
           ),
-          buttons: m(Stack, {orientation: 'horizontal', spacing: 'large'}, [
-            m('span', `Snapshot time: `, m(Timestamp, {trace: this.trace, ts})),
-            (type === ProfileType.NATIVE_HEAP_PROFILE ||
-              type === ProfileType.JAVA_HEAP_SAMPLES) &&
-              m(
-                PopupMenu,
-                {
-                  trigger: m(Button, {
-                    icon: 'file_download',
-                    label: 'Download',
-                    title: 'Download profile',
-                  }),
-                },
-                m(MenuItem, {
-                  icon: 'file_download',
-                  label: 'Pprof profile',
-                  onclick: async () => {
-                    await downloadPprof(this.trace, this.upid, ts);
-                  },
-                }),
-              ),
-          ]),
+          buttons: m(
+            'span',
+            `Snapshot time: `,
+            m(Timestamp, {trace: this.trace, ts}),
+          ),
         },
         m(TreeExplorerPanel, {
           trace: this.trace,
@@ -295,9 +284,34 @@ export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel
             this.state = state;
             this.onStateChange(state);
           },
+          extraDownloadItems: this.pprofDownloadItems(type, ts),
         }),
       ),
     );
+  }
+
+  // The pprof is produced by traceconv from the raw trace, so it always
+  // covers the whole snapshot: nothing the tree explorer does to the
+  // displayed tree can be reflected in it.
+  private pprofDownloadItems(
+    type: ProfileType,
+    ts: time,
+  ): ReadonlyArray<ExportDownloadItem> {
+    const profileType = pprofProfileType(type);
+    if (profileType === undefined || this.isAreaSelection) {
+      return [];
+    }
+    return [
+      {
+        label: 'Pprof profile (.pb)',
+        icon: 'file_download',
+        description:
+          'Whole snapshot, converted from the trace: filters, the selected ' +
+          'measure and the view direction are not applied.',
+        title: 'Download the full profile as pprof, for use with pprof tools',
+        onDownload: () => downloadPprof(this.trace, this.upid, ts, profileType),
+      },
+    ];
   }
 
   private maybeShowModal(
@@ -643,7 +657,30 @@ function flamegraphMetricsForHeapProfile(
   });
 }
 
-async function downloadPprof(trace: Trace, upid: number, ts: time) {
+// The traceconv conversion mode for a profile type, or undefined for the
+// types traceconv cannot emit as pprof. All heapprofd-backed heaps (native,
+// ART samples and custom allocators) are allocator profiles; the ART heap
+// dump is a heap graph. The OOME callstack is a single stack rather than a
+// profile, so it has no pprof of its own.
+function pprofProfileType(type: ProfileType): PprofProfileType | undefined {
+  switch (type) {
+    case ProfileType.NATIVE_HEAP_PROFILE:
+    case ProfileType.JAVA_HEAP_SAMPLES:
+    case ProfileType.GENERIC_HEAP_PROFILE:
+      return 'alloc';
+    case ProfileType.JAVA_HEAP_GRAPH:
+      return 'java-heap';
+    case ProfileType.OOME_CALLSTACK:
+      return undefined;
+  }
+}
+
+async function downloadPprof(
+  trace: Trace,
+  upid: number,
+  ts: time,
+  profileType: PprofProfileType,
+) {
   const pid = await trace.engine.query(
     `select pid from process where upid = ${upid}`,
   );
@@ -655,11 +692,9 @@ async function downloadPprof(trace: Trace, upid: number, ts: time) {
     return;
   }
   const blob = await trace.getTraceFile();
-  // This is only reachable for heapprofd-based profiles (native heap and
-  // Java heap samples), which are both allocator profiles for traceconv.
   await convertTraceToPprofAndDownload(
     blob,
-    'alloc',
+    profileType,
     pid.firstRow({pid: NUM}).pid,
     ts,
   );

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
@@ -70,6 +70,7 @@ export function createHeapProfileTrack(
         tsEnd,
         detailsPanelState,
         onDetailsPanelStateChange,
+        /* isAreaSelection= */ false,
         onNodeSelected,
       );
     },

--- a/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
@@ -418,6 +418,7 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
                         state;
                     });
                   },
+                  /* isAreaSelection= */ true,
                 );
         }
         // Hide the tab entirely when this selection has no flamegraph for this

--- a/ui/src/widgets/export_button.scss
+++ b/ui/src/widgets/export_button.scss
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Two-line label for a host-provided export: name on top, muted caveat
+// beneath. Capped and wrapped so a long caveat does not stretch the menu.
+.pf-export-item {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  max-width: 320px;
+
+  &__desc {
+    font-size: smaller;
+    color: var(--pf-color-text-muted);
+    white-space: normal;
+    overflow-wrap: anywhere;
+    line-height: 1.25;
+    margin-top: 2px;
+  }
+}

--- a/ui/src/widgets/export_button.ts
+++ b/ui/src/widgets/export_button.ts
@@ -12,21 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import './export_button.scss';
 import m from 'mithril';
 import {download} from '../base/download_utils';
 import {Icons} from '../base/semantic_icons';
 import {Button} from './button';
 import {ActionButtonHelper} from './action_button_helper';
 import {copyToClipboard} from '../base/clipboard';
-import {MenuItem, PopupMenu} from './menu';
+import {MenuDivider, MenuItem, PopupMenu} from './menu';
 
 export type ExportFormat = 'tsv' | 'json' | 'markdown';
 
+// A download the host produces itself, for formats this widget cannot build
+// out of the data it is showing.
+export interface ExportDownloadItem {
+  readonly label: string;
+  readonly icon?: string;
+  // Muted second line under the label. Use it to spell out how the item
+  // differs from the built-in exports, e.g. that filters do not apply to it.
+  readonly description?: string;
+  readonly title?: string;
+  readonly onDownload: () => Promise<void>;
+}
+
 export interface ExportButtonAttrs {
+  // Builds the exported representation of the currently displayed data.
   readonly onExportData: (format: ExportFormat) => Promise<string>;
 
   // Base name used for downloaded files. Defaults to 'data_export'.
   readonly fileBaseName?: string;
+
+  // Host-provided downloads, appended to the Download submenu.
+  readonly extraDownloadItems?: ReadonlyArray<ExportDownloadItem>;
 }
 
 /**
@@ -46,6 +63,7 @@ export class ExportButton implements m.ClassComponent<ExportButtonAttrs> {
     const loading = this.helper.state === 'working';
     const icon = this.helper.state === 'done' ? Icons.Check : Icons.Download;
     const baseName = fileBaseName ?? 'data_export';
+    const extras = attrs.extraDownloadItems ?? [];
 
     return m(
       PopupMenu,
@@ -125,8 +143,28 @@ export class ExportButton implements m.ClassComponent<ExportButtonAttrs> {
               });
             },
           }),
+          extras.length > 0 && m(MenuDivider),
+          extras.map((item) => this.renderExtraItem(item)),
         ]),
       ],
     );
+  }
+
+  private renderExtraItem(item: ExportDownloadItem): m.Children {
+    return m(MenuItem, {
+      icon: item.icon,
+      title: item.title,
+      label:
+        item.description === undefined
+          ? item.label
+          : m(
+              '.pf-export-item',
+              m('div', item.label),
+              m('.pf-export-item__desc', item.description),
+            ),
+      onclick: async () => {
+        await this.helper.execute(item.onDownload);
+      },
+    });
   }
 }

--- a/ui/src/widgets/tree_explorer_filter_bar.ts
+++ b/ui/src/widgets/tree_explorer_filter_bar.ts
@@ -20,7 +20,11 @@ import {Chip} from './chip';
 import {Intent} from './common';
 import {CopyToClipboardButton} from './copy_to_clipboard_button';
 import {EmptyState} from './empty_state';
-import {ExportButton, type ExportFormat} from './export_button';
+import {
+  ExportButton,
+  type ExportDownloadItem,
+  type ExportFormat,
+} from './export_button';
 import {Form, FormLabel} from './form';
 import {Icon} from './icon';
 import {MiddleEllipsis} from './middle_ellipsis';
@@ -73,6 +77,10 @@ export interface TreeExplorerFilterBarAttrs {
   // Undefined hides the export button.
   readonly onExportData?: (format: ExportFormat) => Promise<string>;
   readonly exportFileBaseName?: string;
+
+  // Downloads the host produces itself, appended to the export menu for
+  // representations this bar cannot build from the displayed tree.
+  readonly extraDownloadItems?: ReadonlyArray<ExportDownloadItem>;
 }
 
 // The filtering / measure-selection bar shared by all tree explorer views.
@@ -243,6 +251,7 @@ export class TreeExplorerFilterBar implements m.ClassComponent<TreeExplorerFilte
         m(ExportButton, {
           fileBaseName: attrs.exportFileBaseName ?? 'tree_explorer',
           onExportData: attrs.onExportData,
+          extraDownloadItems: attrs.extraDownloadItems,
         }),
       this.showHighlightSearch &&
         !attrs.highlightDisabled &&


### PR DESCRIPTION
traceconv can convert a Java heap graph to pprof, but the UI only ever
asked it for allocator profiles, so ART heap dumps had no pprof export
at all. Map each profile type to the flag traceconv expects rather than
hardcoding --alloc.

The download also sat in a button of its own beside the snapshot time,
leaving two unrelated download affordances in one panel. Fold it into
the flamegraph's Export menu, which grows a way for a host to contribute
a download the widget cannot build from the data it is showing.

That export comes from traceconv reading the whole trace, so nothing the
tree explorer does to the displayed tree reaches it. Say so under the
menu entry. Drop the entry for area selections, whose time range does
not name a snapshot traceconv can convert.

