### PR TITLE
tp: reduce setup on the ordinary track event import path

### DIFF
--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -25,9 +25,11 @@
 #include <utility>
 #include <vector>
 
+#include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/dynamic_string_writer.h"
+#include "perfetto/ext/base/no_destructor.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/ext/base/string_utils.h"
@@ -135,7 +137,9 @@ class TrackEventEventImporter {
         sequence_state_(event_data->trace_packet_data.sequence_state.get()),
         blob_(blob),
         event_(blob_),
-        legacy_event_(event_.legacy_event()),
+        legacy_event_(event_.has_legacy_event()
+                          ? legacy_event_storage_.emplace(event_.legacy_event())
+                          : EmptyLegacyEvent()),
         defaults_(event_data->trace_packet_data.sequence_state
                       ->GetTrackEventDefaults()),
         thread_timestamp_(event_data->thread_timestamp),
@@ -223,6 +227,22 @@ class TrackEventEventImporter {
 
  private:
   StringId ParseTrackEventCategory() {
+    // The common event has no inline categories and at most one interned
+    // one; both are settled before the counts below.
+    if (PERFETTO_LIKELY(!event_.has_categories())) {
+      if (!event_.has_category_iids()) {
+        return kNullStringId;
+      }
+      auto it = event_.category_iids();
+      uint64_t iid = *it;
+      if (PERFETTO_LIKELY(!++it)) {
+        return ParseSingleInternedCategory(iid);
+      }
+    }
+    return ParseTrackEventCategoriesSlow();
+  }
+
+  PERFETTO_NO_INLINE StringId ParseTrackEventCategoriesSlow() {
     StringId category_id = kNullStringId;
 
     auto category_iids = event_.category_iids();
@@ -234,19 +254,7 @@ class TrackEventEventImporter {
 
     // If there's a single category, we can avoid building a concatenated
     // string.
-    if (PERFETTO_LIKELY(!has_multiple_categories && category_iids)) {
-      uint64_t iid = *category_iids;
-      if (auto id = sequence_state_->InternedStringId(
-              protos::pbzero::InternedData::kEventCategoriesFieldNumber, iid)) {
-        category_id = *id;
-      } else {
-        base::DynamicStringWriter writer;
-        writer.AppendLiteral("unknown(");
-        writer.AppendUnsignedInt(iid);
-        writer.AppendChar(')');
-        category_id = storage_->InternString(writer.GetStringView());
-      }
-    } else if (!has_multiple_categories && category_strings) {
+    if (!has_multiple_categories && category_strings) {
       category_id = storage_->InternString(*category_strings);
     } else if (has_multiple_categories) {
       // We concatenate the category strings together since we currently only
@@ -273,6 +281,22 @@ class TrackEventEventImporter {
     }
 
     return category_id;
+  }
+
+  StringId ParseSingleInternedCategory(uint64_t iid) {
+    if (auto id = sequence_state_->InternedStringId(
+            protos::pbzero::InternedData::kEventCategoriesFieldNumber, iid)) {
+      return *id;
+    }
+    return InternUnknownCategory(iid);
+  }
+
+  PERFETTO_NO_INLINE StringId InternUnknownCategory(uint64_t iid) {
+    base::DynamicStringWriter writer;
+    writer.AppendLiteral("unknown(");
+    writer.AppendUnsignedInt(iid);
+    writer.AppendChar(')');
+    return storage_->InternString(writer.GetStringView());
   }
 
   StringId ParseTrackEventName() {
@@ -512,10 +536,30 @@ class TrackEventEventImporter {
 
   base::StatusOr<TrackId> ParseTrackAssociationInternal(
       std::optional<TrackId> opt_id) {
-    TrackTracker* track_tracker = context_->track_tracker.get();
-
     // Legacy phases may imply a different track than the one specified by
     // the fallback (or default track uuid) above.
+    if (PERFETTO_UNLIKELY(legacy_event_.has_phase())) {
+      std::optional<TrackId> legacy_track_id;
+      RETURN_IF_ERROR(ParseLegacyPhaseTrackAssociation(&legacy_track_id));
+      if (legacy_track_id) {
+        return *legacy_track_id;
+      }
+    }
+
+    if (!track_uuid_ && fallback_to_legacy_pid_tid_tracks_) {
+      return context_->track_tracker->InternThreadTrack(*utid_);
+    }
+    if (!opt_id) {
+      return base::ErrStatus(
+          "track_event_parser: unable to find track matching UUID %" PRIu64,
+          track_uuid_);
+    }
+    return *opt_id;
+  }
+
+  // Sets |*track_id| if the legacy phase implies a track of its own.
+  PERFETTO_NO_INLINE base::Status ParseLegacyPhaseTrackAssociation(
+      std::optional<TrackId>* track_id) {
     switch (legacy_event_.phase()) {
       case 'b':
       case 'e':
@@ -556,9 +600,10 @@ class TrackEventEventImporter {
                                ":" + legacy_event_.id_scope().ToStdString();
           id_scope = storage_->InternString(base::StringView(concat));
         }
-        return context_->track_compressor->InternLegacyAsyncTrack(
+        *track_id = context_->track_compressor->InternLegacyAsyncTrack(
             name_id_, upid_.value_or(0), source_id, source_id_is_process_scoped,
             id_scope, AsyncSliceTypeForPhase(legacy_event_.phase()));
+        break;
       }
       case 'i':
       case 'I': {
@@ -570,7 +615,7 @@ class TrackEventEventImporter {
             // track based on the tid/pid of the sequence.
             break;
           case LegacyEvent::SCOPE_GLOBAL:
-            return context_->track_tracker->InternTrack(
+            *track_id = context_->track_tracker->InternTrack(
                 tracks::kLegacyGlobalInstantsBlueprint, tracks::Dimensions(),
                 tracks::BlueprintName(),
                 [this](ArgsTracker::BoundInserter& inserter) {
@@ -579,8 +624,9 @@ class TrackEventEventImporter {
                       Variadic::String(
                           context_->storage->InternString("chrome")));
                 });
+            break;
           case LegacyEvent::SCOPE_PROCESS:
-            return context_->track_tracker->InternTrack(
+            *track_id = context_->track_tracker->InternTrack(
                 tracks::kChromeProcessInstantBlueprint,
                 tracks::Dimensions(*upid_), tracks::BlueprintName(),
                 [this](ArgsTracker::BoundInserter& inserter) {
@@ -589,22 +635,14 @@ class TrackEventEventImporter {
                       Variadic::String(
                           context_->storage->InternString("chrome")));
                 });
+            break;
         }
         break;
       }
       default:
         break;
     }
-
-    if (!track_uuid_ && fallback_to_legacy_pid_tid_tracks_) {
-      return track_tracker->InternThreadTrack(*utid_);
-    }
-    if (!opt_id) {
-      return base::ErrStatus(
-          "track_event_parser: unable to find track matching UUID %" PRIu64,
-          track_uuid_);
-    }
-    return *opt_id;
+    return base::OkStatus();
   }
 
   int32_t ParsePhaseOrType() {
@@ -667,9 +705,15 @@ class TrackEventEventImporter {
     return base::OkStatus();
   }
 
-  void ParseLegacyThreadTimeAndInstructionsAsCounters() {
-    if (!utid_)
-      return;
+  // The bodies of the per-event helpers below are rare for most events, so
+  // only their presence checks are inlined into Import().
+  PERFETTO_ALWAYS_INLINE void ParseLegacyThreadTimeAndInstructionsAsCounters() {
+    if (utid_ && (thread_timestamp_ || thread_instruction_count_))
+      ParseLegacyThreadTimeAndInstructionsAsCountersImpl();
+  }
+
+  PERFETTO_NO_INLINE void ParseLegacyThreadTimeAndInstructionsAsCountersImpl() {
+    PERFETTO_DCHECK(utid_);
     // When these fields are set, we don't expect TrackDescriptor-based counters
     // for thread time or instruction count for this thread in the trace, so we
     // intern separate counter tracks based on name + utid. Note that we cannot
@@ -701,12 +745,14 @@ class TrackEventEventImporter {
     }
   }
 
-  void ParseExtraCounterValues() {
-    if (!event_.has_extra_counter_values() &&
-        !event_.has_extra_double_counter_values()) {
-      return;
+  PERFETTO_ALWAYS_INLINE void ParseExtraCounterValues() {
+    if (event_.has_extra_counter_values() ||
+        event_.has_extra_double_counter_values()) {
+      ParseExtraCounterValuesImpl();
     }
+  }
 
+  PERFETTO_NO_INLINE void ParseExtraCounterValuesImpl() {
     // Add integer extra counter values.
     size_t index = 0;
     protozero::RepeatedFieldIterator<uint64_t> track_uuid_it;
@@ -890,7 +936,15 @@ class TrackEventEventImporter {
     return base::OkStatus();
   }
 
-  void MaybeParseTrackEventFlows(SliceId slice_id) {
+  PERFETTO_ALWAYS_INLINE void MaybeParseTrackEventFlows(SliceId slice_id) {
+    if (event_.has_flow_ids_old() || event_.has_flow_ids() ||
+        event_.has_terminating_flow_ids_old() ||
+        event_.has_terminating_flow_ids()) {
+      ParseTrackEventFlows(slice_id);
+    }
+  }
+
+  PERFETTO_NO_INLINE void ParseTrackEventFlows(SliceId slice_id) {
     if (event_.has_flow_ids_old() || event_.has_flow_ids()) {
       auto it =
           event_.has_flow_ids() ? event_.flow_ids() : event_.flow_ids_old();
@@ -921,10 +975,12 @@ class TrackEventEventImporter {
     }
   }
 
-  void MaybeParseFlowEventV2(SliceId slice_id) {
-    if (!legacy_event_.has_bind_id()) {
-      return;
-    }
+  PERFETTO_ALWAYS_INLINE void MaybeParseFlowEventV2(SliceId slice_id) {
+    if (legacy_event_.has_bind_id())
+      ParseFlowEventV2(slice_id);
+  }
+
+  PERFETTO_NO_INLINE void ParseFlowEventV2(SliceId slice_id) {
     if (!legacy_event_.has_flow_direction()) {
       context_->stats_tracker->IncrementStats(stats::flow_without_direction);
       return;
@@ -947,7 +1003,7 @@ class TrackEventEventImporter {
     }
   }
 
-  void MaybeParseFlowEvents(SliceId slice_id) {
+  PERFETTO_ALWAYS_INLINE void MaybeParseFlowEvents(SliceId slice_id) {
     MaybeParseFlowEventV2(slice_id);
     MaybeParseTrackEventFlows(slice_id);
   }
@@ -1264,35 +1320,27 @@ class TrackEventEventImporter {
       PERFETTO_DLOG("ParseTrackEventArgs error: %s", status.c_message());
     };
 
-    std::optional<ArgsParser> args_writer;
     if (inserter) {
-      if (event_.has_correlation_id()) {
-        base::StackString<512> id_str("tp:#%" PRIu64, event_.correlation_id());
-        inserter->AddArg(parser_->correlation_id_key_id_,
-                         Variadic::String(context_->storage->InternString(
-                             id_str.string_view())));
-      }
-      if (event_.has_correlation_id_str()) {
-        inserter->AddArg(parser_->correlation_id_key_id_,
-                         Variadic::String(storage_->InternString(
-                             base::StringView(event_.correlation_id_str()))));
-      }
-      if (event_.has_correlation_id_str_iid()) {
-        if (auto id = sequence_state_->InternedStringId(
-                protos::pbzero::InternedData::kCorrelationIdStrFieldNumber,
-                event_.correlation_id_str_iid())) {
-          inserter->AddArg(parser_->correlation_id_key_id_,
-                           Variadic::String(*id));
-        }
+      if (event_.has_correlation_id() || event_.has_correlation_id_str() ||
+          event_.has_correlation_id_str_iid()) {
+        ParseCorrelationId(inserter);
       }
       if (legacy_trace_source_id_) {
         inserter->AddArg(parser_->legacy_trace_source_id_key_id_,
                          Variadic::Integer(*legacy_trace_source_id_));
       }
-      log_errors(ParseCallstack());
-      args_writer.emplace(ts_, *inserter, *storage_, *context_->process_tracker,
-                          sequence_state_, /*support_json=*/true);
+      if (event_.has_callstack_iid() || event_.has_callstack())
+        log_errors(ParseCallstack());
     }
+    std::optional<ArgsParser> args_writer;
+    auto writer = [&]() -> ArgsParser& {
+      if (!args_writer) {
+        args_writer.emplace(ts_, *inserter, *storage_,
+                            *context_->process_tracker, sequence_state_,
+                            /*support_json=*/true);
+      }
+      return *args_writer;
+    };
 
     field_context_.utid = utid_.value_or(TrackEventFieldContext::kNone);
     field_context_.upid = upid_.value_or(TrackEventFieldContext::kNone);
@@ -1315,11 +1363,11 @@ class TrackEventEventImporter {
           continue;
         }
       }
-      if (!args_writer || !track_event_idx) {
+      if (!inserter || !track_event_idx) {
         continue;
       }
       log_errors(parser_->args_parser_.ParseMessageField(
-          *track_event_idx, field, *args_writer, &unknown_extensions,
+          *track_event_idx, field, writer(), &unknown_extensions,
           &repeated_field_index));
     }
     if (unknown_extensions > 0) {
@@ -1333,8 +1381,7 @@ class TrackEventEventImporter {
     if (event_.has_debug_annotations()) {
       auto key = parser_->args_parser_.EnterDictionary("debug");
       for (auto it = event_.debug_annotations(); it; ++it) {
-        log_errors(
-            parser_->args_parser_.ParseDebugAnnotation(*it, *args_writer));
+        log_errors(parser_->args_parser_.ParseDebugAnnotation(*it, writer()));
       }
     }
 
@@ -1342,6 +1389,28 @@ class TrackEventEventImporter {
       inserter->AddArg(parser_->legacy_event_passthrough_utid_id_,
                        Variadic::UnsignedInteger(*legacy_passthrough_utid_),
                        ArgsTracker::UpdatePolicy::kSkipIfExists);
+    }
+  }
+
+  PERFETTO_NO_INLINE void ParseCorrelationId(BoundInserter* inserter) {
+    if (event_.has_correlation_id()) {
+      base::StackString<512> id_str("tp:#%" PRIu64, event_.correlation_id());
+      inserter->AddArg(parser_->correlation_id_key_id_,
+                       Variadic::String(context_->storage->InternString(
+                           id_str.string_view())));
+    }
+    if (event_.has_correlation_id_str()) {
+      inserter->AddArg(parser_->correlation_id_key_id_,
+                       Variadic::String(storage_->InternString(
+                           base::StringView(event_.correlation_id_str()))));
+    }
+    if (event_.has_correlation_id_str_iid()) {
+      if (auto id = sequence_state_->InternedStringId(
+              protos::pbzero::InternedData::kCorrelationIdStrFieldNumber,
+              event_.correlation_id_str_iid())) {
+        inserter->AddArg(parser_->correlation_id_key_id_,
+                         Variadic::String(*id));
+      }
     }
   }
 
@@ -1425,6 +1494,12 @@ class TrackEventEventImporter {
     return base::OkStatus();
   }
 
+  static const LegacyEvent::Decoder& EmptyLegacyEvent() {
+    static const base::NoDestructor<LegacyEvent::Decoder> kEmpty(nullptr,
+                                                                 size_t{0});
+    return kEmpty.ref();
+  }
+
   TraceProcessorContext* context_;
   TrackEventTracker* track_event_tracker_;
   TraceStorage* storage_;
@@ -1435,7 +1510,10 @@ class TrackEventEventImporter {
   PacketSequenceStateGeneration* sequence_state_;
   ConstBytes blob_;
   SelectiveTrackEventDecoder event_;
-  LegacyEvent::Decoder legacy_event_;
+  // Most events have no legacy part; those share one empty decoder instead
+  // of constructing one per event.
+  std::optional<LegacyEvent::Decoder> legacy_event_storage_;
+  const LegacyEvent::Decoder& legacy_event_;
   protos::pbzero::TrackEventDefaults::Decoder* defaults_;
   // Handed to every field parser; the row and args are filled in per row.
   TrackEventFieldContext field_context_;

--- a/src/trace_processor/importers/proto/track_event_parser.h
+++ b/src/trace_processor/importers/proto/track_event_parser.h
@@ -66,9 +66,19 @@ class TrackEventParser {
  private:
   friend class TrackEventEventImporter;
 
-  TrackEventExtensionParser* ParserForField(uint32_t field_id) const {
-    auto* it = extension_parser_context_->parsers_by_field.Find(field_id);
-    return it ? *it : nullptr;
+  // Consecutive events tend to carry the same fields, so the field looked
+  // up last is remembered, including a field without a parser. Parsers are
+  // only ever added, so a changed count means the answer may have changed.
+  TrackEventExtensionParser* ParserForField(uint32_t field_id) {
+    const auto& by_field = extension_parser_context_->parsers_by_field;
+    if (field_id != last_parser_field_id_ ||
+        by_field.size() != last_parser_count_) {
+      auto* it = by_field.Find(field_id);
+      last_parser_ = it ? *it : nullptr;
+      last_parser_field_id_ = field_id;
+      last_parser_count_ = by_field.size();
+    }
+    return last_parser_;
   }
 
   // The TrackEvent descriptor's index in the pool, resolved once.
@@ -126,6 +136,9 @@ class TrackEventParser {
   TrackEventExtensionParserContext* extension_parser_context_;
   ChromeStringLookup chrome_string_lookup_;
   std::optional<uint32_t> track_event_descriptor_idx_;
+  TrackEventExtensionParser* last_parser_ = nullptr;
+  uint32_t last_parser_field_id_ = 0;
+  size_t last_parser_count_ = 0;
   ActiveChromeProcessesTracker active_chrome_processes_tracker_;
   DummyMemoryMapping* inline_callstack_dummy_mapping_ = nullptr;
 };


### PR DESCRIPTION
Construct argument writers lazily and share the empty legacy decoder.
Handle single interned categories directly and keep uncommon legacy and
correlation handling out of line. Cache the last field handler,
invalidating the lookup when another handler is registered.

On the interned buildprof trace, against its parent:
- Wall time: 19.66s -> 18.53s (-5.7%).
- User instructions: 289.388G -> 278.381G (-3.80%).
- Executable .text: 8,907,474 -> 8,910,578 bytes (+3,104).