### PR TITLE
ui: GpuCompute: correct the Summary tab and rename Workload Analysis

### DIFF
--- a/ai/skills/perfetto/workflows/gpu/compute/compute_workload_analysis.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/compute_workload_analysis.md
@@ -1,4 +1,4 @@
-# Compute kernel — workload analysis (which pipeline is the limit?)
+# Compute kernel — Compute Workload Analysis (which pipeline is the limit?)
 
 For a compute-bound kernel, "compute-bound" isn't the end of the story — *which*
 execution pipeline is saturated determines the lever. This workflow looks at
@@ -9,7 +9,7 @@ extraction and read the values back here.
 
 ## Get the data
 
-- **NVIDIA / CUDA:** [nvidia/workload_analysis.md]($SKILL_ROOT/workflows/gpu/compute/nvidia/workload_analysis.md).
+- **NVIDIA / CUDA:** [nvidia/compute_workload_analysis.md]($SKILL_ROOT/workflows/gpu/compute/nvidia/compute_workload_analysis.md).
 - Other vendors: the per-pipeline breakdown is vendor-specific; for others use
   whatever instruction-throughput / IPC that vendor exposes.
 

--- a/ai/skills/perfetto/workflows/gpu/compute/kernel_analysis.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/kernel_analysis.md
@@ -8,8 +8,8 @@ is the lever. A single device-wide "GPU utilization %" cannot answer any of
 these; you need the per-kernel decomposition.
 
 It decomposes each compute kernel into four lenses — Speed of Light, Occupancy,
-Workload Analysis, and Launch Statistics — computed directly from the trace's
-GPU counters and kernel launch args.
+Compute Workload Analysis, and Launch Statistics — computed directly from the
+trace's GPU counters and kernel launch args.
 
 If the user has not yet loaded a trace into `trace_processor`, follow
 `$SKILL_ROOT/infra-references/querying.md` first, then come back here.
@@ -60,8 +60,8 @@ workflow; read the one you need.
   breakdown: [speed_of_light.md]($SKILL_ROOT/workflows/gpu/compute/speed_of_light.md).
 - **Occupancy** — is launch config / resource pressure the limit, and which
   resource: [occupancy.md]($SKILL_ROOT/workflows/gpu/compute/occupancy.md).
-- **Workload Analysis** — which execution pipeline is saturated (for
-  compute-bound kernels): [workload_analysis.md]($SKILL_ROOT/workflows/gpu/compute/workload_analysis.md).
+- **Compute Workload Analysis** — which execution pipeline is saturated (for
+  compute-bound kernels): [compute_workload_analysis.md]($SKILL_ROOT/workflows/gpu/compute/compute_workload_analysis.md).
 - **Launch Statistics** — the raw launch configuration and whether it is sane:
   [launch_statistics.md]($SKILL_ROOT/workflows/gpu/compute/launch_statistics.md).
 

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/compute_workload_analysis.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/compute_workload_analysis.md
@@ -1,11 +1,11 @@
-# NVIDIA — workload analysis extraction
+# NVIDIA — Compute Workload Analysis extraction
 
 The NVIDIA extraction behind the saturated-pipe / instruction-mix analysis. Run
 it, then apply the interpretation from
-[workload_analysis.md]($SKILL_ROOT/workflows/gpu/compute/workload_analysis.md).
+[compute_workload_analysis.md]($SKILL_ROOT/workflows/gpu/compute/compute_workload_analysis.md).
 
 ```bash
-trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/compute/nvidia/scripts/workload_analysis.sql
+trace_processor query --remote SESSION --query-file $SKILL_ROOT/workflows/gpu/compute/nvidia/scripts/compute_workload_analysis.sql
 ```
 
 One row per compute kernel (longest first). Display label → output column →

--- a/ai/skills/perfetto/workflows/gpu/compute/nvidia/scripts/compute_workload_analysis.sql
+++ b/ai/skills/perfetto/workflows/gpu/compute/nvidia/scripts/compute_workload_analysis.sql
@@ -21,7 +21,7 @@
 --
 -- Interpret: the highest pipe % is the most-utilized pipeline; a single pipe
 -- near peak while sm_busy_pct is lower points to a pipe bottleneck / imbalance;
--- consider a different precision or instruction mix. See compute/workload_analysis.md.
+-- consider a different precision or instruction mix. See compute/compute_workload_analysis.md.
 
 CREATE PERFETTO TABLE _kernels AS
 SELECT

