### PR TITLE
tp: stdlib: Add frame_event_time to android_input_events

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/input.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/input.sql
@@ -70,13 +70,15 @@ WITH
   _extracted_input_read_args AS (
     SELECT
       name,
-      str_split(str_split(str_split(name, 'id=', 1), ',', 0), ')', 0) AS input_event_id,
-      ts AS read_time
+      regexp_extract(name, 'id=([^,\)]+)') AS input_event_id,
+      ts AS read_time,
+      cast_int!(regexp_extract(name, 'eventTime=(\d+)')) AS event_time
     FROM slice
     WHERE
       name GLOB 'UnwantedInteractionBlocker::notifyMotion*'
   )
-SELECT name, input_event_id, read_time FROM _extracted_input_read_args;
+SELECT name, input_event_id, read_time, event_time
+FROM _extracted_input_read_args;
 
 CREATE PERFETTO TABLE _event_seq_to_input_event_id AS
 WITH
@@ -249,7 +251,7 @@ SELECT
   _input_event_id_to_android_frame.frame_id,
   event_seq,
   event_action,
-  event_time,
+  _input_event_id_to_android_frame.event_time,
   _input_event_id_to_android_frame.is_speculative_match
 FROM _input_event_id_to_android_frame
 RIGHT JOIN _event_seq_to_input_event_id
@@ -344,7 +346,9 @@ CREATE PERFETTO TABLE android_input_events(
   -- Indicates if the frame association was speculative rather than exact based on id match.
   is_speculative_frame BOOL,
   -- Timestamp when the input event actually occurred.
-  event_time TIMESTAMP
+  event_time TIMESTAMP,
+  -- Timestamp of the input event that the frame receives. This can differ from event_time due to resampling.
+  frame_event_time TIMESTAMP
 )
 AS
 WITH
@@ -414,7 +418,8 @@ SELECT
   receive.track_id AS receive_track_id,
   frame.frame_id,
   frame.is_speculative_match AS is_speculative_frame,
-  frame.event_time
+  read_time.event_time,
+  frame.event_time AS frame_event_time
 FROM dispatch
 JOIN receive
   ON receive.dispatch_event_channel = dispatch.event_channel

--- a/test/trace_processor/diff_tests/stdlib/android/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/android/tests.py
@@ -1494,15 +1494,16 @@ class AndroidStdlib(TestSuite):
         process_name,
         event_type,
         event_action,
-        event_time
+        event_time,
+        frame_event_time
         FROM android_input_events
         WHERE end_to_end_latency_dur IS NOT NULL
         ORDER BY dispatch_ts
       """,
         out=Csv("""
-        "total_latency_dur","handling_latency_dur","dispatch_latency_dur","end_to_end_latency_dur","tid","thread_name","upid","pid","process_name","event_type","event_action","event_time"
-        3422992,2937418,363000,51007097,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION","HOVER_MOVE",12394215174000
-        2139405,1956366,81387,50642855,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION","SCROLL",12394215174000
+        "total_latency_dur","handling_latency_dur","dispatch_latency_dur","end_to_end_latency_dur","tid","thread_name","upid","pid","process_name","event_type","event_action","event_time","frame_event_time"
+        3422992,2937418,363000,51007097,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION","HOVER_MOVE","[NULL]",12394215174000
+        2139405,1956366,81387,50642855,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION","SCROLL","[NULL]",12394215174000
       """))
 
   def test_job_scheduler_events(self):


### PR DESCRIPTION
The event time used in the frame can differ from the actual event time of the input event due to resampling. As a result, this PR explicitly partitions the frame event time to its own field. We then ensure that the exact "event_time" field is always populated with the real event time from InputReader which is important for event correlation.

Drive-by: Replace the nested str_split with regexp_extract in _input_read_time

Bug: 454761692