### PR TITLE
ui: [NOT FOR REVIEW] stream postMessage traces

### DIFF
--- a/docs/visualization/deep-linking-to-perfetto-ui.md
+++ b/docs/visualization/deep-linking-to-perfetto-ui.md
@@ -74,11 +74,13 @@ window. The message should be a JavaScript object with a single `perfetto` key:
 ```js
 {
   'perfetto': {
-    buffer: ArrayBuffer;
+    buffer?: ArrayBuffer;              // Exactly one of buffer or stream
+    stream?: ReadableStream;           // Exactly one of buffer or stream
+    bytesTotal?: number;               // Optional stream size
     title: string;
-    fileName?: string;    // Optional
-    url?: string;         // Optional
-    appStateHash?: string // Optional
+    fileName?: string;                 // Optional
+    url?: string;                      // Optional
+    appStateHash?: string              // Optional
   }
 }
 ```
@@ -86,7 +88,12 @@ window. The message should be a JavaScript object with a single `perfetto` key:
 The properties of the `perfetto` object are:
 
 - `buffer`: An `ArrayBuffer` containing the raw trace data. You would typically
-  get this by fetching a trace file from your backend.
+  get this by fetching a trace file from your backend. Exactly one of `buffer`
+  or `stream` is required.
+- `stream`: A transferred `ReadableStream` containing the trace data. Use this
+  to avoid loading the whole trace into memory before opening it.
+- `bytesTotal` (optional): The total stream size for progress reporting. Zero or
+  omitted means unknown.
 - `title`: A human-readable string that will be displayed as the title of the
   trace in the UI. This helps users distinguish between different traces if they
   have multiple tabs open.
@@ -96,6 +103,22 @@ The properties of the `perfetto` object are:
   below.
 - `appStateHash` (optional): A hash for restoring the UI state when sharing. See
   the "Sharing" section below.
+
+To transfer a stream, include it in the transfer list:
+
+```js
+const response = await fetch('/api/trace');
+const stream = response.body;
+handle.postMessage(
+    {perfetto: {stream, title: 'My trace', bytesTotal: 0}}, '*', [stream]);
+```
+
+The stream must be transferred as shown above and must not have been read first.
+The browser regulates how quickly the source produces data while Perfetto loads
+it. Streamed traces are not retained and therefore cannot be downloaded,
+shared, or cached. See the
+[embedding API reference](/docs/visualization/embedding-api-reference.md) for
+the precise stream requirements.
 
 ### Sharing traces and UI state
 
@@ -176,7 +199,8 @@ The source website must not be served with the
 
 The Perfetto UI is client-only and doesn't require any server-side interaction.
 Traces pushed via `postMessage()` are kept only in the browser memory/cache and
-are not sent to any server.
+are not sent to any server. Streamed traces are consumed while loading and are
+not added to the browser cache.
 
 ## Customizing the UI with URL parameters
 

--- a/docs/visualization/embedding-api-reference.md
+++ b/docs/visualization/embedding-api-reference.md
@@ -43,24 +43,39 @@ multiplex other traffic over the same channel.
 
 ## Opening a trace
 
-To open a trace, post an object with a single `perfetto` key:
+To open a trace, post an object with a single `perfetto` key. Pass exactly
+one of `buffer` or `stream`:
 
 ```js
 iframe.contentWindow.postMessage({perfetto: {buffer, title}}, '*');
+```
+
+A `ReadableStream` must be transferred. Backpressure propagates from trace
+parsing to the stream producer, bounding how far the producer can run ahead:
+
+```js
+iframe.contentWindow.postMessage(
+    {perfetto: {stream, title, bytesTotal}}, '*', [stream]);
 ```
 
 Fields of the `perfetto` object:
 
 | Field          | Type                                                      | Required | Default | Meaning                                                                                                                              |
 | -------------- | -------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `buffer`       | `ArrayBuffer`                                             | Yes      | -       | Raw trace bytes, e.g. from `fetch(...).then(r => r.arrayBuffer())`.                                                                  |