--- a/ai/skills/perfetto/workflows/gpu/compute/speed_of_light.md
+++ b/ai/skills/perfetto/workflows/gpu/compute/speed_of_light.md
@@ -32,8 +32,9 @@ Read Compute Throughput vs Memory Throughput (both are achieved-vs-theoretical �
 
 - **Compute Throughput high, Memory Throughput lower → compute-bound.** The
   compute units are the ceiling; the lever is the math — go to
-  [workload_analysis.md]($SKILL_ROOT/workflows/gpu/compute/workload_analysis.md) for the saturated pipeline, and
-  consider a cheaper precision or doing less work.
+  [compute_workload_analysis.md]($SKILL_ROOT/workflows/gpu/compute/compute_workload_analysis.md)
+  for the saturated pipeline, and consider a cheaper precision or doing less
+  work.
 - **Memory Throughput high, Compute Throughput lower → memory-bound.** The
   memory system is the ceiling; locate it in the hierarchy:
   - **DRAM Throughput high** → DRAM-bandwidth bound; the lever is locality /

--- a/docs/data-sources/gpu.md
+++ b/docs/data-sources/gpu.md
@@ -404,7 +404,7 @@ COMPUTE`) is selected:
   duration, occupancy, and other hardware metrics. Double-click jumps to
   the details view for that kernel.
 - **Details** — per-section metric tables (Speed-of-Light, Launch
-  Statistics, Occupancy, Workload Analysis), with optional baseline
+  Statistics, Occupancy, Compute Workload Analysis), with optional baseline
   comparison between two kernels.
 - **Toolbar** — kernel selector, baseline pin, terminology switch
   (CUDA / OpenCL / vendor-supplied), and automatic unit conversion

--- a/ui/src/plugins/com.meta.GpuCompute/README.md
+++ b/ui/src/plugins/com.meta.GpuCompute/README.md
@@ -127,7 +127,7 @@ Built-in sections (in `section/`):
 | `section/speed_of_light.ts` | Compute and memory throughput overview |
 | `section/launch_statistics.ts` | Kernel launch configuration |
 | `section/occupancy.ts` | Warp occupancy and limiting factors |
-| `section/workload_analysis.ts` | Per-pipeline utilization |
+| `section/compute_workload_analysis.ts` | Per-pipeline utilization |
 
 ### Well-Known Metrics
 

--- a/ui/src/plugins/com.meta.GpuCompute/index.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/index.ts
@@ -76,7 +76,9 @@ class Compute {
 
   private sliceId: number | undefined = -1;
   private options: KernelLaunchOption[] = [];
-  private summaryRows: SummaryRow[] = [];
+  // Undefined until the prefetch completes, so that a tab opened before then
+  // runs its own query instead of caching an empty table.
+  private summaryRows: SummaryRow[] | undefined;
   private knownKernelIds = new Set<number>();
 
   // Selection-driven metric fetching via QuerySlot. Selection changes
@@ -417,19 +419,27 @@ export default class GpuComputePlugin implements PerfettoPlugin {
       content: content,
     });
 
-    try {
-      const rows = await fetchKernelSummaryRows(
-        this.getContext(),
-        trace.engine,
-      );
-      content.setSummaryRows(rows);
-      content.setOptions(rows.map((r) => ({id: r.id, label: r.demangledName})));
-      if (rows.length > 0) {
-        trace.tabs.showTab(tabUri);
+    // The summary query is built from the well-known metric roles, and a
+    // plugin that depends on this one registers its ids in its own
+    // onTraceLoad, which runs after this one. onTraceReady is the first point
+    // at which the registry holds every id.
+    trace.onTraceReady.addListener(async () => {
+      try {
+        const rows = await fetchKernelSummaryRows(
+          this.getContext(),
+          trace.engine,
+        );
+        content.setSummaryRows(rows);
+        content.setOptions(
+          rows.map((r) => ({id: r.id, label: r.demangledName})),
+        );
+        if (rows.length > 0) {
+          trace.tabs.showTab(tabUri);
+        }
+      } catch (e) {
+        console.warn('GpuCompute: failed to fetch kernel launch list:', e);
+        content.setOptions([]);
       }
-    } catch (e) {
-      console.warn('GpuCompute: failed to fetch kernel launch list:', e);
-      content.setOptions([]);
-    }
+    });
   }
 }

--- a/ui/src/plugins/com.meta.GpuCompute/index.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/index.ts
@@ -31,7 +31,7 @@ import type {SummaryRow} from './summary';
 import {registerSpeedOfLightSection} from './section/speed_of_light';
 import {registerLaunchStatisticsSection} from './section/launch_statistics';
 import {registerOccupancySection} from './section/occupancy';
-import {registerWorkloadAnalysisSection} from './section/workload_analysis';
+import {registerComputeWorkloadAnalysisSection} from './section/compute_workload_analysis';
 import {cudaTerminology} from './terminology/cuda';
 import {openclTerminology} from './terminology/opencl';
 import {TerminologyRegistry} from './terminology';
@@ -373,7 +373,7 @@ export default class GpuComputePlugin implements PerfettoPlugin {
     registerSpeedOfLightSection(this.sectionRegistry);
     registerLaunchStatisticsSection(this.sectionRegistry);
     registerOccupancySection(this.sectionRegistry);
-    registerWorkloadAnalysisSection(this.sectionRegistry);
+    registerComputeWorkloadAnalysisSection(this.sectionRegistry);
   }
 
   registerAnalysisProvider(provider: AnalysisProvider): void {

--- a/ui/src/plugins/com.meta.GpuCompute/section/compute_workload_analysis.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/section/compute_workload_analysis.ts
@@ -14,10 +14,12 @@
 
 import type {SectionRegistry} from './index';
 
-export function registerWorkloadAnalysisSection(reg: SectionRegistry): void {
+export function registerComputeWorkloadAnalysisSection(
+  reg: SectionRegistry,
+): void {
   reg.registerSection({
-    id: 'com.meta.GpuCompute.Section.WorkloadAnalysis',
-    title: 'Workload Analysis',
+    id: 'com.meta.GpuCompute.Section.ComputeWorkloadAnalysis',
+    title: 'Compute Workload Analysis',
     order: 3,
     launchMetrics: [],
     counterMetrics: [

--- a/ui/src/plugins/com.meta.GpuCompute/summary.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/summary.ts
@@ -17,7 +17,7 @@
 // Shows a sortable, double-click-navigable list of every compute kernel
 // launch in the trace.  Each row contains the kernel's demangled name,
 // duration, compute/memory throughput, register count, and grid size
-// rendered as relative percent-bars so hot kernels stand out visually.
+// rendered as percent-bars so hot kernels stand out visually.
 
 import m from 'mithril';
 import type {Engine} from '../../trace_processor/engine';
@@ -49,8 +49,6 @@ const PAGE_SIZE = 100;
 type SummaryState = {
   rows?: SummaryRow[];
   maxDurationNSec?: number;
-  maxComputePct?: number;
-  maxMemoryPct?: number;
   maxRegisters?: number;
   maxGridSize?: number;
   launchIndexBySliceId: Map<number, number>;
@@ -75,6 +73,16 @@ const renderRelPercentBar = (
   const clamped = Math.max(0, Math.min(curVal, maxVal));
   const pct = Math.max(0, Math.min(100, (clamped / maxVal) * 100));
   return renderPercentBar(pct, null, false, label ?? '');
+};
+
+// Renders a bar whose width and label are the value itself, for metrics
+// already expressed as a percentage of a hardware peak.
+const renderAbsPercentBar = (val?: number | string | null): m.Children => {
+  const curVal = Number(val);
+  if (val == null || !Number.isFinite(curVal)) {
+    return renderPercentBar(0, null, false, '—');
+  }
+  return renderPercentBar(Math.max(0, Math.min(100, curVal)), null, true);
 };
 
 // =============================================================================
@@ -289,8 +297,6 @@ export const KernelSummarySection: m.Component<
     state.maxDurationNSec = finiteMax(
       rows.map((r) => Number(r.durationNSecNum)),
     );
-    state.maxComputePct = finiteMax(rows.map((r) => Number(r.computePct)));
-    state.maxMemoryPct = finiteMax(rows.map((r) => Number(r.memoryPct)));
     state.maxRegisters = finiteMax(
       rows.map((r) => Number(r.registersPerThread)),
     );
@@ -441,19 +447,11 @@ export const KernelSummarySection: m.Component<
                   ),
                   m(
                     'td.pf-gpu-compute__summary-td',
-                    renderRelPercentBar(
-                      Number(r.computePct),
-                      state.maxComputePct,
-                      label(r.computePct),
-                    ),
+                    renderAbsPercentBar(r.computePct),
                   ),
                   m(
                     'td.pf-gpu-compute__summary-td',
-                    renderRelPercentBar(
-                      Number(r.memoryPct),
-                      state.maxMemoryPct,
-                      label(r.memoryPct),
-                    ),
+                    renderAbsPercentBar(r.memoryPct),
                   ),
                   m(
                     'td.pf-gpu-compute__summary-td',


### PR DESCRIPTION
Small fixes so a vendor plugin can register its own metrics into the
GpuCompute tab.

- Fix the Summary tab so a dependent plugin's metric ids reach it. The
  prefetch ran before those plugins had registered, so the columns came out
  empty and stayed empty.

- Scale the compute and memory throughput bars against the hardware peak
  rather than the largest value in the table, and label them with a percent
  sign. On a capture spanning 0.03% to 0.93% of peak, a kernel at the mean
  0.47% filled 51% of its bar, and the busiest always pinned at 100%.

- Rename "Workload Analysis" to "Compute Workload Analysis". It covers
  per-pipeline compute utilization only, and the plain name collides with the
  memory counterpart a vendor plugin registers alongside it.

- Rename the matching workflow in the Perfetto agent skill, so an agent and a
  user read one name for one section.