### PR TITLE
ui: Migrate TreeExplorer to AsyncMemo

### DIFF
--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -16,7 +16,11 @@ import './aggregation_adapter.scss';
 import m from 'mithril';
 import {type time, Time} from '../base/time';
 import {exists} from '../base/utils';
-import type {AreaSelection, AreaSelectionTab} from '../public/selection';
+import {
+  areaSelectionKey,
+  type AreaSelection,
+  type AreaSelectionTab,
+} from '../public/selection';
 import type {Trace} from '../public/trace';
 import type {Track} from '../public/track';
 import {
@@ -315,11 +319,7 @@ export function createAggregationTab(
     name: aggregator.getTabName(),
     priority,
     render(selection: AreaSelection) {
-      const selectionKey = {
-        start: selection.start,
-        end: selection.end,
-        tracks: selection.trackUris,
-      };
+      const selectionKey = areaSelectionKey(selection);
       const aggregation = aggregationMemo.use({
         key: selectionKey,
         compute: () => {

--- a/ui/src/components/tree_explorer_fetcher.ts
+++ b/ui/src/components/tree_explorer_fetcher.ts
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AsyncDisposableStack} from '../base/disposable_stack';
 import {ensureExists} from '../base/assert';
+import {
+  AsyncMemo,
+  AtomicTaskQueue,
+  type AsyncMemoResult,
+} from '../base/async_memo';
 import type {Engine} from '../trace_processor/engine';
 import {
   createVirtualTable,
@@ -37,7 +41,6 @@ import {metricId} from '../widgets/tree_explorer';
 import type {Trace} from '../public/trace';
 import {sqliteString} from '../base/string_utils';
 import {parseUserFilterRegex} from '../widgets/flamegraph_regex';
-import type {SharedAsyncDisposable} from '../base/shared_disposable';
 
 export interface TreeExplorerQueryColumn {
   // The name of the column in SQL.
@@ -169,74 +172,91 @@ export function metricsFromTableOrSubquery(
   return metrics;
 }
 
-interface MetricTable {
+interface MetricTable extends AsyncDisposable {
   readonly metric: TreeExplorerQueryMetric;
   readonly table: DisposableSqlEntity;
   readonly unfilteredCumulativeValue: number;
 }
 
-export type TreeExplorerFetcherDependency =
-  SharedAsyncDisposable<AsyncDisposable>;
-
 // Fetches tree explorer data by querying an `Engine`: turns a
 // (metric, state) pair into the filtered tree the views display. Purely a
 // data-layer object with no rendering; TreeExplorerPanel drives it.
+//
+// All work (table creation, tree fetches, disposal) is scheduled on a single
+// AtomicTaskQueue through AsyncMemo, so a metric's virtual table is only
+// disposed after any in-flight query against it has completed.
 export class TreeExplorerFetcher implements AsyncDisposable {
-  private readonly dependencies: ReadonlyArray<
-    SharedAsyncDisposable<AsyncDisposable>
-  >;
-  private readonly metricTables: MetricTable[] = [];
+  // One memo per metric object we have seen. The map key *is* the identity:
+  // a new metric object (same id, different SQL) gets a new memo and a new
+  // table. `seq` is a stable numeric stand-in for the metric in the JSON
+  // memo keys (metric objects are not JSON-serializable).
+  private readonly tableMemos = new Map<
+    TreeExplorerQueryMetric,
+    {memo: AsyncMemo<MetricTable>; seq: number}
+  >();
+  private readonly dataMemo: AsyncMemo<TreeExplorerData>;
+  private nextSeq = 0;
 
   constructor(
     private readonly trace: Trace,
-    dependencies: ReadonlyArray<TreeExplorerFetcherDependency> = [],
+    private readonly queue = new AtomicTaskQueue(),
   ) {
-    this.dependencies = dependencies.map((d) => d.clone());
+    this.dataMemo = new AsyncMemo<TreeExplorerData>(queue);
   }
 
   async [Symbol.asyncDispose](): Promise<void> {
-    for (const entry of this.metricTables) {
-      await entry.table[Symbol.asyncDispose]();
-    }
-    for (const dependency of this.dependencies ?? []) {
-      await dependency[Symbol.asyncDispose]?.();
+    this.dataMemo.dispose();
+    // Disposing a memo schedules its cache disposal through the shared
+    // queue, i.e. after any in-flight work on it; the queue handles the
+    // synchronization, we just ask every memo to go away.
+    for (const {memo} of this.tableMemos.values()) {
+      memo.dispose();
     }
   }
 
-  // Fetches the tree for the metric selected in `state`, with all of
-  // `state`'s filters and view applied. Returns undefined if the fetcher's
-  // dependencies were disposed while the fetch was in flight.
-  async fetch(
+  // Call once per render: returns the tree currently available for the
+  // metric selected in `state` and schedules any needed work. `state.view`
+  // must already be the effective view (see TreeExplorerPanel).
+  use(
     metrics: ReadonlyArray<TreeExplorerQueryMetric>,
     state: TreeExplorerState,
-  ): Promise<TreeExplorerData | undefined> {
+  ): AsyncMemoResult<TreeExplorerData> {
     const metric = ensureExists(
       metrics.find((x) => state.selectedMetricId === metricId(x)),
     );
-    // Clone all dependencies so they cannot be dropped while this function
-    // is running. Disposing these clones after the function returns does not
-    // drop the tables while either this instance or the caller still owns a
-    // clone.
-    await using trash = new AsyncDisposableStack();
-    for (const dependency of this.dependencies ?? []) {
-      // If the dependency is disposed, it means that we have already ended
-      // up cleaning up the object so none of this matters. Just return.
-      if (dependency.isDisposed) {
-        return undefined;
-      }
-      trash.use(dependency.clone());
+    let entry = this.tableMemos.get(metric);
+    if (entry === undefined) {
+      entry = {
+        memo: new AsyncMemo<MetricTable>(this.queue),
+        seq: ++this.nextSeq,
+      };
+      this.tableMemos.set(metric, entry);
     }
-    const table = await this.getMetricTable(metric);
-    return await computeTree(this.trace.engine, table, state);
+    // The memo is dedicated to this metric object, so its key is constant:
+    // the table is created once and kept for the fetcher's lifetime.
+    const table = entry.memo.use({
+      key: {},
+      compute: () => this.createMetricTable(metric),
+    }).data;
+
+    if (!table) {
+      return {isPending: true};
+    }
+
+    return this.dataMemo.use({
+      key: {
+        metricSeq: entry.seq,
+        filters: state.filters,
+        addedMetricIds: state.addedMetricIds,
+        view: state.view,
+      },
+      compute: () => computeTree(this.trace.engine, table!, state),
+    });
   }
 
-  private async getMetricTable(
+  private async createMetricTable(
     metric: TreeExplorerQueryMetric,
   ): Promise<MetricTable> {
-    const cached = this.metricTables.find((entry) => entry.metric === metric);
-    if (cached) {
-      return cached;
-    }
     if (metric.dependencySql !== undefined) {
       await this.trace.engine.query(metric.dependencySql);
     }
@@ -267,15 +287,14 @@ export class TreeExplorerFetcher implements AsyncDisposable {
         ))
         where __intrinsic_flamegraph_find(_tree_id, 'SUPER_ROOT')
       `);
-      const entry = {
+      return {
         metric,
         table,
         unfilteredCumulativeValue: result.firstRow({
           cumulative_value: NUM,
         }).cumulative_value,
+        [Symbol.asyncDispose]: () => table[Symbol.asyncDispose](),
       };
-      this.metricTables.push(entry);
-      return entry;
     } catch (error) {
       await table[Symbol.asyncDispose]();
       throw error;

--- a/ui/src/components/tree_explorer_fetcher.ts
+++ b/ui/src/components/tree_explorer_fetcher.ts
@@ -142,8 +142,8 @@ export interface MetricsFromTableOrSubqueryOptions {
 }
 
 // Given a table and columns on those table (corresponding to metrics),
-// returns an array of `TreeExplorerQueryMetric` structs which can be passed
-// in TreeExplorerPanel's attrs.
+// returns an array of `TreeExplorerQueryMetric` structs which can be handed to
+// a `TreeExplorerFetcher` (and rendered by TreeExplorerPanel).
 //
 // `tableOrSubquery` should have the columns `id`, `parentId`, `name` and all
 // columns specified by `tableMetrics[].name`, `unaggregatableProperties` and
@@ -178,38 +178,38 @@ interface MetricTable extends AsyncDisposable {
   readonly unfilteredCumulativeValue: number;
 }
 
+interface MetricTableSlot {
+  readonly metric: TreeExplorerQueryMetric;
+  readonly memo: AsyncMemo<MetricTable>;
+}
+
 // Fetches tree explorer data by querying an `Engine`: turns a
 // (metric, state) pair into the filtered tree the views display. Purely a
 // data-layer object with no rendering; TreeExplorerPanel drives it.
-//
-// All work (table creation, tree fetches, disposal) is scheduled on a single
-// AtomicTaskQueue through AsyncMemo, so a metric's virtual table is only
-// disposed after any in-flight query against it has completed.
-export class TreeExplorerFetcher implements AsyncDisposable {
-  // One memo per metric object we have seen. The map key *is* the identity:
-  // a new metric object (same id, different SQL) gets a new memo and a new
-  // table. `seq` is a stable numeric stand-in for the metric in the JSON
-  // memo keys (metric objects are not JSON-serializable).
-  private readonly tableMemos = new Map<
-    TreeExplorerQueryMetric,
-    {memo: AsyncMemo<MetricTable>; seq: number}
-  >();
+export class TreeExplorerFetcher implements Disposable {
+  private readonly slots: ReadonlyArray<MetricTableSlot>;
   private readonly dataMemo: AsyncMemo<TreeExplorerData>;
-  private nextSeq = 0;
 
   constructor(
     private readonly trace: Trace,
-    private readonly queue = new AtomicTaskQueue(),
+    readonly metrics: ReadonlyArray<TreeExplorerQueryMetric>,
+    queue = new AtomicTaskQueue(),
   ) {
+    this.slots = metrics.map((metric) => ({
+      metric,
+      memo: new AsyncMemo<MetricTable>(queue),
+    }));
     this.dataMemo = new AsyncMemo<TreeExplorerData>(queue);
   }
 
-  async [Symbol.asyncDispose](): Promise<void> {
+  // Disposal only *schedules* the drops on the queue, so that they land after
+  // any in-flight query, hence there is nothing to await. It must stay
+  // synchronous: callers may invoke this from inside a queued task (e.g. an
+  // AsyncMemo evicting a cache entry), and awaiting a queued task from there
+  // would deadlock.
+  [Symbol.dispose](): void {
     this.dataMemo.dispose();
-    // Disposing a memo schedules its cache disposal through the shared
-    // queue, i.e. after any in-flight work on it; the queue handles the
-    // synchronization, we just ask every memo to go away.
-    for (const {memo} of this.tableMemos.values()) {
+    for (const {memo} of this.slots) {
       memo.dispose();
     }
   }
@@ -217,40 +217,30 @@ export class TreeExplorerFetcher implements AsyncDisposable {
   // Call once per render: returns the tree currently available for the
   // metric selected in `state` and schedules any needed work. `state.view`
   // must already be the effective view (see TreeExplorerPanel).
-  use(
-    metrics: ReadonlyArray<TreeExplorerQueryMetric>,
-    state: TreeExplorerState,
-  ): AsyncMemoResult<TreeExplorerData> {
-    const metric = ensureExists(
-      metrics.find((x) => state.selectedMetricId === metricId(x)),
+  use(state: TreeExplorerState): AsyncMemoResult<TreeExplorerData> {
+    const index = this.metrics.findIndex(
+      (x) => state.selectedMetricId === metricId(x),
     );
-    let entry = this.tableMemos.get(metric);
-    if (entry === undefined) {
-      entry = {
-        memo: new AsyncMemo<MetricTable>(this.queue),
-        seq: ++this.nextSeq,
-      };
-      this.tableMemos.set(metric, entry);
-    }
-    // The memo is dedicated to this metric object, so its key is constant:
-    // the table is created once and kept for the fetcher's lifetime.
-    const table = entry.memo.use({
+    const {metric, memo} = ensureExists(this.slots[index]);
+    // The memo is dedicated to this metric, so its key is constant: the
+    // table is created once and kept for the fetcher's lifetime.
+    const table = memo.use({
       key: {},
       compute: () => this.createMetricTable(metric),
     }).data;
 
-    if (!table) {
+    if (table === undefined) {
       return {isPending: true};
     }
 
     return this.dataMemo.use({
       key: {
-        metricSeq: entry.seq,
+        metricIndex: index,
         filters: state.filters,
         addedMetricIds: state.addedMetricIds,
         view: state.view,
       },
-      compute: () => computeTree(this.trace.engine, table!, state),
+      compute: () => computeTree(this.trace.engine, table, state),
     });
   }
 

--- a/ui/src/components/tree_explorer_panel.ts
+++ b/ui/src/components/tree_explorer_panel.ts
@@ -15,7 +15,6 @@
 import './tree_explorer_panel.scss';
 import m from 'mithril';
 import {assertUnreachable, ensureExists} from '../base/assert';
-import type {Trace} from '../public/trace';
 import {EmptyState} from '../widgets/empty_state';
 import {Spinner} from '../widgets/spinner';
 import {Flamegraph, buildFlamegraphExportString} from '../widgets/flamegraph';
@@ -24,31 +23,32 @@ import {TreeExplorerFilterBar} from '../widgets/tree_explorer_filter_bar';
 import {TreeExplorerViewSwitcher} from '../widgets/tree_explorer_view_switcher';
 import {
   computeHighlightRegex,
+  createDefaultTreeExplorerState,
   metricId,
   type TreeExplorerAddableMetric,
   type TreeExplorerData,
   type TreeExplorerState,
   type TreeExplorerView,
 } from '../widgets/tree_explorer';
-import {
+import type {
   TreeExplorerFetcher,
-  type TreeExplorerQueryMetric,
+  TreeExplorerQueryMetric,
 } from './tree_explorer_fetcher';
 import {
   TreeExplorerFlatView,
   TreeExplorerTreeView,
   buildFlatExportString,
 } from './tree_explorer_table_views';
-import type {AtomicTaskQueue} from '../base/async_memo';
 
 export interface TreeExplorerPanelAttrs {
-  readonly trace: Trace;
-
-  // The metrics to render. Undefined shows a loading state.
-  readonly metrics?: ReadonlyArray<TreeExplorerQueryMetric>;
+  // The fetcher supplying the tree, or undefined to show a pending state.
+  // Owned by the caller: this panel never creates or disposes it, so that the
+  // lifetime of the engine-side resources the metric SQL depends on is decided
+  // in one place (where the metrics themselves are created).
+  readonly fetcher: TreeExplorerFetcher;
 
   // Caller-owned tree explorer state (filters, view, selected metric). When
-  // `metrics` change, pass `updateTreeExplorerState(state, metrics)` to keep
+  // metrics change, pass `updateTreeExplorerState(state, metrics)` to keep
   // the selected metric valid. Undefined shows an empty pending state.
   readonly state?: TreeExplorerState;
 
@@ -60,43 +60,28 @@ export interface TreeExplorerPanelAttrs {
   // Host-provided downloads shown alongside the built-in exports of the
   // displayed tree, for representations the panel cannot build itself.
   readonly extraDownloadItems?: ReadonlyArray<ExportDownloadItem>;
-
-  // Queue shared with the owner of any engine-side resources (e.g. temp
-  // tables) that the metric SQL depends on. If the owner disposes those
-  // resources through this same queue (e.g. as the AsyncDisposable result of
-  // an AsyncMemo on it), the disposal is serialized after this panel's
-  // in-flight queries. When omitted the fetcher uses a private queue and the
-  // host is responsible for keeping such resources alive for the panel's
-  // lifetime.
-  readonly queue?: AtomicTaskQueue;
 }
 
-// The batteries-included tree explorer: owns a `TreeExplorerFetcher` (created
-// in the constructor from `attrs.trace` / `attrs.queue`, disposed on unmount)
-// and composes the view switcher, the shared filter bar and the active view
-// (flamegraph canvas, call tree or flat function table) of the fetched tree.
-// Lets area-selection tabs and details panels render a tree explorer without
-// managing `[Symbol.asyncDispose]` themselves.
+// The batteries-included tree explorer: composes the view switcher, the shared
+// filter bar and the active view (flamegraph canvas, call tree or flat
+// function table) of the tree supplied by `attrs.fetcher`.
 //
-// The fetcher is created once, so hosts must remount the panel (new key or
-// position) when `trace` or `queue` identity changes.
-//
-// Hosts that want the view switcher elsewhere (a DetailsShell header, an
-// existing tab strip) compose `TreeExplorerViewSwitcher`,
-// `TreeExplorerFilterBar` and the views directly instead of using this panel.
+// The panel is stateless with respect to fetching: the fetcher is created by
+// the host where the metrics are created, and disposed by that host when the
+// metrics are superseded. Hosts that want the view switcher elsewhere (a
+// DetailsShell header, an existing tab strip) compose
+// `TreeExplorerViewSwitcher`, `TreeExplorerFilterBar` and the views directly
+// instead of using this panel.
 export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttrs> {
-  private readonly fetcher: TreeExplorerFetcher;
   private highlightPattern = '';
 
-  constructor({attrs}: m.CVnode<TreeExplorerPanelAttrs>) {
-    this.fetcher = new TreeExplorerFetcher(attrs.trace, attrs.queue);
-  }
-
   view({attrs}: m.CVnode<TreeExplorerPanelAttrs>): m.Children {
-    const {metrics, state} = attrs;
+    const {fetcher, state = createDefaultTreeExplorerState(fetcher.metrics)} =
+      attrs;
+    const metrics = fetcher?.metrics;
     const data =
-      metrics !== undefined && state !== undefined
-        ? this.fetcher.use(metrics, {...state, view: effectiveView(state)}).data
+      fetcher !== undefined && state !== undefined
+        ? fetcher.use({...state, view: effectiveView(state)}).data
         : undefined;
 
     const shownState = state ?? {
@@ -153,12 +138,13 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
               : 'flamegraph',
         extraDownloadItems: attrs.extraDownloadItems,
       }),
-      this.renderView(attrs, shownState, highlightRegex, data),
+      this.renderView(attrs, shownMetrics, shownState, highlightRegex, data),
     );
   }
 
   private renderView(
     attrs: TreeExplorerPanelAttrs,
+    metrics: ReadonlyArray<TreeExplorerQueryMetric>,
     state: TreeExplorerState,
     highlightRegex: RegExp | undefined,
     data: TreeExplorerData | undefined,
@@ -166,7 +152,7 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
     const displayMode = state.displayMode;
     if (displayMode === 'flamegraph') {
       return m(Flamegraph, {
-        metrics: attrs.metrics ?? [],
+        metrics,
         state,
         data,
         highlightRegex,
@@ -184,8 +170,7 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
       );
     }
     const unit =
-      (attrs.metrics ?? []).find((x) => metricId(x) === state.selectedMetricId)
-        ?.unit ?? '';
+      metrics.find((x) => metricId(x) === state.selectedMetricId)?.unit ?? '';
     switch (displayMode) {
       case 'tree':
         return m(TreeExplorerTreeView, {data, unit});
@@ -194,10 +179,6 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
       default:
         assertUnreachable(displayMode);
     }
-  }
-
-  async onremove(): Promise<void> {
-    await this.fetcher[Symbol.asyncDispose]();
   }
 }
 

--- a/ui/src/components/tree_explorer_panel.ts
+++ b/ui/src/components/tree_explorer_panel.ts
@@ -14,8 +14,6 @@
 
 import './tree_explorer_panel.scss';
 import m from 'mithril';
-import {AsyncLimiter} from '../base/async_limiter';
-import {Monitor} from '../base/monitor';
 import {assertUnreachable, ensureExists} from '../base/assert';
 import type {Trace} from '../public/trace';
 import {EmptyState} from '../widgets/empty_state';
@@ -34,7 +32,6 @@ import {
 } from '../widgets/tree_explorer';
 import {
   TreeExplorerFetcher,
-  type TreeExplorerFetcherDependency,
   type TreeExplorerQueryMetric,
 } from './tree_explorer_fetcher';
 import {
@@ -42,6 +39,7 @@ import {
   TreeExplorerTreeView,
   buildFlatExportString,
 } from './tree_explorer_table_views';
+import type {AtomicTaskQueue} from '../base/async_memo';
 
 export interface TreeExplorerPanelAttrs {
   readonly trace: Trace;
@@ -59,80 +57,48 @@ export interface TreeExplorerPanelAttrs {
   readonly addableMetrics?: ReadonlyArray<TreeExplorerAddableMetric>;
   readonly onAddMetric?: (metric: TreeExplorerAddableMetric) => void;
 
-  // Perfetto tables / indices the metric SQL depends on. The panel forwards
-  // them to the inner `TreeExplorerFetcher`, which disposes them along with
-  // itself on unmount or when the array reference changes.
-  readonly dependencies?: ReadonlyArray<TreeExplorerFetcherDependency>;
-
   // Host-provided downloads shown alongside the built-in exports of the
   // displayed tree, for representations the panel cannot build itself.
   readonly extraDownloadItems?: ReadonlyArray<ExportDownloadItem>;
+
+  // Queue shared with the owner of any engine-side resources (e.g. temp
+  // tables) that the metric SQL depends on. If the owner disposes those
+  // resources through this same queue (e.g. as the AsyncDisposable result of
+  // an AsyncMemo on it), the disposal is serialized after this panel's
+  // in-flight queries. When omitted the fetcher uses a private queue and the
+  // host is responsible for keeping such resources alive for the panel's
+  // lifetime.
+  readonly queue?: AtomicTaskQueue;
 }
 
 // The batteries-included tree explorer: owns a `TreeExplorerFetcher` (created
-// on first render, disposed on unmount or when `trace` / `dependencies`
-// identity changes) and composes the view switcher, the shared filter bar
-// and the active view (flamegraph canvas, call tree or flat function table)
-// of the fetched tree. Lets area-selection tabs and details panels render a
-// tree explorer without managing `[Symbol.asyncDispose]` themselves.
+// in the constructor from `attrs.trace` / `attrs.queue`, disposed on unmount)
+// and composes the view switcher, the shared filter bar and the active view
+// (flamegraph canvas, call tree or flat function table) of the fetched tree.
+// Lets area-selection tabs and details panels render a tree explorer without
+// managing `[Symbol.asyncDispose]` themselves.
+//
+// The fetcher is created once, so hosts must remount the panel (new key or
+// position) when `trace` or `queue` identity changes.
 //
 // Hosts that want the view switcher elsewhere (a DetailsShell header, an
 // existing tab strip) compose `TreeExplorerViewSwitcher`,
 // `TreeExplorerFilterBar` and the views directly instead of using this panel.
 export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttrs> {
-  private fetcher?: TreeExplorerFetcher;
-  private lastTrace?: Trace;
-  private lastDeps?: ReadonlyArray<TreeExplorerFetcherDependency>;
-
-  private data?: TreeExplorerData;
-  private readonly queryLimiter = new AsyncLimiter();
-  private lastAttrs?: TreeExplorerPanelAttrs;
-  private monitor = this.createMonitor();
+  private readonly fetcher: TreeExplorerFetcher;
   private highlightPattern = '';
 
-  // Watches everything that affects the fetched tree. Notably absent:
-  // displayMode, which only changes how the already-fetched tree is shown —
-  // except through effectiveView(), whose result it can change (flat mode
-  // always fetches the TOP_DOWN shape).
-  private createMonitor(): Monitor {
-    return new Monitor([
-      () => this.lastAttrs?.metrics,
-      () => this.lastAttrs?.state?.filters,
-      () => this.lastAttrs?.state?.selectedMetricId,
-      () => this.lastAttrs?.state?.addedMetricIds,
-      () =>
-        this.lastAttrs?.state &&
-        JSON.stringify(effectiveView(this.lastAttrs.state)),
-    ]);
+  constructor({attrs}: m.CVnode<TreeExplorerPanelAttrs>) {
+    this.fetcher = new TreeExplorerFetcher(attrs.trace, attrs.queue);
   }
 
   view({attrs}: m.CVnode<TreeExplorerPanelAttrs>): m.Children {
-    this.lastAttrs = attrs;
-    if (
-      this.fetcher === undefined ||
-      this.lastTrace !== attrs.trace ||
-      this.lastDeps !== attrs.dependencies
-    ) {
-      void this.fetcher?.[Symbol.asyncDispose]();
-      this.fetcher = new TreeExplorerFetcher(attrs.trace, attrs.dependencies);
-      this.lastTrace = attrs.trace;
-      this.lastDeps = attrs.dependencies;
-      // A new fetcher has no tables yet: force a refetch even if the
-      // metrics/state references are unchanged.
-      this.monitor = this.createMonitor();
-    }
-    const fetcher = this.fetcher;
     const {metrics, state} = attrs;
-    if (this.monitor.ifStateChanged()) {
-      this.data = undefined;
-      if (metrics && state) {
-        const fetchState = {...state, view: effectiveView(state)};
-        this.queryLimiter.schedule(async () => {
-          this.data = undefined;
-          this.data = await fetcher.fetch(metrics, fetchState);
-        });
-      }
-    }
+    const data =
+      metrics !== undefined && state !== undefined
+        ? this.fetcher.use(metrics, {...state, view: effectiveView(state)}).data
+        : undefined;
+
     const shownState = state ?? {
       view: {kind: 'TOP_DOWN' as const},
       selectedMetricId: '',
@@ -155,7 +121,7 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
       m(TreeExplorerFilterBar, {
         metrics: shownMetrics,
         state: shownState,
-        data: this.data,
+        data: data,
         onStateChange: attrs.onStateChange,
         addableMetrics: attrs.addableMetrics,
         onAddMetric: attrs.onAddMetric,
@@ -170,10 +136,14 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
           selectedMetric === undefined
             ? undefined
             : async (format) => {
-                const data = ensureExists(this.data);
+                const dataExists = ensureExists(data);
                 return displayMode === 'flat'
-                  ? buildFlatExportString(data, selectedMetric, format)
-                  : buildFlamegraphExportString(data, selectedMetric, format);
+                  ? buildFlatExportString(dataExists, selectedMetric, format)
+                  : buildFlamegraphExportString(
+                      dataExists,
+                      selectedMetric,
+                      format,
+                    );
               },
         exportFileBaseName:
           displayMode === 'flat'
@@ -183,7 +153,7 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
               : 'flamegraph',
         extraDownloadItems: attrs.extraDownloadItems,
       }),
-      this.renderView(attrs, shownState, highlightRegex),
+      this.renderView(attrs, shownState, highlightRegex, data),
     );
   }
 
@@ -191,18 +161,19 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
     attrs: TreeExplorerPanelAttrs,
     state: TreeExplorerState,
     highlightRegex: RegExp | undefined,
+    data: TreeExplorerData | undefined,
   ): m.Children {
     const displayMode = state.displayMode;
     if (displayMode === 'flamegraph') {
       return m(Flamegraph, {
         metrics: attrs.metrics ?? [],
         state,
-        data: this.data,
+        data,
         highlightRegex,
         onStateChange: attrs.onStateChange,
       });
     }
-    if (this.data === undefined) {
+    if (data === undefined) {
       return m(
         '.pf-tree-explorer__loading',
         m(
@@ -217,17 +188,16 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
         ?.unit ?? '';
     switch (displayMode) {
       case 'tree':
-        return m(TreeExplorerTreeView, {data: this.data, unit});
+        return m(TreeExplorerTreeView, {data, unit});
       case 'flat':
-        return m(TreeExplorerFlatView, {data: this.data, unit});
+        return m(TreeExplorerFlatView, {data, unit});
       default:
         assertUnreachable(displayMode);
     }
   }
 
   async onremove(): Promise<void> {
-    await this.fetcher?.[Symbol.asyncDispose]();
-    this.fetcher = undefined;
+    await this.fetcher[Symbol.asyncDispose]();
   }
 }
 

--- a/ui/src/plugins/com.android.DayExplorer/index.ts
+++ b/ui/src/plugins/com.android.DayExplorer/index.ts
@@ -21,15 +21,17 @@ import {CounterTrack} from '../../components/tracks/counter_track';
 import {TrackNode} from '../../public/workspace';
 import {STR, LONG, LONG_NULL} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
-import {type AreaSelection, areaSelectionsEqual} from '../../public/selection';
+import {areaSelectionKey, type AreaSelection} from '../../public/selection';
 import {
   TREE_EXPLORER_STATE_SCHEMA,
   updateTreeExplorerState,
 } from '../../widgets/tree_explorer';
 import {
   metricsFromTableOrSubquery,
+  TreeExplorerFetcher,
   type TreeExplorerQueryMetric,
 } from '../../components/tree_explorer_fetcher';
+import {Memo} from '../../base/memo';
 import {TreeExplorerPanel} from '../../components/tree_explorer_panel';
 import SupportPlugin from '../com.android.AndroidLongBatterySupport';
 import type {Store} from '../../base/store';
@@ -147,28 +149,26 @@ export default class DayExplorerPlugin implements PerfettoPlugin {
   }
 
   private createDayExplorerFlameGraphPanel(trace: Trace) {
-    let previousSelection: AreaSelection | undefined;
-    let flamegraphMetrics: ReadonlyArray<TreeExplorerQueryMetric> | undefined;
+    const fetcherMemo = new Memo<TreeExplorerFetcher | undefined>();
     return {
       id: 'day_explorer_flamegraph_selection',
       name: 'Day Explorer Flamegraph',
       render: (selection: AreaSelection) => {
-        const selectionChanged =
-          previousSelection === undefined ||
-          !areaSelectionsEqual(previousSelection, selection);
-        previousSelection = selection;
-        if (selectionChanged) {
-          flamegraphMetrics = this.computeDayExplorerFlameGraph(selection);
-        }
-        if (flamegraphMetrics === undefined) {
+        const fetcher = fetcherMemo.use({
+          key: areaSelectionKey(selection),
+          compute: () => {
+            const metrics = this.computeDayExplorerFlameGraph(selection);
+            return metrics && new TreeExplorerFetcher(trace, metrics);
+          },
+        });
+        if (fetcher === undefined) {
           return undefined;
         }
         const store = ensureExists(this.store);
         return {
           isLoading: false,
           content: m(TreeExplorerPanel, {
-            trace,
-            metrics: flamegraphMetrics,
+            fetcher,
             state: store.state.areaSelectionFlamegraphState,
             onStateChange: (state) => {
               store.edit((draft) => {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/callstack_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/callstack_view.ts
@@ -14,7 +14,8 @@
 
 import m from 'mithril';
 import type {Trace} from '../../../public/trace';
-import type {TreeExplorerQueryMetric} from '../../../components/tree_explorer_fetcher';
+import {TreeExplorerFetcher} from '../../../components/tree_explorer_fetcher';
+import {Memo} from '../../../base/memo';
 import {TreeExplorerPanel} from '../../../components/tree_explorer_panel';
 import {
   createDefaultTreeExplorerState,
@@ -45,8 +46,9 @@ interface CallstackViewAttrs {
 export class CallstackView implements m.ClassComponent<CallstackViewAttrs> {
   private oomeData?: OomeData;
   private oomeDataLoaded = false;
-  private cachedMetrics?: ReadonlyArray<TreeExplorerQueryMetric>;
-  private cachedKey?: string;
+  // The fetcher is created for the dump it serves and disposed by the memo when
+  // the dump changes or when this view is removed.
+  private readonly fetcherMemo = new Memo<TreeExplorerFetcher>();
   private readonly limiter = new AsyncLimiter();
   private monitor?: Monitor;
 
@@ -69,16 +71,11 @@ export class CallstackView implements m.ClassComponent<CallstackViewAttrs> {
     }
 
     if (!this.oomeDataLoaded) {
-      return m(
-        DetailsShell,
-        {title: 'Callstack', fillHeight: true, className: 'pf-hde-tab--padded'},
-        m(TreeExplorerPanel, {
-          trace: attrs.trace,
-          metrics: undefined,
-          state: attrs.state,
-          onStateChange: attrs.onStateChange,
-        }),
-      );
+      return m(DetailsShell, {
+        title: 'Callstack',
+        fillHeight: true,
+        className: 'pf-hde-tab--padded',
+      });
     }
 
     if (this.oomeData === undefined) {
@@ -102,12 +99,12 @@ export class CallstackView implements m.ClassComponent<CallstackViewAttrs> {
 
     const upid = this.oomeData.upid;
     const ts = this.oomeData.ts;
-    const key = `${upid}:${ts}`;
-    if (this.cachedMetrics === undefined || key !== this.cachedKey) {
-      this.cachedMetrics = buildOomeCallstackMetrics(ts);
-      this.cachedKey = key;
-    }
-    const metrics = this.cachedMetrics;
+    const fetcher = this.fetcherMemo.use({
+      key: {upid, ts},
+      compute: () =>
+        new TreeExplorerFetcher(attrs.trace, buildOomeCallstackMetrics(ts)),
+    });
+    const metrics = fetcher.metrics;
 
     let state = attrs.state;
     if (state === undefined) {
@@ -123,12 +120,15 @@ export class CallstackView implements m.ClassComponent<CallstackViewAttrs> {
         {orientation: 'vertical'},
         renderOomeDetails(this.oomeData?.details),
         m(TreeExplorerPanel, {
-          trace: attrs.trace,
-          metrics,
+          fetcher,
           state,
           onStateChange: attrs.onStateChange,
         }),
       ),
     );
+  }
+
+  onremove(): void {
+    this.fetcherMemo.dispose();
   }
 }

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
@@ -16,7 +16,11 @@ import m from 'mithril';
 import {download} from '../../../base/download_utils';
 import type {Trace} from '../../../public/trace';
 import type {time} from '../../../base/time';
-import type {TreeExplorerQueryMetric} from '../../../components/tree_explorer_fetcher';
+import {
+  TreeExplorerFetcher,
+  type TreeExplorerQueryMetric,
+} from '../../../components/tree_explorer_fetcher';
+import {Memo} from '../../../base/memo';
 import {TreeExplorerPanel} from '../../../components/tree_explorer_panel';
 import {
   createDefaultTreeExplorerState,
@@ -179,8 +183,9 @@ function buildHeapGraphMetrics(
 }
 
 export function FlamegraphView(): m.Component<FlamegraphViewAttrs> {
-  let cachedMetrics: ReadonlyArray<TreeExplorerQueryMetric> | undefined;
-  let cachedKey: string | undefined;
+  // The fetcher is created for the dump it serves and disposed by the memo when
+  // the dump changes or when this view is removed.
+  const fetcherMemo = new Memo<TreeExplorerFetcher>();
 
   // Mirrors dev.perfetto.HeapProfile: if the heap graph is incomplete we gate
   // the flamegraph behind a dismissible warning modal. Keyed by dump so it
@@ -193,16 +198,15 @@ export function FlamegraphView(): m.Component<FlamegraphViewAttrs> {
 
   return {
     view({attrs}) {
-      const key = `${attrs.upid}:${attrs.ts}`;
-      if (cachedMetrics === undefined || key !== cachedKey) {
-        cachedMetrics = buildHeapGraphMetrics(
-          attrs.upid,
-          attrs.ts,
-          attrs.onShowObjects,
-        );
-        cachedKey = key;
-      }
-      const metrics = cachedMetrics;
+      const fetcher = fetcherMemo.use({
+        key: {upid: attrs.upid, ts: attrs.ts},
+        compute: () =>
+          new TreeExplorerFetcher(
+            attrs.trace,
+            buildHeapGraphMetrics(attrs.upid, attrs.ts, attrs.onShowObjects),
+          ),
+      });
+      const metrics = fetcher.metrics;
 
       const incomplete = incompleteSlot.use({
         key: {upid: attrs.upid, ts: attrs.ts},
@@ -229,8 +233,7 @@ export function FlamegraphView(): m.Component<FlamegraphViewAttrs> {
             incomplete.dismissed = true;
           }),
         m(TreeExplorerPanel, {
-          trace: attrs.trace,
-          metrics,
+          fetcher,
           state,
           onStateChange: attrs.onStateChange,
           extraDownloadItems: [
@@ -248,6 +251,9 @@ export function FlamegraphView(): m.Component<FlamegraphViewAttrs> {
           ],
         }),
       ];
+    },
+    onremove() {
+      fetcherMemo.dispose();
     },
   };
 }

--- a/ui/src/plugins/dev.perfetto.AggregateProfiles/aggregate_profiles_page.ts
+++ b/ui/src/plugins/dev.perfetto.AggregateProfiles/aggregate_profiles_page.ts
@@ -17,6 +17,7 @@ import {assertExists, assertIsInstance} from '../../base/assert';
 import {Memo} from '../../base/memo';
 import {maybeUndefined} from '../../base/utils';
 import {TreeExplorerPanel} from '../../components/tree_explorer_panel';
+import {TreeExplorerFetcher} from '../../components/tree_explorer_fetcher';
 import type {Trace} from '../../public/trace';
 import {Button} from '../../widgets/button';
 import {Callout} from '../../widgets/callout';
@@ -25,11 +26,7 @@ import {EmptyState} from '../../widgets/empty_state';
 import {HotkeyContext} from '../../widgets/hotkey_context';
 import {Select} from '../../widgets/select';
 import {Stack, StackAuto, StackFixed} from '../../widgets/stack';
-import {
-  createDefaultTreeExplorerState,
-  type TreeExplorerState,
-  updateTreeExplorerState,
-} from '../../widgets/tree_explorer';
+import {updateTreeExplorerState} from '../../widgets/tree_explorer';
 import type {AggregateProfile, AggregateProfilesPageState} from './types';
 
 const HIDE_PAGE_EXPLANATION_KEY = 'hideAggregateProfilesPageExplanation';
@@ -43,7 +40,10 @@ export interface AggregateProfilesPageAttrs {
 }
 
 export class AggregateProfilesPage implements m.ClassComponent<AggregateProfilesPageAttrs> {
-  private readonly memo = new Memo<TreeExplorerState>();
+  // The fetcher (and so the virtual tables built for the metrics) is created
+  // for the profile it serves and disposed by the memo when the user switches
+  // profile, so at most one generation is alive at a time.
+  private readonly fetcherMemo = new Memo<TreeExplorerFetcher>();
 
   view({attrs}: m.CVnode<AggregateProfilesPageAttrs>): m.Children {
     // Use the selected profile from the state or just use the first one if none
@@ -91,6 +91,10 @@ export class AggregateProfilesPage implements m.ClassComponent<AggregateProfiles
     );
   }
 
+  onremove(): void {
+    this.fetcherMemo.dispose();
+  }
+
   private stepProfile(attrs: AggregateProfilesPageAttrs, step: number): void {
     if (attrs.profiles.length < 2) return;
     const cur = attrs.profiles.findIndex(
@@ -119,27 +123,15 @@ export class AggregateProfilesPage implements m.ClassComponent<AggregateProfiles
     selectedProfile: AggregateProfile,
     attrs: AggregateProfilesPageAttrs,
   ): m.Children {
-    // This is a hack necessitated by two issues:
-    // 1. TreeExplorerPanel is unable to handle state=undefined despite it being
-    //    optional in the attrs interface defintion.
-    // 2. The flamegraph compares attrs by reference equality to detect changes,
-    //    so while we could simply recreate the state every frame if it's
-    //    undefined and avoid the memo entirely - this would trigger an infite
-    //    loading loop as we'd have a new object reference every frame.
-    let flamegraphState = attrs.state.flamegraphState;
-    if (flamegraphState === undefined) {
-      flamegraphState = this.memo.use({
-        key: selectedProfile.id,
-        compute: () => {
-          return createDefaultTreeExplorerState(selectedProfile.metrics);
-        },
-      });
-    }
+    const fetcher = this.fetcherMemo.use({
+      key: {profileId: selectedProfile.id},
+      compute: () =>
+        new TreeExplorerFetcher(attrs.trace, selectedProfile.metrics),
+    });
 
     return m(TreeExplorerPanel, {
-      trace: attrs.trace,
-      metrics: selectedProfile.metrics,
-      state: flamegraphState,
+      fetcher,
+      state: attrs.state.flamegraphState,
       onStateChange: (state) => {
         attrs.onStateChange({
           ...attrs.state,

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -19,6 +19,7 @@ import {extensions} from '../../components/extensions';
 import type {time} from '../../base/time';
 import {
   type TreeExplorerQueryMetric,
+  TreeExplorerFetcher,
   metricsFromTableOrSubquery,
 } from '../../components/tree_explorer_fetcher';
 import {TreeExplorerPanel} from '../../components/tree_explorer_panel';
@@ -177,7 +178,9 @@ interface Props {
   type: ProfileType;
 }
 
-export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel {
+export class HeapProfileFlamegraphDetailsPanel
+  implements TrackEventDetailsPanel, Disposable
+{
   private readonly props: Props;
   private flamegraphModalDismissed = false;
   private oomeDetails?: OomeDetails;
@@ -193,6 +196,11 @@ export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel
   };
 
   readonly metrics: ReadonlyArray<TreeExplorerQueryMetric>;
+
+  // Created next to the metrics it serves and owned by this panel: whoever
+  // replaces the panel is responsible for disposing it (see the area-selection
+  // tab and track details panel which create these panels).
+  private readonly fetcher: TreeExplorerFetcher;
 
   constructor(
     private readonly trace: Trace,
@@ -230,6 +238,11 @@ export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel
       this.state = createDefaultTreeExplorerState(this.metrics);
       onStateChange(this.state);
     }
+    this.fetcher = new TreeExplorerFetcher(this.trace, this.metrics);
+  }
+
+  [Symbol.dispose](): void {
+    this.fetcher[Symbol.dispose]();
   }
 
   async load() {
@@ -276,8 +289,7 @@ export class HeapProfileFlamegraphDetailsPanel implements TrackEventDetailsPanel
           ),
         },
         m(TreeExplorerPanel, {
-          trace: this.trace,
-          metrics: this.metrics,
+          fetcher: this.fetcher,
           state: this.state,
           onStateChange: (state) => {
             this.state = state;

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
@@ -17,6 +17,7 @@ import {materialColorScheme} from '../../components/colorizer';
 import {Time, type time} from '../../base/time';
 import {formatBytesIec} from '../../base/bytes_format';
 import {SliceTrack} from '../../components/tracks/slice_track';
+import {Memo} from '../../base/memo';
 import type {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, LONG_NULL, NUM, STR} from '../../trace_processor/query_result';
@@ -39,6 +40,11 @@ export function createHeapProfileTrack(
     ts: time;
   }) => void,
 ) {
+  // One panel at a time: `detailsPanel` is called again for every selection,
+  // and the memo disposes the previous panel (and so the fetcher, and so the
+  // virtual tables built for its metrics) as soon as the key changes.
+  const panelMemo = new Memo<HeapProfileFlamegraphDetailsPanel>();
+
   return SliceTrack.create({
     trace,
     uri,
@@ -61,18 +67,22 @@ export function createHeapProfileTrack(
       const ts = Time.fromRaw(row.ts);
       const tsEnd = Time.fromRaw(row.ts + row.dur);
       const descriptor = profileDescriptor(row.type);
-      return new HeapProfileFlamegraphDetailsPanel(
-        trace,
-        heapProfileIsIncomplete,
-        upid,
-        descriptor,
-        ts,
-        tsEnd,
-        detailsPanelState,
-        onDetailsPanelStateChange,
-        /* isAreaSelection= */ false,
-        onNodeSelected,
-      );
+      return panelMemo.use({
+        key: {type: row.type, ts, tsEnd},
+        compute: () =>
+          new HeapProfileFlamegraphDetailsPanel(
+            trace,
+            heapProfileIsIncomplete,
+            upid,
+            descriptor,
+            ts,
+            tsEnd,
+            detailsPanelState,
+            onDetailsPanelStateChange,
+            /* isAreaSelection= */ false,
+            onNodeSelected,
+          ),
+      });
     },
     sliceName: (row) => intervalSliceName(row),
     tooltip: (slice) => intervalTooltip(slice.row),

--- a/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
@@ -29,6 +29,7 @@ import {TREE_EXPLORER_STATE_SCHEMA} from '../../widgets/tree_explorer';
 import type {Store} from '../../base/store';
 import {z} from 'zod';
 import {ensureExists} from '../../base/assert';
+import {Memo} from '../../base/memo';
 import {
   isProfileDescriptor,
   type ProfileDescriptor,
@@ -36,8 +37,8 @@ import {
   ProfileType,
 } from './common';
 import {
+  areaSelectionKey,
   type AreaSelection,
-  areaSelectionsEqual,
   type AreaSelectionTab,
 } from '../../public/selection';
 import {HeapProfileFlamegraphDetailsPanel} from './heap_profile_details_panel';
@@ -382,8 +383,10 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
     descriptor: ProfileDescriptor,
     priority: number,
   ): AreaSelectionTab {
-    let previousSelection: AreaSelection | undefined;
-    let flamegraphPanel: HeapProfileFlamegraphDetailsPanel | undefined;
+    // One panel at a time, created for the selection it renders and disposed by
+    // the memo as soon as the selection moves on. One memo per registered tab:
+    // the selection key alone does not distinguish two heap types.
+    const panelMemo = new Memo<HeapProfileFlamegraphDetailsPanel | undefined>();
     return {
       id: `heap_profiler_flamegraph_selection_${descriptor.heapName}`,
       name: `${descriptor.label} flamegraph`,
@@ -392,17 +395,14 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
       priority: -priority,
       render: (selection: AreaSelection) => {
         const store = ensureExists(this.store);
-        const selectionChanged =
-          previousSelection === undefined ||
-          !areaSelectionsEqual(previousSelection, selection);
-        previousSelection = selection;
-        if (selectionChanged) {
-          const upids = matchingTracks(selection, descriptor.type).map(
-            (track) => track.tags!.upid,
-          );
-          // For the time being support selecting exactly one process.
-          flamegraphPanel =
-            upids.length !== 1
+        const panel = panelMemo.use({
+          key: areaSelectionKey(selection),
+          compute: () => {
+            const upids = matchingTracks(selection, descriptor.type).map(
+              (track) => track.tags!.upid,
+            );
+            // For the time being support selecting exactly one process.
+            return upids.length !== 1
               ? undefined
               : new HeapProfileFlamegraphDetailsPanel(
                   trace,
@@ -420,13 +420,14 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
                   },
                   /* isAreaSelection= */ true,
                 );
-        }
+          },
+        });
         // Hide the tab entirely when this selection has no flamegraph for this
         // heap type, rather than showing a tab handle with empty content.
-        if (flamegraphPanel === undefined) {
+        if (panel === undefined) {
           return undefined;
         }
-        return {isLoading: false, content: flamegraphPanel.render()};
+        return {isLoading: false, content: panel.render()};
       },
     };
   }

--- a/ui/src/plugins/dev.perfetto.StackSamples/index.ts
+++ b/ui/src/plugins/dev.perfetto.StackSamples/index.ts
@@ -15,17 +15,19 @@
 import m from 'mithril';
 import {z} from 'zod';
 import {ensureExists} from '../../base/assert';
+import {Memo} from '../../base/memo';
 import type {Store} from '../../base/store';
 import {
   metricsFromTableOrSubquery,
+  TreeExplorerFetcher,
   type TreeExplorerQueryMetric,
 } from '../../components/tree_explorer_fetcher';
 import {TreeExplorerPanel} from '../../components/tree_explorer_panel';
 import type {PerfettoPlugin} from '../../public/plugin';
 import {
+  areaSelectionKey,
   type AreaSelection,
   type AreaSelectionTab,
-  areaSelectionsEqual,
 } from '../../public/selection';
 import type {Trace} from '../../public/trace';
 import type {Track} from '../../public/track';
@@ -199,26 +201,29 @@ export function createStackSampleAreaSelectionTab(
   trace: Trace,
   config: StackSampleAreaSelectionTabConfig,
 ): AreaSelectionTab {
-  let previousSelection: AreaSelection | undefined;
-  let flamegraphMetrics: ReadonlyArray<TreeExplorerQueryMetric> | undefined;
+  // The fetcher (and so the virtual tables built for the metrics) is created
+  // for the selection it serves and disposed by the memo as soon as the
+  // selection changes, so at most one generation is alive at a time.
+  const fetcherMemo = new Memo<TreeExplorerFetcher | undefined>();
 
   return {
     id: `stack_sample_flamegraph_${encodeURIComponent(config.source)}`,
     name: `${config.title} Sample Flamegraph`,
     render: (selection: AreaSelection) => {
-      const changed =
-        previousSelection === undefined ||
-        !areaSelectionsEqual(previousSelection, selection);
-      if (changed) {
-        previousSelection = selection;
-        flamegraphMetrics = computeFlamegraphMetrics(selection, config);
-      }
-      if (flamegraphMetrics === undefined) return undefined;
+      const fetcher = fetcherMemo.use({
+        key: areaSelectionKey(selection),
+        compute: () => {
+          const metrics = computeFlamegraphMetrics(selection, config);
+          return metrics === undefined
+            ? undefined
+            : new TreeExplorerFetcher(trace, metrics);
+        },
+      });
+      if (fetcher === undefined) return undefined;
       return {
         isLoading: false,
         content: m(TreeExplorerPanel, {
-          trace,
-          metrics: flamegraphMetrics,
+          fetcher,
           state: config.getState(),
           onStateChange: config.setState,
         }),

--- a/ui/src/plugins/dev.perfetto.StackSamples/profiling_track.ts
+++ b/ui/src/plugins/dev.perfetto.StackSamples/profiling_track.ts
@@ -16,13 +16,14 @@ import m from 'mithril';
 import {getColorForSample} from '../../components/colorizer';
 import {
   metricsFromTableOrSubquery,
-  type TreeExplorerQueryMetric,
+  TreeExplorerFetcher,
 } from '../../components/tree_explorer_fetcher';
 import {TreeExplorerPanel} from '../../components/tree_explorer_panel';
 import {FlamegraphProfile} from '../../components/flamegraph_profile';
 import {DetailsShell} from '../../widgets/details_shell';
 import {Timestamp} from '../../components/widgets/timestamp';
 import {Time, type time} from '../../base/time';
+import {Memo} from '../../base/memo';
 import {
   createDefaultTreeExplorerState,
   type TreeExplorerState,
@@ -108,6 +109,11 @@ export function createProfilingTrack(
   detailsPanelState: TreeExplorerState | undefined,
   onDetailsPanelStateChange: (state: TreeExplorerState) => void,
 ) {
+  // The metrics (and so the fetcher which owns the virtual tables built from
+  // them) depend only on the selected sample timestamp: the memo keeps exactly
+  // one generation alive and disposes it when the selection moves on.
+  const fetcherMemo = new Memo<TreeExplorerFetcher>();
+
   return SliceTrack.create({
     trace,
     uri,
@@ -116,9 +122,11 @@ export function createProfilingTrack(
     colorizer: (row) => getColorForSample(row.callsiteId),
     detailsPanel: (row) => {
       const ts = Time.fromRaw(row.ts);
-      const metrics: ReadonlyArray<TreeExplorerQueryMetric> =
-        metricsFromTableOrSubquery({
-          tableOrSubquery: `
+      const fetcher = fetcherMemo.use({
+        key: {ts},
+        compute: () => {
+          const metrics = metricsFromTableOrSubquery({
+            tableOrSubquery: `
             (
               select
                 id,
@@ -132,26 +140,30 @@ export function createProfilingTrack(
               ))
             )
           `,
-          tableMetrics: [
-            {
-              name: config.metricName,
-              unit: '',
-              columnName: 'self_count',
-            },
-          ],
-          dependencySql: `include perfetto module ${config.sqlModule}`,
-          unaggregatableProperties: [
-            {name: 'mapping_name', displayName: 'Mapping'},
-          ],
-          aggregatableProperties: [
-            {
-              name: 'source_location',
-              displayName: 'Source Location',
-              mergeAggregation: 'ONE_OR_SUMMARY',
-            },
-          ],
-          nameColumnLabel: 'Symbol',
-        });
+            tableMetrics: [
+              {
+                name: config.metricName,
+                unit: '',
+                columnName: 'self_count',
+              },
+            ],
+            dependencySql: `include perfetto module ${config.sqlModule}`,
+            unaggregatableProperties: [
+              {name: 'mapping_name', displayName: 'Mapping'},
+            ],
+            aggregatableProperties: [
+              {
+                name: 'source_location',
+                displayName: 'Source Location',
+                mergeAggregation: 'ONE_OR_SUMMARY',
+              },
+            ],
+            nameColumnLabel: 'Symbol',
+          });
+          return new TreeExplorerFetcher(trace, metrics);
+        },
+      });
+      const metrics = fetcher.metrics;
       // Use provided state or create initial state once
       let state = detailsPanelState ?? createDefaultTreeExplorerState(metrics);
       if (detailsPanelState === undefined) {
@@ -169,7 +181,7 @@ export function createProfilingTrack(
               state = newState;
               onDetailsPanelStateChange(newState);
             },
-            metrics,
+            fetcher,
           ),
         // TODO(lalitm): we should be able remove this around the 26Q2 timeframe
         // We moved serialization from being attached to selections to instead being
@@ -192,7 +204,7 @@ function renderProfilingDetailsPanel(
   config: ProfilingTrackConfig,
   state: TreeExplorerState,
   onStateChange: (state: TreeExplorerState) => void,
-  metrics: ReadonlyArray<TreeExplorerQueryMetric>,
+  fetcher: TreeExplorerFetcher,
 ): m.Children {
   return m(
     FlamegraphProfile,
@@ -203,7 +215,7 @@ function renderProfilingDetailsPanel(
         title: config.panelTitle,
         buttons: m('span', 'Timestamp: ', m(Timestamp, {trace, ts})),
       },
-      m(TreeExplorerPanel, {trace, metrics, state, onStateChange}),
+      m(TreeExplorerPanel, {fetcher, state, onStateChange}),
     ),
   );
 }

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -25,12 +25,12 @@ import {sliceDistributionCellRenderers} from '../../components/details/slice_det
 import {openDistributionTab} from '../../components/distribution_panel';
 import {
   metricsFromTableOrSubquery,
-  type TreeExplorerQueryMetric,
+  TreeExplorerFetcher,
 } from '../../components/tree_explorer_fetcher';
 import {TreeExplorerPanel} from '../../components/tree_explorer_panel';
 import type {MinimapRow} from '../../public/minimap';
 import type {PerfettoPlugin} from '../../public/plugin';
-import type {AreaSelection} from '../../public/selection';
+import {areaSelectionKey, type AreaSelection} from '../../public/selection';
 import type {Trace} from '../../public/trace';
 import {COUNTER_TRACK_KIND, SLICE_TRACK_KIND} from '../../public/track_kinds';
 import {getMachineCount, getTrackName} from '../../public/utils';
@@ -79,7 +79,7 @@ type TraceProcessorTrackPluginState = z.infer<
 >;
 
 interface SliceFlamegraphData extends AsyncDisposable {
-  readonly metrics: ReadonlyArray<TreeExplorerQueryMetric>;
+  readonly fetcher: TreeExplorerFetcher;
 }
 
 function createDetailsPanel(trace: Trace, utid: number | null) {
@@ -662,16 +662,12 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
       id: 'slice_flamegraph_selection',
       name: 'Slice Flamegraph',
       render: (selection: AreaSelection) => {
-        const selectionKey = {
-          start: selection.start,
-          end: selection.end,
-          tracks: selection.trackUris,
-        };
+        const selectionKey = areaSelectionKey(selection);
         const {isPending, data: computed} = memo.use({
           key: {
             selection: selectionKey,
           },
-          compute: () => this.computeSliceFlamegraph(trace, selection),
+          compute: () => this.computeSliceFlamegraph(trace, queue, selection),
         });
 
         // No data returned, return undefined to hide the tab.
@@ -685,9 +681,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
           content:
             computed &&
             m(TreeExplorerPanel, {
-              queue,
-              trace,
-              metrics: computed.metrics,
+              fetcher: computed.fetcher,
               state: store.state.areaSelectionFlamegraphState,
               onStateChange: (state) => {
                 store.edit((draft) => {
@@ -702,6 +696,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
 
   private async computeSliceFlamegraph(
     trace: Trace,
+    queue: AtomicTaskQueue,
     currentSelection: AreaSelection,
   ): Promise<SliceFlamegraphData | undefined> {
     const trackIds = [];
@@ -830,13 +825,23 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
         metrics,
       );
     });
+    // The fetcher is created here, next to the metrics it serves, and moved
+    // into the returned object: it dies with this generation, so its virtual
+    // tables (which read from `iiTable`) never outlive the tables themselves.
+    const fetcher = new TreeExplorerFetcher(trace, metrics, queue);
     // Move the resources into the returned object: the implicit scope-exit
     // dispose becomes a no-op on the happy path, and cleans up if anything
     // above throws.
     const owned = disposables.move();
     return {
-      metrics,
-      [Symbol.asyncDispose]: () => owned[Symbol.asyncDispose](),
+      fetcher,
+      [Symbol.asyncDispose]: async () => {
+        // Dispose the fetcher first: its virtual tables are built from the
+        // tables `owned` drops. Its disposal is queued, so it lands after any
+        // in-flight query against those tables.
+        fetcher[Symbol.dispose]();
+        await owned[Symbol.asyncDispose]();
+      },
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -14,10 +14,8 @@
 
 import m from 'mithril';
 import {removeFalsyValues} from '../../base/array_utils';
-import {AsyncLimiter} from '../../base/async_limiter';
 import {ensureExists} from '../../base/assert';
 import {AsyncDisposableStack} from '../../base/disposable_stack';
-import {SharedAsyncDisposable} from '../../base/shared_disposable';
 import {Time} from '../../base/time';
 import {
   createAggregationTab,
@@ -27,13 +25,12 @@ import {sliceDistributionCellRenderers} from '../../components/details/slice_det
 import {openDistributionTab} from '../../components/distribution_panel';
 import {
   metricsFromTableOrSubquery,
-  type TreeExplorerFetcherDependency,
   type TreeExplorerQueryMetric,
 } from '../../components/tree_explorer_fetcher';
 import {TreeExplorerPanel} from '../../components/tree_explorer_panel';
 import type {MinimapRow} from '../../public/minimap';
 import type {PerfettoPlugin} from '../../public/plugin';
-import {type AreaSelection, areaSelectionsEqual} from '../../public/selection';
+import type {AreaSelection} from '../../public/selection';
 import type {Trace} from '../../public/trace';
 import {COUNTER_TRACK_KIND, SLICE_TRACK_KIND} from '../../public/track_kinds';
 import {getMachineCount, getTrackName} from '../../public/utils';
@@ -71,6 +68,7 @@ import {
 } from '../../trace_processor/sql_utils';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
 import {CallstackDetailsSection} from './callstack_details_section';
+import {AsyncMemo, AtomicTaskQueue} from '../../base/async_memo';
 
 const TRACE_PROCESSOR_TRACK_PLUGIN_STATE_SCHEMA = z.object({
   areaSelectionFlamegraphState: TREE_EXPLORER_STATE_SCHEMA.optional(),
@@ -82,7 +80,6 @@ type TraceProcessorTrackPluginState = z.infer<
 
 interface SliceFlamegraphData extends AsyncDisposable {
   readonly metrics: ReadonlyArray<TreeExplorerQueryMetric>;
-  readonly dependencies: ReadonlyArray<TreeExplorerFetcherDependency>;
 }
 
 function createDetailsPanel(trace: Trace, utid: number | null) {
@@ -658,41 +655,39 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
   }
 
   private createSliceFlameGraphPanel(trace: Trace) {
-    let previousSelection: AreaSelection | undefined;
-    let computed: SliceFlamegraphData | undefined;
-    let isLoading = false;
-    const limiter = new AsyncLimiter();
+    const queue = new AtomicTaskQueue();
+    const memo = new AsyncMemo<SliceFlamegraphData | undefined>(queue);
 
     return {
       id: 'slice_flamegraph_selection',
       name: 'Slice Flamegraph',
       render: (selection: AreaSelection) => {
-        const selectionChanged =
-          previousSelection === undefined ||
-          !areaSelectionsEqual(previousSelection, selection);
-        previousSelection = selection;
-        if (selectionChanged) {
-          limiter.schedule(async () => {
-            const previousComputed = computed;
-            computed = undefined;
-            isLoading = true;
-            await previousComputed?.[Symbol.asyncDispose]();
-            computed = await this.computeSliceFlamegraph(trace, selection);
-            isLoading = false;
-          });
-        }
-        if (computed === undefined && !isLoading) {
+        const selectionKey = {
+          start: selection.start,
+          end: selection.end,
+          tracks: selection.trackUris,
+        };
+        const {isPending, data: computed} = memo.use({
+          key: {
+            selection: selectionKey,
+          },
+          compute: () => this.computeSliceFlamegraph(trace, selection),
+        });
+
+        // No data returned, return undefined to hide the tab.
+        if (computed === undefined && !isPending) {
           return undefined;
         }
+
         const store = ensureExists(this.store);
         return {
-          isLoading,
+          isLoading: isPending,
           content:
             computed &&
             m(TreeExplorerPanel, {
+              queue,
               trace,
               metrics: computed.metrics,
-              dependencies: computed.dependencies,
               state: store.state.areaSelectionFlamegraphState,
               onStateChange: (state) => {
                 store.edit((draft) => {
@@ -743,7 +738,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
       },
     });
 
-    await using disposables = new AsyncDisposableStack();
+    const disposables = new AsyncDisposableStack();
     const iiTable = disposables.use(
       await createIITable(
         trace.engine,
@@ -835,12 +830,9 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
         metrics,
       );
     });
-    const dependency: TreeExplorerFetcherDependency =
-      SharedAsyncDisposable.wrap(disposables.move());
     return {
       metrics,
-      dependencies: [dependency],
-      [Symbol.asyncDispose]: () => dependency[Symbol.asyncDispose](),
+      [Symbol.asyncDispose]: () => disposables[Symbol.asyncDispose](),
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -738,7 +738,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
       },
     });
 
-    const disposables = new AsyncDisposableStack();
+    await using disposables = new AsyncDisposableStack();
     const iiTable = disposables.use(
       await createIITable(
         trace.engine,
@@ -830,9 +830,13 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
         metrics,
       );
     });
+    // Move the resources into the returned object: the implicit scope-exit
+    // dispose becomes a no-op on the happy path, and cleans up if anything
+    // above throws.
+    const owned = disposables.move();
     return {
       metrics,
-      [Symbol.asyncDispose]: () => disposables[Symbol.asyncDispose](),
+      [Symbol.asyncDispose]: () => owned[Symbol.asyncDispose](),
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.TrackEvent/track_event_callstack_flamegraph.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/track_event_callstack_flamegraph.ts
@@ -15,9 +15,11 @@
 import m from 'mithril';
 import {AsyncMemo} from '../../base/async_memo';
 import {sqliteString} from '../../base/string_utils';
+import {Memo} from '../../base/memo';
 import {TreeExplorerPanel} from '../../components/tree_explorer_panel';
 import {
   metricsFromTableOrSubquery,
+  TreeExplorerFetcher,
   type TreeExplorerQueryMetric,
 } from '../../components/tree_explorer_fetcher';
 import type {AreaSelection, AreaSelectionTab} from '../../public/selection';
@@ -35,17 +37,15 @@ interface Metadata {
   readonly availableArgs: ReadonlyArray<string>;
 }
 
-interface MetricsCache {
-  readonly key: string;
-  readonly metrics: ReadonlyArray<TreeExplorerQueryMetric>;
-}
-
 export class TrackEventCallstackFlamegraphTab implements AreaSelectionTab {
   readonly id = 'track_event_callstack_flamegraph';
   readonly name = 'Track Event Callstacks';
 
   private readonly metadataSlot = new AsyncMemo<Metadata>();
-  private metricsCache?: MetricsCache;
+  // The fetcher (and so the virtual tables built for the metrics) is created
+  // for the metric set it serves and disposed by the memo as soon as that set
+  // changes, so at most one generation is alive at a time.
+  private readonly fetcherMemo = new Memo<TreeExplorerFetcher>();
 
   constructor(
     private readonly trace: Trace,
@@ -70,15 +70,20 @@ export class TrackEventCallstackFlamegraphTab implements AreaSelectionTab {
 
     const state = this.getState();
     const addedMetricIds = state?.addedMetricIds ?? [];
-    const metrics = this.getMetrics(
-      samplesSql,
-      metadata.data.hasWeight,
-      addedMetricIds,
-    );
+    const {hasWeight} = metadata.data;
+    const fetcher = this.fetcherMemo.use({
+      key: {samplesSql, hasWeight, addedMetricIds},
+      compute: () =>
+        new TreeExplorerFetcher(
+          this.trace,
+          buildMetrics(samplesSql, hasWeight, addedMetricIds),
+        ),
+    });
+    const metrics = fetcher.metrics;
     const currentState = updateTreeExplorerState(state, metrics);
     if (currentState !== state) {
-      // Persist so the state reference is stable on the next render:
-      // TreeExplorerPanel refetches whenever the state identity changes.
+      // Persist so the selected metric is stable on the next render, rather
+      // than being re-derived (and possibly changing) every frame.
       this.setState(currentState);
     }
     const added = new Set(addedMetricIds);
@@ -89,8 +94,7 @@ export class TrackEventCallstackFlamegraphTab implements AreaSelectionTab {
     return {
       isLoading: metadata.isPending,
       content: m(TreeExplorerPanel, {
-        trace: this.trace,
-        metrics,
+        fetcher,
         addableMetrics,
         state: currentState,
         onAddMetric: (metric) => {
@@ -135,19 +139,6 @@ export class TrackEventCallstackFlamegraphTab implements AreaSelectionTab {
       if (it.key !== null) availableArgs.push(it.key);
     }
     return {hasWeight, availableArgs};
-  }
-
-  private getMetrics(
-    samplesSql: string,
-    hasWeight: boolean,
-    addedMetricIds: ReadonlyArray<string>,
-  ): ReadonlyArray<TreeExplorerQueryMetric> {
-    const key = `${samplesSql}\0${hasWeight}\0${addedMetricIds.join('\0')}`;
-    if (this.metricsCache?.key === key) return this.metricsCache.metrics;
-
-    const metrics = buildMetrics(samplesSql, hasWeight, addedMetricIds);
-    this.metricsCache = {key, metrics};
-    return metrics;
   }
 }
 

--- a/ui/src/public/selection.ts
+++ b/ui/src/public/selection.ts
@@ -74,6 +74,33 @@ export function areaSelectionsEqual(a: AreaSelection, b: AreaSelection) {
   return true;
 }
 
+/**
+ * The serializable identity of an area selection, suitable for use as a memo or
+ * cache key. Two selections produce equal keys if and only if
+ * `areaSelectionsEqual` considers them equal.
+ *
+ * Note that `tracks` (the resolved Track objects) is deliberately not part of
+ * the key: it is derived from `trackUris` by the selection manager.
+ */
+export interface AreaSelectionKey {
+  readonly start: time;
+  readonly end: time;
+  readonly trackUris: ReadonlyArray<string>;
+}
+
+/**
+ * Returns the memo key for an area selection. See `AreaSelectionKey`. Note:
+ * This is only necessary because selections are not directly serializable due
+ * to the inclusion of derived track data (the tracks field).
+ */
+export function areaSelectionKey(selection: AreaSelection): AreaSelectionKey {
+  return {
+    start: selection.start,
+    end: selection.end,
+    trackUris: selection.trackUris,
+  };
+}
+
 export interface SelectionManager {
   readonly selection: Selection;
 


### PR DESCRIPTION
This patch switches out the query loading with AsyncMemos, which vastly simplifies the management of asynchronous data fetching and caching, including dependency management. This avoids any race condition bugs where dependencies tables are dropped before the dependant table gets a chance to use it.