### PR TITLE
profiling: skip Build-ID lookup for device mappings in unwinder

### DIFF
--- a/src/profiling/common/unwind_support.cc
+++ b/src/profiling/common/unwind_support.cc
@@ -130,7 +130,8 @@ unwindstack::DexFiles* UnwindingMetadata::GetDexFiles(
 #endif
 
 std::string UnwindingMetadata::GetBuildId(const unwindstack::FrameData& frame) {
-  if (frame.map_info != nullptr && !frame.map_info->name().empty()) {
+  if (frame.map_info != nullptr && !frame.map_info->name().empty() &&
+      !(frame.map_info->flags() & unwindstack::MAPS_FLAGS_DEVICE_MAP)) {
     return frame.map_info->GetBuildID();
   }
 


### PR DESCRIPTION
When profiling graphics workloads, stack frames or speculative return addresses can point into GPU buffer objects mapped through device nodes such as /dev/dri/renderD128.

Previously, UnwindingMetadata::GetBuildId() treated any non-empty map name as an on-disk ELF file and delegated to MapInfo::GetBuildID(), which attempts to open() the backing file. On Android, opening device nodes like /dev/dri/renderD128 triggers an SELinux denial.

Bug: 555467273
Test: perfetto_unittests --gtest_filter="*UnwindingTest*"
