### PR TITLE
docs: fix the pprof collection instructions

### DIFF
--- a/docs/getting-started/other-formats.md
+++ b/docs/getting-started/other-formats.md
@@ -1144,16 +1144,24 @@ involves collecting CPU profiles from Go programs or converting `perf.data` file
     `runtime/pprof` package to programmatically collect a profile or use the
     `net/http/pprof` package to expose a profiling endpoint on a running server.
 
-    To collect a profile from a running server, you can use the `go tool pprof`
-    command:
+    To collect a profile from a running server, fetch the profiling endpoint
+    directly:
+
+    ```bash
+    curl -o cpu.pprof 'http://localhost:6060/debug/pprof/profile?seconds=30'
+    ```
+
+    `go tool pprof <url>` collects the same 30-second profile: it saves a copy
+    under `$HOME/pprof/`, prints the path it used and then enters interactive
+    mode. From there, the `proto` command writes the profile out again:
 
     ```bash
     go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+    (pprof) proto >cpu.pprof
     ```
 
-    This will collect a 30-second CPU profile and open it in the pprof tool.
-    You can then save the profile to a file using the `save` command in the
-    pprof tool.
+    The resulting file is gzip-compressed; the Perfetto UI and trace processor
+    read it as-is, without decompressing it first.
 
 2.  **Convert Linux `perf.data` to pprof format:** Use the `perf_to_profile`
     tool from the `perf_data_converter` package.


### PR DESCRIPTION
The "How to Generate" steps for pprof end with:

> This will collect a 30-second CPU profile and open it in the pprof tool. You
> can then save the profile to a file using the `save` command in the pprof
> tool.

`save` is not a pprof command. On Go 1.26.2, against a real `net/http/pprof`
server:

```
(pprof) save
unrecognized command: "save"
```

Two things actually work, and the section now says both:

* `curl -o cpu.pprof 'http://localhost:6060/debug/pprof/profile?seconds=30'` —
  the file imports directly.
* `go tool pprof <url>` already saves the profile before it drops into
  interactive mode and prints where it put it
  (`Saved profile in /Users/…/pprof/pprof.<binary>.samples.cpu.001.pb.gz`), so
  no extra step is needed at all. If you want it somewhere specific, the
  interactive command is `proto`, not `save`:
  `(pprof) proto >cpu.pprof`.

All three files were fed to `trace_processor_shell` and import fine (10-16
samples over a 5-30 s window, 36 callsites), which is also why the section now
mentions that the profile is gzip-compressed and needs no decompression — that
tripped me up first.

The `perf_to_profile` invocation in the same section is correct — upstream's
usage string is
`Usage: perf_to_profile -i <input perf data> -o <output profile> [-f]` — so it
is left untouched. Mentioning it as a control: this section is not wrong
systematically, just in that one sentence.

**Testing:** `tools/run_presubmit` — Succeeded. Docs-only change.
