### PR TITLE
tp: trim per-event work on the track event tokenize and import path

### DIFF
--- a/include/perfetto/protozero/proto_decoder.h
+++ b/include/perfetto/protozero/proto_decoder.h
@@ -386,6 +386,24 @@ class PERFETTO_EXPORT_COMPONENT TypedProtoDecoderBase : public ProtoDecoder {
     return kInvalidField;
   }
 
+  // True if the message contained at least one field with an id beyond the
+  // highest id known in-tree (typically an out-of-tree extension). Such
+  // fields are not stored here; this lets callers skip a selective re-decode
+  // via unknown_fields() when there is nothing to find.
+  bool has_out_of_range_fields() const { return has_out_of_range_fields_; }
+
+  // True if any field whose bit is set in |mask| is present. |mask| is laid
+  // out like the presence bitmap (bit i of word i / 64 for field id i) and
+  // holds |words| words; bits beyond the known field range are ignored.
+  bool HasAnyField(const uint64_t* mask, size_t words) const {
+    size_t presence_words = (num_fields_ + 63) / 64;
+    for (size_t i = 0; i < words && i < presence_words; ++i) {
+      if (presence_[i] & mask[i])
+        return true;
+    }
+    return false;
+  }
+
   // True if the field with the given id was seen while decoding: tests bit
   // |id| of the presence bitmap. The caller must check that |id| is within
   // the bitmap, i.e. <= the decoder's MAX_FIELD_ID. Note that |id| may
