### PR TITLE
tp: Remove 'Unknown field in merged class' DLOG message from deobfuscator

### DIFF
--- a/src/trace_processor/util/deobfuscation/deobfuscator.cc
+++ b/src/trace_processor/util/deobfuscation/deobfuscator.cc
@@ -155,13 +155,7 @@ base::Status ParseMergedClass(SimpleJsonParser& parser,
       }
       return FieldResult::Handled{};
     }
-    FieldResult res =
-        ParseMergedClassesField(parser, key, out.nested_merged_classes);
-    if (!res.handled) {
-      PERFETTO_DLOG("Unknown field in merged class JSON: %.*s",
-                    static_cast<int>(key.size()), key.data());
-    }
-    return res;
+    return ParseMergedClassesField(parser, key, out.nested_merged_classes);
   });
 }
 


### PR DESCRIPTION
This is not actionable and creates log spam for each merged classes comment in the proguard.map file.