### PR TITLE
tp: Support dsu_target in linux_devfreq_dsu_counter

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/linux/devfreq.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/devfreq.sql
@@ -61,4 +61,6 @@ CREATE PERFETTO TABLE linux_devfreq_dsu_counter(
 AS
 SELECT id, ts, dur, freq AS dsu_freq FROM _get_devfreq_counters('*devfreq_dsu')
 UNION ALL
-SELECT id, ts, dur, freq AS dsu_freq FROM _get_devfreq_counters('*dsufreq');
+SELECT id, ts, dur, freq AS dsu_freq FROM _get_devfreq_counters('*dsufreq')
+UNION ALL
+SELECT id, ts, dur, freq AS dsu_freq FROM _get_devfreq_counters('*dsu_target');


### PR DESCRIPTION
Add pattern matching for `dsu_target` devfreq devices in linux_devfreq_dsu_counter table. This allows capturing DSU frequency events on newer platforms (e.g. Tensor G6) where the kernel devfreq node is named `dsu_target`.

Test: UI test and SQL test
Bug: 553610666
