### PR TITLE
perfetto_cmd: protect persistent traces against duplicate session names

### DIFF
--- a/src/perfetto_cmd/perfetto_cmd.h
+++ b/src/perfetto_cmd/perfetto_cmd.h
@@ -161,7 +161,7 @@ class PerfettoCmd : public Consumer {
       int fd,
       const base::ScopedMmap& mmap,
       const std::string& file_name);
-  static void WaitForPreviousRebootTraceUpload(
+  static base::Status WaitForRebootTraceUploadOrCleanup(
       const std::string& session_name,
       const std::string& target_file_path);
   static std::optional<TraceConfig> ParseTraceConfigFromMmapedTrace(

--- a/src/perfetto_cmd/perfetto_cmd_android.cc
+++ b/src/perfetto_cmd/perfetto_cmd_android.cc
@@ -16,6 +16,7 @@
 
 #include "src/perfetto_cmd/perfetto_cmd.h"
 
+#include <sys/file.h>
 #include <sys/sendfile.h>
 #include <sys/system_properties.h>
 
@@ -204,7 +205,10 @@ void PerfettoCmd::ReportTraceToAndroidFrameworkOrCrash() {
   }
 
   if (!persistent_file_path_.empty()) {
-    PERFETTO_CHECK(!unlink(persistent_file_path_.c_str()));
+    // Explicitly release the advisory lock before unlinking the file.
+    flock(trace_fd, LOCK_UN);
+    PERFETTO_CHECK(unlink(persistent_file_path_.c_str()) == 0 ||
+                   errno == ENOENT);
   }
 }
 
@@ -284,15 +288,16 @@ base::ScopedFile PerfettoCmd::CreateUnlinkedTmpFile() {
   return fd;
 }
 
-void PerfettoCmd::WaitForPreviousRebootTraceUpload(
+base::Status PerfettoCmd::WaitForRebootTraceUploadOrCleanup(
     const std::string& session_name,
     const std::string& target_file_path) {
   // Only block if a persistent trace file with the SAME session name exists on
   // disk.
   if (!base::FileExists(target_file_path)) {
-    return;
+    return base::OkStatus();
   }
 
+  // Wait for after reboot task to unlink traces.
   const auto deadline = base::GetBootTimeNs() + kBootTraceCleanupTimeoutNs;
   std::string cur_prop;
   do {
@@ -301,6 +306,29 @@ void PerfettoCmd::WaitForPreviousRebootTraceUpload(
       base::SleepMicroseconds(500 * 1000);
     }
   } while (cur_prop.empty() && base::GetBootTimeNs() < deadline);
+
+  if (!base::FileExists(target_file_path)) {
+    return base::OkStatus();
+  }
+
+  // File exists after waiting for reboot task. Check if an active session is
+  // holding the lock before doing any cleanup.
+  {
+    base::ScopedFile existing_fd =
+        base::OpenFile(target_file_path, O_RDWR | O_CLOEXEC);
+    if (existing_fd) {
+      if (flock(existing_fd.get(), LOCK_EX | LOCK_NB) != 0) {
+        if (errno == EWOULDBLOCK || errno == EAGAIN) {
+          return base::ErrStatus(
+              "A persistent tracing session for '%s' is already running (%s is "
+              "locked).",
+              session_name.c_str(), target_file_path.c_str());
+        }
+        PERFETTO_PLOG("Failed to check flock on %s", target_file_path.c_str());
+      }
+      existing_fd.reset();
+    }
+  }
 
   if (cur_prop.empty()) {
     android_stats::MaybeLogUploadEvent(
@@ -311,21 +339,20 @@ void PerfettoCmd::WaitForPreviousRebootTraceUpload(
         "Timed out waiting for uploader to set property status for session "
         "'%s'! Unlinked '%s'.",
         session_name.c_str(), target_file_path.c_str());
-    return;
-  }
-
-  // If property is set, but the persistent trace file STILL exists on disk,
-  // log error and unlink file.
-  if (base::FileExists(target_file_path)) {
+  } else {
+    // If property is set, but the persistent trace file STILL exists on disk,
+    // and not used by other sessions, log error and unlink file.
     android_stats::MaybeLogUploadEvent(
         PerfettoStatsdAtom::kRebootTraceUploadLeftover, /*uuid_lsb=*/0,
         /*uuid_msb=*/0, session_name);
     remove(target_file_path.c_str());
     PERFETTO_ELOG(
         "Persistent trace file '%s' still exists on disk even though property "
-        "is set to '%s'! Unlinked file.",
+        "is set to '%s'! A previous crash or failed reboot cleanup may have "
+        "left this file behind. Unlinked file.",
         target_file_path.c_str(), cur_prop.c_str());
   }
+  return base::OkStatus();
 }
 
 // static
@@ -337,22 +364,31 @@ base::ScopedFile PerfettoCmd::WaitForUploadCompleteAndCreatePersistentTmpFile(
   base::StackString<256> file_path("%s/%s.tmp", dir_path.c_str(),
                                    sanitized_name.c_str());
 
-  // Wait for any previous pending reboot trace upload for this session name to
-  // complete if the persistent trace file exists on disk.
-  WaitForPreviousRebootTraceUpload(sanitized_name, file_path.c_str());
-
-  // Unconditionally unlink any pre-existing file on disk before creating a new
-  // one. If another process (e.g. background uploader) is currently reading the
-  // previous file, unlinking preserves its open inode so the upload is not
-  // corrupted while allowing us to create a fresh file for the new session.
-  remove(file_path.c_str());
+  // Handle pre-existing persistent trace files (waiting for reboot uploader,
+  // detecting active sessions, and cleaning up leftovers from crashes).
+  base::Status status =
+      WaitForRebootTraceUploadOrCleanup(sanitized_name, file_path.c_str());
+  if (!status.ok()) {
+    PERFETTO_LOG("%s", status.c_message());
+    return base::ScopedFile();
+  }
 
   auto fd = base::OpenFile(file_path.c_str(),
                            O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0600);
   if (!fd) {
     PERFETTO_PLOG("Could not create persistent trace file %s",
                   file_path.c_str());
-  } else if (out_file_path) {
+    return fd;
+  }
+
+  // Acquire an advisory exclusive lock on the newly created persistent file so
+  // any future duplicate session knows this file is actively in use.
+  if (flock(fd.get(), LOCK_EX | LOCK_NB) != 0) {
+    PERFETTO_PLOG("Failed to acquire flock on persistent trace file %s",
+                  file_path.c_str());
+  }
+
+  if (out_file_path) {
     *out_file_path = file_path.c_str();
   }
   return fd;
@@ -444,6 +480,15 @@ int PerfettoCmd::UploadPersistentTracesAfterReboot() {
     if (!fd) {
       PERFETTO_PLOG("reboot-trace: Failed to open persistent trace %s",
                     full_path.c_str());
+    }
+    if (fd && flock(fd.get(), LOCK_EX | LOCK_NB) != 0) {
+      if (errno == EWOULDBLOCK || errno == EAGAIN) {
+        PERFETTO_LOG(
+            "reboot-trace: Persistent trace %s is locked by an active session, "
+            "skipping.",
+            full_path.c_str());
+        continue;
+      }
     }
     // Unlink immediately regardless of open status to guarantee disk cleanup.
     unlink(full_path.c_str());

--- a/src/perfetto_cmd/perfetto_cmd_unittest.cc
+++ b/src/perfetto_cmd/perfetto_cmd_unittest.cc
@@ -24,7 +24,10 @@
 #include "src/perfetto_cmd/packet_writer.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+#include <sys/file.h>
 #include <sys/system_properties.h>
+#include <sys/wait.h>
+#include "perfetto/ext/base/android_utils.h"
 #include "protos/perfetto/trace/android/recovered_trace_info.pbzero.h"
 #endif
 
@@ -72,11 +75,11 @@ class PerfettoCmdlineUnitTest : public ::testing::Test {
     return PerfettoCmd::TruncateAndAnnotatePersistentTrace(fd, mmap, file_name);
   }
 
-  static void WaitForPreviousRebootTraceUpload(
+  static base::Status WaitForRebootTraceUploadOrCleanup(
       const std::string& session_name,
       const std::string& target_file_path) {
-    PerfettoCmd::WaitForPreviousRebootTraceUpload(session_name,
-                                                  target_file_path);
+    return PerfettoCmd::WaitForRebootTraceUploadOrCleanup(session_name,
+                                                          target_file_path);
   }
 #endif
 };
@@ -431,15 +434,17 @@ TEST_F(PerfettoCmdlineUnitTest,
 }
 
 TEST_F(PerfettoCmdlineUnitTest,
-       WaitForPreviousRebootTraceUploadNonExistentFileReturnsImmediately) {
-  // Should return immediately when the .tmp trace file does not exist on disk
+       WaitForRebootTraceUploadOrCleanupNonExistentFileReturnsImmediately) {
+  // Should return immediately (true) when the .tmp trace file does not exist on
+  // disk
   std::string non_existent_path =
       "/data/misc/perfetto-traces/persistent/non_existent_session_9999.tmp";
   EXPECT_FALSE(base::FileExists(non_existent_path));
 
   auto start = base::GetBootTimeNs();
-  WaitForPreviousRebootTraceUpload("non_existent_session_9999",
-                                   non_existent_path);
+  EXPECT_TRUE(WaitForRebootTraceUploadOrCleanup("non_existent_session_9999",
+                                                non_existent_path)
+                  .ok());
   auto elapsed_ns = (base::GetBootTimeNs() - start).count();
 
   // Assert execution returns immediately (under 100 milliseconds)
@@ -447,17 +452,105 @@ TEST_F(PerfettoCmdlineUnitTest,
 }
 
 TEST_F(PerfettoCmdlineUnitTest,
-       WaitForPreviousRebootTraceUploadFileExistsWithPropertySetCleansUpFile) {
+       WaitForRebootTraceUploadOrCleanupActiveSessionPreservesFile) {
+  base::TempFile temp_file = base::TempFile::Create();
+  std::string path = temp_file.path();
+  temp_file.Unlink();
+  base::ScopedFile fd = base::OpenFile(path, O_CREAT | O_RDWR, 0600);
+  ASSERT_TRUE(fd);
+  ASSERT_EQ(flock(fd.get(), LOCK_EX | LOCK_NB), 0);
+
+  // Set property indicating reboot upload has already started or finished.
+  ASSERT_EQ(__system_property_set("traced.reboot_trace.status", "1:100000000"),
+            0)
+      << "Failed to set traced.reboot_trace.status. Ensure test runs as root.";
+  ASSERT_FALSE(base::GetAndroidProp("traced.reboot_trace.status").empty());
+
+  // Active session is holding the lock: Step 2 must return error status and NOT
+  // delete the file.
+  EXPECT_FALSE(
+      WaitForRebootTraceUploadOrCleanup("active_session_test", path).ok());
+  EXPECT_TRUE(base::FileExists(path));
+}
+
+TEST_F(PerfettoCmdlineUnitTest,
+       WaitForRebootTraceUploadOrCleanupStaleFileCleansUpLeftover) {
   base::TempFile temp_file = base::TempFile::Create();
   std::string path = temp_file.path();
   temp_file.Unlink();
   base::ScopedFile fd = base::OpenFile(path, O_CREAT | O_RDWR, 0600);
   EXPECT_TRUE(base::FileExists(path));
+  fd.reset();  // File is closed/unlocked (previous session dead/crashed)
 
-  // Set property indicating previous upload has started or finished
-  __system_property_set("traced.reboot_trace.status", "1:100000000");
+  // Set property indicating reboot upload has already started or finished.
+  ASSERT_EQ(__system_property_set("traced.reboot_trace.status", "1:100000000"),
+            0)
+      << "Failed to set traced.reboot_trace.status. Ensure test runs as root.";
+  ASSERT_FALSE(base::GetAndroidProp("traced.reboot_trace.status").empty());
 
-  WaitForPreviousRebootTraceUpload("finished_session_test", path);
+  EXPECT_TRUE(
+      WaitForRebootTraceUploadOrCleanup("crashed_session_test", path).ok());
+  // Stale file is cleaned up in Step 4 so new session can proceed.
+  EXPECT_FALSE(base::FileExists(path));
+}
+
+TEST_F(PerfettoCmdlineUnitTest, FlockDetectsActiveSessionOnExistingFile) {
+  base::TempFile temp_file = base::TempFile::Create();
+  std::string path = temp_file.path();
+  temp_file.Unlink();
+  base::ScopedFile fd1 = base::OpenFile(path, O_CREAT | O_RDWR, 0600);
+  ASSERT_TRUE(fd1);
+  ASSERT_EQ(flock(fd1.get(), LOCK_EX | LOCK_NB), 0);
+
+  // A second open should fail to acquire an exclusive non-blocking lock.
+  base::ScopedFile fd2 = base::OpenFile(path, O_RDWR);
+  ASSERT_TRUE(fd2);
+  EXPECT_EQ(flock(fd2.get(), LOCK_EX | LOCK_NB), -1);
+  EXPECT_TRUE(errno == EWOULDBLOCK || errno == EAGAIN);
+
+  // Releasing fd1 releases the lock, allowing fd2 to acquire it.
+  fd1.reset();
+  EXPECT_EQ(flock(fd2.get(), LOCK_EX | LOCK_NB), 0);
+}
+
+TEST_F(
+    PerfettoCmdlineUnitTest,
+    WaitForRebootTraceUploadOrCleanupProcessCrashReleasesLockAndCleansUpFile) {
+  base::TempFile temp_file = base::TempFile::Create();
+  std::string path = temp_file.path();
+  temp_file.Unlink();
+
+  // Fork a child process that creates the persistent file, acquires the
+  // exclusive flock, and then simulates an abnormal crash via abort().
+  pid_t pid = fork();
+  ASSERT_GE(pid, 0);
+  if (pid == 0) {
+    base::ScopedFile fd = base::OpenFile(path, O_CREAT | O_RDWR, 0600);
+    if (!fd || flock(fd.get(), LOCK_EX | LOCK_NB) != 0) {
+      _exit(1);
+    }
+    // Simulate process crash while holding the lock.
+    abort();
+  }
+
+  int status = 0;
+  ASSERT_EQ(waitpid(pid, &status, 0), pid);
+  EXPECT_TRUE(WIFSIGNALED(status));
+
+  // The child process crashed. The file still exists on disk, but the kernel
+  // automatically released its flock lock upon process termination.
+  EXPECT_TRUE(base::FileExists(path));
+
+  // Set property indicating reboot upload task has finished.
+  ASSERT_EQ(__system_property_set("traced.reboot_trace.status", "1:100000000"),
+            0)
+      << "Failed to set traced.reboot_trace.status. Ensure test runs as root.";
+  ASSERT_FALSE(base::GetAndroidProp("traced.reboot_trace.status").empty());
+
+  // A subsequent session should detect that no active process holds the lock,
+  // clean up the leftover file from the crashed session, and succeed.
+  EXPECT_TRUE(
+      WaitForRebootTraceUploadOrCleanup("after_crash_session", path).ok());
   EXPECT_FALSE(base::FileExists(path));
 }
 #endif


### PR DESCRIPTION
Use advisory file locks (flock) on persistent .tmp trace files to prevent duplicate
sessions with the same name from deleting or corrupting traces of an active session.

- Hold LOCK_EX on the persistent trace file while session is active.
- Skip unlinking and fail startup if an active session holds the lock.
- Skip reboot upload if file is locked by an active session.
- Add unit tests for duplicate session rejection and stale cleanup.

Bug: 382209797
Test: perfetto_unittests --gtest_filter="PerfettoCmdlineUnitTest.*"

