### PR TITLE
ui: Bulk columnar decode for QueryResult

### DIFF
--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -49,6 +49,7 @@ import {Memo} from '../base/memo';
 import {assertExists} from '../base/assert';
 import {Button, ButtonGroup} from '../widgets/button';
 import {SharedAsyncDisposable} from '../base/shared_disposable';
+import type {LONG, NUM} from '../trace_processor/query_result';
 
 export interface AggregationData extends AsyncDisposable {
   readonly sqlTable: SharedAsyncDisposable<DisposableSqlEntity>;
@@ -172,7 +173,7 @@ export function selectTracksAndGetDataset<T extends DatasetSchema>(
  * @returns A disposable SQL entity representing the new table.
  */
 export async function createIITable<
-  T extends {ts: bigint; dur: bigint; id: number},
+  T extends {ts: typeof LONG; dur: typeof LONG; id: typeof NUM},
 >(
   engine: Engine,
   dataset: Dataset<T>,

--- a/ui/src/components/distribution_panel.ts
+++ b/ui/src/components/distribution_panel.ts
@@ -18,7 +18,12 @@ import {AsyncMemo} from '../base/async_memo';
 import {Icons} from '../base/semantic_icons';
 import type {Trace} from '../public/trace';
 import type {Dataset, DatasetSchema} from '../trace_processor/dataset';
-import {NUM, type Row, type SqlValue} from '../trace_processor/query_result';
+import {
+  NUM,
+  type SpecType,
+  type Row,
+  type SqlValue,
+} from '../trace_processor/query_result';
 import {sqlValueToSqliteString} from '../trace_processor/sql_utils';
 import {
   createPerfettoTable,
@@ -617,7 +622,7 @@ function requiredSchema(
   },
   columns: ReadonlyArray<string>,
 ): DatasetSchema {
-  const schema: Record<string, SqlValue> = {};
+  const schema: SpecType = {};
   for (const col of new Set([
     ...columns,
     ...(inputs.filter === undefined ? [] : [inputs.filter.col]),

--- a/ui/src/components/tracks/counter_track.ts
+++ b/ui/src/components/tracks/counter_track.ts
@@ -16,7 +16,6 @@ import m from 'mithril';
 import {valueIfAllEqual} from '../../base/array_utils';
 import {assertUnreachable} from '../../base/assert';
 import {searchSegment} from '../../base/binary_search';
-import {deferChunkedTask} from '../../base/chunked_task';
 import {HSLColor} from '../../base/color';
 import type {Point2D} from '../../base/geom';
 import {formatNumber} from '../../base/number_format';
@@ -45,7 +44,6 @@ import {
 import {MenuItem} from '../../widgets/menu';
 import {checkerboardExcept} from '../checkerboard';
 import {BufferedBounds} from './buffered_bounds';
-import {CHUNKED_TASK_BACKGROUND_PRIORITY} from './feature_flags';
 import {RangeSharer} from './range_sharer';
 
 export type ChartHeightSize = 1 | 2 | 4 | 8 | 16 | 32;
@@ -910,46 +908,35 @@ export class CounterTrack implements TrackRenderer {
 
     if (signal.isCancelled) throw TASK_CANCELLED;
 
-    const priority = CHUNKED_TASK_BACKGROUND_PRIORITY.get()
-      ? 'background'
-      : undefined;
-    const task = await deferChunkedTask({priority});
-
-    const it = queryRes.iter({
+    const cols = queryRes.decodeColumns({
       tsRel: NUM,
       minDisplayValue: NUM,
       maxDisplayValue: NUM,
       lastDisplayValue: NUM,
     });
+    const tsRelCol = cols.tsRel;
+    const minCol = cols.minDisplayValue;
+    const maxCol = cols.maxDisplayValue;
+    const lastCol = cols.lastDisplayValue;
 
     const numRows = queryRes.numRows();
-    const timestampsRel = new Float32Array(numRows);
-    const timestampsRelNext = new Float32Array(numRows);
-    const minDisplayValues = new Float32Array(numRows);
-    const maxDisplayValues = new Float32Array(numRows);
-    const lastDisplayValues = new Float32Array(numRows);
+    const timestampsRel = new Float32Array(tsRelCol);
+    const minDisplayValues = new Float32Array(minCol);
+    const maxDisplayValues = new Float32Array(maxCol);
+    const lastDisplayValues = new Float32Array(lastCol);
+
     let min = 0;
     let max = 0;
-
-    for (let row = 0; it.valid(); it.next(), row++) {
-      if (signal.isCancelled) throw TASK_CANCELLED;
-      if (row % 50 === 0 && task.shouldYield()) {
-        await task.yield();
-      }
-
-      timestampsRel[row] = it.tsRel;
-      minDisplayValues[row] = it.minDisplayValue;
-      maxDisplayValues[row] = it.maxDisplayValue;
-      lastDisplayValues[row] = it.lastDisplayValue;
-      min = Math.min(min, it.minDisplayValue);
-      max = Math.max(max, it.maxDisplayValue);
-
-      if (row > 0) {
-        // Fill in the next
-        timestampsRelNext[row - 1] = it.tsRel;
-      }
+    for (let row = 0; row < numRows; row++) {
+      min = Math.min(min, minCol[row]);
+      max = Math.max(max, maxCol[row]);
     }
 
+    // timestampsRelNext[i] = timestampsRel[i+1], last element = end - start.
+    const timestampsRelNext = new Float32Array(numRows);
+    if (numRows > 1) {
+      timestampsRelNext.set(timestampsRel.subarray(1));
+    }
     if (numRows > 0) {
       timestampsRelNext[numRows - 1] = Number(end - start);
     }

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -55,7 +55,6 @@ import {
   LONG_NULL,
   NUM_NULL,
   type IterResultFor,
-  type RowIterator,
 } from '../../trace_processor/query_result';
 import {
   createPerfettoTable,
@@ -807,7 +806,9 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     return result.maybeFirstRow({rowCount: NUM})?.rowCount ?? 0;
   }
 
-  private useData(trackCtx: TrackRenderContext): DataFrame<IterResultFor<T>> | undefined {
+  private useData(
+    trackCtx: TrackRenderContext,
+  ): DataFrame<IterResultFor<T>> | undefined {
     const {resolution, visibleWindow} = trackCtx;
 
     const dataset = this.getDataset();
@@ -913,41 +914,46 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
     // Initialize buffers
     const count = queryResult.numRows();
-    const xs = new Float32Array(count);
-    const depths = new Uint16Array(count);
     const instants = new Array<Instant<IterResultFor<T>>>(count);
 
-    const it = queryResult.iter({
+    const cols = queryResult.decodeColumns({
       __id: NUM,
       __ts: NUM,
       __count: NUM,
       __depth: NUM,
       ...dataset.schema,
     });
+    const idCol = cols.__id;
+    const tsCol = cols.__ts;
+    const countCol = cols.__count;
+    const depthCol = cols.__depth;
+    const schemaKeys = Object.keys(dataset.schema);
+    const schemaCols = schemaKeys.map((k) => cols[k]);
+    const xs = new Float32Array(tsCol);
+    const depths = new Uint16Array(depthCol);
 
-    for (let i = 0; it.valid(); it.next(), ++i) {
+    for (let i = 0; i < count; i++) {
       if (i % 64 === 0) {
         if (signal.isCancelled) throw TASK_CANCELLED;
         if (task.shouldYield()) await task.yield();
       }
 
-      const id = it.__id;
-      const ts = it.__ts;
-      const count = it.__count;
-      const depth = it.__depth;
-      const title = this.getTitle(it);
-      const subtitle = this.getSubtitle(it);
-      const colorScheme = this.getColor(it, title);
-      const row = this.extractKeys(it, dataset.schema);
+      // Building the row object for every row is inefficient but we need to do
+      // it for compatibility with the various callbacks, and changing these
+      // would change the track API.
+      // TODO(stevegolton): Change the getTitle(), getSubtitle(), getColor()
+      // callbacks to avoid having to build a row object for every row.
+      const row = this.buildSchemaRow(schemaKeys, schemaCols, i);
+      const title = this.getTitle(row);
+      const subtitle = this.getSubtitle(row);
+      const colorScheme = this.getColor(row, title);
 
-      xs[i] = ts;
-      depths[i] = depth;
       instants[i] = {
-        id,
+        id: idCol[i],
         title,
         subtitle,
         colorScheme,
-        count,
+        count: countCol[i],
         row,
       };
     }
@@ -1014,13 +1020,8 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     const task = await this.deferChunkedTask();
 
     const count = sliceQueryRes.numRows();
-    const starts = new Float32Array(count);
-    const ends = new Float32Array(count);
-    const depths = new Uint16Array(count);
-    const patterns = new Uint8Array(count);
-    const slices = new Array<Slice<IterResultFor<T>>>(count);
 
-    const it = sliceQueryRes.iter({
+    const cols = sliceQueryRes.decodeColumns({
       __id: NUM,
       __start: NUM,
       __end: NUM_NULL,
@@ -1029,38 +1030,46 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
       __incomplete: NUM,
       ...dataset.schema,
     });
+    const idCol = cols.__id;
+    const startCol = cols.__start;
+    const endCol = cols.__end;
+    const countCol = cols.__count;
+    const depthCol = cols.__depth;
+    const incompleteCol = cols.__incomplete;
+    const schemaKeys = Object.keys(dataset.schema);
+    const schemaCols = schemaKeys.map((k) => cols[k]);
 
-    for (let i = 0; it.valid(); it.next(), ++i) {
+    const starts = new Float32Array(startCol);
+    const ends = new Float32Array(count);
+    const depths = new Uint16Array(depthCol);
+    const patterns = new Uint8Array(count);
+    const slices = new Array<Slice<IterResultFor<T>>>(count);
+
+    for (let i = 0; i < count; i++) {
       if (i % 64 === 0) {
         if (signal.isCancelled) throw TASK_CANCELLED;
         if (task.shouldYield()) await task.yield();
       }
 
-      const count = it.__count;
-      const id = it.__id;
-      const start = it.__start;
-      const end = it.__end;
-      const depth = it.__depth;
-      const title = this.getTitle(it);
-      const subtitle = this.getSubtitle(it);
-      const colorScheme = this.getColor(it, title);
-      const isIncomplete = it.__incomplete === 1;
-      const row = this.extractKeys(it, dataset.schema);
+      const row = this.buildSchemaRow(schemaKeys, schemaCols, i);
+      const title = this.getTitle(row);
+      const subtitle = this.getSubtitle(row);
+      const colorScheme = this.getColor(row, title);
+      const end = endCol[i];
+      const isIncomplete = incompleteCol[i] === 1;
 
-      starts[i] = start;
       // Incomplete slices are assigned a +Infinity end
       ends[i] = end === null ? Number.POSITIVE_INFINITY : end;
-      depths[i] = depth;
       patterns[i] = isIncomplete
         ? RECT_PATTERN_FADE_RIGHT
-        : (this.attrs.slicePattern?.(it) ?? 0);
+        : (this.attrs.slicePattern?.(row) ?? 0);
       slices[i] = {
-        id,
+        id: idCol[i],
         title,
         subtitle,
         colorScheme,
-        count,
-        fillRatio: this.attrs.fillRatio?.(it) ?? 1,
+        count: countCol[i],
+        fillRatio: this.attrs.fillRatio?.(row) ?? 1,
         row,
       };
     }
@@ -1075,19 +1084,18 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     };
   }
 
-  // Efficiently copy a sebset of keys from a raw value based on some template.
-  // Note: Only the template's keys are used, the values are ignored (hence the
-  // unknown value types).
-  private extractKeys(
-    from: RowIterator<T>,
-    template: Record<string, unknown>,
+  // Reads the dataset.schema columns out of the decoded columnar arrays (cols[k]
+  // holds the data for schema key k) into a per-row object for the callbacks.
+  private buildSchemaRow(
+    keys: readonly string[],
+    cols: readonly ArrayLike<SqlValue>[],
+    i: number,
   ): IterResultFor<T> {
-    const result: Record<string, SqlValue> = {};
-    // eslint-disable-next-line guard-for-in
-    for (const k in template) {
-      result[k] = from[k] as SqlValue;
+    const row: Record<string, SqlValue> = {};
+    for (let k = 0; k < keys.length; k++) {
+      row[keys[k]] = cols[k][i];
     }
-    return result as unknown as IterResultFor<T>;
+    return row as IterResultFor<T>;
   }
 
   private async deferChunkedTask() {
@@ -1108,7 +1116,10 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     return '';
   }
 
-  private getColor(row: IterResultFor<T>, title: string | undefined): ColorScheme {
+  private getColor(
+    row: IterResultFor<T>,
+    title: string | undefined,
+  ): ColorScheme {
     if (this.attrs.colorizer) return this.attrs.colorizer(row);
     if (title) return getColorForSlice(title);
     return getColorForSlice(`${row.id}`);

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -54,7 +54,7 @@ import {
   NUM,
   LONG_NULL,
   NUM_NULL,
-  type IterResultFor,
+  type InferRowType,
 } from '../../trace_processor/query_result';
 import {
   createPerfettoTable,
@@ -242,7 +242,7 @@ export interface SliceTrackAttrs<T extends DatasetSchema> {
   /**
    * Override the color scheme for each event.
    */
-  colorizer?(row: IterResultFor<T>): ColorScheme;
+  colorizer?(row: InferRowType<T>): ColorScheme;
 
   /**
    * Optional function returning a key for invalidating cached slice data frames when track attributes/modes change.
@@ -252,32 +252,32 @@ export interface SliceTrackAttrs<T extends DatasetSchema> {
   /**
    * Override the text displayed on each event (title).
    */
-  sliceName?(row: IterResultFor<T>): string;
+  sliceName?(row: InferRowType<T>): string;
 
   /**
    * Override the subtitle displayed on each event.
    */
-  sliceSubtitle?(row: IterResultFor<T>): string;
+  sliceSubtitle?(row: InferRowType<T>): string;
 
   /**
    * Override the tooltip content for each event.
    */
-  tooltip?(slice: SliceOrInstant<IterResultFor<T>>): m.Children;
+  tooltip?(slice: SliceOrInstant<InferRowType<T>>): m.Children;
 
   /**
    * Customize the details panel for events on this track.
    */
-  detailsPanel?(row: IterResultFor<T>): TrackEventDetailsPanel;
+  detailsPanel?(row: InferRowType<T>): TrackEventDetailsPanel;
 
   /**
    * Define the fill ratio for slices (0.0 to 1.0).
    */
-  fillRatio?(row: IterResultFor<T>): number;
+  fillRatio?(row: InferRowType<T>): number;
 
   /**
    * Override the pattern for each slice (e.g., RECT_PATTERN_HATCHED for RT threads).
    */
-  slicePattern?(row: IterResultFor<T>): number;
+  slicePattern?(row: InferRowType<T>): number;
 
   /**
    * Define buttons displayed on the track shell.
@@ -289,23 +289,23 @@ export interface SliceTrackAttrs<T extends DatasetSchema> {
    * ColorVariant values (one per slice) to control each slice's color.
    */
   onUpdatedSlices?(
-    slices: readonly SliceOrInstant<IterResultFor<T>>[],
+    slices: readonly SliceOrInstant<InferRowType<T>>[],
   ): ColorVariant[];
 
   /**
    * Called when a slice is hovered.
    */
-  onSliceOver?(args: OnSliceOverArgs<IterResultFor<T>>): void;
+  onSliceOver?(args: OnSliceOverArgs<InferRowType<T>>): void;
 
   /**
    * Called when hover leaves a slice.
    */
-  onSliceOut?(args: OnSliceOutArgs<IterResultFor<T>>): void;
+  onSliceOut?(args: OnSliceOutArgs<InferRowType<T>>): void;
 
   /**
    * Called when a slice is clicked. Overrides the default selection behavior.
    */
-  onSliceClick?(args: OnSliceClickArgs<IterResultFor<T>>): void;
+  onSliceClick?(args: OnSliceClickArgs<InferRowType<T>>): void;
 }
 
 interface Tables extends AsyncDisposable {
@@ -338,16 +338,16 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
   private readonly instantWidthPx: number;
   private readonly queue = new AtomicTaskQueue();
   private readonly tablesSlot = new AsyncMemo<Tables>(this.queue);
-  private readonly dataFrameSlot = new AsyncMemo<DataFrame<IterResultFor<T>>>(
+  private readonly dataFrameSlot = new AsyncMemo<DataFrame<InferRowType<T>>>(
     this.queue,
   );
   private readonly bufferedBounds = new BufferedBounds();
   private readonly hoverMonitor = new Monitor([() => this.hoveredSlice?.id]);
 
-  private hoveredSlice?: SliceOrInstant<IterResultFor<T>>;
+  private hoveredSlice?: SliceOrInstant<InferRowType<T>>;
   private charWidth = {title: -1, subtitle: -1};
   private computedTrackHeight = 0;
-  private currentDataFrame?: DataFrame<IterResultFor<T>>;
+  private currentDataFrame?: DataFrame<InferRowType<T>>;
   private rowCount: number;
 
   /**
@@ -474,7 +474,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
   private renderSlices(
     trackCtx: TrackRenderContext,
-    sliceBuffers: SliceBuffers<IterResultFor<T>>,
+    sliceBuffers: SliceBuffers<InferRowType<T>>,
     xTransform: Transform1D,
     pxEnd: number,
     pxPerNs: number,
@@ -648,7 +648,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
   private renderInstants(
     trackCtx: TrackRenderContext,
-    instantBuffers: InstantBuffers<IterResultFor<T>>,
+    instantBuffers: InstantBuffers<InferRowType<T>>,
     xTransform: Transform1D,
     pxPerNs: number,
     baseOffsetPx: number,
@@ -808,7 +808,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
   private useData(
     trackCtx: TrackRenderContext,
-  ): DataFrame<IterResultFor<T>> | undefined {
+  ): DataFrame<InferRowType<T>> | undefined {
     const {resolution, visibleWindow} = trackCtx;
 
     const dataset = this.getDataset();
@@ -888,7 +888,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     resolution: duration,
     signal: CancellationSignal,
     dataset: SourceDataset<T>,
-  ): Promise<InstantBuffers<IterResultFor<T>>> {
+  ): Promise<InstantBuffers<InferRowType<T>>> {
     const sqlSource = generateRenderQuery(dataset);
     const extraCols = Object.keys(dataset.schema)
       .map((c) => `s.${c} as ${c}`)
@@ -914,7 +914,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
     // Initialize buffers
     const count = queryResult.numRows();
-    const instants = new Array<Instant<IterResultFor<T>>>(count);
+    const instants = new Array<Instant<InferRowType<T>>>(count);
 
     const cols = queryResult.decodeColumns({
       __id: NUM,
@@ -974,7 +974,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     resolution: duration,
     signal: CancellationSignal,
     dataset: SourceDataset<T>,
-  ): Promise<SliceBuffers<IterResultFor<T>>> {
+  ): Promise<SliceBuffers<InferRowType<T>>> {
     const engine = this.trace.engine;
     const sqlSource = generateRenderQuery(dataset);
     const extraCols = Object.keys(dataset.schema)
@@ -1043,7 +1043,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     const ends = new Float32Array(count);
     const depths = new Uint16Array(depthCol);
     const patterns = new Uint8Array(count);
-    const slices = new Array<Slice<IterResultFor<T>>>(count);
+    const slices = new Array<Slice<InferRowType<T>>>(count);
 
     for (let i = 0; i < count; i++) {
       if (i % 64 === 0) {
@@ -1090,12 +1090,12 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     keys: readonly string[],
     cols: readonly ArrayLike<SqlValue>[],
     i: number,
-  ): IterResultFor<T> {
+  ): InferRowType<T> {
     const row: Record<string, SqlValue> = {};
     for (let k = 0; k < keys.length; k++) {
       row[keys[k]] = cols[k][i];
     }
-    return row as IterResultFor<T>;
+    return row as InferRowType<T>;
   }
 
   private async deferChunkedTask() {
@@ -1105,19 +1105,19 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     return await deferChunkedTask({priority});
   }
 
-  private getTitle(row: IterResultFor<T>): string {
+  private getTitle(row: InferRowType<T>): string {
     if (this.attrs.sliceName) return this.attrs.sliceName(row);
     if ('name' in row && typeof row.name === 'string') return row.name;
     return '';
   }
 
-  private getSubtitle(row: IterResultFor<T>): string {
+  private getSubtitle(row: InferRowType<T>): string {
     if (this.attrs.sliceSubtitle) return this.attrs.sliceSubtitle(row);
     return '';
   }
 
   private getColor(
-    row: IterResultFor<T>,
+    row: InferRowType<T>,
     title: string | undefined,
   ): ColorScheme {
     if (this.attrs.colorizer) return this.attrs.colorizer(row);
@@ -1126,7 +1126,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
   }
 
   private onUpdatedSlices(
-    slices: readonly SliceOrInstant<IterResultFor<T>>[],
+    slices: readonly SliceOrInstant<InferRowType<T>>[],
   ): readonly ColorVariant[] {
     if (this.attrs.onUpdatedSlices) {
       return this.attrs.onUpdatedSlices(slices);
@@ -1136,7 +1136,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
   }
 
   private highlightHoveredAndSameTitle(
-    slices: readonly SliceOrInstant<IterResultFor<T>>[],
+    slices: readonly SliceOrInstant<InferRowType<T>>[],
   ): readonly ColorVariant[] {
     const hoveredSlice = this.hoveredSlice;
     const highlightedSliceName = this.attrs.trace.timeline.highlightedSliceName;
@@ -1241,7 +1241,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     x,
     y,
     timescale,
-  }: TrackMouseEvent): undefined | SliceOrInstant<IterResultFor<T>> {
+  }: TrackMouseEvent): undefined | SliceOrInstant<InferRowType<T>> {
     if (!this.currentDataFrame) return undefined;
 
     const trackHeight = this.computedTrackHeight;
@@ -1402,13 +1402,13 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
   detailsPanel(sel: TrackEventSelection): TrackEventDetailsPanel | undefined {
     if (this.attrs.detailsPanel) {
-      return this.attrs.detailsPanel(sel as unknown as IterResultFor<T>);
+      return this.attrs.detailsPanel(sel as unknown as InferRowType<T>);
     } else {
       const dataset = getDataset(this.attrs);
       return new SliceTrackDetailsPanel(
         this.trace,
         dataset,
-        sel as unknown as IterResultFor<T>,
+        sel as unknown as InferRowType<T>,
       );
     }
   }
@@ -1479,7 +1479,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
 export function renderTooltip<T extends RowSchema>(
   trace: Trace,
-  slice: SliceOrInstant<IterResultFor<T>>,
+  slice: SliceOrInstant<InferRowType<T>>,
   opts: {readonly title?: string; readonly extras?: m.Children} = {},
 ): m.Children {
   const durationFormatted = formatDurationForTooltip(trace, slice.row.dur);

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -54,6 +54,8 @@ import {
   NUM,
   LONG_NULL,
   NUM_NULL,
+  type IterResultFor,
+  type RowIterator,
 } from '../../trace_processor/query_result';
 import {
   createPerfettoTable,
@@ -241,7 +243,7 @@ export interface SliceTrackAttrs<T extends DatasetSchema> {
   /**
    * Override the color scheme for each event.
    */
-  colorizer?(row: T): ColorScheme;
+  colorizer?(row: IterResultFor<T>): ColorScheme;
 
   /**
    * Optional function returning a key for invalidating cached slice data frames when track attributes/modes change.
@@ -251,32 +253,32 @@ export interface SliceTrackAttrs<T extends DatasetSchema> {
   /**
    * Override the text displayed on each event (title).
    */
-  sliceName?(row: T): string;
+  sliceName?(row: IterResultFor<T>): string;
 
   /**
    * Override the subtitle displayed on each event.
    */
-  sliceSubtitle?(row: T): string;
+  sliceSubtitle?(row: IterResultFor<T>): string;
 
   /**
    * Override the tooltip content for each event.
    */
-  tooltip?(slice: SliceOrInstant<T>): m.Children;
+  tooltip?(slice: SliceOrInstant<IterResultFor<T>>): m.Children;
 
   /**
    * Customize the details panel for events on this track.
    */
-  detailsPanel?(row: T): TrackEventDetailsPanel;
+  detailsPanel?(row: IterResultFor<T>): TrackEventDetailsPanel;
 
   /**
    * Define the fill ratio for slices (0.0 to 1.0).
    */
-  fillRatio?(row: T): number;
+  fillRatio?(row: IterResultFor<T>): number;
 
   /**
    * Override the pattern for each slice (e.g., RECT_PATTERN_HATCHED for RT threads).
    */
-  slicePattern?(row: T): number;
+  slicePattern?(row: IterResultFor<T>): number;
 
   /**
    * Define buttons displayed on the track shell.
@@ -287,22 +289,24 @@ export interface SliceTrackAttrs<T extends DatasetSchema> {
    * Called once per render cycle before drawing. Return an array of
    * ColorVariant values (one per slice) to control each slice's color.
    */
-  onUpdatedSlices?(slices: readonly SliceOrInstant<T>[]): ColorVariant[];
+  onUpdatedSlices?(
+    slices: readonly SliceOrInstant<IterResultFor<T>>[],
+  ): ColorVariant[];
 
   /**
    * Called when a slice is hovered.
    */
-  onSliceOver?(args: OnSliceOverArgs<T>): void;
+  onSliceOver?(args: OnSliceOverArgs<IterResultFor<T>>): void;
 
   /**
    * Called when hover leaves a slice.
    */
-  onSliceOut?(args: OnSliceOutArgs<T>): void;
+  onSliceOut?(args: OnSliceOutArgs<IterResultFor<T>>): void;
 
   /**
    * Called when a slice is clicked. Overrides the default selection behavior.
    */
-  onSliceClick?(args: OnSliceClickArgs<T>): void;
+  onSliceClick?(args: OnSliceClickArgs<IterResultFor<T>>): void;
 }
 
 interface Tables extends AsyncDisposable {
@@ -312,11 +316,11 @@ interface Tables extends AsyncDisposable {
 }
 
 export type RowSchema = {
-  readonly id?: number;
-  readonly ts: bigint;
-  readonly dur?: bigint | null;
-  readonly depth?: number;
-  readonly layer?: number;
+  readonly id?: typeof NUM;
+  readonly ts: typeof LONG;
+  readonly dur?: typeof LONG_NULL;
+  readonly depth?: typeof NUM;
+  readonly layer?: typeof NUM;
 } & DatasetSchema;
 
 function getDataset<T extends DatasetSchema>(
@@ -335,14 +339,16 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
   private readonly instantWidthPx: number;
   private readonly queue = new AtomicTaskQueue();
   private readonly tablesSlot = new AsyncMemo<Tables>(this.queue);
-  private readonly dataFrameSlot = new AsyncMemo<DataFrame<T>>(this.queue);
+  private readonly dataFrameSlot = new AsyncMemo<DataFrame<IterResultFor<T>>>(
+    this.queue,
+  );
   private readonly bufferedBounds = new BufferedBounds();
   private readonly hoverMonitor = new Monitor([() => this.hoveredSlice?.id]);
 
-  private hoveredSlice?: SliceOrInstant<T>;
+  private hoveredSlice?: SliceOrInstant<IterResultFor<T>>;
   private charWidth = {title: -1, subtitle: -1};
   private computedTrackHeight = 0;
-  private currentDataFrame?: DataFrame<T>;
+  private currentDataFrame?: DataFrame<IterResultFor<T>>;
   private rowCount: number;
 
   /**
@@ -469,7 +475,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
   private renderSlices(
     trackCtx: TrackRenderContext,
-    sliceBuffers: SliceBuffers<T>,
+    sliceBuffers: SliceBuffers<IterResultFor<T>>,
     xTransform: Transform1D,
     pxEnd: number,
     pxPerNs: number,
@@ -643,7 +649,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
   private renderInstants(
     trackCtx: TrackRenderContext,
-    instantBuffers: InstantBuffers<T>,
+    instantBuffers: InstantBuffers<IterResultFor<T>>,
     xTransform: Transform1D,
     pxPerNs: number,
     baseOffsetPx: number,
@@ -801,7 +807,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     return result.maybeFirstRow({rowCount: NUM})?.rowCount ?? 0;
   }
 
-  private useData(trackCtx: TrackRenderContext): DataFrame<T> | undefined {
+  private useData(trackCtx: TrackRenderContext): DataFrame<IterResultFor<T>> | undefined {
     const {resolution, visibleWindow} = trackCtx;
 
     const dataset = this.getDataset();
@@ -881,7 +887,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     resolution: duration,
     signal: CancellationSignal,
     dataset: SourceDataset<T>,
-  ): Promise<InstantBuffers<T>> {
+  ): Promise<InstantBuffers<IterResultFor<T>>> {
     const sqlSource = generateRenderQuery(dataset);
     const extraCols = Object.keys(dataset.schema)
       .map((c) => `s.${c} as ${c}`)
@@ -909,7 +915,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     const count = queryResult.numRows();
     const xs = new Float32Array(count);
     const depths = new Uint16Array(count);
-    const instants = new Array<Instant<T>>(count);
+    const instants = new Array<Instant<IterResultFor<T>>>(count);
 
     const it = queryResult.iter({
       __id: NUM,
@@ -962,7 +968,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     resolution: duration,
     signal: CancellationSignal,
     dataset: SourceDataset<T>,
-  ): Promise<SliceBuffers<T>> {
+  ): Promise<SliceBuffers<IterResultFor<T>>> {
     const engine = this.trace.engine;
     const sqlSource = generateRenderQuery(dataset);
     const extraCols = Object.keys(dataset.schema)
@@ -1012,7 +1018,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     const ends = new Float32Array(count);
     const depths = new Uint16Array(count);
     const patterns = new Uint8Array(count);
-    const slices = new Array<Slice<T>>(count);
+    const slices = new Array<Slice<IterResultFor<T>>>(count);
 
     const it = sliceQueryRes.iter({
       __id: NUM,
@@ -1072,13 +1078,16 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
   // Efficiently copy a sebset of keys from a raw value based on some template.
   // Note: Only the template's keys are used, the values are ignored (hence the
   // unknown value types).
-  private extractKeys(from: T, template: Record<keyof T, unknown>): T {
-    const result = {} as T;
+  private extractKeys(
+    from: RowIterator<T>,
+    template: Record<string, unknown>,
+  ): IterResultFor<T> {
+    const result: Record<string, SqlValue> = {};
     // eslint-disable-next-line guard-for-in
     for (const k in template) {
-      result[k] = from[k];
+      result[k] = from[k] as SqlValue;
     }
-    return result;
+    return result as unknown as IterResultFor<T>;
   }
 
   private async deferChunkedTask() {
@@ -1088,25 +1097,25 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     return await deferChunkedTask({priority});
   }
 
-  private getTitle(row: T): string {
+  private getTitle(row: IterResultFor<T>): string {
     if (this.attrs.sliceName) return this.attrs.sliceName(row);
     if ('name' in row && typeof row.name === 'string') return row.name;
     return '';
   }
 
-  private getSubtitle(row: T): string {
+  private getSubtitle(row: IterResultFor<T>): string {
     if (this.attrs.sliceSubtitle) return this.attrs.sliceSubtitle(row);
     return '';
   }
 
-  private getColor(row: T, title: string | undefined): ColorScheme {
+  private getColor(row: IterResultFor<T>, title: string | undefined): ColorScheme {
     if (this.attrs.colorizer) return this.attrs.colorizer(row);
     if (title) return getColorForSlice(title);
     return getColorForSlice(`${row.id}`);
   }
 
   private onUpdatedSlices(
-    slices: readonly SliceOrInstant<T>[],
+    slices: readonly SliceOrInstant<IterResultFor<T>>[],
   ): readonly ColorVariant[] {
     if (this.attrs.onUpdatedSlices) {
       return this.attrs.onUpdatedSlices(slices);
@@ -1116,7 +1125,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
   }
 
   private highlightHoveredAndSameTitle(
-    slices: readonly SliceOrInstant<T>[],
+    slices: readonly SliceOrInstant<IterResultFor<T>>[],
   ): readonly ColorVariant[] {
     const hoveredSlice = this.hoveredSlice;
     const highlightedSliceName = this.attrs.trace.timeline.highlightedSliceName;
@@ -1221,7 +1230,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     x,
     y,
     timescale,
-  }: TrackMouseEvent): undefined | SliceOrInstant<T> {
+  }: TrackMouseEvent): undefined | SliceOrInstant<IterResultFor<T>> {
     if (!this.currentDataFrame) return undefined;
 
     const trackHeight = this.computedTrackHeight;
@@ -1382,13 +1391,13 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
   detailsPanel(sel: TrackEventSelection): TrackEventDetailsPanel | undefined {
     if (this.attrs.detailsPanel) {
-      return this.attrs.detailsPanel(sel as unknown as T);
+      return this.attrs.detailsPanel(sel as unknown as IterResultFor<T>);
     } else {
       const dataset = getDataset(this.attrs);
       return new SliceTrackDetailsPanel(
         this.trace,
         dataset,
-        sel as unknown as T,
+        sel as unknown as IterResultFor<T>,
       );
     }
   }
@@ -1457,9 +1466,9 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
 
 // Helper functions
 
-export function renderTooltip(
+export function renderTooltip<T extends RowSchema>(
   trace: Trace,
-  slice: SliceOrInstant<RowSchema>,
+  slice: SliceOrInstant<IterResultFor<T>>,
   opts: {readonly title?: string; readonly extras?: m.Children} = {},
 ): m.Children {
   const durationFormatted = formatDurationForTooltip(trace, slice.row.dur);

--- a/ui/src/components/tracks/slice_track_details_panel.ts
+++ b/ui/src/components/tracks/slice_track_details_panel.ts
@@ -24,6 +24,7 @@ import {Tree, TreeNode} from '../../widgets/tree';
 import {DurationWidget} from '../widgets/duration';
 import {Timestamp} from '../widgets/timestamp';
 import type {RowSchema} from './slice_track';
+import type {IterResultFor} from '../../trace_processor/query_result';
 import {exists} from '../../base/utils';
 import {Time} from '../../base/time';
 
@@ -42,7 +43,7 @@ export class SliceTrackDetailsPanel<
   constructor(
     private readonly trace: Trace,
     private readonly dataset: SourceDataset<T>,
-    private readonly data: T,
+    private readonly data: IterResultFor<T>,
   ) {}
 
   render() {

--- a/ui/src/components/tracks/slice_track_details_panel.ts
+++ b/ui/src/components/tracks/slice_track_details_panel.ts
@@ -24,7 +24,7 @@ import {Tree, TreeNode} from '../../widgets/tree';
 import {DurationWidget} from '../widgets/duration';
 import {Timestamp} from '../widgets/timestamp';
 import type {RowSchema} from './slice_track';
-import type {IterResultFor} from '../../trace_processor/query_result';
+import type {InferRowType} from '../../trace_processor/query_result';
 import {exists} from '../../base/utils';
 import {Time} from '../../base/time';
 
@@ -43,7 +43,7 @@ export class SliceTrackDetailsPanel<
   constructor(
     private readonly trace: Trace,
     private readonly dataset: SourceDataset<T>,
-    private readonly data: IterResultFor<T>,
+    private readonly data: InferRowType<T>,
   ) {}
 
   render() {

--- a/ui/src/plugins/com.android.AndroidInputLifecycle/android_input_event_source.ts
+++ b/ui/src/plugins/com.android.AndroidInputLifecycle/android_input_event_source.ts
@@ -17,8 +17,7 @@ import {
   LONG_NULL,
   NUM_NULL,
   STR_NULL,
-  type Row,
-  type SqlValue,
+  type SpecType,
   type QueryResult as DbQueryResult,
 } from '../../trace_processor/query_result';
 import {type duration, Time, Duration} from '../../base/time';
@@ -43,11 +42,10 @@ export interface InputChainRow {
   allTrackUris: string[];
 }
 
-interface InputLifecycleSpec extends Row {
-  input_id: string | null;
-  channel: string | null;
-  total_latency: bigint | null;
-  [key: string]: SqlValue;
+interface InputLifecycleSpec extends SpecType {
+  readonly input_id: typeof STR_NULL;
+  readonly channel: typeof STR_NULL;
+  readonly total_latency: typeof LONG_NULL;
 }
 
 export class AndroidInputEventSource {
@@ -290,12 +288,14 @@ export class AndroidInputEventSource {
 
       // TODO(ivankc) Consider how to properly handle this in the context of extensions.
       const totalLatency =
-        it.total_latency !== null ? Duration.fromRaw(it.total_latency) : null;
+        it.get('total_latency') !== null
+          ? Duration.fromRaw(it.get('total_latency') as bigint)
+          : null;
 
       rows.push({
         uiRowId: `row-${index++}`,
-        inputEventId: it.input_id,
-        channel: it.channel ?? '',
+        inputEventId: it.get('input_id') as string | null,
+        channel: (it.get('channel') as string | null) ?? '',
         totalLatency,
         stagesData,
         allTrackUris,

--- a/ui/src/plugins/com.android.AndroidInputLifecycle/android_input_event_source.ts
+++ b/ui/src/plugins/com.android.AndroidInputLifecycle/android_input_event_source.ts
@@ -288,14 +288,12 @@ export class AndroidInputEventSource {
 
       // TODO(ivankc) Consider how to properly handle this in the context of extensions.
       const totalLatency =
-        it.get('total_latency') !== null
-          ? Duration.fromRaw(it.get('total_latency') as bigint)
-          : null;
+        it.total_latency !== null ? Duration.fromRaw(it.total_latency) : null;
 
       rows.push({
         uiRowId: `row-${index++}`,
-        inputEventId: it.get('input_id') as string | null,
-        channel: (it.get('channel') as string | null) ?? '',
+        inputEventId: it.input_id,
+        channel: it.channel ?? '',
         totalLatency,
         stagesData,
         allTrackUris,

--- a/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
@@ -22,7 +22,7 @@ import {
   NUM_NULL,
   STR_NULL,
   UNKNOWN,
-  type SqlValue,
+  type SpecValue,
   LONG_NULL,
 } from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
@@ -798,7 +798,7 @@ export default class implements PerfettoPlugin {
       }
 
       // Add schema entries for dynamic columns
-      const argsSchema: Record<string, SqlValue> = {};
+      const argsSchema: Record<string, SpecValue> = {};
       for (const arg of args) {
         argsSchema[safeArg(arg)] = UNKNOWN;
       }

--- a/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
@@ -22,8 +22,8 @@ import {
   NUM_NULL,
   STR_NULL,
   UNKNOWN,
-  type SpecValue,
   LONG_NULL,
+  type SpecType,
 } from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
 import SupportPlugin from '../com.android.AndroidLongBatterySupport';
@@ -798,7 +798,7 @@ export default class implements PerfettoPlugin {
       }
 
       // Add schema entries for dynamic columns
-      const argsSchema: Record<string, SpecValue> = {};
+      const argsSchema: SpecType = {};
       for (const arg of args) {
         argsSchema[safeArg(arg)] = UNKNOWN;
       }

--- a/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
@@ -278,13 +278,6 @@ export class CpuFreqTrack implements TrackRenderer {
     const idleRows = idleResult.numRows();
     assertTrue(freqRows == idleRows);
 
-    // Allocate arrays for Data and StepAreaBuffers
-    const timestamps = new BigInt64Array(freqRows);
-    const minFreqKHz = new Uint32Array(freqRows);
-    const maxFreqKHz = new Uint32Array(freqRows);
-    const lastFreqKHz = new Uint32Array(freqRows);
-    const lastIdleValues = new Int8Array(freqRows);
-
     // StepAreaBuffers arrays (raw data values, transform applied at render time)
     const xs = new Float32Array(freqRows); // Relative timestamps in ns
     const xnext = new Float32Array(freqRows); // Next relative timestamp in ns
@@ -293,43 +286,55 @@ export class CpuFreqTrack implements TrackRenderer {
     const maxYs = new Float32Array(freqRows); // Min freq (lower value = higher Y after transform)
     const fills = new Float32Array(freqRows); // 1.0 when not idle, 0.0 when idle
 
-    const freqIt = freqResult.iter({
+    const freqCols = freqResult.decodeColumns({
       ts: LONG,
       minFreq: NUM,
       maxFreq: NUM,
       lastFreq: NUM,
     });
-    const idleIt = idleResult.iter({
+    const idleCols = idleResult.decodeColumns({
       lastIdle: NUM,
     });
-    for (let i = 0; freqIt.valid(); ++i, freqIt.next(), idleIt.next()) {
-      if (i % 50 === 0) {
+    const tsCol = freqCols.ts;
+    const minFreqCol = freqCols.minFreq;
+    const maxFreqCol = freqCols.maxFreq;
+    const lastFreqCol = freqCols.lastFreq;
+    const lastIdleCol = idleCols.lastIdle;
+
+    const timestamps = tsCol;
+    const minFreqKHz = new Uint32Array(minFreqCol);
+    const maxFreqKHz = new Uint32Array(maxFreqCol);
+    const lastFreqKHz = new Uint32Array(lastFreqCol);
+    const lastIdleValues = new Int8Array(lastIdleCol);
+
+    for (let i = 0; i < freqRows; ++i) {
+      if (i % 64 === 0) {
         if (signal.isCancelled) return TASK_CANCELLED;
         if (task.shouldYield()) {
           await task.yield();
         }
       }
 
-      timestamps[i] = freqIt.ts;
-      minFreqKHz[i] = freqIt.minFreq;
-      maxFreqKHz[i] = freqIt.maxFreq;
-      lastFreqKHz[i] = freqIt.lastFreq;
-      lastIdleValues[i] = idleIt.lastIdle;
+      const ts = tsCol[i];
+      const minFreq = minFreqCol[i];
+      const maxFreq = maxFreqCol[i];
+      const lastFreq = lastFreqCol[i];
+      const lastIdle = lastIdleCol[i];
 
       // Populate step area buffers with raw values
-      const x = Number(freqIt.ts - start);
+      const x = Number(ts - start);
       xs[i] = Math.max(0, x); // Clamp to the start of the frame
-      ys[i] = freqIt.lastFreq;
+      ys[i] = lastFreq;
 
-      fills[i] = idleIt.lastIdle < 0 ? 1.0 : 0.0;
+      fills[i] = lastIdle < 0 ? 1.0 : 0.0;
       if (i > 0) {
         xnext[i - 1] = x;
         const yprev = ys[i - 1];
-        minYs[i] = Math.min(freqIt.minFreq, yprev);
-        maxYs[i] = Math.max(freqIt.maxFreq, yprev);
+        minYs[i] = Math.min(minFreq, yprev);
+        maxYs[i] = Math.max(maxFreq, yprev);
       } else {
-        minYs[i] = freqIt.minFreq;
-        maxYs[i] = freqIt.maxFreq;
+        minYs[i] = minFreq;
+        maxYs[i] = maxFreq;
       }
     }
 

--- a/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
@@ -51,11 +51,11 @@ interface PathPart {
 }
 
 type GpuSliceDataset = SourceDataset<{
-  id: number;
-  name: string;
-  ts: bigint;
-  dur: bigint;
-  depth: number;
+  id: typeof NUM;
+  name: typeof STR;
+  ts: typeof LONG;
+  dur: typeof LONG;
+  depth: typeof NUM;
 }>;
 
 // A GPU-by-process leaf can combine slices from multiple global GPU hardware

--- a/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
@@ -376,17 +376,16 @@ export class GroupSummaryTrack implements TrackRenderer {
       utid: NUM,
     });
 
-    const counts = new Uint32Array(it.count);
     const starts = it.ts;
+    const counts = new Uint32Array(it.count);
     const lanes = new Uint32Array(it.lane);
     const depths = new Uint16Array(it.lane);
     const utids = new Int32Array(it.utid);
-
     const ends = new BigInt64Array(numRows);
     const startRelNs = new Float32Array(numRows);
     const endRelNs = new Float32Array(numRows);
     const colorSchemes = new Array(numRows);
-    let finalSample = end;
+    let frameEnd = end;
 
     for (let row = 0; row < numRows; row++) {
       // Periodically check for cancellation during iteration
@@ -405,7 +404,7 @@ export class GroupSummaryTrack implements TrackRenderer {
       const endTs = ts + dur;
 
       ends[row] = endTs;
-      finalSample = Time.max(Time.fromRaw(endTs), finalSample);
+      frameEnd = Time.max(Time.fromRaw(endTs), frameEnd);
 
       // Store relative timestamps as floats for fast rendering
       // TODO(stevegolton): Calculate these in SQL.
@@ -421,7 +420,7 @@ export class GroupSummaryTrack implements TrackRenderer {
 
     const slices: Data = {
       start,
-      end: finalSample,
+      end: frameEnd,
       resolution,
       length: numRows,
       maxLanes,

--- a/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
@@ -367,29 +367,8 @@ export class GroupSummaryTrack implements TrackRenderer {
     const task = await deferChunkedTask({priority});
 
     const numRows = queryRes.numRows();
-    const slices: Data = {
-      start,
-      end,
-      resolution,
-      length: numRows,
-      maxLanes,
-      counts: new Uint32Array(numRows),
-      starts: new BigInt64Array(numRows),
-      ends: new BigInt64Array(numRows),
-      lanes: new Uint32Array(numRows),
-      utids: new Int32Array(numRows),
-      colorSchemes: new Array(numRows),
-      // Relative timestamps for fast rendering
-      startRelNs: new Float32Array(numRows),
-      endRelNs: new Float32Array(numRows),
-      depths: new Uint16Array(numRows),
-      // Working buffer for per-frame color computation
-      renderColors: new Uint32Array(numRows),
-      // Reusable patterns buffer (all zeros - no patterns)
-      patterns: new Uint8Array(numRows),
-    };
 
-    const it = queryRes.iter({
+    const it = queryRes.decodeColumns({
       count: NUM,
       ts: LONG,
       dur: LONG,
@@ -397,7 +376,19 @@ export class GroupSummaryTrack implements TrackRenderer {
       utid: NUM,
     });
 
-    for (let row = 0; it.valid(); it.next(), row++) {
+    const counts = new Uint32Array(it.count);
+    const starts = it.ts;
+    const lanes = new Uint32Array(it.lane);
+    const depths = new Uint16Array(it.lane);
+    const utids = new Int32Array(it.utid);
+
+    const ends = new BigInt64Array(numRows);
+    const startRelNs = new Float32Array(numRows);
+    const endRelNs = new Float32Array(numRows);
+    const colorSchemes = new Array(numRows);
+    let finalSample = end;
+
+    for (let row = 0; row < numRows; row++) {
       // Periodically check for cancellation during iteration
       if (row % 50 === 0) {
         if (signal.isCancelled) {
@@ -409,29 +400,47 @@ export class GroupSummaryTrack implements TrackRenderer {
         }
       }
 
-      const ts = it.ts;
-      const dur = it.dur;
+      const ts = it.ts[row];
+      const dur = it.dur[row];
       const endTs = ts + dur;
 
-      slices.counts[row] = it.count;
-      slices.starts[row] = ts;
-      slices.ends[row] = endTs;
-      slices.lanes[row] = it.lane;
-      slices.utids[row] = it.utid;
-      slices.end = Time.max(Time.fromRaw(endTs), slices.end);
+      ends[row] = endTs;
+      finalSample = Time.max(Time.fromRaw(endTs), finalSample);
 
       // Store relative timestamps as floats for fast rendering
-      slices.startRelNs[row] = Number(ts - start);
-      slices.endRelNs[row] = Number(endTs - start);
-
-      slices.depths[row] = it.lane;
+      // TODO(stevegolton): Calculate these in SQL.
+      startRelNs[row] = Number(ts - start);
+      endRelNs[row] = Number(endTs - start);
 
       // Cache color scheme for 'sched' mode (depends on utid).
       if (this.mode === 'sched') {
-        const threadInfo = this.threads.get(it.utid);
-        slices.colorSchemes[row] = colorForThread(threadInfo);
+        const threadInfo = this.threads.get(it.utid[row]);
+        colorSchemes[row] = colorForThread(threadInfo);
       }
     }
+
+    const slices: Data = {
+      start,
+      end: finalSample,
+      resolution,
+      length: numRows,
+      maxLanes,
+      counts,
+      starts,
+      ends,
+      lanes,
+      utids,
+      colorSchemes,
+      // Relative timestamps for fast rendering
+      startRelNs,
+      endRelNs,
+      depths,
+      // Working buffer for per-frame color computation
+      renderColors: new Uint32Array(numRows),
+      // Reusable patterns buffer (all zeros - no patterns)
+      patterns: new Uint8Array(numRows),
+    };
+
     return slices;
   }
 

--- a/ui/src/plugins/dev.perfetto.Smaps/smaps_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.Smaps/smaps_details_panel.ts
@@ -27,7 +27,7 @@ import {Timestamp} from '../../components/widgets/timestamp';
 import type {TrackEventDetailsPanel} from '../../public/details_panel';
 import type {Trace} from '../../public/trace';
 import type {Engine} from '../../trace_processor/engine';
-import {NUM_NULL, type Row} from '../../trace_processor/query_result';
+import {NUM_NULL, type SpecType} from '../../trace_processor/query_result';
 import {DetailsShell} from '../../widgets/details_shell';
 import {Spinner} from '../../widgets/spinner';
 
@@ -76,7 +76,7 @@ export async function computeInitialColumns(
     SELECT ${numeric.map((c) => `MAX(${c.name}) AS ${c.name}`).join(', ')}
     FROM process_memory_mappings
   `);
-  const spec: Row = {};
+  const spec: SpecType = {};
   for (const c of numeric) {
     spec[c.name] = NUM_NULL;
   }

--- a/ui/src/plugins/dev.perfetto.StackSamples/profiling_track.ts
+++ b/ui/src/plugins/dev.perfetto.StackSamples/profiling_track.ts
@@ -31,6 +31,7 @@ import {
 import type {Trace} from '../../public/trace';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import type {SourceDataset} from '../../trace_processor/dataset';
+import type {LONG, NUM} from '../../trace_processor/query_result';
 
 /**
  * Configuration for creating a profiling track (CPU profile, perf samples, etc)
@@ -41,9 +42,9 @@ export interface ProfilingTrackConfig {
    * Must have schema: {id: NUM, ts: LONG, callsiteId: NUM}
    */
   readonly dataset: SourceDataset<{
-    id: number;
-    ts: bigint;
-    callsiteId: number;
+    id: typeof NUM;
+    ts: typeof LONG;
+    callsiteId: typeof NUM;
   }>;
 
   /**

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/android.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/android.ts
@@ -15,6 +15,7 @@
 import m from 'mithril';
 import type {Engine} from '../../../trace_processor/engine';
 import {
+  type IterResultFor,
   LONG,
   NUM_NULL,
   STR,
@@ -37,7 +38,7 @@ const packageDataSpec = {
   profileableFromShell: NUM_NULL,
 };
 
-type PackageData = typeof packageDataSpec;
+type PackageData = IterResultFor<typeof packageDataSpec>;
 
 const androidGameInterventionRowSpec = {
   package_name: STR,
@@ -57,7 +58,9 @@ const androidGameInterventionRowSpec = {
   battery_mode_fps: NUM_NULL,
 };
 
-type AndroidGameInterventionRow = typeof androidGameInterventionRowSpec;
+type AndroidGameInterventionRow = IterResultFor<
+  typeof androidGameInterventionRowSpec
+>;
 
 const aflagRowSpec = {
   ts: LONG,
@@ -70,7 +73,7 @@ const aflagRowSpec = {
   valuePickedFrom: STR_NULL,
 };
 
-type AflagRow = typeof aflagRowSpec;
+type AflagRow = IterResultFor<typeof aflagRowSpec>;
 
 export interface AndroidData {
   packageList: PackageData[];

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/android.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/android.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import type {Engine} from '../../../trace_processor/engine';
 import {
-  type IterResultFor,
+  type InferRowType,
   LONG,
   NUM_NULL,
   STR,
@@ -38,7 +38,7 @@ const packageDataSpec = {
   profileableFromShell: NUM_NULL,
 };
 
-type PackageData = IterResultFor<typeof packageDataSpec>;
+type PackageData = InferRowType<typeof packageDataSpec>;
 
 const androidGameInterventionRowSpec = {
   package_name: STR,
@@ -58,7 +58,7 @@ const androidGameInterventionRowSpec = {
   battery_mode_fps: NUM_NULL,
 };
 
-type AndroidGameInterventionRow = IterResultFor<
+type AndroidGameInterventionRow = InferRowType<
   typeof androidGameInterventionRowSpec
 >;
 
@@ -73,7 +73,7 @@ const aflagRowSpec = {
   valuePickedFrom: STR_NULL,
 };
 
-type AflagRow = IterResultFor<typeof aflagRowSpec>;
+type AflagRow = InferRowType<typeof aflagRowSpec>;
 
 export interface AndroidData {
   packageList: PackageData[];

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/machines.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/machines.ts
@@ -17,7 +17,7 @@ import type {Engine} from '../../../trace_processor/engine';
 import {
   NUM_NULL,
   STR_NULL,
-  type IterResultFor,
+  type InferRowType,
 } from '../../../trace_processor/query_result';
 import {Section} from '../../../widgets/section';
 import {Grid, GridCell, GridHeaderCell} from '../../../widgets/grid';
@@ -37,7 +37,7 @@ const machineRowSpec = {
   androidSdkVersion: NUM_NULL,
 };
 
-type MachineRow = IterResultFor<typeof machineRowSpec>;
+type MachineRow = InferRowType<typeof machineRowSpec>;
 
 export interface MachinesData {
   machines: MachineRow[];

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/machines.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/machines.ts
@@ -14,7 +14,11 @@
 
 import m from 'mithril';
 import type {Engine} from '../../../trace_processor/engine';
-import {NUM_NULL, STR_NULL} from '../../../trace_processor/query_result';
+import {
+  NUM_NULL,
+  STR_NULL,
+  type IterResultFor,
+} from '../../../trace_processor/query_result';
 import {Section} from '../../../widgets/section';
 import {Grid, GridCell, GridHeaderCell} from '../../../widgets/grid';
 
@@ -33,7 +37,7 @@ const machineRowSpec = {
   androidSdkVersion: NUM_NULL,
 };
 
-type MachineRow = typeof machineRowSpec;
+type MachineRow = IterResultFor<typeof machineRowSpec>;
 
 export interface MachinesData {
   machines: MachineRow[];

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/traces.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/traces.ts
@@ -14,7 +14,11 @@
 
 import m from 'mithril';
 import type {Engine} from '../../../trace_processor/engine';
-import {NUM_NULL, STR_NULL} from '../../../trace_processor/query_result';
+import {
+  NUM_NULL,
+  STR_NULL,
+  type IterResultFor,
+} from '../../../trace_processor/query_result';
 import {Section} from '../../../widgets/section';
 import {Grid, GridCell, GridHeaderCell} from '../../../widgets/grid';
 
@@ -29,7 +33,7 @@ const traceRowSpec = {
   machines: STR_NULL,
 };
 
-type TraceRow = typeof traceRowSpec;
+type TraceRow = IterResultFor<typeof traceRowSpec>;
 
 export interface TracesData {
   readonly traces: TraceRow[];

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/traces.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/traces.ts
@@ -17,7 +17,7 @@ import type {Engine} from '../../../trace_processor/engine';
 import {
   NUM_NULL,
   STR_NULL,
-  type IterResultFor,
+  type InferRowType,
 } from '../../../trace_processor/query_result';
 import {Section} from '../../../widgets/section';
 import {Grid, GridCell, GridHeaderCell} from '../../../widgets/grid';
@@ -33,7 +33,7 @@ const traceRowSpec = {
   machines: STR_NULL,
 };
 
-type TraceRow = IterResultFor<typeof traceRowSpec>;
+type TraceRow = InferRowType<typeof traceRowSpec>;
 
 export interface TracesData {
   readonly traces: TraceRow[];

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/utils.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/utils.ts
@@ -14,7 +14,11 @@
 
 import m from 'mithril';
 import type {Engine} from '../../trace_processor/engine';
-import {NUM_NULL, STR} from '../../trace_processor/query_result';
+import {
+  NUM_NULL,
+  STR,
+  type IterResultFor,
+} from '../../trace_processor/query_result';
 import {Icon} from '../../widgets/icon';
 import {Tooltip} from '../../widgets/tooltip';
 import {Card} from '../../widgets/card';
@@ -57,7 +61,7 @@ export const statsSpec = {
   traceId: NUM_NULL,
 };
 
-export type StatsSectionRow = typeof statsSpec;
+export type StatsSectionRow = IterResultFor<typeof statsSpec>;
 
 export interface TraceInfo {
   readonly id: number;

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/utils.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/utils.ts
@@ -17,7 +17,7 @@ import type {Engine} from '../../trace_processor/engine';
 import {
   NUM_NULL,
   STR,
-  type IterResultFor,
+  type InferRowType,
 } from '../../trace_processor/query_result';
 import {Icon} from '../../widgets/icon';
 import {Tooltip} from '../../widgets/tooltip';
@@ -61,7 +61,7 @@ export const statsSpec = {
   traceId: NUM_NULL,
 };
 
-export type StatsSectionRow = IterResultFor<typeof statsSpec>;
+export type StatsSectionRow = InferRowType<typeof statsSpec>;
 
 export interface TraceInfo {
   readonly id: number;

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/utils.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/utils.ts
@@ -20,7 +20,7 @@ import type {
   QueryResult,
   Row,
   SpecType,
-  IterResultFor,
+  InferRowType,
 } from '../../trace_processor/query_result';
 import {SqlRef} from '../../widgets/sql_ref';
 import type {SqlTableDefinition} from '../../components/widgets/sql/table/table_description';
@@ -147,14 +147,14 @@ export function infoTooltip(text: string): m.Child {
 export function rows<R extends SpecType>(
   queryResult: QueryResult,
   spec: R,
-): IterResultFor<R>[] {
-  const results: IterResultFor<R>[] = [];
+): InferRowType<R>[] {
+  const results: InferRowType<R>[] = [];
   for (const it = queryResult.iter(spec); it.valid(); it.next()) {
     const row: Row = {};
     for (const key of Object.keys(spec)) {
       row[key] = it[key];
     }
-    results.push(row as IterResultFor<R>);
+    results.push(row as InferRowType<R>);
   }
   return results;
 }

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/utils.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/utils.ts
@@ -16,7 +16,12 @@ import m from 'mithril';
 import {Anchor} from '../../widgets/anchor';
 import {Icons} from '../../base/semantic_icons';
 import type {Trace} from '../../public/trace';
-import type {QueryResult, Row} from '../../trace_processor/query_result';
+import type {
+  QueryResult,
+  Row,
+  SpecType,
+  IterResultFor,
+} from '../../trace_processor/query_result';
 import {SqlRef} from '../../widgets/sql_ref';
 import type {SqlTableDefinition} from '../../components/widgets/sql/table/table_description';
 import {MenuItem} from '../../widgets/menu';
@@ -139,14 +144,17 @@ export function infoTooltip(text: string): m.Child {
  * Warning: Only use this function in contexts where the number of rows is
  * guaranteed to be small. Prefer doing transformations in SQL where possible.
  */
-export function rows<R extends Row>(queryResult: QueryResult, spec: R): R[] {
-  const results: R[] = [];
+export function rows<R extends SpecType>(
+  queryResult: QueryResult,
+  spec: R,
+): IterResultFor<R>[] {
+  const results: IterResultFor<R>[] = [];
   for (const it = queryResult.iter(spec); it.valid(); it.next()) {
     const row: Row = {};
     for (const key of Object.keys(spec)) {
       row[key] = it[key];
     }
-    results.push(row as R);
+    results.push(row as IterResultFor<R>);
   }
   return results;
 }

--- a/ui/src/public/search.ts
+++ b/ui/src/public/search.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type {time} from '../base/time';
-import type {SqlValue} from '../trace_processor/query_result';
+import type {SpecValue} from '../trace_processor/query_result';
 import type {Track} from './track';
 
 export type SearchSource = 'cpu' | 'log' | 'slice' | 'track' | 'event';
@@ -45,7 +45,7 @@ export interface FilterExpression {
    * These columns will be available in the query for the WHERE clause to
    * reference, but won't be included in the final result set.
    */
-  readonly columns?: Readonly<Record<string, SqlValue>>;
+  readonly columns?: Readonly<Record<string, SpecValue>>;
 }
 
 export interface SearchProvider {

--- a/ui/src/test/chrome_scroll_jank_plugin.test.ts
+++ b/ui/src/test/chrome_scroll_jank_plugin.test.ts
@@ -20,8 +20,6 @@ import {
   SCROLL_TIMELINE_V4_TRACK,
   type TrackSpec,
 } from '../plugins/org.chromium.ChromeScrollJank/tracks';
-import {Time, type time} from '../base/time';
-import {NUM} from '../trace_processor/query_result';
 
 let pth: PerfettoTestHelper;
 let page: Page;
@@ -38,8 +36,7 @@ test.afterEach(async () => await page.close());
 
 async function selectPluginSlice(
   trackSpec: TrackSpec,
-  name: string,
-  ts: time,
+  eventId: number,
 ): Promise<void> {
   // We cannot use `PerfettoTestHelper.searchSlice()` because omnibox search
   // results don't include track events (slices) created by plugins.
@@ -53,26 +50,14 @@ async function selectPluginSlice(
   // ```
   //
   // but it would break easily, in which case updating the coordinates manually
-  // would be very tedious. So we do the following instead.
+  // would be very tedious. So we select the slice directly by its ID.
+  // The IDs are stable for the given test trace (chrome/scroll_m144.pftrace).
   await page.evaluate(
-    async ({tableName, trackUri, name, ts}) => {
+    ({trackUri, eventId}) => {
       const trace = self.app.trace!;
-
-      // Step 1: Find the ID of the slice.
-      const result = await trace.engine.query(`
-        SELECT id
-        FROM ${tableName}
-        WHERE name = '${name}' AND ts = ${ts}
-      `);
-      if (result.numRows() > 1) {
-        throw new Error('Multiple slices match');
-      }
-      const id = result.firstRow({id: NUM}).id;
-
-      // Step 2: Select the slice.
-      trace.selection.selectTrackEvent(trackUri, id);
+      trace.selection.selectTrackEvent(trackUri, eventId);
     },
-    {tableName: trackSpec.tableName, trackUri: trackSpec.uri, name, ts},
+    {trackUri: trackSpec.uri, eventId},
   );
 }
 
@@ -87,11 +72,7 @@ test('event_latency_track', async () => {
 
   // Select the 'RendererCompositorQueueingDelay' stage within the first
   // janky EventLatency.
-  await selectPluginSlice(
-    EVENT_LATENCY_TRACK,
-    'RendererCompositorQueueingDelay',
-    Time.fromRaw(16784825798017n),
-  );
+  await selectPluginSlice(EVENT_LATENCY_TRACK, 25012);
   await trk.scrollIntoViewIfNeeded();
   await pth.waitForIdleAndScreenshot('details_panel_stage.png', {
     locator: page.locator('.pf-timeline-page__timeline'),
@@ -111,11 +92,7 @@ test('event_latency_track', async () => {
   );
 
   // Go back to the first janky EventLatency and then jump the corresponding frame.
-  await selectPluginSlice(
-    EVENT_LATENCY_TRACK,
-    'Janky EventLatency',
-    Time.fromRaw(16784822412017n),
-  );
+  await selectPluginSlice(EVENT_LATENCY_TRACK, 24945);
   await page
     .getByText('Frame where this was the first presented EventLatency')
     .click();
@@ -134,11 +111,7 @@ test('scroll_timeline_track', async () => {
 
   // Select the 'GenerationToBrowserMain' stage within the first inertial scroll
   // update.
-  await selectPluginSlice(
-    SCROLL_TIMELINE_TRACK,
-    'GenerationToBrowserMain',
-    Time.fromRaw(16784307235017n),
-  );
+  await selectPluginSlice(SCROLL_TIMELINE_TRACK, 2456);
   await trk.scrollIntoViewIfNeeded();
   await pth.waitForIdleAndScreenshot('details_panel_stage.png', {
     locator: page.locator('.pf-timeline-page__timeline'),
@@ -161,11 +134,7 @@ test('scroll_timeline_track', async () => {
 
   // Go back to the first inertial scroll update and then jump the corresponding
   // frame.
-  await selectPluginSlice(
-    SCROLL_TIMELINE_TRACK,
-    'Inertial Scroll Update',
-    Time.fromRaw(16784307235017n),
-  );
+  await selectPluginSlice(SCROLL_TIMELINE_TRACK, 2455);
   await page
     .getByText('Frame where this was the first presented scroll update')
     .click();
@@ -184,11 +153,7 @@ test('scroll_timeline_v4_track', async () => {
 
   // Select the 'Real scroll update input generation' stage within the second
   // janky frame.
-  await selectPluginSlice(
-    SCROLL_TIMELINE_V4_TRACK,
-    'Real scroll update input generation',
-    Time.fromRaw(16784838286017n),
-  );
+  await selectPluginSlice(SCROLL_TIMELINE_V4_TRACK, 291);
   await trk.scrollIntoViewIfNeeded();
   await pth.waitForIdleAndScreenshot(
     'scroll_timeline_v4_details_panel_stage.png',
@@ -210,11 +175,7 @@ test('scroll_timeline_v4_track', async () => {
   );
 
   // Go back to the second janky frame and then jump the corresponding frame.
-  await selectPluginSlice(
-    SCROLL_TIMELINE_V4_TRACK,
-    'Janky Frame',
-    Time.fromRaw(16784838286017n),
-  );
+  await selectPluginSlice(SCROLL_TIMELINE_V4_TRACK, 290);
   await page.getByText('First scroll update in this frame').click();
   await pth.waitForIdleAndScreenshot(
     'scroll_timeline_v4_details_panel_link_to_scroll_timeline.png',

--- a/ui/src/test/chrome_scroll_jank_plugin.test.ts
+++ b/ui/src/test/chrome_scroll_jank_plugin.test.ts
@@ -21,6 +21,7 @@ import {
   type TrackSpec,
 } from '../plugins/org.chromium.ChromeScrollJank/tracks';
 import {Time, type time} from '../base/time';
+import {NUM} from '../trace_processor/query_result';
 
 let pth: PerfettoTestHelper;
 let page: Page;
@@ -66,7 +67,7 @@ async function selectPluginSlice(
       if (result.numRows() > 1) {
         throw new Error('Multiple slices match');
       }
-      const id = result.firstRow({id: Number()}).id;
+      const id = result.firstRow({id: NUM}).id;
 
       // Step 2: Select the slice.
       trace.selection.selectTrackEvent(trackUri, id);

--- a/ui/src/test/startup_commands_allowlist.test.ts
+++ b/ui/src/test/startup_commands_allowlist.test.ts
@@ -15,6 +15,7 @@
 import {test, expect} from '@playwright/test';
 import {PerfettoTestHelper} from './perfetto_ui_test_helper';
 import {STARTUP_COMMAND_ALLOWLIST} from '../core/startup_command_allowlist';
+import {NUM} from '../trace_processor/query_result';
 
 interface CommandTestCase {
   id: string;
@@ -242,7 +243,7 @@ const COMMAND_TEST_CASES: CommandTestCase[] = [
 
       // Verify we got the expected constant value (cannot use NUM here as
       // we are inside the puppeteer context).
-      const row = result.firstRow({test_value: Number()});
+      const row = result.firstRow({test_value: NUM});
       if (row.test_value !== 42) {
         throw new Error(`Expected test_value=42, got: ${row.test_value}`);
       }

--- a/ui/src/test/startup_commands_allowlist.test.ts
+++ b/ui/src/test/startup_commands_allowlist.test.ts
@@ -15,7 +15,6 @@
 import {test, expect} from '@playwright/test';
 import {PerfettoTestHelper} from './perfetto_ui_test_helper';
 import {STARTUP_COMMAND_ALLOWLIST} from '../core/startup_command_allowlist';
-import {NUM} from '../trace_processor/query_result';
 
 interface CommandTestCase {
   id: string;
@@ -243,9 +242,10 @@ const COMMAND_TEST_CASES: CommandTestCase[] = [
 
       // Verify we got the expected constant value (cannot use NUM here as
       // we are inside the puppeteer context).
-      const row = result.firstRow({test_value: NUM});
-      if (row.test_value !== 42) {
-        throw new Error(`Expected test_value=42, got: ${row.test_value}`);
+      const row = result.firstRow({});
+      const testValue = row.get('test_value');
+      if (Number(testValue) !== 42) {
+        throw new Error(`Expected test_value=42, got: ${testValue}`);
       }
     },
   },

--- a/ui/src/trace_processor/dataset.ts
+++ b/ui/src/trace_processor/dataset.ts
@@ -18,7 +18,6 @@ import {
   checkExtends,
   NUM,
   type SpecType,
-  type SpecValue,
   type SqlValue,
   unionTypes,
   UNKNOWN,
@@ -303,14 +302,14 @@ export class UnionDataset<
   get schema(): T {
     // Find the minimal set of columns that are supported by all datasets of
     // the union
-    let unionSchema: Record<string, SpecValue> | undefined = undefined;
+    let unionSchema: SpecType | undefined = undefined;
     this.union.forEach((ds) => {
       const dsSchema = ds.schema;
       if (unionSchema === undefined) {
         // First time just use this one
         unionSchema = dsSchema;
       } else {
-        const newSch: Record<string, SpecValue> = {};
+        const newSch: SpecType = {};
         for (const [key, value] of Object.entries(unionSchema)) {
           if (key in dsSchema) {
             const commonType = unionTypes(value, dsSchema[key]);
@@ -587,13 +586,13 @@ export class UnionDatasetWithLineage<
 
   get schema(): T {
     // Compute union schema from all datasets
-    let unionSchema: Record<string, SpecValue> | undefined = undefined;
+    let unionSchema: SpecType | undefined = undefined;
     this.sourceDatasets.forEach((ds) => {
       const dsSchema = ds.schema;
       if (unionSchema === undefined) {
         unionSchema = dsSchema;
       } else {
-        const newSch: Record<string, SpecValue> = {};
+        const newSch: SpecType = {};
         for (const [key, value] of Object.entries(unionSchema)) {
           if (key in dsSchema) {
             const commonType = unionTypes(value, dsSchema[key]);

--- a/ui/src/trace_processor/dataset.ts
+++ b/ui/src/trace_processor/dataset.ts
@@ -17,6 +17,8 @@ import {getOrCreate} from '../base/utils';
 import {
   checkExtends,
   NUM,
+  type SpecType,
+  type SpecValue,
   type SqlValue,
   unionTypes,
   UNKNOWN,
@@ -66,9 +68,10 @@ export interface Dataset<T extends DatasetSchema = DatasetSchema> {
 
 /**
  * Defines a list of columns and types that define the shape of the data
- * represented by a dataset.
+ * represented by a dataset. Uses the same type as the query result spec
+ * so that dataset schemas can be passed directly to iter()/decodeColumns().
  */
-export type DatasetSchema = Readonly<Record<string, SqlValue>>;
+export type DatasetSchema = SpecType;
 
 /**
  * A filter used to express that a column must equal a value.
@@ -300,14 +303,14 @@ export class UnionDataset<
   get schema(): T {
     // Find the minimal set of columns that are supported by all datasets of
     // the union
-    let unionSchema: Record<string, SqlValue> | undefined = undefined;
+    let unionSchema: Record<string, SpecValue> | undefined = undefined;
     this.union.forEach((ds) => {
       const dsSchema = ds.schema;
       if (unionSchema === undefined) {
         // First time just use this one
         unionSchema = dsSchema;
       } else {
-        const newSch: Record<string, SqlValue> = {};
+        const newSch: Record<string, SpecValue> = {};
         for (const [key, value] of Object.entries(unionSchema)) {
           if (key in dsSchema) {
             const commonType = unionTypes(value, dsSchema[key]);
@@ -584,13 +587,13 @@ export class UnionDatasetWithLineage<
 
   get schema(): T {
     // Compute union schema from all datasets
-    let unionSchema: Record<string, SqlValue> | undefined = undefined;
+    let unionSchema: Record<string, SpecValue> | undefined = undefined;
     this.sourceDatasets.forEach((ds) => {
       const dsSchema = ds.schema;
       if (unionSchema === undefined) {
         unionSchema = dsSchema;
       } else {
-        const newSch: Record<string, SqlValue> = {};
+        const newSch: Record<string, SpecValue> = {};
         for (const [key, value] of Object.entries(unionSchema)) {
           if (key in dsSchema) {
             const commonType = unionTypes(value, dsSchema[key]);
@@ -709,7 +712,10 @@ ${indent(chunk.join('\nUNION ALL\n'), 2)}
    * @param row - A row object containing __groupid and __partition values
    * @returns The source dataset(s) that produced this row
    */
-  resolveLineage(row: typeof lineageSchema): readonly Dataset[] {
+  resolveLineage(row: {
+    __groupid: number;
+    __partition: SqlValue;
+  }): readonly Dataset[] {
     const groupId = row.__groupid as number;
     const partitionValue = row.__partition;
 

--- a/ui/src/trace_processor/query_result.ts
+++ b/ui/src/trace_processor/query_result.ts
@@ -60,7 +60,8 @@ export type SqlValue =
 
 // The column type constants are branded with unique string-literal types so
 // that each is uniquely identifiable at the type level (via typeof). This
-// allows mapped types like DecodeIterType to distinguish them.
+// allows mapped types like DecodeColumnType to distinguish them. The brands
+// are erased at runtime; the constants retain their original values.
 export const UNKNOWN = {__brand: 'UNKNOWN'} as const;
 export const NUM = {__brand: 'NUM', __nonNullish: true} as const;
 export const STR = {__brand: 'STR', __nonNullish: true} as const;
@@ -70,6 +71,78 @@ export const BLOB = {__brand: 'BLOB', __nonNullish: true} as const;
 export const BLOB_NULL = {__brand: 'BLOB'} as const;
 export const LONG = {__brand: 'LONG', __nonNullish: true} as const;
 export const LONG_NULL = {__brand: 'LONG'} as const;
+
+// One decoded column produced by QueryResult.decodeColumns(). The runtime type
+// depends on the requested column type:
+//  - NUM       -> Float64Array
+//  - LONG      -> BigInt64Array
+//  - NUM_NULL  -> Array<number | null>
+//  - LONG_NULL -> Array<bigint | null>
+//  - STR/STR_NULL -> Array<string | null>
+//  - BLOB/*    -> Array<SqlValue>
+export type ColumnarColumn =
+  | Float64Array
+  | BigInt64Array
+  | Array<string>
+  | Array<number | null>
+  | Array<bigint | null>
+  | Array<string | null>
+  | Array<SqlValue>;
+
+// Maps a spec value to the concrete column type produced by decodeColumns().
+// Uses the branded types on the constants so each is uniquely distinguishable
+// regardless of TypeScript literal widening.
+export type DecodeColumnType<V> = V extends typeof UNKNOWN
+  ? Array<SqlValue>
+  : V extends typeof NUM
+    ? Float64Array
+    : V extends typeof LONG
+      ? BigInt64Array
+      : V extends typeof NUM_NULL
+        ? Array<number | null>
+        : V extends typeof LONG_NULL
+          ? Array<bigint | null>
+          : V extends typeof STR
+            ? Array<string | null>
+            : V extends typeof STR_NULL
+              ? Array<string | null>
+              : Array<SqlValue>;
+
+// The fully-typed result of decodeColumns() for a given spec.
+export type ColumnarResultFor<T extends SpecType> = {
+  readonly [K in keyof T]: DecodeColumnType<T[K]>;
+};
+
+export interface ColumnarResult {
+  readonly [columnName: string]: ColumnarColumn;
+}
+
+// Maps a spec value to the concrete row type produced by iter().
+// Uses the branded types on the constants so each is uniquely distinguishable
+// regardless of TypeScript literal widening.
+export type DecodeIterType<V> = V extends typeof UNKNOWN
+  ? SqlValue
+  : V extends typeof NUM
+    ? number
+    : V extends typeof LONG
+      ? bigint
+      : V extends typeof NUM_NULL
+        ? number | null
+        : V extends typeof LONG_NULL
+          ? bigint | null
+          : V extends typeof STR
+            ? string
+            : V extends typeof STR_NULL
+              ? string | null
+              : V extends typeof BLOB
+                ? Uint8Array<ArrayBuffer>
+                : V extends typeof BLOB_NULL
+                  ? Uint8Array<ArrayBuffer> | null
+                  : never;
+
+export type IterResultFor<T extends SpecType> = {
+  readonly [K in keyof T]: DecodeIterType<T[K]>;
+};
 
 const SHIFT_32BITS = 32n;
 
@@ -180,10 +253,65 @@ function readVarIntAsNumber(buf: Uint8Array, cursor: {pos: number}): number {
   return lo + hi * 4294967296;
 }
 
+// Writes an int64 varint directly into the backing buffer of a BigInt64Array,
+// through an Int32Array view over the same buffer, avoiding the allocation of
+// an intermediate bigint per cell. The two int32 stores below are bit-exact
+// equivalent to BigInt64Array[i] = BigInt.asIntN(64, (BigInt(hi) << 32n) | BigInt(lo)),
+// because typed-array stores apply ToInt32 to the value and the two's-complement
+// 64-bit pattern is exactly the (lo, hi) pair. Only valid on little-endian
+// platforms (see IS_LITTLE_ENDIAN below).
+// As in readVarIntAsNumber, the byte loops are bounded (4 + 1 + 5), so malformed
+// input cannot spin.
+function readVarIntIntoInt32s(
+  buf: Uint8Array,
+  cursor: {pos: number},
+  lo32: Int32Array,
+  outIdx: number,
+): void {
+  let pos = cursor.pos;
+  let lo = 0;
+  let hi = 0;
+  let b = 0;
+  let i = 0;
+  for (; i < 4; ++i) {
+    b = buf[pos++];
+    lo = (lo | ((b & 127) << (i * 7))) >>> 0;
+    if (b < 128) {
+      cursor.pos = pos;
+      lo32[outIdx * 2] = lo;
+      lo32[outIdx * 2 + 1] = 0;
+      return;
+    }
+  }
+  b = buf[pos++];
+  lo = (lo | ((b & 127) << 28)) >>> 0;
+  hi = (hi | ((b & 127) >> 4)) >>> 0;
+  if (b >= 128) {
+    for (i = 0; i < 5; ++i) {
+      b = buf[pos++];
+      hi = (hi | ((b & 127) << (i * 7 + 3))) >>> 0;
+      if (b < 128) break;
+    }
+  }
+  cursor.pos = pos;
+  lo32[outIdx * 2] = lo;
+  lo32[outIdx * 2 + 1] = hi;
+}
+
+// Typed arrays share the platform endianness. All browsers the UI runs on are
+// little-endian, but keep a runtime check so that on an exotic big-endian host
+// we fall back to the bigint-based path rather than corrupting values.
+const IS_LITTLE_ENDIAN =
+  new Uint8Array(new Uint32Array([0x04030201]).buffer)[0] === 0x01;
+
 // Fast decode varint int64 into a bigint
 // Inspired by
 // https://github.com/protobufjs/protobuf.js/blob/56b1e64979dae757b67a21d326e16acee39f2267/src/reader.js#L123
-export function decodeInt64Varint(buf: Uint8Array, pos: number): bigint {
+export function decodeInt64Varint(
+  buf: Uint8Array,
+  cursor: {pos: number},
+): bigint {
+  let pos = cursor.pos;
   let hi: number = 0;
   let lo: number = 0;
   let i = 0;
@@ -194,6 +322,7 @@ export function decodeInt64Varint(buf: Uint8Array, pos: number): bigint {
       // 1st..4th
       lo = (lo | ((buf[pos] & 127) << (i * 7))) >>> 0;
       if (buf[pos++] < 128) {
+        cursor.pos = pos;
         return BigInt(lo);
       }
     }
@@ -201,6 +330,7 @@ export function decodeInt64Varint(buf: Uint8Array, pos: number): bigint {
     lo = (lo | ((buf[pos] & 127) << 28)) >>> 0;
     hi = (hi | ((buf[pos] & 127) >> 4)) >>> 0;
     if (buf[pos++] < 128) {
+      cursor.pos = pos;
       return (BigInt(hi) << SHIFT_32BITS) | BigInt(lo);
     }
     i = 0;
@@ -212,11 +342,13 @@ export function decodeInt64Varint(buf: Uint8Array, pos: number): bigint {
       // 1st..3rd
       lo = (lo | ((buf[pos] & 127) << (i * 7))) >>> 0;
       if (buf[pos++] < 128) {
+        cursor.pos = pos;
         return BigInt(lo);
       }
     }
     // 4th
     lo = (lo | ((buf[pos++] & 127) << (i * 7))) >>> 0;
+    cursor.pos = pos;
     return (BigInt(hi) << SHIFT_32BITS) | BigInt(lo);
   }
   if (buf.length - pos > 4) {
@@ -225,6 +357,7 @@ export function decodeInt64Varint(buf: Uint8Array, pos: number): bigint {
       // 6th..10th
       hi = (hi | ((buf[pos] & 127) << (i * 7 + 3))) >>> 0;
       if (buf[pos++] < 128) {
+        cursor.pos = pos;
         const big = (BigInt(hi) << SHIFT_32BITS) | BigInt(lo);
         return BigInt.asIntN(64, big);
       }
@@ -237,6 +370,7 @@ export function decodeInt64Varint(buf: Uint8Array, pos: number): bigint {
       // 6th..10th
       hi = (hi | ((buf[pos] & 127) << (i * 7 + 3))) >>> 0;
       if (buf[pos++] < 128) {
+        cursor.pos = pos;
         const big = (BigInt(hi) << SHIFT_32BITS) | BigInt(lo);
         return BigInt.asIntN(64, big);
       }
@@ -286,34 +420,6 @@ export type SpecValue =
 export interface SpecType {
   [key: string]: SpecValue;
 }
-
-// Maps a spec value to the concrete row type produced when the value at that
-// column is read by iter()/firstRow().
-export type DecodeIterType<V> = V extends typeof UNKNOWN
-  ? SqlValue
-  : V extends typeof NUM
-    ? number
-    : V extends typeof LONG
-      ? bigint
-      : V extends typeof NUM_NULL
-        ? number | null
-        : V extends typeof LONG_NULL
-          ? bigint | null
-          : V extends typeof STR
-            ? string
-            : V extends typeof STR_NULL
-              ? string | null
-              : V extends typeof BLOB
-                ? Uint8Array<ArrayBuffer>
-                : V extends typeof BLOB_NULL
-                  ? Uint8Array<ArrayBuffer> | null
-                  : never;
-
-// The fully-typed row produced when reading a query result with the given
-// spec.
-export type IterResultFor<T extends SpecType> = {
-  readonly [K in keyof T]: DecodeIterType<T[K]>;
-};
 
 // The methods that any iterator has to implement.
 export interface RowIteratorBase {
@@ -396,6 +502,84 @@ function isCompatible(actual: CellType, expected: SpecValue): boolean {
   }
 }
 
+// One pass over the packed cell types (bytes[start..end)), building per-column
+// bitmasks of the cell types present (seen[c] gets bit 1<<type set) and
+// returning the MAXIMUM cell type value seen. Callers treat any type above
+// CELL_BLOB as out of the known range. (The max, not the bitwise OR: an OR
+// would exceed CELL_BLOB for perfectly valid mixed batches, e.g.
+// CELL_VARINT | CELL_STRING == 6, needlessly falling back to the slow path.)
+// Shared by RowIteratorImpl.tryMoveToNextBatch() and QueryResultImpl
+// .decodeColumns() for cheap spec-vs-actual type validation: the walk body is
+// one array read and two ORs, and the expensive per-type compatibility check
+// only runs once per column.
+function scanCellTypeMasks(
+  bytes: Uint8Array,
+  start: number,
+  end: number,
+  numColumns: number,
+  seen: Uint32Array,
+): number {
+  let maxType = 0;
+  let col = 0;
+  for (let i = start; i < end; i++) {
+    const t = bytes[i];
+    seen[col] |= 1 << t;
+    if (t > maxType) maxType = t;
+    if (++col === numColumns) col = 0;
+  }
+  return maxType;
+}
+
+// True if every cell type present in |mask| is compatible with |expType|.
+function isMaskCompatible(mask: number, expType: SpecValue): boolean {
+  while (mask !== 0) {
+    const t = 31 - Math.clz32(mask & -mask);
+    mask &= mask - 1;
+    if (!isCompatible(t as CellType, expType)) return false;
+  }
+  return true;
+}
+
+// Slow path shared by iter() and decodeColumns(): walks the cells of one
+// column to find the first incompatible one, so the thrown error can name the
+// offending row and column. |rowOffset| is added to the within-batch row index
+// (decodeColumns() passes the number of rows decoded from earlier batches).
+// Normally throws; if nothing is found (possible when the masks aliased due
+// to a cell type outside the known range) it just returns and the caller's
+// own decode loop rejects the invalid cell type.
+function throwOnIncompatibleCell(
+  bytes: Uint8Array,
+  start: number,
+  end: number,
+  numColumns: number,
+  col: number,
+  expType: SpecValue,
+  colName: string,
+  rowOffset: number,
+  errorInfo: QueryErrorInfo,
+): void {
+  for (let i = start + col; i < end; i += numColumns) {
+    const actualType = bytes[i] as CellType;
+    if (isCompatible(actualType, expType)) continue;
+    let err;
+    if (actualType === CellType.CELL_NULL) {
+      err =
+        'SQL value is NULL but that was not expected' +
+        ` (expected type: ${columnTypeToString(expType)}). ` +
+        'Did you mean NUM_NULL, LONG_NULL, STR_NULL or BLOB_NULL?';
+    } else {
+      err = `Incompatible cell type. Expected: ${columnTypeToString(
+        expType,
+      )} actual: ${CELL_TYPE_NAMES[actualType]}`;
+    }
+    const row = rowOffset + Math.floor((i - start) / numColumns);
+    throw new QueryError(
+      `Error @ row: ${row} col: '${colName}': ${err}`,
+      errorInfo,
+    );
+  }
+}
+
 // This has to match CellType in trace_processor.proto.
 enum CellType {
   CELL_NULL = 1,
@@ -429,6 +613,21 @@ export interface QueryResult {
   // now we keep everything in memory in the QueryResultImpl object.
   // iter<T extends Row>(spec: T): RowIterator<T>;
   iter<T extends SpecType>(spec: T): RowIterator<T>;
+
+  // Bulk-decodes the requested columns across all currently-available rows in a
+  // single pass, returning one dense array per column (see ColumnarColumn for
+  // the per-type representation). This is substantially faster than iter() for
+  // large result sets where the caller wants whole columns: it loops over every
+  // row inside one function (avoiding a per-row valid()/next() round-trip
+  // through the iterator's bound-method wrappers) and writes into typed arrays
+  // instead of a generic per-row object keyed by column name. Prefer this over
+  // iter() on hot track-loading paths that pull millions of cells.
+  //
+  // Cell types are validated up-front per batch (same checks and same errors
+  // as iter()): a mismatch between the spec and the actual query result types,
+  // including NULL cells for the non-nullable spec types (NUM/LONG/STR),
+  // throws a QueryError.
+  decodeColumns<T extends SpecType>(spec: T): ColumnarResultFor<T>;
 
   // Like iter() for queries that expect only one row. It embeds the valid()
   // check (i.e. throws if no rows are available) and returns directly the
@@ -587,6 +786,205 @@ class QueryResultImpl implements QueryResult, WritableQueryResult {
   iter<T extends SpecType>(spec: T): RowIterator<T> {
     const impl = new RowIteratorImplWithRowData(spec, this);
     return impl as {} as RowIterator<T>;
+  }
+
+  decodeColumns<T extends SpecType>(spec: T): ColumnarResultFor<T> {
+    const colNames = this.columnNames;
+    const numColumns = colNames.length;
+    const total = this._numRows;
+
+    // Per-column plan, indexed by column position. `kind` selects how the cell
+    // is materialised and into which output array; ignored columns (kind 0)
+    // still advance the per-type cursors but store nothing.
+    const enum Kind {
+      Ignore = 0,
+      Num = 1, // -> Float64Array
+      Long = 2, // -> BigInt64Array
+      Str = 3, // -> Array<string | null>
+      Blob = 4, // -> Array<SqlValue>
+      NumNull = 5, // -> Array<number | null>
+      LongNull = 6, // -> Array<bigint | null>
+    }
+    const kinds = new Uint8Array(numColumns);
+    // The original spec value per column (undefined = column not requested),
+    // used by the type validation pre-pass below and for its error messages.
+    const specValues = new Array<SpecValue | undefined>(numColumns);
+    // For LONG columns backed by a BigInt64Array (little-endian only), an
+    // Int32Array view over the same buffer, used to store varints without
+    // materializing a bigint. Indexed by column position; undefined otherwise.
+    const longLo32s = new Array<Int32Array | undefined>(numColumns);
+    // dests is indexed by column position; entries are typed/plain arrays whose
+    // element type is governed by kinds[c]. The stores below cast per-kind.
+    const dests = new Array<ColumnarColumn | undefined>(numColumns);
+    const out: {[k: string]: ColumnarColumn} = {};
+
+    for (const name of Object.keys(spec)) {
+      const c = colNames.indexOf(name);
+      if (c < 0) {
+        throw new QueryError(
+          `Column ${name} not found in the SQL result ` +
+            `set {${colNames.join(' ')}}`,
+          this._errorInfo,
+        );
+      }
+      const t = spec[name];
+      let kind: Kind;
+      let dest: ColumnarColumn;
+      if (t === NUM) {
+        kind = Kind.Num;
+        dest = new Float64Array(total);
+      } else if (t === NUM_NULL) {
+        kind = Kind.NumNull;
+        dest = new Array<number | null>(total);
+      } else if (t === LONG) {
+        kind = Kind.Long;
+        const longArr = new BigInt64Array(total);
+        dest = longArr;
+        if (IS_LITTLE_ENDIAN) {
+          longLo32s[c] = new Int32Array(longArr.buffer, 0, total * 2);
+        }
+      } else if (t === LONG_NULL) {
+        kind = Kind.LongNull;
+        dest = new Array<bigint | null>(total);
+      } else if (t === STR || t === STR_NULL) {
+        kind = Kind.Str;
+        dest = new Array<string | null>(total);
+      } else {
+        kind = Kind.Blob;
+        dest = new Array<SqlValue>(total);
+      }
+      kinds[c] = kind;
+      // Row's index signature is SqlValue, but spec objects only ever hold
+      // SpecValues (see the checks above).
+      specValues[c] = t as SpecValue;
+      dests[c] = dest;
+      out[name] = dest;
+    }
+
+    let row = 0;
+    const batches = this.batches;
+    for (let b = 0; b < batches.length; b++) {
+      const batch = batches[b];
+      if (batch.numCells === 0) continue;
+      const bytes = batch.batchBytes;
+      const f64 = batch.float64Cells;
+      const strs = batch.stringCells;
+      const blobs = batch.blobCells;
+      const ctEnd = batch.cellTypesOff + batch.cellTypesLen;
+      let ctOff = batch.cellTypesOff;
+
+      // Type validation pre-pass, shared with iter(): one cheap byte scan per
+      // batch building per-column cell-type bitmasks; the spec compatibility
+      // check then only runs once per column. On mismatch this throws the
+      // same QueryError that iter() would (same message format), including
+      // NULL cells for the non-nullable spec types (NUM/LONG/STR), which
+      // previously decoded as sentinels (NaN / 0n).
+      const seen = new Uint32Array(numColumns);
+      const maxCellType = scanCellTypeMasks(
+        bytes,
+        ctOff,
+        ctEnd,
+        numColumns,
+        seen,
+      );
+      // A type outside the known range would alias in the bitmask (JS shifts
+      // are mod 32), so fall back to walking every cell in that case.
+      const trustMasks = maxCellType <= CellType.CELL_BLOB;
+      for (let c = 0; c < numColumns; c++) {
+        const expType = specValues[c];
+        if (expType === undefined) continue;
+        if (trustMasks && isMaskCompatible(seen[c], expType)) continue;
+        // Slow path: throws, naming the first offending row and column.
+        throwOnIncompatibleCell(
+          bytes,
+          ctOff,
+          ctEnd,
+          numColumns,
+          c,
+          expType,
+          colNames[c],
+          row, // Rows already decoded from earlier batches.
+          this._errorInfo,
+        );
+      }
+
+      const varintCursor = {pos: batch.varintOff};
+      let fIdx = 0;
+      let sIdx = 0;
+      let bIdx = 0;
+
+      while (ctOff < ctEnd) {
+        for (let c = 0; c < numColumns; c++) {
+          const cellType = bytes[ctOff++];
+          const kind = kinds[c];
+          switch (cellType) {
+            case CellType.CELL_VARINT:
+              if (kind === Kind.Num || kind === Kind.NumNull) {
+                const v = readVarIntAsNumber(bytes, varintCursor);
+                (dests[c] as Array<number | null>)[row] = v;
+              } else if (kind === Kind.Long) {
+                const lo32 = longLo32s[c];
+                if (lo32 !== undefined) {
+                  readVarIntIntoInt32s(bytes, varintCursor, lo32, row);
+                } else {
+                  // Big-endian fallback: go through a bigint.
+                  const v = decodeInt64Varint(bytes, varintCursor);
+                  (dests[c] as BigInt64Array)[row] = v;
+                }
+              } else {
+                const v = decodeInt64Varint(bytes, varintCursor);
+                if (dests[c] !== undefined) {
+                  (dests[c] as Array<bigint | null>)[row] = v;
+                }
+              }
+              break;
+            case CellType.CELL_FLOAT64: {
+              const v = f64[fIdx++];
+              if (dests[c] !== undefined) {
+                (dests[c] as Array<number | null>)[row] = v;
+              }
+              break;
+            }
+            case CellType.CELL_STRING: {
+              const v = strs[sIdx++];
+              if (kind === Kind.Str) {
+                (dests[c] as Array<string | null>)[row] = v;
+              }
+              break;
+            }
+            case CellType.CELL_NULL:
+              // The validation pre-pass above rejects NULLs for the
+              // non-nullable spec types, so this is normally only reachable
+              // for nullable columns (which store null). The sentinel stores
+              // below are defensive: they can only run for batches containing
+              // out-of-range cell types, where the switch default below throws
+              // on the invalid cell anyway.
+              if (kind === Kind.Num) {
+                (dests[c] as Float64Array)[row] = NaN;
+              } else if (kind === Kind.Long) {
+                (dests[c] as BigInt64Array)[row] = 0n;
+              } else if (kind !== Kind.Ignore) {
+                (dests[c] as Array<SqlValue>)[row] = null;
+              }
+              break;
+            case CellType.CELL_BLOB: {
+              const v = blobs[bIdx++];
+              if (kind === Kind.Blob) {
+                (dests[c] as Array<SqlValue>)[row] = new Uint8Array(v);
+              }
+              break;
+            }
+            default:
+              throw new QueryError(
+                `Invalid cell type ${cellType}`,
+                this._errorInfo,
+              );
+          }
+        }
+        row++;
+      }
+    }
+    return out as ColumnarResultFor<T>;
   }
 
   firstRow<T extends SpecType>(spec: T): IterResultFor<T> {
@@ -985,13 +1383,7 @@ class RowIteratorImpl implements RowIteratorBase {
             rowData[colName] = readVarIntAsNumber(batchBytes, varintCursor);
           } else {
             // LONG, LONG_NULL, or unspecified - return as bigint
-            let varintPos = varintCursor.pos;
-            rowData[colName] = decodeInt64Varint(batchBytes, varintPos);
-            // Skip past the varint just decoded.
-            while (batchBytes[varintPos++] >= 128) {
-              /* advance */
-            }
-            varintCursor.pos = varintPos;
+            rowData[colName] = decodeInt64Varint(batchBytes, varintCursor);
           }
           break;
 
@@ -1065,76 +1457,51 @@ class RowIteratorImpl implements RowIteratorBase {
 
     assertTrue(numColumns > 0);
 
-    // Collect, per column, the set of cell types present in this batch. This is
-    // the same walk over every cell as before, but the body is one array read
-    // and two ORs rather than a modulo, a lookup and a call into isCompatible.
-    // The per-cell checking only happens if a column turns out to hold
-    // something unexpected, so the error messages are unchanged.
+    // Collect, per column, the set of cell types present in this batch and
+    // check them against the spec (scanCellTypeMasks() /
+    // throwOnIncompatibleCell() are shared with decodeColumns()).
     const seen = new Uint32Array(numColumns);
-    let typeUnion = 0;
-    let col = 0;
-    for (let i = this.nextCellTypeOff; i < this.cellTypesEnd; i++) {
-      const t = this.batchBytes[i];
-      seen[col] |= 1 << t;
-      typeUnion |= t;
-      if (++col === numColumns) col = 0;
-    }
+    const maxCellType = scanCellTypeMasks(
+      this.batchBytes,
+      this.nextCellTypeOff,
+      this.cellTypesEnd,
+      numColumns,
+      seen,
+    );
 
     // A type outside the known range would alias in the bitmask above (JS
     // shifts are mod 32), so fall back to checking every cell in that case.
-    const trustMasks = typeUnion <= CellType.CELL_BLOB;
+    const trustMasks = maxCellType <= CellType.CELL_BLOB;
     for (let c = 0; c < numColumns; c++) {
       const expType = this.colTypes[c];
       // If undefined, the caller doesn't want to read this column at all, so
       // it can be whatever.
       if (expType === undefined) continue;
-      if (trustMasks) {
-        let mask = seen[c];
-        let ok = true;
-        while (mask !== 0) {
-          const t = 31 - Math.clz32(mask & -mask);
-          mask &= mask - 1;
-          if (!isCompatible(t as CellType, expType)) {
-            ok = false;
-            break;
-          }
-        }
-        if (ok) continue;
-      }
+      if (trustMasks && isMaskCompatible(seen[c], expType)) continue;
       this.checkColumnCellTypes(c, expType, numColumns);
     }
     return true;
   }
 
   // Slow path: walks the cells of one column to find the first incompatible
-  // one, so the thrown error can name the offending row.
+  // one, so the thrown error can name the offending row. Delegates to the
+  // shared throwOnIncompatibleCell() (also used by decodeColumns()).
   private checkColumnCellTypes(
     col: number,
     expType: SpecValue,
     numColumns: number,
   ): void {
-    for (
-      let i = this.nextCellTypeOff + col;
-      i < this.cellTypesEnd;
-      i += numColumns
-    ) {
-      const actualType = this.batchBytes[i] as CellType;
-      if (isCompatible(actualType, expType)) continue;
-      let err;
-      if (actualType === CellType.CELL_NULL) {
-        err =
-          'SQL value is NULL but that was not expected' +
-          ` (expected type: ${columnTypeToString(expType)}). ` +
-          'Did you mean NUM_NULL, LONG_NULL, STR_NULL or BLOB_NULL?';
-      } else {
-        err = `Incompatible cell type. Expected: ${columnTypeToString(
-          expType,
-        )} actual: ${CELL_TYPE_NAMES[actualType]}`;
-      }
-      const row = Math.floor(i / numColumns);
-      const colName = this.columnNames[col];
-      throw this.makeError(`Error @ row: ${row} col: '${colName}': ${err}`);
-    }
+    throwOnIncompatibleCell(
+      this.batchBytes,
+      this.nextCellTypeOff,
+      this.cellTypesEnd,
+      numColumns,
+      col,
+      expType,
+      this.columnNames[col],
+      0,
+      this.resultObj.errorInfo,
+    );
   }
 }
 
@@ -1179,6 +1546,9 @@ class WaitableQueryResultImpl
   // QueryResult implementation. Proxies all calls to the impl object.
   iter<T extends SpecType>(spec: T) {
     return this.impl.iter(spec);
+  }
+  decodeColumns<T extends SpecType>(spec: T) {
+    return this.impl.decodeColumns(spec);
   }
   firstRow<T extends SpecType>(spec: T) {
     return this.impl.firstRow(spec);

--- a/ui/src/trace_processor/query_result.ts
+++ b/ui/src/trace_processor/query_result.ts
@@ -62,15 +62,15 @@ export type SqlValue =
 // that each is uniquely identifiable at the type level (via typeof). This
 // allows mapped types like DecodeColumnType to distinguish them. The brands
 // are erased at runtime; the constants retain their original values.
-export const UNKNOWN = {__brand: 'UNKNOWN'} as const;
 export const NUM = {__brand: 'NUM', __nonNullish: true} as const;
 export const STR = {__brand: 'STR', __nonNullish: true} as const;
+export const BLOB = {__brand: 'BLOB', __nonNullish: true} as const;
+export const LONG = {__brand: 'LONG', __nonNullish: true} as const;
 export const NUM_NULL = {__brand: 'NUM'} as const;
 export const STR_NULL = {__brand: 'STR'} as const;
-export const BLOB = {__brand: 'BLOB', __nonNullish: true} as const;
 export const BLOB_NULL = {__brand: 'BLOB'} as const;
-export const LONG = {__brand: 'LONG', __nonNullish: true} as const;
 export const LONG_NULL = {__brand: 'LONG'} as const;
+export const UNKNOWN = {} as const;
 
 // One decoded column produced by QueryResult.decodeColumns(). The runtime type
 // depends on the requested column type:
@@ -92,21 +92,11 @@ export type ColumnarColumn =
 // Maps a spec value to the concrete column type produced by decodeColumns().
 // Uses the branded types on the constants so each is uniquely distinguishable
 // regardless of TypeScript literal widening.
-export type DecodeColumnType<V> = V extends typeof UNKNOWN
-  ? Array<SqlValue>
-  : V extends typeof NUM
-    ? Float64Array
-    : V extends typeof LONG
-      ? BigInt64Array
-      : V extends typeof NUM_NULL
-        ? Array<number | null>
-        : V extends typeof LONG_NULL
-          ? Array<bigint | null>
-          : V extends typeof STR
-            ? Array<string | null>
-            : V extends typeof STR_NULL
-              ? Array<string | null>
-              : Array<SqlValue>;
+export type DecodeColumnType<V> = V extends typeof NUM
+  ? Float64Array
+  : V extends typeof LONG
+    ? BigInt64Array
+    : Array<DecodeRowType<V>>;
 
 // The fully-typed result of decodeColumns() for a given spec.
 export type ColumnarResultFor<T extends SpecType> = {
@@ -120,28 +110,28 @@ export interface ColumnarResult {
 // Maps a spec value to the concrete row type produced by iter().
 // Uses the branded types on the constants so each is uniquely distinguishable
 // regardless of TypeScript literal widening.
-export type DecodeIterType<V> = V extends typeof UNKNOWN
-  ? SqlValue
-  : V extends typeof NUM
-    ? number
-    : V extends typeof LONG
-      ? bigint
-      : V extends typeof NUM_NULL
-        ? number | null
-        : V extends typeof LONG_NULL
-          ? bigint | null
-          : V extends typeof STR
-            ? string
-            : V extends typeof STR_NULL
-              ? string | null
-              : V extends typeof BLOB
-                ? Uint8Array<ArrayBuffer>
-                : V extends typeof BLOB_NULL
-                  ? Uint8Array<ArrayBuffer> | null
+export type DecodeRowType<V> = V extends typeof NUM
+  ? number
+  : V extends typeof LONG
+    ? bigint
+    : V extends typeof NUM_NULL
+      ? number | null
+      : V extends typeof LONG_NULL
+        ? bigint | null
+        : V extends typeof STR
+          ? string
+          : V extends typeof STR_NULL
+            ? string | null
+            : V extends typeof BLOB
+              ? Uint8Array<ArrayBuffer>
+              : V extends typeof BLOB_NULL
+                ? Uint8Array<ArrayBuffer> | null
+                : V extends typeof UNKNOWN
+                  ? SqlValue
                   : never;
 
-export type IterResultFor<T extends SpecType> = {
-  readonly [K in keyof T]: DecodeIterType<T[K]>;
+export type InferRowType<T extends SpecType> = {
+  readonly [K in keyof T]: DecodeRowType<T[K]>;
 };
 
 const SHIFT_32BITS = 32n;
@@ -443,8 +433,7 @@ export interface RowIteratorBase {
 // const iter = queryResult.iter({name: STR, surname: STR, id: NUM});
 // for (; iter.valid(); iter.next())
 //  console.log(iter.name, iter.surname);
-export type RowIterator<T extends SpecType> = RowIteratorBase &
-  IterResultFor<T>;
+export type RowIterator<T extends SpecType> = RowIteratorBase & InferRowType<T>;
 
 function columnTypeToString(t: SpecValue): string {
   switch (t) {
@@ -632,10 +621,10 @@ export interface QueryResult {
   // Like iter() for queries that expect only one row. It embeds the valid()
   // check (i.e. throws if no rows are available) and returns directly the
   // first result.
-  firstRow<T extends SpecType>(spec: T): IterResultFor<T>;
+  firstRow<T extends SpecType>(spec: T): InferRowType<T>;
 
   // Like firstRow() but returns undefined if no rows are available.
-  maybeFirstRow<T extends SpecType>(spec: T): IterResultFor<T> | undefined;
+  maybeFirstRow<T extends SpecType>(spec: T): InferRowType<T> | undefined;
 
   // If != undefined the query errored out and error() contains the message.
   error(): string | undefined;
@@ -689,13 +678,13 @@ export interface QueryResult {
 export function materializeRows<T extends SpecType>(
   result: QueryResult,
   spec: T,
-): IterResultFor<T>[] {
-  const rows: IterResultFor<T>[] = [];
+): InferRowType<T>[] {
+  const rows: InferRowType<T>[] = [];
   const cols = Object.keys(spec);
   for (const it = result.iter(spec); it.valid(); it.next()) {
     const row: Record<string, SqlValue> = {};
     for (const col of cols) row[col] = it.get(col);
-    rows.push(row as IterResultFor<T>);
+    rows.push(row as InferRowType<T>);
   }
   return rows;
 }
@@ -987,18 +976,18 @@ class QueryResultImpl implements QueryResult, WritableQueryResult {
     return out as ColumnarResultFor<T>;
   }
 
-  firstRow<T extends SpecType>(spec: T): IterResultFor<T> {
+  firstRow<T extends SpecType>(spec: T): InferRowType<T> {
     const impl = new RowIteratorImplWithRowData(spec, this);
     assertTrue(impl.valid());
-    return impl as {} as RowIterator<T> as IterResultFor<T>;
+    return impl as {} as RowIterator<T> as InferRowType<T>;
   }
 
-  maybeFirstRow<T extends SpecType>(spec: T): IterResultFor<T> | undefined {
+  maybeFirstRow<T extends SpecType>(spec: T): InferRowType<T> | undefined {
     const impl = new RowIteratorImplWithRowData(spec, this);
     if (!impl.valid()) {
       return undefined;
     }
-    return impl as {} as RowIterator<T> as IterResultFor<T>;
+    return impl as {} as RowIterator<T> as InferRowType<T>;
   }
 
   // Can be called only once.

--- a/ui/src/trace_processor/query_result.ts
+++ b/ui/src/trace_processor/query_result.ts
@@ -426,6 +426,12 @@ export interface RowIteratorBase {
   get(columnName: string): SqlValue;
 }
 
+// Has all the types available on it directly + the column getter
+export type RowWithGetter<T extends SpecType> = InferRowType<T> &
+  Row & {
+    get(columnName: string): SqlValue;
+  };
+
 // A RowIterator is a type that has all the fields defined in the query spec
 // plus the valid() and next() operators. This is to ultimately allow the
 // clients to do:
@@ -621,10 +627,10 @@ export interface QueryResult {
   // Like iter() for queries that expect only one row. It embeds the valid()
   // check (i.e. throws if no rows are available) and returns directly the
   // first result.
-  firstRow<T extends SpecType>(spec: T): InferRowType<T>;
+  firstRow<T extends SpecType>(spec: T): RowWithGetter<T>;
 
   // Like firstRow() but returns undefined if no rows are available.
-  maybeFirstRow<T extends SpecType>(spec: T): InferRowType<T> | undefined;
+  maybeFirstRow<T extends SpecType>(spec: T): RowWithGetter<T> | undefined;
 
   // If != undefined the query errored out and error() contains the message.
   error(): string | undefined;
@@ -976,18 +982,18 @@ class QueryResultImpl implements QueryResult, WritableQueryResult {
     return out as ColumnarResultFor<T>;
   }
 
-  firstRow<T extends SpecType>(spec: T): InferRowType<T> {
+  firstRow<T extends SpecType>(spec: T): RowWithGetter<T> {
     const impl = new RowIteratorImplWithRowData(spec, this);
     assertTrue(impl.valid());
-    return impl as {} as RowIterator<T> as InferRowType<T>;
+    return impl as {} as Row as RowWithGetter<T>;
   }
 
-  maybeFirstRow<T extends SpecType>(spec: T): InferRowType<T> | undefined {
+  maybeFirstRow<T extends SpecType>(spec: T): RowWithGetter<T> | undefined {
     const impl = new RowIteratorImplWithRowData(spec, this);
     if (!impl.valid()) {
       return undefined;
     }
-    return impl as {} as RowIterator<T> as InferRowType<T>;
+    return impl as {} as Row as RowWithGetter<T>;
   }
 
   // Can be called only once.

--- a/ui/src/trace_processor/query_result.ts
+++ b/ui/src/trace_processor/query_result.ts
@@ -58,20 +58,23 @@ import {Duration, type duration, Time, type time} from '../base/time';
 export type SqlValue =
   string | number | bigint | null | Uint8Array<ArrayBuffer>;
 
-export const UNKNOWN: SqlValue = null;
-export const NUM = 0;
-export const STR = 'str';
-export const NUM_NULL: number | null = 1;
-export const STR_NULL: string | null = 'str_null';
-export const BLOB: Uint8Array<ArrayBuffer> = new Uint8Array();
-export const BLOB_NULL: Uint8Array<ArrayBuffer> | null = new Uint8Array();
-export const LONG: bigint = 0n;
-export const LONG_NULL: bigint | null = 1n;
+// The column type constants are branded with unique string-literal types so
+// that each is uniquely identifiable at the type level (via typeof). This
+// allows mapped types like DecodeIterType to distinguish them.
+export const UNKNOWN = {__brand: 'UNKNOWN'} as const;
+export const NUM = {__brand: 'NUM', __nonNullish: true} as const;
+export const STR = {__brand: 'STR', __nonNullish: true} as const;
+export const NUM_NULL = {__brand: 'NUM'} as const;
+export const STR_NULL = {__brand: 'STR'} as const;
+export const BLOB = {__brand: 'BLOB', __nonNullish: true} as const;
+export const BLOB_NULL = {__brand: 'BLOB'} as const;
+export const LONG = {__brand: 'LONG', __nonNullish: true} as const;
+export const LONG_NULL = {__brand: 'LONG'} as const;
 
 const SHIFT_32BITS = 32n;
 
 // Describes the inheritance tree of the above types.
-const inheritanceTree = new Map<SqlValue, {readonly extends?: SqlValue}>([
+const inheritanceTree = new Map<SpecValue, {readonly extends?: SpecValue}>([
   [NUM, {extends: NUM_NULL}],
   [NUM_NULL, {extends: UNKNOWN}],
   [LONG, {extends: LONG_NULL}],
@@ -90,7 +93,7 @@ const inheritanceTree = new Map<SqlValue, {readonly extends?: SqlValue}>([
  * @param actual - The type to test.
  * @returns - True if `actual` extends `required`.
  */
-export function checkExtends(required: SqlValue, actual: SqlValue): boolean {
+export function checkExtends(required: SpecValue, actual: SpecValue): boolean {
   // If the types are the same, just return true
   if (required === actual) return true;
 
@@ -102,9 +105,9 @@ export function checkExtends(required: SqlValue, actual: SqlValue): boolean {
  * Returns the closest common ancestor of two types.
  */
 export function unionTypes(
-  typeA: SqlValue,
-  typeB: SqlValue,
-): SqlValue | undefined {
+  typeA: SpecValue,
+  typeB: SpecValue,
+): SpecValue | undefined {
   // If the types are the same, just return the same type
   if (typeA === typeB) return typeA;
 
@@ -125,8 +128,8 @@ export function unionTypes(
 /**
  * Returns the ancestry path from the given type to the root, inclusive.
  */
-function getAncestryPath(type: SqlValue): SqlValue[] {
-  const path: SqlValue[] = [type];
+function getAncestryPath(type: SpecValue): SpecValue[] {
+  const path: SpecValue[] = [type];
   let current = inheritanceTree.get(type);
 
   while (current && current.extends !== undefined) {
@@ -269,6 +272,49 @@ export interface Row {
   [key: string]: SqlValue;
 }
 
+export type SpecValue =
+  | typeof UNKNOWN
+  | typeof NUM
+  | typeof LONG
+  | typeof NUM_NULL
+  | typeof LONG_NULL
+  | typeof STR
+  | typeof STR_NULL
+  | typeof BLOB
+  | typeof BLOB_NULL;
+
+export interface SpecType {
+  [key: string]: SpecValue;
+}
+
+// Maps a spec value to the concrete row type produced when the value at that
+// column is read by iter()/firstRow().
+export type DecodeIterType<V> = V extends typeof UNKNOWN
+  ? SqlValue
+  : V extends typeof NUM
+    ? number
+    : V extends typeof LONG
+      ? bigint
+      : V extends typeof NUM_NULL
+        ? number | null
+        : V extends typeof LONG_NULL
+          ? bigint | null
+          : V extends typeof STR
+            ? string
+            : V extends typeof STR_NULL
+              ? string | null
+              : V extends typeof BLOB
+                ? Uint8Array<ArrayBuffer>
+                : V extends typeof BLOB_NULL
+                  ? Uint8Array<ArrayBuffer> | null
+                  : never;
+
+// The fully-typed row produced when reading a query result with the given
+// spec.
+export type IterResultFor<T extends SpecType> = {
+  readonly [K in keyof T]: DecodeIterType<T[K]>;
+};
+
 // The methods that any iterator has to implement.
 export interface RowIteratorBase {
   valid(): boolean;
@@ -291,9 +337,10 @@ export interface RowIteratorBase {
 // const iter = queryResult.iter({name: STR, surname: STR, id: NUM});
 // for (; iter.valid(); iter.next())
 //  console.log(iter.name, iter.surname);
-export type RowIterator<T extends Row> = RowIteratorBase & T;
+export type RowIterator<T extends SpecType> = RowIteratorBase &
+  IterResultFor<T>;
 
-function columnTypeToString(t: SqlValue): string {
+function columnTypeToString(t: SpecValue): string {
   switch (t) {
     case NUM:
       return 'NUM';
@@ -318,7 +365,7 @@ function columnTypeToString(t: SqlValue): string {
   }
 }
 
-function isCompatible(actual: CellType, expected: SqlValue): boolean {
+function isCompatible(actual: CellType, expected: SpecValue): boolean {
   switch (actual) {
     case CellType.CELL_NULL:
       return (
@@ -381,15 +428,15 @@ export interface QueryResult {
   // keep the data around so they can redraw them on each animation frame. For
   // now we keep everything in memory in the QueryResultImpl object.
   // iter<T extends Row>(spec: T): RowIterator<T>;
-  iter<T extends Row>(spec: T): RowIterator<T>;
+  iter<T extends SpecType>(spec: T): RowIterator<T>;
 
   // Like iter() for queries that expect only one row. It embeds the valid()
   // check (i.e. throws if no rows are available) and returns directly the
   // first result.
-  firstRow<T extends Row>(spec: T): T;
+  firstRow<T extends SpecType>(spec: T): IterResultFor<T>;
 
   // Like firstRow() but returns undefined if no rows are available.
-  maybeFirstRow<T extends Row>(spec: T): T | undefined;
+  maybeFirstRow<T extends SpecType>(spec: T): IterResultFor<T> | undefined;
 
   // If != undefined the query errored out and error() contains the message.
   error(): string | undefined;
@@ -440,16 +487,16 @@ export interface QueryResult {
 // the array-materializing counterpart to iter(): use it when you want every row
 // up front rather than streaming through them.
 // Example: const rows = materializeRows(result, {id: NUM, name: STR});
-export function materializeRows<T extends Row>(
+export function materializeRows<T extends SpecType>(
   result: QueryResult,
   spec: T,
-): T[] {
-  const rows: T[] = [];
+): IterResultFor<T>[] {
+  const rows: IterResultFor<T>[] = [];
   const cols = Object.keys(spec);
   for (const it = result.iter(spec); it.valid(); it.next()) {
     const row: Record<string, SqlValue> = {};
     for (const col of cols) row[col] = it.get(col);
-    rows.push(row as T);
+    rows.push(row as IterResultFor<T>);
   }
   return rows;
 }
@@ -537,23 +584,23 @@ class QueryResultImpl implements QueryResult, WritableQueryResult {
     return this._elapsedTimeMs;
   }
 
-  iter<T extends Row>(spec: T): RowIterator<T> {
+  iter<T extends SpecType>(spec: T): RowIterator<T> {
     const impl = new RowIteratorImplWithRowData(spec, this);
     return impl as {} as RowIterator<T>;
   }
 
-  firstRow<T extends Row>(spec: T): T {
+  firstRow<T extends SpecType>(spec: T): IterResultFor<T> {
     const impl = new RowIteratorImplWithRowData(spec, this);
     assertTrue(impl.valid());
-    return impl as {} as RowIterator<T> as T;
+    return impl as {} as RowIterator<T> as IterResultFor<T>;
   }
 
-  maybeFirstRow<T extends Row>(spec: T): T | undefined {
+  maybeFirstRow<T extends SpecType>(spec: T): IterResultFor<T> | undefined {
     const impl = new RowIteratorImplWithRowData(spec, this);
     if (!impl.valid()) {
       return undefined;
     }
-    return impl as {} as RowIterator<T> as T;
+    return impl as {} as RowIterator<T> as IterResultFor<T>;
   }
 
   // Can be called only once.
@@ -828,7 +875,7 @@ class RowIteratorImpl implements RowIteratorBase {
   // The spec passed to the iter call containing the expected types, e.g.:
   // {'colA': NUM, 'colB': NUM_NULL, 'colC': STRING}.
   // This doesn't ever change.
-  readonly rowSpec: Row;
+  readonly rowSpec: SpecType;
 
   // The object that holds the current row. This points to the parent
   // RowIteratorImplWithRowData instance that created this class.
@@ -847,7 +894,7 @@ class RowIteratorImpl implements RowIteratorBase {
   private batchBytes = new Uint8Array();
   private columnNames: string[] = [];
   // rowSpec resolved by column position; see tryMoveToNextBatch().
-  private colTypes: Array<SqlValue | undefined> = [];
+  private colTypes: Array<SpecValue | undefined> = [];
   private numColumns = 0;
   private cellTypesEnd = -1; // -1 so the 1st next() hits tryMoveToNextBatch().
   private float64Cells = new Float64Array();
@@ -865,7 +912,7 @@ class RowIteratorImpl implements RowIteratorBase {
   private nextBlobCell = 0;
   private isValid = false;
 
-  constructor(querySpec: Row, rowData: Row, res: QueryResultImpl) {
+  constructor(querySpec: SpecType, rowData: Row, res: QueryResultImpl) {
     Object.assign(this, querySpec);
     this.rowData = rowData;
     this.rowSpec = {...querySpec}; // ... -> Copy all the key/value pairs.
@@ -1063,7 +1110,7 @@ class RowIteratorImpl implements RowIteratorBase {
   // one, so the thrown error can name the offending row.
   private checkColumnCellTypes(
     col: number,
-    expType: SqlValue,
+    expType: SpecValue,
     numColumns: number,
   ): void {
     for (
@@ -1103,7 +1150,7 @@ class RowIteratorImplWithRowData implements RowIteratorBase {
   valid: () => boolean;
   get: (columnName: string) => SqlValue;
 
-  constructor(querySpec: Row, res: QueryResultImpl) {
+  constructor(querySpec: SpecType, res: QueryResultImpl) {
     const thisAsRow = this as {} as Row;
     Object.assign(thisAsRow, querySpec);
     this._impl = new RowIteratorImpl(querySpec, thisAsRow, res);
@@ -1130,13 +1177,13 @@ class WaitableQueryResultImpl
   }
 
   // QueryResult implementation. Proxies all calls to the impl object.
-  iter<T extends Row>(spec: T) {
+  iter<T extends SpecType>(spec: T) {
     return this.impl.iter(spec);
   }
-  firstRow<T extends Row>(spec: T) {
+  firstRow<T extends SpecType>(spec: T) {
     return this.impl.firstRow(spec);
   }
-  maybeFirstRow<T extends Row>(spec: T) {
+  maybeFirstRow<T extends SpecType>(spec: T) {
     return this.impl.maybeFirstRow(spec);
   }
   waitAllRows() {

--- a/ui/src/trace_processor/query_result_benchmark_unittest.ts
+++ b/ui/src/trace_processor/query_result_benchmark_unittest.ts
@@ -1,0 +1,772 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use it except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Micro-benchmark for the QueryResult decode hot path. This mirrors what
+// SliceTrack / CounterTrack do when loading large tracks (1000s..1Ms of rows):
+// take a raw trace_processor.QueryResult protobuf (as produced by TP / the Wasm
+// engine) and turn it into fully-processed, per-row typed arrays.
+//
+// It compares the two processing paths:
+//   1. iter() per-row decoding
+//   2. decodeColumns() bulk columnar decoding
+//
+// The timed region covers decode work only. Checksums are used to (a) verify
+// that both paths agree and (b) keep the JIT from eliminating the decode, but
+// they are computed in a separate, untimed pass so they don't contaminate the
+// measured numbers (see bench()).
+//
+// (The allocation-free varint reader only exists on this branch - to measure
+// it, run this same benchmark on `main` and compare the iter() number; see
+// the note emitted at the end.)
+//
+// This is NOT a correctness test. It's a perf harness kept under the
+// *_unittest.ts glob purely so it runs in the same Vite/Vitest environment
+// (protobufjs init, module resolution). Run it explicitly with:
+//
+//   RUN_BENCH=1 ui/run-unittests -t 'QueryResultBenchmark'
+//
+// It is gated behind RUN_BENCH=1 so it doesn't slow down the normal test suite.
+
+import {
+  createQueryResult,
+  LONG,
+  NUM,
+  STR,
+  type ColumnarResultFor,
+  type QueryResult,
+  type RowIterator,
+  type SpecType,
+} from './query_result';
+
+// trace_processor.proto QueryResult.CellsBatch.CellType values. Hard-coded
+// (rather than imported from the generated protobufjs module) for clarity.
+const CELL_VARINT = 2;
+const CELL_FLOAT64 = 3;
+const CELL_STRING = 4;
+
+// --- Minimal protobuf wire encoder ---------------------------------------
+// We hand-encode the trace_processor.QueryResult bytes rather than going
+// through protobufjs because QueryResult's reader hand-parses the wire format
+// anyway, so this is exactly what it consumes.
+
+function pushVarint(arr: number[], value: number): void {
+  // value is a non-negative integer that may exceed 2**32, so we avoid 32-bit
+  // bitwise ops and use arithmetic instead.
+  while (value > 127) {
+    arr.push((value % 128) + 128);
+    value = Math.floor(value / 128);
+  }
+  arr.push(value);
+}
+
+function pushTag(arr: number[], field: number, wireType: number): void {
+  pushVarint(arr, field * 8 + wireType);
+}
+
+// Appends a length-delimited (wire type 2) field carrying |payload|.
+function pushLenDelim(arr: number[], field: number, payload: number[]): void {
+  pushTag(arr, field, 2);
+  pushVarint(arr, payload.length);
+  for (let i = 0; i < payload.length; i++) arr.push(payload[i]);
+}
+
+const textEncoder = new TextEncoder();
+function utf8(s: string): number[] {
+  return Array.from(textEncoder.encode(s));
+}
+
+// The columns of a typical ftrace instant / slice track: id, ts, count,
+// depth (integers) plus a STR name. ts holds realistic nanosecond
+// timestamps (well above INT32_MAX) so it exercises the expensive multi-byte
+// varint path; the others are small.
+const COLUMN_NAMES = ['id', 'ts', 'dur', 'count', 'depth', 'upid', 'name'];
+const NAMES = [
+  'sched_wakeup',
+  'sched_switch',
+  'cpu_idle',
+  'irq_handler_entry',
+  'workqueue_execute_start',
+];
+
+// Per-row integer values, in scan order: [id, ts, dur, count, depth, upid].
+function rowInts(r: number): [number, number, number, number, number, number] {
+  return [
+    r, // id        (small)
+    1_500_000_000_000 + r * 7919, // ts  (~1.5ms-base ns, multi-byte varint)
+    (r % 100000) + 1, // dur  (medium)
+    (r % 7) + 1, // count     (small)
+    r % 4, // depth     (small)
+    100000 + (r % 500), // upid  (medium)
+  ];
+}
+
+// Builds an encoded trace_processor.QueryResult with `numRows` rows split into
+// batches of ~`rowsPerBatch`. Integer cells are CELL_VARINT (what the
+// HTTP+RPC path emits, and what `main` always emits).
+function buildInstantTrackResult(
+  numRows: number,
+  rowsPerBatch: number,
+): Uint8Array[] {
+  const out: Uint8Array[] = [];
+  let row = 0;
+  let firstBatch = true;
+  while (row < numRows) {
+    const n = Math.min(rowsPerBatch, numRows - row);
+    const cellTypes: number[] = []; // packed CellType per cell.
+    const varints: number[] = []; // packed varint payload.
+    const stringCells: string[] = [];
+
+    const pushInt = (v: number) => {
+      cellTypes.push(CELL_VARINT);
+      pushVarint(varints, v);
+    };
+
+    for (let i = 0; i < n; i++) {
+      const r = row + i;
+      const [id, ts, dur, count, depth, upid] = rowInts(r);
+      pushInt(id);
+      pushInt(ts);
+      pushInt(dur);
+      pushInt(count);
+      pushInt(depth);
+      pushInt(upid);
+      cellTypes.push(CELL_STRING);
+      stringCells.push(NAMES[r % NAMES.length]);
+    }
+    const isLast = row + n >= numRows;
+
+    // CellsBatch payload. Field numbers: cells=1, varint_cells=2,
+    // string_cells=5, is_last_batch=6.
+    const batch: number[] = [];
+    const cellsBuf: number[] = [];
+    for (const ct of cellTypes) pushVarint(cellsBuf, ct);
+    pushLenDelim(batch, 1, cellsBuf);
+    if (varints.length) pushLenDelim(batch, 2, varints);
+    pushLenDelim(batch, 5, utf8(stringCells.join('\0')));
+    pushTag(batch, 6, 0);
+    pushVarint(batch, isLast ? 1 : 0);
+
+    // QueryResult wrapper. Field numbers: column_names=1, batch=3.
+    const top: number[] = [];
+    if (firstBatch) {
+      for (const name of COLUMN_NAMES) pushLenDelim(top, 1, utf8(name));
+    }
+    pushLenDelim(top, 3, batch);
+
+    out.push(Uint8Array.from(top));
+    firstBatch = false;
+    row += n;
+  }
+  return out;
+}
+
+function makeResult(encodedBatches: Uint8Array[]): QueryResult {
+  const qr = createQueryResult({query: 'benchmark'});
+  for (const b of encodedBatches) {
+    qr.appendResultBatch(b as Uint8Array<ArrayBuffer>);
+  }
+  return qr;
+}
+
+const SPEC = {
+  id: NUM,
+  ts: LONG,
+  dur: LONG,
+  count: NUM,
+  depth: NUM,
+  upid: NUM,
+  name: STR,
+} as const;
+
+// --- Timed decode wrappers -----------------------------------------------
+// These run ONLY the decode work inside the timed region (see bench()): no
+// checksum arithmetic, no copying into secondary buffers. The result is
+// returned (and stashed into the benchSink black hole outside the timed
+// window) so the JIT cannot dead-code-eliminate the decode itself:
+//  - decodeColumns() allocates the output arrays and they escape to the caller;
+//  - iter() writes every cell into the iterator object, which also escapes.
+function decodeOnly<T extends SpecType>(
+  qr: QueryResult,
+  spec: T,
+): ColumnarResultFor<T> {
+  return qr.decodeColumns(spec);
+}
+
+function iterOnly<T extends SpecType>(
+  qr: QueryResult,
+  spec: T,
+): RowIterator<T> {
+  const it = qr.iter(spec);
+  for (; it.valid(); it.next()) {
+    // Decode only: next() stores every cell value into `it`.
+  }
+  return it; // Escapes into benchSink: forces all per-cell stores to be kept.
+}
+
+// --- Untimed verification passes for the instant-track workload ------------
+// Both must produce the same value; % 65521 keeps the accumulator bounded and
+// the per-row work identical between the two paths.
+function instantChecksumIter(qr: QueryResult): number {
+  let checksum = 0;
+  const it = qr.iter(SPEC);
+  for (; it.valid(); it.next()) {
+    checksum +=
+      (it.id +
+        Number(it.ts) +
+        Number(it.dur) +
+        it.count +
+        it.depth +
+        it.upid +
+        it.name.length) %
+      65521;
+  }
+  return checksum;
+}
+
+function instantChecksumColumns(qr: QueryResult): number {
+  const count = qr.numRows();
+  const cols = qr.decodeColumns(SPEC);
+  const ids = cols.id;
+  const tss = cols.ts;
+  const durs = cols.dur;
+  const counts = cols.count;
+  const depths = cols.depth;
+  const upids = cols.upid;
+  const names = cols.name;
+  let checksum = 0;
+  for (let i = 0; i < count; i++) {
+    checksum +=
+      (ids[i] +
+        Number(tss[i]) +
+        Number(durs[i]) +
+        counts[i] +
+        depths[i] +
+        upids[i] +
+        (names[i] ?? '').length) %
+      65521;
+  }
+  return checksum;
+}
+
+// A LONG-only variant: this exercises the int64 varint -> bigint hot path
+// (and the BigInt64Array direct-store path in decodeColumns()) without the
+// small-integer NUM cells and strings diluting the measurements. The values
+// are realistic: nanosecond timestamps (6-byte varints), durations, track ids
+// and process upids (medium varints).
+const LONG_COLUMN_NAMES = ['ts', 'dur', '__track_id', 'upid'];
+const LONG_SPEC = {
+  ts: LONG,
+  dur: LONG,
+  __track_id: LONG,
+  upid: LONG,
+} as const;
+
+function buildLongOnlyResult(
+  numRows: number,
+  rowsPerBatch: number,
+): Uint8Array[] {
+  const out: Uint8Array[] = [];
+  let row = 0;
+  let firstBatch = true;
+  while (row < numRows) {
+    const n = Math.min(rowsPerBatch, numRows - row);
+    const cellTypes: number[] = [];
+    const varints: number[] = [];
+
+    const pushInt = (v: number) => {
+      cellTypes.push(CELL_VARINT);
+      pushVarint(varints, v);
+    };
+
+    for (let i = 0; i < n; i++) {
+      const r = row + i;
+      pushInt(1_500_000_000_000 + r * 7919); // ts
+      pushInt((r % 100000) + 1); // dur
+      pushInt(100000 + (r % 500)); // track_id
+      pushInt(200000 + (r % 1000)); // upid
+    }
+    const isLast = row + n >= numRows;
+
+    // CellsBatch payload. Field numbers: cells=1, varint_cells=2,
+    // is_last_batch=6.
+    const batch: number[] = [];
+    const cellsBuf: number[] = [];
+    for (const ct of cellTypes) pushVarint(cellsBuf, ct);
+    pushLenDelim(batch, 1, cellsBuf);
+    if (varints.length) pushLenDelim(batch, 2, varints);
+    pushTag(batch, 6, 0);
+    pushVarint(batch, isLast ? 1 : 0);
+
+    // QueryResult wrapper. Field numbers: column_names=1, batch=3.
+    const top: number[] = [];
+    if (firstBatch) {
+      for (const name of LONG_COLUMN_NAMES) pushLenDelim(top, 1, utf8(name));
+    }
+    pushLenDelim(top, 3, batch);
+
+    out.push(Uint8Array.from(top));
+    firstBatch = false;
+    row += n;
+  }
+  return out;
+}
+
+// A NUM-varint-only variant: same shape as the long-only one, but every column
+// is NUM and fed by CELL_VARINT cells (varint -> JS number -> Float64Array),
+// which exercises the allocation-free number varint reader
+// (readVarIntAsNumber) on the same realistic value ranges without any bigint
+// work at all. NOTE: unlike the LONG case, the varint bits cannot be written
+// directly into the Float64Array here, because a double's bit pattern is the
+// IEEE754 encoding of the integer, not the integer itself; an int->double
+// conversion is inherent to this path.
+const NUM_COLUMN_NAMES = ['ts', 'dur', 'count', 'depth'];
+const NUM_SPEC = {
+  ts: NUM,
+  dur: NUM,
+  count: NUM,
+  depth: NUM,
+} as const;
+
+function buildVarintOnlyResult(
+  numRows: number,
+  rowsPerBatch: number,
+): Uint8Array[] {
+  const out: Uint8Array[] = [];
+  let row = 0;
+  let firstBatch = true;
+  while (row < numRows) {
+    const n = Math.min(rowsPerBatch, numRows - row);
+    const cellTypes: number[] = [];
+    const varints: number[] = [];
+
+    const pushInt = (v: number) => {
+      cellTypes.push(CELL_VARINT);
+      pushVarint(varints, v);
+    };
+
+    for (let i = 0; i < n; i++) {
+      const r = row + i;
+      pushInt(1_500_000_000_000 + r * 7919); // ts
+      pushInt((r % 100000) + 1); // dur
+      pushInt((r % 7) + 1); // count
+      pushInt(r % 4); // depth
+    }
+    const isLast = row + n >= numRows;
+
+    // CellsBatch payload. Field numbers: cells=1, varint_cells=2,
+    // is_last_batch=6.
+    const batch: number[] = [];
+    const cellsBuf: number[] = [];
+    for (const ct of cellTypes) pushVarint(cellsBuf, ct);
+    pushLenDelim(batch, 1, cellsBuf);
+    if (varints.length) pushLenDelim(batch, 2, varints);
+    pushTag(batch, 6, 0);
+    pushVarint(batch, isLast ? 1 : 0);
+
+    // QueryResult wrapper. Field numbers: column_names=1, batch=3.
+    const top: number[] = [];
+    if (firstBatch) {
+      for (const name of NUM_COLUMN_NAMES) pushLenDelim(top, 1, utf8(name));
+    }
+    pushLenDelim(top, 3, batch);
+
+    out.push(Uint8Array.from(top));
+    firstBatch = false;
+    row += n;
+  }
+  return out;
+}
+
+// Untimed verification passes (see bench()). Both must produce the same
+// value; the % 65521 keeps the accumulator bounded and the per-row work
+// identical between the two paths.
+function numVarintChecksumIter(qr: QueryResult): number {
+  let checksum = 0;
+  const it = qr.iter(NUM_SPEC);
+  for (; it.valid(); it.next()) {
+    checksum += (it.ts + it.dur + it.count + it.depth) % 65521;
+  }
+  return checksum;
+}
+
+function numVarintChecksumColumns(qr: QueryResult): number {
+  const count = qr.numRows();
+  const cols = qr.decodeColumns(NUM_SPEC);
+  const tss = cols.ts;
+  const durs = cols.dur;
+  const counts = cols.count;
+  const depths = cols.depth;
+  let checksum = 0;
+  for (let i = 0; i < count; i++) {
+    checksum += (tss[i] + durs[i] + counts[i] + depths[i]) % 65521;
+  }
+  return checksum;
+}
+
+// A NUM-float64-only variant: every column is NUM, fed by CELL_FLOAT64 cells
+// (the fixed64-packed field 3), which is what TraceProcessor emits for REAL
+// and float results. Note: an Int32Array word-pair bit-copy (as done for the
+// LONG varint path) was tried here and measured ~26% SLOWER than the plain
+// Float64Array->Float64Array store (two loads+stores vs one movsd), so the
+// simple copy is kept; it is already allocation-free in optimized code.
+const F64_COLUMN_NAMES = ['ts', 'dur', '__value', '__scale'];
+const F64_SPEC = {
+  ts: NUM,
+  dur: NUM,
+  __value: NUM,
+  __scale: NUM,
+} as const;
+
+// Scratch buffer for little-endian double encoding (the proto wire format
+// mandates little-endian for fixed64 fields).
+const f64Scratch = new DataView(new ArrayBuffer(8));
+
+function pushF64(arr: number[], value: number): void {
+  f64Scratch.setFloat64(0, value, true);
+  for (let i = 0; i < 8; i++) arr.push(f64Scratch.getUint8(i));
+}
+
+function f64RowValues(r: number): [number, number, number, number] {
+  return [
+    1_500_000_000_000.25 + r * 7919.5, // ts  (ns, multi-byte mantissa)
+    (r % 100000) + 0.5, // dur
+    ((r % 7) + 1) * 1.5, // value
+    (r % 4) * 0.25, // scale
+  ];
+}
+
+function buildFloat64OnlyResult(
+  numRows: number,
+  rowsPerBatch: number,
+): Uint8Array[] {
+  const out: Uint8Array[] = [];
+  let row = 0;
+  let firstBatch = true;
+  while (row < numRows) {
+    const n = Math.min(rowsPerBatch, numRows - row);
+    const cellTypes: number[] = [];
+    const f64Cells: number[] = [];
+
+    for (let i = 0; i < n; i++) {
+      const r = row + i;
+      const [ts, dur, value, scale] = f64RowValues(r);
+      for (let c = 0; c < 4; c++) cellTypes.push(CELL_FLOAT64);
+      pushF64(f64Cells, ts);
+      pushF64(f64Cells, dur);
+      pushF64(f64Cells, value);
+      pushF64(f64Cells, scale);
+    }
+    const isLast = row + n >= numRows;
+
+    // CellsBatch payload. Field numbers: cells=1, float64_cells=3,
+    // is_last_batch=6.
+    const batch: number[] = [];
+    const cellsBuf: number[] = [];
+    for (const ct of cellTypes) pushVarint(cellsBuf, ct);
+    pushLenDelim(batch, 1, cellsBuf);
+    pushLenDelim(batch, 3, f64Cells);
+    pushTag(batch, 6, 0);
+    pushVarint(batch, isLast ? 1 : 0);
+
+    // QueryResult wrapper. Field numbers: column_names=1, batch=3.
+    const top: number[] = [];
+    if (firstBatch) {
+      for (const name of F64_COLUMN_NAMES) pushLenDelim(top, 1, utf8(name));
+    }
+    pushLenDelim(top, 3, batch);
+
+    out.push(Uint8Array.from(top));
+    firstBatch = false;
+    row += n;
+  }
+  return out;
+}
+
+// Plain sums (no modulo: the identical operation order in both paths keeps
+// the float results bit-identical, which doubles as a stricter equality
+// check than an integer checksum). Untimed verification passes (see bench()).
+function float64ChecksumIter(qr: QueryResult): number {
+  let checksum = 0;
+  const it = qr.iter(F64_SPEC);
+  for (; it.valid(); it.next()) {
+    checksum += it.ts + it.dur + it.__value + it.__scale;
+  }
+  return checksum;
+}
+
+function float64ChecksumColumns(qr: QueryResult): number {
+  const count = qr.numRows();
+  const cols = qr.decodeColumns(F64_SPEC);
+  const tss = cols.ts;
+  const durs = cols.dur;
+  const values = cols.__value;
+  const scales = cols.__scale;
+  let checksum = 0;
+  for (let i = 0; i < count; i++) {
+    checksum += tss[i] + durs[i] + values[i] + scales[i];
+  }
+  return checksum;
+}
+
+// Untimed verification passes (see bench()). The % 65521 keeps the checksum
+// bounded and avoids bigint growth; the work is identical in both paths.
+function longChecksumIter(qr: QueryResult): bigint {
+  let checksum = 0n;
+  const it = qr.iter(LONG_SPEC);
+  for (; it.valid(); it.next()) {
+    checksum += (it.ts + it.dur + it.__track_id + it.upid) % 65521n;
+  }
+  return checksum;
+}
+
+function longChecksumColumns(qr: QueryResult): bigint {
+  const count = qr.numRows();
+  const cols = qr.decodeColumns(LONG_SPEC);
+  const tss = cols.ts;
+  const durs = cols.dur;
+  const trackIds = cols.__track_id;
+  const upids = cols.upid;
+  let checksum = 0n;
+  for (let i = 0; i < count; i++) {
+    checksum += (tss[i] + durs[i] + trackIds[i] + upids[i]) % 65521n;
+  }
+  return checksum;
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+const shouldRun = process.env.RUN_BENCH === '1';
+const maybe = shouldRun ? test : test.skip;
+
+const NUM_ROWS = 1_000_000;
+const ROWS_PER_BATCH = 5_000; // ~ production 128KB batches.
+const WARMUP = 5;
+const ITERS = 25;
+
+interface BenchStats {
+  readonly label: string;
+  readonly min: number;
+  readonly median: number;
+  readonly mean: number;
+  readonly checksum: number | bigint;
+}
+
+// Black hole for timed results. Assigning to a module-level variable after
+// t1 (outside the timed window) keeps the decode outputs observable for the
+// JIT without adding any consumption work to the measured loop. Wrapped in
+// an object so tsc's noUnusedLocals doesn't flag it as write-only.
+const benchSink: {v: unknown} = {v: undefined};
+
+// Times `timed(qr)` over a freshly-rebuilt QueryResult each iteration. The
+// checksum is NOT part of the timed region: after the timed loop, `checksumOf`
+// runs once, untimed, on a fresh result, so the verification work cannot
+// contaminate the measurements (it exists to prove both paths agree and to
+// keep the decode from being dead-code-eliminated, not to be measured).
+function bench<R>(
+  label: string,
+  encoded: Uint8Array[],
+  timed: (qr: QueryResult) => R,
+  checksumOf: (qr: QueryResult) => number | bigint,
+): BenchStats {
+  const samples: number[] = [];
+  for (let i = 0; i < WARMUP + ITERS; i++) {
+    const qr = makeResult(encoded);
+    const t0 = performance.now();
+    const res = timed(qr);
+    const t1 = performance.now();
+    benchSink.v = res; // Consume outside the timed window: no DCE, no cost.
+    if (i >= WARMUP) samples.push(t1 - t0);
+  }
+  const checksum = checksumOf(makeResult(encoded));
+  samples.sort((a, b) => a - b);
+  return {
+    label,
+    min: samples[0],
+    median: samples[Math.floor(samples.length / 2)],
+    mean: samples.reduce((a, b) => a + b, 0) / samples.length,
+    checksum,
+  };
+}
+
+function report(stats: BenchStats): string {
+  const rowsPerSec = NUM_ROWS / (stats.median / 1000);
+  return (
+    `  ${stats.label.padEnd(20)} ` +
+    `min=${stats.min.toFixed(1)}ms median=${stats.median.toFixed(1)}ms ` +
+    `mean=${stats.mean.toFixed(1)}ms  ` +
+    `${fmt(Math.round(rowsPerSec))} rows/s ` +
+    `(${((stats.median / NUM_ROWS) * 1e6).toFixed(1)} ns/row)\n`
+  );
+}
+
+function emit(text: string) {
+  process.stderr.write(text);
+  const outFile = process.env.BENCH_OUT;
+  if (outFile !== undefined) {
+    const fs = require('node:fs');
+    fs.appendFileSync(outFile, text);
+  }
+}
+
+describe('QueryResultBenchmark', () => {
+  maybe(
+    'instant track decode: iter() vs decodeColumns()',
+    () => {
+      const encoded = buildInstantTrackResult(NUM_ROWS, ROWS_PER_BATCH);
+
+      const iterStats = bench(
+        'iter()',
+        encoded,
+        (qr) => iterOnly(qr, SPEC),
+        instantChecksumIter,
+      );
+      const colStats = bench(
+        'decodeColumns()',
+        encoded,
+        (qr) => decodeOnly(qr, SPEC),
+        instantChecksumColumns,
+      );
+
+      // Both paths must produce identical results.
+      expect(colStats.checksum).toBe(iterStats.checksum);
+
+      const m = (s: BenchStats) => s.median;
+      const speedup = (m(iterStats) / m(colStats)).toFixed(2);
+
+      emit(
+        `\n[QueryResultBenchmark] instant track, ${fmt(NUM_ROWS)} rows ` +
+          `(7 cols: 4 NUM + 2 LONG + 1 STR), ${ITERS} iters, median ms\n\n` +
+          report(iterStats) +
+          report(colStats) +
+          `\n  Speedup (iter -> decodeColumns): ${speedup}x\n`,
+      );
+
+      expect(iterStats.median).toBeGreaterThan(0);
+    },
+    600_000,
+  );
+
+  maybe(
+    'num-varint-only decode: iter() vs decodeColumns()',
+    () => {
+      const encoded = buildVarintOnlyResult(NUM_ROWS, ROWS_PER_BATCH);
+
+      const iterStats = bench(
+        'iter()',
+        encoded,
+        (qr) => iterOnly(qr, NUM_SPEC),
+        numVarintChecksumIter,
+      );
+      const colStats = bench(
+        'decodeColumns()',
+        encoded,
+        (qr) => decodeOnly(qr, NUM_SPEC),
+        numVarintChecksumColumns,
+      );
+
+      // Both paths must produce identical results.
+      expect(colStats.checksum).toBe(iterStats.checksum);
+
+      const m = (s: BenchStats) => s.median;
+      const speedup = (m(iterStats) / m(colStats)).toFixed(2);
+
+      emit(
+        `\n[QueryResultBenchmark] num-varint-only, ${fmt(NUM_ROWS)} rows ` +
+          `(4 NUM varint columns, no strings), ${ITERS} iters, median ms\n\n` +
+          report(iterStats) +
+          report(colStats) +
+          `\n  Speedup (iter -> decodeColumns): ${speedup}x\n`,
+      );
+
+      expect(iterStats.median).toBeGreaterThan(0);
+    },
+    600_000,
+  );
+
+  maybe(
+    'num-float64-only decode: iter() vs decodeColumns()',
+    () => {
+      const encoded = buildFloat64OnlyResult(NUM_ROWS, ROWS_PER_BATCH);
+
+      const iterStats = bench(
+        'iter()',
+        encoded,
+        (qr) => iterOnly(qr, F64_SPEC),
+        float64ChecksumIter,
+      );
+      const colStats = bench(
+        'decodeColumns()',
+        encoded,
+        (qr) => decodeOnly(qr, F64_SPEC),
+        float64ChecksumColumns,
+      );
+
+      // Both paths must produce identical results.
+      expect(colStats.checksum).toBe(iterStats.checksum);
+
+      const m = (s: BenchStats) => s.median;
+      const speedup = (m(iterStats) / m(colStats)).toFixed(2);
+
+      emit(
+        `\n[QueryResultBenchmark] num-float64-only, ${fmt(NUM_ROWS)} rows ` +
+          `(4 NUM float64 columns, no strings), ${ITERS} iters, median ms\n\n` +
+          report(iterStats) +
+          report(colStats) +
+          `\n  Speedup (iter -> decodeColumns): ${speedup}x\n`,
+      );
+
+      expect(iterStats.median).toBeGreaterThan(0);
+    },
+    600_000,
+  );
+
+  maybe(
+    'long-only decode: iter() vs decodeColumns()',
+    () => {
+      const encoded = buildLongOnlyResult(NUM_ROWS, ROWS_PER_BATCH);
+
+      const iterStats = bench(
+        'iter()',
+        encoded,
+        (qr) => iterOnly(qr, LONG_SPEC),
+        longChecksumIter,
+      );
+      const colStats = bench(
+        'decodeColumns()',
+        encoded,
+        (qr) => decodeOnly(qr, LONG_SPEC),
+        longChecksumColumns,
+      );
+
+      // Both paths must produce identical results.
+      expect(colStats.checksum).toBe(iterStats.checksum);
+
+      const m = (s: BenchStats) => s.median;
+      const speedup = (m(iterStats) / m(colStats)).toFixed(2);
+
+      emit(
+        `\n[QueryResultBenchmark] long-only, ${fmt(NUM_ROWS)} rows ` +
+          `(4 LONG columns, no strings), ${ITERS} iters, median ms\n\n` +
+          report(iterStats) +
+          report(colStats) +
+          `\n  Speedup (iter -> decodeColumns): ${speedup}x\n`,
+      );
+
+      expect(iterStats.median).toBeGreaterThan(0);
+    },
+    600_000,
+  );
+});

--- a/ui/src/trace_processor/query_result_unittest.ts
+++ b/ui/src/trace_processor/query_result_unittest.ts
@@ -27,7 +27,6 @@ import {
   STR_NULL,
   unionTypes,
   UNKNOWN,
-  type SpecValue,
 } from './query_result';
 
 const T = protos.QueryResult.CellsBatch.CellType;
@@ -281,6 +280,149 @@ test('QueryResult.MultipleBatches', async () => {
   expect(qr.numRows()).toBe(2);
 });
 
+test('QueryResult.decodeColumns', () => {
+  // Two batches, mixed cell types, to also exercise batch switching and the
+  // varint cursor reset between batches.
+  const resProto = protos.QueryResult.create({
+    columnNames: ['n', 'l', 's', 'f'],
+    batch: [
+      {
+        cells: [
+          T.CELL_VARINT,
+          T.CELL_VARINT,
+          T.CELL_STRING,
+          T.CELL_FLOAT64,
+          T.CELL_VARINT,
+          T.CELL_VARINT,
+          T.CELL_STRING,
+          T.CELL_FLOAT64,
+        ],
+        varintCells: [1, 1000000000000, -5, 42],
+        stringCells: ['foo', 'bar'].join('\0'),
+        float64Cells: [1.5, 2.5],
+        isLastBatch: false,
+      },
+      {
+        cells: [T.CELL_VARINT, T.CELL_VARINT, T.CELL_NULL, T.CELL_FLOAT64],
+        varintCells: [7, 99],
+        stringCells: '',
+        float64Cells: [3.5],
+        isLastBatch: true,
+      },
+    ],
+  });
+
+  const qr = createQueryResult({query: 'Some query'});
+  qr.appendResultBatch(protos.QueryResult.encode(resProto).finish());
+  expect(qr.numRows()).toBe(3);
+
+  // n: NUM -> Float64Array, l: LONG -> BigInt64Array, s: STR -> string[],
+  // f: NUM -> Float64Array.
+  const cols = qr.decodeColumns({
+    n: NUM,
+    l: LONG,
+    s: STR_NULL,
+    f: NUM,
+  });
+
+  expect(cols.n).toBeInstanceOf(Float64Array);
+  expect(Array.from(cols.n)).toEqual([1, -5, 7]);
+  expect(cols.l).toBeInstanceOf(BigInt64Array);
+  expect(Array.from(cols.l)).toEqual([1000000000000n, 42n, 99n]);
+  expect(cols.s).toEqual(['foo', 'bar', null]);
+  expect(Array.from(cols.f)).toEqual([1.5, 2.5, 3.5]);
+
+  // Selecting a subset of columns must still decode correctly (the unselected
+  // columns' cells are skipped but their cursors still advance).
+  const subset = qr.decodeColumns({s: STR_NULL});
+  expect(subset.s).toEqual(['foo', 'bar', null]);
+
+  // Unknown column throws.
+  expect(() => qr.decodeColumns({nope: NUM})).toThrowError(/nope.*not found/);
+});
+
+// decodeColumns() must reject spec/wire mismatches the same way iter() does.
+test('QueryResult.decodeColumnsTypeErrors', () => {
+  // Incompatible: NUM spec but string cells on the wire, in the middle row.
+  const incompatible = protos.QueryResult.create({
+    columnNames: ['x'],
+    batch: [
+      {
+        cells: [T.CELL_VARINT, T.CELL_STRING, T.CELL_VARINT],
+        varintCells: [1, 3],
+        stringCells: 'oops',
+        isLastBatch: true,
+      },
+    ],
+  });
+  const qr1 = createQueryResult({query: 'Some query'});
+  qr1.appendResultBatch(protos.QueryResult.encode(incompatible).finish());
+  expect(() => qr1.decodeColumns({x: NUM})).toThrowError(
+    /Incompatible cell type.*Expected: NUM actual: STRING/,
+  );
+  expect(() => qr1.decodeColumns({x: NUM})).toThrowError(
+    /Error @ row: 1 col: 'x'/,
+  );
+
+  // NULL on a non-nullable spec must throw, like iter().
+  const nulls = protos.QueryResult.create({
+    columnNames: ['x', 'y'],
+    batch: [
+      {
+        cells: [T.CELL_VARINT, T.CELL_NULL],
+        varintCells: [1],
+        isLastBatch: true,
+      },
+    ],
+  });
+  const qr2 = createQueryResult({query: 'Some query'});
+  qr2.appendResultBatch(protos.QueryResult.encode(nulls).finish());
+  expect(() => qr2.decodeColumns({x: NUM, y: NUM})).toThrowError(
+    /Error @ row: 0 col: 'y': SQL value is NULL but that was not expected/,
+  );
+  // The nullable spec type is fine.
+  expect(() => qr2.decodeColumns({x: NUM, y: NUM_NULL})).not.toThrow();
+
+  // LONG + float64 cells must throw (matches iter()'s compatibility rules).
+  const longFloat = protos.QueryResult.create({
+    columnNames: ['x'],
+    batch: [
+      {
+        cells: [T.CELL_FLOAT64],
+        float64Cells: [1.5],
+        isLastBatch: true,
+      },
+    ],
+  });
+  const qr3 = createQueryResult({query: 'Some query'});
+  qr3.appendResultBatch(protos.QueryResult.encode(longFloat).finish());
+  expect(() => qr3.decodeColumns({x: LONG})).toThrowError(
+    /Incompatible cell type.*Expected: LONG actual: FLOAT64/,
+  );
+
+  // The row number in the error must account for rows from earlier batches.
+  const twoBatches = protos.QueryResult.create({
+    columnNames: ['x'],
+    batch: [
+      {
+        cells: [T.CELL_VARINT, T.CELL_VARINT],
+        varintCells: [1, 2],
+        isLastBatch: false,
+      },
+      {
+        cells: [T.CELL_VARINT, T.CELL_STRING],
+        varintCells: [3],
+        stringCells: 'oops',
+        isLastBatch: true,
+      },
+    ],
+  });
+  const qr4 = createQueryResult({query: 'Some query'});
+  qr4.appendResultBatch(protos.QueryResult.encode(twoBatches).finish());
+  expect(() => qr4.decodeColumns({x: NUM})).toThrowError(
+    /Error @ row: 3 col: 'x'/,
+  );
+});
 // Regression test for b/194891824 .
 test('QueryResult.DuplicateColumnNames', () => {
   const batch = protos.QueryResult.CellsBatch.create({
@@ -364,7 +506,7 @@ test('QueryResult.WaitMoreRows', async () => {
 
 describe('decodeInt64Varint', () => {
   test('Parsing empty input should throw an error', () => {
-    expect(() => decodeInt64Varint(new Uint8Array(), 0)).toThrow(
+    expect(() => decodeInt64Varint(new Uint8Array(), {pos: 0})).toThrow(
       'Index out of range',
     );
   });
@@ -377,7 +519,7 @@ describe('decodeInt64Varint', () => {
     ];
 
     testData.forEach(([input, expected]) => {
-      expect(decodeInt64Varint(input, 0)).toEqual(expected);
+      expect(decodeInt64Varint(input, {pos: 0})).toEqual(expected);
     });
   });
 
@@ -396,7 +538,7 @@ describe('decodeInt64Varint', () => {
     ];
 
     testData.forEach(([input, expected]) => {
-      expect(decodeInt64Varint(input, 0)).toEqual(expected);
+      expect(decodeInt64Varint(input, {pos: 0})).toEqual(expected);
     });
   });
 
@@ -423,7 +565,7 @@ describe('decodeInt64Varint', () => {
     ];
 
     testData.forEach(([input, expected]) => {
-      expect(decodeInt64Varint(input, 0)).toEqual(expected);
+      expect(decodeInt64Varint(input, {pos: 0})).toEqual(expected);
     });
   });
 
@@ -434,7 +576,9 @@ describe('decodeInt64Varint', () => {
     ];
 
     testData.forEach((input) => {
-      expect(() => decodeInt64Varint(input, 0)).toThrow('Index out of range');
+      expect(() => decodeInt64Varint(input, {pos: 0})).toThrow(
+        'Index out of range',
+      );
     });
   });
 });
@@ -514,12 +658,5 @@ describe('checkExtends', () => {
     // Testing across different type families
     expect(checkExtends(UNKNOWN, STR)).toBe(true);
     expect(checkExtends(NUM_NULL, STR)).toBe(false);
-  });
-
-  it('should handle non-existent types gracefully', () => {
-    const CUSTOM = 'CUSTOM' as unknown as SpecValue;
-    // Type doesn't exist in the colTypes map
-    expect(() => checkExtends(CUSTOM, NUM)).not.toThrow();
-    expect(checkExtends(CUSTOM, NUM)).toBe(false);
   });
 });

--- a/ui/src/trace_processor/query_result_unittest.ts
+++ b/ui/src/trace_processor/query_result_unittest.ts
@@ -27,6 +27,7 @@ import {
   STR_NULL,
   unionTypes,
   UNKNOWN,
+  type SpecValue,
 } from './query_result';
 
 const T = protos.QueryResult.CellsBatch.CellType;
@@ -516,7 +517,7 @@ describe('checkExtends', () => {
   });
 
   it('should handle non-existent types gracefully', () => {
-    const CUSTOM = 'CUSTOM';
+    const CUSTOM = 'CUSTOM' as unknown as SpecValue;
     // Type doesn't exist in the colTypes map
     expect(() => checkExtends(CUSTOM, NUM)).not.toThrow();
     expect(checkExtends(CUSTOM, NUM)).toBe(false);


### PR DESCRIPTION
Currently all queries must be iterated out row by row which involves mutating the row object for every iteration. On heavy queries with many rows (such as tracks) this overhead can add up. In addition, most tracks ultimately require the data in columnar TypedArrays in order to load into WebGL buffers, so round tripping to a row object is wasteful.

This patch introduces a new QueryResult API - `decodeColumns(spec)` - which takes the same spec object as `.iter(spec)` but returns all rows in one go as a set of columnar based `TypedArray`s. Building arrays directly allows certain shortcuts to be taken such as avoiding creating bigints and simply copying bytes.

`decodeColumns()` runs around 2-4x faster than `iter()`, depending on the row spec.

This patch also migrates SliceTrack, CounterTrack,  GroupSummaryTrack, and CpuFreqTrack over to `decodeColumns()`. For compatibility, some row oriented work is still done in SliceTrack which leaves some performance on the table but changing this would involve changing track API, and this is out of scope of this PR.

Added a benchmark utility to compare the relative performance of `iter()` and `decodeColumns()`, which can be run using the following command:

```bash
RUN_BENCH=1 ui/run-unittests -f 'QueryResultBenchmark' -n
```

Note: Changes in unrelated parts of the codebase are related to the fact that the type of the row spec has been decoupled from the type of the row itself. This was a neat trick but doesn't work for decodeColumns as we need to translate the spec to columnar TypedArrays - e.g. NUM -> Float64Array. Unfortunately Typescript cannot tell the difference between the NUM and NUM_NULL types in type based meta-programming.

The spec types (NUM, STR, LONG, etc...) how now been changed to objects - so that each one is distinct and can be translated to the equivalent TypedArray. Another advantage is we can make the various specs extend one another properly so that spec subtyping works. E.g. `{foo: NUM}` can be used where `{foo: UNKNOWN}` or `{foo: NUM_NULL}` is expected, but not where `{foo: STR}` is expected.