### PR TITLE
tp: reduce token buffer allocation and extraction work

### DIFF
--- a/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
@@ -116,7 +116,8 @@ void ProtoTraceParserImpl::ParseTracePacket(int64_t ts, TracePacketData data) {
   }
 }
 
-void ProtoTraceParserImpl::ParseTrackEvent(int64_t ts, TrackEventData data) {
+void ProtoTraceParserImpl::ParseTrackEvent(int64_t ts,
+                                           const TrackEventData& data) {
   const TraceBlobView& blob = data.trace_packet_data.packet;
   protos::pbzero::TracePacket::Decoder packet(blob.data(), blob.length());
   module_context_->track_module->ParseTrackEventData(packet, ts, data);

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl.h
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl.h
@@ -43,7 +43,7 @@ class ProtoTraceParserImpl {
   ProtoTraceParserImpl(TraceProcessorContext*, ProtoImporterModuleContext*);
   ~ProtoTraceParserImpl();
 
-  void ParseTrackEvent(int64_t ts, TrackEventData data);
+  void ParseTrackEvent(int64_t ts, const TrackEventData& data);
   void ParseTracePacket(int64_t ts, TracePacketData data);
   void ParseEtwEvent(uint32_t cpu, int64_t /*ts*/, TracePacketData data);
   void ParseFtraceEvent(uint32_t cpu, int64_t /*ts*/, FtraceData data);

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -96,8 +96,8 @@ class TrackEventSink
     : public TraceSorter::Sink<TrackEventData, TrackEventSink> {
  public:
   explicit TrackEventSink(ProtoTraceParserImpl* parser) : parser_(parser) {}
-  void Parse(int64_t ts, TrackEventData data) {
-    parser_->ParseTrackEvent(ts, std::move(data));
+  void Parse(int64_t ts, const TrackEventData& data) {
+    parser_->ParseTrackEvent(ts, data);
   }
 
  private:

--- a/src/trace_processor/sorter/trace_token_buffer.cc
+++ b/src/trace_processor/sorter/trace_token_buffer.cc
@@ -139,28 +139,24 @@ std::pair<BumpAllocator::AllocId, uint8_t*> TraceTokenBuffer::AppendCommon(
     Desc& desc,
     const TraceBlobView& packet,
     RefPtr<PacketSequenceStateGeneration> sequence_state) {
-  BumpAllocator::AllocId alloc_id =
-      AllocAndResizeInternedVectors(GetAllocSize(desc));
-  InternedIndex interned_index = GetInternedIndex(alloc_id);
+  void* raw;
+  BumpAllocator::AllocId alloc_id = allocator_.Alloc(GetAllocSize(desc), &raw);
+  CurrentChunk& chunk = ChunkFor(alloc_id.chunk_index);
 
-  desc.intern_blob_offset = InternTraceBlob(interned_index, packet);
-  desc.intern_blob_index =
-      static_cast<uint16_t>(interned_blobs_.at(interned_index).size() - 1);
+  desc.intern_blob_offset = InternTraceBlob(*chunk.blobs, packet);
+  desc.intern_blob_index = static_cast<uint16_t>(chunk.blobs->size() - 1);
   desc.intern_seq_index =
-      InternSeqState(interned_index, std::move(sequence_state));
+      InternSeqState(*chunk.seqs, std::move(sequence_state));
 
-  uint8_t* ptr = static_cast<uint8_t*>(allocator_.GetPointer(alloc_id));
-  ptr = AppendToPtr(ptr, desc);
+  uint8_t* ptr = AppendToPtr(static_cast<uint8_t*>(raw), desc);
   uint64_t packet_size = static_cast<uint64_t>(packet.size());
   ptr = AppendToPtr(ptr, packet_size);
   return {alloc_id, ptr};
 }
 
 template <typename Desc>
-std::pair<TracePacketData, uint8_t*> TraceTokenBuffer::ExtractCommon(
-    Id id,
-    Desc* out_desc) {
-  uint8_t* ptr = static_cast<uint8_t*>(allocator_.GetPointer(id.alloc_id));
+std::pair<TracePacketData, uint8_t*>
+TraceTokenBuffer::ExtractCommon(Id id, Desc* out_desc, uint8_t* ptr) {
   *out_desc = ExtractFromPtr<Desc>(&ptr);
   uint64_t packet_size = ExtractFromPtr<uint64_t>(&ptr);
 
@@ -175,7 +171,7 @@ std::pair<TracePacketData, uint8_t*> TraceTokenBuffer::ExtractCommon(
   return {TracePacketData{std::move(tbv), std::move(seq)}, ptr};
 }
 
-TraceTokenBuffer::Id TraceTokenBuffer::Append(TrackEventData ted) {
+TraceTokenBuffer::Id TraceTokenBuffer::Append(TrackEventData&& ted) {
   // TrackEventData (and TracePacketData) are two big contributors to the size
   // of the peak memory usage by sorted. The main reasons for this are a) object
   // padding and b) using more bits than necessary to store their contents.
@@ -238,16 +234,20 @@ TraceTokenBuffer::Id TraceTokenBuffer::Append(FtraceData data) {
 template <>
 TracePacketData TraceTokenBuffer::Extract<TracePacketData>(Id id) {
   TracePacketDataDescriptor desc;
-  auto [data, ptr] = ExtractCommon(id, &desc);
+  auto allocation = allocator_.GetAllocation(id.alloc_id);
+  auto [data, ptr] =
+      ExtractCommon(id, &desc, static_cast<uint8_t*>(allocation.data()));
   base::ignore_result(ptr);
-  allocator_.Free(id.alloc_id);
+  allocator_.Free(allocation);
   return std::move(data);
 }
 
 template <>
 FtraceData TraceTokenBuffer::Extract<FtraceData>(Id id) {
   FtraceDataDescriptor desc;
-  auto [tpd, ptr] = ExtractCommon(id, &desc);
+  auto allocation = allocator_.GetAllocation(id.alloc_id);
+  auto [tpd, ptr] =
+      ExtractCommon(id, &desc, static_cast<uint8_t*>(allocation.data()));
   FtraceData data{std::move(tpd.packet), std::move(tpd.sequence_state),
                   FtraceData::kRawTsUnset};
   if (desc.has_raw_ts) {
@@ -255,14 +255,16 @@ FtraceData TraceTokenBuffer::Extract<FtraceData>(Id id) {
   }
   data.insert_ftrace_event = desc.insert_ftrace_event;
   data.parse_event = desc.parse_event;
-  allocator_.Free(id.alloc_id);
+  allocator_.Free(allocation);
   return data;
 }
 
 template <>
 TrackEventData TraceTokenBuffer::Extract<TrackEventData>(Id id) {
   TrackEventDataDescriptor desc;
-  auto [tpd, ptr] = ExtractCommon(id, &desc);
+  auto allocation = allocator_.GetAllocation(id.alloc_id);
+  auto [tpd, ptr] =
+      ExtractCommon(id, &desc, static_cast<uint8_t*>(allocation.data()));
   TrackEventData ted{std::move(tpd.packet), std::move(tpd.sequence_state)};
   if (desc.has_thread_instruction_count) {
     ted.thread_instruction_count = ExtractFromPtr<int64_t>(&ptr);
@@ -276,27 +278,28 @@ TrackEventData TraceTokenBuffer::Extract<TrackEventData>(Id id) {
   for (uint32_t i = 0; i < desc.extra_counter_count; ++i) {
     ted.extra_counter_values[i] = ExtractFromPtr<double>(&ptr);
   }
-  allocator_.Free(id.alloc_id);
+  allocator_.Free(allocation);
   return ted;
 }
 
-uint32_t TraceTokenBuffer::InternTraceBlob(InternedIndex interned_index,
+uint32_t TraceTokenBuffer::InternTraceBlob(BlobWithOffsets& blobs,
                                            const TraceBlobView& tbv) {
-  BlobWithOffsets& blobs = interned_blobs_.at(interned_index);
+  RefPtr<TraceBlob> blob = tbv.blob();
+  size_t offset = tbv.offset();
   if (blobs.empty()) {
-    return AddTraceBlob(interned_index, tbv);
+    return AddTraceBlob(blobs, std::move(blob), offset);
   }
 
   BlobWithOffset& last_blob = blobs.back();
-  if (last_blob.blob != tbv.blob().get()) {
-    return AddTraceBlob(interned_index, tbv);
+  if (last_blob.blob != blob.get()) {
+    return AddTraceBlob(blobs, std::move(blob), offset);
   }
 
   // Offsets can go backwards when deferred packets (e.g., those waiting for
   // clock snapshots) are pushed after regular packets. In that case, we just
   // add a new blob entry rather than relying on the relative offset.
-  if (last_blob.offset_in_blob > tbv.offset()) {
-    return AddTraceBlob(interned_index, tbv);
+  if (last_blob.offset_in_blob > offset) {
+    return AddTraceBlob(blobs, std::move(blob), offset);
   }
 
   // To allow our offsets in the store to be 16 bits, we intern not only the
@@ -304,9 +307,9 @@ uint32_t TraceTokenBuffer::InternTraceBlob(InternedIndex interned_index,
   // we can store offset always as uint16 at the cost of storing blobs here more
   // often: this more than pays for itself as in the majority of cases the
   // offsets are small anyway.
-  size_t rel_offset = tbv.offset() - last_blob.offset_in_blob;
+  size_t rel_offset = offset - last_blob.offset_in_blob;
   if (rel_offset > TrackEventDataDescriptor::kMaxOffsetFromInternedBlob) {
-    return AddTraceBlob(interned_index, tbv);
+    return AddTraceBlob(blobs, std::move(blob), offset);
   }
 
   // Intentionally "leak" this pointer. This essentially keeps the refcount
@@ -315,18 +318,17 @@ uint32_t TraceTokenBuffer::InternTraceBlob(InternedIndex interned_index,
   //
   // Calls to this function are paired to the matching Extract<T> which picks
   // up this "leaked" pointer.
-  TraceBlob* leaked = tbv.blob().ReleaseUnsafe();
+  TraceBlob* leaked = blob.ReleaseUnsafe();
   base::ignore_result(leaked);
   return static_cast<uint32_t>(rel_offset);
 }
 
 uint16_t TraceTokenBuffer::InternSeqState(
-    InternedIndex interned_index,
+    SequenceStates& states,
     RefPtr<PacketSequenceStateGeneration> ptr) {
   // Look back at most 32 elements. This should be far enough in most cases
   // unless either: a) we are essentially round-robining between >32 sequences
   // b) we are churning through generations. Either case seems pathological.
-  SequenceStates& states = interned_seqs_.at(interned_index);
   size_t lookback = std::min<size_t>(32u, states.size());
   for (uint32_t i = 0; i < lookback; ++i) {
     uint16_t idx = static_cast<uint16_t>(states.size() - 1 - i);
@@ -343,40 +345,39 @@ uint16_t TraceTokenBuffer::InternSeqState(
   return static_cast<uint16_t>(states.size() - 1);
 }
 
-uint32_t TraceTokenBuffer::AddTraceBlob(InternedIndex interned_index,
-                                        const TraceBlobView& tbv) {
-  BlobWithOffsets& blobs = interned_blobs_.at(interned_index);
-  blobs.emplace_back(BlobWithOffset{tbv.blob().ReleaseUnsafe(), tbv.offset()});
+uint32_t TraceTokenBuffer::AddTraceBlob(BlobWithOffsets& blobs,
+                                        RefPtr<TraceBlob> blob,
+                                        size_t offset) {
+  blobs.emplace_back(BlobWithOffset{blob.ReleaseUnsafe(), offset});
   PERFETTO_CHECK(blobs.size() <= std::numeric_limits<uint16_t>::max());
   return 0u;
 }
 
 void TraceTokenBuffer::FreeMemory() {
   uint64_t erased = allocator_.EraseFrontFreeChunks();
+  if (erased == 0) {
+    return;
+  }
   PERFETTO_CHECK(erased <= std::numeric_limits<size_t>::max());
   interned_blobs_.erase_front(static_cast<size_t>(erased));
   interned_seqs_.erase_front(static_cast<size_t>(erased));
   PERFETTO_CHECK(interned_blobs_.size() == interned_seqs_.size());
+  // The queues changed shape so the cached chunk pointers are stale.
+  current_chunk_ = CurrentChunk();
 }
 
-BumpAllocator::AllocId TraceTokenBuffer::AllocAndResizeInternedVectors(
-    uint32_t size) {
-  uint64_t erased = allocator_.erased_front_chunks_count();
-  BumpAllocator::AllocId alloc_id = allocator_.Alloc(size);
-  uint64_t allocator_chunks_size = alloc_id.chunk_index - erased + 1;
-
-  // The allocator should never "remove" chunks from being tracked.
-  PERFETTO_DCHECK(allocator_chunks_size >= interned_blobs_.size());
-
-  // We should add at most one chunk in the allocator.
-  uint64_t chunks_added = allocator_chunks_size - interned_blobs_.size();
-  PERFETTO_DCHECK(chunks_added <= 1);
+void TraceTokenBuffer::SwitchChunk(uint64_t chunk_index) {
+  uint64_t index = chunk_index - allocator_.erased_front_chunks_count();
   PERFETTO_DCHECK(interned_blobs_.size() == interned_seqs_.size());
-  for (uint64_t i = 0; i < chunks_added; ++i) {
+  // The allocator opens at most one chunk per allocation.
+  PERFETTO_DCHECK(index <= interned_blobs_.size());
+  if (index == interned_blobs_.size()) {
     interned_blobs_.emplace_back();
     interned_seqs_.emplace_back();
   }
-  return alloc_id;
+  current_chunk_.chunk_index = chunk_index;
+  current_chunk_.blobs = &interned_blobs_.at(static_cast<size_t>(index));
+  current_chunk_.seqs = &interned_seqs_.at(static_cast<size_t>(index));
 }
 
 TraceTokenBuffer::InternedIndex TraceTokenBuffer::GetInternedIndex(

--- a/src/trace_processor/sorter/trace_token_buffer.h
+++ b/src/trace_processor/sorter/trace_token_buffer.h
@@ -18,6 +18,7 @@
 #define SRC_TRACE_PROCESSOR_SORTER_TRACE_TOKEN_BUFFER_H_
 
 #include <cstdint>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -56,11 +57,13 @@ class TraceTokenBuffer {
   PERFETTO_WARN_UNUSED_RESULT Id Append(T object) {
     static_assert(sizeof(T) % 8 == 0, "Size must be a multiple of 8");
     static_assert(alignof(T) == 8, "Alignment must be 8");
-    BumpAllocator::AllocId id = AllocAndResizeInternedVectors(sizeof(T));
-    new (allocator_.GetPointer(id)) T(std::move(object));
+    void* ptr;
+    BumpAllocator::AllocId id = allocator_.Alloc(sizeof(T), &ptr);
+    ChunkFor(id.chunk_index);
+    new (ptr) T(std::move(object));
     return Id{id};
   }
-  PERFETTO_WARN_UNUSED_RESULT Id Append(TrackEventData);
+  PERFETTO_WARN_UNUSED_RESULT Id Append(TrackEventData&&);
   PERFETTO_WARN_UNUSED_RESULT Id Append(FtraceData);
   PERFETTO_WARN_UNUSED_RESULT Id Append(TracePacketData);
 
@@ -109,9 +112,29 @@ class TraceTokenBuffer {
   // Functions to intern TraceBlob and PacketSequenceStateGeneration: as these
   // are often shared between packets, we can significantly reduce memory use
   // by only storing them once.
-  uint32_t InternTraceBlob(InternedIndex, const TraceBlobView&);
-  uint16_t InternSeqState(InternedIndex, RefPtr<PacketSequenceStateGeneration>);
-  uint32_t AddTraceBlob(InternedIndex, const TraceBlobView&);
+  uint32_t InternTraceBlob(BlobWithOffsets&, const TraceBlobView&);
+  uint16_t InternSeqState(SequenceStates&,
+                          RefPtr<PacketSequenceStateGeneration>);
+  uint32_t AddTraceBlob(BlobWithOffsets&, RefPtr<TraceBlob>, size_t offset);
+
+  // Nearly every append lands in the chunk of the previous one, so keep that
+  // chunk's intern vectors at hand instead of walking the queues each time.
+  // Cleared whenever the queues change shape.
+  struct CurrentChunk {
+    uint64_t chunk_index = std::numeric_limits<uint64_t>::max();
+    BlobWithOffsets* blobs = nullptr;
+    SequenceStates* seqs = nullptr;
+  };
+  // Returns the intern vectors of the allocator chunk |chunk_index|, adding
+  // them if the allocator has just opened that chunk. Every allocation must
+  // pass through here to keep the vectors in step with the chunks.
+  CurrentChunk& ChunkFor(uint64_t chunk_index) {
+    if (PERFETTO_UNLIKELY(current_chunk_.chunk_index != chunk_index)) {
+      SwitchChunk(chunk_index);
+    }
+    return current_chunk_;
+  }
+  void SwitchChunk(uint64_t chunk_index);
 
   // Common prologue shared between Append(TrackEventData|TracePacketData|
   // FtraceData): allocates storage sized for |desc|, fills its intern_* fields,
@@ -131,14 +154,16 @@ class TraceTokenBuffer {
   // (where any per-type optional fields live). The caller is responsible for
   // freeing the allocation.
   template <typename Desc>
-  std::pair<TracePacketData, uint8_t*> ExtractCommon(Id id, Desc* out_desc);
+  std::pair<TracePacketData, uint8_t*> ExtractCommon(Id id,
+                                                     Desc* out_desc,
+                                                     uint8_t* ptr);
 
-  BumpAllocator::AllocId AllocAndResizeInternedVectors(uint32_t size);
   InternedIndex GetInternedIndex(BumpAllocator::AllocId);
 
   BumpAllocator allocator_;
   base::CircularQueue<BlobWithOffsets> interned_blobs_;
   base::CircularQueue<SequenceStates> interned_seqs_;
+  CurrentChunk current_chunk_;
 };
 
 // GCC7 does not like us declaring these inside the class so define these

--- a/src/trace_processor/util/bump_allocator.cc
+++ b/src/trace_processor/util/bump_allocator.cc
@@ -19,7 +19,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
-#include <optional>
 #include <utility>
 
 #include "perfetto/base/compiler.h"
@@ -49,33 +48,13 @@ BumpAllocator::~BumpAllocator() {
   }
 }
 
-BumpAllocator::AllocId BumpAllocator::Alloc(uint32_t size) {
-  // Size is required to be a multiple of 8 to avoid needing to deal with
-  // alignment. It must also be at most kChunkSize as we do not support cross
-  // chunk spanning allocations.
-  PERFETTO_DCHECK(size % 8 == 0);
-  PERFETTO_DCHECK(size <= kChunkSize);
-
-  // Fast path: check if we have space to service this allocation in the current
-  // chunk.
-  std::optional<AllocId> alloc_id = TryAllocInLastChunk(size);
-  if (alloc_id) {
-    return *alloc_id;
-  }
-
-  // Slow path: we don't have enough space in the last chunk so we create one.
+void BumpAllocator::AddChunk() {
   Chunk chunk;
   chunk.allocation = Allocate(kChunkSize);
   chunks_.emplace_back(std::move(chunk));
 
   // Ensure that we haven't exceeded the maximum number of chunks.
   PERFETTO_CHECK(LastChunkIndex() < kMaxChunkCount);
-
-  // This time the allocation should definitely succeed in the last chunk (which
-  // we just added).
-  alloc_id = TryAllocInLastChunk(size);
-  PERFETTO_CHECK(alloc_id);
-  return *alloc_id;
 }
 
 void BumpAllocator::Free(AllocId id) {
@@ -91,6 +70,14 @@ void* BumpAllocator::GetPointer(AllocId id) {
   PERFETTO_CHECK(queue_index <= std::numeric_limits<size_t>::max());
   return chunks_.at(static_cast<size_t>(queue_index)).allocation.get() +
          id.chunk_offset;
+}
+
+BumpAllocator::Allocation BumpAllocator::GetAllocation(AllocId id) {
+  uint64_t queue_index = ChunkIndexToQueueIndex(id.chunk_index);
+  PERFETTO_CHECK(queue_index <= std::numeric_limits<size_t>::max());
+  Chunk& chunk = chunks_.at(static_cast<size_t>(queue_index));
+  return Allocation(chunk.allocation.get() + id.chunk_offset,
+                    &chunk.unfreed_allocations);
 }
 
 uint64_t BumpAllocator::EraseFrontFreeChunks() {
@@ -114,41 +101,6 @@ BumpAllocator::AllocId BumpAllocator::PastTheEndId() {
     return AllocId{LastChunkIndex() + 1, 0};
   }
   return AllocId{LastChunkIndex(), chunks_.back().bump_offset};
-}
-
-std::optional<BumpAllocator::AllocId> BumpAllocator::TryAllocInLastChunk(
-    uint32_t size) {
-  if (chunks_.empty()) {
-    return std::nullopt;
-  }
-
-  // TODO(266983484): consider switching this to bump downwards instead of
-  // upwards for more efficient code generation.
-  Chunk& chunk = chunks_.back();
-
-  // Verify some invariants:
-  // 1) The allocation must exist
-  // 2) The bump must be in the bounds of the chunk.
-  PERFETTO_DCHECK(chunk.allocation);
-  PERFETTO_DCHECK(chunk.bump_offset <= kChunkSize);
-
-  // If the end of the allocation ends up after this chunk, we cannot service it
-  // in this chunk.
-  uint32_t alloc_offset = chunk.bump_offset;
-  uint32_t new_bump_offset = chunk.bump_offset + size;
-  if (new_bump_offset > kChunkSize) {
-    return std::nullopt;
-  }
-
-  // Set the new offset equal to the end of this allocation and increment the
-  // unfreed allocation counter.
-  chunk.bump_offset = new_bump_offset;
-  chunk.unfreed_allocations++;
-
-  // Unpoison the allocation range to allow access to it on ASAN builds.
-  PERFETTO_ASAN_UNPOISON(chunk.allocation.get() + alloc_offset, size);
-
-  return AllocId{LastChunkIndex(), alloc_offset};
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/util/bump_allocator.h
+++ b/src/trace_processor/util/bump_allocator.h
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <optional>
 #include <tuple>
 
 #include "perfetto/base/logging.h"
@@ -112,8 +111,30 @@ class BumpAllocator {
   // than or equal to |kChunkSize|.
   //
   // Returns an |AllocId| which can be converted to a pointer using
-  // |GetPointer|.
-  AllocId Alloc(uint32_t size);
+  // |GetPointer|; |*ptr| receives that pointer directly.
+  AllocId Alloc(uint32_t size, void** ptr) {
+    // Size is required to be a multiple of 8 to avoid needing to deal with
+    // alignment. It must also be at most kChunkSize as we do not support cross
+    // chunk spanning allocations.
+    PERFETTO_DCHECK(size % 8 == 0);
+    PERFETTO_DCHECK(size <= kChunkSize);
+    if (PERFETTO_UNLIKELY(chunks_.empty() ||
+                          chunks_.back().bump_offset + size > kChunkSize)) {
+      AddChunk();
+    }
+    Chunk& chunk = chunks_.back();
+    uint32_t offset = chunk.bump_offset;
+    chunk.bump_offset = offset + size;
+    chunk.unfreed_allocations++;
+    // Unpoison the allocation range to allow access to it on ASAN builds.
+    PERFETTO_ASAN_UNPOISON(chunk.allocation.get() + offset, size);
+    *ptr = chunk.allocation.get() + offset;
+    return AllocId{LastChunkIndex(), offset};
+  }
+  AllocId Alloc(uint32_t size) {
+    void* ptr;
+    return Alloc(size, &ptr);
+  }
 
   // Frees an allocation previously allocated by |Alloc|. This function is *not*
   // idempotent.
@@ -128,6 +149,28 @@ class BumpAllocator {
   // The caller is only allowed to access up to |size| bytes, where |size| ==
   // the |size| argument to Alloc.
   void* GetPointer(AllocId);
+
+  // A resolved allocation for reading and then freeing with one chunk lookup.
+  // Free it before allocating again or erasing chunks, which can move metadata.
+  class Allocation {
+   public:
+    void* data() const { return data_; }
+
+   private:
+    friend class BumpAllocator;
+    Allocation(void* data, uint32_t* unfreed_allocations)
+        : data_(data), unfreed_allocations_(unfreed_allocations) {}
+
+    void* data_;
+    uint32_t* unfreed_allocations_;
+  };
+
+  Allocation GetAllocation(AllocId);
+
+  void Free(const Allocation& allocation) {
+    PERFETTO_DCHECK(*allocation.unfreed_allocations_ > 0);
+    --*allocation.unfreed_allocations_;
+  }
 
   // Removes chunks from the start of this allocator where all the allocations
   // in the chunks have been freed. This releases the memory back to the system.
@@ -162,9 +205,8 @@ class BumpAllocator {
     uint32_t unfreed_allocations = 0;
   };
 
-  // Tries to allocate |size| bytes in the final chunk in |chunks_|. Returns
-  // an AllocId if this was successful or std::nullopt otherwise.
-  std::optional<AllocId> TryAllocInLastChunk(uint32_t size);
+  // Appends a chunk for the allocations the last one cannot fit.
+  void AddChunk();
 
   uint64_t ChunkIndexToQueueIndex(uint64_t chunk_index) const {
     return chunk_index - erased_front_chunks_count_;


### PR DESCRIPTION
Return each bump allocation together with its address and retain the
current chunk metadata to avoid repeated allocation-id lookups.

Resolve the data pointer and release bookkeeping together during
extraction, then free only after reading all fields. This avoids a
second chunk lookup without reading an allocation after freeing it.

Recorded buildprof results:
- Wall time: 30.52s -> 29.57s (-3.11%).
- User instructions: 455.313G -> 447.673G (-1.68%).
