### PR TITLE
tp: finish operators after the last input

### DIFF
--- a/src/trace_processor/core/exec/operator.h
+++ b/src/trace_processor/core/exec/operator.h
@@ -66,7 +66,8 @@ enum class OpResult : uint8_t {
 // One input batch can produce more than one output batch: an operator which
 // fans out returns kHaveMoreOutput and is called again with the same input.
 // This is why input and output are separate batches: the input has to survive
-// being read more than once.
+// being read more than once. Output can also come after the last input, from
+// Finish().
 class Operator {
  public:
   virtual ~Operator();
@@ -80,6 +81,15 @@ class Operator {
   virtual OpResult Execute(const RowBatch& in,
                            RowBatch& out,
                            OperatorState& state) const = 0;
+
+  // Called once after the last input batch, for an operator which holds rows
+  // back to let them go. The results mean what they do for Execute(): keep
+  // returning kHaveMoreOutput to be called again. An operator which holds
+  // nothing back leaves `out` empty.
+  virtual OpResult Finish(RowBatch& out, OperatorState&) const {
+    out.Reset();
+    return OpResult::kNeedMoreInput;
+  }
 
   // Resets `state` so the plan can be run again. An operator which carries
   // nothing between batches has nothing to do here.

--- a/src/trace_processor/core/exec/operator_unittest.cc
+++ b/src/trace_processor/core/exec/operator_unittest.cc
@@ -302,6 +302,59 @@ TEST(SinkTest, ReopeningRereadsFromTheStart) {
   EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2));
 }
 
+// Passes every batch through, then lets `count` rows go after the last one,
+// one batch each, numbered from `first`. Stands in for an operator holding
+// rows back. A negative `first` makes Finish() fail.
+class Trailer final : public Operator {
+ public:
+  Trailer(int64_t first, uint32_t count) : first_(first), count_(count) {}
+
+  std::unique_ptr<OperatorState> MakeState() const override {
+    return std::make_unique<State>();
+  }
+  OpResult Execute(const RowBatch& in,
+                   RowBatch& out,
+                   OperatorState&) const override {
+    out.CopyFrom(in);
+    return OpResult::kNeedMoreInput;
+  }
+  OpResult Finish(RowBatch& out, OperatorState& state) const override {
+    State& s = state.Cast<State>();
+    if (first_ < 0) {
+      s.status = base::ErrStatus("trailer broke");
+      return OpResult::kError;
+    }
+    out.Reset();
+    if (s.let_go == count_) {
+      return OpResult::kNeedMoreInput;
+    }
+    out.AddColumn(ColumnView::Reference(StorageType{Id{}}, nullptr, nullptr));
+    out.Compose(RowSelection::Range(static_cast<uint32_t>(first_) + s.let_go),
+                1);
+    out.SetCardinality(1);
+    return ++s.let_go == count_ ? OpResult::kNeedMoreInput
+                                : OpResult::kHaveMoreOutput;
+  }
+  void Rewind(OperatorState& state) const override {
+    state.Cast<State>().let_go = 0;
+  }
+  base::Status status(const OperatorState& state) const override {
+    return state.Cast<const State>().status;
+  }
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+    uint32_t let_go = 0;
+    base::Status status = base::OkStatus();
+  };
+
+  int64_t first_;
+  uint32_t count_;
+};
+
+Trailer::State::~State() = default;
+
 // One input batch can produce more than one output batch: the operator says
 // so and is called again with the same input.
 TEST(OperatorTest, AnOperatorCanFanOut) {
@@ -323,6 +376,72 @@ TEST(OperatorTest, FanOutNestsInnermostFirst) {
   Pipeline pipeline(source, std::move(ops));
 
   EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 0, 1, 0, 1, 0, 1));
+}
+
+TEST(FinishTest, AnOperatorCanLetRowsGoAfterTheLastInput) {
+  ArraySource source({10, 20, 30});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<Trailer>(99, 1));
+  Pipeline pipeline(source, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 2, 99));
+}
+
+TEST(FinishTest, FinishCanFanOut) {
+  ArraySource source({10});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<Trailer>(97, 3));
+  Pipeline pipeline(source, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 97, 98, 99));
+}
+
+// What an operator lets go at the end is pushed through the operators above
+// it, fan-out included.
+TEST(FinishTest, RowsLetGoPassThroughTheOperatorsAbove) {
+  ArraySource source({10, 20});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<Trailer>(99, 1));
+  ops.push_back(std::make_unique<Twice>());
+  Pipeline pipeline(source, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 0, 1, 99, 99));
+}
+
+// An operator is only finished once everything below it has been, so the
+// rows the lower one lets go reach it as ordinary input first.
+TEST(FinishTest, OperatorsAreFinishedBottomUp) {
+  ArraySource source({10});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<Trailer>(7, 1));
+  ops.push_back(std::make_unique<Trailer>(8, 1));
+  Pipeline pipeline(source, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 7, 8));
+}
+
+TEST(FinishTest, RewindFinishesAgain) {
+  ArraySource source({10, 20});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<Trailer>(99, 1));
+  Pipeline pipeline(source, std::move(ops));
+
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 99));
+  EXPECT_THAT(Drain(pipeline), ElementsAre(0, 1, 99));
+}
+
+TEST(FinishTest, AFailingFinishIsReported) {
+  ArraySource source({10, 20});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<Trailer>(-1, 1));
+  Pipeline pipeline(source, std::move(ops));
+  RowCursor cursor(pipeline);
+  std::vector<uint32_t> rows;
+  for (cursor.Open(); !cursor.eof(); cursor.Next()) {
+    rows.push_back(cursor.Value<uint32_t>(0));
+  }
+  EXPECT_THAT(rows, ElementsAre(0, 1));
+  EXPECT_EQ(cursor.status().message(), "trailer broke");
 }
 
 }  // namespace

