### PR TITLE
tp: prove StringPool read path is concurrent-safe under locking

### DIFF
--- a/src/trace_processor/containers/BUILD.gn
+++ b/src/trace_processor/containers/BUILD.gn
@@ -52,6 +52,7 @@ perfetto_unittest_source_set("unittests") {
     "../../../include/perfetto/protozero",
     "../../../protos/perfetto/trace_processor:zero",
     "../../base",
+    "../util:concurrency_stress_test_util",
   ]
 }
 

--- a/src/trace_processor/containers/string_pool.h
+++ b/src/trace_processor/containers/string_pool.h
@@ -210,14 +210,19 @@ class StringPool {
     // Perform a hashtable insertion with a null ID just to check if the string
     // is already inserted. If it's not, overwrite 0 with the actual Id.
     auto hash = base::MurmurHashValue(str);
-    MaybeLockGuard guard{mutex_, should_acquire_mutex_};
-    auto [id, inserted] = string_index_.Insert(hash, Id());
-    if (PERFETTO_LIKELY(!inserted)) {
-      PERFETTO_DCHECK(Get(*id) == str);
-      return *id;
+    Id result;
+    {
+      MaybeLockGuard guard{mutex_, should_acquire_mutex_};
+      auto [id, inserted] = string_index_.Insert(hash, Id());
+      if (PERFETTO_UNLIKELY(inserted)) {
+        *id = InsertString(str);
+        return *id;
+      }
+      result = *id;
     }
-    *id = InsertString(str);
-    return *id;
+    // Get() takes the mutex for large strings, so validate after unlocking.
+    PERFETTO_DCHECK(Get(result) == str);
+    return result;
   }
 
   // Given a string, returns the id for the string if it exists in the string
@@ -227,13 +232,18 @@ class StringPool {
       return Id::Null();
     }
     auto hash = base::MurmurHashValue(str);
-    MaybeLockGuard guard{mutex_, should_acquire_mutex_};
-    Id* id = string_index_.Find(hash);
-    if (id) {
-      PERFETTO_DCHECK(Get(*id) == str);
-      return *id;
+    Id result;
+    {
+      MaybeLockGuard guard{mutex_, should_acquire_mutex_};
+      Id* id = string_index_.Find(hash);
+      if (!id) {
+        return std::nullopt;
+      }
+      result = *id;
     }
-    return std::nullopt;
+    // Copy the id before unlocking: concurrent interns can rehash the index.
+    PERFETTO_DCHECK(Get(result) == str);
+    return result;
   }
 
   // Given a StringId, returns the string for that id.
@@ -290,6 +300,13 @@ class StringPool {
   }
 
   // Sets the locking mode of the string pool.
+  //
+  // With locking enabled, any number of threads may read (Get/GetId/...) and
+  // intern concurrently. Interns are serialized by |mutex_|. Get() of an
+  // already interned small string is lock-free and safe against concurrent
+  // interns: |blocks_| never reallocates, a new block lands in a different slot
+  // than the one being read, and a block's bytes are written once before its
+  // Id is published. Large strings are always read and written under |mutex_|.
   void set_locking(bool should_lock) { should_acquire_mutex_ = should_lock; }
 
  private:

--- a/src/trace_processor/containers/string_pool_unittest.cc
+++ b/src/trace_processor/containers/string_pool_unittest.cc
@@ -17,14 +17,19 @@
 #include "src/trace_processor/containers/string_pool.h"
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <random>
+#include <string>
+#include <vector>
 
 #include "perfetto/ext/base/string_view.h"
 #include "src/trace_processor/containers/null_term_string_view.h"
+#include "src/trace_processor/util/concurrency_stress_test_util.h"
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto::trace_processor {
@@ -165,6 +170,21 @@ TEST_F(StringPoolTest, LargeString) {
   }
 }
 
+TEST_F(StringPoolTest, InternAndRetrieveWithLocking) {
+  pool_.set_locking(true);
+  for (size_t size : {size_t{0}, size_t{16}, kMinLargeStringSizeBytes}) {
+    std::string str(size, 'x');
+    base::StringView view(str);
+    auto id = pool_.InternString(view);
+    ASSERT_EQ(id.is_large_string(), size >= kMinLargeStringSizeBytes);
+    ASSERT_EQ(pool_.Get(id), view);
+    // Both operations validate the existing string in debug builds. For large
+    // strings this used to acquire the same mutex twice and deadlock.
+    ASSERT_EQ(pool_.GetId(view), id);
+    ASSERT_EQ(pool_.InternString(view), id);
+  }
+}
+
 TEST_F(StringPoolTest, MaxSmallStringIdOnBlockBoundary) {
   // Null string should be at (0, 0).
   pool_.InternString(base::StringView());
@@ -184,6 +204,103 @@ TEST_F(StringPoolTest, MaxSmallStringIdOnBlockBoundary) {
   StringPool::Id max_id = pool_.MaxSmallStringId();
   ASSERT_EQ(max_id.block_index(), 1u);
   ASSERT_EQ(max_id.block_offset(), 0u);
+}
+
+// Deterministic strings of varied lengths. Every 500th is large enough for the
+// |large_strings_| path.
+std::vector<std::string> MakeVariedStrings(size_t count, size_t large_size) {
+  std::minstd_rand0 rnd_engine(0);
+  std::vector<std::string> strings;
+  strings.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    size_t length;
+    if (i % 500 == 499) {
+      length = large_size + (rnd_engine() % 4096);
+    } else {
+      length = rnd_engine() % 256;
+    }
+    std::string s;
+    s.reserve(length);
+    for (size_t j = 0; j < length; ++j)
+      s.push_back(static_cast<char>('A' + (rnd_engine() % 26)));
+    // The index prefix keeps even tiny strings unique.
+    strings.push_back(std::to_string(i) + ":" + s);
+  }
+  return strings;
+}
+
+// Reads of an otherwise immutable pool must be safe from many threads.
+TEST_F(StringPoolTest, ConcurrentReadsNoInterns) {
+  pool_.set_locking(true);
+
+  constexpr size_t kNumStrings = 4000;
+  std::vector<std::string> strings =
+      MakeVariedStrings(kNumStrings, kMinLargeStringSizeBytes);
+  std::vector<StringPool::Id> ids;
+  ids.reserve(kNumStrings);
+  for (const auto& s : strings)
+    ids.push_back(pool_.InternString(base::StringView(s)));
+
+  ConcurrentlyRun(8, 16, [&](uint32_t thread_idx) {
+    // Each thread starts at a different offset so the reads spread across
+    // blocks and large strings at once.
+    for (size_t i = 0; i < kNumStrings; ++i) {
+      size_t k = (i + thread_idx * 257) % kNumStrings;
+      const std::string& expected = strings[k];
+      NullTermStringView got = pool_.Get(ids[k]);
+      PERFETTO_CHECK(got == base::StringView(expected));
+
+      std::optional<StringPool::Id> looked_up =
+          pool_.GetId(base::StringView(expected));
+      PERFETTO_CHECK(looked_up.has_value());
+      PERFETTO_CHECK(*looked_up == ids[k]);
+    }
+  });
+}
+
+// Get() of a published id is lock-free. Concurrent interns, which allocate new
+// blocks and append large strings under the lock, must not corrupt it.
+TEST_F(StringPoolTest, ConcurrentReadsWhileLockedInterns) {
+  pool_.set_locking(true);
+
+  constexpr size_t kNumBaseStrings = 4000;
+  std::vector<std::string> base_strings =
+      MakeVariedStrings(kNumBaseStrings, kMinLargeStringSizeBytes);
+  std::vector<StringPool::Id> base_ids;
+  base_ids.reserve(kNumBaseStrings);
+  for (const auto& s : base_strings)
+    base_ids.push_back(pool_.InternString(base::StringView(s)));
+
+  constexpr size_t kReadWindow = 128;
+  constexpr uint32_t kThreadCount = 8;
+  constexpr uint32_t kIterations = 2000;
+  ConcurrentlyRun(kThreadCount, kIterations, [&](uint32_t thread_idx) {
+    // Half the threads intern new strings, the other half read existing ids.
+    if (thread_idx % 2 == 0) {
+      static std::atomic<uint64_t> counter{0};
+      uint64_t n = counter.fetch_add(1, std::memory_order_relaxed);
+      // 4 writers x kIterations x ~2KB is ~16MB, so several new 4MB blocks get
+      // allocated while the readers run. Every 1000th string is a large one.
+      std::string s = "writer-" + std::to_string(thread_idx) + "-" +
+                      std::to_string(n) + ":";
+      s.append(n % 1000 == 999 ? kMinLargeStringSizeBytes + 1 : 2048, 'x');
+      pool_.InternString(base::StringView(s));
+    } else {
+      uint64_t base = static_cast<uint64_t>(thread_idx) * 257;
+      for (size_t i = 0; i < kReadWindow; ++i) {
+        size_t k = (base + i) % kNumBaseStrings;
+        NullTermStringView got = pool_.Get(base_ids[k]);
+        PERFETTO_CHECK(got == base::StringView(base_strings[k]));
+      }
+    }
+  });
+
+  // Every base id must still resolve after the churn.
+  for (size_t i = 0; i < kNumBaseStrings; ++i)
+    ASSERT_EQ(pool_.Get(base_ids[i]), base::StringView(base_strings[i]));
+
+  // The writers must actually have forced block growth for this to mean much.
+  ASSERT_GT(pool_.MaxSmallStringId().block_index(), 0u);
 }
 
 }  // namespace


### PR DESCRIPTION
Adds two ThreadSanitizer stress tests proving the StringPool read path
is safe for the multi-connection design, where string columns are read
on every query thread:

 - ConcurrentReadsNoInterns: 8 threads concurrently Get()/GetId() a
   finalized pool (small, block-spanning and >1MB large strings).
 - ConcurrentReadsWhileLockedInterns: with locking enabled, reader
   threads do lock-free Get() of pre-existing ids while writer threads
   continuously intern ~2KB strings, forcing several real 4MB-block
   allocations during the read window (the new-block publication path),
   plus occasional large-string appends. The test asserts the bytes of
   every pre-existing id stay intact and self-validates that block
   growth actually occurred.

No production fix was required: the lock-free Get() is safe against
concurrent interns because |blocks_| is a fixed array that never
reallocates (a new block writes a different slot), block bytes are
written forward-only before the Id is published, and large strings are
fully mutex-guarded. Documents this concurrency contract on
set_locking() — including that concurrent interns from multiple threads
are serialized by the mutex and supported (the prior draft contract
wrongly stated otherwise).