### PR TITLE
tp: order tree rows parent first without breaking the pipeline

### DIFF
--- a/src/trace_processor/core/exec/BUILD.gn
+++ b/src/trace_processor/core/exec/BUILD.gn
@@ -92,7 +92,10 @@ perfetto_unittest_source_set("unittests") {
 if (enable_perfetto_benchmarks) {
   source_set("benchmarks") {
     testonly = true
-    sources = [ "tree_number_nodes_benchmark.cc" ]
+    sources = [
+      "tree_number_nodes_benchmark.cc",
+      "tree_order_benchmark.cc",
+    ]
     deps = [
       ":exec",
       "../../../../gn:benchmark",

--- a/src/trace_processor/core/exec/tree_order.cc
+++ b/src/trace_processor/core/exec/tree_order.cc
@@ -26,6 +26,7 @@
 #include "src/trace_processor/core/exec/column_view.h"
 #include "src/trace_processor/core/exec/operator.h"
 #include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/row_selection.h"
 #include "src/trace_processor/core/exec/row_store.h"
 #include "src/trace_processor/core/exec/tree_number_nodes.h"
 #include "src/trace_processor/core/util/bit_vector.h"
@@ -36,6 +37,7 @@ namespace perfetto::trace_processor::core::exec {
 namespace {
 
 constexpr char kChildFirst[] = "TREE ORDER CHILD FIRST";
+constexpr char kParentFirst[] = "TREE ORDER PARENT FIRST";
 
 bool IsNodeColumn(const ColumnView& column) {
   return column.kind() == ColumnView::Kind::kFlat && column.type().Is<Uint32>();
@@ -239,6 +241,186 @@ void TreeChildFirst::Reset(Breaker::State& state) const {
   s.rows.Clear();
   s.order.clear();
   s.emitted = 0;
+}
+
+TreeParentFirst::TreeParentFirst(uint32_t node_column, uint32_t parent_column)
+    : node_column_(node_column), parent_column_(parent_column) {}
+
+TreeParentFirst::~TreeParentFirst() = default;
+TreeParentFirst::State::~State() = default;
+
+void TreeParentFirst::State::Nodes::Grow(uint32_t new_count) {
+  if (new_count <= count) {
+    return;
+  }
+  count = new_count;
+  auto size = static_cast<uint32_t>(first_waiting.size());
+  if (new_count <= size) {
+    return;
+  }
+  // Grown geometrically, as resize allocates exactly what it is asked for.
+  uint32_t new_size = std::max(new_count, size * 2);
+  has_row.resize(new_size);
+  out.resize(new_size);
+  first_waiting.resize(new_size);
+  std::fill(first_waiting.data() + size, first_waiting.data() + new_size,
+            kNoNode);
+}
+
+void TreeParentFirst::State::Nodes::Clear() {
+  count = 0;
+  has_row.clear();
+  out.clear();
+  first_waiting.clear();
+}
+
+void TreeParentFirst::State::Held::Clear() {
+  rows.Clear();
+  node.clear();
+  next_waiting.clear();
+  let_go = 0;
+}
+
+std::unique_ptr<OperatorState> TreeParentFirst::MakeState() const {
+  return std::make_unique<State>();
+}
+
+base::Status TreeParentFirst::status(const OperatorState& state) const {
+  return state.Cast<const State>().status;
+}
+
+void TreeParentFirst::Release(uint32_t node, State& s) const {
+  for (uint32_t row = s.nodes.first_waiting[node]; row != kNoNode;
+       row = s.held.next_waiting[row]) {
+    s.letting_go.push_back(row);
+  }
+  s.nodes.first_waiting[node] = kNoNode;
+}
+
+OpResult TreeParentFirst::LetGo(RowBatch& out, State& s) const {
+  auto total = static_cast<uint32_t>(s.letting_go.size());
+  uint32_t count = std::min(kMaxBatchRows, total - s.served);
+  const uint32_t* begin = s.letting_go.data() + s.served;
+  s.held.rows.View(&out, Span<const uint32_t>(begin, begin + count));
+  s.served += count;
+  if (s.served < total) {
+    return OpResult::kHaveMoreOutput;
+  }
+  s.letting_go.clear();
+  s.served = 0;
+  return OpResult::kNeedMoreInput;
+}
+
+OpResult TreeParentFirst::Execute(const RowBatch& in,
+                                  RowBatch& out,
+                                  OperatorState& state) const {
+  State& s = state.Cast<State>();
+  if (s.served < s.letting_go.size()) {
+    return LetGo(out, s);
+  }
+  uint32_t count = in.size();
+  if (count == 0) {
+    out.CopyFrom(in);
+    return OpResult::kNeedMoreInput;
+  }
+  const ColumnView* node_column;
+  const ColumnView* parent_column;
+  s.status = NodeColumns(in, node_column_, parent_column_, kParentFirst,
+                         &node_column, &parent_column);
+  if (!s.status.ok()) {
+    return OpResult::kError;
+  }
+
+  // A row passes if its parent is out, whether from an earlier batch or
+  // earlier in this one, and releases whatever was waiting on it. Otherwise
+  // it waits on its parent. Released rows only go out after the batch, so
+  // they are not marked out yet: a row arriving under one of them in this
+  // same batch has to wait too, or it would go out ahead of its parent.
+  s.passing.clear();
+  s.holding.clear();
+  for (uint32_t i = 0; i < count; ++i) {
+    uint32_t node = node_column->Value<uint32_t>(i);
+    uint32_t parent = parent_column->Value<uint32_t>(i);
+    if (node == parent) {
+      s.status = base::ErrStatus("%s: a node is its own parent", kParentFirst);
+      return OpResult::kError;
+    }
+    s.nodes.Grow(std::max(node, parent == kNoNode ? 0 : parent) + 1);
+    if (s.nodes.has_row.is_set(node)) {
+      s.status = base::ErrStatus("%s: more than one row has the same node",
+                                 kParentFirst);
+      return OpResult::kError;
+    }
+    s.nodes.has_row.set(node);
+    if (parent != kNoNode && !s.nodes.out.is_set(parent)) {
+      // The row it will be in `held` once the batch's held rows are copied.
+      auto row = static_cast<uint32_t>(s.held.node.size());
+      s.holding.push_back(i);
+      s.held.node.push_back(node);
+      s.held.next_waiting.push_back(s.nodes.first_waiting[parent]);
+      s.nodes.first_waiting[parent] = row;
+      continue;
+    }
+    s.passing.push_back(i);
+    s.nodes.out.set(node);
+    Release(node, s);
+  }
+
+  if (!s.holding.empty()) {
+    auto held = static_cast<uint32_t>(s.holding.size());
+    s.held_batch.CopyFrom(in);
+    s.held_batch.Slice(RowSelection::Indices(s.holding.span()), held);
+    s.status = s.held.rows.Append(s.held_batch);
+    if (!s.status.ok()) {
+      return OpResult::kError;
+    }
+  }
+
+  // A released row releases what waits on it in turn. Scanning `letting_go`
+  // as it grows picks up the rows held under released ones in this batch.
+  for (uint32_t i = 0; i < s.letting_go.size(); ++i) {
+    uint32_t node = s.held.node[s.letting_go[i]];
+    s.nodes.out.set(node);
+    Release(node, s);
+  }
+  s.held.let_go += static_cast<uint32_t>(s.letting_go.size());
+
+  if (s.passing.empty()) {
+    if (s.letting_go.empty()) {
+      out.CopyFrom(in);
+      out.Slice(RowSelection::Range(0), 0);
+      return OpResult::kNeedMoreInput;
+    }
+    return LetGo(out, s);
+  }
+  out.CopyFrom(in);
+  if (s.passing.size() < count) {
+    out.Slice(RowSelection::Indices(s.passing.span()),
+              static_cast<uint32_t>(s.passing.size()));
+  }
+  return s.letting_go.empty() ? OpResult::kNeedMoreInput
+                              : OpResult::kHaveMoreOutput;
+}
+
+OpResult TreeParentFirst::Finish(RowBatch& out, OperatorState& state) const {
+  State& s = state.Cast<State>();
+  out.Reset();
+  if (s.held.rows.size() != s.held.let_go) {
+    s.status = base::ErrStatus(
+        "%s: a row names a parent which is not itself a row in the input",
+        kParentFirst);
+    return OpResult::kError;
+  }
+  return OpResult::kNeedMoreInput;
+}
+
+void TreeParentFirst::Rewind(OperatorState& state) const {
+  State& s = state.Cast<State>();
+  s.nodes.Clear();
+  s.held.Clear();
+  s.letting_go.clear();
+  s.served = 0;
+  s.status = base::OkStatus();
 }
 
 }  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/tree_order.h
+++ b/src/trace_processor/core/exec/tree_order.h
@@ -86,6 +86,88 @@ class TreeChildFirst : public Breaker {
   uint32_t parent_column_;
 };
 
+// TREE ORDER PARENT FIRST: puts tree rows into an order where every parent
+// precedes its children. A fold down a tree runs over this order.
+//
+// Not a breaker: a row can go out as soon as its parent has. Rows whose
+// parent is already out stream straight through as views of their batch.
+// Only a row arriving before its parent is held: copied aside and let go the
+// moment the parent arrives, together with whatever is held under it. So the
+// cost is proportional to how far out of order the input is, nothing for
+// ordered input and everything for reversed input, and the planner never
+// needs to know which. Rows once held stay copied until the next rewind.
+//
+// The order is parent first and nothing more: not a pre-order, so a fold
+// down keeps a value per node rather than a path. The input columns are node
+// numbers, which TreeNumberNodes produces. No column is added.
+class TreeParentFirst : public Operator {
+ public:
+  TreeParentFirst(uint32_t node_column, uint32_t parent_column);
+  ~TreeParentFirst() override;
+
+  std::unique_ptr<OperatorState> MakeState() const override;
+  OpResult Execute(const RowBatch& in,
+                   RowBatch& out,
+                   OperatorState& state) const override;
+  OpResult Finish(RowBatch& out, OperatorState& state) const override;
+  void Rewind(OperatorState& state) const override;
+  base::Status status(const OperatorState& state) const override;
+
+ private:
+  struct State : OperatorState {
+    ~State() override;
+
+    // What is known about each node number.
+    struct Nodes {
+      uint32_t count = 0;
+      BitVector has_row;
+      // The node's row is out, or is on its way out in `letting_go`.
+      BitVector out;
+      // The first row of `held` waiting on this node, or kNoNode.
+      FlexVector<uint32_t> first_waiting;
+
+      void Grow(uint32_t count);
+      void Clear();
+    };
+
+    // Rows which arrived before their parent. Each knows its node and the
+    // next row waiting on the same parent, which with `first_waiting` makes
+    // a list per parent. A row let go stays here, so this only grows until
+    // the next rewind.
+    struct Held {
+      RowStore rows;
+      FlexVector<uint32_t> node;
+      FlexVector<uint32_t> next_waiting;
+      uint32_t let_go = 0;
+
+      void Clear();
+    };
+
+    Nodes nodes;
+    Held held;
+
+    // Rows of `held` on their way out after the current batch, served a
+    // batch at a time from `served`.
+    FlexVector<uint32_t> letting_go;
+    uint32_t served = 0;
+
+    // Scratch for one batch: which of its rows pass straight through, which
+    // are held, and the held ones sliced out to be copied.
+    FlexVector<uint32_t> passing;
+    FlexVector<uint32_t> holding;
+    RowBatch held_batch;
+
+    base::Status status = base::OkStatus();
+  };
+
+  // Moves every row waiting on `node` to `letting_go`.
+  void Release(uint32_t node, State&) const;
+  OpResult LetGo(RowBatch& out, State&) const;
+
+  uint32_t node_column_;
+  uint32_t parent_column_;
+};
+
 }  // namespace perfetto::trace_processor::core::exec
 
 #endif  // SRC_TRACE_PROCESSOR_CORE_EXEC_TREE_ORDER_H_

--- a/src/trace_processor/core/exec/tree_order_benchmark.cc
+++ b/src/trace_processor/core/exec/tree_order_benchmark.cc
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/exec/tree_order.h"
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/exec/dataframe_scan.h"
+#include "src/trace_processor/core/exec/operator.h"
+#include "src/trace_processor/core/exec/pipeline.h"
+#include "src/trace_processor/core/exec/row_batch.h"
+#include "src/trace_processor/core/exec/tree_number_nodes.h"
+
+namespace perfetto::trace_processor::core::exec {
+namespace {
+
+inline constexpr auto kTree = dataframe::CreateTypedDataframeSpec(
+    {"id", "parent_id"},
+    dataframe::CreateTypedColumnSpec(Uint32{},
+                                     NonNull{},
+                                     Unsorted{},
+                                     NoDuplicates{}),
+    dataframe::CreateTypedColumnSpec(Uint32{},
+                                     SparseNullWithPopcountAlways{},
+                                     Unsorted{},
+                                     HasDuplicates{}));
+
+enum class Arrival : int64_t { kParentFirst, kChildFirst, kShuffled };
+
+std::optional<uint32_t> ParentOf(uint32_t id) {
+  if (id == 0) {
+    return std::nullopt;
+  }
+  return (id - 1) / 2;
+}
+
+// A binary tree of `rows` nodes whose rows arrive in the given order.
+dataframe::Dataframe BuildTree(uint32_t rows,
+                               Arrival arrival,
+                               StringPool* pool) {
+  std::vector<uint32_t> ids(rows);
+  for (uint32_t i = 0; i < rows; ++i) {
+    ids[i] = i;
+  }
+  if (arrival == Arrival::kChildFirst) {
+    std::reverse(ids.begin(), ids.end());
+  } else if (arrival == Arrival::kShuffled) {
+    std::mt19937 rng(7);
+    std::shuffle(ids.begin(), ids.end(), rng);
+  }
+  dataframe::Dataframe df =
+      dataframe::Dataframe::CreateFromTypedSpec(kTree, pool);
+  for (uint32_t id : ids) {
+    df.InsertUnchecked(kTree, id, ParentOf(id));
+  }
+  df.Finalize();
+  return df;
+}
+
+void Run(benchmark::State& state, const Source& source, uint32_t rows) {
+  std::unique_ptr<OperatorState> run = source.MakeState();
+  RowBatch out;
+  for (auto _ : state) {
+    source.Rewind(*run);
+    while (source.GetData(out, *run)) {
+      benchmark::DoNotOptimize(out.column(2).data());
+    }
+    if (!source.status(*run).ok()) {
+      state.SkipWithError(source.status(*run).c_message());
+      return;
+    }
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * rows);
+}
+
+// Numbering alone, to compare the ordering against.
+void BM_TreeOrderNumberOnly(benchmark::State& state) {
+  StringPool pool;
+  auto rows = static_cast<uint32_t>(state.range(0));
+  dataframe::Dataframe df =
+      BuildTree(rows, static_cast<Arrival>(state.range(1)), &pool);
+  DataframeScan scan(df, {0, 1});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<TreeNumberNodes>(0, 1));
+  Pipeline pipeline(scan, std::move(ops));
+  Run(state, pipeline, rows);
+}
+
+void BM_TreeParentFirst(benchmark::State& state) {
+  StringPool pool;
+  auto rows = static_cast<uint32_t>(state.range(0));
+  dataframe::Dataframe df =
+      BuildTree(rows, static_cast<Arrival>(state.range(1)), &pool);
+  DataframeScan scan(df, {0, 1});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<TreeNumberNodes>(0, 1));
+  ops.push_back(std::make_unique<TreeParentFirst>(2, 3));
+  Pipeline pipeline(scan, std::move(ops));
+  Run(state, pipeline, rows);
+}
+
+void BM_TreeChildFirst(benchmark::State& state) {
+  StringPool pool;
+  auto rows = static_cast<uint32_t>(state.range(0));
+  dataframe::Dataframe df =
+      BuildTree(rows, static_cast<Arrival>(state.range(1)), &pool);
+  DataframeScan scan(df, {0, 1});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<TreeNumberNodes>(0, 1));
+  Pipeline numbered(scan, std::move(ops));
+  TreeChildFirst order(numbered, 2, 3);
+  Run(state, order, rows);
+}
+
+void Arrivals(benchmark::internal::Benchmark* b) {
+  for (int64_t rows : {10000, 1000000}) {
+    for (Arrival arrival :
+         {Arrival::kParentFirst, Arrival::kChildFirst, Arrival::kShuffled}) {
+      b->Args({rows, static_cast<int64_t>(arrival)});
+    }
+  }
+}
+
+BENCHMARK(BM_TreeOrderNumberOnly)->Apply(Arrivals);
+BENCHMARK(BM_TreeParentFirst)->Apply(Arrivals);
+BENCHMARK(BM_TreeChildFirst)->Apply(Arrivals);
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::exec

--- a/src/trace_processor/core/exec/tree_order_unittest.cc
+++ b/src/trace_processor/core/exec/tree_order_unittest.cc
@@ -425,5 +425,179 @@ TEST(TreeChildFirstTest, IsADepthFirstPostOrder) {
   EXPECT_EQ(totals, expected);
 }
 
+// Numbers the rows, then puts them parent first.
+std::vector<std::unique_ptr<Operator>> NumberParentFirst() {
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<TreeNumberNodes>(0, 1));
+  ops.push_back(std::make_unique<TreeParentFirst>(3, 4));
+  return ops;
+}
+
+// Every parent appears before all of its children.
+void ExpectParentFirst(const Output& out) {
+  std::vector<int64_t> seen;
+  for (uint32_t i = 0; i < out.node.size(); ++i) {
+    if (out.parent[i] >= 0) {
+      EXPECT_NE(std::find(seen.begin(), seen.end(), out.parent[i]), seen.end())
+          << "row " << i << " came before its parent";
+    }
+    seen.push_back(out.node[i]);
+  }
+}
+
+TEST(TreeParentFirstTest, RowsInOrderStreamThrough) {
+  RowSource source(ParentFirstRows(), 2);
+  Pipeline pipeline(source, NumberParentFirst());
+
+  Output out = Drain(pipeline);
+  ASSERT_TRUE(out.status.ok()) << out.status.message();
+  EXPECT_THAT(out.payload, ElementsAre(100, 101, 102, 103));
+  EXPECT_THAT(out.node, ElementsAre(0, 1, 2, 3));
+  EXPECT_THAT(out.parent, ElementsAre(-1, 0, 0, 1));
+}
+
+// A row arriving before its parent waits for it; the rest of the batch goes
+// on ahead.
+TEST(TreeParentFirstTest, ARowBeforeItsParentWaitsForIt) {
+  std::vector<Row> rows = {
+      {1, 0, 101}, {0, std::nullopt, 100}, {2, 0, 102}, {3, 1, 103}};
+  RowSource source(rows, 4);
+  Pipeline pipeline(source, NumberParentFirst());
+
+  Output out = Drain(pipeline);
+  ASSERT_TRUE(out.status.ok()) << out.status.message();
+  EXPECT_THAT(out.payload, ElementsAre(100, 102, 101, 103));
+  ExpectParentFirst(out);
+}
+
+TEST(TreeParentFirstTest, AHeldRowIsLetGoWhenItsParentArrivesLater) {
+  RowSource source(ChildFirstRows(), 2);
+  Pipeline pipeline(source, NumberParentFirst());
+
+  Output out = Drain(pipeline);
+  ASSERT_TRUE(out.status.ok()) << out.status.message();
+  ExpectParentFirst(out);
+  std::vector<int64_t> payload = out.payload;
+  std::sort(payload.begin(), payload.end());
+  EXPECT_THAT(payload, ElementsAre(100, 101, 102, 103));
+}
+
+// More rows let go at once than fit in a batch come out over several.
+TEST(TreeParentFirstTest, RowsLetGoSpanBatches) {
+  std::vector<Row> rows;
+  for (int64_t id = 1; id <= kMaxBatchRows * 2 + 5; ++id) {
+    rows.push_back({id, 0, id});
+  }
+  rows.push_back({0, std::nullopt, 0});
+  RowSource source(rows, 1000);
+  Pipeline pipeline(source, NumberParentFirst());
+
+  Output out = Drain(pipeline);
+  ASSERT_TRUE(out.status.ok()) << out.status.message();
+  ASSERT_EQ(out.payload.size(), rows.size());
+  EXPECT_EQ(out.payload.front(), 0);
+  std::vector<int64_t> payload = out.payload;
+  std::sort(payload.begin(), payload.end());
+  for (size_t i = 0; i < payload.size(); ++i) {
+    ASSERT_EQ(payload[i], static_cast<int64_t>(i));
+  }
+}
+
+TEST(TreeParentFirstTest, AParentWhichIsNotARowIsReported) {
+  RowSource source({{0, std::nullopt, 100}, {1, 42, 101}}, 2);
+  Pipeline pipeline(source, NumberParentFirst());
+
+  Output out = Drain(pipeline);
+  EXPECT_THAT(out.payload, ElementsAre(100));
+  EXPECT_FALSE(out.status.ok());
+  EXPECT_THAT(out.status.message(), testing::HasSubstr("not itself a row"));
+}
+
+TEST(TreeParentFirstTest, ACycleIsReported) {
+  RowSource source({{0, 1, 100}, {1, 0, 101}}, 2);
+  Pipeline pipeline(source, NumberParentFirst());
+
+  Output out = Drain(pipeline);
+  EXPECT_TRUE(out.payload.empty());
+  EXPECT_FALSE(out.status.ok());
+  EXPECT_THAT(out.status.message(), testing::HasSubstr("not itself a row"));
+}
+
+TEST(TreeParentFirstTest, ASelfParentIsReported) {
+  RowSource source({{0, 0, 100}}, 1);
+  Pipeline pipeline(source, NumberParentFirst());
+
+  Output out = Drain(pipeline);
+  EXPECT_FALSE(out.status.ok());
+  EXPECT_THAT(out.status.message(), testing::HasSubstr("own parent"));
+}
+
+TEST(TreeParentFirstTest, DuplicateNumberedNodesAreReported) {
+  NumberedSource source({0, 1, 0}, {1, kNoNode, 1}, {100, 101, 102});
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.push_back(std::make_unique<TreeParentFirst>(0, 1));
+  Pipeline pipeline(source, std::move(ops));
+  Execution run(pipeline);
+  while (run.Next()) {
+  }
+  EXPECT_FALSE(run.status().ok());
+  EXPECT_THAT(run.status().message(), testing::HasSubstr("same node"));
+}
+
+TEST(TreeParentFirstTest, RewindReadsTheInputAgain) {
+  RowSource source(ChildFirstRows(), 2);
+  Pipeline pipeline(source, NumberParentFirst());
+  Execution run(pipeline);
+  Output first = Drain(&run);
+  ASSERT_TRUE(first.status.ok()) << first.status.message();
+
+  source.SetRows(
+      {{3, 1, 203}, {2, 0, 202}, {1, 0, 201}, {0, std::nullopt, 200}});
+  run.Rewind();
+  Output second = Drain(&run);
+  ASSERT_TRUE(second.status.ok()) << second.status.message();
+  ExpectParentFirst(second);
+  std::vector<int64_t> payload = second.payload;
+  std::sort(payload.begin(), payload.end());
+  EXPECT_THAT(payload, ElementsAre(200, 201, 202, 203));
+}
+
+TEST(TreeParentFirstTest, RewindDiscardsHeldRows) {
+  RowSource source({{0, std::nullopt, 100}, {1, 42, 101}}, 2);
+  Pipeline pipeline(source, NumberParentFirst());
+  Execution run(pipeline);
+  Output failed = Drain(&run);
+  ASSERT_FALSE(failed.status.ok());
+
+  source.SetRows(ParentFirstRows());
+  run.Rewind();
+  Output recovered = Drain(&run);
+  ASSERT_TRUE(recovered.status.ok()) << recovered.status.message();
+  EXPECT_THAT(recovered.payload, ElementsAre(100, 101, 102, 103));
+}
+
+TEST(TreeParentFirstTest, AShuffledTreeComesOutParentFirst) {
+  std::mt19937 rng(31);
+  std::vector<Row> rows;
+  rows.push_back({0, std::nullopt, 0});
+  for (int64_t id = 1; id < 3000; ++id) {
+    int64_t parent = std::uniform_int_distribution<int64_t>(0, id - 1)(rng);
+    rows.push_back({id, parent, id});
+  }
+  std::shuffle(rows.begin(), rows.end(), rng);
+
+  RowSource source(rows, 256);
+  Pipeline pipeline(source, NumberParentFirst());
+  Output out = Drain(pipeline);
+  ASSERT_TRUE(out.status.ok()) << out.status.message();
+  ASSERT_EQ(out.node.size(), rows.size());
+  ExpectParentFirst(out);
+  std::vector<int64_t> payload = out.payload;
+  std::sort(payload.begin(), payload.end());
+  for (size_t i = 0; i < payload.size(); ++i) {
+    ASSERT_EQ(payload[i], static_cast<int64_t>(i));
+  }
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor::core::exec


### PR DESCRIPTION
Folding down a tree needs every parent before its children. Unlike child
first, that order needs no knowledge of the input as a whole: a row can
go out as soon as its parent has, so there is no reason to hold the
whole input.

TreeParentFirst streams every row whose parent is already out as a view
of its batch. A row arriving before its parent is copied aside and let go
the moment the parent arrives, along with whatever is held under it. The
cost is proportional to how far out of order the input is: nothing for
ordered input, everything for reversed input. The planner never needs to
know which, and never needs to leave the operator out.

Rows still held when the input ends name a parent which is never a row,
which Finish() reports.