### PR TITLE
perfetto: expose flush reason and flags in shared lib C ABI

### DIFF
--- a/contrib/rust-sdk/perfetto-sys/src/bindings.rs
+++ b/contrib/rust-sdk/perfetto-sys/src/bindings.rs
@@ -144,6 +144,15 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn PerfettoDsFlushDone(arg1: *mut PerfettoDsAsyncFlusher);
 }
+pub const PerfettoDsFlushReason_PERFETTO_DS_FLUSH_REASON_UNKNOWN: PerfettoDsFlushReason = 0;
+pub const PerfettoDsFlushReason_PERFETTO_DS_FLUSH_REASON_PERIODIC: PerfettoDsFlushReason = 1;
+pub const PerfettoDsFlushReason_PERFETTO_DS_FLUSH_REASON_TRACE_STOP: PerfettoDsFlushReason = 2;
+pub const PerfettoDsFlushReason_PERFETTO_DS_FLUSH_REASON_TRACE_CLONE: PerfettoDsFlushReason = 3;
+pub const PerfettoDsFlushReason_PERFETTO_DS_FLUSH_REASON_EXPLICIT: PerfettoDsFlushReason = 4;
+pub type PerfettoDsFlushReason = ::std::os::raw::c_uint;
+unsafe extern "C" {
+    pub fn PerfettoDsOnFlushArgsGetReason(args: *mut PerfettoDsOnFlushArgs) -> u64;
+}
 pub type PerfettoDsOnFlushCb = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: *mut PerfettoDsImpl,

--- a/include/perfetto/public/abi/data_source_abi.h
+++ b/include/perfetto/public/abi/data_source_abi.h
@@ -127,6 +127,7 @@ typedef void (*PerfettoDsOnDestroyCb)(struct PerfettoDsImpl*,
                                       void* inst_ctx);
 
 // Opaque handle used to perform operations from the OnFlush callback.
+// Pointers to this struct are valid only during the OnFlush callback.
 struct PerfettoDsOnFlushArgs;
 
 // Opaque handle used to signal when the data source flush operation is
@@ -143,6 +144,22 @@ PerfettoDsOnFlushArgsPostpone(struct PerfettoDsOnFlushArgs*);
 // source instance (whose stop operation was previously postponed with
 // PerfettoDsOnFlushArgsPostpone).
 PERFETTO_SDK_EXPORT void PerfettoDsFlushDone(struct PerfettoDsAsyncFlusher*);
+
+// Reason for the flush operation.
+// Mirrors `perfetto::FlushFlags::Reason` in
+// `perfetto/tracing/core/flush_flags.h`. Keep this enum aligned with it.
+enum PerfettoDsFlushReason {
+  PERFETTO_DS_FLUSH_REASON_UNKNOWN = 0,
+  PERFETTO_DS_FLUSH_REASON_PERIODIC = 1,
+  PERFETTO_DS_FLUSH_REASON_TRACE_STOP = 2,
+  PERFETTO_DS_FLUSH_REASON_TRACE_CLONE = 3,
+  PERFETTO_DS_FLUSH_REASON_EXPLICIT = 4,
+};
+
+// Returns the reason for the flush operation (see enum PerfettoDsFlushReason).
+// `args` is valid only during the OnFlush callback.
+PERFETTO_SDK_EXPORT uint64_t
+PerfettoDsOnFlushArgsGetReason(struct PerfettoDsOnFlushArgs* args);
 
 // Called when the tracing service requires all the pending tracing data to be
 // flushed for a data source instance. `user_arg` is the value passed to

--- a/src/shared_lib/data_source.cc
+++ b/src/shared_lib/data_source.cc
@@ -463,6 +463,14 @@ void PerfettoDsFlushDone(PerfettoDsAsyncFlusher* stopper) {
   delete cb;
 }
 
+uint64_t PerfettoDsOnFlushArgsGetReason(struct PerfettoDsOnFlushArgs* args) {
+  if (!args) {
+    return PERFETTO_DS_FLUSH_REASON_UNKNOWN;
+  }
+  auto* flush_args = reinterpret_cast<const ShlibDataSource::FlushArgs*>(args);
+  return static_cast<uint64_t>(flush_args->flush_flags.reason());
+}
+
 void* PerfettoDsImplGetInstanceLocked(struct PerfettoDsImpl* ds_impl,
                                       PerfettoDsInstanceIndex idx) {
   auto* internal_state = ds_impl->cpp_type.static_state()->TryGet(idx);

--- a/src/shared_lib/test/api_integrationtest.cc
+++ b/src/shared_lib/test/api_integrationtest.cc
@@ -1053,6 +1053,25 @@ TEST_F(SharedLibDataSourceTest, FlushDone) {
   t.join();
 }
 
+TEST_F(SharedLibDataSourceTest, FlushReason) {
+  TracingSession tracing_session =
+      TracingSession::Builder().set_data_source_name(kDataSourceName2).Build();
+
+  uint64_t reason = PERFETTO_DS_FLUSH_REASON_UNKNOWN;
+  WaitableEvent flush_called;
+
+  EXPECT_CALL(ds2_callbacks_, OnFlush(_, _, kDataSource2UserArg, _, _))
+      .WillOnce([&](struct PerfettoDsImpl*, PerfettoDsInstanceIndex, void*,
+                    void*, struct PerfettoDsOnFlushArgs* args) {
+        reason = PerfettoDsOnFlushArgsGetReason(args);
+        flush_called.Notify();
+      });
+
+  tracing_session.FlushBlocking(/*timeout_ms=*/10000);
+  flush_called.WaitForNotification();
+  EXPECT_EQ(reason, static_cast<uint64_t>(PERFETTO_DS_FLUSH_REASON_EXPLICIT));
+}
+
 TEST_F(SharedLibDataSourceTest, ThreadLocalState) {
   bool ignored = false;
   void* const kTlsPtr = &ignored;


### PR DESCRIPTION
Expose the flush reason (PerfettoDsFlushReason) and raw 64-bit flush flags via PerfettoDsOnFlushArgsGetReason() and
PerfettoDsOnFlushArgsGetFlags() in the public shared library C ABI.

This allows producers (such as the Android platform Perfetto data source bindings) to distinguish between periodic flushes, session stops, and clone snapshots (kTraceClone).
