### PR TITLE
tp: give the RPC layer one framing stream per connection

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20898,6 +20898,7 @@ filegroup {
     name: "perfetto_src_trace_processor_rpc_unittests",
     srcs: [
         "src/trace_processor/rpc/query_result_serializer_unittest.cc",
+        "src/trace_processor/rpc/rpc_unittest.cc",
         "src/trace_processor/rpc/session_paths_unittest.cc",
     ],
 }

--- a/src/trace_processor/rpc/BUILD.gn
+++ b/src/trace_processor/rpc/BUILD.gn
@@ -167,6 +167,7 @@ perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
     "query_result_serializer_unittest.cc",
+    "rpc_unittest.cc",
     "session_paths_unittest.cc",
   ]
   deps = [

--- a/src/trace_processor/rpc/httpd.cc
+++ b/src/trace_processor/rpc/httpd.cc
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <initializer_list>
 #include <memory>
 #include <optional>
@@ -25,8 +26,10 @@
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/http/http_server.h"
 #include "perfetto/ext/base/lock_free_task_runner.h"
+#include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
@@ -51,6 +54,14 @@ const char* kDefaultAllowedCORSOrigins[] = {
     "http://127.0.0.1:10000",
 };
 
+// base::MurmurHash refuses raw pointers; here identity is exactly the key.
+struct ConnHasher {
+  size_t operator()(const base::HttpServerConnection* conn) const {
+    return static_cast<size_t>(
+        base::MurmurHashValue(reinterpret_cast<uintptr_t>(conn)));
+  }
+};
+
 class Httpd : public base::HttpRequestHandler {
  public:
   explicit Httpd(Rpc& rpc);
@@ -65,10 +76,19 @@ class Httpd : public base::HttpRequestHandler {
   // HttpRequestHandler implementation.
   void OnHttpRequest(const base::HttpRequest&) override;
   void OnWebsocketMessage(const base::WebsocketMessage&) override;
+  void OnHttpConnectionClosed(base::HttpServerConnection*) override;
+
+  // The RPC byte-pipe carried by |conn|, created on first use: most
+  // connections (the REST endpoints, /status polls) never carry one.
+  Rpc::Stream& GetRpcStream(base::HttpServerConnection* conn);
 
   static void ServeHelpPage(const base::HttpRequest&);
 
   Rpc& global_trace_processor_rpc_;
+  base::FlatHashMap<base::HttpServerConnection*,
+                    std::unique_ptr<Rpc::Stream>,
+                    ConnHasher>
+      streams_;
   base::MaybeLockFreeTaskRunner task_runner_;
   base::HttpServer http_srv_;
   std::unique_ptr<IdleReaper> reaper_;
@@ -181,13 +201,11 @@ void Httpd::OnHttpRequest(const base::HttpRequest& req) {
     // Start the chunked reply.
     conn.SendResponseHeaders("200 OK", chunked_headers,
                              base::HttpServerConnection::kOmitContentLength);
-    global_trace_processor_rpc_.SetRpcResponseFunction(
-        [&](const void* data, uint32_t len) {
-          SendRpcChunk(&conn, data, len);
-        });
-    // OnRpcRequest() will call SendRpcChunk() one or more times.
-    global_trace_processor_rpc_.OnRpcRequest(req.body.data(), req.body.size());
-    global_trace_processor_rpc_.SetRpcResponseFunction(nullptr);
+    if (!req.body.empty()) {
+      auto write = GetRpcStream(&conn).BeginRequest(req.body.size());
+      memcpy(write.data(), req.body.data(), req.body.size());
+      write.EndRequest(req.body.size());
+    }
 
     // Terminate chunked stream.
     conn.SendResponseBody("0\r\n\r\n", 5);
@@ -312,13 +330,26 @@ void Httpd::OnHttpRequest(const base::HttpRequest& req) {
 void Httpd::OnWebsocketMessage(const base::WebsocketMessage& msg) {
   if (reaper_)
     reaper_->OnActivity();
-  global_trace_processor_rpc_.SetRpcResponseFunction(
-      [&](const void* data, uint32_t len) {
-        SendRpcChunk(msg.conn, data, len);
-      });
-  // OnRpcRequest() will call SendRpcChunk() one or more times.
-  global_trace_processor_rpc_.OnRpcRequest(msg.data.data(), msg.data.size());
-  global_trace_processor_rpc_.SetRpcResponseFunction(nullptr);
+  if (msg.data.empty())
+    return;
+  auto write = GetRpcStream(msg.conn).BeginRequest(msg.data.size());
+  memcpy(write.data(), msg.data.data(), msg.data.size());
+  write.EndRequest(msg.data.size());
+}
+
+Rpc::Stream& Httpd::GetRpcStream(base::HttpServerConnection* conn) {
+  auto& stream = streams_[conn];
+  if (!stream) {
+    stream = std::make_unique<Rpc::Stream>(
+        global_trace_processor_rpc_, [conn](const void* data, uint32_t len) {
+          SendRpcChunk(conn, data, len);
+        });
+  }
+  return *stream;
+}
+
+void Httpd::OnHttpConnectionClosed(base::HttpServerConnection* conn) {
+  streams_.Erase(conn);
 }
 
 }  // namespace

--- a/src/trace_processor/rpc/rpc.cc
+++ b/src/trace_processor/rpc/rpc.cc
@@ -245,24 +245,25 @@ void Rpc::ResetTraceProcessorInternal(const Config& config) {
     on_trace_processor_created_(trace_processor_.get());
   }
 
-  // Deliberately not resetting the RPC channel state (rxbuf_, {tx,rx}_seq_id_).
+  // Deliberately not touching the RPC channel state: the Streams' tokenizers
+  // and Rpc's own {tx,rx} sequence ids.
   // This is invoked from the same client to clear the current trace state
   // before loading a new one. The IPC channel is orthogonal to that and the
   // message numbering continues regardless of the reset.
 }
 
-void Rpc::OnRpcRequest(const void* data, size_t len) {
-  rxbuf_.Append(data, len);
-  DrainRxBuf();
-}
+Rpc::Stream::Stream(Rpc& rpc, RpcResponseFunction response_fn)
+    : rpc_(rpc), response_fn_(std::move(response_fn)) {}
+
+Rpc::Stream::~Stream() = default;
 
 Rpc::RequestHandle::~RequestHandle() {
-  PERFETTO_CHECK(rpc_ == nullptr);
+  PERFETTO_CHECK(stream_ == nullptr);
 }
 
 Rpc::RequestHandle::RequestHandle(RequestHandle&& other) noexcept
-    : rpc_(other.rpc_), write_(std::move(other.write_)) {
-  other.rpc_ = nullptr;
+    : stream_(other.stream_), write_(std::move(other.write_)) {
+  other.stream_ = nullptr;
 }
 
 Rpc::RequestHandle& Rpc::RequestHandle::operator=(
@@ -273,47 +274,47 @@ Rpc::RequestHandle& Rpc::RequestHandle::operator=(
 }
 
 void Rpc::RequestHandle::EndRequest(size_t size_written) {
-  PERFETTO_CHECK(rpc_ != nullptr);
-  Rpc* rpc = std::exchange(rpc_, nullptr);
+  PERFETTO_CHECK(stream_ != nullptr);
+  Stream* stream = std::exchange(stream_, nullptr);
   write_.EndWrite(size_written);
-  rpc->FinishRpcRequest();
-  rpc->DrainRxBuf();
+  stream->FinishRequest();
+  stream->rpc_.DrainStream(*stream);
 }
 
 void Rpc::RequestHandle::AbortRequest() {
-  PERFETTO_CHECK(rpc_ != nullptr);
+  PERFETTO_CHECK(stream_ != nullptr);
   write_.AbortWrite();
-  std::exchange(rpc_, nullptr)->FinishRpcRequest();
+  std::exchange(stream_, nullptr)->FinishRequest();
 }
 
-Rpc::RequestHandle Rpc::BeginRpcRequest(size_t size) {
+Rpc::RequestHandle Rpc::Stream::BeginRequest(size_t size) {
   // The handle keeps the caller from losing a reservation, but not from
   // holding two at once. The ring buffer has the same guard for its own
-  // handles; this one is here so the CHECK fires at the Rpc API boundary.
+  // handles; this one is here so the CHECK fires at the Stream API boundary.
   PERFETTO_CHECK(!request_in_flight_);
   request_in_flight_ = true;
   return RequestHandle(this, rxbuf_.BeginWrite(size));
 }
 
-void Rpc::FinishRpcRequest() {
+void Rpc::Stream::FinishRequest() {
   PERFETTO_CHECK(request_in_flight_);
   request_in_flight_ = false;
 }
 
-void Rpc::DrainRxBuf() {
+void Rpc::DrainStream(Stream& stream) {
   for (;;) {
-    auto msg = rxbuf_.ReadMessage();
+    auto msg = stream.rxbuf_.ReadMessage();
     if (!msg.valid()) {
       if (msg.fatal_framing_error) {
         protozero::HeapBuffered<TraceProcessorRpcStream> err_msg;
         err_msg->add_msg()->set_fatal_error("RPC framing error");
         auto err = err_msg.SerializeAsArray();
-        rpc_response_fn_(err.data(), static_cast<uint32_t>(err.size()));
-        rpc_response_fn_(nullptr, 0);  // Disconnect.
+        stream.response_fn_(err.data(), static_cast<uint32_t>(err.size()));
+        stream.response_fn_(nullptr, 0);  // Disconnect.
       }
       break;
     }
-    ParseRpcRequest(msg.start, msg.len);
+    ParseRpcRequest(stream, msg.start, msg.len);
   }
 }
 
@@ -350,7 +351,7 @@ TraceProcessor::MetatraceCategories MetatraceCategoriesToPublicEnum(
 
 // [data, len] here is a tokenized TraceProcessorRpc proto message, without the
 // size header.
-void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
+void Rpc::ParseRpcRequest(Stream& stream, const uint8_t* data, size_t len) {
   RpcProto::Decoder req(data, len);
 
   // We allow restarting the sequence from 0. This happens when refreshing the
@@ -366,8 +367,8 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
     protozero::HeapBuffered<TraceProcessorRpcStream> err_msg;
     err_msg->add_msg()->set_fatal_error(err_str);
     auto err = err_msg.SerializeAsArray();
-    rpc_response_fn_(err.data(), static_cast<uint32_t>(err.size()));
-    rpc_response_fn_(nullptr, 0);  // Disconnect.
+    stream.response_fn_(err.data(), static_cast<uint32_t>(err.size()));
+    stream.response_fn_(nullptr, 0);  // Disconnect.
     return;
   }
   rx_seq_id_ = req.seq();
@@ -388,7 +389,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
           result->set_error(res.message());
         }
       }
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_FINALIZE_TRACE_DATA: {
@@ -398,7 +399,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
       if (!res.ok()) {
         result->set_error(res.message());
       }
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_QUERY_STREAMING: {
@@ -406,7 +407,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
         Response resp(tx_seq_id_++, req_type);
         auto* result = resp->set_query_result();
         result->set_error(kErrFieldNotSet);
-        resp.Send(rpc_response_fn_);
+        resp.Send(stream.response_fn_);
       } else {
         protozero::ConstBytes args = req.query_args();
         protos::pbzero::QueryArgs::Decoder query(args.data, args.size);
@@ -425,13 +426,13 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
 
         QueryResultSerializer serializer(std::move(it), t_start);
         StreamSerializerResponses(&serializer, req_type, &tx_seq_id_,
-                                  rpc_response_fn_, /*header=*/nullptr);
+                                  stream.response_fn_, /*header=*/nullptr);
       }
       break;
     }
     case RpcProto::TPM_STATEMENT_STREAMING: {
       if (!req.has_statement_args()) {
-        SendSingleStatementResponse(req_type, &tx_seq_id_, rpc_response_fn_,
+        SendSingleStatementResponse(req_type, &tx_seq_id_, stream.response_fn_,
                                     /*header=*/nullptr, kErrFieldNotSet);
         break;
       }
@@ -455,7 +456,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
       // are invalid in both forms. Offsets in the gap between the two sizes
       // are rejected by ExecuteNextStatement's own range check below.
       if (offset > sql.size()) {
-        SendSingleStatementResponse(req_type, &tx_seq_id_, rpc_response_fn_,
+        SendSingleStatementResponse(req_type, &tx_seq_id_, stream.response_fn_,
                                     /*header=*/nullptr,
                                     "StatementArgs.start_offset out of range");
         break;
@@ -464,8 +465,9 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
           trace_processor_->ExecuteNextStatement(sql, &offset);
       if (!it.has_value()) {
         StatementStreamHeader header{offset, /*statement_executed=*/false};
-        SendSingleStatementResponse(req_type, &tx_seq_id_, rpc_response_fn_,
-                                    &header, /*error=*/nullptr);
+        SendSingleStatementResponse(req_type, &tx_seq_id_, stream.response_fn_,
+                                    &header,
+                                    /*error=*/nullptr);
         break;
       }
 
@@ -477,7 +479,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
       QueryResultSerializer serializer(std::move(*it), t_start);
       StatementStreamHeader header{offset, statement_executed};
       StreamSerializerResponses(&serializer, req_type, &tx_seq_id_,
-                                rpc_response_fn_, &header);
+                                stream.response_fn_, &header);
       break;
     }
     case RpcProto::TPM_COMPUTE_METRIC: {
@@ -489,7 +491,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
         protozero::ConstBytes args = req.compute_metric_args();
         ComputeMetricInternal(args.data, args.size, result);
       }
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_SUMMARIZE_TRACE: {
@@ -501,7 +503,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
         protozero::ConstBytes args = req.trace_summary_args();
         ComputeTraceSummaryInternal(args.data, args.size, result);
       }
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_GET_METRIC_DESCRIPTORS: {
@@ -509,13 +511,13 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
       auto descriptor_set = trace_processor_->GetMetricDescriptors();
       auto* result = resp->set_metric_descriptors();
       result->AppendRawProtoBytes(descriptor_set.data(), descriptor_set.size());
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_RESTORE_INITIAL_TABLES: {
       trace_processor_->RestoreInitialTables();
       Response resp(tx_seq_id_++, req_type);
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_ENABLE_METATRACE: {
@@ -524,27 +526,27 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
       EnableMetatrace(args.data, args.size);
 
       Response resp(tx_seq_id_++, req_type);
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_DISABLE_AND_READ_METATRACE: {
       Response resp(tx_seq_id_++, req_type);
       DisableAndReadMetatraceInternal(resp->set_metatrace());
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_GET_STATUS: {
       Response resp(tx_seq_id_++, req_type);
       std::vector<uint8_t> status = GetStatus();
       resp->set_status()->AppendRawProtoBytes(status.data(), status.size());
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_RESET_TRACE_PROCESSOR: {
       Response resp(tx_seq_id_++, req_type);
       protozero::ConstBytes args = req.reset_trace_processor_args();
       ResetTraceProcessor(args.data, args.size);
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_REGISTER_SQL_PACKAGE: {
@@ -554,7 +556,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
       if (!status.ok()) {
         res->set_error(status.message());
       }
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_CREATE_SUMMARIZER: {
@@ -577,7 +579,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
           result->set_summarizer_id(summarizer_id);
         }
       }
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_UPDATE_SUMMARIZER_SPEC: {
@@ -610,7 +612,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
           query->set_was_dropped(sync_info.was_dropped);
         }
       }
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_QUERY_SUMMARIZER: {
@@ -644,7 +646,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
           result->set_standalone_sql(query_result.standalone_sql);
         }
       }
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     case RpcProto::TPM_EXPORT: {
@@ -661,7 +663,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
                               result->set_data(chunk, chunk_len);
                             }
                             result->set_has_more(has_more);
-                            resp.Send(rpc_response_fn_);
+                            resp.Send(stream.response_fn_);
                             return base::OkStatus();
                           })
                  : base::ErrStatus("Export format is required");
@@ -670,7 +672,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
         auto* result = resp->set_export_result();
         result->set_error(status.message());
         result->set_has_more(false);
-        resp.Send(rpc_response_fn_);
+        resp.Send(stream.response_fn_);
       }
       break;
     }
@@ -688,7 +690,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
         // Erasing will call the Summarizer destructor which drops all tables.
         summarizers_.Erase(summarizer_id);
       }
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
     default: {
@@ -699,7 +701,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
       Response resp(tx_seq_id_++, req_type);
       resp->set_invalid_request(
           static_cast<RpcProto::TraceProcessorMethod>(req_type));
-      resp.Send(rpc_response_fn_);
+      resp.Send(stream.response_fn_);
       break;
     }
   }  // switch(req_type)

--- a/src/trace_processor/rpc/rpc.h
+++ b/src/trace_processor/rpc/rpc.h
@@ -81,9 +81,18 @@ class Rpc {
   // exchanged on these pipes are TraceProcessorRpc protos (defined in
   // trace_processor.proto). This has been introduced in Perfetto v15.
 
-  // A reservation inside the tokenizer for a transport to read into. Must be
-  // consumed exactly once: EndRequest() reports how many bytes were written
-  // and dispatches whatever messages completed, AbortRequest() discards it;
+  // The size argument is a uint32_t and not size_t to avoid ABI mismatches
+  // with Wasm, where size_t = uint32_t.
+  // (nullptr, 0) has the semantic of "close the channel" and is issued when an
+  // unrecoverable wire-protocol framing error is detected.
+  using RpcResponseFunction =
+      std::function<void(const void* /*data*/, uint32_t /*len*/)>;
+
+  class Stream;
+
+  // A reservation inside a Stream's tokenizer to read into. Must be consumed
+  // exactly once: EndRequest() reports how many bytes were written and
+  // dispatches whatever messages completed, AbortRequest() discards it;
   // dropping one fails a CHECK.
   class RequestHandle {
    public:
@@ -101,36 +110,58 @@ class Rpc {
     void EndRequest(size_t size_written);
     void AbortRequest();
 
-    explicit operator bool() const { return rpc_ != nullptr; }
+    // False once consumed or moved from.
+    explicit operator bool() const { return stream_ != nullptr; }
 
    private:
-    friend class Rpc;
-    RequestHandle(Rpc* rpc, protozero::ProtoRingBuffer::WriteHandle write)
-        : rpc_(rpc), write_(std::move(write)) {}
+    friend class Stream;
+    RequestHandle(Stream* stream, protozero::ProtoRingBuffer::WriteHandle write)
+        : stream_(stream), write_(std::move(write)) {}
 
-    Rpc* rpc_ = nullptr;
+    Stream* stream_ = nullptr;
     protozero::ProtoRingBuffer::WriteHandle write_;
   };
 
-  // Pushes data received by the RPC channel into the parser. Inbound messages
-  // are tokenized and turned into TraceProcessor method invocations. The bytes
-  // do not need to be a whole TraceProcessorRpc message: they can be a portion
-  // of it or a union of >1 messages.
-  // OnRpcRequest() is the copying equivalent, for transports that cannot read
-  // into the reservation directly.
-  // Responses are sent throught the RpcResponseFunction (below).
-  void OnRpcRequest(const void* data, size_t len);
-  PERFETTO_WARN_UNUSED_RESULT RequestHandle BeginRpcRequest(size_t size);
+  // One byte-pipe: an HTTP connection, a websocket, a unix socket, or the one
+  // postmessage channel in the Wasm case. A transport that serves several
+  // peers at once owns a Stream per peer.
+  //
+  // A Stream owns only the framing state: the tokenizer holding a message that
+  // arrived in pieces. Interleaving the bytes of two peers into one tokenizer
+  // corrupts both, hence one per connection.
+  //
+  // The message sequence ids stay on Rpc and shared: a second peer numbering
+  // from its own 0 breaks the sequence, which is how two clients on one
+  // TraceProcessor (e.g. two UI tabs on the same --httpd instance) are
+  // detected and told so.
+  class Stream {
+   public:
+    // |rpc| must outlive this. |response_fn| is called, possibly several times
+    // for a single request, with this stream's responses.
+    Stream(Rpc& rpc, RpcResponseFunction response_fn);
+    ~Stream();
 
-  // The size argument is a uint32_t and not size_t to avoid ABI mismatches
-  // with Wasm, where size_t = uint32_t.
-  // (nullptr, 0) has the semantic of "close the channel" and is issued when an
-  // unrecoverable wire-protocol framing error is detected.
-  using RpcResponseFunction =
-      std::function<void(const void* /*data*/, uint32_t /*len*/)>;
-  void SetRpcResponseFunction(RpcResponseFunction f) {
-    rpc_response_fn_ = std::move(f);
-  }
+    Stream(const Stream&) = delete;
+    Stream& operator=(const Stream&) = delete;
+
+    // Pushes data received on this pipe into the parser. Inbound messages are
+    // tokenized and turned into TraceProcessor method invocations. The bytes
+    // do not need to be a whole TraceProcessorRpc message: they can be a
+    // portion of it or a union of >1 messages, as long as the stream sees the
+    // peer's bytes in order and without gaps.
+    PERFETTO_WARN_UNUSED_RESULT RequestHandle BeginRequest(size_t size);
+
+   private:
+    friend class Rpc;
+    friend class RequestHandle;
+
+    void FinishRequest();
+
+    Rpc& rpc_;
+    RpcResponseFunction response_fn_;
+    protozero::ProtoRingBuffer rxbuf_;
+    bool request_in_flight_ = false;
+  };
 
   // 2. TraceProcessor legacy RPC endpoints.
   // The methods below are exposed for the old RPC interfaces, where each RPC
@@ -185,8 +216,8 @@ class Rpc {
  private:
   base::Status ExportSqlite(const ExportCallback&);
 
-  void ParseRpcRequest(const uint8_t*, size_t);
-  void DrainRxBuf();
+  void ParseRpcRequest(Stream&, const uint8_t*, size_t);
+  void DrainStream(Stream&);
   void ResetTraceProcessor(const uint8_t*, size_t);
   base::Status RegisterSqlPackage(protozero::ConstBytes);
   void ResetTraceProcessorInternal(const Config&);
@@ -200,7 +231,6 @@ class Rpc {
                                    protos::pbzero::TraceSummaryResult*);
   void DisableAndReadMetatraceInternal(
       protos::pbzero::DisableAndReadMetatraceResult*);
-  void FinishRpcRequest();
 
   Config default_config_;
   TraceProcessor::PlatformInterface* platform_ = nullptr;
@@ -208,9 +238,8 @@ class Rpc {
 
   Config current_config_;
   std::unique_ptr<TraceProcessor> trace_processor_;
-  RpcResponseFunction rpc_response_fn_;
-  protozero::ProtoRingBuffer rxbuf_;
-  bool request_in_flight_ = false;
+  // Deliberately shared by every Stream: a second peer talking to the same
+  // TraceProcessor breaks the sequence, which is how that is detected.
   int64_t tx_seq_id_ = 0;
   int64_t rx_seq_id_ = 0;
   bool eof_ = false;

--- a/src/trace_processor/rpc/rpc_unittest.cc
+++ b/src/trace_processor/rpc/rpc_unittest.cc
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/rpc/rpc.h"
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "perfetto/protozero/scattered_heap_buffer.h"
+#include "test/gtest_and_gmock.h"
+
+#include "protos/perfetto/trace_processor/trace_processor.pbzero.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+using ::testing::HasSubstr;
+using RpcProto = protos::pbzero::TraceProcessorRpc;
+
+// Collects everything a Stream sends back, and whether it was disconnected.
+class ResponseSink {
+ public:
+  Rpc::RpcResponseFunction Fn() {
+    return [this](const void* data, uint32_t len) {
+      if (data == nullptr) {
+        disconnected = true;
+        return;
+      }
+      auto* p = static_cast<const uint8_t*>(data);
+      bytes.insert(bytes.end(), p, p + len);
+    };
+  }
+
+  // The responses concatenated, for substring assertions on error strings.
+  std::string AsString() const {
+    return std::string(reinterpret_cast<const char*>(bytes.data()),
+                       bytes.size());
+  }
+
+  std::vector<uint8_t> bytes;
+  bool disconnected = false;
+};
+
+// A TraceProcessorRpc{seq, request} framed as a TraceProcessorRpcStream.msg.
+std::vector<uint8_t> RpcMessage(int64_t seq, RpcProto::TraceProcessorMethod m) {
+  protozero::HeapBuffered<protos::pbzero::TraceProcessorRpcStream> stream;
+  auto* msg = stream->add_msg();
+  msg->set_seq(seq);
+  msg->set_request(m);
+  return stream.SerializeAsArray();
+}
+
+void Write(Rpc::Stream& stream, const std::vector<uint8_t>& data) {
+  auto write = stream.BeginRequest(data.size());
+  memcpy(write.data(), data.data(), data.size());
+  write.EndRequest(data.size());
+}
+
+// The sequence ids stay shared across streams on purpose: a second peer
+// numbering from its own 0 is how two clients on one TraceProcessor are
+// detected. Streams must not paper over that.
+TEST(RpcStreamTest, SecondPeerStillTripsTheSequenceCheck) {
+  Rpc rpc;
+  ResponseSink sink_a;
+  ResponseSink sink_b;
+  Rpc::Stream a(rpc, sink_a.Fn());
+  Rpc::Stream b(rpc, sink_b.Fn());
+
+  Write(a, RpcMessage(1, RpcProto::TPM_GET_STATUS));
+  Write(a, RpcMessage(2, RpcProto::TPM_GET_STATUS));
+  EXPECT_FALSE(sink_a.disconnected);
+  EXPECT_THAT(sink_a.AsString(), ::testing::Not(HasSubstr("ERR:rpc_seq")));
+
+  // |b| restarts from 1, which cannot follow |a|'s 2.
+  Write(b, RpcMessage(1, RpcProto::TPM_GET_STATUS));
+  EXPECT_THAT(sink_b.AsString(), HasSubstr("ERR:rpc_seq"));
+  EXPECT_TRUE(sink_b.disconnected);
+}
+
+// A single peer on its own stream is undisturbed by the check.
+TEST(RpcStreamTest, OnePeerRunsItsSequenceToCompletion) {
+  Rpc rpc;
+  ResponseSink sink;
+  Rpc::Stream stream(rpc, sink.Fn());
+
+  for (int64_t seq = 1; seq <= 3; seq++)
+    Write(stream, RpcMessage(seq, RpcProto::TPM_GET_STATUS));
+
+  EXPECT_FALSE(sink.disconnected);
+  EXPECT_THAT(sink.AsString(), ::testing::Not(HasSubstr("ERR:rpc_seq")));
+  EXPECT_FALSE(sink.bytes.empty());
+}
+
+// A message split across reads must not be corrupted by another stream's
+// bytes landing in between: the half-received message lives in the stream.
+TEST(RpcStreamTest, InterleavedPartialMessagesDoNotCorruptEachOther) {
+  Rpc rpc;
+  ResponseSink sink_a;
+  ResponseSink sink_b;
+  Rpc::Stream a(rpc, sink_a.Fn());
+  Rpc::Stream b(rpc, sink_b.Fn());
+
+  // Consecutive seq ids: the point here is framing, and the shared sequence
+  // check would otherwise fire first and mask it.
+  auto msg_a = RpcMessage(1, RpcProto::TPM_GET_STATUS);
+  auto msg_b = RpcMessage(2, RpcProto::TPM_GET_STATUS);
+
+  // Split both in half and interleave the halves.
+  std::vector<uint8_t> a1(msg_a.begin(), msg_a.begin() + 3);
+  std::vector<uint8_t> a2(msg_a.begin() + 3, msg_a.end());
+  std::vector<uint8_t> b1(msg_b.begin(), msg_b.begin() + 3);
+  std::vector<uint8_t> b2(msg_b.begin() + 3, msg_b.end());
+
+  Write(a, a1);
+  Write(b, b1);
+  // Neither is complete yet, so nothing should have been dispatched.
+  EXPECT_TRUE(sink_a.bytes.empty());
+  EXPECT_TRUE(sink_b.bytes.empty());
+
+  Write(a, a2);
+  Write(b, b2);
+
+  EXPECT_FALSE(sink_a.disconnected);
+  EXPECT_FALSE(sink_b.disconnected);
+  EXPECT_FALSE(sink_a.bytes.empty());
+  EXPECT_FALSE(sink_b.bytes.empty());
+  EXPECT_THAT(sink_a.AsString(), ::testing::Not(HasSubstr("framing error")));
+  EXPECT_THAT(sink_b.AsString(), ::testing::Not(HasSubstr("framing error")));
+  EXPECT_THAT(sink_b.AsString(), ::testing::Not(HasSubstr("ERR:rpc_seq")));
+}
+
+// A stream that dies mid-message takes its own framing state with it.
+TEST(RpcStreamTest, ClosingStreamMidMessageLeavesOthersAlone) {
+  Rpc rpc;
+  ResponseSink sink_b;
+  Rpc::Stream b(rpc, sink_b.Fn());
+
+  {
+    ResponseSink sink_a;
+    Rpc::Stream a(rpc, sink_a.Fn());
+    auto msg = RpcMessage(1, RpcProto::TPM_GET_STATUS);
+    Write(a, {msg.begin(), msg.begin() + 3});  // Half a message, then gone.
+  }
+
+  Write(b, RpcMessage(1, RpcProto::TPM_GET_STATUS));
+  EXPECT_FALSE(sink_b.disconnected);
+  EXPECT_FALSE(sink_b.bytes.empty());
+  EXPECT_THAT(sink_b.AsString(), ::testing::Not(HasSubstr("framing error")));
+}
+
+// A framing error is reported to the stream that caused it, and only it.
+TEST(RpcStreamTest, FramingErrorIsScopedToOneStream) {
+  Rpc rpc;
+  ResponseSink sink_a;
+  ResponseSink sink_b;
+  Rpc::Stream a(rpc, sink_a.Fn());
+  Rpc::Stream b(rpc, sink_b.Fn());
+
+  // Field 1 with a non-length-delimited wire type: an unrecoverable framing
+  // error.
+  const std::vector<uint8_t> garbage{0x08, 0x00};
+  Write(a, garbage);
+
+  EXPECT_TRUE(sink_a.disconnected);
+  EXPECT_THAT(sink_a.AsString(), HasSubstr("RPC framing error"));
+
+  Write(b, RpcMessage(1, RpcProto::TPM_GET_STATUS));
+  EXPECT_FALSE(sink_b.disconnected);
+  EXPECT_THAT(sink_b.AsString(), ::testing::Not(HasSubstr("framing error")));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/rpc/stdiod.cc
+++ b/src/trace_processor/rpc/stdiod.cc
@@ -39,8 +39,15 @@ namespace perfetto::trace_processor {
 
 base::Status RunStdioRpcServer(Rpc& rpc) {
   constexpr size_t kReadSize = 4096;
+  // stdin/stdout is a single pipe with a single peer, hence one stream.
+  Rpc::Stream stream(rpc, [](const void* ptr, uint32_t size) {
+    auto ret = base::WriteAll(STDOUT_FILENO, ptr, size);
+    if (ret < 0 || static_cast<uint32_t>(ret) != size) {
+      PERFETTO_FATAL("Failed to write response");
+    }
+  });
   for (;;) {
-    Rpc::RequestHandle req = rpc.BeginRpcRequest(kReadSize);
+    Rpc::RequestHandle req = stream.BeginRequest(kReadSize);
     auto ret = base::Read(STDIN_FILENO, req.data(), req.size());
     if (ret <= 0) {
       req.AbortRequest();
@@ -48,14 +55,7 @@ base::Status RunStdioRpcServer(Rpc& rpc) {
         return base::ErrStatus("Failed while reading the buffer");
       return base::OkStatus();
     }
-    rpc.SetRpcResponseFunction([](const void* ptr, uint32_t size) {
-      auto ret = base::WriteAll(STDOUT_FILENO, ptr, size);
-      if (ret < 0 || static_cast<uint32_t>(ret) != size) {
-        PERFETTO_FATAL("Failed to write response");
-      }
-    });
     req.EndRequest(static_cast<size_t>(ret));
-    rpc.SetRpcResponseFunction(nullptr);
   }
 }
 

--- a/src/trace_processor/rpc/unixd.cc
+++ b/src/trace_processor/rpc/unixd.cc
@@ -118,6 +118,9 @@ class UnixRpcServer : public base::UnixSocket::EventListener {
  private:
   struct ClientConn {
     std::unique_ptr<base::UnixSocket> sock;
+    // Framing state for this client. Kept per connection so that a peer that
+    // disconnects mid-message cannot leave a partial frame in another's.
+    std::unique_ptr<Rpc::Stream> stream;
   };
 
   ClientConn* FindConn(base::UnixSocket* self);
@@ -265,7 +268,16 @@ void UnixRpcServer::OnNewIncomingConnection(
     base::UnixSocket*,
     std::unique_ptr<base::UnixSocket> new_conn) {
   auto conn = std::make_unique<ClientConn>();
+  base::UnixSocket* sock = new_conn.get();
   conn->sock = std::move(new_conn);
+  conn->stream = std::make_unique<Rpc::Stream>(
+      rpc_, [sock](const void* resp, uint32_t resp_len) {
+        if (resp == nullptr) {
+          sock->Shutdown(/*notify=*/false);
+          return;
+        }
+        sock->Send(resp, resp_len);
+      });
   clients_.push_back(std::move(conn));
 }
 
@@ -287,34 +299,25 @@ UnixRpcServer::ClientConn* UnixRpcServer::FindConn(base::UnixSocket* self) {
 }
 
 void UnixRpcServer::OnDataAvailable(base::UnixSocket* self) {
-  if (!FindConn(self))
+  ClientConn* conn = FindConn(self);
+  if (!conn)
     return;
 
   if (reaper_)
     reaper_->set_query_in_flight(true);
 
-  // A framing error makes Rpc emit a fatal_error message and then call the
-  // response function with nullptr, which tears the connection down below.
-  rpc_.SetRpcResponseFunction([self](const void* resp, uint32_t resp_len) {
-    if (resp == nullptr) {
-      self->Shutdown(/*notify=*/false);
-      return;
-    }
-    self->Send(resp, resp_len);
-  });
-
-  // A session serves one client at a time, so no second byte stream can
-  // interleave with this one inside Rpc's tokenizer.
+  // Read straight into this connection's stream and let it dispatch whatever
+  // messages complete. The stream keeps the framing state, so a peer that
+  // stops mid-message holds up only itself.
   for (;;) {
     constexpr size_t kReadSize = 4096;
-    Rpc::RequestHandle req = rpc_.BeginRpcRequest(kReadSize);
+    Rpc::RequestHandle req = conn->stream->BeginRequest(kReadSize);
     size_t rx_bytes = self->Receive(req.data(), req.size());
     req.EndRequest(rx_bytes);
     if (rx_bytes == 0)
       break;
   }
 
-  rpc_.SetRpcResponseFunction(nullptr);
   if (reaper_) {
     reaper_->set_query_in_flight(false);
     reaper_->OnActivity();

--- a/src/trace_processor/rpc/wasm_bridge.cc
+++ b/src/trace_processor/rpc/wasm_bridge.cc
@@ -30,6 +30,7 @@ namespace {
 using RpcResponseFn = void(const void*, uint32_t);
 
 Rpc* g_trace_processor_rpc;
+Rpc::Stream* g_rpc_stream;
 Rpc::RequestHandle* g_pending_request;
 
 uint32_t g_max_write_size;
@@ -65,11 +66,11 @@ uint8_t* trace_processor_rpc_init(RpcResponseFn* resp_function,
   // buffer with the response (a proto-encoded TraceProcessorRpc message) and
   // postMessage() it to the controller. See the comment in wasm_bridge.ts for
   // an overview of the JS<>Wasm callstack.
-  g_trace_processor_rpc->SetRpcResponseFunction(resp_function);
+  g_rpc_stream = new Rpc::Stream(*g_trace_processor_rpc, resp_function);
 
   g_max_write_size = max_write_size;
-  g_pending_request = new Rpc::RequestHandle(
-      g_trace_processor_rpc->BeginRpcRequest(g_max_write_size));
+  g_pending_request =
+      new Rpc::RequestHandle(g_rpc_stream->BeginRequest(g_max_write_size));
   return g_pending_request->data();
 }
 
@@ -78,7 +79,7 @@ uint8_t* trace_processor_rpc_init(RpcResponseFn* resp_function,
 uint8_t* EMSCRIPTEN_KEEPALIVE trace_processor_on_rpc_request(uint32_t);
 uint8_t* trace_processor_on_rpc_request(uint32_t size) {
   g_pending_request->EndRequest(size);
-  *g_pending_request = g_trace_processor_rpc->BeginRpcRequest(g_max_write_size);
+  *g_pending_request = g_rpc_stream->BeginRequest(g_max_write_size);
   return g_pending_request->data();
 }
 


### PR DESCRIPTION
Rpc holds a single tokenizer for the whole process, even though several
transports serve more than one peer at a time. A tokenizer holds the
message that arrived in pieces, so interleaving the bytes of two peers
into one corrupts both.

unixd.cc had already worked around this by keeping a ProtoRingBuffer per
connection and forwarding only whole messages, and httpd.cc is about to
need the same thing: once it reads payloads straight into the tokenizer,
two connections mid-payload at once alias each other's memory.

Introduce Rpc::Stream, owning the framing state of one byte-pipe: the
tokenizer and the response function. Transports that serve one peer
(Wasm, stdiod) hold one stream; those that serve many (httpd, unixd)
hold one per connection. unixd loses its hand-rolled tokenizer and
message-forwarding loop, as the stream does that now.

The message sequence ids deliberately stay on Rpc, shared by every
stream. They are not framing state: a second peer numbering its requests
from its own 0 breaks the sequence, and that is how two clients on one
TraceProcessor - two UI tabs on the same --httpd instance, say - are
detected and told so. Per-connection tokenizers make that check more
useful rather than replacing it, because the peers now reach it with
their framing intact instead of first shredding each other's messages.

This also retires the SetRpcResponseFunction(fn)/SetRpcResponseFunction
(nullptr) dance every transport had to perform around each dispatch: the
response function is handed to the stream once, at construction.
