### PR TITLE
ui: Make widget attrs properties readonly

### DIFF
--- a/ui/src/widgets/card.ts
+++ b/ui/src/widgets/card.ts
@@ -20,7 +20,7 @@ import {classNames} from '../base/classnames';
 
 export interface CardAttrs extends HTMLAttrs {
   // Whether the card should have a hover effect.
-  interactive?: boolean;
+  readonly interactive?: boolean;
 }
 
 export class Card implements m.ClassComponent<CardAttrs> {
@@ -39,7 +39,7 @@ export class Card implements m.ClassComponent<CardAttrs> {
 
 export interface CardStackAttrs extends HTMLAttrs {
   // The direction of the stack, defaults to 'vertical'.
-  direction?: 'vertical' | 'horizontal';
+  readonly direction?: 'vertical' | 'horizontal';
 }
 
 export class CardStack implements m.ClassComponent<CardStackAttrs> {

--- a/ui/src/widgets/drawer_panel.ts
+++ b/ui/src/widgets/drawer_panel.ts
@@ -93,10 +93,10 @@ export interface DrawerPanelAttrs {
   readonly activeTabKey?: string;
 
   // Called when a tab is clicked.
-  onTabChange?(key: string): void;
+  readonly onTabChange?: (key: string) => void;
 
   // Called when a tab's close button is clicked.
-  onTabClose?(key: string): void;
+  readonly onTabClose?: (key: string) => void;
 
   // ===== Common options =====
   // Whether the drawer is currently visible or not (when in controlled mode).
@@ -109,7 +109,7 @@ export interface DrawerPanelAttrs {
   readonly startingHeight?: number;
 
   // Called when the drawer visibility is changed.
-  onVisibilityChange?(visibility: DrawerPanelVisibility): void;
+  readonly onVisibilityChange?: (visibility: DrawerPanelVisibility) => void;
 }
 
 /**

--- a/ui/src/widgets/editor.ts
+++ b/ui/src/widgets/editor.ts
@@ -64,16 +64,16 @@ export interface EditorAttrs extends HTMLAttrs {
   readonly readonly?: boolean;
 
   // Callback for the Ctrl/Cmd + Enter key binding.
-  onExecute?: (text: string) => void;
+  readonly onExecute?: (text: string) => void;
 
   // Callback for the Ctrl/Cmd + S key binding.
-  onSave?: () => void;
+  readonly onSave?: () => void;
 
   // Callback for the Alt/Opt + Shift + F key binding.
-  onFormat?: (text: string) => void;
+  readonly onFormat?: (text: string) => void;
 
   // Callback for every change to the editor's content.
-  onUpdate?: (text: string) => void;
+  readonly onUpdate?: (text: string) => void;
 
   // Extra CodeMirror extensions supplied by the caller (e.g. the LSP
   // integration from the SqlLsp plugin).

--- a/ui/src/widgets/form.ts
+++ b/ui/src/widgets/form.ts
@@ -22,33 +22,33 @@ import {Intent} from '../widgets/common';
 export interface FormAttrs extends HTMLAttrs {
   // Text to show on the "submit" button.
   // Defaults to "Submit".
-  submitLabel?: string;
+  readonly submitLabel?: string;
 
   // Icon to show on the "submit" button.
-  submitIcon?: string;
+  readonly submitIcon?: string;
 
   // Text to show on the "cancel" button.
   // No button is rendered if this value is omitted.
-  cancelLabel?: string;
+  readonly cancelLabel?: string;
 
   // Text to show on the "reset" button.
   // No button is rendered if this value is omitted.
-  resetLabel?: string;
+  readonly resetLabel?: string;
 
   // Action to take when the form is submitted either by the enter key or
   // the submit button.
-  onSubmit?: (e: Event) => void;
+  readonly onSubmit?: (e: Event) => void;
 
   // Action to take when the form is cancelled.
-  onCancel?: () => void;
+  readonly onCancel?: () => void;
 
   // Prevent default form action on submit. Defaults to true.
-  preventDefault?: boolean;
+  readonly preventDefault?: boolean;
 
   // Custom validation function. If provided, it will be called in addition to
   // the native HTML form validation. The submit button will be disabled if
   // this function returns false.
-  validation?: () => boolean;
+  readonly validation?: () => boolean;
 }
 
 // A simple wrapper around a <form> element providing some opinionated default
@@ -151,7 +151,7 @@ export class FormLabel implements m.ClassComponent<HTMLLabelAttrs> {
 
 export interface FormRowAttrs extends HTMLAttrs {
   // Number of columns in the grid layout (default: 2)
-  columns?: number;
+  readonly columns?: number;
 }
 
 // A container for placing multiple FormLabel elements side by side in a grid.

--- a/ui/src/widgets/menu.ts
+++ b/ui/src/widgets/menu.ts
@@ -22,28 +22,27 @@ import {Popup, type PopupAttrs, PopupPosition} from './popup';
 
 export interface MenuItemAttrs extends HTMLAttrs {
   // Text to display on the menu button.
-  label: m.Children;
+  readonly label: m.Children;
   // Optional left icon.
-  icon?: string;
+  readonly icon?: string;
   // Optional right icon.
-  rightIcon?: string;
+  readonly rightIcon?: string;
   // Make the item appear greyed out block any interaction with it. No events
   // will be fired.
   // Defaults to false.
-  disabled?: boolean;
+  readonly disabled?: boolean;
   // Always show the button as if the "active" pseudo class were applied, which
   // makes the button look permanently pressed.
   // Useful for when the button represents some toggleable state, such as
   // showing/hiding a popup menu.
   // Defaults to false.
-  active?: boolean;
+  readonly active?: boolean;
   // If this menu item is a descendant of a popup, this setting means that
   // clicking it will result in the popup being dismissed.
   // Defaults to false when menuitem has children, true otherwise.
-  closePopupOnClick?: boolean;
-
+  readonly closePopupOnClick?: boolean;
   // Callback for when the menu is opened (only when the menu item has children).
-  onChange?(isOpen: boolean): void;
+  readonly onChange?: (isOpen: boolean) => void;
 }
 
 // An interactive menu element with an icon.

--- a/ui/src/widgets/middle_ellipsis.ts
+++ b/ui/src/widgets/middle_ellipsis.ts
@@ -16,9 +16,9 @@ import './middle_ellipsis.scss';
 import m from 'mithril';
 
 export interface MiddleEllipsisAttrs {
-  text: string;
-  endChars?: number;
-  className?: string;
+  readonly text: string;
+  readonly endChars?: number;
+  readonly className?: string;
 }
 
 function replaceLeadingTrailingSpacesWithNbsp(text: string) {

--- a/ui/src/widgets/modal.ts
+++ b/ui/src/widgets/modal.ts
@@ -47,26 +47,26 @@ import {Intent} from './common';
 // showModal()/closeModal() are irrelevant in this case.
 
 export interface ModalAttrs {
-  title: string;
-  icon?: string;
-  className?: string;
-  buttons?: ModalButton[];
-  vAlign?: 'MIDDLE' /* default */ | 'TOP';
+  readonly title: string;
+  readonly icon?: string;
+  readonly className?: string;
+  readonly buttons?: ModalButton[];
+  readonly vAlign?: 'MIDDLE' /* default */ | 'TOP';
 
   // Used to disambiguate between different modal dialogs that might overlap
   // due to different client showing modal dialogs at the same time. This needs
   // to match the key passed to closeModal() (if non-undefined). If the key is
   // not provided, showModal will make up a random key in the showModal() call.
-  key?: string;
+  readonly key?: string;
 
   // A callback that is called when the dialog is closed, whether by pressing
   // any buttons or hitting ESC or clicking outside of the modal.
-  onClose?: () => void;
+  readonly onClose?: () => void;
 
   // The content/body of the modal dialog. This can be either:
   // 1. A static set of children, for simple dialogs which content never change.
   // 2. A factory method that returns a m() vnode for dyamic content.
-  content?: m.Children | (() => m.Children);
+  readonly content?: m.Children | (() => m.Children);
 }
 
 export interface ModalButton {

--- a/ui/src/widgets/multiselect.ts
+++ b/ui/src/widgets/multiselect.ts
@@ -42,11 +42,11 @@ export interface MultiSelectDiff {
 }
 
 export interface MultiSelectAttrs {
-  options: MultiSelectOption[];
-  onChange?: (diffs: MultiSelectDiff[]) => void;
-  repeatCheckedItemsAtTop?: boolean;
-  showNumSelected?: boolean;
-  fixedSize?: boolean;
+  readonly options: MultiSelectOption[];
+  readonly onChange?: (diffs: MultiSelectDiff[]) => void;
+  readonly repeatCheckedItemsAtTop?: boolean;
+  readonly showNumSelected?: boolean;
+  readonly fixedSize?: boolean;
   readonly showSelectAllButton?: boolean;
 }
 

--- a/ui/src/widgets/popup.ts
+++ b/ui/src/widgets/popup.ts
@@ -49,33 +49,33 @@ type OnChangeCallback = (shouldOpen: boolean) => void;
 export interface PopupAttrs {
   // Which side of the trigger to place to popup.
   // Defaults to "Auto"
-  position?: PopupPosition;
+  readonly position?: PopupPosition;
   // The element used to open and close the popup, and the target which the near
   // which the popup should hover.
   // Beware this element will have its `onclick`, `ref`, and `active` attributes
   // overwritten.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  trigger: m.Vnode<any, any>;
+  readonly trigger: m.Vnode<any, any>;
   // Close when the escape key is pressed
   // Defaults to true.
-  closeOnEscape?: boolean;
+  readonly closeOnEscape?: boolean;
   // Close on mouse down somewhere other than the popup or trigger.
   // Defaults to true.
-  closeOnOutsideClick?: boolean;
+  readonly closeOnOutsideClick?: boolean;
   // Controls whether the popup is open or not.
   // When provided, the popup operates in controlled mode and will not
   // automatically toggle on trigger clicks. The parent component must
   // handle opening the popup (e.g., via the trigger's onclick handler).
   // When omitted, the popup operates in uncontrolled mode and
   // automatically toggles when the trigger is clicked.
-  isOpen?: boolean;
+  readonly isOpen?: boolean;
   // Called when the popup isOpen state should be changed in controlled mode.
-  onChange?: OnChangeCallback;
+  readonly onChange?: OnChangeCallback;
   // Space delimited class names applied to the popup div.
-  className?: string;
+  readonly className?: string;
   // Whether to show a little arrow pointing to our trigger element.
   // Defaults to true.
-  showArrow?: boolean;
+  readonly showArrow?: boolean;
   // Whether this popup should form a new popup group.
   // When nesting popups, grouping controls how popups are closed.
   // When closing popups via the Escape key, each group is closed one by one,
@@ -83,34 +83,34 @@ export interface PopupAttrs {
   // When using a magic button to close groups (see DISMISS_POPUP_GROUP_CLASS),
   // only the group in which the button lives and it's children will be closed.
   // Defaults to true.
-  createNewGroup?: boolean;
+  readonly createNewGroup?: boolean;
   // Called when the popup mounts, passing the popup's dom element.
-  onPopupMount?: (dom: HTMLElement) => void;
+  readonly onPopupMount?: (dom: HTMLElement) => void;
   // Called when the popup unmounts, padding the popup's dom element.
-  onPopupUnMount?: (dom: HTMLElement) => void;
+  readonly onPopupUnMount?: (dom: HTMLElement) => void;
   // Popup matches the width of the trigger element. Default = false.
-  matchWidth?: boolean;
+  readonly matchWidth?: boolean;
   // Distance in px between the popup and its trigger. Default = 0.
-  offset?: number;
+  readonly offset?: number;
   // Cross-axial popup offset in px. Defaults to 0.
   // When position is *-end or *-start, this setting specifies where start and
   // end is as an offset from the edge of the popup.
   // Positive values move the positioning away from the edge towards the center
   // of the popup.
   // If position is not *-end or *-start, this setting has no effect.
-  edgeOffset?: number;
+  readonly edgeOffset?: number;
   // If true, the popup will not have a maximum width and will instead fit its
   // content. This is useful for popups that have a lot of buttons or other
   // content that should not be constrained by a maximum width.
   // Defaults to false.
-  fitContent?: boolean;
+  readonly fitContent?: boolean;
   // If true, the popup will appear when the trigger is on right clicked rather
   // than when it's left clicked.
-  isContextMenu?: boolean;
+  readonly isContextMenu?: boolean;
   // If true, position the popup at the cursor location rather than the trigger
   // element. When omitted with isContextMenu=true, defaults to true. When omitted
   // with isContextMenu=false, defaults to false.
-  positionAtCursor?: boolean;
+  readonly positionAtCursor?: boolean;
 }
 
 // A popup is a portal whose position is dynamically updated so that it floats

--- a/ui/src/widgets/portal.ts
+++ b/ui/src/widgets/portal.ts
@@ -24,20 +24,20 @@ export interface MountOptions {
 
 export interface PortalAttrs {
   // Space delimited class list forwarded to our portal element.
-  className?: string;
+  readonly className?: string;
   // Inline styles forwarded to our portal element.
-  style?: Style;
+  readonly style?: Style;
   // Called before our portal is created, allowing customization of where in the
   // DOM the portal is mounted.
   // The dom parameter is a dummy element representing where the portal would be
   // located if it were rendered into the normal tree hierarchy.
-  onBeforeContentMount?: (dom: Element) => MountOptions;
+  readonly onBeforeContentMount?: (dom: Element) => MountOptions;
   // Called after our portal is created and its content rendered.
-  onContentMount?: (portalElement: HTMLElement) => void;
+  readonly onContentMount?: (portalElement: HTMLElement) => void;
   // Called after our portal's content is updated.
-  onContentUpdate?: (portalElement: HTMLElement) => void;
+  readonly onContentUpdate?: (portalElement: HTMLElement) => void;
   // Called before our portal is removed.
-  onContentUnmount?: (portalElement: HTMLElement) => void;
+  readonly onContentUnmount?: (portalElement: HTMLElement) => void;
 }
 
 // A portal renders children into a a div outside of the normal hierarchy of the

--- a/ui/src/widgets/resize_handle.ts
+++ b/ui/src/widgets/resize_handle.ts
@@ -19,11 +19,11 @@ import type {MithrilEvent} from '../base/mithril_utils';
 
 export interface ResizeHandleAttrs extends HTMLAttrs {
   // Called with delta (relative change)
-  onResize?(deltaPx: number): void;
+  readonly onResize?: (deltaPx: number) => void;
   // Called with absolute position relative to offsetParent
-  onResizeAbsolute?(positionPx: number): void;
-  onResizeStart?(): void;
-  onResizeEnd?(): void;
+  readonly onResizeAbsolute?: (positionPx: number) => void;
+  readonly onResizeStart?: () => void;
+  readonly onResizeEnd?: () => void;
   // Direction of the resize handle:
   // - 'vertical' (default): horizontal bar that can be dragged up/down
   // - 'horizontal': vertical bar that can be dragged left/right

--- a/ui/src/widgets/section.ts
+++ b/ui/src/widgets/section.ts
@@ -18,9 +18,9 @@ import type {HTMLAttrs} from './common';
 
 export interface SectionAttrs extends Omit<HTMLAttrs, 'title'> {
   // The content of the section header (string or custom content)
-  title: string | m.Children;
+  readonly title: string | m.Children;
   // Optional description/subtitle for the section
-  subtitle?: string;
+  readonly subtitle?: string;
 }
 
 export class Section implements m.ClassComponent<SectionAttrs> {

--- a/ui/src/widgets/sql_ref.ts
+++ b/ui/src/widgets/sql_ref.ts
@@ -22,15 +22,15 @@ import {MenuItem, PopupMenu} from './menu';
 // given a table name and an ID.
 export interface SqlRefAttrs {
   // The name of the table our row lives in.
-  table: string;
+  readonly table: string;
   // The ID of our row.
   // If not provided, `table[Unknown]` is shown with no popup menu.
-  id?: number | bigint;
+  readonly id?: number | bigint;
   // The name of the ID column of the table.
   // If not provided, defaults to 'id'.
-  idColumnName?: string;
+  readonly idColumnName?: string;
   // Optional additional popup menu items.
-  additionalMenuItems?: m.Children;
+  readonly additionalMenuItems?: m.Children;
 }
 
 export class SqlRef implements m.ClassComponent<SqlRefAttrs> {

--- a/ui/src/widgets/tab_strip.ts
+++ b/ui/src/widgets/tab_strip.ts
@@ -30,7 +30,7 @@ export interface TabStripAttrs {
   readonly className?: string;
   readonly tabs: ReadonlyArray<TabOption>;
   readonly currentTabKey: string;
-  onTabChange(key: string): void;
+  readonly onTabChange: (key: string) => void;
 }
 
 /** @deprecated Use {@link Tabs} from `./tabs` instead. */

--- a/ui/src/widgets/tabs.ts
+++ b/ui/src/widgets/tabs.ts
@@ -46,22 +46,25 @@ export interface TabsAttrs {
   // If not provided, the component manages its own state (uncontrolled mode).
   readonly activeTabKey?: string;
   // Called when a tab is clicked.
-  onTabChange?(key: string): void;
+  readonly onTabChange?: (key: string) => void;
   // Called when a tab's close button is clicked.
-  onTabClose?(key: string): void;
+  readonly onTabClose?: (key: string) => void;
   // Called when a tab's title is renamed via inline editing. When set, tabs
   // with a string title become renamable on double-click (tabs with non-string
   // titles are not affected). If the input is cleared (empty after trim) or
   // Escape is pressed, the rename is cancelled and this callback is not fired.
-  onTabRename?(key: string, newTitle: string): void;
+  readonly onTabRename?: (key: string, newTitle: string) => void;
   // Whether tabs can be reordered via drag and drop.
   readonly reorderable?: boolean;
   // Called when tabs are reordered. Receives the key of the dragged tab and
   // the key of the tab it was dropped before (or undefined if dropped at end).
-  onTabReorder?(draggedKey: string, beforeKey: string | undefined): void;
+  readonly onTabReorder?: (
+    draggedKey: string,
+    beforeKey: string | undefined,
+  ) => void;
   // Called when the "new tab" button is clicked. When set, a "+" button is
   // shown at the end of the tab bar.
-  onNewTab?(): void;
+  readonly onNewTab?: () => void;
   // Custom content to render in place of the default "+" button. When set,
   // onNewTab is ignored and this content is rendered instead.
   readonly newTabContent?: m.Children;

--- a/ui/src/widgets/tag_input.ts
+++ b/ui/src/widgets/tag_input.ts
@@ -21,16 +21,16 @@ import {Stack} from './stack';
 import {Icon} from './icon';
 
 export interface TagInputAttrs extends HTMLFocusableAttrs {
-  value?: string;
-  onChange?: (text: string) => void;
-  tags: ReadonlyArray<string>;
-  onTagAdd: (text: string) => void;
-  onTagRemove: (index: number) => void;
-  placeholder?: string;
+  readonly value?: string;
+  readonly onChange?: (text: string) => void;
+  readonly tags: ReadonlyArray<string>;
+  readonly onTagAdd: (text: string) => void;
+  readonly onTagRemove: (index: number) => void;
+  readonly placeholder?: string;
   // Optional icon to display on the left of the text field.
-  leftIcon?: string;
+  readonly leftIcon?: string;
   // Optional custom tag renderer (e.g., to use MiddleEllipsis for label)
-  renderTag?: (text: string, onRemove: () => void) => m.Children;
+  readonly renderTag?: (text: string, onRemove: () => void) => m.Children;
 }
 
 const INPUT_REF = 'input';

--- a/ui/src/widgets/text_paragraph.ts
+++ b/ui/src/widgets/text_paragraph.ts
@@ -18,10 +18,10 @@ import {classNames} from '../base/classnames';
 
 export interface TextParagraphAttrs {
   // Paragraph text.
-  text: string;
+  readonly text: string;
   // Whether to compress multiple spaces (e.g. the string is multi-line but
   // should render with the default UI wrapping)
-  compressSpace?: boolean;
+  readonly compressSpace?: boolean;
 }
 
 export class TextParagraph implements m.ClassComponent<TextParagraphAttrs> {

--- a/ui/src/widgets/tooltip.ts
+++ b/ui/src/widgets/tooltip.ts
@@ -30,35 +30,35 @@ import type {ExtendedModifiers} from './popper_utils';
 export interface TooltipAttrs {
   // Which side of the trigger to place to tooltip.
   // Defaults to "Auto"
-  position?: PopupPosition;
+  readonly position?: PopupPosition;
   // The element used to open and close the tooltip, and to which the tooltip
   // will be anchored. Beware this element will have its `onmouseenter`,
   // `onmouseleave`, `ref` attributes overwritten.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  trigger: m.Vnode<any, any>;
+  readonly trigger: m.Vnode<any, any>;
   // Space delimited class names applied to the tooltip div.
-  className?: string;
+  readonly className?: string;
   // Whether to show a little arrow pointing to our trigger element.
   // Defaults to true.
-  showArrow?: boolean;
+  readonly showArrow?: boolean;
   // Called when the tooltip mounts, passing the tooltip's dom element.
-  onTooltipMount?: (dom: HTMLElement) => void;
+  readonly onTooltipMount?: (dom: HTMLElement) => void;
   // Called when the tooltip unmounts, padding the tooltip's dom element.
-  onTooltipUnMount?: (dom: HTMLElement) => void;
+  readonly onTooltipUnMount?: (dom: HTMLElement) => void;
   // Distance in px between the tooltip and its trigger. Default = 0.
-  offset?: number;
+  readonly offset?: number;
   // Cross-axial tooltip offset in px. Defaults to 0.
   // When position is *-end or *-start, this setting specifies where start and
   // end is as an offset from the edge of the tooltip.
   // Positive values move the positioning away from the edge towards the center
   // of the tooltip.
   // If position is not *-end or *-start, this setting has no effect.
-  edgeOffset?: number;
+  readonly edgeOffset?: number;
   // If true, the tooltip will not have a maximum width and will instead fit its
   // content. This is useful for tooltips that have a lot of buttons or other
   // content that should not be constrained by a maximum width.
   // Defaults to false.
-  fitContent?: boolean;
+  readonly fitContent?: boolean;
 }
 
 // A tooltip is a portal whose position is dynamically updated so that it floats

--- a/ui/src/widgets/track_shell.ts
+++ b/ui/src/widgets/track_shell.ts
@@ -109,19 +109,28 @@ export interface TrackShellAttrs extends HTMLAttrs {
   readonly lite?: boolean;
 
   // Called when the track is expanded or collapsed (when the node is clicked).
-  onCollapsedChanged?(collapsed: boolean): void;
+  readonly onCollapsedChanged?: (collapsed: boolean) => void;
 
   // Mouse events within the track content element.
-  onTrackContentMouseMove?(pos: Point2D, contentSize: Bounds2D): void;
-  onTrackContentMouseOut?(): void;
-  onTrackContentClick?(pos: Point2D, contentSize: Bounds2D): boolean;
-  onTrackContentDoubleClick?(pos: Point2D, contentSize: Bounds2D): boolean;
+  readonly onTrackContentMouseMove?: (
+    pos: Point2D,
+    contentSize: Bounds2D,
+  ) => void;
+  readonly onTrackContentMouseOut?: () => void;
+  readonly onTrackContentClick?: (
+    pos: Point2D,
+    contentSize: Bounds2D,
+  ) => boolean;
+  readonly onTrackContentDoubleClick?: (
+    pos: Point2D,
+    contentSize: Bounds2D,
+  ) => boolean;
 
   // If reorderable, these functions will be called when track shells are
   // dragged and dropped.
-  onMoveBefore?(nodeId: string): void;
-  onMoveInside?(nodeId: string): void;
-  onMoveAfter?(nodeId: string): void;
+  readonly onMoveBefore?: (nodeId: string) => void;
+  readonly onMoveInside?: (nodeId: string) => void;
+  readonly onMoveAfter?: (nodeId: string) => void;
 }
 
 export class TrackShell implements m.ClassComponent<TrackShellAttrs> {

--- a/ui/src/widgets/virtual_overlay_canvas.ts
+++ b/ui/src/widgets/virtual_overlay_canvas.ts
@@ -94,7 +94,7 @@ export interface VirtualOverlayCanvasAttrs extends HTMLAttrs {
 
   // Called when the canvas needs to be repainted due to a layout shift or
   // or resize.
-  onCanvasRedraw?(ctx: VirtualOverlayCanvasDrawContext): void;
+  readonly onCanvasRedraw?: (ctx: VirtualOverlayCanvasDrawContext) => void;
 
   // When true the canvas will not be redrawn on mithril update cycles. Disable
   // this if you want to manage the canvas redraw cycle yourself (i.e. possibly
@@ -105,11 +105,11 @@ export interface VirtualOverlayCanvasAttrs extends HTMLAttrs {
   // Called when the canvas is mounted. The passed api object exposes
   // imperative methods for controlling the canvas. Any returned disposable
   // will be disposed of when the component is removed.
-  onMount?(api: VirtualOverlayCanvasApi): Disposable | void;
+  readonly onMount?: (api: VirtualOverlayCanvasApi) => Disposable | void;
 
   // Override styles from base interface, only allowing object type styles
   // rather than strings.
-  style?: Partial<CSSStyleDeclaration>;
+  readonly style?: Partial<CSSStyleDeclaration>;
 
   // Enable a second canvas for WebGL rendering. When enabled, webglCanvas and
   // webglCtx will be provided in the draw context.


### PR DESCRIPTION
Small code tidy-up - should be a no-op.

- Prepend readonly to all members of *Attrs interfaces under
  ui/src/widgets.
- Convert embedded functions in *Attrs interfaces to arrow functions
  so that they can also be marked readonly.
