### PR TITLE
proto_merger: ignore LINT comments in proto_merger

### DIFF
--- a/src/tools/proto_merger/proto_file.cc
+++ b/src/tools/proto_merger/proto_file.cc
@@ -217,9 +217,25 @@ Output InitFromDescriptor(const Descriptor& desc) {
   if (!desc.GetSourceLocation(&source_loc))
     return {};
 
+  auto filter_lint_comments =
+      [](const std::vector<std::string>& lines) -> std::vector<std::string> {
+    std::vector<std::string> parsed;
+    for (const auto& line : lines) {
+      std::string t = base::TrimWhitespace(line);
+      if (base::StartsWith(t, "LINT.IfChange") ||
+          base::StartsWith(t, "LINT.ThenChange")) {
+        continue;
+      }
+      parsed.push_back(line);
+    }
+    return parsed;
+  };
+
   Output out;
-  out.leading_comments = base::SplitString(source_loc.leading_comments, "\n");
-  out.trailing_comments = base::SplitString(source_loc.trailing_comments, "\n");
+  out.leading_comments = filter_lint_comments(
+      base::SplitString(source_loc.leading_comments, "\n"));
+  out.trailing_comments = filter_lint_comments(
+      base::SplitString(source_loc.trailing_comments, "\n"));
   return out;
 }
 

--- a/src/tools/proto_merger/proto_file_serializer_unittest.cc
+++ b/src/tools/proto_merger/proto_file_serializer_unittest.cc
@@ -1289,6 +1289,41 @@ TEST(ExtensionProtoMergerTest, UnassociatedHelpersAreOmitted) {
   EXPECT_THAT(out, Not(HasSubstr("UnusedHelper")));
   EXPECT_THAT(out, Not(HasSubstr("OtherMessage")));
 }
+
+TEST(ProtoFileSerializerTest, IgnoresLintComments) {
+  base::TempDir temp_dir = base::TempDir::Create();
+  protozero::MultiFileErrorCollectorImpl mfe;
+
+  std::string proto_content = R"(
+    syntax = "proto2";
+    // LINT.IfChange
+    // This is a valid comment
+    message Foo {
+      optional int32 a = 1;
+    }
+    // LINT.ThenChange
+  )";
+
+  TempProtoFile temp_input(temp_dir.path(), "input.proto", proto_content);
+
+  google::protobuf::compiler::DiskSourceTree dst;
+  dst.MapPath("", temp_dir.path());
+  dst.MapPath("", ".");
+  dst.MapPath("", "buildtools/protobuf/src");
+
+  google::protobuf::compiler::Importer importer_input(&dst, &mfe);
+  const auto* input_desc = importer_input.Import("input.proto");
+
+  ASSERT_NE(input_desc, nullptr);
+
+  ProtoFile input_file = ProtoFileFromDescriptor("", *input_desc);
+  std::string out = ProtoFileToDotProto(input_file);
+
+  EXPECT_THAT(out, testing::HasSubstr("This is a valid comment"));
+  EXPECT_THAT(out, testing::Not(testing::HasSubstr("LINT.IfChange")));
+  EXPECT_THAT(out, testing::Not(testing::HasSubstr("LINT.ThenChange")));
+}
+
 }  // namespace
 }  // namespace proto_merger
 }  // namespace perfetto


### PR DESCRIPTION
LINT comments shouldn't be forwarded in automatically generated files, as they depend on the original sources and so can't be updated at the same with them.