### PR TITLE
tp: Support dynamic out-of-tree (OOT) Wattson SoC power models

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3038,6 +3038,7 @@ cc_test {
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen",
@@ -3444,6 +3445,7 @@ cc_test {
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen_headers",
@@ -14027,6 +14029,7 @@ genrule {
         "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_interned_data.proto",
         "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.proto",
         "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.proto",
+        "protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.proto",
         "protos/third_party/android/frameworks/base/proto/tracing/winscope/app/statusbarmanager.proto",
         "protos/third_party/android/frameworks/base/proto/tracing/winscope/app/window_configuration.proto",
         "protos/third_party/android/frameworks/base/proto/tracing/winscope/content/activityinfo.proto",
@@ -14586,6 +14589,7 @@ genrule {
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
     ],
     tools: [
         "aprotoc",
@@ -14646,6 +14650,7 @@ genrule {
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
     ],
     tools: [
         "aprotoc",
@@ -14706,6 +14711,50 @@ genrule {
     cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --proto_path=external/protobuf/src --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero)",
     out: [
         "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_track_event.pbzero.h",
+    ],
+    export_include_dirs: [
+        ".",
+        "protos",
+    ],
+}
+
+// GN: //protos/third_party/android/frameworks/base/proto/tracing:wattson_soc_model_zero
+filegroup {
+    name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
+    srcs: [
+        "protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.proto",
+    ],
+}
+
+// GN: //protos/third_party/android/frameworks/base/proto/tracing:wattson_soc_model_zero
+genrule {
+    name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen",
+    srcs: [
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero)",
+    out: [
+        "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.pbzero.cc",
+    ],
+}
+
+// GN: //protos/third_party/android/frameworks/base/proto/tracing:wattson_soc_model_zero
+genrule {
+    name: "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen_headers",
+    srcs: [
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero)",
+    out: [
+        "external/perfetto/protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.pbzero.h",
     ],
     export_include_dirs: [
         ".",
@@ -19576,6 +19625,7 @@ python_binary_host {
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
         "tools/gen_tp_table_headers.py",
     ],
@@ -19639,6 +19689,7 @@ python_binary_host {
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
         "tools/gen_tp_table_headers.py",
     ],
@@ -19713,6 +19764,7 @@ python_binary_host {
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
         "tools/gen_tp_table_headers.py",
     ],
@@ -19801,6 +19853,7 @@ python_binary_host {
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
         "tools/gen_tp_table_headers.py",
     ],
@@ -20096,6 +20149,7 @@ python_binary_host {
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
         "tools/gen_tp_table_headers.py",
     ],
@@ -20160,6 +20214,7 @@ python_binary_host {
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
         "tools/gen_tp_table_headers.py",
     ],
@@ -20223,6 +20278,7 @@ python_binary_host {
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
         "tools/gen_tp_table_headers.py",
     ],
@@ -21155,6 +21211,7 @@ genrule {
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
     ],
     tools: [
@@ -21195,6 +21252,8 @@ genrule {
         "src/trace_processor/tables/track_tables_py.h",
         "src/trace_processor/tables/v8_tables_fwd.h",
         "src/trace_processor/tables/v8_tables_py.h",
+        "src/trace_processor/tables/wattson_tables_fwd.h",
+        "src/trace_processor/tables/wattson_tables_py.h",
         "src/trace_processor/tables/winscope_tables_fwd.h",
         "src/trace_processor/tables/winscope_tables_py.h",
     ],
@@ -21223,6 +21282,7 @@ python_binary_host {
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
         "tools/gen_tp_table_headers.py",
     ],
@@ -21323,6 +21383,7 @@ cc_library_static {
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen",
@@ -21596,6 +21657,7 @@ cc_library_static {
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen_headers",
@@ -21704,6 +21766,7 @@ cc_library_static {
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen_headers",
@@ -24197,6 +24260,7 @@ cc_test {
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen",
@@ -24795,6 +24859,7 @@ cc_test {
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen_headers",
@@ -25459,6 +25524,7 @@ cc_library_static {
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen",
@@ -25714,6 +25780,7 @@ cc_library_static {
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen_headers",
@@ -25820,6 +25887,7 @@ cc_library_static {
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen_headers",
@@ -26015,6 +26083,7 @@ cc_binary {
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen",
         ":perfetto_src_base_base",
         ":perfetto_src_base_check_cpu_optimizations",
@@ -26075,6 +26144,7 @@ cc_binary {
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen_headers",
     ],
     defaults: [
@@ -26168,6 +26238,7 @@ cc_binary_host {
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen",
+        ":perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen",
         ":perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen",
@@ -26433,6 +26504,7 @@ cc_binary_host {
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero_gen_headers",
+        "perfetto_protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero_gen_headers",
         "perfetto_protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero_gen_headers",

--- a/Android.bp
+++ b/Android.bp
@@ -18439,6 +18439,7 @@ filegroup {
         "src/trace_processor/importers/proto/v8_sequence_state.cc",
         "src/trace_processor/importers/proto/v8_tracker.cc",
         "src/trace_processor/importers/proto/vulkan_memory_tracker.cc",
+        "src/trace_processor/importers/proto/wattson_soc_model_module.cc",
     ],
 }
 
@@ -18618,6 +18619,7 @@ filegroup {
         "src/trace_processor/importers/proto/proto_trace_reader_unittest.cc",
         "src/trace_processor/importers/proto/proto_trace_tokenizer_unittest.cc",
         "src/trace_processor/importers/proto/string_encoding_utils_unittests.cc",
+        "src/trace_processor/importers/proto/wattson_soc_model_module_unittest.cc",
     ],
 }
 

--- a/BUILD
+++ b/BUILD
@@ -3170,6 +3170,8 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/v8_tracker.h",
         "src/trace_processor/importers/proto/vulkan_memory_tracker.cc",
         "src/trace_processor/importers/proto/vulkan_memory_tracker.h",
+        "src/trace_processor/importers/proto/wattson_soc_model_module.cc",
+        "src/trace_processor/importers/proto/wattson_soc_model_module.h",
     ],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -676,6 +676,7 @@ perfetto_cc_library(
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
+               ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
                ":protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero",
                ":protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero",
                ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero",
@@ -1009,6 +1010,7 @@ perfetto_cc_library(
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
+               ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
                ":protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero",
                ":protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero",
                ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero",
@@ -5706,6 +5708,7 @@ perfetto_cc_tp_tables(
         "src/trace_processor/tables/trace_proto_tables.py",
         "src/trace_processor/tables/track_tables.py",
         "src/trace_processor/tables/v8_tables.py",
+        "src/trace_processor/tables/wattson_tables.py",
         "src/trace_processor/tables/winscope_tables.py",
     ],
     outs = [
@@ -5742,6 +5745,8 @@ perfetto_cc_tp_tables(
         "src/trace_processor/tables/track_tables_py.h",
         "src/trace_processor/tables/v8_tables_fwd.h",
         "src/trace_processor/tables/v8_tables_py.h",
+        "src/trace_processor/tables/wattson_tables_fwd.h",
+        "src/trace_processor/tables/wattson_tables_py.h",
         "src/trace_processor/tables/winscope_tables_fwd.h",
         "src/trace_processor/tables/winscope_tables_py.h",
     ],
@@ -7541,6 +7546,7 @@ perfetto_proto_library(
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_protos",
         ":protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_protos",
         ":protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_protos",
         ":protos_third_party_android_frameworks_native_tracing_frameworks_native_track_event_protos",
@@ -10154,6 +10160,7 @@ perfetto_proto_library(
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_protos",
         ":protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_protos",
         ":protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_protos",
         ":protos_third_party_android_frameworks_native_tracing_frameworks_native_track_event_protos",
@@ -10570,11 +10577,13 @@ perfetto_proto_library(
         ":protos_perfetto_trace_translation_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_protos",
     ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_non_minimal_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_protos",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_protos",
     ],
 )
 
@@ -10626,6 +10635,7 @@ perfetto_cc_protozero_library(
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_protos",
+        ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
     ],
 )
 
@@ -10658,6 +10668,25 @@ perfetto_cc_protozero_library(
         ":protos_perfetto_trace_track_event_zero",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_common_zero",
         ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_protos",
+    ],
+)
+
+# GN target: //protos/third_party/android/frameworks/base/proto/tracing:wattson_soc_model_source_set
+perfetto_proto_library(
+    name = "protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_protos",
+    srcs = [
+        "protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.proto",
+    ],
+    visibility = [
+        PERFETTO_CONFIG.proto_library_visibility,
+    ],
+)
+
+# GN target: //protos/third_party/android/frameworks/base/proto/tracing:wattson_soc_model_zero
+perfetto_cc_protozero_library(
+    name = "protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
+    deps = [
+        ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_protos",
     ],
 )
 
@@ -11911,6 +11940,7 @@ perfetto_cc_library(
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
+               ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
                ":protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero",
                ":protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero",
                ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero",
@@ -12248,6 +12278,7 @@ perfetto_cc_binary(
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_interned_data_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_trace_packet_zero",
                ":protos_third_party_android_frameworks_base_proto_tracing_frameworks_base_track_event_zero",
+               ":protos_third_party_android_frameworks_base_proto_tracing_wattson_soc_model_zero",
                ":protos_third_party_android_frameworks_native_tracing_frameworks_native_interned_data_zero",
                ":protos_third_party_android_frameworks_native_tracing_frameworks_native_trace_packet_zero",
                ":protos_third_party_android_frameworks_native_tracing_winscope_winscope_extensions_zero",

--- a/protos/third_party/android/frameworks/base/proto/tracing/BUILD.gn
+++ b/protos/third_party/android/frameworks/base/proto/tracing/BUILD.gn
@@ -18,6 +18,10 @@ perfetto_proto_library("frameworks_base_common_@TYPE@") {
   sources = [ "frameworks_base_common.proto" ]
 }
 
+perfetto_proto_library("wattson_soc_model_@TYPE@") {
+  sources = [ "wattson_soc_model.proto" ]
+}
+
 # Imports field_options.proto (a custom option), so it is protozero-only.
 perfetto_proto_library("frameworks_base_track_event_@TYPE@") {
   proto_generators = [ "zero" ]
@@ -44,6 +48,7 @@ perfetto_proto_library("frameworks_base_trace_packet_@TYPE@") {
   public_deps = [
     ":frameworks_base_common_@TYPE@",
     ":frameworks_base_interned_data_@TYPE@",
+    ":wattson_soc_model_@TYPE@",
     "../../../../../../perfetto/trace:non_minimal_@TYPE@",
   ]
   import_dirs = [ "${perfetto_protobuf_src_dir}" ]

--- a/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.proto
@@ -22,6 +22,7 @@ syntax = "proto2";
 import public "protos/perfetto/trace/trace_packet.proto";
 import "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_common.proto";
 import "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_interned_data.proto";
+import "protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.proto";
 
 package com.android.internal;
 
@@ -157,5 +158,7 @@ message FrameworksBaseTracePacket {
     optional VideoFrameError video_frame_error = 1001;
     optional AndroidProcessStateSnapshot android_process_state = 1002;
     optional AndroidFreezerStateSnapshot android_freezer_state = 1003;
+    // Wattson SoC power model definition.
+    optional WattsonSocModel wattson_soc_model = 1004;
   }
 }

--- a/protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.proto
+++ b/protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.proto
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+
+package com.android.internal;
+
+// Hardware topology & cluster configurations (replaces hardcoded rows in
+// device_infos.sql).
+message WattsonCpuTopology {
+  // Maps an individual physical CPU core to its cpufreq policy group.
+  message CpuMap {
+    optional int32 cpu = 1;
+    optional int32 policy = 2;
+    // Optional per-CPU override for deep idle offset (in ns).
+    optional int64 deep_idle_offset_ns = 3;
+    // Optional per-CPU override for 2D dependency vote by frequency.
+    optional bool vote_by_freq = 4;
+  }
+
+  // Properties belonging strictly to a cpufreq policy cluster.
+  message PolicyConfig {
+    optional int32 policy = 1;
+    // Deep idle time offset for this policy cluster (in nanoseconds).
+    optional int64 deep_idle_offset_ns = 2;
+    // Whether this policy cluster's 2D dependency votes by frequency.
+    optional bool vote_by_freq = 3;
+  }
+
+  // Mapping from nominal idle states to override idle states.
+  message IdleStateOverride {
+    optional int64 nominal_idle = 1;
+    optional int64 override_idle = 2;
+  }
+
+  repeated CpuMap cpu_map = 1;
+  repeated PolicyConfig policy_configs = 2;
+  repeated IdleStateOverride idle_state_map = 3;
+  optional bool use_devfreq = 4;
+}
+
+// CPU 1D Power Curve: Static, active, and idle power per policy frequency.
+message WattsonCpu1DCurve {
+  optional uint32 policy = 1;
+  optional uint32 freq_khz = 2;
+  optional double static_mw = 3;
+  optional double active_mw = 4;
+  optional double idle0_mw = 5;
+  optional double idle1_mw = 6;
+}
+
+// CPU 2D Power Curve: Power with inter-cluster frequency dependency.
+message WattsonCpu2DCurve {
+  optional uint32 policy = 1;
+  optional uint32 freq_khz = 2;
+  optional uint32 dep_policy = 3;
+  optional uint32 dep_freq_khz = 4;
+  optional double static_mw = 5;
+  optional double active_mw = 6;
+  optional double idle0_mw = 7;
+  optional double idle1_mw = 8;
+  optional double interconnect_mw = 9;
+}
+
+// GPU Power Curve: Active and multi-level idle power per GPU frequency.
+message WattsonGpuCurve {
+  optional uint32 freq_khz = 1;
+  optional double active_mw = 2;
+  optional double idle1_mw = 3;
+  optional double idle2_mw = 4;
+}
+
+// L3 Cache Power Curve: Hit/miss power per frequency and dependent CPU policy.
+message WattsonL3Curve {
+  optional uint32 freq_khz = 1;
+  optional uint32 dep_policy = 2;
+  optional uint32 dep_freq_khz = 3;
+  optional double l3_hit_mw = 4;
+  optional double l3_miss_mw = 5;
+}
+
+// TPU Power Curve: Active power per TPU cluster, frequency, and concurrent
+// requests.
+message WattsonTpuCurve {
+  optional uint32 cluster = 1;
+  optional uint32 requests = 2;
+  optional uint32 freq_khz = 3;
+  optional double active_mw = 4;
+}
+
+// Wattson SoC power model definition containing device hardware topology
+// and empirical power curves (CPU 1D/2D, GPU, L3, TPU).
+message WattsonSocModel {
+  enum ModelSource {
+    SOURCE_UNSPECIFIED = 0;
+    SOURCE_BUILTIN = 1;       // Compiled into Trace Processor binary
+    SOURCE_SOC_VENDOR = 2;    // Baseline model from SoC vendor
+    SOURCE_OEM_OVERRIDE = 3;  // OEM-calibrated / chassis-tuned model
+  }
+
+  // ===========================================================================
+  // 1–15: Metadata, Provenance, and Hardware Topology
+  // ===========================================================================
+  optional string device_name =
+      1;  // Canonical SoC model name (e.g. "Tensor G6")
+  optional string model_variant =
+      2;  // Specific SKU / chassis (e.g. "pixel11_pro")
+  optional ModelSource model_source = 3;         // Origin tier
+  optional uint32 model_version = 4;             // Monotonic version number
+  optional string vendor_name = 5;               // e.g. "Google", "Samsung"
+  optional WattsonCpuTopology cpu_topology = 6;  // Structured CPU topology
+  optional int32 gpu_id = 7;                     // GPU instance ID in trace
+
+  // ===========================================================================
+  // 16+: Subsystem Power Curves
+  // ===========================================================================
+  repeated WattsonCpu1DCurve cpu_1d_curves = 16;
+  repeated WattsonCpu2DCurve cpu_2d_curves = 17;
+  repeated WattsonGpuCurve gpu_curves = 18;
+  repeated WattsonL3Curve l3_curves = 19;
+  repeated WattsonTpuCurve tpu_curves = 20;
+}

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -211,6 +211,8 @@ source_set("full") {
     "v8_tracker.h",
     "vulkan_memory_tracker.cc",
     "vulkan_memory_tracker.h",
+    "wattson_soc_model_module.cc",
+    "wattson_soc_model_module.h",
   ]
   deps = [
     ":gen_cc_android_extension_descriptor",
@@ -238,6 +240,8 @@ source_set("full") {
     "../../../../protos/perfetto/trace/system_info:zero",
     "../../../../protos/perfetto/trace/translation:zero",
     "../../../../protos/third_party/android/art:art_heap_graph_zero",
+    "../../../../protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_trace_packet_zero",
+    "../../../../protos/third_party/android/frameworks/base/proto/tracing:wattson_soc_model_zero",
     "../../../../protos/third_party/android/frameworks/native/tracing:frameworks_native_trace_packet_zero",
     "../../../../protos/third_party/android/packages/modules/bluetooth/tracing:bluetooth_tracing_zero",
     "../../../base",
@@ -362,6 +366,7 @@ perfetto_unittest_source_set("unittests") {
     "proto_trace_reader_unittest.cc",
     "proto_trace_tokenizer_unittest.cc",
     "string_encoding_utils_unittests.cc",
+    "wattson_soc_model_module_unittest.cc",
   ]
   deps = [
     ":full",
@@ -388,6 +393,8 @@ perfetto_unittest_source_set("unittests") {
     "../../../../protos/perfetto/trace/track_event:zero",
     "../../../../protos/third_party/android/art:art_heap_graph_zero",
     "../../../../protos/third_party/android/connectivity:connectivity_network_trace_zero",
+    "../../../../protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_trace_packet_zero",
+    "../../../../protos/third_party/android/frameworks/base/proto/tracing:wattson_soc_model_zero",
     "../../../../protos/third_party/chromium:zero",
     "../../../base:test_support",
     "../../../protozero",

--- a/src/trace_processor/importers/proto/additional_modules.cc
+++ b/src/trace_processor/importers/proto/additional_modules.cc
@@ -43,6 +43,7 @@
 #include "src/trace_processor/importers/proto/trace.descriptor.h"
 #include "src/trace_processor/importers/proto/translation_table_module.h"
 #include "src/trace_processor/importers/proto/v8_module.h"
+#include "src/trace_processor/importers/proto/wattson_soc_model_module.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
 namespace perfetto::trace_processor {
@@ -86,6 +87,8 @@ void RegisterAdditionalModules(ProtoImporterModuleContext* module_context,
       new ProfileModule(module_context, context));
   module_context->modules.emplace_back(
       new AppWakelockModule(module_context, context));
+  module_context->modules.emplace_back(
+      new WattsonSocModelModule(module_context, context));
   module_context->modules.emplace_back(
       new ConcurrentSessionsModule(module_context, context));
   module_context->modules.emplace_back(

--- a/src/trace_processor/importers/proto/wattson_soc_model_module.cc
+++ b/src/trace_processor/importers/proto/wattson_soc_model_module.cc
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/wattson_soc_model_module.h"
+
+#include <cstdint>
+#include <string>
+
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/string_view.h"
+#include "perfetto/protozero/field.h"
+#include "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.pbzero.h"
+#include "protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.pbzero.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/wattson_tables_py.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor {
+
+using ::com::android::internal::pbzero::FrameworksBaseTracePacket;
+using ::com::android::internal::pbzero::WattsonCpu1DCurve;
+using ::com::android::internal::pbzero::WattsonCpu2DCurve;
+using ::com::android::internal::pbzero::WattsonCpuTopology;
+using ::com::android::internal::pbzero::WattsonGpuCurve;
+using ::com::android::internal::pbzero::WattsonL3Curve;
+using ::com::android::internal::pbzero::WattsonSocModel;
+using ::com::android::internal::pbzero::WattsonTpuCurve;
+using ::protozero::ConstBytes;
+
+WattsonSocModelModule::WattsonSocModelModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context), context_(context) {
+  RegisterForField(FrameworksBaseTracePacket::kWattsonSocModelFieldNumber);
+}
+
+WattsonSocModelModule::~WattsonSocModelModule() = default;
+
+void WattsonSocModelModule::ParseField(const ParseFieldArgs& args) {
+  if (args.field.id() ==
+      FrameworksBaseTracePacket::kWattsonSocModelFieldNumber) {
+    ParseWattsonSocModel(
+        args.field.Cast<FrameworksBaseTracePacket::kWattsonSocModel>());
+  }
+}
+
+void WattsonSocModelModule::ParseWattsonSocModel(ConstBytes blob) {
+  WattsonSocModel::Decoder model(blob);
+
+  // 1. Device Info / Metadata
+  StringId device_name_id =
+      model.has_device_name()
+          ? context_->storage->InternString(model.device_name())
+          : context_->storage->InternString("Custom_SoC");
+
+  tables::WattsonCustomDeviceInfoTable::Row info_row;
+  info_row.device_name = device_name_id;
+  info_row.use_devfreq = 0;
+  if (model.has_gpu_id()) {
+    info_row.gpu_id = model.gpu_id();
+  }
+
+  // 2. Structured CPU Topology
+  if (model.has_cpu_topology()) {
+    WattsonCpuTopology::Decoder topology(model.cpu_topology());
+    if (topology.has_use_devfreq()) {
+      info_row.use_devfreq = topology.use_devfreq() ? 1 : 0;
+    }
+
+    base::FlatHashMap<int32_t, int64_t> policy_deep_idle;
+    base::FlatHashMap<int32_t, bool> policy_vote_by_freq;
+
+    for (auto it = topology.policy_configs(); it; ++it) {
+      WattsonCpuTopology::PolicyConfig::Decoder cfg(*it);
+      if (cfg.has_policy()) {
+        if (cfg.has_deep_idle_offset_ns()) {
+          policy_deep_idle[cfg.policy()] = cfg.deep_idle_offset_ns();
+        }
+        if (cfg.has_vote_by_freq()) {
+          policy_vote_by_freq[cfg.policy()] = cfg.vote_by_freq();
+        }
+      }
+    }
+
+    for (auto it = topology.cpu_map(); it; ++it) {
+      WattsonCpuTopology::CpuMap::Decoder cpu_map(*it);
+      int32_t cpu = cpu_map.cpu();
+      int32_t policy = cpu_map.policy();
+
+      tables::WattsonCustomCpuPolicyTable::Row row;
+      row.cpu = cpu;
+      row.policy = policy;
+      context_->storage->mutable_wattson_custom_cpu_policy_table()->Insert(row);
+
+      if (cpu_map.has_deep_idle_offset_ns()) {
+        tables::WattsonCustomDeepIdleOffsetTable::Row dio_row;
+        dio_row.cpu = cpu;
+        dio_row.offset_ns = cpu_map.deep_idle_offset_ns();
+        context_->storage->mutable_wattson_custom_deep_idle_offset_table()
+            ->Insert(dio_row);
+      } else if (auto* offset = policy_deep_idle.Find(policy)) {
+        tables::WattsonCustomDeepIdleOffsetTable::Row dio_row;
+        dio_row.cpu = cpu;
+        dio_row.offset_ns = *offset;
+        context_->storage->mutable_wattson_custom_deep_idle_offset_table()
+            ->Insert(dio_row);
+      }
+
+      bool vote = cpu_map.has_vote_by_freq()
+                      ? cpu_map.vote_by_freq()
+                      : (policy_vote_by_freq.Find(policy)
+                             ? *policy_vote_by_freq.Find(policy)
+                             : false);
+      if (vote) {
+        tables::WattsonCustomVoteByFreqTable::Row vbf_row;
+        vbf_row.cpu = cpu;
+        context_->storage->mutable_wattson_custom_vote_by_freq_table()->Insert(
+            vbf_row);
+      }
+    }
+
+    for (auto it = topology.idle_state_map(); it; ++it) {
+      WattsonCpuTopology::IdleStateOverride::Decoder idle(*it);
+      tables::WattsonCustomIdleStateMapTable::Row row;
+      row.nominal_idle = idle.nominal_idle();
+      row.override_idle = static_cast<int32_t>(idle.override_idle());
+      context_->storage->mutable_wattson_custom_idle_state_map_table()->Insert(
+          row);
+    }
+  }
+
+  context_->storage->mutable_wattson_custom_device_info_table()->Insert(
+      info_row);
+
+  // 3. CPU 1D Curves (Field 16)
+  for (auto cpu_1d_it = model.cpu_1d_curves(); cpu_1d_it; ++cpu_1d_it) {
+    WattsonCpu1DCurve::Decoder curve(*cpu_1d_it);
+    tables::WattsonCustomCurvesCpu1DTable::Row row;
+    row.policy = static_cast<int32_t>(curve.policy());
+    row.freq_khz = static_cast<int64_t>(curve.freq_khz());
+    row.static_mw = curve.static_mw();
+    row.active_mw = curve.active_mw();
+    row.idle0_mw = curve.idle0_mw();
+    row.idle1_mw = curve.idle1_mw();
+    context_->storage->mutable_wattson_custom_curves_cpu_1d_table()->Insert(
+        row);
+  }
+
+  // 4. CPU 2D Curves (Field 17)
+  for (auto cpu_2d_it = model.cpu_2d_curves(); cpu_2d_it; ++cpu_2d_it) {
+    WattsonCpu2DCurve::Decoder curve(*cpu_2d_it);
+    tables::WattsonCustomCurvesCpu2DTable::Row row;
+    row.policy = static_cast<int32_t>(curve.policy());
+    row.freq_khz = static_cast<int64_t>(curve.freq_khz());
+    row.dep_policy = static_cast<int32_t>(curve.dep_policy());
+    row.dep_freq = static_cast<int64_t>(curve.dep_freq_khz());
+    row.static_mw = curve.static_mw();
+    row.active_mw = curve.active_mw();
+    row.idle0_mw = curve.idle0_mw();
+    row.idle1_mw = curve.idle1_mw();
+    row.interconnect_mw = curve.interconnect_mw();
+    context_->storage->mutable_wattson_custom_curves_cpu_2d_table()->Insert(
+        row);
+  }
+
+  // 5. L3 Curves (Field 19)
+  for (auto l3_it = model.l3_curves(); l3_it; ++l3_it) {
+    WattsonL3Curve::Decoder curve(*l3_it);
+    tables::WattsonCustomCurvesL3Table::Row row;
+    row.freq_khz = static_cast<int64_t>(curve.freq_khz());
+    row.dep_policy = static_cast<int32_t>(curve.dep_policy());
+    row.dep_freq = static_cast<int64_t>(curve.dep_freq_khz());
+    row.l3_hit_mw = curve.l3_hit_mw();
+    row.l3_miss_mw = curve.l3_miss_mw();
+    context_->storage->mutable_wattson_custom_curves_l3_table()->Insert(row);
+  }
+
+  // 6. GPU Curves (Field 18)
+  for (auto gpu_it = model.gpu_curves(); gpu_it; ++gpu_it) {
+    WattsonGpuCurve::Decoder curve(*gpu_it);
+    tables::WattsonCustomCurvesGpuTable::Row row;
+    row.freq_khz = static_cast<int64_t>(curve.freq_khz());
+    row.active_mw = curve.active_mw();
+    row.idle1_mw = curve.idle1_mw();
+    row.idle2_mw = curve.idle2_mw();
+    context_->storage->mutable_wattson_custom_curves_gpu_table()->Insert(row);
+  }
+
+  // 7. TPU Curves (Field 20)
+  for (auto tpu_it = model.tpu_curves(); tpu_it; ++tpu_it) {
+    WattsonTpuCurve::Decoder curve(*tpu_it);
+    tables::WattsonCustomCurvesTpuTable::Row row;
+    row.cluster = static_cast<int32_t>(curve.cluster());
+    row.requests = static_cast<int32_t>(curve.requests());
+    row.freq = static_cast<int64_t>(curve.freq_khz());
+    row.active_mw = curve.active_mw();
+    context_->storage->mutable_wattson_custom_curves_tpu_table()->Insert(row);
+  }
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/wattson_soc_model_module.h
+++ b/src/trace_processor/importers/proto/wattson_soc_model_module.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WATTSON_SOC_MODEL_MODULE_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WATTSON_SOC_MODEL_MODULE_H_
+
+#include <cstdint>
+
+#include "perfetto/protozero/field.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+
+namespace perfetto::trace_processor {
+
+class TraceProcessorContext;
+
+class WattsonSocModelModule : public ProtoImporterModule {
+ public:
+  WattsonSocModelModule(ProtoImporterModuleContext* module_context,
+                        TraceProcessorContext* context);
+  ~WattsonSocModelModule() override;
+
+  void ParseField(const ParseFieldArgs& args) override;
+
+ private:
+  void ParseWattsonSocModel(protozero::ConstBytes blob);
+
+  TraceProcessorContext* const context_;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WATTSON_SOC_MODEL_MODULE_H_

--- a/src/trace_processor/importers/proto/wattson_soc_model_module_unittest.cc
+++ b/src/trace_processor/importers/proto/wattson_soc_model_module_unittest.cc
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/wattson_soc_model_module.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/trace_processor/trace_blob.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
+#include "protos/perfetto/common/builtin_clock.pbzero.h"
+#include "protos/perfetto/trace/trace.pbzero.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.pbzero.h"
+#include "protos/third_party/android/frameworks/base/proto/tracing/wattson_soc_model.pbzero.h"
+#include "src/trace_processor/importers/common/args_translation_table.h"
+#include "src/trace_processor/importers/common/clock_tracker.h"
+#include "src/trace_processor/importers/common/global_args_tracker.h"
+#include "src/trace_processor/importers/common/global_metadata_tracker.h"
+#include "src/trace_processor/importers/common/global_stats_tracker.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
+#include "src/trace_processor/importers/common/machine_tracker.h"
+#include "src/trace_processor/importers/common/metadata_tracker.h"
+#include "src/trace_processor/importers/common/process_track_translation_table.h"
+#include "src/trace_processor/importers/common/slice_tracker.h"
+#include "src/trace_processor/importers/common/slice_translation_table.h"
+#include "src/trace_processor/importers/common/stats_tracker.h"
+#include "src/trace_processor/importers/common/track_compressor.h"
+#include "src/trace_processor/importers/common/track_tracker.h"
+#include "src/trace_processor/importers/proto/additional_modules.h"
+#include "src/trace_processor/importers/proto/proto_trace_reader.h"
+#include "src/trace_processor/sorter/trace_sorter.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/wattson_tables_py.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/types/trace_processor_context_ptr.h"
+#include "src/trace_processor/util/clock_synchronizer.h"
+#include "src/trace_processor/util/descriptors.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+using ::com::android::internal::pbzero::FrameworksBaseTracePacket;
+using ::com::android::internal::pbzero::WattsonCpu1DCurve;
+using ::com::android::internal::pbzero::WattsonCpu2DCurve;
+using ::com::android::internal::pbzero::WattsonCpuTopology;
+using ::com::android::internal::pbzero::WattsonGpuCurve;
+using ::com::android::internal::pbzero::WattsonL3Curve;
+using ::com::android::internal::pbzero::WattsonSocModel;
+using ::com::android::internal::pbzero::WattsonTpuCurve;
+using ::testing::DoubleEq;
+using ::testing::Eq;
+
+class WattsonSocModelModuleTest : public testing::Test {
+ public:
+  WattsonSocModelModuleTest() {
+    context_.register_additional_proto_modules = &RegisterAdditionalModules;
+    context_.storage = std::make_unique<TraceStorage>();
+    context_.global_stats_tracker =
+        std::make_unique<GlobalStatsTracker>(context_.storage.get());
+    storage_ = context_.storage.get();
+    context_.machine_tracker =
+        std::make_unique<MachineTracker>(&context_, kDefaultMachineId);
+    context_.global_metadata_tracker =
+        std::make_unique<GlobalMetadataTracker>(context_.storage.get());
+    context_.trace_state =
+        TraceProcessorContextPtr<TraceProcessorContext::TraceState>::MakeRoot(
+            TraceProcessorContext::TraceState{TraceId(0)});
+    context_.stats_tracker = std::make_unique<StatsTracker>(&context_);
+    context_.metadata_tracker = std::make_unique<MetadataTracker>(&context_);
+    context_.import_logs_tracker =
+        std::make_unique<ImportLogsTracker>(&context_, TraceId(1));
+    context_.trace_time_state = std::make_unique<TraceTimeState>(
+        ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_BOOTTIME));
+    primary_sync_ = std::make_unique<ClockSynchronizer>(
+        context_.trace_time_state.get(),
+        std::make_unique<ClockSynchronizerListenerImpl>(&context_));
+    context_.clock_tracker = std::make_unique<ClockTracker>(
+        &context_, primary_sync_.get(), /*is_primary=*/true);
+    context_.track_tracker = std::make_unique<TrackTracker>(&context_);
+    context_.slice_tracker = std::make_unique<SliceTracker>(&context_);
+    context_.global_args_tracker =
+        std::make_unique<GlobalArgsTracker>(storage_);
+    context_.slice_translation_table =
+        std::make_unique<SliceTranslationTable>(storage_);
+    context_.process_track_translation_table =
+        std::make_unique<ProcessTrackTranslationTable>(storage_);
+    context_.args_translation_table =
+        std::make_unique<ArgsTranslationTable>(storage_);
+    context_.track_compressor = std::make_unique<TrackCompressor>(&context_);
+    context_.descriptor_pool_ = std::make_unique<DescriptorPool>();
+
+    context_.sorter = std::make_unique<TraceSorter>(
+        &context_, TraceSorter::SortingMode::kFullSort);
+    reader_ = std::make_unique<ProtoTraceReader>(&context_);
+  }
+
+  void Tokenize(const uint8_t* data, size_t size) {
+    auto blob = TraceBlob::CopyFrom(data, size);
+    auto status = reader_->Parse(TraceBlobView(std::move(blob)));
+    ASSERT_TRUE(status.ok()) << status.message();
+    context_.sorter->ExtractEventsForced();
+  }
+
+ protected:
+  TraceProcessorContext context_;
+  TraceStorage* storage_;
+  std::unique_ptr<ClockSynchronizer> primary_sync_;
+  std::unique_ptr<ProtoTraceReader> reader_;
+};
+
+TEST_F(WattsonSocModelModuleTest, ParseWattsonSocModel) {
+  protozero::HeapBuffered<protos::pbzero::Trace> trace;
+
+  // Build a WattsonSocModel
+  protozero::HeapBuffered<WattsonSocModel> model;
+  model->set_device_name("Tensor G6");
+  model->set_gpu_id(0);
+
+  auto* topology = model->set_cpu_topology();
+  topology->set_use_devfreq(true);
+
+  // CPU policies: CPU 0..3 -> policy 0, CPU 4..6 -> policy 4, CPU 7 -> policy 7
+  {
+    auto* cp = topology->add_cpu_map();
+    cp->set_cpu(0);
+    cp->set_policy(0);
+    cp->set_deep_idle_offset_ns(0);
+  }
+  for (int cpu = 1; cpu < 4; ++cpu) {
+    auto* cp = topology->add_cpu_map();
+    cp->set_cpu(cpu);
+    cp->set_policy(0);
+  }
+  for (int cpu = 4; cpu < 7; ++cpu) {
+    auto* cp = topology->add_cpu_map();
+    cp->set_cpu(cpu);
+    cp->set_policy(4);
+  }
+  {
+    auto* cp = topology->add_cpu_map();
+    cp->set_cpu(7);
+    cp->set_policy(7);
+  }
+
+  // Policy config for policy 7: 200000ns deep idle offset, vote by freq
+  {
+    auto* pc = topology->add_policy_configs();
+    pc->set_policy(7);
+    pc->set_deep_idle_offset_ns(200000);
+    pc->set_vote_by_freq(true);
+  }
+
+  // Idle state map: nominal 2 -> override 1
+  {
+    auto* idle = topology->add_idle_state_map();
+    idle->set_nominal_idle(2);
+    idle->set_override_idle(1);
+  }
+
+  // 1D power curve: policy 0 @ 1000000 kHz
+  {
+    auto* c1d = model->add_cpu_1d_curves();
+    c1d->set_policy(0);
+    c1d->set_freq_khz(1000000);
+    c1d->set_static_mw(5.5);
+    c1d->set_active_mw(45.0);
+    c1d->set_idle0_mw(1.2);
+    c1d->set_idle1_mw(0.1);
+  }
+
+  // 2D power curve: policy 7 @ 3000000 kHz, dep_policy 4 @ 2000000 kHz
+  {
+    auto* c2d = model->add_cpu_2d_curves();
+    c2d->set_policy(7);
+    c2d->set_freq_khz(3000000);
+    c2d->set_dep_policy(4);
+    c2d->set_dep_freq_khz(2000000);
+    c2d->set_static_mw(25.0);
+    c2d->set_active_mw(350.0);
+    c2d->set_idle0_mw(2.5);
+    c2d->set_idle1_mw(0.2);
+    c2d->set_interconnect_mw(18.0);
+  }
+
+  // L3 curve
+  {
+    auto* l3 = model->add_l3_curves();
+    l3->set_freq_khz(1500000);
+    l3->set_dep_policy(4);
+    l3->set_dep_freq_khz(2000000);
+    l3->set_l3_hit_mw(12.5);
+    l3->set_l3_miss_mw(34.0);
+  }
+
+  // GPU curve
+  {
+    auto* gpu = model->add_gpu_curves();
+    gpu->set_freq_khz(800000);
+    gpu->set_active_mw(280.0);
+    gpu->set_idle1_mw(6.0);
+    gpu->set_idle2_mw(1.5);
+  }
+
+  // TPU curve
+  {
+    auto* tpu = model->add_tpu_curves();
+    tpu->set_cluster(0);
+    tpu->set_requests(1);
+    tpu->set_freq_khz(1200000);
+    tpu->set_active_mw(420.0);
+  }
+
+  auto model_bytes = model.SerializeAsArray();
+
+  // Wrap in TracePacket
+  auto* packet = trace->add_packet();
+  packet->set_timestamp(1000);
+  packet->AppendBytes(FrameworksBaseTracePacket::kWattsonSocModelFieldNumber,
+                      reinterpret_cast<const char*>(model_bytes.data()),
+                      model_bytes.size());
+
+  auto trace_bytes = trace.SerializeAsArray();
+  Tokenize(trace_bytes.data(), trace_bytes.size());
+
+  // 1. Verify Device Info Table
+  const auto& dev_table = storage_->wattson_custom_device_info_table();
+  ASSERT_EQ(dev_table.row_count(), 1u);
+  EXPECT_STREQ(storage_->GetString(dev_table[0].device_name()).c_str(),
+               "Tensor G6");
+  EXPECT_EQ(dev_table[0].use_devfreq(), 1);
+  EXPECT_EQ(dev_table[0].gpu_id().value_or(-1), 0);
+
+  // 2. Verify CPU Policies Table
+  const auto& policy_table = storage_->wattson_custom_cpu_policy_table();
+  ASSERT_EQ(policy_table.row_count(), 8u);
+  EXPECT_EQ(policy_table[0].cpu(), 0);
+  EXPECT_EQ(policy_table[0].policy(), 0);
+  EXPECT_EQ(policy_table[4].cpu(), 4);
+  EXPECT_EQ(policy_table[4].policy(), 4);
+  EXPECT_EQ(policy_table[7].cpu(), 7);
+  EXPECT_EQ(policy_table[7].policy(), 7);
+
+  // 3. Verify Deep Idle Offsets
+  const auto& dio_table = storage_->wattson_custom_deep_idle_offset_table();
+  ASSERT_EQ(dio_table.row_count(), 2u);
+  EXPECT_EQ(dio_table[0].cpu(), 0);
+  EXPECT_EQ(dio_table[0].offset_ns(), 0);
+  EXPECT_EQ(dio_table[1].cpu(), 7);
+  EXPECT_EQ(dio_table[1].offset_ns(), 200000);
+
+  // 4. Verify Idle State Map
+  const auto& idle_table = storage_->wattson_custom_idle_state_map_table();
+  ASSERT_EQ(idle_table.row_count(), 1u);
+  EXPECT_EQ(idle_table[0].nominal_idle(), 2);
+  EXPECT_EQ(idle_table[0].override_idle(), 1);
+
+  // 5. Verify Vote By Freq
+  const auto& vbf_table = storage_->wattson_custom_vote_by_freq_table();
+  ASSERT_EQ(vbf_table.row_count(), 1u);
+  EXPECT_EQ(vbf_table[0].cpu(), 7);
+
+  // 6. Verify 1D Curves
+  const auto& c1d_table = storage_->wattson_custom_curves_cpu_1d_table();
+  ASSERT_EQ(c1d_table.row_count(), 1u);
+  EXPECT_EQ(c1d_table[0].policy(), 0);
+  EXPECT_EQ(c1d_table[0].freq_khz(), 1000000);
+  EXPECT_THAT(c1d_table[0].static_mw(), DoubleEq(5.5));
+  EXPECT_THAT(c1d_table[0].active_mw(), DoubleEq(45.0));
+
+  // 7. Verify 2D Curves
+  const auto& c2d_table = storage_->wattson_custom_curves_cpu_2d_table();
+  ASSERT_EQ(c2d_table.row_count(), 1u);
+  EXPECT_EQ(c2d_table[0].policy(), 7);
+  EXPECT_EQ(c2d_table[0].freq_khz(), 3000000);
+  EXPECT_EQ(c2d_table[0].dep_policy(), 4);
+  EXPECT_EQ(c2d_table[0].dep_freq(), 2000000);
+  EXPECT_THAT(c2d_table[0].static_mw(), DoubleEq(25.0));
+  EXPECT_THAT(c2d_table[0].active_mw(), DoubleEq(350.0));
+  EXPECT_THAT(c2d_table[0].interconnect_mw(), DoubleEq(18.0));
+
+  // 8. Verify L3 Curves
+  const auto& l3_table = storage_->wattson_custom_curves_l3_table();
+  ASSERT_EQ(l3_table.row_count(), 1u);
+  EXPECT_EQ(l3_table[0].freq_khz(), 1500000);
+  EXPECT_THAT(l3_table[0].l3_hit_mw(), DoubleEq(12.5));
+  EXPECT_THAT(l3_table[0].l3_miss_mw(), DoubleEq(34.0));
+
+  // 9. Verify GPU Curves
+  const auto& gpu_table = storage_->wattson_custom_curves_gpu_table();
+  ASSERT_EQ(gpu_table.row_count(), 1u);
+  EXPECT_EQ(gpu_table[0].freq_khz(), 800000);
+  EXPECT_THAT(gpu_table[0].active_mw(), DoubleEq(280.0));
+
+  // 10. Verify TPU Curves
+  const auto& tpu_table = storage_->wattson_custom_curves_tpu_table();
+  ASSERT_EQ(tpu_table.row_count(), 1u);
+  EXPECT_EQ(tpu_table[0].cluster(), 0);
+  EXPECT_EQ(tpu_table[0].requests(), 1);
+  EXPECT_EQ(tpu_table[0].freq(), 1200000);
+  EXPECT_THAT(tpu_table[0].active_mw(), DoubleEq(420.0));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/curves/cpu_1d.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/curves/cpu_1d.sql
@@ -18,4 +18,14 @@
 -- rows come from the wattson plugin (see
 -- src/trace_processor/plugins/wattson/).
 CREATE PERFETTO TABLE _device_curves_1d AS
+SELECT
+  (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+  policy,
+  freq_khz,
+  static_mw AS static,
+  active_mw AS active,
+  idle0_mw AS idle0,
+  idle1_mw AS idle1
+FROM __intrinsic_wattson_custom_curves_cpu_1d
+UNION ALL
 SELECT * FROM __intrinsic_wattson_curves_cpu_1d();

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/curves/cpu_2d.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/curves/cpu_2d.sql
@@ -18,4 +18,17 @@
 -- come from the wattson plugin (see
 -- src/trace_processor/plugins/wattson/).
 CREATE PERFETTO TABLE _device_curves_2d AS
+SELECT
+  (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+  policy,
+  freq_khz,
+  dep_policy,
+  dep_freq,
+  static_mw AS static,
+  active_mw AS active,
+  idle0_mw AS idle0,
+  idle1_mw AS idle1,
+  interconnect_mw AS interconnect
+FROM __intrinsic_wattson_custom_curves_cpu_2d
+UNION ALL
 SELECT * FROM __intrinsic_wattson_curves_cpu_2d();

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/curves/gpu.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/curves/gpu.sql
@@ -16,4 +16,12 @@
 -- Device specific GPU curves. The rows come from the wattson plugin
 -- (see src/trace_processor/plugins/wattson/).
 CREATE PERFETTO TABLE _gpu_device_curves AS
+SELECT
+  (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+  freq_khz,
+  active_mw AS active,
+  idle1_mw AS idle1,
+  idle2_mw AS idle2
+FROM __intrinsic_wattson_custom_curves_gpu
+UNION ALL
 SELECT * FROM __intrinsic_wattson_curves_gpu();

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/curves/l3.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/curves/l3.sql
@@ -16,4 +16,13 @@
 -- Device specific L3 curves. The rows come from the wattson plugin
 -- (see src/trace_processor/plugins/wattson/).
 CREATE PERFETTO TABLE _device_curves_l3 AS
+SELECT
+  (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+  freq_khz,
+  dep_policy,
+  dep_freq,
+  l3_hit_mw AS l3_hit,
+  l3_miss_mw AS l3_miss
+FROM __intrinsic_wattson_custom_curves_l3
+UNION ALL
 SELECT * FROM __intrinsic_wattson_curves_l3();

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/curves/tpu.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/curves/tpu.sql
@@ -16,4 +16,12 @@
 -- Device specific TPU curves. The rows come from the wattson plugin
 -- (see src/trace_processor/plugins/wattson/).
 CREATE PERFETTO TABLE _tpu_device_curves AS
+SELECT
+  (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+  cluster,
+  requests,
+  freq,
+  active_mw AS active
+FROM __intrinsic_wattson_custom_curves_tpu
+UNION ALL
 SELECT * FROM __intrinsic_wattson_curves_tpu();

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
@@ -20,6 +20,13 @@ INCLUDE PERFETTO MODULE wattson.utils;
 -- Device specific info for deep idle time offsets
 CREATE PERFETTO TABLE _device_cpu_deep_idle_offsets AS
 WITH
+  custom_data AS (
+    SELECT
+      (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+      cpu,
+      offset_ns
+    FROM __intrinsic_wattson_custom_deep_idle_offset
+  ),
   data(device, cpu, offset_ns) AS (
     SELECT *
     FROM (
@@ -112,6 +119,8 @@ WITH
         ), ("SM8750", 7, 0)
     ) AS _values
   )
+SELECT * FROM custom_data
+UNION ALL
 SELECT * FROM data;
 
 CREATE PERFETTO TABLE _linux_soc_compatible_map AS
@@ -196,6 +205,8 @@ WITH
   soc_model AS (
     SELECT
       coalesce(
+        -- Get custom dynamic model if present
+        (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1),
         -- Get guest model from metadata, which takes precedence if set
         (
           SELECT coalesce(map.wattson_device, m.str_value)
@@ -255,6 +266,13 @@ JOIN _device_cpu_deep_idle_offsets AS map
 -- Device specific mapping from CPU to policy
 CREATE PERFETTO TABLE _cpu_to_policy_map AS
 WITH
+  custom_data AS (
+    SELECT
+      (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+      cpu,
+      policy
+    FROM __intrinsic_wattson_custom_cpu_policy
+  ),
   data(device, cpu, policy) AS (
     SELECT *
     FROM (
@@ -342,6 +360,8 @@ WITH
         ), ("SM8750", 5, 0), ("SM8750", 6, 6), ("SM8750", 7, 6)
     ) AS _values
   )
+SELECT * FROM custom_data
+UNION ALL
 SELECT * FROM data;
 
 -- Prefilter table based on device
@@ -388,10 +408,19 @@ FROM _dev_policies;
 -- Devices that require using devfreq
 CREATE PERFETTO TABLE _use_devfreq AS
 WITH
+  custom_data AS (
+    SELECT
+      (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device
+    FROM __intrinsic_wattson_custom_device_info
+    WHERE
+      use_devfreq = 1
+  ),
   data(device) AS (
     SELECT *
     FROM (VALUES ("Tensor G4"), ("Tensor G5"), ("Tensor G6")) AS _values
   )
+SELECT * FROM custom_data
+UNION ALL
 SELECT * FROM data;
 
 -- Creates non-empty table if device needs devfreq
@@ -410,6 +439,13 @@ WHERE
 -- Devices that require idle state mapping
 CREATE PERFETTO TABLE _idle_state_map AS
 WITH
+  custom_data AS (
+    SELECT
+      (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+      nominal_idle,
+      override_idle
+    FROM __intrinsic_wattson_custom_idle_state_map
+  ),
   data(device, nominal_idle, override_idle) AS (
     SELECT *
     FROM (
@@ -447,6 +483,8 @@ WITH
         ), ("SXR2230P", 2, 1)
     ) AS _values
   )
+SELECT * FROM custom_data
+UNION ALL
 SELECT * FROM data;
 
 -- idle_mapping override filtered for device
@@ -466,6 +504,12 @@ SELECT
 -- frequency (as opposed to the default, vote by power)
 CREATE PERFETTO TABLE _vote_by_freq AS
 WITH
+  custom_data AS (
+    SELECT
+      (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+      cpu
+    FROM __intrinsic_wattson_custom_vote_by_freq
+  ),
   data(device, cpu) AS (
     SELECT *
     FROM (
@@ -477,6 +521,8 @@ WITH
         ), ("Tensor G6", 4), ("Tensor G6", 5), ("Tensor G6", 6)
     ) AS _values
   )
+SELECT * FROM custom_data
+UNION ALL
 SELECT * FROM data;
 
 -- Gets all CPUs on device and whether the CPU vote is be freq or power
@@ -497,8 +543,18 @@ ORDER BY
 -- Device specific mapping to GPU ID
 CREATE PERFETTO TABLE _gpuid_map AS
 WITH
+  custom_data AS (
+    SELECT
+      (SELECT device_name FROM __intrinsic_wattson_custom_device_info LIMIT 1) AS device,
+      gpu_id
+    FROM __intrinsic_wattson_custom_device_info
+    WHERE
+      gpu_id IS NOT NULL
+  ),
   data(device, gpu_id) AS (
     SELECT *
     FROM (VALUES ("Tensor G5", 0), ("Tensor G6", 0), ("Tensor", 1)) AS _values
   )
+SELECT * FROM custom_data
+UNION ALL
 SELECT * FROM data;

--- a/src/trace_processor/plugins/storage_tables/storage_tables.cc
+++ b/src/trace_processor/plugins/storage_tables/storage_tables.cc
@@ -42,6 +42,7 @@
 #include "src/trace_processor/tables/state_tables_py.h"     // IWYU pragma: keep
 #include "src/trace_processor/tables/trace_proto_tables_py.h"  // IWYU pragma: keep
 #include "src/trace_processor/tables/v8_tables_py.h"        // IWYU pragma: keep
+#include "src/trace_processor/tables/wattson_tables_py.h"   // IWYU pragma: keep
 #include "src/trace_processor/tables/winscope_tables_py.h"  // IWYU pragma: keep
 #include "src/trace_processor/types/trace_processor_context.h"
 
@@ -183,6 +184,16 @@ class StorageTablesPlugin : public Plugin<StorageTablesPlugin> {
     AddDataframe(out, s->mutable_memory_snapshot_node_table());
     AddDataframe(out, s->mutable_experimental_proto_path_table());
     AddDataframe(out, s->mutable_arg_table());
+    AddDataframe(out, s->mutable_wattson_custom_device_info_table());
+    AddDataframe(out, s->mutable_wattson_custom_cpu_policy_table());
+    AddDataframe(out, s->mutable_wattson_custom_deep_idle_offset_table());
+    AddDataframe(out, s->mutable_wattson_custom_idle_state_map_table());
+    AddDataframe(out, s->mutable_wattson_custom_vote_by_freq_table());
+    AddDataframe(out, s->mutable_wattson_custom_curves_cpu_1d_table());
+    AddDataframe(out, s->mutable_wattson_custom_curves_cpu_2d_table());
+    AddDataframe(out, s->mutable_wattson_custom_curves_l3_table());
+    AddDataframe(out, s->mutable_wattson_custom_curves_gpu_table());
+    AddDataframe(out, s->mutable_wattson_custom_curves_tpu_table());
     AddDataframe(out, s->mutable_heap_graph_object_table());
     AddDataframe(out, s->mutable_heap_graph_primitive_table());
     AddDataframe(out, s->mutable_heap_graph_object_data_table());

--- a/src/trace_processor/storage/trace_storage.cc
+++ b/src/trace_processor/storage/trace_storage.cc
@@ -44,6 +44,7 @@
 #include "src/trace_processor/tables/trace_proto_tables_py.h"  // IWYU pragma: keep
 #include "src/trace_processor/tables/track_tables_py.h"     // IWYU pragma: keep
 #include "src/trace_processor/tables/v8_tables_py.h"        // IWYU pragma: keep
+#include "src/trace_processor/tables/wattson_tables_py.h"   // IWYU pragma: keep
 #include "src/trace_processor/tables/winscope_tables_py.h"  // IWYU pragma: keep
 #include "src/trace_processor/types/variadic.h"
 

--- a/src/trace_processor/storage/trace_storage.h
+++ b/src/trace_processor/storage/trace_storage.h
@@ -1047,6 +1047,95 @@ class TraceStorage {
     return mutable_table<tables::ProtoLogTable>();
   }
 
+  const tables::WattsonCustomDeviceInfoTable& wattson_custom_device_info_table()
+      const {
+    return table<tables::WattsonCustomDeviceInfoTable>();
+  }
+  tables::WattsonCustomDeviceInfoTable*
+  mutable_wattson_custom_device_info_table() {
+    return mutable_table<tables::WattsonCustomDeviceInfoTable>();
+  }
+
+  const tables::WattsonCustomCpuPolicyTable& wattson_custom_cpu_policy_table()
+      const {
+    return table<tables::WattsonCustomCpuPolicyTable>();
+  }
+  tables::WattsonCustomCpuPolicyTable*
+  mutable_wattson_custom_cpu_policy_table() {
+    return mutable_table<tables::WattsonCustomCpuPolicyTable>();
+  }
+
+  const tables::WattsonCustomDeepIdleOffsetTable&
+  wattson_custom_deep_idle_offset_table() const {
+    return table<tables::WattsonCustomDeepIdleOffsetTable>();
+  }
+  tables::WattsonCustomDeepIdleOffsetTable*
+  mutable_wattson_custom_deep_idle_offset_table() {
+    return mutable_table<tables::WattsonCustomDeepIdleOffsetTable>();
+  }
+
+  const tables::WattsonCustomIdleStateMapTable&
+  wattson_custom_idle_state_map_table() const {
+    return table<tables::WattsonCustomIdleStateMapTable>();
+  }
+  tables::WattsonCustomIdleStateMapTable*
+  mutable_wattson_custom_idle_state_map_table() {
+    return mutable_table<tables::WattsonCustomIdleStateMapTable>();
+  }
+
+  const tables::WattsonCustomVoteByFreqTable&
+  wattson_custom_vote_by_freq_table() const {
+    return table<tables::WattsonCustomVoteByFreqTable>();
+  }
+  tables::WattsonCustomVoteByFreqTable*
+  mutable_wattson_custom_vote_by_freq_table() {
+    return mutable_table<tables::WattsonCustomVoteByFreqTable>();
+  }
+
+  const tables::WattsonCustomCurvesCpu1DTable&
+  wattson_custom_curves_cpu_1d_table() const {
+    return table<tables::WattsonCustomCurvesCpu1DTable>();
+  }
+  tables::WattsonCustomCurvesCpu1DTable*
+  mutable_wattson_custom_curves_cpu_1d_table() {
+    return mutable_table<tables::WattsonCustomCurvesCpu1DTable>();
+  }
+
+  const tables::WattsonCustomCurvesCpu2DTable&
+  wattson_custom_curves_cpu_2d_table() const {
+    return table<tables::WattsonCustomCurvesCpu2DTable>();
+  }
+  tables::WattsonCustomCurvesCpu2DTable*
+  mutable_wattson_custom_curves_cpu_2d_table() {
+    return mutable_table<tables::WattsonCustomCurvesCpu2DTable>();
+  }
+
+  const tables::WattsonCustomCurvesL3Table& wattson_custom_curves_l3_table()
+      const {
+    return table<tables::WattsonCustomCurvesL3Table>();
+  }
+  tables::WattsonCustomCurvesL3Table* mutable_wattson_custom_curves_l3_table() {
+    return mutable_table<tables::WattsonCustomCurvesL3Table>();
+  }
+
+  const tables::WattsonCustomCurvesGpuTable& wattson_custom_curves_gpu_table()
+      const {
+    return table<tables::WattsonCustomCurvesGpuTable>();
+  }
+  tables::WattsonCustomCurvesGpuTable*
+  mutable_wattson_custom_curves_gpu_table() {
+    return mutable_table<tables::WattsonCustomCurvesGpuTable>();
+  }
+
+  const tables::WattsonCustomCurvesTpuTable& wattson_custom_curves_tpu_table()
+      const {
+    return table<tables::WattsonCustomCurvesTpuTable>();
+  }
+  tables::WattsonCustomCurvesTpuTable*
+  mutable_wattson_custom_curves_tpu_table() {
+    return mutable_table<tables::WattsonCustomCurvesTpuTable>();
+  }
+
   const tables::WinscopeTraceRectTable& winscope_trace_rect_table() const {
     return table<tables::WinscopeTraceRectTable>();
   }

--- a/src/trace_processor/tables/BUILD.gn
+++ b/src/trace_processor/tables/BUILD.gn
@@ -42,6 +42,7 @@ perfetto_tp_tables("tables_python") {
     "trace_proto_tables.py",
     "track_tables.py",
     "v8_tables.py",
+    "wattson_tables.py",
     "winscope_tables.py",
   ]
   generate_docs = true

--- a/src/trace_processor/tables/wattson_tables.py
+++ b/src/trace_processor/tables/wattson_tables.py
@@ -1,0 +1,253 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contains tables for dynamic/out-of-tree Wattson SoC power models."""
+
+from python.generators.trace_processor_table.public import Column as C
+from python.generators.trace_processor_table.public import CppAccess
+from python.generators.trace_processor_table.public import CppDouble
+from python.generators.trace_processor_table.public import CppInt32
+from python.generators.trace_processor_table.public import CppInt64
+from python.generators.trace_processor_table.public import CppOptional
+from python.generators.trace_processor_table.public import CppString
+from python.generators.trace_processor_table.public import Table
+from python.generators.trace_processor_table.public import TableDoc
+
+WATTSON_CUSTOM_DEVICE_INFO_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomDeviceInfoTable",
+    sql_name="__intrinsic_wattson_custom_device_info",
+    columns=[
+        C("device_name", CppString(), cpp_access=CppAccess.READ),
+        C("use_devfreq", CppInt32(), cpp_access=CppAccess.READ),
+        C("gpu_id", CppOptional(CppInt32()), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="Metadata for dynamically imported Wattson SoC power model.",
+        group="Wattson",
+        columns={
+            "device_name": "Canonical SoC/device name.",
+            "use_devfreq": "1 if devfreq is required, 0 otherwise.",
+            "gpu_id": "GPU hardware ID.",
+        },
+    ),
+)
+
+WATTSON_CUSTOM_CPU_POLICY_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomCpuPolicyTable",
+    sql_name="__intrinsic_wattson_custom_cpu_policy",
+    columns=[
+        C("cpu", CppInt32(), cpp_access=CppAccess.READ),
+        C("policy", CppInt32(), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="CPU core to cpufreq policy mapping for dynamically imported model.",
+        group="Wattson",
+        columns={
+            "cpu": "CPU core index.",
+            "policy": "cpufreq policy index.",
+        },
+    ),
+)
+
+WATTSON_CUSTOM_DEEP_IDLE_OFFSET_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomDeepIdleOffsetTable",
+    sql_name="__intrinsic_wattson_custom_deep_idle_offset",
+    columns=[
+        C("cpu", CppInt32(), cpp_access=CppAccess.READ),
+        C("offset_ns", CppInt64(), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="Deep idle transition latency offsets per CPU.",
+        group="Wattson",
+        columns={
+            "cpu": "CPU core index.",
+            "offset_ns": "Deep idle offset in nanoseconds.",
+        },
+    ),
+)
+
+WATTSON_CUSTOM_IDLE_STATE_MAP_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomIdleStateMapTable",
+    sql_name="__intrinsic_wattson_custom_idle_state_map",
+    columns=[
+        C("nominal_idle", CppInt64(), cpp_access=CppAccess.READ),
+        C("override_idle", CppInt32(), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="Idle state remapping for dynamically imported model.",
+        group="Wattson",
+        columns={
+            "nominal_idle": "Nominal idle state.",
+            "override_idle": "Override idle state index.",
+        },
+    ),
+)
+
+WATTSON_CUSTOM_VOTE_BY_FREQ_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomVoteByFreqTable",
+    sql_name="__intrinsic_wattson_custom_vote_by_freq",
+    columns=[
+        C("cpu", CppInt32(), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="CPUs whose 2D dependency votes by frequency instead of power.",
+        group="Wattson",
+        columns={
+            "cpu": "CPU core index.",
+        },
+    ),
+)
+
+WATTSON_CUSTOM_CURVES_CPU_1D_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomCurvesCpu1DTable",
+    sql_name="__intrinsic_wattson_custom_curves_cpu_1d",
+    columns=[
+        C("policy", CppInt32(), cpp_access=CppAccess.READ),
+        C("freq_khz", CppInt64(), cpp_access=CppAccess.READ),
+        C("static_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("active_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("idle0_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("idle1_mw", CppDouble(), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="CPU 1D empirical power curves for dynamically imported model.",
+        group="Wattson",
+        columns={
+            "policy": "cpufreq policy.",
+            "freq_khz": "Frequency in kHz.",
+            "static_mw": "Static power in mW.",
+            "active_mw": "Active power in mW.",
+            "idle0_mw": "Idle state 0 power in mW.",
+            "idle1_mw": "Idle state 1 power in mW.",
+        },
+    ),
+)
+
+WATTSON_CUSTOM_CURVES_CPU_2D_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomCurvesCpu2DTable",
+    sql_name="__intrinsic_wattson_custom_curves_cpu_2d",
+    columns=[
+        C("policy", CppInt32(), cpp_access=CppAccess.READ),
+        C("freq_khz", CppInt64(), cpp_access=CppAccess.READ),
+        C("dep_policy", CppInt32(), cpp_access=CppAccess.READ),
+        C("dep_freq", CppInt64(), cpp_access=CppAccess.READ),
+        C("static_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("active_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("idle0_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("idle1_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("interconnect_mw", CppDouble(), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="CPU 2D empirical power curves for dynamically imported model.",
+        group="Wattson",
+        columns={
+            "policy": "cpufreq policy.",
+            "freq_khz": "Frequency in kHz.",
+            "dep_policy": "Dependent policy.",
+            "dep_freq": "Dependent frequency in kHz.",
+            "static_mw": "Static power in mW.",
+            "active_mw": "Active power in mW.",
+            "idle0_mw": "Idle state 0 power in mW.",
+            "idle1_mw": "Idle state 1 power in mW.",
+            "interconnect_mw": "Interconnect power in mW.",
+        },
+    ),
+)
+
+WATTSON_CUSTOM_CURVES_L3_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomCurvesL3Table",
+    sql_name="__intrinsic_wattson_custom_curves_l3",
+    columns=[
+        C("freq_khz", CppInt64(), cpp_access=CppAccess.READ),
+        C("dep_policy", CppInt32(), cpp_access=CppAccess.READ),
+        C("dep_freq", CppInt64(), cpp_access=CppAccess.READ),
+        C("l3_hit_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("l3_miss_mw", CppDouble(), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="L3 cache empirical power curves.",
+        group="Wattson",
+        columns={
+            "freq_khz": "Frequency in kHz.",
+            "dep_policy": "Dependent policy.",
+            "dep_freq": "Dependent frequency in kHz.",
+            "l3_hit_mw": "L3 hit power in mW.",
+            "l3_miss_mw": "L3 miss power in mW.",
+        },
+    ),
+)
+
+WATTSON_CUSTOM_CURVES_GPU_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomCurvesGpuTable",
+    sql_name="__intrinsic_wattson_custom_curves_gpu",
+    columns=[
+        C("freq_khz", CppInt64(), cpp_access=CppAccess.READ),
+        C("active_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("idle1_mw", CppDouble(), cpp_access=CppAccess.READ),
+        C("idle2_mw", CppDouble(), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="GPU empirical power curves.",
+        group="Wattson",
+        columns={
+            "freq_khz": "Frequency in kHz.",
+            "active_mw": "Active power in mW.",
+            "idle1_mw": "Idle state 1 power in mW.",
+            "idle2_mw": "Idle state 2 power in mW.",
+        },
+    ),
+)
+
+WATTSON_CUSTOM_CURVES_TPU_TABLE = Table(
+    python_module=__file__,
+    class_name="WattsonCustomCurvesTpuTable",
+    sql_name="__intrinsic_wattson_custom_curves_tpu",
+    columns=[
+        C("cluster", CppInt32(), cpp_access=CppAccess.READ),
+        C("requests", CppInt32(), cpp_access=CppAccess.READ),
+        C("freq", CppInt64(), cpp_access=CppAccess.READ),
+        C("active_mw", CppDouble(), cpp_access=CppAccess.READ),
+    ],
+    tabledoc=TableDoc(
+        doc="TPU empirical power curves.",
+        group="Wattson",
+        columns={
+            "cluster": "Cluster index.",
+            "requests": "Request count.",
+            "freq": "Frequency.",
+            "active_mw": "Active power in mW.",
+        },
+    ),
+)
+
+ALL_TABLES = [
+    WATTSON_CUSTOM_DEVICE_INFO_TABLE,
+    WATTSON_CUSTOM_CPU_POLICY_TABLE,
+    WATTSON_CUSTOM_DEEP_IDLE_OFFSET_TABLE,
+    WATTSON_CUSTOM_IDLE_STATE_MAP_TABLE,
+    WATTSON_CUSTOM_VOTE_BY_FREQ_TABLE,
+    WATTSON_CUSTOM_CURVES_CPU_1D_TABLE,
+    WATTSON_CUSTOM_CURVES_CPU_2D_TABLE,
+    WATTSON_CUSTOM_CURVES_L3_TABLE,
+    WATTSON_CUSTOM_CURVES_GPU_TABLE,
+    WATTSON_CUSTOM_CURVES_TPU_TABLE,
+]


### PR DESCRIPTION
This PR introduces end-to-end support for dynamic out-of-tree (OOT) Wattson SoC power models. Trace Processor can now ingest SoC power models directly embedded in trace packets (`WattsonSocModel`, field 1004 of `FrameworksBaseTracePacket`) without requiring device models and power curves to be hardcoded in upstream Perfetto stdlib.