### PR TITLE
base: give flat_hash_map's IsLookupKeyAllowed external linkage (clang 23 -Wunused-template)

### DIFF
--- a/include/perfetto/ext/base/flat_hash_map.h
+++ b/include/perfetto/ext/base/flat_hash_map.h
@@ -112,7 +112,7 @@ struct HashEq<double> {
 // 2. Hasher has is_transparent AND Hasher is invocable with K AND Key and K
 // are equality comparable
 template <typename K, typename Key, typename Hasher>
-static constexpr bool IsLookupKeyAllowed() {
+constexpr bool IsLookupKeyAllowed() {
   if constexpr (HasIsTransparent<Hasher>::value) {
     return std::is_invocable_v<Hasher, const K&> &&
            std::is_invocable_v<std::equal_to<>, const Key&, const K&>;


### PR DESCRIPTION
`flat_hash_map_v2_internal::IsLookupKeyAllowed` is a namespace-scope `constexpr` function template, so it is implicitly inline; declaring it `static` makes it an internal-linkage template that every translation unit including `flat_hash_map.h` without instantiating `FlatHashMap` never instantiates. clang 23.1.0 puts `-Wunused-template` under `-Wall` and reports exactly that:

```
third_party/perfetto/sdk/perfetto.cc:53071:23: error: unused function template 'IsLookupKeyAllowed' [-Werror,-Wunused-template]
```

which breaks `-Werror` consumers of the amalgamated SDK such as Firefox (seen building Firefox with clang 23.1.0 against SDK v56.1). Dropping the `static` changes nothing else.