--- a/src/trace_processor/core/exec/pipeline.cc
+++ b/src/trace_processor/core/exec/pipeline.cc
@@ -48,6 +48,8 @@ std::unique_ptr<OperatorState> Pipeline::MakeState() const {
 void Pipeline::Rewind(OperatorState& state) const {
   State& s = state.Cast<State>();
   s.pending.clear();
+  s.source_done = false;
+  s.finishing = 0;
   source_.Rewind(*s.source);
   for (uint32_t i = 0; i < operators_.size(); ++i) {
     operators_[i]->Rewind(*s.operators[i]);
@@ -70,30 +72,48 @@ bool Pipeline::GetData(RowBatch& out, OperatorState& state) const {
   if (operators_.empty()) {
     return source_.GetData(out, *s.source);
   }
+  auto count = static_cast<uint32_t>(operators_.size());
   // TODO(lalitm): nothing between batches checks for cancellation, so a
   // long-running pipeline cannot be interrupted; check an interrupt flag here
   // once one is plumbed through.
   for (;;) {
     uint32_t first;
-    if (s.pending.empty()) {
-      if (!source_.GetData(s.batches[0], *s.source)) {
-        return false;
-      }
-      first = 0;
-    } else {
+    bool finish = false;
+    if (!s.pending.empty()) {
       first = s.pending.back();
       s.pending.pop_back();
+    } else if (!s.source_done) {
+      if (!source_.GetData(s.batches[0], *s.source)) {
+        if (!source_.status(*s.source).ok()) {
+          return false;
+        }
+        s.source_done = true;
+        continue;
+      }
+      first = 0;
+    } else if (s.finishing < count) {
+      first = s.finishing;
+      finish = true;
+    } else {
+      return false;
     }
     bool filled = true;
-    for (uint32_t i = first; i < operators_.size(); ++i) {
-      RowBatch& dst = i + 1 == operators_.size() ? out : s.batches[i + 1];
-      OpResult result =
-          operators_[i]->Execute(s.batches[i], dst, *s.operators[i]);
+    for (uint32_t i = first; i < count; ++i) {
+      RowBatch& dst = i + 1 == count ? out : s.batches[i + 1];
+      OpResult result;
+      if (finish && i == first) {
+        result = operators_[i]->Finish(dst, *s.operators[i]);
+        if (result == OpResult::kNeedMoreInput) {
+          ++s.finishing;
+        }
+      } else {
+        result = operators_[i]->Execute(s.batches[i], dst, *s.operators[i]);
+        if (result == OpResult::kHaveMoreOutput) {
+          s.pending.push_back(i);
+        }
+      }
       if (result == OpResult::kError) {
         return false;
-      }
-      if (result == OpResult::kHaveMoreOutput) {
-        s.pending.push_back(i);
       }
       if (dst.size() == 0) {
         filled = false;

--- a/src/trace_processor/core/exec/pipeline.h
+++ b/src/trace_processor/core/exec/pipeline.h
@@ -28,6 +28,10 @@ namespace perfetto::trace_processor::core::exec {
 
 // A source followed by a chain of operators, itself exposed as a Source. Its
 // state holds the state of every node in the chain.
+//
+// Each batch of the source is pushed through the operators in turn. Once the
+// source is done, each operator in turn is finished, and what it lets go is
+// pushed through the operators above it before the next one is finished.
 class Pipeline : public Source {
  public:
   Pipeline(const Source&, std::vector<std::unique_ptr<Operator>>);
@@ -50,6 +54,10 @@ class Pipeline : public Source {
     // Operators with more output for the input they already hold, deepest
     // last, since the deepest has to be drained first.
     std::vector<uint32_t> pending;
+    bool source_done = false;
+    // Once the source is done, the operator being finished. Every operator
+    // below it has been finished and had its output pushed through.
+    uint32_t finishing = 0;
   };
 
   const Source& source_;


### PR DESCRIPTION
An operator which holds rows back has nowhere to let them go once the
source runs dry, and no way to report rows it is still holding. Finish()
is called once after the last batch and can return output, fan out, or
fail, just as Execute() can.

The pipeline finishes its operators from the bottom up. Whatever one lets
go is pushed through the operators above it as ordinary input before the
next one is finished, so an operator sees all of its input before its own
Finish() runs.