### PR TITLE
ui: Add setting to default to flamegraph tab in Heap Dump Explorer

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
@@ -15,7 +15,9 @@
 import './styles.scss';
 import m from 'mithril';
 import {z} from 'zod';
+import type {App} from '../../public/app';
 import type {PerfettoPlugin} from '../../public/plugin';
+import type {Setting} from '../../public/settings';
 import type {Trace} from '../../public/trace';
 import {NUM} from '../../trace_processor/query_result';
 import HeapProfilePlugin, {
@@ -27,9 +29,21 @@ import {migrateHdeState} from './persisted_state';
 
 const PLUGIN_ID = 'com.android.HeapDumpExplorer';
 
-export default class implements PerfettoPlugin {
+export default class HeapDumpExplorerPlugin implements PerfettoPlugin {
   static readonly id = PLUGIN_ID;
   static readonly dependencies = [HeapProfilePlugin];
+  private static defaultFlamegraphSetting: Setting<boolean>;
+
+  static onActivate(app: App) {
+    HeapDumpExplorerPlugin.defaultFlamegraphSetting = app.settings.register({
+      id: 'com.android.HeapDumpExplorerDefaultFlamegraph',
+      name: 'Heap Dump Explorer: Default to Flamegraph',
+      description:
+        'Make the flamegraph the first selected tab rather than the overview page in Heap Dump Explorer',
+      schema: z.boolean(),
+      defaultValue: false,
+    });
+  }
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     const hideDefaultChangedHint = ctx.settings.register({
@@ -40,6 +54,8 @@ export default class implements PerfettoPlugin {
       schema: z.boolean(),
       defaultValue: false,
     });
+
+    const defaultFlamegraph = HeapDumpExplorerPlugin.defaultFlamegraphSetting;
 
     const res = await ctx.engine.query(
       'SELECT count(*) AS cnt FROM heap_graph LIMIT 1',
@@ -54,6 +70,7 @@ export default class implements PerfettoPlugin {
       ctx,
       ctx.engine,
       hideDefaultChangedHint,
+      defaultFlamegraph,
       store,
     );
     const restored = await session.loadDumps();

--- a/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
@@ -29,6 +29,14 @@ export type NavState =
   | {view: 'callstack'; params: Record<string, never>};
 
 export type NavView = NavState['view'];
+export type DefaultNavView = 'overview' | 'flamegraph';
+
+function defaultNavState(view: DefaultNavView): NavState {
+  if (view === 'flamegraph') {
+    return {view: 'flamegraph', params: {}};
+  }
+  return {view: 'overview', params: {}};
+}
 
 // A `key=value` query fragment (URI-encoded), or '' when the value is absent.
 function queryParam(key: string, value?: string): string {
@@ -47,7 +55,7 @@ function pathSegment(base: string, value?: string): string {
 function stateToParts(state: NavState): {path: string; query: string} {
   switch (state.view) {
     case 'overview':
-      return {path: '', query: ''};
+      return {path: 'overview', query: ''};
     case 'classes':
       return {
         path: 'classes',
@@ -106,8 +114,11 @@ export function stateToSubpage(state: NavState): string {
   return query ? `${path}?${query}` : path;
 }
 
-export function subpageToState(subpage: string | undefined): NavState {
-  if (!subpage) return {view: 'overview', params: {}};
+export function subpageToState(
+  subpage: string | undefined,
+  defaultView: DefaultNavView = 'overview',
+): NavState {
+  if (!subpage) return defaultNavState(defaultView);
 
   const [path, queryStr] = subpage.split('?', 2);
   const sp = new URLSearchParams(queryStr ?? '');
@@ -127,6 +138,7 @@ export function subpageToState(subpage: string | undefined): NavState {
 
   switch (view) {
     case '':
+      return defaultNavState(defaultView);
     case 'overview':
       return {view: 'overview', params: {}};
     case 'classes': {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/nav_state_unittest.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/nav_state_unittest.ts
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, expect, it} from 'vitest';
+import {stateToPath, stateToSubpage, subpageToState} from './nav_state';
+
+describe('nav_state', () => {
+  it('defaults to overview when defaultView is omitted or overview', () => {
+    expect(subpageToState(undefined)).toEqual({
+      view: 'overview',
+      params: {},
+    });
+    expect(subpageToState('')).toEqual({
+      view: 'overview',
+      params: {},
+    });
+    expect(subpageToState(undefined, 'overview')).toEqual({
+      view: 'overview',
+      params: {},
+    });
+    expect(subpageToState('', 'overview')).toEqual({
+      view: 'overview',
+      params: {},
+    });
+  });
+
+  it('defaults to flamegraph when defaultView is flamegraph', () => {
+    expect(subpageToState(undefined, 'flamegraph')).toEqual({
+      view: 'flamegraph',
+      params: {},
+    });
+    expect(subpageToState('', 'flamegraph')).toEqual({
+      view: 'flamegraph',
+      params: {},
+    });
+  });
+
+  it('parses explicit views regardless of defaultView', () => {
+    expect(subpageToState('overview', 'flamegraph')).toEqual({
+      view: 'overview',
+      params: {},
+    });
+    expect(subpageToState('flamegraph', 'overview')).toEqual({
+      view: 'flamegraph',
+      params: {},
+    });
+    expect(subpageToState('classes?root=Foo', 'flamegraph')).toEqual({
+      view: 'classes',
+      params: {rootClass: 'Foo'},
+    });
+    expect(subpageToState('objects_java.lang.String', 'flamegraph')).toEqual({
+      view: 'objects',
+      params: {cls: 'java.lang.String'},
+    });
+  });
+
+  it('serializes overview and flamegraph states to path and subpage', () => {
+    expect(stateToPath({view: 'overview', params: {}})).toBe('overview');
+    expect(stateToSubpage({view: 'overview', params: {}})).toBe('overview');
+    expect(stateToPath({view: 'flamegraph', params: {}})).toBe('flamegraph');
+    expect(stateToSubpage({view: 'flamegraph', params: {}})).toBe('flamegraph');
+  });
+});

--- a/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
@@ -23,6 +23,7 @@ import {SQL_PREAMBLE} from './components';
 import {flamegraphQuery} from './views/flamegraph_objects_view';
 import * as queries from './queries';
 import {
+  type DefaultNavView,
   type NavState,
   type NavView,
   stateToPath,
@@ -86,8 +87,13 @@ export class HeapDumpExplorerSession {
     readonly trace: Trace,
     readonly engine: Engine,
     readonly hideDefaultChangedHint: Setting<boolean>,
+    readonly defaultFlamegraph: Setting<boolean>,
     private readonly store: Store<HdeState>,
   ) {}
+
+  get defaultView(): DefaultNavView {
+    return this.defaultFlamegraph.get() ? 'flamegraph' : 'overview';
+  }
 
   get dumps(): ReadonlyArray<queries.HeapDump> {
     return this._dumps;
@@ -136,7 +142,7 @@ export class HeapDumpExplorerSession {
     this.switchToDump(d);
     const view = this.nav.view;
     if (view === 'object' || view === 'flamegraph-objects') {
-      this.navigate('overview');
+      this.navigate(this.defaultView);
     }
     m.redraw();
   }
@@ -155,11 +161,14 @@ export class HeapDumpExplorerSession {
   }
 
   get nav(): NavState {
-    return subpageToState(this.store.state.nav);
+    return subpageToState(this.store.state.nav, this.defaultView);
   }
 
   // The current nav as a route path (no query params).
   get navPath(): string {
+    if (this.store.state.nav === undefined) {
+      return '';
+    }
     return stateToPath(this.nav);
   }
 
@@ -196,7 +205,7 @@ export class HeapDumpExplorerSession {
     // sync and clobbers the user's later manual filter edits. Query params are
     // already gone (the router strips them), but path-encoded ones (e.g.
     // objects_<class>) survive in the URL, so we must rewrite it here.
-    const nav = subpageToState(this.store.state.nav);
+    const nav = subpageToState(this.store.state.nav, this.defaultView);
     delete (nav.params as Record<string, unknown>)[key];
     const sub = stateToSubpage(nav);
     this.store.edit((s) => {
@@ -212,7 +221,9 @@ export class HeapDumpExplorerSession {
     const incomingPath = (sub ?? '').split('?')[0];
     if (incomingPath !== this.navPath) {
       this.store.edit((s) => {
-        s.nav = stateToSubpage(subpageToState(sub));
+        s.nav = sub
+          ? stateToSubpage(subpageToState(sub, this.defaultView))
+          : undefined;
       });
     }
   }
@@ -286,7 +297,7 @@ export class HeapDumpExplorerSession {
       active.pathHashes === pathHashes &&
       active.isDominator === isDominator
     ) {
-      this.navigate('overview');
+      this.navigate(this.defaultView);
     }
   }
 
@@ -345,7 +356,7 @@ export class HeapDumpExplorerSession {
     this.store.edit((s) => {
       s.instanceTabs = (s.instanceTabs ?? []).filter((t) => t.objId !== objId);
     });
-    if (wasActive) this.navigate('overview');
+    if (wasActive) this.navigate(this.defaultView);
   }
 
   syncInstanceTabFromNav(): void {


### PR DESCRIPTION
Add a boolean setting that makes the flamegraph tab open by default in the heap dump explorer page