### PR TITLE
tp: stop re-resolving per-generation packet state on every packet

### DIFF
--- a/src/trace_processor/importers/common/clock_tracker.h
+++ b/src/trace_processor/importers/common/clock_tracker.h
@@ -163,7 +163,7 @@ class ClockTracker {
                             int64_t to_ts = 0);
 
   // Returns the trace default clock, if one has been set.
-  std::optional<ClockId> trace_default_clock() const {
+  const std::optional<ClockId>& trace_default_clock() const {
     return trace_default_clock_;
   }
 

--- a/src/trace_processor/importers/proto/packet_sequence_state_generation.h
+++ b/src/trace_processor/importers/proto/packet_sequence_state_generation.h
@@ -122,13 +122,20 @@ class PacketSequenceStateGeneration : public RefCounted {
     return &*trace_packet_defaults_;
   }
 
-  // Returns |nullptr| if no defaults were set.
+  // Returns |nullptr| if no defaults were set. The defaults are fixed for
+  // the lifetime of a generation, so the decoder is resolved once.
   protos::pbzero::TracePacketDefaults::Decoder* GetTracePacketDefaults() {
+    if (PERFETTO_LIKELY(trace_packet_defaults_resolved_)) {
+      return trace_packet_defaults_decoder_;
+    }
+    trace_packet_defaults_resolved_ = true;
     if (!trace_packet_defaults_.has_value()) {
       return nullptr;
     }
-    return trace_packet_defaults_
-        ->GetOrCreateDecoder<protos::pbzero::TracePacketDefaults>();
+    trace_packet_defaults_decoder_ =
+        trace_packet_defaults_
+            ->GetOrCreateDecoder<protos::pbzero::TracePacketDefaults>();
+    return trace_packet_defaults_decoder_;
   }
 
   // Returns |nullptr| if no TrackEventDefaults were set. The defaults are
@@ -196,6 +203,9 @@ class PacketSequenceStateGeneration : public RefCounted {
 
   // Per-slice state.
   std::optional<InternedMessageView> trace_packet_defaults_;
+  bool trace_packet_defaults_resolved_ = false;
+  protos::pbzero::TracePacketDefaults::Decoder* trace_packet_defaults_decoder_ =
+      nullptr;
   bool track_event_defaults_resolved_ = false;
   protos::pbzero::TrackEventDefaults::Decoder* track_event_defaults_ = nullptr;
   // TODO(carlscab): Should not be needed as clients of this class should not

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -441,10 +441,12 @@ base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
     if (PERFETTO_UNLIKELY(!timestamp_clock_id && defaults)) {
       timestamp_clock_id = defaults->timestamp_clock_id();
     }
-    std::optional<ClockTracker::ClockId> default_clock;
+    const ClockTracker::ClockId* default_clock = nullptr;
     if (PERFETTO_UNLIKELY(!timestamp_clock_id)) {
-      default_clock = context_->clock_tracker->trace_default_clock();
-      if (default_clock) {
+      const std::optional<ClockTracker::ClockId>& trace_default =
+          context_->clock_tracker->trace_default_clock();
+      if (trace_default) {
+        default_clock = &*trace_default;
         timestamp_clock_id = default_clock->clock_id;
       }
     }

--- a/src/trace_processor/importers/proto/protovm_incremental_tracing.cc
+++ b/src/trace_processor/importers/proto/protovm_incremental_tracing.cc
@@ -76,7 +76,8 @@ void ProtoVmIncrementalTracing::ProcessProtoVmsPacket(
 std::optional<TraceBlobView> ProtoVmIncrementalTracing::TryProcessPatch(
     const SelectiveTracePacketDecoder& patch,
     const TraceBlobView& packet) {
-  if (PERFETTO_UNLIKELY(!patch.has_trusted_packet_sequence_id())) {
+  if (PERFETTO_LIKELY(sequence_id_to_vms_.size() == 0) ||
+      PERFETTO_UNLIKELY(!patch.has_trusted_packet_sequence_id())) {
     return std::nullopt;
   }
   std::vector<protovm::Vm*>* vms =


### PR DESCRIPTION
The ProtoVM patch check hashed the sequence id on every packet although
no VM is configured in almost every trace, the trace packet defaults
decoder was re-resolved per packet although the defaults are fixed for
a generation, and the default clock was copied per packet. The check
returns early without VMs, the decoder is memoized like the track
event defaults already were, and the clock is borrowed.

Instructions to load a 3.1 GB trace of 23.7M track events go from
459.93G to 458.13G (-0.4%), and for chrome_android_systrace from
10.25G to 10.22G (-0.2%). Output is identical on both.
