### PR TITLE
protozero: let transports read directly into ProtoRingBuffer

### DIFF
--- a/include/perfetto/ext/protozero/proto_ring_buffer.h
+++ b/include/perfetto/ext/protozero/proto_ring_buffer.h
@@ -17,8 +17,10 @@
 #ifndef INCLUDE_PERFETTO_EXT_PROTOZERO_PROTO_RING_BUFFER_H_
 #define INCLUDE_PERFETTO_EXT_PROTOZERO_PROTO_RING_BUFFER_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
+#include "perfetto/base/compiler.h"
 #include "perfetto/ext/base/paged_memory.h"
 
 namespace protozero {
@@ -115,6 +117,44 @@ class RingBufferMessageReader {
   // Will invaildate the pointers previously handed out.
   void Append(const void* data, size_t len);
 
+  // Returned by BeginWrite() and must be given back to EndWrite() (to keep
+  // what was written) or AbortWrite() (to discard it). It enforces that
+  // writes are neither left pending nor interleaved: only one handle can
+  // exist at a time, and letting it go out of scope without passing it to
+  // EndWrite()/AbortWrite() causes a CHECK. The buffer will not recompact or
+  // grow while a handle is outstanding.
+  class WriteHandle {
+   public:
+    WriteHandle() = default;
+    ~WriteHandle();
+
+    WriteHandle(WriteHandle&&) noexcept;
+    WriteHandle& operator=(WriteHandle&&) noexcept;
+    WriteHandle(const WriteHandle&) = delete;
+    WriteHandle& operator=(const WriteHandle&) = delete;
+
+    uint8_t* data() const { return data_; }
+    size_t size() const { return size_; }
+
+    void EndWrite(size_t size_written);
+    void AbortWrite();
+
+    explicit operator bool() const { return reader_ != nullptr; }
+
+   private:
+    friend class RingBufferMessageReader;
+    WriteHandle(RingBufferMessageReader* reader, uint8_t* data, size_t size)
+        : reader_(reader), data_(data), size_(size) {}
+
+    RingBufferMessageReader* reader_ = nullptr;
+    uint8_t* data_ = nullptr;
+    size_t size_ = 0;
+  };
+
+  // Zero-copy counterpart of Append(): the caller reads straight into the
+  // returned reservation (e.g. by passing data() to read(2)).
+  PERFETTO_WARN_UNUSED_RESULT WriteHandle BeginWrite(size_t size);
+
   // If a message can be read, it returns the boundaries of the message
   // (without including the preamble) and advances the read cursor.
   // If no message is available, returns a null range.
@@ -131,11 +171,16 @@ class RingBufferMessageReader {
   virtual Message TryReadMessage(const uint8_t* start, const uint8_t* end) = 0;
 
  private:
+  friend class WriteHandle;
+
+  void FinishWrite(size_t size_written);
+
   perfetto::base::PagedMemory buf_;
   Message fastpath_{};
   bool failed_ = false;  // Set in case of an unrecoverable framing faiulre.
   size_t rd_ = 0;        // Offset of the read cursor in |buf_|.
   size_t wr_ = 0;        // Offset of the write cursor in |buf_|.
+  bool write_in_flight_ = false;
 };
 
 class ProtoRingBuffer final : public RingBufferMessageReader {

--- a/src/protozero/proto_ring_buffer.cc
+++ b/src/protozero/proto_ring_buffer.cc
@@ -16,6 +16,10 @@
 
 #include "perfetto/ext/protozero/proto_ring_buffer.h"
 
+#include <new>
+#include <utility>
+
+#include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/paged_memory.h"
 #include "perfetto/protozero/proto_utils.h"
@@ -76,40 +80,47 @@ RingBufferMessageReader::RingBufferMessageReader()
     : buf_(perfetto::base::PagedMemory::Allocate(kGrowBytes)) {}
 RingBufferMessageReader::~RingBufferMessageReader() = default;
 
-void RingBufferMessageReader::Append(const void* data_void, size_t data_len) {
-  if (failed_)
-    return;
-  const uint8_t* data = static_cast<const uint8_t*>(data_void);
+RingBufferMessageReader::WriteHandle::~WriteHandle() {
+  PERFETTO_CHECK(reader_ == nullptr);
+}
+
+RingBufferMessageReader::WriteHandle::WriteHandle(WriteHandle&& other) noexcept
+    : reader_(other.reader_), data_(other.data_), size_(other.size_) {
+  other.reader_ = nullptr;
+}
+
+RingBufferMessageReader::WriteHandle&
+RingBufferMessageReader::WriteHandle::operator=(WriteHandle&& other) noexcept {
+  this->~WriteHandle();  // CHECKs that any reservation held was consumed.
+  new (this) WriteHandle(std::move(other));
+  return *this;
+}
+
+RingBufferMessageReader::WriteHandle RingBufferMessageReader::BeginWrite(
+    size_t data_len) {
+  PERFETTO_CHECK(data_len <= kMaxMsgSize);
+  // A second reservation could recompact or grow the buffer under the first.
+  PERFETTO_CHECK(!write_in_flight_);
   PERFETTO_DCHECK(wr_ <= buf_.size());
   PERFETTO_DCHECK(wr_ >= rd_);
+
+  // Nothing can be tokenized any more, so recycle the whole buffer for the
+  // bytes EndWrite() is about to drop.
+  if (PERFETTO_UNLIKELY(failed_))
+    rd_ = wr_ = 0;
 
   // If the last call to ReadMessage() consumed all the data in the buffer and
   // there are no incomplete messages pending, restart from the beginning rather
   // than keep ringing. This is the most common case.
-  if (rd_ == wr_)
+  if (PERFETTO_LIKELY(rd_ == wr_))
     rd_ = wr_ = 0;
-
-  // The caller is expected to always issue a ReadMessage() after each Append().
-  PERFETTO_CHECK(!fastpath_.valid());
-  if (rd_ == wr_) {
-    auto msg = TryReadMessage(data, data + data_len);
-    if (msg.valid() && msg.end() == (data + data_len)) {
-      // Fastpath: in many cases, the underlying stream will effectively
-      // preserve the atomicity of messages for most small messages.
-      // In this case we can avoid the extra buf_ roundtrip and just pass a
-      // pointer to |data| + (proto preamble len).
-      // The next call to ReadMessage)= will return |fastpath_|.
-      fastpath_ = std::move(msg);
-      return;
-    }
-  }
 
   size_t avail = buf_.size() - wr_;
   if (data_len > avail) {
     // This whole section should be hit extremely rarely.
 
     // Try first just recompacting the buffer by moving everything to the left.
-    // This can happen if we received "a message and a bit" on each Append call
+    // This can happen if we received "a message and a bit" on each write call
     // so we ended pup in a situation like:
     // buf_: [unused space] [msg1 incomplete]
     //                      ^rd_             ^wr_
@@ -133,21 +144,65 @@ void RingBufferMessageReader::Append(const void* data_void, size_t data_len) {
       while (data_len > new_size - wr_)
         new_size += kGrowBytes;
       if (new_size > kMaxMsgSize * 2) {
+        // These bytes can never amount to a message (e.g. a never-ending
+        // varint). |buf_| exceeds kMaxMsgSize by now, so dropping them leaves
+        // room for the write, which EndWrite() will then discard.
         failed_ = true;
-        return;
+        rd_ = wr_ = 0;
+        write_in_flight_ = true;
+        return WriteHandle(this, static_cast<uint8_t*>(buf_.Get()), data_len);
       }
       auto new_buf = perfetto::base::PagedMemory::Allocate(new_size);
       memcpy(new_buf.Get(), buf_.Get(), buf_.size());
       buf_ = std::move(new_buf);
-      avail = new_size - wr_;
       // No need to touch rd_ / wr_ cursors.
     }
   }
 
-  // Append the received data at the end of the ring buffer.
-  uint8_t* buf = static_cast<uint8_t*>(buf_.Get());
-  memcpy(&buf[wr_], data, data_len);
-  wr_ += data_len;
+  write_in_flight_ = true;
+  return WriteHandle(this, static_cast<uint8_t*>(buf_.Get()) + wr_, data_len);
+}
+
+void RingBufferMessageReader::WriteHandle::EndWrite(size_t size_written) {
+  PERFETTO_CHECK(reader_ != nullptr);
+  PERFETTO_CHECK(size_written <= size_);
+  std::exchange(reader_, nullptr)->FinishWrite(size_written);
+}
+
+void RingBufferMessageReader::WriteHandle::AbortWrite() {
+  PERFETTO_CHECK(reader_ != nullptr);
+  std::exchange(reader_, nullptr)->FinishWrite(0);
+}
+
+void RingBufferMessageReader::FinishWrite(size_t size_written) {
+  write_in_flight_ = false;
+  if (PERFETTO_LIKELY(!failed_))
+    wr_ += size_written;
+}
+
+void RingBufferMessageReader::Append(const void* data_void, size_t data_len) {
+  if (failed_)
+    return;
+  const uint8_t* data = static_cast<const uint8_t*>(data_void);
+
+  // The caller is expected to always issue a ReadMessage() after each Append().
+  PERFETTO_CHECK(!fastpath_.valid());
+  if (rd_ == wr_) {
+    auto msg = TryReadMessage(data, data + data_len);
+    if (msg.valid() && msg.end() == (data + data_len)) {
+      // Fastpath: in many cases, the underlying stream will effectively
+      // preserve the atomicity of messages for most small messages.
+      // In this case we can avoid the extra buf_ roundtrip and just pass a
+      // pointer to |data| + (proto preamble len).
+      // The next call to ReadMessage)= will return |fastpath_|.
+      fastpath_ = std::move(msg);
+      return;
+    }
+  }
+
+  WriteHandle handle = BeginWrite(data_len);
+  memcpy(handle.data(), data, data_len);
+  handle.EndWrite(data_len);
 }
 
 RingBufferMessageReader::Message RingBufferMessageReader::ReadMessage() {

--- a/src/protozero/proto_ring_buffer_unittest.cc
+++ b/src/protozero/proto_ring_buffer_unittest.cc
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#include <algorithm>
+#include <cstring>
 #include <list>
 #include <ostream>
 #include <random>
@@ -262,6 +264,71 @@ TEST(RingBufferTest, FixedLengthRingBuffer) {
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(msg.start),
                         static_cast<size_t>(msg.len)),
             "abc");
+}
+
+// A read(2) can come back short, so EndWrite() may report fewer bytes than
+// BeginWrite() reserved. The tests above always write what they reserve.
+TEST_F(ProtoRingBufferTest, PartialWrites) {
+  ProtoRingBuffer buf;
+  auto expected = MakeProtoMessage(/*field_id=*/7, /*len=*/4096);
+
+  buf.BeginWrite(4096).EndWrite(0);  // The socket had nothing for us.
+  EXPECT_FALSE(buf.ReadMessage().valid());
+
+  for (size_t written = 0; written < last_msg_.size();) {
+    // Reserve far more than we intend to write, as a socket reader would.
+    auto handle = buf.BeginWrite(4096);
+    size_t n = std::min<size_t>(37, last_msg_.size() - written);
+    memcpy(handle.data(), &last_msg_[written], n);
+    handle.EndWrite(n);
+    written += n;
+    if (written < last_msg_.size())
+      ASSERT_FALSE(buf.ReadMessage().valid());
+  }
+  EXPECT_EQ(buf.ReadMessage(), expected);
+}
+
+TEST_F(ProtoRingBufferTest, AbortedWriteKeepsNothing) {
+  ProtoRingBuffer buf;
+  auto expected = MakeProtoMessage(/*field_id=*/7, /*len=*/32);
+
+  auto aborted = buf.BeginWrite(4096);
+  memset(aborted.data(), 0xff, 4096);
+  aborted.AbortWrite();
+  EXPECT_FALSE(buf.ReadMessage().valid());
+
+  auto handle = buf.BeginWrite(last_msg_.size());
+  memcpy(handle.data(), last_msg_.data(), last_msg_.size());
+  handle.EndWrite(last_msg_.size());
+  EXPECT_EQ(buf.ReadMessage(), expected);
+}
+
+TEST_F(ProtoRingBufferTest, MovedHandleCommitsOnce) {
+  ProtoRingBuffer buf;
+  auto expected = MakeProtoMessage(/*field_id=*/7, /*len=*/32);
+
+  auto handle = buf.BeginWrite(last_msg_.size());
+  memcpy(handle.data(), last_msg_.data(), last_msg_.size());
+  auto moved = std::move(handle);
+  EXPECT_FALSE(static_cast<bool>(handle));
+  EXPECT_TRUE(static_cast<bool>(moved));
+  moved.EndWrite(last_msg_.size());
+  EXPECT_EQ(buf.ReadMessage(), expected);
+}
+
+// A stream that can never form a message grows the buffer until the reader
+// gives up. That path used to return without recording the reservation size,
+// so the caller's EndWrite() tripped a CHECK and took the process down.
+TEST_F(ProtoRingBufferTest, GivingUpDoesNotAbort) {
+  ProtoRingBuffer buf;
+  constexpr size_t kChunk = 64 * 1024 * 1024;
+  std::vector<uint8_t> continuation_bytes(kChunk, 0x80);
+  for (int i = 0; i < 4; i++) {
+    auto handle = buf.BeginWrite(kChunk);
+    memcpy(handle.data(), continuation_bytes.data(), kChunk);
+    handle.EndWrite(kChunk);
+    buf.ReadMessage();
+  }
 }
 
 }  // namespace

--- a/src/protozero/test/proto_ring_buffer_benchmark.cc
+++ b/src/protozero/test/proto_ring_buffer_benchmark.cc
@@ -15,11 +15,148 @@
 #include <benchmark/benchmark.h>
 
 #include <algorithm>
+#include <cstring>
 #include <string>
+#include <vector>
 
+#include "perfetto/base/compiler.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/protozero/proto_ring_buffer.h"
+#include "perfetto/protozero/proto_utils.h"
 #include "src/base/test/utils.h"
+
+namespace {
+
+std::string LoadTestTrace() {
+  std::string trace_data;
+  static const char kTestTrace[] = "test/data/example_android_trace_30s.pb";
+  perfetto::base::ReadFile(perfetto::base::GetTestDataPath(kTestTrace),
+                           &trace_data);
+  PERFETTO_CHECK(!trace_data.empty());
+  return trace_data;
+}
+
+// Stands in for the read(2)/recv(2) that brings bytes in from the outside
+// world: like those, it fills a buffer chosen by the caller. That is the one
+// copy no scheme avoids; the benchmarks below differ only in whether the buffer
+// belongs to the transport or to the ring buffer.
+PERFETTO_NO_INLINE void ProduceBytes(void* dst, const void* src, size_t size) {
+  memcpy(dst, src, size);
+}
+
+// Ingestion as the transports used to do it: read into a staging buffer of the
+// transport's own, then hand those bytes to Append(), which copies them again.
+void BM_ProtoRingBufferIngestStaged(benchmark::State& state) {
+  const std::string trace_data = LoadTestTrace();
+  const auto read_size = static_cast<size_t>(state.range(0));
+  std::vector<uint8_t> staging(read_size);
+
+  protozero::ProtoRingBuffer buffer;
+  size_t offset = 0, bytes_ingested = 0, total_packet_size = 0;
+  for (auto _ : state) {
+    size_t n = std::min(read_size, trace_data.size() - offset);
+    ProduceBytes(staging.data(), trace_data.data() + offset, n);
+    buffer.Append(staging.data(), n);
+    // The trace holds whole messages only, so by the time we get back to the
+    // start the buffer has drained and the wrap is seamless.
+    offset = (offset + n) % trace_data.size();
+    bytes_ingested += n;
+    for (;;) {
+      auto msg = buffer.ReadMessage();
+      if (!msg.valid())
+        break;
+      total_packet_size += msg.len;
+    }
+  }
+  benchmark::DoNotOptimize(total_packet_size);
+  state.SetBytesProcessed(static_cast<int64_t>(bytes_ingested));
+}
+
+// Ingestion as they do it now: read straight into the ring buffer, so the bytes
+// are copied exactly once.
+void BM_ProtoRingBufferIngestZeroCopy(benchmark::State& state) {
+  const std::string trace_data = LoadTestTrace();
+  const auto read_size = static_cast<size_t>(state.range(0));
+
+  protozero::ProtoRingBuffer buffer;
+  size_t offset = 0, bytes_ingested = 0, total_packet_size = 0;
+  for (auto _ : state) {
+    size_t n = std::min(read_size, trace_data.size() - offset);
+    auto write = buffer.BeginWrite(n);
+    ProduceBytes(write.data(), trace_data.data() + offset, n);
+    write.EndWrite(n);
+    offset = (offset + n) % trace_data.size();
+    bytes_ingested += n;
+    for (;;) {
+      auto msg = buffer.ReadMessage();
+      if (!msg.valid())
+        break;
+      total_packet_size += msg.len;
+    }
+  }
+  benchmark::DoNotOptimize(total_packet_size);
+  state.SetBytesProcessed(static_cast<int64_t>(bytes_ingested));
+}
+
+// unixd used to tokenize each message out of a per-connection ProtoRingBuffer,
+// re-serialize its TraceProcessorRpcStream preamble, and push preamble +
+// payload through a second ProtoRingBuffer inside Rpc, so every message was
+// copied and tokenized twice. It now reads straight into Rpc's tokenizer.
+void RunDispatch(benchmark::State& state, bool reframe) {
+  namespace pu = protozero::proto_utils;
+  const std::string trace_data = LoadTestTrace();
+  constexpr size_t kReadSize = 4096;
+
+  protozero::ProtoRingBuffer conn_buf, rpc_buf;
+  size_t offset = 0, bytes_ingested = 0, total_packet_size = 0;
+  for (auto _ : state) {
+    size_t n = std::min(kReadSize, trace_data.size() - offset);
+    auto write = conn_buf.BeginWrite(n);
+    ProduceBytes(write.data(), trace_data.data() + offset, n);
+    write.EndWrite(n);
+    offset = (offset + n) % trace_data.size();
+    bytes_ingested += n;
+    for (;;) {
+      auto msg = conn_buf.ReadMessage();
+      if (!msg.valid())
+        break;
+      if (!reframe) {
+        total_packet_size += msg.len;
+        continue;
+      }
+      uint8_t preamble[16];
+      uint8_t* end = preamble;
+      end = pu::WriteVarInt(pu::MakeTagLengthDelimited(1), end);
+      end = pu::WriteVarInt(msg.len, end);
+      rpc_buf.Append(preamble, static_cast<size_t>(end - preamble));
+      rpc_buf.Append(msg.start, msg.len);
+      for (;;) {
+        auto inner = rpc_buf.ReadMessage();
+        if (!inner.valid())
+          break;
+        total_packet_size += inner.len;
+      }
+    }
+  }
+  benchmark::DoNotOptimize(total_packet_size);
+  state.SetBytesProcessed(static_cast<int64_t>(bytes_ingested));
+}
+
+void BM_ProtoRingBufferDispatchReframed(benchmark::State& state) {
+  RunDispatch(state, /*reframe=*/true);
+}
+
+void BM_ProtoRingBufferDispatchDirect(benchmark::State& state) {
+  RunDispatch(state, /*reframe=*/false);
+}
+
+}  // namespace
+
+// 4096 is what the socket transports read; 1MB is what traceconv reads.
+BENCHMARK(BM_ProtoRingBufferIngestStaged)->Arg(4096)->Arg(1024 * 1024);
+BENCHMARK(BM_ProtoRingBufferIngestZeroCopy)->Arg(4096)->Arg(1024 * 1024);
+BENCHMARK(BM_ProtoRingBufferDispatchReframed);
+BENCHMARK(BM_ProtoRingBufferDispatchDirect);
 
 static void BM_ProtoRingBufferReadLargeChunks(benchmark::State& state) {
   std::string trace_data;

--- a/src/trace_processor/rpc/remote_trace_processor.cc
+++ b/src/trace_processor/rpc/remote_trace_processor.cc
@@ -291,9 +291,6 @@ base::Status RemoteTraceProcessor::SendStream(
 }
 
 base::Status RemoteTraceProcessor::ReadResponse(std::vector<uint8_t>* out) {
-  // Hoisted out of the loop: ProtoRingBuffer's fastpath can return a message
-  // pointing into the last buffer passed to Append(), so it must stay alive.
-  uint8_t buf[4096];
   for (;;) {
     auto msg = rxbuf_.ReadMessage();
     if (msg.fatal_framing_error)
@@ -302,10 +299,16 @@ base::Status RemoteTraceProcessor::ReadResponse(std::vector<uint8_t>* out) {
       out->assign(msg.start, msg.start + msg.len);
       return base::OkStatus();
     }
-    ASSIGN_OR_RETURN(size_t n, transport_->Recv(buf, sizeof(buf)));
-    if (n == 0)
+    constexpr size_t kReadSize = 4096;
+    auto handle = rxbuf_.BeginWrite(kReadSize);
+    base::StatusOr<size_t> n = transport_->Recv(handle.data(), handle.size());
+    if (!n.ok()) {
+      handle.AbortWrite();
+      return n.status();
+    }
+    handle.EndWrite(*n);
+    if (*n == 0)
       return base::ErrStatus("Session closed the connection");
-    rxbuf_.Append(buf, n);
   }
 }
 

--- a/src/trace_processor/rpc/rpc.cc
+++ b/src/trace_processor/rpc/rpc.cc
@@ -253,6 +253,54 @@ void Rpc::ResetTraceProcessorInternal(const Config& config) {
 
 void Rpc::OnRpcRequest(const void* data, size_t len) {
   rxbuf_.Append(data, len);
+  DrainRxBuf();
+}
+
+Rpc::RequestHandle::~RequestHandle() {
+  PERFETTO_CHECK(rpc_ == nullptr);
+}
+
+Rpc::RequestHandle::RequestHandle(RequestHandle&& other) noexcept
+    : rpc_(other.rpc_), write_(std::move(other.write_)) {
+  other.rpc_ = nullptr;
+}
+
+Rpc::RequestHandle& Rpc::RequestHandle::operator=(
+    RequestHandle&& other) noexcept {
+  this->~RequestHandle();  // CHECKs that any reservation held was consumed.
+  new (this) RequestHandle(std::move(other));
+  return *this;
+}
+
+void Rpc::RequestHandle::EndRequest(size_t size_written) {
+  PERFETTO_CHECK(rpc_ != nullptr);
+  Rpc* rpc = std::exchange(rpc_, nullptr);
+  write_.EndWrite(size_written);
+  rpc->FinishRpcRequest();
+  rpc->DrainRxBuf();
+}
+
+void Rpc::RequestHandle::AbortRequest() {
+  PERFETTO_CHECK(rpc_ != nullptr);
+  write_.AbortWrite();
+  std::exchange(rpc_, nullptr)->FinishRpcRequest();
+}
+
+Rpc::RequestHandle Rpc::BeginRpcRequest(size_t size) {
+  // The handle keeps the caller from losing a reservation, but not from
+  // holding two at once. The ring buffer has the same guard for its own
+  // handles; this one is here so the CHECK fires at the Rpc API boundary.
+  PERFETTO_CHECK(!request_in_flight_);
+  request_in_flight_ = true;
+  return RequestHandle(this, rxbuf_.BeginWrite(size));
+}
+
+void Rpc::FinishRpcRequest() {
+  PERFETTO_CHECK(request_in_flight_);
+  request_in_flight_ = false;
+}
+
+void Rpc::DrainRxBuf() {
   for (;;) {
     auto msg = rxbuf_.ReadMessage();
     if (!msg.valid()) {

--- a/src/trace_processor/rpc/rpc.h
+++ b/src/trace_processor/rpc/rpc.h
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 
+#include "perfetto/base/compiler.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/protozero/proto_ring_buffer.h"
@@ -80,12 +81,46 @@ class Rpc {
   // exchanged on these pipes are TraceProcessorRpc protos (defined in
   // trace_processor.proto). This has been introduced in Perfetto v15.
 
+  // A reservation inside the tokenizer for a transport to read into. Must be
+  // consumed exactly once: EndRequest() reports how many bytes were written
+  // and dispatches whatever messages completed, AbortRequest() discards it;
+  // dropping one fails a CHECK.
+  class RequestHandle {
+   public:
+    RequestHandle() = default;
+    ~RequestHandle();
+
+    RequestHandle(RequestHandle&&) noexcept;
+    RequestHandle& operator=(RequestHandle&&) noexcept;
+    RequestHandle(const RequestHandle&) = delete;
+    RequestHandle& operator=(const RequestHandle&) = delete;
+
+    uint8_t* data() const { return write_.data(); }
+    size_t size() const { return write_.size(); }
+
+    void EndRequest(size_t size_written);
+    void AbortRequest();
+
+    explicit operator bool() const { return rpc_ != nullptr; }
+
+   private:
+    friend class Rpc;
+    RequestHandle(Rpc* rpc, protozero::ProtoRingBuffer::WriteHandle write)
+        : rpc_(rpc), write_(std::move(write)) {}
+
+    Rpc* rpc_ = nullptr;
+    protozero::ProtoRingBuffer::WriteHandle write_;
+  };
+
   // Pushes data received by the RPC channel into the parser. Inbound messages
-  // are tokenized and turned into TraceProcessor method invocations. |data|
-  // does not need to be a whole TraceProcessorRpc message. It can be a portion
+  // are tokenized and turned into TraceProcessor method invocations. The bytes
+  // do not need to be a whole TraceProcessorRpc message: they can be a portion
   // of it or a union of >1 messages.
+  // OnRpcRequest() is the copying equivalent, for transports that cannot read
+  // into the reservation directly.
   // Responses are sent throught the RpcResponseFunction (below).
   void OnRpcRequest(const void* data, size_t len);
+  PERFETTO_WARN_UNUSED_RESULT RequestHandle BeginRpcRequest(size_t size);
 
   // The size argument is a uint32_t and not size_t to avoid ABI mismatches
   // with Wasm, where size_t = uint32_t.
@@ -151,6 +186,7 @@ class Rpc {
   base::Status ExportSqlite(const ExportCallback&);
 
   void ParseRpcRequest(const uint8_t*, size_t);
+  void DrainRxBuf();
   void ResetTraceProcessor(const uint8_t*, size_t);
   base::Status RegisterSqlPackage(protozero::ConstBytes);
   void ResetTraceProcessorInternal(const Config&);
@@ -164,6 +200,7 @@ class Rpc {
                                    protos::pbzero::TraceSummaryResult*);
   void DisableAndReadMetatraceInternal(
       protos::pbzero::DisableAndReadMetatraceResult*);
+  void FinishRpcRequest();
 
   Config default_config_;
   TraceProcessor::PlatformInterface* platform_ = nullptr;
@@ -173,6 +210,7 @@ class Rpc {
   std::unique_ptr<TraceProcessor> trace_processor_;
   RpcResponseFunction rpc_response_fn_;
   protozero::ProtoRingBuffer rxbuf_;
+  bool request_in_flight_ = false;
   int64_t tx_seq_id_ = 0;
   int64_t rx_seq_id_ = 0;
   bool eof_ = false;

--- a/src/trace_processor/rpc/stdiod.cc
+++ b/src/trace_processor/rpc/stdiod.cc
@@ -38,13 +38,14 @@
 namespace perfetto::trace_processor {
 
 base::Status RunStdioRpcServer(Rpc& rpc) {
-  char buffer[4096];
+  constexpr size_t kReadSize = 4096;
   for (;;) {
-    auto ret = base::Read(STDIN_FILENO, buffer, base::ArraySize(buffer));
-    if (ret == -1) {
-      return base::ErrStatus("Failed while reading the buffer");
-    }
-    if (ret == 0) {
+    Rpc::RequestHandle req = rpc.BeginRpcRequest(kReadSize);
+    auto ret = base::Read(STDIN_FILENO, req.data(), req.size());
+    if (ret <= 0) {
+      req.AbortRequest();
+      if (ret == -1)
+        return base::ErrStatus("Failed while reading the buffer");
       return base::OkStatus();
     }
     rpc.SetRpcResponseFunction([](const void* ptr, uint32_t size) {
@@ -53,7 +54,7 @@ base::Status RunStdioRpcServer(Rpc& rpc) {
         PERFETTO_FATAL("Failed to write response");
       }
     });
-    rpc.OnRpcRequest(buffer, static_cast<size_t>(ret));
+    req.EndRequest(static_cast<size_t>(ret));
     rpc.SetRpcResponseFunction(nullptr);
   }
 }

--- a/src/trace_processor/rpc/unixd.cc
+++ b/src/trace_processor/rpc/unixd.cc
@@ -32,8 +32,6 @@
 #include "perfetto/ext/base/lock_free_task_runner.h"
 #include "perfetto/ext/base/unix_socket.h"
 #include "perfetto/ext/base/utils.h"
-#include "perfetto/ext/protozero/proto_ring_buffer.h"
-#include "perfetto/protozero/proto_utils.h"
 #include "src/trace_processor/rpc/rpc.h"
 #include "src/trace_processor/rpc/session_lifecycle.h"
 #include "src/trace_processor/rpc/session_paths.h"
@@ -120,11 +118,9 @@ class UnixRpcServer : public base::UnixSocket::EventListener {
  private:
   struct ClientConn {
     std::unique_ptr<base::UnixSocket> sock;
-    protozero::ProtoRingBuffer rxbuf;
   };
 
   ClientConn* FindConn(base::UnixSocket* self);
-  void DispatchMessage(base::UnixSocket* sock, const uint8_t* data, size_t len);
   void Shutdown();
 
   Rpc& rpc_;
@@ -291,54 +287,33 @@ UnixRpcServer::ClientConn* UnixRpcServer::FindConn(base::UnixSocket* self) {
 }
 
 void UnixRpcServer::OnDataAvailable(base::UnixSocket* self) {
-  ClientConn* conn = FindConn(self);
-  if (!conn)
+  if (!FindConn(self))
     return;
-
-  // Drain everything currently readable into this connection's framing buffer.
-  char buf[4096];
-  for (;;) {
-    size_t n = self->Receive(buf, sizeof(buf));
-    if (n == 0)
-      break;
-    conn->rxbuf.Append(buf, n);
-  }
-
-  // Forward only *whole* TraceProcessorRpc messages to the shared Rpc. Each is
-  // re-wrapped in its TraceProcessorRpcStream framing so Rpc's own tokenizer
-  // never sees a partial frame, even if a different connection disconnects
-  // mid-message.
-  for (;;) {
-    auto msg = conn->rxbuf.ReadMessage();
-    if (!msg.valid()) {
-      if (msg.fatal_framing_error)
-        self->Shutdown(/*notify=*/false);
-      break;
-    }
-    DispatchMessage(self, msg.start, msg.len);
-  }
-}
-
-void UnixRpcServer::DispatchMessage(base::UnixSocket* sock,
-                                    const uint8_t* data,
-                                    size_t len) {
-  namespace pu = protozero::proto_utils;
-  uint8_t preamble[16];
-  uint8_t* preamble_end = preamble;
-  preamble_end = pu::WriteVarInt(pu::MakeTagLengthDelimited(1), preamble_end);
-  preamble_end = pu::WriteVarInt(len, preamble_end);
 
   if (reaper_)
     reaper_->set_query_in_flight(true);
-  rpc_.SetRpcResponseFunction([sock](const void* resp, uint32_t resp_len) {
+
+  // A framing error makes Rpc emit a fatal_error message and then call the
+  // response function with nullptr, which tears the connection down below.
+  rpc_.SetRpcResponseFunction([self](const void* resp, uint32_t resp_len) {
     if (resp == nullptr) {
-      sock->Shutdown(/*notify=*/false);
+      self->Shutdown(/*notify=*/false);
       return;
     }
-    sock->Send(resp, resp_len);
+    self->Send(resp, resp_len);
   });
-  rpc_.OnRpcRequest(preamble, static_cast<size_t>(preamble_end - preamble));
-  rpc_.OnRpcRequest(data, len);
+
+  // A session serves one client at a time, so no second byte stream can
+  // interleave with this one inside Rpc's tokenizer.
+  for (;;) {
+    constexpr size_t kReadSize = 4096;
+    Rpc::RequestHandle req = rpc_.BeginRpcRequest(kReadSize);
+    size_t rx_bytes = self->Receive(req.data(), req.size());
+    req.EndRequest(rx_bytes);
+    if (rx_bytes == 0)
+      break;
+  }
+
   rpc_.SetRpcResponseFunction(nullptr);
   if (reaper_) {
     reaper_->set_query_in_flight(false);

--- a/src/traceconv/trace_to_text.cc
+++ b/src/traceconv/trace_to_text.cc
@@ -59,7 +59,13 @@ class OnlineTraceToText {
   }
   OnlineTraceToText(const OnlineTraceToText&) = delete;
   OnlineTraceToText& operator=(const OnlineTraceToText&) = delete;
-  void Feed(const uint8_t* data, size_t len);
+  uint8_t* BeginWrite(size_t size) {
+    pending_write_ = ring_buffer_.BeginWrite(size);
+    return pending_write_.data();
+  }
+  void EndWrite(size_t size_written);
+  void AbortWrite() { pending_write_.AbortWrite(); }
+
   bool ok() const { return ok_; }
   const std::string& error() const { return error_; }
 
@@ -73,6 +79,7 @@ class OnlineTraceToText {
   std::string error_;
   std::ostream* output_;
   protozero::ProtoRingBuffer ring_buffer_;
+  protozero::ProtoRingBuffer::WriteHandle pending_write_;
   DescriptorPool pool_;
   size_t bytes_processed_ = 0;
   size_t packet_ = 0;
@@ -124,8 +131,8 @@ void OnlineTraceToText::PrintCompressedPackets(protozero::ConstBytes packets,
   WriteToOutput(output_, "}\n");
 }
 
-void OnlineTraceToText::Feed(const uint8_t* data, size_t len) {
-  ring_buffer_.Append(data, static_cast<size_t>(len));
+void OnlineTraceToText::EndWrite(size_t size_written) {
+  pending_write_.EndWrite(size_written);
   while (true) {
     auto token = ring_buffer_.ReadMessage();
     if (token.fatal_framing_error) {
@@ -197,16 +204,23 @@ class InputReader {
 base::Status TraceToText(std::istream* input,
                          std::ostream* output,
                          const TraceToTextOptions& options) {
-  constexpr size_t kMaxMsgSize = protozero::ProtoRingBuffer::kMaxMsgSize;
-  std::unique_ptr<uint8_t[]> buffer(new uint8_t[kMaxMsgSize]);
+  constexpr uint32_t kReadSize = 1024 * 1024;
+  std::unique_ptr<uint8_t[]> buffer(new uint8_t[kReadSize]);
   uint32_t buffer_len = 0;
 
   InputReader input_reader(input);
   OnlineTraceToText online_trace_to_text(output, options);
 
-  input_reader.Read(buffer.get(), &buffer_len, kMaxMsgSize);
+  // Sniff the first chunk inside the tokenizer's own buffer, so a proto trace
+  // is never copied. Only a compressed one moves to the decompressor's input.
+  uint8_t* first = online_trace_to_text.BeginWrite(kReadSize);
+  input_reader.Read(first, &buffer_len, kReadSize);
   trace_processor::CompressedTraceType type =
-      trace_processor::SniffCompressedTraceType(buffer.get(), buffer_len);
+      trace_processor::SniffCompressedTraceType(first, buffer_len);
+  if (type != trace_processor::CompressedTraceType::kProto) {
+    memcpy(buffer.get(), first, buffer_len);
+    online_trace_to_text.AbortWrite();
+  }
 
   if (type == trace_processor::CompressedTraceType::kGzip ||
       type == trace_processor::CompressedTraceType::kZstd) {
@@ -224,7 +238,7 @@ base::Status TraceToText(std::istream* input,
     }
 
     using ResultCode = util::Decompressor::ResultCode;
-    uint8_t out[4096];
+    constexpr size_t kExtractSize = 4096;
     ResultCode code = ResultCode::kNeedsMoreInput;
     do {
       // A frame that ended right at the previous chunk's edge means this chunk
@@ -234,14 +248,15 @@ base::Status TraceToText(std::istream* input,
 
       decompressor->Feed(buffer.get(), buffer_len);
       for (;;) {
-        auto res = decompressor->ExtractOutput(out, sizeof(out));
+        auto res = decompressor->ExtractOutput(
+            online_trace_to_text.BeginWrite(kExtractSize), kExtractSize);
         if (res.ret == ResultCode::kError) {
+          online_trace_to_text.AbortWrite();
           EndProgressLine();
           return base::ErrStatus(
               "failed to decompress, trace is likely corrupt");
         }
-        if (res.bytes_written > 0)
-          online_trace_to_text.Feed(out, res.bytes_written);
+        online_trace_to_text.EndWrite(res.bytes_written);
         if (!online_trace_to_text.ok()) {
           EndProgressLine();
           return base::ErrStatus("failed to convert trace to text: %s",
@@ -262,7 +277,7 @@ base::Status TraceToText(std::istream* input,
       // At EOF, Read() returns true once more with buffer_len == 0; stop rather
       // than feed an empty chunk, which would flip `code` off kEof and be
       // misread as a truncated stream below.
-    } while (input_reader.Read(buffer.get(), &buffer_len, kMaxMsgSize) &&
+    } while (input_reader.Read(buffer.get(), &buffer_len, kReadSize) &&
              buffer_len > 0);
 
     if (code != ResultCode::kEof) {
@@ -279,13 +294,14 @@ base::Status TraceToText(std::istream* input,
     return base::OkStatus();
   } else if (type == trace_processor::CompressedTraceType::kProto) {
     do {
-      online_trace_to_text.Feed(buffer.get(), buffer_len);
+      online_trace_to_text.EndWrite(buffer_len);
       if (!online_trace_to_text.ok()) {
         EndProgressLine();
         return base::ErrStatus("failed to convert trace to text: %s",
                                online_trace_to_text.error().c_str());
       }
-    } while (input_reader.Read(buffer.get(), &buffer_len, kMaxMsgSize));
+    } while (input_reader.Read(online_trace_to_text.BeginWrite(kReadSize),
+                               &buffer_len, kReadSize));
     if (!input_reader.ok()) {
       EndProgressLine();
       return base::ErrStatus("failed to read trace: %s",


### PR DESCRIPTION
Every transport kept a staging buffer, read into it, then handed those
bytes to Append(), which copied them again. BeginWrite()/EndWrite() lets
read(2) deposit them in the ring buffer directly, so they are copied
once.

The reservation is handed out as a move-only WriteHandle that must be
consumed exactly once, by EndWrite() to keep what was written or
AbortWrite() to discard it; dropping one fails a CHECK. Holding it in a
value the compiler tracks is what makes the pattern safe to use: the
buffer refuses to recompact, grow or hand out a second reservation while
one is outstanding, so bytes cannot move under a pointer someone still
holds. Rpc::RequestHandle carries the same contract out to the
transports.

```
  out/linux_clang_release/perfetto_benchmarks \
      --benchmark_filter='ProtoRingBufferIngest|ProtoRingBufferDispatch'
  ingest, 4KB reads    142 ns -> 98.3 ns
  ingest, 1MB reads   38.4 us -> 19.2 us
  dispatch             171 ns -> 99.1 ns
```

traceconv also drops a 64MB read buffer: peak RSS 62.7MB -> 13.6MB.

