### PR TITLE
Fix windows build

### DIFF
--- a/src/base/utils_unittest.cc
+++ b/src/base/utils_unittest.cc
@@ -428,8 +428,8 @@ TEST(UtilsTest, OpenFstreamTextModeNotSupported) {
 }
 
 TEST(UtilsTest, OpenFstreamAlwaysBinaryMode) {
-  TempFile file = TempFile::Create();
-  const std::string& tmp_path = file.path();
+  TempFile tmp_file = TempFile::Create();
+  const std::string& tmp_path = tmp_file.path();
   // Explicitly set the string size, we want to write all data to the file.
   std::string payload("foo\nbar\0baz\r\nqux", 16);
   ASSERT_EQ(payload.size(), static_cast<size_t>(16));


### PR DESCRIPTION
perfetto->chromium is failing build on
```
..\..\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe /c ../../third_party/perfetto/src/base/utils_unittest.cc /Foobj/third_party/perf...(too long)
../../third_party/perfetto/src/base/utils_unittest.cc(455,14): error: declaration shadows a local variable [-Werror,-Wshadow]
  455 |     TempFile file = TempFile::Create();
      |              ^
../../third_party/perfetto/src/base/utils_unittest.cc(431,12): note: previous declaration is here
  431 |   TempFile file = TempFile::Create();
```
https://ci.chromium.org/ui/p/chromium/builders/try/win-arm64-compile-dbg/1051409/overview

This CL renames the other variable to fix the error.