### PR TITLE
stdlib: fix lock attribution in android.lock_held stdlib module

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/lock_held.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/lock_held.sql
@@ -96,15 +96,19 @@ WITH
       (
         _android_lock_held_raw,
         (
-          SELECT id, ts, dur, blocking_utid AS utid
+          SELECT id, ts, dur, lock_name, blocking_utid AS utid
           FROM android_monitor_contention
-          WHERE blocking_utid IS NOT NULL
+          WHERE blocking_utid IS NOT NULL AND lock_name IS NOT NULL
         )
       ),
-      (utid)
+      (lock_name, utid)
     ) AS ii
     JOIN android_monitor_contention AS mc
       ON mc.id = ii.id_1
+    JOIN _android_lock_held_raw AS raw
+      ON raw.id = ii.id_0
+    WHERE
+      mc.ts >= raw.ts
     GROUP BY
       held_id
   )


### PR DESCRIPTION
Partition interval intersection on (lock_name, utid) rather than utid alone to avoid attributing monitor contention from one lock (e.g. ams) to another concurrently held lock (e.g. wms) on the same thread.

Additionally, require that the monitor contention slice started at or after the lock held start time `(mc.ts >= raw.ts)` so that point-in-time blocking method samples taken prior to this lock hold are not erroneously attributed.

BUG=b/559488910
