### PR TITLE
tp: add pipeline breakers

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17766,6 +17766,7 @@ filegroup {
     name: "perfetto_src_trace_processor_core_exec_exec",
     srcs: [
         "src/trace_processor/core/exec/assert_type.cc",
+        "src/trace_processor/core/exec/breaker.cc",
         "src/trace_processor/core/exec/column_view.cc",
         "src/trace_processor/core/exec/dataframe_scan.cc",
         "src/trace_processor/core/exec/operator.cc",
@@ -17787,6 +17788,7 @@ filegroup {
     name: "perfetto_src_trace_processor_core_exec_unittests",
     srcs: [
         "src/trace_processor/core/exec/assert_type_unittest.cc",
+        "src/trace_processor/core/exec/breaker_unittest.cc",
         "src/trace_processor/core/exec/dataframe_scan_unittest.cc",
         "src/trace_processor/core/exec/operator_unittest.cc",
         "src/trace_processor/core/exec/row_batch_unittest.cc",

--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -19,6 +19,8 @@ source_set("exec") {
   sources = [
     "assert_type.cc",
     "assert_type.h",
+    "breaker.cc",
+    "breaker.h",
     "column_chunk.h",
     "column_view.cc",
     "column_view.h",
@@ -52,13 +54,18 @@ source_set("exec") {
 source_set("test_utils") {
   testonly = true
   sources = [ "test_utils.h" ]
-  deps = [ ":exec" ]
+  deps = [
+    ":exec",
+    "../../../base",
+    "../common",
+  ]
 }
 
 perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
     "assert_type_unittest.cc",
+    "breaker_unittest.cc",
     "dataframe_scan_unittest.cc",
     "operator_unittest.cc",
     "row_batch_unittest.cc",

--- a/src/trace_processor/core/exec/breaker.cc
+++ b/src/trace_processor/core/exec/breaker.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/breaker.h"
+
+#include <memory>
+#include <utility>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+Breaker::Breaker(const Source& input) : input_(input) {}
+Breaker::~Breaker() = default;
+Breaker::State::~State() = default;
+
+std::unique_ptr<OperatorState> Breaker::MakeState() const {
+  std::unique_ptr<State> state = CreateState();
+  state->input = input_.MakeState();
+  return state;
+}
+
+bool Breaker::GetData(RowBatch& out, OperatorState& state) const {
+  State& s = state.Cast<State>();
+  if (!s.status.ok()) {
+    return false;
+  }
+  if (!s.filled) {
+    while (input_.GetData(s.batch, *s.input)) {
+      if (!Consume(s.batch, s)) {
+        return false;
+      }
+    }
+    base::Status input_status = input_.status(*s.input);
+    if (!input_status.ok()) {
+      s.status = std::move(input_status);
+      return false;
+    }
+    if (!Finish(s)) {
+      return false;
+    }
+    s.filled = true;
+  }
+  return Serve(out, s);
+}
+
+void Breaker::Rewind(OperatorState& state) const {
+  State& s = state.Cast<State>();
+  input_.Rewind(*s.input);
+  Reset(s);
+  s.status = base::OkStatus();
+  s.filled = false;
+}
+
+base::Status Breaker::status(const OperatorState& state) const {
+  const State& s = state.Cast<const State>();
+  return s.status.ok() ? input_.status(*s.input) : s.status;
+}
+
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/breaker.h
+++ b/src/trace_processor/core/exec/breaker.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_BREAKER_H_
+#define SRC_TRACE_PROCESSOR_CORE_EXEC_BREAKER_H_
+
+#include <memory>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+
+namespace perfetto::trace_processor::core::exec {
+
+// A sink for one pipeline and the source of the next.
+//
+// A plan is push all the way up: a Pipeline pushes each batch of its source
+// through its operators. Only at the top is it pulled from. Some steps cannot
+// be pushed through, because nothing can come out until everything has gone
+// in; sorting is the classic case. A breaker is that step: the pipeline below
+// pushes every batch into Consume(), Finish() runs once after the last, and
+// only then does the pipeline above start pulling batches out.
+//
+// What drives the push is the first pull: GetData() drains the input before
+// serving anything, so a breaker sits in a plan wherever a Source does.
+class Breaker : public Source {
+ public:
+  struct State : OperatorState {
+    ~State() override;
+
+    std::unique_ptr<OperatorState> input;
+    // The batch of the input being consumed.
+    RowBatch batch;
+    base::Status status = base::OkStatus();
+    bool filled = false;
+  };
+
+  ~Breaker() override;
+
+  // The sink half. Each batch of the input goes into Consume(), then Finish()
+  // runs once. Both return false on failure, having set the status.
+  virtual bool Consume(const RowBatch& in, State& state) const = 0;
+  virtual bool Finish(State& state) const = 0;
+
+  std::unique_ptr<OperatorState> MakeState() const final;
+  bool GetData(RowBatch& out, OperatorState& state) const final;
+  void Rewind(OperatorState& state) const final;
+  base::Status status(const OperatorState& state) const final;
+
+ protected:
+  explicit Breaker(const Source& input);
+  Breaker(Source&&) = delete;
+
+  // Creates the state; the base fills in what it owns.
+  virtual std::unique_ptr<State> CreateState() const = 0;
+  // The source half: fills `out` from what was consumed, or returns false
+  // when nothing is left or on failure.
+  virtual bool Serve(RowBatch& out, State& state) const = 0;
+  // Drops everything consumed so the input can be read again.
+  virtual void Reset(State& state) const = 0;
+
+ private:
+  const Source& input_;
+};
+
+}  // namespace perfetto::trace_processor::core::exec
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_BREAKER_H_

--- a/src/trace_processor/core/exec/breaker_unittest.cc
+++ b/src/trace_processor/core/exec/breaker_unittest.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/breaker.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_cursor.h"
+#include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/test_utils.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+using test::ArraySource;
+using test::FailingSource;
+using test::Sequence;
+using ::testing::ElementsAre;
+
+// Buffers every value and serves them back to front, which is only possible
+// once the whole input is in. A negative value is refused.
+class Reverse final : public Breaker {
+ public:
+  explicit Reverse(const Source& input) : Breaker(input) {}
+
+  bool Consume(const RowBatch& in, Breaker::State& state) const override {
+    State& s = state.Cast<State>();
+    for (uint32_t row = 0; row < in.size(); ++row) {
+      int64_t value = in.column(1).Value<int64_t>(row);
+      if (value < 0) {
+        s.status = base::ErrStatus("negative value");
+        return false;
+      }
+      s.values.push_back(value);
+    }
+    return true;
+  }
+  bool Finish(Breaker::State& state) const override {
+    State& s = state.Cast<State>();
+    std::reverse(s.values.begin(), s.values.end());
+    return true;
+  }
+
+ private:
+  struct State : Breaker::State {
+    ~State() override;
+    std::vector<int64_t> values;
+    uint32_t served = 0;
+  };
+
+  std::unique_ptr<Breaker::State> CreateState() const override {
+    return std::make_unique<State>();
+  }
+  bool Serve(RowBatch& out, Breaker::State& state) const override {
+    State& s = state.Cast<State>();
+    auto rows = static_cast<uint32_t>(s.values.size());
+    if (s.served == rows) {
+      return false;
+    }
+    uint32_t count = std::min(kMaxBatchRows, rows - s.served);
+    out.Reset();
+    out.AddColumn(ColumnView::Reference(StorageType{Int64{}}, s.values.data()));
+    out.Compose(RowSelection::Range(s.served), count);
+    out.SetCardinality(count);
+    s.served += count;
+    return true;
+  }
+  void Reset(Breaker::State& state) const override {
+    State& s = state.Cast<State>();
+    s.values.clear();
+    s.served = 0;
+  }
+};
+
+Reverse::State::~State() = default;
+
+std::vector<int64_t> DrainValues(const Source& source) {
+  std::vector<int64_t> values;
+  RowCursor cursor(source);
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    values.push_back(cursor.Value<int64_t>(0));
+  }
+  return values;
+}
+
+TEST(BreakerTest, ServesOnlyOnceTheWholeInputIsIn) {
+  ArraySource source(Sequence(kMaxBatchRows * 2 + 7));
+  Reverse reverse(source);
+
+  std::vector<int64_t> values = DrainValues(reverse);
+  ASSERT_EQ(values.size(), kMaxBatchRows * 2u + 7u);
+  EXPECT_EQ(values.front(), kMaxBatchRows * 2 + 6);
+  EXPECT_EQ(values.back(), 0);
+}
+
+TEST(BreakerTest, RewindReadsTheInputAgain) {
+  ArraySource source({1, 2, 3});
+  Reverse reverse(source);
+  RowCursor cursor(reverse);
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+  }
+  std::vector<int64_t> again;
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    again.push_back(cursor.Value<int64_t>(0));
+  }
+  EXPECT_THAT(again, ElementsAre(3, 2, 1));
+  EXPECT_TRUE(cursor.status().ok());
+}
+
+TEST(BreakerTest, AFailingInputIsReported) {
+  FailingSource source;
+  Reverse reverse(source);
+  RowCursor cursor(reverse);
+  EXPECT_FALSE(cursor.Open());
+  EXPECT_EQ(cursor.status().message(), "input broke");
+}
+
+TEST(BreakerTest, AFailingConsumeIsReported) {
+  ArraySource source({1, -2, 3});
+  Reverse reverse(source);
+  RowCursor cursor(reverse);
+  EXPECT_FALSE(cursor.Open());
+  EXPECT_EQ(cursor.status().message(), "negative value");
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/operator_unittest.cc
+++ b/src/trace_processor/core/exec/operator_unittest.cc
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "perfetto/base/status.h"
 #include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/core/exec/column_view.h"
 #include "src/trace_processor/core/exec/operator.h"
@@ -26,54 +27,16 @@
 #include "src/trace_processor/core/exec/row_batch.h"
 #include "src/trace_processor/core/exec/row_cursor.h"
 #include "src/trace_processor/core/exec/row_selection.h"
+#include "src/trace_processor/core/exec/test_utils.h"
 #include "src/trace_processor/core/util/span.h"
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto::trace_processor::core::exec {
 namespace {
 
+using test::ArraySource;
+using test::Sequence;
 using ::testing::ElementsAre;
-
-// A source shaped like a dataframe scan: an id column so every batch carries
-// its row indices, plus the values themselves.
-class ArraySource final : public Source {
- public:
-  explicit ArraySource(std::vector<int64_t> values)
-      : values_(std::move(values)) {}
-
-  std::unique_ptr<OperatorState> MakeState() const override {
-    return std::make_unique<State>();
-  }
-  void Rewind(OperatorState& state) const override {
-    state.Cast<State>().emitted = 0;
-  }
-
-  bool GetData(RowBatch& out, OperatorState& state) const override {
-    State& s = state.Cast<State>();
-    auto rows = static_cast<uint32_t>(values_.size());
-    if (s.emitted == rows) {
-      return false;
-    }
-    uint32_t count = std::min(kMaxBatchRows, rows - s.emitted);
-    out.Reset();
-    out.AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
-    out.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values_.data()));
-    out.Compose(RowSelection::Range(s.emitted), count);
-    out.SetCardinality(count);
-    s.emitted += count;
-    return true;
-  }
-
- private:
-  struct State : OperatorState {
-    ~State() override;
-    uint32_t emitted = 0;
-  };
-
-  std::vector<int64_t> values_;
-};
-
-ArraySource::State::~State() = default;
 
 // Keeps every second row, standing in for a real operator. The rows it picks
 // are scratch for one execution, so they live in the state, not the plan.
@@ -124,14 +87,6 @@ class Execution {
   std::unique_ptr<OperatorState> state_;
   RowBatch batch_;
 };
-
-std::vector<int64_t> Sequence(uint32_t count) {
-  std::vector<int64_t> values(count);
-  for (uint32_t i = 0; i < count; ++i) {
-    values[i] = i;
-  }
-  return values;
-}
 
 // Reads a pipeline a row at a time, the way a consumer would.
 std::vector<uint32_t> Drain(const Pipeline& pipeline) {

--- a/src/trace_processor/core/exec/test_utils.h
+++ b/src/trace_processor/core/exec/test_utils.h
@@ -17,12 +17,19 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_EXEC_TEST_UTILS_H_
 #define SRC_TRACE_PROCESSOR_CORE_EXEC_TEST_UTILS_H_
 
+#include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
+#include "perfetto/base/status.h"
+#include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/core/exec/column_view.h"
+#include "src/trace_processor/core/exec/operator.h"
 #include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
 
 namespace perfetto::trace_processor::core::exec::test {
 
@@ -54,6 +61,85 @@ std::vector<std::optional<T>> ReadNullableColumn(const RowBatch& batch,
   }
   return values;
 }
+
+// A source shaped like a dataframe scan: an id column so every batch carries
+// its row indices, plus the values themselves.
+class ArraySource final : public Source {
+ public:
+  explicit ArraySource(std::vector<int64_t> values)
+      : values_(std::move(values)) {}
+
+  std::unique_ptr<OperatorState> MakeState() const override {
+    return std::make_unique<State>();
+  }
+  void Rewind(OperatorState& state) const override {
+    state.Cast<State>().emitted = 0;
+  }
+
+  bool GetData(RowBatch& out, OperatorState& state) const override {
+    State& s = state.Cast<State>();
+    auto rows = static_cast<uint32_t>(values_.size());
+    if (s.emitted == rows) {
+      return false;
+    }
+    uint32_t count = std::min(kMaxBatchRows, rows - s.emitted);
+    out.Reset();
+    out.AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
+    out.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values_.data()));
+    out.Compose(RowSelection::Range(s.emitted), count);
+    out.SetCardinality(count);
+    s.emitted += count;
+    return true;
+  }
+
+ private:
+  struct State : OperatorState {
+    uint32_t emitted = 0;
+  };
+
+  std::vector<int64_t> values_;
+};
+
+inline std::vector<int64_t> Sequence(uint32_t count) {
+  std::vector<int64_t> values(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    values[i] = i;
+  }
+  return values;
+}
+
+// Emits one batch, then fails.
+class FailingSource final : public Source {
+ public:
+  std::unique_ptr<OperatorState> MakeState() const override {
+    return std::make_unique<State>();
+  }
+  void Rewind(OperatorState& state) const override {
+    state.Cast<State>().emitted = false;
+  }
+  bool GetData(RowBatch& out, OperatorState& state) const override {
+    State& s = state.Cast<State>();
+    if (s.emitted) {
+      return false;
+    }
+    out.Reset();
+    out.AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
+    out.AddColumn(ColumnView::Reference(StorageType{Int64{}}, values_));
+    out.SetCardinality(2);
+    s.emitted = true;
+    return true;
+  }
+  base::Status status(const OperatorState& state) const override {
+    return state.Cast<const State>().emitted ? base::ErrStatus("input broke")
+                                             : base::OkStatus();
+  }
+
+ private:
+  struct State : OperatorState {
+    bool emitted = false;
+  };
+  int64_t values_[2] = {1, 2};
+};
 
 }  // namespace perfetto::trace_processor::core::exec::test
 


### PR DESCRIPTION
A plan is push all the way up and only pulled from at the top. Some steps
cannot be pushed through because nothing can come out until everything
has gone in, sorting being the classic case. Until now each such step
had to be written as a Source wrapping a Source and drain its input by
hand, hiding that it is a sink for one pipeline and the source of the
next.

Breaker makes that shape explicit. The pipeline below pushes each batch
into Consume(), Finish() runs once after the last, and only then does the
pipeline above pull batches out. The base owns the input state, the drain
loop, error propagation from the input and rewinding, so a concrete
breaker only supplies the two halves.