### PR TITLE
ui: add anew "compact" time format (9y8m7d6m5s4ms3us2ns)

### DIFF
--- a/ui/src/base/time.ts
+++ b/ui/src/base/time.ts
@@ -192,6 +192,12 @@ export class Time {
     return Time.toMicros(time).toString() + ' µs';
   }
 
+  // Format as a compact list of units relative to zero, e.g. "1h2m3s4ms".
+  static formatCompact(time: time): string {
+    const sign = time < 0 ? '-' : '';
+    return sign + Duration.format(BigintMath.abs(time), '');
+  }
+
   static toTimecode(time: time): Timecode {
     return new Timecode(time);
   }
@@ -295,7 +301,7 @@ export class Duration {
   }
 
   // Print duration with absolute precision.
-  static format(duration: duration): string {
+  static format(duration: duration, separator = ' '): string {
     let result = '';
     if (duration < 1) return '0s';
     const unitAndValue: [string, bigint][] = [
@@ -311,11 +317,11 @@ export class Duration {
     unitAndValue.forEach(([unit, unitSize]) => {
       if (duration >= unitSize) {
         const unitCount = duration / unitSize;
-        result += unitCount.toLocaleString() + unit + ' ';
+        result += unitCount.toLocaleString() + unit + separator;
         duration = duration % unitSize;
       }
     });
-    return result.slice(0, -1);
+    return result.slice(0, result.length - separator.length);
   }
 
   static formatSeconds(dur: duration): string {

--- a/ui/src/base/time_unittest.ts
+++ b/ui/src/base/time_unittest.ts
@@ -42,6 +42,16 @@ test('Duration.format', () => {
   expect(Duration.format(86_400_000_000_001n)).toEqual('1d 1ns');
   expect(Duration.format(31_536_000_000_000_000n)).toEqual('1y');
   expect(Duration.format(31_536_000_000_000_001n)).toEqual('1y 1ns');
+  expect(Duration.format(63_222_111_100n, '')).toEqual('1m3s222ms111µs100ns');
+});
+
+test('Time.formatCompact', () => {
+  expect(Time.formatCompact(t(0n))).toEqual('0s');
+  expect(Time.formatCompact(t(63_222_111_100n))).toEqual('1m3s222ms111µs100ns');
+  expect(Time.formatCompact(t(-63_222_111_100n))).toEqual(
+    '-1m3s222ms111µs100ns',
+  );
+  expect(Time.formatCompact(t(31_622_400_000_000_001n))).toEqual('1y1d1ns');
 });
 
 test('Duration.humanise', () => {

--- a/ui/src/components/time_utils.ts
+++ b/ui/src/components/time_utils.ts
@@ -38,6 +38,8 @@ export function formatDuration(trace: Trace, dur: duration): string {
     case TimestampFormat.Timecode:
     case TimestampFormat.CustomTimezone:
       return renderFormattedDuration(trace, dur);
+    case TimestampFormat.Compact:
+      return renderFormattedDuration(trace, dur, '');
     case TimestampFormat.TraceNs:
       return dur.toString();
     case TimestampFormat.TraceNsLocale:
@@ -54,13 +56,17 @@ export function formatDuration(trace: Trace, dur: duration): string {
   }
 }
 
-function renderFormattedDuration(trace: Trace, dur: duration): string {
+function renderFormattedDuration(
+  trace: Trace,
+  dur: duration,
+  separator = ' ',
+): string {
   const fmt = trace.timeline.durationPrecision;
   switch (fmt) {
     case DurationPrecision.HumanReadable:
       return Duration.humanise(dur);
     case DurationPrecision.Full:
-      return Duration.format(dur);
+      return Duration.format(dur, separator);
     default:
       const x: never = fmt;
       throw new Error(`Invalid format ${x}`);

--- a/ui/src/components/widgets/duration_precision_menu_items.ts
+++ b/ui/src/components/widgets/duration_precision_menu_items.ts
@@ -38,6 +38,7 @@ export class DurationPrecisionMenuItem implements m.ClassComponent<DurationPreci
         case TimestampFormat.Timecode:
         case TimestampFormat.UTC:
         case TimestampFormat.TraceTz:
+        case TimestampFormat.Compact:
           return true;
         default:
           return false;

--- a/ui/src/components/widgets/timestamp.ts
+++ b/ui/src/components/widgets/timestamp.ts
@@ -73,6 +73,8 @@ export class Timestamp implements m.ClassComponent<TimestampAttrs> {
       case TimestampFormat.Timecode:
       case TimestampFormat.CustomTimezone:
         return renderTimecode(time);
+      case TimestampFormat.Compact:
+        return Time.formatCompact(time);
       case TimestampFormat.TraceNs:
         return time.toString();
       case TimestampFormat.TraceNsLocale:

--- a/ui/src/components/widgets/timestamp_format_menu.ts
+++ b/ui/src/components/widgets/timestamp_format_menu.ts
@@ -49,6 +49,7 @@ export class TimestampFormatMenuItem implements m.ClassComponent<TimestampFormat
       renderMenuItem(TF.Seconds, 'Seconds'),
       renderMenuItem(TF.Milliseconds, 'Milliseconds'),
       renderMenuItem(TF.Microseconds, 'Microseconds'),
+      renderMenuItem(TF.Compact, 'Compact'),
       renderMenuItem(TF.TraceNs, 'Raw'),
       renderMenuItem(TF.TraceNsLocale, 'Raw (with locale-specific formatting)'),
       m(

--- a/ui/src/core/timeline.ts
+++ b/ui/src/core/timeline.ts
@@ -384,6 +384,7 @@ export class TimelineImpl implements Timeline {
       case TimestampFormat.Seconds:
       case TimestampFormat.Milliseconds:
       case TimestampFormat.Microseconds:
+      case TimestampFormat.Compact:
         return this.traceInfo.start;
       case TimestampFormat.TraceNs:
       case TimestampFormat.TraceNsLocale:

--- a/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
@@ -548,6 +548,7 @@ export default class CoreCommands implements PerfettoPlugin {
             {format: TF.Seconds, name: 'Seconds'},
             {format: TF.Milliseconds, name: 'Milliseconds'},
             {format: TF.Microseconds, name: 'Microseconds'},
+            {format: TF.Compact, name: 'Compact'},
             {format: TF.TraceNs, name: 'Trace nanoseconds'},
             {
               format: TF.TraceNsLocale,

--- a/ui/src/core_plugins/dev.perfetto.Timeline/minimap.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/minimap.ts
@@ -243,6 +243,9 @@ function renderTimestamp(
     case TimestampFormat.Microseconds:
       ctx.fillText(Time.formatMicroseconds(time), x, y, minWidth);
       break;
+    case TimestampFormat.Compact:
+      ctx.fillText(Time.formatCompact(time), x, y, minWidth);
+      break;
     default:
       assertUnreachable(fmt);
   }

--- a/ui/src/core_plugins/dev.perfetto.Timeline/time_axis_panel.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/time_axis_panel.ts
@@ -84,6 +84,8 @@ export class TimeAxisPanel {
         return Time.formatMilliseconds(start);
       case TimestampFormat.Microseconds:
         return Time.formatMicroseconds(start);
+      case TimestampFormat.Compact:
+        return Time.formatCompact(start);
       case TimestampFormat.TraceNs:
         return start.toString();
       case TimestampFormat.TraceNsLocale:
@@ -183,6 +185,14 @@ export class TimeAxisPanel {
         return renderRawTimestamp(
           ctx,
           Time.formatMicroseconds(time),
+          x,
+          y,
+          minWidth,
+        );
+      case TimestampFormat.Compact:
+        return renderRawTimestamp(
+          ctx,
+          Time.formatCompact(time),
           x,
           y,
           minWidth,

--- a/ui/src/core_plugins/dev.perfetto.Timeline/time_selection_panel.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/time_selection_panel.ts
@@ -366,6 +366,8 @@ export class TimeSelectionPanel {
         return Time.formatMilliseconds(time);
       case TimestampFormat.Microseconds:
         return Time.formatMicroseconds(time);
+      case TimestampFormat.Compact:
+        return Time.formatCompact(time);
       default:
         assertUnreachable(fmt);
     }

--- a/ui/src/public/timeline.ts
+++ b/ui/src/public/timeline.ts
@@ -26,6 +26,7 @@ export enum TimestampFormat {
   UTC = 'utc',
   CustomTimezone = 'customTimezone',
   TraceTz = 'traceTz',
+  Compact = 'compact',
 }
 
 export enum DurationPrecision {


### PR DESCRIPTION
Playing aroudn and honestly feel this is the nicest format. I would like
this to become the default eventually but for now an option is fine.