### PR TITLE
Promote BatteryStatus and PlugType to top level tracks.

### DIFF
--- a/src/trace_processor/importers/common/tracks_common.h
+++ b/src/trace_processor/importers/common/tracks_common.h
@@ -210,6 +210,18 @@ inline constexpr auto kAndroidScreenStateBlueprint =
                              tracks::DimensionBlueprints(),
                              tracks::StaticNameBlueprint("ScreenState"));
 
+inline constexpr auto kAndroidBatteryStatusBlueprint =
+    tracks::CounterBlueprint("battery_status",
+                             tracks::UnknownUnitBlueprint(),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("BatteryStatus"));
+
+inline constexpr auto kAndroidPlugTypeBlueprint =
+    tracks::CounterBlueprint("plug_type",
+                             tracks::UnknownUnitBlueprint(),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("PlugType"));
+
 inline constexpr auto kAndroidBatteryStatsBlueprint = tracks::CounterBlueprint(
     "battery_stats",
     tracks::UnknownUnitBlueprint(),

--- a/src/trace_processor/importers/proto/android_probes_parser.cc
+++ b/src/trace_processor/importers/proto/android_probes_parser.cc
@@ -138,8 +138,6 @@ AndroidProbesParser::AndroidProbesParser(TraceProcessorContext* context,
     : context_(context),
       tracker_(tracker),
       power_rails_args_tracker_(std::make_unique<ArgsTracker>(context)),
-      battery_status_id_(context->storage->InternString("BatteryStatus")),
-      plug_type_id_(context->storage->InternString("PlugType")),
       energy_consumer_id_(
           context_->storage->InternString("energy_consumer_id")),
       consumer_type_id_(context_->storage->InternString("consumer_type")),
@@ -666,16 +664,16 @@ void AndroidProbesParser::ParseAndroidSystemProperty(int64_t ts,
       continue;
     }
 
-    std::optional<StringId> mapped_name_id;
     if (name == "debug.tracing.battery_status") {
-      mapped_name_id = battery_status_id_;
+      context_->event_tracker->PushCounter(
+          ts, *state,
+          context_->track_tracker->InternTrack(
+              tracks::kAndroidBatteryStatusBlueprint));
     } else if (name == "debug.tracing.plug_type") {
-      mapped_name_id = plug_type_id_;
-    }
-    if (mapped_name_id) {
-      TrackId track = context_->track_tracker->InternTrack(
-          kBlueprint, tracks::Dimensions(name), *mapped_name_id);
-      context_->event_tracker->PushCounter(ts, *state, track);
+      context_->event_tracker->PushCounter(
+          ts, *state,
+          context_->track_tracker->InternTrack(
+              tracks::kAndroidPlugTypeBlueprint));
     }
   }
 }

--- a/src/trace_processor/importers/proto/android_probes_parser.h
+++ b/src/trace_processor/importers/proto/android_probes_parser.h
@@ -67,8 +67,6 @@ class AndroidProbesParser {
 
   std::unique_ptr<ArgsTracker> power_rails_args_tracker_;
 
-  const StringId battery_status_id_;
-  const StringId plug_type_id_;
   const StringId energy_consumer_id_;
   const StringId consumer_type_id_;
   const StringId ordinal_id_;

--- a/src/trace_processor/importers/systrace/systrace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser.cc
@@ -322,22 +322,30 @@ void SystraceParser::ParseSystracePoint(
         }
         // TODO(lalitm): we should not add LMK events to the counters table
         // once the UI has support for displaying instants.
-      } else if (point.name == "ScreenState") {
-        // Promote ScreenState to its own top level counter.
-        TrackId track = context_->track_tracker->InternTrack(
+      }
+
+      std::optional<TrackId> promoted;
+      if (point.name == "ScreenState") {
+        promoted = context_->track_tracker->InternTrack(
             tracks::kAndroidScreenStateBlueprint);
-        context_->event_tracker->PushCounter(
-            ts, static_cast<double>(point.int_value), track);
-        return;
+      } else if (point.name == "BatteryStatus") {
+        promoted = context_->track_tracker->InternTrack(
+            tracks::kAndroidBatteryStatusBlueprint);
+      } else if (point.name == "PlugType") {
+        promoted = context_->track_tracker->InternTrack(
+            tracks::kAndroidPlugTypeBlueprint);
       } else if (point.name.StartsWith("battery_stats.")) {
         // Promote battery_stats conters to global tracks.
         // Track name and definition should be kept in sync with
         // android_probes_parser.cc
-        TrackId track = context_->track_tracker->InternTrack(
+        promoted = context_->track_tracker->InternTrack(
             tracks::kAndroidBatteryStatsBlueprint,
             tracks::Dimensions(point.name));
+      }
+
+      if (promoted) {
         context_->event_tracker->PushCounter(
-            ts, static_cast<double>(point.int_value), track);
+            ts, static_cast<double>(point.int_value), *promoted);
         return;
       }
 


### PR DESCRIPTION
These previously were top level when emit by the periodic poller, but process level when emit by atrace. This leads to two separate track_ids that can lead to incorrect results when trying to use them normally. This fixes #7302