### PR TITLE
perfetto: add sdk variant of libperfetto_client_experimental

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1372,10 +1372,12 @@ cc_library_static {
         "-DPERFETTO_REGEX_FORCE_STD",
         "-DZLIB_IMPLEMENTATION",
     ],
+    stl: "libc++_static",
     apex_available: [
         "//apex_available:anyapex",
         "//apex_available:platform",
     ],
+    sdk_version: "current",
     min_sdk_version: "30",
     target: {
         android: {
@@ -27379,6 +27381,9 @@ aconfig_declarations {
 cc_aconfig_library {
     name: "perfetto_flags_c_lib",
     aconfig_declarations: "perfetto_flags-aconfig",
+    // All flags read from C++ are fixed read-only, and this drops the runtime
+    // deps (libbase, aconfig storage) that have no sdk variant.
+    mode: "force-read-only",
     vendor_available: true,
     product_available: true,
     apex_available: [
@@ -27386,6 +27391,9 @@ cc_aconfig_library {
         "//apex_available:platform",
         "com.android.profiling",
     ],
+    sdk_version: "current",
+    // The sdk variant would otherwise use the NDK "system" STL (no libc++).
+    stl: "libc++_static",
     min_sdk_version: "30",
 }
 

--- a/Android.bp.extras
+++ b/Android.bp.extras
@@ -318,6 +318,9 @@ aconfig_declarations {
 cc_aconfig_library {
     name: "perfetto_flags_c_lib",
     aconfig_declarations: "perfetto_flags-aconfig",
+    // All flags read from C++ are fixed read-only, and this drops the runtime
+    // deps (libbase, aconfig storage) that have no sdk variant.
+    mode: "force-read-only",
     vendor_available: true,
     product_available: true,
     apex_available: [
@@ -325,6 +328,9 @@ cc_aconfig_library {
         "//apex_available:platform",
         "com.android.profiling",
     ],
+    sdk_version: "current",
+    // The sdk variant would otherwise use the NDK "system" STL (no libc++).
+    stl: "libc++_static",
     min_sdk_version: "30",
 }
 

--- a/perfetto_flags.aconfig
+++ b/perfetto_flags.aconfig
@@ -2,12 +2,6 @@ package: "perfetto.flags"
 container: "system"
 
 flag {
-  name: "save_all_traces_in_bugreport"
-  namespace: "perfetto"
-  description: "This flag controls whether dumpstate invokes perfetto --save-for-bugreport (when disabled, old behavrior) or --save-all-for-bugreport (when enabled, new behavior). save-all serializes all the eligible active traces, rather than only the one with the highest bugreport score"
-  bug: "321196572"
-}
-flag {
   name: "test_read_only_flag"
   namespace: "perfetto"
   description: "A test flag for verifying that support for read-only flags in Perfetto works correctly."

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -352,6 +352,8 @@ additional_args = {
     'libperfetto_client_experimental': [
         ('apex_available',
          {'//apex_available:platform', '//apex_available:anyapex'}),
+        ('sdk_version', 'current'),
+        ('stl', 'libc++_static'),
         ('min_sdk_version', '30'),
         ('shared_libs', {'liblog'}),
         ('export_include_dirs', {'include', buildflags_dir}),


### PR DESCRIPTION
Modules built with sdk_version can only link deps that have an sdk
variant, and no perfetto library provided one.

- Add sdk_version: "current" to libperfetto_client_experimental.
  Existing platform/vendor/host consumers are unaffected.
- Make perfetto_flags_c_lib force-read-only and give it sdk_version too.
  Its production-mode deps (libbase, aconfig storage) have no sdk
  variant. All flags read from C++ are fixed read-only, so no behaviour
  change.
- Set stl: "libc++_static" on both. sdk variants otherwise default to
  the NDK "system" STL, which has no libc++.
- Delete the obsolete, non read-only save_all_traces_in_bugreport flag.

Build and Tests pass:
  - http://ag/q/topic:%22libperfetto_sdk_variant%22
  -  http://android-build/abtd/run/L39000030178677719/
  - http://android-build/abtd/run/L87100030178538702/
