### PR TITLE
tp: remove recursive Perfetto SQL functions

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/created_function.cc
+++ b/src/trace_processor/perfetto_sql/engine/created_function.cc
@@ -20,15 +20,11 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <queue>
-#include <stack>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
-#include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/ext/base/string_view.h"
@@ -42,7 +38,6 @@
 #include "src/trace_processor/sqlite/sqlite_connection.h"
 #include "src/trace_processor/sqlite/sqlite_utils.h"
 #include "src/trace_processor/tp_metatrace.h"
-#include "src/trace_processor/util/owned_sql_value.h"
 #include "src/trace_processor/util/sql_argument.h"
 
 namespace perfetto::trace_processor {
@@ -138,269 +133,6 @@ base::Status BindArguments(sqlite3_stmt* stmt,
   return base::OkStatus();
 }
 
-class Memoizer {
- public:
-  // Supported arguments. For now, only functions with a single int argument are
-  // supported.
-  using MemoizedArgs = int64_t;
-
-  // Enables memoization.
-  // Only functions with a single int argument returning ints are supported.
-  base::Status EnableMemoization(const FunctionPrototype& prototype) {
-    if (prototype.arguments.size() != 1 ||
-        TypeToSqlValueType(prototype.arguments[0].type()) !=
-            SqlValue::Type::kLong) {
-      return base::ErrStatus(
-          "EXPERIMENTAL_MEMOIZE: Function %s should take one int argument",
-          prototype.function_name.c_str());
-    }
-    enabled_ = true;
-    return base::OkStatus();
-  }
-
-  // Returns the memoized value for the current invocation if it exists.
-  std::optional<SqlValue> GetMemoizedValue(MemoizedArgs args) {
-    if (!enabled_) {
-      return std::nullopt;
-    }
-    OwnedSqlValue* value = memoized_values_.Find(args);
-    if (!value) {
-      return std::nullopt;
-    }
-    return value->AsSqlValue();
-  }
-
-  bool HasMemoizedValue(MemoizedArgs args) {
-    return GetMemoizedValue(args).has_value();
-  }
-
-  // Saves the return value of the current invocation for memoization.
-  void Memoize(MemoizedArgs args, SqlValue value) {
-    if (!enabled_) {
-      return;
-    }
-    memoized_values_.Insert(args, OwnedSqlValue(value));
-  }
-
-  // Checks that the function has a single int argument and returns it.
-  static std::optional<MemoizedArgs> AsMemoizedArgs(size_t argc,
-                                                    sqlite3_value** argv) {
-    if (argc != 1) {
-      return std::nullopt;
-    }
-    SqlValue arg = sqlite::utils::SqliteValueToSqlValue(argv[0]);
-    if (arg.type != SqlValue::Type::kLong) {
-      return std::nullopt;
-    }
-    return arg.AsLong();
-  }
-
-  bool enabled() const { return enabled_; }
-
- private:
-  bool enabled_ = false;
-  base::FlatHashMap<MemoizedArgs, OwnedSqlValue> memoized_values_;
-};
-
-// A helper to unroll recursive calls: to minimise the amount of stack space
-// used, memoized recursive calls are evaluated using an on-heap queue.
-//
-// We compute the function in two passes:
-// - In the first pass, we evaluate the statement to discover which recursive
-//   calls it makes, returning null from recursive calls and ignoring the
-//   result.
-// - In the second pass, we evaluate the statement again, but this time we
-//   memoize the result of each recursive call.
-//
-// We maintain a queue for scheduled "first pass" calls and a stack for the
-// scheduled "second pass" calls, evaluating available first pass calls, then
-// second pass calls. When we evaluate a first pass call, the further calls to
-// CreatedFunction::Run will just add it to the "first pass" queue. The second
-// pass, however, will evaluate the function normally, typically just using the
-// memoized result for the dependent calls. However, if the recursive calls
-// depend on the return value of the function, we will proceed with normal
-// recursion.
-//
-// To make it more concrete, consider an following example.
-// We have a function computing factorial (f) and we want to compute f(3).
-//
-// SELECT create_function('f(x INT)', 'INT',
-// 'SELECT IIF($x = 0, 1, $x * f($x - 1))');
-// SELECT experimental_memoize('f');
-// SELECT f(3);
-//
-// - We start with a call to f(3). It executes the statement as normal, which
-//   recursively calls f(2).
-// - When f(2) is called, we detect that it is a recursive call and we start
-//   unrolling it, entering RecursiveCallUnroller::Run.
-// - We schedule first pass for 2 and the state of the unroller
-//   is first_pass: [2], second_pass: [].
-// - Then we compute the first pass for f(2). It calls f(1), which is ignored
-//   due to OnFunctionCall returning kIgnoreDueToFirstPass and 1 is added to the
-//   first pass queue. 2 is taked out of the first pass queue and moved to the
-//   second pass stack. State: first_pass: [1], second_pass: [2].
-// - Then we compute the first pass for 1. The similar thing happens: f(0) is
-//   called and ignored, 0 is added to first_pass, 1 is added to second_pass.
-//   State: first_pass: [0], second_pass: [2, 1].
-// - Then we compute the first pass for 0. It doesn't make further calls, so
-//   0 is moved to the second pass stack.
-//   State: first_pass: [], second_pass: [2, 1, 0].
-// - Then we compute the second pass for 0. It just returns 1.
-//   State: first_pass: [], second_pass: [2, 1], results: {0: 1}.
-// - Then we compute the second pass for 1. It calls f(0), which is memoized.
-//   State: first_pass: [], second_pass: [2], results: {0: 1, 1: 1}.
-// - Then we compute the second pass for 1. It calls f(1), which is memoized.
-//   State: first_pass: [], second_pass: [], results: {0: 1, 1: 1, 2: 2}.
-// - As both first_pass and second_pass are empty, we return from
-//   RecursiveCallUnroller::Run.
-// - Control is returned to CreatedFunction::Run for f(2), which returns
-//   memoized value.
-// - Then control is returned to CreatedFunction::Run for f(3), which completes
-//   the computation.
-class RecursiveCallUnroller {
- public:
-  RecursiveCallUnroller(PerfettoSqlConnection* connection,
-                        sqlite3_stmt* stmt,
-                        const FunctionPrototype& prototype,
-                        Memoizer& memoizer)
-      : engine_(connection),
-        stmt_(stmt),
-        prototype_(prototype),
-        memoizer_(memoizer) {}
-
-  // Whether we should just return null due to us being in the "first pass".
-  enum class FunctionCallState : uint8_t {
-    kIgnoreDueToFirstPass,
-    kEvaluate,
-  };
-
-  base::StatusOr<FunctionCallState> OnFunctionCall(
-      Memoizer::MemoizedArgs args) {
-    // If we are in the second pass, we just continue the function execution,
-    // including checking if a memoized value is available and returning it.
-    //
-    // We generally expect a memoized value to be available, but there are
-    // cases when it might not be the case, e.g. when which recursive calls are
-    // made depends on the return value of the function, e.g. for the following
-    // function, the first pass will not detect f(y) calls, so they will
-    // be computed recursively.
-    // f(x): SELECT max(f(y)) FROM y WHERE y < f($x - 1);
-    if (state_ == State::kComputingSecondPass) {
-      return FunctionCallState::kEvaluate;
-    }
-    if (!memoizer_.HasMemoizedValue(args)) {
-      ArgState* state = visited_.Find(args);
-      if (state) {
-        // Detect recursive loops, e.g. f(1) calling f(2) calling f(1).
-        if (*state == ArgState::kEvaluating) {
-          return base::ErrStatus("Infinite recursion detected");
-        }
-      } else {
-        visited_.Insert(args, ArgState::kScheduled);
-        first_pass_.push(args);
-      }
-    }
-    return FunctionCallState::kIgnoreDueToFirstPass;
-  }
-
-  base::Status Run(Memoizer::MemoizedArgs initial_args) {
-    PERFETTO_TP_TRACE(metatrace::Category::FUNCTION_CALL,
-                      "UNROLL_RECURSIVE_FUNCTION_CALL",
-                      [&](metatrace::Record* r) {
-                        r->AddArg("Function", prototype_.function_name);
-                        r->AddArg("Arg 0", std::to_string(initial_args));
-                      });
-
-    first_pass_.push(initial_args);
-    visited_.Insert(initial_args, ArgState::kScheduled);
-
-    while (!first_pass_.empty() || !second_pass_.empty()) {
-      // If we have scheduled first pass calls, we evaluate them first.
-      if (!first_pass_.empty()) {
-        state_ = State::kComputingFirstPass;
-        Memoizer::MemoizedArgs args = first_pass_.front();
-
-        PERFETTO_TP_TRACE(metatrace::Category::FUNCTION_CALL,
-                          "SQL_FUNCTION_CALL", [&](metatrace::Record* r) {
-                            r->AddArg("Function", prototype_.function_name);
-                            r->AddArg("Type", "UnrollRecursiveCall_FirstPass");
-                            r->AddArg("Arg 0", std::to_string(args));
-                          });
-
-        first_pass_.pop();
-        second_pass_.push(args);
-        Evaluate(args).status();
-        continue;
-      }
-
-      state_ = State::kComputingSecondPass;
-      Memoizer::MemoizedArgs args = second_pass_.top();
-
-      PERFETTO_TP_TRACE(metatrace::Category::FUNCTION_CALL, "SQL_FUNCTION_CALL",
-                        [&](metatrace::Record* r) {
-                          r->AddArg("Function", prototype_.function_name);
-                          r->AddArg("Type", "UnrollRecursiveCall_SecondPass");
-                          r->AddArg("Arg 0", std::to_string(args));
-                        });
-
-      visited_.Insert(args, ArgState::kEvaluating);
-      second_pass_.pop();
-      base::StatusOr<std::optional<int64_t>> result = Evaluate(args);
-      RETURN_IF_ERROR(result.status());
-      std::optional<int64_t> maybe_int_result = result.value();
-      if (!maybe_int_result.has_value()) {
-        continue;
-      }
-      visited_.Insert(args, ArgState::kEvaluated);
-      memoizer_.Memoize(args, SqlValue::Long(*maybe_int_result));
-    }
-    return base::OkStatus();
-  }
-
- private:
-  // This function returns:
-  // - base::ErrStatus if the evaluation of the function failed.
-  // - std::nullopt if the function returned a non-integer value.
-  // - the result of the function otherwise.
-  base::StatusOr<std::optional<int64_t>> Evaluate(Memoizer::MemoizedArgs args) {
-    RETURN_IF_ERROR(MaybeBindIntArgument(stmt_, prototype_.function_name,
-                                         prototype_.arguments[0], args));
-    base::StatusOr<SqlValue> result = EvaluateScalarStatement(
-        stmt_, engine_->sqlite_connection()->db(), prototype_);
-    sqlite3_reset(stmt_);
-    sqlite3_clear_bindings(stmt_);
-    RETURN_IF_ERROR(result.status());
-    if (result->type != SqlValue::Type::kLong) {
-      return std::optional<int64_t>(std::nullopt);
-    }
-    return std::optional<int64_t>(result->long_value);
-  }
-
-  PerfettoSqlConnection* engine_;
-  sqlite3_stmt* stmt_;
-  const FunctionPrototype& prototype_;
-  Memoizer& memoizer_;
-
-  // Current state of the evaluation.
-  enum class State : uint8_t {
-    kComputingFirstPass,
-    kComputingSecondPass,
-  };
-  State state_ = State::kComputingFirstPass;
-
-  // A state of evaluation of a given argument.
-  enum class ArgState : uint8_t {
-    kScheduled,
-    kEvaluating,
-    kEvaluated,
-  };
-
-  // See the class-level comment for the explanation of the two passes.
-  std::queue<Memoizer::MemoizedArgs> first_pass_;
-  base::FlatHashMap<Memoizer::MemoizedArgs, ArgState> visited_;
-  std::stack<Memoizer::MemoizedArgs> second_pass_;
-};
-
 }  // namespace
 
 // This class is used to store the state of a CREATE_FUNCTION call.
