### PR TITLE
tp+ui: parse VirtualDisplayComposite field from FrameworksNativeTracePacket instead of FrameTimelineEvent

### DIFF
--- a/protos/third_party/android/frameworks/native/tracing/frameworks_native_trace_packet.proto
+++ b/protos/third_party/android/frameworks/native/tracing/frameworks_native_trace_packet.proto
@@ -378,22 +378,8 @@ message FrameTimelineEvent {
     optional int64 cookie = 1;
   };
 
-  // Emitted once per composite queued to a virtual display's output surface
-  // (e.g. a display-video mirror feeding a MediaCodec input surface). Ties the
-  // frame-timeline token of that composite to the exact present time stamped on
-  // the queued buffer. A surface-input encoder carries that buffer timestamp
-  // through unchanged as the frame's presentation time, so present_time_us
-  // equals the encoded frame's presentationTimeUs and a consumer can join the
-  // token to that frame with certainty.
-  message VirtualDisplayComposite {
-    // SurfaceFlinger's id for the virtual display.
-    optional int64 display_id = 1;
-    // The frame-timeline token (vsync id) of the composite.
-    optional int64 vsync_id = 2;
-    // CLOCK_MONOTONIC present time stamped on the queued buffer, in
-    // microseconds. Equals the encoded frame's presentationTimeUs.
-    optional int64 present_time_us = 3;
-  };
+  reserved 6;
+  reserved "virtual_display_composite";
 
   oneof event {
     ExpectedDisplayFrameStart expected_display_frame_start = 1;
@@ -403,14 +389,30 @@ message FrameTimelineEvent {
     ActualSurfaceFrameStart actual_surface_frame_start = 4;
 
     FrameEnd frame_end = 5;
-
-    VirtualDisplayComposite virtual_display_composite = 6;
   }
 }
+
+// Emitted once per composite queued to a virtual display's output surface
+// (e.g. a display-video mirror feeding a MediaCodec input surface). Ties the
+// frame-timeline token of that composite to the exact present time stamped on
+// the queued buffer. A surface-input encoder carries that buffer timestamp
+// through unchanged as the frame's presentation time, so present_time_us
+// equals the encoded frame's presentationTimeUs and a consumer can join the
+// token to that frame with certainty.
+message VirtualDisplayComposite {
+  // SurfaceFlinger's id for the virtual display.
+  optional int64 display_id = 1;
+  // The frame-timeline token (vsync id) of the composite.
+  optional int64 vsync_id = 2;
+  // CLOCK_MONOTONIC present time stamped on the queued buffer, in
+  // microseconds. Equals the encoded frame's presentationTimeUs.
+  optional int64 present_time_us = 3;
+};
 
 message FrameworksNativeTracePacket {
   extend perfetto.protos.TracePacket {
     optional FrameTimelineEvent frame_timeline_event = 76;
     optional EvdevEvent evdev_event = 121;
+    optional VirtualDisplayComposite virtual_display_composite = 1100;
   }
 }

