### PR TITLE
protozero: remove Append() and its fastpath

### DIFF
--- a/include/perfetto/ext/protozero/proto_ring_buffer.h
+++ b/include/perfetto/ext/protozero/proto_ring_buffer.h
@@ -44,7 +44,8 @@ namespace protozero {
 //
 // This class maintains inbound requests in a ring buffer.
 // The expected usage is:
-// ring_buf.Append(data, len);
+// auto write = ring_buf.BeginWrite(len);
+// write.EndWrite(read(fd, write.data(), write.size()));
 // for (;;) {
 //   auto msg = ring_buf.ReadMessage();
 //   if (!msg.valid())
@@ -52,9 +53,9 @@ namespace protozero {
 //   Decode(msg);
 // }
 //
-// After each call to Append, the caller is expected to call ReadMessage() until
+// After each write, the caller is expected to call ReadMessage() until
 // it returns an invalid message (signalling no more messages could be decoded).
-// Note that a single Append can "unblock" > 1 messages, which is why the caller
+// Note that a single write can "unblock" > 1 messages, which is why the caller
 // needs to keep calling ReadMessage in a loop.
 //
 // Internal architecture
@@ -62,14 +63,14 @@ namespace protozero {
 // Internally this is similar to a ring-buffer, with the caveat that it never
 // wraps, it only expands. Expansions are rare. The deal is that in most cases
 // the read cursor follows very closely the write cursor. For instance, if the
-// underlying transport behaves as a dgram socket, after each Append, the read
+// underlying transport behaves as a dgram socket, after each write, the read
 // cursor will chase completely the write cursor. Even if the underlying stream
 // is not always atomic, the expectation is that the read cursor will eventually
 // reach the write one within few messages.
 // A visual example, imagine we have four messages: 2it 4will 2be 4fine
 // Visually:
 //
-// Append("2it4wi"): A message and a bit:
+// Write("2it4wi"): A message and a bit:
 // [ 2it 4wi                     ]
 // ^R       ^W
 //
@@ -77,14 +78,14 @@ namespace protozero {
 // [ 2it 4wi                     ]
 //      ^R ^W
 //
-// Append("ll2be4f")
+// Write("ll2be4f")
 // [ 2it 4will 2be 4f            ]
 //      ^R           ^W
 //
 // After the ReadMessage() loop:
 // [ 2it 4will 2be 4f            ]
 //                ^R ^W
-// Append("ine")
+// Write("ine")
 // [ 2it 4will 2be 4fine         ]
 //                ^R    ^W
 //
@@ -96,7 +97,7 @@ namespace protozero {
 // Given that each message is expected to be at most kMaxMsgSize (64 MB), the
 // expansion is bound at 2 * kMaxMsgSize.
 
-class RingBufferMessageReader {
+class ProtoRingBuffer {
  public:
   static constexpr size_t kMaxMsgSize = 64 * 1024 * 1024;
   struct Message {
@@ -108,14 +109,10 @@ class RingBufferMessageReader {
     inline bool valid() const { return !!start; }
   };
 
-  RingBufferMessageReader();
-  virtual ~RingBufferMessageReader();
-  RingBufferMessageReader(const RingBufferMessageReader&) = delete;
-  RingBufferMessageReader& operator=(const RingBufferMessageReader&) = delete;
-
-  // Appends data into the ring buffer, recompacting or resizing it if needed.
-  // Will invaildate the pointers previously handed out.
-  void Append(const void* data, size_t len);
+  ProtoRingBuffer();
+  ~ProtoRingBuffer();
+  ProtoRingBuffer(const ProtoRingBuffer&) = delete;
+  ProtoRingBuffer& operator=(const ProtoRingBuffer&) = delete;
 
   // Returned by BeginWrite() and must be given back to EndWrite() (to keep
   // what was written) or AbortWrite() (to discard it). It enforces that
@@ -139,36 +136,32 @@ class RingBufferMessageReader {
     void EndWrite(size_t size_written);
     void AbortWrite();
 
-    explicit operator bool() const { return reader_ != nullptr; }
+    explicit operator bool() const { return buffer_ != nullptr; }
 
    private:
-    friend class RingBufferMessageReader;
-    WriteHandle(RingBufferMessageReader* reader, uint8_t* data, size_t size)
-        : reader_(reader), data_(data), size_(size) {}
+    friend class ProtoRingBuffer;
+    WriteHandle(ProtoRingBuffer* buffer, uint8_t* data, size_t size)
+        : buffer_(buffer), data_(data), size_(size) {}
 
-    RingBufferMessageReader* reader_ = nullptr;
+    ProtoRingBuffer* buffer_ = nullptr;
     uint8_t* data_ = nullptr;
     size_t size_ = 0;
   };
 
-  // Zero-copy counterpart of Append(): the caller reads straight into the
-  // returned reservation (e.g. by passing data() to read(2)).
+  // The caller reads straight into the reservation (e.g. by passing data() to
+  // read(2)).
   PERFETTO_WARN_UNUSED_RESULT WriteHandle BeginWrite(size_t size);
 
   // If a message can be read, it returns the boundaries of the message
   // (without including the preamble) and advances the read cursor.
   // If no message is available, returns a null range.
-  // The returned pointer is only valid until the next call to Append(), as
-  // that can recompact or resize the underlying buffer.
+  // The returned pointer is only valid until the next call to BeginWrite(),
+  // as that can recompact or resize the underlying buffer.
   Message ReadMessage();
 
   // Exposed for testing.
   size_t capacity() const { return buf_.size(); }
   size_t avail() const { return buf_.size() - (wr_ - rd_); }
-
- protected:
-  // Subclasses must implement the header parsing.
-  virtual Message TryReadMessage(const uint8_t* start, const uint8_t* end) = 0;
 
  private:
   friend class WriteHandle;
@@ -176,21 +169,10 @@ class RingBufferMessageReader {
   void FinishWrite(size_t size_written);
 
   perfetto::base::PagedMemory buf_;
-  Message fastpath_{};
   bool failed_ = false;  // Set in case of an unrecoverable framing faiulre.
   size_t rd_ = 0;        // Offset of the read cursor in |buf_|.
   size_t wr_ = 0;        // Offset of the write cursor in |buf_|.
   bool write_in_flight_ = false;
-};
-
-class ProtoRingBuffer final : public RingBufferMessageReader {
- public:
-  ProtoRingBuffer();
-  ~ProtoRingBuffer() override final;
-
- protected:
-  Message TryReadMessage(const uint8_t* start,
-                         const uint8_t* end) override final;
 };
 
 }  // namespace protozero

--- a/src/protozero/proto_ring_buffer.cc
+++ b/src/protozero/proto_ring_buffer.cc
@@ -76,28 +76,27 @@ ProtoRingBuffer::Message TryReadProtoMessage(const uint8_t* start,
 
 }  // namespace
 
-RingBufferMessageReader::RingBufferMessageReader()
+ProtoRingBuffer::ProtoRingBuffer()
     : buf_(perfetto::base::PagedMemory::Allocate(kGrowBytes)) {}
-RingBufferMessageReader::~RingBufferMessageReader() = default;
+ProtoRingBuffer::~ProtoRingBuffer() = default;
 
-RingBufferMessageReader::WriteHandle::~WriteHandle() {
-  PERFETTO_CHECK(reader_ == nullptr);
+ProtoRingBuffer::WriteHandle::~WriteHandle() {
+  PERFETTO_CHECK(buffer_ == nullptr);
 }
 
-RingBufferMessageReader::WriteHandle::WriteHandle(WriteHandle&& other) noexcept
-    : reader_(other.reader_), data_(other.data_), size_(other.size_) {
-  other.reader_ = nullptr;
+ProtoRingBuffer::WriteHandle::WriteHandle(WriteHandle&& other) noexcept
+    : buffer_(other.buffer_), data_(other.data_), size_(other.size_) {
+  other.buffer_ = nullptr;
 }
 
-RingBufferMessageReader::WriteHandle&
-RingBufferMessageReader::WriteHandle::operator=(WriteHandle&& other) noexcept {
+ProtoRingBuffer::WriteHandle& ProtoRingBuffer::WriteHandle::operator=(
+    WriteHandle&& other) noexcept {
   this->~WriteHandle();  // CHECKs that any reservation held was consumed.
   new (this) WriteHandle(std::move(other));
   return *this;
 }
 
-RingBufferMessageReader::WriteHandle RingBufferMessageReader::BeginWrite(
-    size_t data_len) {
+ProtoRingBuffer::WriteHandle ProtoRingBuffer::BeginWrite(size_t data_len) {
   PERFETTO_CHECK(data_len <= kMaxMsgSize);
   // A second reservation could recompact or grow the buffer under the first.
   PERFETTO_CHECK(!write_in_flight_);
@@ -163,59 +162,30 @@ RingBufferMessageReader::WriteHandle RingBufferMessageReader::BeginWrite(
   return WriteHandle(this, static_cast<uint8_t*>(buf_.Get()) + wr_, data_len);
 }
 
-void RingBufferMessageReader::WriteHandle::EndWrite(size_t size_written) {
-  PERFETTO_CHECK(reader_ != nullptr);
+void ProtoRingBuffer::WriteHandle::EndWrite(size_t size_written) {
+  PERFETTO_CHECK(buffer_ != nullptr);
   PERFETTO_CHECK(size_written <= size_);
-  std::exchange(reader_, nullptr)->FinishWrite(size_written);
+  ProtoRingBuffer* buffer = buffer_;
+  buffer_ = nullptr;
+  buffer->FinishWrite(size_written);
 }
 
-void RingBufferMessageReader::WriteHandle::AbortWrite() {
-  PERFETTO_CHECK(reader_ != nullptr);
-  std::exchange(reader_, nullptr)->FinishWrite(0);
+void ProtoRingBuffer::WriteHandle::AbortWrite() {
+  PERFETTO_CHECK(buffer_ != nullptr);
+  ProtoRingBuffer* buffer = buffer_;
+  buffer_ = nullptr;
+  buffer->FinishWrite(0);
 }
 
-void RingBufferMessageReader::FinishWrite(size_t size_written) {
+void ProtoRingBuffer::FinishWrite(size_t size_written) {
   write_in_flight_ = false;
   if (PERFETTO_LIKELY(!failed_))
     wr_ += size_written;
 }
 
-void RingBufferMessageReader::Append(const void* data_void, size_t data_len) {
-  if (failed_)
-    return;
-  const uint8_t* data = static_cast<const uint8_t*>(data_void);
-
-  // The caller is expected to always issue a ReadMessage() after each Append().
-  PERFETTO_CHECK(!fastpath_.valid());
-  if (rd_ == wr_) {
-    auto msg = TryReadMessage(data, data + data_len);
-    if (msg.valid() && msg.end() == (data + data_len)) {
-      // Fastpath: in many cases, the underlying stream will effectively
-      // preserve the atomicity of messages for most small messages.
-      // In this case we can avoid the extra buf_ roundtrip and just pass a
-      // pointer to |data| + (proto preamble len).
-      // The next call to ReadMessage)= will return |fastpath_|.
-      fastpath_ = std::move(msg);
-      return;
-    }
-  }
-
-  WriteHandle handle = BeginWrite(data_len);
-  memcpy(handle.data(), data, data_len);
-  handle.EndWrite(data_len);
-}
-
-RingBufferMessageReader::Message RingBufferMessageReader::ReadMessage() {
+ProtoRingBuffer::Message ProtoRingBuffer::ReadMessage() {
   if (failed_)
     return FramingError();
-
-  if (fastpath_.valid()) {
-    // The fastpath can only be hit when the buffer is empty.
-    PERFETTO_CHECK(rd_ == wr_);
-    auto msg = std::move(fastpath_);
-    fastpath_ = Message{};
-    return msg;
-  }
 
   uint8_t* buf = static_cast<uint8_t*>(buf_.Get());
 
@@ -223,7 +193,7 @@ RingBufferMessageReader::Message RingBufferMessageReader::ReadMessage() {
   if (rd_ >= wr_)
     return Message{};  // Completely empty.
 
-  auto msg = TryReadMessage(&buf[rd_], &buf[wr_]);
+  auto msg = TryReadProtoMessage(&buf[rd_], &buf[wr_]);
   if (!msg.valid()) {
     failed_ = failed_ || msg.fatal_framing_error;
     return msg;  // Return |msg| because it could be a framing error.
@@ -234,14 +204,6 @@ RingBufferMessageReader::Message RingBufferMessageReader::ReadMessage() {
   auto msg_outer_len = static_cast<size_t>(msg_end - &buf[rd_]);
   rd_ += msg_outer_len;
   return msg;
-}
-
-ProtoRingBuffer::ProtoRingBuffer() = default;
-ProtoRingBuffer::~ProtoRingBuffer() = default;
-
-ProtoRingBuffer::Message ProtoRingBuffer::TryReadMessage(const uint8_t* start,
-                                                         const uint8_t* end) {
-  return TryReadProtoMessage(start, end);
 }
 
 }  // namespace protozero

--- a/src/protozero/proto_ring_buffer_unittest.cc
+++ b/src/protozero/proto_ring_buffer_unittest.cc
@@ -63,6 +63,12 @@ using ::perfetto::base::ArraySize;
 
 constexpr uint32_t kMaxMsgSize = ProtoRingBuffer::kMaxMsgSize;
 
+void Write(ProtoRingBuffer* buf, const void* data, size_t len) {
+  auto handle = buf->BeginWrite(len);
+  memcpy(handle.data(), data, len);
+  handle.EndWrite(len);
+}
+
 class ProtoRingBufferTest : public ::testing::Test {
  public:
   ProtoRingBuffer::Message MakeProtoMessage(uint32_t field_id,
@@ -100,35 +106,6 @@ class ProtoRingBufferTest : public ::testing::Test {
   std::vector<uint8_t> last_msg_;
 };
 
-// Test that when appending buffers that contain whole messages the ring buffer
-// is skipped.
-TEST_F(ProtoRingBufferTest, Fastpath) {
-  ProtoRingBuffer buf;
-  for (uint32_t i = 0; i < 10; i++) {
-    // Write a whole message that hits the fastpath.
-    auto expected = MakeProtoMessage(/*field_id=*/i + 1, /*len=*/i * 7);
-    buf.Append(last_msg_.data(), last_msg_.size());
-    // Shouln't take any space the buffer because it hits the fastpath.
-    EXPECT_EQ(buf.avail(), buf.capacity());
-    auto actual = buf.ReadMessage();
-    ASSERT_TRUE(actual.valid());
-    EXPECT_EQ(actual.start, expected.start);  // Should point to the same buf.
-    EXPECT_EQ(actual, expected);
-
-    // Now write a message in two fragments. It won't hit the fastpath
-    expected = MakeProtoMessage(/*field_id*/ 1, /*len=*/32);
-    buf.Append(last_msg_.data(), 13);
-    EXPECT_LT(buf.avail(), buf.capacity());
-    EXPECT_FALSE(buf.ReadMessage().valid());
-
-    // Append 2nd fragment.
-    buf.Append(last_msg_.data() + 13, last_msg_.size() - 13);
-    actual = buf.ReadMessage();
-    ASSERT_TRUE(actual.valid());
-    EXPECT_EQ(actual, expected);
-  }
-}
-
 TEST_F(ProtoRingBufferTest, CoalescingStream) {
   ProtoRingBuffer buf;
   last_msg_.reserve(1024);
@@ -148,7 +125,7 @@ TEST_F(ProtoRingBufferTest, CoalescingStream) {
   // of a message (the 20 ones) or more than a message.
   uint32_t written = 0;
   for (uint32_t i = 0; i < ArraySize(frag_lens); i++) {
-    buf.Append(&last_msg_[written], frag_lens[i]);
+    Write(&buf, &last_msg_[written], frag_lens[i]);
     written += frag_lens[i];
     for (;;) {
       auto msg = buf.ReadMessage();
@@ -187,7 +164,7 @@ TEST_F(ProtoRingBufferTest, RandomSizes) {
   for (uint32_t frag_sum = 0; frag_sum < total;) {
     uint32_t frag_len = static_cast<uint32_t>(1 + (rnd() % 32768));
     frag_len = std::min(frag_len, total - frag_sum);
-    buf.Append(&last_msg_[frag_sum], frag_len);
+    Write(&buf, &last_msg_[frag_sum], frag_len);
     frag_sum += frag_len;
     for (;;) {
       auto msg = buf.ReadMessage();
@@ -207,14 +184,14 @@ TEST_F(ProtoRingBufferTest, HandleProtoErrorsGracefully) {
   // Append a partial valid 32 byte message, followed by some invalild
   // data.
   auto expected = MakeProtoMessage(1, 32);
-  buf.Append(last_msg_.data(), last_msg_.size() - 1);
+  Write(&buf, last_msg_.data(), last_msg_.size() - 1);
   auto msg = buf.ReadMessage();
   EXPECT_FALSE(msg.valid());
   EXPECT_FALSE(msg.fatal_framing_error);
 
   uint8_t invalid[] = {0x7f, 0x7f, 0x7f, 0x7f};
   invalid[0] = last_msg_.back();
-  buf.Append(invalid, sizeof(invalid));
+  Write(&buf, invalid, sizeof(invalid));
 
   // The first message should be valild
   msg = buf.ReadMessage();
@@ -226,44 +203,8 @@ TEST_F(ProtoRingBufferTest, HandleProtoErrorsGracefully) {
     EXPECT_FALSE(msg.valid());
     EXPECT_TRUE(msg.fatal_framing_error);
 
-    buf.Append(invalid, sizeof(invalid));
+    Write(&buf, invalid, sizeof(invalid));
   }
-}
-
-// A customised ring buffer message reader where every message has a
-// fixed length of |message_length|.
-class FixedLengthRingBuffer final : public RingBufferMessageReader {
- public:
-  FixedLengthRingBuffer(size_t message_length)
-      : RingBufferMessageReader(), message_length_(message_length) {}
-
- protected:
-  virtual Message TryReadMessage(const uint8_t* start,
-                                 const uint8_t* end) override {
-    Message msg{};
-    if (message_length_ <= static_cast<size_t>(end - start)) {
-      msg.start = start;
-      msg.len = static_cast<uint32_t>(message_length_);
-      msg.field_id = 0;
-    }
-    return msg;
-  }
-
- private:
-  size_t message_length_;
-};
-
-TEST(RingBufferTest, FixedLengthRingBuffer) {
-  FixedLengthRingBuffer buf(3);
-  EXPECT_FALSE(buf.ReadMessage().valid());
-  buf.Append("a", 1);
-  EXPECT_FALSE(buf.ReadMessage().valid());
-  buf.Append("bc", 2);
-  FixedLengthRingBuffer::Message msg = buf.ReadMessage();
-  EXPECT_TRUE(msg.valid());
-  EXPECT_EQ(std::string(reinterpret_cast<const char*>(msg.start),
-                        static_cast<size_t>(msg.len)),
-            "abc");
 }
 
 // A read(2) can come back short, so EndWrite() may report fewer bytes than

--- a/src/protozero/test/proto_ring_buffer_benchmark.cc
+++ b/src/protozero/test/proto_ring_buffer_benchmark.cc
@@ -26,137 +26,11 @@
 #include "src/base/test/utils.h"
 
 namespace {
-
-std::string LoadTestTrace() {
-  std::string trace_data;
-  static const char kTestTrace[] = "test/data/example_android_trace_30s.pb";
-  perfetto::base::ReadFile(perfetto::base::GetTestDataPath(kTestTrace),
-                           &trace_data);
-  PERFETTO_CHECK(!trace_data.empty());
-  return trace_data;
+void Write(protozero::ProtoRingBuffer* buf, const void* data, size_t len) {
+  auto write = buf->BeginWrite(len);
+  memcpy(write.data(), data, len);
+  write.EndWrite(len);
 }
-
-// Stands in for the read(2)/recv(2) that brings bytes in from the outside
-// world: like those, it fills a buffer chosen by the caller. That is the one
-// copy no scheme avoids; the benchmarks below differ only in whether the buffer
-// belongs to the transport or to the ring buffer.
-PERFETTO_NO_INLINE void ProduceBytes(void* dst, const void* src, size_t size) {
-  memcpy(dst, src, size);
-}
-
-// Ingestion as the transports used to do it: read into a staging buffer of the
-// transport's own, then hand those bytes to Append(), which copies them again.
-void BM_ProtoRingBufferIngestStaged(benchmark::State& state) {
-  const std::string trace_data = LoadTestTrace();
-  const auto read_size = static_cast<size_t>(state.range(0));
-  std::vector<uint8_t> staging(read_size);
-
-  protozero::ProtoRingBuffer buffer;
-  size_t offset = 0, bytes_ingested = 0, total_packet_size = 0;
-  for (auto _ : state) {
-    size_t n = std::min(read_size, trace_data.size() - offset);
-    ProduceBytes(staging.data(), trace_data.data() + offset, n);
-    buffer.Append(staging.data(), n);
-    // The trace holds whole messages only, so by the time we get back to the
-    // start the buffer has drained and the wrap is seamless.
-    offset = (offset + n) % trace_data.size();
-    bytes_ingested += n;
-    for (;;) {
-      auto msg = buffer.ReadMessage();
-      if (!msg.valid())
-        break;
-      total_packet_size += msg.len;
-    }
-  }
-  benchmark::DoNotOptimize(total_packet_size);
-  state.SetBytesProcessed(static_cast<int64_t>(bytes_ingested));
-}
-
-// Ingestion as they do it now: read straight into the ring buffer, so the bytes
-// are copied exactly once.
-void BM_ProtoRingBufferIngestZeroCopy(benchmark::State& state) {
-  const std::string trace_data = LoadTestTrace();
-  const auto read_size = static_cast<size_t>(state.range(0));
-
-  protozero::ProtoRingBuffer buffer;
-  size_t offset = 0, bytes_ingested = 0, total_packet_size = 0;
-  for (auto _ : state) {
-    size_t n = std::min(read_size, trace_data.size() - offset);
-    auto write = buffer.BeginWrite(n);
-    ProduceBytes(write.data(), trace_data.data() + offset, n);
-    write.EndWrite(n);
-    offset = (offset + n) % trace_data.size();
-    bytes_ingested += n;
-    for (;;) {
-      auto msg = buffer.ReadMessage();
-      if (!msg.valid())
-        break;
-      total_packet_size += msg.len;
-    }
-  }
-  benchmark::DoNotOptimize(total_packet_size);
-  state.SetBytesProcessed(static_cast<int64_t>(bytes_ingested));
-}
-
-// unixd used to tokenize each message out of a per-connection ProtoRingBuffer,
-// re-serialize its TraceProcessorRpcStream preamble, and push preamble +
-// payload through a second ProtoRingBuffer inside Rpc, so every message was
-// copied and tokenized twice. It now reads straight into Rpc's tokenizer.
-void RunDispatch(benchmark::State& state, bool reframe) {
-  namespace pu = protozero::proto_utils;
-  const std::string trace_data = LoadTestTrace();
-  constexpr size_t kReadSize = 4096;
-
-  protozero::ProtoRingBuffer conn_buf, rpc_buf;
-  size_t offset = 0, bytes_ingested = 0, total_packet_size = 0;
-  for (auto _ : state) {
-    size_t n = std::min(kReadSize, trace_data.size() - offset);
-    auto write = conn_buf.BeginWrite(n);
-    ProduceBytes(write.data(), trace_data.data() + offset, n);
-    write.EndWrite(n);
-    offset = (offset + n) % trace_data.size();
-    bytes_ingested += n;
-    for (;;) {
-      auto msg = conn_buf.ReadMessage();
-      if (!msg.valid())
-        break;
-      if (!reframe) {
-        total_packet_size += msg.len;
-        continue;
-      }
-      uint8_t preamble[16];
-      uint8_t* end = preamble;
-      end = pu::WriteVarInt(pu::MakeTagLengthDelimited(1), end);
-      end = pu::WriteVarInt(msg.len, end);
-      rpc_buf.Append(preamble, static_cast<size_t>(end - preamble));
-      rpc_buf.Append(msg.start, msg.len);
-      for (;;) {
-        auto inner = rpc_buf.ReadMessage();
-        if (!inner.valid())
-          break;
-        total_packet_size += inner.len;
-      }
-    }
-  }
-  benchmark::DoNotOptimize(total_packet_size);
-  state.SetBytesProcessed(static_cast<int64_t>(bytes_ingested));
-}
-
-void BM_ProtoRingBufferDispatchReframed(benchmark::State& state) {
-  RunDispatch(state, /*reframe=*/true);
-}
-
-void BM_ProtoRingBufferDispatchDirect(benchmark::State& state) {
-  RunDispatch(state, /*reframe=*/false);
-}
-
-}  // namespace
-
-// 4096 is what the socket transports read; 1MB is what traceconv reads.
-BENCHMARK(BM_ProtoRingBufferIngestStaged)->Arg(4096)->Arg(1024 * 1024);
-BENCHMARK(BM_ProtoRingBufferIngestZeroCopy)->Arg(4096)->Arg(1024 * 1024);
-BENCHMARK(BM_ProtoRingBufferDispatchReframed);
-BENCHMARK(BM_ProtoRingBufferDispatchDirect);
 
 static void BM_ProtoRingBufferReadLargeChunks(benchmark::State& state) {
   std::string trace_data;
@@ -173,7 +47,7 @@ static void BM_ProtoRingBufferReadLargeChunks(benchmark::State& state) {
       total_packet_size += msg.len;
     } else {
       state.PauseTiming();
-      buffer.Append(trace_data.data(), trace_data.size());
+      Write(&buffer, trace_data.data(), trace_data.size());
       state.ResumeTiming();
     }
   }
@@ -201,7 +75,7 @@ static void BM_ProtoRingBufferRead(benchmark::State& state) {
     } else {
       state.PauseTiming();
       size_t sz = std::min(kChunkSize, trace_data.size() - offset);
-      buffer.Append(trace_data.data() + offset, sz);
+      Write(&buffer, trace_data.data() + offset, sz);
       offset = (offset + sz) % trace_data.size();
       state.ResumeTiming();
     }
@@ -210,3 +84,5 @@ static void BM_ProtoRingBufferRead(benchmark::State& state) {
 }
 
 BENCHMARK(BM_ProtoRingBufferRead);
+
+}  // namespace


### PR DESCRIPTION
Append()'s fastpath returned messages pointing into the caller's buffer,
valid only until the next call. That is why RemoteTraceProcessor had to
hoist its read buffer out of the loop, and it is what stops a Message
from owning its storage. Every caller now writes through BeginWrite(),
so both can go.

Also collapses RingBufferMessageReader into ProtoRingBuffer: the virtual
had a single production implementation, and a test-only subclass whose
coverage the ProtoRingBuffer tests subsume.

The benchmarks added to motivate the switch go too: their "before" arm
is the staging buffer this removes.

