### PR TITLE
tp: Merge android battery/screen state tracks from the same machine

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/battery/charging_states.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/battery/charging_states.sql
@@ -39,7 +39,16 @@ AS
 -- union is populated but not both.
 WITH
   _counter AS (
-    SELECT counter.id, ts, counter.track_id, value
+    SELECT
+      counter.id,
+      ts,
+      -- Note: counter_leading_intervals! partitions on track_id. We alias
+      -- machine_id to track_id to partition intervals by machine rather
+      -- than by individual track, merging all tracks on the same machine.
+      -- TODO(stevegolton): Fix this when PerfettoSQL supports customizable
+      -- partition columns in counter_leading_intervals!.
+      COALESCE(counter_track.machine_id, 0) AS track_id,
+      value
     FROM counter
     JOIN counter_track
       ON counter_track.id = counter.track_id
@@ -51,7 +60,7 @@ WITH
       intervals.id,
       intervals.ts,
       intervals.dur,
-      counter_track.machine_id,
+      intervals.track_id AS machine_id,
       CASE intervals.value
         WHEN 2 THEN 'charging'
         WHEN 3 THEN 'discharging'
@@ -67,8 +76,6 @@ WITH
         WHEN 5 THEN 'Full'
       END AS charging_state
     FROM counter_leading_intervals!(_counter) AS intervals
-    JOIN counter_track
-      ON counter_track.id = intervals.track_id
     WHERE
       dur > 0
   )
@@ -80,7 +87,7 @@ SELECT
   ROW_NUMBER() OVER () AS id,
   ts,
   dur,
-  machine_id,
+  COALESCE(machine_id, 0) AS machine_id,
   COALESCE(short_charging_state, 'unknown') AS short_charging_state,
   COALESCE(charging_state, 'Unknown') AS charging_state
 FROM _intervals_fill_gaps!((machine_id), (short_charging_state, charging_state), _intervals);

--- a/src/trace_processor/perfetto_sql/stdlib/android/battery/charging_states.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/battery/charging_states.sql
@@ -45,8 +45,8 @@ WITH
       -- Note: counter_leading_intervals! partitions on track_id. We alias
       -- machine_id to track_id to partition intervals by machine rather
       -- than by individual track, merging all tracks on the same machine.
-      -- TODO(stevegolton): Fix this when PerfettoSQL supports customizable
-      -- partition columns in counter_leading_intervals!.
+      -- TODO(stevegolton): Fix this when PerfettoSQL Next adds support for
+      -- customizable partition columns in counter_leading_intervals!.
       COALESCE(counter_track.machine_id, 0) AS track_id,
       value
     FROM counter

