### PR TITLE
tp: move the tracing service's packet handlers into a module

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -18508,6 +18508,7 @@ filegroup {
         "src/trace_processor/importers/proto/proto_trace_tokenizer.cc",
         "src/trace_processor/importers/proto/protovm_incremental_tracing.cc",
         "src/trace_processor/importers/proto/stack_profile_sequence_state.cc",
+        "src/trace_processor/importers/proto/tracing_service_module.cc",
         "src/trace_processor/importers/proto/track_event_extension_parser.cc",
         "src/trace_processor/importers/proto/track_event_module.cc",
         "src/trace_processor/importers/proto/track_event_parser.cc",

--- a/BUILD
+++ b/BUILD
@@ -3356,6 +3356,8 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/selective_track_event_decoder.h",
         "src/trace_processor/importers/proto/stack_profile_sequence_state.cc",
         "src/trace_processor/importers/proto/stack_profile_sequence_state.h",
+        "src/trace_processor/importers/proto/tracing_service_module.cc",
+        "src/trace_processor/importers/proto/tracing_service_module.h",
         "src/trace_processor/importers/proto/track_event_event_importer.h",
         "src/trace_processor/importers/proto/track_event_extension_parser.cc",
         "src/trace_processor/importers/proto/track_event_extension_parser.h",

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -65,6 +65,8 @@ source_set("minimal") {
     "selective_track_event_decoder.h",
     "stack_profile_sequence_state.cc",
     "stack_profile_sequence_state.h",
+    "tracing_service_module.cc",
+    "tracing_service_module.h",
     "track_event_event_importer.h",
     "track_event_extension_parser.cc",
     "track_event_extension_parser.h",

--- a/src/trace_processor/importers/proto/default_modules.cc
+++ b/src/trace_processor/importers/proto/default_modules.cc
@@ -22,12 +22,16 @@
 #include "src/trace_processor/importers/proto/memory_tracker_snapshot_module.h"
 #include "src/trace_processor/importers/proto/metadata_minimal_module.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/importers/proto/tracing_service_module.h"
 #include "src/trace_processor/importers/proto/track_event_module.h"
 
 namespace perfetto::trace_processor {
 
 void RegisterDefaultModules(ProtoImporterModuleContext* module_context,
                             TraceProcessorContext* context) {
+  module_context->modules.emplace_back(
+      new TracingServiceModule(module_context, context));
+
   // Ftrace and Etw modules are special, because they have an extra method for
   // parsing the ftrace/etw packets. So we need to store a pointer to it
   // separately.

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -61,7 +61,6 @@
 #include "src/trace_processor/tables/metadata_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/types/variadic.h"
-#include "src/trace_processor/util/decompressor.h"
 #include "src/trace_processor/util/descriptors.h"
 #include "src/trace_processor/util/trace_type.h"
 
@@ -71,8 +70,6 @@
 #include "protos/perfetto/common/trace_stats.pbzero.h"
 #include "protos/perfetto/config/trace_config.pbzero.h"
 #include "protos/perfetto/trace/clock_snapshot.pbzero.h"
-#include "protos/perfetto/trace/extension_descriptor.pbzero.h"
-#include "protos/perfetto/trace/perfetto/tracing_service_event.pbzero.h"
 #include "protos/perfetto/trace/remote_clock_sync.pbzero.h"
 #include "protos/perfetto/trace/trace.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
@@ -237,37 +234,6 @@ base::Status ProtoTraceReader::Parse(TraceBlobView blob) {
   });
 }
 
-base::Status ProtoTraceReader::ParseExtensionDescriptor(ConstBytes descriptor) {
-  protos::pbzero::ExtensionDescriptor::Decoder decoder(descriptor.data,
-                                                       descriptor.size);
-
-  const uint8_t* data = nullptr;
-  size_t size = 0;
-  std::optional<util::DecompressedBuffer> decompressed;
-  if (decoder.has_extension_set()) {
-    auto extension = decoder.extension_set();
-    data = extension.data;
-    size = extension.size;
-  } else if (decoder.has_extension_set_gzip()) {
-    auto gzipped = decoder.extension_set_gzip();
-    decompressed = util::DecompressToBuffer(util::CompressionType::kGzip,
-                                            gzipped.data, gzipped.size);
-    if (!decompressed || decompressed->size == 0) {
-      return base::ErrStatus(
-          "Failed to decompress gzipped extension descriptor (ERR:tp-corrupt)");
-    }
-    data = decompressed->data.get();
-    size = decompressed->size;
-  } else {
-    return base::OkStatus();
-  }
-
-  return context_->descriptor_pool_->AddFromFileDescriptorSet(
-      data, size,
-      /*skip_prefixes*/ {},
-      /*merge_existing_messages=*/true);
-}
-
 base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
   protos::pbzero::TracePacket::Decoder decoder(packet.data(), packet.length());
   if (PERFETTO_UNLIKELY(decoder.bytes_left())) {
@@ -374,29 +340,6 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
   if (decoder.has_remote_clock_sync()) {
     PERFETTO_DCHECK(!is_machine_dispatcher_);
     return ParseRemoteClockSync(decoder.remote_clock_sync());
-  }
-
-  if (decoder.has_service_event()) {
-    PERFETTO_DCHECK(decoder.has_timestamp());
-    int64_t ts = static_cast<int64_t>(decoder.timestamp());
-    // TracingServiceImpl always stamps lifecycle events with GetBootTimeNs(),
-    // so these timestamps are BOOTTIME regardless of primary_trace_clock.
-    // Convert explicitly: this path bypasses the generic timestamp conversion.
-    // If the conversion fails (e.g. clock snapshotting was disabled), keep
-    // the raw value, which is trace time in that case.
-    uint32_t timestamp_clock_id = decoder.has_timestamp_clock_id()
-                                      ? decoder.timestamp_clock_id()
-                                      : protos::pbzero::BUILTIN_CLOCK_BOOTTIME;
-    if (auto trace_ts = context_->clock_tracker->ToTraceTime(
-            ClockId::Machine(timestamp_clock_id), ts, packet.offset(),
-            /*suppress_errors=*/true)) {
-      ts = *trace_ts;
-    }
-    return ParseServiceEvent(ts, decoder.service_event());
-  }
-
-  if (decoder.has_extension_descriptor()) {
-    return ParseExtensionDescriptor(decoder.extension_descriptor());
   }
 
   auto* state = GetIncrementalStateForPacketSequence(seq_id);
@@ -1038,54 +981,6 @@ ProtoTraceReader::CalculateClockOffsets(
   }
 
   return clock_offsets;
-}
-
-base::Status ProtoTraceReader::ParseServiceEvent(int64_t ts, ConstBytes blob) {
-  protos::pbzero::TracingServiceEvent::Decoder tse(blob);
-  if (tse.tracing_started()) {
-    context_->metadata_tracker->SetMetadata(metadata::tracing_started_ns,
-                                            Variadic::Integer(ts));
-  }
-  if (tse.tracing_disabled()) {
-    context_->metadata_tracker->SetMetadata(metadata::tracing_disabled_ns,
-                                            Variadic::Integer(ts));
-  }
-  if (tse.all_data_sources_started()) {
-    context_->metadata_tracker->SetMetadata(
-        metadata::all_data_source_started_ns, Variadic::Integer(ts));
-  }
-  if (tse.all_data_sources_flushed()) {
-    context_->metadata_tracker->AppendMetadata(
-        metadata::all_data_source_flushed_ns, Variadic::Integer(ts));
-    context_->sorter->NotifyFlushEvent();
-  }
-  if (tse.read_tracing_buffers_completed()) {
-    context_->sorter->NotifyReadBufferEvent();
-  }
-  if (tse.has_slow_starting_data_sources()) {
-    protos::pbzero::TracingServiceEvent::DataSources::Decoder msg(
-        tse.slow_starting_data_sources());
-    for (auto it = msg.data_source(); it; it++) {
-      protos::pbzero::TracingServiceEvent::DataSources::DataSource::Decoder
-          data_source(*it);
-      std::string formatted = data_source.producer_name().ToStdString() + " " +
-                              data_source.data_source_name().ToStdString();
-      context_->metadata_tracker->AppendMetadata(
-          metadata::slow_start_data_source,
-          Variadic::String(
-              context_->storage->InternString(base::StringView(formatted))));
-    }
-  }
-  if (tse.has_clone_started()) {
-    context_->stats_tracker->SetStats(stats::traced_clone_started_timestamp_ns,
-                                      ts);
-  }
-  if (tse.has_buffer_cloned()) {
-    context_->stats_tracker->SetIndexedStats(
-        stats::traced_buf_clone_done_timestamp_ns,
-        static_cast<int>(tse.buffer_cloned()), ts);
-  }
-  return base::OkStatus();
 }
 
 void ProtoTraceReader::ParseTraceStats(ConstBytes blob) {

--- a/src/trace_processor/importers/proto/proto_trace_reader.h
+++ b/src/trace_processor/importers/proto/proto_trace_reader.h
@@ -129,7 +129,6 @@ class ProtoTraceReader : public ChunkedTraceReader {
   base::Status TimestampTokenizeAndPushToSorter(
       const protos::pbzero::TracePacket_Decoder&,
       TraceBlobView);
-  base::Status ParseServiceEvent(int64_t ts, ConstBytes);
   base::Status ParseClockSnapshot(ConstBytes blob, uint32_t seq_id);
   base::Status ParseRemoteClockSync(ConstBytes blob);
 
@@ -164,7 +163,6 @@ class ProtoTraceReader : public ChunkedTraceReader {
     }
     return &*builder;
   }
-  base::Status ParseExtensionDescriptor(ConstBytes descriptor);
 
   TraceProcessorContext* context_;
   ProtoTraceTokenizer tokenizer_;

--- a/src/trace_processor/importers/proto/tracing_service_module.cc
+++ b/src/trace_processor/importers/proto/tracing_service_module.cc
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/tracing_service_module.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/string_view.h"
+#include "perfetto/protozero/field.h"
+#include "src/trace_processor/importers/common/clock_tracker.h"
+#include "src/trace_processor/importers/common/metadata_tracker.h"
+#include "src/trace_processor/importers/common/stats_tracker.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/sorter/trace_sorter.h"
+#include "src/trace_processor/storage/metadata.h"
+#include "src/trace_processor/storage/stats.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/types/variadic.h"
+#include "src/trace_processor/util/decompressor.h"
+#include "src/trace_processor/util/descriptors.h"
+
+#include "protos/perfetto/common/builtin_clock.pbzero.h"
+#include "protos/perfetto/trace/extension_descriptor.pbzero.h"
+#include "protos/perfetto/trace/perfetto/tracing_service_event.pbzero.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+
+namespace perfetto::trace_processor {
+
+using TracePacket = protos::pbzero::TracePacket;
+
+TracingServiceModule::TracingServiceModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context), context_(context) {
+  RegisterForField(TracePacket::kServiceEventFieldNumber);
+  RegisterForField(TracePacket::kExtensionDescriptorFieldNumber);
+}
+
+TracingServiceModule::~TracingServiceModule() = default;
+
+ModuleResult TracingServiceModule::TokenizePacket(
+    const TokenizePacketArgs& args) {
+  switch (args.field.id()) {
+    case TracePacket::kServiceEventFieldNumber: {
+      // TracingServiceImpl always stamps lifecycle events with
+      // GetBootTimeNs(), so the timestamp as written is BOOTTIME regardless
+      // of primary_trace_clock. Convert it explicitly from the decoder
+      // rather than using |args.ts|. If the conversion fails (e.g. clock
+      // snapshotting was disabled), keep the raw value, which is trace time
+      // in that case.
+      PERFETTO_DCHECK(args.decoder.has_timestamp());
+      int64_t ts = static_cast<int64_t>(args.decoder.timestamp());
+      uint32_t timestamp_clock_id =
+          args.decoder.has_timestamp_clock_id()
+              ? args.decoder.timestamp_clock_id()
+              : protos::pbzero::BUILTIN_CLOCK_BOOTTIME;
+      if (auto trace_ts = context_->clock_tracker->ToTraceTime(
+              ClockId::Machine(timestamp_clock_id), ts, args.packet->offset(),
+              /*suppress_errors=*/true)) {
+        ts = *trace_ts;
+      }
+      return ParseServiceEvent(ts,
+                               args.field.Cast<TracePacket::kServiceEvent>());
+    }
+    case TracePacket::kExtensionDescriptorFieldNumber:
+      return ParseExtensionDescriptor(
+          args.field.Cast<TracePacket::kExtensionDescriptor>());
+    default:
+      return ModuleResult::Ignored();
+  }
+}
+
+base::Status TracingServiceModule::ParseServiceEvent(int64_t ts,
+                                                     ConstBytes blob) {
+  protos::pbzero::TracingServiceEvent::Decoder tse(blob);
+  if (tse.tracing_started()) {
+    context_->metadata_tracker->SetMetadata(metadata::tracing_started_ns,
+                                            Variadic::Integer(ts));
+  }
+  if (tse.tracing_disabled()) {
+    context_->metadata_tracker->SetMetadata(metadata::tracing_disabled_ns,
+                                            Variadic::Integer(ts));
+  }
+  if (tse.all_data_sources_started()) {
+    context_->metadata_tracker->SetMetadata(
+        metadata::all_data_source_started_ns, Variadic::Integer(ts));
+  }
+  if (tse.all_data_sources_flushed()) {
+    context_->metadata_tracker->AppendMetadata(
+        metadata::all_data_source_flushed_ns, Variadic::Integer(ts));
+    context_->sorter->NotifyFlushEvent();
+  }
+  if (tse.read_tracing_buffers_completed()) {
+    context_->sorter->NotifyReadBufferEvent();
+  }
+  if (tse.has_slow_starting_data_sources()) {
+    protos::pbzero::TracingServiceEvent::DataSources::Decoder msg(
+        tse.slow_starting_data_sources());
+    for (auto it = msg.data_source(); it; it++) {
+      protos::pbzero::TracingServiceEvent::DataSources::DataSource::Decoder
+          data_source(*it);
+      std::string formatted = data_source.producer_name().ToStdString() + " " +
+                              data_source.data_source_name().ToStdString();
+      context_->metadata_tracker->AppendMetadata(
+          metadata::slow_start_data_source,
+          Variadic::String(
+              context_->storage->InternString(base::StringView(formatted))));
+    }
+  }
+  if (tse.has_clone_started()) {
+    context_->stats_tracker->SetStats(stats::traced_clone_started_timestamp_ns,
+                                      ts);
+  }
+  if (tse.has_buffer_cloned()) {
+    context_->stats_tracker->SetIndexedStats(
+        stats::traced_buf_clone_done_timestamp_ns,
+        static_cast<int>(tse.buffer_cloned()), ts);
+  }
+  return base::OkStatus();
+}
+
+base::Status TracingServiceModule::ParseExtensionDescriptor(
+    ConstBytes descriptor) {
+  protos::pbzero::ExtensionDescriptor::Decoder decoder(descriptor.data,
+                                                       descriptor.size);
+
+  const uint8_t* data = nullptr;
+  size_t size = 0;
+  std::optional<util::DecompressedBuffer> decompressed;
+  if (decoder.has_extension_set()) {
+    auto extension = decoder.extension_set();
+    data = extension.data;
+    size = extension.size;
+  } else if (decoder.has_extension_set_gzip()) {
+    auto gzipped = decoder.extension_set_gzip();
+    decompressed = util::DecompressToBuffer(util::CompressionType::kGzip,
+                                            gzipped.data, gzipped.size);
+    if (!decompressed || decompressed->size == 0) {
+      return base::ErrStatus(
+          "Failed to decompress gzipped extension descriptor (ERR:tp-corrupt)");
+    }
+    data = decompressed->data.get();
+    size = decompressed->size;
+  } else {
+    return base::OkStatus();
+  }
+
+  return context_->descriptor_pool_->AddFromFileDescriptorSet(
+      data, size,
+      /*skip_prefixes*/ {},
+      /*merge_existing_messages=*/true);
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/tracing_service_module.h
+++ b/src/trace_processor/importers/proto/tracing_service_module.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_TRACING_SERVICE_MODULE_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_TRACING_SERVICE_MODULE_H_
+
+#include <cstdint>
+
+#include "perfetto/base/status.h"
+#include "perfetto/protozero/field.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+
+namespace perfetto::trace_processor {
+
+class TraceProcessorContext;
+
+// Handles the packets the tracing service emits about the trace itself and
+// that nothing else in the pipeline depends on: service lifecycle events
+// and extension descriptors. Clock snapshots stay in ProtoTraceReader,
+// since resolving any packet's timestamp depends on them.
+class TracingServiceModule : public ProtoImporterModule {
+ public:
+  using ConstBytes = protozero::ConstBytes;
+
+  TracingServiceModule(ProtoImporterModuleContext* module_context,
+                       TraceProcessorContext* context);
+  ~TracingServiceModule() override;
+
+  ModuleResult TokenizePacket(const TokenizePacketArgs& args) override;
+
+ private:
+  base::Status ParseServiceEvent(int64_t ts, ConstBytes blob);
+  base::Status ParseExtensionDescriptor(ConstBytes descriptor);
+
+  TraceProcessorContext* const context_;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_TRACING_SERVICE_MODULE_H_

--- a/test/trace_processor/diff_tests/metrics/chrome/proto_content.out
+++ b/test/trace_processor/diff_tests/metrics/chrome/proto_content.out
@@ -1,10 +1,10 @@
 "path","total_size"
-"TracePacket",364932
+"TracePacket",364941
 "TracePacket.#track_event.TrackEvent",254590
-"TracePacket.#trusted_uid.int32",95260
+"TracePacket.#trusted_uid.int32",95262
 "TracePacket.#track_event.TrackEvent.#debug_annotations.DebugAnnotation.#string_value.string",73911
-"TracePacket.#timestamp.uint64",66933
-"TracePacket.#trusted_packet_sequence_id.uint32",39091
+"TracePacket.#timestamp.uint64",66939
+"TracePacket.#trusted_packet_sequence_id.uint32",39092
 "TracePacket.#sequence_flags.uint32",39020
 "TracePacket.#track_event.TrackEvent.#extra_counter_values.int64",36079
 "TracePacket.#track_event.TrackEvent.#chrome_latency_info.ChromeLatencyInfo",33452


### PR DESCRIPTION
Service lifecycle events and extension descriptors were handled by
ProtoTraceReader itself although nothing about them needs the reader:
they consume their field and are done, which is what importer modules
are for. They move verbatim into TracingServiceModule. Clock snapshots
stay in the reader, since resolving any packet's timestamp, including
the snapshot's own, depends on them.

The two packet types now pass through the content analyzer like every
other module-handled packet, which moves the proto_content diff test
expectation by one packet. Instructions are unchanged.