@@ -411,150 +143,62 @@ class State : public CreatedFunction::UserData {
   explicit State(PerfettoSqlConnection* connection) : engine_(connection) {}
   ~State() override;
 
-  // Prepare a statement and push it into the stack of allocated statements
-  // for this function.
   base::Status PrepareStatement() {
     SqliteConnection::PreparedStatement stmt =
         engine_->sqlite_connection()->PrepareStatement(*sql_);
     RETURN_IF_ERROR(stmt.status());
+    stmt_ = std::move(stmt);
     is_valid_ = true;
-    stmts_.push_back(std::move(stmt));
     return base::OkStatus();
   }
 
-  // Sets the state of the function. Should be called only when the function
-  // is invalid (i.e. when it is first created or when the previous statement
-  // failed to prepare).
-  void Reset(FunctionPrototype prototype,
-             sql_argument::Type return_type,
-             SqlSource sql) {
-    // Re-registration of valid functions is not allowed.
+  void Reset(FunctionPrototype prototype, SqlSource sql) {
     PERFETTO_DCHECK(!is_valid_);
-    PERFETTO_DCHECK(stmts_.empty());
+    PERFETTO_DCHECK(!stmt_);
 
     prototype_ = std::move(prototype);
-    return_type_ = return_type;
     sql_ = std::move(sql);
   }
 
-  // This function is called each time the function is called.
-  // It ensures that we have a statement for the current recursion level,
-  // allocating a new one if needed.
-  base::Status PushStackEntry() {
-    ++current_recursion_level_;
-    if (current_recursion_level_ > stmts_.size()) {
-      return PrepareStatement();
+  base::Status BeginExecution() {
+    if (is_executing_) {
+      return base::ErrStatus("%s: recursive calls are not supported",
+                             prototype_.function_name.c_str());
     }
+    if (!stmt_) {
+      RETURN_IF_ERROR(PrepareStatement());
+    }
+    is_executing_ = true;
     return base::OkStatus();
   }
 
-  // Returns the statement that is used for the current invocation.
-  sqlite3_stmt* CurrentStatement() {
-    return stmts_[current_recursion_level_ - 1].sqlite_stmt();
-  }
-
-  // This function is called each time the function returns and resets the
-  // statement that this invocation used.
-  void PopStackEntry() {
-    if (current_recursion_level_ > stmts_.size()) {
-      // This is possible if we didn't prepare the statement and returned
-      // an error.
-      return;
-    }
+  void EndExecution() {
+    PERFETTO_CHECK(is_executing_);
     sqlite3_reset(CurrentStatement());
     sqlite3_clear_bindings(CurrentStatement());
-    --current_recursion_level_;
+    is_executing_ = false;
   }
 
-  base::StatusOr<RecursiveCallUnroller::FunctionCallState> OnFunctionCall(
-      Memoizer::MemoizedArgs args) {
-    if (!recursive_call_unroller_) {
-      return RecursiveCallUnroller::FunctionCallState::kEvaluate;
-    }
-    return recursive_call_unroller_->OnFunctionCall(args);
-  }
-
-  // Called before checking the function for memoization.
-  base::Status UnrollRecursiveCallIfNeeded(Memoizer::MemoizedArgs args) {
-    if (!memoizer_.enabled() || !is_in_recursive_call() ||
-        recursive_call_unroller_) {
-      return base::OkStatus();
-    }
-    // If we are in a recursive call, we need to check if we have already
-    // computed the result for the current arguments.
-    if (memoizer_.HasMemoizedValue(args)) {
-      return base::OkStatus();
-    }
-
-    // If we are in a beginning of a function call:
-    // - is a recursive,
-    // - can be memoized,
-    // - hasn't been memoized already, and
-    // - hasn't start unrolling yet;
-    // start the unrolling and run the unrolling loop.
-    recursive_call_unroller_ = std::make_unique<RecursiveCallUnroller>(
-        engine_, CurrentStatement(), prototype_, memoizer_);
-    auto status = recursive_call_unroller_->Run(args);
-    recursive_call_unroller_.reset();
-    return status;
-  }
-
-  // Schedule a statement to be validated that it is indeed doesn't have any
-  // more rows.
-  void ScheduleEmptyStatementValidation(sqlite3_stmt* stmt) {
-    empty_stmts_to_validate_.push_back(stmt);
-  }
-
-  base::Status ValidateEmptyStatements() {
-    while (!empty_stmts_to_validate_.empty()) {
-      sqlite3_stmt* stmt = empty_stmts_to_validate_.back();
-      empty_stmts_to_validate_.pop_back();
-      RETURN_IF_ERROR(CheckNoMoreRows(stmt, engine_->sqlite_connection()->db(),
-                                      prototype_));
-    }
-    return base::OkStatus();
-  }
-
-  bool is_in_recursive_call() const { return current_recursion_level_ > 1; }
-
-  base::Status EnableMemoization() {
-    return memoizer_.EnableMemoization(prototype_);
+  sqlite3_stmt* CurrentStatement() {
+    PERFETTO_DCHECK(stmt_);
+    return stmt_->sqlite_stmt();
   }
 
   PerfettoSqlConnection* connection() const { return engine_; }
 
   const FunctionPrototype& prototype() const { return prototype_; }
 
-  sql_argument::Type return_type() const { return return_type_; }
-
-  const std::string& sql() const { return sql_->sql(); }
-
   bool is_valid() const { return is_valid_; }
 
-  Memoizer& memoizer() { return memoizer_; }
+  bool is_executing() const { return is_executing_; }
 
  private:
   PerfettoSqlConnection* engine_;
   FunctionPrototype prototype_;
-  sql_argument::Type return_type_;
   std::optional<SqlSource> sql_;
-  // Perfetto SQL functions support recursion. Given that each function call in
-  // the stack requires a dedicated statement, we maintain a stack of prepared
-  // statements and use the top one for each new call (allocating a new one if
-  // needed).
-  std::vector<SqliteConnection::PreparedStatement> stmts_;
-  // A list of statements to verify to ensure that they don't have more rows
-  // in VerifyPostConditions.
-  std::vector<sqlite3_stmt*> empty_stmts_to_validate_;
-  size_t current_recursion_level_ = 0;
-  // Function re-registration is not allowed, but the user is allowed to define
-  // the function again if the first call failed. |is_valid_| flag helps that
-  // by tracking whether the current function definition is valid (in which case
-  // re-registration is not allowed).
+  std::optional<SqliteConnection::PreparedStatement> stmt_;
   bool is_valid_ = false;
-  Memoizer memoizer_;
-  // Set if we are in a middle of unrolling a recursive call.
-  std::unique_ptr<RecursiveCallUnroller> recursive_call_unroller_;
+  bool is_executing_ = false;
 };
 
 State::~State() = default;
@@ -568,7 +212,12 @@ bool CreatedFunction::IsValid(UserData* ctx) {
   return static_cast<State*>(ctx)->is_valid();
 }
 
+bool CreatedFunction::IsExecuting(UserData* ctx) {
+  return static_cast<State*>(ctx)->is_executing();
+}
+
 void CreatedFunction::Reset(UserData* ctx, PerfettoSqlConnection* connection) {
+  PERFETTO_CHECK(!IsExecuting(ctx));
   ctx->~UserData();
   new (ctx) State(connection);
 }
@@ -578,17 +227,14 @@ void CreatedFunction::Step(sqlite3_context* ctx,
                            sqlite3_value** argv) {
   auto* state = static_cast<State*>(CreatedFunction::GetUserData(ctx));
 
-  // RAII cleanup to ensure PopStackEntry is called
-  struct ScopedCleanup {
-    State* state;
-    ~ScopedCleanup() { state->PopStackEntry(); }
-  };
-  ScopedCleanup scoped_cleanup{state};
-
-  // Enter the function and ensure that we have a statement allocated.
-  if (auto status = state->PushStackEntry(); !status.ok()) {
+  if (auto status = state->BeginExecution(); !status.ok()) {
     return sqlite::utils::SetError(ctx, status.c_message());
   }
+  struct ScopedCleanup {
+    State* state;
+    ~ScopedCleanup() { state->EndExecution(); }
+  };
+  ScopedCleanup scoped_cleanup{state};
 
   size_t expected_argc = state->prototype().arguments.size();
   if (static_cast<size_t>(argc) != expected_argc) {
@@ -599,11 +245,9 @@ void CreatedFunction::Step(sqlite3_context* ctx,
                  .c_message());
   }
 
-  // Type check all the arguments.
   for (size_t i = 0; i < expected_argc; ++i) {
     sqlite3_value* arg = argv[i];
     sql_argument::Type type = state->prototype().arguments[i].type();
-    // Skip type checking for ANY type - it accepts all types.
     if (type == sql_argument::Type::kAny) {
       continue;
     }
@@ -616,34 +260,6 @@ void CreatedFunction::Step(sqlite3_context* ctx,
                                state->prototype().function_name.c_str(),
                                sqlite3_value_text(arg), i, status.c_message())
                    .c_message());
-    }
-  }
-
-  std::optional<Memoizer::MemoizedArgs> memoized_args =
-      Memoizer::AsMemoizedArgs(size_t(argc), argv);
-
-  if (memoized_args) {
-    // Handle recursive call unrolling
-    auto unroll_state = state->OnFunctionCall(*memoized_args);
-    if (!unroll_state.ok()) {
-      return sqlite::utils::SetError(ctx, unroll_state.status().c_message());
-    }
-    if (*unroll_state ==
-        RecursiveCallUnroller::FunctionCallState::kIgnoreDueToFirstPass) {
-      return sqlite::utils::ReturnNullFromFunction(ctx);
-    }
-
-    if (auto status = state->UnrollRecursiveCallIfNeeded(*memoized_args);
-        !status.ok()) {
-      return sqlite::utils::SetError(ctx, status.c_message());
-    }
-
-    // Check for memoized value
-    if (auto memoized_value =
-            state->memoizer().GetMemoizedValue(*memoized_args)) {
-      SqlValue out = *memoized_value;
-      ReturnSqlValue(ctx, out);
-      return;
     }
   }
 
@@ -660,7 +276,6 @@ void CreatedFunction::Step(sqlite3_context* ctx,
         }
       });
 
-  // Bind arguments and execute the user's SQL
   if (auto status = BindArguments(state->CurrentStatement(), state->prototype(),
                                   size_t(argc), argv);
       !status.ok()) {
@@ -674,39 +289,26 @@ void CreatedFunction::Step(sqlite3_context* ctx,
     return sqlite::utils::SetError(ctx, result.status().c_message());
   }
 
-  SqlValue out = result.value();
-  state->ScheduleEmptyStatementValidation(state->CurrentStatement());
-
-  if (memoized_args) {
-    state->memoizer().Memoize(*memoized_args, out);
-  }
-
-  // Return the result directly
-  ReturnSqlValue(ctx, out);
-
-  // Verify post-conditions
-  if (auto verify_status = state->ValidateEmptyStatements();
-      !verify_status.ok()) {
-    sqlite::utils::SetError(ctx, verify_status.c_message());
+  ReturnSqlValue(ctx, result.value());
+  if (auto status = CheckNoMoreRows(
+          state->CurrentStatement(),
+          state->connection()->sqlite_connection()->db(), state->prototype());
+      !status.ok()) {
+    sqlite::utils::SetError(ctx, status.c_message());
   }
 }
 
 base::Status CreatedFunction::Prepare(CreatedFunction::UserData* ctx,
                                       FunctionPrototype prototype,
-                                      sql_argument::Type return_type,
                                       SqlSource source) {
   State* state = static_cast<State*>(ctx);
-  state->Reset(std::move(prototype), return_type, std::move(source));
+  state->Reset(std::move(prototype), std::move(source));
 
   // Ideally, we would unregister the function here if the statement prep
   // failed, but SQLite doesn't allow unregistering functions inside active
   // statements. So instead we'll just try to prepare the statement when calling
   // this function, which will return an error.
   return state->PrepareStatement();
-}
-
-base::Status CreatedFunction::EnableMemoization(UserData* ctx) {
-  return static_cast<State*>(ctx)->EnableMemoization();
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/engine/created_function.h
+++ b/src/trace_processor/perfetto_sql/engine/created_function.h
@@ -27,7 +27,6 @@
 #include "src/trace_processor/sqlite/bindings/sqlite_function.h"
 #include "src/trace_processor/sqlite/sql_source.h"
 #include "src/trace_processor/types/destructible.h"
-#include "src/trace_processor/util/sql_argument.h"
 
 namespace perfetto::trace_processor {
 
@@ -45,12 +44,9 @@ struct CreatedFunction : public sqlite::Function<CreatedFunction> {
   // Glue code for PerfettoSqlConnection.
   static std::unique_ptr<UserData> MakeContext(PerfettoSqlConnection*);
   static bool IsValid(UserData*);
+  static bool IsExecuting(UserData*);
   static void Reset(UserData*, PerfettoSqlConnection*);
-  static base::Status Prepare(UserData*,
-                              FunctionPrototype,
-                              sql_argument::Type return_type,
-                              SqlSource sql);
-  static base::Status EnableMemoization(UserData*);
+  static base::Status Prepare(UserData*, FunctionPrototype, SqlSource sql);
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.cc
@@ -326,7 +326,7 @@ std::unique_ptr<PerfettoSqlConnection> PerfettoSqlConnection::Fork() {
 
 PerfettoSqlConnection::~PerfettoSqlConnection() {
   // Scalar function contexts can hold prepared statements (e.g.
-  // CreatedFunction::State::stmts_) that must be finalized before the
+  // CreatedFunction::State::stmt_) that must be finalized before the
   // underlying sqlite3* is closed. Explicitly unregister every entry now so
   // SQLite invokes each function's FnCtxDestructor while the database is
   // still alive; |connection_| is destroyed below.
@@ -888,7 +888,6 @@ const dataframe::Dataframe* PerfettoSqlConnection::GetDataframeOrNull(
 base::Status PerfettoSqlConnection::RegisterLegacyRuntimeFunction(
     bool replace,
     const FunctionPrototype& prototype,
-    sql_argument::Type return_type,
     SqlSource sql) {
   int created_argc = static_cast<int>(prototype.arguments.size());
   // Refuse to clobber a C++ intrinsic. The reused-ctx fast path below ends in
@@ -913,11 +912,16 @@ base::Status PerfettoSqlConnection::RegisterLegacyRuntimeFunction(
           "CREATE PERFETTO FUNCTION[prototype=%s]: function already exists",
           prototype.ToString().c_str());
     }
+    if (CreatedFunction::IsExecuting(ctx)) {
+      return base::ErrStatus(
+          "CREATE PERFETTO FUNCTION[prototype=%s]: cannot redefine a function "
+          "while it is executing",
+          prototype.ToString().c_str());
+    }
     CreatedFunction::Reset(ctx, this);
   } else {
-    // We register the function with SQLite before we prepare the statement so
-    // the statement can reference the function itself, enabling recursive
-    // calls.
+    // Register before preparing so a failed definition retains a context that
+    // can be replaced by a later valid definition.
     std::unique_ptr<CreatedFunction::UserData> created_fn_ctx =
         CreatedFunction::MakeContext(this);
     ctx = created_fn_ctx.get();
@@ -927,7 +931,7 @@ base::Status PerfettoSqlConnection::RegisterLegacyRuntimeFunction(
     RETURN_IF_ERROR(
         RegisterFunction<CreatedFunction>(std::move(created_fn_ctx), args));
   }
-  return CreatedFunction::Prepare(ctx, prototype, return_type, std::move(sql));
+  return CreatedFunction::Prepare(ctx, prototype, std::move(sql));
 }
 
 base::Status PerfettoSqlConnection::ExecuteCreateTable(
@@ -1056,28 +1060,6 @@ base::Status PerfettoSqlConnection::ExecuteCreateView(
   }
   RETURN_IF_ERROR(Execute(create_view.create_view_sql).status());
   return base::OkStatus();
-}
-
-base::Status PerfettoSqlConnection::EnableSqlFunctionMemoization(
-    const std::string& name) {
-  constexpr int kSupportedArgCount = 1;
-  // Refuse EXPERIMENTAL_MEMOIZE on intrinsics: their ctx is opaque and casting
-  // it to CreatedFunction::UserData* would walk a non-existent vtable inside
-  // EnableMemoization.
-  if (IsIntrinsicFunction(name, kSupportedArgCount)) {
-    return base::ErrStatus(
-        "EXPERIMENTAL_MEMOIZE: '%s' is a built-in function and cannot be "
-        "memoized",
-        name.c_str());
-  }
-  auto* ctx = static_cast<CreatedFunction::UserData*>(
-      GetFunctionContextOrNull(name, kSupportedArgCount));
-  if (!ctx) {
-    return base::ErrStatus(
-        "EXPERIMENTAL_MEMOIZE: Function '%s'(INT) does not exist",
-        name.c_str());
-  }
-  return CreatedFunction::EnableMemoization(ctx);
 }
 
 base::Status PerfettoSqlConnection::ExecuteInclude(
@@ -1314,8 +1296,7 @@ base::Status PerfettoSqlConnection::ExecuteCreateFunction(
   }
 
   if (!cf.returns.is_table) {
-    return RegisterLegacyRuntimeFunction(cf.replace, cf.prototype,
-                                         cf.returns.scalar_type, cf.sql);
+    return RegisterLegacyRuntimeFunction(cf.replace, cf.prototype, cf.sql);
   }
 
   auto state = std::make_unique<RuntimeTableFunctionModule::State>(
@@ -1498,8 +1479,7 @@ base::Status PerfettoSqlConnection::RegisterFunctionAndAddToRegistry(
 
   // Track ownership / kind. This is the only place that records whether a
   // function's context is opaque (intrinsic) or a typed Destructible-derived
-  // state; the security-sensitive paths in |RegisterLegacyRuntimeFunction| and
-  // |EnableSqlFunctionMemoization| consult |IsIntrinsicFunction| before
+  // state. RegisterLegacyRuntimeFunction consults IsIntrinsicFunction before
   // downcasting. Keys are lowercased to match SQLite's case-insensitive
   // function namespace; otherwise CREATE OR REPLACE PERFETTO FUNCTION
   // IMPORT(...) (mixed-case) could bypass the intrinsic check.

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_connection.h
@@ -293,9 +293,6 @@ class PerfettoSqlConnection {
                                       typename Function::Context* ctx,
                                       bool deterministic = true);
 
-  // Enables memoization for the given SQL function.
-  base::Status EnableSqlFunctionMemoization(const std::string& name);
-
   SqliteConnection* sqlite_connection() { return connection_.get(); }
 
   // Test-only accessor for the |PerfettoSqlDatabase| backing this connection.
@@ -363,14 +360,13 @@ class PerfettoSqlConnection {
   // Find dataframe registered with this connection with provided name.
   const dataframe::Dataframe* GetDataframeOrNull(const std::string& name) const;
 
-  // Registers a function with the prototype |prototype| which returns a value
-  // of |return_type| and is implemented by executing the SQL statement |sql|.
+  // Registers a function with the prototype |prototype| implemented by
+  // executing the SQL statement |sql|.
   //
   // LEGACY: This function uses SQL-based function definitions. For new code,
   // prefer RegisterFunction() which uses C++ implementations.
   base::Status RegisterLegacyRuntimeFunction(bool replace,
                                              const FunctionPrototype& prototype,
-                                             sql_argument::Type return_type,
                                              SqlSource sql);
 
  private:
@@ -604,7 +600,7 @@ class PerfettoSqlConnection {
   //    intrinsic's context with a CreatedFunction::State.
   //
   // 2) Teardown: scalar function contexts can hold prepared statements
-  //    (CreatedFunction::State::stmts_); those must be finalized before the
+  //    (CreatedFunction::State::stmt_); those must be finalized before the
   //    underlying sqlite3* is closed. The destructor walks this map and
   //    explicitly unregisters every entry, which triggers SQLite to invoke
   //    each entry's |FnCtxDestructor| in turn.

--- a/src/trace_processor/plugins/create_function/create_function.cc
+++ b/src/trace_processor/plugins/create_function/create_function.cc
@@ -17,8 +17,6 @@
 #include "src/trace_processor/plugins/create_function/create_function.h"
 
 #include <memory>
-#include <queue>
-#include <stack>
 #include <vector>
 
 #include "perfetto/base/compiler.h"
@@ -76,35 +74,13 @@ void CreateFunction::Step(sqlite3_context* ctx,
   }
 
   auto register_status = connection->RegisterLegacyRuntimeFunction(
-      true /* replace */, prototype, *type,
+      true /* replace */, prototype,
       SqlSource::FromTraceProcessorImplementation(std::move(sql_defn_str)));
   if (!register_status.ok()) {
     return sqlite::utils::SetError(ctx, register_status);
   }
 
   // CREATE_FUNCTION returns no value (void function)
-  return sqlite::utils::ReturnVoidFromFunction(ctx);
-}
-
-void ExperimentalMemoize::Step(sqlite3_context* ctx,
-                               int argc,
-                               sqlite3_value** argv) {
-  PERFETTO_DCHECK(argc == 1);
-
-  auto* connection = GetUserData(ctx);
-
-  if (sqlite::value::Type(argv[0]) != sqlite::Type::kText) {
-    return sqlite::utils::SetError(
-        ctx, "EXPERIMENTAL_MEMOIZE: function_name must be string");
-  }
-
-  std::string function_name = sqlite::value::Text(argv[0]);
-  auto status = connection->EnableSqlFunctionMemoization(function_name);
-  if (!status.ok()) {
-    return sqlite::utils::SetError(ctx, status);
-  }
-
-  // EXPERIMENTAL_MEMOIZE returns no value (void function)
   return sqlite::utils::ReturnVoidFromFunction(ctx);
 }
 
@@ -118,7 +94,6 @@ class CreateFunctionPlugin : public Plugin<CreateFunctionPlugin> {
   void RegisterFunctions(PerfettoSqlConnection* connection,
                          std::vector<FunctionRegistration>& out) override {
     out.push_back(MakeFunctionRegistration<CreateFunction>(connection));
-    out.push_back(MakeFunctionRegistration<ExperimentalMemoize>(connection));
   }
 };
 

--- a/src/trace_processor/plugins/create_function/create_function.h
+++ b/src/trace_processor/plugins/create_function/create_function.h
@@ -39,19 +39,6 @@ struct CreateFunction : public sqlite::Function<CreateFunction> {
   static void Step(sqlite3_context* ctx, int argc, sqlite3_value** argv);
 };
 
-// Implementation of MEMOIZE SQL function.
-// SELECT EXPERIMENTAL_MEMOIZE('my_func') enables memoization for the results of
-// the calls to `my_func`. `my_func` must be a Perfetto SQL function created
-// through CREATE_FUNCTION that takes a single integer argument and returns a
-// int.
-struct ExperimentalMemoize : public sqlite::Function<ExperimentalMemoize> {
-  static constexpr char kName[] = "experimental_memoize";
-  static constexpr int kArgCount = 1;
-
-  using UserData = PerfettoSqlConnection;
-  static void Step(sqlite3_context* ctx, int argc, sqlite3_value** argv);
-};
-
 }  // namespace perfetto::trace_processor
 
 namespace perfetto::trace_processor::create_function {

--- a/test/trace_processor/diff_tests/syntax/function_tests.py
+++ b/test/trace_processor/diff_tests/syntax/function_tests.py
@@ -15,7 +15,7 @@
 
 from python.generators.diff_tests.testing import Path, DataPath, Metric
 from python.generators.diff_tests.testing import Csv, Json, TextProto, BinaryProto
-from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import DiffTestBlueprint, ExpectedError
 from python.generators.diff_tests.testing import TestSuite
 from python.generators.diff_tests.testing import PrintProfileProto
 from google.protobuf import text_format
@@ -107,210 +107,18 @@ class PerfettoFunction(TestSuite):
         1
       """))
 
-  def test_legacy_create_function_recursive(self):
+  def test_legacy_create_function_rejects_recursion(self):
     return DiffTestBlueprint(
         trace=TextProto(""),
         query="""
-        -- Compute factorial.
         SELECT create_function('f(x INT)', 'INT',
         '
           SELECT IIF($x = 0, 1, $x * f($x - 1))
         ');
 
-        SELECT f(5) as result;
+        SELECT f(5);
       """,
-        out=Csv("""
-        "result"
-        120
-      """))
-
-  def test_legacy_create_function_recursive_string(self):
-    return DiffTestBlueprint(
-        trace=TextProto(""),
-        query="""
-        -- Compute factorial.
-        SELECT create_function('f(x INT)', 'STRING',
-        '
-          SELECT IIF(
-            $x = 0,
-            "",
-            -- 97 is the ASCII code for "a".
-            f($x - 1) || char(96 + $x) || f($x - 1))
-        ');
-
-        SELECT f(4) as result;
-      """,
-        out=Csv("""
-          "result"
-          "abacabadabacaba"
-      """))
-
-  def test_legacy_create_function_recursive_string_memoized(self):
-    return DiffTestBlueprint(
-        trace=TextProto(""),
-        query="""
-        -- Compute factorial.
-        SELECT create_function('f(x INT)', 'STRING',
-        '
-          SELECT IIF(
-            $x = 0,
-            "",
-            -- 97 is the ASCII code for "a".
-            f($x - 1) || char(96 + $x) || f($x - 1))
-        ');
-
-        SELECT experimental_memoize('f');
-
-        SELECT f(4) as result;
-      """,
-        out=Csv("""
-          "result"
-          "abacabadabacaba"
-      """))
-
-  def test_legacy_create_function_memoize(self):
-    return DiffTestBlueprint(
-        trace=TextProto(""),
-        query="""
-        -- Compute 2^n inefficiently to test memoization.
-        -- If it times out, memoization is not working.
-        SELECT create_function('f(x INT)', 'INT',
-        '
-          SELECT IIF($x = 0, 1, f($x - 1) + f($x - 1))
-        ');
-
-        SELECT EXPERIMENTAL_MEMOIZE('f');
-
-        -- 2^50 is too expensive to compute, but memoization makes it fast.
-        SELECT f(50) as result;
-      """,
-        out=Csv("""
-        "result"
-        1125899906842624
-      """))
-
-  def test_legacy_create_function_memoize_float(self):
-    return DiffTestBlueprint(
-        trace=TextProto(""),
-        query="""
-        -- Compute 2^n inefficiently to test memoization.
-        -- If it times out, memoization is not working.
-        SELECT create_function('f(x INT)', 'FLOAT',
-        '
-          SELECT $x + 0.5
-        ');
-
-        SELECT EXPERIMENTAL_MEMOIZE('f');
-
-        SELECT printf("%.1f", f(1)) as result
-        UNION ALL
-        SELECT printf("%.1f", f(1)) as result
-        UNION ALL
-        SELECT printf("%.1f", f(1)) as result
-      """,
-        out=Csv("""
-        "result"
-        "1.5"
-        "1.5"
-        "1.5"
-      """))
-
-  def test_legacy_create_function_memoize_intermittent_memoization(self):
-    return DiffTestBlueprint(
-        trace=TextProto(""),
-        query="""
-        -- This function returns NULL for odd numbers and 1 for even numbers.
-        -- As we do not memoize NULL results, we would only memoize the results
-        -- for even numbers.
-        SELECT create_function('f(x INT)', 'INT',
-        '
-          SELECT IIF($x = 0, 1,
-            IIF(f($x - 1) IS NULL, 1, NULL)
-          )
-        ');
-
-        SELECT EXPERIMENTAL_MEMOIZE('f');
-
-        SELECT
-          f(50) as f_50,
-          f(51) as f_51;
-      """,
-        out=Csv("""
-        "f_50","f_51"
-        1,"[NULL]"
-      """))
-
-  def test_legacy_create_function_memoize_subtree_size(self):
-    # Tree:
-    #            1
-    #           / \
-    #          /   \
-    #         /     \
-    #        2       3
-    #       / \     / \
-    #      4   5   6   7
-    #     / \  |   |  | \
-    #    8   9 10 11 12 13
-    #    |   |
-    #   14   15
-    return DiffTestBlueprint(
-        trace=TextProto(""),
-        query="""
-        CREATE PERFETTO TABLE tree AS
-        WITH data(id, parent_id) as (VALUES
-          (1, NULL),
-          (2, 1),
-          (3, 1),
-          (4, 2),
-          (5, 2),
-          (6, 3),
-          (7, 3),
-          (8, 4),
-          (9, 4),
-          (10, 5),
-          (11, 6),
-          (12, 7),
-          (13, 7),
-          (14, 8),
-          (15, 9)
-        )
-        SELECT * FROM data;
-
-        SELECT create_function('subtree_size(id INT)', 'INT',
-        '
-          SELECT 1 + IFNULL((
-            SELECT
-              SUM(subtree_size(child.id))
-            FROM tree child
-            WHERE child.parent_id = $id
-          ), 0)
-        ');
-
-        SELECT EXPERIMENTAL_MEMOIZE('subtree_size');
-
-        SELECT
-          id, subtree_size(id) as size
-        FROM tree
-        ORDER BY id;
-      """,
-        out=Csv("""
-        "id","size"
-        1,15
-        2,8
-        3,6
-        4,5
-        5,2
-        6,2
-        7,3
-        8,2
-        9,2
-        10,1
-        11,1
-        12,1
-        13,1
-        14,1
-        15,1
-      """))
+        out=ExpectedError('f: recursive calls are not supported'))
 
   def test_create_function_variadic_delegate(self):
     return DiffTestBlueprint(


### PR DESCRIPTION
They were never used in practice and/or achieved popularity and slow
down non-recursive functions. There's also a subtle UAF (see b/552636369).

Fix it by just removing support for them altogether.

