### PR TITLE
proto_merger: Fix extensions order

### DIFF
--- a/src/tools/proto_merger/extension_proto_merger.cc
+++ b/src/tools/proto_merger/extension_proto_merger.cc
@@ -68,26 +68,29 @@ ImportResult ImportProto(const std::string& proto_file,
 }
 
 // Recursively collects all extension files and their helper dependencies,
-// skipping standard base Perfetto protos and google protobuf descriptors.
+// skipping standard base Perfetto protos, google protobuf descriptors,
+// and the input base proto itself.
 void CollectExtensionFiles(
     const google::protobuf::FileDescriptor* file,
+    const google::protobuf::FileDescriptor* input_desc,
     std::unordered_set<const google::protobuf::FileDescriptor*>& visited,
     std::vector<const google::protobuf::FileDescriptor*>& out) {
-  if (!file || !visited.insert(file).second) {
+  if (!file || file == input_desc || !visited.insert(file).second) {
     return;
   }
 
   std::string name(file->name());
   if (base::StartsWith(name, "protos/perfetto/") ||
-      base::StartsWith(name, "google/protobuf/")) {
+      base::StartsWith(name, "google/protobuf/") ||
+      (input_desc && name == input_desc->name())) {
     return;
   }
 
-  out.push_back(file);
-
   for (int i = 0; i < file->dependency_count(); ++i) {
-    CollectExtensionFiles(file->dependency(i), visited, out);
+    CollectExtensionFiles(file->dependency(i), input_desc, visited, out);
   }
+
+  out.push_back(file);
 }
 
 const char kUsage[] =
@@ -190,7 +193,8 @@ base::Status MergeExtensions(const std::string& input,
       return base::ErrStatus("Failed to import extension proto: %s",
                              raw_path.c_str());
     }
-    CollectExtensionFiles(ext_desc, visited_descs, extension_descs);
+    CollectExtensionFiles(ext_desc, input_proto.file_descriptor, visited_descs,
+                          extension_descs);
   }
 
   // Convert the input descriptor into a ProtoFile model while inlining all

