### PR TITLE
tp: signifcantly reduce symbolization traffic to llvm-symbolizer

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -22020,6 +22020,7 @@ filegroup {
         "src/trace_processor/util/symbolizer/breakpad_parser_unittest.cc",
         "src/trace_processor/util/symbolizer/breakpad_symbolizer_unittest.cc",
         "src/trace_processor/util/symbolizer/local_symbolizer_unittest.cc",
+        "src/trace_processor/util/symbolizer/symbolize_database_unittest.cc",
     ],
 }
 

--- a/src/trace_processor/util/symbolizer/BUILD.gn
+++ b/src/trace_processor/util/symbolizer/BUILD.gn
@@ -117,6 +117,17 @@ perfetto_unittest_source_set("unittests") {
     "breakpad_symbolizer_unittest.cc",
     "local_symbolizer_unittest.cc",
   ]
+  if (enable_perfetto_trace_processor) {
+    sources += [ "symbolize_database_unittest.cc" ]
+    deps += [
+      ":symbolize_database",
+      "../../../../include/perfetto/trace_processor:trace_processor",
+      "../../../../protos/perfetto/trace:cpp",
+      "../../../../protos/perfetto/trace/interned_data:cpp",
+      "../../../../protos/perfetto/trace/profiling:cpp",
+      "../../../../protos/perfetto/trace/track_event:cpp",
+    ]
+  }
   if (enable_perfetto_llvm_symbolizer) {
     sources += [ "llvm_symbolizer_unittest.cc" ]
     deps += [ ":llvm_symbolizer" ]

--- a/src/trace_processor/util/symbolizer/symbolize_database.cc
+++ b/src/trace_processor/util/symbolizer/symbolize_database.cc
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -56,11 +57,19 @@ namespace perfetto::profiling {
 namespace {
 using trace_processor::Iterator;
 
+// Runtime mapping start/end addresses do not affect symbolization. Group by
+// the fields used for address correction and by rel_pc so repeated mappings
+// emit one llvm-symbolizer request per effective address.
 constexpr const char* kQueryUnsymbolized =
     R"(
       select
-        spm.id,
-        spf.rel_pc
+        spm.build_id,
+        spm.name,
+        spm.exact_offset,
+        spm.start_offset,
+        spm.load_bias,
+        spf.rel_pc,
+        count(*)
       from __intrinsic_stack_profile_frame spf
       join __intrinsic_stack_profile_mapping spm on spf.mapping = spm.id
       where (
@@ -69,6 +78,20 @@ constexpr const char* kQueryUnsymbolized =
           or spm.name GLOB '[[]kernel.kallsyms]*'
         )
         and spf.symbol_set_id IS NULL
+      group by
+        spm.build_id,
+        spm.name,
+        spm.exact_offset,
+        spm.start_offset,
+        spm.load_bias,
+        spf.rel_pc
+      order by
+        spm.build_id,
+        spm.name,
+        spm.exact_offset,
+        spm.start_offset,
+        spm.load_bias,
+        spf.rel_pc
     )";
 
 // Query to get mappings with empty build IDs and their frame counts.
@@ -84,67 +107,6 @@ constexpr const char* kQueryMappingsWithoutBuildId =
         and spf.symbol_set_id IS NULL
       group by spm.name
     )";
-
-struct UnsymbolizedFrames {
-  UnsymbolizedMapping mapping;
-  std::vector<uint64_t> rel_pc;
-};
-
-std::optional<UnsymbolizedMapping> GetMappingById(
-    trace_processor::TraceProcessor* tp,
-    int64_t id) {
-  Iterator it = tp->ExecuteQuery(R"(
-      SELECT build_id, name, exact_offset, start_offset, load_bias
-      FROM __intrinsic_stack_profile_mapping WHERE id = )" +
-                                 std::to_string(id));
-  if (!it.Next()) {
-    return std::nullopt;
-  }
-
-  trace_processor::BuildId build_id =
-      trace_processor::BuildId::FromHex(it.Get(0).AsString());
-  std::string name = it.Get(1).AsString();
-  uint64_t exact_offset = static_cast<uint64_t>(it.Get(2).AsLong());
-  uint64_t start_offset = static_cast<uint64_t>(it.Get(3).AsLong());
-  int64_t load_bias = it.Get(4).AsLong();
-  PERFETTO_CHECK(load_bias >= 0);
-
-  return UnsymbolizedMapping{build_id.raw(), name, exact_offset, start_offset,
-                             static_cast<uint64_t>(load_bias)};
-}
-
-std::map<int64_t, std::vector<uint64_t>> GetUnsymbolizedFrameIdsByMappingId(
-    trace_processor::TraceProcessor* tp) {
-  std::map<int64_t, std::vector<uint64_t>> unsymbolized;
-  Iterator it = tp->ExecuteQuery(kQueryUnsymbolized);
-  while (it.Next()) {
-    int64_t mapping_id = it.Get(0).AsLong();
-    int64_t rel_pc = it.Get(1).AsLong();
-    unsymbolized[mapping_id].emplace_back(rel_pc);
-  }
-  if (!it.Status().ok()) {
-    PERFETTO_DFATAL_OR_ELOG("Invalid iterator: %s",
-                            it.Status().message().c_str());
-    return {};
-  }
-  return unsymbolized;
-}
-
-std::vector<UnsymbolizedFrames> GetUnsymbolizedFrames(
-    trace_processor::TraceProcessor* tp) {
-  std::vector<UnsymbolizedFrames> res;
-  for (auto& entry : GetUnsymbolizedFrameIdsByMappingId(tp)) {
-    int64_t mapping_id = entry.first;
-    std::vector<uint64_t>& frame_ids = entry.second;
-    std::optional<UnsymbolizedMapping> mapping = GetMappingById(tp, mapping_id);
-    if (!mapping) {
-      continue;
-    }
-    res.push_back(
-        UnsymbolizedFrames{std::move(*mapping), std::move(frame_ids)});
-  }
-  return res;
-}
 
 std::vector<std::pair<std::string, uint32_t>> GetMappingsWithoutBuildId(
     trace_processor::TraceProcessor* tp) {
@@ -202,12 +164,14 @@ SymbolizationOutput SymbolizeDatabaseWithSymbolizer(
     trace_processor::TraceProcessor* tp,
     Symbolizer* symbolizer) {
   PERFETTO_CHECK(symbolizer);
-  auto unsymbolized = GetUnsymbolizedFrames(tp);
+  auto unsymbolized = CollectUnsymbolizedFrames(tp);
   Symbolizer::Environment env = {GetOsRelease(tp)};
 
   SymbolizationOutput output;
-  for (const auto& [unsymbolized_mapping, rel_pcs] : unsymbolized) {
-    uint32_t frame_count = static_cast<uint32_t>(rel_pcs.size());
+  for (const UnsymbolizedFrames& frames : unsymbolized) {
+    const UnsymbolizedMapping& unsymbolized_mapping = frames.mapping;
+    const std::vector<uint64_t>& rel_pcs = frames.rel_pcs;
+    uint32_t frame_count = frames.frame_count;
     SymbolizeResult res =
         symbolizer->Symbolize(env, unsymbolized_mapping, rel_pcs);
     if (res.frames.empty()) {
@@ -419,6 +383,49 @@ void FormatSkippedMappings(
 }
 
 }  // namespace
+
+std::vector<UnsymbolizedFrames> CollectUnsymbolizedFrames(
+    trace_processor::TraceProcessor* tp) {
+  std::vector<UnsymbolizedFrames> result;
+  Iterator it = tp->ExecuteQuery(kQueryUnsymbolized);
+  while (it.Next()) {
+    trace_processor::BuildId build_id =
+        trace_processor::BuildId::FromHex(it.Get(0).AsString());
+    int64_t load_bias = it.Get(4).AsLong();
+    int64_t frame_count = it.Get(6).AsLong();
+    PERFETTO_CHECK(load_bias >= 0);
+    PERFETTO_CHECK(frame_count >= 0);
+
+    UnsymbolizedMapping mapping{
+        build_id.raw(),
+        it.Get(1).AsString(),
+        static_cast<uint64_t>(it.Get(2).AsLong()),
+        static_cast<uint64_t>(it.Get(3).AsLong()),
+        static_cast<uint64_t>(load_bias),
+    };
+    bool same_mapping =
+        !result.empty() && result.back().mapping.build_id == mapping.build_id &&
+        result.back().mapping.name == mapping.name &&
+        result.back().mapping.exact_offset == mapping.exact_offset &&
+        result.back().mapping.start_offset == mapping.start_offset &&
+        result.back().mapping.load_bias == mapping.load_bias;
+    if (!same_mapping)
+      result.push_back({std::move(mapping), {}, 0});
+
+    UnsymbolizedFrames& group = result.back();
+    PERFETTO_CHECK(static_cast<uint64_t>(group.frame_count) +
+                       static_cast<uint64_t>(frame_count) <=
+                   std::numeric_limits<uint32_t>::max());
+    group.rel_pcs.push_back(static_cast<uint64_t>(it.Get(5).AsLong()));
+    group.frame_count += static_cast<uint32_t>(frame_count);
+  }
+  if (!it.Status().ok()) {
+    PERFETTO_DFATAL_OR_ELOG("Failed to query unsymbolized frames: %s",
+                            it.Status().message().c_str());
+    return {};
+  }
+  return result;
+}
 
 SymbolizerResult SymbolizeDatabase(trace_processor::TraceProcessor* tp,
                                    const SymbolizerConfig& config) {

--- a/src/trace_processor/util/symbolizer/symbolize_database.h
+++ b/src/trace_processor/util/symbolizer/symbolize_database.h
@@ -57,6 +57,17 @@ struct SymbolizerConfig {
   std::vector<std::string> breakpad_paths;
 };
 
+// A group of equivalent mappings and their unique relative program counters.
+// |frame_count| retains the number of original frame rows for diagnostics.
+struct UnsymbolizedFrames {
+  UnsymbolizedMapping mapping;
+  std::vector<uint64_t> rel_pcs;
+  uint32_t frame_count = 0;
+};
+
+std::vector<UnsymbolizedFrames> CollectUnsymbolizedFrames(
+    trace_processor::TraceProcessor* tp);
+
 // Record of a successful symbolization for a mapping.
 struct SuccessfulMapping {
   std::string mapping_name;

--- a/src/trace_processor/util/symbolizer/symbolize_database_unittest.cc
+++ b/src/trace_processor/util/symbolizer/symbolize_database_unittest.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/symbolizer/symbolize_database.h"
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "perfetto/trace_processor/trace_processor.h"
+#include "protos/perfetto/trace/interned_data/interned_data.gen.h"
+#include "protos/perfetto/trace/profiling/profile_common.gen.h"
+#include "protos/perfetto/trace/profiling/profile_packet.gen.h"
+#include "protos/perfetto/trace/trace.gen.h"
+#include "protos/perfetto/trace/trace_packet.gen.h"
+#include "protos/perfetto/trace/track_event/thread_descriptor.gen.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::profiling {
+namespace {
+
+void AddProfile(protos::gen::Trace* trace,
+                uint32_t sequence_id,
+                uint64_t mapping_start,
+                uint64_t exact_offset,
+                const std::vector<uint64_t>& rel_pcs) {
+  auto* intern_packet = trace->add_packet();
+  intern_packet->set_trusted_packet_sequence_id(sequence_id);
+  intern_packet->set_incremental_state_cleared(true);
+
+  auto* thread = intern_packet->mutable_thread_descriptor();
+  thread->set_pid(static_cast<int32_t>(sequence_id));
+  thread->set_tid(static_cast<int32_t>(sequence_id));
+
+  auto* interned = intern_packet->mutable_interned_data();
+  auto* build_id = interned->add_build_ids();
+  build_id->set_iid(1);
+  build_id->set_str("build-id");
+
+  auto* mapping = interned->add_mappings();
+  mapping->set_iid(1);
+  mapping->set_build_id(1);
+  mapping->set_start(mapping_start);
+  mapping->set_end(mapping_start + 0x10000);
+  mapping->set_exact_offset(exact_offset);
+
+  auto* callstack = interned->add_callstacks();
+  callstack->set_iid(1);
+  for (size_t i = 0; i < rel_pcs.size(); ++i) {
+    auto* frame = interned->add_frames();
+    frame->set_iid(i + 1);
+    frame->set_mapping_id(1);
+    frame->set_rel_pc(rel_pcs[i]);
+    callstack->add_frame_ids(i + 1);
+  }
+
+  auto* sample_packet = trace->add_packet();
+  sample_packet->set_trusted_packet_sequence_id(sequence_id);
+  auto* samples = sample_packet->mutable_streaming_profile_packet();
+  samples->add_callstack_iid(1);
+  samples->add_timestamp_delta_us(1);
+}
+
+std::unique_ptr<trace_processor::TraceProcessor> LoadTrace(
+    const protos::gen::Trace& trace) {
+  auto tp = trace_processor::TraceProcessor::CreateInstance({});
+  std::string serialized = trace.SerializeAsString();
+  std::unique_ptr<uint8_t[]> data(new uint8_t[serialized.size()]);
+  memcpy(data.get(), serialized.data(), serialized.size());
+  PERFETTO_CHECK(tp->Parse(std::move(data), serialized.size()).ok());
+  tp->NotifyEndOfFile();
+  return tp;
+}
+
+TEST(SymbolizeDatabaseTest, CoalescesEquivalentMappingsAndAddresses) {
+  protos::gen::Trace trace;
+  AddProfile(&trace, 1, 0x100000, 0, {0x10, 0x20});
+  AddProfile(&trace, 2, 0x200000, 0, {0x10, 0x20});
+
+  auto tp = LoadTrace(trace);
+  std::vector<UnsymbolizedFrames> frames = CollectUnsymbolizedFrames(tp.get());
+
+  ASSERT_EQ(frames.size(), 1u);
+  EXPECT_THAT(frames[0].rel_pcs, testing::ElementsAre(0x10u, 0x20u));
+  EXPECT_EQ(frames[0].frame_count, 4u);
+}
+
+TEST(SymbolizeDatabaseTest, KeepsAddressCorrectionGroupsSeparate) {
+  protos::gen::Trace trace;
+  AddProfile(&trace, 1, 0x100000, 0, {0x10, 0x20});
+  AddProfile(&trace, 2, 0x200000, 0x1000, {0x10, 0x20});
+
+  auto tp = LoadTrace(trace);
+  std::vector<UnsymbolizedFrames> frames = CollectUnsymbolizedFrames(tp.get());
+
+  ASSERT_EQ(frames.size(), 2u);
+  EXPECT_THAT(frames[0].rel_pcs, testing::ElementsAre(0x10u, 0x20u));
+  EXPECT_THAT(frames[1].rel_pcs, testing::ElementsAre(0x10u, 0x20u));
+  EXPECT_EQ(frames[0].frame_count, 2u);
+  EXPECT_EQ(frames[1].frame_count, 2u);
+}
+
+}  // namespace
+}  // namespace perfetto::profiling


### PR DESCRIPTION
We were not properly deduplicating mappings across processes when we
were symbolizing with llvm-symbolizer meaning we were unnecessarily
doing tons of extra IO operations and symbolization requests. This
was further compounded by switching back and forth between mappings
instead of consistently doing all the symbolization for one mapping
then moving onto the next.

Bug: https://github.com/google/perfetto/issues/6383