-| `title`        | `string`                                                 | Yes      | -       | Trace title shown in the UI.                                                                                                          |
+| `buffer`       | `ArrayBuffer`                                             | One of `buffer` or `stream` | - | Raw trace bytes, e.g. from `fetch(...).then(r => r.arrayBuffer())`.                                                  |
+| `stream`       | `ReadableStream<ArrayBuffer \| ArrayBufferView>`          | One of `buffer` or `stream` | - | Transferred stream of raw trace chunks.                                                                             |
+| `bytesTotal`   | `number`                                                  | No       | `0`     | Total stream size for progress reporting; `0` means unknown.                                                                          |
+| `title`        | `string`                                                  | Yes      | -       | Trace title shown in the UI.                                                                                                          |
 | `fileName`     | `string`                                                 | No       | -       | Suggested file name if the user downloads the trace.                                                                                 |
 | `url`          | `string`                                                 | No       | -       | Sharing URL. See sharing details in [Deep linking to the Perfetto UI](/docs/visualization/deep-linking-to-perfetto-ui.md).          |
 | `appStateHash` | `string`                                                 | No       | -       | 40-char hex hash; restores saved UI state from GCS. See [Deep linking to the Perfetto UI](/docs/visualization/deep-linking-to-perfetto-ui.md). |
 | `localOnly`    | `boolean`                                                | No       | `true`  | Defaults to `true` for posted traces, which disables download and share. Set `false` to enable them.                                |
 | `keepApiOpen`  | `boolean`                                                | No       | `false` | If `true`, the listener stays active so the host can post more traces later. If `false`/omitted, the handler removes its own message listener after the first trace (avoids duplicate posts, b/182502595). |
 | `pluginArgs`   | `{[pluginId: string]: {[key: string]: unknown}}`         | No       | -       | Passed to plugins' `onTraceLoad()`.                                                                                                  |
+
+Streamed traces are not retained after parsing, so they cannot be downloaded,
+shared, or cached. `fileName`, `url`, `localOnly`, and `pluginArgs` therefore do
+not apply to streams.
 
 ### Bare ArrayBuffer shorthand
 

