### PR TITLE
tp: parse decoded argument fields directly using scalar schemas

### DIFF
--- a/include/perfetto/protozero/proto_decoder.h
+++ b/include/perfetto/protozero/proto_decoder.h
@@ -327,7 +327,8 @@ class UnifiedRepeatedFieldIterator {
 //   static constexpr SelectiveDecodeMask<TracePacket::kTimestampFieldNumber,
 //                                        TracePacket::kInternedDataFieldNumber>
 //       kMask{};
-//   SelectiveTypedProtoDecoder<MAX_FIELD_ID> decoder(data, size, kMask);
+//   SelectiveTypedProtoDecoder<TypedProtoDecoder<MAX_FIELD_ID>> decoder(
+//       data, size, kMask);
 //   for (const Field& f : decoder.unknown_fields()) { ... }
 template <uint32_t... kFieldIds>
 class SelectiveDecodeMask {
@@ -619,11 +620,16 @@ class PERFETTO_EXPORT_COMPONENT TypedProtoDecoderBase : public ProtoDecoder {
 template <int MAX_FIELD_ID, bool = false>
 class TypedProtoDecoder : public TypedProtoDecoderBase {
  public:
+  // The highest field id known to this decoder; see has_out_of_range_fields().
+  static constexpr uint32_t kMaxFieldId = static_cast<uint32_t>(MAX_FIELD_ID);
+
   TypedProtoDecoder(const uint8_t* buffer, size_t length)
-      : TypedProtoDecoder(SkipParseTag{},
-                          buffer,
-                          length,
-                          /*num_fields=*/MAX_FIELD_ID + 1) {
+      : TypedProtoDecoderBase(on_stack_storage_,
+                              presence_storage_,
+                              /*num_fields=*/MAX_FIELD_ID + 1,
+                              PROTOZERO_DECODER_INITIAL_STACK_CAPACITY,
+                              buffer,
+                              length) {
     TypedProtoDecoderBase::ParseAllFields();
   }
 
@@ -654,21 +660,6 @@ class TypedProtoDecoder : public TypedProtoDecoderBase {
     }
     return *this;
   }
-
- protected:
-  // Sets up the storage but does not parse: for subclasses that drive
-  // ParseAllFields() themselves (see SelectiveTypedProtoDecoder).
-  struct SkipParseTag {};
-  TypedProtoDecoder(SkipParseTag,
-                    const uint8_t* buffer,
-                    size_t length,
-                    uint32_t num_fields)
-      : TypedProtoDecoderBase(on_stack_storage_,
-                              presence_storage_,
-                              num_fields,
-                              PROTOZERO_DECODER_INITIAL_STACK_CAPACITY,
-                              buffer,
-                              length) {}
 
  private:
   void MaybeCopyOnStackStorage(const TypedProtoDecoder& other) {
@@ -709,37 +700,34 @@ class TypedProtoDecoder : public TypedProtoDecoderBase {
 //   static constexpr SelectiveDecodeMask<TracePacket::kTimestampFieldNumber,
 //                                        TracePacket::kInternedDataFieldNumber>
 //       kMask{};
-//   SelectiveTypedProtoDecoder<MAX_FIELD_ID> decoder(data, size, kMask);
+//   SelectiveTypedProtoDecoder<TypedProtoDecoder<MAX_FIELD_ID>> decoder(
+//       data, size, kMask);
 //   for (const Field& f : decoder.unknown_fields()) { ... }
-template <int MAX_FIELD_ID>
-class SelectiveTypedProtoDecoder : public TypedProtoDecoder<MAX_FIELD_ID> {
-  using Base = TypedProtoDecoder<MAX_FIELD_ID>;
-
+template <typename Decoder>
+class SelectiveTypedProtoDecoder : public Decoder {
  public:
-  // The dense window is capped at the mask's extent: |num_fields_| is the
-  // only id bound the decode loop checks, so capping it both bounds the mask
-  // read and makes every id above the mask spill, letting the mask be sized
-  // to the allowlisted ids only rather than to MAX_FIELD_ID.
-  // |mask| is only read during this call.
+  // |Decoder| is a TypedProtoDecoder or a generated message decoder, whose
+  // typed accessors this class inherits. The dense window is capped at the
+  // mask's extent: |num_fields_| is the only id bound the decode loop checks,
+  // so capping it both bounds the mask read and makes every id above the
+  // mask spill, letting the mask be sized to the allowlisted ids only rather
+  // than to the decoder's max field id. |mask| is only read during this call.
   template <uint32_t... kFieldIds>
   SelectiveTypedProtoDecoder(const uint8_t* buffer,
                              size_t length,
                              const SelectiveDecodeMask<kFieldIds...>& mask)
-      : Base(typename Base::SkipParseTag{},
-             buffer,
-             length,
-             /*num_fields=*/
-             std::min(static_cast<uint32_t>(MAX_FIELD_ID),
-                      SelectiveDecodeMask<kFieldIds...>::kMaxFieldId) +
-                 1) {
-    // The base constructor cleared the presence bitmap only up to the capped
-    // |num_fields_|. at<>() skips the range check for ids below the on-stack
-    // capacity and tests the presence bit directly, so the rest of the bitmap
-    // must be cleared too.
-    constexpr uint32_t kPresenceWords = (MAX_FIELD_ID + 1 + 63) / 64;
-    const uint32_t cleared_words = (this->num_fields_ + 63) / 64;
-    memset(this->presence_ + cleared_words, 0,
-           (kPresenceWords - cleared_words) * sizeof(uint64_t));
+      : Decoder(nullptr, 0) {
+    // The empty decode above set up the storage and cleared the whole
+    // presence bitmap without parsing anything; point it at the real buffer
+    // and parse selectively.
+    this->begin_ = buffer;
+    this->end_ = buffer + length;
+    this->read_ptr_ = buffer;
+    this->num_fields_ =
+        std::min(Decoder::kMaxFieldId,
+                 SelectiveDecodeMask<kFieldIds...>::kMaxFieldId) +
+        1;
+    this->size_ = std::min(this->num_fields_, this->capacity_ - 1);
     spill_ = spill_storage_;
     uint32_t spill_capacity = kSpillStackCapacity;
     this->ParseAllFieldsSelective(mask.data(), &spill_, &spill_capacity,
@@ -753,7 +741,7 @@ class SelectiveTypedProtoDecoder : public TypedProtoDecoder<MAX_FIELD_ID> {
   }
 
   SelectiveTypedProtoDecoder(SelectiveTypedProtoDecoder&& other) noexcept
-      : Base(std::move(other)),
+      : Decoder(std::move(other)),
         spill_(other.spill_),
         spill_size_(other.spill_size_),
         heap_spill_(std::move(other.heap_spill_)) {

--- a/src/protozero/proto_decoder_unittest.cc
+++ b/src/protozero/proto_decoder_unittest.cc
@@ -670,7 +670,8 @@ TEST(ProtoDecoderTest, SpillMaskSplitsDenseAndSpilled) {
   // The mask sizes itself to its highest id (3): field 4 below spills via the
   // range check, field 2 via its unset mask bit.
   static constexpr SelectiveDecodeMask<1, 3> mask{};
-  SelectiveTypedProtoDecoder<10> tpd(data.data(), data.size(), mask);
+  SelectiveTypedProtoDecoder<TypedProtoDecoder<10>> tpd(data.data(),
+                                                        data.size(), mask);
 
   // Allowlisted ids are dense, with the usual O(1) access.
   EXPECT_EQ(tpd.Get(1).as_int32(), 10);
@@ -701,7 +702,8 @@ TEST(ProtoDecoderTest, SpillMaskSpillsExtensionIds) {
   auto data = message.SerializeAsArray();
 
   static constexpr SelectiveDecodeMask<1> mask{};
-  SelectiveTypedProtoDecoder<3> tpd(data.data(), data.size(), mask);
+  SelectiveTypedProtoDecoder<TypedProtoDecoder<3>> tpd(data.data(), data.size(),
+                                                       mask);
   EXPECT_EQ(tpd.Get(1).as_int32(), 11);
   auto unknown = tpd.unknown_fields();
   ASSERT_EQ(unknown.end() - unknown.begin(), 1);
@@ -719,7 +721,8 @@ TEST(ProtoDecoderTest, SpillMaskAtBeyondDenseWindow) {
   // whose presence bit lives in a bitmap word beyond the shrunk window --
   // spill, and at<>()/Get() see an invalid field.
   static constexpr SelectiveDecodeMask<1> mask{};
-  SelectiveTypedProtoDecoder<70> tpd(data.data(), data.size(), mask);
+  SelectiveTypedProtoDecoder<TypedProtoDecoder<70>> tpd(data.data(),
+                                                        data.size(), mask);
 
   EXPECT_EQ(tpd.Get(1).as_int32(), 11);
   EXPECT_FALSE(tpd.at<70>().valid());
@@ -740,7 +743,8 @@ TEST(ProtoDecoderTest, SpillMaskHeapExpansion) {
   auto data = message.SerializeAsArray();
 
   static constexpr SelectiveDecodeMask<1> mask{};
-  SelectiveTypedProtoDecoder<3> tpd(data.data(), data.size(), mask);
+  SelectiveTypedProtoDecoder<TypedProtoDecoder<3>> tpd(data.data(), data.size(),
+                                                       mask);
   auto unknown = tpd.unknown_fields();
   ASSERT_EQ(unknown.end() - unknown.begin(),
             static_cast<ptrdiff_t>(kNumSpilled));
@@ -760,7 +764,8 @@ TEST(ProtoDecoderTest, SpillMaskDenseRepeatedUnaffected) {
   auto data = message.SerializeAsArray();
 
   static constexpr SelectiveDecodeMask<1> mask{};
-  SelectiveTypedProtoDecoder<3> tpd(data.data(), data.size(), mask);
+  SelectiveTypedProtoDecoder<TypedProtoDecoder<3>> tpd(data.data(), data.size(),
+                                                       mask);
 
   // Dense repeated fields keep their FIFO iteration and last-wins Get().
   std::vector<int32_t> res;
@@ -780,8 +785,9 @@ TEST(ProtoDecoderTest, SpillMaskMovePreservesSpill) {
   auto data = message.SerializeAsArray();
 
   static constexpr SelectiveDecodeMask<1> mask{};
-  SelectiveTypedProtoDecoder<3> tpd(data.data(), data.size(), mask);
-  SelectiveTypedProtoDecoder<3> moved(std::move(tpd));
+  SelectiveTypedProtoDecoder<TypedProtoDecoder<3>> tpd(data.data(), data.size(),
+                                                       mask);
+  SelectiveTypedProtoDecoder<TypedProtoDecoder<3>> moved(std::move(tpd));
 
   EXPECT_EQ(moved.Get(1).as_int32(), 11);
   auto unknown = moved.unknown_fields();

--- a/src/protozero/test/proto_decoder_benchmark.cc
+++ b/src/protozero/test/proto_decoder_benchmark.cc
@@ -184,8 +184,9 @@ uint64_t ScanPacketsSelective(const LoadedTrace& trace) {
       kDenseMask{};
   uint64_t acc = 0;
   for (const ConstBytes& p : trace.packets) {
-    protozero::SelectiveTypedProtoDecoder<kMaxDirectFieldId> d(p.data, p.size,
-                                                               kDenseMask);
+    protozero::SelectiveTypedProtoDecoder<
+        protozero::TypedProtoDecoder<kMaxDirectFieldId>>
+        d(p.data, p.size, kDenseMask);
     if (d.at<TP::kTimestampFieldNumber>().valid())
       acc += d.at<TP::kTimestampFieldNumber>().as_uint64();
     acc += d.at<TP::kTrustedPacketSequenceIdFieldNumber>().as_uint32();

--- a/src/trace_processor/importers/proto/selective_trace_packet_decoder.h
+++ b/src/trace_processor/importers/proto/selective_trace_packet_decoder.h
@@ -268,8 +268,8 @@ class SelectiveTracePacketDecoder {
   }
 
  private:
-  protozero::SelectiveTypedProtoDecoder<static_cast<int>(
-      internal::TracePacketDenseMask::kMaxFieldId)>
+  protozero::SelectiveTypedProtoDecoder<protozero::TypedProtoDecoder<
+      static_cast<int>(internal::TracePacketDenseMask::kMaxFieldId)>>
       decoder_;
 };
 

--- a/src/trace_processor/importers/proto/selective_track_event_decoder.h
+++ b/src/trace_processor/importers/proto/selective_track_event_decoder.h
@@ -32,20 +32,32 @@ using TrackEventField = TypedProtoField;
 
 namespace internal {
 
-// The TrackEvent fields the parser reads by name (the dense allowlist for
-// selective decoding below). Every other field -- in particular the out-of-tree
-// extensions (`extensions 1000 to 9999`) -- lands in unknown_fields().
-using TrackEventDenseMask = protozero::SelectiveDecodeMask<
-    protos::pbzero::TrackEvent::kTypeFieldNumber,
-    protos::pbzero::TrackEvent::kTrackUuidFieldNumber,
+// The TrackEvent fields that describe the event itself, read through the
+// generated accessors. Every other field is imported as args: the in-tree
+// arg fields such as task_execution and the chrome typed messages, and the
+// out-of-tree extensions (`extensions 1000 to 9999`). Those land in
+// unknown_fields(), in wire order, which drives arg field dispatch.
+using TrackEventCoreMask = protozero::SelectiveDecodeMask<
+    protos::pbzero::TrackEvent::kTimestampDeltaUsFieldNumber,
+    protos::pbzero::TrackEvent::kThreadTimeDeltaUsFieldNumber,
     protos::pbzero::TrackEvent::kCategoryIidsFieldNumber,
-    protos::pbzero::TrackEvent::kCategoriesFieldNumber,
+    protos::pbzero::TrackEvent::kDebugAnnotationsFieldNumber,
+    protos::pbzero::TrackEvent::kLegacyEventFieldNumber,
+    protos::pbzero::TrackEvent::kThreadInstructionCountDeltaFieldNumber,
+    protos::pbzero::TrackEvent::kTypeFieldNumber,
     protos::pbzero::TrackEvent::kNameIidFieldNumber,
+    protos::pbzero::TrackEvent::kTrackUuidFieldNumber,
+    protos::pbzero::TrackEvent::kExtraCounterValuesFieldNumber,
+    protos::pbzero::TrackEvent::kTimestampAbsoluteUsFieldNumber,
+    protos::pbzero::TrackEvent::kThreadTimeAbsoluteUsFieldNumber,
+    protos::pbzero::TrackEvent::kThreadInstructionCountAbsoluteFieldNumber,
+    protos::pbzero::TrackEvent::kCategoriesFieldNumber,
     protos::pbzero::TrackEvent::kNameFieldNumber,
     protos::pbzero::TrackEvent::kCounterValueFieldNumber,
-    protos::pbzero::TrackEvent::kDoubleCounterValueFieldNumber,
     protos::pbzero::TrackEvent::kExtraCounterTrackUuidsFieldNumber,
-    protos::pbzero::TrackEvent::kExtraCounterValuesFieldNumber,
+    protos::pbzero::TrackEvent::kFlowIdsOldFieldNumber,
+    protos::pbzero::TrackEvent::kTerminatingFlowIdsOldFieldNumber,
+    protos::pbzero::TrackEvent::kDoubleCounterValueFieldNumber,
     protos::pbzero::TrackEvent::kExtraDoubleCounterTrackUuidsFieldNumber,
     protos::pbzero::TrackEvent::kExtraDoubleCounterValuesFieldNumber,
     protos::pbzero::TrackEvent::kFlowIdsFieldNumber,
@@ -55,61 +67,25 @@ using TrackEventDenseMask = protozero::SelectiveDecodeMask<
     protos::pbzero::TrackEvent::kCorrelationIdStrIidFieldNumber,
     protos::pbzero::TrackEvent::kCallstackFieldNumber,
     protos::pbzero::TrackEvent::kCallstackIidFieldNumber,
-    protos::pbzero::TrackEvent::kDebugAnnotationsFieldNumber,
-    protos::pbzero::TrackEvent::kTaskExecutionFieldNumber,
-    protos::pbzero::TrackEvent::kLogMessageFieldNumber,
-    protos::pbzero::TrackEvent::kCcSchedulerStateFieldNumber,
-    protos::pbzero::TrackEvent::kChromeUserEventFieldNumber,
-    protos::pbzero::TrackEvent::kChromeKeyedServiceFieldNumber,
-    protos::pbzero::TrackEvent::kChromeLegacyIpcFieldNumber,
-    protos::pbzero::TrackEvent::kChromeHistogramSampleFieldNumber,
-    protos::pbzero::TrackEvent::kChromeLatencyInfoFieldNumber,
-    protos::pbzero::TrackEvent::kChromeApplicationStateInfoFieldNumber,
-    protos::pbzero::TrackEvent::kChromeRendererSchedulerStateFieldNumber,
-    protos::pbzero::TrackEvent::kChromeWindowHandleEventInfoFieldNumber,
-    protos::pbzero::TrackEvent::kChromeActiveProcessesFieldNumber,
-    protos::pbzero::TrackEvent::kScreenshotFieldNumber,
-    protos::pbzero::TrackEvent::kSourceLocationFieldNumber,
-    protos::pbzero::TrackEvent::kSourceLocationIidFieldNumber,
-    protos::pbzero::TrackEvent::kChromeMessagePumpFieldNumber,
-    protos::pbzero::TrackEvent::kChromeMojoEventInfoFieldNumber,
-    protos::pbzero::TrackEvent::kLegacyEventFieldNumber>;
+    protos::pbzero::TrackEvent::kCallstackWeightFieldNumber>;
 
-inline constexpr TrackEventDenseMask kTrackEventDenseMask{};
+inline constexpr TrackEventCoreMask kTrackEventCoreMask{};
 
 }  // namespace internal
 
-// Hand-maintained wrapper around protozero::SelectiveTypedProtoDecoder for
-// TrackEvent, mirroring SelectiveTracePacketDecoder. The allowlist is the set
-// of in-tree TrackEvent fields; every other field -- in particular out-of-tree
-// extensions (`extensions 1000 to 9999`) -- lands in unknown_fields(), which
-// drives TrackEvent extension plugin dispatch.
-//
-// The parser still reads in-tree fields via the generated TrackEvent::Decoder;
-// this wrapper exists to enumerate extension fields cheaply and in wire order.
-class SelectiveTrackEventDecoder {
+// The generated TrackEvent decoder, decoded selectively: the fields of the
+// event itself are available through the generated accessors, every other
+// field is in unknown_fields(). One decode serves both the row and the arg
+// field dispatch.
+class SelectiveTrackEventDecoder : public protozero::SelectiveTypedProtoDecoder<
+                                       protos::pbzero::TrackEvent::Decoder> {
  public:
-  using TrackEvent = protos::pbzero::TrackEvent;
-
   SelectiveTrackEventDecoder(const uint8_t* data, size_t length)
-      : decoder_(data, length, internal::kTrackEventDenseMask) {}
+      : SelectiveTypedProtoDecoder(data,
+                                   length,
+                                   internal::kTrackEventCoreMask) {}
   explicit SelectiveTrackEventDecoder(protozero::ConstBytes blob)
       : SelectiveTrackEventDecoder(blob.data, blob.size) {}
-
-  // All the fields not in the allowlist, in wire order, with repeated
-  // occurrences preserved. Drives extension plugin dispatch.
-  protozero::UnknownFieldRange unknown_fields() const {
-    return decoder_.unknown_fields();
-  }
-
-  static constexpr bool ContainsField(uint32_t id) {
-    return internal::kTrackEventDenseMask.contains(id);
-  }
-
- private:
-  protozero::SelectiveTypedProtoDecoder<static_cast<int>(
-      internal::TrackEventDenseMask::kMaxFieldId)>
-      decoder_;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/track_event_arg_fields.cc
+++ b/src/trace_processor/importers/proto/track_event_arg_fields.cc
@@ -142,6 +142,8 @@ TrackEventExtensionParser::Result TrackEventArgFieldParser::OnTrackEventField(
         stats::track_event_parser_errors);
     PERFETTO_DLOG("ParseTrackEventArgs error: %s", status.c_message());
   };
+  // Fields the generic reflection also covers return kIgnored so that their
+  // plain args are added as well.
   switch (field.id()) {
     case TrackEvent::kSourceLocationIidFieldNumber:
       log_errors(AddSourceLocationArgs(
@@ -150,10 +152,10 @@ TrackEventExtensionParser::Result TrackEventArgFieldParser::OnTrackEventField(
     case TrackEvent::kTaskExecutionFieldNumber:
       log_errors(
           ParseTaskExecution(field.Cast<TrackEvent::kTaskExecution>(), event));
-      return Result::kIgnored;
+      return Result::kHandled;
     case TrackEvent::kLogMessageFieldNumber:
       log_errors(ParseLogMessage(field.Cast<TrackEvent::kLogMessage>(), event));
-      return Result::kIgnored;
+      return Result::kHandled;
     case TrackEvent::kScreenshotFieldNumber:
       ParseScreenshot(field.Cast<TrackEvent::kScreenshot>(), event);
       return Result::kIgnored;

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -102,30 +102,6 @@ using protozero::ConstBytes;
 constexpr int64_t kPendingThreadDuration = -1;
 constexpr int64_t kPendingThreadInstructionDelta = -1;
 
-// The in-tree TrackEvent fields imported as args rather than into the row:
-// see TrackEventEventImporter::ParseTrackEventArgs.
-using TrackEvent = protos::pbzero::TrackEvent;
-constexpr protozero::SelectiveDecodeMask<
-    TrackEvent::kTaskExecutionFieldNumber,
-    TrackEvent::kLogMessageFieldNumber,
-    TrackEvent::kCcSchedulerStateFieldNumber,
-    TrackEvent::kChromeUserEventFieldNumber,
-    TrackEvent::kChromeKeyedServiceFieldNumber,
-    TrackEvent::kChromeLegacyIpcFieldNumber,
-    TrackEvent::kChromeHistogramSampleFieldNumber,
-    TrackEvent::kChromeLatencyInfoFieldNumber,
-    TrackEvent::kSourceLocationFieldNumber,
-    TrackEvent::kSourceLocationIidFieldNumber,
-    TrackEvent::kChromeMessagePumpFieldNumber,
-    TrackEvent::kChromeMojoEventInfoFieldNumber,
-    TrackEvent::kChromeApplicationStateInfoFieldNumber,
-    TrackEvent::kChromeRendererSchedulerStateFieldNumber,
-    TrackEvent::kChromeWindowHandleEventInfoFieldNumber,
-    TrackEvent::kChromeActiveProcessesFieldNumber,
-    TrackEvent::kScreenshotFieldNumber>
-    kArgFields{};
-constexpr size_t kArgFieldsWords = decltype(kArgFields)::kMaxFieldId / 64 + 1;
-
 inline TrackCompressor::AsyncSliceType AsyncSliceTypeForPhase(int32_t phase) {
   switch (phase) {
     case 'b':
@@ -1260,13 +1236,6 @@ class TrackEventEventImporter {
     return base::OkStatus();
   }
 
-  const SelectiveTrackEventDecoder& selective_decoder() {
-    if (!selective_decoder_) {
-      selective_decoder_.emplace(blob_);
-    }
-    return *selective_decoder_;
-  }
-
   using RowKind = TrackEventFieldContext::RowKind;
 
   void ParseSliceArgs(BoundInserter* inserter) {
@@ -1280,10 +1249,10 @@ class TrackEventEventImporter {
   }
 
   // Adds the event's args to |inserter| and dispatches every field that is
-  // imported as args rather than into the row to the parser registered for
-  // it, then reflects the event into the args table unless a parser claimed
-  // its field. |inserter| is null for a row that takes no args, in which
-  // case only the parsers run.
+  // imported as args rather than into the row: each goes to the parser
+  // registered for it, then is reflected into the args table unless that
+  // parser claimed it. |inserter| is null for a row that takes no args, in
+  // which case only the parsers run.
   void ParseTrackEventArgs(BoundInserter* inserter,
                            RowKind row_kind,
                            uint32_t row_id) {
@@ -1331,41 +1300,34 @@ class TrackEventEventImporter {
     field_context_.row_id = row_id;
     field_context_.args = inserter;
 
-    bool reflect = true;
-    auto dispatch = [&](const protozero::Field& field) {
-      TrackEventExtensionParser* p = parser_->ParserForField(field.id());
-      if (p && p->OnTrackEventField(TrackEventExtensionField(field),
-                                    field_context_) ==
-                   TrackEventExtensionParser::Result::kHandled) {
-        reflect = false;
-      }
-    };
-    if (event_.HasAnyField(kArgFields.data(), kArgFieldsWords)) {
-      for (uint32_t id = 0; id <= decltype(kArgFields)::kMaxFieldId; ++id) {
-        if (kArgFields.contains(id) && event_.HasField(id)) {
-          dispatch(event_.Get(id));
+    int unknown_extensions = 0;
+    std::optional<uint32_t> track_event_idx =
+        parser_->TrackEventDescriptorIdx();
+    util::ProtoToArgsParser::RepeatedFieldIndex repeated_field_index;
+    // Every field that is not part of the event itself is an arg field or
+    // an extension, in wire order: each goes to its parser, then is reflected
+    // unless the parser claimed it.
+    for (const protozero::Field& field : event_.unknown_fields()) {
+      if (TrackEventExtensionParser* p = parser_->ParserForField(field.id())) {
+        if (p->OnTrackEventField(TrackEventExtensionField(field),
+                                 field_context_) ==
+            TrackEventExtensionParser::Result::kHandled) {
+          continue;
         }
       }
-    }
-    // Extension fields are out-of-tree by definition.
-    if (event_.has_out_of_range_fields()) {
-      for (const protozero::Field& f : selective_decoder().unknown_fields()) {
-        dispatch(f);
+      if (!args_writer || !track_event_idx) {
+        continue;
       }
+      log_errors(parser_->args_parser_.ParseMessageField(
+          *track_event_idx, field, *args_writer, &unknown_extensions,
+          &repeated_field_index));
+    }
+    if (unknown_extensions > 0) {
+      context_->stats_tracker->IncrementStats(stats::unknown_extension_fields,
+                                              unknown_extensions);
     }
     if (!inserter) {
       return;
-    }
-
-    if (reflect) {
-      int unknown_extensions = 0;
-      log_errors(parser_->args_parser_.ParseMessage(
-          blob_, ".perfetto.protos.TrackEvent", &parser_->reflect_fields_,
-          *args_writer, &unknown_extensions));
-      if (unknown_extensions > 0) {
-        context_->stats_tracker->IncrementStats(stats::unknown_extension_fields,
-                                                unknown_extensions);
-      }
     }
 
     if (event_.has_debug_annotations()) {
@@ -1472,10 +1434,8 @@ class TrackEventEventImporter {
   const TrackEventData* event_data_;
   PacketSequenceStateGeneration* sequence_state_;
   ConstBytes blob_;
-  TrackEvent::Decoder event_;
+  SelectiveTrackEventDecoder event_;
   LegacyEvent::Decoder legacy_event_;
-  // Built on first use; shared by every consumer of out-of-tree fields.
-  std::optional<SelectiveTrackEventDecoder> selective_decoder_;
   protos::pbzero::TrackEventDefaults::Decoder* defaults_;
   // Handed to every field parser; the row and args are filled in per row.
   TrackEventFieldContext field_context_;

--- a/src/trace_processor/importers/proto/track_event_parser.cc
+++ b/src/trace_processor/importers/proto/track_event_parser.cc
@@ -290,9 +290,6 @@ TrackEventParser::TrackEventParser(
         return std::nullopt;
       });
 
-  for (uint16_t index : kReflectFields) {
-    reflect_fields_.push_back(index);
-  }
   extension_parser_context_->parsers.emplace_back(
       std::make_unique<TrackEventArgFieldParser>(
           extension_parser_context_, context,
@@ -466,6 +463,14 @@ void TrackEventParser::ParseTrackEvent(int64_t ts,
     context_->stats_tracker->IncrementStats(stats::track_event_parser_errors);
     PERFETTO_DLOG("ParseTrackEvent error: %s", status.c_message());
   }
+}
+
+std::optional<uint32_t> TrackEventParser::TrackEventDescriptorIdx() {
+  if (!track_event_descriptor_idx_) {
+    track_event_descriptor_idx_ = context_->descriptor_pool_->FindDescriptorIdx(
+        ".perfetto.protos.TrackEvent");
+  }
+  return track_event_descriptor_idx_;
 }
 
 void TrackEventParser::AddActiveProcess(int64_t packet_timestamp, int32_t pid) {

--- a/src/trace_processor/importers/proto/track_event_parser.h
+++ b/src/trace_processor/importers/proto/track_event_parser.h
@@ -37,11 +37,6 @@ namespace perfetto::trace_processor {
 
 // Field numbers to be added to args table automatically via reflection
 //
-// TODO(ddrone): replace with a predicate on field id to import new fields
-// automatically
-static constexpr uint16_t kReflectFields[] = {
-    24, 25, 26, 27, 28, 29, 32, 33, 34, 35, 38, 39, 40, 41, 43, 49, 50};
-
 class PacketSequenceStateGeneration;
 class TraceProcessorContext;
 class TrackEventTracker;
@@ -75,6 +70,9 @@ class TrackEventParser {
     auto* it = extension_parser_context_->parsers_by_field.Find(field_id);
     return it ? *it : nullptr;
   }
+
+  // The TrackEvent descriptor's index in the pool, resolved once.
+  std::optional<uint32_t> TrackEventDescriptorIdx();
 
   void ParseChromeProcessDescriptor(UniquePid, protozero::ConstBytes);
   void ParseChromeThreadDescriptor(UniqueTid, protozero::ConstBytes);
@@ -127,7 +125,7 @@ class TrackEventParser {
 
   TrackEventExtensionParserContext* extension_parser_context_;
   ChromeStringLookup chrome_string_lookup_;
-  std::vector<uint32_t> reflect_fields_;
+  std::optional<uint32_t> track_event_descriptor_idx_;
   ActiveChromeProcessesTracker active_chrome_processes_tracker_;
   DummyMemoryMapping* inline_callstack_dummy_mapping_ = nullptr;
 };

--- a/src/trace_processor/util/descriptors.cc
+++ b/src/trace_processor/util/descriptors.cc
@@ -432,6 +432,7 @@ base::Status DescriptorPool::AddFromFileDescriptorSet(
     size_t size,
     const std::vector<std::string>& skip_prefixes,
     bool merge_existing_messages) {
+  generation_++;
   protos::pbzero::FileDescriptorSet::Decoder proto(file_descriptor_set_proto,
                                                    size);
   std::vector<ExtensionInfo> extensions;

--- a/src/trace_processor/util/descriptors.h
+++ b/src/trace_processor/util/descriptors.h
@@ -246,7 +246,12 @@ class DescriptorPool {
 
   std::vector<uint8_t> SerializeAsDescriptorSet() const;
 
+  // Bumped whenever a descriptor is added or changed, so that state derived
+  // from the pool can tell it is stale.
+  uint32_t generation() const { return generation_; }
+
   void AddProtoDescriptorForTesting(ProtoDescriptor descriptor) {
+    generation_++;
     AddProtoDescriptor(std::move(descriptor));
   }
 
@@ -324,6 +329,8 @@ class DescriptorPool {
   // Adds a new descriptor to the pool and returns its index. There must not be
   // already a descriptor with the same full_name in the pool.
   uint32_t AddProtoDescriptor(ProtoDescriptor descriptor);
+
+  uint32_t generation_ = 0;
 
   bool DescriptorsStructurallyEqual(
       uint32_t root_existing_idx,

--- a/src/trace_processor/util/proto_to_args_parser.cc
+++ b/src/trace_processor/util/proto_to_args_parser.cc
@@ -69,6 +69,16 @@ bool IsFieldAllowed(const FieldDescriptor& field,
                    field.number()) != allowed_fields->end();
 }
 
+int& RepeatedFieldIndexFor(std::vector<std::pair<uint32_t, int>>& index,
+                           uint32_t field_id) {
+  for (auto& entry : index) {
+    if (entry.first == field_id)
+      return entry.second;
+  }
+  index.emplace_back(field_id, 0);
+  return index.back().second;
+}
+
 }  // namespace
 
 struct ProtoToArgsParser::WorkItem {
@@ -80,7 +90,7 @@ struct ProtoToArgsParser::WorkItem {
   const ProtoDescriptor* descriptor;
 
   // A map to track the index of repeated fields *at this nesting level*.
-  std::unordered_map<size_t, int> repeated_field_index;
+  RepeatedFieldIndex repeated_field_index;
 
   // The set of fields seen in this message, for handling defaults.
   std::unordered_set<uint32_t> existing_fields;
@@ -208,7 +218,9 @@ uint32_t ProtoToArgsParser::CreatePathChild(uint64_t key,
   // key_prefix_.flat_key already has this field's name appended by the caller.
   StringPool::Id flat_key_id =
       string_pool_.InternString(base::StringView(key_prefix_.flat_key));
-  return AppendPathNode(key, flat_key_id, has_array);
+  uint32_t idx = AppendPathNode(key, flat_key_id, has_array);
+  path_nodes_[idx].override = FindOverrideForKey();
+  return idx;
 }
 
 uint32_t ProtoToArgsParser::AppendPathNode(uint64_t key,
@@ -218,7 +230,7 @@ uint32_t ProtoToArgsParser::AppendPathNode(uint64_t key,
   PathNode node;
   node.flat_key_id = flat_key_id;
   node.has_array = has_array;
-  path_nodes_.push_back(node);
+  path_nodes_.push_back(std::move(node));
   path_index_.Insert(key, idx);
   return idx;
 }
@@ -274,6 +286,9 @@ base::Status ProtoToArgsParser::ParseMessage(
   uint32_t root_path = slot ? *slot
                             : AppendPathNode(root_key, StringPool::Id::Null(),
                                              /*has_array=*/false);
+  if (!allowed_fields_ && TryRunFlatMessage(root_path, *idx, cb, delegate)) {
+    return base::OkStatus();
+  }
   work_stack_.emplace_back(WorkItem{protozero::ProtoDecoder(cb),
                                     root_descriptor,
                                     {},
@@ -282,6 +297,61 @@ base::Status ProtoToArgsParser::ParseMessage(
                                     true,
                                     root_path});
   return RunWorkLoop(delegate);
+}
+
+base::Status ProtoToArgsParser::ParseMessageField(
+    uint32_t descriptor_idx,
+    const protozero::Field& field,
+    Delegate& delegate,
+    int* unknown_extensions,
+    RepeatedFieldIndex* repeated_field_index) {
+  PERFETTO_DCHECK(work_stack_.empty());
+  PERFETTO_DCHECK(descriptor_idx < pool_.descriptors().size());
+  allowed_fields_ = nullptr;
+  unknown_extensions_ = unknown_extensions;
+  add_defaults_ = false;
+  uint64_t root_key = PathEdgeKey(kNoPath, descriptor_idx);
+  uint32_t* slot = path_index_.Find(root_key);
+  uint32_t root_path = slot ? *slot
+                            : AppendPathNode(root_key, StringPool::Id::Null(),
+                                             /*has_array=*/false);
+  if (field.type() == protozero::proto_utils::ProtoWireType::kLengthDelimited) {
+    if (auto* child = path_index_.Find(PathEdgeKey(root_path, field.id()))) {
+      uint32_t node = *child;
+      const auto& path = path_nodes_[node];
+      if (!path.override && path.resolved_idx &&
+          pool_.descriptors()[*path.resolved_idx].type() ==
+              ProtoDescriptor::Type::kMessage &&
+          TryRunFlatMessage(node, *path.resolved_idx, field.as_bytes(),
+                            delegate)) {
+        return base::OkStatus();
+      }
+    }
+  }
+  // The root item has nothing left to read: the loop only drains whatever
+  // HandleField pushes for the field.
+  work_stack_.emplace_back(WorkItem{protozero::ProtoDecoder(nullptr, 0),
+                                    &pool_.descriptors()[descriptor_idx],
+                                    {},
+                                    {},
+                                    ScopedNestedKeyContext(key_prefix_),
+                                    false,
+                                    root_path});
+  // The caller's index is lent to the root item for the field.
+  if (repeated_field_index) {
+    std::get<WorkItem>(work_stack_.back())
+        .repeated_field_index.swap(*repeated_field_index);
+  }
+  base::Status status =
+      HandleField(std::get<WorkItem>(work_stack_.back()), field, delegate);
+  if (repeated_field_index) {
+    // HandleField may have pushed an item; the root is the first.
+    std::get<WorkItem>(work_stack_.front())
+        .repeated_field_index.swap(*repeated_field_index);
+  }
+  // Drain the stack even after an error, as ParseMessage does.
+  base::Status loop_status = RunWorkLoop(delegate);
+  return status.ok() ? loop_status : status;
 }
 
 base::Status ProtoToArgsParser::RunWorkLoop(Delegate& delegate) {
@@ -314,116 +384,93 @@ base::Status ProtoToArgsParser::RunWorkLoop(Delegate& delegate) {
   return base::OkStatus();
 }
 
+void ProtoToArgsParser::PrepareFlatMessage(uint32_t node,
+                                           uint32_t descriptor_idx) {
+  using FD = protos::pbzero::FieldDescriptorProto;
+  path_nodes_[node].flat_fields.Clear();
+  path_nodes_[node].flat_generation = pool_.generation();
+  path_nodes_[node].flat_eligible = false;
+  const auto& descriptor = pool_.descriptors()[descriptor_idx];
+  for (const auto& [id, field] : descriptor.fields()) {
+    if (field.is_repeated() || field.is_pid() || field.is_tid() ||
+        field.flags_enum_descriptor_idx() || field.type() == FD::TYPE_MESSAGE ||
+        field.type() == FD::TYPE_GROUP || field.type() < FD::TYPE_DOUBLE ||
+        field.type() > FD::TYPE_SINT64) {
+      return;
+    }
+  }
+  ScopedNestedKeyContext message_context(key_prefix_);
+  auto key = path_nodes_[node].flat_key_id;
+  if (key != StringPool::Id::Null()) {
+    auto prefix = string_pool_.Get(key);
+    key_prefix_.flat_key.assign(prefix.c_str(), prefix.size());
+    key_prefix_.key = key_prefix_.flat_key;
+  }
+  for (const auto& [id, field] : descriptor.fields()) {
+    ScopedNestedKeyContext field_context(key_prefix_);
+    AppendProtoType(key_prefix_.flat_key, field.name());
+    AppendProtoType(key_prefix_.key, field.name());
+    uint32_t child = GetOrCreatePathChild(node, id, false);
+    if (field_overrides_.Find(key_prefix_.flat_key)) {
+      return;
+    }
+    path_nodes_[child].resolved_done = false;
+    path_nodes_[node].flat_fields.Insert(
+        id, {&field, child, path_nodes_[child].flat_key_id});
+  }
+  path_nodes_[node].flat_eligible = true;
+}
+
+bool ProtoToArgsParser::TryRunFlatMessage(uint32_t node,
+                                          uint32_t descriptor_idx,
+                                          protozero::ConstBytes bytes,
+                                          Delegate& delegate) {
+  if (node == kNoPath || add_defaults_ || path_nodes_[node].has_array) {
+    return false;
+  }
+  if (path_nodes_[node].flat_generation != pool_.generation()) {
+    PrepareFlatMessage(node, descriptor_idx);
+  }
+  if (!path_nodes_[node].flat_eligible) {
+    return false;
+  }
+  const auto& fields = path_nodes_[node].flat_fields;
+  protozero::ProtoDecoder decoder(bytes);
+  bool empty = true;
+  for (auto field = decoder.ReadField(); field.valid();
+       field = decoder.ReadField()) {
+    empty = false;
+    auto* cached = fields.Find(field.id());
+    if (!cached) {
+      if (unknown_extensions_) {
+        ++*unknown_extensions_;
+      }
+      continue;
+    }
+    key_prefix_.flat_key_id = cached->key;
+    key_prefix_.key_id = cached->key;
+    auto status =
+        ParseSimpleField(*cached->descriptor, field, cached->node, delegate);
+    PERFETTO_DCHECK(status.ok());
+  }
+  if (empty) {
+    auto key = path_nodes_[node].flat_key_id;
+    if (key == StringPool::Id::Null()) {
+      InternCurrentKey();
+      delegate.AddNull(key_prefix_.flat_key_id, key_prefix_.key_id);
+    } else {
+      delegate.AddNull(key, key);
+    }
+  }
+  return true;
+}
+
 base::Status ProtoToArgsParser::StepProtoMessage(WorkItem& item,
                                                  Delegate& delegate,
                                                  bool& done) {
   protozero::Field field = item.decoder.ReadField();
   if (field.valid()) {
-    item.empty_message = false;
-    const auto* field_descriptor = item.descriptor->FindFieldByTag(field.id());
-    if (!field_descriptor) {
-      if (unknown_extensions_ != nullptr) {
-        (*unknown_extensions_)++;
-      }
-      // Unknown field, possibly an unknown extension.
-      return base::OkStatus();
-    }
-
-    if (add_defaults_) {
-      item.existing_fields.insert(field_descriptor->number());
-    }
-
-    // The allowlist only applies to the top-level message.
-    if (work_stack_.size() == 1 &&
-        !IsFieldAllowed(*field_descriptor, allowed_fields_)) {
-      // Field is neither an extension, nor is allowed to be reflected.
-      return base::OkStatus();
-    }
-
-    // Detect packed fields based on the serialized wire type instead of the
-    // descriptor flag to tolerate proto/descriptor mismatches.
-    using FieldDescriptorProto = protos::pbzero::FieldDescriptorProto;
-    using PWT = protozero::proto_utils::ProtoWireType;
-    const auto descriptor_type = field_descriptor->type();
-    const bool is_length_delimited = field.type() == PWT::kLengthDelimited;
-    const bool looks_packed =
-        field_descriptor->is_repeated() && is_length_delimited &&
-        descriptor_type != FieldDescriptorProto::TYPE_MESSAGE &&
-        descriptor_type != FieldDescriptorProto::TYPE_STRING &&
-        descriptor_type != FieldDescriptorProto::TYPE_BYTES;
-    if (looks_packed) {
-      return ParsePackedField(*field_descriptor, item.repeated_field_index,
-                              field, item.path, delegate);
-    }
-
-    ScopedNestedKeyContext field_key_context(key_prefix_);
-    AppendProtoType(key_prefix_.flat_key, field_descriptor->name());
-    if (field_descriptor->is_repeated()) {
-      std::string prefix_part = field_descriptor->name();
-      int& index = item.repeated_field_index[field.id()];
-      std::string number = std::to_string(index);
-      prefix_part.reserve(prefix_part.length() + number.length() + 2);
-      prefix_part.append("[");
-      prefix_part.append(number);
-      prefix_part.append("]");
-      index++;
-      AppendProtoType(key_prefix_.key, prefix_part);
-    } else {
-      AppendProtoType(key_prefix_.key, field_descriptor->name());
-    }
-
-    // kNoPath for dynamic DebugAnnotation subtrees, which intern keys directly.
-    uint32_t node =
-        item.path != kNoPath
-            ? GetOrCreatePathChild(item.path, field_descriptor->number(),
-                                   field_descriptor->is_repeated())
-            : kNoPath;
-
-    if (std::optional<base::Status> status =
-            MaybeApplyOverrideForField(field, delegate)) {
-      return *status;
-    }
-
-    if (field_descriptor->type() == FieldDescriptorProto::TYPE_MESSAGE) {
-      const std::string& resolved = field_descriptor->resolved_type_name();
-      if (debug_annotation_enabled_ && resolved == kDebugAnnotationTypeName) {
-        // Hand off to the DebugAnnotation path on the same work stack so
-        // DebugAnnotation -> proto_value -> DebugAnnotation cycles do not
-        // grow the C++ stack. DebugAnnotation entries use their own naming
-        // via the "name" field, so the field name we just appended is
-        // dropped before the DA item enters the dictionary.
-        field_key_context.RemoveFieldSuffix();
-        return PushDebugAnnotation(field.as_bytes(), delegate);
-      }
-      std::optional<uint32_t> desc_idx =
-          ResolveTypeDescriptorIdx(*field_descriptor, node);
-      if (!desc_idx) {
-        return base::ErrStatus("Failed to find proto descriptor for %s",
-                               resolved.c_str());
-      }
-      work_stack_.emplace_back(
-          WorkItem{protozero::ProtoDecoder(field.as_bytes()),
-                   &pool_.descriptors()[*desc_idx],
-                   {},
-                   {},
-                   std::move(field_key_context),
-                   true,
-                   node});
-      return base::OkStatus();
-    }
-    // Leaf scalar: reuse the cached flat_key id; only the per-occurrence key
-    // (with an array on the path) needs interning. No node => intern directly.
-    if (node != kNoPath) {
-      const PathNode& n = path_nodes_[node];
-      key_prefix_.flat_key_id = n.flat_key_id;
-      key_prefix_.key_id =
-          n.has_array
-              ? string_pool_.InternString(base::StringView(key_prefix_.key))
-              : n.flat_key_id;
-    } else {
-      InternCurrentKey();
-    }
-    return ParseSimpleField(*field_descriptor, field, node, delegate);
+    return HandleField(item, field, delegate);
   }
 
   done = true;
@@ -435,6 +482,122 @@ base::Status ProtoToArgsParser::StepProtoMessage(WorkItem& item,
     delegate.AddNull(key_prefix_.flat_key_id, key_prefix_.key_id);
   }
   return base::OkStatus();
+}
+
+base::Status ProtoToArgsParser::HandleField(WorkItem& item,
+                                            const protozero::Field& field,
+                                            Delegate& delegate) {
+  item.empty_message = false;
+  const auto* field_descriptor = item.descriptor->FindFieldByTag(field.id());
+  if (!field_descriptor) {
+    if (unknown_extensions_ != nullptr) {
+      (*unknown_extensions_)++;
+    }
+    // Unknown field, possibly an unknown extension.
+    return base::OkStatus();
+  }
+
+  if (add_defaults_) {
+    item.existing_fields.insert(field_descriptor->number());
+  }
+
+  // The allowlist only applies to the top-level message.
+  if (work_stack_.size() == 1 &&
+      !IsFieldAllowed(*field_descriptor, allowed_fields_)) {
+    // Field is neither an extension, nor is allowed to be reflected.
+    return base::OkStatus();
+  }
+
+  // Detect packed fields based on the serialized wire type instead of the
+  // descriptor flag to tolerate proto/descriptor mismatches.
+  using FieldDescriptorProto = protos::pbzero::FieldDescriptorProto;
+  using PWT = protozero::proto_utils::ProtoWireType;
+  const auto descriptor_type = field_descriptor->type();
+  const bool is_length_delimited = field.type() == PWT::kLengthDelimited;
+  const bool looks_packed =
+      field_descriptor->is_repeated() && is_length_delimited &&
+      descriptor_type != FieldDescriptorProto::TYPE_MESSAGE &&
+      descriptor_type != FieldDescriptorProto::TYPE_STRING &&
+      descriptor_type != FieldDescriptorProto::TYPE_BYTES;
+  if (looks_packed) {
+    return ParsePackedField(*field_descriptor, item.repeated_field_index, field,
+                            item.path, delegate);
+  }
+
+  ScopedNestedKeyContext field_key_context(key_prefix_);
+  AppendProtoType(key_prefix_.flat_key, field_descriptor->name());
+  if (field_descriptor->is_repeated()) {
+    std::string prefix_part = field_descriptor->name();
+    int& index = RepeatedFieldIndexFor(item.repeated_field_index, field.id());
+    std::string number = std::to_string(index);
+    prefix_part.reserve(prefix_part.length() + number.length() + 2);
+    prefix_part.append("[");
+    prefix_part.append(number);
+    prefix_part.append("]");
+    index++;
+    AppendProtoType(key_prefix_.key, prefix_part);
+  } else {
+    AppendProtoType(key_prefix_.key, field_descriptor->name());
+  }
+
+  // kNoPath for dynamic DebugAnnotation subtrees, which intern keys directly.
+  uint32_t node =
+      item.path != kNoPath
+          ? GetOrCreatePathChild(item.path, field_descriptor->number(),
+                                 field_descriptor->is_repeated())
+          : kNoPath;
+
+  // kNoPath subtrees intern keys directly and look the override up by key.
+  ParsingOverrideForField* override =
+      node != kNoPath ? path_nodes_[node].override : FindOverrideForKey();
+  if (override) {
+    if (std::optional<base::Status> status = (*override)(field, delegate)) {
+      return *status;
+    }
+  }
+
+  if (field_descriptor->type() == FieldDescriptorProto::TYPE_MESSAGE) {
+    const std::string& resolved = field_descriptor->resolved_type_name();
+    if (debug_annotation_enabled_ && resolved == kDebugAnnotationTypeName) {
+      // Hand off to the DebugAnnotation path on the same work stack so
+      // DebugAnnotation -> proto_value -> DebugAnnotation cycles do not
+      // grow the C++ stack. DebugAnnotation entries use their own naming
+      // via the "name" field, so the field name we just appended is
+      // dropped before the DA item enters the dictionary.
+      field_key_context.RemoveFieldSuffix();
+      return PushDebugAnnotation(field.as_bytes(), delegate);
+    }
+    std::optional<uint32_t> desc_idx =
+        ResolveTypeDescriptorIdx(*field_descriptor, node);
+    if (!desc_idx) {
+      return base::ErrStatus("Failed to find proto descriptor for %s",
+                             resolved.c_str());
+    }
+    if (TryRunFlatMessage(node, *desc_idx, field.as_bytes(), delegate)) {
+      return base::OkStatus();
+    }
+    work_stack_.emplace_back(WorkItem{protozero::ProtoDecoder(field.as_bytes()),
+                                      &pool_.descriptors()[*desc_idx],
+                                      {},
+                                      {},
+                                      std::move(field_key_context),
+                                      true,
+                                      node});
+    return base::OkStatus();
+  }
+  // Leaf scalar: reuse the cached flat_key id; only the per-occurrence key
+  // (with an array on the path) needs interning. No node => intern directly.
+  if (node != kNoPath) {
+    const PathNode& n = path_nodes_[node];
+    key_prefix_.flat_key_id = n.flat_key_id;
+    key_prefix_.key_id =
+        n.has_array
+            ? string_pool_.InternString(base::StringView(key_prefix_.key))
+            : n.flat_key_id;
+  } else {
+    InternCurrentKey();
+  }
+  return ParseSimpleField(*field_descriptor, field, node, delegate);
 }
 
 base::Status ProtoToArgsParser::AddMessageDefaults(WorkItem& item,
@@ -462,7 +625,7 @@ base::Status ProtoToArgsParser::AddMessageDefaults(WorkItem& item,
 
 base::Status ProtoToArgsParser::ParsePackedField(
     const FieldDescriptor& field_descriptor,
-    std::unordered_map<size_t, int>& repeated_field_index,
+    RepeatedFieldIndex& repeated_field_index,
     protozero::Field field,
     uint32_t parent_path,
     Delegate& delegate) {
@@ -486,7 +649,7 @@ base::Status ProtoToArgsParser::ParsePackedField(
     f.initialize(field.id(), static_cast<uint8_t>(wire_type), new_value, 0);
 
     std::string prefix_part = field_descriptor.name();
-    int& index = repeated_field_index[field.id()];
+    int& index = RepeatedFieldIndexFor(repeated_field_index, field.id());
     std::string number = std::to_string(index);
     prefix_part.reserve(prefix_part.length() + number.length() + 2);
     prefix_part.append("[");
@@ -510,9 +673,12 @@ base::Status ProtoToArgsParser::ParsePackedField(
       InternCurrentKey();
     }
 
-    if (std::optional<base::Status> status =
-            MaybeApplyOverrideForField(f, delegate)) {
-      return *status;
+    ParsingOverrideForField* override =
+        node != kNoPath ? path_nodes_[node].override : FindOverrideForKey();
+    if (override) {
+      if (std::optional<base::Status> status = (*override)(f, delegate)) {
+        return *status;
+      }
     }
     return ParseSimpleField(field_descriptor, f, node, delegate);
   };
@@ -554,19 +720,21 @@ void ProtoToArgsParser::AddParsingOverrideForField(
     const std::string& field,
     ParsingOverrideForField func) {
   field_overrides_[field] = std::move(func);
+  for (auto& node : path_nodes_) {
+    node.flat_generation = 0;
+    node.override = node.flat_key_id.is_null()
+                        ? nullptr
+                        : field_overrides_.Find(
+                              string_pool_.Get(node.flat_key_id).ToStdString());
+  }
 }
 
-std::optional<base::Status> ProtoToArgsParser::MaybeApplyOverrideForField(
-    const protozero::Field& field,
-    Delegate& delegate) {
-  // Avoid hashing the flat_key on the per-field hot path when no field
-  // overrides are registered.
+ProtoToArgsParser::ParsingOverrideForField*
+ProtoToArgsParser::FindOverrideForKey() {
+  // Avoid hashing the flat_key when no field overrides are registered.
   if (field_overrides_.size() == 0)
-    return std::nullopt;
-  ParsingOverrideForField* func = field_overrides_.Find(key_prefix_.flat_key);
-  if (!func)
-    return std::nullopt;
-  return (*func)(field, delegate);
+    return nullptr;
+  return field_overrides_.Find(key_prefix_.flat_key);
 }
 
 base::Status ProtoToArgsParser::ParseSimpleField(

--- a/src/trace_processor/util/proto_to_args_parser.h
+++ b/src/trace_processor/util/proto_to_args_parser.h
@@ -243,6 +243,25 @@ class ProtoToArgsParser {
                             int* unknown_extensions = nullptr,
                             bool add_defaults = false);
 
+  // Occurrence counts of the repeated fields met so far in one message,
+  // which number their keys ("field[i]").
+  using RepeatedFieldIndex = std::vector<std::pair<uint32_t, int>>;
+
+  // Parses a single already-decoded |field| of the message type at
+  // |descriptor_idx| in the pool, as if it were the only field of that
+  // message, and emits args via the delegate. For a caller that has decoded
+  // the message itself this skips the walk over the fields it does not want
+  // reflected. A field with no descriptor counts towards
+  // |unknown_extensions|. A caller parsing several fields of one message
+  // passes the same |repeated_field_index| to each call so that the
+  // occurrences of a repeated field are numbered across them.
+  base::Status ParseMessageField(
+      uint32_t descriptor_idx,
+      const protozero::Field& field,
+      Delegate& delegate,
+      int* unknown_extensions = nullptr,
+      RepeatedFieldIndex* repeated_field_index = nullptr);
+
   // These methods can be called from parsing overrides to enter nested
   // contexts. The contexts are left when the returned scope is destroyed or
   // RemoveFieldSuffix() is called.
@@ -287,6 +306,11 @@ class ProtoToArgsParser {
 
   base::Status RunWorkLoop(Delegate& delegate);
   base::Status StepProtoMessage(WorkItem& item, Delegate& delegate, bool& done);
+  // Handles one field read from |item|'s message: emits a leaf or pushes
+  // the work item for a submessage.
+  base::Status HandleField(WorkItem& item,
+                           const protozero::Field& field,
+                           Delegate& delegate);
   // Emits default-valued args for fields absent from |item|. Outlined; the
   // caller only reaches it (under UNLIKELY) when add_defaults is set.
   PERFETTO_NO_INLINE base::Status AddMessageDefaults(WorkItem& item,
@@ -316,16 +340,14 @@ class ProtoToArgsParser {
                                   bool added_entry,
                                   Delegate& delegate);
 
-  base::Status ParsePackedField(
-      const FieldDescriptor& field_descriptor,
-      std::unordered_map<size_t, int>& repeated_field_index,
-      protozero::Field field,
-      uint32_t parent_path,
-      Delegate& delegate);
+  base::Status ParsePackedField(const FieldDescriptor& field_descriptor,
+                                RepeatedFieldIndex& repeated_field_index,
+                                protozero::Field field,
+                                uint32_t parent_path,
+                                Delegate& delegate);
 
-  std::optional<base::Status> MaybeApplyOverrideForField(
-      const protozero::Field&,
-      Delegate& delegate);
+  // The override registered for the current key_prefix_.flat_key, if any.
+  ParsingOverrideForField* FindOverrideForKey();
 
   base::Status ParseSimpleField(const FieldDescriptor& descriptor,
                                 const protozero::Field& field,
@@ -356,6 +378,12 @@ class ProtoToArgsParser {
       std::string_view from,
       std::string_view to);
 
+  struct FlatField {
+    const FieldDescriptor* descriptor;
+    uint32_t node;
+    StringPool::Id key;
+  };
+
   // A node in the traversal tree, a flattened trie over the descriptor path.
   // Nodes live in the |path_nodes_| arena and reference each other by index, so
   // the arena can grow without invalidating handles. Each field is a pure
@@ -373,7 +401,22 @@ class ProtoToArgsParser {
     // True if this node or an ancestor is repeated, so |key| (with "[i]")
     // differs from |flat_key| and is interned per occurrence.
     bool has_array = false;
+
+    uint32_t flat_generation = 0;
+    bool flat_eligible = false;
+    base::FlatHashMap<uint32_t, FlatField> flat_fields;
+    // The override registered for this node's flat key, if any. Looked up
+    // once when the node is created, so overrides must be registered before
+    // the first parse.
+    ParsingOverrideForField* override = nullptr;
   };
+
+  bool TryRunFlatMessage(uint32_t node,
+                         uint32_t descriptor_idx,
+                         protozero::ConstBytes bytes,
+                         Delegate& delegate);
+  PERFETTO_NO_INLINE void PrepareFlatMessage(uint32_t node,
+                                             uint32_t descriptor_idx);
 
   // Sentinel |path_nodes_| index: no descriptor path to cache.
   static constexpr uint32_t kNoPath = std::numeric_limits<uint32_t>::max();

--- a/src/trace_processor/util/proto_to_args_parser_unittest.cc
+++ b/src/trace_processor/util/proto_to_args_parser_unittest.cc
@@ -188,6 +188,111 @@ class ProtoToArgsParserTest : public ::testing::Test,
       interned_source_locations_;
 };
 
+TEST_F(ProtoToArgsParserTest, FlatMessageFallbackPreservesValues) {
+  using namespace protozero::test::protos::pbzero;
+  DescriptorPool pool;
+  ASSERT_OK(pool.AddFromFileDescriptorSet(kTestMessagesDescriptor.data(),
+                                          kTestMessagesDescriptor.size()));
+  ProtoToArgsParser parser(pool, string_pool_);
+  for (int i = 1; i <= 3; i++) {
+    protozero::HeapBuffered<EveryField> msg{kChunkSize, kChunkSize};
+    msg->set_field_int32(i);
+    msg->set_field_string(std::string(static_cast<size_t>(i), 'x'));
+    msg->set_small_enum(i % 2 ? SmallEnum::TO_BE : SmallEnum::NOT_TO_BE);
+    auto binary_proto = msg.SerializeAsArray();
+    ASSERT_OK(parser.ParseMessage(
+        protozero::ConstBytes{binary_proto.data(), binary_proto.size()},
+        ".protozero.test.protos.EveryField", nullptr, *this));
+  }
+  EXPECT_THAT(
+      args(),
+      testing::ElementsAre(
+          "field_int32 field_int32 1", "field_string field_string x",
+          "small_enum small_enum TO_BE", "field_int32 field_int32 2",
+          "field_string field_string xx", "small_enum small_enum NOT_TO_BE",
+          "field_int32 field_int32 3", "field_string field_string xxx",
+          "small_enum small_enum TO_BE"));
+}
+
+TEST_F(ProtoToArgsParserTest, FlatMessageFallbackHandlesDifferentFields) {
+  using namespace protozero::test::protos::pbzero;
+  DescriptorPool pool;
+  ASSERT_OK(pool.AddFromFileDescriptorSet(kTestMessagesDescriptor.data(),
+                                          kTestMessagesDescriptor.size()));
+  ProtoToArgsParser parser(pool, string_pool_);
+  auto parse = [&](const std::vector<uint8_t>& binary_proto) {
+    ASSERT_OK(parser.ParseMessage(
+        protozero::ConstBytes{binary_proto.data(), binary_proto.size()},
+        ".protozero.test.protos.EveryField", nullptr, *this));
+  };
+  for (int i = 1; i <= 2; i++) {
+    protozero::HeapBuffered<EveryField> msg{kChunkSize, kChunkSize};
+    msg->set_field_int32(i);
+    msg->set_field_string("a");
+    parse(msg.SerializeAsArray());
+  }
+  // Same prefix, then an unfamiliar field.
+  {
+    protozero::HeapBuffered<EveryField> msg{kChunkSize, kChunkSize};
+    msg->set_field_int32(3);
+    msg->set_field_string("b");
+    msg->set_field_bool(true);
+    parse(msg.SerializeAsArray());
+  }
+  // A different first field.
+  {
+    protozero::HeapBuffered<EveryField> msg{kChunkSize, kChunkSize};
+    msg->set_field_uint32(4);
+    msg->set_field_int32(5);
+    parse(msg.SerializeAsArray());
+  }
+  // A shorter message.
+  {
+    protozero::HeapBuffered<EveryField> msg{kChunkSize, kChunkSize};
+    msg->set_field_int32(6);
+    parse(msg.SerializeAsArray());
+  }
+  EXPECT_THAT(args(),
+              testing::ElementsAre(
+                  "field_int32 field_int32 1", "field_string field_string a",
+                  "field_int32 field_int32 2", "field_string field_string a",
+                  "field_int32 field_int32 3", "field_string field_string b",
+                  "field_bool field_bool true", "field_uint32 field_uint32 4",
+                  "field_int32 field_int32 5", "field_int32 field_int32 6"));
+}
+
+TEST_F(ProtoToArgsParserTest, FlatMessagesRespectAllowlistAndNesting) {
+  using namespace protozero::test::protos::pbzero;
+  DescriptorPool pool;
+  ASSERT_OK(pool.AddFromFileDescriptorSet(kTestMessagesDescriptor.data(),
+                                          kTestMessagesDescriptor.size()));
+  ProtoToArgsParser parser(pool, string_pool_);
+  std::vector<uint32_t> allowed = {EveryField::kFieldInt32FieldNumber};
+  for (int i = 1; i <= 2; i++) {
+    protozero::HeapBuffered<EveryField> msg{kChunkSize, kChunkSize};
+    msg->set_field_int32(i);
+    msg->set_field_string("skipped");
+    auto binary_proto = msg.SerializeAsArray();
+    ASSERT_OK(parser.ParseMessage(
+        protozero::ConstBytes{binary_proto.data(), binary_proto.size()},
+        ".protozero.test.protos.EveryField", &allowed, *this));
+  }
+  std::vector<uint32_t> nested_allowed = {NestedA::kSuperNestedFieldNumber};
+  for (int i = 1; i <= 2; i++) {
+    protozero::HeapBuffered<NestedA> msg{kChunkSize, kChunkSize};
+    msg->set_super_nested()->set_value_c(i);
+    auto binary_proto = msg.SerializeAsArray();
+    ASSERT_OK(parser.ParseMessage(
+        protozero::ConstBytes{binary_proto.data(), binary_proto.size()},
+        ".protozero.test.protos.NestedA", &nested_allowed, *this));
+  }
+  EXPECT_THAT(args(),
+              testing::ElementsAre(
+                  "field_int32 field_int32 1", "field_int32 field_int32 2",
+                  "super_nested.value_c super_nested.value_c 1",
+                  "super_nested.value_c super_nested.value_c 2"));
+}
+
 TEST_F(ProtoToArgsParserTest, EnsureTestMessageProtoParses) {
   DescriptorPool pool;
   auto status = pool.AddFromFileDescriptorSet(kTestMessagesDescriptor.data(),
@@ -284,6 +389,66 @@ TEST_F(ProtoToArgsParserTest, PackedEncodingWithoutDescriptorPackedFlag) {
   EXPECT_THAT(args(),
               testing::ElementsAre("repeated_int32 repeated_int32[0] 10",
                                    "repeated_int32 repeated_int32[1] 20"));
+}
+
+// A single decoded field is parsed as if it were the whole message: keys
+// are the same, a submessage is parsed in full, and a field without a
+// descriptor counts as an unknown extension.
+TEST_F(ProtoToArgsParserTest, ParseMessageField) {
+  using namespace protozero::test::protos::pbzero;
+  DescriptorPool pool;
+  ASSERT_OK(pool.AddFromFileDescriptorSet(kTestMessagesDescriptor.data(),
+                                          kTestMessagesDescriptor.size()));
+  ProtoToArgsParser parser(pool, string_pool_);
+  uint32_t nested_a = *pool.FindDescriptorIdx(".protozero.test.protos.NestedA");
+  uint32_t every_field =
+      *pool.FindDescriptorIdx(".protozero.test.protos.EveryField");
+  int unknown = 0;
+  for (int i = 1; i <= 2; i++) {
+    protozero::HeapBuffered<NestedA> msg{kChunkSize, kChunkSize};
+    msg->set_super_nested()->set_value_c(i);
+    auto binary_proto = msg.SerializeAsArray();
+    protozero::ProtoDecoder decoder(binary_proto.data(), binary_proto.size());
+    protozero::Field field = decoder.ReadField();
+    ASSERT_EQ(field.id(),
+              static_cast<uint32_t>(NestedA::kSuperNestedFieldNumber));
+    ASSERT_OK(parser.ParseMessageField(nested_a, field, *this, &unknown));
+  }
+  protozero::HeapBuffered<EveryField> scalar{kChunkSize, kChunkSize};
+  scalar->set_field_string("s");
+  auto scalar_proto = scalar.SerializeAsArray();
+  protozero::ProtoDecoder scalar_decoder(scalar_proto.data(),
+                                         scalar_proto.size());
+  ASSERT_OK(parser.ParseMessageField(every_field, scalar_decoder.ReadField(),
+                                     *this, &unknown));
+  protozero::Field unknown_field;
+  unknown_field.initialize(
+      9999,
+      static_cast<uint8_t>(protozero::proto_utils::ProtoWireType::kVarInt), 1,
+      0);
+  ASSERT_OK(
+      parser.ParseMessageField(every_field, unknown_field, *this, &unknown));
+  EXPECT_EQ(unknown, 1);
+  // Occurrences of a repeated field are numbered across calls that share
+  // an index.
+  protozero::HeapBuffered<EveryField> repeated{kChunkSize, kChunkSize};
+  repeated->add_repeated_int32(10);
+  repeated->add_repeated_int32(20);
+  auto repeated_proto = repeated.SerializeAsArray();
+  protozero::ProtoDecoder repeated_decoder(repeated_proto.data(),
+                                           repeated_proto.size());
+  ProtoToArgsParser::RepeatedFieldIndex index;
+  for (protozero::Field f = repeated_decoder.ReadField(); f.valid();
+       f = repeated_decoder.ReadField()) {
+    ASSERT_OK(
+        parser.ParseMessageField(every_field, f, *this, &unknown, &index));
+  }
+  EXPECT_THAT(args(), testing::ElementsAre(
+                          "super_nested.value_c super_nested.value_c 1",
+                          "super_nested.value_c super_nested.value_c 2",
+                          "field_string field_string s",
+                          "repeated_int32 repeated_int32[0] 10",
+                          "repeated_int32 repeated_int32[1] 20"));
 }
 
 TEST_F(ProtoToArgsParserTest, NestedProto) {


### PR DESCRIPTION
Dispatch track event argument fields from one selective decode in wire
order. Share field handling with whole-message reflection and carry
repeated indices across calls so existing allowlist callers and unknown
field accounting retain their behavior.

Prepare scalar descriptors and keys once per message path, then write
eligible scalar messages without the work stack. Schema eligibility
avoids shape matching and cache churn when optional fields are absent
or reordered. Keep ordinary parsing for repeated fields, nested
messages, overrides and contextual fields. Invalidate prepared schemas
when descriptors or overrides change.

Let selective decoding inherit generated accessors so one decoder serves
both event parsing and argument dispatch. Include compact repeated-index
storage and cached override lookup to support the shared field parser.

On the interned buildprof trace, compared with the two merged PRs:
- Wall time: 30.59s -> 21.71s (-29.0%).
- User instructions: 449.806G -> 323.493G (-28.1%).
- Executable .text: 8,896,898 -> 8,905,154 bytes (+8,256, +0.093%).
