### PR TITLE
tp: add concurrency stress-test harness for multi-threaded TP

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -21859,6 +21859,11 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/util:concurrency_stress_test_util
+filegroup {
+    name: "perfetto_src_trace_processor_util_concurrency_stress_test_util",
+}
+
 // GN: //src/trace_processor/util:decompressor
 filegroup {
     name: "perfetto_src_trace_processor_util_decompressor",
@@ -22128,6 +22133,7 @@ filegroup {
     name: "perfetto_src_trace_processor_util_unittests",
     srcs: [
         "src/trace_processor/util/bump_allocator_unittest.cc",
+        "src/trace_processor/util/concurrency_stress_test_util_unittest.cc",
         "src/trace_processor/util/descriptors_unittest.cc",
         "src/trace_processor/util/flatbuffer_reader_unittest.cc",
         "src/trace_processor/util/galloping_search_unittest.cc",
@@ -24456,6 +24462,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_bump_allocator",
         ":perfetto_src_trace_processor_util_clock",
         ":perfetto_src_trace_processor_util_compressor",
+        ":perfetto_src_trace_processor_util_concurrency_stress_test_util",
         ":perfetto_src_trace_processor_util_decompressor",
         ":perfetto_src_trace_processor_util_deobfuscation_deobfuscator",
         ":perfetto_src_trace_processor_util_deobfuscation_unittests",

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -254,6 +254,15 @@ source_set("galloping_search") {
   deps = [ "../../../gn:default_deps" ]
 }
 
+source_set("concurrency_stress_test_util") {
+  testonly = true
+  sources = [ "concurrency_stress_test_util.h" ]
+  deps = [
+    "../../../gn:default_deps",
+    "../../../include/perfetto/base",
+  ]
+}
+
 source_set("glob") {
   sources = [
     "glob.cc",
@@ -484,6 +493,7 @@ source_set("flatbuffer_reader") {
 source_set("unittests") {
   sources = [
     "bump_allocator_unittest.cc",
+    "concurrency_stress_test_util_unittest.cc",
     "descriptors_unittest.cc",
     "flatbuffer_reader_unittest.cc",
     "galloping_search_unittest.cc",
@@ -507,6 +517,7 @@ source_set("unittests") {
   testonly = true
   deps = [
     ":bump_allocator",
+    ":concurrency_stress_test_util",
     ":decompressor",
     ":descriptors",
     ":flatbuffer_reader",

--- a/src/trace_processor/util/concurrency_stress_test_util.h
+++ b/src/trace_processor/util/concurrency_stress_test_util.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_UTIL_CONCURRENCY_STRESS_TEST_UTIL_H_
+#define SRC_TRACE_PROCESSOR_UTIL_CONCURRENCY_STRESS_TEST_UTIL_H_
+
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+
+namespace perfetto::trace_processor {
+
+// Spawns `thread_count` threads which each call `fn(thread_idx)` `iterations`
+// times, then joins them. Threads block on a start barrier until all have been
+// spawned, so the work overlaps as much as possible and races get a chance to
+// surface under ThreadSanitizer.
+inline void ConcurrentlyRun(
+    uint32_t thread_count,
+    uint32_t iterations,
+    const std::function<void(uint32_t thread_idx)>& fn) {
+  PERFETTO_CHECK(thread_count > 0);
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  uint32_t pending = thread_count;
+
+  std::vector<std::thread> threads;
+  threads.reserve(thread_count);
+  for (uint32_t i = 0; i < thread_count; ++i) {
+    threads.emplace_back([&, i] {
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        if (--pending == 0) {
+          cv.notify_all();
+        } else {
+          cv.wait(lock, [&] { return pending == 0; });
+        }
+      }
+      for (uint32_t iter = 0; iter < iterations; ++iter)
+        fn(i);
+    });
+  }
+
+  for (std::thread& thread : threads)
+    thread.join();
+}
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_UTIL_CONCURRENCY_STRESS_TEST_UTIL_H_

--- a/src/trace_processor/util/concurrency_stress_test_util_unittest.cc
+++ b/src/trace_processor/util/concurrency_stress_test_util_unittest.cc
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/concurrency_stress_test_util.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+TEST(ConcurrencyStressTestUtilTest, InvocationCount) {
+  std::atomic<uint64_t> counter{0};
+  ConcurrentlyRun(8, 1000, [&](uint32_t) { counter.fetch_add(1); });
+  EXPECT_EQ(counter.load(), 8u * 1000u);
+}
+
+TEST(ConcurrencyStressTestUtilTest, RunsThreadsConcurrently) {
+  constexpr uint32_t kThreads = 8;
+
+  // Each thread's first iteration waits until every thread is live. A
+  // sequential harness could never have all threads present at once, so the
+  // bounded wait would time out and fail the assertion instead of hanging.
+  std::atomic<uint32_t> present{0};
+  std::atomic<uint32_t> rendezvous_reached{0};
+  std::atomic<bool> first[kThreads];
+  for (uint32_t i = 0; i < kThreads; ++i)
+    first[i].store(true);
+
+  ConcurrentlyRun(kThreads, 5, [&](uint32_t thread_idx) {
+    if (!first[thread_idx].exchange(false))
+      return;
+    present.fetch_add(1);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (present.load() < kThreads) {
+      if (std::chrono::steady_clock::now() > deadline)
+        return;
+      std::this_thread::yield();
+    }
+    rendezvous_reached.fetch_add(1);
+  });
+
+  EXPECT_EQ(rendezvous_reached.load(), kThreads)
+      << "threads did not all run concurrently";
+}
+
+// Deliberately racy: shows the harness surfaces a data race under
+// ThreadSanitizer. Disabled so it never runs in CI.
+TEST(ConcurrencyStressTestUtilTest, DISABLED_DetectsRaces) {
+  int unguarded = 0;
+  ConcurrentlyRun(8, 1000, [&](uint32_t) { unguarded++; });
+  EXPECT_GE(unguarded, 0);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor


### PR DESCRIPTION
Adds ConcurrentlyRun(), a header-only test utility that spawns N threads,
holds them all on a start barrier until the last arrives, then releases
them simultaneously to maximize the race-overlap window under TSan.

This is the foundation of the trace_processor multithreading effort:
every subsequent PR (concurrent dataframe cursors, StringPool reads,
forked-connection query fan-out) is graded red-green against this harness
under out/linux_tsan.

The self-test verifies the invocation count and that threads genuinely
run concurrently (a rendezvous that fails rather than hangs if the harness
ever ran sequentially). A DISABLED_ test documents that the harness
surfaces a real data race under ThreadSanitizer.