--- a/docs/visualization/embedding-the-ui.md
+++ b/docs/visualization/embedding-the-ui.md
@@ -70,8 +70,8 @@ function waitForReady() {
 ## Step 3: Post the trace
 
 Once the handshake completes, post an object with a single `perfetto` key to the
-iframe's `contentWindow`. Only `buffer` (an `ArrayBuffer` of raw trace bytes) and
-`title` are required:
+iframe's `contentWindow`. Pass `title` and exactly one of `buffer` (an
+`ArrayBuffer` of raw trace bytes) or `stream` (a transferred `ReadableStream`):
 
 ```js
 async function openTrace() {
@@ -96,7 +96,12 @@ async function openTrace() {
 
 The full set of fields on the `perfetto` object:
 
-- `buffer` (required): `ArrayBuffer` of raw trace bytes.
+- `buffer`: `ArrayBuffer` of raw trace bytes. Exactly one of `buffer` or `stream`
+  is required.
+- `stream`: transferred `ReadableStream` containing the trace data. Exactly one
+  of `buffer` or `stream` is required.
+- `bytesTotal` (optional): total stream size used for progress reporting. Zero
+  or omitted means unknown.
 - `title` (required): string shown as the trace title.
 - `fileName` (optional): suggested name if the user downloads the trace.
 - `url` (optional): sharing URL. See [Deep linking](/docs/visualization/deep-linking-to-perfetto-ui.md)
@@ -117,6 +122,35 @@ the first trace.
 TIP: A bare `ArrayBuffer` is also accepted (the UI treats it as a trace titled
 "External trace"), but posting the `{ perfetto: { buffer, title } }` object is
 preferred so you control the title.
+
+### Stream a trace without buffering the whole file
+
+For a large trace, pass the response body directly instead of first converting
+it to an `ArrayBuffer`:
+
+```js
+async function openTraceStream() {
+  await waitForReady();
+
+  const response = await fetch('/api/trace');
+  if (!response.body) throw new Error('Response body is not streamable');
+
+  const stream = response.body;
+  const bytesTotal = Number(response.headers.get('content-length')) || 0;
+  iframe.contentWindow.postMessage(
+    {perfetto: {stream, bytesTotal, title: 'My embedded trace'}},
+    '*',
+    [stream],
+  );
+}
+```
+
+The stream must be transferred as shown above and must not have been read first.
+The browser automatically regulates how quickly data is produced as Perfetto
+loads it. Streamed traces are not retained, so they cannot subsequently be
+downloaded, shared, or cached. See the
+[embedding API reference](/docs/visualization/embedding-api-reference.md) for
+the precise stream requirements.
 
 ## Step 4 (optional): Drive the view
 

--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -226,8 +226,12 @@ export class AppImpl implements App {
     return this.openTrace({type: 'URL', url, serializedAppState});
   }
 
-  openTraceFromStream(stream: TraceStream) {
-    return this.openTrace({type: 'STREAM', stream});
+  openTraceFromStream(
+    stream: TraceStream,
+    title?: string,
+    serializedAppState?: SerializedAppState,
+  ) {
+    return this.openTrace({type: 'STREAM', stream, title, serializedAppState});
   }
 
   openTraceFromBuffer(

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -605,6 +605,9 @@ async function getTraceInfo(
       const arrayBufferSizeMB = Math.ceil(traceSource.buffer.byteLength / 1e6);
       traceTitle += ` (${arrayBufferSizeMB} MB)`;
       break;
+    case 'STREAM':
+      traceTitle = traceSource.title ?? '';
+      break;
     case 'HTTP_RPC':
       traceTitle = `RPC @ ${HttpRpcEngine.hostAndPort}`;
       break;

--- a/ui/src/core/trace_source.ts
+++ b/ui/src/core/trace_source.ts
@@ -47,6 +47,7 @@ export interface TraceUrlSource {
 export interface TraceStreamSource {
   type: 'STREAM';
   stream: TraceStream;
+  title?: string;
 }
 
 export interface TraceHttpRpcSource {

--- a/ui/src/core/trace_stream.ts
+++ b/ui/src/core/trace_stream.ts
@@ -61,6 +61,55 @@ export class TraceFileStream implements TraceStream {
   }
 }
 
+// Loads a trace from a browser ReadableStream. ReadableStreams transferred via
+// postMessage preserve backpressure across windows, bounding how far the sender
+// can run ahead of TraceProcessor.
+export class TraceReadableStream implements TraceStream {
+  private readonly reader: ReadableStreamDefaultReader<unknown>;
+  private bytesRead = 0;
+
+  constructor(
+    stream: ReadableStream<unknown>,
+    private readonly bytesTotal = 0,
+  ) {
+    this.reader = stream.getReader();
+  }
+
+  async readChunk(): Promise<TraceChunk> {
+    const result = await this.reader.read();
+    if (result.done) {
+      this.reader.releaseLock();
+      return {
+        data: new Uint8Array(),
+        eof: true,
+        bytesRead: this.bytesRead,
+        bytesTotal: this.bytesTotal,
+      };
+    }
+
+    const data = traceStreamChunkToUint8Array(result.value);
+    this.bytesRead += data.byteLength;
+    return {
+      data,
+      eof: false,
+      bytesRead: this.bytesRead,
+      bytesTotal: this.bytesTotal,
+    };
+  }
+}
+
+function traceStreamChunkToUint8Array(chunk: unknown): Uint8Array {
+  if (chunk instanceof ArrayBuffer) {
+    return new Uint8Array(chunk);
+  }
+  if (ArrayBuffer.isView(chunk)) {
+    return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+  }
+  throw new Error(
+    'Trace ReadableStream chunks must be ArrayBuffers or ArrayBuffer views',
+  );
+}
+
 // Loads a trace from an ArrayBuffer. For the window.open() + postMessage
 // use-case, used by other dashboards (see post_message_handler.ts).
 export class TraceBufferStream implements TraceStream {

--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -22,11 +22,14 @@ import type {SerializedAppState} from '../core/state_serialization_schema';
 import {parseAppState} from '../core/state_serialization';
 import {BUCKET_NAME, isValidGcsFileName} from '../base/gcs_uploader';
 import {toArrayBuffer} from '../base/utils';
+import {TraceReadableStream} from '../core/trace_stream';
 
 const TRUSTED_ORIGINS_KEY = 'trustedOrigins';
 
 interface PostedTrace {
-  buffer: ArrayBuffer;
+  buffer?: ArrayBuffer;
+  stream?: ReadableStream<unknown>;
+  bytesTotal?: number;
   title: string;
   fileName?: string;
   url?: string;
@@ -56,7 +59,7 @@ interface PostedTrace {
 // pass a view (e.g. Uint8Array) for |buffer| despite PostedTrace typing it as a
 // pure ArrayBuffer, so model that here. sanitizePostedTrace() normalizes it.
 interface RawPostedTrace extends Omit<PostedTrace, 'buffer'> {
-  buffer: ArrayBuffer | ArrayBufferView;
+  buffer?: ArrayBuffer | ArrayBufferView;
 
   // Legacy field: senders that predate the shareable/downloadable split may
   // still pass |localOnly|. localOnly: false opts into both sharing and
@@ -158,8 +161,8 @@ export function parsePostedTrace(
   }
 }
 
-// The message handler supports loading traces from an ArrayBuffer.
-// There is no other requirement than sending the ArrayBuffer as the |data|
+// The message handler supports loading traces from an ArrayBuffer or a
+// transferred ReadableStream. A bare ArrayBuffer can be sent as the |data|
 // property. However, since this will happen across different origins, it is not
 // possible for the source website to inspect whether the message handler is
 // ready, so the message handler always replies to a 'PING' message with 'PONG',
@@ -246,7 +249,7 @@ export function postMessageHandler(messageEvent: MessageEvent) {
     return;
   }
 
-  if (postedTrace.buffer.byteLength === 0) {
+  if (postedTrace.buffer !== undefined && postedTrace.buffer.byteLength === 0) {
     throw new Error('Incoming message trace buffer is empty');
   }
 
@@ -284,7 +287,18 @@ export function postMessageHandler(messageEvent: MessageEvent) {
         appState = parsedState.value;
       }
     }
-    AppImpl.instance.openTraceFromBuffer(postedTrace, appState);
+    if (postedTrace.buffer !== undefined) {
+      AppImpl.instance.openTraceFromBuffer(
+        {...postedTrace, buffer: postedTrace.buffer},
+        appState,
+      );
+    } else {
+      AppImpl.instance.openTraceFromStream(
+        new TraceReadableStream(postedTrace.stream!, postedTrace.bytesTotal),
+        postedTrace.title,
+        appState,
+      );
+    }
   };
 
   const trustAndOpenTrace = () => {
@@ -336,9 +350,6 @@ function sanitizePostedTrace(postedTrace: RawPostedTrace): PostedTrace {
   const localOnly = postedTrace.localOnly ?? true;
   const result: PostedTrace = {
     title: sanitizeString(postedTrace.title),
-    // Senders routinely pass a view (e.g. Uint8Array) despite the static type;
-    // normalize to a pure ArrayBuffer at the boundary. See b/390473162.
-    buffer: toArrayBuffer(postedTrace.buffer),
     keepApiOpen: postedTrace.keepApiOpen,
     // For external traces, we need to disable other features such as
     // downloading and sharing a trace, unless the caller allows it.
@@ -347,6 +358,14 @@ function sanitizePostedTrace(postedTrace: RawPostedTrace): PostedTrace {
     appStateHash: postedTrace.appStateHash,
     pluginArgs: postedTrace.pluginArgs,
   };
+  if (postedTrace.buffer !== undefined) {
+    // Senders routinely pass a view (e.g. Uint8Array) despite the static type;
+    // normalize to a pure ArrayBuffer at the boundary. See b/390473162.
+    result.buffer = toArrayBuffer(postedTrace.buffer);
+  } else {
+    result.stream = postedTrace.stream;
+    result.bytesTotal = sanitizeBytesTotal(postedTrace.bytesTotal);
+  }
   if (postedTrace.fileName !== undefined) {
     result.fileName = sanitizeString(postedTrace.fileName);
   }
@@ -354,6 +373,14 @@ function sanitizePostedTrace(postedTrace: RawPostedTrace): PostedTrace {
     result.url = sanitizeString(postedTrace.url);
   }
   return result;
+}
+
+function sanitizeBytesTotal(bytesTotal: number | undefined): number {
+  return bytesTotal !== undefined &&
+    Number.isFinite(bytesTotal) &&
+    bytesTotal > 0
+    ? Math.floor(bytesTotal)
+    : 0;
 }
 
 function sanitizeString(str: string): string {
@@ -408,13 +435,9 @@ function isPostedTraceWrapped(obj: any): obj is PostedTraceWrapped {
   if (wrapped.perfetto === undefined) {
     return false;
   }
-  // Senders routinely pass a view (e.g. Uint8Array) for |buffer| despite the
-  // static ArrayBuffer type, so accept either. Anything else (string, number,
-  // undefined) is rejected here rather than slipping through and being treated
-  // as an ArrayBuffer downstream.
+  // Exactly one of |buffer| and |stream| must be present.
   const buffer = wrapped.perfetto.buffer;
-  return (
-    (buffer instanceof ArrayBuffer || ArrayBuffer.isView(buffer)) &&
-    typeof wrapped.perfetto.title === 'string'
-  );
+  const hasBuffer = buffer instanceof ArrayBuffer || ArrayBuffer.isView(buffer);
+  const hasStream = wrapped.perfetto.stream instanceof ReadableStream;
+  return hasBuffer !== hasStream && typeof wrapped.perfetto.title === 'string';
 }

--- a/ui/src/frontend/post_message_handler_unittest.ts
+++ b/ui/src/frontend/post_message_handler_unittest.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {TraceReadableStream} from '../core/trace_stream';
 import {isTrustedOrigin, parsePostedTrace} from './post_message_handler';
 
 describe('postMessageHandler', () => {
@@ -87,10 +88,34 @@ describe('parsePostedTrace', () => {
 
       expect(result?.buffer).toBeInstanceOf(ArrayBuffer);
       // Spans exactly the view's bytes, not the full 16-byte buffer.
-      expect(result?.buffer.byteLength).toBe(10);
-      expect(new Uint8Array(result!.buffer)).toEqual(
+      expect(result?.buffer!.byteLength).toBe(10);
+      expect(new Uint8Array(result!.buffer!)).toEqual(
         new Uint8Array([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
       );
+    });
+  });
+
+  describe('stream', () => {
+    test('readable stream is preserved', () => {
+      const stream = new ReadableStream();
+      const result = parsePostedTrace({
+        perfetto: {stream, title: 'foo', bytesTotal: 42},
+      });
+
+      expect(result?.stream).toBe(stream);
+      expect(result?.bytesTotal).toBe(42);
+    });
+
+    test('buffer and stream together are rejected', () => {
+      const result = parsePostedTrace({
+        perfetto: {
+          buffer: new ArrayBuffer(),
+          stream: new ReadableStream(),
+          title: 'foo',
+        },
+      });
+
+      expect(result).toBeUndefined();
     });
   });
 
@@ -161,10 +186,44 @@ describe('parsePostedTrace', () => {
 
       expect(result?.buffer).toBeInstanceOf(ArrayBuffer);
       // Spans exactly the view's bytes, not the full 16-byte buffer.
-      expect(result?.buffer.byteLength).toBe(10);
-      expect(new Uint8Array(result!.buffer)).toEqual(
+      expect(result?.buffer!.byteLength).toBe(10);
+      expect(new Uint8Array(result!.buffer!)).toEqual(
         new Uint8Array([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
       );
     });
+  });
+});
+
+describe('TraceReadableStream', () => {
+  test('only pulls when readChunk is called', async () => {
+    let pulls = 0;
+    const readable = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          pulls++;
+          controller.enqueue(new Uint8Array([pulls]));
+          if (pulls === 2) controller.close();
+        },
+      },
+      {highWaterMark: 0},
+    );
+    const stream = new TraceReadableStream(readable, 2);
+
+    expect(pulls).toBe(0);
+    await expect(stream.readChunk()).resolves.toMatchObject({
+      data: new Uint8Array([1]),
+      eof: false,
+      bytesRead: 1,
+      bytesTotal: 2,
+    });
+    expect(pulls).toBe(1);
+    await expect(stream.readChunk()).resolves.toMatchObject({
+      data: new Uint8Array([2]),
+      eof: false,
+      bytesRead: 2,
+      bytesTotal: 2,
+    });
+    expect(pulls).toBe(2);
+    await expect(stream.readChunk()).resolves.toMatchObject({eof: true});
   });
 });


### PR DESCRIPTION
Allow embedders to transfer a ReadableStream to the UI while preserving backpressure during trace loading. Document the new embedding API and cover stream validation and consumption with tests.
