### PR TITLE
trace_redaction: case-sensitive package matching

### DIFF
--- a/src/trace_redaction/find_package_uid.cc
+++ b/src/trace_redaction/find_package_uid.cc
@@ -57,12 +57,10 @@ base::Status FindPackageUid::Collect(
       continue;
     }
 
-    // Package names should be lowercase, but this check is meant to be more
-    // forgiving.
     base::StringView expected_name(context->package_name.data(),
                                    context->package_name.size());
     base::StringView actual_name(info.name().data, info.name().size);
-    if (!actual_name.CaseInsensitiveEq(expected_name)) {
+    if (actual_name != expected_name) {
       continue;
     }
 

--- a/src/trace_redaction/find_package_uid_unittest.cc
+++ b/src/trace_redaction/find_package_uid_unittest.cc
@@ -275,4 +275,27 @@ TEST(FindPackageUidTest, FailsIfUidStartsInitialized) {
   ASSERT_FALSE(status.ok()) << status.message();
 }
 
+TEST(FindPackageUidTest, RejectsCaseMismatch) {
+  const auto packet = CreatePackageListPacket();
+
+  Context context;
+  context.package_name = "com.google.android.UVExposureReporter";
+
+  const FindPackageUid find;
+
+  const auto decoder = protos::pbzero::TracePacket::Decoder(packet);
+
+  base::Status status = find.Begin(&context);
+  ASSERT_OK(status) << status.message();
+
+  status = find.Collect(decoder, &context);
+  ASSERT_OK(status) << status.message();
+
+  // The package should not match due to case sensitivity.
+  status = find.End(&context);
+  ASSERT_FALSE(status.ok()) << status.message();
+
+  ASSERT_FALSE(context.package_uid.has_value());
+}
+
 }  // namespace perfetto::trace_redaction


### PR DESCRIPTION
Android package names are case-sensitive identifiers. Using case-insensitive comparison could cause mismatched package UID association in packages_list during trace redaction.

Bug: 554956547
Test: perfetto_unittests --gtest_filter="FindPackageUidTest.*"
TAG=agy
CONV=bf6e2915-053a-48a9-8ed1-17ba5fbbbe2a
