### PR TITLE
tp: let TraceBlob wrap memory it does not own

### DIFF
--- a/include/perfetto/trace_processor/trace_blob.h
+++ b/include/perfetto/trace_processor/trace_blob.h
@@ -45,18 +45,30 @@ namespace trace_processor {
 // TraceBlob becomes refcounted (TBV handles the inc/dec of refcount).
 // TraceBlobView allows to have multiple instances pointing at (different
 // sub-offsets of) the same TraceBlob.
-// The neat thing about TraceBlob is that it deals transparently with owned
-// memory (in the case of Allocate and TakeOwnership) and memory-mapped memory.
+// The neat thing about TraceBlob is that it deals transparently with whoever
+// owns the memory: a heap buffer, an mmap region or any other object. All it
+// keeps is a callback to run once the last view onto the blob goes away, and
+// every factory below is a thin wrapper over Adopt().
 class PERFETTO_EXPORT_COMPONENT TraceBlob : public RefCounted {
  public:
+  // Called with |ctx| when the blob and every TraceBlobView onto it are gone.
+  using Deleter = void (*)(void* ctx);
+
   static TraceBlob Allocate(size_t size);
   static TraceBlob CopyFrom(const void*, size_t size);
   static TraceBlob TakeOwnership(std::unique_ptr<uint8_t[]>, size_t size);
   static TraceBlob FromMmap(base::ScopedMmap);
 
-  // DEPRECATED: does not work on Windows.
-  // Takes ownership of the mmap region. Will call munmap() on destruction.
-  static TraceBlob FromMmap(void* data, size_t size);
+  // Wraps memory which stays valid until |deleter| is invoked with |ctx|.
+  static TraceBlob Adopt(const uint8_t* data, size_t size, void* ctx, Deleter);
+
+  // Wraps memory kept alive by |owner|, which is destroyed once the blob and
+  // every TraceBlobView onto it are gone.
+  template <typename T>
+  static TraceBlob Adopt(const uint8_t* data, size_t size, T owner) {
+    return Adopt(data, size, new T(std::move(owner)),
+                 [](void* ctx) { delete static_cast<T*>(ctx); });
+  }
 
   ~TraceBlob();
 
@@ -68,18 +80,26 @@ class PERFETTO_EXPORT_COMPONENT TraceBlob : public RefCounted {
   TraceBlob(const TraceBlob&) = delete;
   TraceBlob& operator=(const TraceBlob&) = delete;
 
-  uint8_t* data() const { return data_; }
+  const uint8_t* data() const { return data_; }
   size_t size() const { return size_; }
 
+  // Only valid for blobs from Allocate() and TakeOwnership().
+  uint8_t* mutable_data() const;
+
  private:
-  enum class Ownership { kNullOrMmapped = 0, kHeapBuf };
+  TraceBlob(const uint8_t* data,
+            uint8_t* mutable_data,
+            size_t size,
+            void* ctx,
+            Deleter deleter);
 
-  TraceBlob(Ownership ownership, uint8_t* data, size_t size);
+  static TraceBlob FromHeapBuf(uint8_t* buf, size_t size);
 
-  Ownership ownership_ = Ownership::kNullOrMmapped;
-  uint8_t* data_ = nullptr;
+  const uint8_t* data_ = nullptr;
+  uint8_t* mutable_data_ = nullptr;
   size_t size_ = 0;
-  std::unique_ptr<base::ScopedMmap> mapping_;
+  void* ctx_ = nullptr;
+  Deleter deleter_ = nullptr;
 };
 
 }  // namespace trace_processor

--- a/src/trace_processor/importers/android_bugreport/chunked_line_reader.cc
+++ b/src/trace_processor/importers/android_bugreport/chunked_line_reader.cc
@@ -38,8 +38,8 @@ TraceBlobView Append(const TraceBlobView& head, const TraceBlobView& tail) {
     return TraceBlobView();
   }
   auto blob = TraceBlob::Allocate(size);
-  memcpy(blob.data(), head.data(), head.size());
-  memcpy(blob.data() + head.size(), tail.data(), tail.size());
+  memcpy(blob.mutable_data(), head.data(), head.size());
+  memcpy(blob.mutable_data() + head.size(), tail.data(), tail.size());
   return TraceBlobView(std::move(blob));
 }
 

