### PR TITLE
ui: restore every probe setting when loading a record config

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_interfaces.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_interfaces.ts
@@ -128,6 +128,13 @@ export interface ProbeSetting {
   // The two methods below are supposed to save/restore the state of the setting
   // in a JSON-serializable entity (object | number | string | boolean). This is
   // to support saving configs into localstorage and sharing them.
+  //
+  // deserialize() must ALWAYS end up setting the value. `state` is undefined
+  // when the config being loaded doesn't mention this setting, and can be
+  // malformed when it comes from a config saved by another version of the UI:
+  // in both cases the setting must go back to its default. A deserialize()
+  // that just ignores the input leaves the setting showing the value from the
+  // config that was loaded before, which is the bug in #7347.
   serialize(): unknown;
   deserialize(state: unknown): void;
 }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_manager.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_manager.ts
@@ -150,19 +150,17 @@ export class ConfigManager {
     this.indirectlyEnabledProbes.clear();
     this.getProbesOrderedByDep().forEach((probe) => {
       const probeState = state[probe.id];
-      if (probeState === undefined || probeState.settings === undefined) {
-        return;
+      // A probe is enabled iff it appears in the serialized state.
+      if (probeState !== undefined) {
+        this.setProbeEnabled(probe.id, true);
       }
-      this.setProbeEnabled(probe.id, true);
-      if (probe.settings === undefined) {
-        // The probe has no settings, there is nothing to restore.
-        // This return is theoretically redundant but is here to make tsc happy.
-        return;
-      }
-      for (const [key, settingState] of Object.entries(probeState.settings)) {
-        if (key in probe.settings) {
-          probe.settings[key].deserialize(settingState);
-        }
+      // Restore ALL the settings the probe declares, not just the ones present
+      // in the config: a setting the config doesn't mention gets undefined,
+      // which puts it back to its default (@see ProbeSetting.deserialize).
+      // Otherwise it would keep the value from the previously loaded config.
+      const settingsState = probeState?.settings ?? {};
+      for (const [key, setting] of Object.entries(probe.settings ?? {})) {
+        setting.deserialize(settingsState[key]);
       }
     });
   }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_manager_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_manager_unittest.ts
@@ -1,0 +1,215 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {errResult} from '../../../base/result';
+import {ConfigManager} from './config_manager';
+import type {RecordProbe, RecordSubpage} from './config_interfaces';
+import {ADV_FTRACE_PROBE_ID, advancedRecordSection} from '../pages/advanced';
+import {androidRecordSection} from '../pages/android';
+import {chromeRecordSection} from '../pages/chrome';
+import {cpuRecordSection} from '../pages/cpu';
+import {gpuRecordSection} from '../pages/gpu';
+import {linuxRecordSection} from '../pages/linux';
+import {memoryRecordSection} from '../pages/memory';
+import {networkRecordSection} from '../pages/network';
+import {perfettoSDKRecordSection} from '../pages/perfetto_sdk';
+import {powerRecordSection} from '../pages/power';
+import {stackSamplingRecordSection} from '../pages/stack_sampling';
+import {
+  ANDROID_PRESETS,
+  CHROME_PRESETS,
+  LINUX_PRESETS,
+  type Preset,
+} from '../presets';
+import {
+  PROBES_SESSION_SCHEMA,
+  type ProbesSchema,
+} from '../serialization_schema';
+
+// All the probe pages of the record page, i.e. everything that can hold a
+// setting. New pages should be added here so that they are covered by the
+// "loading a config resets everything" test below.
+function allProbePages(): RecordSubpage[] {
+  return [
+    chromeRecordSection(
+      async () => errResult('No extension in tests'),
+      () => 'CHROME',
+    ),
+    cpuRecordSection(),
+    gpuRecordSection(),
+    powerRecordSection(),
+    memoryRecordSection(),
+    linuxRecordSection(),
+    androidRecordSection(),
+    perfettoSDKRecordSection(),
+    stackSamplingRecordSection(),
+    networkRecordSection(),
+    advancedRecordSection(),
+  ];
+}
+
+function newConfigManager(): ConfigManager {
+  const cfgMgr = new ConfigManager();
+  for (const page of allProbePages()) {
+    if (page.kind !== 'PROBES_PAGE') continue;
+    cfgMgr.registerProbes(page.probes);
+  }
+  return cfgMgr;
+}
+
+// The value of every setting of every probe, INCLUDING the disabled ones.
+// ConfigManager.serializeProbes() only looks at the enabled probes, so it
+// can't see a stale value hiding in a probe that is currently off (which
+// would pop back up the moment the user re-enables it).
+function dumpAllSettings(cfgMgr: ConfigManager): Record<string, unknown> {
+  const dump: Record<string, unknown> = {};
+  for (const probe of cfgMgr.probesById.values()) {
+    const settings: Record<string, unknown> = {};
+    for (const [id, setting] of Object.entries(probe.settings ?? {})) {
+      settings[id] = setting.serialize();
+    }
+    dump[probe.id] = settings;
+  }
+  return dump;
+}
+
+// Returns a value that is different from `value` but of a plausible shape, so
+// that widgets don't just reject it and fall back on their default.
+function perturb(value: unknown): unknown {
+  if (typeof value === 'boolean') return !value;
+  if (typeof value === 'number') return value + 4321;
+  if (typeof value === 'string') return value + '_perturbed';
+  if (Array.isArray(value)) return [...value, 'perturbed'];
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        k,
+        perturb(v),
+      ]),
+    );
+  }
+  return 'perturbed';
+}
+
+// A config that enables every probe and gives every setting a value that
+// differs from the one it currently holds.
+function everythingPerturbed(cfgMgr: ConfigManager): ProbesSchema {
+  const probes: ProbesSchema = {};
+  for (const probe of cfgMgr.probesById.values()) {
+    const settings: Record<string, unknown> = {};
+    for (const [id, setting] of Object.entries(probe.settings ?? {})) {
+      settings[id] = perturb(setting.serialize());
+    }
+    probes[probe.id] = {settings};
+  }
+  return probes;
+}
+
+function allPresets(): Preset[] {
+  return [...ANDROID_PRESETS, ...LINUX_PRESETS, ...CHROME_PRESETS];
+}
+
+function probesOf(preset: Preset): ProbesSchema {
+  return PROBES_SESSION_SCHEMA.parse(preset.session).probes;
+}
+
+function ftraceProbe(cfgMgr: ConfigManager): RecordProbe {
+  const probe = cfgMgr.probesById.get(ADV_FTRACE_PROBE_ID);
+  if (probe === undefined) throw new Error('No advanced ftrace probe');
+  return probe;
+}
+
+// The FtraceConfig of the TraceConfig generated for the current settings.
+function genFtraceConfig(cfgMgr: ConfigManager) {
+  for (const ds of cfgMgr.genTraceConfig('ANDROID').dataSources ?? []) {
+    const ftraceConfig = ds.config?.ftraceConfig;
+    if (ftraceConfig !== undefined && ftraceConfig !== null) {
+      return ftraceConfig as {symbolizeKsyms?: boolean; bufferSizeKb?: number};
+    }
+  }
+  throw new Error('The generated TraceConfig has no ftrace data source');
+}
+
+describe('ConfigManager', () => {
+  // Regression test for #7347: the ftrace buffer size and the "resolve kernel
+  // symbols" toggle survived the re-selection of the default config, because
+  // the advanced ftrace probe is not part of any preset (it's pulled in as a
+  // dependency of cpu_sched) and nothing restored its settings.
+  it('restores the settings of the probes not in the loaded config', () => {
+    const cfgMgr = newConfigManager();
+    const defaultPreset = ANDROID_PRESETS[0];
+    cfgMgr.deserializeProbes(probesOf(defaultPreset));
+    const pristine = dumpAllSettings(cfgMgr);
+
+    // Turn off "Resolve kernel symbols" and set an ftrace buffer size, as the
+    // user would in the "Advanced ftrace config" page.
+    const settings = ftraceProbe(cfgMgr).settings ?? {};
+    (settings['ksyms'] as unknown as {setEnabled(v: boolean): void}).setEnabled(
+      false,
+    );
+    (settings['bufSize'] as unknown as {setValue(v: number): void}).setValue(
+      4 * 1024,
+    );
+    expect(dumpAllSettings(cfgMgr)).not.toEqual(pristine);
+    expect(genFtraceConfig(cfgMgr).symbolizeKsyms ?? undefined).toEqual(
+      undefined,
+    );
+    expect(genFtraceConfig(cfgMgr).bufferSizeKb).toEqual(4 * 1024);
+
+    // Re-select the default config: everything must go back to how it was.
+    cfgMgr.deserializeProbes(probesOf(defaultPreset));
+    expect(dumpAllSettings(cfgMgr)).toEqual(pristine);
+
+    // ...and that must show up in the generated TraceConfig too.
+    expect(genFtraceConfig(cfgMgr).symbolizeKsyms).toEqual(true);
+    expect(genFtraceConfig(cfgMgr).bufferSizeKb ?? undefined).toEqual(
+      undefined,
+    );
+  });
+
+  // The general form of the test above: whatever the record page was showing
+  // before, loading a config must land on exactly the same state as loading it
+  // on a brand new record page. This covers every probe and every setting,
+  // including the ones added after this test was written.
+  it('loads a config the same way regardless of the previous state', () => {
+    for (const preset of allPresets()) {
+      const reference = newConfigManager();
+      reference.deserializeProbes(probesOf(preset));
+      const expected = dumpAllSettings(reference);
+
+      // 1. From a config where every single setting has been changed.
+      const cfgMgr = newConfigManager();
+      cfgMgr.deserializeProbes(everythingPerturbed(cfgMgr));
+      cfgMgr.deserializeProbes(probesOf(preset));
+      expect(dumpAllSettings(cfgMgr)).toEqual(expected);
+
+      // 2. From each one of the other presets.
+      for (const other of allPresets()) {
+        const fromOther = newConfigManager();
+        fromOther.deserializeProbes(probesOf(other));
+        fromOther.deserializeProbes(probesOf(preset));
+        expect(dumpAllSettings(fromOther)).toEqual(expected);
+      }
+    }
+  });
+
+  it('clears every setting when loading an empty config', () => {
+    const pristine = dumpAllSettings(newConfigManager());
+    const cfgMgr = newConfigManager();
+    cfgMgr.deserializeProbes(everythingPerturbed(cfgMgr));
+    cfgMgr.deserializeProbes({});
+    expect(dumpAllSettings(cfgMgr)).toEqual(pristine);
+    expect(cfgMgr.hasActiveProbes()).toEqual(false);
+  });
+});

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/chrome.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/chrome.ts
@@ -348,6 +348,15 @@ export class ChromeCategoriesWidget implements ProbeSetting {
   }
 
   deserialize(state: unknown): void {
+    // Back to the defaults first: the fields that `state` doesn't carry (it
+    // can be undefined, or the legacy list-only format below) must not keep
+    // the value they had for the previously loaded config.
+    this.options.forEach((o) => (o.checked = false));
+    this.enabledTags.clear();
+    this.disabledTags.clear();
+    this.enabledPresets.clear();
+    this.privacyToggle.deserialize(undefined);
+
     if (Array.isArray(state)) {
       // Backward compatibility for when state was just a list of categories.
       this.maybeDeserializeCategories(state);

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/dropdown.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/dropdown.ts
@@ -33,7 +33,11 @@ export class Dropdown<T extends string | number> implements ProbeSetting {
 
   constructor(readonly attrs: DropdownAttrs<T>) {
     assertTrue(attrs.options.length > 0);
-    this._value = attrs.defaultValue ?? attrs.options[0].value;
+    this._value = this.defaultValue();
+  }
+
+  private defaultValue(): T {
+    return this.attrs.defaultValue ?? this.attrs.options[0].value;
   }
 
   serialize() {
@@ -41,15 +45,10 @@ export class Dropdown<T extends string | number> implements ProbeSetting {
   }
 
   deserialize(state: unknown): void {
-    if (typeof state !== 'string' && typeof state !== 'number') {
-      return;
-    }
     const option = this.attrs.options.find(
       (candidate) => candidate.value === state,
     );
-    if (option) {
-      this._value = option.value;
-    }
+    this._value = option?.value ?? this.defaultValue();
   }
 
   get value(): T {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/multiselect.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/multiselect.ts
@@ -60,20 +60,22 @@ export class TypedMultiselect<T> implements ProbeSetting {
   }
 
   deserialize(state: unknown): void {
-    if (Array.isArray(state) && state.every((x) => typeof x === 'string')) {
-      this._selectedKeys.clear();
-      for (const item of state) {
-        // First, try direct key match
-        if (this.attrs.options.has(item)) {
-          this._selectedKeys.add(item);
-          continue;
-        }
-        // Otherwise, search for a key whose value matches
-        for (const [key, value] of this.attrs.options.entries()) {
-          if (value === item) {
-            this._selectedKeys.add(key);
-            break;
-          }
+    const items =
+      Array.isArray(state) && state.every((x) => typeof x === 'string')
+        ? state
+        : (this.attrs.defaultSelected ?? []);
+    this._selectedKeys.clear();
+    for (const item of items) {
+      // First, try direct key match
+      if (this.attrs.options.has(item)) {
+        this._selectedKeys.add(item);
+        continue;
+      }
+      // Otherwise, search for a key whose value matches
+      for (const [key, value] of this.attrs.options.entries()) {
+        if (value === item) {
+          this._selectedKeys.add(key);
+          break;
         }
       }
     }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
@@ -46,9 +46,7 @@ export class Slider implements ProbeSetting {
   }
 
   deserialize(state: unknown): void {
-    if (typeof state === 'number') {
-      this._value = state;
-    }
+    this.setValue(typeof state === 'number' ? state : undefined);
   }
 
   get value(): number {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/textarea.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/textarea.ts
@@ -35,7 +35,7 @@ export class Textarea implements ProbeSetting {
   }
 
   setText(text: string | undefined) {
-    this._text = text ?? '';
+    this._text = text ?? this.attrs.default ?? '';
     return this._text;
   }
 
@@ -48,9 +48,7 @@ export class Textarea implements ProbeSetting {
   }
 
   deserialize(state: unknown): void {
-    if (typeof state === 'string') {
-      this._text = state;
-    }
+    this.setText(typeof state === 'string' ? state : undefined);
   }
 
   render() {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/toggle.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/toggle.ts
@@ -45,9 +45,7 @@ export class Toggle implements ProbeSetting {
   }
 
   deserialize(state: unknown): void {
-    if (state === true || state === false) {
-      this._enabled = state;
-    }
+    this.setEnabled(typeof state === 'boolean' ? state : undefined);
   }
 
   render() {


### PR DESCRIPTION
Fixes #7347