### PR TITLE
protozero: let tokenized messages outlive the read loop

### DIFF
--- a/include/perfetto/ext/protozero/proto_ring_buffer.h
+++ b/include/perfetto/ext/protozero/proto_ring_buffer.h
@@ -20,8 +20,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <memory>
+
 #include "perfetto/base/compiler.h"
-#include "perfetto/ext/base/paged_memory.h"
 
 namespace protozero {
 
@@ -91,22 +92,56 @@ namespace protozero {
 //
 // In the next ReadMessage() the R cursor will chase the W cursor. When this
 // happens (very frequent) we can just reset both cursors to 0 and restart.
-// If we are unlucky and get to the end of the buffer, two things happen:
-// 1. We try first to recompact the buffer, moving everything left by R.
-// 2. If still there isn't enough space, we expand the buffer.
+// If we reach the end of the buffer, we calculate the space required for the
+// unread bytes and the next write. If compaction provides enough space, we move
+// unread bytes left by R; otherwise we copy them directly into a larger buffer.
 // Given that each message is expected to be at most kMaxMsgSize (64 MB), the
 // expansion is bound at 2 * kMaxMsgSize.
+//
+// Rewinding and recompacting are only possible while no Message points into
+// the buffer. Messages own references to the underlying allocation. If it is
+// still shared when a write needs more room, unread bytes move to another
+// buffer. One previous buffer is kept for reuse, provided it is large enough.
+// This avoids repeated allocations when alternating between two buffers;
+// deeper queues of retained messages can still cause allocation churn.
 
 class ProtoRingBuffer {
+ private:
+  class Buffer;
+  struct BufferDeleter {
+    void operator()(Buffer*) const;
+  };
+  // Each handle owns one reference to the allocation, released by its deleter.
+  using BufferPtr = std::unique_ptr<Buffer, BufferDeleter>;
+
  public:
   static constexpr size_t kMaxMsgSize = 64 * 1024 * 1024;
-  struct Message {
-    const uint8_t* start = nullptr;
-    uint32_t len = 0;
-    uint32_t field_id = 0;
-    bool fatal_framing_error = false;
-    const uint8_t* end() const { return start + len; }
-    inline bool valid() const { return !!start; }
+  // The payload of one field, without its preamble. Keeps the buffer it points
+  // into alive, so it stays valid across further writes and can be moved to
+  // another thread.
+  class Message {
+   public:
+    Message() = default;
+    ~Message();
+    Message(Message&&) noexcept;
+    Message& operator=(Message&&) noexcept;
+    Message(const Message&) = delete;
+    Message& operator=(const Message&) = delete;
+
+    const uint8_t* data() const { return start_; }
+    const uint8_t* end() const { return start_ + len_; }
+    uint32_t size() const { return len_; }
+    uint32_t field_id() const { return field_id_; }
+    bool valid() const { return !!start_; }
+    bool fatal_framing_error() const { return fatal_framing_error_; }
+
+   private:
+    friend class ProtoRingBuffer;
+    BufferPtr buf_;
+    const uint8_t* start_ = nullptr;
+    uint32_t len_ = 0;
+    uint32_t field_id_ = 0;
+    bool fatal_framing_error_ = false;
   };
 
   ProtoRingBuffer();
@@ -155,24 +190,29 @@ class ProtoRingBuffer {
   // If a message can be read, it returns the boundaries of the message
   // (without including the preamble) and advances the read cursor.
   // If no message is available, returns a null range.
-  // The returned pointer is only valid until the next call to BeginWrite(),
-  // as that can recompact or resize the underlying buffer.
   Message ReadMessage();
 
-  // Exposed for testing.
-  size_t capacity() const { return buf_.size(); }
-  size_t avail() const { return buf_.size() - (wr_ - rd_); }
+  // Exposed for testing: total allocations and bytes held by the spare buffer.
+  uint32_t num_buffers_for_testing() const { return num_buffers_; }
+  size_t cached_capacity_for_testing() const;
 
  private:
   friend class WriteHandle;
 
+  BufferPtr AcquireBuffer(size_t capacity);
+  void RecycleBuffer(BufferPtr buffer);
   void FinishWrite(size_t size_written);
 
-  perfetto::base::PagedMemory buf_;
-  bool failed_ = false;  // Set in case of an unrecoverable framing faiulre.
+  // Refcounted; the ring buffer holds one reference, each Message another.
+  BufferPtr buf_;
+  // At most one previous allocation, at least as large as the active buffer.
+  // It can be reused once all Messages referring to it have been released.
+  BufferPtr spare_;
+  bool failed_ = false;  // Set in case of an unrecoverable framing failure.
   size_t rd_ = 0;        // Offset of the read cursor in |buf_|.
   size_t wr_ = 0;        // Offset of the write cursor in |buf_|.
   bool write_in_flight_ = false;
+  uint32_t num_buffers_ = 1;
 };
 
 }  // namespace protozero

--- a/src/protozero/proto_ring_buffer.cc
+++ b/src/protozero/proto_ring_buffer.cc
@@ -16,6 +16,8 @@
 
 #include "perfetto/ext/protozero/proto_ring_buffer.h"
 
+#include <algorithm>
+#include <atomic>
 #include <new>
 #include <utility>
 
@@ -29,8 +31,18 @@ namespace protozero {
 namespace {
 constexpr size_t kGrowBytes = 128 * 1024;
 
-inline ProtoRingBuffer::Message FramingError() {
-  ProtoRingBuffer::Message msg{};
+// The boundaries of a message inside the buffer, before it is turned into a
+// Message holding a reference to that buffer.
+struct Token {
+  const uint8_t* start = nullptr;
+  uint32_t len = 0;
+  uint32_t field_id = 0;
+  bool fatal_framing_error = false;
+  bool valid() const { return !!start; }
+};
+
+inline Token FramingError() {
+  Token msg{};
   msg.fatal_framing_error = true;
   return msg;
 }
@@ -38,13 +50,12 @@ inline ProtoRingBuffer::Message FramingError() {
 // Tries to decode a length-delimited proto field from |start|.
 // Returns a valid boundary if the preamble is valid and the length is within
 // |end|, or an invalid message otherwise.
-ProtoRingBuffer::Message TryReadProtoMessage(const uint8_t* start,
-                                             const uint8_t* end) {
+Token TryReadProtoMessage(const uint8_t* start, const uint8_t* end) {
   namespace proto_utils = protozero::proto_utils;
   uint64_t field_tag = 0;
   auto* start_of_len = proto_utils::ParseVarInt(start, end, &field_tag);
   if (start_of_len == start)
-    return ProtoRingBuffer::Message{};  // Not enough data.
+    return Token{};  // Not enough data.
 
   const uint32_t tag = field_tag & 0x07;
   if (tag !=
@@ -56,7 +67,7 @@ ProtoRingBuffer::Message TryReadProtoMessage(const uint8_t* start,
   uint64_t msg_len = 0;
   auto* start_of_msg = proto_utils::ParseVarInt(start_of_len, end, &msg_len);
   if (start_of_msg == start_of_len)
-    return ProtoRingBuffer::Message{};  // Not enough data.
+    return Token{};  // Not enough data.
 
   if (msg_len > ProtoRingBuffer::kMaxMsgSize) {
     PERFETTO_ELOG("RPC framing error, message too large (%" PRIu64 " > %zu)",
@@ -65,9 +76,9 @@ ProtoRingBuffer::Message TryReadProtoMessage(const uint8_t* start,
   }
 
   if (start_of_msg + msg_len > end)
-    return ProtoRingBuffer::Message{};  // Not enough data.
+    return Token{};  // Not enough data.
 
-  ProtoRingBuffer::Message msg{};
+  Token msg{};
   msg.start = start_of_msg;
   msg.len = static_cast<uint32_t>(msg_len);
   msg.field_id = static_cast<uint32_t>(field_tag >> 3);
@@ -76,9 +87,85 @@ ProtoRingBuffer::Message TryReadProtoMessage(const uint8_t* start,
 
 }  // namespace
 
-ProtoRingBuffer::ProtoRingBuffer()
-    : buf_(perfetto::base::PagedMemory::Allocate(kGrowBytes)) {}
+// The memory messages are tokenized out of. Refcounted, because the messages
+// handed out are slices of it and may outlive the ring buffer.
+class ProtoRingBuffer::Buffer {
+ public:
+  static BufferPtr Create(size_t capacity) {
+    return BufferPtr(new Buffer(capacity));
+  }
+  BufferPtr Share() {
+    refs_.fetch_add(1, std::memory_order_relaxed);
+    return BufferPtr(this);
+  }
+
+  // True if no Message points into this buffer, i.e. its bytes can be recycled
+  // or moved around.
+  bool IsUniquelyOwned() const {
+    return refs_.load(std::memory_order_acquire) == 1;
+  }
+
+  uint8_t* data() { return static_cast<uint8_t*>(mem_.Get()); }
+  size_t size() const { return mem_.size(); }
+
+ private:
+  friend struct BufferDeleter;
+
+  explicit Buffer(size_t capacity)
+      : mem_(perfetto::base::PagedMemory::Allocate(capacity)) {}
+
+  void Release() {
+    if (refs_.fetch_sub(1, std::memory_order_acq_rel) == 1)
+      delete this;
+  }
+
+  std::atomic<uint32_t> refs_{1};
+  perfetto::base::PagedMemory mem_;
+};
+
+void ProtoRingBuffer::BufferDeleter::operator()(Buffer* buffer) const {
+  buffer->Release();
+}
+
+ProtoRingBuffer::Message::~Message() = default;
+
+ProtoRingBuffer::Message::Message(Message&& other) noexcept {
+  *this = std::move(other);
+}
+
+ProtoRingBuffer::Message& ProtoRingBuffer::Message::operator=(
+    Message&& other) noexcept {
+  if (this == &other)
+    return *this;
+  buf_ = std::move(other.buf_);
+  start_ = std::exchange(other.start_, nullptr);
+  len_ = std::exchange(other.len_, 0);
+  field_id_ = std::exchange(other.field_id_, 0);
+  fatal_framing_error_ = std::exchange(other.fatal_framing_error_, false);
+  return *this;
+}
+
+ProtoRingBuffer::ProtoRingBuffer() : buf_(Buffer::Create(kGrowBytes)) {}
 ProtoRingBuffer::~ProtoRingBuffer() = default;
+
+size_t ProtoRingBuffer::cached_capacity_for_testing() const {
+  return spare_ ? spare_->size() : 0;
+}
+
+ProtoRingBuffer::BufferPtr ProtoRingBuffer::AcquireBuffer(size_t capacity) {
+  if (spare_ && spare_->IsUniquelyOwned() && spare_->size() >= capacity)
+    return std::move(spare_);
+  ++num_buffers_;
+  return Buffer::Create(capacity);
+}
+
+void ProtoRingBuffer::RecycleBuffer(BufferPtr buffer) {
+  // Keep only the most recent buffer, and only if it can satisfy future
+  // replacements. In particular, growth must not cache an undersized buffer.
+  spare_.reset();
+  if (buffer->size() >= buf_->size())
+    spare_ = std::move(buffer);
+}
 
 ProtoRingBuffer::WriteHandle::~WriteHandle() {
   PERFETTO_CHECK(buffer_ == nullptr);
@@ -100,66 +187,49 @@ ProtoRingBuffer::WriteHandle ProtoRingBuffer::BeginWrite(size_t data_len) {
   PERFETTO_CHECK(data_len <= kMaxMsgSize);
   // A second reservation could recompact or grow the buffer under the first.
   PERFETTO_CHECK(!write_in_flight_);
-  PERFETTO_DCHECK(wr_ <= buf_.size());
+  PERFETTO_DCHECK(wr_ <= buf_->size());
   PERFETTO_DCHECK(wr_ >= rd_);
 
-  // Nothing can be tokenized any more, so recycle the whole buffer for the
-  // bytes EndWrite() is about to drop.
+  const bool uniquely_owned = buf_->IsUniquelyOwned();
+  // After a framing error, no unread bytes need preserving. Messages already
+  // handed out still own their bytes, so rewinding requires exclusive
+  // ownership.
   if (PERFETTO_UNLIKELY(failed_))
+    rd_ = wr_;
+  if (rd_ == wr_ && uniquely_owned)
     rd_ = wr_ = 0;
 
-  // If the last call to ReadMessage() consumed all the data in the buffer and
-  // there are no incomplete messages pending, restart from the beginning rather
-  // than keep ringing. This is the most common case.
-  if (PERFETTO_LIKELY(rd_ == wr_))
-    rd_ = wr_ = 0;
-
-  size_t avail = buf_.size() - wr_;
-  if (data_len > avail) {
-    // This whole section should be hit extremely rarely.
-
-    // Try first just recompacting the buffer by moving everything to the left.
-    // This can happen if we received "a message and a bit" on each write call
-    // so we ended pup in a situation like:
-    // buf_: [unused space] [msg1 incomplete]
-    //                      ^rd_             ^wr_
-    //
-    // After recompaction:
-    // buf_: [msg1 incomplete]
-    //       ^rd_             ^wr_
-    uint8_t* buf = static_cast<uint8_t*>(buf_.Get());
-    memmove(&buf[0], &buf[rd_], wr_ - rd_);
-    avail += rd_;
-    wr_ -= rd_;
-    rd_ = 0;
-    if (data_len > avail) {
-      // The compaction didn't free up enough space and we need to expand the
-      // ring buffer. Yes, we could have detected this earlier and split the
-      // code paths, rather than first compacting and then realizing it wasn't
-      // sufficient. However, that would make the code harder to reason about,
-      // creating code paths that are nearly never hit, hence making it more
-      // likely to accumulate bugs in future. All this is very rare.
-      size_t new_size = buf_.size();
-      while (data_len > new_size - wr_)
-        new_size += kGrowBytes;
-      if (new_size > kMaxMsgSize * 2) {
-        // These bytes can never amount to a message (e.g. a never-ending
-        // varint). |buf_| exceeds kMaxMsgSize by now, so dropping them leaves
-        // room for the write, which EndWrite() will then discard.
-        failed_ = true;
-        rd_ = wr_ = 0;
-        write_in_flight_ = true;
-        return WriteHandle(this, static_cast<uint8_t*>(buf_.Get()), data_len);
-      }
-      auto new_buf = perfetto::base::PagedMemory::Allocate(new_size);
-      memcpy(new_buf.Get(), buf_.Get(), buf_.size());
-      buf_ = std::move(new_buf);
-      // No need to touch rd_ / wr_ cursors.
+  if (PERFETTO_UNLIKELY(data_len > buf_->size() - wr_)) {
+    size_t pending = wr_ - rd_;
+    size_t required = pending + data_len;
+    if (required > kMaxMsgSize * 2) {
+      // These bytes can never amount to a message (e.g. a never-ending varint).
+      // Reserve space for the write, which FinishWrite() will discard.
+      failed_ = true;
+      pending = 0;
+      required = data_len;
     }
+
+    if (uniquely_owned && required <= buf_->size()) {
+      memmove(buf_->data(), buf_->data() + rd_, pending);
+    } else {
+      // Choose the final capacity before acquiring a buffer, so a write that
+      // must preserve retained messages and grow copies unread bytes only once.
+      const size_t capacity =
+          std::max(buf_->size(),
+                   ((required + kGrowBytes - 1) / kGrowBytes) * kGrowBytes);
+      auto next = AcquireBuffer(capacity);
+      memcpy(next->data(), buf_->data() + rd_, pending);
+      auto previous = std::move(buf_);
+      buf_ = std::move(next);
+      RecycleBuffer(std::move(previous));
+    }
+    rd_ = 0;
+    wr_ = pending;
   }
 
   write_in_flight_ = true;
-  return WriteHandle(this, static_cast<uint8_t*>(buf_.Get()) + wr_, data_len);
+  return WriteHandle(this, buf_->data() + wr_, data_len);
 }
 
 void ProtoRingBuffer::WriteHandle::EndWrite(size_t size_written) {
@@ -184,10 +254,24 @@ void ProtoRingBuffer::FinishWrite(size_t size_written) {
 }
 
 ProtoRingBuffer::Message ProtoRingBuffer::ReadMessage() {
-  if (failed_)
-    return FramingError();
+  // Token only carries boundaries; attaching |buf_| is what keeps the bytes
+  // alive for as long as the caller holds the Message.
+  auto make_message = [this](const Token& tok) {
+    Message msg;
+    msg.fatal_framing_error_ = tok.fatal_framing_error;
+    if (tok.valid()) {
+      msg.buf_ = buf_->Share();
+      msg.start_ = tok.start;
+      msg.len_ = tok.len;
+      msg.field_id_ = tok.field_id;
+    }
+    return msg;
+  };
 
-  uint8_t* buf = static_cast<uint8_t*>(buf_.Get());
+  if (failed_)
+    return make_message(FramingError());
+
+  uint8_t* buf = buf_->data();
 
   PERFETTO_DCHECK(rd_ <= wr_);
   if (rd_ >= wr_)
@@ -196,14 +280,14 @@ ProtoRingBuffer::Message ProtoRingBuffer::ReadMessage() {
   auto msg = TryReadProtoMessage(&buf[rd_], &buf[wr_]);
   if (!msg.valid()) {
     failed_ = failed_ || msg.fatal_framing_error;
-    return msg;  // Return |msg| because it could be a framing error.
+    return make_message(msg);  // Could still be a framing error.
   }
 
   const uint8_t* msg_end = msg.start + msg.len;
   PERFETTO_CHECK(msg_end > &buf[rd_] && msg_end <= &buf[wr_]);
   auto msg_outer_len = static_cast<size_t>(msg_end - &buf[rd_]);
   rd_ += msg_outer_len;
-  return msg;
+  return make_message(msg);
 }
 
 }  // namespace protozero

--- a/src/protozero/proto_ring_buffer_unittest.cc
+++ b/src/protozero/proto_ring_buffer_unittest.cc
@@ -34,18 +34,22 @@ using testing::ElementsAre;
 
 namespace protozero {
 
+struct ExpectedMessage {
+  const uint8_t* start = nullptr;
+  uint32_t len = 0;
+  uint32_t field_id = 0;
+};
+
 // For ASSERT_EQ()
 inline bool operator==(const ProtoRingBuffer::Message& a,
-                       const ProtoRingBuffer::Message& b) {
-  if (a.field_id != b.field_id || a.len != b.len || a.valid() != b.valid())
+                       const ExpectedMessage& b) {
+  if (a.field_id() != b.field_id || a.size() != b.len || !a.valid())
     return false;
-  if (!a.valid())
-    return true;
-  return memcmp(a.start, b.start, a.len) == 0;
+  return memcmp(a.data(), b.start, b.len) == 0;
 }
 
 inline std::ostream& operator<<(std::ostream& stream,
-                                const ProtoRingBuffer::Message& msg) {
+                                const ExpectedMessage& msg) {
   stream << "Message{field_id:" << msg.field_id << ", len:" << msg.len;
   stream << ", payload: \"";
   static constexpr uint32_t kTruncLen = 16;
@@ -55,6 +59,11 @@ inline std::ostream& operator<<(std::ostream& stream,
     stream << "...";
   stream << "\"}";
   return stream;
+}
+
+inline std::ostream& operator<<(std::ostream& stream,
+                                const ProtoRingBuffer::Message& msg) {
+  return stream << ExpectedMessage{msg.data(), msg.size(), msg.field_id()};
 }
 
 namespace {
@@ -71,10 +80,10 @@ void Write(ProtoRingBuffer* buf, const void* data, size_t len) {
 
 class ProtoRingBufferTest : public ::testing::Test {
  public:
-  ProtoRingBuffer::Message MakeProtoMessage(uint32_t field_id,
-                                            uint32_t len,
-                                            bool append = false) {
-    ProtoRingBuffer::Message msg{};
+  ExpectedMessage MakeProtoMessage(uint32_t field_id,
+                                   uint32_t len,
+                                   bool append = false) {
+    ExpectedMessage msg{};
     namespace proto_utils = protozero::proto_utils;
     const uint8_t* initial_ptr = last_msg_.data();
     if (!append)
@@ -109,7 +118,7 @@ class ProtoRingBufferTest : public ::testing::Test {
 TEST_F(ProtoRingBufferTest, CoalescingStream) {
   ProtoRingBuffer buf;
   last_msg_.reserve(1024);
-  std::list<ProtoRingBuffer::Message> expected;
+  std::list<ExpectedMessage> expected;
 
   // Build 6 messages of 100 bytes each (100 does not include preambles).
   for (uint32_t i = 1; i <= 6; i++)
@@ -132,7 +141,7 @@ TEST_F(ProtoRingBufferTest, CoalescingStream) {
       if (!msg.valid())
         break;
       ASSERT_FALSE(expected.empty());
-      ASSERT_EQ(expected.front(), msg);
+      ASSERT_EQ(msg, expected.front());
       expected.pop_front();
     }
   }
@@ -144,7 +153,7 @@ TEST_F(ProtoRingBufferTest, RandomSizes) {
   std::minstd_rand0 rnd(0);
 
   last_msg_.reserve(1024 * 1024 * 64);
-  std::list<ProtoRingBuffer::Message> expected;
+  std::list<ExpectedMessage> expected;
 
   const uint32_t kNumMsg = 100;
   for (uint32_t i = 0; i < kNumMsg; i++) {
@@ -171,7 +180,7 @@ TEST_F(ProtoRingBufferTest, RandomSizes) {
       if (!msg.valid())
         break;
       ASSERT_FALSE(expected.empty());
-      ASSERT_EQ(expected.front(), msg);
+      ASSERT_EQ(msg, expected.front());
       expected.pop_front();
     }
   }
@@ -187,7 +196,7 @@ TEST_F(ProtoRingBufferTest, HandleProtoErrorsGracefully) {
   Write(&buf, last_msg_.data(), last_msg_.size() - 1);
   auto msg = buf.ReadMessage();
   EXPECT_FALSE(msg.valid());
-  EXPECT_FALSE(msg.fatal_framing_error);
+  EXPECT_FALSE(msg.fatal_framing_error());
 
   uint8_t invalid[] = {0x7f, 0x7f, 0x7f, 0x7f};
   invalid[0] = last_msg_.back();
@@ -201,7 +210,7 @@ TEST_F(ProtoRingBufferTest, HandleProtoErrorsGracefully) {
   for (int i = 0; i < 3; i++) {
     msg = buf.ReadMessage();
     EXPECT_FALSE(msg.valid());
-    EXPECT_TRUE(msg.fatal_framing_error);
+    EXPECT_TRUE(msg.fatal_framing_error());
 
     Write(&buf, invalid, sizeof(invalid));
   }
@@ -270,6 +279,162 @@ TEST_F(ProtoRingBufferTest, GivingUpDoesNotAbort) {
     handle.EndWrite(kChunk);
     buf.ReadMessage();
   }
+}
+
+TEST_F(ProtoRingBufferTest, SteadyStateDoesNotAllocate) {
+  ProtoRingBuffer buf;
+  auto expected = MakeProtoMessage(/*field_id=*/1, /*len=*/512);
+  for (int i = 0; i < 1000; i++) {
+    Write(&buf, last_msg_.data(), last_msg_.size());
+    ASSERT_EQ(buf.ReadMessage(), expected);
+    ASSERT_FALSE(buf.ReadMessage().valid());
+  }
+  // The buffer is recycled every time the read cursor catches up with the
+  // write one, so half a megabyte never gets past the first allocation.
+  EXPECT_EQ(buf.num_buffers_for_testing(), 1u);
+}
+
+TEST_F(ProtoRingBufferTest, RetainedMessagesKeepTheirBufferAlive) {
+  ProtoRingBuffer buf;
+  auto expected = MakeProtoMessage(/*field_id=*/5, /*len=*/100 * 1024);
+  std::vector<ProtoRingBuffer::Message> retained;
+  for (int i = 0; i < 16; i++) {
+    Write(&buf, last_msg_.data(), last_msg_.size());
+    retained.push_back(buf.ReadMessage());
+    ASSERT_TRUE(retained.back().valid());
+  }
+  // Messages pinning the buffer push writes onto fresh ones, rather than
+  // clobbering payloads the caller is still holding.
+  EXPECT_GT(buf.num_buffers_for_testing(), 1u);
+  for (const auto& msg : retained)
+    EXPECT_EQ(msg, expected);
+}
+
+TEST_F(ProtoRingBufferTest, MessageOutlivesTheBuffer) {
+  auto expected = MakeProtoMessage(/*field_id=*/3, /*len=*/64);
+  ProtoRingBuffer::Message msg;
+  {
+    ProtoRingBuffer buf;
+    Write(&buf, last_msg_.data(), last_msg_.size());
+    msg = buf.ReadMessage();
+  }
+  EXPECT_EQ(msg, expected);
+}
+
+TEST_F(ProtoRingBufferTest, RetainedMessageWithIncompleteMessageGrowing) {
+  ProtoRingBuffer buf;
+  last_msg_.reserve(512 * 1024);
+  auto first = MakeProtoMessage(/*field_id=*/1, /*len=*/32 * 1024);
+  const size_t first_size = last_msg_.size();
+  auto second = MakeProtoMessage(/*field_id=*/2, /*len=*/256 * 1024,
+                                 /*append=*/true);
+  const size_t split = first_size + 64 * 1024;
+  Write(&buf, last_msg_.data(), split);
+  auto retained = buf.ReadMessage();
+  ASSERT_EQ(retained, first);
+  ASSERT_FALSE(buf.ReadMessage().valid());
+
+  Write(&buf, last_msg_.data() + split, last_msg_.size() - split);
+  EXPECT_EQ(retained, first);
+  EXPECT_EQ(buf.ReadMessage(), second);
+  EXPECT_FALSE(buf.ReadMessage().valid());
+  // Grow directly to the final capacity, without an intermediate allocation.
+  EXPECT_EQ(buf.num_buffers_for_testing(), 2u);
+  EXPECT_EQ(buf.cached_capacity_for_testing(), 0u);
+}
+
+TEST_F(ProtoRingBufferTest, RetainedMessageWithIncompleteMessageReplacing) {
+  ProtoRingBuffer buf;
+  last_msg_.reserve(256 * 1024);
+  auto first = MakeProtoMessage(/*field_id=*/1, /*len=*/64 * 1024);
+  const size_t first_size = last_msg_.size();
+  auto second = MakeProtoMessage(/*field_id=*/2, /*len=*/96 * 1024,
+                                 /*append=*/true);
+  const size_t split = first_size + 32 * 1024;
+  Write(&buf, last_msg_.data(), split);
+  auto retained = buf.ReadMessage();
+  ASSERT_EQ(retained, first);
+  ASSERT_FALSE(buf.ReadMessage().valid());
+
+  Write(&buf, last_msg_.data() + split, last_msg_.size() - split);
+  EXPECT_EQ(retained, first);
+  EXPECT_EQ(buf.ReadMessage(), second);
+  EXPECT_FALSE(buf.ReadMessage().valid());
+  // The pending message fits the original capacity, but cannot overwrite the
+  // retained message. Keep the old allocation for reuse after its release.
+  EXPECT_EQ(buf.num_buffers_for_testing(), 2u);
+  EXPECT_EQ(buf.cached_capacity_for_testing(), 128u * 1024);
+}
+
+TEST_F(ProtoRingBufferTest, GrowthDropsUndersizedSpare) {
+  ProtoRingBuffer buf;
+  MakeProtoMessage(/*field_id=*/1, /*len=*/100 * 1024);
+  Write(&buf, last_msg_.data(), last_msg_.size());
+  auto retained = buf.ReadMessage();
+  Write(&buf, last_msg_.data(), last_msg_.size());
+  ASSERT_TRUE(buf.ReadMessage().valid());
+  ASSERT_GT(buf.cached_capacity_for_testing(), 0u);
+  retained = {};
+
+  auto expected = MakeProtoMessage(/*field_id=*/2, /*len=*/256 * 1024);
+  Write(&buf, last_msg_.data(), last_msg_.size());
+  EXPECT_EQ(buf.ReadMessage(), expected);
+  EXPECT_EQ(buf.cached_capacity_for_testing(), 0u);
+  EXPECT_EQ(buf.num_buffers_for_testing(), 3u);
+}
+
+TEST_F(ProtoRingBufferTest, RetainedMessageSurvivesFramingError) {
+  ProtoRingBuffer buf;
+  auto expected = MakeProtoMessage(/*field_id=*/1, /*len=*/100 * 1024);
+  Write(&buf, last_msg_.data(), last_msg_.size());
+  auto retained = buf.ReadMessage();
+  ASSERT_EQ(retained, expected);
+  const uint8_t invalid = 0;
+  Write(&buf, &invalid, 1);
+  ASSERT_TRUE(buf.ReadMessage().fatal_framing_error());
+
+  for (int i = 0; i < 3; ++i) {
+    Write(&buf, last_msg_.data(), last_msg_.size());
+    EXPECT_TRUE(buf.ReadMessage().fatal_framing_error());
+    EXPECT_EQ(retained, expected);
+  }
+  EXPECT_EQ(buf.num_buffers_for_testing(), 2u);
+}
+
+TEST_F(ProtoRingBufferTest, MovedMessageKeepsOwnership) {
+  auto expected = MakeProtoMessage(/*field_id=*/3, /*len=*/64);
+  ProtoRingBuffer::Message retained;
+  {
+    ProtoRingBuffer buf;
+    Write(&buf, last_msg_.data(), last_msg_.size());
+    auto original = buf.ReadMessage();
+    auto moved = std::move(original);
+    EXPECT_FALSE(original.valid());
+    EXPECT_EQ(original.size(), 0u);
+    EXPECT_EQ(original.field_id(), 0u);
+    EXPECT_EQ(moved, expected);
+    Write(&buf, last_msg_.data(), last_msg_.size());
+    retained = buf.ReadMessage();
+    retained = std::move(moved);
+    EXPECT_FALSE(moved.valid());
+    EXPECT_EQ(moved.size(), 0u);
+    EXPECT_EQ(moved.field_id(), 0u);
+  }
+  EXPECT_EQ(retained, expected);
+}
+
+TEST_F(ProtoRingBufferTest, RetainingOneMessageRecyclesBuffers) {
+  ProtoRingBuffer buf;
+  auto expected = MakeProtoMessage(/*field_id=*/9, /*len=*/100 * 1024);
+  ProtoRingBuffer::Message inflight;
+  for (int i = 0; i < 1000; i++) {
+    Write(&buf, last_msg_.data(), last_msg_.size());
+    inflight = buf.ReadMessage();  // Releases the previous one.
+    ASSERT_EQ(inflight, expected);
+  }
+  // Each message takes up nearly a whole buffer, so every write has to move
+  // onto another one. Handing them off must still not allocate per message.
+  EXPECT_EQ(buf.num_buffers_for_testing(), 2u);
 }
 
 }  // namespace

--- a/src/protozero/test/proto_ring_buffer_benchmark.cc
+++ b/src/protozero/test/proto_ring_buffer_benchmark.cc
@@ -44,7 +44,7 @@ static void BM_ProtoRingBufferReadLargeChunks(benchmark::State& state) {
   for (auto _ : state) {
     protozero::ProtoRingBuffer::Message msg = buffer.ReadMessage();
     if (msg.valid()) {
-      total_packet_size += msg.len;
+      total_packet_size += msg.size();
     } else {
       state.PauseTiming();
       Write(&buffer, trace_data.data(), trace_data.size());
@@ -71,7 +71,7 @@ static void BM_ProtoRingBufferRead(benchmark::State& state) {
   for (auto _ : state) {
     protozero::ProtoRingBuffer::Message msg = buffer.ReadMessage();
     if (msg.valid()) {
-      total_packet_size += msg.len;
+      total_packet_size += msg.size();
     } else {
       state.PauseTiming();
       size_t sz = std::min(kChunkSize, trace_data.size() - offset);

--- a/src/trace_processor/rpc/remote_trace_processor.cc
+++ b/src/trace_processor/rpc/remote_trace_processor.cc
@@ -293,10 +293,10 @@ base::Status RemoteTraceProcessor::SendStream(
 base::Status RemoteTraceProcessor::ReadResponse(std::vector<uint8_t>* out) {
   for (;;) {
     auto msg = rxbuf_.ReadMessage();
-    if (msg.fatal_framing_error)
+    if (msg.fatal_framing_error())
       return base::ErrStatus("RPC framing error from session");
     if (msg.valid()) {
-      out->assign(msg.start, msg.start + msg.len);
+      out->assign(msg.data(), msg.end());
       return base::OkStatus();
     }
     constexpr size_t kReadSize = 4096;

--- a/src/trace_processor/rpc/rpc.cc
+++ b/src/trace_processor/rpc/rpc.cc
@@ -307,7 +307,7 @@ void Rpc::DrainStream(Stream& stream) {
   for (;;) {
     auto msg = stream.rxbuf_.ReadMessage();
     if (!msg.valid()) {
-      if (msg.fatal_framing_error) {
+      if (msg.fatal_framing_error()) {
         protozero::HeapBuffered<TraceProcessorRpcStream> err_msg;
         err_msg->add_msg()->set_fatal_error("RPC framing error");
         auto err = err_msg.SerializeAsArray();
@@ -316,7 +316,7 @@ void Rpc::DrainStream(Stream& stream) {
       }
       break;
     }
-    ParseRpcRequest(stream, msg.start, msg.len);
+    ParseRpcRequest(stream, msg.data(), msg.size());
   }
 }
 

--- a/src/traceconv/trace_to_text.cc
+++ b/src/traceconv/trace_to_text.cc
@@ -135,7 +135,7 @@ void OnlineTraceToText::EndWrite(size_t size_written) {
   pending_write_.EndWrite(size_written);
   while (true) {
     auto token = ring_buffer_.ReadMessage();
-    if (token.fatal_framing_error) {
+    if (token.fatal_framing_error()) {
       error_ = "failed to tokenize trace packet (corrupt or truncated)";
       ok_ = false;
       return;
@@ -146,12 +146,12 @@ void OnlineTraceToText::EndWrite(size_t size_written) {
       break;
     }
 
-    if (token.field_id != protos::pbzero::Trace::kPacketFieldNumber) {
+    if (token.field_id() != protos::pbzero::Trace::kPacketFieldNumber) {
       PERFETTO_ELOG("Skipping invalid field");
       continue;
     }
-    protos::pbzero::TracePacket::Decoder decoder(token.start, token.len);
-    bytes_processed_ += token.len;
+    protos::pbzero::TracePacket::Decoder decoder(token.data(), token.size());
+    bytes_processed_ += token.size();
     if ((packet_++ & 0x3f) == 0) {
       ProgressLine("Processing trace: %8zu KB", bytes_processed_ / 1024);
     }
@@ -163,7 +163,7 @@ void OnlineTraceToText::EndWrite(size_t size_written) {
                              util::CompressionType::kZstd);
     } else {
       WriteToOutput(output_, "packet {\n");
-      protozero::ConstBytes packet = {token.start, token.len};
+      protozero::ConstBytes packet = {token.data(), token.size()};
       std::string text = TracePacketToText(packet, 1 /* indent_depth */);
       output_->write(text.data(), std::streamsize(text.size()));
       WriteToOutput(output_, "\n}\n");


### PR DESCRIPTION
ProtoRingBuffer hands out messages pointing into a buffer that the next
BeginWrite() is free to recompact or grow, so a message is only valid
until the following read. Passing one to another thread - what running
trace processor's RPC off the frontend thread needs - is therefore not
expressible, and the fallback is copying every request out, including
32 MB APPEND_TRACE_DATA chunks.

Refcount the buffer and hand out messages as slices holding a reference.
The write path is unchanged (a single non-wrapping buffer, rewound
whenever the read cursor catches up) except that recompacting, growing
and rewinding are now only allowed while nothing points into the buffer.
When something does, the write moves onto another buffer and the last
message releases the old one.

Measured over 2000 messages, buffers allocated:

```
  msg size  retained    before   after
      512B         0         1       1
      512B         1         8       2
      512B        64         8       2
       64K         1      2000       2
       64K        64      2000    2000
```

out/linux_clang_release/perfetto_benchmarks \
    --benchmark_filter='BM_ProtoRingBuffer.*'

