### PR TITLE
ui: Gracefully handle WebGL context loss and restoration

### DIFF
--- a/ui/src/base/dom_utils.ts
+++ b/ui/src/base/dom_utils.ts
@@ -129,6 +129,20 @@ export function bindEventListener<K extends keyof HTMLElementEventMap>(
   event: K,
   handler: (event: HTMLElementEventMap[K]) => void,
   options?: AddEventListenerOptions,
+): Disposable;
+export function bindEventListener<K extends string>(
+  element: EventTarget,
+  event: K,
+  handler: (
+    event: K extends keyof HTMLElementEventMap ? HTMLElementEventMap[K] : Event,
+  ) => void,
+  options?: AddEventListenerOptions,
+): Disposable;
+export function bindEventListener(
+  element: EventTarget,
+  event: string,
+  handler: (event: Event) => void,
+  options?: AddEventListenerOptions,
 ): Disposable {
   element.addEventListener(event, handler as EventListener, options);
   return {

--- a/ui/src/widgets/virtual_overlay_canvas.ts
+++ b/ui/src/widgets/virtual_overlay_canvas.ts
@@ -32,7 +32,7 @@
 import './virtual_overlay_canvas.scss';
 import m from 'mithril';
 import {DisposableStack} from '../base/disposable_stack';
-import {findRef, toHTMLElement} from '../base/dom_utils';
+import {bindEventListener, findRef, toHTMLElement} from '../base/dom_utils';
 import type {Rect2D, Size2D} from '../base/geom';
 import {ensureExists} from '../base/assert';
 import {VirtualCanvas} from '../base/virtual_canvas';
@@ -195,6 +195,7 @@ export class VirtualOverlayCanvas implements m.ClassComponent<VirtualOverlayCanv
 
     // Create the canvas rendering context
     this.ctx = ensureExists(virtualCanvas.canvasElement.getContext('2d'));
+    const ctx = this.ctx;
 
     // Create WebGL canvas if enabled
     if (attrs.enableWebGL) {
@@ -219,19 +220,29 @@ export class VirtualOverlayCanvas implements m.ClassComponent<VirtualOverlayCanv
       });
       if (webglCtx) {
         this.webglRenderer = new WebGLRenderer(this.ctx, webglCtx);
-        // Fail loudly if we lose context
-        const onContextLost = (e: Event) => {
-          const statusMessage =
-            (e as WebGLContextEvent).statusMessage || 'no status message';
-          throw new Error(`WebGL context lost: ${statusMessage}`);
-        };
-        this.webglCanvas.addEventListener('webglcontextlost', onContextLost);
-        this.trash.defer(() => {
-          this.webglCanvas?.removeEventListener(
+        this.trash.use(
+          bindEventListener(
+            this.webglCanvas,
             'webglcontextlost',
-            onContextLost,
-          );
-        });
+            (e: Event) => {
+              // Set the webgl renderer to undefined means that the canvas
+              // renderer will just be used instead.
+              this.webglRenderer = undefined;
+
+              // Calling preventDefault here allows tells the browser to send us
+              // a 'webglcontextrestored' event when context is restored.
+              e.preventDefault();
+            },
+          ),
+        );
+        this.trash.use(
+          bindEventListener(this.webglCanvas, 'webglcontextrestored', () => {
+            // Recreate the webgl renderer to continue rendering with WebGL.
+            // WebGL state such as buffers and textures shall be recrated lazily
+            // on first render.
+            this.webglRenderer = new WebGLRenderer(ctx, webglCtx);
+          }),
+        );
       }
     }
 


### PR DESCRIPTION
Instead of throwing an error on WebGL context loss, fall back to Canvas2DRenderer by clearing webglRenderer and call preventDefault() so the browser dispatches webglcontextrestored. Recreate the WebGL renderer when the context is restored.

Also update bindEventListener() to infer the event type conditionally when non-standard event names are passed.

## Testing

- Open up an instance of Perfetto + open a trace - you should see the timeline.
- Open up devtools and paste the following snippet - it should exhaust the browser's available contexts. Context should be lost and restored once you interact with the timeline again:

```js
for (let i = 0; i < 20; i++) {
  document.createElement('canvas').getContext('webgl2');
}
```

Fixes: b/559187709
