### PR TITLE
ui: Add 'Show only direct flows' setting to FlowEvents plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,10 @@ Unreleased:
     * Memscope: native callstack snippet table no longer truncates frames.
     * Intelletto: registered tools with Chrome's WebMCP API.
     * Serialize workspaces to permalinks.
+    * Added a "Show only direct flows" setting to the FlowEvents plugin: when
+      enabled, selecting a slice shows only the flows directly connected to it
+      (one step) instead of following the entire flow chain. Useful for traces
+      with dense flow graphs (e.g. build dependencies).
   SDK:
     *
 

--- a/ui/src/core_plugins/dev.perfetto.FlowEvents/flow_manager.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlowEvents/flow_manager.ts
@@ -25,6 +25,7 @@ import type {
 } from '../../public/selection';
 import type {Engine} from '../../trace_processor/engine';
 import type {Raf} from '../../public/raf';
+import type {Setting} from '../../public/settings';
 
 const SHOW_INDIRECT_PRECEDING_FLOWS_FLAG = featureFlags.register({
   id: 'showIndirectPrecedingFlows',
@@ -49,6 +50,7 @@ export class FlowManager {
     private trackMgr: TrackManager,
     private selectionMgr: SelectionManager,
     private raf?: Raf,
+    private directFlowsOnlySetting?: Setting<boolean>,
   ) {}
 
   // TODO(primiano): the only reason why this is not done in the constructor is
@@ -319,6 +321,51 @@ export class FlowManager {
   }
 
   sliceSelected(sliceId: number) {
+    if (this.directFlowsOnlySetting?.get()) {
+      // Only show flows directly connected to the selected slice (one step).
+      const query = `
+      select
+        f.slice_out as beginSliceId,
+        t1.track_id as beginTrackId,
+        t1.name as beginSliceName,
+        CHROME_CUSTOM_SLICE_NAME(t1.slice_id) as beginSliceChromeCustomName,
+        t1.category as beginSliceCategory,
+        t1.ts as beginSliceStartTs,
+        (t1.ts+t1.dur) as beginSliceEndTs,
+        t1.depth as beginDepth,
+        (thread_out.name || ' ' || thread_out.tid) as beginThreadName,
+        (process_out.name || ' ' || process_out.pid) as beginProcessName,
+        f.slice_in as endSliceId,
+        t2.track_id as endTrackId,
+        t2.name as endSliceName,
+        CHROME_CUSTOM_SLICE_NAME(t2.slice_id) as endSliceChromeCustomName,
+        t2.category as endSliceCategory,
+        t2.ts as endSliceStartTs,
+        (t2.ts+t2.dur) as endSliceEndTs,
+        t2.depth as endDepth,
+        (thread_in.name || ' ' || thread_in.tid) as endThreadName,
+        (process_in.name || ' ' || process_in.pid) as endProcessName,
+        extract_arg(f.arg_set_id, 'cat') as category,
+        extract_arg(f.arg_set_id, 'name') as name,
+        f.id as id,
+        slice_is_ancestor(t1.slice_id, t2.slice_id) as flowToDescendant
+      from flow f
+      join slice t1 on f.slice_out = t1.slice_id
+      join slice t2 on f.slice_in = t2.slice_id
+      left join thread_track track_out on track_out.id = t1.track_id
+      left join thread thread_out on thread_out.utid = track_out.utid
+      left join thread_track track_in on track_in.id = t2.track_id
+      left join thread thread_in on thread_in.utid = track_in.utid
+      left join process process_out on process_out.upid = thread_out.upid
+      left join process process_in on process_in.upid = thread_in.upid
+      where f.slice_out = ${sliceId} or f.slice_in = ${sliceId}
+      `;
+      this.queryFlowEvents(query).then((flows) =>
+        this.setConnectedFlows(flows),
+      );
+      return;
+    }
+
     const connectedFlows = SHOW_INDIRECT_PRECEDING_FLOWS_FLAG.get()
       ? `(
            select * from directly_connected_flow(${sliceId})

--- a/ui/src/core_plugins/dev.perfetto.FlowEvents/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlowEvents/index.ts
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 import m from 'mithril';
+import {z} from 'zod';
 import type {TraceImpl} from '../../core/trace_impl';
+import type {App} from '../../public/app';
 import type {PerfettoPlugin} from '../../public/plugin';
+import type {Setting} from '../../public/settings';
 import {FlowEventsAreaSelectedPanel} from './flow_events_panel';
 import {renderFlows} from './flow_events_renderer';
 import {FlowManager} from './flow_manager';
@@ -28,12 +31,28 @@ export default class FlowEventsPlugin implements PerfettoPlugin {
     'Handles rendering flows on top of slice tracks originating from the ' +
     'slice table, and for the flows area selection panel.';
 
+  private static directFlowsOnlySetting: Setting<boolean>;
+
+  static onActivate(app: App): void {
+    FlowEventsPlugin.directFlowsOnlySetting = app.settings.register({
+      id: 'dev.perfetto.DirectFlowsOnly',
+      name: 'Show only direct flows',
+      description:
+        'When enabled, selecting a slice only shows flows directly connected ' +
+        'to it (one step), rather than following the entire flow chain. ' +
+        'Useful for traces with dense flow graphs (e.g. build dependencies).',
+      schema: z.boolean(),
+      defaultValue: false,
+    });
+  }
+
   async onTraceLoad(trace: TraceImpl): Promise<void> {
     const flows = new FlowManager(
       trace.engine,
       trace.tracks,
       trace.selection,
       trace.raf,
+      FlowEventsPlugin.directFlowsOnlySetting,
     );
 
     trace.tracks.registerOverlay({


### PR DESCRIPTION
Add a new setting `dev.perfetto.DirectFlowsOnly` which, when enabled, only renders the immediate flows for a given slice when selected, rather than following the entire flow chain via BFS. This is useful for traces with dense flow graphs (e.g. build dependencies) where the full-chain traversal causes the UI to grind to a halt.

The setting is registered by the FlowEvents plugin and defaults to off (preserving current behaviour). When enabled, the sliceSelected query uses a simple `WHERE` clause on the flow table instead of the `directly_connected_flow()` table function.

Fixes https://github.com/google/perfetto/issues/1004