### PR TITLE
tp: decode each packet once in the proto reader

### DIFF
--- a/src/trace_processor/importers/proto/default_modules.cc
+++ b/src/trace_processor/importers/proto/default_modules.cc
@@ -53,6 +53,8 @@ void RegisterDefaultModules(ProtoImporterModuleContext* module_context,
       new ChromeSystemProbesModule(module_context, context));
   module_context->modules.emplace_back(
       new MetadataMinimalModule(module_context, context));
+  module_context->metadata_minimal_module =
+      static_cast<MetadataMinimalModule*>(module_context->modules.back().get());
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/metadata_minimal_module.cc
+++ b/src/trace_processor/importers/proto/metadata_minimal_module.cc
@@ -44,7 +44,8 @@ MetadataMinimalModule::MetadataMinimalModule(
     ProtoImporterModuleContext* module_context,
     TraceProcessorContext* context)
     : ProtoImporterModule(module_context), context_(context) {
-  RegisterForField(TracePacket::kChromeMetadataFieldNumber);
+  // Chrome metadata is decoded by name for timestamp handling and dispatched
+  // directly by ProtoTraceReader.
   RegisterForField(TracePacket::kChromeBenchmarkMetadataFieldNumber);
 }
 

--- a/src/trace_processor/importers/proto/proto_importer_module.h
+++ b/src/trace_processor/importers/proto/proto_importer_module.h
@@ -44,6 +44,7 @@ namespace trace_processor {
 class EtwModule;
 class FtraceModule;
 class TrackEventModule;
+class MetadataMinimalModule;
 class TraceBlobView;
 class TraceProcessorContext;
 class TrackEventModule;
@@ -191,6 +192,7 @@ struct ProtoImporterModuleContext {
   FtraceModule* ftrace_module = nullptr;
   EtwModule* etw_module = nullptr;
   TrackEventModule* track_module = nullptr;
+  MetadataMinimalModule* metadata_minimal_module = nullptr;
 
   std::unique_ptr<TraceSorter::Stream<TracePacketData>> trace_packet_stream;
   std::unique_ptr<TraceSorter::Stream<TrackEventData>> track_event_stream;

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -51,9 +51,11 @@
 #include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/common/stats_tracker.h"
 #include "src/trace_processor/importers/proto/default_modules.h"
+#include "src/trace_processor/importers/proto/metadata_minimal_module.h"
 #include "src/trace_processor/importers/proto/packet_analyzer.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/proto_trace_parser_impl.h"
+#include "src/trace_processor/importers/proto/track_event_module.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
 #include "src/trace_processor/storage/metadata.h"
 #include "src/trace_processor/storage/stats.h"
@@ -235,7 +237,7 @@ base::Status ProtoTraceReader::Parse(TraceBlobView blob) {
 }
 
 base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
-  protos::pbzero::TracePacket::Decoder decoder(packet.data(), packet.length());
+  SelectiveTracePacketDecoder decoder(packet.data(), packet.length());
   if (PERFETTO_UNLIKELY(decoder.bytes_left())) {
     return base::ErrStatus(
         "Failed to parse proto packet fully; the trace is probably corrupt. "
@@ -280,8 +282,7 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
   } else if (auto new_packet = protovm_.TryProcessPatch(decoder, packet);
              new_packet) {
     packet = std::move(*new_packet);
-    decoder =
-        protos::pbzero::TracePacket::Decoder(packet.data(), packet.length());
+    decoder = SelectiveTracePacketDecoder(packet.data(), packet.length());
   }
 
   uint32_t seq_id = decoder.trusted_packet_sequence_id();
@@ -415,12 +416,12 @@ ProtoTraceReader::ClockResolution ProtoTraceReader::ResolveTimestampToTraceTime(
 
 base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
     TraceBlobView packet) {
-  protos::pbzero::TracePacket::Decoder decoder(packet.data(), packet.length());
+  SelectiveTracePacketDecoder decoder(packet.data(), packet.length());
   return TimestampTokenizeAndPushToSorter(decoder, std::move(packet));
 }
 
 base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
-    const protos::pbzero::TracePacket::Decoder& decoder,
+    const SelectiveTracePacketDecoder& decoder,
     TraceBlobView packet) {
   uint32_t seq_id = decoder.trusted_packet_sequence_id();
   auto* state = GetIncrementalStateForPacketSequence(seq_id);
@@ -448,9 +449,9 @@ base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
       }
     }
 
-    if ((decoder.has_chrome_events() || decoder.has_chrome_metadata()) &&
-        (!timestamp_clock_id ||
-         timestamp_clock_id == protos::pbzero::BUILTIN_CLOCK_MONOTONIC)) {
+    if ((!timestamp_clock_id ||
+         timestamp_clock_id == protos::pbzero::BUILTIN_CLOCK_MONOTONIC) &&
+        (decoder.has_chrome_events() || decoder.has_chrome_metadata())) {
       // Chrome event timestamps are in MONOTONIC domain, but may occur in
       // traces where (a) no clock snapshots exist or (b) no clock_id is
       // specified for their timestamps. Adjust to trace time if we have a clock
@@ -495,19 +496,32 @@ base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
   }
   latest_timestamp_ = std::max(timestamp, latest_timestamp_);
 
+  // Track events and Chrome metadata are read by name, so they go straight
+  // to their modules. Every other payload field is in the spill
+  // list, in wire order, including the out-of-tree `extensions 1000 to
+  // 1999` range; dispatch the registered ones.
+  if (PERFETTO_LIKELY(decoder.has_track_event())) {
+    ModuleResult res = module_context_.track_module->TokenizePacket(
+        {decoder, &packet, timestamp, state->current_generation(),
+         decoder.track_event_field()});
+    if (!res.ignored())
+      return res.ToStatus();
+  }
+  if (PERFETTO_UNLIKELY(decoder.has_chrome_metadata())) {
+    ModuleResult res = module_context_.metadata_minimal_module->TokenizePacket(
+        {decoder, &packet, timestamp, state->current_generation(),
+         decoder.chrome_metadata_field()});
+    if (!res.ignored())
+      return res.ToStatus();
+  }
   auto& modules = module_context_.modules_by_field;
-  // One pass over the packet, dispatching registered fields as they are
-  // found. This also covers fields in the out-of-tree `extensions 1000 to
-  // 1999` range, which the typed |decoder| does not store.
-  SelectiveTracePacketDecoder packet_fields(
-      decoder.begin(), static_cast<size_t>(decoder.end() - decoder.begin()));
-  for (const protozero::Field& f : packet_fields.unknown_fields()) {
+  for (const protozero::Field& f : decoder.unknown_fields()) {
     if (f.id() >= modules.size() || modules[f.id()].empty())
       continue;
     for (ProtoImporterModule* module : modules[f.id()]) {
-      ModuleResult res = module->TokenizePacket(
-          {packet_fields, &packet, timestamp, state->current_generation(),
-           TracePacketField(f)});
+      ModuleResult res = module->TokenizePacket({decoder, &packet, timestamp,
+                                                 state->current_generation(),
+                                                 TracePacketField(f)});
       if (!res.ignored())
         return res.ToStatus();
     }
@@ -544,7 +558,7 @@ void ProtoTraceReader::ParseTraceConfig(protozero::ConstBytes blob) {
 }
 
 void ProtoTraceReader::HandleIncrementalStateCleared(
-    const protos::pbzero::TracePacket::Decoder& packet_decoder,
+    const SelectiveTracePacketDecoder& packet_decoder,
     const TraceBlobView& packet) {
   if (PERFETTO_UNLIKELY(!packet_decoder.has_trusted_packet_sequence_id())) {
     context_->import_logs_tracker->RecordTokenizationLog(
@@ -588,7 +602,7 @@ void ProtoTraceReader::HandleTraceAttributes(protozero::ConstBytes blob) {
 }
 
 void ProtoTraceReader::HandlePreviousPacketDropped(
-    const protos::pbzero::TracePacket::Decoder& packet_decoder,
+    const SelectiveTracePacketDecoder& packet_decoder,
     const TraceBlobView& packet) {
   if (PERFETTO_UNLIKELY(!packet_decoder.has_trusted_packet_sequence_id())) {
     context_->import_logs_tracker->RecordTokenizationLog(
@@ -624,7 +638,7 @@ void ProtoTraceReader::RecordDataLossCauses(SequenceScopedState* seq,
 }
 
 void ProtoTraceReader::ParseTracePacketDefaults(
-    const protos::pbzero::TracePacket_Decoder& packet_decoder,
+    const SelectiveTracePacketDecoder& packet_decoder,
     TraceBlobView trace_packet_defaults) {
   if (PERFETTO_UNLIKELY(!packet_decoder.has_trusted_packet_sequence_id())) {
     context_->import_logs_tracker->RecordTokenizationLog(
@@ -639,7 +653,7 @@ void ProtoTraceReader::ParseTracePacketDefaults(
 }
 
 void ProtoTraceReader::ParseInternedData(
-    const protos::pbzero::TracePacket::Decoder& packet_decoder,
+    const SelectiveTracePacketDecoder& packet_decoder,
     TraceBlobView interned_data) {
   if (PERFETTO_UNLIKELY(!packet_decoder.has_trusted_packet_sequence_id())) {
     context_->import_logs_tracker->RecordTokenizationLog(

--- a/src/trace_processor/importers/proto/proto_trace_reader.h
+++ b/src/trace_processor/importers/proto/proto_trace_reader.h
@@ -32,6 +32,7 @@
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/proto_trace_tokenizer.h"
 #include "src/trace_processor/importers/proto/protovm_incremental_tracing.h"
+#include "src/trace_processor/importers/proto/selective_trace_packet_decoder.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
@@ -42,7 +43,6 @@ struct ConstBytes;
 namespace perfetto {
 
 namespace protos::pbzero {
-class TracePacket_Decoder;
 class TraceConfig_Decoder;
 }  // namespace protos::pbzero
 
@@ -127,7 +127,7 @@ class ProtoTraceReader : public ChunkedTraceReader {
   // Variant for callers that already decoded the packet, so the (wide)
   // TracePacket decoder is not rebuilt per packet.
   base::Status TimestampTokenizeAndPushToSorter(
-      const protos::pbzero::TracePacket_Decoder&,
+      const SelectiveTracePacketDecoder&,
       TraceBlobView);
   base::Status ParseClockSnapshot(ConstBytes blob, uint32_t seq_id);
   base::Status ParseRemoteClockSync(ConstBytes blob);
@@ -136,18 +136,18 @@ class ProtoTraceReader : public ChunkedTraceReader {
   // single-machine by construction) pinned this trace, given evidence that it
   // is actually multi-machine (a remote machine_id or a remote_clock_sync).
   base::Status CheckManifestSingleMachine();
-  void HandleIncrementalStateCleared(const protos::pbzero::TracePacket_Decoder&,
+  void HandleIncrementalStateCleared(const SelectiveTracePacketDecoder&,
                                      const TraceBlobView& packet);
   void HandleFirstPacketOnSequence(uint32_t packet_sequence_id);
-  void HandlePreviousPacketDropped(const protos::pbzero::TracePacket_Decoder&,
+  void HandlePreviousPacketDropped(const SelectiveTracePacketDecoder&,
                                    const TraceBlobView& packet);
   // Breaks down a |previous_packet_dropped| bitmask into per-cause stats
   // (see TracePacket::DataLossReason).
   void RecordDataLossCauses(SequenceScopedState* seq, uint32_t reasons);
   void HandleTraceAttributes(ConstBytes);
-  void ParseTracePacketDefaults(const protos::pbzero::TracePacket_Decoder&,
+  void ParseTracePacketDefaults(const SelectiveTracePacketDecoder&,
                                 TraceBlobView trace_packet_defaults);
-  void ParseInternedData(const protos::pbzero::TracePacket_Decoder&,
+  void ParseInternedData(const SelectiveTracePacketDecoder&,
                          TraceBlobView interned_data);
   void ParseTraceConfig(ConstBytes);
   void ParseTraceStats(ConstBytes);

--- a/src/trace_processor/importers/proto/protovm_incremental_tracing.cc
+++ b/src/trace_processor/importers/proto/protovm_incremental_tracing.cc
@@ -74,7 +74,7 @@ void ProtoVmIncrementalTracing::ProcessProtoVmsPacket(
 }
 
 std::optional<TraceBlobView> ProtoVmIncrementalTracing::TryProcessPatch(
-    const protos::pbzero::TracePacket::Decoder& patch,
+    const SelectiveTracePacketDecoder& patch,
     const TraceBlobView& packet) {
   if (PERFETTO_UNLIKELY(!patch.has_trusted_packet_sequence_id())) {
     return std::nullopt;
@@ -100,7 +100,7 @@ std::optional<TraceBlobView> ProtoVmIncrementalTracing::TryProcessPatch(
 
 TraceBlobView ProtoVmIncrementalTracing::SerializeIncrementalState(
     const protovm::Vm& vm,
-    const protos::pbzero::TracePacket::Decoder& patch) const {
+    const SelectiveTracePacketDecoder& patch) const {
   return context_->blob_packet_writer->WritePacket(
       [&](protos::pbzero::TracePacket* proto) {
         vm.SerializeIncrementalState(proto);

--- a/src/trace_processor/importers/proto/protovm_incremental_tracing.h
+++ b/src/trace_processor/importers/proto/protovm_incremental_tracing.h
@@ -24,6 +24,7 @@
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "src/trace_processor/importers/proto/selective_trace_packet_decoder.h"
 
 namespace perfetto {
 
@@ -43,13 +44,13 @@ class ProtoVmIncrementalTracing {
   void ProcessProtoVmsPacket(protozero::ConstBytes blob,
                              const TraceBlobView& packet);
   std::optional<TraceBlobView> TryProcessPatch(
-      const protos::pbzero::TracePacket::Decoder& patch,
+      const SelectiveTracePacketDecoder& patch,
       const TraceBlobView& packet);
 
  private:
   TraceBlobView SerializeIncrementalState(
       const protovm::Vm& vm,
-      const protos::pbzero::TracePacket::Decoder& patch) const;
+      const SelectiveTracePacketDecoder& patch) const;
 
   TraceProcessorContext* context_;
   base::FlatHashMap<int32_t, std::vector<uint32_t>>

--- a/src/trace_processor/importers/proto/selective_trace_packet_decoder.h
+++ b/src/trace_processor/importers/proto/selective_trace_packet_decoder.h
@@ -33,7 +33,8 @@ using TracePacketField = TypedProtoField;
 
 namespace internal {
 
-// The TracePacket metadata fields the pipeline reads by name (the dense
+// The TracePacket fields the pipeline reads by name: the per-packet
+// metadata and everything ProtoTraceReader consumes itself (the dense
 // allowlist for selective decoding below).
 using TracePacketDenseMask = protozero::SelectiveDecodeMask<
     protos::pbzero::TracePacket::kTimestampFieldNumber,
@@ -46,7 +47,21 @@ using TracePacketDenseMask = protozero::SelectiveDecodeMask<
     protos::pbzero::TracePacket::kIncrementalStateClearedFieldNumber,
     protos::pbzero::TracePacket::kPreviousPacketDroppedFieldNumber,
     protos::pbzero::TracePacket::kFirstPacketOnSequenceFieldNumber,
-    protos::pbzero::TracePacket::kMachineIdFieldNumber>;
+    protos::pbzero::TracePacket::kMachineIdFieldNumber,
+    protos::pbzero::TracePacket::kCompressedPacketsFieldNumber,
+    protos::pbzero::TracePacket::kZstdCompressedPacketsFieldNumber,
+    protos::pbzero::TracePacket::kSynchronizationMarkerFieldNumber,
+    protos::pbzero::TracePacket::kTraceProvenanceFieldNumber,
+    protos::pbzero::TracePacket::kProtovmsFieldNumber,
+    protos::pbzero::TracePacket::kTraceAttributesFieldNumber,
+    protos::pbzero::TracePacket::kTracePacketDefaultsFieldNumber,
+    protos::pbzero::TracePacket::kClockSnapshotFieldNumber,
+    protos::pbzero::TracePacket::kTraceStatsFieldNumber,
+    protos::pbzero::TracePacket::kRemoteClockSyncFieldNumber,
+    protos::pbzero::TracePacket::kTraceConfigFieldNumber,
+    protos::pbzero::TracePacket::kChromeEventsFieldNumber,
+    protos::pbzero::TracePacket::kChromeMetadataFieldNumber,
+    protos::pbzero::TracePacket::kTrackEventFieldNumber>;
 
 inline constexpr TracePacketDenseMask kTracePacketDenseMask{};
 
@@ -128,9 +143,10 @@ class SelectiveTracePacketDecoder {
         .as_bool();
   }
 
-  bool previous_packet_dropped() const {
+  // The data loss reasons, or 0.
+  uint32_t previous_packet_dropped() const {
     return decoder_.at<TracePacket::kPreviousPacketDroppedFieldNumber>()
-        .as_bool();
+        .as_uint32();
   }
 
   bool first_packet_on_sequence() const {
@@ -143,6 +159,92 @@ class SelectiveTracePacketDecoder {
   }
   uint32_t machine_id() const {
     return decoder_.at<TracePacket::kMachineIdFieldNumber>().as_uint32();
+  }
+
+  // Fields consumed by ProtoTraceReader.
+  bool has_compressed_packets() const {
+    return decoder_.at<TracePacket::kCompressedPacketsFieldNumber>().valid();
+  }
+  bool has_zstd_compressed_packets() const {
+    return decoder_.at<TracePacket::kZstdCompressedPacketsFieldNumber>()
+        .valid();
+  }
+  bool has_synchronization_marker() const {
+    return decoder_.at<TracePacket::kSynchronizationMarkerFieldNumber>()
+        .valid();
+  }
+  bool has_trace_provenance() const {
+    return decoder_.at<TracePacket::kTraceProvenanceFieldNumber>().valid();
+  }
+  protozero::ConstBytes trace_provenance() const {
+    return decoder_.at<TracePacket::kTraceProvenanceFieldNumber>().as_bytes();
+  }
+  bool has_protovms() const {
+    return decoder_.at<TracePacket::kProtovmsFieldNumber>().valid();
+  }
+  protozero::ConstBytes protovms() const {
+    return decoder_.at<TracePacket::kProtovmsFieldNumber>().as_bytes();
+  }
+  bool has_trace_attributes() const {
+    return decoder_.at<TracePacket::kTraceAttributesFieldNumber>().valid();
+  }
+  protozero::ConstBytes trace_attributes() const {
+    return decoder_.at<TracePacket::kTraceAttributesFieldNumber>().as_bytes();
+  }
+  bool has_trace_packet_defaults() const {
+    return decoder_.at<TracePacket::kTracePacketDefaultsFieldNumber>().valid();
+  }
+  protozero::ConstBytes trace_packet_defaults() const {
+    return decoder_.at<TracePacket::kTracePacketDefaultsFieldNumber>()
+        .as_bytes();
+  }
+  bool has_clock_snapshot() const {
+    return decoder_.at<TracePacket::kClockSnapshotFieldNumber>().valid();
+  }
+  protozero::ConstBytes clock_snapshot() const {
+    return decoder_.at<TracePacket::kClockSnapshotFieldNumber>().as_bytes();
+  }
+  bool has_trace_stats() const {
+    return decoder_.at<TracePacket::kTraceStatsFieldNumber>().valid();
+  }
+  protozero::ConstBytes trace_stats() const {
+    return decoder_.at<TracePacket::kTraceStatsFieldNumber>().as_bytes();
+  }
+  bool has_remote_clock_sync() const {
+    return decoder_.at<TracePacket::kRemoteClockSyncFieldNumber>().valid();
+  }
+  protozero::ConstBytes remote_clock_sync() const {
+    return decoder_.at<TracePacket::kRemoteClockSyncFieldNumber>().as_bytes();
+  }
+  bool has_trace_config() const {
+    return decoder_.at<TracePacket::kTraceConfigFieldNumber>().valid();
+  }
+  protozero::ConstBytes trace_config() const {
+    return decoder_.at<TracePacket::kTraceConfigFieldNumber>().as_bytes();
+  }
+
+  // Whether the packet was decoded to its end.
+  size_t bytes_left() const { return decoder_.bytes_left(); }
+
+  bool has_chrome_events() const {
+    return decoder_.at<TracePacket::kChromeEventsFieldNumber>().valid();
+  }
+
+  bool has_chrome_metadata() const {
+    return decoder_.at<TracePacket::kChromeMetadataFieldNumber>().valid();
+  }
+  TracePacketField chrome_metadata_field() const {
+    return TracePacketField(
+        decoder_.at<TracePacket::kChromeMetadataFieldNumber>());
+  }
+
+  // Track events are the common payload, so the reader hands them to their
+  // module directly rather than through unknown_fields().
+  bool has_track_event() const {
+    return decoder_.at<TracePacket::kTrackEventFieldNumber>().valid();
+  }
+  TracePacketField track_event_field() const {
+    return TracePacketField(decoder_.at<TracePacket::kTrackEventFieldNumber>());
   }
 
   // All the fields not in the allowlist, in wire order, with repeated

--- a/src/trace_processor/importers/proto/track_event_module.cc
+++ b/src/trace_processor/importers/proto/track_event_module.cc
@@ -44,7 +44,6 @@ TrackEventModule::TrackEventModule(ProtoImporterModuleContext* module_context,
       tokenizer_(module_context, context, track_event_tracker_.get()),
       parser_(&extension_parser_context_, context, track_event_tracker_.get()) {
   RegisterForField(TracePacket::kTrackEventRangeOfInterestFieldNumber);
-  RegisterForField(TracePacket::kTrackEventFieldNumber);
   RegisterForField(TracePacket::kTrackDescriptorFieldNumber);
   RegisterForField(TracePacket::kThreadDescriptorFieldNumber);
   RegisterForField(TracePacket::kProcessDescriptorFieldNumber);


### PR DESCRIPTION
Every TracePacket was decoded twice on the tokenization path: with the
typed decoder in ParsePacket, which reads the reader's fields by name,
and again with SelectiveTracePacketDecoder for module dispatch.

The selective decoder's allowlist now covers every field the reader
reads by name, so ParsePacket decodes once with it and passes it down.
Its spill list remains exactly the payload fields modules are
dispatched on, in wire order; track events are read by name and handed
to their module directly.

Instructions to load a 3.1 GB trace of 23.7M track events go from
473.96G to 459.93G (-3.0%), and for chrome_android_systrace from
10.62G to 10.25G (-3.5%). Output is identical on both.
