### PR TITLE
ui: Merge slice pivot table into the slice flamegraph tab

### DIFF
--- a/ui/src/components/tree_explorer_panel.scss
+++ b/ui/src/components/tree_explorer_panel.scss
@@ -19,7 +19,8 @@
   overflow-y: hidden;
 
   > .pf-flamegraph,
-  > .pf-tree-explorer__grid {
+  > .pf-tree-explorer__grid,
+  > .pf-tree-explorer__extra-tab {
     flex: 1;
     min-height: 0;
   }

--- a/ui/src/components/tree_explorer_panel.ts
+++ b/ui/src/components/tree_explorer_panel.ts
@@ -20,7 +20,10 @@ import {Spinner} from '../widgets/spinner';
 import {Flamegraph, buildFlamegraphExportString} from '../widgets/flamegraph';
 import type {ExportDownloadItem} from '../widgets/export_button';
 import {TreeExplorerFilterBar} from '../widgets/tree_explorer_filter_bar';
-import {TreeExplorerViewSwitcher} from '../widgets/tree_explorer_view_switcher';
+import {
+  TreeExplorerViewSwitcher,
+  type TreeExplorerExtraTab,
+} from '../widgets/tree_explorer_view_switcher';
 import {
   computeHighlightRegex,
   createDefaultTreeExplorerState,
@@ -39,6 +42,13 @@ import {
   TreeExplorerTreeView,
   buildFlatExportString,
 } from './tree_explorer_table_views';
+
+// A host-provided tab shown in the panel's tab strip next to the built-in
+// display modes. Selecting it replaces the filter bar and the tree view with
+// the tab's own content, which is only rendered while the tab is active.
+export interface TreeExplorerPanelTab extends TreeExplorerExtraTab {
+  render(): m.Children;
+}
 
 export interface TreeExplorerPanelAttrs {
   // The fetcher supplying the tree, or undefined to show a pending state.
@@ -60,6 +70,22 @@ export interface TreeExplorerPanelAttrs {
   // Host-provided downloads shown alongside the built-in exports of the
   // displayed tree, for representations the panel cannot build itself.
   readonly extraDownloadItems?: ReadonlyArray<ExportDownloadItem>;
+
+  // Extra tabs plugged into the panel's tab strip, shown before the built-in
+  // tree views.
+  readonly extraTabs?: ReadonlyArray<TreeExplorerPanelTab>;
+
+  // Caller-owned key of the active extra tab; undefined shows the tree views.
+  // Owned by the caller (like `state`) so that it outlives the panel: extra
+  // tabs routinely come and go for a render or two while the host works out
+  // whether they apply, and hosts embedded in tab strips get remounted.
+  // A key with no matching tab falls back to the tree views without being
+  // forgotten: the tab reactivates as soon as it reappears.
+  readonly activeExtraTabKey?: string;
+
+  // Called with the extra tab the user switched to, or undefined when they
+  // switched back to one of the tree views.
+  readonly onActiveExtraTabChange?: (key: string | undefined) => void;
 }
 
 // The batteries-included tree explorer: composes the view switcher, the shared
@@ -79,8 +105,21 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
     const {fetcher, state = createDefaultTreeExplorerState(fetcher.metrics)} =
       attrs;
     const metrics = fetcher?.metrics;
+    const extraTabs = attrs.extraTabs ?? [];
+    // The active tab can be absent - either momentarily, while the host works
+    // out whether it applies to what's selected, or for good. Either way, show
+    // the tree views in the meantime; the key stays put in the host so the tab
+    // comes back if it does.
+    const activeExtraTab = extraTabs.find(
+      (t) => t.key === attrs.activeExtraTabKey,
+    );
+    // Don't spend queries on a tree nobody is looking at: `use()` is what
+    // schedules the work, so skipping it defers the fetch (the memo keeps
+    // whatever it already had) until a tree view is on screen again.
     const data =
-      fetcher !== undefined && state !== undefined
+      activeExtraTab === undefined &&
+      fetcher !== undefined &&
+      state !== undefined
         ? fetcher.use({...state, view: effectiveView(state)}).data
         : undefined;
 
@@ -97,12 +136,23 @@ export class TreeExplorerPanel implements m.ClassComponent<TreeExplorerPanelAttr
     );
     const highlightRegex = computeHighlightRegex(this.highlightPattern);
     const displayMode = shownState.displayMode;
+    const viewSwitcher = m(TreeExplorerViewSwitcher, {
+      state: shownState,
+      onStateChange: attrs.onStateChange,
+      extraTabs,
+      activeExtraTabKey: attrs.activeExtraTabKey,
+      onExtraTabChange: (key) => attrs.onActiveExtraTabChange?.(key),
+    });
+    if (activeExtraTab !== undefined) {
+      return m(
+        '.pf-tree-explorer',
+        viewSwitcher,
+        m('.pf-tree-explorer__extra-tab', activeExtraTab.render()),
+      );
+    }
     return m(
       '.pf-tree-explorer',
-      m(TreeExplorerViewSwitcher, {
-        state: shownState,
-        onStateChange: attrs.onStateChange,
-      }),
+      viewSwitcher,
       m(TreeExplorerFilterBar, {
         metrics: shownMetrics,
         state: shownState,

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -82,6 +82,9 @@ interface SliceFlamegraphData extends AsyncDisposable {
   readonly fetcher: TreeExplorerFetcher;
 }
 
+// Identifies the slice table sub-tab within the tree explorer's tab strip.
+const SLICE_TABLE_SUB_TAB_KEY = 'table';
+
 function createDetailsPanel(trace: Trace, utid: number | null) {
   if (utid === null) {
     return undefined;
@@ -647,9 +650,6 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
       createAggregationTab(ctx, new CounterSelectionAggregator()),
     );
     ctx.selection.registerAreaSelectionTab(
-      createAggregationTab(ctx, new ThreadSliceAggregator(ctx)),
-    );
-    ctx.selection.registerAreaSelectionTab(
       this.createSliceFlameGraphPanel(ctx),
     );
   }
@@ -658,9 +658,21 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
     const queue = new AtomicTaskQueue();
     const memo = new AsyncMemo<SliceFlamegraphData | undefined>(queue);
 
+    // The slice table is the same data as the flamegraph, just aggregated into
+    // a (pivotable) grid, so it lives as a sub-tab of the tree explorer rather
+    // than as a top-level area selection tab of its own.
+    const sliceTableTab = createAggregationTab(
+      trace,
+      new ThreadSliceAggregator(trace),
+    );
+    // The sub-tab lives out here, not in the panel, so that switching to the
+    // flamegraph (or back) sticks across selection changes, and across the
+    // panel being remounted as other area selection tabs come and go.
+    let activeSubTab: string | undefined = SLICE_TABLE_SUB_TAB_KEY;
+
     return {
       id: 'slice_flamegraph_selection',
-      name: 'Slice Flamegraph',
+      name: 'Slices',
       render: (selection: AreaSelection) => {
         const selectionKey = areaSelectionKey(selection);
         const {isPending, data: computed} = memo.use({
@@ -669,15 +681,20 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
           },
           compute: () => this.computeSliceFlamegraph(trace, queue, selection),
         });
+        const tableContent = sliceTableTab.render(selection);
 
         // No data returned, return undefined to hide the tab.
-        if (computed === undefined && !isPending) {
+        if (
+          computed === undefined &&
+          !isPending &&
+          tableContent === undefined
+        ) {
           return undefined;
         }
 
         const store = ensureExists(this.store);
         return {
-          isLoading: isPending,
+          isLoading: isPending || Boolean(tableContent?.isLoading),
           content:
             computed &&
             m(TreeExplorerPanel, {
@@ -688,7 +705,24 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
                   draft.areaSelectionFlamegraphState = state;
                 });
               },
+              extraTabs: removeFalsyValues([
+                tableContent && {
+                  key: SLICE_TABLE_SUB_TAB_KEY,
+                  title: 'Table',
+                  render: () => tableContent.content,
+                },
+              ]),
+              activeExtraTabKey: activeSubTab,
+              onActiveExtraTabChange: (key) => {
+                activeSubTab = key;
+              },
             }),
+          // The grid's export button lives in the details shell header, which
+          // only the top-level tab can populate.
+          buttons:
+            activeSubTab === SLICE_TABLE_SUB_TAB_KEY
+              ? tableContent?.buttons
+              : undefined,
         };
       },
     };

--- a/ui/src/widgets/tree_explorer_view_switcher.ts
+++ b/ui/src/widgets/tree_explorer_view_switcher.ts
@@ -16,14 +16,35 @@ import m from 'mithril';
 import {TabStrip} from './tab_strip';
 import type {TreeExplorerDisplayMode, TreeExplorerState} from './tree_explorer';
 
+// A host-provided tab shown next to the built-in display modes. Keys must not
+// collide with the built-in display modes ('flamegraph', 'tree', 'flat').
+export interface TreeExplorerExtraTab {
+  readonly key: string;
+  readonly title: string;
+}
+
 export interface TreeExplorerViewSwitcherAttrs {
   readonly state: TreeExplorerState;
   readonly onStateChange: (state: TreeExplorerState) => void;
   readonly className?: string;
+
+  // Extra tabs shown before the built-in display modes. Used by hosts that
+  // want to show a different view of the same data (e.g. a table) without
+  // spending a top-level tab on it.
+  readonly extraTabs?: ReadonlyArray<TreeExplorerExtraTab>;
+
+  // The key of the active extra tab. While set, none of the built-in display
+  // modes appear active.
+  readonly activeExtraTabKey?: string;
+
+  // Called with the key of the extra tab the user switched to, or undefined
+  // when they switched back to one of the built-in display modes.
+  readonly onExtraTabChange?: (key: string | undefined) => void;
 }
 
 // Switches a tree explorer between its display modes (flamegraph, call tree,
-// flat function table) by rewriting `state.displayMode`.
+// flat function table) by rewriting `state.displayMode`, plus any extra tabs
+// the host supplies.
 //
 // This is a free-standing widget on purpose: it only needs the caller-owned
 // state, so hosts with their own chrome (a DetailsShell header, an existing
@@ -33,15 +54,25 @@ export interface TreeExplorerViewSwitcherAttrs {
 // panel.
 export class TreeExplorerViewSwitcher implements m.ClassComponent<TreeExplorerViewSwitcherAttrs> {
   view({attrs}: m.CVnode<TreeExplorerViewSwitcherAttrs>): m.Children {
+    const extraTabs = attrs.extraTabs ?? [];
+    const activeExtraTab = extraTabs.find(
+      (t) => t.key === attrs.activeExtraTabKey,
+    );
     return m(TabStrip, {
       className: attrs.className,
       tabs: [
+        ...extraTabs.map(({key, title}) => ({key, title})),
         {key: 'flamegraph', title: 'Flamegraph'},
         {key: 'tree', title: 'Call Tree'},
         {key: 'flat', title: 'Functions'},
       ],
-      currentTabKey: attrs.state.displayMode,
+      currentTabKey: activeExtraTab?.key ?? attrs.state.displayMode,
       onTabChange: (key: string) => {
+        if (extraTabs.some((t) => t.key === key)) {
+          attrs.onExtraTabChange?.(key);
+          return;
+        }
+        attrs.onExtraTabChange?.(undefined);
         attrs.onStateChange({
           ...attrs.state,
           displayMode: key as TreeExplorerDisplayMode,


### PR DESCRIPTION
The slice flamegraph and the slice pivot table were two separate area selection tabs showing the same data in different shapes. Merge them into a single "Slices" tab: the tree explorer panel gained a slot for host-provided tabs, and the slice aggregation datagrid is pushed into it as a "Table" sub-tab alongside Flamegraph / Call Tree / Functions.

The table leads the sub-tab strip and is where the tab lands by default. The active sub-tab is caller-owned, so it sticks across selection changes and across the panel being remounted as other area selection tabs come and go. Tree data is now only fetched when one of the tree views is showing, so sitting on the table doesn't pay for the (much more expensive) flamegraph query on every selection change.

Fixes: https://github.com/google/perfetto/issues/7396