### PR TITLE
ui: Add slider to control GPU counters collection

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/gpu.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/gpu.ts
@@ -14,6 +14,7 @@
 
 import type {RecordProbe, RecordSubpage} from '../config/config_interfaces';
 import type {TraceConfigBuilder} from '../config/trace_config_builder';
+import {Slider} from './widgets/slider';
 
 export function gpuRecordSection(): RecordSubpage {
   return {
@@ -93,6 +94,15 @@ function gpuRenderStages(): RecordProbe {
 }
 
 function gpuMaliCounters(): RecordProbe {
+  const settings = {
+    samplingFreq: new Slider({
+      title: 'Sampling frequency',
+      cssClass: '.thin',
+      default: 10000,
+      values: [1, 10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+      unit: 'Hz',
+    }),
+  };
   return {
     id: 'gpu_mali_counters',
     title: 'Mali GPU Counters',
@@ -100,11 +110,14 @@ function gpuMaliCounters(): RecordProbe {
       'Records Mali GPU performance counters (Available on Valhall+).' +
       'To enable the event producer, run: ```adb shell gpu_counter_producer```',
     supportedPlatforms: ['ANDROID'],
+    settings,
     genConfig: function (tc: TraceConfigBuilder) {
+      const samplingPeriodNs = Math.round(
+        1_000_000_000 / settings.samplingFreq.value,
+      );
       const cfg = tc.addDataSource('gpu.counters', 'default');
       cfg.gpuCounterConfig = {
-        // Update 10 times per second
-        counterPeriodNs: 100000,
+        counterPeriodNs: samplingPeriodNs,
         // All Mali counters
         counterIds: [
           1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,


### PR DESCRIPTION
On some platforms (e.g. mesa's `pps-producer`) collection at 10KHz can have a large CPU performance impact.  Give the user an easy way to select a reasonable GPU counter collection rate, expressed in Hz similar to other collection rates such as stack sampling.

Keep the default at 10KHz to not disturb existing users, but at least erase the comment claiming it is 10Hz.