### PR TITLE
tp: avoid redundant packet reader work

### DIFF
--- a/include/perfetto/trace_processor/trace_blob_view.h
+++ b/include/perfetto/trace_processor/trace_blob_view.h
@@ -76,16 +76,28 @@ class alignas(8) TraceBlobView {
   TraceBlobView& operator=(const TraceBlobView&) = delete;
 
   // [data, data+length] must be <= the current TraceBlobView.
-  TraceBlobView slice(const uint8_t* data, size_t length) const {
+  TraceBlobView slice(const uint8_t* data, size_t length) const& {
     PERFETTO_DCHECK(data >= data_);
     PERFETTO_DCHECK(data + length <= data_ + length_);
     return {data, length, blob_};
   }
 
+  // Transfer ownership when the original view is no longer needed.
+  TraceBlobView slice(const uint8_t* data, size_t length) && {
+    PERFETTO_DCHECK(data >= data_);
+    PERFETTO_DCHECK(data + length <= data_ + length_);
+    return {data, length, std::move(blob_)};
+  }
+
   // Like slice() but takes an offset rather than a pointer as 1st argument.
-  TraceBlobView slice_off(size_t off, size_t length) const {
+  TraceBlobView slice_off(size_t off, size_t length) const& {
     PERFETTO_DCHECK(off + length <= length_);
     return {data_ + off, length, blob_};
+  }
+
+  TraceBlobView slice_off(size_t off, size_t length) && {
+    PERFETTO_DCHECK(off + length <= length_);
+    return {data_ + off, length, std::move(blob_)};
   }
 
   TraceBlobView copy() const { return slice(data_, length_); }

--- a/src/trace_processor/importers/proto/packet_sequence_state_builder.h
+++ b/src/trace_processor/importers/proto/packet_sequence_state_builder.h
@@ -63,7 +63,7 @@ class PacketSequenceStateBuilder {
   bool IsIncrementalStateValid() const { return !packet_loss_; }
 
   // Returns a ref-counted ptr to the current generation.
-  RefPtr<PacketSequenceStateGeneration> current_generation() const {
+  const RefPtr<PacketSequenceStateGeneration>& current_generation() const {
     return generation_;
   }
 

--- a/src/trace_processor/importers/proto/proto_importer_module.h
+++ b/src/trace_processor/importers/proto/proto_importer_module.h
@@ -114,7 +114,8 @@ struct TokenizePacketArgs {
   const SelectiveTracePacketDecoder& decoder;
   TraceBlobView* packet;
   int64_t ts;
-  RefPtr<PacketSequenceStateGeneration> state;
+  // The sequence's current generation; a module that keeps it copies it.
+  const RefPtr<PacketSequenceStateGeneration>& state;
   TracePacketField field;
 };
 

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -63,6 +63,7 @@
 #include "src/trace_processor/tables/metadata_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/types/variadic.h"
+#include "src/trace_processor/util/decompressor.h"
 #include "src/trace_processor/util/descriptors.h"
 #include "src/trace_processor/util/trace_type.h"
 
@@ -244,9 +245,12 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
         "(ERR:tp-corrupt)");
   }
 
-  // Compressed packets are expanded by the tokenizer; none should reach here.
-  PERFETTO_CHECK(!decoder.has_compressed_packets() &&
-                 !decoder.has_zstd_compressed_packets());
+  // A bundle of compressed packets is expanded and each packet parsed in
+  // its place; nothing else in the enclosing packet is read.
+  if (PERFETTO_UNLIKELY((decoder.has_compressed_packets() ||
+                         decoder.has_zstd_compressed_packets()))) {
+    return ParseCompressedPackets(decoder, packet);
+  }
 
   // The top-level reader dispatches packets from other machines to a
   // per-machine reader; host and adopted-machine packets are parsed here.
@@ -285,19 +289,24 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
     decoder = SelectiveTracePacketDecoder(packet.data(), packet.length());
   }
 
+  // Consecutive packets nearly always come from the same sequence, so the
+  // last lookup is kept rather than hashing the id for every packet.
   uint32_t seq_id = decoder.trusted_packet_sequence_id();
-  SequenceScopedState* scoped_state = sequence_state_.Find(seq_id);
+  SequenceScopedState* scoped_state = last_scoped_state_;
   bool inserted = false;
-  if (PERFETTO_UNLIKELY(!scoped_state)) {
-    scoped_state = sequence_state_.Insert(seq_id, {}).first;
-    inserted = true;
+  if (PERFETTO_UNLIKELY(!scoped_state || seq_id != last_seq_id_)) {
+    scoped_state = sequence_state_.Find(seq_id);
+    if (!scoped_state) {
+      scoped_state = sequence_state_.Insert(seq_id, {}).first;
+      inserted = true;
+    }
+    last_seq_id_ = seq_id;
+    last_scoped_state_ = scoped_state;
   }
-  if (decoder.has_trusted_packet_sequence_id()) {
-    if (!inserted) {
-      if (uint32_t reasons = decoder.previous_packet_dropped(); reasons) {
-        ++scoped_state->previous_packet_dropped_count;
-        RecordDataLossCauses(scoped_state, reasons);
-      }
+  if (decoder.has_trusted_packet_sequence_id() && !inserted) {
+    if (uint32_t reasons = decoder.previous_packet_dropped(); reasons) {
+      ++scoped_state->previous_packet_dropped_count;
+      RecordDataLossCauses(scoped_state, reasons);
     }
   }
 
@@ -318,8 +327,8 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
     HandlePreviousPacketDropped(decoder, packet);
   }
 
-  // It is important that we parse defaults before parsing other fields such as
-  // the timestamp, since the defaults could affect them.
+  // It is important that we parse defaults before parsing other fields
+  // such as the timestamp, since the defaults could affect them.
   if (decoder.has_trace_packet_defaults()) {
     auto field = decoder.trace_packet_defaults();
     ParseTracePacketDefaults(decoder, packet.slice(field.data, field.size));
@@ -343,8 +352,8 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
     return ParseRemoteClockSync(decoder.remote_clock_sync());
   }
 
-  auto* state = GetIncrementalStateForPacketSequence(seq_id);
-  if (decoder.sequence_flags() &
+  auto* state = GetIncrementalState(scoped_state);
+  if (sequence_flags &
       protos::pbzero::TracePacket::SEQ_NEEDS_INCREMENTAL_STATE) {
     if (!seq_id) {
       return base::ErrStatus(
@@ -383,7 +392,24 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
     ParseTraceConfig(decoder.trace_config());
   }
 
-  return TimestampTokenizeAndPushToSorter(decoder, std::move(packet));
+  return TimestampTokenizeAndPushToSorter(decoder, std::move(packet), state);
+}
+
+base::Status ProtoTraceReader::ParseCompressedPackets(
+    const SelectiveTracePacketDecoder& decoder,
+    const TraceBlobView& packet) {
+  util::CompressionType codec;
+  protozero::ConstBytes field;
+  if (decoder.has_compressed_packets()) {
+    codec = util::CompressionType::kGzip;
+    field = decoder.compressed_packets();
+  } else {
+    codec = util::CompressionType::kZstd;
+    field = decoder.zstd_compressed_packets();
+  }
+  return tokenizer_.TokenizeCompressedPackets(
+      codec, packet.slice(field.data, field.size),
+      [this](TraceBlobView inner) { return ParsePacket(std::move(inner)); });
 }
 
 ProtoTraceReader::ClockResolution ProtoTraceReader::ResolveTimestampToTraceTime(
@@ -417,14 +443,16 @@ ProtoTraceReader::ClockResolution ProtoTraceReader::ResolveTimestampToTraceTime(
 base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
     TraceBlobView packet) {
   SelectiveTracePacketDecoder decoder(packet.data(), packet.length());
-  return TimestampTokenizeAndPushToSorter(decoder, std::move(packet));
+  auto* state = GetIncrementalStateForPacketSequence(
+      decoder.trusted_packet_sequence_id());
+  return TimestampTokenizeAndPushToSorter(decoder, std::move(packet), state);
 }
 
 base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
     const SelectiveTracePacketDecoder& decoder,
-    TraceBlobView packet) {
+    TraceBlobView packet,
+    PacketSequenceStateBuilder* state) {
   uint32_t seq_id = decoder.trusted_packet_sequence_id();
-  auto* state = GetIncrementalStateForPacketSequence(seq_id);
 
   protos::pbzero::TracePacketDefaults::Decoder* defaults =
       state->current_generation()->GetTracePacketDefaults();

--- a/src/trace_processor/importers/proto/proto_trace_reader.h
+++ b/src/trace_processor/importers/proto/proto_trace_reader.h
@@ -116,6 +116,10 @@ class ProtoTraceReader : public ChunkedTraceReader {
 
   using ConstBytes = protozero::ConstBytes;
   base::Status ParsePacket(TraceBlobView);
+  // Cold path: expands a compressed_packets / zstd_compressed_packets bundle
+  // and parses each packet in it.
+  base::Status ParseCompressedPackets(const SelectiveTracePacketDecoder&,
+                                      const TraceBlobView& packet);
   // Cold path: on the first remote-machine packet, decides whether to adopt it
   // onto the host context and sets adopted_machine_id_ (machine_id or 0).
   base::Status ResolveAdoptedMachine(uint32_t machine_id);
@@ -124,11 +128,12 @@ class ProtoTraceReader : public ChunkedTraceReader {
       uint32_t machine_id,
       std::unique_ptr<ProtoTraceReader>* out);
   base::Status TimestampTokenizeAndPushToSorter(TraceBlobView);
-  // Variant for callers that already decoded the packet, so the (wide)
-  // TracePacket decoder is not rebuilt per packet.
+  // Variant for callers that already decoded the packet and resolved its
+  // sequence state, so neither is redone per packet.
   base::Status TimestampTokenizeAndPushToSorter(
       const SelectiveTracePacketDecoder&,
-      TraceBlobView);
+      TraceBlobView,
+      PacketSequenceStateBuilder* state);
   base::Status ParseClockSnapshot(ConstBytes blob, uint32_t seq_id);
   base::Status ParseRemoteClockSync(ConstBytes blob);
 
@@ -155,13 +160,16 @@ class ProtoTraceReader : public ChunkedTraceReader {
   static base::FlatHashMap<ClockTracker::ClockId, int64_t /*Offset*/>
   CalculateClockOffsets(std::vector<SyncClockSnapshots>&);
 
-  PacketSequenceStateBuilder* GetIncrementalStateForPacketSequence(
-      uint32_t sequence_id) {
-    auto& builder = sequence_state_.Find(sequence_id)->sequence_state_builder;
-    if (!builder) {
+  PacketSequenceStateBuilder* GetIncrementalState(SequenceScopedState* seq) {
+    auto& builder = seq->sequence_state_builder;
+    if (PERFETTO_UNLIKELY(!builder)) {
       builder = PacketSequenceStateBuilder(context_);
     }
     return &*builder;
+  }
+  PacketSequenceStateBuilder* GetIncrementalStateForPacketSequence(
+      uint32_t sequence_id) {
+    return GetIncrementalState(sequence_state_.Find(sequence_id));
   }
 
   TraceProcessorContext* context_;
@@ -183,6 +191,9 @@ class ProtoTraceReader : public ChunkedTraceReader {
   int64_t latest_timestamp_ = 0;
 
   base::FlatHashMap<uint32_t, SequenceScopedState> sequence_state_;
+  // The sequence ParsePacket last looked up; reset whenever the map changes.
+  uint32_t last_seq_id_ = 0;
+  SequenceScopedState* last_scoped_state_ = nullptr;
   StringId skipped_packet_key_id_;
   StringId invalid_incremental_state_key_id_;
   StringId packet_sequence_id_key_id_;

--- a/src/trace_processor/importers/proto/proto_trace_tokenizer.h
+++ b/src/trace_processor/importers/proto/proto_trace_tokenizer.h
@@ -30,7 +30,6 @@
 #include "perfetto/protozero/proto_utils.h"
 #include "perfetto/public/compiler.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
-#include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/util/decompressor.h"
 
 #include "perfetto/ext/base/status_macros.h"
@@ -58,23 +57,33 @@ class ProtoTraceTokenizer {
       // for size/varint).
       const size_t kMinHeaderBytes = 2;
       const size_t kMaxHeaderBytes = 20;
-      std::optional<TraceBlobView> header = reader_.SliceOff(
-          start_offset,
-          std::min(std::max(avail, kMinHeaderBytes), kMaxHeaderBytes));
+      const size_t header_size =
+          std::min(std::max(avail, kMinHeaderBytes), kMaxHeaderBytes);
 
-      // This means that kMinHeaderBytes was not available. Just wait for the
-      // next round.
-      if (PERFETTO_UNLIKELY(!header)) {
-        return base::OkStatus();
+      // The header is read in place when it lies within one chunk, which
+      // avoids slicing a view of it per packet; only a header that straddles
+      // chunks is stitched together.
+      const uint8_t* header_data =
+          reader_.ContiguousAt(start_offset, header_size);
+      std::optional<TraceBlobView> stitched_header;
+      if (PERFETTO_UNLIKELY(!header_data)) {
+        stitched_header = reader_.SliceOff(start_offset, header_size);
+        // This means that kMinHeaderBytes was not available. Just wait for
+        // the next round.
+        if (!stitched_header) {
+          return base::OkStatus();
+        }
+        header_data = stitched_header->data();
       }
+      const uint8_t* header_end = header_data + header_size;
 
       uint64_t tag;
-      const uint8_t* tag_start = header->data();
-      const uint8_t* tag_end = protozero::proto_utils::ParseVarInt(
-          tag_start, header->data() + header->size(), &tag);
+      const uint8_t* tag_start = header_data;
+      const uint8_t* tag_end =
+          protozero::proto_utils::ParseVarInt(tag_start, header_end, &tag);
 
       if (PERFETTO_UNLIKELY(tag_end == tag_start)) {
-        return header->size() < kMaxHeaderBytes
+        return header_size < kMaxHeaderBytes
                    ? base::OkStatus()
                    : base::ErrStatus(
                          "Failed to parse tag @ 0x%zx (ERR:tp-corrupt)",
@@ -90,9 +99,9 @@ class ProtoTraceTokenizer {
             uint64_t varint;
             const uint8_t* varint_start = tag_end;
             const uint8_t* varint_end = protozero::proto_utils::ParseVarInt(
-                tag_end, header->data() + header->size(), &varint);
+                tag_end, header_end, &varint);
             if (PERFETTO_UNLIKELY(varint_end == varint_start)) {
-              return header->size() < kMaxHeaderBytes
+              return header_size < kMaxHeaderBytes
                          ? base::OkStatus()
                          : base::ErrStatus(
                                "Failed to skip varint @ 0x%zx (ERR:tp-corrupt)",
@@ -107,9 +116,9 @@ class ProtoTraceTokenizer {
             uint64_t varint;
             const uint8_t* varint_start = tag_end;
             const uint8_t* varint_end = protozero::proto_utils::ParseVarInt(
-                tag_end, header->data() + header->size(), &varint);
+                tag_end, header_end, &varint);
             if (PERFETTO_UNLIKELY(varint_end == varint_start)) {
-              return header->size() < kMaxHeaderBytes
+              return header_size < kMaxHeaderBytes
                          ? base::OkStatus()
                          : base::ErrStatus(
                                "Failed to skip delimited @ 0x%zx "
@@ -164,12 +173,12 @@ class ProtoTraceTokenizer {
       uint64_t field_size;
       const uint8_t* size_start = tag_end;
       const uint8_t* size_end = protozero::proto_utils::ParseVarInt(
-          size_start, header->data() + header->size(), &field_size);
+          size_start, header_end, &field_size);
 
       // If we had less than the maximum number of header bytes, it's possible
       // that we just need more to actually parse. Otherwise, this is an error.
       if (PERFETTO_UNLIKELY(size_start == size_end)) {
-        return header->size() < kMaxHeaderBytes
+        return header_size < kMaxHeaderBytes
                    ? base::OkStatus()
                    : base::ErrStatus(
                          "Failed to parse TracePacket size (ERR:tp-corrupt)");
@@ -177,7 +186,7 @@ class ProtoTraceTokenizer {
 
       // Empty packets can legitimately happen if the producer ends up emitting
       // no data: just ignore them.
-      auto hdr_size = static_cast<size_t>(size_end - header->data());
+      auto hdr_size = static_cast<size_t>(size_end - header_data);
       if (PERFETTO_UNLIKELY(field_size == 0)) {
         PERFETTO_CHECK(reader_.PopFrontBytes(hdr_size));
         continue;
@@ -191,46 +200,40 @@ class ProtoTraceTokenizer {
       auto packet = reader_.SliceOff(start_offset + hdr_size, field_size);
       PERFETTO_CHECK(packet);
       PERFETTO_CHECK(reader_.PopFrontBytes(hdr_size + field_size));
-      protos::pbzero::TracePacket::Decoder decoder(packet->data(),
-                                                   packet->length());
-      util::CompressionType codec;
-      protozero::ConstBytes field;
-      if (decoder.has_compressed_packets()) {
-        codec = util::CompressionType::kGzip;
-        field = decoder.compressed_packets();
-      } else if (decoder.has_zstd_compressed_packets()) {
-        codec = util::CompressionType::kZstd;
-        field = decoder.zstd_compressed_packets();
-      } else {
-        RETURN_IF_ERROR(callback(std::move(*packet)));
-        continue;
-      }
-
-      TraceBlobView compressed_packets = packet->slice(field.data, field.size);
-      TraceBlobView packets;
-      RETURN_IF_ERROR(
-          Decompress(codec, std::move(compressed_packets), &packets));
-
-      const uint8_t* start = packets.data();
-      const uint8_t* end = packets.data() + packets.length();
-      const uint8_t* ptr = start;
-      while ((end - ptr) > 2) {
-        const uint8_t* packet_outer = ptr;
-        if (PERFETTO_UNLIKELY(*ptr != kTracePacketTag)) {
-          return base::ErrStatus("Expected TracePacket tag (ERR:tp-corrupt)");
-        }
-        uint64_t packet_size = 0;
-        ptr = protozero::proto_utils::ParseVarInt(++ptr, end, &packet_size);
-        const uint8_t* packet_start = ptr;
-        ptr += packet_size;
-        if (PERFETTO_UNLIKELY((ptr - packet_outer) < 2 || ptr > end)) {
-          return base::ErrStatus("Invalid packet size (ERR:tp-corrupt)");
-        }
-        TraceBlobView sliced =
-            packets.slice(packet_start, static_cast<size_t>(packet_size));
-        RETURN_IF_ERROR(callback(std::move(sliced)));
-      }
+      RETURN_IF_ERROR(callback(std::move(*packet)));
     }
+  }
+
+  // Expands a compressed_packets / zstd_compressed_packets bundle and hands
+  // each packet in it to |callback|. The caller decodes the enclosing packet,
+  // so the bundle is not decoded twice.
+  template <typename Callback = base::Status(TraceBlobView)>
+  base::Status TokenizeCompressedPackets(util::CompressionType codec,
+                                         TraceBlobView compressed_packets,
+                                         Callback callback) {
+    TraceBlobView packets;
+    RETURN_IF_ERROR(Decompress(codec, std::move(compressed_packets), &packets));
+
+    const uint8_t* start = packets.data();
+    const uint8_t* end = packets.data() + packets.length();
+    const uint8_t* ptr = start;
+    while ((end - ptr) > 2) {
+      const uint8_t* packet_outer = ptr;
+      if (PERFETTO_UNLIKELY(*ptr != kTracePacketTag)) {
+        return base::ErrStatus("Expected TracePacket tag (ERR:tp-corrupt)");
+      }
+      uint64_t packet_size = 0;
+      ptr = protozero::proto_utils::ParseVarInt(++ptr, end, &packet_size);
+      const uint8_t* packet_start = ptr;
+      ptr += packet_size;
+      if (PERFETTO_UNLIKELY((ptr - packet_outer) < 2 || ptr > end)) {
+        return base::ErrStatus("Invalid packet size (ERR:tp-corrupt)");
+      }
+      TraceBlobView sliced =
+          packets.slice(packet_start, static_cast<size_t>(packet_size));
+      RETURN_IF_ERROR(callback(std::move(sliced)));
+    }
+    return base::OkStatus();
   }
 
  private:

--- a/src/trace_processor/importers/proto/protovm_incremental_tracing.cc
+++ b/src/trace_processor/importers/proto/protovm_incremental_tracing.cc
@@ -73,11 +73,10 @@ void ProtoVmIncrementalTracing::ProcessProtoVmsPacket(
   }
 }
 
-std::optional<TraceBlobView> ProtoVmIncrementalTracing::TryProcessPatch(
+std::optional<TraceBlobView> ProtoVmIncrementalTracing::ProcessPatch(
     const SelectiveTracePacketDecoder& patch,
     const TraceBlobView& packet) {
-  if (PERFETTO_LIKELY(sequence_id_to_vms_.size() == 0) ||
-      PERFETTO_UNLIKELY(!patch.has_trusted_packet_sequence_id())) {
+  if (PERFETTO_UNLIKELY(!patch.has_trusted_packet_sequence_id())) {
     return std::nullopt;
   }
   std::vector<protovm::Vm*>* vms =

--- a/src/trace_processor/importers/proto/protovm_incremental_tracing.h
+++ b/src/trace_processor/importers/proto/protovm_incremental_tracing.h
@@ -21,6 +21,7 @@
 #include <optional>
 #include <vector>
 
+#include "perfetto/base/compiler.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
@@ -43,11 +44,21 @@ class ProtoVmIncrementalTracing {
   void ProcessTraceProvenancePacket(protozero::ConstBytes blob);
   void ProcessProtoVmsPacket(protozero::ConstBytes blob,
                              const TraceBlobView& packet);
+  // Almost no trace has VMs, so that is settled here without a call, on the
+  // path every packet takes.
   std::optional<TraceBlobView> TryProcessPatch(
       const SelectiveTracePacketDecoder& patch,
-      const TraceBlobView& packet);
+      const TraceBlobView& packet) {
+    if (PERFETTO_LIKELY(sequence_id_to_vms_.size() == 0)) {
+      return std::nullopt;
+    }
+    return ProcessPatch(patch, packet);
+  }
 
  private:
+  std::optional<TraceBlobView> ProcessPatch(
+      const SelectiveTracePacketDecoder& patch,
+      const TraceBlobView& packet);
   TraceBlobView SerializeIncrementalState(
       const protovm::Vm& vm,
       const SelectiveTracePacketDecoder& patch) const;

--- a/src/trace_processor/importers/proto/selective_trace_packet_decoder.h
+++ b/src/trace_processor/importers/proto/selective_trace_packet_decoder.h
@@ -165,9 +165,16 @@ class SelectiveTracePacketDecoder {
   bool has_compressed_packets() const {
     return decoder_.at<TracePacket::kCompressedPacketsFieldNumber>().valid();
   }
+  protozero::ConstBytes compressed_packets() const {
+    return decoder_.at<TracePacket::kCompressedPacketsFieldNumber>().as_bytes();
+  }
   bool has_zstd_compressed_packets() const {
     return decoder_.at<TracePacket::kZstdCompressedPacketsFieldNumber>()
         .valid();
+  }
+  protozero::ConstBytes zstd_compressed_packets() const {
+    return decoder_.at<TracePacket::kZstdCompressedPacketsFieldNumber>()
+        .as_bytes();
   }
   bool has_synchronization_marker() const {
     return decoder_.at<TracePacket::kSynchronizationMarkerFieldNumber>()

--- a/src/trace_processor/read_trace.cc
+++ b/src/trace_processor/read_trace.cc
@@ -50,16 +50,7 @@ class SerializingProtoTraceReader : public ChunkedTraceReader {
 
   base::Status Parse(TraceBlobView blob) override {
     return tokenizer_.Tokenize(std::move(blob), [this](TraceBlobView packet) {
-      uint8_t buffer[protozero::proto_utils::kMaxSimpleFieldEncodedSize];
-
-      uint8_t* pos = buffer;
-      pos = protozero::proto_utils::WriteVarInt(kTracePacketTag, pos);
-      pos = protozero::proto_utils::WriteVarInt(packet.length(), pos);
-      output_->insert(output_->end(), buffer, pos);
-
-      output_->insert(output_->end(), packet.data(),
-                      packet.data() + packet.length());
-      return base::OkStatus();
+      return ParsePacket(std::move(packet));
     });
   }
 
@@ -67,6 +58,37 @@ class SerializingProtoTraceReader : public ChunkedTraceReader {
   void OnEventsFullyExtracted() override {}
 
  private:
+  base::Status ParsePacket(TraceBlobView packet) {
+    protos::pbzero::TracePacket::Decoder decoder(packet.data(),
+                                                 packet.length());
+    if (decoder.has_compressed_packets() ||
+        decoder.has_zstd_compressed_packets()) {
+      util::CompressionType codec;
+      protozero::ConstBytes field;
+      if (decoder.has_compressed_packets()) {
+        codec = util::CompressionType::kGzip;
+        field = decoder.compressed_packets();
+      } else {
+        codec = util::CompressionType::kZstd;
+        field = decoder.zstd_compressed_packets();
+      }
+      return tokenizer_.TokenizeCompressedPackets(
+          codec, packet.slice(field.data, field.size),
+          [this](TraceBlobView inner) {
+            return ParsePacket(std::move(inner));
+          });
+    }
+
+    uint8_t buffer[protozero::proto_utils::kMaxSimpleFieldEncodedSize];
+    uint8_t* pos = buffer;
+    pos = protozero::proto_utils::WriteVarInt(kTracePacketTag, pos);
+    pos = protozero::proto_utils::WriteVarInt(packet.length(), pos);
+    output_->insert(output_->end(), buffer, pos);
+    output_->insert(output_->end(), packet.data(),
+                    packet.data() + packet.length());
+    return base::OkStatus();
+  }
+
   static constexpr uint8_t kTracePacketTag =
       protozero::proto_utils::MakeTagLengthDelimited(
           protos::pbzero::Trace::kPacketFieldNumber);

--- a/src/trace_processor/util/trace_blob_view_reader.cc
+++ b/src/trace_processor/util/trace_blob_view_reader.cc
@@ -41,8 +41,7 @@ void TraceBlobViewReader::PushBack(TraceBlobView data) {
   end_offset_ += size;
 }
 
-bool TraceBlobViewReader::PopFrontUntil(const size_t target_offset) {
-  PERFETTO_CHECK(start_offset() <= target_offset);
+bool TraceBlobViewReader::PopFrontUntilSlow(const size_t target_offset) {
   while (!data_.empty()) {
     Entry& entry = data_.front();
     if (target_offset == entry.start_offset) {
@@ -51,7 +50,8 @@ bool TraceBlobViewReader::PopFrontUntil(const size_t target_offset) {
     const size_t bytes_to_pop = target_offset - entry.start_offset;
     if (entry.data.size() > bytes_to_pop) {
       entry.data =
-          entry.data.slice_off(bytes_to_pop, entry.data.size() - bytes_to_pop);
+          std::move(entry.data)
+              .slice_off(bytes_to_pop, entry.data.size() - bytes_to_pop);
       entry.start_offset += bytes_to_pop;
       return true;
     }
@@ -130,7 +130,7 @@ auto TraceBlobViewReader::SliceOffImpl(const size_t offset,
   return visitor.Finalize(std::move(res));
 }
 
-std::optional<TraceBlobView> TraceBlobViewReader::SliceOff(
+std::optional<TraceBlobView> TraceBlobViewReader::SliceOffSlow(
     size_t offset,
     size_t length) const {
   struct Visitor {

--- a/src/trace_processor/util/trace_blob_view_reader.h
+++ b/src/trace_processor/util/trace_blob_view_reader.h
@@ -22,6 +22,7 @@
 #include <cstdio>
 #include <cstring>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include "perfetto/base/logging.h"
@@ -171,7 +172,22 @@ class TraceBlobViewReader {
   //  * if `offset` < 'file_offset()' this method will CHECK fail.
   //  * calling this function invalidates all iterators created from this
   //  reader.
-  bool PopFrontUntil(size_t offset);
+  bool PopFrontUntil(size_t target_offset) {
+    PERFETTO_CHECK(start_offset() <= target_offset);
+    // Nearly every pop stays inside the first chunk.
+    if (PERFETTO_LIKELY(!data_.empty())) {
+      Entry& entry = data_.front();
+      size_t bytes_to_pop = target_offset - entry.start_offset;
+      if (PERFETTO_LIKELY(bytes_to_pop < entry.data.size())) {
+        entry.data =
+            std::move(entry.data)
+                .slice_off(bytes_to_pop, entry.data.size() - bytes_to_pop);
+        entry.start_offset += bytes_to_pop;
+        return true;
+      }
+    }
+    return PopFrontUntilSlow(target_offset);
+  }
 
   // Shrinks the buffer by dropping `bytes` from the front of the buffer. If not
   // enough data is present as much data as possible will be dropped and `false`
@@ -214,7 +230,20 @@ class TraceBlobViewReader {
   // allocate a new chunk of memory and copy over the data instead.
   //
   // NOTE: If `offset` < 'file_offset()' this method will CHECK fail.
-  std::optional<TraceBlobView> SliceOff(size_t offset, size_t length) const;
+  std::optional<TraceBlobView> SliceOff(size_t offset, size_t length) const {
+    // Nearly every slice lies inside the first chunk; the rest is stitched
+    // out of line.
+    if (PERFETTO_LIKELY(!data_.empty() && length != 0)) {
+      const Entry& entry = data_.front();
+      // An |offset| before the chunk wraps |rel_off| past |size|.
+      size_t rel_off = offset - entry.start_offset;
+      size_t size = entry.data.size();
+      if (PERFETTO_LIKELY(rel_off <= size && length <= size - rel_off)) {
+        return entry.data.slice_off(rel_off, length);
+      }
+    }
+    return SliceOffSlow(offset, length);
+  }
 
   // Similar to SliceOff but this method will not combine slices but instead
   // potentially return multiple chunks. Useful if we are extracting slices to
@@ -235,6 +264,9 @@ class TraceBlobViewReader {
   bool empty() const { return data_.empty(); }
 
  private:
+  bool PopFrontUntilSlow(size_t target_offset);
+  std::optional<TraceBlobView> SliceOffSlow(size_t offset, size_t length) const;
+
   template <typename Visitor>
   auto SliceOffImpl(size_t offset, size_t length, Visitor& visitor) const;
 


### PR DESCRIPTION
Detect compressed bundles using the reader's existing decoder and read
contiguous packet headers directly. Retain validated sequence lookups
and inline the common single-chunk reader operations to reduce
per-packet work.

Move-slice blob views when consuming bytes so ownership transfers
without refcount updates or a separate consumed-byte offset. Keep
individual packet field checks instead of maintaining a second inventory
of rare fields.

On the interned buildprof trace, against its parent:
- Wall time: 21.55s -> 20.53s (-4.7%).
- User instructions: 323.492G -> 293.280G (-9.34%).
- Executable .text: 8,905,154 -> 8,906,946 bytes (+1,792).