### PR TITLE
Allow unknown fields in trace summary specs

### DIFF
--- a/src/trace_processor/trace_summary/summary.cc
+++ b/src/trace_processor/trace_summary/summary.cc
@@ -912,7 +912,8 @@ base::Status Summarize(TraceProcessor* processor,
                 kTraceSummaryDescriptor.data(), kTraceSummaryDescriptor.size(),
                 ".perfetto.protos.TraceSummarySpec", "-",
                 std::string_view(reinterpret_cast<const char*>(specs[i].ptr),
-                                 specs[i].size)));
+                                 specs[i].size),
+                /*allow_unknown_fields=*/true));
         spec_decoders.emplace_back(synthetic_protos.back().data(),
                                    synthetic_protos.back().size());
         break;


### PR DESCRIPTION
- Enable this directly in the C++ parser for now to skip custom annotations as those seem to be the more common use case.

- An API option can be added later if callers need strict validation.

Bug: 559483409