--- a/src/trace_processor/perfetto_sql/stdlib/android/battery/doze.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/battery/doze.sql
@@ -32,7 +32,16 @@ CREATE PERFETTO TABLE android_light_idle_state(
 AS
 WITH
   _counter AS (
-    SELECT counter.id, ts, counter.track_id, value
+    SELECT
+      counter.id,
+      ts,
+      -- Note: counter_leading_intervals! partitions on track_id. We alias
+      -- machine_id to track_id to partition intervals by machine rather
+      -- than by individual track, merging all tracks on the same machine.
+      -- TODO(stevegolton): Fix this when PerfettoSQL supports customizable
+      -- partition columns in counter_leading_intervals!.
+      COALESCE(counter_track.machine_id, 0) AS track_id,
+      value
     FROM counter
     JOIN counter_track
       ON counter_track.id = counter.track_id
@@ -43,7 +52,7 @@ SELECT
   intervals.id,
   intervals.ts,
   intervals.dur,
-  counter_track.machine_id,
+  intervals.track_id AS machine_id,
   CASE intervals.value
     -- device is used or on power
     WHEN 0 THEN 'active'
@@ -59,9 +68,7 @@ SELECT
     WHEN 7 THEN 'override'
     ELSE 'unmapped'
   END AS light_idle_state
-FROM counter_leading_intervals!(_counter) AS intervals
-JOIN counter_track
-  ON counter_track.id = intervals.track_id;
+FROM counter_leading_intervals!(_counter) AS intervals;
 
 -- Deep idle states. This is the state machine that more slowly detects deeper
 -- levels of device unuse and restricts background activity further.
@@ -81,7 +88,16 @@ CREATE PERFETTO TABLE android_deep_idle_state(
 AS
 WITH
   _counter AS (
-    SELECT counter.id, ts, counter.track_id, value
+    SELECT
+      counter.id,
+      ts,
+      -- Note: counter_leading_intervals! partitions on track_id. We alias
+      -- machine_id to track_id to partition intervals by machine rather
+      -- than by individual track, merging all tracks on the same machine.
+      -- TODO(stevegolton): Fix this when PerfettoSQL supports customizable
+      -- partition columns in counter_leading_intervals!.
+      COALESCE(counter_track.machine_id, 0) AS track_id,
+      value
     FROM counter
     JOIN counter_track
       ON counter_track.id = counter.track_id
@@ -92,7 +108,7 @@ SELECT
   intervals.id,
   intervals.ts,
   intervals.dur,
-  counter_track.machine_id,
+  intervals.track_id AS machine_id,
   CASE intervals.value
     WHEN 0 THEN 'active'
     WHEN 1 THEN 'inactive'
@@ -109,6 +125,4 @@ SELECT
     WHEN 7 THEN 'quick_doze_delay'
     ELSE 'unmapped'
   END AS deep_idle_state
-FROM counter_leading_intervals!(_counter) AS intervals
-JOIN counter_track
-  ON counter_track.id = intervals.track_id;
+FROM counter_leading_intervals!(_counter) AS intervals;

--- a/src/trace_processor/perfetto_sql/stdlib/android/battery/doze.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/battery/doze.sql
@@ -38,8 +38,8 @@ WITH
       -- Note: counter_leading_intervals! partitions on track_id. We alias
       -- machine_id to track_id to partition intervals by machine rather
       -- than by individual track, merging all tracks on the same machine.
-      -- TODO(stevegolton): Fix this when PerfettoSQL supports customizable
-      -- partition columns in counter_leading_intervals!.
+      -- TODO(stevegolton): Fix this when PerfettoSQL Next adds support for
+      -- customizable partition columns in counter_leading_intervals!.
       COALESCE(counter_track.machine_id, 0) AS track_id,
       value
     FROM counter

--- a/src/trace_processor/perfetto_sql/stdlib/android/screen_state.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/screen_state.sql
@@ -38,19 +38,28 @@ WITH
   screen_state_span AS (
     SELECT *
     FROM counter_leading_intervals!((
-        SELECT counter.id, ts, counter.track_id, value
+        SELECT
+        counter.id,
+        ts,
+        -- Note: counter_leading_intervals! partitions on track_id. We alias
+        -- machine_id to track_id to partition intervals by machine rather
+        -- than by individual track, merging all tracks on the same machine.
+        -- TODO(stevegolton): Fix this when PerfettoSQL supports customizable
+        -- partition columns in counter_leading_intervals!.
+        COALESCE(counter_track.machine_id, 0) AS track_id,
+        value
         FROM counter
         JOIN counter_track ON counter_track.id = counter.track_id
         WHERE
-          name = 'ScreenState'
-      ))
+        name = 'ScreenState'
+    ))
   ),
   mapped_names AS (
     SELECT
       screen_state_span.id,
       screen_state_span.ts,
       screen_state_span.dur,
-      counter_track.machine_id,
+      screen_state_span.track_id AS machine_id,
       -- Should be kept in sync with the enums in Display.java
       CASE screen_state_span.value
         -- Display.STATE_OFF
@@ -95,8 +104,6 @@ WITH
         WHEN 6 THEN 'Screen on (suspend)'
       END AS screen_state
     FROM screen_state_span
-    JOIN counter_track
-      ON counter_track.id = screen_state_span.track_id
     WHERE
       dur > 0
   )
@@ -104,7 +111,7 @@ SELECT
   ROW_NUMBER() OVER () AS id,
   ts,
   dur,
-  machine_id,
+  COALESCE(machine_id, 0) AS machine_id,
   COALESCE(simple_screen_state, 'unknown') AS simple_screen_state,
   COALESCE(short_screen_state, 'unknown') AS short_screen_state,
   COALESCE(screen_state, 'Unknown') AS screen_state

--- a/src/trace_processor/perfetto_sql/stdlib/android/screen_state.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/screen_state.sql
@@ -44,8 +44,8 @@ WITH
         -- Note: counter_leading_intervals! partitions on track_id. We alias
         -- machine_id to track_id to partition intervals by machine rather
         -- than by individual track, merging all tracks on the same machine.
-        -- TODO(stevegolton): Fix this when PerfettoSQL supports customizable
-        -- partition columns in counter_leading_intervals!.
+        -- TODO(stevegolton): Fix this when PerfettoSQL Next adds support for
+        -- customizable partition columns in counter_leading_intervals!.
         COALESCE(counter_track.machine_id, 0) AS track_id,
         value
         FROM counter


### PR DESCRIPTION
PR #7243 made battery charging, doze, and screen state tables multi-machine aware by passing counter.track_id to counter_leading_intervals, presumably under the impression that each machine would only have single track. This caused intervals to be partitioned by individual track rather than by machine, leading to overlapping intervals on devices with multiple tracks per machine and breaking downstream SPAN_JOIN metrics.

Fix this by passing COALESCE(counter_track.machine_id, 0) as the track_id to counter_leading_intervals so tracks on the same machine are merged into a single non-overlapping timeline.

Rolled from google3 cl/975030561.
