### PR TITLE
ui: add TimeseriesViewer counter dashboard plugin

### DIFF
--- a/ui/src/core/embedder/default_plugins.ts
+++ b/ui/src/core/embedder/default_plugins.ts
@@ -98,6 +98,7 @@ export const defaultPlugins = [
   'dev.perfetto.Timeline',
   'dev.perfetto.TimelineSync',
   'dev.perfetto.TraceInfoPage',
+  'dev.perfetto.TimeseriesViewer',
   'dev.perfetto.TraceMetadata',
   'dev.perfetto.TraceProcessorTrack',
   'dev.perfetto.TrackEvent',

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/OWNERS
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/OWNERS
@@ -1,0 +1,1 @@
+zezeozue@google.com

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/counter_index.ts
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/counter_index.ts
@@ -1,0 +1,523 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {formatNumber} from '../../base/number_format';
+import {type duration, type time, Time} from '../../base/time';
+import {
+  counterValueExpression,
+  type YMode,
+} from '../../components/tracks/counter_track';
+import type {Engine} from '../../trace_processor/engine';
+import {
+  LONG,
+  NUM,
+  NUM_NULL,
+  STR_NULL,
+} from '../../trace_processor/query_result';
+import {createVirtualTable} from '../../trace_processor/sql_utils';
+
+// Per-line stroke style.
+export type LineStyle = 'solid' | 'dashed' | 'dotted';
+
+// A counter with at most this many samples is loaded in full (all points) once
+// and reused for every viewport: zoom/pan then just remaps existing points with
+// no re-query and no re-bucketing, so it is perfectly smooth. Larger counters
+// fall back to the per-viewport mipmap. The bound also keeps the drawn point
+// count reasonable (only on-screen lanes are ever drawn).
+const FULL_FETCH_MAX_ROWS = 50_000;
+
+// Fixed colour choices for the per-line override picker. Index N is kept in
+// sync with the .pf-tsv__color-dot--N classes in styles.scss.
+export const COLOR_CHOICES: ReadonlyArray<string> = [
+  '#4285f4',
+  '#ea4335',
+  '#fbbc04',
+  '#34a853',
+  '#ff6d01',
+  '#46bdc6',
+  '#9334e6',
+  '#e91e63',
+  '#00acc1',
+  '#9e9e9e',
+];
+
+// The CSS class that renders a series' colour dot: the palette swatch for its
+// index, or the matching override-colour dot when the user picked one.
+export function swatchClassFor(
+  colorOverride: string | undefined,
+  i: number,
+): string {
+  const ci = colorOverride ? COLOR_CHOICES.indexOf(colorOverride) : -1;
+  return ci >= 0
+    ? `pf-tsv__color-dot--${ci}`
+    : `pf-tsv__swatch--${(i % 8) + 1}`;
+}
+
+// How a counter line is labelled by default (before any per-line override).
+export type NameBy = 'metric' | 'process' | 'thread';
+
+// The owning process/thread of a counter (when it is process/thread-scoped).
+export interface Owner {
+  readonly name: string; // may be '' if the trace has no name
+  readonly id: number; // pid or tid
+}
+
+// Metadata about a single counter track available in the trace.
+export interface CounterTrackInfo {
+  readonly id: number;
+  readonly name: string; // the metric name, e.g. "mem.rss.anon"
+  readonly unit?: string;
+  readonly type?: string;
+  readonly rows: number;
+  // Owner, if this is a process- or thread-scoped counter (used for naming).
+  readonly process?: Owner;
+  readonly thread?: Owner;
+  // True if the counter only ever increases (a cumulative/monotonic total);
+  // such counters are far more informative shown as a rate than a ramp.
+  readonly cumulative: boolean;
+}
+
+// The default y-mode for a freshly added counter: cumulative counters default
+// to 'rate' (their raw value is an uninformative ramp), everything else to
+// 'value'.
+export function defaultYMode(info: CounterTrackInfo): YMode {
+  return info.cumulative ? 'rate' : 'value';
+}
+
+// Units that base/number_format already prefixes well; for these formatMetric
+// defers to it, everything else uses the SI prefixes below.
+const SI_NATIVE_UNITS = new Set([
+  'Hz',
+  'W',
+  'V',
+  'A',
+  'J',
+  'B',
+  'b',
+  'bytes',
+  'bits',
+  'seconds',
+  'hertz',
+  'watts',
+  'volts',
+  'amps',
+  'joules',
+]);
+
+const SI_PREFIXES: ReadonlyArray<[number, string]> = [
+  [1e12, 'T'],
+  [1e9, 'G'],
+  [1e6, 'M'],
+  [1e3, 'K'],
+  [1, ''],
+  [1e-3, 'm'],
+  [1e-6, 'µ'],
+  [1e-9, 'n'],
+];
+
+// Compact metric formatting: 2e8 -> "200M", 1536 -> "1.5K", 85 -> "85".
+function siCompact(value: number): string {
+  if (!Number.isFinite(value)) return String(value);
+  if (value === 0) return '0';
+  const abs = Math.abs(value);
+  for (const [factor, prefix] of SI_PREFIXES) {
+    if (abs >= factor) {
+      const m = value / factor;
+      const am = Math.abs(m);
+      const s =
+        am >= 100 ? m.toFixed(0) : am >= 10 ? m.toFixed(1) : m.toFixed(2);
+      return s.replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1') + prefix;
+    }
+  }
+  return value.toExponential(1); // sub-nano: rare, keep it terse
+}
+
+// Axis/tooltip value formatter: base/number_format for units it prefixes well
+// (bytes -> "200 MB"), else metric SI with the raw unit appended ("200M", not
+// the engineering "200e6").
+export function formatMetric(value: number, unit?: string): string {
+  if (unit !== undefined && SI_NATIVE_UNITS.has(unit)) {
+    return formatNumber(value, unit);
+  }
+  const num = siCompact(value);
+  return unit !== undefined && unit.length > 0 ? `${num} ${unit}` : num;
+}
+
+// The unit for a counter: the counter_track.unit column when present, otherwise
+// inferred from a common trailing unit suffix in the name (e.g. "Heap size
+// (KB)" -> "KB"), which many Android counters use in lieu of the column.
+export function counterUnit(
+  rawUnit: string | undefined,
+  name: string,
+): string | undefined {
+  if (rawUnit !== undefined && rawUnit.length > 0) return rawUnit;
+  const m = /\((KB|MB|GB|bytes|kB|ns|us|ms|%|Hz|kHz|MHz)\)\s*$/.exec(name);
+  return m ? m[1] : undefined;
+}
+
+// A process/thread owner formatted as "name pid" (or "process pid" when the
+// trace carries no name).
+function ownerLabel(o: Owner, kind: 'process' | 'thread'): string {
+  return o.name.length > 0 ? `${o.name} ${o.id}` : `${kind} ${o.id}`;
+}
+
+// The display label for a counter under the given naming scheme. Process/Thread
+// fall back to the metric name for counters with no such owner.
+export function counterLabel(info: CounterTrackInfo, nameBy: NameBy): string {
+  const proc = info.process && ownerLabel(info.process, 'process');
+  const thr = info.thread && ownerLabel(info.thread, 'thread');
+  switch (nameBy) {
+    case 'process':
+      return proc ?? thr ?? info.name;
+    case 'thread':
+      return thr ?? proc ?? info.name;
+    case 'metric':
+    default:
+      return info.name;
+  }
+}
+
+// A fully-disambiguating descriptor (owner + metric) for the picker, so
+// same-named counters (e.g. mem.rss.anon across processes) are always
+// distinguishable there regardless of the chosen naming scheme.
+export function counterDescriptor(info: CounterTrackInfo): string {
+  const proc = info.process && ownerLabel(info.process, 'process');
+  const thr = info.thread && ownerLabel(info.thread, 'thread');
+  if (thr !== undefined) return `${thr} · ${info.name}`;
+  if (proc !== undefined) return `${proc} · ${info.name}`;
+  return info.name;
+}
+
+// A window of downsampled samples for one counter, ready for rendering.
+// Timestamps are stored as nanoseconds relative to the trace start so they fit
+// comfortably in a float64 even for multi-week traces.
+export interface SeriesWindow {
+  readonly start: time;
+  readonly end: time;
+  readonly tsRel: Float64Array; // ns since trace start, ascending
+  readonly minV: Float32Array;
+  readonly maxV: Float32Array;
+  readonly lastV: Float32Array;
+  readonly count: number;
+}
+
+// Lists all counter tracks that actually carry samples, most-populated first.
+// A single grouped scan over `counter` keeps this fast even with hundreds of
+// tracks in weeks-long traces.
+export async function listCounterTracks(
+  engine: Engine,
+): Promise<CounterTrackInfo[]> {
+  // Rank by the number of DISTINCT values, which is a good proxy for "looks
+  // like a real time series": smooth counters (memory, frequency, heap size,
+  // temperature) have many distinct values, while binary/state counters
+  // (cpuidle, *_IDLE) have very few and are pushed down. Dead-constant counters
+  // carry no signal, so they are dropped entirely.
+  // LEFT JOIN the process/thread that owns each counter (when any), so lines can
+  // be labelled by their owner — the effective process is the process counter's
+  // own, or the owning thread's process for thread counters.
+  const res = await engine.query(`
+    SELECT
+      ct.id AS id,
+      ct.name AS name,
+      ct.unit AS unit,
+      ct.type AS type,
+      s.c AS rows,
+      s.decs AS decs,
+      p.pid AS pid,
+      p.name AS pname,
+      th.tid AS tid,
+      th.name AS tname
+    FROM counter_track ct
+    JOIN (
+      -- Per-track stats in one scan. decs counts value decreases (via LAG);
+      -- 0 decreases over a varying counter => monotonic/cumulative.
+      SELECT track_id, COUNT(*) AS c, MIN(value) AS mn, MAX(value) AS mx,
+             COUNT(DISTINCT value) AS nd,
+             SUM(dec) AS decs
+      FROM (
+        SELECT track_id, value,
+          (value < LAG(value) OVER (PARTITION BY track_id ORDER BY ts)) AS dec
+        FROM counter
+      )
+      GROUP BY track_id
+    ) s ON s.track_id = ct.id
+    LEFT JOIN process_counter_track pct ON pct.id = ct.id
+    LEFT JOIN thread_counter_track tct ON tct.id = ct.id
+    LEFT JOIN thread th ON th.utid = tct.utid
+    LEFT JOIN process p ON p.upid = COALESCE(pct.upid, th.upid)
+    WHERE s.c > 0 AND s.mx > s.mn
+    ORDER BY s.nd DESC, s.c DESC, ct.name ASC
+  `);
+
+  const it = res.iter({
+    id: NUM,
+    name: STR_NULL,
+    unit: STR_NULL,
+    type: STR_NULL,
+    rows: NUM,
+    decs: NUM,
+    pid: NUM_NULL,
+    pname: STR_NULL,
+    tid: NUM_NULL,
+    tname: STR_NULL,
+  });
+
+  const out: CounterTrackInfo[] = [];
+  for (; it.valid(); it.next()) {
+    const name = it.name ?? `counter_track ${it.id}`;
+    out.push({
+      id: it.id,
+      name,
+      unit: counterUnit(it.unit ?? undefined, name),
+      type: it.type ?? undefined,
+      rows: it.rows,
+      cumulative: it.decs === 0,
+      process: it.pid !== null ? {name: it.pname ?? '', id: it.pid} : undefined,
+      thread: it.tid !== null ? {name: it.tname ?? '', id: it.tid} : undefined,
+    });
+  }
+  return out;
+}
+
+// One counter's data source. Lazily builds a mipmap virtual table the first
+// time it is queried, then answers per-viewport requests in O(pixels) rows by
+// asking the mipmap for min/max/last per bucket. Cheap to keep hundreds of
+// these around; only the selected ones ever build a table.
+export class CounterSeries {
+  private tableName?: string;
+  private disposeTable?: () => Promise<void>;
+  private fetchSeq = 0;
+  private lastKey = '';
+  // True once the whole series has been loaded (small counters); the chart then
+  // never needs to refetch on zoom/pan.
+  private full = false;
+
+  // Whether this series is hidden (legend / double-click toggle).
+  hidden = false;
+  // Emphasised (stacked-mode multi-select): when any lane is emphasised, the
+  // rest are greyed and sink to the bottom.
+  emphasized = false;
+  // Per-line appearance overrides (undefined colour = palette default).
+  lineStyle: LineStyle = 'solid';
+  colorOverride?: string;
+  // Per-line display-name override (undefined = derived from the naming scheme).
+  nameOverride?: string;
+  // Per-lane height override in px (stacked mode; undefined = the global height).
+  laneHeightOverride?: number;
+
+  // The line's display name: the explicit override, else derived from the
+  // counter's owner/metric under the current naming scheme.
+  label(nameBy: NameBy): string {
+    return this.nameOverride ?? counterLabel(this.info, nameBy);
+  }
+
+  // The most recently fetched window, kept so the chart can keep drawing
+  // (re-mapping by time) while a refined fetch is in flight.
+  window?: SeriesWindow;
+
+  // Whole-trace value range (in the current mode), for the "global" y-range
+  // option. `globalMode` records which mode it was computed for so a mode switch
+  // recomputes it.
+  globalMin?: number;
+  globalMax?: number;
+  globalMode?: YMode;
+
+  constructor(
+    private readonly engine: Engine,
+    readonly info: CounterTrackInfo,
+    private readonly traceStart: time,
+    private yMode: YMode = 'value',
+  ) {}
+
+  private async ensureTable(): Promise<string> {
+    if (this.tableName !== undefined) return this.tableName;
+    // The mipmap is built over the mode's display value (value/delta/rate),
+    // so bucket min/max/last already reflect the selected mode.
+    const table = await createVirtualTable({
+      engine: this.engine,
+      using: `__intrinsic_counter_mipmap((
+        SELECT ts, ${counterValueExpression(this.yMode)} AS value
+        FROM (SELECT ts, value FROM counter WHERE track_id = ${this.info.id})
+      ))`,
+    });
+    this.tableName = table.name;
+    this.disposeTable = async () => {
+      await table[Symbol.asyncDispose]();
+    };
+    return this.tableName;
+  }
+
+  // This series' current value/delta/rate mode.
+  get mode(): YMode {
+    return this.yMode;
+  }
+
+  // Switches value/delta/rate; drops the mipmap so it rebuilds on next fetch.
+  async setYMode(mode: YMode): Promise<void> {
+    if (mode === this.yMode) return;
+    this.yMode = mode;
+    this.fetchSeq++;
+    this.window = undefined;
+    this.lastKey = '';
+    this.full = false;
+    if (this.disposeTable !== undefined) {
+      await this.disposeTable();
+      this.disposeTable = undefined;
+      this.tableName = undefined;
+    }
+  }
+
+  // Whether this counter is loaded in full (small enough to skip the mipmap).
+  get isFull(): boolean {
+    return this.info.rows <= FULL_FETCH_MAX_ROWS;
+  }
+
+  // Loads every sample once and caches it; subsequent viewports reuse it with
+  // no re-query, so zoom/pan is perfectly smooth. min == max == last (no
+  // coalescing); the chart derives the on-screen value range itself.
+  private async fetchAll(): Promise<boolean> {
+    if (this.full && this.window !== undefined) return false;
+    const seq = ++this.fetchSeq;
+    const res = await this.engine.query(`
+      SELECT ts, ${counterValueExpression(this.yMode)} AS v
+      FROM (SELECT ts, value FROM counter WHERE track_id = ${this.info.id})
+      ORDER BY ts
+    `);
+    if (seq !== this.fetchSeq) return false;
+
+    const cols = res.decodeColumns({ts: LONG, v: NUM});
+    const count = res.numRows();
+    const tsRel = new Float64Array(count);
+    const v = new Float32Array(cols.v);
+    const startRaw = this.traceStart;
+    for (let i = 0; i < count; i++) {
+      tsRel[i] = Number(cols.ts[i] - startRaw);
+    }
+    const first = count > 0 ? this.relToTime(tsRel[0]) : this.traceStart;
+    const last = count > 0 ? this.relToTime(tsRel[count - 1]) : this.traceStart;
+    // min/max/last share one array — the samples are the raw values.
+    this.window = {
+      start: first,
+      end: last,
+      tsRel,
+      minV: v,
+      maxV: v,
+      lastV: v,
+      count,
+    };
+    this.full = true;
+    this.lastKey = 'full';
+    return true;
+  }
+
+  // Whole-trace value range in the current mode (for the "global"/"shared"
+  // y-range options), cached until the mode changes. Full counters derive it
+  // from their samples; larger ones ask the mipmap in one coarse query. Returns
+  // true if it changed.
+  async ensureGlobalRange(traceEnd: time): Promise<boolean> {
+    if (this.globalMode === this.yMode && this.globalMin !== undefined) {
+      return false;
+    }
+    if (this.isFull) {
+      if (!this.full || this.window === undefined) await this.fetchAll();
+      const w = this.window;
+      if (w === undefined || w.count === 0) return false;
+      let mn = Infinity;
+      let mx = -Infinity;
+      for (let i = 0; i < w.count; i++) {
+        if (w.minV[i] < mn) mn = w.minV[i];
+        if (w.maxV[i] > mx) mx = w.maxV[i];
+      }
+      this.globalMin = mn;
+      this.globalMax = mx;
+      this.globalMode = this.yMode;
+      return true;
+    }
+    const table = await this.ensureTable();
+    const seq = this.fetchSeq;
+    const dur = traceEnd - this.traceStart;
+    const step = dur > 0n ? dur : 1n; // one bucket spanning the whole trace
+    const res = await this.engine.query(`
+      SELECT MIN(min_value) AS mn, MAX(max_value) AS mx
+      FROM ${table}(${this.traceStart}, ${traceEnd}, ${step})
+    `);
+    if (seq !== this.fetchSeq) return false;
+    const row = res.firstRow({mn: NUM_NULL, mx: NUM_NULL});
+    if (row.mn === null || row.mx === null) return false;
+    this.globalMin = row.mn;
+    this.globalMax = row.mx;
+    this.globalMode = this.yMode;
+    return true;
+  }
+
+  // Fetches (or refetches) the given window at the given bucket resolution.
+  // Returns true if `window` was updated, false if the request was superseded
+  // by a newer one or was identical to the last satisfied request.
+  async fetch(start: time, end: time, resolution: duration): Promise<boolean> {
+    if (this.isFull) return this.fetchAll();
+    const key = `${start}/${end}/${resolution}`;
+    if (key === this.lastKey && this.window !== undefined) return false;
+    const seq = ++this.fetchSeq;
+
+    const table = await this.ensureTable();
+    const res = await this.engine.query(`
+      SELECT
+        min_value AS minV,
+        max_value AS maxV,
+        last_ts AS ts,
+        last_value AS lastV
+      FROM ${table}(${start}, ${end}, ${resolution})
+      ORDER BY last_ts
+    `);
+    if (seq !== this.fetchSeq) return false; // superseded
+
+    const cols = res.decodeColumns({
+      ts: LONG,
+      minV: NUM,
+      maxV: NUM,
+      lastV: NUM,
+    });
+    const count = res.numRows();
+    const tsRel = new Float64Array(count);
+    const minV = new Float32Array(cols.minV);
+    const maxV = new Float32Array(cols.maxV);
+    const lastV = new Float32Array(cols.lastV);
+
+    const startRaw = this.traceStart;
+    for (let i = 0; i < count; i++) {
+      tsRel[i] = Number(cols.ts[i] - startRaw);
+    }
+
+    this.lastKey = key;
+    this.window = {start, end, tsRel, minV, maxV, lastV, count};
+    return true;
+  }
+
+  async dispose(): Promise<void> {
+    this.fetchSeq++;
+    this.window = undefined;
+    this.full = false;
+    if (this.disposeTable !== undefined) {
+      await this.disposeTable();
+      this.disposeTable = undefined;
+      this.tableName = undefined;
+    }
+  }
+
+  // Absolute timestamp (ns since trace start) helper for the trace start, so
+  // callers can convert between rel/abs consistently.
+  relToTime(rel: number): time {
+    return Time.fromRaw(this.traceStart + BigInt(Math.round(rel)));
+  }
+}

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/gridlines.ts
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/gridlines.ts
@@ -1,0 +1,164 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A local, self-contained copy of the timeline's gridline tick generator
+// (core_plugins/dev.perfetto.Timeline/gridline_helper.ts). The import checker
+// disallows a plugin depending on another plugin's internals, and following
+// the precedent set by this plugin's wasd.ts we keep the logic local rather
+// than couple to the Timeline plugin. The step-size table encodes human time
+// units and is effectively immutable, so drawing our sync-mode gridlines from
+// this identical algorithm keeps them locked to the timeline's own axis.
+
+import {assertTrue} from '../../base/assert';
+import {type duration, type time, Time, type TimeSpan} from '../../base/time';
+
+const micros = 1000n;
+const millis = 1000n * micros;
+const seconds = 1000n * millis;
+const minutes = 60n * seconds;
+const hours = 60n * minutes;
+const days = 24n * hours;
+
+// These patterns cover the entire range of 0 - 2^63-1 nanoseconds.
+const patterns: [bigint, string][] = [
+  [1n, '|'],
+  [2n, '|:'],
+  [5n, '|....'],
+  [10n, '|....:....'],
+  [20n, '|.:.'],
+  [50n, '|....'],
+  [100n, '|....:....'],
+  [200n, '|.:.'],
+  [500n, '|....'],
+  [1n * micros, '|....:....'],
+  [2n * micros, '|.:.'],
+  [5n * micros, '|....'],
+  [10n * micros, '|....:....'],
+  [20n * micros, '|.:.'],
+  [50n * micros, '|....'],
+  [100n * micros, '|....:....'],
+  [200n * micros, '|.:.'],
+  [500n * micros, '|....'],
+  [1n * millis, '|....:....'],
+  [2n * millis, '|.:.'],
+  [5n * millis, '|....'],
+  [10n * millis, '|....:....'],
+  [20n * millis, '|.:.'],
+  [50n * millis, '|....'],
+  [100n * millis, '|....:....'],
+  [200n * millis, '|.:.'],
+  [500n * millis, '|....'],
+  [1n * seconds, '|....:....'],
+  [2n * seconds, '|.:.'],
+  [5n * seconds, '|....'],
+  [10n * seconds, '|....:....'],
+  [30n * seconds, '|.:.:.'],
+  [1n * minutes, '|.....'],
+  [2n * minutes, '|.:.'],
+  [5n * minutes, '|.....'],
+  [10n * minutes, '|....:....'],
+  [30n * minutes, '|.:.:.'],
+  [1n * hours, '|.....'],
+  [2n * hours, '|.:.'],
+  [6n * hours, '|.....'],
+  [12n * hours, '|.....:.....'],
+  [1n * days, '|.:.'],
+  [2n * days, '|.:.'],
+  [5n * days, '|....'],
+  [10n * days, '|....:....'],
+  [20n * days, '|.:.'],
+  [50n * days, '|....'],
+  [100n * days, '|....:....'],
+  [200n * days, '|.:.'],
+  [500n * days, '|....'],
+  [1000n * days, '|....:....'],
+  [2000n * days, '|.:.'],
+  [5000n * days, '|....'],
+  [10000n * days, '|....:....'],
+  [20000n * days, '|.:.'],
+  [50000n * days, '|....'],
+  [100000n * days, '|....:....'],
+  [200000n * days, '|.:.'],
+];
+
+// Returns the optimal step size and pattern of ticks within the step.
+function getPattern(minPatternSize: bigint): [duration, string] {
+  for (const [size, pattern] of patterns) {
+    if (size >= minPatternSize) {
+      return [size, pattern];
+    }
+  }
+  throw new Error('Pattern not defined for this minsize');
+}
+
+export enum TickType {
+  MAJOR,
+  MEDIUM,
+  MINOR,
+}
+
+function tickPatternToArray(pattern: string): TickType[] {
+  return Array.from(pattern).map((char) => {
+    switch (char) {
+      case '|':
+        return TickType.MAJOR;
+      case ':':
+        return TickType.MEDIUM;
+      case '.':
+        return TickType.MINOR;
+      default:
+        throw Error(`Invalid char "${char}" in pattern "${pattern}"`);
+    }
+  });
+}
+
+export interface Tick {
+  type: TickType;
+  time: time;
+}
+
+export const MIN_PX_PER_STEP = 120;
+
+export function getMaxMajorTicks(width: number): number {
+  return Math.max(1, Math.floor(width / MIN_PX_PER_STEP));
+}
+
+export function* generateTicks(
+  timeSpan: TimeSpan,
+  maxMajorTicks: number,
+  offset: time = Time.ZERO,
+): Generator<Tick> {
+  assertTrue(timeSpan.duration > 0n, 'timeSpan.duration cannot be lte 0');
+  assertTrue(maxMajorTicks > 0, 'maxMajorTicks cannot be lte 0');
+
+  timeSpan = timeSpan.translate(-offset);
+  const minStepSize = BigInt(
+    Math.floor(Number(timeSpan.duration) / maxMajorTicks),
+  );
+  const [patternSize, pattern] = getPattern(minStepSize);
+  const tickPattern = tickPatternToArray(pattern);
+
+  const stepSize = patternSize / BigInt(tickPattern.length);
+  const start = Time.quantFloor(timeSpan.start, patternSize);
+  const end = timeSpan.end;
+  let patternIndex = 0;
+
+  for (let t = start; t < end; t = Time.add(t, stepSize), patternIndex++) {
+    if (t >= timeSpan.start) {
+      patternIndex = patternIndex % tickPattern.length;
+      const type = tickPattern[patternIndex];
+      yield {type, time: Time.add(t, offset)};
+    }
+  }
+}

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/index.ts
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/index.ts
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './styles.scss';
+import m from 'mithril';
+import type {PerfettoPlugin} from '../../public/plugin';
+import type {Trace} from '../../public/trace';
+import {COUNTER_TRACK_KIND} from '../../public/track_kinds';
+import {ViewerModel} from './model';
+import {TimeseriesView} from './timeseries_view';
+
+const TAB_URI = 'dev.perfetto.TimeseriesViewer#dashboard';
+
+// Counter track ids in an area selection (their COUNTER_TRACK_KIND + trackIds,
+// deduped) — the same recognition the built-in counter aggregator uses.
+function selectedCounterIds(
+  tracks: ReadonlyArray<{
+    tags?: {kinds?: ReadonlyArray<string>; trackIds?: ReadonlyArray<number>};
+  }>,
+): number[] {
+  return [
+    ...new Set(
+      tracks
+        .filter((t) => t.tags?.kinds?.includes(COUNTER_TRACK_KIND))
+        .flatMap((t) => t.tags?.trackIds ?? []),
+    ),
+  ];
+}
+
+// A high-performance, Battery-Historian-style viewer for exploring counters
+// over long (24h–weeks) traces, embedded in the timeline drawer so counters can
+// be related to the tracks above. It appears as a timeline-synced drawer tab —
+// openable from a command (then add counters via the picker) or contextually by
+// selecting counter tracks (or whole groups) in the timeline.
+export default class implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.TimeseriesViewer';
+  static readonly description =
+    'Fast multi-counter timeseries viewer in the timeline drawer (zoom/pan synced, per-lane auto-scaled axes)';
+
+  async onTraceLoad(trace: Trace): Promise<void> {
+    // One shared model, created lazily on first use. Both entry points below
+    // render it, so the counter set and view state stay consistent.
+    let model: ViewerModel | undefined;
+    const getModel = (): ViewerModel => {
+      if (model === undefined) {
+        model = new ViewerModel(trace);
+        void model.init().then(() => m.redraw());
+      }
+      return model;
+    };
+
+    // The viewer as a persistent drawer tab, opened by the command below
+    // even with nothing selected (add counters from its picker).
+    trace.tabs.registerTab({
+      uri: TAB_URI,
+      content: {
+        getTitle: () => 'Timeseries',
+        render: () => m(TimeseriesView, {model: getModel()}),
+      },
+    });
+
+    trace.commands.registerCommand({
+      id: 'dev.perfetto.TimeseriesViewer#open',
+      name: 'Open Timeseries viewer',
+      callback: () => {
+        // Always open empty — add counters from the picker (the contextual
+        // path below is for plotting an existing timeline selection).
+        getModel().deselectAll();
+        trace.tabs.showTab(TAB_URI);
+      },
+    });
+
+    // Contextual: selecting counter tracks (or a group) shows the same
+    // viewer inline in the Current Selection drawer, tracking the selection
+    // (manual picker adds are preserved alongside).
+    trace.selection.registerAreaSelectionTab({
+      id: 'dev.perfetto.TimeseriesViewer',
+      name: 'Timeseries',
+      priority: 50,
+      render(selection) {
+        const ids = selectedCounterIds(selection.tracks);
+        if (ids.length === 0) return undefined;
+        const mdl = getModel();
+        if (!mdl.loading) mdl.setAreaSelection(ids);
+        return {isLoading: false, content: m(TimeseriesView, {model: mdl})};
+      },
+    });
+  }
+}

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/model.ts
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/model.ts
@@ -1,0 +1,566 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {HighPrecisionTimeSpan} from '../../base/high_precision_time_span';
+import {type time, Time} from '../../base/time';
+import type {YMode} from '../../components/tracks/counter_track';
+import type {Trace} from '../../public/trace';
+import {
+  CounterSeries,
+  type CounterTrackInfo,
+  type LineStyle,
+  type NameBy,
+  defaultYMode,
+  listCounterTracks,
+} from './counter_index';
+
+export type YScale = 'linear' | 'log';
+export type YRangeMode = 'fit' | 'global' | 'shared';
+export type LayoutMode = 'stacked' | 'overlay';
+
+// Never let the visible window collapse below this (1us) — keeps zoom sane.
+const MIN_VIEW_DUR = 1_000n;
+
+// Holds all mutable state for one instance of the timeseries viewer: the
+// available counters, which lanes are shown (and in what order), the shared
+// visible time window, and the y-axis scale. Zoom/pan helpers clamp to the
+// trace bounds so the view can never wander off the data.
+export class ViewerModel {
+  readonly trace: Trace;
+  readonly traceStart: time;
+  readonly traceEnd: time;
+
+  all: ReadonlyArray<CounterTrackInfo> = [];
+  selected: CounterSeries[] = [];
+  // Ids currently selected, kept in sync with `selected` for O(1) membership
+  // checks (the picker calls isSelected() per row, so this must not be O(n)).
+  private readonly selectedIds = new Set<number>();
+  // The plotted set is the union of counters added via the picker (manualIds)
+  // and those from the timeline's area selection (areaIds). A new area selection
+  // resets both to just that selection (see setAreaSelection); only the picker's
+  // "+" accumulates.
+  private readonly manualIds = new Set<number>();
+  private readonly areaIds = new Set<number>();
+  yScale: YScale = 'linear';
+  yMode: YMode = 'value';
+  // Y-axis range source (default 'global'). 'global' locks each axis to the
+  // counter's whole-trace range, so magnitudes are comparable across zoom levels
+  // and the axis never moves; 'shared' puts *every* visible lane/line on one
+  // common range (the combined whole-trace range) so their heights are directly
+  // comparable to each other; 'fit' fits each axis to the samples currently in
+  // view (rescales continuously as you zoom).
+  yRangeMode: YRangeMode = 'global';
+  // Default line-naming scheme (per-line overrides win). Metric by default.
+  nameBy: NameBy = 'metric';
+  layout: LayoutMode = 'stacked';
+  // Fill the area under each line in stacked mode (lighter than the line).
+  fill = true;
+  // Overlay-mode axis: true = each line normalised to its own range on a
+  // 0-100% axis (good for comparing shapes); false = one shared absolute axis
+  // labelled with the counters' unit (good for comparing magnitudes). Units by
+  // default.
+  overlayNormalize = false;
+  // Overlay-mode stacked-area chart: areas are stacked cumulatively on a shared
+  // absolute axis (implies a value axis, not %).
+  overlayStacked = false;
+  // Overlay value/stacked axis unit filter: when the selection mixes units, this
+  // scopes the shared axis (and which lines are drawn) to one unit. undefined =
+  // all units on one axis.
+  overlayUnitFilter?: string;
+  // Per-lane height in px (stacked mode). Smaller default than a fit-to-height
+  // layout so lanes aren't huge; adjustable via the toolbar or by dragging a
+  // lane's bottom edge. When the stack is taller than the viewport it scrolls.
+  laneHeight = 96;
+  // Overlay plot height in px; undefined = fill the viewport. Drag the plot's
+  // bottom edge to resize.
+  overlayHeight?: number;
+  // Legend strip max-height in px (drag the chart's top edge to enlarge it and
+  // see more chips); undefined = the compact default.
+  legendHeight?: number;
+  loading = true;
+
+  // Bumped whenever the selection set changes, so the chart knows to refetch.
+  selectionGeneration = 0;
+  // Listeners woken after any state change so the (idle-stopped) render loop
+  // redraws. A set (not a single callback) so more than one chart can share a
+  // model — the contextual area-selection tab and the command-opened drawer tab
+  // render the same model, and Gate keeps both mounted.
+  private readonly invalidateListeners = new Set<() => void>();
+
+  // Registers a redraw listener; returns a disposer to remove it.
+  addInvalidateListener(fn: () => void): () => void {
+    this.invalidateListeners.add(fn);
+    return () => this.invalidateListeners.delete(fn);
+  }
+
+  private invalidate(): void {
+    for (const fn of this.invalidateListeners) fn();
+  }
+
+  constructor(trace: Trace) {
+    this.trace = trace;
+    this.traceStart = trace.traceInfo.start;
+    this.traceEnd = trace.traceInfo.end;
+  }
+
+  async init(): Promise<void> {
+    this.all = await listCounterTracks(this.trace.engine);
+    this.loading = false;
+    this.invalidate();
+  }
+
+  // Rebuilds `selected` to exactly match manualIds ∪ areaIds, preserving the
+  // order of already-selected series and disposing removed ones. All selection
+  // mutations go through here so the two sources stay consistent.
+  private reconcile(): void {
+    const want = new Set<number>([...this.areaIds, ...this.manualIds]);
+    const byId = new Map(this.all.map((i) => [i.id, i]));
+    let changed = false;
+    const removed: CounterSeries[] = [];
+    this.selected = this.selected.filter((s) => {
+      if (want.has(s.info.id)) return true;
+      this.selectedIds.delete(s.info.id);
+      removed.push(s);
+      changed = true;
+      return false;
+    });
+    for (const id of want) {
+      if (this.selectedIds.has(id)) continue;
+      const info = byId.get(id);
+      if (info === undefined) continue;
+      this.selected.push(this.makeSeries(info));
+      this.selectedIds.add(id);
+      changed = true;
+    }
+    // Only fetched series hold a mipmap; disposing unfetched ones is a no-op.
+    if (removed.length > 0) void Promise.all(removed.map((s) => s.dispose()));
+    if (changed) {
+      this.selectionGeneration++;
+      this.invalidate();
+    }
+  }
+
+  // Sets the counters coming from the timeline's area selection. A *changed*
+  // selection resets the plot to exactly those counters — any manual picker adds
+  // from before are dropped, so re-selecting different tracks starts fresh. Only
+  // the drawer's "+" button accumulates onto the current set. An unchanged
+  // selection is a no-op, so manual adds survive while the selection is stable.
+  setAreaSelection(ids: ReadonlyArray<number>): void {
+    const next = new Set(ids);
+    if (
+      next.size === this.areaIds.size &&
+      [...next].every((id) => this.areaIds.has(id))
+    ) {
+      return; // unchanged
+    }
+    this.areaIds.clear();
+    for (const id of ids) this.areaIds.add(id);
+    this.manualIds.clear();
+    this.reconcile();
+  }
+
+  setNameBy(nameBy: NameBy): void {
+    if (nameBy === this.nameBy) return;
+    this.nameBy = nameBy;
+    this.invalidate();
+  }
+
+  // Per-line display-name override (empty string clears it).
+  setName(series: CounterSeries, name: string): void {
+    const trimmed = name.trim();
+    series.nameOverride = trimmed.length > 0 ? trimmed : undefined;
+    this.invalidate();
+  }
+
+  setYScale(scale: YScale): void {
+    if (scale === this.yScale) return;
+    this.yScale = scale;
+    this.invalidate();
+  }
+
+  setYRangeMode(mode: YRangeMode): void {
+    if (mode === this.yRangeMode) return;
+    this.yRangeMode = mode;
+    this.invalidate();
+  }
+
+  setLayout(layout: LayoutMode): void {
+    if (layout === this.layout) return;
+    this.layout = layout;
+    this.invalidate();
+  }
+
+  setLaneHeight(px: number): void {
+    if (px === this.laneHeight) return;
+    this.laneHeight = px;
+    // The global control resets any per-lane overrides so it stays authoritative.
+    for (const s of this.selected) s.laneHeightOverride = undefined;
+    this.selectionGeneration++;
+    this.invalidate();
+  }
+
+  // Per-lane height override (stacked mode; drag a lane's bottom edge).
+  // Bumps the generation so the chart re-fetches: a resize can push a
+  // previously off-screen lane into view.
+  setSeriesLaneHeight(series: CounterSeries, px: number): void {
+    if (series.laneHeightOverride === px) return;
+    series.laneHeightOverride = px;
+    this.selectionGeneration++;
+    this.invalidate();
+  }
+
+  setFill(fill: boolean): void {
+    if (fill === this.fill) return;
+    this.fill = fill;
+    this.invalidate();
+  }
+
+  setOverlayNormalize(normalize: boolean): void {
+    if (normalize === this.overlayNormalize) return;
+    this.overlayNormalize = normalize;
+    this.invalidate();
+  }
+
+  setOverlayStacked(stacked: boolean): void {
+    if (stacked === this.overlayStacked) return;
+    this.overlayStacked = stacked;
+    // Stacking is a shared absolute axis; % normalisation is meaningless there.
+    if (stacked) this.overlayNormalize = false;
+    this.invalidate();
+  }
+
+  setOverlayUnitFilter(unit: string | undefined): void {
+    if (unit === this.overlayUnitFilter) return;
+    this.overlayUnitFilter = unit;
+    this.invalidate();
+  }
+
+  // Distinct units among the selected counters (for the overlay unit picker).
+  selectedUnits(): string[] {
+    const set = new Set<string>();
+    for (const s of this.selected) {
+      if (s.info.unit !== undefined && s.info.unit.length > 0) {
+        set.add(s.info.unit);
+      }
+    }
+    return [...set].sort();
+  }
+
+  setOverlayHeight(px: number | undefined): void {
+    this.overlayHeight = px;
+    this.invalidate();
+  }
+
+  setLegendHeight(px: number): void {
+    this.legendHeight = px;
+    this.invalidate();
+  }
+
+  // Moves a lane to a new position among the *visible* lanes (drag-to-reorder in
+  // stacked mode). Hidden lanes keep their relative order.
+  reorder(series: CounterSeries, toVisibleIdx: number): void {
+    const visible = this.selected.filter((s) => !s.hidden);
+    const from = visible.indexOf(series);
+    if (from < 0) return;
+    const to = Math.max(0, Math.min(toVisibleIdx, visible.length - 1));
+    if (to === from) return;
+    const anchor = visible[to]; // the visible lane we drop onto
+    const arr = this.selected.filter((s) => s !== series);
+    const anchorIdx = arr.indexOf(anchor);
+    arr.splice(to > from ? anchorIdx + 1 : anchorIdx, 0, series);
+    this.selected = arr;
+    this.selectionGeneration++;
+    this.invalidate();
+  }
+
+  // Per-line value/delta/rate (rebuilds just this series' mipmap).
+  async setSeriesYMode(series: CounterSeries, mode: YMode): Promise<void> {
+    await series.setYMode(mode);
+    this.selectionGeneration++;
+    this.invalidate();
+  }
+
+  // Maps a counter_track id to the uri of the timeline track that renders it,
+  // so we can read that track's user-facing settings. Built once (lazily).
+  private uriByCounterId?: Map<number, string>;
+  private counterUri(id: number): string | undefined {
+    if (this.uriByCounterId === undefined) {
+      this.uriByCounterId = new Map();
+      for (const node of this.trace.workspaces.currentWorkspace.flatTracks) {
+        const uri = node.uri;
+        if (uri === undefined) continue;
+        const ids = this.trace.tracks.getTrack(uri)?.tags?.trackIds;
+        if (ids) {
+          for (const cid of ids) {
+            if (!this.uriByCounterId.has(cid)) {
+              this.uriByCounterId.set(cid, uri);
+            }
+          }
+        }
+      }
+    }
+    return this.uriByCounterId.get(id);
+  }
+
+  // The y-mode the user has set on this counter's timeline track (its "Y Mode"
+  // setting), so the viewer mirrors exactly what they see in the timeline.
+  private trackYMode(id: number): YMode | undefined {
+    const uri = this.counterUri(id);
+    if (uri === undefined) return undefined;
+    const s = this.trace.tracks
+      .getTrack(uri)
+      ?.renderer?.settings?.find((x) => x.descriptor.name === 'Y Mode');
+    const v = s?.value;
+    return v === 'value' || v === 'delta' || v === 'rate' ? v : undefined;
+  }
+
+  private makeSeries(info: CounterTrackInfo): CounterSeries {
+    // Prefer the mode the user set on the counter's timeline track so the
+    // viewer maps exactly; otherwise fall back to a sensible default
+    // (cumulative -> rate). The global Value/Delta/Rate toolbar overrides all.
+    const mode = this.trackYMode(info.id) ?? defaultYMode(info);
+    return new CounterSeries(this.trace.engine, info, this.traceStart, mode);
+  }
+
+  // Switches value/delta/rate for every lane; rebuilds mipmaps lazily.
+  async setYMode(mode: YMode): Promise<void> {
+    if (mode === this.yMode) return;
+    this.yMode = mode;
+    await Promise.all(this.selected.map((s) => s.setYMode(mode)));
+    this.selectionGeneration++;
+    this.invalidate();
+  }
+
+  toggleHidden(series: CounterSeries): void {
+    series.hidden = !series.hidden;
+    this.selectionGeneration++;
+    this.invalidate();
+  }
+
+  // Stacked-mode multi-select: click lanes to emphasise them. While any lane is
+  // emphasised the rest are greyed and sink to the bottom; clicking an
+  // emphasised lane again de-selects it, and clicking empty space clears all.
+  toggleEmphasis(series: CounterSeries): void {
+    series.emphasized = !series.emphasized;
+    this.selectionGeneration++; // changes lane order / the on-screen set
+    this.invalidate();
+  }
+
+  hasEmphasis(): boolean {
+    return this.selected.some((s) => s.emphasized && !s.hidden);
+  }
+
+  clearEmphasis(): void {
+    let changed = false;
+    for (const s of this.selected) {
+      if (s.emphasized) {
+        s.emphasized = false;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.selectionGeneration++;
+      this.invalidate();
+    }
+  }
+
+  // True when exactly one of several lines is showing — i.e. the view is
+  // isolated to a single line. Used so a click on empty space un-isolates.
+  isIsolated(): boolean {
+    if (this.selected.length < 2) return false;
+    return this.selected.filter((s) => !s.hidden).length === 1;
+  }
+
+  // Isolate one line: show only it, hide all others (click-to-focus). If it is
+  // already the only visible line, show everything again (click to un-isolate).
+  toggleOnly(series: CounterSeries): void {
+    const isolated =
+      !series.hidden && this.selected.every((s) => s === series || s.hidden);
+    if (isolated) {
+      this.setAllHidden(false);
+    } else {
+      this.showOnly(series);
+    }
+  }
+
+  private showOnly(series: CounterSeries): void {
+    let changed = false;
+    for (const s of this.selected) {
+      const hide = s !== series;
+      if (s.hidden !== hide) {
+        s.hidden = hide;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.selectionGeneration++;
+      this.invalidate();
+    }
+  }
+
+  // Show or hide every selected line at once (legend bulk action): hide all,
+  // then click individual chips to bring them back one at a time.
+  setAllHidden(hidden: boolean): void {
+    let changed = false;
+    for (const s of this.selected) {
+      if (s.hidden !== hidden) {
+        s.hidden = hidden;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.selectionGeneration++;
+      this.invalidate();
+    }
+  }
+
+  setLineStyle(series: CounterSeries, style: LineStyle): void {
+    series.lineStyle = style;
+    this.selectionGeneration++;
+    this.invalidate();
+  }
+
+  // Sets a per-line colour override (undefined restores the palette default).
+  setColor(series: CounterSeries, color: string | undefined): void {
+    series.colorOverride = color;
+    this.selectionGeneration++;
+    this.invalidate();
+  }
+
+  // The visible window is the main timeline's, so the chart pans/zooms in
+  // lock-step with the tracks above.
+  get viewStart(): time {
+    return this.trace.timeline.visibleWindow.start.toTime('floor');
+  }
+  get viewEnd(): time {
+    return this.trace.timeline.visibleWindow.end.toTime('ceil');
+  }
+  get viewDuration(): bigint {
+    return this.viewEnd - this.viewStart;
+  }
+
+  isSelected(id: number): boolean {
+    return this.selectedIds.has(id);
+  }
+
+  // Picker toggle: add to / remove from the manual set. Removing also drops it
+  // from the area set, so a manually-removed line stays gone until the timeline
+  // selection changes again.
+  toggleTrack(info: CounterTrackInfo): void {
+    if (this.selectedIds.has(info.id)) {
+      this.manualIds.delete(info.id);
+      this.areaIds.delete(info.id);
+    } else {
+      this.manualIds.add(info.id);
+    }
+    this.reconcile();
+  }
+
+  // Adds many counters via the picker (manual set). Cheap even for very large
+  // traces: CounterSeries are lightweight and build no mipmap until fetched,
+  // and only the lanes actually on screen are ever fetched/drawn.
+  selectMany(infos: ReadonlyArray<CounterTrackInfo>): void {
+    for (const info of infos) this.manualIds.add(info.id);
+    this.reconcile();
+  }
+
+  selectAll(): void {
+    this.selectMany(this.all);
+  }
+
+  deselectMany(ids: ReadonlyArray<number>): void {
+    for (const id of ids) {
+      this.manualIds.delete(id);
+      this.areaIds.delete(id);
+    }
+    this.reconcile();
+  }
+
+  deselectAll(): void {
+    this.manualIds.clear();
+    this.areaIds.clear();
+    this.reconcile();
+  }
+
+  // Clamp + apply a new visible window, enforcing bounds and a min duration.
+  setView(start: time, end: time): void {
+    let s = start;
+    let e = end;
+    if (e - s < MIN_VIEW_DUR) {
+      const mid = s + (e - s) / 2n;
+      s = Time.fromRaw(mid - MIN_VIEW_DUR / 2n);
+      e = Time.fromRaw(mid + MIN_VIEW_DUR / 2n);
+    }
+    // Shift back inside [traceStart, traceEnd] without changing duration where
+    // possible, then clamp the ends.
+    const dur = e - s;
+    const total = this.traceEnd - this.traceStart;
+    if (dur >= total) {
+      s = this.traceStart;
+      e = this.traceEnd;
+    } else {
+      if (s < this.traceStart) {
+        s = this.traceStart;
+        e = Time.fromRaw(s + dur);
+      }
+      if (e > this.traceEnd) {
+        e = this.traceEnd;
+        s = Time.fromRaw(e - dur);
+      }
+    }
+    // The timeline owns the window; write it back so the whole timeline (and
+    // any other synced views) pan/zoom together.
+    this.trace.timeline.setVisibleWindow(
+      HighPrecisionTimeSpan.fromTime(Time.fromRaw(s), Time.fromRaw(e)),
+    );
+    this.invalidate();
+  }
+
+  // Zoom by `factor` (>1 zooms out, <1 zooms in) keeping `centerTime` fixed.
+  // The math is done relative to the window start so it stays exact for the
+  // very large (boot-relative, weeks-scale) timestamps this plugin targets,
+  // where absolute ns exceeds 2^53 and Number() would lose precision.
+  zoomAt(centerTime: time, factor: number): void {
+    const start = this.viewStart;
+    const c = Number(centerTime - start); // ns from window start, safely < 2^53
+    const e = Number(this.viewEnd - start);
+    const ns = c - c * factor;
+    const ne = c + (e - c) * factor;
+    this.setView(
+      Time.fromRaw(start + BigInt(Math.round(ns))),
+      Time.fromRaw(start + BigInt(Math.round(ne))),
+    );
+  }
+
+  panBy(deltaNs: number): void {
+    const d = BigInt(Math.round(deltaNs));
+    this.setView(
+      Time.fromRaw(this.viewStart + d),
+      Time.fromRaw(this.viewEnd + d),
+    );
+  }
+
+  resetView(): void {
+    this.setView(this.traceStart, this.traceEnd);
+  }
+
+  async dispose(): Promise<void> {
+    const series = this.selected;
+    this.selected = [];
+    this.selectedIds.clear();
+    this.manualIds.clear();
+    this.areaIds.clear();
+    await Promise.all(series.map((s) => s.dispose()));
+  }
+}

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/styles.scss
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/styles.scss
@@ -1,0 +1,478 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-tsv {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--pf-color-background);
+  color: var(--pf-color-text);
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 24px;
+    color: var(--pf-color-text-muted);
+  }
+
+  // Also a .pf-button-bar (flamegraph-style top row); we add framing + wrap.
+  &__toolbar {
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 3px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--pf-color-border);
+    background: var(--pf-color-background-secondary);
+    flex: 0 0 auto;
+
+    // Every control is the same height as a standard compact button (which is
+    // the flamegraph header's height, since both use the same widget): keep the
+    // default 2px vertical padding so heights match, only widening the labelled
+    // toggles horizontally for breathing room. Icon-only buttons get matching
+    // vertical padding so they're the same height as the labelled ones (their
+    // default is 0, which is 4px shorter).
+    .pf-button.pf-compact {
+      &:not(.pf-icon-only) {
+        padding: 2px 12px;
+      }
+      &.pf-icon-only {
+        padding: 2px 4px;
+      }
+    }
+  }
+
+  // Flexible gap that pushes trailing items (the help icon) to the right.
+  &__spacer {
+    flex: 1 1 auto;
+  }
+
+  // Vertical divider between toolbar button groups, with generous breathing
+  // room so the groups read as distinct.
+  &__divider {
+    align-self: stretch;
+    width: 1px;
+    margin: 4px 12px;
+    background: var(--pf-color-border-secondary);
+  }
+
+  &__help {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  &__legend {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px;
+    background: var(--pf-color-background);
+    flex: 0 0 auto;
+    // The strip scrolls; its max-height is the drag-resizable default (set
+    // inline), so a large selection's chips never crowd out the chart.
+    overflow-y: auto;
+  }
+
+  // Draggable splitter between the legend and the chart (drag to resize the
+  // legend). Doubles as the legend's bottom border.
+  &__legend-resize {
+    flex: 0 0 auto;
+    height: 6px;
+    cursor: ns-resize;
+    border-bottom: 1px solid var(--pf-color-border);
+    background: var(--pf-color-background-secondary);
+
+    &:hover {
+      background: var(--pf-color-background-hover);
+    }
+  }
+
+  &__legend-more {
+    font-size: 11px;
+    color: var(--pf-color-text-muted);
+    align-self: center;
+  }
+
+  // Bulk show/hide buttons at the start of the legend strip.
+  &__legend-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-right: 8px;
+    padding-right: 8px;
+    border-right: 1px solid var(--pf-color-border-secondary);
+  }
+
+  &__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    font-size: 11px;
+    border: 1px solid var(--pf-color-border);
+    border-radius: 12px;
+    cursor: pointer;
+    user-select: none;
+    // Fade opacity when a line is hidden/shown so the legend doesn't flicker.
+    transition: opacity 0.15s ease;
+
+    &:hover {
+      background: var(--pf-color-background-hover);
+    }
+
+    &--off {
+      opacity: 0.4;
+      text-decoration: line-through;
+    }
+
+    // Marks a lane that's part of the stacked-mode multi-select (emphasis).
+    &--emphasized {
+      border-color: var(--pf-color-primary);
+      background: var(--pf-color-background-hover);
+    }
+  }
+
+  &__chip-name {
+    cursor: pointer;
+  }
+
+  &__swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background: var(--pf-chart-color-1);
+
+    &--1 {
+      background: var(--pf-chart-color-1);
+    }
+    &--2 {
+      background: var(--pf-chart-color-2);
+    }
+    &--3 {
+      background: var(--pf-chart-color-3);
+    }
+    &--4 {
+      background: var(--pf-chart-color-4);
+    }
+    &--5 {
+      background: var(--pf-chart-color-5);
+    }
+    &--6 {
+      background: var(--pf-chart-color-6);
+    }
+    &--7 {
+      background: var(--pf-chart-color-7);
+    }
+    &--8 {
+      background: var(--pf-chart-color-8);
+    }
+  }
+
+  &__style-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px;
+    min-width: 220px;
+  }
+
+  &__style-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__style-label {
+    width: 46px;
+    font-size: 12px;
+    color: var(--pf-color-text-muted);
+  }
+
+  &__colors {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+  }
+
+  &__color-reset {
+    font-size: 11px;
+    padding: 1px 6px;
+    border: 1px solid var(--pf-color-border);
+    border-radius: 4px;
+    cursor: pointer;
+
+    &:hover {
+      background: var(--pf-color-background-hover);
+    }
+  }
+
+  &__color-dot {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    cursor: pointer;
+    border: 2px solid transparent;
+
+    &--sel {
+      border-color: var(--pf-color-text);
+    }
+
+    &--0 {
+      background: #4285f4;
+    }
+    &--1 {
+      background: #ea4335;
+    }
+    &--2 {
+      background: #fbbc04;
+    }
+    &--3 {
+      background: #34a853;
+    }
+    &--4 {
+      background: #ff6d01;
+    }
+    &--5 {
+      background: #46bdc6;
+    }
+    &--6 {
+      background: #9334e6;
+    }
+    &--7 {
+      background: #e91e63;
+    }
+    &--8 {
+      background: #00acc1;
+    }
+    &--9 {
+      background: #9e9e9e;
+    }
+  }
+
+  &__scale {
+    display: inline-flex;
+    gap: 2px;
+  }
+
+  &__body {
+    position: relative;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  &__chart {
+    position: absolute;
+    inset: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    touch-action: none; // we handle pinch/pan ourselves
+  }
+
+  // Provides the scroll range; its height is set imperatively to the total
+  // stacked content height (or 100% when everything fits).
+  &__scroll-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+
+  &__canvas {
+    display: block;
+    position: sticky;
+    top: 0;
+    cursor: crosshair;
+  }
+
+  &__picker {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 420px;
+    max-height: 60vh;
+    padding: 4px;
+
+    // The MultiSelect widget hard-codes a 280px panel; let it fill the picker so
+    // there's no dead margin on the right.
+    .pf-multiselect-panel {
+      width: 100%;
+    }
+
+    // Keep each counter option to a single ellipsized line — owner·metric names
+    // are long and otherwise wrap to 2–3 lines. Lay the row out as flex so the
+    // label can shrink and ellipsize next to the checkbox.
+    .pf-multiselect-item.pf-checkbox {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+
+      .pf-checkbox__label {
+        min-width: 0;
+        flex: 1 1 auto;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+    }
+  }
+
+  &__picker-nameby {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 0;
+  }
+
+  &__picker-label {
+    font-size: 11px;
+    color: var(--pf-color-text-muted);
+  }
+
+  &__picker-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 0;
+  }
+
+  // Commit row at the bottom of the picker (pending selection -> Apply).
+  &__picker-apply {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding-top: 6px;
+    margin-top: 4px;
+    border-top: 1px solid var(--pf-color-border);
+
+    .pf-tsv__picker-count {
+      margin-right: auto; // push Apply/Cancel to the right
+    }
+  }
+
+  &__picker-list {
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__picker-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 2px 4px;
+    border-radius: 4px;
+
+    &:hover {
+      background: var(--pf-color-background-hover);
+    }
+  }
+
+  &__picker-count {
+    font-size: 11px;
+    color: var(--pf-color-text-muted);
+    white-space: nowrap;
+  }
+
+  &__picker-more {
+    padding: 6px 4px;
+    font-size: 11px;
+    color: var(--pf-color-text-muted);
+  }
+}
+
+.pf-tsv__area-tab {
+  display: flex;
+  align-items: center;
+  padding: 10px;
+}
+
+// Hover tooltip content (rendered inside a Perfetto CursorTooltip portal).
+.pf-tsv__tip {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 11px;
+  min-width: 120px;
+
+  .pf-tsv__tip-time {
+    font-weight: 600;
+    margin-bottom: 2px;
+    color: var(--pf-color-text);
+  }
+
+  .pf-tsv__tip-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    // Non-focused rows are greyed while another line is hovered (fade, not snap).
+    transition: opacity 0.15s ease;
+
+    &--dim {
+      opacity: 0.4;
+    }
+
+    // The summary "Total" row: separated and emphasised, no colour dot.
+    &--total {
+      margin-top: 3px;
+      padding-top: 3px;
+      border-top: 1px solid var(--pf-color-border);
+      font-weight: 600;
+
+      .pf-tsv__tip-name,
+      .pf-tsv__tip-val {
+        color: var(--pf-color-text);
+      }
+    }
+  }
+
+  .pf-tsv__tip-dot {
+    flex: 0 0 auto;
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+
+    &--none {
+      visibility: hidden;
+    }
+  }
+
+  .pf-tsv__tip-name {
+    flex: 1 1 auto;
+    color: var(--pf-color-text-muted);
+    white-space: nowrap;
+  }
+
+  .pf-tsv__tip-val {
+    flex: 0 0 auto;
+    font-variant-numeric: tabular-nums;
+    color: var(--pf-color-text);
+  }
+}
+
+// The counter picker popup is portaled outside .pf-tsv, so this is a top-level
+// rule. Lift the default 350px popup cap so the wider option list (long
+// owner·metric names) and the Apply/Cancel row aren't clipped.
+.pf-tsv__picker-popup {
+  max-width: 460px;
+}

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/time_axis.ts
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/time_axis.ts
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Duration, type duration, type time} from '../../base/time';
+
+// A human-readable label for a time expressed as an offset from a reference
+// (e.g. the zoom-box duration, or the trace start). Using an offset rather than
+// a raw boot timestamp makes magnitudes easy to read.
+export function timeTickLabel(t: time, reference: time): string {
+  const off = (t - reference) as duration;
+  if (off === 0n) return '0';
+  return Duration.humanise(off);
+}

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/timeseries_chart.ts
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/timeseries_chart.ts
@@ -1,0 +1,2161 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {assertUnreachable} from '../../base/assert';
+import {type time, Time, Timecode} from '../../base/time';
+import {TimeScale} from '../../base/time_scale';
+import {
+  type AxisRange,
+  logRange,
+} from '../../components/widgets/charts_svg/common';
+import {CursorTooltip} from '../../widgets/cursor_tooltip';
+import {PopupPosition} from '../../widgets/popup';
+// A local copy of the timeline's tick generator, so our sync-mode gridlines
+// land on the exact same times/pixels as the timeline's own axis.
+import {generateTicks, getMaxMajorTicks, TickType} from './gridlines';
+import {
+  type CounterSeries,
+  formatMetric,
+  type LineStyle,
+  type SeriesWindow,
+  swatchClassFor,
+} from './counter_index';
+import type {ViewerModel} from './model';
+import {timeTickLabel} from './time_axis';
+import {WasdNavigation} from './wasd';
+
+// Width below which the left gutter is too small to also show a counter name
+// (page-style narrow y-axis); the drawer's track-shell-width gutter is wider.
+const PAD_LEFT_DEFAULT = 72;
+const TOP_AXIS = 26; // time axis + labels
+const BOTTOM = 6;
+const LANE_GAP = 10;
+const AXIS_FONT = '10px Roboto, Arial, sans-serif';
+const BUCKETS_PER_PX = 2;
+// Greyed (non-focused) line opacity, and the per-frame easing fraction toward
+// the target opacity so hover greying/un-greying fades instead of snapping
+// (~0.2 settles in ~12 frames / 200ms — the same order as the UI's own hovers).
+const DIM_ALPHA = 0.22;
+const DIM_EASE = 0.2;
+// Target total drawn points across all visible lines. Above this, per-line
+// resolution is coarsened so hundreds/thousands of overlaid lines stay
+// interactive (the mipmap makes coarser cheaper, and fewer segments render
+// faster).
+const TARGET_TOTAL_POINTS = 320_000;
+const FETCH_DEBOUNCE_MS = 40;
+// Re-resolve theme colours at most once every this many draws.
+const REPALETTE_FRAMES = 30;
+// Breathing room inside each lane so the top value/line and the min/max tick
+// labels are never flush against (or clipped by) the lane edges.
+const LANE_PAD_TOP = 10;
+const LANE_PAD_BOTTOM = 6;
+// Roughly how many vertical pixels each y-axis tick wants; used to pick the
+// tick count from the lane height (fewer ticks on short lanes, never cramped).
+const TICK_SPACING_PX = 34;
+// Max lines drawn/fetched at once in overlay mode. Overlaying more than this is
+// not legible, so we cap it (with a note) to stay fast even if the user selects
+// every counter. Stacked mode has no such cap — it only ever touches the lanes
+// currently on screen.
+const MAX_OVERLAY_SERIES = 256;
+
+// A value axis with an adjustable target tick count (charts_svg's niceRange is
+// fixed at ~5, too many for short lanes). `min`/`max` are the *raw* bounds so
+// mapY scales the curve continuously while zooming; only `ticks` are rounded to
+// nice numbers (renderers cull ticks outside min..max), so labels stay legible
+// while the plot never snaps.
+function niceValueTicks(
+  rawMin: number,
+  rawMax: number,
+  approx: number,
+): AxisRange {
+  if (!isFinite(rawMin) || !isFinite(rawMax) || rawMin === rawMax) {
+    const v = isFinite(rawMin) ? rawMin : 0;
+    return {min: v - 1, max: v + 1, ticks: [v - 1, v, v + 1]};
+  }
+  const rough = (rawMax - rawMin) / Math.max(1, approx);
+  const mag = Math.pow(10, Math.floor(Math.log10(rough)));
+  const norm = rough / mag;
+  const step = (norm < 1.5 ? 1 : norm < 3 ? 2 : norm < 7 ? 5 : 10) * mag;
+  const niceMin = Math.floor(rawMin / step) * step;
+  const niceMax = Math.ceil(rawMax / step) * step;
+  const decimals = Math.max(0, -Math.floor(Math.log10(step))) + 2;
+  const ticks: number[] = [];
+  for (let t = niceMin; t <= niceMax + step / 2; t += step) {
+    ticks.push(Number(t.toFixed(decimals)));
+  }
+  return {min: rawMin, max: rawMax, ticks};
+}
+
+// Log-scale counterpart: raw bounds for continuous drawing, power-of-10 tick
+// labels within them (reuses logRange's decade ticks, but keeps the raw bounds
+// so a log zoom doesn't jump at decade boundaries either).
+function logDrawRange(rawMin: number, rawMax: number): AxisRange {
+  return {min: rawMin, max: rawMax, ticks: logRange(rawMin, rawMax).ticks};
+}
+
+// Subsamples an axis' ticks (keeping the endpoints) so at most `maxTicks`
+// remain — used to thin log-scale power-of-10 ticks on short lanes.
+function thinTicks(r: AxisRange, maxTicks: number): AxisRange {
+  if (r.ticks.length <= maxTicks || maxTicks < 2) return r;
+  const stride = Math.ceil((r.ticks.length - 1) / (maxTicks - 1));
+  const ticks = r.ticks.filter((_, i) => i % stride === 0);
+  const last = r.ticks[r.ticks.length - 1];
+  if (ticks[ticks.length - 1] !== last) ticks.push(last);
+  return {min: r.min, max: r.max, ticks};
+}
+
+// First index i in a[0..n) with a[i] >= target, assuming a is ascending; n if
+// none. Used to clip a series' samples to the viewport in O(log n).
+function lowerBound(a: Float64Array, target: number, n: number): number {
+  let lo = 0;
+  let hi = n;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (a[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+interface Palette {
+  readonly text: string;
+  readonly muted: string;
+  readonly border: string;
+  readonly grid: string;
+  readonly bg: string;
+  readonly laneBg: string;
+  readonly accent: string;
+  readonly series: ReadonlyArray<string>;
+}
+
+interface LaneLayout {
+  readonly top: number;
+  readonly bottom: number;
+  readonly height: number;
+}
+
+// One row of the hover tooltip: a counter (with its swatch), or the summary
+// "Total" row (no swatch).
+interface TooltipRow {
+  readonly name: string;
+  readonly value: string;
+  readonly swatch: string;
+  readonly dim: boolean;
+  readonly isTotal?: boolean;
+}
+
+// Adds an alpha channel to a hex colour (palette and override colours are both
+// hex). Used to build the translucent area-fill gradient.
+function toRgba(color: string, alpha: number): string {
+  let h = color.trim();
+  if (!h.startsWith('#')) return color;
+  h = h.slice(1);
+  if (h.length === 3) {
+    h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  }
+  if (h.length !== 6) return color;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return color;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export interface TimeseriesChartAttrs {
+  readonly model: ViewerModel;
+}
+
+// A GPU-friendly Canvas2D viewer: one shared time axis over a vertical
+// stack of per-counter lanes, each auto-scaled to the visible window so the
+// magnitude of every metric is legible at once (Battery-Historian style).
+export class TimeseriesChart implements m.ClassComponent<TimeseriesChartAttrs> {
+  private model!: ViewerModel;
+  private container!: HTMLElement;
+  private canvas!: HTMLCanvasElement;
+  private ctx!: CanvasRenderingContext2D;
+  private ro?: ResizeObserver;
+  // Registration with the shared canvas-redraw scheduler; disposed on unmount.
+  private rafDisposable?: Disposable;
+  private fetchInFlight = 0;
+  private disposed = false;
+  // Cached theme palette: getComputedStyle is expensive, so we resolve it once
+  // and refresh only every REPALETTE_FRAMES draws (picks up theme toggles).
+  private palCache?: Palette;
+  private palAge = 0;
+
+  private cssW = 0;
+  private cssH = 0;
+  private dpr = 1;
+  // Plot insets for the current frame: the y-axis gutter (track-shell width) on
+  // the left, none on the right, so the plot lines up with the tracks above.
+  private padLeft = PAD_LEFT_DEFAULT;
+  private padRight = 0;
+  // Time<->px mapping for the current frame (the timeline's own scale), rebuilt
+  // each draw so data, gridlines and crosshair align exactly with the tracks.
+  private ts?: TimeScale;
+  // Per-frame linear map from ns-since-traceStart to px (the TimeScale is
+  // linear), so xOfRel() needs no per-point BigInt/Time allocation.
+  private relToPxBase = 0;
+  private relToPxSlope = 0;
+  // A pinned crosshair time (sync mode): click the chart to park a reference
+  // line that persists after the pointer leaves; click it again to clear.
+  private pinnedTime?: time;
+  // The counter under the cursor (its info.id): its line is emphasised and the
+  // others greyed while hovering.
+  private focusId?: number;
+  // Per-line current opacity (info.id -> alpha), eased toward its target each
+  // frame so the greying/un-greying fades in smoothly instead of snapping.
+  private readonly dimAlpha = new Map<number, number>();
+  // True while any line's alpha is still easing toward its target, so the
+  // per-frame early-out keeps redrawing until the fade settles.
+  private dimAnimating = false;
+  // The one combined range used by every lane/line in 'shared' y-range mode,
+  // recomputed at the start of each draw (undefined in other modes).
+  private sharedRange?: {min: number; max: number};
+  // Whether any lane is emphasised (multi-select), cached per draw so the
+  // per-line dimmed() check stays O(1).
+  private emphasisActive = false;
+  // Last value this chart wrote to the timeline's shared hover cursor, so we
+  // dedupe writes and only clear it on unmount if we still own it (another
+  // chart sharing the model may have taken it over).
+  private publishedHover?: time;
+  // Distinguishes a single click (isolate / pin) from a double click (hide /
+  // bookmark): the single action fires only if no double-click follows.
+  private clickTimer?: ReturnType<typeof setTimeout>;
+  // Vertical scroll (stacked mode, when the lane stack exceeds the viewport).
+  private scrollInner?: HTMLElement;
+  private scrollTop = 0;
+  // On-screen lane rects for this draw, with the counter's index in
+  // model.selected (`i`) and its position among the visible lanes (`k`), so
+  // hit-testing (crosshair, reorder, resize) maps back exactly. Lane heights can
+  // differ per lane, so positions come from here, not a uniform step.
+  private laneRects: Array<LaneLayout & {i: number; k: number}> = [];
+
+  // Interaction state.
+  private mouseX = -1;
+  private mouseY = -1;
+  private mouseInside = false;
+  private drag?: {
+    mode: 'pan' | 'zoombox';
+    startX: number;
+    curX: number;
+    startView: {s: time; e: time};
+  };
+  private readonly pointers = new Map<number, number>(); // id -> clientX
+  private pinch?: {
+    startDist: number;
+    startView: {s: time; e: time};
+    centerX: number;
+  };
+  // Active height-resize drag (overlay plot height, or stacked lane height).
+  private resize?:
+    | {startY: number; startH: number; kind: 'overlay'}
+    | {startY: number; startH: number; kind: 'lane'; series: CounterSeries};
+  // Active stacked-lane reorder drag (grab a lane by its shell to move it).
+  private laneReorder?: {series: CounterSeries; targetIdx: number};
+  // Bottom edge (px) of the overlay plot, for the resize hit-test.
+  private overlayBottom = 0;
+  // Max stacked total from the last stacked-area draw, so hover hit-testing maps
+  // to the same value axis.
+  private overlayStackMax = 1;
+
+  private fetchTimer?: ReturnType<typeof setTimeout>;
+  private lastFetchSig = '';
+  private lastTipSig = '';
+  private wasd?: WasdNavigation;
+  private removeInvalidateListener?: () => void;
+
+  oncreate(vnode: m.CVnodeDOM<TimeseriesChartAttrs>) {
+    this.model = vnode.attrs.model;
+    this.container = vnode.dom as HTMLElement;
+    this.canvas = this.container.querySelector('canvas') as HTMLCanvasElement;
+    this.scrollInner = this.container.querySelector(
+      '.pf-tsv__scroll-inner',
+    ) as HTMLElement;
+    const ctx = this.canvas.getContext('2d');
+    if (ctx === null) throw new Error('2d context unavailable');
+    this.ctx = ctx;
+
+    this.ro = new ResizeObserver(() => this.wake());
+    this.ro.observe(this.container);
+    this.container.addEventListener('scroll', () => {
+      this.scrollTop = this.container.scrollTop;
+      this.wake();
+    });
+
+    // External (toolbar/legend) mutations wake the render loop.
+    this.removeInvalidateListener = this.model.addInvalidateListener(() =>
+      this.wake(),
+    );
+
+    // WASD navigation, matching the main timeline: A/D pan, W/S zoom at cursor.
+    this.wasd = new WasdNavigation({
+      element: this.canvas,
+      onPanned: (px) => {
+        this.model.panBy(
+          (px / this.plotWidth()) * Number(this.model.viewDuration),
+        );
+        this.wake();
+      },
+      onZoomed: (posPx, ratio) => {
+        if (posPx < this.padLeft) return;
+        this.model.zoomAt(this.xToTime(posPx), 1 - ratio);
+        this.wake();
+      },
+    });
+
+    // Redraw whenever the shared scheduler paints (covers the timeline's own
+    // zoom/pan/hover); our own changes call wake() to request a paint.
+    this.rafDisposable = this.model.trace.raf.addCanvasRedrawCallback(() =>
+      this.render(),
+    );
+
+    this.attachListeners();
+    this.wake();
+  }
+
+  onremove() {
+    this.disposed = true;
+    this.rafDisposable?.[Symbol.dispose]();
+    this.ro?.disconnect();
+    this.wasd?.[Symbol.dispose]();
+    this.removeInvalidateListener?.();
+    if (this.fetchTimer !== undefined) clearTimeout(this.fetchTimer);
+    if (this.clickTimer !== undefined) clearTimeout(this.clickTimer);
+    // Don't leave a stale hover pointer behind — but only clear it if we still
+    // own it (another chart sharing this model may have set it since).
+    const timeline = this.model.trace.timeline;
+    if (timeline.hoverCursorTimestamp === this.publishedHover) {
+      timeline.hoverCursorTimestamp = undefined;
+    }
+  }
+
+  view() {
+    return m(
+      '.pf-tsv__chart',
+      m('.pf-tsv__scroll-inner', m('canvas.pf-tsv__canvas')),
+      this.renderTooltip(),
+    );
+  }
+
+  // A Perfetto cursor-tooltip listing the counter name(s) and value(s) at the
+  // hovered time. Replaces on-chart labels (the legend chips are the legend).
+  private renderTooltip(): m.Children {
+    if (this.disposed || !this.mouseInside) return undefined;
+    if (this.drag !== undefined || this.resize !== undefined) return undefined;
+    if (this.mouseX < this.padLeft || this.mouseX > this.cssW - this.padRight) {
+      return undefined;
+    }
+    const rows = this.tooltipRows();
+    if (rows.length === 0) return undefined;
+    const t = this.xToTime(this.mouseX);
+    return m(
+      CursorTooltip,
+      {position: PopupPosition.Right},
+      m(
+        '.pf-tsv__tip',
+        m('.pf-tsv__tip-time', this.timeLabel(t)),
+        rows.map((r) =>
+          m(
+            '.pf-tsv__tip-row',
+            {
+              className: [
+                r.dim && 'pf-tsv__tip-row--dim',
+                r.isTotal && 'pf-tsv__tip-row--total',
+              ]
+                .filter(Boolean)
+                .join(' '),
+            },
+            r.isTotal
+              ? m('span.pf-tsv__tip-dot.pf-tsv__tip-dot--none')
+              : m(`span.pf-tsv__tip-dot.${r.swatch}`),
+            m('span.pf-tsv__tip-name', r.name),
+            m('span.pf-tsv__tip-val', r.value),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // A cheap signature of what the tooltip currently shows, so pointermove only
+  // triggers a Mithril redraw when the content would actually change (the
+  // CursorTooltip repositions itself independently of Mithril).
+  private tooltipSig(): string {
+    if (this.disposed || !this.mouseInside) return 'off';
+    if (this.drag !== undefined || this.resize !== undefined) return 'off';
+    if (this.mouseX < this.padLeft || this.mouseX > this.cssW - this.padRight) {
+      return 'off';
+    }
+    const lane =
+      this.model.layout === 'overlay' ? 'ov' : this.stackedLaneAt(this.mouseY);
+    return `${this.model.layout}|${lane}|${Math.round(this.mouseX)}|${this.focusId}`;
+  }
+
+  private tooltipRows(): ReadonlyArray<TooltipRow> {
+    const row = (s: CounterSeries, i: number, v: number): TooltipRow => ({
+      name: s.label(this.model.nameBy),
+      value: this.fmt(s, v),
+      swatch: swatchClassFor(s.colorOverride, i),
+      dim: false,
+    });
+    if (this.model.layout === 'overlay') {
+      // Only the hovered line plus the total across visible lines — listing
+      // every counter is unusable with hundreds/thousands selected.
+      const visible = this.overlaySeries();
+      const out: TooltipRow[] = [];
+      const focused = visible.find(({s}) => s.info.id === this.focusId);
+      if (focused !== undefined) {
+        const v = this.valueAtCursor(focused.s);
+        if (v !== undefined) out.push(row(focused.s, focused.i, v));
+      }
+      let total = 0;
+      let any = false;
+      for (const {s} of visible) {
+        const v = this.valueAtCursor(s);
+        if (v !== undefined) {
+          total += v;
+          any = true;
+        }
+      }
+      if (any) {
+        out.push({
+          name: `Total (${visible.length})`,
+          value: formatMetric(total, this.overlayUnit(visible)),
+          swatch: '',
+          dim: false,
+          isTotal: true,
+        });
+      }
+      return out;
+    }
+    // Stacked: just the lane under the cursor (computed from the current scroll
+    // position, so it stays correct even if a draw hasn't happened yet).
+    const i = this.stackedLaneAt(this.mouseY);
+    if (i < 0) return [];
+    const s = this.model.selected[i];
+    const v = this.valueAtCursor(s);
+    return v === undefined ? [] : [row(s, i, v)];
+  }
+
+  // A lane's height: its own override if set, else the global height. Lanes can
+  // differ, so all layout math is cumulative (see the stacked draw).
+  private laneHeightOf(series: CounterSeries): number {
+    return series.laneHeightOverride ?? this.model.laneHeight;
+  }
+
+  // Original selection index of the stacked lane at canvas-y `y`, or -1 if over
+  // a gap/axis. Uses the rects drawn this frame (which carry per-lane geometry),
+  // so it composes with per-lane heights and scroll.
+  private stackedLaneAt(y: number): number {
+    if (y < TOP_AXIS) return -1;
+    for (const r of this.laneRects) {
+      if (y >= r.top && y <= r.bottom) return r.i;
+    }
+    return -1;
+  }
+
+  // The position among the visible lanes nearest canvas-y `y`, for
+  // drag-to-reorder — uses lane centres so the drop target flips at midpoints.
+  // Considers only the on-screen lanes (reorder happens within the view).
+  private visibleLaneIndexAt(y: number): number {
+    if (this.laneRects.length === 0) return -1;
+    let bestK = this.laneRects[0].k;
+    let bestDist = Infinity;
+    for (const r of this.laneRects) {
+      const dist = Math.abs(y - (r.top + r.bottom) / 2);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestK = r.k;
+      }
+    }
+    return bestK;
+  }
+
+  // ---- rendering ----------------------------------------------------------
+
+  // Requests a canvas redraw via the shared scheduler (the conventional path).
+  // Called on any local change (pointer, scroll, resize, model mutation, fetch
+  // completion). External timeline zoom/pan/hover already schedule redraws,
+  // which reach render() through the callback registered in oncreate — so we
+  // follow the timeline without polling.
+  private wake() {
+    if (this.disposed) return;
+    this.model.trace.raf.scheduleCanvasRedraw();
+  }
+
+  // Paints the chart for one frame: (re)fetch when what we need changed, update
+  // hover focus, advance the greying animation, draw. Runs on every shared
+  // canvas redraw (so timeline zoom/pan/hover are followed for free); while the
+  // greying is still easing it asks for the next frame.
+  private render() {
+    // No work when unmounted or when the drawer tab is hidden (zero-width).
+    if (this.disposed || this.container.clientWidth === 0) return;
+    // Read the viewport up front so the fetch signature below reflects the
+    // current width (draw() reads it too, but runs after we've keyed the fetch).
+    this.cssW = this.container.clientWidth;
+    this.cssH = this.container.clientHeight;
+    const m = this.model;
+    // Refetch when what/where/how-much data we need changes: window, layout,
+    // selection, and — because fetching is virtualized to on-screen lanes — the
+    // scroll position, lane height and width.
+    const fetchSig =
+      `${m.layout}|${m.viewStart}|${m.viewEnd}|${m.selectionGeneration}` +
+      `|${Math.round(this.scrollTop)}|${m.laneHeight}|${this.cssW}|${m.yRangeMode}`;
+    if (fetchSig !== this.lastFetchSig) {
+      this.lastFetchSig = fetchSig;
+      this.scheduleFetch();
+    }
+    // Focus (hover): the line under the cursor is emphasised, the rest greyed.
+    this.focusId =
+      this.mouseInside && this.drag === undefined && this.resize === undefined
+        ? this.lineAt(this.mouseX, this.mouseY)?.s.info.id
+        : undefined;
+    this.advanceDim();
+    this.draw();
+    // Keep animating the greying fade until it settles.
+    if (this.dimAnimating) m.trace.raf.scheduleCanvasRedraw();
+  }
+
+  // Eases every line's opacity one step toward its target (1 when focused or
+  // nothing is hovered, DIM_ALPHA when greyed) and flags whether any is still in
+  // transit, so hover/un-hover cross-fades smoothly rather than snapping.
+  private advanceDim() {
+    let animating = false;
+    for (const s of this.model.selected) {
+      const target = this.dimmed(s) ? DIM_ALPHA : 1;
+      // Unseen lines start fully visible so the very first greying still fades.
+      const cur = this.dimAlpha.get(s.info.id) ?? 1;
+      const next = cur + (target - cur) * DIM_EASE;
+      if (Math.abs(target - next) < 0.005) {
+        this.dimAlpha.set(s.info.id, target);
+      } else {
+        this.dimAlpha.set(s.info.id, next);
+        animating = true;
+      }
+    }
+    this.dimAnimating = animating;
+  }
+
+  // The current (eased) opacity for a line — DIM_ALPHA..1.
+  private alphaFor(series: CounterSeries): number {
+    return (
+      this.dimAlpha.get(series.info.id) ?? (this.dimmed(series) ? DIM_ALPHA : 1)
+    );
+  }
+
+  private plotWidth(): number {
+    return Math.max(1, this.cssW - this.padLeft - this.padRight);
+  }
+
+  private seriesColor(series: CounterSeries, i: number, pal: Palette): string {
+    return series.colorOverride ?? pal.series[i % pal.series.length];
+  }
+
+  // Formats a value with the track's unit, adjusted for the line's mode:
+  // delta gets a Δ prefix, rate a /s suffix.
+  private fmt(series: CounterSeries, v: number): string {
+    const u = series.info.unit;
+    if (series.mode === 'delta') return `Δ${formatMetric(v, u)}`;
+    if (series.mode === 'rate') return `${formatMetric(v, u)}/s`;
+    return formatMetric(v, u);
+  }
+
+  private localY(clientY: number): number {
+    return clientY - this.canvas.getBoundingClientRect().top;
+  }
+
+  // If the given y is on a height-resize edge, returns what would be resized.
+  // For stacked lanes this targets the specific lane under the edge, so each
+  // lane resizes independently.
+  private hitResize(
+    y: number,
+  ):
+    | {kind: 'overlay'; startH: number}
+    | {kind: 'lane'; startH: number; series: CounterSeries}
+    | undefined {
+    if (this.model.layout === 'overlay') {
+      if (Math.abs(y - this.overlayBottom) <= 5) {
+        return {kind: 'overlay', startH: this.overlayBottom - TOP_AXIS};
+      }
+      return undefined;
+    }
+    for (const r of this.laneRects) {
+      if (Math.abs(y - r.bottom) <= 4 && r.bottom >= TOP_AXIS) {
+        const series = this.model.selected[r.i];
+        return {kind: 'lane', startH: r.height, series};
+      }
+    }
+    return undefined;
+  }
+
+  // A grip drawn on the resize edge (overlay plot bottom).
+  private drawResizeHandle(pal: Palette, y: number) {
+    const ctx = this.ctx;
+    const cx = (this.padLeft + (this.cssW - this.padRight)) / 2;
+    ctx.save();
+    ctx.fillStyle = pal.laneBg;
+    ctx.strokeStyle = pal.border;
+    ctx.lineWidth = 1;
+    ctx.fillRect(cx - 22, y - 3, 44, 7);
+    ctx.strokeRect(cx - 22 + 0.5, y - 3 + 0.5, 43, 6);
+    ctx.strokeStyle = pal.muted;
+    ctx.beginPath();
+    ctx.moveTo(cx - 10, y - 1);
+    ctx.lineTo(cx + 10, y - 1);
+    ctx.moveTo(cx - 10, y + 1.5);
+    ctx.lineTo(cx + 10, y + 1.5);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  private dashFor(style: LineStyle): number[] {
+    switch (style) {
+      case 'solid':
+        return [];
+      case 'dashed':
+        return [6, 4];
+      case 'dotted':
+        return [2, 3];
+      default:
+        return assertUnreachable(style);
+    }
+  }
+
+  private scheduleFetch() {
+    if (this.fetchTimer !== undefined) clearTimeout(this.fetchTimer);
+    this.fetchTimer = setTimeout(() => this.doFetch(), FETCH_DEBOUNCE_MS);
+  }
+
+  // Which lanes/lines actually need data right now, and at what bucket
+  // resolution. Stacked fetches only the lanes on screen (so any number of
+  // selected counters stays fast); overlay fetches the visible lines, capped.
+  private fetchList(): {series: CounterSeries[]; bpp: number} {
+    const {model} = this;
+    if (model.layout === 'overlay') {
+      const series = model.selected
+        .filter((s) => !s.hidden)
+        .slice(0, MAX_OVERLAY_SERIES);
+      // Coarsen per-line resolution so the total drawn points stay bounded.
+      const bpp = Math.max(
+        0.25,
+        Math.min(
+          BUCKETS_PER_PX,
+          TARGET_TOTAL_POINTS / (Math.max(1, series.length) * this.plotWidth()),
+        ),
+      );
+      return {series, bpp};
+    }
+    // Stacked: each lane is an independent full-width plot, so it gets full
+    // resolution; we fetch only the lanes drawn on screen last frame (draw runs
+    // synchronously before this debounced fetch, so laneRects is current).
+    return {
+      series: this.laneRects.map((r) => this.model.selected[r.i]),
+      bpp: BUCKETS_PER_PX,
+    };
+  }
+
+  private async doFetch() {
+    const {series, bpp} = this.fetchList();
+    const dur = this.model.viewDuration;
+    let step = dur / BigInt(Math.max(1, Math.floor(this.plotWidth() * bpp)));
+    if (step < 1n) step = 1n;
+    const start = this.model.viewStart;
+    const end = this.model.viewEnd;
+    this.fetchInFlight++;
+    const mode = this.model.yRangeMode;
+    const global = mode === 'global';
+    const traceEnd = this.model.traceEnd;
+    const jobs = series.map((s) =>
+      s
+        .fetch(start, end, step)
+        // In 'global' mode also make sure the whole-trace range is available so
+        // the axis can lock to it (cheap + cached per mode).
+        .then(() => (global ? s.ensureGlobalRange(traceEnd) : undefined))
+        .catch(() => {}),
+    );
+    // 'shared' mode needs the whole-trace range of *every* visible line (not
+    // just the on-screen lanes) so the one combined scale is complete.
+    if (mode === 'shared') {
+      for (const s of this.model.selected) {
+        if (s.hidden) continue;
+        jobs.push(s.ensureGlobalRange(traceEnd).catch(() => {}));
+      }
+    }
+    try {
+      await Promise.all(jobs);
+    } finally {
+      this.fetchInFlight--;
+    }
+    this.wake();
+  }
+
+  // ---- coordinate mapping -------------------------------------------------
+
+  // The timeline's track-shell width, read from the CSS var the timeline sets
+  // (--track-shell-width on <body>); the drawer matches it so its plot lines up
+  // with the track content above. Falls back to the timeline's default.
+  private trackShellWidth(): number {
+    const v = getComputedStyle(document.body).getPropertyValue(
+      '--track-shell-width',
+    );
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) && n > 0 ? n : 100;
+  }
+
+  // Time<->px scale for the current frame: the timeline's own visibleWindow over
+  // [track-shell-width, width], so a time maps to the identical pixel as the
+  // tracks above.
+  private makeTimeScale(): TimeScale {
+    return new TimeScale(this.model.trace.timeline.visibleWindow, {
+      left: this.padLeft,
+      right: this.cssW - this.padRight,
+    });
+  }
+
+  // The frame's cached scale (draw() sets this.ts); falls back to a fresh one
+  // for pointer maths that run between frames.
+  private scale(): TimeScale {
+    return this.ts ?? this.makeTimeScale();
+  }
+
+  // x for a time expressed as ns relative to traceStart (series samples are
+  // stored this way). Uses the per-frame linear map (base + rel*slope) computed
+  // in draw(), avoiding a BigInt/Time allocation for every drawn point.
+  private xOfRel(rel: number): number {
+    return this.relToPxBase + rel * this.relToPxSlope;
+  }
+
+  private xToTime(x: number): time {
+    return this.makeTimeScale().pxToHpTime(x).toTime('round');
+  }
+
+  // ---- drawing ------------------------------------------------------------
+
+  private draw() {
+    // cssW/cssH are set by render() before this runs (from the scroller's client
+    // box, which excludes any scrollbar); the sticky canvas always covers exactly
+    // the viewport, and .pf-tsv__scroll-inner provides the scroll range.
+    this.dpr = window.devicePixelRatio || 1;
+    // Use the timeline's exact plot bounds (left = track-shell width, right =
+    // full width) so the drawer's time scale matches the timeline's — crosshairs
+    // and gridlines line up pixel-for-pixel. The left column isn't wasted: it's
+    // drawn as a shell (counter name + axis), mirroring the track shells above.
+    this.padLeft = this.trackShellWidth();
+    this.padRight = 0;
+    // In 'shared' mode, resolve the one common range for this frame up front so
+    // every lane/line agrees (computed from each series' whole-trace range).
+    this.sharedRange =
+      this.model.yRangeMode === 'shared'
+        ? this.computeSharedRange()
+        : undefined;
+    this.emphasisActive = this.model.hasEmphasis();
+    this.ts = this.makeTimeScale();
+    // Precompute the linear rel->px map (base + rel*slope) from two points 1s
+    // apart, so per-point drawing does pure float math with no allocation.
+    const px0 = this.ts.timeToPx(this.model.traceStart);
+    const px1s = this.ts.timeToPx(
+      Time.fromRaw(this.model.traceStart + 1_000_000_000n),
+    );
+    this.relToPxBase = px0;
+    this.relToPxSlope = (px1s - px0) / 1e9;
+    if (this.canvas.width !== this.cssW * this.dpr) {
+      this.canvas.width = Math.max(1, Math.floor(this.cssW * this.dpr));
+    }
+    if (this.canvas.height !== this.cssH * this.dpr) {
+      this.canvas.height = Math.max(1, Math.floor(this.cssH * this.dpr));
+    }
+    // Canvas display size tracks the viewport (computed per frame from the
+    // container + DPR), so it must be set imperatively rather than in CSS.
+    this.canvas.style.width = `${this.cssW}px`;
+    this.canvas.style.height = `${this.cssH}px`;
+
+    const ctx = this.ctx;
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+    const pal = this.getPalette();
+    ctx.clearRect(0, 0, this.cssW, this.cssH);
+    ctx.fillStyle = pal.bg;
+    ctx.fillRect(0, 0, this.cssW, this.cssH);
+
+    const lanesTop = TOP_AXIS;
+    const lanesBottom = this.cssH - BOTTOM;
+
+    // The empty state is a DOM EmptyState in the page, so the chart only ever
+    // mounts with a selection; guard the transient case anyway.
+    if (this.model.selected.length === 0) {
+      this.setScrollHeight(0);
+      return;
+    }
+
+    if (this.model.layout === 'overlay') {
+      this.setScrollHeight(0);
+      this.scrollTop = 0;
+      const full = lanesBottom - lanesTop;
+      const oh = Math.max(60, Math.min(this.model.overlayHeight ?? full, full));
+      const overlayBottom = lanesTop + oh;
+      this.overlayBottom = overlayBottom;
+      this.drawShellGutter(pal, lanesTop, overlayBottom);
+      this.drawOverlay(pal, lanesTop, overlayBottom);
+      this.drawTimeAxis(pal, lanesTop, overlayBottom);
+      this.drawOverlayCrosshair(pal, lanesTop, overlayBottom);
+      this.drawResizeHandle(pal, overlayBottom);
+      this.drawZoomBox(pal, lanesTop, overlayBottom);
+      return;
+    }
+
+    // Stacked: one lane per *visible* (non-hidden) counter, fixed height;
+    // scroll vertically when the stack is taller than the viewport. Colours are
+    // keyed to the original selection index so they stay stable as lanes are
+    // hidden/shown.
+    const lanes = this.visibleLanes();
+    const n = lanes.length;
+    const viewportH = lanesBottom - lanesTop;
+    this.laneRects = [];
+    if (n > 0) {
+      // Each lane can have its own height (dragged bottom edge); the rest fall
+      // back to the global height. Positions are cumulative rather than a
+      // uniform step so per-lane resize composes cleanly.
+      const tops = new Array<number>(n);
+      let acc = 0;
+      for (let k = 0; k < n; k++) {
+        tops[k] = acc;
+        acc += this.laneHeightOf(lanes[k].s) + LANE_GAP;
+      }
+      const contentH = acc - LANE_GAP;
+      this.setScrollHeight(
+        contentH > viewportH ? TOP_AXIS + contentH + BOTTOM : 0,
+      );
+      const maxScroll = Math.max(0, contentH - viewportH);
+      if (this.scrollTop > maxScroll) this.scrollTop = maxScroll;
+
+      this.drawShellGutter(pal, lanesTop, lanesBottom);
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(0, lanesTop, this.cssW, viewportH);
+      ctx.clip();
+      // Only draw the lanes on screen, so any number of selected counters stays
+      // fast (the rest exist as scroll range only).
+      for (let k = 0; k < n; k++) {
+        const h = this.laneHeightOf(lanes[k].s);
+        const top = lanesTop + tops[k] - this.scrollTop;
+        if (top + h < lanesTop || top > lanesBottom) continue;
+        const rect: LaneLayout = {top, bottom: top + h, height: h};
+        this.laneRects.push({i: lanes[k].i, k, ...rect});
+        this.drawLane(pal, lanes[k].s, lanes[k].i, rect);
+      }
+      ctx.restore();
+    } else {
+      this.setScrollHeight(0);
+    }
+
+    // Draw the time axis last so it stays crisp over any scrolled lane.
+    this.drawTimeAxis(pal, lanesTop, lanesBottom);
+    this.drawCrosshair(pal, lanesTop, lanesBottom);
+    this.drawZoomBox(pal, lanesTop, lanesBottom);
+    this.drawLaneReorder(pal, lanesTop);
+  }
+
+  // While dragging a lane to reorder: outline the grabbed lane and show a drop
+  // indicator at the slot boundary where it will land.
+  private drawLaneReorder(pal: Palette, lanesTop: number) {
+    const drag = this.laneReorder;
+    if (drag === undefined) return;
+    const ctx = this.ctx;
+    const lanes = this.visibleLanes();
+    const from = lanes.findIndex((l) => l.s === drag.series);
+    if (from < 0) return;
+    const to = drag.targetIdx;
+    const step = this.model.laneHeight + LANE_GAP;
+    ctx.save();
+    ctx.strokeStyle = pal.accent;
+    // Outline the grabbed lane at its current position.
+    const dragged = this.laneRects.find((r) => r.i === lanes[from].i);
+    if (dragged !== undefined) {
+      ctx.lineWidth = 2;
+      ctx.strokeRect(0.5, dragged.top + 0.5, this.cssW - 1, dragged.height - 1);
+    }
+    // Drop indicator at the boundary the lane will land on.
+    const boundary = to > from ? to + 1 : to;
+    const y = lanesTop + boundary * step - this.scrollTop - LANE_GAP / 2;
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(0, Math.round(y) + 0.5);
+    ctx.lineTo(this.cssW, Math.round(y) + 0.5);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // Selected counters that are currently shown (not hidden via the legend),
+  // each with its original selection index (used for a stable colour).
+  private visibleLanes(): Array<{s: CounterSeries; i: number}> {
+    const out: Array<{s: CounterSeries; i: number}> = [];
+    const sel = this.model.selected;
+    for (let i = 0; i < sel.length; i++) {
+      if (!sel[i].hidden) out.push({s: sel[i], i});
+    }
+    // Emphasised lanes rise to the top, greyed ones sink to the bottom (stable,
+    // so order within each group is preserved). `i` stays the selection index,
+    // so colours don't shift.
+    if (this.model.hasEmphasis()) {
+      out.sort((a, b) => Number(b.s.emphasized) - Number(a.s.emphasized));
+    }
+    return out;
+  }
+
+  // Sizes the scroll spacer: 0/undefined => fit the viewport (no scrollbar),
+  // otherwise the total content height so the container can scroll.
+  private setScrollHeight(totalPx: number): void {
+    if (this.scrollInner === undefined) return;
+    this.scrollInner.style.height = totalPx > 0 ? `${totalPx}px` : '100%';
+  }
+
+  // Normalized y for overlay % mode: maps a value into [top,bottom] using the
+  // series' own visible range (log-aware), so mixed magnitudes are shape-
+  // comparable on one 0-100% plot. Used for the crosshair dots.
+  private overlayY(
+    series: CounterSeries,
+    v: number,
+    top: number,
+    height: number,
+  ): number {
+    const w = series.window;
+    const plotTop = top + LANE_PAD_TOP;
+    const plotH = Math.max(1, height - LANE_PAD_TOP - LANE_PAD_BOTTOM);
+    if (w === undefined) return plotTop + plotH;
+    const r = this.visibleRange(w);
+    return this.mapY(
+      v,
+      {min: r.min, max: r.max, ticks: []},
+      plotTop,
+      plotH,
+      this.model.yScale === 'log',
+    );
+  }
+
+  // Common unit across the visible overlay series, or undefined if they differ
+  // (then the shared value axis shows plain numbers).
+  private overlayUnit(
+    visible: ReadonlyArray<{s: CounterSeries; i: number}>,
+  ): string | undefined {
+    let unit: string | undefined;
+    let first = true;
+    for (const {s} of visible) {
+      if (first) {
+        unit = s.info.unit;
+        first = false;
+      } else if (s.info.unit !== unit) {
+        return undefined;
+      }
+    }
+    return unit;
+  }
+
+  // Combined on-screen value range across all visible overlay series, for the
+  // shared absolute value axis.
+  private overlayCombinedRange(
+    visible: ReadonlyArray<{s: CounterSeries; i: number}>,
+  ): {min: number; max: number} {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const {s} of visible) {
+      const r = this.valueRange(s);
+      if (r === undefined) continue;
+      if (r.min < min) min = r.min;
+      if (r.max > max) max = r.max;
+    }
+    if (min === Infinity) return {min: 0, max: 1};
+    return {min, max};
+  }
+
+  // The shared absolute value axis (a nice-tick range) for overlay Value mode.
+  private overlayAbsRange(
+    visible: ReadonlyArray<{s: CounterSeries; i: number}>,
+    heightPx: number,
+  ): AxisRange {
+    const c = this.overlayCombinedRange(visible);
+    const approx = this.tickTarget(heightPx);
+    if (this.model.yScale === 'log' && c.max > 0) {
+      return thinTicks(
+        logDrawRange(c.min > 0 ? c.min : c.max / 1e3, c.max),
+        approx + 1,
+      );
+    }
+    return niceValueTicks(Math.min(0, c.min), c.max, approx);
+  }
+
+  private drawOverlay(pal: Palette, top: number, bottom: number) {
+    const ctx = this.ctx;
+    const left = this.padLeft;
+    const right = this.cssW - this.padRight;
+    const height = bottom - top;
+
+    ctx.fillStyle = pal.laneBg;
+    ctx.fillRect(left, top, right - left, height);
+    ctx.strokeStyle = pal.border;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(left + 0.5, top + 0.5, right - left - 1, height - 1);
+
+    const visible = this.overlaySeries();
+    if (this.model.overlayStacked) {
+      this.drawOverlayStacked(pal, top, bottom, visible);
+    } else if (this.model.overlayNormalize) {
+      this.drawOverlayNormalized(pal, top, bottom, visible);
+    } else {
+      this.drawOverlayAbsolute(pal, top, bottom, visible);
+    }
+  }
+
+  // Horizontal gridlines + value labels for a shared absolute (unit) axis.
+  private drawOverlayValueAxis(
+    pal: Palette,
+    top: number,
+    bottom: number,
+    range: AxisRange,
+    unit: string | undefined,
+    log: boolean,
+  ) {
+    const ctx = this.ctx;
+    const left = this.padLeft;
+    const right = this.cssW - this.padRight;
+    const plotTop = top + LANE_PAD_TOP;
+    const plotH = Math.max(1, bottom - top - LANE_PAD_TOP - LANE_PAD_BOTTOM);
+    ctx.font = AXIS_FONT;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (const tick of range.ticks) {
+      const y = this.mapY(tick, range, plotTop, plotH, log);
+      if (y < top - 0.5 || y > bottom + 0.5) continue;
+      ctx.strokeStyle = pal.grid;
+      ctx.beginPath();
+      ctx.moveTo(left, Math.round(y) + 0.5);
+      ctx.lineTo(right, Math.round(y) + 0.5);
+      ctx.stroke();
+      ctx.fillStyle = pal.muted;
+      ctx.fillText(formatMetric(tick, unit), left - 6, y);
+    }
+  }
+
+  private drawOverlayNormalized(
+    pal: Palette,
+    top: number,
+    bottom: number,
+    visible: ReadonlyArray<{s: CounterSeries; i: number}>,
+  ) {
+    const ctx = this.ctx;
+    const left = this.padLeft;
+    const right = this.cssW - this.padRight;
+    const height = bottom - top;
+    // Normalized (%) gridlines — each series is scaled to its own window.
+    const gridTop = top + LANE_PAD_TOP;
+    const gridH = Math.max(1, height - LANE_PAD_TOP - LANE_PAD_BOTTOM);
+    const fracs =
+      height < 150
+        ? [0, 0.5, 1]
+        : height < 300
+          ? [0, 0.25, 0.5, 0.75, 1]
+          : [0, 0.2, 0.4, 0.6, 0.8, 1];
+    ctx.font = AXIS_FONT;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (const p of fracs) {
+      const y = gridTop + gridH * (1 - p);
+      ctx.strokeStyle = pal.grid;
+      ctx.beginPath();
+      ctx.moveTo(left, Math.round(y) + 0.5);
+      ctx.lineTo(right, Math.round(y) + 0.5);
+      ctx.stroke();
+      ctx.fillStyle = pal.muted;
+      ctx.fillText(`${Math.round(p * 100)}%`, left - 6, y);
+    }
+    const plotTop = top + LANE_PAD_TOP;
+    const plotH = gridH;
+    const log = this.model.yScale === 'log';
+    // Each series normalised to its own on-screen range (computed once).
+    this.drawOverlayLines(pal, top, bottom, visible, (s) => {
+      const r = this.valueRange(s) ?? {min: 0, max: 1};
+      const range = {min: r.min, max: r.max, ticks: []};
+      return (v: number) => this.mapY(v, range, plotTop, plotH, log);
+    });
+  }
+
+  private drawOverlayAbsolute(
+    pal: Palette,
+    top: number,
+    bottom: number,
+    visible: ReadonlyArray<{s: CounterSeries; i: number}>,
+  ) {
+    const log = this.model.yScale === 'log';
+    const range = this.overlayAbsRange(visible, bottom - top);
+    this.drawOverlayValueAxis(
+      pal,
+      top,
+      bottom,
+      range,
+      this.overlayUnit(visible),
+      log,
+    );
+    const plotTop = top + LANE_PAD_TOP;
+    const plotH = Math.max(1, bottom - top - LANE_PAD_TOP - LANE_PAD_BOTTOM);
+    const yFn = (v: number) => this.mapY(v, range, plotTop, plotH, log);
+    this.drawOverlayLines(pal, top, bottom, visible, () => yFn);
+  }
+
+  // Shared stepped-line drawing for overlay Lines modes. `mkY(series)` returns
+  // the value->y mapper for that series (computed once per series, not per
+  // point).
+  private drawOverlayLines(
+    pal: Palette,
+    top: number,
+    bottom: number,
+    visible: ReadonlyArray<{s: CounterSeries; i: number}>,
+    mkY: (s: CounterSeries) => (v: number) => number,
+  ) {
+    const ctx = this.ctx;
+    const left = this.padLeft;
+    const right = this.cssW - this.padRight;
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(left, top, right - left, bottom - top);
+    ctx.clip();
+    for (const {s: series, i} of visible) {
+      const w = series.window;
+      if (w === undefined || w.count === 0) continue;
+      const yOfV = mkY(series);
+      const stride = this.drawStride(w.count);
+      const last = w.count - 1;
+      ctx.beginPath();
+      for (let k = 0; k <= last; k += stride) {
+        const x = this.xOfRel(w.tsRel[k]);
+        const y = yOfV(w.lastV[k]);
+        if (k === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+        const xn =
+          k + stride <= last ? this.xOfRel(w.tsRel[k + stride]) : right;
+        ctx.lineTo(xn, y);
+      }
+      ctx.strokeStyle = this.seriesColor(series, i, pal);
+      ctx.globalAlpha = this.alphaFor(series); // eased grey for non-focused
+      ctx.lineWidth = 1.5;
+      ctx.lineJoin = 'miter';
+      ctx.setLineDash(this.dashFor(series.lineStyle));
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+    ctx.setLineDash([]);
+    ctx.restore();
+  }
+
+  // Stacked-area overlay: series stacked cumulatively on a shared value axis.
+  // Series have independent sample times, so we resample onto a common pixel
+  // grid (stepped, last value <= x). Stacking sums values, so it is inherently
+  // linear (log scale is ignored here). Negative samples are clamped to 0.
+  private drawOverlayStacked(
+    pal: Palette,
+    top: number,
+    bottom: number,
+    visible: ReadonlyArray<{s: CounterSeries; i: number}>,
+  ) {
+    const ctx = this.ctx;
+    const left = this.padLeft;
+    const right = this.cssW - this.padRight;
+    const plotTop = top + LANE_PAD_TOP;
+    const plotH = Math.max(1, bottom - top - LANE_PAD_TOP - LANE_PAD_BOTTOM);
+    const COL = 3;
+    const xs: number[] = [];
+    for (let x = left; x <= right; x += COL) xs.push(x);
+    if (xs.length === 0 || xs[xs.length - 1] !== right) xs.push(right);
+    const vals = visible.map(({s}) =>
+      xs.map((x) => Math.max(0, this.valueAtX(s, x) ?? 0)),
+    );
+    let maxTotal = 0;
+    if (this.model.yRangeMode !== 'fit') {
+      // Lock the axis to the largest the stack can ever reach (sum of each
+      // series' whole-trace max), so it doesn't rescale while zooming. (A single
+      // shared axis is what a cumulative stacked-area already is, so 'global'
+      // and 'shared' behave the same here.)
+      for (const {s} of visible) {
+        maxTotal += Math.max(0, this.ownRange(s)?.max ?? 0);
+      }
+    } else {
+      for (let c = 0; c < xs.length; c++) {
+        let sum = 0;
+        for (let j = 0; j < visible.length; j++) sum += vals[j][c];
+        if (sum > maxTotal) maxTotal = sum;
+      }
+    }
+    this.overlayStackMax = maxTotal || 1;
+    const range = niceValueTicks(
+      0,
+      maxTotal || 1,
+      this.tickTarget(bottom - top),
+    );
+    this.drawOverlayValueAxis(
+      pal,
+      top,
+      bottom,
+      range,
+      this.overlayUnit(visible),
+      false,
+    );
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(left, top, right - left, bottom - top);
+    ctx.clip();
+    const base = new Float64Array(xs.length);
+    for (let j = 0; j < visible.length; j++) {
+      const {s, i} = visible[j];
+      const color = this.seriesColor(s, i, pal);
+      const a = this.alphaFor(s); // eased grey for non-focused bands
+      // Filled band between the running base and base+value.
+      ctx.beginPath();
+      for (let c = 0; c < xs.length; c++) {
+        const y = this.mapY(base[c] + vals[j][c], range, plotTop, plotH, false);
+        if (c === 0) ctx.moveTo(xs[c], y);
+        else ctx.lineTo(xs[c], y);
+      }
+      for (let c = xs.length - 1; c >= 0; c--) {
+        ctx.lineTo(xs[c], this.mapY(base[c], range, plotTop, plotH, false));
+      }
+      ctx.closePath();
+      ctx.globalAlpha = a;
+      ctx.fillStyle = toRgba(color, 0.55);
+      ctx.fill();
+      // Top edge stroke.
+      ctx.beginPath();
+      for (let c = 0; c < xs.length; c++) {
+        const y = this.mapY(base[c] + vals[j][c], range, plotTop, plotH, false);
+        if (c === 0) ctx.moveTo(xs[c], y);
+        else ctx.lineTo(xs[c], y);
+      }
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1.2;
+      ctx.lineJoin = 'miter';
+      ctx.stroke();
+      for (let c = 0; c < xs.length; c++) base[c] += vals[j][c];
+    }
+    ctx.globalAlpha = 1;
+    ctx.restore();
+  }
+
+  private drawOverlayCrosshair(pal: Palette, top: number, bottom: number) {
+    const cross = this.crosshair();
+    if (cross === undefined) return;
+    const ctx = this.ctx;
+    const height = bottom - top;
+    const x = Math.round(cross.x) + 0.5;
+    ctx.save();
+    ctx.setLineDash([4, 3]);
+    ctx.strokeStyle = pal.accent;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(x, top);
+    ctx.lineTo(x, bottom);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    const label = this.timeLabel(cross.t);
+    ctx.font = AXIS_FONT;
+    ctx.textAlign = 'center';
+    const tw = ctx.measureText(label).width + 8;
+    ctx.fillStyle = pal.accent;
+    ctx.fillRect(cross.x - tw / 2, 1, tw, 13);
+    ctx.fillStyle = pal.bg;
+    ctx.fillText(label, cross.x, 11);
+
+    // A single dot at the hovered (focused) line's sample — dotting every line
+    // is noise (and slow) with a big selection; the tooltip has the details.
+    // Skipped in stacked-area mode (the bands already show the split).
+    const focused =
+      this.focusId === undefined || this.model.overlayStacked
+        ? undefined
+        : this.overlaySeries().find(({s}) => s.info.id === this.focusId);
+    if (focused !== undefined) {
+      const v = this.valueAtX(focused.s, cross.x);
+      if (v !== undefined) {
+        const log = this.model.yScale === 'log';
+        const plotTop = top + LANE_PAD_TOP;
+        const plotH = Math.max(1, height - LANE_PAD_TOP - LANE_PAD_BOTTOM);
+        const y = this.model.overlayNormalize
+          ? this.overlayY(focused.s, v, top, height)
+          : this.mapY(
+              v,
+              this.overlayAbsRange(this.overlaySeries(), height),
+              plotTop,
+              plotH,
+              log,
+            );
+        ctx.beginPath();
+        ctx.fillStyle = this.seriesColor(focused.s, focused.i, pal);
+        ctx.arc(cross.x, y, 3, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.strokeStyle = pal.bg;
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+      }
+    }
+    ctx.restore();
+  }
+
+  // Visible (non-hidden) overlay lines with their selection index, capped so
+  // overlaying a huge selection stays fast and legible.
+  private overlaySeries(): ReadonlyArray<{s: CounterSeries; i: number}> {
+    // In value/stacked overlay a unit filter (when the selection mixes units)
+    // scopes the shared axis to one unit; % mode normalises each line so it
+    // ignores the filter.
+    const unit = !this.model.overlayNormalize
+      ? this.model.overlayUnitFilter
+      : undefined;
+    const out: Array<{s: CounterSeries; i: number}> = [];
+    const sel = this.model.selected;
+    for (let i = 0; i < sel.length && out.length < MAX_OVERLAY_SERIES; i++) {
+      if (sel[i].hidden) continue;
+      if (unit !== undefined && sel[i].info.unit !== unit) continue;
+      out.push({s: sel[i], i});
+    }
+    return out;
+  }
+
+  // The series under the cursor: the lane in stacked mode, the band in
+  // stacked-area, or the nearest line in overlay lines modes. `maxDist` caps how
+  // far (px) a line may be for overlay lines — Infinity (default, for hover
+  // focus) always picks the nearest; a small value (for clicks) leaves empty
+  // space unmatched so a click there pins/bookmarks instead of isolating.
+  private lineAt(
+    x: number,
+    y: number,
+    maxDist = Infinity,
+  ): {s: CounterSeries; i: number} | undefined {
+    if (x < this.padLeft || x > this.cssW - this.padRight) return undefined;
+    if (this.model.layout === 'stacked') {
+      const i = this.stackedLaneAt(y);
+      return i < 0 ? undefined : {s: this.model.selected[i], i};
+    }
+    const top = TOP_AXIS;
+    const bottom = this.overlayBottom;
+    if (y < top || y > bottom) return undefined;
+    const height = bottom - top;
+    const plotTop = top + LANE_PAD_TOP;
+    const plotH = Math.max(1, height - LANE_PAD_TOP - LANE_PAD_BOTTOM);
+    const log = this.model.yScale === 'log';
+    const visible = this.overlaySeries();
+    if (this.model.overlayStacked) {
+      // The cumulative band that contains y (uses the same range as the draw).
+      const range = niceValueTicks(
+        0,
+        this.overlayStackMax || 1,
+        this.tickTarget(height),
+      );
+      let base = 0;
+      for (const {s, i} of visible) {
+        const v = Math.max(0, this.valueAtX(s, x) ?? 0);
+        const yTop = this.mapY(base + v, range, plotTop, plotH, false);
+        const yBot = this.mapY(base, range, plotTop, plotH, false);
+        if (y >= yTop && y <= yBot) return {s, i};
+        base += v;
+      }
+      return undefined;
+    }
+    const absRange = this.model.overlayNormalize
+      ? undefined
+      : this.overlayAbsRange(visible, height);
+    let best: {s: CounterSeries; i: number} | undefined;
+    let bestDist = maxDist;
+    for (const {s, i} of visible) {
+      const v = this.valueAtX(s, x);
+      if (v === undefined) continue;
+      const yv = absRange
+        ? this.mapY(v, absRange, plotTop, plotH, log)
+        : this.overlayY(s, v, top, height);
+      const d = Math.abs(y - yv);
+      if (d < bestDist) {
+        bestDist = d;
+        best = {s, i};
+      }
+    }
+    return best;
+  }
+
+  // True if `series` should be greyed because another line is focused (hovered).
+  private dimmed(series: CounterSeries): boolean {
+    // A persistent multi-select (emphasis) greys everything not selected; absent
+    // that, hovering greys everything but the line under the cursor.
+    if (this.emphasisActive) return !series.emphasized;
+    return this.focusId !== undefined && series.info.id !== this.focusId;
+  }
+
+  private drawTimeAxis(pal: Palette, top: number, bottom: number) {
+    const ctx = this.ctx;
+    ctx.font = AXIS_FONT;
+    ctx.textBaseline = 'alphabetic';
+    this.drawSyncedGridlines(pal, top, bottom);
+    // Axis rule.
+    ctx.strokeStyle = pal.border;
+    ctx.beginPath();
+    ctx.moveTo(this.padLeft, top + 0.5);
+    ctx.lineTo(this.cssW - this.padRight, top + 0.5);
+    ctx.stroke();
+  }
+
+  // Shades the left shell column (synced drawer) and draws its right divider, so
+  // the (aligned) plot's left offset reads as an intentional shell — like the
+  // track shells above — rather than an empty gap.
+  private drawShellGutter(pal: Palette, top: number, bottom: number) {
+    const ctx = this.ctx;
+    ctx.fillStyle = pal.laneBg;
+    ctx.fillRect(0, top, this.padLeft, bottom - top);
+    ctx.strokeStyle = pal.border;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(this.padLeft + 0.5, top);
+    ctx.lineTo(this.padLeft + 0.5, bottom);
+    ctx.stroke();
+  }
+
+  // Time label for the crosshair / gridlines: mirrors the timeline's own
+  // timecode (domain time, [d]HH:MM:SS.mmm) so the markings match exactly.
+  private timeLabel(t: time): string {
+    const tc = new Timecode(this.model.trace.timeline.toDomainTime(t));
+    return `${tc.dhhmmss}.${tc.millis}`;
+  }
+
+  // Vertical gridlines that coincide pixel-for-pixel with the timeline's own,
+  // by reusing its tick generator over the identical time scale, origin and
+  // major-tick spacing. Keeps the drawer visually locked to the tracks above.
+  private drawSyncedGridlines(pal: Palette, top: number, bottom: number) {
+    const ctx = this.ctx;
+    const scale = this.scale();
+    const span = scale.timeSpan.toTimeSpan();
+    if (span.duration <= 0n) return;
+    const offset = this.model.trace.timeline.getTimeAxisOrigin();
+    const maxMajorTicks = getMaxMajorTicks(this.plotWidth());
+    for (const {type, time: t} of generateTicks(span, maxMajorTicks, offset)) {
+      if (type !== TickType.MAJOR) continue;
+      const x = Math.floor(scale.timeToPx(t));
+      ctx.strokeStyle = pal.grid;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(x + 0.5, top);
+      ctx.lineTo(x + 0.5, bottom);
+      ctx.stroke();
+      ctx.fillStyle = pal.muted;
+      ctx.textAlign = 'center';
+      ctx.fillText(this.timeLabel(t), x, TOP_AXIS - 9);
+    }
+  }
+
+  // Target number of y-axis ticks for a lane of the given height. Worst case is
+  // ~2 (min + max); more are added as vertical space permits.
+  private tickTarget(heightPx: number): number {
+    const avail = heightPx - LANE_PAD_TOP - LANE_PAD_BOTTOM;
+    return Math.max(1, Math.min(6, Math.round(avail / TICK_SPACING_PX)));
+  }
+
+  // Value range over the samples currently within the viewport, so the y-axis
+  // fits what's on screen and rescales *continuously* as you zoom (no snap) —
+  // and stays correct when the fetched window is the whole series (small-counter
+  // full cache) rather than exactly the viewport.
+  private visibleRange(w: SeriesWindow): {min: number; max: number} {
+    const n = w.count;
+    if (n === 0) return {min: 0, max: 1};
+    const sRel = Number(this.model.viewStart - this.model.traceStart);
+    const eRel = Number(this.model.viewEnd - this.model.traceStart);
+    let i = lowerBound(w.tsRel, sRel, n);
+    if (i > 0) i--; // include the sample carrying the value at the left edge
+    let min = Infinity;
+    let max = -Infinity;
+    for (; i < n && w.tsRel[i] <= eRel; i++) {
+      if (w.minV[i] < min) min = w.minV[i];
+      if (w.maxV[i] > max) max = w.maxV[i];
+    }
+    if (min === Infinity) {
+      // Viewport is entirely before the first sample; use it as the flat carry.
+      min = w.minV[0];
+      max = w.maxV[0];
+    }
+    return {min, max};
+  }
+
+  // One series' own value range: its whole-trace range in 'global'/'shared'
+  // modes (when computed for the current y-mode), else the viewport range.
+  // Undefined when no data is available yet (caller falls back).
+  private ownRange(
+    series: CounterSeries,
+  ): {min: number; max: number} | undefined {
+    if (
+      this.model.yRangeMode !== 'fit' &&
+      series.globalMode === series.mode &&
+      series.globalMin !== undefined &&
+      series.globalMax !== undefined
+    ) {
+      return {min: series.globalMin, max: series.globalMax};
+    }
+    const w = series.window;
+    return w === undefined || w.count === 0 ? undefined : this.visibleRange(w);
+  }
+
+  // The value range a series' *axis* should use. In 'shared' mode every visible
+  // lane/line uses the one combined range (so heights are comparable); otherwise
+  // it's the series' own range (viewport for 'fit', whole-trace for 'global').
+  private valueRange(
+    series: CounterSeries,
+  ): {min: number; max: number} | undefined {
+    if (this.model.yRangeMode === 'shared') {
+      return this.sharedRange ?? this.ownRange(series);
+    }
+    return this.ownRange(series);
+  }
+
+  // The combined range across all visible lanes/lines, for 'shared' mode.
+  // Recomputed once per draw (see draw()) from each series' own whole-trace
+  // range, so all axes agree.
+  private computeSharedRange(): {min: number; max: number} | undefined {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const s of this.model.selected) {
+      if (s.hidden) continue;
+      const r = this.ownRange(s);
+      if (r === undefined) continue;
+      if (r.min < min) min = r.min;
+      if (r.max > max) max = r.max;
+    }
+    return min === Infinity ? undefined : {min, max};
+  }
+
+  private laneRange(series: CounterSeries, heightPx: number): AxisRange {
+    const approx = this.tickTarget(heightPx);
+    const r = this.valueRange(series);
+    if (r === undefined) return niceValueTicks(0, 1, approx);
+    if (this.model.yScale === 'log' && r.max > 0) {
+      const lo = r.min > 0 ? r.min : r.max / 1e3;
+      return thinTicks(logDrawRange(lo, r.max), approx + 1);
+    }
+    return niceValueTicks(Math.min(0, r.min), r.max, approx);
+  }
+
+  // Maps a value to a y-pixel within [plotTop, plotTop+plotH], linear or log.
+  private mapY(
+    v: number,
+    range: AxisRange,
+    plotTop: number,
+    plotH: number,
+    log: boolean,
+  ): number {
+    const h = Math.max(1, plotH);
+    if (log) {
+      const lo = Math.log10(Math.max(range.min, 1e-9));
+      const hi = Math.log10(Math.max(range.max, 1e-9));
+      const vv = Math.log10(Math.max(v, 1e-9));
+      const f = hi === lo ? 0 : (vv - lo) / (hi - lo);
+      return plotTop + h - f * h;
+    }
+    const span = range.max - range.min || 1;
+    return plotTop + h - ((v - range.min) / span) * h;
+  }
+
+  private yOf(v: number, range: AxisRange, lane: LaneLayout): number {
+    const top = lane.top + LANE_PAD_TOP;
+    const h = lane.bottom - LANE_PAD_BOTTOM - top;
+    return this.mapY(v, range, top, h, this.model.yScale === 'log');
+  }
+
+  // Point-drawing stride so a line never draws more than ~2 samples per pixel —
+  // beyond that is invisible but costs render time. Keeps fully-cached counters
+  // (and dense overlays) fast without changing the on-screen result.
+  private drawStride(count: number): number {
+    const budget = 2 * this.plotWidth();
+    return count > budget ? Math.ceil(count / budget) : 1;
+  }
+
+  private drawLane(
+    pal: Palette,
+    series: CounterSeries,
+    idx: number,
+    lane: LaneLayout,
+  ) {
+    const ctx = this.ctx;
+    const color = this.seriesColor(series, idx, pal);
+    const range = this.laneRange(series, lane.height);
+    const left = this.padLeft;
+    const right = this.cssW - this.padRight;
+
+    // Lane background + frame.
+    ctx.fillStyle = pal.laneBg;
+    ctx.fillRect(left, lane.top, right - left, lane.height);
+    ctx.strokeStyle = pal.border;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(
+      left + 0.5,
+      lane.top + 0.5,
+      right - left - 1,
+      lane.height - 1,
+    );
+
+    // The wide left column is a shell (like the track shells above): show the
+    // counter name, left-aligned and clipped so it never runs into the y-axis
+    // labels on the shell's right edge (only when the gutter is wide enough).
+    if (left > PAD_LEFT_DEFAULT) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(4, lane.top, Math.max(1, left - 52), lane.height);
+      ctx.clip();
+      ctx.fillStyle = pal.text;
+      ctx.font = AXIS_FONT;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'alphabetic';
+      ctx.fillText(series.label(this.model.nameBy), 8, lane.top + 14);
+      ctx.restore();
+    }
+
+    // Horizontal gridlines + y tick labels.
+    ctx.font = AXIS_FONT;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (const tick of range.ticks) {
+      const y = this.yOf(tick, range, lane);
+      if (y < lane.top - 0.5 || y > lane.bottom + 0.5) continue;
+      ctx.strokeStyle = pal.grid;
+      ctx.beginPath();
+      ctx.moveTo(left, Math.round(y) + 0.5);
+      ctx.lineTo(right, Math.round(y) + 0.5);
+      ctx.stroke();
+      ctx.fillStyle = pal.muted;
+      ctx.fillText(this.fmt(series, tick), left - 6, y);
+    }
+
+    this.drawSeries(series, color, range, lane);
+
+    // The counter name lives in the legend chips / hover tooltip, not on the
+    // chart. We keep only a small latest-value badge (no name) at top-right.
+    const w = series.window;
+    if (w !== undefined && w.count > 0) {
+      ctx.textBaseline = 'alphabetic';
+      ctx.textAlign = 'right';
+      ctx.fillStyle = pal.muted;
+      ctx.font = AXIS_FONT;
+      ctx.fillText(
+        this.fmt(series, w.lastV[w.count - 1]),
+        right - 6,
+        lane.top + 13,
+      );
+    }
+  }
+
+  private drawSeries(
+    series: CounterSeries,
+    color: string,
+    range: AxisRange,
+    lane: LaneLayout,
+  ) {
+    const w = series.window;
+    if (w === undefined || w.count === 0) return;
+    const ctx = this.ctx;
+    const n = w.count;
+    const baseY = lane.bottom - LANE_PAD_BOTTOM;
+    // Grey this series out when another line is focused (hovered); eased.
+    const a = this.alphaFor(series);
+    const stride = this.drawStride(n);
+    const last = n - 1;
+    // x of the sample `stride` ahead of i, or the right edge past the end.
+    const nextX = (i: number) =>
+      i + stride <= last
+        ? this.xOfRel(w.tsRel[i + stride])
+        : this.cssW - this.padRight;
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(
+      this.padLeft,
+      lane.top,
+      this.cssW - this.padRight - this.padLeft,
+      lane.height,
+    );
+    ctx.clip();
+
+    // Gradient area under the (stepped) last value — lighter than the line,
+    // fading towards the baseline.
+    if (this.model.fill) {
+      ctx.beginPath();
+      ctx.moveTo(this.xOfRel(w.tsRel[0]), baseY);
+      for (let i = 0; i <= last; i += stride) {
+        const x = this.xOfRel(w.tsRel[i]);
+        const y = this.yOf(w.lastV[i], range, lane);
+        ctx.lineTo(x, y);
+        ctx.lineTo(nextX(i), y);
+      }
+      // Drop to the baseline at the right edge (where the stepped line ends),
+      // not at the last sample, so the area under the final flat segment fills
+      // completely instead of leaving a diagonal gap.
+      ctx.lineTo(this.cssW - this.padRight, baseY);
+      ctx.closePath();
+      const grad = ctx.createLinearGradient(0, lane.top, 0, baseY);
+      grad.addColorStop(0, toRgba(color, 0.32));
+      grad.addColorStop(1, toRgba(color, 0.02));
+      ctx.globalAlpha = a;
+      ctx.fillStyle = grad;
+      ctx.fill();
+    }
+
+    // Min/max band (shows the values coalesced into each bucket).
+    ctx.beginPath();
+    for (let i = 0; i <= last; i += stride) {
+      const x = this.xOfRel(w.tsRel[i]);
+      const xn = nextX(i);
+      const yMax = this.yOf(w.maxV[i], range, lane);
+      ctx.rect(
+        x,
+        yMax,
+        Math.max(1, xn - x),
+        this.yOf(w.minV[i], range, lane) - yMax,
+      );
+    }
+    ctx.globalAlpha = 0.18 * a;
+    ctx.fillStyle = color;
+    ctx.fill();
+
+    // Stepped last-value line.
+    ctx.globalAlpha = a;
+    ctx.beginPath();
+    for (let i = 0; i <= last; i += stride) {
+      const x = this.xOfRel(w.tsRel[i]);
+      const y = this.yOf(w.lastV[i], range, lane);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+      ctx.lineTo(nextX(i), y);
+    }
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.lineJoin = 'miter';
+    ctx.setLineDash(this.dashFor(series.lineStyle));
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // Value of a series at plot-x `x` (the last sample at or before that time).
+  private valueAtX(series: CounterSeries, x: number): number | undefined {
+    const w = series.window;
+    if (w === undefined || w.count === 0) return undefined;
+    const rel = Number(this.xToTime(x) - this.model.traceStart);
+    // Last sample with tsRel <= rel (binary search).
+    let lo = 0;
+    let hi = w.count - 1;
+    let ans = 0;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (w.tsRel[mid] <= rel) {
+        ans = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return w.lastV[ans];
+  }
+
+  // Value at the local mouse cursor (used by the DOM tooltip, which only shows
+  // while the pointer is over the chart).
+  private valueAtCursor(series: CounterSeries): number | undefined {
+    if (!this.mouseInside || this.mouseX < this.padLeft) return undefined;
+    return this.valueAtX(series, this.mouseX);
+  }
+
+  // Where the vertical crosshair sits this frame (and the time under it), or
+  // undefined when nothing is hovered / an interaction is in progress. It
+  // follows the timeline's shared hover cursor, so hovering the tracks above
+  // moves our pointer and hovering here moves theirs.
+  private crosshair(): {x: number; t: time} | undefined {
+    if (this.drag !== undefined || this.resize !== undefined) return undefined;
+    const t = this.model.trace.timeline.hoverCursorTimestamp;
+    if (t === undefined) return undefined;
+    const x = this.scale().timeToPx(t);
+    if (x < this.padLeft || x > this.cssW - this.padRight) return undefined;
+    return {x, t};
+  }
+
+  private drawCrosshair(pal: Palette, top: number, bottom: number) {
+    const cross = this.crosshair();
+    if (cross === undefined) return;
+    const ctx = this.ctx;
+    const x = Math.round(cross.x) + 0.5;
+    ctx.save();
+    ctx.setLineDash([4, 3]);
+    ctx.strokeStyle = pal.accent;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(x, top);
+    ctx.lineTo(x, bottom);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Time label pinned to the top axis.
+    const label = this.timeLabel(cross.t);
+    ctx.font = AXIS_FONT;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'alphabetic';
+    const tw = ctx.measureText(label).width + 8;
+    ctx.fillStyle = pal.accent;
+    ctx.fillRect(cross.x - tw / 2, 1, tw, 13);
+    ctx.fillStyle = pal.bg;
+    ctx.fillText(label, cross.x, 11);
+
+    // Per-lane dots at the hovered sample, using the drawn (scrolled) rects.
+    for (const lane of this.laneRects) {
+      if (lane.bottom < top || lane.top > bottom) continue; // off-screen lane
+      const series = this.model.selected[lane.i];
+      const v = this.valueAtX(series, cross.x);
+      if (v === undefined) continue;
+      const y = this.yOf(v, this.laneRange(series, lane.height), lane);
+      if (y < top || y > bottom) continue;
+      ctx.beginPath();
+      ctx.fillStyle = this.seriesColor(series, lane.i, pal);
+      ctx.arc(cross.x, y, 3, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = pal.bg;
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  private drawZoomBox(pal: Palette, top: number, bottom: number) {
+    if (this.drag === undefined || this.drag.mode !== 'zoombox') return;
+    const ctx = this.ctx;
+    const x0 = Math.min(this.drag.startX, this.drag.curX);
+    const x1 = Math.max(this.drag.startX, this.drag.curX);
+    ctx.save();
+    ctx.fillStyle = pal.accent;
+    ctx.globalAlpha = 0.15;
+    ctx.fillRect(x0, top, x1 - x0, bottom - top);
+    ctx.globalAlpha = 1;
+    ctx.strokeStyle = pal.accent;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(x0 + 0.5, top + 0.5, x1 - x0, bottom - top);
+    const t0 = this.xToTime(x0);
+    const t1 = this.xToTime(x1);
+    const label = timeTickLabel(t1, t0);
+    ctx.font = AXIS_FONT;
+    ctx.textAlign = 'center';
+    ctx.fillStyle = pal.text;
+    ctx.fillText(label, (x0 + x1) / 2, top + 14);
+    ctx.restore();
+  }
+
+  // Returns the theme palette, recomputing (via getComputedStyle) only every
+  // REPALETTE_FRAMES draws so it's not a per-frame layout cost, while still
+  // picking up light/dark theme toggles within a fraction of a second.
+  private getPalette(): Palette {
+    if (this.palCache === undefined || this.palAge <= 0) {
+      this.palCache = this.palette();
+      this.palAge = REPALETTE_FRAMES;
+    }
+    this.palAge--;
+    return this.palCache;
+  }
+
+  private palette(): Palette {
+    const cs = getComputedStyle(this.container);
+    const get = (name: string, fallback: string) => {
+      const v = cs.getPropertyValue(name).trim();
+      return v.length > 0 ? v : fallback;
+    };
+    const series: string[] = [];
+    for (let i = 1; i <= 8; i++) {
+      series.push(get(`--pf-chart-color-${i}`, '#4285f4'));
+    }
+    return {
+      text: get('--pf-color-text', '#202124'),
+      muted: get('--pf-color-text-muted', '#5f6368'),
+      border: get('--pf-color-border', '#dadce0'),
+      grid: get('--pf-color-border-secondary', 'rgba(0,0,0,0.06)'),
+      bg: get('--pf-color-background', '#ffffff'),
+      laneBg: get('--pf-color-background-secondary', 'rgba(0,0,0,0.02)'),
+      accent: get('--pf-color-accent', '#1a73e8'),
+      series,
+    };
+  }
+
+  // ---- interaction --------------------------------------------------------
+
+  private localX(clientX: number): number {
+    return clientX - this.canvas.getBoundingClientRect().left;
+  }
+
+  private attachListeners() {
+    const c = this.canvas;
+
+    // Note: the mouse wheel is intentionally NOT captured for zoom — it scrolls
+    // the stacked lanes (and the page) normally. Zoom is via WASD, drag-select,
+    // or two-finger pinch.
+
+    c.addEventListener('pointerdown', (e: PointerEvent) => {
+      c.setPointerCapture(e.pointerId);
+      const ly = this.localY(e.clientY);
+      // Height-resize takes priority over zoom/pan.
+      const rz = this.hitResize(ly);
+      if (rz !== undefined) {
+        this.resize = {startY: ly, ...rz};
+        this.wake();
+        return;
+      }
+      // Grabbing a stacked lane's shell (name gutter) starts a reorder drag.
+      if (
+        this.model.layout === 'stacked' &&
+        e.button === 0 &&
+        this.localX(e.clientX) < this.padLeft
+      ) {
+        const k = this.visibleLaneIndexAt(ly);
+        const lane = k >= 0 ? this.visibleLanes()[k] : undefined;
+        if (lane !== undefined) {
+          this.laneReorder = {series: lane.s, targetIdx: k};
+          this.canvas.style.cursor = 'grabbing';
+          this.wake();
+          return;
+        }
+      }
+      this.pointers.set(e.pointerId, e.clientX);
+      if (this.pointers.size === 2) {
+        this.beginPinch();
+        this.drag = undefined;
+        return;
+      }
+      const x = this.localX(e.clientX);
+      const pan = e.shiftKey || e.button === 1 || e.button === 2;
+      this.drag = {
+        mode: pan ? 'pan' : 'zoombox',
+        startX: x,
+        curX: x,
+        startView: {s: this.model.viewStart, e: this.model.viewEnd},
+      };
+      this.wake();
+    });
+
+    c.addEventListener('pointermove', (e: PointerEvent) => {
+      if (this.pointers.has(e.pointerId)) {
+        this.pointers.set(e.pointerId, e.clientX);
+      }
+      this.mouseX = this.localX(e.clientX);
+      const ly = this.localY(e.clientY);
+      this.mouseY = ly;
+      this.mouseInside = true;
+      // Active lane reorder: track which slot we'd drop into.
+      if (this.laneReorder !== undefined) {
+        this.laneReorder.targetIdx = this.visibleLaneIndexAt(ly);
+        this.wake();
+        return;
+      }
+      // Move the timeline's shared hover pointer with our cursor (sync mode).
+      this.syncHoverCursor();
+      // Redraw the DOM tooltip only when its content changes (out-of-band
+      // handler, so Mithril won't auto-redraw).
+      const sig = this.tooltipSig();
+      if (sig !== this.lastTipSig) {
+        this.lastTipSig = sig;
+        m.redraw();
+      }
+
+      // Active height resize.
+      if (this.resize !== undefined) {
+        const dy = ly - this.resize.startY;
+        if (this.resize.kind === 'overlay') {
+          const full = this.cssH - BOTTOM - TOP_AXIS;
+          this.model.setOverlayHeight(
+            Math.max(60, Math.min(this.resize.startH + dy, full)),
+          );
+        } else {
+          this.model.setSeriesLaneHeight(
+            this.resize.series,
+            Math.max(40, Math.min(this.resize.startH + dy, 400)),
+          );
+        }
+        this.wake();
+        return;
+      }
+      // Cursor feedback: resize edge, a grabbable stacked-lane shell, else the
+      // crosshair.
+      const overShell =
+        this.model.layout === 'stacked' &&
+        this.mouseX < this.padLeft &&
+        ly > TOP_AXIS;
+      this.canvas.style.cursor =
+        this.drag === undefined && this.hitResize(ly) !== undefined
+          ? 'ns-resize'
+          : overShell
+            ? 'grab'
+            : 'crosshair';
+
+      if (this.pinch !== undefined && this.pointers.size >= 2) {
+        this.updatePinch();
+        this.wake();
+        return;
+      }
+      if (this.drag !== undefined) {
+        this.drag.curX = this.mouseX;
+        if (this.drag.mode === 'pan') {
+          const dxPx = this.drag.curX - this.drag.startX;
+          const dxNs =
+            -(dxPx / this.plotWidth()) *
+            Number(this.drag.startView.e - this.drag.startView.s);
+          this.model.setView(this.drag.startView.s, this.drag.startView.e);
+          this.model.panBy(dxNs);
+        }
+      }
+      this.wake();
+    });
+
+    const end = (e: PointerEvent) => {
+      this.pointers.delete(e.pointerId);
+      if (this.pointers.size < 2) this.pinch = undefined;
+      this.resize = undefined;
+      // Finish a lane reorder.
+      if (this.laneReorder !== undefined) {
+        this.model.reorder(this.laneReorder.series, this.laneReorder.targetIdx);
+        this.laneReorder = undefined;
+        this.canvas.style.cursor = 'crosshair';
+        this.wake();
+        m.redraw();
+        return;
+      }
+      if (this.drag !== undefined && this.drag.mode === 'zoombox') {
+        const x0 = Math.min(this.drag.startX, this.drag.curX);
+        const x1 = Math.max(this.drag.startX, this.drag.curX);
+        if (x1 - x0 > 3) {
+          this.model.setView(this.xToTime(x0), this.xToTime(x1));
+        } else {
+          // A click (no drag). Resolve single- vs double-click before acting.
+          this.scheduleClick(this.drag.startX, this.mouseY);
+        }
+      }
+      this.drag = undefined;
+      this.wake();
+      m.redraw();
+    };
+    c.addEventListener('pointerup', end);
+    c.addEventListener('pointercancel', end);
+
+    c.addEventListener('pointerleave', () => {
+      this.mouseInside = false;
+      // Reverts the shared hover cursor to the pinned time (or clears it).
+      this.syncHoverCursor();
+      this.wake();
+      m.redraw(); // hide the tooltip
+    });
+    c.addEventListener('dblclick', (e: MouseEvent) => {
+      this.onDoubleClick(this.localX(e.clientX), this.localY(e.clientY));
+    });
+    c.addEventListener('contextmenu', (e) => e.preventDefault());
+  }
+
+  // A single click isolates the line under the cursor (show only it), or — on
+  // empty space — parks/clears the reference crosshair. Deferred briefly so a
+  // double-click can pre-empt it.
+  private scheduleClick(x: number, y: number) {
+    if (this.clickTimer !== undefined) clearTimeout(this.clickTimer);
+    this.clickTimer = setTimeout(() => {
+      this.clickTimer = undefined;
+      const hit = this.lineAt(x, y, 12);
+      const stacked = this.model.layout === 'stacked';
+      if (hit !== undefined) {
+        // Stacked: click greys the others and multi-selects (toggle). Overlay:
+        // click isolates the line (show only it).
+        if (stacked) this.model.toggleEmphasis(hit.s);
+        else this.model.toggleOnly(hit.s);
+      } else if (stacked && this.model.hasEmphasis()) {
+        this.model.clearEmphasis(); // click empty space to clear the selection
+      } else if (this.model.isIsolated()) {
+        // Clicking away from the single isolated line brings them all back, so
+        // the isolate doesn't get stuck when the click lands in empty space
+        // (e.g. below a lone overlay-isolated line).
+        this.model.setAllHidden(false);
+      } else {
+        this.togglePinAt(x);
+      }
+      this.wake();
+      m.redraw();
+    }, 220);
+  }
+
+  // A double click hides the line under the cursor (keeping the others), or —
+  // on empty space — drops a persistent bookmark note on the timeline.
+  private onDoubleClick(x: number, y: number) {
+    if (this.clickTimer !== undefined) {
+      clearTimeout(this.clickTimer);
+      this.clickTimer = undefined;
+    }
+    const hit = this.lineAt(x, y, 12);
+    if (hit !== undefined) {
+      if (!hit.s.hidden) this.model.toggleHidden(hit.s);
+    } else {
+      this.model.trace.notes.addNote({timestamp: this.xToTime(x)});
+    }
+    this.wake();
+    m.redraw();
+  }
+
+  // Publishes the timeline's shared hover cursor so the vertical hover pointer
+  // over the tracks tracks our cursor — and vice-versa via crosshair(). While
+  // the pointer is over the plot it follows the cursor; otherwise it falls back
+  // to the pinned time (a parked reference line) or clears. Deduped so an
+  // unchanged value doesn't schedule a redundant timeline redraw.
+  private syncHoverCursor(): void {
+    const inPlot =
+      this.mouseInside &&
+      this.drag === undefined &&
+      this.resize === undefined &&
+      this.mouseX >= this.padLeft &&
+      this.mouseX <= this.cssW - this.padRight;
+    const next = inPlot ? this.xToTime(this.mouseX) : this.pinnedTime;
+    if (next !== this.publishedHover) {
+      this.publishedHover = next;
+      this.model.trace.timeline.hoverCursorTimestamp = next;
+    }
+  }
+
+  // Click-to-pin: park a persistent reference crosshair at plot-x `x` (so it
+  // survives the pointer leaving); clicking on/near the existing pin clears it.
+  private togglePinAt(x: number): void {
+    if (this.pinnedTime !== undefined) {
+      const px = this.scale().timeToPx(this.pinnedTime);
+      if (Math.abs(px - x) < 6) {
+        this.pinnedTime = undefined;
+        this.syncHoverCursor();
+        return;
+      }
+    }
+    this.pinnedTime = this.xToTime(x);
+    this.model.trace.timeline.hoverCursorTimestamp = this.pinnedTime;
+  }
+
+  private beginPinch() {
+    const xs = [...this.pointers.values()];
+    if (xs.length < 2) return;
+    const dist = Math.abs(xs[0] - xs[1]);
+    const midClient = (xs[0] + xs[1]) / 2;
+    this.pinch = {
+      startDist: Math.max(1, dist),
+      startView: {s: this.model.viewStart, e: this.model.viewEnd},
+      centerX: this.localX(midClient),
+    };
+  }
+
+  private updatePinch() {
+    if (this.pinch === undefined) return;
+    const xs = [...this.pointers.values()];
+    if (xs.length < 2) return;
+    const dist = Math.max(1, Math.abs(xs[0] - xs[1]));
+    const factor = this.pinch.startDist / dist; // fingers apart => zoom in
+    this.model.setView(this.pinch.startView.s, this.pinch.startView.e);
+    const centerTime = this.xToTime(this.pinch.centerX);
+    this.model.zoomAt(centerTime, factor);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/timeseries_view.ts
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/timeseries_view.ts
@@ -1,0 +1,620 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {classNames} from '../../base/classnames';
+import type {YMode} from '../../components/tracks/counter_track';
+import {
+  Button,
+  ButtonBar,
+  ButtonGroup,
+  ButtonVariant,
+} from '../../widgets/button';
+import {EmptyState} from '../../widgets/empty_state';
+import {MultiSelect, type MultiSelectDiff} from '../../widgets/multiselect';
+import {Popup, PopupPosition} from '../../widgets/popup';
+import {Spinner} from '../../widgets/spinner';
+import {TextInput} from '../../widgets/text_input';
+import {Tooltip} from '../../widgets/tooltip';
+import {
+  COLOR_CHOICES,
+  type CounterSeries,
+  type CounterTrackInfo,
+  type LineStyle,
+  type NameBy,
+  counterDescriptor,
+  counterLabel,
+  swatchClassFor,
+} from './counter_index';
+import type {ViewerModel} from './model';
+import {TimeseriesChart} from './timeseries_chart';
+
+const LINE_STYLES: ReadonlyArray<LineStyle> = ['solid', 'dashed', 'dotted'];
+// Cap how many legend chips we render (the strip scrolls); with thousands
+// selected we don't want thousands of DOM nodes.
+const LEGEND_MAX = 200;
+// Default legend strip max-height (px) before the user drags to resize it.
+const DEFAULT_LEGEND_H = 66;
+
+export interface TimeseriesViewAttrs {
+  readonly model: ViewerModel;
+}
+
+// The viewer widget: toolbar + legend + Canvas2D chart for a ViewerModel. It
+// holds no lifecycle of its own — the caller owns the model — so the contextual
+// area-selection tab and the command-opened drawer tab can share one instance.
+export class TimeseriesView implements m.ClassComponent<TimeseriesViewAttrs> {
+  // Pending picker selection: edited by the picker's checkboxes/bulk actions
+  // and only committed to the model on "Apply". Seeded from the current
+  // selection when the picker opens, cleared when it closes.
+  private pending?: Set<number>;
+  // Active legend-resize drag (dragging the chart's top edge down/up).
+  private legendDrag?: {startY: number; startH: number};
+
+  // Seeds the pending set from the model's current selection if not already
+  // editing (i.e. the picker just opened).
+  private ensurePending(model: ViewerModel): Set<number> {
+    if (this.pending === undefined) {
+      this.pending = new Set(model.selected.map((s) => s.info.id));
+    }
+    return this.pending;
+  }
+
+  // Popup open/close: discard uncommitted edits when it closes so the next open
+  // re-seeds from the (possibly Apply-updated) selection.
+  private onPickerToggle(shown: boolean) {
+    if (!shown) this.pending = undefined;
+    m.redraw();
+  }
+
+  // Commits the pending set: adds newly-checked counters and removes unchecked
+  // ones so the plotted set matches exactly what's ticked.
+  private applyPending(model: ViewerModel) {
+    const pending = this.pending;
+    if (pending === undefined) return;
+    const byId = new Map(model.all.map((i) => [i.id, i]));
+    const current = new Set(model.selected.map((s) => s.info.id));
+    const toAdd = [...pending]
+      .filter((id) => !current.has(id))
+      .map((id) => byId.get(id))
+      .filter((i): i is CounterTrackInfo => i !== undefined);
+    const toRemove = [...current].filter((id) => !pending.has(id));
+    if (toAdd.length > 0) model.selectMany(toAdd);
+    if (toRemove.length > 0) model.deselectMany(toRemove);
+  }
+
+  view({attrs}: m.CVnode<TimeseriesViewAttrs>) {
+    const model = attrs.model;
+    if (model.loading) {
+      return m(
+        '.pf-tsv',
+        m('.pf-tsv__loading', m(Spinner, {easing: true}), ' Loading counters…'),
+      );
+    }
+    if (model.all.length === 0) {
+      return m(
+        '.pf-tsv',
+        m(EmptyState, {
+          icon: 'ssid_chart',
+          title: 'No counters in this trace',
+          detail: 'This viewer plots counter tracks; this trace has none.',
+        }),
+      );
+    }
+    // Nothing selected — offer the picker (the command opens the drawer empty)
+    // and point at the timeline-selection path too.
+    if (model.selected.length === 0) {
+      return m(
+        '.pf-tsv',
+        m(
+          EmptyState,
+          {
+            icon: 'ssid_chart',
+            title: 'Add counters to plot',
+            detail:
+              'Search and add counters here, or select counter tracks ' +
+              '(or a whole group) in the timeline.',
+          },
+          m(
+            Popup,
+            {
+              position: PopupPosition.Bottom,
+              onChange: (shown: boolean) => this.onPickerToggle(shown),
+              className: 'pf-tsv__picker-popup',
+              trigger: m(Button, {
+                label: 'Add counters',
+                icon: 'add',
+                variant: ButtonVariant.Filled,
+              }),
+            },
+            this.renderPicker(model),
+          ),
+        ),
+      );
+    }
+    return m(
+      '.pf-tsv',
+      this.renderToolbar(model),
+      this.renderLegend(model),
+      this.renderLegendResize(model),
+      m('.pf-tsv__body', m(TimeseriesChart, {model})),
+    );
+  }
+
+  // A draggable splitter under the legend: drag down to enlarge the legend
+  // strip (see/scroll more chips), up to shrink it back.
+  private renderLegendResize(model: ViewerModel) {
+    return m('.pf-tsv__legend-resize', {
+      title: 'Drag to resize the legend',
+      onpointerdown: (e: PointerEvent) => {
+        (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+        this.legendDrag = {
+          startY: e.clientY,
+          startH: model.legendHeight ?? DEFAULT_LEGEND_H,
+        };
+        e.preventDefault();
+      },
+      onpointermove: (e: PointerEvent) => {
+        if (this.legendDrag === undefined) return;
+        const dy = e.clientY - this.legendDrag.startY;
+        model.setLegendHeight(
+          Math.max(28, Math.min(this.legendDrag.startH + dy, 480)),
+        );
+      },
+      onpointerup: (e: PointerEvent) => {
+        this.legendDrag = undefined;
+        (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
+      },
+    });
+  }
+
+  private renderToolbar(model: ViewerModel) {
+    // A connected segmented control (like the flamegraph's toggles) — the
+    // options read as one tab-switch widget rather than separate buttons.
+    const seg = (
+      opts: ReadonlyArray<{
+        label: string;
+        active: boolean;
+        onclick: () => void;
+        title?: string;
+      }>,
+    ) =>
+      m(
+        ButtonGroup,
+        opts.map((o) =>
+          m(Button, {
+            label: o.label,
+            active: o.active,
+            compact: true,
+            onclick: o.onclick,
+            title: o.title,
+          }),
+        ),
+      );
+    const divider = () => m('.pf-tsv__divider');
+    return m(
+      ButtonBar,
+      {className: 'pf-tsv__toolbar'},
+      // Add counters: a compact "+" that opens the searchable picker. Counters
+      // added here union with any coming from the timeline selection.
+      m(
+        Popup,
+        {
+          position: PopupPosition.Bottom,
+          onChange: (shown: boolean) => this.onPickerToggle(shown),
+          className: 'pf-tsv__picker-popup',
+          trigger: m(Button, {
+            icon: 'add',
+            compact: true,
+            title: 'Add counters',
+          }),
+        },
+        this.renderPicker(model),
+      ),
+      divider(),
+      seg([
+        {
+          label: 'Stacked',
+          active: model.layout === 'stacked',
+          onclick: () => model.setLayout('stacked'),
+        },
+        {
+          label: 'Overlay',
+          active: model.layout === 'overlay',
+          onclick: () => model.setLayout('overlay'),
+        },
+      ]),
+      // Per-lane area fill (stacked layout only).
+      model.layout === 'stacked' &&
+        m(Button, {
+          label: 'Area',
+          icon: 'area_chart',
+          active: model.fill,
+          compact: true,
+          title: 'Fill the area under each line',
+          onclick: () => model.setFill(!model.fill),
+        }),
+      // Overlay-only: the stacked-area toggle. The % / Units axis, unit filter
+      // and y-range mode live in the "Display options" menu to keep this row
+      // uncluttered.
+      model.layout === 'overlay' &&
+        m(Button, {
+          label: 'Stacked area',
+          icon: 'area_chart',
+          active: model.overlayStacked,
+          compact: true,
+          title:
+            'Stack the counters as a cumulative area chart (shared value axis)',
+          onclick: () => model.setOverlayStacked(!model.overlayStacked),
+        }),
+      divider(),
+      seg([
+        {
+          label: 'Value',
+          active: model.yMode === 'value',
+          onclick: () => void model.setYMode('value').then(m.redraw),
+        },
+        {
+          label: 'Delta',
+          active: model.yMode === 'delta',
+          onclick: () => void model.setYMode('delta').then(m.redraw),
+        },
+        {
+          label: 'Rate',
+          active: model.yMode === 'rate',
+          onclick: () => void model.setYMode('rate').then(m.redraw),
+        },
+      ]),
+      divider(),
+      m(Button, {
+        icon: 'zoom_out_map',
+        compact: true,
+        title: 'Reset zoom',
+        onclick: () => model.resetView(),
+      }),
+      // Push the trailing controls (display-options menu + help) to the far
+      // right of the toolbar.
+      m('.pf-tsv__spacer'),
+      // Overflow "hamburger" of secondary display options: y-scale and (in
+      // stacked mode) lane height. Kept out of the main row to reduce clutter.
+      m(
+        Popup,
+        {
+          position: PopupPosition.Bottom,
+          trigger: m(Button, {
+            icon: 'menu',
+            compact: true,
+            title: 'Display options',
+          }),
+        },
+        m('.pf-tsv__style-menu', [
+          // Y-axis range mode.
+          m('.pf-tsv__style-row', [
+            m('span.pf-tsv__style-label', 'Range'),
+            seg([
+              {
+                label: 'Global',
+                active: model.yRangeMode === 'global',
+                title: "Locked to each counter's whole-trace range",
+                onclick: () => model.setYRangeMode('global'),
+              },
+              {
+                label: 'Shared',
+                active: model.yRangeMode === 'shared',
+                title:
+                  'One shared axis across all lanes, so heights are comparable',
+                onclick: () => model.setYRangeMode('shared'),
+              },
+              {
+                label: 'Fit',
+                active: model.yRangeMode === 'fit',
+                title: 'Fits the samples currently in view',
+                onclick: () => model.setYRangeMode('fit'),
+              },
+            ]),
+          ]),
+          m('.pf-tsv__style-row', [
+            m('span.pf-tsv__style-label', 'Scale'),
+            seg([
+              {
+                label: 'Linear',
+                active: model.yScale === 'linear',
+                onclick: () => model.setYScale('linear'),
+              },
+              {
+                label: 'Log',
+                active: model.yScale === 'log',
+                onclick: () => model.setYScale('log'),
+              },
+            ]),
+          ]),
+          model.layout === 'stacked' &&
+            m('.pf-tsv__style-row', [
+              m('span.pf-tsv__style-label', 'Height'),
+              seg([
+                {
+                  label: 'S',
+                  active: model.laneHeight === 64,
+                  onclick: () => model.setLaneHeight(64),
+                },
+                {
+                  label: 'M',
+                  active: model.laneHeight === 96,
+                  onclick: () => model.setLaneHeight(96),
+                },
+                {
+                  label: 'L',
+                  active: model.laneHeight === 140,
+                  onclick: () => model.setLaneHeight(140),
+                },
+              ]),
+            ]),
+          // Overlay axis: normalised 0-100% per line, or one shared unit axis.
+          model.layout === 'overlay' &&
+            m('.pf-tsv__style-row', [
+              m('span.pf-tsv__style-label', 'Axis'),
+              seg([
+                {
+                  label: '%',
+                  active: model.overlayNormalize && !model.overlayStacked,
+                  title: 'Each line normalised to its own range (0-100%)',
+                  onclick: () => {
+                    model.setOverlayStacked(false);
+                    model.setOverlayNormalize(true);
+                  },
+                },
+                {
+                  label: 'Units',
+                  active: !model.overlayNormalize || model.overlayStacked,
+                  title: "One shared value axis in the counters' unit",
+                  onclick: () => model.setOverlayNormalize(false),
+                },
+              ]),
+            ]),
+          // Scope the value/stacked axis to one unit when the selection mixes
+          // units (a shared axis across units is meaningless).
+          model.layout === 'overlay' &&
+            !model.overlayNormalize &&
+            model.selectedUnits().length > 1 &&
+            m('.pf-tsv__style-row', [
+              m('span.pf-tsv__style-label', 'Unit'),
+              seg([
+                {
+                  label: 'All',
+                  active: model.overlayUnitFilter === undefined,
+                  onclick: () => model.setOverlayUnitFilter(undefined),
+                },
+                ...model.selectedUnits().map((u) => ({
+                  label: u,
+                  active: model.overlayUnitFilter === u,
+                  onclick: () => model.setOverlayUnitFilter(u),
+                })),
+              ]),
+            ]),
+        ]),
+      ),
+      m(
+        Tooltip,
+        {trigger: m(Button, {icon: 'help_outline', compact: true})},
+        m('.pf-tsv__help', [
+          m('div', 'WASD or pinch — pan & zoom'),
+          m('div', 'drag — select a range to zoom'),
+          m('div', 'shift-drag — pan'),
+          m('div', 'wheel — scroll lanes'),
+          m('div', 'double-click — reset zoom'),
+          m('div', 'drag a lane / plot bottom edge — resize height'),
+        ]),
+      ),
+    );
+  }
+
+  // Clickable legend: one chip per selected counter. Clicking the name toggles
+  // the line's visibility; the gear opens a per-line style/colour menu.
+  private renderLegend(model: ViewerModel) {
+    const extra = model.selected.length - LEGEND_MAX;
+    return m(
+      '.pf-tsv__legend',
+      {style: {maxHeight: `${model.legendHeight ?? DEFAULT_LEGEND_H}px`}},
+      // Bulk visibility: hide everything, then click chips to bring lines back
+      // one at a time (handy for isolating counters when many overlap).
+      model.selected.length > 1 &&
+        m('.pf-tsv__legend-actions', [
+          m(Button, {
+            label: 'Hide all',
+            compact: true,
+            title: 'Hide every line, then click a counter to show it',
+            onclick: () => model.setAllHidden(true),
+          }),
+          m(Button, {
+            label: 'Show all',
+            compact: true,
+            onclick: () => model.setAllHidden(false),
+          }),
+        ]),
+      model.selected.slice(0, LEGEND_MAX).map((s, i) =>
+        m(
+          '.pf-tsv__chip',
+          {
+            key: s.info.id,
+            className: classNames(
+              s.hidden && 'pf-tsv__chip--off',
+              s.emphasized && 'pf-tsv__chip--emphasized',
+            ),
+          },
+          m(`span.pf-tsv__swatch.${swatchClassFor(s.colorOverride, i)}`),
+          m(
+            'span.pf-tsv__chip-name',
+            {
+              onclick: () => model.toggleHidden(s),
+              title: 'Click to show/hide this counter',
+            },
+            s.label(model.nameBy),
+          ),
+          m(
+            Popup,
+            {
+              position: PopupPosition.Bottom,
+              trigger: m(Button, {
+                icon: 'tune',
+                title: 'Line style & colour',
+                compact: true,
+              }),
+            },
+            this.renderStyleMenu(model, s),
+          ),
+          // Remove this counter from the chart (deselect) directly from the
+          // legend, without reopening the picker.
+          m(Button, {
+            icon: 'close',
+            compact: true,
+            title: 'Remove from chart',
+            onclick: () => model.deselectMany([s.info.id]),
+          }),
+        ),
+      ),
+      extra > 0 &&
+        m('span.pf-tsv__legend-more', `+${extra.toLocaleString()} more`),
+    );
+  }
+
+  private renderStyleMenu(model: ViewerModel, s: CounterSeries) {
+    const modes: ReadonlyArray<YMode> = ['value', 'delta', 'rate'];
+    const cap = (x: string) => x.charAt(0).toUpperCase() + x.slice(1);
+    return m('.pf-tsv__style-menu', [
+      // Per-line rename: empty falls back to the naming-scheme default (shown as
+      // the placeholder).
+      m('.pf-tsv__style-row', [
+        m('span.pf-tsv__style-label', 'Name'),
+        m(TextInput, {
+          value: s.nameOverride ?? '',
+          placeholder: counterLabel(s.info, model.nameBy),
+          onInput: (v: string) => model.setName(s, v),
+        }),
+      ]),
+      m('.pf-tsv__style-row', [
+        m('span.pf-tsv__style-label', 'Mode'),
+        m(
+          '.pf-tsv__seg',
+          modes.map((md) =>
+            m(Button, {
+              label: cap(md),
+              active: s.mode === md,
+              compact: true,
+              onclick: () => void model.setSeriesYMode(s, md).then(m.redraw),
+            }),
+          ),
+        ),
+      ]),
+      m('.pf-tsv__style-row', [
+        m('span.pf-tsv__style-label', 'Line'),
+        m(
+          '.pf-tsv__seg',
+          LINE_STYLES.map((st) =>
+            m(Button, {
+              label: cap(st),
+              active: s.lineStyle === st,
+              compact: true,
+              onclick: () => model.setLineStyle(s, st),
+            }),
+          ),
+        ),
+      ]),
+      m('.pf-tsv__style-row', [
+        m('span.pf-tsv__style-label', 'Colour'),
+        m('.pf-tsv__colors', [
+          ...COLOR_CHOICES.map((c, ci) =>
+            m(`span.pf-tsv__color-dot.pf-tsv__color-dot--${ci}`, {
+              className: s.colorOverride === c ? 'pf-tsv__color-dot--sel' : '',
+              title: c,
+              onclick: () => model.setColor(s, c),
+            }),
+          ),
+          m(
+            'span.pf-tsv__color-reset',
+            {
+              title: 'Default colour',
+              onclick: () => model.setColor(s, undefined),
+            },
+            'reset',
+          ),
+        ]),
+      ]),
+    ]);
+  }
+
+  // The picker (ftrace-event-filter style): a MultiSelect with search, Select
+  // All/Filtered and Clear, editing a *pending* set that only takes effect on
+  // Apply. Options are labelled with the disambiguating owner+metric descriptor
+  // (independent of the naming scheme) and searchable by metric or owner.
+  private renderPicker(model: ViewerModel) {
+    const pending = this.ensurePending(model);
+    const cap = (x: string) => x.charAt(0).toUpperCase() + x.slice(1);
+    const nameByOpts: ReadonlyArray<NameBy> = ['metric', 'process', 'thread'];
+    const options = model.all.map((t) => ({
+      id: String(t.id),
+      name: counterDescriptor(t),
+      checked: pending.has(t.id),
+    }));
+    const dirty =
+      pending.size !== model.selected.length ||
+      model.selected.some((s) => !pending.has(s.info.id));
+    return m('.pf-tsv__picker', [
+      // How lines are named on the chart (per-line rename still wins).
+      m('.pf-tsv__picker-nameby', [
+        m('span.pf-tsv__picker-label', 'Name by'),
+        m(
+          ButtonGroup,
+          nameByOpts.map((nb) =>
+            m(Button, {
+              label: cap(nb),
+              active: model.nameBy === nb,
+              compact: true,
+              onclick: () => model.setNameBy(nb),
+            }),
+          ),
+        ),
+      ]),
+      m(MultiSelect, {
+        options,
+        repeatCheckedItemsAtTop: true,
+        showNumSelected: true,
+        onChange: (diffs: MultiSelectDiff[]) => {
+          for (const {id, checked} of diffs) {
+            if (checked) pending.add(Number(id));
+            else pending.delete(Number(id));
+          }
+        },
+      }),
+      // Explicit commit step — nothing plots until Apply.
+      m('.pf-tsv__picker-apply', [
+        m(
+          'span.pf-tsv__picker-count',
+          `${pending.size.toLocaleString()} selected`,
+        ),
+        m(Button, {
+          label: 'Apply',
+          variant: ButtonVariant.Filled,
+          disabled: !dirty,
+          dismissPopup: true,
+          onclick: () => this.applyPending(model),
+        }),
+        m(Button, {
+          label: 'Cancel',
+          dismissPopup: true,
+          onclick: () => (this.pending = undefined),
+        }),
+      ]),
+    ]);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.TimeseriesViewer/wasd.ts
+++ b/ui/src/plugins/dev.perfetto.TimeseriesViewer/wasd.ts
@@ -1,0 +1,203 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DisposableStack} from '../../base/disposable_stack';
+import {currentTargetOffset, elementIsEditable} from '../../base/dom_utils';
+import {KeyMapping} from '../../base/wasd_key_mapping';
+
+// A minimal spring-step driver on requestAnimationFrame — a local equivalent of
+// frontend/animation's Animation (which the import checker won't let a plugin
+// use, as it lives in /frontend). Calls onStep(msSinceStart) each frame until
+// the duration elapses; start() while running just extends the end time.
+class Animation {
+  private startMs = 0;
+  private endMs = 0;
+  private rafId = 0;
+  private running = false;
+
+  constructor(private readonly onStep: (msSinceStart: number) => void) {}
+
+  private readonly frame = (nowMs: number) => {
+    if (!this.running) return;
+    if (nowMs >= this.endMs) {
+      this.running = false;
+      return;
+    }
+    this.onStep(Math.max(Math.round(nowMs - this.startMs), 0));
+    this.rafId = requestAnimationFrame(this.frame);
+  };
+
+  start(durationMs: number) {
+    const nowMs = performance.now();
+    this.endMs = nowMs + durationMs;
+    if (!this.running) {
+      this.startMs = nowMs;
+      this.running = true;
+      this.rafId = requestAnimationFrame(this.frame);
+    }
+  }
+
+  stop() {
+    this.endMs = 0;
+    this.running = false;
+    cancelAnimationFrame(this.rafId);
+  }
+}
+
+// Self-contained WASD horizontal pan/zoom, matching the main timeline's feel
+// (same constants and spring animation). A/D pan, W/S zoom towards the cursor.
+// It is a trimmed copy of the timeline's KeyboardNavigationHandler kept local so
+// this plugin does not depend on another plugin's internals.
+const INITIAL_PAN_STEP_PX = 50;
+const INITIAL_ZOOM_STEP = 0.1;
+const SNAP_FACTOR = 0.4;
+const ACCELERATION_PER_MS = 1 / 50;
+const DEFAULT_ANIMATION_DURATION = 700;
+const ZOOM_RATIO_PER_FRAME = 0.008;
+const KEYBOARD_PAN_PX_PER_FRAME = 8;
+
+enum Pan {
+  None = 0,
+  Left = -1,
+  Right = 1,
+}
+enum Zoom {
+  None = 0,
+  In = 1,
+  Out = -1,
+}
+
+function keyToPan(e: KeyboardEvent): Pan {
+  if (e.code === KeyMapping.KEY_PAN_LEFT) return Pan.Left;
+  if (e.code === KeyMapping.KEY_PAN_RIGHT) return Pan.Right;
+  return Pan.None;
+}
+function keyToZoom(e: KeyboardEvent): Zoom {
+  if (e.code === KeyMapping.KEY_ZOOM_IN) return Zoom.In;
+  if (e.code === KeyMapping.KEY_ZOOM_OUT) return Zoom.Out;
+  return Zoom.None;
+}
+
+export interface WasdNavigationArgs {
+  readonly element: HTMLElement;
+  // Pan the view by `movedPx` pixels (positive = towards later time).
+  readonly onPanned: (movedPx: number) => void;
+  // Zoom by `zoomRatio` centred on element-x `zoomPositionPx`.
+  readonly onZoomed: (zoomPositionPx: number, zoomRatio: number) => void;
+}
+
+export class WasdNavigation implements Disposable {
+  private mouseX: number | undefined;
+  private panning = Pan.None;
+  private panOffsetPx = 0;
+  private targetPanOffsetPx = 0;
+  private zooming = Zoom.None;
+  private zoomRatio = 0;
+  private targetZoomRatio = 0;
+  private readonly panAnimation = new Animation((ms) => this.onPanStep(ms));
+  private readonly zoomAnimation = new Animation((ms) => this.onZoomStep(ms));
+  private readonly trash = new DisposableStack();
+  private readonly args: WasdNavigationArgs;
+  private disposed = false;
+
+  constructor(args: WasdNavigationArgs) {
+    this.args = args;
+    const onKeyDown = (e: Event) => this.onKeyDown(e);
+    const onKeyUp = (e: Event) => this.onKeyUp(e);
+    const onMouseMove = (e: MouseEvent) => {
+      this.mouseX = currentTargetOffset(e).x;
+    };
+    document.body.addEventListener('keydown', onKeyDown);
+    document.body.addEventListener('keyup', onKeyUp);
+    args.element.addEventListener('mousemove', onMouseMove);
+    this.trash.defer(() => {
+      document.body.removeEventListener('keydown', onKeyDown);
+      document.body.removeEventListener('keyup', onKeyUp);
+      args.element.removeEventListener('mousemove', onMouseMove);
+    });
+  }
+
+  [Symbol.dispose]() {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.panAnimation.stop();
+    this.zoomAnimation.stop();
+    this.trash.dispose();
+  }
+
+  private onPanStep(msSinceStart: number) {
+    const step = (this.targetPanOffsetPx - this.panOffsetPx) * SNAP_FACTOR;
+    if (this.panning !== Pan.None) {
+      const velocity = 1 + msSinceStart * ACCELERATION_PER_MS;
+      this.targetPanOffsetPx +=
+        this.panning * Math.max(KEYBOARD_PAN_PX_PER_FRAME * velocity, step);
+    }
+    this.panOffsetPx += step;
+    if (Math.abs(step) > 1e-1) {
+      this.args.onPanned(step);
+    } else {
+      this.panAnimation.stop();
+    }
+  }
+
+  private onZoomStep(msSinceStart: number) {
+    if (this.mouseX === undefined) return;
+    const step = (this.targetZoomRatio - this.zoomRatio) * SNAP_FACTOR;
+    if (this.zooming !== Zoom.None) {
+      const velocity = 1 + msSinceStart * ACCELERATION_PER_MS;
+      this.targetZoomRatio +=
+        this.zooming * Math.max(ZOOM_RATIO_PER_FRAME * velocity, step);
+    }
+    this.zoomRatio += step;
+    if (Math.abs(step) > 1e-6) {
+      this.args.onZoomed(this.mouseX, step);
+    } else {
+      this.zoomAnimation.stop();
+    }
+  }
+
+  private onKeyDown(e: Event) {
+    if (!(e instanceof KeyboardEvent)) return;
+    if (elementIsEditable(e.target)) return;
+    if (e.ctrlKey || e.metaKey) return;
+
+    const pan = keyToPan(e);
+    if (pan !== Pan.None) {
+      if (this.panning !== pan) {
+        this.panAnimation.stop();
+        this.panOffsetPx = 0;
+        this.targetPanOffsetPx = pan * INITIAL_PAN_STEP_PX;
+      }
+      this.panning = pan;
+      this.panAnimation.start(DEFAULT_ANIMATION_DURATION);
+    }
+
+    const zoom = keyToZoom(e);
+    if (zoom !== Zoom.None) {
+      if (this.zooming !== zoom) {
+        this.zoomAnimation.stop();
+        this.zoomRatio = 0;
+        this.targetZoomRatio = zoom * INITIAL_ZOOM_STEP;
+      }
+      this.zooming = zoom;
+      this.zoomAnimation.start(DEFAULT_ANIMATION_DURATION);
+    }
+  }
+
+  private onKeyUp(e: Event) {
+    if (!(e instanceof KeyboardEvent)) return;
+    if (keyToPan(e) !== Pan.None) this.panning = Pan.None;
+    if (keyToZoom(e) !== Zoom.None) this.zooming = Zoom.None;
+  }
+}

--- a/ui/src/widgets/drawer_panel.ts
+++ b/ui/src/widgets/drawer_panel.ts
@@ -152,6 +152,13 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
   // The height when the panel is 'FULLSCREEN'.
   private fullscreenHeight = 0;
 
+  // Height of the drag handle (tabs + resize buttons) above the drawer. The
+  // drawer is a sibling of the handle inside a fixed-height column, so its
+  // height must be capped at fullscreenHeight - handleHeight; otherwise a
+  // full-height (or dragged-to-max) drawer overflows the panel by the handle's
+  // height and its bottom is clipped off-screen.
+  private handleHeight = 0;
+
   // Current visibility state (if not controlled).
   private visibility = DrawerPanelVisibility.VISIBLE;
 
@@ -182,15 +189,15 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
       onVisibilityChange,
     } = attrs;
 
+    // The most the drawer can be without overflowing the panel: the full height
+    // less the handle that sits above it (main content then collapses to 0).
+    const maxHeight = Math.max(0, this.fullscreenHeight - this.handleHeight);
     switch (visibility) {
       case DrawerPanelVisibility.VISIBLE:
-        this.height = Math.min(
-          Math.max(this.resizableHeight, 0),
-          this.fullscreenHeight,
-        );
+        this.height = Math.min(Math.max(this.resizableHeight, 0), maxHeight);
         break;
       case DrawerPanelVisibility.FULLSCREEN:
-        this.height = this.fullscreenHeight;
+        this.height = maxHeight;
         break;
       case DrawerPanelVisibility.COLLAPSED:
         this.height = 0;
@@ -278,6 +285,7 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
   }
 
   oncreate(vnode: m.VnodeDOM<DrawerPanelAttrs, this>) {
+    this.measureHandle(vnode.dom);
     const parent = vnode.dom.parentElement;
     if (parent) {
       this.fullscreenHeight = parent.clientHeight;
@@ -287,6 +295,15 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
       });
       this.resizeObserver.observe(parent);
     }
+  }
+
+  onupdate(vnode: m.VnodeDOM<DrawerPanelAttrs, this>) {
+    this.measureHandle(vnode.dom);
+  }
+
+  private measureHandle(dom: Element) {
+    const handle = dom.querySelector('.pf-drawer-panel__handle');
+    if (handle) this.handleHeight = handle.getBoundingClientRect().height;
   }
 
   onremove() {


### PR DESCRIPTION
Add dev.perfetto.TimeseriesViewer, a fast, Battery-Historian-style dashboard for exploring counters across long (24h-weeks) traces. It stacks any number of counters as lanes over one shared time axis, each lane auto-scaled to the visible window with its own unit-formatted y-axis, so the magnitude of every metric is legible at a glance.

The dashboard lives entirely in the timeline drawer (there is no separate page) so counters can always be related to the tracks above. It opens two ways, both sharing one model:
- Contextually: select counter tracks (or a whole group) and the "Timeseries" area-selection sub-tab plots them inline.
- By command ("Open Timeseries dashboard"): opens a persistent drawer tab even with nothing selected, then add counters from the picker. It is viewport-locked to the timeline: it reads/writes trace.timeline's visible window (so both zoom/pan in lock-step) and uses the timeline's exact plot bounds and tick generator, so the drawer's gridlines and crosshair line up pixel-for-pixel with the tracks above. The plot's left offset (track-shell width) is drawn as a shell column showing each counter's name + y-axis, mirroring the track shells. Hovering the drawer moves the timeline's vertical hover pointer (and vice-versa).

Features
- Layouts: Stacked (per-lane) and Overlay, chosen with a segmented toggle. Overlay style is a second segmented control with three modes: normalised 0-100% (each line to its own visible range, for comparing shapes), a shared absolute value axis in the counters' unit (for comparing magnitudes), and a cumulative stacked-area chart. When the value/stacked axis would mix units, a unit selector scopes the axis (and the lines drawn) to one unit. The crosshair shows each line's real value.
- Value / Delta / Rate y-modes (as the built-in counter tracks), pushed into the mipmap value expression so bucket min/max/last already reflect the mode; set globally or per-line.
- Linear / Log y-scale.
- Y-axis range (Fit / Global / Shared): "Fit" autoscales each axis to the samples in view (rescales as you zoom); "Global" locks each axis to the counter's own whole-trace range so magnitudes stay comparable across zoom levels and the axis never moves; "Shared" puts *every* visible lane/line on one common range (the combined whole-trace range) so their heights are directly comparable to each other. The whole-trace range is mode-aware (recomputed for value/delta/rate) — derived from the in-memory samples for full-cached counters, or one coarse mipmap min/max query over the whole trace for larger ones. Applies to stacked lanes and overlay absolute/normalized; stacked-area (already a shared cumulative axis) treats Global/Shared alike.
- Interaction: WASD or two-finger pinch to zoom at the cursor, drag to select-zoom, shift-drag to pan, double-click / "Reset zoom" to fit. The mouse wheel scrolls the lanes (it does not zoom), so scrolling a tall stack is natural. Hovering a line greys the others (in the chart and the tooltip); single-click isolates it (show only that; click it — or any empty space — again to un-isolate), double-click hides it (keep the rest). The hover tooltip shows just the focused line plus a "Total" across the visible lines (not every counter, which is unusable at scale), and only the focused line gets a dot on the crosshair. On empty space (when not isolated), single-click pins a reference crosshair (parks on the timeline too), double-click drops a persistent bookmark note on the timeline. Area fill under each line (toggleable).
- Add counters: a compact "+" opens a searchable picker (a MultiSelect like the ftrace event filter: search, Select All/Filtered, Clear, selected-on-top). Search matches the metric name and the owning process/thread; ticking edits a pending set that only takes effect on Apply (Cancel discards). Options show a disambiguating owner+metric descriptor, each on a single ellipsized line so long process/thread names don't wrap. Applied counters union with those from the timeline selection (changing the selection keeps manual adds).
- Naming: a "Name by" switch (Metric / Process / Thread, metric by default) labels lines; Process/Thread show the owner (e.g. "system_server 1719"), disambiguating same-named counters. Any line can be renamed from its legend gear.
- Defaults that match the timeline: a line's mode mirrors the "Y Mode" the user set on that counter's timeline track (read via the track's public settings), so the dashboard maps exactly what they see; when there is no such track it falls back to a heuristic (monotonic/cumulative -> rate, else value). The unit comes from counter_track.unit or, when absent, a common trailing name suffix (e.g. "Heap size (KB)"). Axis/tooltip values use metric SI notation ("200M", "1.5G", "516K") rather than engineering ("200e6"): known units defer to base/number_format (so bytes -> "200 MB", Hz -> "3 GHz"); unitless or non-canonical units get an SI prefix with the raw unit appended.
- Legend: click a chip to show/hide its line, or its "x" to remove (deselect) the counter without reopening the picker; "Hide all" / "Show all" bulk controls make it easy to hide everything then reveal counters one at a time. Hidden lanes are dropped from the stacked layout (not just overlay). The gear menu also has per-line rename / mode / solid-dashed-dotted / colour. Drag the splitter below the legend to enlarge the strip and see more chips. In stacked mode, drag a lane by its shell (name gutter) to reorder it (with a drop indicator), or drag a lane's bottom edge to resize just that lane; the S/M/L height control resets per-lane overrides so it stays authoritative. In overlay, drag the plot's bottom edge to resize the shared plot.
- A flamegraph-style toolbar of connected segmented toggles separated by dividers, plus a help hint. The primary controls (layout, area/overlay-axis, Value/Delta/Rate, Fit/Global) sit in the main row with generous padding; secondary display options (Linear/Log scale and, in stacked mode, lane height S/M/L) tuck into a right-aligned "Display options" hamburger menu to keep the row uncluttered. Gridline labels mirror the timeline's own timecode so the markings match.

Performance
- Canvas2D rendering; data comes from the existing __intrinsic_counter_mipmap virtual table, returning min/max/last per bucket at O(pixels) rows for any trace length. Per-viewport queries are debounced and keyed by (window, resolution); only selected lanes build a mipmap.
- Smooth zoom/pan: a counter with up to 50k samples is loaded once in full and reused for every viewport, so zoom/pan just remaps existing points with no re-query and no re-bucketing (no "snap" when motion stops); larger counters fall back to the per-viewport mipmap. The y-axis autoscales continuously from the samples currently on screen (binary-searched), so it rescales smoothly rather than jumping on refetch.
- Virtualized: stacked mode fetches and draws only the lanes on screen; overlay is capped and coarsened by an adaptive resolution that bounds the total drawn point count, keeping hundreds of overlaid lines interactive. Selection membership is an O(1) set so Select-all stays fast at scale. Drawing strides points to ~2/px, so fully-cached counters and dense overlays never stroke more than the screen can show (verified by in-browser frame-time benchmarks; the chart's own draw is a small fraction of the shared-timeline redraw cost).
- Rendering hooks the shared canvas-redraw scheduler (trace.raf .addCanvasRedrawCallback), the same path the timeline's own tracks use: the chart repaints exactly when the timeline repaints (zoom/pan/hover), and does nothing at all when idle (no polling loop). Local changes request a paint via scheduleCanvasRedraw; the greying fade asks for successive frames only until it settles. Nothing is fetched or drawn while the drawer tab is hidden (zero-width) or for lanes scrolled off-screen. Per-point drawing uses a precomputed linear ns->px map (no BigInt/Time allocation per sample), and the theme palette is cached (getComputedStyle is not called per frame).

Smoothness (matches the timeline's own feel):
- Continuous y-scaling on zoom. The value->pixel mapping uses the *raw* data bounds, so an autoscaled lane/area morphs continuously as the visible range changes; only the tick *labels* snap to "nice" round numbers (renderers cull ticks outside the raw bounds). Previously the drawing used the nice-rounded max, so the whole plot jumped a full step whenever the max crossed a round boundary while zooming — most visible in stacked-area. Log scale gets the same treatment (raw bounds, decade labels) so it doesn't jump at decade crossings.
- Hover greying is eased: each line's opacity springs toward its target over ~12 frames (the rAF loop keeps redrawing only until it settles), so focusing/un-focusing and cross-fading between lines is smooth, not a snap; the legend chips and tooltip rows get a matching CSS opacity transition.

Measured: 5,000,000-point counter -> ~0.06 ms per per-viewport query (fixed ~3840 rows out); 100 counters build+fetch ~19 ms; render ~30 ms/frame at 100 lines. Reuses base/number_format, base/time_scale and charts_svg/common. To keep the plugin import-clean (tools/check_imports disallows a plugin depending on /frontend or another plugin's internals), the gridline tick generator and the WASD spring Animation are small local copies that run on requestAnimationFrame rather than importing them. Includes a Playwright e2e test covering command-open, search-add, name-by, drag-zoom, reset, log, hide-all/reveal, overlay (units / stacked-area), per-lane resize, isolate/un-isolate, and the global y-range toggle.

Also fixes a DrawerPanel bug this dashboard exposed: in fullscreen (and when dragged to the maximum), the drawer was sized to the full panel height without accounting for the handle above it, so its bottom (here the chart's) overflowed the panel and was clipped off-screen. The drawer height is now capped at panel-height minus the handle height, so the content always fits.

<img width="2940" height="1602" alt="image" src="https://github.com/user-attachments/assets/6da021a0-0b5d-4f22-88fd-07185751204b" />
<img width="2940" height="1602" alt="image" src="https://github.com/user-attachments/assets/1c09306f-302a-40f2-b58a-e1c95f1e9a6d" />
