### PR TITLE
Add the new extension merger in the gen_bazel tool

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -375,6 +375,21 @@ perfetto_cc_binary(
     ] + PERFETTO_CONFIG.deps.protobuf_full,
 )
 
+# GN target: //src/tools/proto_merger:extension_proto_merger
+perfetto_cc_binary(
+    name = "extension_proto_merger",
+    srcs = [
+        ":src_protozero_multifile_error_collector",
+        ":src_tools_proto_merger_lib",
+        "src/tools/proto_merger/extension_proto_merger_main.cc",
+    ],
+    deps = [
+        ":protos_perfetto_common_passthrough_lite",
+        ":src_base_base",
+        ":src_base_version",
+    ] + PERFETTO_CONFIG.deps.protobuf_full,
+)
+
 # GN target: //src/tools/proto_merger:proto_merger
 perfetto_cc_binary(
     name = "proto_merger",

--- a/tools/gen_bazel
+++ b/tools/gen_bazel
@@ -118,6 +118,7 @@ default_targets = [
     '//src/protozero/protoc_plugin:protozero_plugin',
     '//src/tools/proto_filter:proto_filter',
     '//src/tools/proto_merger:proto_merger',
+    '//src/tools/proto_merger:extension_proto_merger',
     '//src/trace_processor:trace_processor_shell_lib',
     '//src/tools/pfsql:pfsql',
     '//src/trace_processor/rpc:trace_processor_rpc',


### PR DESCRIPTION
Add the new extension merger in the gen_bazel tool.

This will help correctly generate the BUILD rules for the new tool