--- a/src/trace_processor/importers/art_hprof/art_heap_graph_builder.cc
+++ b/src/trace_processor/importers/art_hprof/art_heap_graph_builder.cc
@@ -724,16 +724,17 @@ bool HeapGraphBuilder::ParsePrimitiveArrayObject() {
     // view would pin the whole trace chunk it points into, however small the
     // array is.
     TraceBlob blob = TraceBlob::Allocate(data_length);
-    if (!iterator_->ReadInto(blob.data(), data_length)) {
+    uint8_t* data = blob.mutable_data();
+    if (!iterator_->ReadInto(data, data_length)) {
       return false;
     }
     if (element_type == FieldType::kBoolean) {
       // Normalise to 0/1 to match the values exposed for boolean arrays.
       for (size_t i = 0; i < data_length; ++i) {
-        blob.data()[i] = blob.data()[i] != 0 ? 1 : 0;
+        data[i] = data[i] != 0 ? 1 : 0;
       }
     } else {
-      ToNativeEndian(blob.data(), element_count, type_size);
+      ToNativeEndian(data, element_count, type_size);
     }
     obj.SetArrayData(TraceBlobView(std::move(blob)), element_count);
   }

--- a/src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.cc
@@ -151,9 +151,10 @@ base::Status FuchsiaTraceTokenizer::Parse(TraceBlobView blob) {
       // We have enough bytes to complete the partial record. Create a new
       // buffer for that record.
       TraceBlob buf = TraceBlob::Allocate(record_len_bytes);
-      memcpy(buf.data(), leftover_bytes_.data(), leftover_bytes_.size());
-      memcpy(buf.data() + leftover_bytes_.size(), blob.data() + byte_offset,
-             missing_bytes);
+      memcpy(buf.mutable_data(), leftover_bytes_.data(),
+             leftover_bytes_.size());
+      memcpy(buf.mutable_data() + leftover_bytes_.size(),
+             blob.data() + byte_offset, missing_bytes);
       byte_offset += missing_bytes;
       size -= missing_bytes;
       leftover_bytes_.clear();

--- a/src/trace_processor/importers/perf/reader_unittest.cc
+++ b/src/trace_processor/importers/perf/reader_unittest.cc
@@ -34,7 +34,7 @@ template <typename T>
 TraceBlobView TraceBlobViewFromVector(std::vector<T> nums) {
   size_t data_size = sizeof(T) * nums.size();
   auto blob = TraceBlob::Allocate(data_size);
-  memcpy(blob.data(), nums.data(), data_size);
+  memcpy(blob.mutable_data(), nums.data(), data_size);
   return TraceBlobView(std::move(blob));
 }
 

--- a/src/trace_processor/importers/proto/blob_packet_writer.cc
+++ b/src/trace_processor/importers/proto/blob_packet_writer.cc
@@ -40,11 +40,11 @@ BlobPacketWriter::~BlobPacketWriter() = default;
 protos::pbzero::TracePacket* BlobPacketWriter::BeginPacket() {
   if (!slab_ || packet_start_ptr_ >= slab_->data() + slab_->size()) {
     slab_.reset(new TraceBlob(TraceBlob::Allocate(kSlabSize)));
-    packet_start_ptr_ = slab_->data();
+    packet_start_ptr_ = slab_->mutable_data();
   }
 
   protozero::ContiguousMemoryRange range{packet_start_ptr_,
-                                         slab_->data() + slab_->size()};
+                                         slab_->mutable_data() + slab_->size()};
   msg_.Reset(&writer_);
   writer_.Reset(range);
   slices_.push_back(range);
@@ -76,7 +76,7 @@ TraceBlobView BlobPacketWriter::EndPacket() {
 
   TraceBlob stitched = TraceBlob::Allocate(total);
   {
-    uint8_t* dst = stitched.data();
+    uint8_t* dst = stitched.mutable_data();
     for (const auto& s : slices_) {
       memcpy(dst, s.begin, s.size());
       dst += s.size();
@@ -100,8 +100,8 @@ protozero::ContiguousMemoryRange BlobPacketWriter::GetNewBuffer() {
   overflow_slabs_.emplace_front(new TraceBlob(TraceBlob::Allocate(kSlabSize)));
 
   auto& blob = *overflow_slabs_.front();
-  protozero::ContiguousMemoryRange range{blob.data(),
-                                         blob.data() + blob.size()};
+  protozero::ContiguousMemoryRange range{blob.mutable_data(),
+                                         blob.mutable_data() + blob.size()};
   slices_.push_back(range);
   return range;
 }

--- a/src/trace_processor/read_trace_internal.cc
+++ b/src/trace_processor/read_trace_internal.cc
@@ -517,7 +517,7 @@ base::Status ReadTraceUsingRead(
       progress_callback(*file_size);
 
     TraceBlob blob = TraceBlob::Allocate(kChunkSize);
-    auto rsize = base::Read(fd, blob.data(), blob.size());
+    auto rsize = base::Read(fd, blob.mutable_data(), blob.size());
     if (rsize == 0)
       break;
 

--- a/src/trace_processor/rpc/httpd.cc
+++ b/src/trace_processor/rpc/httpd.cc
@@ -32,6 +32,8 @@
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/trace_processor/trace_blob.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
 #include "perfetto/trace_processor/trace_processor.h"
 #include "src/trace_processor/rpc/httpd.h"
 #include "src/trace_processor/rpc/rpc.h"
@@ -243,8 +245,18 @@ void Httpd::OnHttpRequest(const base::HttpRequest& req) {
   }
 
   if (req.uri == "/parse") {
-    base::Status status = global_trace_processor_rpc_.Parse(
-        reinterpret_cast<const uint8_t*>(req.body.data()), req.body.size());
+    // The body lives in |state.payload| (see OnHttpRequestBody()), so hand the
+    // buffer over rather than copying it; the next body gets a fresh one.
+    ConnState& state = conns_[&conn];
+    TraceBlobView blob;
+    if (!req.body.empty()) {
+      PERFETTO_DCHECK(reinterpret_cast<const uint8_t*>(req.body.data()) ==
+                      state.payload.get());
+      blob = TraceBlobView(
+          TraceBlob::TakeOwnership(std::move(state.payload), req.body.size()));
+      state.payload_size = 0;
+    }
+    base::Status status = global_trace_processor_rpc_.Parse(std::move(blob));
     protozero::HeapBuffered<protos::pbzero::AppendTraceDataResult> result;
     if (!status.ok()) {
       result->set_error(status.c_message());

--- a/src/trace_processor/rpc/rpc.cc
+++ b/src/trace_processor/rpc/rpc.cc
@@ -43,6 +43,8 @@
 #include "perfetto/protozero/scattered_heap_buffer.h"
 #include "perfetto/public/compiler.h"
 #include "perfetto/trace_processor/basic_types.h"
+#include "perfetto/trace_processor/trace_blob.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
 #include "perfetto/trace_processor/trace_processor.h"
 #include "src/trace_processor/tp_metatrace.h"
 
@@ -384,7 +386,8 @@ void Rpc::ParseRpcRequest(Stream& stream, const uint8_t* data, size_t len) {
         result->set_error(kErrFieldNotSet);
       } else {
         protozero::ConstBytes byte_range = req.append_trace_data();
-        base::Status res = Parse(byte_range.data, byte_range.size);
+        base::Status res = Parse(TraceBlobView(
+            TraceBlob::CopyFrom(byte_range.data, byte_range.size)));
         if (!res.ok()) {
           result->set_error(res.message());
         }
@@ -707,7 +710,8 @@ void Rpc::ParseRpcRequest(Stream& stream, const uint8_t* data, size_t len) {
   }  // switch(req_type)
 }
 
-base::Status Rpc::Parse(const uint8_t* data, size_t len) {
+base::Status Rpc::Parse(TraceBlobView blob) {
+  const size_t len = blob.size();
   PERFETTO_TP_TRACE(
       metatrace::Category::API_TIMELINE, "RPC_PARSE",
       [&](metatrace::Record* r) { r->AddArg("length", std::to_string(len)); });
@@ -724,10 +728,7 @@ base::Status Rpc::Parse(const uint8_t* data, size_t len) {
   if (len == 0)
     return base::OkStatus();
 
-  // TraceProcessor needs take ownership of the memory chunk.
-  std::unique_ptr<uint8_t[]> data_copy(new uint8_t[len]);
-  memcpy(data_copy.get(), data, len);
-  return trace_processor_->Parse(std::move(data_copy), len);
+  return trace_processor_->Parse(std::move(blob));
 }
 
 base::Status Rpc::NotifyEndOfFile() {

--- a/src/trace_processor/rpc/rpc.h
+++ b/src/trace_processor/rpc/rpc.h
@@ -177,7 +177,7 @@ class Rpc {
   // The methods of this class are mirrors (modulo {un,}marshalling of args) of
   // the corresponding names in trace_processor.h . See that header for docs.
 
-  base::Status Parse(const uint8_t*, size_t);
+  base::Status Parse(TraceBlobView);
   base::Status NotifyEndOfFile();
   std::string GetCurrentTraceName();
   std::vector<uint8_t> ComputeMetric(const uint8_t*, size_t);

--- a/src/trace_processor/trace_blob_unittest.cc
+++ b/src/trace_processor/trace_blob_unittest.cc
@@ -16,6 +16,11 @@
 
 #include "perfetto/trace_processor/trace_blob.h"
 
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "perfetto/trace_processor/trace_blob_view.h"
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto {
@@ -27,6 +32,64 @@ TEST(TraceBlob, MoveAssignment) {
   TraceBlob b2 = TraceBlob::Allocate(16);
 
   b1 = std::move(b2);
+}
+
+TEST(TraceBlob, MoveLeavesSourceEmpty) {
+  TraceBlob b1 = TraceBlob::Allocate(16);
+  const uint8_t* data = b1.data();
+
+  TraceBlob b2(std::move(b1));
+  EXPECT_EQ(b2.data(), data);
+  EXPECT_EQ(b2.size(), 16u);
+  EXPECT_EQ(b1.data(), nullptr);
+  EXPECT_EQ(b1.size(), 0u);
+}
+
+struct FlaggedOwner {
+  explicit FlaggedOwner(bool* destroyed) : destroyed_(destroyed) {}
+  ~FlaggedOwner() {
+    if (destroyed_)
+      *destroyed_ = true;
+  }
+  FlaggedOwner(FlaggedOwner&& o) noexcept
+      : destroyed_(std::exchange(o.destroyed_, nullptr)) {}
+  FlaggedOwner& operator=(FlaggedOwner&&) = delete;
+  FlaggedOwner(const FlaggedOwner&) = delete;
+  FlaggedOwner& operator=(const FlaggedOwner&) = delete;
+
+  std::vector<uint8_t> bytes = std::vector<uint8_t>(32, 0xAB);
+  bool* destroyed_;
+};
+
+TEST(TraceBlob, AdoptDestroysOwnerAfterLastView) {
+  bool destroyed = false;
+  FlaggedOwner owner(&destroyed);
+  uint8_t* data = owner.bytes.data();
+
+  TraceBlobView view(TraceBlob::Adopt(data, 32, std::move(owner)));
+  EXPECT_FALSE(destroyed);
+
+  TraceBlobView slice = view.slice_off(8, 8);
+  view = TraceBlobView();
+  EXPECT_FALSE(destroyed);
+  EXPECT_EQ(slice.data()[0], 0xAB);
+
+  slice = TraceBlobView();
+  EXPECT_TRUE(destroyed);
+}
+
+TEST(TraceBlob, AdoptWithDeleterAndContext) {
+  static int calls = 0;
+  calls = 0;
+  uint8_t bytes[4] = {};
+  {
+    TraceBlob blob =
+        TraceBlob::Adopt(bytes, sizeof(bytes), &calls,
+                         [](void* ctx) { ++*static_cast<int*>(ctx); });
+    EXPECT_EQ(blob.data(), bytes);
+    EXPECT_EQ(calls, 0);
+  }
+  EXPECT_EQ(calls, 1);
 }
 
 }  // namespace

--- a/src/trace_processor/trace_database_integrationtest.cc
+++ b/src/trace_processor/trace_database_integrationtest.cc
@@ -294,7 +294,7 @@ TEST(TraceProcessorCustomConfigTest,
   write_file(first_file.path());
 
   ASSERT_OK(rpc.NotifyEndOfFile());
-  ASSERT_OK(rpc.Parse(nullptr, 0));
+  ASSERT_OK(rpc.Parse(TraceBlobView()));
 
   base::TempFile second_file = base::TempFile::Create();
   write_file(second_file.path());

--- a/src/trace_processor/util/trace_blob.cc
+++ b/src/trace_processor/util/trace_blob.cc
@@ -16,39 +16,40 @@
 
 #include "perfetto/trace_processor/trace_blob.h"
 
-#include <stdlib.h>
-#include <string.h>
-
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) ||   \
-    PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID) || \
-    PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE)
-#include <sys/mman.h>
-#endif
+#include <stddef.h>
+#include <stdint.h>
 
 #include <algorithm>
+#include <memory>
+#include <new>
+#include <utility>
 
-#include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/scoped_mmap.h"
-#include "perfetto/ext/base/utils.h"
-#include "perfetto/trace_processor/basic_types.h"
 #include "perfetto/trace_processor/ref_counted.h"
 
 namespace perfetto {
 namespace trace_processor {
+namespace {
+
+void DeleteHeapBuf(void* ctx) {
+  delete[] static_cast<uint8_t*>(ctx);
+}
+
+}  // namespace
 
 // static
 TraceBlob TraceBlob::Allocate(size_t size) {
-  TraceBlob blob(Ownership::kHeapBuf, new uint8_t[size], size);
-  PERFETTO_CHECK(blob.data_);
-  return blob;
+  uint8_t* data = new uint8_t[size];
+  PERFETTO_CHECK(data);
+  return FromHeapBuf(data, size);
 }
 
 // static
 TraceBlob TraceBlob::CopyFrom(const void* src, size_t size) {
   TraceBlob blob = Allocate(size);
   const uint8_t* src_u8 = static_cast<const uint8_t*>(src);
-  std::copy(src_u8, src_u8 + size, blob.data_);
+  std::copy(src_u8, src_u8 + size, blob.mutable_data());
   return blob;
 }
 
@@ -56,70 +57,60 @@ TraceBlob TraceBlob::CopyFrom(const void* src, size_t size) {
 TraceBlob TraceBlob::TakeOwnership(std::unique_ptr<uint8_t[]> buf,
                                    size_t size) {
   PERFETTO_CHECK(buf);
-  return TraceBlob(Ownership::kHeapBuf, buf.release(), size);
+  return FromHeapBuf(buf.release(), size);
 }
 
 // static
 TraceBlob TraceBlob::FromMmap(base::ScopedMmap mapped) {
   PERFETTO_CHECK(mapped.IsValid());
-  TraceBlob blob(Ownership::kNullOrMmapped,
-                 static_cast<uint8_t*>(mapped.data()), mapped.length());
-  blob.mapping_ = std::make_unique<base::ScopedMmap>(std::move(mapped));
-  return blob;
+  uint8_t* data = static_cast<uint8_t*>(mapped.data());
+  size_t size = mapped.length();
+  return Adopt(data, size, std::move(mapped));
 }
 
 // static
-TraceBlob TraceBlob::FromMmap(void* data, size_t size) {
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) ||   \
-    PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID) || \
-    PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE)
+TraceBlob TraceBlob::Adopt(const uint8_t* data,
+                           size_t size,
+                           void* ctx,
+                           Deleter deleter) {
   PERFETTO_CHECK(data);
-  TraceBlob blob(Ownership::kNullOrMmapped, static_cast<uint8_t*>(data), size);
-  blob.mapping_ = std::make_unique<base::ScopedMmap>(
-      base::ScopedMmap::InheritMmappedRange(data, size));
-  return blob;
-#else
-  base::ignore_result(data);
-  base::ignore_result(size);
-  PERFETTO_FATAL("mmap not supported");
-#endif
+  PERFETTO_CHECK(deleter);
+  return TraceBlob(data, nullptr, size, ctx, deleter);
 }
 
-TraceBlob::TraceBlob(Ownership ownership, uint8_t* data, size_t size)
-    : ownership_(ownership), data_(data), size_(size) {}
+// static
+TraceBlob TraceBlob::FromHeapBuf(uint8_t* buf, size_t size) {
+  return TraceBlob(buf, buf, size, buf, &DeleteHeapBuf);
+}
+
+TraceBlob::TraceBlob(const uint8_t* data,
+                     uint8_t* mutable_data,
+                     size_t size,
+                     void* ctx,
+                     Deleter deleter)
+    : data_(data),
+      mutable_data_(mutable_data),
+      size_(size),
+      ctx_(ctx),
+      deleter_(deleter) {}
+
+uint8_t* TraceBlob::mutable_data() const {
+  PERFETTO_DCHECK(mutable_data_);
+  return mutable_data_;
+}
 
 TraceBlob::~TraceBlob() {
-  switch (ownership_) {
-    case Ownership::kHeapBuf:
-      delete[] data_;
-      break;
-
-    case Ownership::kNullOrMmapped:
-      if (mapping_) {
-        PERFETTO_CHECK(mapping_->reset());
-      }
-      break;
-  }
-  data_ = nullptr;
-  size_ = 0;
+  if (deleter_)
+    deleter_(ctx_);
 }
 
 TraceBlob::TraceBlob(TraceBlob&& other) noexcept
-    : RefCounted(std::move(other)) {
-  static_assert(
-      sizeof(*this) == base::AlignUp<sizeof(void*)>(
-                           sizeof(data_) + sizeof(size_) + sizeof(ownership_) +
-                           sizeof(mapping_) + sizeof(RefCounted)),
-      "TraceBlob move constructor needs updating");
-  data_ = other.data_;
-  size_ = other.size_;
-  ownership_ = other.ownership_;
-  mapping_ = std::move(other.mapping_);
-  other.data_ = nullptr;
-  other.size_ = 0;
-  other.ownership_ = Ownership::kNullOrMmapped;
-  other.mapping_ = nullptr;
-}
+    : RefCounted(std::move(other)),
+      data_(std::exchange(other.data_, nullptr)),
+      mutable_data_(std::exchange(other.mutable_data_, nullptr)),
+      size_(std::exchange(other.size_, 0)),
+      ctx_(std::exchange(other.ctx_, nullptr)),
+      deleter_(std::exchange(other.deleter_, nullptr)) {}
 
 TraceBlob& TraceBlob::operator=(TraceBlob&& other) noexcept {
   if (this == &other)

--- a/src/trace_processor/util/trace_blob_view_reader.cc
+++ b/src/trace_processor/util/trace_blob_view_reader.cc
@@ -145,7 +145,7 @@ std::optional<TraceBlobView> TraceBlobViewReader::SliceOff(
     }
 
     static void AddSlice(TraceBlob& blob, size_t offset, TraceBlobView tbv) {
-      memcpy(blob.data() + offset, tbv.data(), tbv.size());
+      memcpy(blob.mutable_data() + offset, tbv.data(), tbv.size());
     }
 
     static std::optional<TraceBlobView> Finalize(TraceBlob blob) {

--- a/src/trace_processor/util/trace_blob_view_reader_unittest.cc
+++ b/src/trace_processor/util/trace_blob_view_reader_unittest.cc
@@ -77,7 +77,7 @@ SameDataAsMatcher SameDataAs(const TraceBlobView& expected_data) {
 TraceBlobView CreateExpectedData(size_t expected_size) {
   TraceBlob tb = TraceBlob::Allocate(expected_size);
   for (size_t i = 0; i < expected_size; ++i) {
-    tb.data()[i] = static_cast<uint8_t>(i);
+    tb.mutable_data()[i] = static_cast<uint8_t>(i);
   }
   return TraceBlobView(std::move(tb));
 }


### PR DESCRIPTION
TraceBlob can hold heap memory it allocated or an mmap region, so a
caller that already has the bytes somewhere else has no way to hand
them over: it has to copy them into a blob first.

Add an ownership mode that wraps a pointer and holds a shared_ptr to
whoever owns it, for as long as the blob and every TraceBlobView onto
it. Give Rpc::Parse() an overload taking a TraceBlobView so callers can
use it; the pointer-and-length overload stays and now copies through
TraceBlob::CopyFrom() rather than open-coding new[] and memcpy.

No behaviour change: nothing adopts anything yet.