@@ -564,6 +582,9 @@ class PERFETTO_EXPORT_COMPONENT TypedProtoDecoderBase : public ProtoDecoder {
   // can grow further, up to |capacity_|.
   // |size_| is always <= |capacity_|. But |num_fields_| can be > |size_|.
   uint32_t size_;
+
+  // See has_out_of_range_fields().
+  bool has_out_of_range_fields_ = false;
 
   // Initially equal to kFieldsCapacity of the TypedProtoDecoder
   // specialization. Can grow when falling back on heap-based storage, in which

--- a/src/protozero/proto_decoder.cc
+++ b/src/protozero/proto_decoder.cc
@@ -261,6 +261,7 @@ PERFETTO_ALWAYS_INLINE void TypedProtoDecoderBase::ParseAllFieldsImpl(
       // not stored here because fields_ is indexed directly by field id, and
       // extension ids are sparse and potentially very high. Callers that need
       // them should decode selectively and consume them from unknown_fields().
+      has_out_of_range_fields_ = true;
       continue;
     }
 

--- a/src/trace_processor/importers/proto/packet_sequence_state_generation.h
+++ b/src/trace_processor/importers/proto/packet_sequence_state_generation.h
@@ -131,8 +131,13 @@ class PacketSequenceStateGeneration : public RefCounted {
         ->GetOrCreateDecoder<protos::pbzero::TracePacketDefaults>();
   }
 
-  // Returns |nullptr| if no TrackEventDefaults were set.
+  // Returns |nullptr| if no TrackEventDefaults were set. The defaults are
+  // fixed for the lifetime of a generation, so the lookup is memoized.
   protos::pbzero::TrackEventDefaults::Decoder* GetTrackEventDefaults() {
+    if (PERFETTO_LIKELY(track_event_defaults_resolved_)) {
+      return track_event_defaults_;
+    }
+    track_event_defaults_resolved_ = true;
     auto* packet_defaults_view = GetTracePacketDefaultsView();
     if (packet_defaults_view) {
       auto* track_event_defaults_view =
@@ -141,11 +146,12 @@ class PacketSequenceStateGeneration : public RefCounted {
                                           protos::pbzero::TracePacketDefaults::
                                               kTrackEventDefaultsFieldNumber>();
       if (track_event_defaults_view) {
-        return track_event_defaults_view
-            ->GetOrCreateDecoder<protos::pbzero::TrackEventDefaults>();
+        track_event_defaults_ =
+            track_event_defaults_view
+                ->GetOrCreateDecoder<protos::pbzero::TrackEventDefaults>();
       }
     }
-    return nullptr;
+    return track_event_defaults_;
   }
 
   // Extension point for custom incremental state. Custom state classes need
@@ -190,6 +196,8 @@ class PacketSequenceStateGeneration : public RefCounted {
 
   // Per-slice state.
   std::optional<InternedMessageView> trace_packet_defaults_;
+  bool track_event_defaults_resolved_ = false;
+  protos::pbzero::TrackEventDefaults::Decoder* track_event_defaults_ = nullptr;
   // TODO(carlscab): Should not be needed as clients of this class should not
   // care about validity.
   bool is_incremental_state_valid_ = true;

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -319,7 +319,12 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
   }
 
   uint32_t seq_id = decoder.trusted_packet_sequence_id();
-  auto [scoped_state, inserted] = sequence_state_.Insert(seq_id, {});
+  SequenceScopedState* scoped_state = sequence_state_.Find(seq_id);
+  bool inserted = false;
+  if (PERFETTO_UNLIKELY(!scoped_state)) {
+    scoped_state = sequence_state_.Insert(seq_id, {}).first;
+    inserted = true;
+  }
   if (decoder.has_trusted_packet_sequence_id()) {
     if (!inserted) {
       if (uint32_t reasons = decoder.previous_packet_dropped(); reasons) {
@@ -434,7 +439,7 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
     ParseTraceConfig(decoder.trace_config());
   }
 
-  return TimestampTokenizeAndPushToSorter(std::move(packet));
+  return TimestampTokenizeAndPushToSorter(decoder, std::move(packet));
 }
 
 ProtoTraceReader::ClockResolution ProtoTraceReader::ResolveTimestampToTraceTime(
@@ -468,7 +473,12 @@ ProtoTraceReader::ClockResolution ProtoTraceReader::ResolveTimestampToTraceTime(
 base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
     TraceBlobView packet) {
   protos::pbzero::TracePacket::Decoder decoder(packet.data(), packet.length());
+  return TimestampTokenizeAndPushToSorter(decoder, std::move(packet));
+}
 
+base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
+    const protos::pbzero::TracePacket::Decoder& decoder,
+    TraceBlobView packet) {
   uint32_t seq_id = decoder.trusted_packet_sequence_id();
   auto* state = GetIncrementalStateForPacketSequence(seq_id);
 

--- a/src/trace_processor/importers/proto/proto_trace_reader.h
+++ b/src/trace_processor/importers/proto/proto_trace_reader.h
@@ -124,6 +124,11 @@ class ProtoTraceReader : public ChunkedTraceReader {
       uint32_t machine_id,
       std::unique_ptr<ProtoTraceReader>* out);
   base::Status TimestampTokenizeAndPushToSorter(TraceBlobView);
+  // Variant for callers that already decoded the packet, so the (wide)
+  // TracePacket decoder is not rebuilt per packet.
+  base::Status TimestampTokenizeAndPushToSorter(
+      const protos::pbzero::TracePacket_Decoder&,
+      TraceBlobView);
   base::Status ParseServiceEvent(int64_t ts, ConstBytes);
   base::Status ParseClockSnapshot(ConstBytes blob, uint32_t seq_id);
   base::Status ParseRemoteClockSync(ConstBytes blob);

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -259,47 +259,45 @@ class TrackEventEventImporter {
   StringId ParseTrackEventCategory() {
     StringId category_id = kNullStringId;
 
-    std::vector<uint64_t> category_iids;
-    for (auto it = event_.category_iids(); it; ++it) {
-      category_iids.push_back(*it);
-    }
-    std::vector<protozero::ConstChars> category_strings;
-    for (auto it = event_.categories(); it; ++it) {
-      category_strings.push_back(*it);
-    }
+    auto category_iids = event_.category_iids();
+    auto category_strings = event_.categories();
+    auto has_multiple = [](auto it) { return it && ++it; };
+    bool has_multiple_categories = (category_iids && category_strings) ||
+                                   has_multiple(category_iids) ||
+                                   has_multiple(category_strings);
 
     // If there's a single category, we can avoid building a concatenated
     // string.
-    if (PERFETTO_LIKELY(category_iids.size() == 1 &&
-                        category_strings.empty())) {
+    if (PERFETTO_LIKELY(!has_multiple_categories && category_iids)) {
+      uint64_t iid = *category_iids;
       if (auto id = sequence_state_->InternedStringId(
-              protos::pbzero::InternedData::kEventCategoriesFieldNumber,
-              category_iids[0])) {
+              protos::pbzero::InternedData::kEventCategoriesFieldNumber, iid)) {
         category_id = *id;
       } else {
         base::DynamicStringWriter writer;
         writer.AppendLiteral("unknown(");
-        writer.AppendUnsignedInt(category_iids[0]);
+        writer.AppendUnsignedInt(iid);
         writer.AppendChar(')');
         category_id = storage_->InternString(writer.GetStringView());
       }
-    } else if (category_iids.empty() && category_strings.size() == 1) {
-      category_id = storage_->InternString(category_strings[0]);
-    } else if (category_iids.size() + category_strings.size() > 1) {
+    } else if (!has_multiple_categories && category_strings) {
+      category_id = storage_->InternString(*category_strings);
+    } else if (has_multiple_categories) {
       // We concatenate the category strings together since we currently only
       // support a single "cat" column.
       // TODO(eseckler): Support multi-category events in the table schema.
       std::string categories;
-      for (uint64_t iid : category_iids) {
+      for (auto it = category_iids; it; ++it) {
         auto name = sequence_state_->InternedStringView(
-            protos::pbzero::InternedData::kEventCategoriesFieldNumber, iid);
+            protos::pbzero::InternedData::kEventCategoriesFieldNumber, *it);
         if (!name)
           continue;
         if (!categories.empty())
           categories.append(",");
         categories.append(name->data(), name->size());
       }
-      for (const protozero::ConstChars& cat : category_strings) {
+      for (auto it = category_strings; it; ++it) {
+        protozero::ConstChars cat = *it;
         if (!categories.empty())
           categories.append(",");
         categories.append(cat.data, cat.size);
@@ -970,15 +968,16 @@ class TrackEventEventImporter {
       }
     }
     // gpu_correlation is an out-of-tree extension of TrackEvent (id 3000),
-    // not stored by the typed decoder. FindField does a single early-exit
-    // scan; this runs per event, so avoid collecting all fields.
-    protozero::Field gpu_field =
-        protozero::ProtoDecoder(
-            event_.begin(), static_cast<size_t>(event_.end() - event_.begin()))
-            .FindField(
-                protos::pbzero::GpuTrackEvent::kGpuCorrelationFieldNumber);
+    // not stored by the typed decoder. It is in the selective decoder's
+    // spill area, which extension dispatch already built for this event.
+    if (!event_.has_out_of_range_fields()) {
+      return;
+    }
+    TrackEventField gpu_field = selective_decoder().FindUnknownField(
+        protos::pbzero::GpuTrackEvent::kGpuCorrelationFieldNumber);
     if (gpu_field.valid()) {
-      protos::pbzero::GpuCorrelation::Decoder gpu(gpu_field.as_bytes());
+      protos::pbzero::GpuCorrelation::Decoder gpu(
+          gpu_field.Cast<protos::pbzero::GpuTrackEvent::kGpuCorrelation>());
       for (auto it = gpu.render_stage_submission_event_ids(); it; ++it) {
         context_->gpu_tracker->AddRenderStageSubmission(*it, slice_id);
       }
@@ -1342,6 +1341,13 @@ class TrackEventEventImporter {
     return base::OkStatus();
   }
 
+  const SelectiveTrackEventDecoder& selective_decoder() {
+    if (!selective_decoder_) {
+      selective_decoder_.emplace(blob_);
+    }
+    return *selective_decoder_;
+  }
+
   // Returns false if a parser claimed the event (default args should be
   // skipped). Only scans the blob when a parser is registered.
   template <typename Fn>
@@ -1353,9 +1359,12 @@ class TrackEventEventImporter {
     if (legacy_event_.has_phase()) {
       return true;
     }
+    // Extension fields are out-of-tree by definition.
+    if (!event_.has_out_of_range_fields()) {
+      return true;
+    }
     bool parse_args = true;
-    SelectiveTrackEventDecoder decoder(blob_);
-    for (const protozero::Field& f : decoder.unknown_fields()) {
+    for (const protozero::Field& f : selective_decoder().unknown_fields()) {
       TrackEventExtensionParser* parser = parser_->ParserForField(f.id());
       if (!parser) {
         continue;
@@ -1461,7 +1470,7 @@ class TrackEventEventImporter {
                                               unknown_extensions);
     }
 
-    {
+    if (event_.has_debug_annotations()) {
       auto key = parser_->args_parser_.EnterDictionary("debug");
       for (auto it = event_.debug_annotations(); it; ++it) {
         log_errors(
@@ -1714,6 +1723,8 @@ class TrackEventEventImporter {
   ConstBytes blob_;
   TrackEvent::Decoder event_;
   LegacyEvent::Decoder legacy_event_;
+  // Built on first use; shared by every consumer of out-of-tree fields.
+  std::optional<SelectiveTrackEventDecoder> selective_decoder_;
   protos::pbzero::TrackEventDefaults::Decoder* defaults_;
 
   // Importing state.

--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -68,6 +68,22 @@
 
 namespace perfetto::trace_processor {
 namespace {
+
+// Legacy fields (delta timestamps, thread time and instruction counts, the
+// legacy event) are absent from almost every event; one presence-mask test
+// covers them all.
+using TrackEvent = protos::pbzero::TrackEvent;
+constexpr protozero::SelectiveDecodeMask<
+    TrackEvent::kTimestampDeltaUsFieldNumber,
+    TrackEvent::kTimestampAbsoluteUsFieldNumber,
+    TrackEvent::kThreadTimeDeltaUsFieldNumber,
+    TrackEvent::kThreadTimeAbsoluteUsFieldNumber,
+    TrackEvent::kThreadInstructionCountDeltaFieldNumber,
+    TrackEvent::kThreadInstructionCountAbsoluteFieldNumber,
+    TrackEvent::kLegacyEventFieldNumber>
+    kLegacyTrackEventFields{};
+static_assert(decltype(kLegacyTrackEventFields)::kMaxFieldId < 64,
+              "mask must fit one presence word");
 using protos::pbzero::CounterDescriptor;
 
 class V8Sink : public TraceSorter::Sink<LegacyV8CpuProfileEvent, V8Sink> {
@@ -441,13 +457,16 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
   int64_t timestamp;
   bool timestamp_needs_clock_conversion = false;
   TrackEventData data(std::move(*args.packet), args.state);
-  auto* track_event = args.state->GetCustomState<TrackEventSequenceState>();
+  // The sequence-local state is only needed for deltas.
+  const bool legacy = event.HasAnyField(kLegacyTrackEventFields.data(), 1);
+  TrackEventSequenceState* track_event =
+      legacy ? args.state->GetCustomState<TrackEventSequenceState>() : nullptr;
 
   // TODO(eseckler): Remove handling of timestamps relative to ThreadDescriptors
   // once all producers have switched to clock-domain timestamps (e.g.
   // TracePacket's timestamp).
 
-  if (event.has_timestamp_delta_us()) {
+  if (legacy && event.has_timestamp_delta_us()) {
     // Delta timestamps require a valid ThreadDescriptor packet since the last
     // packet loss.
     if (!track_event->timestamps_valid()) {
@@ -460,7 +479,8 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
     timestamp = track_event->IncrementAndGetTrackEventTimeNs(
         base::SaturatingMultiply(event.timestamp_delta_us(), 1000));
     timestamp_needs_clock_conversion = true;
-  } else if (int64_t ts_absolute_us = event.timestamp_absolute_us()) {
+  } else if (int64_t ts_absolute_us =
+                 legacy ? event.timestamp_absolute_us() : 0) {
     // One-off absolute timestamps don't affect delta computation.
     timestamp = base::SaturatingMultiply(ts_absolute_us, 1000);
     timestamp_needs_clock_conversion = true;
@@ -492,7 +512,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
   }
 
   // Handle legacy sample events which might have timestamps embedded inside.
-  if (PERFETTO_UNLIKELY(event.has_legacy_event())) {
+  if (PERFETTO_UNLIKELY(legacy && event.has_legacy_event())) {
     protos::pbzero::TrackEvent::LegacyEvent::Decoder leg(event.legacy_event());
     if (PERFETTO_UNLIKELY(leg.phase() == 'P')) {
       base::Status status = TokenizeLegacySampleEvent(
@@ -504,7 +524,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
     }
   }
 
-  if (event.has_thread_time_delta_us()) {
+  if (legacy && event.has_thread_time_delta_us()) {
     // Delta timestamps require a valid ThreadDescriptor packet since the last
     // packet loss.
     if (!track_event->timestamps_valid()) {
@@ -516,13 +536,13 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
     }
     data.thread_timestamp = track_event->IncrementAndGetTrackEventThreadTimeNs(
         base::SaturatingMultiply(event.thread_time_delta_us(), 1000));
-  } else if (event.has_thread_time_absolute_us()) {
+  } else if (legacy && event.has_thread_time_absolute_us()) {
     // One-off absolute timestamps don't affect delta computation.
     data.thread_timestamp =
         base::SaturatingMultiply(event.thread_time_absolute_us(), 1000);
   }
 
-  if (event.has_thread_instruction_count_delta()) {
+  if (legacy && event.has_thread_instruction_count_delta()) {
     // Delta timestamps require a valid ThreadDescriptor packet since the last
     // packet loss.
     if (!track_event->timestamps_valid()) {
@@ -536,7 +556,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
     data.thread_instruction_count =
         track_event->IncrementAndGetTrackEventThreadInstructionCount(
             event.thread_instruction_count_delta());
-  } else if (event.has_thread_instruction_count_absolute()) {
+  } else if (legacy && event.has_thread_instruction_count_absolute()) {
     // One-off absolute timestamps don't affect delta computation.
     data.thread_instruction_count = event.thread_instruction_count_absolute();
   }
@@ -592,14 +612,16 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
   size_t index = 0;
   const protozero::RepeatedFieldIterator<uint64_t> kEmptyIterator;
   uint32_t seq_id = args.decoder.trusted_packet_sequence_id();
-  if (!AddExtraCounterValues(
+  if (PERFETTO_UNLIKELY(event.has_extra_counter_values()) &&
+      !AddExtraCounterValues(
           *args.state, data, index, event.extra_counter_values(),
           event.extra_counter_track_uuids(),
           defaults ? defaults->extra_counter_track_uuids() : kEmptyIterator,
           seq_id, &data.trace_packet_data.packet)) {
     return ModuleResult::Handled();
   }
-  if (!AddExtraCounterValues(
+  if (PERFETTO_UNLIKELY(event.has_extra_double_counter_values()) &&
+      !AddExtraCounterValues(
           *args.state, data, index, event.extra_double_counter_values(),
           event.extra_double_counter_track_uuids(),
           defaults ? defaults->extra_double_counter_track_uuids()


### PR DESCRIPTION
Several costs were paid on every track event without doing anything
useful for it: two heap allocations to look at a single inline
category, two scans of the raw event bytes for out-of-tree fields
that are almost never there, a second typed decode of every packet in
the reader, a sequence-state insert per packet, a walk of the interned
submessage map to find the track event defaults on every call, six
repeated-field iterators for extra counter values, entering the
"debug" args dictionary for events without debug annotations, and
seven separate checks for legacy timestamp fields.

Each is skipped when it does not apply: the category is counted
through its iterator, the typed decoder records whether it skipped an
out-of-range field, the decoder is passed through, the defaults are
memoized per generation, and the legacy fields are tested with one
presence mask.

Instructions to load a 3.1 GB trace of 23.7M track events go from
540.05G to 473.96G (-12.2%), and for chrome_android_systrace from
11.87G to 10.62G (-10.5%). Output is identical on both.
