### PR TITLE
ui: Link memory overview bitmap section to heap dump explorer

### DIFF
--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/section_widgets.ts
@@ -131,6 +131,11 @@ export function heapDumpClassHref(cls: string): string {
   return `#!/heapdump/objects_${encodeURIComponent(cls)}`;
 }
 
+// Link to the Heap Dump Explorer's bitmaps view.
+export function heapDumpBitmapsHref(): string {
+  return '#!/heapdump/bitmaps';
+}
+
 // A class-name cell. The class name links to that class's instances in the Heap
 // Dump Explorer. When `retainers` are given, each one adds a `↳ via <owner>`
 // line naming an app-side class that dominates this (library) class's instances

--- a/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
+++ b/ui/src/plugins/dev.perfetto.Memscope/views/landing_page/summary/bitmaps_section.ts
@@ -18,6 +18,7 @@
 
 import m from 'mithril';
 import {AsyncMemo} from '../../../../../base/async_memo';
+import {Icons} from '../../../../../base/semantic_icons';
 import {Time, type time} from '../../../../../base/time';
 import type {Trace} from '../../../../../public/trace';
 import {
@@ -29,6 +30,7 @@ import {
 } from '../../../../../trace_processor/query_result';
 import {Panel} from '../../../components/panel';
 import {Callout} from '../../../components/callout';
+import {Anchor} from '../../../../../widgets/anchor';
 import {Intent} from '../../../../../widgets/common';
 import {
   deltaText,
@@ -41,6 +43,7 @@ import {nearestByTs} from '../selection';
 import {
   deltaCell,
   emptyPanel,
+  heapDumpBitmapsHref,
   loadingPanel,
   shortClassName,
   topTable,
@@ -417,7 +420,18 @@ export class BitmapsSection implements m.ClassComponent<BitmapsSectionAttrs> {
 
     return m(
       Panel,
-      m(Panel.Header, {title: TITLE, subtitle: SUBTITLE}),
+      m(Panel.Header, {
+        title: TITLE,
+        subtitle: SUBTITLE,
+        controls: m(
+          Anchor,
+          {
+            href: heapDumpBitmapsHref(),
+            icon: Icons.UpdateSelection,
+          },
+          'Open in Heap Dump Explorer',
+        ),
+      }),
       m(
         Panel.Body,
         m(Stack, {spacing: 'large'}, [


### PR DESCRIPTION
Add a link in the header controls of Memory Overview's bitmap section
to navigate directly to Heap Dump Explorer's bitmaps view.
