### PR TITLE
ui: Fix integer overflow in slice minimap

### DIFF
--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -853,12 +853,13 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
               SELECT
                 bucket,
                 upid,
-                IFNULL(SUM(utid_sum) / CAST(${resolution} AS FLOAT), 0) AS load
+                SUM(utid_load) AS load
               FROM thread
               INNER JOIN (
                 SELECT
                   IFNULL(CAST((ts - ${traceSpan.start}) / ${resolution} AS INT), 0) AS bucket,
-                  SUM(dur) AS utid_sum,
+                  -- Divide before summing to avoid overflowing duration totals.
+                  SUM(dur / CAST(${resolution} AS FLOAT)) AS utid_load,
                   utid
                 FROM slice
                 INNER JOIN thread_track ON slice.track_id = thread_track.id


### PR DESCRIPTION
- Divide durations by the resolution as floats before summing.
- Avoid overflow in thread and process totals.
- Rename utid_sum to utid_load to reflect the normalized values.
- Remove the redundant IFNULL around the load sum.
  Durations are non-null, resolution is positive, and groups contain rows.

```
Error stack:
Traceback (most recent call last):
  File "stdin" line 2 col 15
    SELECT
    ^
integer overflow
EngineTag: dev.perfetto.TraceProcessorTrack
- WasmEngineProxy.query (../../src/trace_processor/engine.ts:621:6)
- async EngineProxy.query (../../src/trace_processor/engine.ts:821:4)
- async Object.getData (../../src/plugins/dev.perfetto.TraceProcessorTrack/index.ts:800:8)
- async MinimapManagerImpl.load (../../src/core/minimap_manager.ts:56:4)
- async loadTraceIntoEngine (../../src/core/load_trace.ts:291:2)
- async loadTrace (../../src/core/load_trace.ts:147:2)
- async Object.work (../../src/core/app_impl.ts:267:8)
- async AsyncLimiter.runTaskQueue (../../src/base/async_limiter.ts:65:10)
- ```

Bug: 559323830