### PR TITLE
tp: handle track event argument fields through extensions

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -18525,6 +18525,7 @@ filegroup {
         "src/trace_processor/importers/proto/protovm_incremental_tracing.cc",
         "src/trace_processor/importers/proto/stack_profile_sequence_state.cc",
         "src/trace_processor/importers/proto/tracing_service_module.cc",
+        "src/trace_processor/importers/proto/track_event_arg_fields.cc",
         "src/trace_processor/importers/proto/track_event_extension_parser.cc",
         "src/trace_processor/importers/proto/track_event_module.cc",
         "src/trace_processor/importers/proto/track_event_parser.cc",

--- a/BUILD
+++ b/BUILD
@@ -3358,6 +3358,8 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/stack_profile_sequence_state.h",
         "src/trace_processor/importers/proto/tracing_service_module.cc",
         "src/trace_processor/importers/proto/tracing_service_module.h",
+        "src/trace_processor/importers/proto/track_event_arg_fields.cc",
+        "src/trace_processor/importers/proto/track_event_arg_fields.h",
         "src/trace_processor/importers/proto/track_event_event_importer.h",
         "src/trace_processor/importers/proto/track_event_extension_parser.cc",
         "src/trace_processor/importers/proto/track_event_extension_parser.h",

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -67,6 +67,8 @@ source_set("minimal") {
     "stack_profile_sequence_state.h",
     "tracing_service_module.cc",
     "tracing_service_module.h",
+    "track_event_arg_fields.cc",
+    "track_event_arg_fields.h",
     "track_event_event_importer.h",
     "track_event_extension_parser.cc",
     "track_event_extension_parser.h",

--- a/src/trace_processor/importers/proto/selective_track_event_decoder.h
+++ b/src/trace_processor/importers/proto/selective_track_event_decoder.h
@@ -102,16 +102,6 @@ class SelectiveTrackEventDecoder {
     return decoder_.unknown_fields();
   }
 
-  // Returns the first unknown field with the given id (invalid if absent).
-  // Linear, but the number of unknown fields per event is tiny.
-  TrackEventField FindUnknownField(uint32_t id) const {
-    for (const protozero::Field& f : decoder_.unknown_fields()) {
-      if (f.id() == id)
-        return TrackEventField(f);
-    }
-    return TrackEventField(protozero::Field{});
-  }
-
   static constexpr bool ContainsField(uint32_t id) {
     return internal::kTrackEventDenseMask.contains(id);
   }

--- a/src/trace_processor/importers/proto/track_event_arg_fields.cc
+++ b/src/trace_processor/importers/proto/track_event_arg_fields.cc
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/track_event_arg_fields.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/base64.h"
+#include "perfetto/ext/base/string_view.h"
+#include "src/trace_processor/importers/common/args_tracker.h"
+#include "src/trace_processor/importers/common/gpu_tracker.h"
+#include "src/trace_processor/importers/common/process_tracker.h"
+#include "src/trace_processor/importers/common/stats_tracker.h"
+#include "src/trace_processor/importers/proto/active_chrome_processes_tracker.h"
+#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/storage/stats.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/android_tables_py.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/types/variadic.h"
+
+#include "protos/perfetto/common/android_log_constants.pbzero.h"
+#include "protos/perfetto/trace/gpu/gpu_track_event.pbzero.h"
+#include "protos/perfetto/trace/interned_data/interned_data.pbzero.h"
+#include "protos/perfetto/trace/track_event/chrome_active_processes.pbzero.h"
+#include "protos/perfetto/trace/track_event/chrome_histogram_sample.pbzero.h"
+#include "protos/perfetto/trace/track_event/log_message.pbzero.h"
+#include "protos/perfetto/trace/track_event/screenshot.pbzero.h"
+#include "protos/perfetto/trace/track_event/source_location.pbzero.h"
+#include "protos/perfetto/trace/track_event/task_execution.pbzero.h"
+#include "protos/perfetto/trace/track_event/track_event.pbzero.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+using TrackEvent = protos::pbzero::TrackEvent;
+
+protos::pbzero::AndroidLogPriority ToAndroidLogPriority(
+    protos::pbzero::LogMessage::Priority prio) {
+  switch (prio) {
+    case protos::pbzero::LogMessage::Priority::PRIO_UNSPECIFIED:
+      return protos::pbzero::AndroidLogPriority::PRIO_UNSPECIFIED;
+    case protos::pbzero::LogMessage::Priority::PRIO_UNUSED:
+      return protos::pbzero::AndroidLogPriority::PRIO_UNUSED;
+    case protos::pbzero::LogMessage::Priority::PRIO_VERBOSE:
+      return protos::pbzero::AndroidLogPriority::PRIO_VERBOSE;
+    case protos::pbzero::LogMessage::Priority::PRIO_DEBUG:
+      return protos::pbzero::AndroidLogPriority::PRIO_DEBUG;
+    case protos::pbzero::LogMessage::Priority::PRIO_INFO:
+      return protos::pbzero::AndroidLogPriority::PRIO_INFO;
+    case protos::pbzero::LogMessage::Priority::PRIO_WARN:
+      return protos::pbzero::AndroidLogPriority::PRIO_WARN;
+    case protos::pbzero::LogMessage::Priority::PRIO_ERROR:
+      return protos::pbzero::AndroidLogPriority::PRIO_ERROR;
+    case protos::pbzero::LogMessage::Priority::PRIO_FATAL:
+      return protos::pbzero::AndroidLogPriority::PRIO_FATAL;
+  }
+  return protos::pbzero::AndroidLogPriority::PRIO_UNSPECIFIED;
+}
+
+}  // namespace
+
+TrackEventArgFieldParser::TrackEventArgFieldParser(
+    TrackEventExtensionParserContext* extension_context,
+    TraceProcessorContext* context,
+    ActiveChromeProcessesTracker* active_processes_tracker)
+    : TrackEventExtensionParser(extension_context),
+      trace_context_(context),
+      active_processes_tracker_(active_processes_tracker),
+      task_file_name_args_key_id_(
+          context->storage->InternString("task.posted_from.file_name")),
+      task_function_name_args_key_id_(
+          context->storage->InternString("task.posted_from.function_name")),
+      task_line_number_args_key_id_(
+          context->storage->InternString("task.posted_from.line_number")),
+      log_message_body_key_id_(
+          context->storage->InternString("track_event.log_message.message")),
+      log_message_source_location_function_name_key_id_(
+          context->storage->InternString(
+              "track_event.log_message.function_name")),
+      log_message_source_location_file_name_key_id_(
+          context->storage->InternString("track_event.log_message.file_name")),
+      log_message_source_location_line_number_key_id_(
+          context->storage->InternString(
+              "track_event.log_message.line_number")),
+      log_message_priority_id_(
+          context->storage->InternString("track_event.priority")),
+      source_location_function_name_key_id_(
+          context->storage->InternString("source.function_name")),
+      source_location_file_name_key_id_(
+          context->storage->InternString("source.file_name")),
+      source_location_line_number_key_id_(
+          context->storage->InternString("source.line_number")),
+      histogram_name_key_id_(
+          context->storage->InternString("chrome_histogram_sample.name")) {
+  RegisterTrackEventExtension(TrackEvent::kSourceLocationIidFieldNumber);
+  RegisterTrackEventExtension(TrackEvent::kTaskExecutionFieldNumber);
+  RegisterTrackEventExtension(TrackEvent::kLogMessageFieldNumber);
+  RegisterTrackEventExtension(TrackEvent::kScreenshotFieldNumber);
+  RegisterTrackEventExtension(TrackEvent::kChromeHistogramSampleFieldNumber);
+  RegisterTrackEventExtension(TrackEvent::kChromeActiveProcessesFieldNumber);
+  RegisterTrackEventExtension(
+      protos::pbzero::GpuTrackEvent::kGpuCorrelationFieldNumber);
+}
+
+TrackEventArgFieldParser::~TrackEventArgFieldParser() = default;
+
+TrackEventExtensionParser::Result TrackEventArgFieldParser::OnTrackEventField(
+    const TrackEventExtensionField& field,
+    const TrackEventFieldContext& event) {
+  if (field.id() == protos::pbzero::GpuTrackEvent::kGpuCorrelationFieldNumber) {
+    ParseGpuCorrelation(
+        field.Cast<protos::pbzero::GpuTrackEvent::kGpuCorrelation>(), event);
+    return Result::kIgnored;
+  }
+  // A row without args takes nothing from these fields.
+  if (!event.args) {
+    return Result::kIgnored;
+  }
+  auto log_errors = [this](const base::Status& status) {
+    if (status.ok())
+      return;
+    // Log error but continue parsing the other args.
+    trace_context_->stats_tracker->IncrementStats(
+        stats::track_event_parser_errors);
+    PERFETTO_DLOG("ParseTrackEventArgs error: %s", status.c_message());
+  };
+  switch (field.id()) {
+    case TrackEvent::kSourceLocationIidFieldNumber:
+      log_errors(AddSourceLocationArgs(
+          field.Cast<TrackEvent::kSourceLocationIid>(), event));
+      return Result::kIgnored;
+    case TrackEvent::kTaskExecutionFieldNumber:
+      log_errors(
+          ParseTaskExecution(field.Cast<TrackEvent::kTaskExecution>(), event));
+      return Result::kIgnored;
+    case TrackEvent::kLogMessageFieldNumber:
+      log_errors(ParseLogMessage(field.Cast<TrackEvent::kLogMessage>(), event));
+      return Result::kIgnored;
+    case TrackEvent::kScreenshotFieldNumber:
+      ParseScreenshot(field.Cast<TrackEvent::kScreenshot>(), event);
+      return Result::kIgnored;
+    case TrackEvent::kChromeHistogramSampleFieldNumber:
+      log_errors(ParseHistogramName(
+          field.Cast<TrackEvent::kChromeHistogramSample>(), event));
+      return Result::kIgnored;
+    case TrackEvent::kChromeActiveProcessesFieldNumber:
+      ParseActiveProcesses(field.Cast<TrackEvent::kChromeActiveProcesses>(),
+                           event);
+      return Result::kIgnored;
+    default:
+      return Result::kIgnored;
+  }
+}
+
+base::Status TrackEventArgFieldParser::AddSourceLocationArgs(
+    uint64_t iid,
+    const TrackEventFieldContext& event) {
+  if (!iid)
+    return base::ErrStatus("SourceLocation with invalid iid");
+
+  auto* decoder = event.sequence_state->LookupInternedMessage<
+      protos::pbzero::InternedData::kSourceLocationsFieldNumber,
+      protos::pbzero::SourceLocation>(iid);
+  if (!decoder)
+    return base::ErrStatus("SourceLocation with invalid iid");
+
+  TraceStorage* storage = trace_context_->storage.get();
+  std::string file_name = NormalizePathSeparators(decoder->file_name());
+  event.args->AddArg(
+      source_location_file_name_key_id_,
+      Variadic::String(storage->InternString(base::StringView(file_name))));
+  event.args->AddArg(
+      source_location_function_name_key_id_,
+      Variadic::String(storage->InternString(decoder->function_name())));
+  event.args->AddArg(source_location_line_number_key_id_,
+                     Variadic::UnsignedInteger(decoder->line_number()));
+  return base::OkStatus();
+}
+
+base::Status TrackEventArgFieldParser::ParseTaskExecution(
+    protozero::ConstBytes task_execution,
+    const TrackEventFieldContext& event) {
+  protos::pbzero::TaskExecution::Decoder task(task_execution);
+  uint64_t iid = task.posted_from_iid();
+  if (!iid)
+    return base::ErrStatus("TaskExecution with invalid posted_from_iid");
+
+  auto* decoder = event.sequence_state->LookupInternedMessage<
+      protos::pbzero::InternedData::kSourceLocationsFieldNumber,
+      protos::pbzero::SourceLocation>(iid);
+  if (!decoder)
+    return base::ErrStatus("TaskExecution with invalid posted_from_iid");
+
+  TraceStorage* storage = trace_context_->storage.get();
+  std::string file_name = NormalizePathSeparators(decoder->file_name());
+  event.args->AddArg(
+      task_file_name_args_key_id_,
+      Variadic::String(storage->InternString(base::StringView(file_name))));
+  event.args->AddArg(
+      task_function_name_args_key_id_,
+      Variadic::String(storage->InternString(decoder->function_name())));
+  event.args->AddArg(task_line_number_args_key_id_,
+                     Variadic::UnsignedInteger(decoder->line_number()));
+  return base::OkStatus();
+}
+
+base::Status TrackEventArgFieldParser::ParseLogMessage(
+    protozero::ConstBytes blob,
+    const TrackEventFieldContext& event) {
+  if (!event.has_utid())
+    return base::ErrStatus("LogMessage without thread association");
+
+  TraceStorage* storage = trace_context_->storage.get();
+  protos::pbzero::LogMessage::Decoder message(blob);
+
+  std::optional<StringId> body_id = event.sequence_state->InternedStringId(
+      protos::pbzero::InternedData::kLogMessageBodyFieldNumber,
+      message.body_iid());
+  if (!body_id)
+    return base::ErrStatus("LogMessage with invalid body_iid");
+
+  const StringId log_message_id = *body_id;
+  event.args->AddArg(log_message_body_key_id_,
+                     Variadic::String(log_message_id));
+
+  StringId source_location_id = kNullStringId;
+  if (message.has_source_location_iid()) {
+    auto* source_location_decoder = event.sequence_state->LookupInternedMessage<
+        protos::pbzero::InternedData::kSourceLocationsFieldNumber,
+        protos::pbzero::SourceLocation>(message.source_location_iid());
+    if (!source_location_decoder)
+      return base::ErrStatus("LogMessage with invalid source_location_iid");
+    const std::string source_location =
+        source_location_decoder->file_name().ToStdString() + ":" +
+        std::to_string(source_location_decoder->line_number());
+    source_location_id =
+        storage->InternString(base::StringView(source_location));
+
+    event.args->AddArg(log_message_source_location_file_name_key_id_,
+                       Variadic::String(storage->InternString(
+                           source_location_decoder->file_name())));
+    event.args->AddArg(log_message_source_location_function_name_key_id_,
+                       Variadic::String(storage->InternString(
+                           source_location_decoder->function_name())));
+    event.args->AddArg(
+        log_message_source_location_line_number_key_id_,
+        Variadic::Integer(source_location_decoder->line_number()));
+  }
+
+  // The track event log message doesn't specify any priority. UI never
+  // displays priorities < 2 (VERBOSE in android). Let's make all the track
+  // event logs show up as INFO.
+  int32_t priority = protos::pbzero::AndroidLogPriority::PRIO_INFO;
+  if (message.has_prio()) {
+    priority = ToAndroidLogPriority(
+        static_cast<protos::pbzero::LogMessage::Priority>(message.prio()));
+    event.args->AddArg(log_message_priority_id_, Variadic::Integer(priority));
+  }
+
+  tables::LogTable::Row log_row;
+  log_row.ts = event.ts;
+  log_row.utid = event.utid;
+  log_row.prio = static_cast<uint32_t>(priority);
+  log_row.log_source = storage->InternString("android_logcat");
+  log_row.tag = source_location_id != kNullStringId
+                    ? std::make_optional(source_location_id)
+                    : std::nullopt;
+  log_row.msg = log_message_id;
+  storage->mutable_log_table()->Insert(log_row);
+  return base::OkStatus();
+}
+
+base::Status TrackEventArgFieldParser::ParseHistogramName(
+    protozero::ConstBytes blob,
+    const TrackEventFieldContext& event) {
+  protos::pbzero::ChromeHistogramSample::Decoder sample(blob);
+  if (!sample.has_name_iid())
+    return base::OkStatus();
+
+  if (sample.has_name()) {
+    return base::ErrStatus(
+        "name is already set for ChromeHistogramSample: only one of name and "
+        "name_iid can be set.");
+  }
+
+  std::optional<StringId> name_id = event.sequence_state->InternedStringId(
+      protos::pbzero::InternedData::kHistogramNamesFieldNumber,
+      sample.name_iid());
+  if (!name_id)
+    return base::ErrStatus("HistogramName with invalid name_iid");
+
+  event.args->AddArg(histogram_name_key_id_, Variadic::String(*name_id));
+  return base::OkStatus();
+}
+
+void TrackEventArgFieldParser::ParseScreenshot(
+    protozero::ConstBytes screenshot_bytes,
+    const TrackEventFieldContext& event) {
+  TraceStorage* storage = trace_context_->storage.get();
+  protos::pbzero::Screenshot::Decoder screenshot(screenshot_bytes);
+  if (screenshot.has_jpg_image()) {
+    std::string base64_jpg = base::Base64Encode(screenshot.jpg_image().data,
+                                                screenshot.jpg_image().size);
+    event.args->AddArg(
+        storage->InternString("screenshot.jpg_image"),
+        Variadic::String(storage->InternString(base::StringView(base64_jpg))));
+  }
+  if (screenshot.has_pam_image()) {
+    std::string base64_pam = base::Base64Encode(screenshot.pam_image().data,
+                                                screenshot.pam_image().size);
+    event.args->AddArg(
+        storage->InternString("screenshot.pam_image"),
+        Variadic::String(storage->InternString(base::StringView(base64_pam))));
+  }
+  if (screenshot.has_ppm_image()) {
+    std::string base64_ppm = base::Base64Encode(screenshot.ppm_image().data,
+                                                screenshot.ppm_image().size);
+    event.args->AddArg(
+        storage->InternString("screenshot.ppm_image"),
+        Variadic::String(storage->InternString(base::StringView(base64_ppm))));
+  }
+}
+
+void TrackEventArgFieldParser::ParseGpuCorrelation(
+    protozero::ConstBytes blob,
+    const TrackEventFieldContext& event) {
+  if (event.row_kind != TrackEventFieldContext::RowKind::kSlice) {
+    return;
+  }
+  SliceId slice_id = event.slice_id();
+  protos::pbzero::GpuCorrelation::Decoder gpu(blob);
+  for (auto it = gpu.render_stage_submission_event_ids(); it; ++it) {
+    trace_context_->gpu_tracker->AddRenderStageSubmission(*it, slice_id);
+  }
+  for (auto it = gpu.render_stage_wait_event_ids(); it; ++it) {
+    trace_context_->gpu_tracker->AddRenderStageWait(*it, slice_id);
+  }
+}
+
+void TrackEventArgFieldParser::ParseActiveProcesses(
+    protozero::ConstBytes blob,
+    const TrackEventFieldContext& event) {
+  protos::pbzero::ChromeActiveProcesses::Decoder message(blob);
+  for (auto it = message.pid(); it; ++it) {
+    UniquePid upid = trace_context_->process_tracker->GetOrCreateProcess(
+        static_cast<uint32_t>(*it));
+    active_processes_tracker_->AddActiveProcessMetadata(event.ts, upid);
+  }
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/track_event_arg_fields.h
+++ b/src/trace_processor/importers/proto/track_event_arg_fields.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_TRACK_EVENT_ARG_FIELDS_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_TRACK_EVENT_ARG_FIELDS_H_
+
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "perfetto/protozero/field.h"
+#include "src/trace_processor/importers/proto/track_event_extension_parser.h"
+#include "src/trace_processor/storage/trace_storage.h"
+
+namespace perfetto::trace_processor {
+
+class ActiveChromeProcessesTracker;
+class TraceProcessorContext;
+
+// Paths on Windows use backslash rather than slash as a separator.
+// Normalise the paths by replacing backslashes with slashes to make it
+// easier to write cross-platform scripts.
+inline std::string NormalizePathSeparators(const protozero::ConstChars& path) {
+  std::string result(path.data, path.size);
+  for (char& c : result) {
+    if (c == '\\')
+      c = '/';
+  }
+  return result;
+}
+
+// The TrackEvent fields the core importer handles beyond a plain reflection
+// into args: interned source locations, log messages, screenshots, histogram
+// names, the active process list and the gpu correlation extension.
+// Registered by the track event parser alongside the plugins' extension
+// parsers.
+class TrackEventArgFieldParser : public TrackEventExtensionParser {
+ public:
+  TrackEventArgFieldParser(TrackEventExtensionParserContext*,
+                           TraceProcessorContext*,
+                           ActiveChromeProcessesTracker*);
+  ~TrackEventArgFieldParser() override;
+
+  Result OnTrackEventField(const TrackEventExtensionField& field,
+                           const TrackEventFieldContext& event) override;
+
+ private:
+  base::Status AddSourceLocationArgs(uint64_t iid,
+                                     const TrackEventFieldContext& event);
+  base::Status ParseTaskExecution(protozero::ConstBytes,
+                                  const TrackEventFieldContext& event);
+  base::Status ParseLogMessage(protozero::ConstBytes,
+                               const TrackEventFieldContext& event);
+  base::Status ParseHistogramName(protozero::ConstBytes,
+                                  const TrackEventFieldContext& event);
+  void ParseScreenshot(protozero::ConstBytes,
+                       const TrackEventFieldContext& event);
+  void ParseActiveProcesses(protozero::ConstBytes,
+                            const TrackEventFieldContext& event);
+  void ParseGpuCorrelation(protozero::ConstBytes,
+                           const TrackEventFieldContext& event);
+
+  TraceProcessorContext* const trace_context_;
+  ActiveChromeProcessesTracker* const active_processes_tracker_;
+
+  const StringId task_file_name_args_key_id_;
+  const StringId task_function_name_args_key_id_;
+  const StringId task_line_number_args_key_id_;
+  const StringId log_message_body_key_id_;
+  const StringId log_message_source_location_function_name_key_id_;
+  const StringId log_message_source_location_file_name_key_id_;
+  const StringId log_message_source_location_line_number_key_id_;
+  const StringId log_message_priority_id_;
+  const StringId source_location_function_name_key_id_;
+  const StringId source_location_file_name_key_id_;
+  const StringId source_location_line_number_key_id_;
+  const StringId histogram_name_key_id_;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_TRACK_EVENT_ARG_FIELDS_H_

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -43,9 +43,7 @@
 #include "src/trace_processor/importers/common/cpu_tracker.h"
 #include "src/trace_processor/importers/common/event_tracker.h"
 #include "src/trace_processor/importers/common/flow_tracker.h"
-#include "src/trace_processor/importers/common/gpu_tracker.h"
 
-#include "protos/perfetto/trace/gpu/gpu_track_event.pbzero.h"
 #include "src/trace_processor/importers/common/mapping_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
@@ -104,17 +102,29 @@ using protozero::ConstBytes;
 constexpr int64_t kPendingThreadDuration = -1;
 constexpr int64_t kPendingThreadInstructionDelta = -1;
 
-// Paths on Windows use backslash rather than slash as a separator.
-// Normalise the paths by replacing backslashes with slashes to make it
-// easier to write cross-platform scripts.
-inline std::string NormalizePathSeparators(const protozero::ConstChars& path) {
-  std::string result(path.data, path.size);
-  for (char& c : result) {
-    if (c == '\\')
-      c = '/';
-  }
-  return result;
-}
+// The in-tree TrackEvent fields imported as args rather than into the row:
+// see TrackEventEventImporter::ParseTrackEventArgs.
+using TrackEvent = protos::pbzero::TrackEvent;
+constexpr protozero::SelectiveDecodeMask<
+    TrackEvent::kTaskExecutionFieldNumber,
+    TrackEvent::kLogMessageFieldNumber,
+    TrackEvent::kCcSchedulerStateFieldNumber,
+    TrackEvent::kChromeUserEventFieldNumber,
+    TrackEvent::kChromeKeyedServiceFieldNumber,
+    TrackEvent::kChromeLegacyIpcFieldNumber,
+    TrackEvent::kChromeHistogramSampleFieldNumber,
+    TrackEvent::kChromeLatencyInfoFieldNumber,
+    TrackEvent::kSourceLocationFieldNumber,
+    TrackEvent::kSourceLocationIidFieldNumber,
+    TrackEvent::kChromeMessagePumpFieldNumber,
+    TrackEvent::kChromeMojoEventInfoFieldNumber,
+    TrackEvent::kChromeApplicationStateInfoFieldNumber,
+    TrackEvent::kChromeRendererSchedulerStateFieldNumber,
+    TrackEvent::kChromeWindowHandleEventInfoFieldNumber,
+    TrackEvent::kChromeActiveProcessesFieldNumber,
+    TrackEvent::kScreenshotFieldNumber>
+    kArgFields{};
+constexpr size_t kArgFieldsWords = decltype(kArgFields)::kMaxFieldId / 64 + 1;
 
 inline TrackCompressor::AsyncSliceType AsyncSliceTypeForPhase(int32_t phase) {
   switch (phase) {
@@ -130,29 +140,6 @@ inline TrackCompressor::AsyncSliceType AsyncSliceTypeForPhase(int32_t phase) {
       return TrackCompressor::AsyncSliceType::kInstant;
   }
   PERFETTO_FATAL("For GCC");
-}
-
-inline protos::pbzero::AndroidLogPriority ToAndroidLogPriority(
-    protos::pbzero::LogMessage::Priority prio) {
-  switch (prio) {
-    case protos::pbzero::LogMessage::Priority::PRIO_UNSPECIFIED:
-      return protos::pbzero::AndroidLogPriority::PRIO_UNSPECIFIED;
-    case protos::pbzero::LogMessage::Priority::PRIO_UNUSED:
-      return protos::pbzero::AndroidLogPriority::PRIO_UNUSED;
-    case protos::pbzero::LogMessage::Priority::PRIO_VERBOSE:
-      return protos::pbzero::AndroidLogPriority::PRIO_VERBOSE;
-    case protos::pbzero::LogMessage::Priority::PRIO_DEBUG:
-      return protos::pbzero::AndroidLogPriority::PRIO_DEBUG;
-    case protos::pbzero::LogMessage::Priority::PRIO_INFO:
-      return protos::pbzero::AndroidLogPriority::PRIO_INFO;
-    case protos::pbzero::LogMessage::Priority::PRIO_WARN:
-      return protos::pbzero::AndroidLogPriority::PRIO_WARN;
-    case protos::pbzero::LogMessage::Priority::PRIO_ERROR:
-      return protos::pbzero::AndroidLogPriority::PRIO_ERROR;
-    case protos::pbzero::LogMessage::Priority::PRIO_FATAL:
-      return protos::pbzero::AndroidLogPriority::PRIO_FATAL;
-  }
-  return protos::pbzero::AndroidLogPriority::PRIO_UNSPECIFIED;
 }
 
 class TrackEventEventImporter {
@@ -177,7 +164,10 @@ class TrackEventEventImporter {
                       ->GetTrackEventDefaults()),
         thread_timestamp_(event_data->thread_timestamp),
         thread_instruction_count_(event_data->thread_instruction_count),
-        packet_sequence_id_(packet_sequence_id) {}
+        packet_sequence_id_(packet_sequence_id) {
+    field_context_.ts = ts;
+    field_context_.sequence_state = sequence_state_;
+  }
 
   base::Status Import() {
     // TODO(eseckler): This legacy event field will eventually be replaced by
@@ -667,11 +657,7 @@ class TrackEventEventImporter {
 
     context_->event_tracker->PushCounter(
         ts_, static_cast<double>(event_data_->counter_value), track_id,
-        [this](BoundInserter* inserter) {
-          if (DispatchCounterParsers(CounterId(inserter->id()))) {
-            ParseTrackEventArgs(inserter);
-          }
-        });
+        [this](BoundInserter* inserter) { ParseCounterArgs(inserter); });
     return base::OkStatus();
   }
 
@@ -694,16 +680,12 @@ class TrackEventEventImporter {
       auto opt_state_id =
           context_->state_tracker->UpdateState(ts_, track_id, kNullStringId);
       if (opt_state_id) {
-        DispatchStateParsers(*opt_state_id);
+        ParseTrackEventArgs(nullptr, RowKind::kState, opt_state_id->value);
       }
     } else {
       context_->state_tracker->UpdateState(
           ts_, track_id, state_id, category_id_,
-          [this](BoundInserter* inserter) {
-            if (DispatchStateParsers(StateId(inserter->id()))) {
-              ParseTrackEventArgs(inserter);
-            }
-          });
+          [this](BoundInserter* inserter) { ParseStateArgs(inserter); });
     }
 
     return base::OkStatus();
@@ -817,11 +799,8 @@ class TrackEventEventImporter {
 
     ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationBegin());
     auto opt_slice_id = context_->slice_tracker->Begin(
-        ts_, track_id, category_id_, name_id_, [this](BoundInserter* inserter) {
-          if (DispatchSliceParsers(SliceId(inserter->id()))) {
-            ParseTrackEventArgs(inserter);
-          }
-        });
+        ts_, track_id, category_id_, name_id_,
+        [this](BoundInserter* inserter) { ParseSliceArgs(inserter); });
     if (opt_slice_id.has_value()) {
       auto rr = (*context_->storage->mutable_slice_table())[*opt_slice_id];
       if (thread_timestamp_) {
@@ -843,11 +822,8 @@ class TrackEventEventImporter {
     }
     ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationEnd());
     auto opt_slice_id = context_->slice_tracker->End(
-        ts_, track_id, category_id_, name_id_, [this](BoundInserter* inserter) {
-          if (DispatchSliceParsers(SliceId(inserter->id()))) {
-            ParseTrackEventArgs(inserter);
-          }
-        });
+        ts_, track_id, category_id_, name_id_,
+        [this](BoundInserter* inserter) { ParseSliceArgs(inserter); });
     if (!opt_slice_id)
       return base::OkStatus();
 
@@ -884,7 +860,7 @@ class TrackEventEventImporter {
     ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationForLegacy());
     auto opt_slice_id = context_->slice_tracker->Scoped(
         ts_, track_id, category_id_, name_id_, duration_ns,
-        [this](BoundInserter* inserter) { ParseTrackEventArgs(inserter); });
+        [this](BoundInserter* inserter) { ParseSliceArgs(inserter); });
     if (opt_slice_id.has_value()) {
       auto rr = (*context_->storage->mutable_slice_table())[*opt_slice_id];
       if (thread_timestamp_) {
@@ -967,24 +943,6 @@ class TrackEventEventImporter {
                                     /* close_flow = */ true);
       }
     }
-    // gpu_correlation is an out-of-tree extension of TrackEvent (id 3000),
-    // not stored by the typed decoder. It is in the selective decoder's
-    // spill area, which extension dispatch already built for this event.
-    if (!event_.has_out_of_range_fields()) {
-      return;
-    }
-    TrackEventField gpu_field = selective_decoder().FindUnknownField(
-        protos::pbzero::GpuTrackEvent::kGpuCorrelationFieldNumber);
-    if (gpu_field.valid()) {
-      protos::pbzero::GpuCorrelation::Decoder gpu(
-          gpu_field.Cast<protos::pbzero::GpuTrackEvent::kGpuCorrelation>());
-      for (auto it = gpu.render_stage_submission_event_ids(); it; ++it) {
-        context_->gpu_tracker->AddRenderStageSubmission(*it, slice_id);
-      }
-      for (auto it = gpu.render_stage_wait_event_ids(); it; ++it) {
-        context_->gpu_tracker->AddRenderStageWait(*it, slice_id);
-      }
-    }
   }
 
   void MaybeParseFlowEventV2(SliceId slice_id) {
@@ -1025,10 +983,7 @@ class TrackEventEventImporter {
     int64_t tidelta = 0;
     std::optional<tables::SliceTable::Id> opt_slice_id;
     auto args_inserter = [this, phase](BoundInserter* inserter) {
-      if (!DispatchSliceParsers(SliceId(inserter->id()))) {
-        return;
-      }
-      ParseTrackEventArgs(inserter);
+      ParseSliceArgs(inserter);
       // For legacy MARK event, add phase for JSON exporter.
       if (phase == 'R') {
         std::string phase_string(1, static_cast<char>(phase));
@@ -1062,10 +1017,7 @@ class TrackEventEventImporter {
 
   base::Status ParseAsyncBeginEvent(char phase) {
     auto args_inserter = [this, phase](BoundInserter* inserter) {
-      if (!DispatchSliceParsers(SliceId(inserter->id()))) {
-        return;
-      }
-      ParseTrackEventArgs(inserter);
+      ParseSliceArgs(inserter);
 
       if (phase == 'b')
         return;
@@ -1102,11 +1054,8 @@ class TrackEventEventImporter {
   base::Status ParseAsyncEndEvent() {
     ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationEnd());
     auto opt_slice_id = context_->slice_tracker->End(
-        ts_, track_id, category_id_, name_id_, [this](BoundInserter* inserter) {
-          if (DispatchSliceParsers(SliceId(inserter->id()))) {
-            ParseTrackEventArgs(inserter);
-          }
-        });
+        ts_, track_id, category_id_, name_id_,
+        [this](BoundInserter* inserter) { ParseSliceArgs(inserter); });
     if (!opt_slice_id)
       return base::OkStatus();
 
@@ -1130,7 +1079,7 @@ class TrackEventEventImporter {
     auto opt_slice_id = context_->slice_tracker->Scoped(
         ts_, track_id, category_id_, name_id_, duration_ns,
         [this, phase](BoundInserter* inserter) {
-          ParseTrackEventArgs(inserter);
+          ParseSliceArgs(inserter);
 
           PERFETTO_DCHECK(phase == 'T' || phase == 'p');
           std::string phase_string(1, static_cast<char>(phase));
@@ -1154,11 +1103,7 @@ class TrackEventEventImporter {
     int64_t tidelta = 0;
     auto opt_slice_id = context_->slice_tracker->Scoped(
         ts_, track_id, category_id_, name_id_, duration_ns,
-        [this](BoundInserter* inserter) {
-          if (DispatchSliceParsers(SliceId(inserter->id()))) {
-            ParseTrackEventArgs(inserter);
-          }
-        });
+        [this](BoundInserter* inserter) { ParseSliceArgs(inserter); });
     if (!opt_slice_id.has_value()) {
       return base::OkStatus();
     }
@@ -1310,34 +1255,8 @@ class TrackEventEventImporter {
     // No need to parse legacy_event.instant_event_scope() because we import
     // instant events into the slice table.
 
-    ParseTrackEventArgs(&inserter);
-    return base::OkStatus();
-  }
-
-  base::Status ParseScreenshotArgs(ConstBytes screenshot_bytes,
-                                   BoundInserter* inserter) {
-    protos::pbzero::Screenshot::Decoder screenshot(screenshot_bytes);
-    if (screenshot.has_jpg_image()) {
-      std::string base64_jpg = base::Base64Encode(screenshot.jpg_image().data,
-                                                  screenshot.jpg_image().size);
-      inserter->AddArg(storage_->InternString("screenshot.jpg_image"),
-                       Variadic::String(storage_->InternString(
-                           base::StringView(base64_jpg))));
-    }
-    if (screenshot.has_pam_image()) {
-      std::string base64_pam = base::Base64Encode(screenshot.pam_image().data,
-                                                  screenshot.pam_image().size);
-      inserter->AddArg(storage_->InternString("screenshot.pam_image"),
-                       Variadic::String(storage_->InternString(
-                           base::StringView(base64_pam))));
-    }
-    if (screenshot.has_ppm_image()) {
-      std::string base64_ppm = base::Base64Encode(screenshot.ppm_image().data,
-                                                  screenshot.ppm_image().size);
-      inserter->AddArg(storage_->InternString("screenshot.ppm_image"),
-                       Variadic::String(storage_->InternString(
-                           base::StringView(base64_ppm))));
-    }
+    ParseTrackEventArgs(&inserter, RowKind::kNone,
+                        TrackEventFieldContext::kNone);
     return base::OkStatus();
   }
 
@@ -1348,57 +1267,26 @@ class TrackEventEventImporter {
     return *selective_decoder_;
   }
 
-  // Returns false if a parser claimed the event (default args should be
-  // skipped). Only scans the blob when a parser is registered.
-  template <typename Fn>
-  bool DispatchParsers(Fn on_field) {
-    if (PERFETTO_LIKELY(!parser_->has_parsers())) {
-      return true;
-    }
-    // Extension parsers are not dispatched for legacy events.
-    if (legacy_event_.has_phase()) {
-      return true;
-    }
-    // Extension fields are out-of-tree by definition.
-    if (!event_.has_out_of_range_fields()) {
-      return true;
-    }
-    bool parse_args = true;
-    for (const protozero::Field& f : selective_decoder().unknown_fields()) {
-      TrackEventExtensionParser* parser = parser_->ParserForField(f.id());
-      if (!parser) {
-        continue;
-      }
-      if (on_field(parser, TrackEventExtensionField(f)) ==
-          TrackEventExtensionParser::Result::kHandled) {
-        parse_args = false;
-      }
-    }
-    return parse_args;
+  using RowKind = TrackEventFieldContext::RowKind;
+
+  void ParseSliceArgs(BoundInserter* inserter) {
+    ParseTrackEventArgs(inserter, RowKind::kSlice, inserter->id());
+  }
+  void ParseCounterArgs(BoundInserter* inserter) {
+    ParseTrackEventArgs(inserter, RowKind::kCounter, inserter->id());
+  }
+  void ParseStateArgs(BoundInserter* inserter) {
+    ParseTrackEventArgs(inserter, RowKind::kState, inserter->id());
   }
 
-  bool DispatchSliceParsers(SliceId id) {
-    return DispatchParsers([id, this](TrackEventExtensionParser* parser,
-                                      const TrackEventExtensionField& f) {
-      return parser->OnTrackEventSliceExtension(f, id, sequence_state_);
-    });
-  }
-
-  bool DispatchCounterParsers(CounterId id) {
-    return DispatchParsers([id, this](TrackEventExtensionParser* parser,
-                                      const TrackEventExtensionField& f) {
-      return parser->OnTrackEventCounterExtension(f, id, sequence_state_);
-    });
-  }
-
-  bool DispatchStateParsers(StateId id) {
-    return DispatchParsers([id, this](TrackEventExtensionParser* parser,
-                                      const TrackEventExtensionField& f) {
-      return parser->OnTrackEventStateExtension(f, id, sequence_state_);
-    });
-  }
-
-  void ParseTrackEventArgs(BoundInserter* inserter) {
+  // Adds the event's args to |inserter| and dispatches every field that is
+  // imported as args rather than into the row to the parser registered for
+  // it, then reflects the event into the args table unless a parser claimed
+  // its field. |inserter| is null for a row that takes no args, in which
+  // case only the parsers run.
+  void ParseTrackEventArgs(BoundInserter* inserter,
+                           RowKind row_kind,
+                           uint32_t row_id) {
     auto log_errors = [this](const base::Status& status) {
       if (status.ok())
         return;
@@ -1407,74 +1295,84 @@ class TrackEventEventImporter {
       PERFETTO_DLOG("ParseTrackEventArgs error: %s", status.c_message());
     };
 
-    if (event_.has_source_location_iid()) {
-      log_errors(AddSourceLocationArgs(event_.source_location_iid(), inserter));
-    }
-
-    if (event_.has_task_execution()) {
-      log_errors(ParseTaskExecutionArgs(event_.task_execution(), inserter));
-    }
-    if (event_.has_log_message()) {
-      log_errors(ParseLogMessage(event_.log_message(), inserter));
-    }
-    if (event_.has_screenshot()) {
-      log_errors(ParseScreenshotArgs(event_.screenshot(), inserter));
-    }
-    if (event_.has_chrome_histogram_sample()) {
-      log_errors(
-          ParseHistogramName(event_.chrome_histogram_sample(), inserter));
-    }
-    if (event_.has_chrome_active_processes()) {
-      protos::pbzero::ChromeActiveProcesses::Decoder message(
-          event_.chrome_active_processes());
-      for (auto it = message.pid(); it; ++it) {
-        parser_->AddActiveProcess(ts_, *it);
-      }
-    }
-    if (event_.has_correlation_id()) {
-      base::StackString<512> id_str("tp:#%" PRIu64, event_.correlation_id());
-      inserter->AddArg(parser_->correlation_id_key_id_,
-                       Variadic::String(context_->storage->InternString(
-                           id_str.string_view())));
-    }
-
-    if (event_.has_correlation_id_str()) {
-      inserter->AddArg(parser_->correlation_id_key_id_,
-                       Variadic::String(storage_->InternString(
-                           base::StringView(event_.correlation_id_str()))));
-    }
-    if (event_.has_correlation_id_str_iid()) {
-      if (auto id = sequence_state_->InternedStringId(
-              protos::pbzero::InternedData::kCorrelationIdStrFieldNumber,
-              event_.correlation_id_str_iid())) {
+    std::optional<ArgsParser> args_writer;
+    if (inserter) {
+      if (event_.has_correlation_id()) {
+        base::StackString<512> id_str("tp:#%" PRIu64, event_.correlation_id());
         inserter->AddArg(parser_->correlation_id_key_id_,
-                         Variadic::String(*id));
+                         Variadic::String(context_->storage->InternString(
+                             id_str.string_view())));
+      }
+      if (event_.has_correlation_id_str()) {
+        inserter->AddArg(parser_->correlation_id_key_id_,
+                         Variadic::String(storage_->InternString(
+                             base::StringView(event_.correlation_id_str()))));
+      }
+      if (event_.has_correlation_id_str_iid()) {
+        if (auto id = sequence_state_->InternedStringId(
+                protos::pbzero::InternedData::kCorrelationIdStrFieldNumber,
+                event_.correlation_id_str_iid())) {
+          inserter->AddArg(parser_->correlation_id_key_id_,
+                           Variadic::String(*id));
+        }
+      }
+      if (legacy_trace_source_id_) {
+        inserter->AddArg(parser_->legacy_trace_source_id_key_id_,
+                         Variadic::Integer(*legacy_trace_source_id_));
+      }
+      log_errors(ParseCallstack());
+      args_writer.emplace(ts_, *inserter, *storage_, *context_->process_tracker,
+                          sequence_state_, /*support_json=*/true);
+    }
+
+    field_context_.utid = utid_.value_or(TrackEventFieldContext::kNone);
+    field_context_.upid = upid_.value_or(TrackEventFieldContext::kNone);
+    field_context_.row_kind = row_kind;
+    field_context_.row_id = row_id;
+    field_context_.args = inserter;
+
+    bool reflect = true;
+    auto dispatch = [&](const protozero::Field& field) {
+      TrackEventExtensionParser* p = parser_->ParserForField(field.id());
+      if (p && p->OnTrackEventField(TrackEventExtensionField(field),
+                                    field_context_) ==
+                   TrackEventExtensionParser::Result::kHandled) {
+        reflect = false;
+      }
+    };
+    if (event_.HasAnyField(kArgFields.data(), kArgFieldsWords)) {
+      for (uint32_t id = 0; id <= decltype(kArgFields)::kMaxFieldId; ++id) {
+        if (kArgFields.contains(id) && event_.HasField(id)) {
+          dispatch(event_.Get(id));
+        }
       }
     }
-    if (legacy_trace_source_id_) {
-      inserter->AddArg(parser_->legacy_trace_source_id_key_id_,
-                       Variadic::Integer(*legacy_trace_source_id_));
+    // Extension fields are out-of-tree by definition.
+    if (event_.has_out_of_range_fields()) {
+      for (const protozero::Field& f : selective_decoder().unknown_fields()) {
+        dispatch(f);
+      }
+    }
+    if (!inserter) {
+      return;
     }
 
-    log_errors(ParseCallstack());
-
-    ArgsParser args_writer(ts_, *inserter, *storage_,
-                           *context_->process_tracker, sequence_state_,
-                           /*support_json=*/true);
-    int unknown_extensions = 0;
-    log_errors(parser_->args_parser_.ParseMessage(
-        blob_, ".perfetto.protos.TrackEvent", &parser_->reflect_fields_,
-        args_writer, &unknown_extensions));
-    if (unknown_extensions > 0) {
-      context_->stats_tracker->IncrementStats(stats::unknown_extension_fields,
-                                              unknown_extensions);
+    if (reflect) {
+      int unknown_extensions = 0;
+      log_errors(parser_->args_parser_.ParseMessage(
+          blob_, ".perfetto.protos.TrackEvent", &parser_->reflect_fields_,
+          *args_writer, &unknown_extensions));
+      if (unknown_extensions > 0) {
+        context_->stats_tracker->IncrementStats(stats::unknown_extension_fields,
+                                                unknown_extensions);
+      }
     }
 
     if (event_.has_debug_annotations()) {
       auto key = parser_->args_parser_.EnterDictionary("debug");
       for (auto it = event_.debug_annotations(); it; ++it) {
         log_errors(
-            parser_->args_parser_.ParseDebugAnnotation(*it, args_writer));
+            parser_->args_parser_.ParseDebugAnnotation(*it, *args_writer));
       }
     }
 
@@ -1483,37 +1381,6 @@ class TrackEventEventImporter {
                        Variadic::UnsignedInteger(*legacy_passthrough_utid_),
                        ArgsTracker::UpdatePolicy::kSkipIfExists);
     }
-  }
-
-  base::Status ParseTaskExecutionArgs(ConstBytes task_execution,
-                                      BoundInserter* inserter) {
-    protos::pbzero::TaskExecution::Decoder task(task_execution);
-    uint64_t iid = task.posted_from_iid();
-    if (!iid)
-      return base::ErrStatus("TaskExecution with invalid posted_from_iid");
-
-    auto* decoder = sequence_state_->LookupInternedMessage<
-        protos::pbzero::InternedData::kSourceLocationsFieldNumber,
-        protos::pbzero::SourceLocation>(iid);
-    if (!decoder)
-      return base::ErrStatus("TaskExecution with invalid posted_from_iid");
-
-    StringId file_name_id = kNullStringId;
-    StringId function_name_id = kNullStringId;
-    uint32_t line_number = 0;
-
-    std::string file_name = NormalizePathSeparators(decoder->file_name());
-    file_name_id = storage_->InternString(base::StringView(file_name));
-    function_name_id = storage_->InternString(decoder->function_name());
-    line_number = decoder->line_number();
-
-    inserter->AddArg(parser_->task_file_name_args_key_id_,
-                     Variadic::String(file_name_id));
-    inserter->AddArg(parser_->task_function_name_args_key_id_,
-                     Variadic::String(function_name_id));
-    inserter->AddArg(parser_->task_line_number_args_key_id_,
-                     Variadic::UnsignedInteger(line_number));
-    return base::OkStatus();
   }
 
   void MaybeInsertTrackEventCallstack(SliceId slice_id, TrackId track_id) {
@@ -1533,122 +1400,6 @@ class TrackEventEventImporter {
       row.weight = event_.callstack_weight();
     }
     table->Insert(row);
-  }
-
-  base::Status AddSourceLocationArgs(uint64_t iid, BoundInserter* inserter) {
-    if (!iid)
-      return base::ErrStatus("SourceLocation with invalid iid");
-
-    auto* decoder = sequence_state_->LookupInternedMessage<
-        protos::pbzero::InternedData::kSourceLocationsFieldNumber,
-        protos::pbzero::SourceLocation>(iid);
-    if (!decoder)
-      return base::ErrStatus("SourceLocation with invalid iid");
-
-    StringId file_name_id = kNullStringId;
-    StringId function_name_id = kNullStringId;
-    uint32_t line_number = 0;
-
-    std::string file_name = NormalizePathSeparators(decoder->file_name());
-    file_name_id = storage_->InternString(base::StringView(file_name));
-    function_name_id = storage_->InternString(decoder->function_name());
-    line_number = decoder->line_number();
-
-    inserter->AddArg(parser_->source_location_file_name_key_id_,
-                     Variadic::String(file_name_id));
-    inserter->AddArg(parser_->source_location_function_name_key_id_,
-                     Variadic::String(function_name_id));
-    inserter->AddArg(parser_->source_location_line_number_key_id_,
-                     Variadic::UnsignedInteger(line_number));
-    return base::OkStatus();
-  }
-
-  base::Status ParseLogMessage(ConstBytes blob, BoundInserter* inserter) {
-    if (!utid_)
-      return base::ErrStatus("LogMessage without thread association");
-
-    protos::pbzero::LogMessage::Decoder message(blob);
-
-    std::optional<StringId> body_id = sequence_state_->InternedStringId(
-        protos::pbzero::InternedData::kLogMessageBodyFieldNumber,
-        message.body_iid());
-    if (!body_id)
-      return base::ErrStatus("LogMessage with invalid body_iid");
-
-    const StringId log_message_id = *body_id;
-    inserter->AddArg(parser_->log_message_body_key_id_,
-                     Variadic::String(log_message_id));
-
-    StringId source_location_id = kNullStringId;
-    if (message.has_source_location_iid()) {
-      auto* source_location_decoder = sequence_state_->LookupInternedMessage<
-          protos::pbzero::InternedData::kSourceLocationsFieldNumber,
-          protos::pbzero::SourceLocation>(message.source_location_iid());
-      if (!source_location_decoder)
-        return base::ErrStatus("LogMessage with invalid source_location_iid");
-      const std::string source_location =
-          source_location_decoder->file_name().ToStdString() + ":" +
-          std::to_string(source_location_decoder->line_number());
-      source_location_id =
-          storage_->InternString(base::StringView(source_location));
-
-      inserter->AddArg(parser_->log_message_source_location_file_name_key_id_,
-                       Variadic::String(storage_->InternString(
-                           source_location_decoder->file_name())));
-      inserter->AddArg(
-          parser_->log_message_source_location_function_name_key_id_,
-          Variadic::String(storage_->InternString(
-              source_location_decoder->function_name())));
-      inserter->AddArg(
-          parser_->log_message_source_location_line_number_key_id_,
-          Variadic::Integer(source_location_decoder->line_number()));
-    }
-
-    // The track event log message doesn't specify any priority. UI never
-    // displays priorities < 2 (VERBOSE in android). Let's make all the track
-    // event logs show up as INFO.
-    int32_t priority = protos::pbzero::AndroidLogPriority::PRIO_INFO;
-    if (message.has_prio()) {
-      priority = ToAndroidLogPriority(
-          static_cast<protos::pbzero::LogMessage::Priority>(message.prio()));
-      inserter->AddArg(parser_->log_message_priority_id_,
-                       Variadic::Integer(priority));
-    }
-
-    tables::LogTable::Row log_row;
-    log_row.ts = ts_;
-    log_row.utid = utid_;
-    log_row.prio = static_cast<uint32_t>(priority);
-    log_row.log_source = storage_->InternString("android_logcat");
-    log_row.tag = source_location_id != kNullStringId
-                      ? std::make_optional(source_location_id)
-                      : std::nullopt;
-    log_row.msg = log_message_id;
-    storage_->mutable_log_table()->Insert(log_row);
-
-    return base::OkStatus();
-  }
-
-  base::Status ParseHistogramName(ConstBytes blob, BoundInserter* inserter) {
-    protos::pbzero::ChromeHistogramSample::Decoder sample(blob);
-    if (!sample.has_name_iid())
-      return base::OkStatus();
-
-    if (sample.has_name()) {
-      return base::ErrStatus(
-          "name is already set for ChromeHistogramSample: only one of name and "
-          "name_iid can be set.");
-    }
-
-    std::optional<StringId> name_id = sequence_state_->InternedStringId(
-        protos::pbzero::InternedData::kHistogramNamesFieldNumber,
-        sample.name_iid());
-    if (!name_id)
-      return base::ErrStatus("HistogramName with invalid name_iid");
-
-    inserter->AddArg(parser_->histogram_name_key_id_,
-                     Variadic::String(*name_id));
-    return base::OkStatus();
   }
 
   base::Status ParseCallstack() {
@@ -1726,6 +1477,8 @@ class TrackEventEventImporter {
   // Built on first use; shared by every consumer of out-of-tree fields.
   std::optional<SelectiveTrackEventDecoder> selective_decoder_;
   protos::pbzero::TrackEventDefaults::Decoder* defaults_;
+  // Handed to every field parser; the row and args are filled in per row.
+  TrackEventFieldContext field_context_;
 
   // Importing state.
   StringId category_id_;

--- a/src/trace_processor/importers/proto/track_event_extension_parser.cc
+++ b/src/trace_processor/importers/proto/track_event_extension_parser.cc
@@ -26,27 +26,9 @@ TrackEventExtensionParser::TrackEventExtensionParser(
 
 TrackEventExtensionParser::~TrackEventExtensionParser() = default;
 
-TrackEventExtensionParser::Result
-TrackEventExtensionParser::OnTrackEventCounterExtension(
+TrackEventExtensionParser::Result TrackEventExtensionParser::OnTrackEventField(
     const TrackEventExtensionField&,
-    CounterId,
-    PacketSequenceStateGeneration*) {
-  return Result::kIgnored;
-}
-
-TrackEventExtensionParser::Result
-TrackEventExtensionParser::OnTrackEventSliceExtension(
-    const TrackEventExtensionField&,
-    SliceId,
-    PacketSequenceStateGeneration*) {
-  return Result::kIgnored;
-}
-
-TrackEventExtensionParser::Result
-TrackEventExtensionParser::OnTrackEventStateExtension(
-    const TrackEventExtensionField&,
-    StateId,
-    PacketSequenceStateGeneration*) {
+    const TrackEventFieldContext&) {
   return Result::kIgnored;
 }
 

--- a/src/trace_processor/importers/proto/track_event_extension_parser.h
+++ b/src/trace_processor/importers/proto/track_event_extension_parser.h
@@ -18,10 +18,13 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_TRACK_EVENT_EXTENSION_PARSER_H_
 
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <vector>
 
+#include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "src/trace_processor/importers/common/args_tracker.h"
 #include "src/trace_processor/importers/proto/typed_proto_field.h"
 #include "src/trace_processor/storage/trace_storage.h"
 
@@ -30,54 +33,80 @@ namespace perfetto::trace_processor {
 struct TrackEventExtensionParserContext;
 class PacketSequenceStateGeneration;
 
-// A single out-of-tree extension field (`extensions 1000 to 9999`) of a
-// TrackEvent, handed to plugins. The plugin decodes it with the generated field
-// metadata of the extension it owns, e.g.
-//   field.Cast<FrameworksBaseTrackEvent::kProcessStart>()  // -> ConstBytes
+// A single field of a TrackEvent handed to a parser: an in-tree field that
+// is imported as args rather than into the row, or an out-of-tree extension
+// (`extensions 1000 to 9999`). Decode it with the generated field metadata,
+// e.g. field.Cast<FrameworksBaseTrackEvent::kProcessStart>().
 using TrackEventExtensionField = TypedProtoField;
 
-// Base class for plugins that handle TrackEvent extension fields. This is the
-// TrackEvent-extension analogue of ProtoImporterModule: a plugin registers (via
-// RegisterTrackEventExtension) the extension field ids it owns, and the
-// matching On*() callback is invoked after the core counter/slice/state row has
-// been inserted, so the plugin receives its Id and can populate its own side
-// tables.
+// The event a field belongs to, as far as the importer has got with it.
+// Built once per event by the importer and handed to every parser.
+struct TrackEventFieldContext {
+  enum class RowKind : uint8_t { kNone, kSlice, kCounter, kState };
+  static constexpr uint32_t kNone = std::numeric_limits<uint32_t>::max();
+
+  int64_t ts = 0;
+  PacketSequenceStateGeneration* sequence_state = nullptr;
+  // kNone when the event has no thread or process association.
+  UniqueTid utid = kNone;
+  UniquePid upid = kNone;
+
+  // The row the event was imported as. kNone for a legacy event imported
+  // into the raw table.
+  RowKind row_kind = RowKind::kNone;
+  uint32_t row_id = kNone;
+
+  // Args of that row, or null when the row takes none.
+  ArgsTracker::BoundInserter* args = nullptr;
+
+  bool has_utid() const { return utid != kNone; }
+  bool has_upid() const { return upid != kNone; }
+  SliceId slice_id() const {
+    PERFETTO_DCHECK(row_kind == RowKind::kSlice);
+    return SliceId(row_id);
+  }
+  CounterId counter_id() const {
+    PERFETTO_DCHECK(row_kind == RowKind::kCounter);
+    return CounterId(row_id);
+  }
+  StateId state_id() const {
+    PERFETTO_DCHECK(row_kind == RowKind::kState);
+    return StateId(row_id);
+  }
+};
+
+// Parses the TrackEvent fields it registered for. Every field of an event
+// that the importer does not consume for the row itself is dispatched, in
+// order, to the parser registered for its id and then reflected into the
+// args table unless the parser claimed it. In-tree fields such as
+// task_execution and out-of-tree extensions are handled alike; plugins
+// register theirs via RegisterTrackEventExtensions.
 //
-// Each extension field id is owned by exactly one plugin. Only modern
-// counter/slice/state events are dispatched, never legacy ones.
+// Each field id is owned by exactly one parser. Dispatch happens after the
+// row has been inserted, so the parser receives its id.
 class TrackEventExtensionParser {
  public:
-  // kHandled means the parser skips the default flattening of the event into
-  // the args table; kIgnored leaves it untouched.
+  // kHandled skips the reflection of the field into the args table;
+  // kIgnored leaves it to happen.
   enum class Result { kHandled, kIgnored };
 
   explicit TrackEventExtensionParser(TrackEventExtensionParserContext* context);
   virtual ~TrackEventExtensionParser();
 
-  // Default to kIgnored so a plugin only overrides the kinds it handles.
-  virtual Result OnTrackEventCounterExtension(
-      const TrackEventExtensionField& field,
-      CounterId id,
-      PacketSequenceStateGeneration* sequence_state);
-  virtual Result OnTrackEventSliceExtension(
-      const TrackEventExtensionField& field,
-      SliceId id,
-      PacketSequenceStateGeneration* sequence_state);
-  virtual Result OnTrackEventStateExtension(
-      const TrackEventExtensionField& field,
-      StateId id,
-      PacketSequenceStateGeneration* sequence_state);
+  virtual Result OnTrackEventField(const TrackEventExtensionField& field,
+                                   const TrackEventFieldContext& event);
 
  protected:
-  // Registers this plugin as the owner of |field_id| (CHECKs if already owned).
+  // Registers this parser as the owner of |field_id| (CHECKs if already
+  // owned).
   void RegisterTrackEventExtension(uint32_t field_id);
 
   TrackEventExtensionParserContext* context_;
 };
 
-// Per-trace registry of TrackEvent extension parsers, mirroring
+// Per-trace registry of TrackEvent field parsers, mirroring
 // ProtoImporterModuleContext: |parsers| owns them and |parsers_by_field| maps
-// each registered extension field id to its owner.
+// each registered field id to its owner.
 struct TrackEventExtensionParserContext {
   std::vector<std::unique_ptr<TrackEventExtensionParser>> parsers;
   base::FlatHashMap<uint32_t, TrackEventExtensionParser*> parsers_by_field;

--- a/src/trace_processor/importers/proto/track_event_parser.cc
+++ b/src/trace_processor/importers/proto/track_event_parser.cc
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -39,6 +40,7 @@
 #include "src/trace_processor/importers/common/synthetic_tid.h"
 #include "src/trace_processor/importers/common/virtual_memory_mapping.h"
 #include "src/trace_processor/importers/proto/stack_profile_sequence_state.h"
+#include "src/trace_processor/importers/proto/track_event_arg_fields.h"
 #include "src/trace_processor/importers/proto/track_event_event_importer.h"
 #include "src/trace_processor/importers/proto/track_event_tracker.h"
 #include "src/trace_processor/storage/stats.h"
@@ -158,32 +160,8 @@ TrackEventParser::TrackEventParser(
           context->storage->InternString("thread_time")),
       counter_name_thread_instruction_count_id_(
           context->storage->InternString("thread_instruction_count")),
-      task_file_name_args_key_id_(
-          context->storage->InternString("task.posted_from.file_name")),
-      task_function_name_args_key_id_(
-          context->storage->InternString("task.posted_from.function_name")),
-      task_line_number_args_key_id_(
-          context->storage->InternString("task.posted_from.line_number")),
       job_scheduler_job_name_args_key_id_(
           context->storage->InternString("job_scheduler_job.job_name")),
-      log_message_body_key_id_(
-          context->storage->InternString("track_event.log_message.message")),
-      log_message_source_location_function_name_key_id_(
-          context->storage->InternString(
-              "track_event.log_message.function_name")),
-      log_message_source_location_file_name_key_id_(
-          context->storage->InternString("track_event.log_message.file_name")),
-      log_message_source_location_line_number_key_id_(
-          context->storage->InternString(
-              "track_event.log_message.line_number")),
-      log_message_priority_id_(
-          context->storage->InternString("track_event.priority")),
-      source_location_function_name_key_id_(
-          context->storage->InternString("source.function_name")),
-      source_location_file_name_key_id_(
-          context->storage->InternString("source.file_name")),
-      source_location_line_number_key_id_(
-          context->storage->InternString("source.line_number")),
       raw_legacy_event_id_(
           context->storage->InternString("track_event.legacy_event")),
       legacy_event_passthrough_utid_id_(
@@ -222,8 +200,6 @@ TrackEventParser::TrackEventParser(
           context->storage->InternString("legacy_event.bind_to_enclosing")),
       legacy_event_flow_direction_key_id_(
           context->storage->InternString("legacy_event.flow_direction")),
-      histogram_name_key_id_(
-          context->storage->InternString("chrome_histogram_sample.name")),
       flow_direction_value_in_id_(context->storage->InternString("in")),
       flow_direction_value_out_id_(context->storage->InternString("out")),
       flow_direction_value_inout_id_(context->storage->InternString("inout")),
@@ -317,6 +293,10 @@ TrackEventParser::TrackEventParser(
   for (uint16_t index : kReflectFields) {
     reflect_fields_.push_back(index);
   }
+  extension_parser_context_->parsers.emplace_back(
+      std::make_unique<TrackEventArgFieldParser>(
+          extension_parser_context_, context,
+          &active_chrome_processes_tracker_));
 }
 
 void TrackEventParser::ParseTrackDescriptor(

--- a/src/trace_processor/importers/proto/track_event_parser.h
+++ b/src/trace_processor/importers/proto/track_event_parser.h
@@ -71,10 +71,6 @@ class TrackEventParser {
  private:
   friend class TrackEventEventImporter;
 
-  bool has_parsers() const {
-    return !extension_parser_context_->parsers.empty();
-  }
-
   TrackEventExtensionParser* ParserForField(uint32_t field_id) const {
     auto* it = extension_parser_context_->parsers_by_field.Find(field_id);
     return it ? *it : nullptr;
@@ -94,18 +90,7 @@ class TrackEventParser {
 
   const StringId counter_name_thread_time_id_;
   const StringId counter_name_thread_instruction_count_id_;
-  const StringId task_file_name_args_key_id_;
-  const StringId task_function_name_args_key_id_;
-  const StringId task_line_number_args_key_id_;
   const StringId job_scheduler_job_name_args_key_id_;
-  const StringId log_message_body_key_id_;
-  const StringId log_message_source_location_function_name_key_id_;
-  const StringId log_message_source_location_file_name_key_id_;
-  const StringId log_message_source_location_line_number_key_id_;
-  const StringId log_message_priority_id_;
-  const StringId source_location_function_name_key_id_;
-  const StringId source_location_file_name_key_id_;
-  const StringId source_location_line_number_key_id_;
   const StringId raw_legacy_event_id_;
   const StringId legacy_event_passthrough_utid_id_;
   const StringId legacy_event_category_key_id_;
@@ -124,7 +109,6 @@ class TrackEventParser {
   const StringId legacy_event_bind_id_key_id_;
   const StringId legacy_event_bind_to_enclosing_key_id_;
   const StringId legacy_event_flow_direction_key_id_;
-  const StringId histogram_name_key_id_;
   const StringId flow_direction_value_in_id_;
   const StringId flow_direction_value_out_id_;
   const StringId flow_direction_value_inout_id_;

--- a/src/trace_processor/plugins/android_framework_track_event/android_framework_track_event.cc
+++ b/src/trace_processor/plugins/android_framework_track_event/android_framework_track_event.cc
@@ -61,11 +61,12 @@ class Parser : public TrackEventExtensionParser {
   }
   ~Parser() override = default;
 
-  Result OnTrackEventSliceExtension(
-      const TrackEventExtensionField& field,
-      SliceId id,
-      PacketSequenceStateGeneration* /*sequence_state*/) override {
-    int64_t ts = trace_context_->storage->slice_table()[id].ts();
+  Result OnTrackEventField(const TrackEventExtensionField& field,
+                           const TrackEventFieldContext& event) override {
+    if (event.row_kind != TrackEventFieldContext::RowKind::kSlice) {
+      return Result::kIgnored;
+    }
+    int64_t ts = event.ts;
     switch (field.id()) {
       case FBTE::kProcessStartEventFieldNumber:
         HandleProcessStart(field.Cast<FBTE::kProcessStartEvent>(), ts);

--- a/src/trace_processor/plugins/android_job_scheduler/android_job_scheduler_tracker.cc
+++ b/src/trace_processor/plugins/android_job_scheduler/android_job_scheduler_tracker.cc
@@ -46,14 +46,15 @@ AndroidJobSchedulerTracker::AndroidJobSchedulerTracker(
   RegisterTrackEventExtension(kJobSchedulerJobExtensionFieldId);
 }
 
-TrackEventExtensionParser::Result
-AndroidJobSchedulerTracker::OnTrackEventSliceExtension(
+TrackEventExtensionParser::Result AndroidJobSchedulerTracker::OnTrackEventField(
     const TrackEventExtensionField& field,
-    SliceId slice_id,
-    PacketSequenceStateGeneration* sequence_state) {
-  if (field.id() != kJobSchedulerJobExtensionFieldId) {
+    const TrackEventFieldContext& event) {
+  if (field.id() != kJobSchedulerJobExtensionFieldId ||
+      event.row_kind != TrackEventFieldContext::RowKind::kSlice) {
     return Result::kIgnored;
   }
+  SliceId slice_id = event.slice_id();
+  PacketSequenceStateGeneration* sequence_state = event.sequence_state;
 
   auto job_blob = field.Cast<com::android::internal::pbzero::
                                  FrameworksBaseTrackEvent::kJobSchedulerJob>();
@@ -70,7 +71,7 @@ AndroidJobSchedulerTracker::OnTrackEventSliceExtension(
     }
   }
 
-  int64_t ts = trace_context_->storage->slice_table()[slice_id].ts();
+  int64_t ts = event.ts;
   auto* table = trace_context_->storage
                     ->mutable_android_job_scheduler_track_event_table();
 

--- a/src/trace_processor/plugins/android_job_scheduler/android_job_scheduler_tracker.h
+++ b/src/trace_processor/plugins/android_job_scheduler/android_job_scheduler_tracker.h
@@ -42,10 +42,8 @@ class AndroidJobSchedulerTracker : public TrackEventExtensionParser {
   AndroidJobSchedulerTracker(TrackEventExtensionParserContext*,
                              TraceProcessorContext*);
 
-  Result OnTrackEventSliceExtension(
-      const TrackEventExtensionField& field,
-      SliceId id,
-      PacketSequenceStateGeneration* sequence_state) override;
+  Result OnTrackEventField(const TrackEventExtensionField& field,
+                           const TrackEventFieldContext& event) override;
 
  private:
   StringId InternEnum(DescriptorPool::CachedDescriptor& cache,

--- a/src/trace_processor/plugins/android_job_scheduler/android_job_scheduler_tracker_unittest.cc
+++ b/src/trace_processor/plugins/android_job_scheduler/android_job_scheduler_tracker_unittest.cc
@@ -98,7 +98,11 @@ TEST_F(AndroidJobSchedulerTrackerTest, ParseAndroidJobSchedulerJob) {
   slice_row.ts = 1000;
   auto slice_id = context.storage->mutable_slice_table()->Insert(slice_row).id;
 
-  tracker->OnTrackEventSliceExtension(extension_field, slice_id, nullptr);
+  TrackEventFieldContext event;
+  event.ts = 1000;
+  event.row_kind = TrackEventFieldContext::RowKind::kSlice;
+  event.row_id = slice_id.value;
+  tracker->OnTrackEventField(extension_field, event);
 
   const auto& table =
       context.storage->android_job_scheduler_track_event_table();
@@ -160,7 +164,11 @@ TEST_F(AndroidJobSchedulerTrackerTest,
   slice_row.ts = 1000;
   auto slice_id = context.storage->mutable_slice_table()->Insert(slice_row).id;
 
-  tracker->OnTrackEventSliceExtension(extension_field, slice_id, nullptr);
+  TrackEventFieldContext event;
+  event.ts = 1000;
+  event.row_kind = TrackEventFieldContext::RowKind::kSlice;
+  event.row_id = slice_id.value;
+  tracker->OnTrackEventField(extension_field, event);
 
   const auto& table =
       context.storage->android_job_scheduler_track_event_table();
@@ -207,7 +215,11 @@ TEST_F(AndroidJobSchedulerTrackerTest, ParseAndroidJobSchedulerJob_Defaults) {
   slice_row.ts = 1000;
   auto slice_id = context.storage->mutable_slice_table()->Insert(slice_row).id;
 
-  tracker->OnTrackEventSliceExtension(extension_field, slice_id, nullptr);
+  TrackEventFieldContext event;
+  event.ts = 1000;
+  event.row_kind = TrackEventFieldContext::RowKind::kSlice;
+  event.row_id = slice_id.value;
+  tracker->OnTrackEventField(extension_field, event);
 
   const auto& table =
       context.storage->android_job_scheduler_track_event_table();

--- a/src/trace_processor/plugins/android_process_state/android_process_state_module.cc
+++ b/src/trace_processor/plugins/android_process_state/android_process_state_module.cc
@@ -66,11 +66,9 @@ void AndroidProcessStateModule::OnEventsFullyExtracted() {
 
 AndroidProcessStateExtensionParser::AndroidProcessStateExtensionParser(
     TrackEventExtensionParserContext* context,
-    TraceProcessorContext* trace_context,
+    TraceProcessorContext*,
     AndroidProcessStateTracker* tracker)
-    : TrackEventExtensionParser(context),
-      trace_context_(trace_context),
-      tracker_(tracker) {
+    : TrackEventExtensionParser(context), tracker_(tracker) {
   RegisterTrackEventExtension(
       fb::FrameworksBaseTrackEvent::kProcessStateChangedEventFieldNumber);
   RegisterTrackEventExtension(
@@ -81,11 +79,13 @@ AndroidProcessStateExtensionParser::~AndroidProcessStateExtensionParser() =
     default;
 
 TrackEventExtensionParser::Result
-AndroidProcessStateExtensionParser::OnTrackEventSliceExtension(
+AndroidProcessStateExtensionParser::OnTrackEventField(
     const TrackEventExtensionField& field,
-    SliceId id,
-    PacketSequenceStateGeneration*) {
-  int64_t ts = trace_context_->storage->slice_table()[id].ts();
+    const TrackEventFieldContext& event) {
+  if (event.row_kind != TrackEventFieldContext::RowKind::kSlice) {
+    return Result::kIgnored;
+  }
+  int64_t ts = event.ts;
   switch (field.id()) {
     case fb::FrameworksBaseTrackEvent::kProcessStateChangedEventFieldNumber:
       tracker_->ParseProcessStateChange(

--- a/src/trace_processor/plugins/android_process_state/android_process_state_module.h
+++ b/src/trace_processor/plugins/android_process_state/android_process_state_module.h
@@ -47,17 +47,14 @@ class AndroidProcessStateModule : public ProtoImporterModule {
 class AndroidProcessStateExtensionParser : public TrackEventExtensionParser {
  public:
   AndroidProcessStateExtensionParser(TrackEventExtensionParserContext* context,
-                                     TraceProcessorContext* trace_context,
+                                     TraceProcessorContext*,
                                      AndroidProcessStateTracker* tracker);
   ~AndroidProcessStateExtensionParser() override;
 
-  Result OnTrackEventSliceExtension(
-      const TrackEventExtensionField& field,
-      SliceId id,
-      PacketSequenceStateGeneration* sequence_state) override;
+  Result OnTrackEventField(const TrackEventExtensionField& field,
+                           const TrackEventFieldContext& event) override;
 
  private:
-  TraceProcessorContext* const trace_context_;
   AndroidProcessStateTracker* const tracker_;
 };
 


### PR DESCRIPTION
Give each argument field the same handler interface as extension fields.
Move built-in handlers out of the event importer and port the in-tree
plugins, making field ownership explicit before changing reflection.

Recorded buildprof results:
- Wall time: 29.57s -> 29.21s (-1.20%).
- User instructions: 447.673G -> 445.418G (-0.50%).
