### PR TITLE
tp: dispatch all registered extension fields in ParseTracePacket

### DIFF
--- a/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
@@ -85,16 +85,21 @@ void ProtoTraceParserImpl::ParseTracePacket(int64_t ts, TracePacketData data) {
   const TraceBlobView& blob = data.packet;
   // TODO(eseckler): Propagate statuses from modules.
   auto& modules = module_context_->modules_by_field;
-  // One pass over the packet: the first registered field found wins. This
-  // also covers fields in the out-of-tree `extensions 1000 to 1999` range,
-  // which a typed decoder would not store. Packets claimed by a module skip
-  // the full typed decode below entirely.
+  // Dispatch all registered fields found in the packet to their respective
+  // modules. This covers out-of-tree extensions (1000 to 1999) which a typed
+  // decoder would not store. Note that some producers (e.g. Android framework
+  // dumpers) may emit multiple extension fields within the same TracePacket.
+  // If any registered field was parsed, skip the fallback typed decode below.
   SelectiveTracePacketDecoder packet_fields(blob.data(), blob.length());
+  bool parsed = false;
   for (const protozero::Field& f : packet_fields.unknown_fields()) {
     if (f.id() >= modules.size() || modules[f.id()].empty())
       continue;
     for (ProtoImporterModule* module : modules[f.id()])
       module->ParseField({packet_fields, ts, data, TracePacketField(f)});
+    parsed = true;
+  }
+  if (parsed) {
     return;
   }
 

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -82,6 +82,8 @@
 #include "protos/perfetto/common/sys_stats_counters.pbzero.h"
 #include "protos/perfetto/common/trace_attributes.pbzero.h"
 #include "protos/perfetto/config/trace_config.pbzero.h"
+#include "protos/perfetto/trace/android/android_game_intervention_list.pbzero.h"
+#include "protos/perfetto/trace/android/initial_display_state.pbzero.h"
 #include "protos/perfetto/trace/android/packages_list.pbzero.h"
 #include "protos/perfetto/trace/android/recovered_trace_info.pbzero.h"
 #include "protos/perfetto/trace/chrome/chrome_benchmark_metadata.pbzero.h"
@@ -3179,6 +3181,29 @@ TEST_F(ProtoTraceParserTest, NonEmptyCpuInfo) {
   EXPECT_STREQ(context_.storage->GetString(cpu_table[0].processor()).c_str(),
                "ARMv8 Processor rev 0 (v8l)");
   EXPECT_EQ(cpu_table[0].capacity(), 1024u);
+}
+
+TEST_F(ProtoTraceParserTest, MultiExtensionFieldPacketDispatch) {
+  auto* packet = trace_->add_packet();
+  packet->set_timestamp(1000);
+
+  auto* game_list = packet->set_android_game_intervention_list();
+  auto* game_pkg = game_list->add_game_packages();
+  game_pkg->set_name("com.example.game");
+  game_pkg->set_uid(10001);
+  game_pkg->set_current_mode(1);
+
+  auto* display = packet->set_initial_display_state();
+  display->set_display_state(1);
+
+  EXPECT_CALL(*event_, PushCounter(1000, 1.0, testing::_));
+
+  ASSERT_TRUE(Tokenize().ok());
+  context_.sorter->ExtractEventsForced();
+
+  const auto& game_table =
+      context_.storage->android_game_intervention_list_table();
+  EXPECT_EQ(game_table.row_count(), 1u);
 }
 
 }  // namespace

--- a/test/trace_processor/diff_tests/parser/android/android_process_state.textproto
+++ b/test/trace_processor/diff_tests/parser/android/android_process_state.textproto
@@ -121,7 +121,8 @@ packet {
     }
   }
 }
-# Trace-stop dump for process state (contains pid 100, pid 200, pid 300, and pid 400).
+# Trace-stop dump for process state and freezer state in a single TracePacket
+# (exercises multi-extension field dispatch on the same packet).
 packet {
   timestamp: 10000
   [com.android.internal.FrameworksBaseTracePacket.android_process_state] {
@@ -154,11 +155,6 @@ packet {
       proc_state: 1003
     }
   }
-}
-# Trace-stop dump for freezer state (contains pid 100 and pid 600).
-# PID 600 tests dump-only freezer records.
-packet {
-  timestamp: 10000
   [com.android.internal.FrameworksBaseTracePacket.android_freezer_state] {
     record {
       pid: 100


### PR DESCRIPTION
When a TracePacket contains multiple registered extension fields (e.g., Android's ProcessStateDataSource emitting both android_process_state and android_freezer_state in a single snapshot packet), ParseTracePacket previously returned on the first registered field, dropping any subsequent extension fields in the same packet.

Although canonical Perfetto packets usually contain a single payload in the oneof data field, out-of-tree extensions are independent optional fields and can be co-located in a single packet.

This change iterates through all registered fields present in the packet before returning, ensuring all extension payloads are dispatched.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
