### PR TITLE
ui: Use number instead of bigint for Day Explorer track IDs

### DIFF
--- a/docs/AGENTS-ui.md
+++ b/docs/AGENTS-ui.md
@@ -360,22 +360,24 @@ async onTraceLoad(trace: Trace): Promise<void> {
 
 ### Prefer `NUM` (number) over `LONG` (bigint) for TraceProcessor ID fields
 
-When pulling out TraceProcessor ID columns (e.g. `track_id`, `upid`, `utid`, `slice.id`, `process_id`), use `NUM`/`NUM_NULL` and `number` instead of `LONG`/`LONG_NULL` and `bigint`:
+When pulling out TraceProcessor-assigned ID columns (e.g. `track_id`, `upid`, `utid`, `slice.id`), use `NUM`/`NUM_NULL` and `number` instead of `LONG`/`LONG_NULL` and `bigint`:
 
 ```typescript
 const iter = result.iter({
-  track_id: NUM,   // number — preferred for IDs
-  // track_id: LONG, // bigint — avoid for IDs
+  track_id: NUM,   // GOOD: number — preferred for IDs
+  // track_id: LONG, // BAD: bigint — avoid for IDs
 });
 ```
 
-TraceProcessor IDs are assigned sequentially by the engine, so they are small integers guaranteed to fit well within the 2^53 limit of JS `number`s (the largest safe integer). Using `number` avoids the awkwardness of `bigint` arithmetic and comparisons (`1n !== 1`), the need for `Number()`/`BigInt()` conversions at boundaries (e.g. track tags, URLs, JSON), lets the query result decode into a `Float64Array` instead of a `BigInt64Array`, and avoids the performance hit of `bigint` operations, which are significantly slower than native number ops.
+TraceProcessor IDs are assigned sequentially by the engine, so they are small integers guaranteed to fit well within the 2^53 limit of JS `number`s (the largest safe integer). Using `number` avoids the awkwardness of `bigint` arithmetic and comparisons (`1n !== 1`), the need for `Number()`/`BigInt()` conversions at boundaries (e.g. track tags, URLs, JSON), and avoids the performance hit of `bigint` operations, which are significantly slower than number ops.
 
-**When to use `LONG`**: timestamps (`ts`) and durations (`dur`) in nanoseconds should use `LONG`/`bigint`, as they can genuinely exceed 2^53 — e.g. a timestamp in ns overflows once the trace clock passes ~262 days, and large `dur` values or arithmetic on ns timestamps (deltas, sums) can exceed it well before that. `bigint` is the only safe representation for those values.
+### Prefer `LONG` (bigint) over `NUM` (number) for timestamps and durations
+
+Timestamps (`ts`) and durations (`dur`) in nanoseconds should use `LONG`/`bigint`, as they can genuinely exceed 2^53 — e.g. a ns timestamp overflows once the trace spans ~104 days (2^53 ns), and arithmetic on ns values (e.g. sums) can exceed it well before that. `bigint` is the only safe representation for those values.
 
 ### Keep times and durations as `Time`/`Duration` where possible
 
-The UI has first-class types for these values in `ui/src/base/time.ts`: the branded `time` type (via the `Time` class) and `duration` (via the `Duration` class). When pulling `ts`/`dur` (or any ns timestamp/duration) out of a query result, immediately convert to these types rather than passing raw `bigint`s around:
+The UI has first-class types for these values in `ui/src/base/time.ts`: the branded `time` type (via the `Time` class) and `duration`, which is a type alias for `bigint` (via the `Duration` class). When pulling `ts`/`dur` (or any ns timestamp/duration) out of a query result, immediately convert to these types rather than passing raw `bigint`s around:
 
 ```typescript
 const iter = result.iter({
@@ -389,7 +391,7 @@ for (; iter.valid(); iter.next()) {
 }
 ```
 
-The branded `time` type prevents accidentally mixing up times and durations (or plain bigints) at compile time, and both types provide helpers for arithmetic, formatting, and clamping. Only hold raw `bigint`s at the query boundary; convert to `Time`/`Duration` as soon as you leave the query iteration.
+Because `time` is branded, TypeScript will reject passing a `duration` or plain `bigint` where a `time` is expected (and vice versa), catching time/duration mixups at compile time. Both classes also provide helpers for arithmetic and formatting (e.g. `Time.add`/`Time.clamp`, `Duration.humanise`/`Duration.format`, `Timecode`). Only hold raw `bigint`s at the query boundary; convert to `Time`/`Duration` as soon as you leave the query iteration.
 
 ## Track creation
 

--- a/docs/AGENTS-ui.md
+++ b/docs/AGENTS-ui.md
@@ -358,6 +358,39 @@ async onTraceLoad(trace: Trace): Promise<void> {
 }
 ```
 
+### Prefer `NUM` (number) over `LONG` (bigint) for TraceProcessor ID fields
+
+When pulling out TraceProcessor ID columns (e.g. `track_id`, `upid`, `utid`, `slice.id`, `process_id`), use `NUM`/`NUM_NULL` and `number` instead of `LONG`/`LONG_NULL` and `bigint`:
+
+```typescript
+const iter = result.iter({
+  track_id: NUM,   // number — preferred for IDs
+  // track_id: LONG, // bigint — avoid for IDs
+});
+```
+
+TraceProcessor IDs are assigned sequentially by the engine, so they are small integers guaranteed to fit well within the 2^53 limit of JS `number`s (the largest safe integer). Using `number` avoids the awkwardness of `bigint` arithmetic and comparisons (`1n !== 1`), the need for `Number()`/`BigInt()` conversions at boundaries (e.g. track tags, URLs, JSON), lets the query result decode into a `Float64Array` instead of a `BigInt64Array`, and avoids the performance hit of `bigint` operations, which are significantly slower than native number ops.
+
+**When to use `LONG`**: timestamps (`ts`) and durations (`dur`) in nanoseconds should use `LONG`/`bigint`, as they can genuinely exceed 2^53 — e.g. a timestamp in ns overflows once the trace clock passes ~262 days, and large `dur` values or arithmetic on ns timestamps (deltas, sums) can exceed it well before that. `bigint` is the only safe representation for those values.
+
+### Keep times and durations as `Time`/`Duration` where possible
+
+The UI has first-class types for these values in `ui/src/base/time.ts`: the branded `time` type (via the `Time` class) and `duration` (via the `Duration` class). When pulling `ts`/`dur` (or any ns timestamp/duration) out of a query result, immediately convert to these types rather than passing raw `bigint`s around:
+
+```typescript
+const iter = result.iter({
+  ts: LONG,
+  dur: LONG,
+});
+
+for (; iter.valid(); iter.next()) {
+  const start = Time.fromRaw(iter.ts);      // time (branded bigint)
+  const dur = Duration.fromRaw(iter.dur);   // duration
+}
+```
+
+The branded `time` type prevents accidentally mixing up times and durations (or plain bigints) at compile time, and both types provide helpers for arithmetic, formatting, and clamping. Only hold raw `bigint`s at the query boundary; convert to `Time`/`Duration` as soon as you leave the query iteration.
+
 ## Track creation
 
 Rarely you need to create a new Track from scratch.

--- a/ui/src/plugins/com.android.DayExplorer/index.ts
+++ b/ui/src/plugins/com.android.DayExplorer/index.ts
@@ -19,7 +19,7 @@ import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import type {PerfettoPlugin} from '../../public/plugin';
 import {CounterTrack} from '../../components/tracks/counter_track';
 import {TrackNode} from '../../public/workspace';
-import {STR, LONG, LONG_NULL} from '../../trace_processor/query_result';
+import {STR, LONG, LONG_NULL, NUM} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {type AreaSelection, areaSelectionsEqual} from '../../public/selection';
 import {
@@ -71,14 +71,14 @@ export default class DayExplorerPlugin implements PerfettoPlugin {
     );
 
     const group = support.getOrCreateGroup(ctx, groupName);
-    await this.addDayExplorerRecursive(ctx, group, limit, -1n);
+    await this.addDayExplorerRecursive(ctx, group, limit, -1);
   }
 
   private async addDayExplorerRecursive(
     ctx: Trace,
     parent: TrackNode,
     limit: number,
-    parentId: bigint,
+    parentId: number,
   ): Promise<void> {
     const children = await ctx.engine.query(`
       SELECT track_id, display_name, cast(round(total_energy_uws / 3600000) as int) as energy_mwh
@@ -90,7 +90,7 @@ export default class DayExplorerPlugin implements PerfettoPlugin {
     `);
 
     const childIter = children.iter({
-      track_id: LONG,
+      track_id: NUM,
       display_name: STR,
       energy_mwh: LONG,
     });
@@ -121,7 +121,7 @@ export default class DayExplorerPlugin implements PerfettoPlugin {
     name: string,
     groupKey: string,
     query: string,
-    trackId: bigint,
+    trackId: number,
   ): Promise<TrackNode> {
     const uri = `/day_explorer_${uuidv4()}`;
     const renderer = await CounterTrack.createMaterialized({
@@ -136,7 +136,7 @@ export default class DayExplorerPlugin implements PerfettoPlugin {
       renderer,
       tags: {
         kinds: [DAY_EXPLORER_TRACK_KIND],
-        trackId: Number(trackId),
+        trackId: trackId,
       },
     });
 
@@ -188,7 +188,7 @@ export default class DayExplorerPlugin implements PerfettoPlugin {
     // selection. The selection is used to filter by time, and we filter the graph
     // to only include energy from the selected tracks and their recursive descendants.
     // If a physical track is selected, we exclude label roots to avoid double-counting.
-    const selectedTrackIds: bigint[] = [];
+    const selectedTrackIds: number[] = [];
 
     for (const trackInfo of currentSelection.tracks) {
       if (
@@ -196,8 +196,8 @@ export default class DayExplorerPlugin implements PerfettoPlugin {
         trackInfo.tags.trackId !== undefined
       ) {
         const trackId = trackInfo.tags.trackId;
-        if (typeof trackId === 'string' || typeof trackId === 'number') {
-          selectedTrackIds.push(BigInt(trackId));
+        if (typeof trackId === 'number') {
+          selectedTrackIds.push(trackId);
         }
       }
     }


### PR DESCRIPTION
In day explorer, track ids are being cast as bigints in various places, however track ids are small integers so the bigint round-trip and Number() conversions are unnecessary.

Use NUM and plain numbers throughout, and drop the dead string branch when reading the tag from the selection.

Also adds guidance to docs/AGENTS-ui.md: prefer NUM/number over LONG/bigint for sequential TraceProcessor ID fields, reserve LONG for ns timestamps/durations that can exceed 2^53, and convert query results to the Time/Duration types via fromRaw() as soon as they leave the query iteration.