### PR TITLE
ui: Fix connected flows panel showing all connected flows

### DIFF
--- a/ui/src/components/details/connected_flows.ts
+++ b/ui/src/components/details/connected_flows.ts
@@ -76,6 +76,12 @@ export async function getConnectedFlows(
   const nullToStr = (s: null | string): string => (s === null ? 'NULL' : s);
 
   for (; it.valid(); it.next()) {
+    // Only include flows directly connected to the slice (one hop),
+    // not the full transitive closure from directly_connected_flow.
+    if (it.sliceIn !== sliceId && it.sliceOut !== sliceId) {
+      continue;
+    }
+
     const row: FlowRow = {
       id: it.id,
       sliceId: asSliceSqlId(it.otherSliceId),


### PR DESCRIPTION
The consolidation of flow events into a single plugin in #7030 introduced a bug where the single selection flow events panel now displays all following events in the chain.

This patch limits the output of `getConnectedFlows()` to directly connected ones only.

Note: While filtering in JS like this is inefficient - this is what the old code did. Optimising this is a problem for another patch.