--- a/src/tools/proto_merger/proto_file.cc
+++ b/src/tools/proto_merger/proto_file.cc
@@ -370,14 +370,23 @@ ProtoFile ProtoFileFromDescriptor(
   for (int i = 0; i < desc.enum_type_count(); ++i) {
     file.enums.push_back(EnumFromDescriptor(*desc.enum_type(i)));
   }
-  for (int i = 0; i < desc.message_type_count(); ++i) {
-    file.messages.push_back(
-        MessageFromDescriptor(*desc.message_type(i), extension_files));
-  }
-
-  // Relocate helper messages and enums from the extension files to the top
-  // level of the output.
-  for (const auto* ext_file_desc : extension_files) {
+  std::unordered_set<const google::protobuf::FileDescriptor*> relocated_files;
+  auto relocate_helpers =
+      [&](const google::protobuf::FileDescriptor* ext_file_desc,
+          auto& self) -> void {
+    if (!ext_file_desc || ext_file_desc == &desc ||
+        ext_file_desc->name() == desc.name() ||
+        !relocated_files.insert(ext_file_desc).second) {
+      return;
+    }
+    for (int d = 0; d < ext_file_desc->dependency_count(); ++d) {
+      const auto* dep = ext_file_desc->dependency(d);
+      if (dep != &desc && dep->name() != desc.name() &&
+          std::find(extension_files.begin(), extension_files.end(), dep) !=
+              extension_files.end()) {
+        self(dep, self);
+      }
+    }
     for (int i = 0; i < ext_file_desc->enum_type_count(); ++i) {
       auto en = EnumFromDescriptor(*ext_file_desc->enum_type(i));
       if (!FindByName(file.enums, en.name)) {
@@ -391,6 +400,31 @@ ProtoFile ProtoFileFromDescriptor(
         file.messages.push_back(std::move(msg));
       }
     }
+  };
+
+  for (int i = 0; i < desc.message_type_count(); ++i) {
+    const auto* base_msg_desc = desc.message_type(i);
+
+    // Relocate helper messages and enums from extension files that extend
+    // this base message, placing them immediately before the target message.
+    for (const auto* ext_file_desc : extension_files) {
+      const auto* ext_pool = ext_file_desc->pool();
+      const auto* ext_containing_type =
+          ext_pool->FindMessageTypeByName(base_msg_desc->full_name());
+      if (ext_containing_type) {
+        std::vector<const google::protobuf::FieldDescriptor*> pool_extensions;
+        ext_pool->FindAllExtensions(ext_containing_type, &pool_extensions);
+        for (const auto* ext_field : pool_extensions) {
+          if (ext_field->file() == ext_file_desc) {
+            relocate_helpers(ext_file_desc, relocate_helpers);
+            break;
+          }
+        }
+      }
+    }
+
+    file.messages.push_back(
+        MessageFromDescriptor(*base_msg_desc, extension_files));
   }
 
   return file;

--- a/src/tools/proto_merger/proto_file_serializer_unittest.cc
+++ b/src/tools/proto_merger/proto_file_serializer_unittest.cc
@@ -1105,10 +1105,14 @@ TEST(ExtensionProtoMergerTest, MergeExtensionsEndToEnd) {
   EXPECT_THAT(out,
               HasSubstr("optional AppWakelockBundle app_wakelock = 1100;"));
 
-  // Verify relocated helper types
+  // Verify relocated helper types appear BEFORE their target message
   EXPECT_THAT(out, HasSubstr("enum ReceiverType {"));
   EXPECT_THAT(out, HasSubstr("message AndroidMessageQueue {"));
   EXPECT_THAT(out, HasSubstr("message AppWakelockBundle {"));
+  EXPECT_LT(out.find("message AndroidMessageQueue {"),
+            out.find("message TrackEvent {"));
+  EXPECT_LT(out.find("message AppWakelockBundle {"),
+            out.find("message TracePacket {"));
 }
 
 TEST(ExtensionProtoMergerTest, CrossFileExtensionDependency) {
@@ -1156,6 +1160,50 @@ TEST(ExtensionProtoMergerTest, CrossFileExtensionDependency) {
   EXPECT_THAT(out, HasSubstr("message TrackEvent {"));
   EXPECT_THAT(out, HasSubstr("optional SharedMeta shared_meta = 3000;"));
   EXPECT_THAT(out, HasSubstr("message SharedMeta {"));
+  EXPECT_LT(out.find("message SharedMeta {"), out.find("message TrackEvent {"));
+}
+
+TEST(ExtensionProtoMergerTest, UnassociatedHelpersAreOmitted) {
+  base::TempDir temp_dir = base::TempDir::Create();
+  std::string base_content = R"(
+    syntax = "proto2";
+    package perfetto.protos;
+
+    message TrackEvent {
+      optional string name = 1;
+      extensions 1000 to 9999;
+    }
+  )";
+
+  std::string ext_content = R"(
+    syntax = "proto2";
+    package com.android.unassociated;
+    import "base.proto";
+
+    message UnusedHelper {
+      optional string data = 1;
+    }
+
+    message OtherMessage {
+      extensions 100 to 200;
+    }
+
+    extend OtherMessage {
+      optional UnusedHelper unused = 101;
+    }
+  )";
+
+  TempProtoFile temp_base(temp_dir.path(), "base.proto", base_content);
+  TempProtoFile temp_ext(temp_dir.path(), "ext.proto", ext_content);
+
+  std::string out;
+  base::Status status =
+      MergeExtensions("base.proto", temp_dir.path(), {"ext.proto"}, &out);
+  ASSERT_TRUE(status.ok()) << status.message();
+
+  EXPECT_THAT(out, HasSubstr("message TrackEvent {"));
+  EXPECT_THAT(out, Not(HasSubstr("UnusedHelper")));
+  EXPECT_THAT(out, Not(HasSubstr("OtherMessage")));
 }
 }  // namespace
 }  // namespace proto_merger


### PR DESCRIPTION
Fix extensions order. Before this PR all extension enums + messages merged are added at the end of the file. 
With this PR they are added in the right place, above the extension targets