--- a/src/trace_processor/plugins/video_frame_importer/BUILD.gn
+++ b/src/trace_processor/plugins/video_frame_importer/BUILD.gn
@@ -63,6 +63,7 @@ perfetto_unittest_source_set("unittests") {
     "../../../../include/perfetto/trace_processor:storage",
     "../../../../protos/perfetto/trace:zero",
     "../../../../protos/third_party/android/frameworks/base/proto/tracing:frameworks_base_trace_packet_zero",
+    "../../../../protos/third_party/android/frameworks/native/tracing:frameworks_native_trace_packet_zero",
     "../../../protozero",
     "../../importers/common",
     "../../importers/common:parser_types",

--- a/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
+++ b/src/trace_processor/plugins/video_frame_importer/video_frame_module.cc
@@ -44,11 +44,11 @@
 
 namespace perfetto::trace_processor {
 
-using ::com::android::internal::pbzero::FrameTimelineEvent;
 using ::com::android::internal::pbzero::FrameworksBaseTracePacket;
 using ::com::android::internal::pbzero::FrameworksNativeTracePacket;
 using ::com::android::internal::pbzero::VideoFrame;
 using ::com::android::internal::pbzero::VideoFrameError;
+using ::com::android::internal::pbzero::VirtualDisplayComposite;
 using ::perfetto::protos::pbzero::TracePacket;
 
 VideoFrameModule::VideoFrameModule(ProtoImporterModuleContext* mc,
@@ -61,11 +61,10 @@ VideoFrameModule::VideoFrameModule(ProtoImporterModuleContext* mc,
       au_data_(au_data) {
   RegisterForField(FrameworksBaseTracePacket::kVideoFrameFieldNumber);
   RegisterForField(FrameworksBaseTracePacket::kVideoFrameErrorFieldNumber);
-  // Also observe frame-timeline events, to pick out VirtualDisplayComposite and
-  // join the exact composite token onto each video frame by present time. This
-  // field is also handled by GraphicsEventModule; multiple modules per field is
-  // supported.
-  RegisterForField(FrameworksNativeTracePacket::kFrameTimelineEventFieldNumber);
+  // Observe VirtualDisplayComposite events to join the composite vsync token
+  // onto each video frame by matching present time.
+  RegisterForField(
+      FrameworksNativeTracePacket::kVirtualDisplayCompositeFieldNumber);
 }
 
 VideoFrameModule::~VideoFrameModule() = default;
@@ -108,9 +107,10 @@ void VideoFrameModule::ParseField(const ParseFieldArgs& args) {
           args.field.Cast<FrameworksBaseTracePacket::kVideoFrameError>(),
           args.ts);
       break;
-    case FrameworksNativeTracePacket::kFrameTimelineEventFieldNumber:
-      ParseFrameTimelineEvent(
-          args.field.Cast<FrameworksNativeTracePacket::kFrameTimelineEvent>());
+    case FrameworksNativeTracePacket::kVirtualDisplayCompositeFieldNumber:
+      ParseVirtualDisplayComposite(
+          args.field
+              .Cast<FrameworksNativeTracePacket::kVirtualDisplayComposite>());
       break;
     default:
       break;
@@ -246,13 +246,9 @@ void VideoFrameModule::ParseVideoFrameError(protozero::ConstBytes bytes,
       });
 }
 
-void VideoFrameModule::ParseFrameTimelineEvent(protozero::ConstBytes bytes) {
-  FrameTimelineEvent::Decoder event(bytes);
-  if (!event.has_virtual_display_composite()) {
-    return;
-  }
-  FrameTimelineEvent::VirtualDisplayComposite::Decoder vdc(
-      event.virtual_display_composite());
+void VideoFrameModule::ParseVirtualDisplayComposite(
+    protozero::ConstBytes bytes) {
+  VirtualDisplayComposite::Decoder vdc(bytes);
   if (!vdc.has_present_time_us() || !vdc.has_vsync_id()) {
     return;
   }

--- a/src/trace_processor/plugins/video_frame_importer/video_frame_module.h
+++ b/src/trace_processor/plugins/video_frame_importer/video_frame_module.h
@@ -69,7 +69,7 @@ class VideoFrameModule : public ProtoImporterModule {
                        int64_t ts,
                        const TracePacketData& data);
   void ParseVideoFrameError(protozero::ConstBytes bytes, int64_t ts);
-  void ParseFrameTimelineEvent(protozero::ConstBytes bytes);
+  void ParseVirtualDisplayComposite(protozero::ConstBytes bytes);
 
   struct StreamInfo {
     // display_name and codec_string arrive on the codec_config packet and

--- a/src/trace_processor/plugins/video_frame_importer/video_frame_module_unittest.cc
+++ b/src/trace_processor/plugins/video_frame_importer/video_frame_module_unittest.cc
@@ -36,6 +36,7 @@
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "protos/third_party/android/frameworks/base/proto/tracing/frameworks_base_trace_packet.pbzero.h"
+#include "protos/third_party/android/frameworks/native/tracing/frameworks_native_trace_packet.pbzero.h"
 
 #include "test/gtest_and_gmock.h"
 
@@ -43,7 +44,9 @@ namespace perfetto::trace_processor {
 namespace {
 
 using ::com::android::internal::pbzero::FrameworksBaseTracePacket;
+using ::com::android::internal::pbzero::FrameworksNativeTracePacket;
 using ::com::android::internal::pbzero::VideoFrame;
+using ::com::android::internal::pbzero::VirtualDisplayComposite;
 using ::perfetto::protos::pbzero::TracePacket;
 
 class VideoFrameModuleTest : public testing::Test {
@@ -80,6 +83,56 @@ class VideoFrameModuleTest : public testing::Test {
                       int64_t ts) {
     protozero::HeapBuffered<VideoFrame> vf;
     vf->set_display_id(display_id);
+    std::vector<uint8_t> au(au_size, 0xAB);
+    vf->set_au_data(au.data(), au.size());
+    std::vector<uint8_t> vf_bytes = vf.SerializeAsArray();
+
+    protozero::HeapBuffered<TracePacket> packet;
+    packet->AppendBytes(FrameworksBaseTracePacket::kVideoFrameFieldNumber,
+                        vf_bytes.data(), vf_bytes.size());
+    std::vector<uint8_t> bytes = packet.SerializeAsArray();
+
+    TraceBlobView tbv(TraceBlob::CopyFrom(bytes.data(), bytes.size()));
+    TracePacketData tpd{tbv.copy(), {}};
+    SelectiveTracePacketDecoder decoder(tbv.data(), tbv.length());
+    TracePacketField field = decoder.FindUnknownField(
+        FrameworksBaseTracePacket::kVideoFrameFieldNumber);
+    ASSERT_TRUE(field.valid());
+    module.ParseField({decoder, ts, tpd, field});
+  }
+
+  void PushVirtualDisplayComposite(VideoFrameModule& module,
+                                   int64_t present_time_us,
+                                   int64_t vsync_id) {
+    protozero::HeapBuffered<VirtualDisplayComposite> vdc;
+    vdc->set_present_time_us(present_time_us);
+    vdc->set_vsync_id(vsync_id);
+    std::vector<uint8_t> vdc_bytes = vdc.SerializeAsArray();
+
+    protozero::HeapBuffered<TracePacket> packet;
+    packet->AppendBytes(
+        FrameworksNativeTracePacket::kVirtualDisplayCompositeFieldNumber,
+        vdc_bytes.data(), vdc_bytes.size());
+    std::vector<uint8_t> bytes = packet.SerializeAsArray();
+
+    TraceBlobView tbv(TraceBlob::CopyFrom(bytes.data(), bytes.size()));
+    TracePacketData tpd{tbv.copy(), {}};
+    SelectiveTracePacketDecoder decoder(tbv.data(), tbv.length());
+    TracePacketField field = decoder.FindUnknownField(
+        FrameworksNativeTracePacket::kVirtualDisplayCompositeFieldNumber);
+    ASSERT_TRUE(field.valid());
+    module.ParseField({decoder, /*ts=*/0, tpd, field});
+  }
+
+  // Overload of PushAccessUnit that also populates pts_us
+  void PushAccessUnitWithPts(VideoFrameModule& module,
+                             uint32_t display_id,
+                             size_t au_size,
+                             int64_t ts,
+                             uint64_t pts_us) {
+    protozero::HeapBuffered<VideoFrame> vf;
+    vf->set_display_id(display_id);
+    vf->set_pts_us(pts_us);
     std::vector<uint8_t> au(au_size, 0xAB);
     vf->set_au_data(au.data(), au.size());
     std::vector<uint8_t> vf_bytes = vf.SerializeAsArray();
@@ -161,6 +214,26 @@ TEST_F(VideoFrameModuleTest, CapIsPerStream) {
   // overflow, and exactly one stream hit the cap.
   EXPECT_EQ(FrameRowCount(), 5u);
   EXPECT_EQ(SizeCapHits(), 1);
+}
+
+TEST_F(VideoFrameModuleTest, LinksFrameTimelineVsyncId) {
+  auto module = MakeModule();
+  constexpr int64_t kPtsUs = 500000;
+  constexpr int64_t kVsyncId = 42;
+
+  // 1. Push VirtualDisplayComposite packet
+  PushVirtualDisplayComposite(*module, kPtsUs, kVsyncId);
+
+  // 2. Push VideoFrame access unit with matching pts_us
+  PushAccessUnitWithPts(*module, /*display_id=*/0, /*au_size=*/30, /*ts=*/1000,
+                        kPtsUs);
+
+  // 3. Trigger end-of-trace backfill
+  module->OnEventsFullyExtracted();
+
+  // 4. Verify backfill succeeded
+  ASSERT_EQ(FrameRowCount(), 1u);
+  EXPECT_EQ((*table_)[0].frame_timeline_vsync_id(), kVsyncId);
 }
 
 }  // namespace


### PR DESCRIPTION
tp+ui: parse VirtualDisplayComposite field 1100 for display-video vsync linkage

Support the dedicated android.surfaceflinger.virtualdisplay data source by
parsing VirtualDisplayComposite directly from FrameworksNativeTracePacket
extension field 1100 instead of FrameTimelineEvent.

Corresponds to Android frameworks/native CL ag/41999993.
