### PR TITLE
tp: trim packet decoding and plain event tokenization

### DIFF
--- a/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
@@ -29,6 +29,7 @@
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/protozero/field.h"
+#include "perfetto/protozero/proto_decoder.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/containers/null_term_string_view.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
@@ -119,8 +120,20 @@ void ProtoTraceParserImpl::ParseTracePacket(int64_t ts, TracePacketData data) {
 void ProtoTraceParserImpl::ParseTrackEvent(int64_t ts,
                                            const TrackEventData& data) {
   const TraceBlobView& blob = data.trace_packet_data.packet;
-  protos::pbzero::TracePacket::Decoder packet(blob.data(), blob.length());
-  module_context_->track_module->ParseTrackEventData(packet, ts, data);
+  protozero::ProtoDecoder packet(blob.data(), blob.length());
+  protozero::ConstBytes event{};
+  uint32_t sequence_id = 0;
+  for (auto field = packet.ReadField(); field.valid();
+       field = packet.ReadField()) {
+    if (field.id() == protos::pbzero::TracePacket::kTrackEventFieldNumber) {
+      event = field.as_bytes();
+    } else if (field.id() == protos::pbzero::TracePacket::
+                                 kTrustedPacketSequenceIdFieldNumber) {
+      sequence_id = field.as_uint32();
+    }
+  }
+  module_context_->track_module->ParseTrackEventData(ts, data, event,
+                                                     sequence_id);
 }
 
 void ProtoTraceParserImpl::ParseEtwEvent(uint32_t cpu,

--- a/src/trace_processor/importers/proto/track_event_module.cc
+++ b/src/trace_processor/importers/proto/track_event_module.cc
@@ -101,13 +101,6 @@ void TrackEventModule::OnFirstPacketOnSequence(uint32_t packet_sequence_id) {
   track_event_tracker_->OnFirstPacketOnSequence(packet_sequence_id);
 }
 
-void TrackEventModule::ParseTrackEventData(const TracePacket::Decoder& decoder,
-                                           int64_t ts,
-                                           const TrackEventData& data) {
-  parser_.ParseTrackEvent(ts, &data, decoder.track_event(),
-                          decoder.trusted_packet_sequence_id());
-}
-
 void TrackEventModule::OnEventsFullyExtracted() {
   parser_.OnEventsFullyExtracted();
 }

--- a/src/trace_processor/importers/proto/track_event_module.h
+++ b/src/trace_processor/importers/proto/track_event_module.h
@@ -44,9 +44,12 @@ class TrackEventModule : public ProtoImporterModule {
 
   void OnFirstPacketOnSequence(uint32_t) override;
 
-  void ParseTrackEventData(const protos::pbzero::TracePacket::Decoder& decoder,
-                           int64_t ts,
-                           const TrackEventData& data);
+  void ParseTrackEventData(int64_t ts,
+                           const TrackEventData& data,
+                           protozero::ConstBytes event,
+                           uint32_t sequence_id) {
+    parser_.ParseTrackEvent(ts, &data, event, sequence_id);
+  }
 
   void OnEventsFullyExtracted() override;
 

--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -451,6 +451,16 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
 
   protos::pbzero::TrackEvent::Decoder event(
       args.field.Cast<protos::pbzero::TracePacket::kTrackEvent>());
+  const bool legacy = event.HasAnyField(kLegacyTrackEventFields.data(), 1);
+  const bool needs_processing = legacy || event.has_extra_counter_values() ||
+                                event.has_extra_double_counter_values() ||
+                                event.type() == TrackEvent::TYPE_COUNTER ||
+                                event.type() == TrackEvent::TYPE_STATE;
+  if (!needs_processing && args.decoder.has_timestamp() && args.ts >= 0) {
+    module_context_->track_event_stream->Push(
+        args.ts, TrackEventData(std::move(*args.packet), args.state));
+    return ModuleResult::Handled();
+  }
   protos::pbzero::TrackEventDefaults::Decoder* defaults =
       args.state->GetTrackEventDefaults();
 
@@ -458,7 +468,6 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
   bool timestamp_needs_clock_conversion = false;
   TrackEventData data(std::move(*args.packet), args.state);
   // The sequence-local state is only needed for deltas.
-  const bool legacy = event.HasAnyField(kLegacyTrackEventFields.data(), 1);
   TrackEventSequenceState* track_event =
       legacy ? args.state->GetCustomState<TrackEventSequenceState>() : nullptr;
 


### PR DESCRIPTION
Track event import only needs the event payload and packet sequence id.
Collect both in one shared decoder walk instead of building a typed
packet decoder, preserving last-occurrence semantics. Inline the module
forwarding method.

Reuse the tokenizer's decoded fields to bypass defaults and counter
setup when the event needs no processing and already has a valid
timestamp. Legacy fields, extra counters, counter/state events, and
missing or negative timestamps retain the existing path.

On the interned buildprof trace, against its parent:
- Wall time: 20.53s -> 19.66s (-4.2%).
- User instructions: 293.280G -> 289.388G (-1.33%).
- Executable .text: 8,906,946 -> 8,907,474 bytes (+528).