### PR TITLE
ui: fix flamegraph crash on heap profiles with negative sizes

### DIFF
--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -630,8 +630,8 @@ function flamegraphMetricsForHeapProfile(
         from _android_heap_profile_callstacks_for_allocations!((
           select
             callsite_id,
-            iif(positive_alloc, size, 0) as size,
-            iif(positive_alloc, count, 0) as count,
+            max(iif(positive_alloc, size, 0), 0) as size,
+            max(iif(positive_alloc, count, 0), 0) as count,
             max(size, 0) as alloc_size,
             max(count, 0) as alloc_count
           from heap_profile_allocation a


### PR DESCRIPTION
The heap profile flamegraph subquery passed raw per-row sizes through `iif(positive_alloc, size, 0)` without clamping. Individual rows within a callsite with net-positive count can still have negative sizes (deallocations), causing the flamegraph intrinsic to reject them with "value columns must be non-negative".

Clamp with `max(..., 0)` to match the existing pattern already used for `alloc_size` and `alloc_count`.

Fixes: https://b.corp.google.com/issues/554195579